### PR TITLE
ci: run the cloud stack e2e suite that nothing was running

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -17,6 +17,8 @@ on:
       - "packages/cloud/routing/**"
       - "packages/cloud/infra/**"
       - "packages/cloud/scripts/**"
+      - "packages/cloud/e2e/**"
+      - "packages/cloud/test-mocks/**"
       - "packages/scripts/test-cloud-run.mjs"
       - "packages/scripts/test-cloud-run-helpers.mjs"
       - "packages/scripts/test-cloud-run-flush.self-test.mjs"
@@ -36,6 +38,8 @@ on:
       - "packages/cloud/routing/**"
       - "packages/cloud/infra/**"
       - "packages/cloud/scripts/**"
+      - "packages/cloud/e2e/**"
+      - "packages/cloud/test-mocks/**"
       - "packages/scripts/test-cloud-run.mjs"
       - "packages/scripts/test-cloud-run-helpers.mjs"
       - "packages/scripts/test-cloud-run-flush.self-test.mjs"
@@ -162,5 +166,42 @@ jobs:
         run: >-
           bun test --config=/dev/null --isolate
           packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-lock.integration.test.ts
-      - name: Run cloud e2e tests
+      # `test:cloud:e2e` is the packages/cloud/api lane, NOT the Playwright stack
+      # in packages/cloud/e2e. The two were easy to confuse while this job was
+      # the only thing named "e2e", which is how 31 of that stack's 33 specs
+      # went unrun; `stack-e2e-tests` below owns them.
+      - name: Run cloud API e2e tests
         run: bun run test:cloud:e2e
+
+  # The packages/cloud/e2e Playwright suite: it boots the real local stack —
+  # PGlite over a TCP bridge, the in-process control-plane mock, the cloud-api
+  # Worker as a subprocess — and drives real flows through it. Every proof of
+  # the shared-to-dedicated funnel lives here, and until now none of it ran:
+  # the smoke lane passes --no-cloud, the job above runs a different suite, and
+  # the nightly names only two specs (#18474).
+  stack-e2e-tests:
+    runs-on: ubuntu-24.04
+    # Measured, not estimated: the full suite is 3.9 min locally (72 specs,
+    # workers:1, one stack boot). 25 leaves room for a cold CI runner and the
+    # config's `retries: 1`, which re-runs only what failed.
+    timeout-minutes: 25
+    needs: [lint-and-types]
+    env:
+      NODE_ENV: test
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: ./.github/actions/cloud-setup-test-env
+      - name: Install Playwright browsers
+        run: PLAYWRIGHT_INSTALL_CWD=packages/cloud/e2e .github/scripts/install-playwright-browsers.sh chromium
+      - name: Run cloud stack e2e suite
+        run: bun run cloud:e2e
+      - name: Upload stack logs and Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: cloud-stack-e2e
+          path: |
+            packages/cloud/e2e/.logs
+            packages/cloud/e2e/test-results
+          if-no-files-found: warn
+          retention-days: 7


### PR DESCRIPTION
# Relates to

Refs #18474 · surfaces #18475

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, branched from current `origin/develop`, zero conflicts.
- [x] `bun install` run after sync; the workflow contract gates are recorded below.
- [x] A reviewer can confirm the change from the measurement and the job graph.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was loaded for this change`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from current `origin/develop`; zero conflicts.

# Risks

**Medium — and the risk is worth naming precisely, because it is not about this diff.**

This adds a lane that runs 72 specs which have never run in CI. **Four of them fail today on unmodified `develop` product code** (#18475). So this job will be red on cloud-touching PRs from the moment it lands.

That is the intended consequence: the suite is red because the funnel is broken, and the reason nobody knew is that nothing ran it. But it is a real decision for the reviewer:

- **Land now** — the lane is red until #18475 is fixed, and every cloud PR carries a failing check.
- **Land after #18475** — the funnel gets fixed first, then this lands green.

I have deliberately **not** excluded the four failing specs to make the lane green. That would reproduce the exact failure this PR exists to end: a suite that reports success while not covering the thing it names. #18474's own acceptance criteria say a failing spec must fail the lane.

# Background

## What does this PR do?

Runs `packages/cloud/e2e` — the Playwright suite that boots the real local cloud stack — on pull requests that touch the surfaces it covers.

Three gaps composed to make 31 of its 33 specs unreachable:

1. The `smoke` lane passes `--no-cloud`, which excludes `@elizaos/cloud-e2e` outright.
2. The job named `e2e-tests` here runs `test:cloud:e2e`, which resolves to `packages/cloud/api test:e2e` — a **different suite** that shares the word "e2e".
3. The only caller of `cloud:e2e` is `monetized-loop-nightly.yml`, which names two specs.

On top of that, the workflow's path filter did not list `packages/cloud/e2e`, so editing a spec triggered nothing.

## What kind of change is this?

Improvements — CI coverage.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The renamed step. `Run cloud e2e tests` → `Run cloud API e2e tests`: that ambiguity is how this gap survived, and naming it is most of the fix.

## Detailed testing steps

The suite was run locally in full against `develop` product code to set the timeout from measurement rather than estimate, and to establish what the lane will actually report on day one.

# Evidence Gate

<!-- evidence-head:31e53e649a1b161d8da53b78a88bd6e419c29fdc -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this change adds a CI job; no rendered surface exists before or after.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this change adds a CI job; no rendered surface exists before or after.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing flow in a workflow job definition.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server process changed; the suite's own runner output is the artifact and it is attached below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer code changed, so there is no console or network trace to capture.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behaviour is touched.
<!-- evidence-row:domain-artifacts -->
- [x] The artifact is the local full-suite run that set the timeout and established the day-one state.

<details><summary>Full cloud e2e suite, local, against develop product code</summary>

```
$ bun --conditions=eliza-source playwright test --reporter=list
  63 passed
  4 failed
  5 skipped
  (3.9m)

failed:
  app-client-handoff-success.spec.ts:53   switched -> timed-out
  shared-to-dedicated-upgrade.spec.ts:65  switched -> timed-out
  app-client-onboarding.spec.ts:34        ApiError: Not found
  bluebubbles-gateway.spec.ts:168         onboardingInboundBody toMatchObject mismatch
$ actionlint .github/workflows/cloud-tests.yml   -> clean
$ node packages/scripts/ci-bun-version-contract.mjs   -> passed
$ node packages/scripts/ci-turbo-cache-contract.mjs   -> passed
$ bun test packages/scripts/__tests__/github-action-pinning.test.ts
 11 pass  0 fail
```

</details>

All four failures are the shared-to-dedicated funnel; the other 63 pass in the same run on the same stack. That clustering is why they are filed as a product concern (#18475) rather than dismissed as local noise.

<!-- evidence-row:ocr-review -->
- [x] N/A - no pixels are produced or changed by a workflow job definition.

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - no contribution skill was loaded for this change
Attribution status: self-reported
— [stan-cloud]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"N/A - no contribution skill was loaded for this change"} -->
