### PR TITLE
fix(core): honor RecursiveCharacterTextSplitter length metrics

### DIFF
--- a/packages/core/src/utils/recursive-character-text-splitter.test.ts
+++ b/packages/core/src/utils/recursive-character-text-splitter.test.ts
@@ -1,17 +1,18 @@
 /**
- * Deterministic unit coverage for {@link RecursiveCharacterTextSplitter}. The
- * splitter is pure — no clock, no I/O — so every case is an exact
- * input/output assertion.
+ * Deterministic unit and regression coverage for
+ * {@link RecursiveCharacterTextSplitter}. The harness uses exact input/output
+ * assertions and spies only on the structured warning boundary.
  *
  * The invariants worth guarding are the ones a refactor can silently break:
- * separators are consumed coarsest-first and only fall through when the current
- * one is absent; a separator is embedded in a `RegExp` when `keepSeparator` is
- * set, so one containing regex metacharacters must still split literally; no
- * chunk may exceed `chunkSize` while the text is still divisible; and merging
- * must neither drop nor duplicate content beyond the requested overlap.
+ * separators are selected coarsest-first and oversized pieces recurse through
+ * progressively finer separators; a retained separator is embedded in a
+ * `RegExp`, so metacharacters must still split literally; custom length metrics
+ * apply to separators as well as content; and merging must neither drop content
+ * nor carry more than the requested overlap.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import logger from "../logger";
 import { RecursiveCharacterTextSplitter } from "./recursive-character-text-splitter";
 
 /** Space-separated atoms, each far shorter than any chunkSize used below. */
@@ -91,7 +92,9 @@ describe("splitText", () => {
 			keepSeparator: false,
 		});
 		const text = "aaaa\n\nbbbb\n\ncccc";
