### PR TITLE
fix(core): render future timestamps as "in X" instead of "X ago"

### DIFF
--- a/packages/core/src/__tests__/messages-format.test.ts
+++ b/packages/core/src/__tests__/messages-format.test.ts
@@ -1,11 +1,12 @@
 /**
- * Coverage for `formatMessages` conversation-history rendering: attachment
- * read-advertisement gating, reacted-to message restoration, and bot-sender
- * tagging. Pure formatter test — no runtime or model.
+ * Coverage for `formatMessages` and `formatPosts` conversation-history
+ * rendering: attachment read-advertisement gating, reacted-to message
+ * restoration, bot-sender tagging, and timestamp tense in the rendered
+ * transcript. Pure formatter test — no runtime or model.
  */
-import { describe, expect, it } from "vitest";
-import type { Media, Memory, UUID } from "../types/index.ts";
-import { formatMessages } from "../utils.ts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Entity, Media, Memory, UUID } from "../types/index.ts";
+import { formatMessages, formatPosts } from "../utils.ts";
 
 const roomId = "00000000-0000-0000-0000-000000000001" as UUID;
 
@@ -185,5 +186,71 @@ describe("formatMessages", () => {
 		expect(rendered).toContain(
 			"Stored content available via ATTACHMENT action=read",
 		);
+	});
+});
+
+describe("transcript timestamp tense", () => {
+	// These transcripts are rendered into prompt text the model reads, so a
+	// future-dated memory (clock skew, a scheduled item) must not be described
+	// as having already happened. The clock is frozen to pin exact offsets.
+	const NOW = 1768478400000;
+	const entityId = "00000000-0000-0000-0000-000000000002" as UUID;
+	const agentId = "00000000-0000-0000-0000-000000000003" as UUID;
+	const entities: Entity[] = [{ id: entityId, names: ["Ada"], agentId }];
+
+	function messageAt(createdAt: number): Memory {
+		return {
+			id: "00000000-0000-0000-0000-000000000031" as UUID,
+			entityId,
+			roomId,
+			createdAt,
+			content: { text: "the demo starts soon", source: "discord" },
+		} as Memory;
+	}
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("formatMessages renders a future createdAt as 'in …', not '… ago'", () => {
+		const rendered = formatMessages({
+			messages: [messageAt(NOW + 5 * 60_000)],
+			entities,
+		});
+
+		expect(rendered).toContain("(in 5 minutes)");
+		expect(rendered).not.toContain("ago)");
+	});
+
+	it("formatMessages keeps rendering a past createdAt as '… ago'", () => {
+		const rendered = formatMessages({
+			messages: [messageAt(NOW - 5 * 60_000)],
+			entities,
+		});
+
+		expect(rendered).toContain("(5 minutes ago)");
+	});
+
+	it("formatPosts renders a future createdAt as 'in …', not '… ago'", () => {
+		const rendered = formatPosts({
+			messages: [messageAt(NOW + 5 * 60_000)],
+			entities,
+		});
+
+		expect(rendered).toContain("Date: in 5 minutes");
+	});
+
+	it("formatPosts keeps rendering a past createdAt as '… ago'", () => {
+		const rendered = formatPosts({
+			messages: [messageAt(NOW - 5 * 60_000)],
+			entities,
+		});
+
+		expect(rendered).toContain("Date: 5 minutes ago");
 	});
 });

