### PR TITLE
test(cloud): cover normalizeTokenAddress

### DIFF
--- a/packages/cloud/shared/src/lib/utils/token-address.test.ts
+++ b/packages/cloud/shared/src/lib/utils/token-address.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Deterministic unit coverage for `normalizeTokenAddress`. The function is pure,
+ * so every case is an exact input/output assertion.
+ *
+ * The behaviours worth pinning are the ones a refactor can invert without any
+ * other test noticing: an explicit EVM chain lowercases regardless of what the
+ * address looks like, an unknown or absent chain falls back to a strict
+ * 0x + 40-hex shape check, and everything else is returned byte-for-byte so a
+ * case-sensitive base58 or bech32 address is never corrupted.
+ */
+
+import { describe, expect, it } from "vitest";
+import { normalizeTokenAddress } from "./token-address";
+
+const MIXED_EVM = "0xAbCdEf0123456789AbCdEf0123456789AbCdEf01";
+const LOWER_EVM = MIXED_EVM.toLowerCase();
+/** Real-shaped Solana mint: base58, case-sensitive, cannot begin with "0". */
+const SOLANA = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+/** Cosmos bech32: lowercase payload but a case-sensitive encoding overall. */
+const BECH32 = "cosmos1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu";
+
+describe("normalizeTokenAddress", () => {
+  describe("known EVM chain", () => {
+    it.each([
+      "ethereum",
+      "base",
+      "arbitrum",
+      "optimism",
+      "polygon",
+      "avalanche",
+      "bsc",
+      "binance",
+      "zksync",
+      "zora",
+    ])("lowercases on %s", (chain) => {
+      expect(normalizeTokenAddress(MIXED_EVM, chain)).toBe(LOWER_EVM);
+    });
+
+    it("matches the chain name case-insensitively", () => {
+      expect(normalizeTokenAddress(MIXED_EVM, "Ethereum")).toBe(LOWER_EVM);
+      expect(normalizeTokenAddress(MIXED_EVM, "BASE")).toBe(LOWER_EVM);
+      // Asserted on a NON-EVM-shaped address on purpose: with an 0x address the
+      // shape fallback lowercases it anyway, so a broken chain fold would still
+      // look correct. Here the chain lookup is the only path that can lowercase.
+      expect(normalizeTokenAddress(SOLANA, "Ethereum")).toBe(SOLANA.toLowerCase());
+      expect(normalizeTokenAddress(SOLANA, "BASE")).toBe(SOLANA.toLowerCase());
+    });
+
+    it("trusts the chain label over the address shape", () => {
+      // Documented consequence of the decision tree: an explicit EVM chain
+      // lowercases whatever it is given. A caller that mislabels a base58
+      // address as EVM gets a destructively lowercased value back, so the
+      // chain argument must come from the same source as the address.
+      expect(normalizeTokenAddress(SOLANA, "ethereum")).toBe(SOLANA.toLowerCase());
+    });
+  });
+
+  describe("unknown or absent chain", () => {
+    it.each([undefined, null, "", "solana", "sui", "tron", "1", "eth-mainnet"])(
+      "falls back to the address shape for chain %p",
+      (chain) => {
+        expect(normalizeTokenAddress(MIXED_EVM, chain)).toBe(LOWER_EVM);
+      },
+    );
+
+    it("leaves case-sensitive non-EVM addresses untouched", () => {
+      expect(normalizeTokenAddress(SOLANA)).toBe(SOLANA);
+      expect(normalizeTokenAddress(SOLANA, "solana")).toBe(SOLANA);
+      expect(normalizeTokenAddress(BECH32, "cosmos")).toBe(BECH32);
+    });
+  });
+
+  describe("shape heuristic is strict", () => {
+    it.each([
+      ["too short", "0xAbCdEf"],
+      ["39 hex digits", `0x${"A".repeat(39)}`],
+      ["41 hex digits", `0x${"A".repeat(41)}`],
+      ["non-hex digit", `0x${"A".repeat(39)}Z`],
+      ["missing 0x prefix", "AbCdEf0123456789AbCdEf0123456789AbCdEf01"],
+      ["uppercase 0X prefix", MIXED_EVM.replace("0x", "0X")],
+      ["leading whitespace", ` ${MIXED_EVM}`],
+      ["trailing whitespace", `${MIXED_EVM} `],
+    ])("preserves casing for a %s value", (_label, address) => {
+      expect(normalizeTokenAddress(address)).toBe(address);
+    });
+  });
+
+  describe("invariants", () => {
+    it("is idempotent", () => {
+      for (const [address, chain] of [
+        [MIXED_EVM, "ethereum"],
+        [MIXED_EVM, undefined],
+        [SOLANA, "solana"],
+        [BECH32, undefined],
+      ] as Array<[string, string | undefined]>) {
+        const once = normalizeTokenAddress(address, chain);
+        expect(normalizeTokenAddress(once, chain)).toBe(once);
+      }
+    });
+
+    it("never changes the length or the character set beyond case", () => {
+      for (const address of [MIXED_EVM, SOLANA, BECH32]) {
+        const out = normalizeTokenAddress(address, "ethereum");
+        expect(out).toHaveLength(address.length);
+        expect(out).toBe(address.toLowerCase());
+      }
+    });
+
+    it("returns the empty string unchanged", () => {
+      expect(normalizeTokenAddress("")).toBe("");
+      expect(normalizeTokenAddress("", "ethereum")).toBe("");
+    });
+  });
+});


### PR DESCRIPTION
# Relates to

No tracking issue — `packages/cloud/shared/src/lib/utils/token-address.ts` had no test file. No behavior is changed by this PR.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused suites, typecheck, and Biome recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passes post-sync; see **Known gaps / failures**.

