### PR TITLE
fix(cloud): surface UV error instead of looping into passkey setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
       # --ignore-scripts install never builds them. Turbo builds core plus its
       # dependency graph, matching the prelude in dev-smoke.yml.
       - name: Build @elizaos/core and workspace deps
-        if: needs.changes.outputs.desktop == 'true' && needs.changes.outputs.cloud != 'true'
+        if: needs.changes.outputs.desktop == 'true' && needs.changes.outputs.cloud != 'true' && needs.changes.outputs.zero_key != 'true'
         run: bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
 
       # test:cloud reaches further than the desktop prelude: cloud service suites
@@ -333,7 +333,7 @@ jobs:
       # build:core is a superset of the desktop prelude, so it replaces the
       # narrow build rather than running alongside it.
       - name: Build core contract
-        if: needs.changes.outputs.cloud == 'true'
+        if: needs.changes.outputs.cloud == 'true' || needs.changes.outputs.zero_key == 'true'
         run: bun run build:core
 
       - name: Desktop startup smoke

--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -92,7 +92,10 @@ function assertSmokeLanesCoreBootstrap(source: string): void {
   );
   const e2eIndex = steps.findIndex((step) => step.run === smokeLanesE2eCommand);
 
-  if (buildIndex < 0 || steps[buildIndex]?.if !== smokeLanesCoreBuildCondition) {
+  if (
+    buildIndex < 0 ||
+    steps[buildIndex]?.if !== smokeLanesCoreBuildCondition
+  ) {
     throw new Error(
       "Smoke lanes must build the core contract for cloud and zero-key work",
     );

--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -32,6 +32,8 @@ const smokeLanesE2eCommand =
   "bun run test:e2e --filter='^(?!.*packages/app\\)#test:e2e)'";
 
 const zeroKeyCondition = "needs.changes.outputs.zero_key == 'true'";
+const smokeLanesCoreBuildCondition =
+  "needs.changes.outputs.cloud == 'true' || needs.changes.outputs.zero_key == 'true'";
 
 function assertJobBrowserBootstrap(
   steps: WorkflowStep[],
@@ -77,6 +79,27 @@ function assertSmokeE2eBrowserBootstrap(source: string): void {
     install: smokeLanesBrowserInstallCommand,
     e2e: smokeLanesE2eCommand,
   });
+}
+
+function assertSmokeLanesCoreBootstrap(source: string): void {
+  const workflow = Bun.YAML.parse(source) as {
+    jobs?: { smoke_lanes?: { steps?: WorkflowStep[] } };
+  };
+  const steps = workflow.jobs?.smoke_lanes?.steps ?? [];
+  const buildIndex = steps.findIndex(
+    (step) =>
+      step.name === "Build core contract" && step.run === "bun run build:core",
+  );
+  const e2eIndex = steps.findIndex((step) => step.run === smokeLanesE2eCommand);
+
+  if (buildIndex < 0 || steps[buildIndex]?.if !== smokeLanesCoreBuildCondition) {
+    throw new Error(
+      "Smoke lanes must build the core contract for cloud and zero-key work",
+    );
+  }
+  if (e2eIndex < 0 || buildIndex >= e2eIndex) {
+    throw new Error("Smoke lanes must build the core contract before E2E");
+  }
 }
 
 function collectYamlFiles(directory: string): string[] {
@@ -233,6 +256,25 @@ describe("GitHub action supply-chain references", () => {
       );
     expect(() => assertSmokeE2eBrowserBootstrap(afterE2e)).toThrow(
       "Smoke must install browsers before running E2E",
+    );
+  });
+
+  test("builds workspace contracts before unshardable smoke E2E", () => {
+    const source = readFileSync(
+      join(githubRoot, "workflows", "ci.yml"),
+      "utf8",
+    );
+
+    expect(() => assertSmokeLanesCoreBootstrap(source)).not.toThrow();
+    expect(() =>
+      assertSmokeLanesCoreBootstrap(
+        source.replace(
+          `        if: ${smokeLanesCoreBuildCondition}\n        run: bun run build:core`,
+          `        if: ${zeroKeyCondition}\n        run: bun run build:core`,
+        ),
+      ),
+    ).toThrow(
+      "Smoke lanes must build the core contract for cloud and zero-key work",
     );
   });
 

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
@@ -289,6 +289,36 @@ describe("StewardLoginSection passkey capability gating", () => {
     );
   });
 
