### PR TITLE
fix(chat): canonicalize shared SSE chat event typing end to end (#17122)

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Exercises the real shared-agent route handler with a bodyless coordinator
+ * response, proving its boundary fallback is a canonical typed SSE error.
+ */
+import { expect, mock, test } from "bun:test";
+import * as coordinatorActual from "@/lib/services/shared-runtime/conversation-coordinator";
+
+const coordinateSharedStream = mock(
+  async () =>
+    new Response(null, { headers: { "Content-Type": "text/event-stream" } }),
+);
+
+mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
+  ...coordinatorActual,
+  coordinateSharedStream,
+}));
+
+const { __agentStreamTestHooks } = await import("./route");
+
+test("bodyless coordinator responses carry the canonical error type", async () => {
+  const response = await __agentStreamTestHooks.handlePost(
+    new Request("https://api.example.test/api/v1/eliza/agents/agent-1/stream", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "message.send",
+        params: { text: "hello" },
+      }),
+    }),
+    { params: Promise.resolve({ agentId: "agent-1" }) },
+    {
+      agent: { id: "agent-1" } as never,
+      namespace: {} as never,
+      executionCtx: { waitUntil: () => undefined },
+    },
+  );
+
+  expect(response.status).toBe(200);
+  const body = await response.text();
+  expect(body).toContain("event: error");
+  const data = JSON.parse(
+    body.split("data: ")[1]?.split("\n")[0] ?? "{}",
+  ) as Record<string, unknown>;
+  expect(data).toEqual({
+    message: "Sandbox is not running or unreachable",
+    type: "error",
+  });
+});

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.ts
@@ -8,6 +8,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { AgentSandbox } from "@/db/repositories/agent-sandboxes";
 import { errorToResponse, ValidationError } from "@/lib/api/errors";
+import { chatSseFrame } from "@/lib/services/chat-sse-frames";
 import type { BridgeRequest } from "@/lib/services/eliza-sandbox-bridge";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { coordinateSharedStream } from "@/lib/services/shared-runtime/conversation-coordinator";
@@ -109,7 +110,9 @@ async function __hono_POST(
       (async () => {
         await writer.write(
           encoder.encode(
-            `event: error\ndata: ${JSON.stringify({ message: "Sandbox is not running or unreachable" })}\n\n`,
+            chatSseFrame("error", {
+              message: "Sandbox is not running or unreachable",
+            }),
           ),
         );
         await writer.close();

--- a/packages/cloud/services/container-control-plane/src/chat-sse-contract.test.ts
+++ b/packages/cloud/services/container-control-plane/src/chat-sse-contract.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Drives the real control-plane HTTP boundary to ensure invalid stream calls
+ * remain machine-classifiable SSE rather than an untyped named event.
+ */
+import { afterAll, expect, test } from "bun:test";
+import { app } from "./index";
+
+const previousToken = process.env.CONTAINER_CONTROL_PLANE_TOKEN;
+process.env.CONTAINER_CONTROL_PLANE_TOKEN = "chat-sse-contract-token";
+
+afterAll(() => {
+  if (previousToken === undefined) {
+    delete process.env.CONTAINER_CONTROL_PLANE_TOKEN;
+  } else {
+    process.env.CONTAINER_CONTROL_PLANE_TOKEN = previousToken;
+  }
+});
+
+test("invalid JSON-RPC stream requests carry the canonical error type", async () => {
+  const response = await app.request("/api/v1/eliza/agents/agent-1/stream", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-container-control-plane-token": "chat-sse-contract-token",
+      "x-eliza-user-id": "user-1",
+      "x-eliza-organization-id": "org-1",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "heartbeat" }),
+  });
+
+  expect(response.status).toBe(400);
+  const body = await response.text();
+  expect(body).toContain("event: error");
+  const data = JSON.parse(
+    body.split("data: ")[1]?.split("\n")[0] ?? "{}",
+  ) as Record<string, unknown>;
+  expect(data).toEqual({
+    message: "Invalid JSON-RPC stream request",
+    type: "error",
+  });
+});

--- a/packages/cloud/services/container-control-plane/src/index.ts
+++ b/packages/cloud/services/container-control-plane/src/index.ts
@@ -17,6 +17,7 @@ import {
 import { ApiError } from "@elizaos/cloud-shared/lib/api/errors";
 import { containersEnv } from "@elizaos/cloud-shared/lib/config/containers-env";
 import { runWithCloudBindingsAsync } from "@elizaos/cloud-shared/lib/runtime/cloud-bindings";
+import { chatSseFrame } from "@elizaos/cloud-shared/lib/services/chat-sse-frames";
 import { WarmPoolManager } from "@elizaos/cloud-shared/lib/services/containers/agent-warm-pool";
 import { getHetznerPoolContainerCreator } from "@elizaos/cloud-shared/lib/services/containers/agent-warm-pool-creator";
 import { evaluateForwardedDatabaseUrl } from "@elizaos/cloud-shared/lib/services/containers/forwarded-database-url-guard";
@@ -1158,14 +1159,23 @@ app.post("/api/v1/eliza/agents/:id/stream", (c) =>
         );
         if (!status.error) {
           return new Response(
-            `data: ${JSON.stringify({ text: fallbackText })}\n\nevent: done\ndata: ${JSON.stringify({})}\n\n`,
+            chatSseFrame("chunk", {
+              text: fallbackText,
+              fullText: fallbackText,
+            }) +
+              chatSseFrame("done", {
+                text: fallbackText,
+                fullText: fallbackText,
+              }),
             { status: 200, headers: streamHeaders },
           );
         }
       }
 
       return new Response(
-        `event: error\ndata: ${JSON.stringify({ message: "Sandbox is not running or unreachable" })}\n\n`,
+        chatSseFrame("error", {
+          message: "Sandbox is not running or unreachable",
+        }),
         { status: 200, headers: streamHeaders },
       );
     }