# Risks

Low. Test-only: one new file, no source file touched, no public surface changed.

# Background

## What does this PR do?

Adds the first test coverage for `normalizeTokenAddress`. The helper is pure, so every case is an exact input/output assertion.

It pins the branches a refactor can invert without anything else noticing:

- a **known EVM chain lowercases regardless of address shape**, and the chain name is matched case-insensitively
- an **unknown or absent chain** falls back to a strict `0x` + 40-hex check — asserted against 39/41 digits, a non-hex digit, a missing prefix, an uppercase `0X`, and surrounding whitespace
- **everything else is returned byte-for-byte**, so a case-sensitive base58 (Solana) or bech32 (Cosmos) address is never corrupted
- idempotence, length preservation, and the empty string

One behaviour is worth a reviewer's eye rather than just a test: with an explicit EVM `chain`, the address shape is not consulted at all, so a mislabelled base58 address is destructively lowercased. `address` and `chain` both arrive as user-supplied API parameters (`v1/agents/route.ts:192`, `v1/agents/by-token/route.ts:47`) with only a length check. It is self-consistent — `findByTokenAddress` filters on the same `chain`, so a mislabelled record still round-trips under the same label — so I have pinned the current behaviour rather than changed it. If the intent is that a shape mismatch should win, that is a follow-up, and the test documents which way it currently resolves.

## What kind of change is this?

Improvements — test coverage only, no production code touched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/utils/token-address.test.ts` is the whole diff. The mutation scorecard below is the argument that it is not vacuous.

## Detailed testing steps

```bash
bun install
bun test --cwd packages/cloud/shared src/lib/utils/token-address.test.ts
```

# Evidence Gate

<!-- evidence-head:3199f6c6db3d59fa40943195986e9cb5f124c30b -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only change; the diff adds one .test.ts file under packages/cloud/shared and touches no rendered surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only change; no rendered surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is a unit-test file whose full output is inline below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — full transcript inline below: both test lanes, the mutation runs proving each assertion group fails when its invariant is broken, the restored source back to green, and lint.

<details>
<summary>test lanes + mutation scorecard + lint</summary>

```text
# Evidence log — test(cloud): cover normalizeTokenAddress
# head: 3199f6c6db3d59fa40943195986e9cb5f124c30b
# node v24.15.0  bun 1.3.14

===== 1. vitest lane =====
 Test Files  1 passed (1)
      Tests  32 passed (32)

===== 2. the package's own runner (bun test) =====
 32 pass
 0 fail
 46 expect() calls
Ran 32 tests across 1 file. [59.00ms]

===== 3. mutation scorecard (source restored after each) =====
baseline (unmutated)                             Tests  32 passed (32)

M1 shape regex drops the 40-digit length bound   Tests  3 failed | 29 passed (32)
M2 shape regex becomes case-sensitive hex only   Tests  8 failed | 24 passed (32)
M3 chain lookup loses its case folding           Tests  1 failed | 31 passed (32)
M4 chain branch removed (shape heuristic only)   Tests  3 failed | 29 passed (32)
M5 shape fallback removed (chain branch only)    Tests  8 failed | 24 passed (32)
M6 normalize always lowercases                   Tests  9 failed | 23 passed (32)

restored                                         Tests  32 passed (32)
git diff --stat -> (clean)

===== 4. lint =====
Checked 1 file in 26ms. No fixes applied.
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path is exercised.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model code path changed; no production source file is modified by this PR.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - the helper returns a normalised string; every input/output pair is asserted inline in the test file and visible in the transcript above.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model path changed.`

## Backend + frontend logs

Frontend: `N/A - no frontend path exercised.` Backend: full transcript is inline on the `backend-logs` row above.

### Proof the suite is not vacuous

Each invariant was checked by mutating the source and confirming the matching assertions fail; the source was restored after every run (`git diff --stat` clean, 32/32 green again).

| # | mutation applied to `token-address.ts` | result |
| --- | --- | --- |
| M1 | shape regex drops the 40-digit length bound | **3 failed** |
| M2 | shape regex becomes case-sensitive hex only | **8 failed** |
| M3 | chain lookup loses its `.toLowerCase()` | **1 failed** |
| M4 | chain branch removed (shape heuristic only) | **3 failed** |
| M5 | shape fallback removed (chain branch only) | **8 failed** |
| M6 | `normalizeTokenAddress` always lowercases | **9 failed** |

**M3 initially survived**, and closing that is the one place this suite got better rather than just longer. The case-insensitivity assertion originally used the mixed-case `0x…` address — with the chain fold broken, `"Ethereum"` misses the set, but the shape fallback lowercases the address anyway, so the mutant still looked correct. The assertion now also runs against a base58 address, where the chain lookup is the only path that can lowercase; M3 fails immediately. Worth flagging because it is the exact shape of a test that passes for the wrong reason.

## Screenshots (before / after) + video walkthrough

`N/A - test-only change with no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, or STT path involved.`

## Known gaps / failures

- Runner: this package's `test` script is `bun test`, but the immediate siblings in `src/lib/utils/` (`agent-username.test.ts`, `app-url.test.ts`, `cors.test.ts`) import from `vitest`, so this file follows them. It passes under **both** lanes — `bun test` 32 pass / 0 fail, and the repo vitest lane 32 passed — and the transcript shows both.
- `bun run --cwd packages/cloud/shared typecheck` is clean. I did not run the full `bun run verify`; the diff is a single new test file with no production import graph change, and the focused package typecheck, both test lanes, and Biome are recorded above.
