### PR TITLE
fix(discord): reconcile status reactions stranded by a hard kill on startup

### DIFF
--- a/plugins/plugin-discord/__tests__/startup-reaction-reconcile.test.ts
+++ b/plugins/plugin-discord/__tests__/startup-reaction-reconcile.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Covers the startup stranded-reaction scan (elizaOS/eliza#16318): the bot's
+ * own in-progress markers (⏳/🤔) left by a hard kill are removed from recent
+ * messages, terminal/others' reactions are untouched, every dimension of the
+ * scan is hard-capped, and failures are counted and logged, never thrown.
+ * Uses plain-object discord.js fakes, matching service-shutdown-drain.test.ts.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+	reconcileStrandedStatusReactions,
+	STARTUP_SCAN_MAX_AGE_MS,
+} from "../startup-reaction-reconcile.ts";
+
+const BOT_ID = "bot-user-1";
+const NOW = 1_700_000_000_000;
+
+function makeLogger() {
+	return { info: vi.fn(), warn: vi.fn() };
+}
+
+function makeReaction(me: boolean) {
+	return { me, users: { remove: vi.fn(async () => {}) } };
+}
+
+function makeMessage({
+	ageMs = 60_000,
+	reactions = {} as Record<string, ReturnType<typeof makeReaction>>,
+} = {}) {
+	return {
+		createdTimestamp: NOW - ageMs,
+		reactions: {
+			resolve: (emoji: string) => reactions[emoji],
+		},
+	};
+}
+
+function makeChannel(
+	messages: ReturnType<typeof makeMessage>[],
+	{ viewable = true, textBased = true, failFetch = false } = {},
+) {
+	return {
+		id: `channel-${Math.random().toString(36).slice(2, 8)}`,
+		viewable,
+		isTextBased: () => textBased,
+		messages: {
+			fetch: vi.fn(async ({ limit }: { limit: number }) => {
+				if (failFetch) throw new Error("Missing Access");
+				return new Map(
+					messages.slice(0, limit).map((message, index) => [index, message]),
+				);
+			}),
+		},
+	};
+}
+
+function makeClient(
+	guildChannels: ReturnType<typeof makeChannel>[],
+	{ dmChannels = [] as ReturnType<typeof makeChannel>[], botId = BOT_ID } = {},
+) {
+	const dmEntries = dmChannels.map(
+		(channel) => [channel.id, { ...channel, isDMBased: () => true }] as const,
+	);
+	return {
+		user: botId ? { id: botId } : null,
+		guilds: {
+			cache: new Map([
+				[
+					"guild-1",
+					{
+						channels: {
+							cache: new Map(
+								guildChannels.map((channel) => [channel.id, channel]),
+							),
+						},
+					},
+				],
+			]),
+		},
+		channels: { cache: new Map(dmEntries) },
+	};
+}
+
+function scan(
+	client: ReturnType<typeof makeClient>,
+	overrides: Record<string, unknown> = {},
+) {
+	return reconcileStrandedStatusReactions({
+		client: client as unknown as Parameters<
+			typeof reconcileStrandedStatusReactions
+		>[0]["client"],
+		logger: makeLogger(),
+		now: () => NOW,
+		...overrides,
+	});
+}
+
+describe("reconcileStrandedStatusReactions", () => {
+	it("removes the bot's own stranded in-progress markers and reports them", async () => {
+		const thinking = makeReaction(true);
+		const queued = makeReaction(true);
+		const message = makeMessage({
+			reactions: { "🤔": thinking, "⏳": queued },
+		});
+		const summary = await scan(makeClient([makeChannel([message])]));
+
+		expect(thinking.users.remove).toHaveBeenCalledWith(BOT_ID);
+		expect(queued.users.remove).toHaveBeenCalledWith(BOT_ID);
+		expect(summary).toMatchObject({
+			reactionsCleared: 2,
+			failures: 0,
+			timedOut: false,
+		});
+	});
+
+	it("leaves other users' identical emojis untouched", async () => {
+		const someoneElses = makeReaction(false);
+		const message = makeMessage({ reactions: { "🤔": someoneElses } });
+		const summary = await scan(makeClient([makeChannel([message])]));
+
+		expect(someoneElses.users.remove).not.toHaveBeenCalled();
+		expect(summary.reactionsCleared).toBe(0);
+	});
+
+	it("never asks for the terminal ❌ marker", async () => {
+		const resolve = vi.fn(() => undefined);
+		const message = { createdTimestamp: NOW - 1000, reactions: { resolve } };
+		await scan(makeClient([makeChannel([message as never])]));
+
+		const askedFor = resolve.mock.calls.map((call) => call[0]);
+		expect(askedFor).not.toContain("❌");
+		expect(askedFor).toEqual(expect.arrayContaining(["⏳", "🤔"]));
+	});
+
+	it("skips messages older than the age cap", async () => {
+		const stale = makeReaction(true);
+		const old = makeMessage({
+			ageMs: STARTUP_SCAN_MAX_AGE_MS + 1,
+			reactions: { "🤔": stale },
+		});
+		const summary = await scan(makeClient([makeChannel([old])]));
+
+		expect(stale.users.remove).not.toHaveBeenCalled();
+		expect(summary.messagesInspected).toBe(1);
+		expect(summary.reactionsCleared).toBe(0);
+	});
+
+	it("honors the channel cap and per-channel message limit", async () => {
+		const channels = Array.from({ length: 5 }, () =>
+			makeChannel([makeMessage(), makeMessage(), makeMessage()]),
+		);
+		const summary = await scan(makeClient(channels), {
+			maxChannels: 2,
+			messagesPerChannel: 1,
+		});
+
+		expect(summary.channelsScanned).toBe(2);
+		expect(summary.messagesInspected).toBe(2);
+		expect(channels[0].messages.fetch).toHaveBeenCalledWith({ limit: 1 });
+		expect(channels[2].messages.fetch).not.toHaveBeenCalled();
+	});
+
+	it("stops between channels when the time budget elapses and says so", async () => {
+		const first = makeChannel([makeMessage()]);
+		const second = makeChannel([makeMessage()]);
+		let tick = 0;
+		const summary = await reconcileStrandedStatusReactions({
+			client: makeClient([first, second]) as unknown as Parameters<
+				typeof reconcileStrandedStatusReactions
+			>[0]["client"],
+			logger: makeLogger(),
+			// First call stamps startedAt; later calls step past the budget.
+			now: () => NOW + 40_000 * tick++,
+			timeBudgetMs: 30_000,
+		});
+
+		expect(summary.timedOut).toBe(true);
+		expect(summary.channelsScanned).toBeLessThan(2);
+	});
+
+	it("counts a failed channel fetch, logs it, and continues", async () => {
+		const broken = makeChannel([], { failFetch: true });
+		const ok = makeReaction(true);
+		const healthy = makeChannel([makeMessage({ reactions: { "🤔": ok } })]);
+		const logger = makeLogger();
+		const summary = await reconcileStrandedStatusReactions({
+			client: makeClient([broken, healthy]) as unknown as Parameters<
+				typeof reconcileStrandedStatusReactions
+			>[0]["client"],
+			logger,
+			now: () => NOW,
+		});
+
+		expect(summary.failures).toBe(1);
+		expect(summary.reactionsCleared).toBe(1);
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		expect(logger.warn.mock.calls[0][0]).toContain(broken.id);
+	});
+
+	it("counts a failed removal and keeps scanning", async () => {
+		const failing = makeReaction(true);
+		failing.users.remove = vi.fn(async () => {
+			throw new Error("Missing Permissions");
+		});
+		const fine = makeReaction(true);
+		const message = makeMessage({ reactions: { "⏳": failing, "🤔": fine } });
+		const summary = await scan(makeClient([makeChannel([message])]));
+
+		expect(summary.failures).toBe(1);
+		expect(summary.reactionsCleared).toBe(1);
+	});
+
+	it("skips non-viewable and non-text channels, includes cached DMs", async () => {
+		const hidden = makeChannel([makeMessage()], { viewable: false });
+		const voice = makeChannel([makeMessage()], { textBased: false });
+		const dmReaction = makeReaction(true);
+		const dm = makeChannel([makeMessage({ reactions: { "🤔": dmReaction } })]);
+		const summary = await scan(
+			makeClient([hidden, voice], { dmChannels: [dm] }),
+		);
+
+		expect(summary.channelsScanned).toBe(1);
+		expect(dmReaction.users.remove).toHaveBeenCalledWith(BOT_ID);
+	});
+
+	it("skips entirely and warns when the client has no user id", async () => {
+		const logger = makeLogger();
+		const channel = makeChannel([makeMessage()]);
+		const summary = await reconcileStrandedStatusReactions({
+			client: makeClient([channel], { botId: "" }) as unknown as Parameters<
+				typeof reconcileStrandedStatusReactions
+			>[0]["client"],
+			logger,
+			now: () => NOW,
+		});
+
+		expect(summary.channelsScanned).toBe(0);
+		expect(channel.messages.fetch).not.toHaveBeenCalled();
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+	});
+});

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -157,6 +157,10 @@ import {
 	registerDiscordSlashCommands,
 	type SlashCommandRegistrationHost,
 } from "./slash-command-registration";