--- a/packages/core/src/utils/time-format.test.ts
+++ b/packages/core/src/utils/time-format.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the relative-time formatter. Deterministic and self-contained:
+ * each case pins an offset from `Date.now()` in the middle of its bucket (so the
+ * few milliseconds that elapse inside the call cannot cross a boundary) and
+ * asserts the exact rendered string. Covers past, future, and sub-minute
+ * offsets for both the compact (`formatRelativeTime`) and verbose
+ * (`formatTimestamp`) styles.
+ */
+import { describe, expect, it } from "vitest";
+import { formatRelativeTime, formatTimestamp } from "./time-format";
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe("formatRelativeTime (compact)", () => {
+	it("renders sub-minute offsets as 'just now' in both directions", () => {
+		expect(formatRelativeTime(Date.now() - 30 * SECOND)).toBe("just now");
+		expect(formatRelativeTime(Date.now() + 30 * SECOND)).toBe("just now");
+	});
+
+	it("suffixes past offsets with 'ago'", () => {
+		expect(formatRelativeTime(Date.now() - (5 * MINUTE + 20 * SECOND))).toBe(
+			"5m ago",
+		);
+		expect(formatRelativeTime(Date.now() - (2 * HOUR + 10 * MINUTE))).toBe(
+			"2h ago",
+		);
+		expect(formatRelativeTime(Date.now() - (1 * DAY + 1 * HOUR))).toBe(
+			"Yesterday",
+		);
+		expect(formatRelativeTime(Date.now() - (3 * DAY + 1 * HOUR))).toBe(
+			"3d ago",
+		);
+	});
+
+	it("prefixes future offsets with 'in' rather than reporting them as past", () => {
+		expect(formatRelativeTime(Date.now() + (5 * MINUTE + 20 * SECOND))).toBe(
+			"in 5m",
+		);
+		expect(formatRelativeTime(Date.now() + (2 * HOUR + 10 * MINUTE))).toBe(
+			"in 2h",
+		);
+		expect(formatRelativeTime(Date.now() + (1 * DAY + 1 * HOUR))).toBe(
+			"Tomorrow",
+		);
+		expect(formatRelativeTime(Date.now() + (3 * DAY + 1 * HOUR))).toBe("in 3d");
+	});
+});
+
+describe("formatTimestamp (verbose)", () => {
+	it("pluralizes and suffixes past offsets", () => {
+		expect(formatTimestamp(Date.now() - (1 * MINUTE + 20 * SECOND))).toBe(
+			"1 minute ago",
+		);
+		expect(formatTimestamp(Date.now() - (5 * MINUTE + 20 * SECOND))).toBe(
+			"5 minutes ago",
+		);
+		expect(formatTimestamp(Date.now() - (3 * HOUR + 10 * MINUTE))).toBe(
+			"3 hours ago",
+		);
+		expect(formatTimestamp(Date.now() - (2 * DAY + 1 * HOUR))).toBe(
+			"2 days ago",
+		);
+	});
+
+	it("prefixes future offsets with 'in' and keeps pluralization", () => {
+		expect(formatTimestamp(Date.now() + (1 * MINUTE + 20 * SECOND))).toBe(
+			"in 1 minute",
+		);
+		expect(formatTimestamp(Date.now() + (5 * MINUTE + 20 * SECOND))).toBe(
+			"in 5 minutes",
+		);
+		expect(formatTimestamp(Date.now() + (3 * HOUR + 10 * MINUTE))).toBe(
+			"in 3 hours",
+		);
+		expect(formatTimestamp(Date.now() + (2 * DAY + 1 * HOUR))).toBe(
+			"in 2 days",
+		);
+	});
+});