--- a/packages/cloud/services/container-control-plane/src/index.ts
+++ b/packages/cloud/services/container-control-plane/src/index.ts
@@ -1134,7 +1134,7 @@ app.post("/api/v1/eliza/agents/:id/stream", (c) =>
       body.method !== "message.send"
     ) {
       return new Response(
-        `event: error\ndata: ${JSON.stringify({ message: "Invalid JSON-RPC stream request" })}\n\n`,
+        chatSseFrame("error", { message: "Invalid JSON-RPC stream request" }),
         { status: 400, headers: streamHeaders },
       );
     }

--- a/packages/cloud/shared/src/lib/services/chat-sse-frames.test.ts
+++ b/packages/cloud/shared/src/lib/services/chat-sse-frames.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Contract tests for the canonical chat SSE frame builder shared by every
+ * Cloud chat producer (#17122): each frame keeps its named `event:` line,
+ * stamps the canonical JSON `type`, and the canonical type cannot be
+ * overridden by a payload field.
+ */
+import { describe, expect, test } from "bun:test";
+import { chatSseFrame } from "./chat-sse-frames";
+
+describe("chatSseFrame", () => {
+  test("stamps the canonical JSON type for each named event", () => {
+    expect(chatSseFrame("chunk", { text: "hi" })).toBe(
+      'event: chunk\ndata: {"text":"hi","type":"token"}\n\n',
+    );
+    expect(chatSseFrame("done", { fullText: "hi" })).toBe(
+      'event: done\ndata: {"fullText":"hi","type":"done"}\n\n',
+    );
+    expect(chatSseFrame("error", { message: "boom" })).toBe(
+      'event: error\ndata: {"message":"boom","type":"error"}\n\n',
+    );
+  });
+
+  test("the canonical type wins over a conflicting payload field", () => {
+    const frame = chatSseFrame("done", { type: "token", fullText: "hi" });
+    const data = JSON.parse(frame.split("\ndata: ")[1] ?? "{}") as {
+      type?: string;
+    };
+    expect(data.type).toBe("done");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/chat-sse-frames.test.ts
+++ b/packages/cloud/shared/src/lib/services/chat-sse-frames.test.ts
@@ -5,7 +5,7 @@
  * overridden by a payload field.
  */
 import { describe, expect, test } from "bun:test";
-import { chatSseFrame } from "./chat-sse-frames";
+import { chatSseFrame, normalizeChatSseDonePayload } from "./chat-sse-frames";
 
 describe("chatSseFrame", () => {
   test("stamps the canonical JSON type for each named event", () => {
@@ -26,5 +26,44 @@ describe("chatSseFrame", () => {
       type?: string;
     };
     expect(data.type).toBe("done");
+  });
+});
+
+describe("normalizeChatSseDonePayload", () => {
+  test("preserves the terminal client contract and authoritative upstream IDs", () => {
+    expect(
+      normalizeChatSseDonePayload(
+        {
+          messageId: "upstream-assistant",
+          userMessageId: "upstream-user",
+          text: "final answer",
+          actionResults: [{ actionName: "VIEWS", success: true }],
+          usage: { totalTokens: 4 },
+          failureKind: "no_provider",
+          accountConnect: { provider: "openai" },
+          untrustedExtra: "drop-me",
+        },
+        { messageId: "fallback", fullText: "partial" },
+      ),
+    ).toEqual({
+      userMessageId: "upstream-user",
+      failureKind: "no_provider",
+      accountConnect: { provider: "openai" },
+      actionResults: [{ actionName: "VIEWS", success: true }],
+      usage: { totalTokens: 4 },
+      messageId: "upstream-assistant",
+      text: "final answer",
+      fullText: "final answer",
+    });
+  });
+
+  test("uses generated identity and accumulated text only when upstream omits them", () => {
+    expect(
+      normalizeChatSseDonePayload({}, { messageId: "generated", fullText: "accumulated" }),
+    ).toEqual({
+      messageId: "generated",
+      text: "accumulated",
+      fullText: "accumulated",
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/chat-sse-frames.ts
+++ b/packages/cloud/shared/src/lib/services/chat-sse-frames.ts
@@ -10,6 +10,22 @@
 
 export type ChatSseEventName = "chunk" | "done" | "error";
 
+/** Terminal fields understood by the shared UI stream reducer. */
+const DONE_METADATA_FIELDS = [
+  "transcriptVisibility",
+  "agentName",
+  "userMessageId",
+  "assistantEphemeral",
+  "historyRefreshRequired",
+  "thought",
+  "noResponseReason",
+  "failureKind",
+  "accountConnect",
+  "localInference",
+  "actionResults",
+  "usage",
+] as const;
+
 const EVENT_JSON_TYPE = {
   chunk: "token",
   done: "done",
@@ -21,4 +37,35 @@ export function chatSseFrame(event: ChatSseEventName, payload: Record<string, un
     ...payload,
     type: EVENT_JSON_TYPE[event],
   })}\n\n`;
+}
+
+/**
+ * Normalizes a dedicated-agent terminal event without dropping planner or
+ * persistence metadata. Only fields consumed by the shared client cross this
+ * proxy boundary; arbitrary upstream properties are intentionally excluded.
+ */
+export function normalizeChatSseDonePayload(
+  payload: Record<string, unknown>,
+  fallback: { messageId: string; fullText: string },
+): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {};
+  for (const field of DONE_METADATA_FIELDS) {
+    if (Object.hasOwn(payload, field)) normalized[field] = payload[field];
+  }
+
+  const upstreamMessageId = payload.messageId;
+  normalized.messageId =
+    typeof upstreamMessageId === "string" && upstreamMessageId.trim()
+      ? upstreamMessageId
+      : fallback.messageId;
+
+  const fullText =
+    typeof payload.fullText === "string"
+      ? payload.fullText
+      : typeof payload.text === "string"
+        ? payload.text
+        : fallback.fullText;
+  normalized.text = fullText;
+  normalized.fullText = fullText;
+  return normalized;
 }

--- a/packages/cloud/shared/src/lib/services/chat-sse-frames.ts
+++ b/packages/cloud/shared/src/lib/services/chat-sse-frames.ts
@@ -1,0 +1,24 @@
+/**
+ * Canonical SSE chat-frame construction for every Cloud chat producer: the
+ * shared runtime, the sandbox and its bridge, and the control-plane fallback.
+ * Each frame keeps its legacy named `event:` line for consumers that dispatch
+ * on it while stamping the additive JSON `type` the shared UI client
+ * classifies on, so a terminal `done` or `error` frame can never be misread as
+ * another token by a client that ignores SSE event names (#17122). The
+ * canonical `type` is written last so no payload field can override it.
+ */
+
+export type ChatSseEventName = "chunk" | "done" | "error";
+
+const EVENT_JSON_TYPE = {
+  chunk: "token",
+  done: "done",
+  error: "error",
+} as const satisfies Record<ChatSseEventName, string>;
+
+export function chatSseFrame(event: ChatSseEventName, payload: Record<string, unknown>): string {
+  return `event: ${event}\ndata: ${JSON.stringify({
+    ...payload,
+    type: EVENT_JSON_TYPE[event],
+  })}\n\n`;
+}

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-delta-sse.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-delta-sse.test.ts
@@ -160,6 +160,27 @@ for (const [label, make] of normalizers) {
       expect(done?.data.text).toBe("Hello");
     });
 
+    test("preserves authoritative terminal IDs, action, usage, and failure metadata", async () => {
+      const body =
+        'data: {"type":"token","text":"Open notes"}\n\n' +
+        'data: {"type":"done","messageId":"assistant-1","userMessageId":"user-1","fullText":"Opened notes","actionResults":[{"actionName":"VIEWS","success":true}],"usage":{"totalTokens":3},"failureKind":"provider_gate","accountConnect":{"provider":"openai"},"untrustedExtra":"drop"}\n\n';
+      const events = await readEvents(make().normalizeBridgeSseResponse(sseResponse(body)));
+
+      const done = events.find((event) => event.event === "done")?.data;
+      expect(done).toMatchObject({
+        type: "done",
+        messageId: "assistant-1",
+        userMessageId: "user-1",
+        text: "Opened notes",
+        fullText: "Opened notes",
+        actionResults: [{ actionName: "VIEWS", success: true }],
+        usage: { totalTokens: 3 },
+        failureKind: "provider_gate",
+        accountConnect: { provider: "openai" },
+      });
+      expect(done?.untrustedExtra).toBeUndefined();
+    });
+
     test("buffers split SSE frames before parsing and accumulating", async () => {
       const events = await readEvents(
         make().normalizeBridgeSseResponse(

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
@@ -11,7 +11,7 @@ import crypto from "node:crypto";
 import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { logger } from "../utils/logger";
-import { chatSseFrame } from "./chat-sse-frames";
+import { chatSseFrame, normalizeChatSseDonePayload } from "./chat-sse-frames";
 
 export interface BridgeRequest {
   jsonrpc: "2.0";
@@ -379,13 +379,14 @@ export class ElizaSandboxBridgeService {
           return;
         }
         if (data?.type === "done") {
-          const finalText = typeof data.fullText === "string" ? data.fullText : accumulated;
           controller.enqueue(
-            chatSseFrame("done", {
-              messageId,
-              text: finalText,
-              fullText: finalText,
-            }),
+            chatSseFrame(
+              "done",
+              normalizeChatSseDonePayload(data, {
+                messageId,
+                fullText: accumulated,
+              }),
+            ),
           );
           return;
         }

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
@@ -11,6 +11,7 @@ import crypto from "node:crypto";
 import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { logger } from "../utils/logger";
+import { chatSseFrame } from "./chat-sse-frames";
 
 export interface BridgeRequest {
   jsonrpc: "2.0";
@@ -367,22 +368,24 @@ export class ElizaSandboxBridgeService {
           const delta = typeof data.text === "string" ? data.text : "";
           accumulated = typeof data.fullText === "string" ? data.fullText : accumulated + delta;
           controller.enqueue(
-            `event: chunk\ndata: ${JSON.stringify({
+            chatSseFrame("chunk", {
               messageId,
               chunk: delta,
               text: delta,
               fullText: accumulated,
               timestamp: Date.now(),
-            })}\n\n`,
+            }),
           );
           return;
         }
         if (data?.type === "done") {
+          const finalText = typeof data.fullText === "string" ? data.fullText : accumulated;
           controller.enqueue(
-            `event: done\ndata: ${JSON.stringify({
+            chatSseFrame("done", {
               messageId,
-              text: typeof data.fullText === "string" ? data.fullText : accumulated,
-            })}\n\n`,
+              text: finalText,
+              fullText: finalText,
+            }),
           );
           return;
         }
@@ -1120,10 +1123,11 @@ export class ElizaSandboxBridgeService {
       messageId,
       chunk: text,
       text,
+      fullText: text,
       timestamp: Date.now(),
     };
     return new Response(
-      `event: chunk\ndata: ${JSON.stringify(chunk)}\n\nevent: done\ndata: ${JSON.stringify({ messageId, text })}\n\n`,
+      chatSseFrame("chunk", chunk) + chatSseFrame("done", { messageId, text, fullText: text }),
       {
         status: 200,
         headers: {
@@ -1135,7 +1139,7 @@ export class ElizaSandboxBridgeService {
   }
 
   private createBridgeSseErrorResponse(message: string): Response {
-    return new Response(`event: error\ndata: ${JSON.stringify({ message })}\n\n`, {
+    return new Response(chatSseFrame("error", { message }), {
       status: 200,
       headers: {
         "Content-Type": "text/event-stream; charset=utf-8",

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -75,6 +75,7 @@ import {
 } from "./ai-billing";
 import { aiBillingRecordsService } from "./ai-billing-records";
 import { apiKeysService } from "./api-keys";
+import { chatSseFrame } from "./chat-sse-frames";
 import { imageRequiresDigestPin, isCodingContainerImageAllowed } from "./coding-containers";
 import type { CreditReconciliationResult, CreditReservation } from "./credits";
 import { holdsCountedNodeSlot, isDeletionContinuation } from "./docker-node-workload-queries";
@@ -3793,13 +3794,13 @@ export class ElizaSandboxService {
                 reply += part.text;
                 controller.enqueue(
                   encoder.encode(
-                    `event: chunk\ndata: ${JSON.stringify({
+                    chatSseFrame("chunk", {
                       messageId,
                       chunk: part.text,
                       text: part.text,
                       fullText: reply,
                       timestamp: Date.now(),
-                    })}\n\n`,
+                    }),
                   ),
                 );
                 continue;
@@ -3902,24 +3903,24 @@ export class ElizaSandboxService {
               }
               // Attach a VIEWS navigation handoff for a deterministic nav turn so
               // the PWA opens the view (findViewActionHandoff → navigate event in
-              // packages/ui/src/view-action-handoff.ts). Non-nav turns omit it,
-              // so the `done` frame is byte-identical to before for normal chat.
+              // packages/ui/src/view-action-handoff.ts). Non-nav turns omit it.
               const doneData = turn.navIntent
                 ? {
                     messageId,
                     text: finalReply,
+                    fullText: finalReply,
                     actionResults: [navIntentActionResult(turn.navIntent)],
                   }
-                : { messageId, text: finalReply };
-              controller.enqueue(
-                encoder.encode(`event: done\ndata: ${JSON.stringify(doneData)}\n\n`),
-              );
+                : { messageId, text: finalReply, fullText: finalReply };
+              controller.enqueue(encoder.encode(chatSseFrame("done", doneData)));
             }
             if (!finished) {
               await settleReservation(0);
               controller.enqueue(
                 encoder.encode(
-                  `event: error\ndata: ${JSON.stringify({ message: "Shared runtime stream ended without completion" })}\n\n`,
+                  chatSseFrame("error", {
+                    message: "Shared runtime stream ended without completion",
+                  }),
                 ),
               );
             }
@@ -3936,9 +3937,7 @@ export class ElizaSandboxService {
               agentId: rec.id,
             });
             controller.enqueue(
-              encoder.encode(
-                `event: error\ndata: ${JSON.stringify({ message: "Shared runtime stream failed" })}\n\n`,
-              ),
+              encoder.encode(chatSseFrame("error", { message: "Shared runtime stream failed" })),
             );
           } finally {
             controller.close();
@@ -6146,10 +6145,11 @@ export class ElizaSandboxService {
       messageId,
       chunk: text,
       text,
+      fullText: text,
       timestamp: Date.now(),
     };
     return new Response(
-      `event: chunk\ndata: ${JSON.stringify(chunk)}\n\nevent: done\ndata: ${JSON.stringify({ messageId, text })}\n\n`,
+      chatSseFrame("chunk", chunk) + chatSseFrame("done", { messageId, text, fullText: text }),
       {
         status: 200,
         headers: {
@@ -6194,22 +6194,24 @@ export class ElizaSandboxService {
           const delta = typeof data.text === "string" ? data.text : "";
           accumulated = typeof data.fullText === "string" ? data.fullText : accumulated + delta;
           controller.enqueue(
-            `event: chunk\ndata: ${JSON.stringify({
+            chatSseFrame("chunk", {
               messageId,
               chunk: delta,
               text: delta,
               fullText: accumulated,
               timestamp: Date.now(),
-            })}\n\n`,
+            }),
           );
           return;
         }
         if (data?.type === "done") {
+          const finalText = typeof data.fullText === "string" ? data.fullText : accumulated;
           controller.enqueue(
-            `event: done\ndata: ${JSON.stringify({
+            chatSseFrame("done", {
               messageId,
-              text: typeof data.fullText === "string" ? data.fullText : accumulated,
-            })}\n\n`,
+              text: finalText,
+              fullText: finalText,
+            }),
           );
           return;
         }
@@ -6247,7 +6249,7 @@ export class ElizaSandboxService {
   }
 
   private createBridgeSseErrorResponse(message: string): Response {
-    return new Response(`event: error\ndata: ${JSON.stringify({ message })}\n\n`, {
+    return new Response(chatSseFrame("error", { message }), {
       status: 200,
       headers: {
         "Content-Type": "text/event-stream; charset=utf-8",

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -75,7 +75,7 @@ import {
 } from "./ai-billing";
 import { aiBillingRecordsService } from "./ai-billing-records";
 import { apiKeysService } from "./api-keys";
-import { chatSseFrame } from "./chat-sse-frames";
+import { chatSseFrame, normalizeChatSseDonePayload } from "./chat-sse-frames";
 import { imageRequiresDigestPin, isCodingContainerImageAllowed } from "./coding-containers";
 import type { CreditReconciliationResult, CreditReservation } from "./credits";
 import { holdsCountedNodeSlot, isDeletionContinuation } from "./docker-node-workload-queries";
@@ -6205,13 +6205,14 @@ export class ElizaSandboxService {
           return;
         }
         if (data?.type === "done") {
-          const finalText = typeof data.fullText === "string" ? data.fullText : accumulated;
           controller.enqueue(
-            chatSseFrame("done", {
-              messageId,
-              text: finalText,
-              fullText: finalText,
-            }),
+            chatSseFrame(
+              "done",
+              normalizeChatSseDonePayload(data, {
+                messageId,
+                fullText: accumulated,
+              }),
+            ),
           );
           return;
         }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
@@ -107,4 +107,22 @@ describe("handleCanonicalScopedAgentStream", () => {
       retryable: true,
     });
   });
+
+  test("emits a canonical typed SSE error when the coordinator has no body", async () => {
+    coordinateSharedStream.mockResolvedValueOnce(
+      new Response(null, { headers: { "Content-Type": "text/event-stream" } }),
+    );
+
+    const res = await handleCanonicalScopedAgentStream(BASE);
+    const body = await res.text();
+    expect(body).toContain("event: error");
+    const data = JSON.parse(body.split("data: ")[1]?.split("\n")[0] ?? "{}") as Record<
+      string,
+      unknown
+    >;
+    expect(data).toEqual({
+      message: "Agent produced no streamed response",
+      type: "error",
+    });
+  });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -9,6 +9,7 @@ import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
 import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
 import { InsufficientCreditsError, RateLimitError } from "../../api/errors";
 import { logger } from "../../utils/logger";
+import { chatSseFrame } from "../chat-sse-frames";
 import type { BridgeRequest } from "../eliza-sandbox-bridge";
 import { applyCorsHeaders } from "../proxy/cors";
 import { coordinateSharedStream } from "./conversation-coordinator";
@@ -184,9 +185,9 @@ export async function handleCanonicalScopedAgentStream(
   }
 
   if (!upstream.body) {
-    const body = `event: error\ndata: ${JSON.stringify({
+    const body = chatSseFrame("error", {
       message: "Agent produced no streamed response",
-    })}\n\n`;
+    });
     return addStreamTimingHeaders(
       applyCorsHeaders(
         new Response(body, { headers: STREAM_HEADERS }),

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -546,6 +546,34 @@ describe("SharedRuntimeChatService", () => {
     expect(settleCalls).toEqual([0.004]);
   });
 
+  test("no-model degradation remains a complete canonical SSE turn", async () => {
+    streamTurn = {
+      degraded: true,
+      reply: "Eliza is temporarily unavailable (no shared model configured).",
+    };
+
+    const body = await (await new SharedRuntimeChatService().stream(agent, rpc, harness())).text();
+    const frames = body
+      .split("\n\n")
+      .filter(Boolean)
+      .map((frame) => {
+        const lines = frame.split("\n");
+        return {
+          event: lines.find((line) => line.startsWith("event: "))?.slice(7),
+          data: JSON.parse(lines.find((line) => line.startsWith("data: "))?.slice(6) ?? "{}"),
+        };
+      });
+
+    expect(frames.map((frame) => frame.event)).toEqual(["chunk", "done"]);
+    expect(frames.map((frame) => frame.data.type)).toEqual(["token", "done"]);
+    expect(frames[1]?.data.fullText).toBe(
+      "Eliza is temporarily unavailable (no shared model configured).",
+    );
+    expect(frames[1]?.data.messageId).toBe(frames[0]?.data.messageId);
+    expect(frames[1]?.data.userMessageId).toBe(frames[0]?.data.userMessageId);
+    expect(settleCalls).toEqual([0]);
+  });
+
   test("every SSE frame carries the canonical JSON type and done carries authoritative fullText (#17122)", async () => {
     const service = new SharedRuntimeChatService();
     const response = await service.stream(agent, rpc, harness());

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -546,6 +546,31 @@ describe("SharedRuntimeChatService", () => {
     expect(settleCalls).toEqual([0.004]);
   });
 
+  test("every SSE frame carries the canonical JSON type and done carries authoritative fullText (#17122)", async () => {
+    const service = new SharedRuntimeChatService();
+    const response = await service.stream(agent, rpc, harness());
+    const frames = (await response.text())
+      .split("\n\n")
+      .filter((frame) => frame.trim().length > 0)
+      .map((frame) => {
+        const lines = frame.split("\n");
+        const event = lines.find((line) => line.startsWith("event: "))?.slice("event: ".length);
+        const data = JSON.parse(
+          lines.find((line) => line.startsWith("data: "))?.slice("data: ".length) ?? "{}",
+        ) as Record<string, unknown>;
+        return { event, data };
+      });
+    expect(frames.length).toBeGreaterThanOrEqual(2);
+    for (const frame of frames) {
+      expect(frame.event).toBeDefined();
+      expect(frame.data.type).toBe(frame.event === "chunk" ? "token" : frame.event);
+    }
+    const doneData = frames.find((frame) => frame.event === "done")?.data ?? {};
+    const fullText = doneData.fullText;
+    expect(fullText).toBe(doneData.text);
+    expect(typeof fullText === "string" && fullText.length > 0).toBe(true);
+  });
+
   test("stream error and no-parts paths conservatively settle unknown usage", async () => {
     const service = new SharedRuntimeChatService();
     streamTurn = { degraded: false };

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -756,9 +756,27 @@ export class SharedRuntimeChatService {
     if (turn.degraded) {
       detachRequestAbort();
       await billing?.settle(0);
-      return new Response(turn.reply ?? "", {
-        headers: { "Content-Type": "text/event-stream; charset=utf-8" },
-      });
+      const reply = turn.reply?.trim() ?? "";
+      if (!reply) return sseError("Shared runtime is unavailable");
+      return new Response(
+        chatSseFrame("chunk", {
+          messageId: messageIds.assistant,
+          userMessageId: messageIds.user,
+          chunk: reply,
+          text: reply,
+          fullText: reply,
+          timestamp: Date.now(),
+        }) +
+          chatSseFrame("done", {
+            messageId: messageIds.assistant,
+            userMessageId: messageIds.user,
+            text: reply,
+            fullText: reply,
+          }),
+        {
+          headers: { "Content-Type": "text/event-stream; charset=utf-8" },
+        },
+      );
     }
     if (!turn.parts) {
       detachRequestAbort();

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -29,6 +29,7 @@ import {
   recordUsageAnalytics,
 } from "../ai-billing";
 import { aiBillingRecordsService } from "../ai-billing-records";
+import { chatSseFrame } from "../chat-sse-frames";
 import type { CreditReconciliationResult, CreditReservation } from "../credits";
 import type { BridgeRequest, BridgeResponse } from "../eliza-sandbox-bridge";
 import { isInferenceAdmissionDispatchMarkError } from "../inference-admission-gate";
@@ -530,7 +531,7 @@ function settleFailedProviderWorkOffPath(
 }
 
 function sseError(message: string): Response {
-  return new Response(`event: error\ndata: ${JSON.stringify({ message })}\n\n`, {
+  return new Response(chatSseFrame("error", { message }), {
     headers: { "Content-Type": "text/event-stream; charset=utf-8" },
   });
 }
@@ -834,7 +835,14 @@ export class SharedRuntimeChatService {
               if (consumerCanceled) continue;
               controller.enqueue(
                 encoder.encode(
-                  `event: chunk\ndata: ${JSON.stringify({ messageId: messageIds.assistant, userMessageId: messageIds.user, chunk: part.text, text: part.text, fullText: streamedReply, timestamp: Date.now() })}\n\n`,
+                  chatSseFrame("chunk", {
+                    messageId: messageIds.assistant,
+                    userMessageId: messageIds.user,
+                    chunk: part.text,
+                    text: part.text,
+                    fullText: streamedReply,
+                    timestamp: Date.now(),
+                  }),
                 ),
               );
               continue;
@@ -854,7 +862,9 @@ export class SharedRuntimeChatService {
               );
               controller.enqueue(
                 encoder.encode(
-                  `event: error\ndata: ${JSON.stringify({ message: "Shared runtime stream produced an empty reply" })}\n\n`,
+                  chatSseFrame("error", {
+                    message: "Shared runtime stream produced an empty reply",
+                  }),
                 ),
               );
               continue;
@@ -875,14 +885,16 @@ export class SharedRuntimeChatService {
                   messageId: messageIds.assistant,
                   userMessageId: messageIds.user,
                   text: finalReply,
+                  fullText: finalReply,
                   actionResults: [navIntentActionResult(turn.navIntent)],
                 }
               : {
                   messageId: messageIds.assistant,
                   userMessageId: messageIds.user,
                   text: finalReply,
+                  fullText: finalReply,
                 };
-            controller.enqueue(encoder.encode(`event: done\ndata: ${JSON.stringify(done)}\n\n`));
+            controller.enqueue(encoder.encode(chatSseFrame("done", done)));
           }
           if (!finished) {
             await finalizeMessages(streamedReply, true, () =>
@@ -891,7 +903,9 @@ export class SharedRuntimeChatService {
             if (!consumerCanceled) {
               controller.enqueue(
                 encoder.encode(
-                  `event: error\ndata: ${JSON.stringify({ message: "Shared runtime stream ended without completion" })}\n\n`,
+                  chatSseFrame("error", {
+                    message: "Shared runtime stream ended without completion",
+                  }),
                 ),
               );
             }
@@ -917,9 +931,7 @@ export class SharedRuntimeChatService {
           });
           if (!consumerCanceled) {
             controller.enqueue(
-              encoder.encode(
-                `event: error\ndata: ${JSON.stringify({ message: "Shared runtime stream failed" })}\n\n`,
-              ),
+              encoder.encode(chatSseFrame("error", { message: "Shared runtime stream failed" })),
             );
           }
         } finally {

--- a/packages/cloud/test-mocks/src/control-plane/server.ts
+++ b/packages/cloud/test-mocks/src/control-plane/server.ts
@@ -1,4 +1,5 @@
 /** Builds the container control-plane mock HTTP app: route handlers over the in-memory mock store. */
+import { chatSseFrame } from "@elizaos/cloud-shared/lib/services/chat-sse-frames";
 import { type Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import {
@@ -1070,7 +1071,7 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
     };
     if (body?.jsonrpc !== "2.0" || typeof body.method !== "string") {
       return new Response(
-        `event: error\ndata: ${JSON.stringify({ message: "Invalid JSON-RPC stream request" })}\n\n`,
+        chatSseFrame("error", { message: "Invalid JSON-RPC stream request" }),
         { status: 400, headers: streamHeaders },
       );
     }

--- a/packages/ui/src/api/client-base-legacy-named-events.test.ts
+++ b/packages/ui/src/api/client-base-legacy-named-events.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Client reducer coverage for legacy named SSE chat events (#17122): producers
+ * such as the shared runtime, sandbox bridge, and control-plane fallback emit
+ * `event: chunk|done|error` frames whose JSON payload has no `type`. The
+ * client maps the SSE event name only when `type` is absent (explicit JSON
+ * type wins), completes exactly once on a named done frame, preserves its
+ * terminal metadata, and surfaces a named error frame as a structured
+ * StreamGenerationError. Deterministic fake reader, no live model.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client";
+import { StreamGenerationError } from "./client-base";
+
+type OnTokenCall = [token: string, accumulated?: string];
+
+function streamFromSse(sse: string): { client: ElizaClient } {
+  const encoder = new TextEncoder();
+  const read = vi
+    .fn()
+    .mockResolvedValueOnce({ done: false, value: encoder.encode(sse) })
+    .mockRejectedValueOnce(new Error("read after terminal event"));
+  const cancel = vi.fn(async () => {});
+  const request = vi.fn(
+    async () =>
+      ({
+        ok: true,
+        status: 200,
+        body: { getReader: () => ({ read, cancel }) },
+      }) as unknown as Response,
+  );
+  const client = new ElizaClient("http://agent.example:31337", "token");
+  client.setRequestTransport({ request });
+  return { client };
+}
+
+describe("legacy named SSE chat events", () => {
+  it("completes on an untyped named done frame without duplicating its text (shared-runtime replay)", async () => {
+    const { client } = streamFromSse(
+      'event: chunk\ndata: {"text":"Hello","fullText":"Hello"}\n\n' +
+        'event: done\ndata: {"messageId":"m1","text":"Hello"}\n\n',
+    );
+    const calls: OnTokenCall[] = [];
+    const onToken = vi.fn((token: string, accumulated?: string) => {
+      calls.push([token, accumulated]);
+    });
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/c/messages/stream",
+      "hi",
+      onToken,
+    );
+
+    expect(calls).toEqual([["Hello", "Hello"]]);
+    expect(result.text).toBe("Hello");
+    expect(result.completed).toBe(true);
+    expect(result.messageId).toBe("m1");
+  });
+
+  it("preserves actionResults and authoritative text from an untyped named done frame", async () => {
+    const { client } = streamFromSse(
+      'event: chunk\ndata: {"text":"Opening","fullText":"Opening"}\n\n' +
+        'event: done\ndata: {"messageId":"m2","text":"Opening the notes view","actionResults":[{"actionName":"VIEWS","success":true}]}\n\n',
+    );
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/c/messages/stream",
+      "open notes",
+      vi.fn(),
+    );
+
+    expect(result.completed).toBe(true);
+    expect(result.text).toBe("Opening the notes view");
+    expect(result.actionResults).toEqual([
+      { actionName: "VIEWS", success: true },
+    ]);
+  });
+
+  it("lets an explicit JSON type win over a conflicting SSE event name", async () => {
+    const { client } = streamFromSse(
+      'event: done\ndata: {"type":"token","text":"partial","fullText":"partial"}\n\n' +
+        'data: {"type":"done","fullText":"partial done","agentName":"Eliza"}\n\n',
+    );
+    const calls: OnTokenCall[] = [];
+    const onToken = vi.fn((token: string, accumulated?: string) => {
+      calls.push([token, accumulated]);
+    });
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/c/messages/stream",
+      "hi",
+      onToken,
+    );
+
+    // The mislabeled frame streams as a token; only the typed done terminates.
+    expect(calls).toEqual([["partial", "partial"]]);
+    expect(result.text).toBe("partial done");
+    expect(result.completed).toBe(true);
+  });
+
+  it("surfaces an untyped named error frame as StreamGenerationError instead of ignoring it", async () => {
+    const { client } = streamFromSse(
+      'event: error\ndata: {"message":"Sandbox is not running or unreachable"}\n\n',
+    );
+
+    let thrown: unknown;
+    try {
+      await client.streamChatEndpoint(
+        "/api/conversations/c/messages/stream",
+        "hi",
+        vi.fn(),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(StreamGenerationError);
+    expect((thrown as StreamGenerationError).message).toBe(
+      "Sandbox is not running or unreachable",
+    );
+  });
+
+  it("still classifies an untyped, unnamed frame carrying text as a token", async () => {
+    const { client } = streamFromSse(
+      'data: {"text":"Fallback reply"}\n\n' +
+        'event: done\ndata: {"text":"Fallback reply"}\n\n',
+    );
+    const calls: OnTokenCall[] = [];
+    const onToken = vi.fn((token: string, accumulated?: string) => {
+      calls.push([token, accumulated]);
+    });
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/c/messages/stream",
+      "hi",
+      onToken,
+    );
+
+    expect(calls).toEqual([["Fallback reply", "Fallback reply"]]);
+    expect(result.text).toBe("Fallback reply");
+    expect(result.completed).toBe(true);
+  });
+});

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -304,11 +304,46 @@ function findSseEventBreak(
     : { index: crlfBreak, length: 4 };
 }
 
-function parseStreamChatDataLine(line: string): StreamChatEvent | null {
+// Producers that predate the canonical JSON `type` (shared-runtime, sandbox,
+// bridge, and control-plane fallback chat) classify frames only through their
+// SSE event name. Map those names when `type` is absent so a terminal `done`
+// or `error` frame is never misread as another token (#17122). An explicit
+// JSON `type` always wins over the event name.
+const LEGACY_SSE_EVENT_TYPES: Record<string, string> = {
+  chunk: "token",
+  done: "done",
+  error: "error",
+};
+
+// Per the SSE spec the `event:` field names the whole event block regardless
+// of field order, and a later `event:` line overwrites an earlier one.
+function sseEventName(lines: readonly string[]): string | undefined {
+  let name: string | undefined;
+  for (const line of lines) {
+    if (line.startsWith("event:")) name = line.slice(6).trim() || undefined;
+  }
+  return name;
+}
+
+function parseStreamChatDataLine(
+  line: string,
+  eventName?: string,
+): StreamChatEvent | null {
   const payload = line.startsWith("data:") ? line.slice(5).trim() : "";
   if (!payload) return null;
   try {
     const parsed = JSON.parse(payload) as StreamChatEvent;
+    if (!parsed.type && eventName && LEGACY_SSE_EVENT_TYPES[eventName]) {
+      parsed.type = LEGACY_SSE_EVENT_TYPES[eventName];
+      if (
+        parsed.type === "done" &&
+        typeof parsed.fullText !== "string" &&
+        typeof parsed.text === "string"
+      ) {
+        // Legacy named done frames carried the authoritative reply in `text`.
+        parsed.fullText = parsed.text;
+      }
+    }
     if (!parsed.type && typeof parsed.text === "string") parsed.type = "token";
     return parsed;
   } catch {
@@ -411,8 +446,9 @@ function applyStreamChatDataLine(
   ) => void,
   onStatus?: (status: ChatTurnStatus) => void,
   onToolEvent?: (event: ChatToolCallEvent) => void,
+  eventName?: string,
 ): boolean {
-  const parsed = parseStreamChatDataLine(line);
+  const parsed = parseStreamChatDataLine(line, eventName);
   if (!parsed) return false;
   if (parsed.type === "token") {
     return applyStreamChatTokenEvent(parsed, state, onToken);
@@ -2195,7 +2231,9 @@ export class ElizaClient {
       while (eventBreak) {
         const rawEvent = buffer.slice(0, eventBreak.index);
         buffer = buffer.slice(eventBreak.index + eventBreak.length);
-        for (const line of rawEvent.split(/\r?\n/)) {
+        const eventLines = rawEvent.split(/\r?\n/);
+        const eventName = sseEventName(eventLines);
+        for (const line of eventLines) {
           if (!line.startsWith("data:")) continue;
           if (
             applyStreamChatDataLine(
@@ -2204,6 +2242,7 @@ export class ElizaClient {
               onToken,
               onStatus,
               onToolEvent,
+              eventName,
             )
           ) {
             buffer = "";
@@ -2221,7 +2260,9 @@ export class ElizaClient {
     }
 
     if (!streamState.receivedDone && buffer.trim()) {
-      for (const line of buffer.split(/\r?\n/)) {
+      const trailingLines = buffer.split(/\r?\n/);
+      const trailingEventName = sseEventName(trailingLines);
+      for (const line of trailingLines) {
         if (line.startsWith("data:")) {
           applyStreamChatDataLine(
             line,
@@ -2229,6 +2270,7 @@ export class ElizaClient {
             onToken,
             onStatus,
             onToolEvent,
+            trailingEventName,
           );
         }
       }


### PR DESCRIPTION
# Relates to

Closes #17122

# Summary

This fixes the shared chat SSE contract at the producer, normalizer, transport,
and client boundaries.

- `chatSseFrame()` is now the single builder for named `chunk`, `done`, and
  `error` frames. It preserves the named SSE event while stamping the canonical
  additive JSON type (`token`, `done`, or `error`).
- The UI client remains backward-compatible with legacy named frames, but an
  explicit JSON `type` always wins.
- Both sandbox normalizers now use one allowlisted terminal-payload normalizer.
  It preserves the IDs, action results, usage, account-connect, failure, and
  transcript metadata the UI actually consumes while dropping arbitrary
  upstream fields.
- The no-model degraded path now emits one canonical token and exactly one
  canonical terminal frame, or a typed error when no reply is available.
- The container-control-plane, Cloud API, and canonical scoped-stream fallbacks
  no longer hand-build untyped error frames.

The result is one authoritative terminal reply: no duplicated `HelloHello`, no
silently ignored error, and no lost terminal metadata.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact head `8e6689836fbc6ecae617e5c74419aa2bcc28f021`
      is rebased on `origin/develop` at
      `c1cf54e04d3305b2a090d6b71dfe4c3fb328597e` with zero conflicts.
- [x] The pinned Bun 1.3.14 install was refreshed after that rebase.
- [x] `git diff --check` passes.

# Risk and compatibility

Low to medium. The JSON `type` is additive and named `event:` lines remain.
Legacy named events are mapped only when JSON `type` is absent. The one intended
behavior change is that a named error now terminates the turn as a structured
stream error instead of being silently discarded.

# Testing

Run on the exact patch after the maintainer repair:

- 42 focused tests pass across the shared frame builder/runtime, both sandbox
  normalizers, canonical scoped stream, real container-control-plane HTTP
  boundary, real Cloud API handler boundary, and UI legacy reducer.
- Cloud shared, container-control-plane, Cloud API, and UI typechecks pass. The
  Cloud API check includes Wrangler's production dry-run bundle.
- `bun run build:core` passes all four targets (Node, browser, edge, testing).
- `bun run verify` passes all 350 repository checks after the final rebase and
  install refresh.
- `bun run --cwd packages/app audit:app` completed 214/215 captures with
  `broken=0`. The only failures are four pre-existing minimalism-ratchet
  baselines in builtin-browser mobile portrait/landscape, builtin-plugins mobile
  portrait, and builtin-trajectories mobile landscape. This PR changes no
  rendered source.

Reviewer starting points:

1. `packages/cloud/shared/src/lib/services/chat-sse-frames.ts`
2. `packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts`
3. `packages/cloud/shared/src/lib/services/eliza-sandbox.ts` and
   `eliza-sandbox-bridge.ts`
4. `packages/ui/src/api/client-base.ts`

# Evidence Gate

<!-- evidence-head:8e6689836fbc6ecae617e5c74419aa2bcc28f021 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - wire/protocol defect below rendered
      components; no view or styling changes`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered surface changed; the app
      audit nevertheless completed with broken=0`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - deterministic wire and HTTP-boundary tests are
      the direct proof for this transport contract`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - this is a deterministic in-process SSE framing
      contract, not a deployed backend state transition; the exact-head review
      records 42 focused tests including real container-control-plane and Cloud
      API HTTP boundary cases, plus 350/350 repository verification checks`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no rendered flow or browser network path changes;
      the five-test UI reducer suite directly replays legacy named token, done,
      and error frames and proves completion, precedence, metadata preservation,
      and structured error surfacing`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - this change classifies deterministic SSE wire
      frames and does not alter prompts, model/provider selection, planner
      behavior, or action execution; a live model cannot add coverage to the
      producer/normalizer/client framing contract exercised here`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - this transport-only change creates no DB row,
      memory, scheduled item, generated media, or other persistent artifact;
      focused tests assert the exact emitted SSE transcript including named
      event, canonical JSON type, authoritative IDs/fullText, terminal metadata
      allowlist, and arbitrary-field rejection`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface changed`.

# Known gaps / failures

None in the changed contract. The four app-audit minimalism-ratchet failures
listed above are unchanged `develop` baseline captures and no capture is marked
broken.

AI provider/model: anthropic / claude-fable-5  
Client / agent tooling: claude-code  
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza  
Attribution status: self-reported  
— [kenjohnscreates]
