### PR TITLE
feat(homepage): canonical staging build env + one-command verified staging deploy

### DIFF
--- a/packages/homepage/.env.staging
+++ b/packages/homepage/.env.staging
@@ -1,0 +1,29 @@
+# Canonical STAGING build environment for packages/homepage -> https://staging.eliza.app
+#
+# NON-SECRET values only: Vite inlines every VITE_* value into the public
+# bundle, so nothing here is (or may ever be) confidential.
+#
+# This file is the single source of truth for staging builds. It is consumed
+# automatically by `vite build --mode staging`, which both local deploys
+# (`bun run deploy:staging`) and CI (.github/workflows/deploy-homepage-staging.yml)
+# must invoke so the two paths cannot drift.
+
+# Staging cloud API (staging peer of https://www.elizacloud.ai).
+VITE_ELIZACLOUD_API_URL=https://staging.elizacloud.ai
+
+# Discord OAuth application: the STAGING Eliza App bot (@eliza staging,
+# application id 1474591626759376967) — matches ELIZA_APP_DISCORD_APPLICATION_ID
+# on the eliza-cloud-api-staging Worker. Deliberately NOT the prod client id
+# (repo variable VITE_DISCORD_CLIENT_ID = prod).
+VITE_DISCORD_CLIENT_ID=1474591626759376967
+
+# Telegram Login Widget: staging bot TBD.
+# TODO(staging-telegram-bot): create a staging bot, set its token as
+# ELIZA_APP_TELEGRAM_BOT_TOKEN on eliza-cloud-api-staging, then fill both
+# values here (widget bot and worker token must be the same bot or Telegram
+# login validation fails). Until then the Telegram button on staging is dead.
+VITE_TELEGRAM_BOT_ID=
+VITE_TELEGRAM_BOT_USERNAME=
+
+# WhatsApp business number: single shared number, no staging peer exists.
+VITE_WHATSAPP_PHONE_NUMBER=+14159611510

--- a/packages/homepage/.gitignore
+++ b/packages/homepage/.gitignore
@@ -38,6 +38,9 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+# Committed on purpose: canonical non-secret staging build config (see the
+# file header). Vite inlines these into the public bundle anyway.
+!.env.staging
 
 # vercel
 .vercel

--- a/packages/homepage/package.json
+++ b/packages/homepage/package.json
@@ -9,6 +9,7 @@
     "build": "bun --bun vite build",
     "postbuild": "node scripts/prune-unused-static-assets.mjs",
     "deploy:preview": "bun run build && bunx wrangler@4.116.0 pages deploy dist --project-name eliza-app-home",
+    "deploy:staging": "node scripts/deploy-staging.mjs",
     "deploy:production": "bun run build && bunx wrangler@4.116.0 pages deploy dist --project-name eliza-app-home --branch main",
     "clean": "node ../scripts/rm-path-recursive.mjs dist",
     "check:release-data": "node ../app-core/scripts/check-homepage-release-data.mjs",

