### PR TITLE
fix(ci): isolate Cloudflare Pages previews by PR identity

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -1225,12 +1225,12 @@ jobs:
     # Hosted unconditionally to preserve CI/placement workload separation.
     runs-on: ubuntu-latest
     timeout-minutes: 75
-    # Schema gate (#11208): canonical deploys only run after migrate-db
-    # succeeded, so the frontend never goes live ahead of the schema its API
-    # features expect. Pull requests build artifacts above, but credentialed
-    # deployment occurs only in the trusted workflow_run consumer.
-    needs: [migrate-db, build-pages]
-    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.build-pages.result == 'success' }}
+    # Release gate (#11208/#18088): build the Pages artifacts in parallel with
+    # the API, but do not move a canonical Pages alias until both the artifact
+    # and the matching API deployment have succeeded. Pull requests publish
+    # only through the separate trusted workflow_run consumer.
+    needs: [deploy-api, build-pages]
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.deploy-api.result == 'success' && needs.build-pages.result == 'success' }}
     env:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-console
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
@@ -1672,11 +1672,11 @@ jobs:
     # Hosted unconditionally to preserve CI/placement workload separation.
     runs-on: ubuntu-latest
     timeout-minutes: 75
-    # Schema gate (#11208): same contract as deploy-console — canonical deploys
-    # require a successful migrate-db. PR artifacts are consumed only by the
-    # separate trusted preview workflow.
-    needs: [migrate-db, build-pages]
-    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.build-pages.result == 'success' }}
+    # Release gate (#11208/#18088): same contract as deploy-console. Canonical
+    # Pages aliases wait for the matching API deployment; pull-request artifacts
+    # are consumed only by the separate trusted preview workflow.
+    needs: [deploy-api, build-pages]
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.deploy-api.result == 'success' && needs.build-pages.result == 'success' }}
     env:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-app
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -1454,18 +1454,32 @@ jobs:
         id: pages
         working-directory: ${{ env.CHECKOUT_DIR }}
         env:
-          PR_HEAD_REF: ${{ github.head_ref }}
           EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARGET_ENVIRONMENT: ${{ inputs.environment }}
         run: |
+          set -euo pipefail
+
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            echo "branch=$PR_HEAD_REF" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.environment }}" = "production" ]; then
-            echo "branch=main" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "branch=develop" >> "$GITHUB_OUTPUT"
+            if ! [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+              echo "::error::Pull-request Pages branch requires a valid immutable PR number"
+              exit 1
+            fi
+            pages_branch="pr-${PR_NUMBER}"
+            case "$pages_branch" in
+              main|develop)
+                echo "::error::Pull-request Pages branch may not target canonical branch $pages_branch"
+                exit 1
+                ;;
+            esac
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$TARGET_ENVIRONMENT" = "production" ]; then
+            pages_branch="main"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            pages_branch="develop"
           else
-            echo "branch=${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
+            pages_branch="${GITHUB_REF#refs/heads/}"
           fi
+          echo "branch=$pages_branch" >> "$GITHUB_OUTPUT"
 
       - name: Check Cloudflare credentials
         id: cf
@@ -1870,18 +1884,32 @@ jobs:
         id: pages
         working-directory: ${{ env.CHECKOUT_DIR }}
         env:
-          PR_HEAD_REF: ${{ github.head_ref }}
           EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARGET_ENVIRONMENT: ${{ inputs.environment }}
         run: |
+          set -euo pipefail
+
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            echo "branch=$PR_HEAD_REF" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.environment }}" = "production" ]; then
-            echo "branch=main" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "branch=develop" >> "$GITHUB_OUTPUT"
+            if ! [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+              echo "::error::Pull-request Pages branch requires a valid immutable PR number"
+              exit 1
+            fi
+            pages_branch="pr-${PR_NUMBER}"
+            case "$pages_branch" in
+              main|develop)
+                echo "::error::Pull-request Pages branch may not target canonical branch $pages_branch"
+                exit 1
+                ;;
+            esac
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$TARGET_ENVIRONMENT" = "production" ]; then
+            pages_branch="main"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            pages_branch="develop"
           else
-            echo "branch=${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
+            pages_branch="${GITHUB_REF#refs/heads/}"
           fi
+          echo "branch=$pages_branch" >> "$GITHUB_OUTPUT"
 
       - name: Check Cloudflare credentials
         id: cf

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -16,6 +16,9 @@ name: Cloud CF Deploy
 # Per environment (both projects):
 # - push to develop  -> staging   (api-staging.elizacloud.ai; staging.* / app-staging.*)
 # - push to main     -> production (api.elizacloud.ai; elizacloud.ai / app.elizacloud.ai)
+# - pull_request     -> build isolated Pages artifacts without credentials;
+#                       `.github/workflows/cloud-cf-pr-preview-deploy.yml`
+#                       performs the trusted `pr-<number>` deployment afterward.
 #
 # Required repo secrets:
 #   CLOUDFLARE_API_TOKEN   - account-scoped token with Workers + Pages edit perms
@@ -51,6 +54,20 @@ on:
       - "packages/app-core/**"
       - "packages/ui/**"
       - ".github/workflows/cloud-cf-deploy.yml"
