### PR TITLE
fix(cloud): restore first-party CORS for the eliza.app homepage auth flows

### DIFF
--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
@@ -74,6 +74,13 @@ describe("isFirstPartyOrigin", () => {
     // the browser preflight (the 2026-08-11 "phone number step fails" QA).
     expect(isFirstPartyOrigin("https://eliza.app")).toBe(true);
     expect(isFirstPartyOrigin("https://www.eliza.app")).toBe(true);
+    // The staging homepage (deploy-homepage-staging.yml -> staging.eliza.app)
+    // runs the same auth flows against staging.elizacloud.ai, which serves
+    // this same allowlist.
+    expect(isFirstPartyOrigin("https://staging.eliza.app")).toBe(true);
+    // Never a broad suffix match: sibling lookalikes stay third-party.
+    expect(isFirstPartyOrigin("https://evil-eliza.app")).toBe(false);
+    expect(isFirstPartyOrigin("https://eliza.app.evil.example")).toBe(false);
     expect(isFirstPartyOrigin("http://localhost:5173")).toBe(true);
     expect(isFirstPartyOrigin("https://supakan.nubs.site")).toBe(false);
     expect(isFirstPartyOrigin("https://evil.example.com")).toBe(false);

--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
@@ -68,6 +68,12 @@ describe("isFirstPartyOrigin", () => {
     expect(isFirstPartyOrigin("https://app-staging.elizacloud.ai")).toBe(true);
     expect(isFirstPartyOrigin("https://develop.eliza-app.pages.dev")).toBe(true);
     expect(isFirstPartyOrigin("https://random.eliza-app.pages.dev")).toBe(false);
+    // The eliza.app homepage runs the get-started auth flows (Telegram widget
+    // phone step, Discord OAuth callback) against /api/eliza-app/* on
+    // elizacloud.ai. Without first-party CORS every one of those POSTs dies in
+    // the browser preflight (the 2026-08-11 "phone number step fails" QA).
+    expect(isFirstPartyOrigin("https://eliza.app")).toBe(true);
+    expect(isFirstPartyOrigin("https://www.eliza.app")).toBe(true);
     expect(isFirstPartyOrigin("http://localhost:5173")).toBe(true);
     expect(isFirstPartyOrigin("https://supakan.nubs.site")).toBe(false);
     expect(isFirstPartyOrigin("https://evil.example.com")).toBe(false);

--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts
@@ -62,6 +62,12 @@ const STATIC_ALLOWED_ORIGINS = new Set<string>([
   // legacy allowlist in lib/utils/cors.ts, which always included eliza.app.
   "https://eliza.app",
   "https://www.eliza.app",
+  // staging.eliza.app (CF Pages project eliza-home-staging, deployed by
+  // .github/workflows/deploy-homepage-staging.yml) is the same homepage built
+  // against staging.elizacloud.ai. The staging worker runs this same
+  // allowlist, so without this entry every staging auth POST dies in
+  // preflight exactly like the prod outage this PR fixes.
+  "https://staging.eliza.app",
 ]);
 const PAGES_PREVIEW_SUFFIX = ".eliza-cloud-enq.pages.dev";
 

--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts
@@ -54,6 +54,14 @@ const STATIC_ALLOWED_ORIGINS = new Set<string>([
   "https://os.elizacloud.ai",
   "https://eliza.ai",
   "https://www.eliza.ai",
+  // The eliza.app homepage (packages/homepage) hosts /get-started, whose
+  // Telegram-widget phone step and Discord OAuth callback POST directly to
+  // /api/eliza-app/auth/* on elizacloud.ai. Those calls are browser-enforced
+  // cross-origin requests, so this origin must be first-party or every
+  // homepage auth flow fails in preflight with no ACAO header. Mirrors the
+  // legacy allowlist in lib/utils/cors.ts, which always included eliza.app.
+  "https://eliza.app",
+  "https://www.eliza.app",
 ]);
 const PAGES_PREVIEW_SUFFIX = ".eliza-cloud-enq.pages.dev";
 

--- a/packages/homepage/.env.example
+++ b/packages/homepage/.env.example
@@ -1,7 +1,7 @@
 # Copy this file to .env.local and configure for your environment
 
 # For production (default):
-# VITE_ELIZACLOUD_API_URL=https://www.elizacloud.ai
+# VITE_ELIZACLOUD_API_URL=https://elizacloud.ai
 #
 # For local development with eliza-cloud-v2:
 # VITE_ELIZACLOUD_API_URL=http://localhost:3000
@@ -9,7 +9,7 @@
 # Note: When running locally, start eliza-cloud-v2 on port 3000 first,
 # then run eliza-app on port 4444 (bun run dev)
 
-VITE_ELIZACLOUD_API_URL=https://www.elizacloud.ai
+VITE_ELIZACLOUD_API_URL=https://elizacloud.ai
 
 # Bot numeric ID (first part of bot token before the colon)
 # Example: If token is 8202935775:AAGL9Dhf..., use 8202935775

--- a/packages/homepage/AGENTS.md
+++ b/packages/homepage/AGENTS.md
@@ -111,7 +111,7 @@ All vars use the `VITE_` prefix (browser-exposed). Set in `.env.local`.
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `VITE_ELIZACLOUD_API_URL` | `https://www.elizacloud.ai` | Eliza Cloud backend base URL |
+| `VITE_ELIZACLOUD_API_URL` | `https://elizacloud.ai` | Eliza Cloud backend base URL |
 | `VITE_TELEGRAM_BOT_USERNAME` | — | Telegram bot username (from @BotFather) |
 | `VITE_TELEGRAM_BOT_ID` | — | Numeric Telegram bot ID |
 | `VITE_DISCORD_CLIENT_ID` | — | Discord Application ID for OAuth2 |

--- a/packages/homepage/CLAUDE.md
+++ b/packages/homepage/CLAUDE.md
@@ -111,7 +111,7 @@ All vars use the `VITE_` prefix (browser-exposed). Set in `.env.local`.
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `VITE_ELIZACLOUD_API_URL` | `https://www.elizacloud.ai` | Eliza Cloud backend base URL |
+| `VITE_ELIZACLOUD_API_URL` | `https://elizacloud.ai` | Eliza Cloud backend base URL |
 | `VITE_TELEGRAM_BOT_USERNAME` | — | Telegram bot username (from @BotFather) |
 | `VITE_TELEGRAM_BOT_ID` | — | Numeric Telegram bot ID |
 | `VITE_DISCORD_CLIENT_ID` | — | Discord Application ID for OAuth2 |

--- a/packages/homepage/README.md
+++ b/packages/homepage/README.md
@@ -14,7 +14,7 @@ cp .env.example .env.local
 
 | Variable | Description |
 |---|---|
-| `VITE_ELIZACLOUD_API_URL` | Eliza Cloud backend URL (defaults to `https://www.elizacloud.ai`) |
+| `VITE_ELIZACLOUD_API_URL` | Eliza Cloud backend URL (defaults to `https://elizacloud.ai`) |
 | `VITE_TELEGRAM_BOT_USERNAME` | Telegram bot username from @BotFather |
 | `VITE_TELEGRAM_BOT_ID` | Numeric Telegram bot ID (first part of bot token before `:`) |
 | `VITE_DISCORD_CLIENT_ID` | Discord Application ID (from Developer Portal → General Information) |

--- a/packages/homepage/scripts/run-playwright-web-server.mjs
+++ b/packages/homepage/scripts/run-playwright-web-server.mjs
@@ -59,7 +59,7 @@ const vite = spawn(
     cwd: homepageDir,
     env: {
       ...process.env,
-      VITE_ELIZACLOUD_API_URL: "https://www.elizacloud.ai",
+      VITE_ELIZACLOUD_API_URL: "https://elizacloud.ai",
       // Deterministic fake bot id so Telegram onboarding specs run in every
       // lane, including fork-safe jobs that carry no repository variables.
       // Specs stub window.Telegram.Login and intercept the network; nothing

--- a/packages/homepage/src/lib/api/client.ts
+++ b/packages/homepage/src/lib/api/client.ts
@@ -2,7 +2,11 @@
  * Browser fetch helpers for calling the Eliza Cloud API from the static
  * homepage.
  */
-const ELIZACLOUD_DEFAULT_URL = "https://www.elizacloud.ai";
+// Apex, not `www.`: the www host 308-redirects to the apex, and CORS
+// preflights never follow redirects — with the www default every
+// /api/eliza-app/* POST from the homepage died before reaching the API
+// (the get-started Telegram phone step and Discord callback failures).
+const ELIZACLOUD_DEFAULT_URL = "https://elizacloud.ai";
 
 function getBaseUrl(): string {
   return (

--- a/packages/homepage/tests/e2e/aesthetic-audit.spec.ts
+++ b/packages/homepage/tests/e2e/aesthetic-audit.spec.ts
@@ -53,7 +53,7 @@ const mockUser = {
 };
 
 async function installCloudMocks(page: Page) {
-  await page.route("https://www.elizacloud.ai/api/eliza-app/**", (route) => {
+  await page.route("https://elizacloud.ai/api/eliza-app/**", (route) => {
     const url = new URL(route.request().url());
     if (url.pathname === "/api/eliza-app/user/me") {
       return route.fulfill({
@@ -69,44 +69,41 @@ async function installCloudMocks(page: Page) {
     }
     return route.fulfill({ status: 404, json: { error: "Unhandled mock" } });
   });
-  await page.route(
-    "https://www.elizacloud.ai/api/auth/siws/**",
-    async (route) => {
-      const u = new URL(route.request().url());
-      if (u.pathname === "/api/auth/siws/nonce") {
-        return route.fulfill({
-          json: {
-            nonce: "test-nonce-abcdef",
-            domain: "www.elizacloud.ai",
-            uri: "https://www.elizacloud.ai",
-            chainId: "solana:mainnet",
-            version: "1",
-            statement: "Sign in to Eliza Cloud",
+  await page.route("https://elizacloud.ai/api/auth/siws/**", async (route) => {
+    const u = new URL(route.request().url());
+    if (u.pathname === "/api/auth/siws/nonce") {
+      return route.fulfill({
+        json: {
+          nonce: "test-nonce-abcdef",
+          domain: "www.elizacloud.ai",
+          uri: "https://www.elizacloud.ai",
+          chainId: "solana:mainnet",
+          version: "1",
+          statement: "Sign in to Eliza Cloud",
+        },
+      });
+    }
+    if (u.pathname === "/api/auth/siws/verify") {
+      return route.fulfill({
+        json: {
+          apiKey: TEST_TOKEN,
+          address: "11111111111111111111111111111111",
+          isNewAccount: true,
+          user: {
+            id: "user_siws_audit",
+            wallet_address: "11111111111111111111111111111111",
+            organization_id: "org_siws_audit",
           },
-        });
-      }
-      if (u.pathname === "/api/auth/siws/verify") {
-        return route.fulfill({
-          json: {
-            apiKey: TEST_TOKEN,
-            address: "11111111111111111111111111111111",
-            isNewAccount: true,
-            user: {
-              id: "user_siws_audit",
-              wallet_address: "11111111111111111111111111111111",
-              organization_id: "org_siws_audit",
-            },
-            organization: {
-              id: "org_siws_audit",
-              name: "SIWS Audit Org",
-              slug: "siws-audit",
-            },
+          organization: {
+            id: "org_siws_audit",
+            name: "SIWS Audit Org",
+            slug: "siws-audit",
           },
-        });
-      }
-      return route.fulfill({ status: 404 });
-    },
-  );
+        },
+      });
+    }
+    return route.fulfill({ status: 404 });
+  });
 }
 
 async function seedAuthed(page: Page) {

--- a/packages/homepage/tests/e2e/app-routes-flow.spec.ts
+++ b/packages/homepage/tests/e2e/app-routes-flow.spec.ts
@@ -31,7 +31,7 @@ const mockUser = {
 async function installHomepageApiMocks(page: Page) {
   let linkedPhone: string | null = null;
 
-  await page.route("https://www.elizacloud.ai/api/eliza-app/**/chat", (route) =>
+  await page.route("https://elizacloud.ai/api/eliza-app/**/chat", (route) =>
     route.fulfill({
       json: {
         messages: [
@@ -46,7 +46,7 @@ async function installHomepageApiMocks(page: Page) {
     }),
   );
 
-  await page.route("https://www.elizacloud.ai/api/eliza-app/**", (route) => {
+  await page.route("https://elizacloud.ai/api/eliza-app/**", (route) => {
     const url = new URL(route.request().url());
     const path = url.pathname;
 

--- a/packages/homepage/tests/e2e/contact-sheet-capture.spec.ts
+++ b/packages/homepage/tests/e2e/contact-sheet-capture.spec.ts
@@ -63,7 +63,7 @@ const mockUser = {
 };
 
 async function installCloudMocks(page: Page) {
-  await page.route("https://www.elizacloud.ai/api/eliza-app/**", (route) => {
+  await page.route("https://elizacloud.ai/api/eliza-app/**", (route) => {
     const url = new URL(route.request().url());
     if (url.pathname === "/api/eliza-app/user/me") {
       return route.fulfill({

--- a/packages/homepage/tests/e2e/telegram-return.spec.ts
+++ b/packages/homepage/tests/e2e/telegram-return.spec.ts
@@ -37,62 +37,59 @@ test("redeems a bot continuation inside signed Telegram auth", async ({
   await page.route("https://telegram.org/js/**", (route) =>
     route.fulfill({ contentType: "application/javascript", body: "" }),
   );
-  await page.route(
-    "https://www.elizacloud.ai/api/eliza-app/**",
-    async (route) => {
-      const request = route.request();
-      const url = new URL(request.url());
-      if (url.pathname === "/api/eliza-app/auth/telegram") {
-        authBodies.push(request.postDataJSON());
-        return route.fulfill({
-          json: {
-            success: true,
-            user: {
-              id: "telegram-return-user",
-              telegram_id: "123456789",
-              telegram_username: "sam",
-              phone_number: "+14155550123",
-              name: "Sam",
-              organization_id: "telegram-return-org",
-            },
-            session: {
-              token: "redeemed-session-token",
-              expires_at: "2026-08-09T00:00:00.000Z",
-            },
-            is_new_user: false,
-            continuation_redeemed: true,
+  await page.route("https://elizacloud.ai/api/eliza-app/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (url.pathname === "/api/eliza-app/auth/telegram") {
+      authBodies.push(request.postDataJSON());
+      return route.fulfill({
+        json: {
+          success: true,
+          user: {
+            id: "telegram-return-user",
+            telegram_id: "123456789",
+            telegram_username: "sam",
+            phone_number: "+14155550123",
+            name: "Sam",
+            organization_id: "telegram-return-org",
           },
-        });
-      }
-      if (url.pathname === "/api/eliza-app/onboarding/chat") {
-        browserContinuationCalls += 1;
-        return route.fulfill({
-          status: 500,
-          json: { error: "unexpected browser redemption" },
-        });
-      }
-      if (url.pathname === "/api/eliza-app/user/me") {
-        return route.fulfill({
-          json: {
-            user: {
-              id: "telegram-return-user",
-              telegram_id: "123456789",
-              telegram_username: "sam",
-              telegram_first_name: "Sam",
-              organization_id: "telegram-return-org",
-              created_at: "2026-01-01T00:00:00.000Z",
-            },
-            organization: {
-              id: "telegram-return-org",
-              name: "Telegram Return Org",
-              credit_balance: "5.00",
-            },
+          session: {
+            token: "redeemed-session-token",
+            expires_at: "2026-08-09T00:00:00.000Z",
           },
-        });
-      }
-      return route.fulfill({ status: 404, json: { error: "Unhandled mock" } });
-    },
-  );
+          is_new_user: false,
+          continuation_redeemed: true,
+        },
+      });
+    }
+    if (url.pathname === "/api/eliza-app/onboarding/chat") {
+      browserContinuationCalls += 1;
+      return route.fulfill({
+        status: 500,
+        json: { error: "unexpected browser redemption" },
+      });
+    }
+    if (url.pathname === "/api/eliza-app/user/me") {
+      return route.fulfill({
+        json: {
+          user: {
+            id: "telegram-return-user",
+            telegram_id: "123456789",
+            telegram_username: "sam",
+            telegram_first_name: "Sam",
+            organization_id: "telegram-return-org",
+            created_at: "2026-01-01T00:00:00.000Z",
+          },
+          organization: {
+            id: "telegram-return-org",
+            name: "Telegram Return Org",
+            credit_balance: "5.00",
+          },
+        },
+      });
+    }
+    return route.fulfill({ status: 404, json: { error: "Unhandled mock" } });
+  });
 
   await page.goto(
     "/get-started?method=telegram&link=true&onboardingSession=opaque-session-id",
@@ -145,49 +142,46 @@ test("does not return to Telegram unless the server confirms redemption", async 
   await page.route("https://telegram.org/js/**", (route) =>
     route.fulfill({ contentType: "application/javascript", body: "" }),
   );
-  await page.route(
-    "https://www.elizacloud.ai/api/eliza-app/**",
-    async (route) => {
-      const url = new URL(route.request().url());
-      if (url.pathname === "/api/eliza-app/auth/telegram") {
-        return route.fulfill({
-          json: {
-            success: true,
-            user: {
-              id: "telegram-return-user",
-              telegram_id: "123456789",
-              phone_number: "+14155550123",
-              organization_id: "telegram-return-org",
-            },
-            session: {
-              token: "unredeemed-session-token",
-              expires_at: "2026-08-09T00:00:00.000Z",
-            },
-            is_new_user: false,
-            continuation_redeemed: false,
+  await page.route("https://elizacloud.ai/api/eliza-app/**", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname === "/api/eliza-app/auth/telegram") {
+      return route.fulfill({
+        json: {
+          success: true,
+          user: {
+            id: "telegram-return-user",
+            telegram_id: "123456789",
+            phone_number: "+14155550123",
+            organization_id: "telegram-return-org",
           },
-        });
-      }
-      if (url.pathname === "/api/eliza-app/user/me") {
-        return route.fulfill({
-          json: {
-            user: {
-              id: "telegram-return-user",
-              telegram_id: "123456789",
-              organization_id: "telegram-return-org",
-              created_at: "2026-01-01T00:00:00.000Z",
-            },
-            organization: {
-              id: "telegram-return-org",
-              name: "Telegram Return Org",
-              credit_balance: "5.00",
-            },
+          session: {
+            token: "unredeemed-session-token",
+            expires_at: "2026-08-09T00:00:00.000Z",
           },
-        });
-      }
-      return route.fulfill({ status: 404, json: { error: "Unhandled mock" } });
-    },
-  );
+          is_new_user: false,
+          continuation_redeemed: false,
+        },
+      });
+    }
+    if (url.pathname === "/api/eliza-app/user/me") {
+      return route.fulfill({
+        json: {
+          user: {
+            id: "telegram-return-user",
+            telegram_id: "123456789",
+            organization_id: "telegram-return-org",
+            created_at: "2026-01-01T00:00:00.000Z",
+          },
+          organization: {
+            id: "telegram-return-org",
+            name: "Telegram Return Org",
+            credit_balance: "5.00",
+          },
+        },
+      });
+    }
+    return route.fulfill({ status: 404, json: { error: "Unhandled mock" } });
+  });
 
   await page.goto(
     "/get-started?method=telegram&link=true&onboardingSession=opaque-session-id",
@@ -213,7 +207,7 @@ test("a completed Telegram handoff offers a direct return to the bot", async ({
   await page.addInitScript((token) => {
     window.localStorage.setItem("eliza_app_session", token as string);
   }, TEST_TOKEN);
-  await page.route("https://www.elizacloud.ai/api/eliza-app/**", (route) => {
+  await page.route("https://elizacloud.ai/api/eliza-app/**", (route) => {
     const url = new URL(route.request().url());
     if (url.pathname === "/api/eliza-app/user/me") {
       return route.fulfill({

--- a/packages/homepage/tests/e2e/visual.spec.ts
+++ b/packages/homepage/tests/e2e/visual.spec.ts
@@ -50,7 +50,7 @@ async function prepareProfileAuth(page: Page) {
   await page.addInitScript(() => {
     window.localStorage.setItem("eliza_app_session", "homepage-visual-token");
   });
-  await page.route("https://www.elizacloud.ai/api/eliza-app/**", (route) =>
+  await page.route("https://elizacloud.ai/api/eliza-app/**", (route) =>
     route.fulfill({
       json: {
         user: {

--- a/packages/homepage/tests/smoke.node.test.mjs
+++ b/packages/homepage/tests/smoke.node.test.mjs
@@ -1,5 +1,5 @@
 /**
- * Homepage asset, caching, and build-configuration contracts exercised without importing the React tree.
+ * Homepage asset, caching, API-origin, and build-configuration contracts exercised without importing the React tree.
  *
  * The package test script runs under node:test, so this avoids pulling three.js
  * or adding Vitest just to confirm the entry component remains exportable.
@@ -28,6 +28,18 @@ const shaderBackgroundPath = resolve(
   "../src/components/ShaderBackground/ShaderBackground.tsx",
 );
 const visualRegressionSpecPath = resolve(__dirname, "./e2e/visual.spec.ts");
+const cloudApiClientPath = resolve(__dirname, "../src/lib/api/client.ts");
+const playwrightLauncherPath = resolve(
+  __dirname,
+  "../scripts/run-playwright-web-server.mjs",
+);
+const cloudRouteMockPaths = [
+  "./e2e/aesthetic-audit.spec.ts",
+  "./e2e/app-routes-flow.spec.ts",
+  "./e2e/contact-sheet-capture.spec.ts",
+  "./e2e/telegram-return.spec.ts",
+  "./e2e/visual.spec.ts",
+].map((relativePath) => resolve(__dirname, relativePath));
 const globalStylesPath = resolve(__dirname, "../src/index.css");
 const iphoneModelPath = resolve(
   __dirname,
@@ -96,6 +108,26 @@ test("visual regression compares the quality-validated capture itself", () => {
     /const screenshot = await captureScreenshotWithQualityRetry\(/,
   );
   assert.match(visualSpec, /expect\(screenshot\)\.toMatchSnapshot\(/);
+});
+
+test("cloud API defaults, the e2e server, and route mocks use the apex origin", () => {
+  const apexOrigin = "https://elizacloud.ai";
+  const redirectedOrigin = "https://www.elizacloud.ai";
+  const client = readFileSync(cloudApiClientPath, "utf8");
+  const launcher = readFileSync(playwrightLauncherPath, "utf8");
+
+  assert.ok(client.includes(`ELIZACLOUD_DEFAULT_URL = "${apexOrigin}"`));
+  assert.ok(launcher.includes(`VITE_ELIZACLOUD_API_URL: "${apexOrigin}"`));
+  assert.ok(!client.includes(`ELIZACLOUD_DEFAULT_URL = "${redirectedOrigin}"`));
+  assert.ok(
+    !launcher.includes(`VITE_ELIZACLOUD_API_URL: "${redirectedOrigin}"`),
+  );
+
+  for (const routeMockPath of cloudRouteMockPaths) {
+    const routeMock = readFileSync(routeMockPath, "utf8");
+    assert.ok(routeMock.includes(`${apexOrigin}/api/eliza-app/`));
+    assert.ok(!routeMock.includes(`route("${redirectedOrigin}/api/eliza-app/`));
+  }
 });
 
 test("large visual assets receive a durable browser cache policy", () => {


### PR DESCRIPTION
## The bug (Shadow's QA, 2026-08-11)

On https://eliza.app/get-started?method=telegram, the Telegram Login widget succeeds, the page asks for a **mobile number**, and submitting it always fails with the generic *"Something went wrong. Please try again."*

## Root cause (verified live against prod + staging)

The phone step's POST never reaches the API. Two stacked CORS regressions:

1. **`https://eliza.app` is missing from `STATIC_ALLOWED_ORIGINS`** in the consolidated Hono `corsMiddleware` (`packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts`). A preflight from Origin `https://eliza.app` to `https://elizacloud.ai/api/eliza-app/auth/telegram` returns **no `Access-Control-Allow-Origin` header at all** (the control origin `https://elizacloud.ai` reflects fine). The legacy allowlist in `lib/utils/cors.ts` always included eliza.app; the newer first-party set dropped it.
2. **The homepage API client defaults to `https://www.elizacloud.ai`**, which **308-redirects** to the apex — and CORS preflights never follow redirects, so even an allowlisted origin dies on the www hop.

In-page repro from `https://eliza.app/get-started` (headless Chromium):
```
fetch https://www.elizacloud.ai/api/eliza-app/auth/telegram → TypeError: Failed to fetch
fetch https://elizacloud.ai/api/eliza-app/auth/telegram     → TypeError: Failed to fetch
```
→ `handlePhoneSubmit` lands in the generic catch. The failure is 100%, input-independent — and it equally breaks the **Discord OAuth code exchange** and SIWS on eliza.app; telegram is just where QA hit it first.

## Fix

- Add `https://eliza.app` + `https://www.eliza.app` to `STATIC_ALLOWED_ORIGINS` (browser-credentialed first-party, matching the legacy allowlist).
- Default `packages/homepage/src/lib/api/client.ts`, the real Playwright web-server environment, `.env.example`, README, and package guides to the apex host so no preflight ever meets the 308. E2E route mocks match the same origin, and a source contract now prevents those inputs from drifting apart.

## Proof

- New allowlist assertions **fail on develop, pass here** (verified stash/run/restore).
- `cloud-api-hono-cors.test.ts`: 19 pass / 0 fail with the fix.
- homepage `bun run test`: 86 pass / 0 fail, including the new API-origin contract; `tsc -b` clean; Biome clean.
- Real `playwright.config.ts` webServer + `telegram-return.spec.ts`: 3 pass / 0 fail at exact head.

## Notes

- No adapter/connector files touched.
- This unblocks the legacy telegram flow; unifying telegram onboarding onto the ElizaCloud/Steward continuation (the #18161 Discord pattern) is a separate PR on `sol/tg-steward-onboarding-20260811`.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic-proxy/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: moltbot subagent (0xSolace fleet)
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

# Evidence Gate

<!-- evidence-head:518fd65e076057ebc5fa3258140b63ee317c02f0 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered-UI change (CORS allowlist + API base-URL constant + e2e mock hosts); the user-visible failure is a network error, evidenced in the frontend log receipts below.
<!-- evidence-row:after-screenshots -->
- [x] N/A - same reason; no visual surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI flow changed; the fix is verifiable from the preflight receipts + regression test (fails on develop, passes here).
<!-- evidence-row:backend-logs -->
- [x] [homepage + real Playwright proof](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18447-homepage-proof-518fd65e.txt) and [CORS proof](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18447-cors-proof-518fd65e.txt) — exact head `518fd65e076057ebc5fa3258140b63ee317c02f0`: homepage 86 pass, real Telegram Playwright 3 pass, CORS 19 pass, typecheck/lint/guide parity clean.
<!-- evidence-row:frontend-logs -->
- [x] [18447-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18447-frontend-logs.txt) — live preflight receipts: apex returns NO ACAO for Origin eliza.app (control origin reflects), www 308s so preflights die; in-page fetch repro from https://eliza.app/get-started → TypeError: Failed to fetch.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain data produced; the change is HTTP-layer CORS policy, evidenced by the header receipts above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this diff (only a .ts constant under packages/homepage; e2e spec files are test files).

# Review remediation provenance

- AI assistance: yes
- Provider/model: OpenAI / GPT-5 (Codex system-reported model family; the deployment variant is not exposed to this session)
- Agent tooling: Codex
- Scope: exact-head review remediation, tests, evidence, and merge handling
- Provenance status: self-reported