--- a/packages/homepage/scripts/deploy-staging.mjs
+++ b/packages/homepage/scripts/deploy-staging.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * One-command staging deploy for the homepage: build (staging mode) -> deploy
+ * to the eliza-home-staging Cloudflare Pages project -> verify that
+ * https://staging.eliza.app actually serves the new bundle.
+ *
+ * Exists because the manual flow has two silent failure modes that both bit us
+ * on 2026-08-11:
+ *
+ *   1. Hand-exported VITE_ vars: forget one and Vite silently inlines the prod
+ *      default. Fixed by `--mode staging` + the committed .env.staging file
+ *      (single source of truth; CI must use the same invocation).
+ *   2. `wrangler pages deploy` without `--branch develop`: the project's
+ *      production branch is `develop`, so a branchless deploy from any other
+ *      local branch lands in a PREVIEW slot — wrangler prints a green success
+ *      URL and the real domain keeps serving the old bundle. Fixed by always
+ *      passing --branch develop and then polling the domain for the freshly
+ *      built entry assets, failing loudly if they never show up.
+ *
+ * Usage: bun run deploy:staging          (from packages/homepage)
+ *        node scripts/deploy-staging.mjs [--skip-build] [--allow-dirty]
+ */
+
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PROJECT = "eliza-home-staging";
+const BRANCH = "develop"; // = the project's production branch. NEVER omit.
+const STAGING_URL = "https://staging.eliza.app/";
+const WRANGLER_VERSION = "4.116.0"; // keep aligned with deploy:preview/production
+const VERIFY_ATTEMPTS = 20;
+const VERIFY_INTERVAL_MS = 6000;
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.resolve(here, "..");
+const args = new Set(process.argv.slice(2));
+
+function fail(msg) {
+  console.error(`\n[deploy:staging] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+function run(cmd, opts = {}) {
+  console.log(`[deploy:staging] $ ${cmd}`);
+  execSync(cmd, { stdio: "inherit", cwd: pkgRoot, ...opts });
+}
+
+// --- Preflight -------------------------------------------------------------
+
+if (!existsSync(path.join(pkgRoot, ".env.staging"))) {
+  fail(".env.staging missing — it is the canonical staging build config and is committed to the repo.");
+}
+
+const dirty = execSync("git status --porcelain -- .", { cwd: pkgRoot }).toString().trim();
+if (dirty && !args.has("--allow-dirty")) {
+  console.error(dirty);
+  fail("homepage worktree is dirty. Staging should serve committed code. Commit first, or pass --allow-dirty if you are intentionally smoke-testing WIP.");
+}
+
+// Shell-inherited VITE_ vars outrank .env.staging in Vite's precedence order —
+// exactly the hand-exported-env failure this script exists to kill. Scrub them.
+const buildEnv = { ...process.env };
+for (const key of Object.keys(buildEnv)) {
+  if (key.startsWith("VITE_")) {
+    console.warn(`[deploy:staging] scrubbing inherited ${key} (would override .env.staging)`);
+    delete buildEnv[key];
+  }
+}
+// Stamp asset filenames with the real commit (vite.config.ts reads GITHUB_SHA).
+buildEnv.GITHUB_SHA = execSync("git rev-parse HEAD", { cwd: pkgRoot }).toString().trim();
+
+// --- Build -----------------------------------------------------------------
+
+if (!args.has("--skip-build")) {
+  // `bun run build` triggers pre/postbuild (channel-config guard, asset sync,
+  // release data, asset pruning); extra args flow through to `vite build`.
+  run("bun run build --mode staging", { env: buildEnv });
+}
+
+// --- Sanity: bundle must point at staging, never prod ---------------------
+
+const distDir = path.join(pkgRoot, "dist");
+const indexHtml = path.join(distDir, "index.html");
+if (!existsSync(indexHtml)) fail("dist/index.html missing — build did not run?");
+
+const grepProd = execSync(
+  `grep -rl "https://www.elizacloud.ai" assets/ 2>/dev/null || true`,
+  { cwd: distDir },
+).toString().trim();
+if (grepProd) {
+  console.error(grepProd);
+  fail("built bundle references the PROD API (www.elizacloud.ai). --mode staging did not take effect; refusing to deploy to staging.");
+}
+const grepStaging = execSync(
+  `grep -rl "https://staging.elizacloud.ai" assets/ 2>/dev/null || true`,
+  { cwd: distDir },
+).toString().trim();
+if (!grepStaging) {
+  fail("built bundle has no staging.elizacloud.ai reference — unexpected; refusing to deploy.");
+}
+
+// Entry assets referenced by index.html: these filenames are content+commit
+// hashed, so "the domain serves them" == "the domain serves this build".
+const html = readFileSync(indexHtml, "utf8");
+const localAssets = [...html.matchAll(/assets\/[A-Za-z0-9._-]+\.(?:js|css)/g)].map((m) => m[0]);
+if (localAssets.length === 0) fail("no hashed assets found in dist/index.html");
+console.log(`[deploy:staging] build fingerprint: ${localAssets.join(", ")}`);
+
+// --- Deploy ----------------------------------------------------------------
+
+run(
+  `bunx wrangler@${WRANGLER_VERSION} pages deploy dist --project-name ${PROJECT} --branch ${BRANCH} --commit-hash ${buildEnv.GITHUB_SHA} --commit-dirty=${dirty ? "true" : "false"}`,
+);
+
+// --- Verify the DOMAIN (not the per-deploy preview URL) --------------------
+
+console.log(`[deploy:staging] verifying ${STAGING_URL} serves this build...`);
+let served = "";
+for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt++) {
+  try {
+    const res = await fetch(STAGING_URL, {
+      headers: { "cache-control": "no-cache" },
+      redirect: "follow",
+    });
+    served = await res.text();
+    if (res.ok && localAssets.every((a) => served.includes(a))) {
+      console.log(`[deploy:staging] OK — ${STAGING_URL} serves the new bundle (attempt ${attempt}).`);
+      process.exit(0);
+    }
+  } catch (err) {
+    console.warn(`[deploy:staging] fetch failed (attempt ${attempt}): ${err.message}`);
+  }
+  await new Promise((r) => setTimeout(r, VERIFY_INTERVAL_MS));
+}
+
+const servedAssets = [...served.matchAll(/assets\/[A-Za-z0-9._-]+\.(?:js|css)/g)].map((m) => m[0]);
+console.error(`[deploy:staging] expected: ${localAssets.join(", ")}`);
+console.error(`[deploy:staging] domain serves: ${servedAssets.join(", ") || "(no assets / fetch failed)"}`);
+fail(
+  `${STAGING_URL} did not pick up the new bundle after ${(VERIFY_ATTEMPTS * VERIFY_INTERVAL_MS) / 1000}s. ` +
+    `Most likely the deploy landed in a preview slot (wrong --branch) or the project's production branch changed. ` +
+    `Check: bunx wrangler@${WRANGLER_VERSION} pages deployment list --project-name ${PROJECT}`,
+);


### PR DESCRIPTION
## What

Codifies the homepage → staging.eliza.app deploy path so it stops depending on tribal knowledge (hand-exported `VITE_` vars + a hand-typed `wrangler pages deploy` where a missed `--branch develop` silently no-ops into a preview slot — that bit us twice in one day, 2026-08-11).

### 1. `packages/homepage/.env.staging` (committed, non-secret)
Single source of truth for staging builds, consumed by `vite build --mode staging`:
- `VITE_ELIZACLOUD_API_URL=https://staging.elizacloud.ai`
- `VITE_DISCORD_CLIENT_ID=1474591626759376967` (the STAGING Eliza App Discord application — matches `ELIZA_APP_DISCORD_APPLICATION_ID` on the eliza-cloud-api-staging Worker; the repo variable holds the prod id)
- `VITE_WHATSAPP_PHONE_NUMBER` (shared number, no staging peer)
- `VITE_TELEGRAM_BOT_ID`/`VITE_TELEGRAM_BOT_USERNAME`: **empty with an inline TODO** — no staging Telegram bot exists yet. Widget bot and worker `ELIZA_APP_TELEGRAM_BOT_TOKEN` must be the same bot, so filling this waits for that bot.

Everything here is inlined into the public bundle by Vite; nothing is or can be secret. `packages/homepage/.gitignore` gets a scoped `!.env.staging` un-ignore with a comment saying why.

### 2. `bun run deploy:staging` (`scripts/deploy-staging.mjs`)
One command: build → guard → deploy → **verify the domain**.
- Builds via `bun run build --mode staging` (pre/postbuild hooks — channel-config guard, asset sync, release data, pruning — all still run; verified).
- Scrubs inherited `VITE_*` shell vars first, so a stale hand-export can never override the committed contract.
- Refuses to deploy a bundle containing `https://www.elizacloud.ai` (i.e. staging mode didn't take).
- Always deploys with `--project-name eliza-home-staging --branch develop` — `develop` is that project's production branch, and a branchless deploy from any other local branch lands in a preview slot while wrangler still prints a green success URL.
- Then polls `https://staging.eliza.app` until the domain serves the freshly built (commit-stamped) entry assets from `dist/index.html`; exits non-zero with a diff of expected-vs-served assets otherwise. No more silent no-op deploys.
- Refuses dirty worktrees by default (`--allow-dirty` to override for intentional WIP smoke tests).

## Relationship to #18442 (staging CI)
Local-manual and CI deploys should be the *same invocation*. #18442 currently injects `VITE_ELIZACLOUD_API_URL` per-step and uses the prod repo variables for channel ids; once this lands, that workflow should switch its build step to `bun run build --mode staging` and drop the per-step VITE_ env injection so `.env.staging` is the single source for both paths. Flagged to the lane that owns #18442 — not amended here to avoid collision.

## Verification
- `bun run build --mode staging`: bundle references `staging.elizacloud.ai`, **zero** `www.elizacloud.ai` refs, staging Discord id `1474591626759376967` present in get-started chunk.
- `node --check` on the script; deploy+verify loop exercised against the live `eliza-home-staging` project during today's QA (same commands, hand-run).

No prod surface touched: `deploy:preview` / `deploy:production` untouched; script cannot name `eliza-app-home`.