+      - ".github/workflows/cloud-cf-pr-preview-deploy.yml"
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "packages/cloud/api/**"
+      - "packages/cloud/shared/**"
+      - "packages/cloud/services/**"
+      - "packages/cloud/sdk/**"
+      - "packages/cloud/scripts/**"
+      - "packages/app/**"
+      - "packages/app-core/**"
+      - "packages/ui/**"
+      - ".github/workflows/cloud-cf-deploy.yml"
+      - ".github/workflows/cloud-cf-pr-preview-deploy.yml"
   workflow_dispatch:
     inputs:
       environment:
@@ -1083,6 +1100,25 @@ jobs:
       artifact_run_attempt: ${{ steps.pages-artifact.outputs.run_attempt }}
       artifact_source_sha: ${{ steps.pages-artifact.outputs.source_sha }}
     steps:
+      - name: Validate PR preview identity
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Pull-request Pages branch requires a valid immutable PR number"
+            exit 1
+          fi
+          pages_branch="pr-${PR_NUMBER}"
+          case "$pages_branch" in
+            main|develop)
+              echo "::error::Pull-request Pages branch may not target canonical branch $pages_branch"
+              exit 1
+              ;;
+          esac
+          echo "Pages artifacts are bound to trusted preview branch ${pages_branch}." >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Bind Pages artifacts to this producer attempt
@@ -1189,15 +1225,12 @@ jobs:
     # Hosted unconditionally to preserve CI/placement workload separation.
     runs-on: ubuntu-latest
     timeout-minutes: 75
-    # Schema gate (#11208): real (non-PR) deploys only run after migrate-db
+    # Schema gate (#11208): canonical deploys only run after migrate-db
     # succeeded, so the frontend never goes live ahead of the schema its API
-    # features expect. PR previews are the ONE allowed skip: migrate-db is
-    # skipped on pull_request, and previews build against the staging API
-    # without repo secrets. `!cancelled()` overrides the implicit success()
-    # so the skipped-dependency preview case can run; everything else is
-    # fail-closed (failed/cancelled migrate-db -> this job is skipped).
+    # features expect. Pull requests build artifacts above, but credentialed
+    # deployment occurs only in the trusted workflow_run consumer.
     needs: [migrate-db, build-pages]
-    if: ${{ !cancelled() && needs.build-pages.result == 'success' }}
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.build-pages.result == 'success' }}
     env:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-console
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
@@ -1495,7 +1528,6 @@ jobs:
             echo "configured=false" >> "$GITHUB_OUTPUT"
             MSG="CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID not configured. Add them at https://github.com/elizaOS/eliza/settings/secrets/actions."
             if [ "$EVENT_NAME" = "pull_request" ]; then
-              # PRs from forks legitimately lack access to repo secrets.
               echo "::warning::$MSG Skipping Pages deploy (PR event)." >> "$GITHUB_STEP_SUMMARY"
             else
               echo "::error::$MSG Refusing to silently skip Pages deploy on $EVENT_NAME event." >> "$GITHUB_STEP_SUMMARY"
@@ -1632,20 +1664,19 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-app:
     name: Deploy App (Pages · app.elizacloud.ai)
-    # Per-env (or per-PR) job concurrency so a newer main promote queues behind
-    # the in-flight prod Pages deploy instead of cancelling it (#11640); PR
-    # previews keep a per-PR group that DOES dedupe (cancel-in-progress).
+    # Per-env concurrency so a newer main promote queues behind the in-flight
+    # prod Pages deploy instead of cancelling it (#11640).
     concurrency:
       group: cloud-cf-deploy-app-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging') }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     # Hosted unconditionally to preserve CI/placement workload separation.
     runs-on: ubuntu-latest
     timeout-minutes: 75
-    # Schema gate (#11208): same contract as deploy-console — non-PR deploys
-    # require a successful migrate-db; PR previews (migrate-db skipped) still
-    # run; failed/cancelled migrate-db skips this job (fail-closed).
+    # Schema gate (#11208): same contract as deploy-console — canonical deploys
+    # require a successful migrate-db. PR artifacts are consumed only by the
+    # separate trusted preview workflow.
     needs: [migrate-db, build-pages]
-    if: ${{ !cancelled() && needs.build-pages.result == 'success' }}
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.build-pages.result == 'success' }}
     env:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-app
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}

