### PR TITLE
fix(cloud-shared): autoscaler proactive headroom, maxNodes 14->16 (#18413)

### DIFF
--- a/packages/cloud/shared/src/lib/services/containers/node-autoscaler.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-autoscaler.test.ts
@@ -94,7 +94,7 @@ afterAll(() => {
 });
 
 import { InMemoryComputeProvider } from "./compute-provider-fake";
-import { type AutoscalePolicy, NodeAutoscaler } from "./node-autoscaler";
+import { type AutoscalePolicy, DEFAULT_AUTOSCALE_POLICY, NodeAutoscaler } from "./node-autoscaler";
 
 const policy: AutoscalePolicy = {
   minFreeSlotsBuffer: 4,
@@ -480,5 +480,86 @@ describe("NodeAutoscaler full provision\u2192healthy\u2192drain loop (#8920)", (
     const drained = await autoscaler.evaluateCapacity();
     expect(drained.healthyNodeCount).toBe(0);
     expect(drained.shouldScaleUp).toBe(true);
+  });
+});
+
+// Every other suite in this file supplies a custom policy (maxNodes: 4), so a
+// silent revert of the DEFAULT cap would keep the whole file green. This block
+// pins the shipped default (14 \u2192 16, #18437 / #18413) and observes the cap
+// boundary under DEFAULT_AUTOSCALE_POLICY itself: with zero free slots the
+// capacity need always wants a node, leaving `enabled.length < maxNodes` as the
+// only gate \u2014 15 nodes must scale up (15 < 16) and 16 must be capped. If the
+// default reverts to 14, the 15-node case caps out and fails.
+describe("DEFAULT_AUTOSCALE_POLICY cap regression (#18413)", () => {
+  const CREATED_AT = Date.parse("2026-05-15T12:00:00Z");
+  // 1h after creation \u2192 safely past the default scaleUpCooldownMs (5m), so the
+  // cooldown gate cannot mask the maxNodes gate.
+  const NOW = CREATED_AT + 60 * 60 * 1000;
+  const NODE_CAPACITY = 8;
+  let originalAgentImagePlatform: string | undefined;
+
+  function fullyAllocatedNode(index: number): DockerNode {
+    return {
+      id: `db-cap-${index}`,
+      node_id: `cap-node-${index}`,
+      hostname: `10.0.1.${index}`,
+      ssh_port: 22,
+      ssh_user: "root",
+      capacity: NODE_CAPACITY,
+      allocated_count: NODE_CAPACITY,
+      enabled: true,
+      status: "healthy",
+      metadata: { architecture: "arm64" },
+      created_at: new Date(CREATED_AT),
+      updated_at: new Date(CREATED_AT),
+    } as DockerNode;
+  }
+
+  beforeEach(() => {
+    originalAgentImagePlatform = process.env[AGENT_IMAGE_PLATFORM];
+    process.env[AGENT_IMAGE_PLATFORM] = "linux/arm64";
+    mocks.findAllNodes.mockReset();
+    mocks.countAllocated.mockReset();
+    mocks.countRetained.mockReset();
+    mocks.nodes = [];
+    mocks.findAllNodes.mockImplementation(() => Promise.resolve(mocks.nodes));
+    // Every healthy node reports zero free slots, so the capacity need alone
+    // wants a scale-up and the maxNodes cap is the only remaining gate.
+    mocks.countAllocated.mockResolvedValue(NODE_CAPACITY);
+    mocks.countRetained.mockResolvedValue(0);
+  });
+
+  afterEach(() => {
+    restoreEnv(AGENT_IMAGE_PLATFORM, originalAgentImagePlatform);
+  });
+
+  test("ships maxNodes 16 as the default cap (#18437)", () => {
+    expect(DEFAULT_AUTOSCALE_POLICY.maxNodes).toBe(16);
+  });
+
+  test("15 enabled fully-allocated nodes still scale up under the default cap", async () => {
+    mocks.nodes = Array.from({ length: 15 }, (_, i) => fullyAllocatedNode(i));
+    const autoscaler = new NodeAutoscaler(DEFAULT_AUTOSCALE_POLICY, () => NOW);
+
+    // 15 < 16: one node of proactive headroom must remain. A revert to the old
+    // default (14) turns this into 15 < 14 and the assertion fails.
+    await expect(autoscaler.evaluateCapacity()).resolves.toMatchObject({
+      enabledNodeCount: 15,
+      healthyNodeCount: 15,
+      totalAvailable: 0,
+      shouldScaleUp: true,
+    });
+  });
+
+  test("16 enabled fully-allocated nodes are capped under the default cap", async () => {
+    mocks.nodes = Array.from({ length: 16 }, (_, i) => fullyAllocatedNode(i));
+    const autoscaler = new NodeAutoscaler(DEFAULT_AUTOSCALE_POLICY, () => NOW);
+
+    await expect(autoscaler.evaluateCapacity()).resolves.toMatchObject({
+      enabledNodeCount: 16,
+      healthyNodeCount: 16,
+      totalAvailable: 0,
+      shouldScaleUp: false,
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts
@@ -62,10 +62,15 @@ export interface AutoscalePolicy {
 export const DEFAULT_AUTOSCALE_POLICY: AutoscalePolicy = {
   minFreeSlotsBuffer: containersEnv.autoscaleMinFreeSlotsBuffer(),
   minHotAvailableSlots: containersEnv.autoscaleMinHotAvailableSlots(),
-  // Launch capacity bump 12 → 14 (#18052): the launch chain enables the warm
-  // pool, whose standing replenishment consumes slots the old ceiling had
-  // reserved for on-demand provisioning headroom.
-  maxNodes: 14,
+  // Launch capacity: 12 → 14 (#18052) enabled the warm pool but left the cap
+  // equal to the enabled-node count, so `enabled.length < maxNodes` (the
+  // scale-up gate) was already false — zero proactive headroom (#18413).
+  // 14 → 16 restores a real 2-node buffer so the pool can provision ahead of
+  // demand and absorb one node flapping without immediately re-capping.
+  // Only effective if provisionable `docker_nodes` capacity is >= 16; if the
+  // authoritative provisionable count is lower, that is the true ceiling and
+  // physical nodes must be added first (see #18413).
+  maxNodes: 16,
   scaleUpCooldownMs: 5 * 60 * 1000,
   idleNodeMinAgeMs: 30 * 60 * 1000,
   defaultServerType: containersEnv.defaultHcloudServerType(),


### PR DESCRIPTION
Repairs the **#18351 seam** recorded in #18413.

## Defect
#18052 set `maxNodes: 14` while the fleet has **14 enabled nodes**. The scale-up gate is strict — `enabled.length < this.policy.maxNodes` (`node-autoscaler.ts:179`) — so `14 < 14` is false and the bump created **zero proactive headroom**. My original 1-line approval of #18351 verified mechanics but not fleet-size ground truth; this repairs that.

## Fix
`maxNodes: 14 → 16` for a real 2-node buffer. Value is **vps-agent's cost-owner decision** (HQ #18309, under the operator's blanket grant): 16 over 15 because the autoscaler should provision proactively — 2 nodes let it add ahead of demand and absorb one node flapping without immediately re-capping; 1-node headroom re-hits the ceiling the moment it scales once.

## ⚠️ Merge contingency (do not merge until confirmed)
This only helps if **provisionable `docker_nodes` capacity is ≥ 16**. If the authoritative admin count is exactly 14 physical, raising `maxNodes` alone is inert — the real fix is adding physical nodes, and `maxNodes` should track `provisionable + 2`. **@kepler / infra: confirm the authoritative provisionable count before merge**; if <16, set `maxNodes = provisionable` and file the add-nodes follow-up. Post-deploy readback must show `enabled < maxNodes` with real headroom.

## Verification (honest status)
- Biome clean on the changed file.
- No test asserts `DEFAULT_AUTOSCALE_POLICY.maxNodes` — the autoscaler suite constructs its own policy (`maxNodes: 4`), so this literal-constant change is isolated. CI runs the full cloud lane.
- Local package test lane was **not** run green in the isolated worktree (monorepo build-order needs `@elizaos/core` built first — unrelated to this constant); not claiming otherwise.

- Before screenshots `N/A - backend capacity constant, no UI surface`.
- After screenshots `N/A - backend capacity constant, no UI surface`.
- Walkthrough video `N/A - no UI surface`.
- Backend logs: post-deploy autoscaler policy readback (maxNodes=16, enabled<maxNodes) is the required domain artifact — attached on deploy per the contingency.
- Frontend logs `N/A - no frontend change`.
- Real-LLM trajectory `N/A - no model path involved`.
- Domain artifacts: post-deploy `docker_nodes` count + policy dump showing real headroom.
- OCR review `N/A - no rendered visual surface`.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"N/A - no contribution skill used"} -->

<!-- evidence-head:686181338359cc20cd28eed3363ba22eec0dac40 -->

<!-- evidence-row:before-screenshots -->
- N/A - backend capacity constant only; no UI surface changed

<!-- evidence-row:after-screenshots -->
- N/A - backend capacity constant only; no UI surface changed

<!-- evidence-row:walkthrough-video -->
- N/A - no UI surface or user interaction changed

<!-- evidence-row:backend-logs -->
- N/A - post-deploy autoscaler policy readback (maxNodes=16, enabled<maxNodes) is the required artifact; will be attached on deploy per merge contingency note

<!-- evidence-row:frontend-logs -->
- N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- N/A - no agent, model, action, provider, or prompt path involved

<!-- evidence-row:domain-artifacts -->
- N/A - post-deploy docker_nodes count and policy dump showing real headroom will be attached on deploy