-		expect(await kept.splitText(text)).toEqual(await dropped.splitText(text));
+		const expected = ["aaaa", "bbbb", "cccc"];
+		expect(await kept.splitText(text)).toEqual(expected);
+		expect(await dropped.splitText(text)).toEqual(expected);
 	});
 
 	it("falls through separators coarsest to finest", async () => {
@@ -129,7 +132,20 @@ describe("splitText", () => {
 			chunkOverlap: 0,
 			separators: ["\n\n"],
 		});
-		expect(await splitter.splitText("abcdefghijkl")).toEqual(["abcdefghijkl"]);
+		const warnSpy = vi
+			.spyOn(logger, "warn")
+			.mockImplementation(() => undefined);
+		try {
+			expect(await splitter.splitText("abcdefghijkl")).toEqual([
+				"abcdefghijkl",
+			]);
+			expect(warnSpy).toHaveBeenCalledOnce();
+			expect(warnSpy).toHaveBeenCalledWith(
+				"[RecursiveCharacterTextSplitter] Created a chunk of size 12, which is longer than the specified 5",
+			);
+		} finally {
+			warnSpy.mockRestore();
+		}
 	});
 
 	it("honours an async lengthFunction instead of raw character count", async () => {
@@ -141,6 +157,38 @@ describe("splitText", () => {
 		});
 		// Every atom counts double, so "aa bb" (10 by that measure) fills a chunk.
 		expect(await splitter.splitText("aa bb cc")).toEqual(["aa bb", "cc"]);
+	});
+
+	it("measures dropped separators with the custom length function", async () => {
+		const weightedLength = async (text: string) =>
+			Array.from(text).reduce(
+				(total, character) => total + (character === "|" ? 4 : 1),
+				0,
+			);
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 7,
+			chunkOverlap: 0,
+			separators: ["|", ""],
+			keepSeparator: false,
+			lengthFunction: weightedLength,
+		});
+
+		const chunks = await splitter.splitText("aa|bb|cc");
+		expect(chunks).toEqual(["aa", "bb", "cc"]);
+		for (const chunk of chunks) {
+			expect(await weightedLength(chunk)).toBeLessThanOrEqual(7);
+		}
+	});
+
+	it("counts dropped separators toward the requested overlap", async () => {
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 5,
+			chunkOverlap: 2,
+			separators: ["-", ""],
+			keepSeparator: false,
+		});
+
+		expect(await splitter.splitText("a-b-c-d")).toEqual(["a-b-c", "c-d"]);
 	});
 
 	describe("separators containing regex metacharacters", () => {

--- a/packages/core/src/utils/recursive-character-text-splitter.test.ts
+++ b/packages/core/src/utils/recursive-character-text-splitter.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Deterministic unit coverage for {@link RecursiveCharacterTextSplitter}. The
+ * splitter is pure — no clock, no I/O — so every case is an exact
+ * input/output assertion.
+ *
+ * The invariants worth guarding are the ones a refactor can silently break:
+ * separators are consumed coarsest-first and only fall through when the current
+ * one is absent; a separator is embedded in a `RegExp` when `keepSeparator` is
+ * set, so one containing regex metacharacters must still split literally; no
+ * chunk may exceed `chunkSize` while the text is still divisible; and merging
+ * must neither drop nor duplicate content beyond the requested overlap.
+ */
+
+import { describe, expect, it } from "vitest";
+import { RecursiveCharacterTextSplitter } from "./recursive-character-text-splitter";
+
+/** Space-separated atoms, each far shorter than any chunkSize used below. */
+const WORDS = Array.from({ length: 40 }, (_, i) => `w${i}`).join(" ");
+
+describe("constructor", () => {
+	it("rejects an overlap that is not smaller than the chunk", () => {
+		expect(
+			() =>
+				new RecursiveCharacterTextSplitter({ chunkSize: 10, chunkOverlap: 10 }),
+		).toThrow("Cannot have chunkOverlap >= chunkSize");
+		expect(
+			() =>
+				new RecursiveCharacterTextSplitter({ chunkSize: 10, chunkOverlap: 20 }),
+		).toThrow("Cannot have chunkOverlap >= chunkSize");
+	});
+
+	it("accepts an overlap smaller than the chunk", () => {
+		expect(
+			() =>
+				new RecursiveCharacterTextSplitter({ chunkSize: 10, chunkOverlap: 9 }),
+		).not.toThrow();
+	});
+});
+
+describe("splitText", () => {
+	it("returns the whole text when it already fits", async () => {
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 100,
+			chunkOverlap: 0,
+		});
+		expect(await splitter.splitText("hello world")).toEqual(["hello world"]);
+	});
+
+	it("yields nothing for input with no retainable content", async () => {
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 100,
+			chunkOverlap: 0,
+		});
+		expect(await splitter.splitText("")).toEqual([]);
+		expect(await splitter.splitText("   \n\n  ")).toEqual([]);
+	});
+
+	it("merges pieces up to chunkSize instead of emitting one per separator", async () => {
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 20,
+			chunkOverlap: 0,
+		});
+		expect(await splitter.splitText("aaaa\n\nbbbb\n\ncccc")).toEqual([
+			"aaaa\n\nbbbb\n\ncccc",
+		]);
+	});
+
+	it("splits on the paragraph separator once the merge no longer fits", async () => {
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 6,
+			chunkOverlap: 0,
+		});
+		expect(await splitter.splitText("aaaa\n\nbbbb\n\ncccc")).toEqual([
+			"aaaa",
+			"bbbb",
+			"cccc",
+		]);
+	});
+
+	it("trims the retained separator off a chunk boundary", async () => {
+		// keepSeparator splits on a lookahead, so a piece carries its leading
+		// separator; joinDocs trims the merged result, so the boundary text does
+		// not surface in the output either way.
+		const kept = new RecursiveCharacterTextSplitter({
+			chunkSize: 6,
+			chunkOverlap: 0,
+		});
+		const dropped = new RecursiveCharacterTextSplitter({
+			chunkSize: 6,
+			chunkOverlap: 0,
+			keepSeparator: false,
+		});
+		const text = "aaaa\n\nbbbb\n\ncccc";
+		expect(await kept.splitText(text)).toEqual(await dropped.splitText(text));
+	});
+
+	it("falls through separators coarsest to finest", async () => {
+		// The paragraph break wins where present; the two halves are then split on
+		// the line break rather than on spaces.
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 9,
+			chunkOverlap: 0,
+		});
+		expect(await splitter.splitText("aa bb\ncc dd\n\nee ff")).toEqual([
+			"aa bb",
+			"cc dd",
+			"ee ff",
+		]);
+	});
+
+	it("carries chunkOverlap from the end of a chunk into the next", async () => {
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 10,
+			chunkOverlap: 5,
+			separators: [" ", ""],
+		});
+		expect(await splitter.splitText("aa bb cc dd ee ff")).toEqual([
+			"aa bb cc",
+			"cc dd ee",
+			"ee ff",
+		]);
+	});
+
+	it("emits an indivisible piece whole rather than truncating it", async () => {
+		// No separator in the list matches, so the piece cannot be reduced; the
+		// splitter is documented to emit it (and warn) instead of cutting content.
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 5,
+			chunkOverlap: 0,
+			separators: ["\n\n"],
+		});
+		expect(await splitter.splitText("abcdefghijkl")).toEqual(["abcdefghijkl"]);
+	});
+
+	it("honours an async lengthFunction instead of raw character count", async () => {
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 10,
+			chunkOverlap: 0,
+			separators: [" ", ""],
+			lengthFunction: async (text) => text.length * 2,
+		});
+		// Every atom counts double, so "aa bb" (10 by that measure) fills a chunk.
+		expect(await splitter.splitText("aa bb cc")).toEqual(["aa bb", "cc"]);
+	});
+
+	describe("separators containing regex metacharacters", () => {
+		// keepSeparator embeds the separator in a lookahead RegExp, so an
+		// unescaped metacharacter would change what the pattern matches.
+		it.each([
+			["|", "aaa|bbb|ccc"],
+			[".", "aaa.bbb.ccc"],
+			["+", "aaa+bbb+ccc"],
+			["(", "aaa(bbb(ccc"],
+			["$", "aaa$bbb$ccc"],
+		])("splits literally on %j", async (separator, text) => {
+			const splitter = new RecursiveCharacterTextSplitter({
+				chunkSize: 8,
+				chunkOverlap: 0,
+				separators: [separator, ""],
+			});
+			expect(await splitter.splitText(text)).toEqual([
+				`aaa${separator}bbb`,
+				`${separator}ccc`,
+			]);
+		});
+	});
+
+	describe("invariants across chunk sizes", () => {
+		const sizes = [5, 7, 10, 13, 20, 33];
+
+		it.each(sizes)(
+			"keeps every chunk within chunkSize %i",
+			async (chunkSize) => {
+				for (const chunkOverlap of [0, Math.floor(chunkSize / 3)]) {
+					const splitter = new RecursiveCharacterTextSplitter({
+						chunkSize,
+						chunkOverlap,
+						separators: [" ", ""],
+					});
+					for (const chunk of await splitter.splitText(WORDS)) {
+						expect(chunk.length).toBeLessThanOrEqual(chunkSize);
+					}
+				}
+			},
+		);
+
+		it.each(sizes)(
+			"loses no content at chunkSize %i with no overlap",
+			async (chunkSize) => {
+				const splitter = new RecursiveCharacterTextSplitter({
+					chunkSize,
+					chunkOverlap: 0,
+					separators: [" ", ""],
+				});
+				expect((await splitter.splitText(WORDS)).join(" ")).toBe(WORDS);
+			},
+		);
+	});
+});