+import {
+	reconcileStrandedStatusReactions,
+	STARTUP_REACTION_SCAN_SETTING,
+} from "./startup-reaction-reconcile";
 import type { StatusReactionController } from "./status-reactions";
 import type {
 	BuildMemoryFromMessageOptions,
@@ -3345,6 +3349,24 @@ export class DiscordService extends Service implements IDiscordService {
 	) {
 		const state = this.requireAccountState(accountId);
 		await onReadyExtracted(this.createAccountServiceFacade(state), readyClient);
+		// Detached: a stranded-reaction cleanup must never reject the ready
+		// path (a post-ready throw is treated as a terminal login failure),
+		// and it needs no result — it logs its own summary (#16318).
+		const scanSetting = String(
+			this.runtime.getSetting(STARTUP_REACTION_SCAN_SETTING) ?? "",
+		).toLowerCase();
+		if (scanSetting !== "0" && scanSetting !== "false") {
+			void reconcileStrandedStatusReactions({
+				client: readyClient,
+				logger: this.runtime.logger,
+			}).catch((error) => {
+				this.runtime.logger.warn(
+					`[DiscordService] Startup reaction scan failed for account ${accountId}: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			});
+		}
 		const voiceChannelIds = String(
 			this.runtime.getSetting("DISCORD_VOICE_CHANNEL_ID") ?? "",
 		)

--- a/plugins/plugin-discord/startup-reaction-reconcile.ts
+++ b/plugins/plugin-discord/startup-reaction-reconcile.ts
@@ -1,0 +1,185 @@
+/**
+ * Startup reconciliation of status reactions stranded by an unclean shutdown
+ * (elizaOS/eliza#16318).
+ *
+ * The shutdown drain (#17749) reconciles reactions for turns it can observe,
+ * but a hard-killed process (SIGKILL, OOM) never runs that path: the bot's
+ * ⏳/🤔 stays on the message forever and the bot looks stuck. This scan runs
+ * once per account after the client is ready and removes the bot's own
+ * in-progress markers from recent messages. It removes rather than swaps to
+ * ❌: by the time the process is back, the message may already have been
+ * re-sent and answered, and stamping a retroactive error onto an old message
+ * misleads more than a quiet cleanup.
+ *
+ * Every dimension is hard-capped (channels, messages per channel, message
+ * age, wall-clock budget) so the scan completes quickly on large guilds, and
+ * every failure is counted and logged with channel context, never thrown:
+ * this runs detached from the ready path, where a rejection would be treated
+ * as a terminal login failure.
+ */
+import type { Client, Message, TextBasedChannel } from "discord.js";
+import { IN_PROGRESS_STATUS_EMOJIS } from "./status-reactions";
+
+/** Setting/env name; set to "0" or "false" to disable the scan entirely. */
+export const STARTUP_REACTION_SCAN_SETTING = "DISCORD_STARTUP_REACTION_SCAN";
+
+/** Hard cap on channels inspected across all guilds plus cached DMs. */
+export const STARTUP_SCAN_MAX_CHANNELS = 50;
+
+/** Recent messages fetched per channel (one fetch per channel). */
+export const STARTUP_SCAN_MESSAGES_PER_CHANNEL = 25;
+
+/** Messages older than this are left alone even if a marker survives. */
+export const STARTUP_SCAN_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Wall-clock budget for the whole scan. When it elapses the scan stops
+ * between channels and reports `timedOut: true` — a partial cleanup that
+ * says so beats an unbounded crawl of a large guild.
+ */
+export const STARTUP_SCAN_TIME_BUDGET_MS = 30_000;
+
+export interface StartupReconcileSummary {
+	channelsScanned: number;
+	messagesInspected: number;
+	reactionsCleared: number;
+	/** Fetch/remove failures — counted and logged, never thrown. */
+	failures: number;
+	/** True when the time budget elapsed before all channels were scanned. */
+	timedOut: boolean;
+}
+
+interface ScanLogger {
+	info: (message: string) => void;
+	warn: (message: string) => void;
+}
+
+interface ReconcileOptions {
+	client: Client;
+	logger: ScanLogger;
+	/** Injected clock for tests. */
+	now?: () => number;
+	maxChannels?: number;
+	messagesPerChannel?: number;
+	maxAgeMs?: number;
+	timeBudgetMs?: number;
+}
+
+function channelLabel(channel: { id?: string }): string {
+	return typeof channel?.id === "string" ? channel.id : "unknown-channel";
+}
+
+/** Collect scannable channels: guild text channels the bot can read, then cached DMs. */
+function collectChannels(client: Client, cap: number): TextBasedChannel[] {
+	const channels: TextBasedChannel[] = [];
+	const seen = new Set<string>();
+	const push = (channel: unknown) => {
+		if (channels.length >= cap) return;
+		const candidate = channel as TextBasedChannel & {
+			viewable?: boolean;
+			isTextBased?: () => boolean;
+			id: string;
+		};
+		if (!candidate || typeof candidate.isTextBased !== "function") return;
+		if (!candidate.isTextBased()) return;
+		if (candidate.viewable === false) return;
+		if (seen.has(candidate.id)) return;
+		seen.add(candidate.id);
+		channels.push(candidate);
+	};
+	for (const guild of client.guilds.cache.values()) {
+		for (const channel of guild.channels.cache.values()) {
+			push(channel);
+			if (channels.length >= cap) return channels;
+		}
+	}
+	for (const channel of client.channels.cache.values()) {
+		const dm = channel as { isDMBased?: () => boolean };
+		if (typeof dm.isDMBased === "function" && dm.isDMBased()) push(channel);
+		if (channels.length >= cap) break;
+	}
+	return channels;
+}
+
+export async function reconcileStrandedStatusReactions(
+	options: ReconcileOptions,
+): Promise<StartupReconcileSummary> {
+	const {
+		client,
+		logger,
+		now = Date.now,
+		maxChannels = STARTUP_SCAN_MAX_CHANNELS,
+		messagesPerChannel = STARTUP_SCAN_MESSAGES_PER_CHANNEL,
+		maxAgeMs = STARTUP_SCAN_MAX_AGE_MS,
+		timeBudgetMs = STARTUP_SCAN_TIME_BUDGET_MS,
+	} = options;
+
+	const summary: StartupReconcileSummary = {
+		channelsScanned: 0,
+		messagesInspected: 0,
+		reactionsCleared: 0,
+		failures: 0,
+		timedOut: false,
+	};
+	const botId = client.user?.id;
+	if (!botId) {
+		logger.warn(
+			"[DiscordService] Startup reaction scan skipped: client has no user id.",
+		);
+		return summary;
+	}
+
+	const startedAt = now();
+	const channels = collectChannels(client, maxChannels);
+
+	for (const channel of channels) {
+		if (now() - startedAt > timeBudgetMs) {
+			summary.timedOut = true;
+			break;
+		}
+		summary.channelsScanned += 1;
+		let messages: Iterable<Message>;
+		try {
+			const fetched = await channel.messages.fetch({
+				limit: messagesPerChannel,
+			});
+			messages = fetched.values();
+		} catch (error) {
+			summary.failures += 1;
+			logger.warn(
+				`[DiscordService] Startup reaction scan could not fetch messages in channel ${channelLabel(channel)}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			continue;
+		}
+		for (const message of messages) {
+			summary.messagesInspected += 1;
+			const age = now() - message.createdTimestamp;
+			if (age > maxAgeMs) continue;
+			for (const emoji of IN_PROGRESS_STATUS_EMOJIS) {
+				const reaction = message.reactions?.resolve(emoji);
+				// `me` is populated on fetched messages; only the bot's own
+				// marker is crash residue — other users' identical emojis are
+				// their reactions, not ours to remove.
+				if (reaction?.me !== true) continue;
+				try {
+					await reaction.users.remove(botId);
+					summary.reactionsCleared += 1;
+				} catch (error) {
+					summary.failures += 1;
+					logger.warn(
+						`[DiscordService] Startup reaction scan could not remove ${emoji} in channel ${channelLabel(channel)}: ${
+							error instanceof Error ? error.message : String(error)
+						}`,
+					);
+				}
+			}
+		}
+	}
+
+	logger.info(
+		`[DiscordService] Startup reaction scan: ${summary.reactionsCleared} stranded marker(s) cleared across ${summary.channelsScanned} channel(s), ${summary.messagesInspected} message(s) inspected, ${summary.failures} failure(s)${summary.timedOut ? ", stopped at time budget" : ""}.`,
+	);
+	return summary;
+}

--- a/plugins/plugin-discord/status-reactions.ts
+++ b/plugins/plugin-discord/status-reactions.ts
@@ -30,6 +30,20 @@ const EMOJI_QUEUED = "⏳";
 const EMOJI_THINKING = "🤔";
 const EMOJI_ERROR = "❌";
 
+/**
+ * The non-terminal markers a turn shows while it is still being processed.
+ * A bot-authored reaction from this set that survives a process death is
+ * unambiguous crash residue: every live path either advances it (`transition`
+ * removes the previous emoji), clears it (`setDone`), or replaces it with the
+ * terminal ❌ (`setError` / `abandon`). The startup reconcile scan removes
+ * exactly this set and must never touch ❌, which is deliberate terminal
+ * state. Exported so the scan cannot drift from the controller's emojis.
+ */
+export const IN_PROGRESS_STATUS_EMOJIS: readonly string[] = [
+	EMOJI_QUEUED,
+	EMOJI_THINKING,
+];
+
 export function shouldShowStatusReaction(
 	scope: StatusReactionScope,
 	message: DiscordMessage,


### PR DESCRIPTION
# Relates to

Slice of #16318 (startup reconciliation only), per [the claim comment](https://github.com/elizaOS/eliza/issues/16318#issuecomment-5257455439). This PR must NOT close the issue: the runtime-level inbound ingress cordon, packaged-runtime (electrobun) supervisor behavior, and the live restart-during-turn drain evidence for the supervisor slice remain open there. The supervisor-chain slice merged in #18435.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and focused verification were run after sync; details in
      Testing below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passes post-sync (plugin tests, plugin typecheck,
      biome on touched files, `git diff --check`).

# Risks

Low. One new module plus a detached call on the Discord ready path. The scan is read-mostly (one `messages.fetch` per channel, removals only of the bot's own in-progress reactions), hard-capped on every dimension (50 channels, 25 messages per channel, 24 h age, 30 s wall clock), cannot reject the ready path (detached, all failures caught and logged), and can be disabled outright with `DISCORD_STARTUP_REACTION_SCAN=0`.

# Background

## What does this PR do?

The shutdown drain that merged in #17749 reconciles status reactions for turns it can observe, but a hard-killed process (SIGKILL, OOM) never runs that path: the bot's own ⏳/🤔 stays on the message forever and the bot looks stuck. This is the "startup reconciliation" acceptance item of #16318.

On client ready, a detached bounded scan (`plugins/plugin-discord/startup-reaction-reconcile.ts`) removes the bot's own stranded in-progress markers from recent messages:

- Only the bot's own reactions (`reaction.me` gate); other users' identical emojis are theirs.
- Only in-progress markers (⏳/🤔, exported as `IN_PROGRESS_STATUS_EMOJIS` from `status-reactions.ts` so the scan cannot drift from the controller). The terminal ❌ is deliberate state and is never touched.
- Removal rather than retroactive error-stamping: by restart time the message may already have been re-sent and answered; a quiet cleanup misleads less than a late ❌.
- Every failure is counted and logged with channel context, never thrown: the ready path treats a post-ready throw as a terminal login failure.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

None. Defaults and the disable switch are documented at the definition site.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-discord/startup-reaction-reconcile.ts` (the whole scan is ~190 lines).
2. The detached wiring in `onReadyForAccount` (`plugins/plugin-discord/service.ts`).
3. `plugins/plugin-discord/__tests__/startup-reaction-reconcile.test.ts`: 10 deterministic tests with plain-object discord.js fakes (same idiom as `service-shutdown-drain.test.ts`) covering the `me` gate, the never-touch-❌ invariant, both caps, the age cutoff, the time budget, fetch/removal failure paths, DM inclusion, and the no-user skip.

Commands run at this head:

```bash
bun run --cwd plugins/plugin-discord test -- __tests__/startup-reaction-reconcile.test.ts   # 10/10
bun run --cwd plugins/plugin-discord typecheck                                              # 0 errors
bun x biome check <touched files>                                                           # clean
git diff --check                                                                            # clean
```

## Detailed testing steps

Live reproduction (performed for the evidence below): configure a real Discord bot, point the model provider at an endpoint that accepts and never responds so a turn holds at 🤔, then `kill -9` the runtime mid-turn. The reaction survives the process. Restart: the scan removes it within seconds of login.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:a942d3202a9ccd6f98dff73aab6a48996700c374 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: real Discord client screenshots of the held 🤔 mid-turn and the stranded 🤔 with the bot offline after SIGKILL (attached in a comment; row patched after upload).
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: the same message clean after the startup scan (attached in a comment; row patched after upload).
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - the three screenshots plus the boot log capture the full lifecycle; no app UI flow is involved`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end: full boot log of the reconciling restart pasted below.

<details>
<summary>Reconciling restart, key lines (real server: 20 viewable channels, 194 recent messages)</summary>

```
  [eliza] Starting API and UI dev servers in parallel...
  [eliza] Agent ready (5.2s)
 Info       [eliza] deferred: ✓ discord registered (49ms)
 Info       #agent:Eliza  [DiscordService] Startup reaction scan: 1 stranded marker(s) cleared across 20 channel(s), 194 message(s) inspected, 0 failure(s).
```

A prior boot on the same server with nothing stranded reported the idempotent
pass: `0 stranded marker(s) cleared across 20 channel(s), 194 message(s)
inspected, 0 failure(s).`

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend involvement`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model change; the live run deliberately used an unresponsive model endpoint to hold a turn open`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real Discord message state across the crash/restart boundary, captured in the three screenshots (before-screenshots and after-screenshots rows).
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered app surface; the Discord client screenshots are third-party UI`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no model-facing change; the live turn was deliberately held open against an unresponsive endpoint.`

## Backend + frontend logs

Backend: the reconciling-restart excerpt above; the full cleaned boot log is attached alongside the screenshots. Frontend: `N/A - no frontend involvement`.

## Screenshots (before / after) + video walkthrough

### Before

Held 🤔 during a live turn, then the same reaction stranded with the bot offline after `kill -9` (attached in a comment; rows patched after upload).

### After

The same message with the marker removed seconds after the restarted bot logged in (attached in a comment; row patched after upload).

### Walkthrough video

`N/A - screenshots plus logs capture the full lifecycle.`

## Audio / voice walkthrough

`N/A - no voice surface.`

## Known gaps / failures

- The compute receipt below reports zero project-attributed tokens with `unavailable` confidence: the isolated build environment has no local Claude Code usage data for ccusage to read. Signed zero rather than fabricated usage, per the skill contract.
- Discovered while producing the live evidence and worth a maintainer's eye: dev-host log filtering suppresses agent-scoped `info` lines by default, so the scan's summary is invisible under plain `bun run dev` (it appears with `ELIZA_DEV_VERBOSE_LOGS=1`). This PR keeps the summary at `info` deliberately; if the scan's outcome should be dev-visible by default, that is a one-line severity choice to make in review.
- The ingress cordon, packaged-runtime supervisors, and the supervisor slice's live drain evidence remain open on #16318, per the claim.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [claude-code-wbaxterh]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZS2K83T8XC11NTCE93W9W4R","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-11T18:50:42.170Z","completed_at":"2026-08-12T00:20:30.846Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ6-B_keoGBnP1vX0AEdBc1-mwYlyxZ0hgzt21ESQWaQ","device_key_id":"972ca87555be4523e052622617f964f99285337b7f81650e8da644fb2ac176b6","device_signature":"V5r4FOZDKCdM9mk-w-8HIlNDQn_Ou5f_RjEIXpQg38HU6IQt6oDKfhzdvT6knzU_Fi6OOcld0JME6ya2_QhQCQ"}} -->
