### PR TITLE
fix(registry): remove generic Adanos tags

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-adanos.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-adanos.json
@@ -6,8 +6,6 @@
   "homepage": "https://adanos.org/",
   "version": "0.1.0",
   "tags": [
-    "elizaos",
-    "plugin",
     "market-sentiment",
     "stocks",
     "crypto",

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1119,8 +1119,6 @@
       "description": "Read-only Adanos stock and crypto market sentiment for elizaOS agents.",
       "homepage": "https://adanos.org/",
       "topics": [
-        "elizaos",
-        "plugin",
         "market-sentiment",
         "stocks",
         "crypto",


### PR DESCRIPTION
# Relates to

#18302

# Background

The Adanos entry used the generic tags `elizaos` and `plugin`. Those terms describe every entry in this registry and reduce the precision of tag-based discovery. This follow-up keeps only the discriminative domain tags while regenerating the derived registry artifact.

# Testing

- `bun run --cwd packages/registry generate` — deterministic; worktree remained clean.
- `bun run --cwd packages/registry validate` — 39 entries validated.
- `bun run --cwd packages/registry test` — 6 files, 36 tests passed.
- `bun run --cwd packages/registry typecheck` — passed.
- `bun run --cwd packages/registry lint:check` — passed.
- `bun run --cwd packages/registry format:check` — passed.
- `git diff --check origin/develop...HEAD` — passed.

# Evidence Gate

<!-- evidence-head:5b60bd8df4374ebea48b00c2bbf01243ca02148b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - registry metadata only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - registry metadata only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - registry metadata only; no interactive flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime behavior changed.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, model, provider, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the reviewed registry JSON and deterministic generated registry are the complete artifacts.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed.

# Risks

Low. This removes two redundant search tags from one third-party registry entry and its generated representation; package identity and runtime behavior are unchanged.

<!-- contribution-attribution:v1 -->
- AI assistance: `yes`
- Model(s) used: `openai/gpt-5.6-sol`
- Agent tooling: `Codex desktop`
- Provenance status: `maintainer-authored`
