### PR TITLE
fix(shared): promote byte sizes that round across a unit boundary

### DIFF
--- a/packages/shared/src/utils/format.test.ts
+++ b/packages/shared/src/utils/format.test.ts
@@ -39,6 +39,26 @@ describe("formatByteSize", () => {
     expect(formatByteSize(1024 ** 4)).toBe("1.0 TB");
     expect(formatByteSize(1536, { precision: 2 })).toBe("1.50 KB");
   });
+
+  it("promotes a value that rounds across a unit boundary instead of rendering an impossible magnitude", () => {
+    // 1024**2 - 1 bytes is 1023.999… KB; toFixed used to render "1024.0 KB",
+    // a magnitude the KB unit can never legitimately display.
+    expect(formatByteSize(1024 ** 2 - 1)).toBe("1.0 MB");
+    expect(formatByteSize(1024 ** 3 - 1)).toBe("1.0 GB");
+    expect(formatByteSize(1024 ** 4 - 1)).toBe("1.0 TB");
+    expect(formatByteSize(1024 ** 2 - 1, { precision: 2 })).toBe("1.00 MB");
+  });
+
+  it("keeps values that round below the boundary in their own unit", () => {
+    // 1023.94 KB rounds to "1023.9 KB" — no promotion.
+    expect(formatByteSize(Math.floor(1023.94 * 1024))).toBe("1023.9 KB");
+    // At precision 0 the KB threshold for promotion is 1023.5 KB.
+    expect(formatByteSize(1023 * 1024, { precision: 0 })).toBe("1023 KB");
+  });
+
+  it("lets TB display 1024 and above because there is no larger unit", () => {
+    expect(formatByteSize(1024 ** 5)).toBe("1024.0 TB");
+  });
 });
 
 describe("formatDurationMs", () => {

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -91,17 +91,26 @@ export function formatByteSize(
   if (bytes == null || !Number.isFinite(bytes) || bytes < 0) {
     return unknownLabel;
   }
-  if (bytes >= 1024 ** 4) {
-    return `${(bytes / 1024 ** 4).toFixed(tbPrecision)} TB`;
-  }
-  if (bytes >= 1024 ** 3) {
-    return `${(bytes / 1024 ** 3).toFixed(gbPrecision)} GB`;
-  }
-  if (bytes >= 1024 ** 2) {
-    return `${(bytes / 1024 ** 2).toFixed(mbPrecision)} MB`;
-  }
-  if (bytes >= 1024) {
-    return `${(bytes / 1024).toFixed(kbPrecision)} KB`;
+  // Largest unit first. A value just under a boundary can ROUND across it —
+  // 1024**2 - 1 bytes is 1023.999… KB, which toFixed renders as the impossible
+  // "1024.0 KB" — so when the rounded magnitude reaches 1024 the value is
+  // promoted to the next-larger unit instead (same defect class the duration
+  // formatter below guards against). TB, having no larger unit, legitimately
+  // displays magnitudes of 1024 and above.
+  const units = [
+    { size: 1024 ** 4, suffix: "TB", precision: tbPrecision },
+    { size: 1024 ** 3, suffix: "GB", precision: gbPrecision },
+    { size: 1024 ** 2, suffix: "MB", precision: mbPrecision },
+    { size: 1024, suffix: "KB", precision: kbPrecision },
+  ];
+  for (const [index, unit] of units.entries()) {
+    if (bytes < unit.size) continue;
+    const rounded = (bytes / unit.size).toFixed(unit.precision);
+    const larger = units[index - 1];
+    if (larger && Number(rounded) >= 1024) {
+      return `${(bytes / larger.size).toFixed(larger.precision)} ${larger.suffix}`;
+    }
+    return `${rounded} ${unit.suffix}`;
   }
   return `${bytes} B`;
 }


### PR DESCRIPTION
# Relates to

No tracking issue — small, self-contained correctness fix in a shared display
formatter. Third in a series with #18471 (core) and #18483 (ui): boundary and
direction defects in the display formatters, each proven by a failing test on
`develop`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop`
      (`12ad4c342`) with zero conflicts.
- [x] The full `packages/shared` test suite, package typecheck, and Biome were
      run on the exact head; see **Known gaps / failures** for the one
      unrelated environment blocker on the root gate.
- [x] A reviewer can confirm the change works without reading the code, from the
      deterministic unit tests and their before/after output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop` (`12ad4c342`); zero conflicts.
- [x] Package gates pass on the exact head: the complete `packages/shared`
      Vitest suite (121 files, 1377 tests), `bun run --cwd packages/shared
      typecheck` (exit 0, after building the `@elizaos/cloud-routing` workspace
      artifact it references), and Biome on the changed files. The root
      `bun run verify` blocker is documented in **Known gaps**.

# Risks

Low. The change is confined to one pure formatter in
`packages/shared/src/utils/format.ts` plus tests. Every non-boundary output is
byte-identical to before (the full 1377-test shared suite passes unchanged
apart from the new cases), so file lists, model catalogs, backup panels, and
other `formatByteSize` callers see no change except where the old output was
an impossible magnitude.

# Background

## What does this PR do?

`formatByteSize` picked the display unit from the raw byte count and rounded
afterwards, so a value just under a unit boundary rounded **across** it:

| input | before | after |
| --- | --- | --- |
| `1024**2 − 1` bytes (1023.999… KB) | `1024.0 KB` | `1.0 MB` |
| `1024**3 − 1` bytes | `1024.0 MB` | `1.0 GB` |
| `1024**4 − 1` bytes | `1024.0 GB` | `1.0 TB` |
| `1024**2 − 1` bytes at `precision: 2` | `1024.00 KB` | `1.00 MB` |
| `1023.94 KB` | `1023.9 KB` | `1023.9 KB` (unchanged — no promotion below the boundary) |
| `1024**5` bytes | `1024.0 TB` | `1024.0 TB` (unchanged — TB is the top unit) |

`1024.0 KB` is a magnitude the KB unit can never legitimately display. This is
the same defect class the duration formatter in the same file already guards
against (its comment: *"values just under a boundary render as nonsense like
'60s' / '60m' / '24h'"*) — the byte formatter simply lacked the guard. The unit
is now chosen with the rounding in view: when the rounded magnitude reaches
1024, the value is promoted to the next-larger unit at that unit's precision.
TB, having no larger unit, legitimately renders magnitudes of 1024 and above.
A promoted magnitude is strictly below 1 (the loop enters at the first unit the
raw value reaches), so promotion can never cascade.

## What kind of change is this?

Bug fix (non-breaking; only previously-impossible boundary output changes).

# Documentation changes needed?

None; the behavior comment is in the code.

# Testing

## Where should a reviewer start?

The new boundary cases in `packages/shared/src/utils/format.test.ts`, then the
`units` loop in `formatByteSize`
(`packages/shared/src/utils/format.ts`).

## Detailed testing steps

```bash
bun run --cwd packages/shared test src/utils/format.test.ts
bun run --cwd packages/shared test        # full suite
bun run --cwd packages/shared typecheck
```

**Against `develop` (the boundary case fails, proving the bug):**

```
 FAIL  src/utils/format.test.ts > formatByteSize > promotes a value that rounds across a unit boundary instead of rendering an impossible magnitude
AssertionError: expected '1024.0 KB' to be '1.0 MB'
      Tests  1 failed | 9 passed (10)
```

The 9 passing cases include every pre-existing assertion, confirming this fix
does not change non-boundary behavior.

**With this fix applied (exact head):**

```
 Test Files  1 passed (1)
      Tests  10 passed (10)

full package suite:
 Test Files  121 passed (121)
      Tests  1377 passed (1377)
```

`bun run --cwd packages/shared typecheck` exits 0; Biome reports no issues on
the changed files.

# Evidence Gate

<!-- evidence-head:03b316eeaee44573d39cc61435833743bfdfef9b -->

This diff changes one `.ts` utility and its `.test.ts` — a pure formatting
helper with no rendered UI, server route, model, or database surface. The
reviewer-facing proof is the deterministic unit tests above.

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - pure .ts formatter change; no rendered-UI source file in the diff`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - pure .ts formatter change; no rendered-UI source file in the diff`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-facing flow changes; the change is a pure return value consumed by existing components`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - pure function with no logging or server code path; proven by the unit tests above`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no network request or state change is involved; the deterministic vitest run in Testing is the applicable proof`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - display-only byte-size formatter; no model, provider, action, prompt, or evaluator path is touched and no text it produces reaches a model prompt`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - produces no database rows, memories, tasks, files, or on-chain output`.
<!-- evidence-row:ocr-review -->
- [ ] OCR review `N/A - no rendered visual surface changes; no .tsx/CSS/SVG file in the diff`.

# Evidence Details

## Real LLM-call trajectory

`N/A - display-only shared formatter; nothing it produces is embedded into
model prompt text`.

## Backend + frontend logs

`N/A - pure utility function; the deterministic unit tests in the Testing
section are the applicable proof`.

## Screenshots (before / after) + video walkthrough

`N/A - no rendered-UI source file changes (.ts only)`.

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change`.

## Known gaps / failures

The root `bun run verify` gate was not run to completion in this environment:
the pinned toolchain is Node `24.15.0`, this machine runs Node `25.2.1`, and a
subset of cross-platform native optional dependencies could not be fetched
locally. This is an environment limitation unrelated to the change. On the
exact head, the owning package's gates all pass: the complete
`packages/shared` Vitest suite (121 files / 1377 tests), package typecheck
(exit 0), and Biome on the changed files.

---

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [freesoldev-cc]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZSVBSWNBKEK22PNWB4AD21J","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T02:03:32.629Z","completed_at":"2026-08-12T02:09:42.381Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAlLzquoL3Gkw72mIFndBJOfLMFIypwYpDpM977u8wnLM","device_key_id":"4bc1698a54f1d212421e7c9fb7995eedfb360fe9ead936dd2c7430a78a61632d","device_signature":"ZeMHTuZqSY5UC_Q-NTKVNkExTHWqfp5KNkQEKXSlEg-TMi9Hd08QVcSQOPG0a5b09gbPh48UWlWTL6PzDorcAg"}} -->