--- a/.github/workflows/cloud-cf-pr-preview-deploy.yml
+++ b/.github/workflows/cloud-cf-pr-preview-deploy.yml
@@ -1,0 +1,139 @@
+name: Cloud CF PR Preview Deploy
+
+# Privileged consumer for the unprivileged pull_request build in
+# cloud-cf-deploy.yml. This workflow is loaded from the default branch, never
+# checks out the pull-request ref, and treats downloaded build artifacts as
+# untrusted data. It deploys static output only: PR-authored Functions and
+# Wrangler configuration never reach Cloudflare bindings. Repository secrets
+# are exposed only to the final Wrangler process after the source run and
+# immutable PR identity have been validated.
+
+on:
+  workflow_run:
+    workflows: [Cloud CF Deploy]
+    types: [completed]
+
+permissions:
+  actions: read
+
+concurrency:
+  group: cloud-cf-pr-preview-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    name: Deploy ${{ matrix.surface }} preview
+    if: >-
+      ${{
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.pull_requests[0].number > 0 &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
+        github.event.workflow_run.actor.login != 'dependabot[bot]'
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - surface: console
+            project: eliza-cloud
+          - surface: app
+            project: eliza-app
+    steps:
+      - name: Validate trusted source and resolve Pages branch
+        id: source
+        env:
+          ACTOR: ${{ github.event.workflow_run.actor.login }}
+          HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          SOURCE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          SOURCE_EVENT: ${{ github.event.workflow_run.event }}
+          SOURCE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          if [ "$SOURCE_EVENT" != "pull_request" ] || [ "$SOURCE_CONCLUSION" != "success" ]; then
+            echo "::error::Preview deployment requires a successful pull_request producer run"
+            exit 1
+          fi
+          if [ "$HEAD_REPOSITORY" != "$GITHUB_REPOSITORY" ] || [ "$ACTOR" = "dependabot[bot]" ]; then
+            echo "::error::Fork and Dependabot producer runs are not trusted for preview deployment"
+            exit 1
+          fi
+          for value in "$SOURCE_RUN_ID" "$SOURCE_RUN_ATTEMPT" "$PR_NUMBER"; do
+            if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
+              echo "::error::Preview deployment requires valid immutable run and PR identities"
+              exit 1
+            fi
+          done
+
+          pages_branch="pr-${PR_NUMBER}"
+          case "$pages_branch" in
+            main|develop)
+              echo "::error::Pull-request Pages branch may not target canonical branch $pages_branch"
+              exit 1
+              ;;
+          esac
+          echo "branch=$pages_branch" >> "$GITHUB_OUTPUT"
+          echo "artifact=pages-${{ matrix.surface }}-${SOURCE_RUN_ID}-${SOURCE_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+
+      - name: Download immutable untrusted Pages artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: ${{ steps.source.outputs.artifact }}
+          path: preview-artifact
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Stage static artifact without PR Functions or configuration
+        env:
+          ARTIFACT_DIR: ${{ github.workspace }}/preview-artifact
+          STATIC_DIR: ${{ github.workspace }}/preview-static
+        run: |
+          set -euo pipefail
+          if [ ! -d "$ARTIFACT_DIR/dist" ]; then
+            echo "::error::Pages artifact is missing dist/"
+            exit 1
+          fi
+          if find "$ARTIFACT_DIR/dist" -type l -print -quit | grep -q .; then
+            echo "::error::Pages static artifact may not contain symbolic links"
+            exit 1
+          fi
+          if find "$ARTIFACT_DIR/dist" -name _worker.js -print -quit | grep -q .; then
+            echo "::error::Pages static artifact may not contain executable _worker.js content"
+            exit 1
+          fi
+          mkdir -p "$STATIC_DIR"
+          cp -R "$ARTIFACT_DIR/dist" "$STATIC_DIR/dist"
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
+      - name: Deploy to isolated Cloudflare Pages branch
+        working-directory: preview-static
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          PAGES_BRANCH: ${{ steps.source.outputs.branch }}
+          PAGES_PROJECT: ${{ matrix.project }}
+        run: |
+          set -euo pipefail
+          if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "::error::Cloudflare Pages preview credentials are not configured"
+            exit 1
+          fi
+          for attempt in 1 2 3; do
+            if bunx wrangler@4.100.0 pages deploy ./dist --project-name="$PAGES_PROJECT" --branch="$PAGES_BRANCH"; then
+              exit 0
+            fi
+            if [ "$attempt" = "3" ]; then
+              echo "::error::Cloudflare Pages preview deploy failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "::warning::Cloudflare Pages preview deploy attempt ${attempt} failed; retrying"
+            sleep $((attempt * 20))
+          done

--- a/packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
@@ -1,9 +1,9 @@
 /**
- * Executable contract for Cloudflare Pages branch isolation in deploy workflow.
+ * Executable contract for credential-safe Cloudflare Pages PR previews.
  *
- * The harness parses both App and Console jobs, executes their embedded Bash
- * resolvers, and fault-injects a canonical PR result to keep the downstream
- * rejection reachable even though the valid derivation always uses `pr-<id>`.
+ * Pull requests build unprivileged artifacts. A default-branch workflow_run
+ * consumer validates the source, stages static output without PR-authored
+ * Functions/configuration, and deploys both surfaces to `pr-<number>`.
  */
 import { describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
@@ -13,46 +13,84 @@ import { resolveGnuBash } from "../lib/gnu-shell.mjs";
 import { spawnSync } from "../lib/spawn-sync-captured.mjs";
 
 const repoRoot = new URL("../../../", import.meta.url);
-const workflowSource = readFileSync(
+const producerSource = readFileSync(
   new URL(".github/workflows/cloud-cf-deploy.yml", repoRoot),
+  "utf8",
+);
+const consumerSource = readFileSync(
+  new URL(".github/workflows/cloud-cf-pr-preview-deploy.yml", repoRoot),
   "utf8",
 );
 
 interface WorkflowStep {
   env?: Record<string, string>;
   id?: string;
+  if?: string;
   name?: string;
   run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+  [key: string]: unknown;
 }
 
 interface WorkflowJob {
+  if?: string;
+  needs?: string | string[];
   steps?: WorkflowStep[];
+  strategy?: {
+    matrix?: {
+      include?: Array<Record<string, string>>;
+    };
+  };
+}
+
+interface WorkflowTrigger {
+  branches?: string[];
+  paths?: string[];
+  types?: string[];
+  workflows?: string[];
 }
 
 interface Workflow {
   jobs?: Record<string, WorkflowJob>;
+  on?: {
+    pull_request?: WorkflowTrigger;
+    pull_request_target?: WorkflowTrigger;
+    push?: WorkflowTrigger;
+    workflow_run?: WorkflowTrigger;
+  };
+  permissions?: Record<string, string>;
 }
 
-const workflow = Bun.YAML.parse(workflowSource) as Workflow;
+const producer = Bun.YAML.parse(producerSource) as Workflow;
+const consumer = Bun.YAML.parse(consumerSource) as Workflow;
 const deployJobs = ["deploy-console", "deploy-app"] as const;
 const GNU_BASH = resolveGnuBash();
 const executedDescribe = GNU_BASH ? describe : describe.skip;
 
-function pagesBranchStep(jobId: (typeof deployJobs)[number]): WorkflowStep {
+function namedStep(
+  workflow: Workflow,
+  jobId: string,
+  name: string,
+): WorkflowStep {
   const step = workflow.jobs?.[jobId]?.steps?.find(
-    (candidate) => candidate.name === "Resolve Pages branch",
+    (candidate) => candidate.name === name,
   );
-  if (!step?.run) {
-    throw new Error(`Missing Pages branch resolver for ${jobId}`);
+  if (!step) {
+    throw new Error(`Missing ${name} step for ${jobId}`);
   }
   return step;
 }
 
 interface ResolverInput {
-  eventName: string;
-  githubRef?: string;
+  actor?: string;
+  conclusion?: string;
+  headRepository?: string;
   prNumber?: string;
-  targetEnvironment?: string;
+  sourceEvent?: string;
+  sourceRunAttempt?: string;
+  sourceRunId?: string;
+  surface?: "app" | "console";
 }
 
 function injectCanonicalPrResult(script: string, branch: "develop" | "main") {
@@ -66,31 +104,44 @@ function injectCanonicalPrResult(script: string, branch: "develop" | "main") {
   return script.replace(derivation, `pages_branch="${branch}"`);
 }
 
-function runResolver(
-  step: WorkflowStep,
+function runTrustedResolver(
   input: ResolverInput,
   faultBranch?: "develop" | "main",
 ) {
+  const step = namedStep(
+    consumer,
+    "deploy-preview",
+    "Validate trusted source and resolve Pages branch",
+  );
   if (!GNU_BASH || !step.run) {
     throw new Error("Pages branch resolver execution requires bash >= 4");
   }
 
   const directory = mkdtempSync(join(tmpdir(), "cloud-cf-pages-branch-"));
   const outputPath = join(directory, "github-output");
+  const surface = input.surface ?? "console";
+  const expandedScript = step.run.replaceAll(
+    "$" + "{{ matrix.surface }}",
+    surface,
+  );
   const script = faultBranch
-    ? injectCanonicalPrResult(step.run, faultBranch)
-    : step.run;
+    ? injectCanonicalPrResult(expandedScript, faultBranch)
+    : expandedScript;
 
   try {
     const result = spawnSync(GNU_BASH, ["-c", script], {
       encoding: "utf8",
       env: {
         ...process.env,
-        EVENT_NAME: input.eventName,
+        ACTOR: input.actor ?? "trusted-contributor",
         GITHUB_OUTPUT: outputPath,
-        GITHUB_REF: input.githubRef ?? "refs/heads/develop",
-        PR_NUMBER: input.prNumber ?? "",
-        TARGET_ENVIRONMENT: input.targetEnvironment ?? "",
+        GITHUB_REPOSITORY: "elizaOS/eliza",
+        HEAD_REPOSITORY: input.headRepository ?? "elizaOS/eliza",
+        PR_NUMBER: input.prNumber ?? "18088",
+        SOURCE_CONCLUSION: input.conclusion ?? "success",
+        SOURCE_EVENT: input.sourceEvent ?? "pull_request",
+        SOURCE_RUN_ATTEMPT: input.sourceRunAttempt ?? "2",
+        SOURCE_RUN_ID: input.sourceRunId ?? "123456",
       },
     });
     return {
@@ -102,115 +153,149 @@ function runResolver(
   }
 }
 
-describe("Cloud CF Pages branch workflow contract", () => {
-  test("keeps App and Console on the same immutable PR identity inputs", () => {
-    const consoleStep = pagesBranchStep("deploy-console");
-    const appStep = pagesBranchStep("deploy-app");
-
-    expect(consoleStep.id).toBe("pages");
-    expect(consoleStep.env).toEqual({
-      EVENT_NAME: "$" + "{{ github.event_name }}",
-      PR_NUMBER: "$" + "{{ github.event.pull_request.number }}",
-      TARGET_ENVIRONMENT: "$" + "{{ inputs.environment }}",
+describe("Cloud CF PR preview workflow contract", () => {
+  test("subscribes the unprivileged producer to path-scoped pull requests", () => {
+    expect(producer.on?.pull_request).toEqual({
+      branches: ["main", "develop"],
+      paths: producer.on?.push?.paths,
     });
-    expect(appStep.env).toEqual(consoleStep.env);
-    expect(appStep.run).toBe(consoleStep.run);
-    expect(workflowSource).not.toContain("PR_HEAD_REF");
+    expect(producer.on?.pull_request_target).toBeUndefined();
+    expect(producer.permissions).toEqual({ contents: "read" });
+  });
+
+  test("keeps PR builds reachable while excluding every credentialed deploy job", () => {
+    const buildJob = producer.jobs?.["build-pages"];
+    expect(buildJob?.needs).toBe("migrate-db");
+    expect(buildJob?.if).toContain(
+      "github.event_name == 'pull_request' && needs.migrate-db.result == 'skipped'",
+    );
+    expect(
+      namedStep(producer, "build-pages", "Validate PR preview identity").if,
+    ).toBe("github.event_name == 'pull_request'");
+    expect(JSON.stringify(buildJob)).not.toContain("secrets.");
+
+    for (const jobId of deployJobs) {
+      const job = producer.jobs?.[jobId];
+      expect(job?.needs).toEqual(["migrate-db", "build-pages"]);
+      expect(job?.if).toBe(
+        "$" +
+          "{{ !cancelled() && github.event_name != 'pull_request' && needs.build-pages.result == 'success' }}",
+      );
+    }
+  });
+
+  test("uses a read-only trusted workflow_run consumer with strict source guards", () => {
+    expect(consumer.on).toEqual({
+      workflow_run: {
+        workflows: ["Cloud CF Deploy"],
+        types: ["completed"],
+      },
+    });
+    expect(consumer.permissions).toEqual({ actions: "read" });
+
+    const condition = consumer.jobs?.["deploy-preview"]?.if ?? "";
+    expect(condition).toContain("workflow_run.event == 'pull_request'");
+    expect(condition).toContain("workflow_run.conclusion == 'success'");
+    expect(condition).toContain("workflow_run.pull_requests[0].number > 0");
+    expect(condition).toContain(
+      "workflow_run.head_repository.full_name == github.repository",
+    );
+    expect(condition).toContain(
+      "workflow_run.actor.login != 'dependabot[bot]'",
+    );
+    expect(consumerSource).not.toContain("pull_request_target");
+  });
+
+  test("never checks out PR code or deploys its Functions/configuration", () => {
+    expect(consumerSource).not.toContain("actions/checkout");
+    const stage = namedStep(
+      consumer,
+      "deploy-preview",
+      "Stage static artifact without PR Functions or configuration",
+    );
+    expect(stage.run).toContain('cp -R "$ARTIFACT_DIR/dist"');
+    expect(stage.run).not.toMatch(/cp[^\n]*(?:functions|wrangler\.toml)/);
+    expect(stage.run).toContain('find "$ARTIFACT_DIR/dist" -type l');
+    expect(stage.run).toContain('find "$ARTIFACT_DIR/dist" -name _worker.js');
+  });
+
+  test("binds both final Wrangler deploys to the intended project and resolved branch", () => {
+    expect(
+      consumer.jobs?.["deploy-preview"]?.strategy?.matrix?.include,
+    ).toEqual([
+      { surface: "console", project: "eliza-cloud" },
+      { surface: "app", project: "eliza-app" },
+    ]);
+
+    const deploy = namedStep(
+      consumer,
+      "deploy-preview",
+      "Deploy to isolated Cloudflare Pages branch",
+    );
+    expect(deploy.env).toMatchObject({
+      PAGES_BRANCH: "$" + "{{ steps.source.outputs.branch }}",
+      PAGES_PROJECT: "$" + "{{ matrix.project }}",
+    });
+    expect(deploy.run).toContain(
+      'wrangler@4.100.0 pages deploy ./dist --project-name="$PAGES_PROJECT" --branch="$PAGES_BRANCH"',
+    );
   });
 });
 
-executedDescribe("Cloud CF Pages branch resolver", () => {
-  test("isolates ordinary and develop-to-main pull requests for both surfaces", () => {
-    const cases = [
-      { prNumber: "18088", expected: "branch=pr-18088\n" },
-      { prNumber: "18028", expected: "branch=pr-18028\n" },
-    ];
-
-    for (const jobId of deployJobs) {
-      const step = pagesBranchStep(jobId);
-      for (const input of cases) {
-        const result = runResolver(step, {
-          eventName: "pull_request",
-          githubRef: `refs/pull/${input.prNumber}/merge`,
-          prNumber: input.prNumber,
-        });
+executedDescribe("trusted Cloud CF PR preview resolver", () => {
+  test("isolates ordinary and develop-to-main PRs for both surfaces", () => {
+    for (const surface of ["console", "app"] as const) {
+      for (const prNumber of ["18088", "18028"]) {
+        const result = runTrustedResolver({ prNumber, surface });
         expect(result.status).toBe(0);
-        expect(result.output).toBe(input.expected);
+        expect(result.output).toBe(
+          `branch=pr-${prNumber}\nartifact=pages-${surface}-123456-2\n`,
+        );
         expect(result.output).not.toMatch(/branch=(?:main|develop)\n/);
       }
     }
   });
 
-  test("rejects missing and malformed pull-request identities", () => {
-    const invalidNumbers = ["", "0", "01", "-1", "1.5", "main", "1/main"];
-
-    for (const jobId of deployJobs) {
-      const step = pagesBranchStep(jobId);
-      for (const prNumber of invalidNumbers) {
-        const result = runResolver(step, {
-          eventName: "pull_request",
-          prNumber,
-        });
+  test("rejects missing or malformed immutable run and PR identities", () => {
+    const invalidValues = ["", "0", "01", "-1", "1.5", "main", "1/main"];
+    for (const invalid of invalidValues) {
+      for (const field of [
+        "prNumber",
+        "sourceRunAttempt",
+        "sourceRunId",
+      ] as const) {
+        const result = runTrustedResolver({ [field]: invalid });
         expect(result.status).toBe(1);
         expect(result.output).toBe("");
         expect(result.stdout).toContain(
-          "Pull-request Pages branch requires a valid immutable PR number",
+          "requires valid immutable run and PR identities",
         );
       }
+    }
+  });
+
+  test("rejects untrusted producer event, outcome, repository, and actor", () => {
+    const cases: ResolverInput[] = [
+      { sourceEvent: "push" },
+      { conclusion: "failure" },
+      { headRepository: "fork/example" },
+      { actor: "dependabot[bot]" },
+    ];
+    for (const input of cases) {
+      const result = runTrustedResolver(input);
+      expect(result.status).toBe(1);
+      expect(result.output).toBe("");
     }
   });
 
   test("fails closed if PR branch derivation ever yields a canonical branch", () => {
-    for (const jobId of deployJobs) {
-      const step = pagesBranchStep(jobId);
-      for (const canonicalBranch of ["main", "develop"] as const) {
-        const result = runResolver(
-          step,
-          { eventName: "pull_request", prNumber: "18088" },
-          canonicalBranch,
-        );
-        expect(result.status).toBe(1);
-        expect(result.output).toBe("");
-        expect(result.stdout).toContain(
-          `Pull-request Pages branch may not target canonical branch ${canonicalBranch}`,
-        );
-      }
-    }
-  });
-
-  test("preserves canonical push and manual-dispatch branch behavior", () => {
-    const cases: Array<{ input: ResolverInput; expected: string }> = [
-      {
-        input: { eventName: "push", githubRef: "refs/heads/develop" },
-        expected: "branch=develop\n",
-      },
-      {
-        input: { eventName: "push", githubRef: "refs/heads/main" },
-        expected: "branch=main\n",
-      },
-      {
-        input: {
-          eventName: "workflow_dispatch",
-          targetEnvironment: "staging",
-        },
-        expected: "branch=develop\n",
-      },
-      {
-        input: {
-          eventName: "workflow_dispatch",
-          targetEnvironment: "production",
-        },
-        expected: "branch=main\n",
-      },
-    ];
-
-    for (const jobId of deployJobs) {
-      const step = pagesBranchStep(jobId);
-      for (const { input, expected } of cases) {
-        const result = runResolver(step, input);
-        expect(result.status).toBe(0);
-        expect(result.output).toBe(expected);
-      }
+    for (const canonicalBranch of ["main", "develop"] as const) {
+      const result = runTrustedResolver({}, canonicalBranch);
+      expect(result.status).toBe(1);
+      expect(result.output).toBe("");
+      expect(result.stdout).toContain(
+        `Pull-request Pages branch may not target canonical branch ${canonicalBranch}`,
+      );
     }
   });
 });

--- a/packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
@@ -163,7 +163,7 @@ describe("Cloud CF PR preview workflow contract", () => {
     expect(producer.permissions).toEqual({ contents: "read" });
   });
 
-  test("keeps PR builds reachable while excluding every credentialed deploy job", () => {
+  test("keeps PR builds reachable and gates canonical Pages on the API", () => {
     const buildJob = producer.jobs?.["build-pages"];
     expect(buildJob?.needs).toBe("migrate-db");
     expect(buildJob?.if).toContain(
@@ -176,10 +176,10 @@ describe("Cloud CF PR preview workflow contract", () => {
 
     for (const jobId of deployJobs) {
       const job = producer.jobs?.[jobId];
-      expect(job?.needs).toEqual(["migrate-db", "build-pages"]);
+      expect(job?.needs).toEqual(["deploy-api", "build-pages"]);
       expect(job?.if).toBe(
         "$" +
-          "{{ !cancelled() && github.event_name != 'pull_request' && needs.build-pages.result == 'success' }}",
+          "{{ !cancelled() && github.event_name != 'pull_request' && needs.deploy-api.result == 'success' && needs.build-pages.result == 'success' }}",
       );
     }
   });

--- a/packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Executable contract for Cloudflare Pages branch isolation in deploy workflow.
+ *
+ * The harness parses both App and Console jobs, executes their embedded Bash
+ * resolvers, and fault-injects a canonical PR result to keep the downstream
+ * rejection reachable even though the valid derivation always uses `pr-<id>`.
+ */
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveGnuBash } from "../lib/gnu-shell.mjs";
+import { spawnSync } from "../lib/spawn-sync-captured.mjs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const workflowSource = readFileSync(
+  new URL(".github/workflows/cloud-cf-deploy.yml", repoRoot),
+  "utf8",
+);
+
+interface WorkflowStep {
+  env?: Record<string, string>;
+  id?: string;
+  name?: string;
+  run?: string;
+}
+
+interface WorkflowJob {
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+const workflow = Bun.YAML.parse(workflowSource) as Workflow;
+const deployJobs = ["deploy-console", "deploy-app"] as const;
+const GNU_BASH = resolveGnuBash();
+const executedDescribe = GNU_BASH ? describe : describe.skip;
+
+function pagesBranchStep(jobId: (typeof deployJobs)[number]): WorkflowStep {
+  const step = workflow.jobs?.[jobId]?.steps?.find(
+    (candidate) => candidate.name === "Resolve Pages branch",
+  );
+  if (!step?.run) {
+    throw new Error(`Missing Pages branch resolver for ${jobId}`);
+  }
+  return step;
+}
+
+interface ResolverInput {
+  eventName: string;
+  githubRef?: string;
+  prNumber?: string;
+  targetEnvironment?: string;
+}
+
+function injectCanonicalPrResult(script: string, branch: "develop" | "main") {
+  const derivation = 'pages_branch="pr-$' + '{PR_NUMBER}"';
+  const matches = script.split(derivation).length - 1;
+  if (matches !== 1) {
+    throw new Error(
+      `Expected exactly one immutable PR branch derivation, found ${matches}`,
+    );
+  }
+  return script.replace(derivation, `pages_branch="${branch}"`);
+}
+
+function runResolver(
+  step: WorkflowStep,
+  input: ResolverInput,
+  faultBranch?: "develop" | "main",
+) {
+  if (!GNU_BASH || !step.run) {
+    throw new Error("Pages branch resolver execution requires bash >= 4");
+  }
+
+  const directory = mkdtempSync(join(tmpdir(), "cloud-cf-pages-branch-"));
+  const outputPath = join(directory, "github-output");
+  const script = faultBranch
+    ? injectCanonicalPrResult(step.run, faultBranch)
+    : step.run;
+
+  try {
+    const result = spawnSync(GNU_BASH, ["-c", script], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        EVENT_NAME: input.eventName,
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_REF: input.githubRef ?? "refs/heads/develop",
+        PR_NUMBER: input.prNumber ?? "",
+        TARGET_ENVIRONMENT: input.targetEnvironment ?? "",
+      },
+    });
+    return {
+      ...result,
+      output: existsSync(outputPath) ? readFileSync(outputPath, "utf8") : "",
+    };
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+describe("Cloud CF Pages branch workflow contract", () => {
+  test("keeps App and Console on the same immutable PR identity inputs", () => {
+    const consoleStep = pagesBranchStep("deploy-console");
+    const appStep = pagesBranchStep("deploy-app");
+
+    expect(consoleStep.id).toBe("pages");
+    expect(consoleStep.env).toEqual({
+      EVENT_NAME: "$" + "{{ github.event_name }}",
+      PR_NUMBER: "$" + "{{ github.event.pull_request.number }}",
+      TARGET_ENVIRONMENT: "$" + "{{ inputs.environment }}",
+    });
+    expect(appStep.env).toEqual(consoleStep.env);
+    expect(appStep.run).toBe(consoleStep.run);
+    expect(workflowSource).not.toContain("PR_HEAD_REF");
+  });
+});
+
+executedDescribe("Cloud CF Pages branch resolver", () => {
+  test("isolates ordinary and develop-to-main pull requests for both surfaces", () => {
+    const cases = [
+      { prNumber: "18088", expected: "branch=pr-18088\n" },
+      { prNumber: "18028", expected: "branch=pr-18028\n" },
+    ];
+
+    for (const jobId of deployJobs) {
+      const step = pagesBranchStep(jobId);
+      for (const input of cases) {
+        const result = runResolver(step, {
+          eventName: "pull_request",
+          githubRef: `refs/pull/${input.prNumber}/merge`,
+          prNumber: input.prNumber,
+        });
+        expect(result.status).toBe(0);
+        expect(result.output).toBe(input.expected);
+        expect(result.output).not.toMatch(/branch=(?:main|develop)\n/);
+      }
+    }
+  });
+
+  test("rejects missing and malformed pull-request identities", () => {
+    const invalidNumbers = ["", "0", "01", "-1", "1.5", "main", "1/main"];
+
+    for (const jobId of deployJobs) {
+      const step = pagesBranchStep(jobId);
+      for (const prNumber of invalidNumbers) {
+        const result = runResolver(step, {
+          eventName: "pull_request",
+          prNumber,
+        });
+        expect(result.status).toBe(1);
+        expect(result.output).toBe("");
+        expect(result.stdout).toContain(
+          "Pull-request Pages branch requires a valid immutable PR number",
+        );
+      }
+    }
+  });
+
+  test("fails closed if PR branch derivation ever yields a canonical branch", () => {
+    for (const jobId of deployJobs) {
+      const step = pagesBranchStep(jobId);
+      for (const canonicalBranch of ["main", "develop"] as const) {
+        const result = runResolver(
+          step,
+          { eventName: "pull_request", prNumber: "18088" },
+          canonicalBranch,
+        );
+        expect(result.status).toBe(1);
+        expect(result.output).toBe("");
+        expect(result.stdout).toContain(
+          `Pull-request Pages branch may not target canonical branch ${canonicalBranch}`,
+        );
+      }
+    }
+  });
+
+  test("preserves canonical push and manual-dispatch branch behavior", () => {
+    const cases: Array<{ input: ResolverInput; expected: string }> = [
+      {
+        input: { eventName: "push", githubRef: "refs/heads/develop" },
+        expected: "branch=develop\n",
+      },
+      {
+        input: { eventName: "push", githubRef: "refs/heads/main" },
+        expected: "branch=main\n",
+      },
+      {
+        input: {
+          eventName: "workflow_dispatch",
+          targetEnvironment: "staging",
+        },
+        expected: "branch=develop\n",
+      },
+      {
+        input: {
+          eventName: "workflow_dispatch",
+          targetEnvironment: "production",
+        },
+        expected: "branch=main\n",
+      },
+    ];
+
+    for (const jobId of deployJobs) {
+      const step = pagesBranchStep(jobId);
+      for (const { input, expected } of cases) {
+        const result = runResolver(step, input);
+        expect(result.status).toBe(0);
+        expect(result.output).toBe(expected);
+      }
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

Fixes #18088.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Rebased onto `origin/develop@e26069eb35f55128261b9aaab2fbd3db32f74e27` with zero conflicts.
- [x] Full `bun install` and `bun run verify` were run after final sync.
- [x] The final destination, privilege boundary, canonical release ordering, and adversarial identities are executable contracts.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol; OpenAI/GPT-5 maintainer review repair`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza/SKILL.md`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact base: `e26069eb35f55128261b9aaab2fbd3db32f74e27`.
- [x] Exact head: `738dfb756a9c9391b0442a7572cd51b20e56a725`.
- [x] Repository verification: 350/350 tasks.

# Risks

Medium, limited to Cloudflare Pages release/preview automation. Pull requests
have read-only repository permission and build artifacts without Cloudflare
credentials. A default-branch `workflow_run` consumer accepts only successful
same-repository, non-Dependabot PR runs, never checks out PR code, and deploys
only a staged static `dist/` tree to `pr-<number>`. It rejects symlinks and
`_worker.js`, and it never copies PR-authored Functions or Wrangler configuration.
Fork and Dependabot PRs intentionally remain build-only.

Canonical Pages deploys now also wait for the matching API deployment to
succeed. The Pages artifacts can still build in parallel with the API; only the
public alias mutation is ordered. This closes both the release-PR branch
collision and the frontend-before-API skew window documented in #18088.

# Background

## What does this PR do?

- Restores the path-scoped, unprivileged `pull_request` producer.
- Keeps every secret-bearing job unreachable on a PR event.
- Adds a least-privilege default-branch `workflow_run` consumer.
- Validates event, conclusion, repository, actor, run ID, run attempt, and PR ID.
- Downloads the artifact by exact source run/attempt identity.
- Maps Console → `eliza-cloud` and App → `eliza-app`, always on `pr-<number>`.
- Fails closed on malformed identities or any canonical PR destination.
- Makes canonical Console/App deploys depend on successful `deploy-api` and the
  exact Pages artifact, so staging/production aliases cannot advance first.
- Adds parsed-workflow plus executed GNU Bash contracts for the full mapping and
  rejection paths.

## What kind of change is this?

Deployment bug fix and workflow security hardening.

# Documentation changes needed?

No separate document is needed; the trust boundary and release ordering are
documented inline beside the workflow contracts.

# Testing

## Where should a reviewer start?

Start with `packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts`,
then inspect `.github/workflows/cloud-cf-deploy.yml` and
`.github/workflows/cloud-cf-pr-preview-deploy.yml` together.

## Detailed testing steps

```bash
bun test packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
actionlint .github/workflows/cloud-cf-deploy.yml .github/workflows/cloud-cf-pr-preview-deploy.yml
bunx biome check packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
node packages/scripts/run-script-tests.mjs --inventory
bun run verify
```

# Evidence Gate

Evidence matches the exact pushed commit.
<!-- evidence-head:738dfb756a9c9391b0442a7572cd51b20e56a725 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - workflow-only routing has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - workflow-only routing has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - no interactive product flow changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs:

<details>
<summary>Exact-head workflow and repository verification</summary>

```text
$ bun test packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
9 passed; 0 failed; 116 expectations

$ actionlint .github/workflows/cloud-cf-deploy.yml .github/workflows/cloud-cf-pr-preview-deploy.yml
PASS (actionlint 1.7.12)

$ node packages/scripts/run-script-tests.mjs --inventory
125 executable tests discovered; 1 explicit exclusion; 0 orphan scripts

$ bun run verify
Tasks: 350 successful, 350 total

$ bun install
Checked 3,459 installs across 3,765 packages (no changes)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend runtime, request, response, or state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no Cloudflare resource or deployment was mutated during review; the deployment contract is validated hermetically before merge.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface changed.

# Evidence Details

## Security review

The privileged workflow uses the default-branch definition, does not check out
or execute the pull-request tree, passes no untrusted string directly into shell
source, downloads one exact-run artifact, stages only `dist/` into a clean
directory, and invokes a pinned Wrangler version with explicit project/branch.
The static tree is untrusted content, but cannot carry Pages Functions, advanced
mode `_worker.js`, symlinks, or a working-directory Wrangler config into the
credentialed process.

## Real LLM-call trajectory

N/A - deterministic CI workflow behavior only.

## Screenshots (before / after) + video walkthrough

N/A - no rendered or interactive surface changed.

## Known gaps / failures

The trusted `workflow_run` consumer is loaded from the default branch and cannot
perform a live preview deploy until this workflow has merged. The exact-head fork
run can prove the unprivileged producer build; it intentionally cannot deploy.
No Cloudflare deployment, alias, domain, secret, or resource was mutated during
review. This is a rollout constraint, not an untested code path: trigger,
privilege, artifact, mapping, and final command contracts are all parsed and the
identity resolver is executed against positive and adversarial cases.