--- a/packages/core/src/utils/time-format.test.ts
+++ b/packages/core/src/utils/time-format.test.ts
@@ -1,12 +1,11 @@
 /**
- * Unit tests for the relative-time formatter. Deterministic and self-contained:
- * each case pins an offset from `Date.now()` in the middle of its bucket (so the
- * few milliseconds that elapse inside the call cannot cross a boundary) and
- * asserts the exact rendered string. Covers past, future, and sub-minute
- * offsets for both the compact (`formatRelativeTime`) and verbose
- * (`formatTimestamp`) styles.
+ * Unit tests for the relative-time formatter. Deterministic: the clock is
+ * frozen with fake timers so exact thresholds and ±1ms boundaries around 60s,
+ * 60m, and 24h can be asserted without slack. Past magnitudes floor (legacy
+ * behavior, byte-identical output); future magnitudes ceil, so "in N <unit>"
+ * always names the minimal N such that the moment arrives within N units.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { formatRelativeTime, formatTimestamp } from "./time-format";
 
 const SECOND = 1000;
@@ -14,69 +13,100 @@ const MINUTE = 60 * SECOND;
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 
+// 2026-01-15T12:00:00.000Z — an arbitrary fixed instant.
+const NOW = 1768478400000;
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
 describe("formatRelativeTime (compact)", () => {
 	it("renders sub-minute offsets as 'just now' in both directions", () => {
-		expect(formatRelativeTime(Date.now() - 30 * SECOND)).toBe("just now");
-		expect(formatRelativeTime(Date.now() + 30 * SECOND)).toBe("just now");
+		expect(formatRelativeTime(NOW)).toBe("just now");
+		expect(formatRelativeTime(NOW - 30 * SECOND)).toBe("just now");
+		expect(formatRelativeTime(NOW + 30 * SECOND)).toBe("just now");
+		expect(formatRelativeTime(NOW - MINUTE + 1)).toBe("just now");
+		expect(formatRelativeTime(NOW + MINUTE - 1)).toBe("just now");
 	});
 
-	it("suffixes past offsets with 'ago'", () => {
-		expect(formatRelativeTime(Date.now() - (5 * MINUTE + 20 * SECOND))).toBe(
-			"5m ago",
-		);
-		expect(formatRelativeTime(Date.now() - (2 * HOUR + 10 * MINUTE))).toBe(
-			"2h ago",
-		);
-		expect(formatRelativeTime(Date.now() - (1 * DAY + 1 * HOUR))).toBe(
-			"Yesterday",
-		);
-		expect(formatRelativeTime(Date.now() - (3 * DAY + 1 * HOUR))).toBe(
-			"3d ago",
-		);
+	it("floors past magnitudes and suffixes 'ago' (legacy output unchanged)", () => {
+		expect(formatRelativeTime(NOW - MINUTE)).toBe("1m ago");
+		expect(formatRelativeTime(NOW - MINUTE - 1)).toBe("1m ago");
+		expect(formatRelativeTime(NOW - 5 * MINUTE)).toBe("5m ago");
+		expect(formatRelativeTime(NOW - HOUR + 1)).toBe("59m ago");
+		expect(formatRelativeTime(NOW - HOUR)).toBe("1h ago");
+		expect(formatRelativeTime(NOW - HOUR - 1)).toBe("1h ago");
+		expect(formatRelativeTime(NOW - DAY + 1)).toBe("23h ago");
+		expect(formatRelativeTime(NOW - DAY)).toBe("Yesterday");
+		expect(formatRelativeTime(NOW - DAY - 1)).toBe("Yesterday");
+		expect(formatRelativeTime(NOW - 3 * DAY)).toBe("3d ago");
 	});
 
-	it("prefixes future offsets with 'in' rather than reporting them as past", () => {
-		expect(formatRelativeTime(Date.now() + (5 * MINUTE + 20 * SECOND))).toBe(
-			"in 5m",
-		);
-		expect(formatRelativeTime(Date.now() + (2 * HOUR + 10 * MINUTE))).toBe(
-			"in 2h",
-		);
-		expect(formatRelativeTime(Date.now() + (1 * DAY + 1 * HOUR))).toBe(
-			"Tomorrow",
-		);
-		expect(formatRelativeTime(Date.now() + (3 * DAY + 1 * HOUR))).toBe("in 3d");
+	it("ceils future magnitudes and prefixes 'in'", () => {
+		// The motivating defect: a target computed as now + 5 minutes has lost
+		// milliseconds by the time the clock is read; ceil must still say 5m.
+		expect(formatRelativeTime(NOW + 5 * MINUTE)).toBe("in 5m");
+		expect(formatRelativeTime(NOW + 5 * MINUTE - 1)).toBe("in 5m");
+		expect(formatRelativeTime(NOW + MINUTE)).toBe("in 1m");
+		expect(formatRelativeTime(NOW + HOUR - 1)).toBe("in 1h");
+		expect(formatRelativeTime(NOW + HOUR)).toBe("in 1h");
+		expect(formatRelativeTime(NOW + 3 * DAY)).toBe("in 3d");
+	});
+
+	it("renders the one-day bucket as Tomorrow/Yesterday", () => {
+		expect(formatRelativeTime(NOW + DAY - 1)).toBe("Tomorrow");
+		expect(formatRelativeTime(NOW + DAY)).toBe("Tomorrow");
+		expect(formatRelativeTime(NOW - DAY)).toBe("Yesterday");
+	});
+
+	it("rounds a future moment just past a boundary up to the next unit", () => {
+		// "in N <unit>" promises arrival within N units, so 60s+1ms cannot claim
+		// "in 1m" — the minimal true N is 2. Same rule at each unit scale.
+		expect(formatRelativeTime(NOW + MINUTE + 1)).toBe("in 2m");
+		expect(formatRelativeTime(NOW + HOUR + 1)).toBe("in 2h");
+		expect(formatRelativeTime(NOW + DAY + 1)).toBe("in 2d");
+	});
+
+	it("falls back to a locale date at a week and beyond", () => {
+		expect(formatRelativeTime(NOW - 8 * DAY)).not.toMatch(/ago|now/);
+		expect(formatRelativeTime(NOW + 8 * DAY)).not.toMatch(/in |now/);
 	});
 });
 
 describe("formatTimestamp (verbose)", () => {
-	it("pluralizes and suffixes past offsets", () => {
-		expect(formatTimestamp(Date.now() - (1 * MINUTE + 20 * SECOND))).toBe(
-			"1 minute ago",
-		);
-		expect(formatTimestamp(Date.now() - (5 * MINUTE + 20 * SECOND))).toBe(
-			"5 minutes ago",
-		);
-		expect(formatTimestamp(Date.now() - (3 * HOUR + 10 * MINUTE))).toBe(
-			"3 hours ago",
-		);
-		expect(formatTimestamp(Date.now() - (2 * DAY + 1 * HOUR))).toBe(
-			"2 days ago",
-		);
+	it("renders sub-minute offsets as 'just now' in both directions", () => {
+		expect(formatTimestamp(NOW - MINUTE + 1)).toBe("just now");
+		expect(formatTimestamp(NOW + MINUTE - 1)).toBe("just now");
 	});
 
-	it("prefixes future offsets with 'in' and keeps pluralization", () => {
-		expect(formatTimestamp(Date.now() + (1 * MINUTE + 20 * SECOND))).toBe(
-			"in 1 minute",
-		);
-		expect(formatTimestamp(Date.now() + (5 * MINUTE + 20 * SECOND))).toBe(
-			"in 5 minutes",
-		);
-		expect(formatTimestamp(Date.now() + (3 * HOUR + 10 * MINUTE))).toBe(
-			"in 3 hours",
-		);
-		expect(formatTimestamp(Date.now() + (2 * DAY + 1 * HOUR))).toBe(
-			"in 2 days",
-		);
+	it("floors past magnitudes, pluralizes, and suffixes 'ago'", () => {
+		expect(formatTimestamp(NOW - MINUTE)).toBe("1 minute ago");
+		expect(formatTimestamp(NOW - 5 * MINUTE)).toBe("5 minutes ago");
+		expect(formatTimestamp(NOW - HOUR)).toBe("1 hour ago");
+		expect(formatTimestamp(NOW - 3 * HOUR)).toBe("3 hours ago");
+		expect(formatTimestamp(NOW - DAY)).toBe("1 day ago");
+		expect(formatTimestamp(NOW - 2 * DAY - HOUR)).toBe("2 days ago");
+	});
+
+	it("ceils future magnitudes, pluralizes, and prefixes 'in'", () => {
+		expect(formatTimestamp(NOW + MINUTE)).toBe("in 1 minute");
+		expect(formatTimestamp(NOW + 5 * MINUTE)).toBe("in 5 minutes");
+		expect(formatTimestamp(NOW + 5 * MINUTE - 1)).toBe("in 5 minutes");
+		expect(formatTimestamp(NOW + HOUR - 1)).toBe("in 1 hour");
+		expect(formatTimestamp(NOW + HOUR)).toBe("in 1 hour");
+		expect(formatTimestamp(NOW + DAY - 1)).toBe("in 1 day");
+		expect(formatTimestamp(NOW + DAY)).toBe("in 1 day");
+		expect(formatTimestamp(NOW + 2 * DAY)).toBe("in 2 days");
+	});
+
+	it("rounds a future moment just past a boundary up to the next unit", () => {
+		expect(formatTimestamp(NOW + MINUTE + 1)).toBe("in 2 minutes");
+		expect(formatTimestamp(NOW + HOUR + 1)).toBe("in 2 hours");
+		expect(formatTimestamp(NOW + DAY + 1)).toBe("in 2 days");
 	});
 });

--- a/packages/core/src/utils/time-format.ts
+++ b/packages/core/src/utils/time-format.ts
@@ -8,10 +8,18 @@ function describeRelativeTime(
 	const diff = now - timestamp;
 	const future = diff < 0;
 	const absDiff = Math.abs(diff);
-	const seconds = Math.floor(absDiff / 1000);
-	const minutes = Math.floor(seconds / 60);
-	const hours = Math.floor(minutes / 60);
-	const days = Math.floor(hours / 24);
+
+	// Direction-aware rounding. Future magnitudes round UP so "in N <unit>"
+	// always means the moment arrives within N units: a target computed as
+	// now + 5 minutes has already lost a few milliseconds by the time this
+	// function reads the clock, and flooring would render it "in 4m". Past
+	// magnitudes keep the original floor, so every past-direction string is
+	// unchanged. Each unit is derived from absDiff directly because
+	// ceil(ceil(x/a)/b) overshoots where ceil(x/(a*b)) does not.
+	const round = future ? Math.ceil : Math.floor;
+	const minutes = round(absDiff / 60000);
+	const hours = round(absDiff / 3600000);
+	const days = round(absDiff / 86400000);
 
 	// A magnitude ("5 minutes", "3d") carries no direction; the tense is applied
 	// here. A past timestamp reads "<magnitude> ago"; a future one reads
@@ -35,7 +43,9 @@ function describeRelativeTime(
 		return tense(`${days} day${days !== 1 ? "s" : ""}`);
 	}
 
-	if (seconds < 60) {
+	// The raw-millisecond threshold keeps compact and verbose "just now"
+	// windows identical in both directions.
+	if (absDiff < 60000) {
 		return "just now";
 	}
 	if (minutes < 60) {

--- a/packages/core/src/utils/time-format.ts
+++ b/packages/core/src/utils/time-format.ts
@@ -6,39 +6,49 @@ function describeRelativeTime(
 ): string {
 	const now = Date.now();
 	const diff = now - timestamp;
+	const future = diff < 0;
 	const absDiff = Math.abs(diff);
 	const seconds = Math.floor(absDiff / 1000);
 	const minutes = Math.floor(seconds / 60);
 	const hours = Math.floor(minutes / 60);
 	const days = Math.floor(hours / 24);
 
+	// A magnitude ("5 minutes", "3d") carries no direction; the tense is applied
+	// here. A past timestamp reads "<magnitude> ago"; a future one reads
+	// "in <magnitude>". Without this split every branch fell through to "ago",
+	// so a timestamp ahead of now — clock skew, a scheduled item, or a record
+	// dated slightly in the future — was described as though it had already
+	// happened.
+	const tense = (magnitude: string): string =>
+		future ? `in ${magnitude}` : `${magnitude} ago`;
+
 	if (style === "verbose") {
 		if (absDiff < 60000) {
 			return "just now";
 		}
 		if (minutes < 60) {
-			return `${minutes} minute${minutes !== 1 ? "s" : ""} ago`;
+			return tense(`${minutes} minute${minutes !== 1 ? "s" : ""}`);
 		}
 		if (hours < 24) {
-			return `${hours} hour${hours !== 1 ? "s" : ""} ago`;
+			return tense(`${hours} hour${hours !== 1 ? "s" : ""}`);
 		}
-		return `${days} day${days !== 1 ? "s" : ""} ago`;
+		return tense(`${days} day${days !== 1 ? "s" : ""}`);
 	}
 
 	if (seconds < 60) {
 		return "just now";
 	}
 	if (minutes < 60) {
-		return `${minutes}m ago`;
+		return tense(`${minutes}m`);
 	}
 	if (hours < 24) {
-		return `${hours}h ago`;
+		return tense(`${hours}h`);
 	}
 	if (days === 1) {
-		return "Yesterday";
+		return future ? "Tomorrow" : "Yesterday";
 	}
 	if (days < 7) {
-		return `${days}d ago`;
+		return tense(`${days}d`);
 	}
 	return new Date(timestamp).toLocaleDateString(undefined, {
 		month: "short",
@@ -58,6 +68,8 @@ function describeRelativeTime(
  * formatRelativeTime(Date.now() - 300000) // => "5m ago"
  * formatRelativeTime(Date.now() - 7200000) // => "2h ago"
  * formatRelativeTime(Date.now() - 86400000) // => "Yesterday"
+ * formatRelativeTime(Date.now() + 300000) // => "in 5m"
+ * formatRelativeTime(Date.now() + 86400000) // => "Tomorrow"
  * formatRelativeTime(Date.now() - 604800000) // => "Jan 15" (or similar)
  * ```
  */