--- a/packages/core/src/utils/recursive-character-text-splitter.ts
+++ b/packages/core/src/utils/recursive-character-text-splitter.ts
@@ -70,10 +70,14 @@ export class RecursiveCharacterTextSplitter {
 	): Promise<string[]> {
 		const docs: string[] = [];
 		const currentDoc: string[] = [];
+		const separatorLength = await this.lengthFunction(separator);
 		let total = 0;
 		for (const d of splits) {
 			const len = await this.lengthFunction(d);
-			if (total + len + currentDoc.length * separator.length > this.chunkSize) {
+			if (
+				total + len + (currentDoc.length > 0 ? separatorLength : 0) >
+				this.chunkSize
+			) {
 				if (total > this.chunkSize) {
 					logger.warn(
 						`[RecursiveCharacterTextSplitter] Created a chunk of size ${total}, which is longer than the specified ${this.chunkSize}`,
@@ -84,19 +88,21 @@ export class RecursiveCharacterTextSplitter {
 					if (doc !== null) docs.push(doc);
 					while (
 						total > this.chunkOverlap ||
-						(total + len + currentDoc.length * separator.length >
+						(total + len + (currentDoc.length > 0 ? separatorLength : 0) >
 							this.chunkSize &&
 							total > 0)
 					) {
 						const first = currentDoc[0];
 						if (first === undefined) break;
-						total -= await this.lengthFunction(first);
+						total -=
+							(await this.lengthFunction(first)) +
+							(currentDoc.length > 1 ? separatorLength : 0);
 						currentDoc.shift();
 					}
 				}
 			}
 			currentDoc.push(d);
-			total += len;
+			total += len + (currentDoc.length > 1 ? separatorLength : 0);
 		}
 		const doc = this.joinDocs(currentDoc, separator);
 		if (doc !== null) docs.push(doc);
@@ -127,7 +133,8 @@ export class RecursiveCharacterTextSplitter {
 		const goodSplits: string[] = [];
 		const sepForMerge = this.keepSeparator ? "" : separator;
 		for (const s of splits) {
-			if ((await this.lengthFunction(s)) < this.chunkSize) {
+			const splitLength = await this.lengthFunction(s);
+			if (splitLength < this.chunkSize) {
 				goodSplits.push(s);
 			} else {
 				if (goodSplits.length) {
@@ -136,6 +143,11 @@ export class RecursiveCharacterTextSplitter {
 					goodSplits.length = 0;
 				}
 				if (!newSeparators) {
+					if (splitLength > this.chunkSize) {
+						logger.warn(
+							`[RecursiveCharacterTextSplitter] Created a chunk of size ${splitLength}, which is longer than the specified ${this.chunkSize}`,
+						);
+					}
 					finalChunks.push(s);
 				} else {
 					const otherInfo = await this._splitText(s, newSeparators);


### PR DESCRIPTION
# Relates to

No tracking issue. This began as the first focused test suite for
`RecursiveCharacterTextSplitter`; exact-head review found and repaired two
production contract defects in the same surface.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto exact base `85b0a86f6bb344f23bb1f477752cf99c68a0e590` with zero conflicts.
- [x] A full `bun install` and `bun run verify` were run after final sync.
- [x] The owning package's focused/full tests, typecheck, and all build targets pass.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5 (original contribution); OpenAI/GPT-5 (maintainer review repair)`
<!-- attribution-row:client -->
- Agent tooling: `claude-code; Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@85b0a86f6bb344f23bb1f477752cf99c68a0e590`; zero conflicts.
- [x] Exact head is `7b49a744f012e2b0585a2ab5e98765bc3ac980b5`.
- [x] `bun run verify` passes post-sync: 350/350 tasks.

# Risks

Low and localized to text chunk accounting in `@elizaos/core`. The fix changes
chunk boundaries only when a custom `lengthFunction` gives separators a weight
different from `separator.length`, or when overlap is used while separators are
dropped. These are the intended public constructor semantics. Oversized terminal
pieces remain intact and now emit the warning promised by the module contract.

# Background

## What does this PR do?

- Adds 30 deterministic tests for constructor validation, separator recursion,
  regex metacharacters, retained/dropped separators, overlap, indivisible chunks,
  custom metrics, and content preservation.
- Measures separators through the configured async `lengthFunction`, instead of
  silently mixing raw string length into a custom metric.
- Includes separator weight in merge, projection, and overlap-removal totals.
- Reports a structured warning when an indivisible terminal chunk exceeds
  `chunkSize`, while preserving the chunk rather than truncating content.

The original 28-test contribution was thoughtful, but its custom-length case did
not assign non-default weight to a separator. Exact-head review used that missing
boundary to expose the production accounting error and added regressions for both
weighted separators and dropped-separator overlap.

## What kind of change is this?

Bug fix plus regression coverage.

# Documentation changes needed?

No external documentation change is required. The implementation header and
tests now describe the actual metric and oversized-piece contracts.

# Testing

## Where should a reviewer start?

Start with
`packages/core/src/utils/recursive-character-text-splitter.test.ts`, especially
the weighted-separator and `keepSeparator: false` overlap regressions, then inspect
the accounting in `mergeSplits`.

## Detailed testing steps

```bash
bun test packages/core/src/utils/recursive-character-text-splitter.test.ts
bun run --cwd packages/core test
bun run --cwd packages/core typecheck
bun run --cwd packages/core build
bun run --cwd packages/core build:browser
bun run --cwd packages/core build:edge
bun run --cwd packages/core build:testing
bun run verify
```

# Evidence Gate

Evidence matches the exact pushed commit.
<!-- evidence-head:7b49a744f012e2b0585a2ab5e98765bc3ac980b5 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - core text splitting has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - core text splitting has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - no interactive flow changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs:

<details>
<summary>Exact-head core and repository verification transcript</summary>

```text
$ bun test packages/core/src/utils/recursive-character-text-splitter.test.ts
30 passed; 0 failed

$ bun run --cwd packages/core test
506 test files; 5,565 passed; 1 skipped; 0 failed

$ bun run --cwd packages/core typecheck
PASS

$ bun run --cwd packages/core build && bun run --cwd packages/core build:browser
Node, browser, edge, testing, and declaration builds: PASS

$ bun run verify
Tasks: 350 successful, 350 total

$ bun install
Checked 3,459 installs across 3,765 packages (no changes)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend runtime or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - the contract produces in-memory string chunks only; exact outputs are asserted by the test suite.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface changed.

# Evidence Details

## Backend + frontend logs

Exact-head verification on Bun 1.3.14 and Node 24.15.0:

```text
focused splitter suite: 30 passed, 0 failed
full @elizaos/core lane: 506 files; 5,565 passed; 1 skipped; 0 failed
@elizaos/core typecheck: PASS
@elizaos/core Node/browser/edge/testing builds and declarations: PASS
bun run verify: 350 successful, 350 total
bun install: 3,459 installs across 3,765 packages; no dependency changes
git diff --check: PASS
```

The regressions specifically prove that:

- a separator whose custom metric weight is not its UTF-16 length participates
  correctly in both chunk-size and overlap accounting;
- dropped separators do not leave stale separator weight in the overlap window;
- an indivisible oversized piece is preserved and emits the documented warning.

## Real LLM-call trajectory

N/A - this is deterministic core utility behavior.

## Screenshots (before / after) + video walkthrough

N/A - no rendered or interactive surface changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT path changed.

## Known gaps / failures

None in the changed surface. The full package lane and repository verification
are green on the exact head.