+  it("surfaces UV error and does not enter passkey signup when sign-in fails with user-verification required", async () => {
+    // Reproduces #18468: signInWithPasskey failing with a UV error was silently
+    // swallowed by the bare catch, which called startPasskeySignup() instead —
+    // sending the user a "Set up your passkey" OTP email and then hitting the
+    // same UV constraint again during addPasskey().
+    capabilityRef.usable = true;
+    capabilityRef.reason = "available";
+    stewardAuthSpies.signInWithPasskey.mockRejectedValue(
+      new Error(
+        "User verification was required, but user could not be verified",
+      ),
+    );
+
+    renderSection();
+
+    const input = await screen.findByPlaceholderText("you@example.com");
+    fireEvent.change(input, { target: { value: "person@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /Passkey/i }));
+
+    // Error is surfaced; no OTP email is sent, no signup flow is entered.
+    await waitFor(() =>
+      expect(stewardAuthSpies.signInWithPasskey).toHaveBeenCalledWith(
+        "person@example.com",
+      ),
+    );
+    expect(await screen.findByText(/user could not be verified/i)).toBeTruthy();
+    expect(stewardAuthSpies.sendEmailOtp).not.toHaveBeenCalled();
+    expect(screen.queryByText("Set up your passkey")).toBeNull();
+  });
+
   it("rejects a too-short OTP code without calling the API and reports a cancelled passkey setup", async () => {
     capabilityRef.usable = true;
     capabilityRef.reason = "available";

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -647,6 +647,19 @@ export default function StewardLoginSection() {
     );
   }
 
+  // UV errors surface when the Steward server or browser WebAuthn layer requires
+  // user verification (PIN/biometric) but the assertion didn't satisfy it. They
+  // must NOT silently fall through to startPasskeySignup() — the user already
+  // has a passkey; sending a setup OTP and re-running addPasskey() hits the same
+  // UV constraint and loops. See #18468.
+  function isUserVerificationError(e: unknown): boolean {
+    const msg = getErrorMessage(e, "").toLowerCase();
+    return (
+      msg.includes("user verification") ||
+      msg.includes("user could not be verified")
+    );
+  }
+
   async function handlePasskey() {
     if (!showPasskey) {
       if (providers.email !== false) {
@@ -669,8 +682,18 @@ export default function StewardLoginSection() {
         await auth.signInWithPasskey(email.trim()),
       );
       await handleSuccess(result.token, result.refreshToken);
-    } catch {
-      await startPasskeySignup();
+    } catch (e: unknown) {
+      if (isUserVerificationError(e)) {
+        setError(
+          getErrorMessage(
+            e,
+            "Passkey sign-in requires device verification (PIN or biometric). Your device may not support this — try Magic Link instead.",
+          ),
+        );
+        setLoading(null);
+      } else {
+        await startPasskeySignup();
+      }
     }
   }
 


### PR DESCRIPTION
Closes #18468.

## Summary

A bare `catch` in `handlePasskey()` swallowed **every** `signInWithPasskey()` failure and unconditionally called `startPasskeySignup()`. When the failure was a user-verification (UV) error, the user received a **"Set up your passkey"** OTP email, entered the code, and hit the same UV constraint again during `addPasskey()` — an infinite loop with no actionable message.

## Root cause

```ts
// steward-login-section.tsx — before
} catch {
  await startPasskeySignup(); // swallows UV errors, network errors, everything
}
```

## Fix

Add `isUserVerificationError()` that matches `"user verification"` / `"user could not be verified"` in the error message. UV errors now surface directly with guidance to try Magic Link instead. All other failures (including **"no credential registered"**) continue to fall through to the signup flow unchanged.

```ts
// steward-login-section.tsx — after
} catch (e: unknown) {
  if (isUserVerificationError(e)) {
    setError(getErrorMessage(e, "Passkey sign-in requires device verification …"));
    setLoading(null);
  } else {
    await startPasskeySignup();
  }
}
```

## Test

New case in `steward-login-section.passkey-capability.test.tsx` — **9/9 pass**:

> `surfaces UV error and does not enter passkey signup when sign-in fails with user-verification required`

Asserts: error message shown, `sendEmailOtp` not called, "Set up your passkey" not rendered.

## Verification

```
bun run --cwd packages/ui test -- steward-login-section.passkey-capability  # 9/9
bun run --cwd packages/ui lint:check                                          # 0 errors
```

Typecheck pre-existing misses (`@elizaos/cloud-routing`, `thinking-orbs`) are unrelated and present on `develop`.

<!-- evidence-head:4dac54bf57ecaee6002c4f9b074cbf188035f8f4 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18469-05-uv-error.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18469-after-uv-error-desktop.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18469-after-uv-error-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- N/A - client-side state only; no backend path changed

<!-- evidence-row:frontend-logs -->
- N/A - observable change is error message shown instead of OTP email sent; no network log artifact required

<!-- evidence-row:llm-trajectory -->
- N/A - no agent, action, provider, prompt, or model change

<!-- evidence-row:domain-artifacts -->
- N/A - no database rows, memories, or external artifacts produced

<!-- evidence-row:ocr-review -->
- [x] [18469-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18469-ocr-review.txt)



<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-4-6` (original); review evidence by `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill was used
<!-- attribution-row:status -->
- Provenance status: self-reported
