### PR TITLE
fix(security): block loader-hijack env keys missing from BLOCKED_ENV_KEYS

### DIFF
--- a/packages/agent/src/config/blocked-env-keys.test.ts
+++ b/packages/agent/src/config/blocked-env-keys.test.ts
@@ -1,10 +1,13 @@
 /**
  * Verifies BLOCKED_ENV_KEYS is the single secret-key denylist shared by API env
  * writes and startup env collection: it must be the same Set instance the
- * plugin-discovery helpers use, cover the canonical secret keys, and make
- * collectConfigEnvVars drop those keys while passing safe ones through.
+ * plugin-discovery helpers use, cover the canonical secret keys, make
+ * collectConfigEnvVars drop those keys while passing safe ones through, and
+ * remain a superset of core's BLOCKED_SPAWN_ENV_KEYS so the config/API write
+ * path cannot drift behind the spawn-side denylist it mirrors.
  * Deterministic, no live services.
  */
+import { BLOCKED_SPAWN_ENV_KEYS } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { BLOCKED_ENV_KEYS } from "./blocked-env-keys";
 import { collectConfigEnvVars } from "./env-vars";
@@ -39,5 +42,38 @@ describe("BLOCKED_ENV_KEYS", () => {
       SAFE_PUBLIC_FLAG: "enabled",
       SAFE_DIRECT_VALUE: "direct",
     });
+  });
+
+  it("keeps the code-injection category a superset of core's spawn-side denylist", () => {
+    for (const key of BLOCKED_SPAWN_ENV_KEYS) {
+      expect(BLOCKED_ENV_KEYS.has(key)).toBe(true);
+    }
+  });
+
+  it("blocks the loader-hijack keys the spawn denylist already blocks", () => {
+    for (const key of [
+      "LD_AUDIT",
+      "DYLD_FRAMEWORK_PATH",
+      "PYTHONPATH",
+      "PYTHONSTARTUP",
+      "PYTHONHOME",
+      "PERL5OPT",
+      "PERL5LIB",
+      "RUBYOPT",
+      "RUBYLIB",
+    ]) {
+      expect(BLOCKED_ENV_KEYS.has(key)).toBe(true);
+    }
+  });
+
+  it("does not block ordinary keys that merely resemble a blocked name", () => {
+    for (const key of [
+      "NODE_ENV",
+      "PYTHON_VERSION",
+      "LD_FLAGS",
+      "RUBY_VERSION",
+    ]) {
+      expect(BLOCKED_ENV_KEYS.has(key)).toBe(false);
+    }
   });
 });

--- a/packages/agent/src/config/blocked-env-keys.ts
+++ b/packages/agent/src/config/blocked-env-keys.ts
@@ -9,12 +9,31 @@
  * - Privilege escalation and step-up tokens
  * - Wallet/steward/private trading secrets
  * - Database connection strings
+ *
+ * The code-injection category must remain a superset of core's
+ * `BLOCKED_SPAWN_ENV_KEYS`: that list guards a caller-supplied child
+ * environment, this one guards writes that land in `process.env` and are
+ * inherited by every child spawned without an explicit env override.
  */
 export const BLOCKED_ENV_KEYS = new Set([
   "LD_PRELOAD",
   "LD_LIBRARY_PATH",
+  // ld.so audit hook: loads an arbitrary shared object into every spawned
+  // dynamically linked binary — same code-injection primitive as LD_PRELOAD.
+  "LD_AUDIT",
   "DYLD_INSERT_LIBRARIES",
   "DYLD_LIBRARY_PATH",
+  "DYLD_FRAMEWORK_PATH",
+  // Interpreter hijack vars (same class as NODE_OPTIONS/NODE_PATH below):
+  // attacker-controlled module paths / auto-run options for spawned
+  // python/perl/ruby processes. All are on sudo's default env_delete list.
+  "PYTHONPATH",
+  "PYTHONSTARTUP",
+  "PYTHONHOME",
+  "PERL5OPT",
+  "PERL5LIB",
+  "RUBYOPT",
+  "RUBYLIB",
   "NODE_OPTIONS",
   "NODE_EXTRA_CA_CERTS",
   "NODE_TLS_REJECT_UNAUTHORIZED",


### PR DESCRIPTION
## Summary

`BLOCKED_ENV_KEYS` (`packages/agent/src/config/blocked-env-keys.ts`) guards config/API environment writes that land in `process.env` and are inherited by every spawned child that doesn't get an explicit env override. Its code-injection category was a strict subset of core's `BLOCKED_SPAWN_ENV_KEYS` (`packages/core/src/security/spawn-env-policy.ts`): it blocked `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` but not the equivalent `LD_AUDIT`/`DYLD_FRAMEWORK_PATH` primitives, and had no Python/Perl/Ruby interpreter-hijack coverage at all.

- Adds the 9 missing keys: `LD_AUDIT`, `DYLD_FRAMEWORK_PATH`, `PYTHONPATH`, `PYTHONSTARTUP`, `PYTHONHOME`, `PERL5OPT`, `PERL5LIB`, `RUBYOPT`, `RUBYLIB` — listed literally (not spread from core) per the module-init capture constraint `mcp-server-config.ts` already documents.
- Records the superset invariant in the file header.
- Adds a regression test asserting `BLOCKED_ENV_KEYS` remains a superset of core's `BLOCKED_SPAWN_ENV_KEYS`, plus positive assertions for the 9 new keys and negative assertions for look-alike-but-safe keys (`NODE_ENV`, `PYTHON_VERSION`, `LD_FLAGS`, `RUBY_VERSION`).

Fixes #18423

## Test plan

- [x] `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/config/` — 19/19 pass
- [x] `bunx vitest run --config packages/core/vitest.config.ts packages/core/src/security/spawn-env-policy.test.ts` — 13/13 pass
- [x] `bun run --cwd packages/agent lint:check` — clean
- [x] `bun run --cwd packages/agent typecheck` — same pre-existing baseline failures with or without this change (confirmed via `git stash` diff); unrelated to this fix (missing `@elizaos/cloud-routing` package and unbuilt plugin subpath exports)

## Out of scope (flagged for follow-up, not part of #18423's acceptance criteria)

- `packages/docs/security.md` documents an older/shorter version of this key list and is now slightly stale.
- Two independent, copy-pasted denylists have the same gap and aren't wired to either canonical list: `packages/agent/src/api/config-env.ts` (`BLOCKED_CONFIG_ENV_KEYS`) and `plugins/plugin-elizacloud/src/lib/config-env.ts` (`BLOCKED_CONFIG_ENV_KEYS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)