### PR DESCRIPTION
# Relates to

No tracking issue — this is a small, self-contained correctness fix in a core utility.

# Summary

`describeRelativeTime` previously discarded the sign of its timestamp delta and always emitted past-tense text. Future timestamps caused by scheduled data or clock skew therefore rendered as `5m ago` / `5 minutes ago`.

This PR makes the output direction-aware while preserving every past-time string:

- future durations use ceiling semantics (`in 5m`, `in 5 minutes`) so the countdown never understates the remaining time;
- past durations retain the existing floor semantics and output;
- the raw sub-minute threshold remains shared by compact and verbose styles;
- exact and ±1 ms boundaries around one minute, one hour, and one day are frozen-clock tested;
- `formatMessages` and `formatPosts` contract tests prove the corrected tense reaches their rendered transcript text.

The implementation is deliberately kept in the existing core formatter. `Intl.RelativeTimeFormat` would introduce localization and wording changes beyond this bug fix.

# Sync with develop

- [x] Targets `develop` and is rebased onto `f6d3175ec35d033e9419ada55d8bb7d2038fa8eb` with zero conflicts.
- [x] Exact reviewed head: `7d11909d622c16bd7d82b86257d6da6a9bb63b42`.

# Testing

Maintainer verification on the pinned Bun 1.3.14 / Node 24.15.0 toolchain:

```text
bun run --cwd packages/core test time-format       10/10 passed
bun run --cwd packages/core test messages-format  11/11 passed
bun run --cwd packages/core typecheck              passed
bun run --cwd packages/core build                  Node/browser/edge/testing passed
bun run verify                                     350/350 tasks + audits passed
```

Representative frozen-clock behavior:

| Input | Before | After |
| --- | --- | --- |
| `now + 5 min - 1 ms` | `4m ago` | `in 5m` |
| `now + 1 hour - 1 ms` | `59m ago` | `in 1h` |
| `now + 24 hours - 1 ms` | `23h ago` | `Tomorrow` |
| `now - 24 hours` | `Yesterday` | `Yesterday` |

# Risks

Low. The source change is confined to one pure formatting helper. Existing past-direction behavior is pinned by tests. The only changed output is the previously incorrect future direction, including transcript-renderer consumers.

# Evidence Gate

<!-- evidence-head:7d11909d622c16bd7d82b86257d6da6a9bb63b42 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - the diff changes a core string formatter and has no rendered UI source surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - the diff changes a core string formatter and has no rendered UI source surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no interactive user flow; the observable contract is the returned and transcript-rendered string.
<!-- evidence-row:backend-logs -->
- [x] N/A - the pure formatter performs no backend request or logging; exact outputs are covered by deterministic tests.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, provider, prompt template, action, or evaluator behavior changes; deterministic `formatMessages` and `formatPosts` tests pin the only affected prompt-text contract.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the formatter creates no database row, memory, task, file, or external side effect.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changes.

# Known gaps / failures

None on the exact reviewed head.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
