### PR TITLE
fix(cloud): refuse placement onto a node that cannot hold the memory ceiling

### DIFF
--- a/packages/cloud/shared/.env.example
+++ b/packages/cloud/shared/.env.example
@@ -359,7 +359,11 @@ CONTAINERS_SSH_KEY=
 HCLOUD_TOKEN=
 CONTAINERS_AUTOSCALE_PUBLIC_SSH_KEY=
 CONTAINERS_HCLOUD_LOCATION=fsn1
-CONTAINERS_HCLOUD_SERVER_TYPE=cpx32
+# Must hold CONTAINERS_AUTOSCALE_NODE_CAPACITY x CONTAINERS_AGENT_MEMORY_LIMIT_MB
+# plus host overhead. ccx33 is 32 GB, which fits the default 8 slots x 3072 MiB;
+# an 8 GB type here would license 24 GiB of ceilings and the kernel OOM-kills
+# booting agents on a node the control plane still reports as healthy.
+CONTAINERS_HCLOUD_SERVER_TYPE=ccx33
 
 # Optional bootstrap callback used by newly autoscaled nodes to self-register
 # in docker_nodes after cloud-init finishes.

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-memory-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-memory-admission.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Memory admission tests for node placement.
+ *
+ * The outage these pin, measured on staging 2026-08-12: node
+ * `eliza-core-40661ddb` (7745 MiB of RAM, `capacity=4`) already carried two
+ * agents at a 3072 MiB ceiling each. Placement is pure slot arithmetic, so
+ * `4 - 2 = 2 > 0` selected it; `docker create` then committed a third 3072 MiB
+ * ceiling on a 7.6 GiB box. The booting agent asked for ~2090 MiB, the kernel
+ * fired a GLOBAL OOM (`constraint=CONSTRAINT_NONE`), and `unless-stopped`
+ * relaunched it every ~29s — `RestartCount=58`, 21 `Out of memory: Killed`,
+ * while `docker inspect` still reported `OOMKilled=false` because Docker only
+ * sets that flag for a cgroup-limit kill.
+ *
+ * These tests drive the REAL manager with a stubbed SSH client + repository.
+ * The fixtures are the measured numbers, so a future tweak to the reserve or
+ * the predicate has to keep refusing the node that actually fell over — and
+ * keep admitting the 251 GiB robot that carried 16 agents with zero kills.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as realDockerNodesNs from "../../db/repositories/docker-nodes";
+import type { DockerNode } from "../../db/schemas/docker-nodes";
+import * as realLoggerNs from "../utils/logger";
+import * as realDockerNodeWorkloadsNs from "./docker-node-workloads";
+import * as realDockerSshNs from "./docker-ssh";
+
+const realDockerNodes = { ...realDockerNodesNs };
+const realDockerNodeWorkloads = { ...realDockerNodeWorkloadsNs };
+const realDockerSsh = { ...realDockerSshNs };
+const realLogger = { ...realLoggerNs };
+
+let enabledNodes: DockerNode[] = [];
+let probeOutputByHost: Record<string, string> = {};
+const execCommands: string[] = [];
+const warnings: Array<{ message: string; context?: unknown }> = [];
+
+mock.module("../utils/logger", () => ({
+  ...realLogger,
+  logger: {
+    info: () => {},
+    debug: () => {},
+    error: () => {},
+    warn: (message: string, context?: unknown) => {
+      warnings.push({ message, context });
+    },
+  },
+}));
+
+mock.module("../../db/repositories/docker-nodes", () => ({
+  dockerNodesRepository: {
+    findEnabled: () => Promise.resolve(enabledNodes),
+    updateStatus: () => Promise.resolve(),
+    setHostKeyFingerprint: () => Promise.resolve(),
+  },
+}));
+
+mock.module("./docker-node-workloads", () => ({
+  countAllocatedWorkloadsOnNode: () => Promise.resolve(0),
+}));
+
+mock.module("./docker-ssh", () => ({
+  DockerSSHClient: {
+    // Positional signature, mirroring `sshClientForNode`:
+    // getClient(hostname, sshPort, hostKeyFingerprint, sshUser, onFingerprint).
+    getClient: (hostname: string) => ({
+      connect: () => Promise.resolve(),
+      exec: (command: string) => {
+        execCommands.push(command);
+        return Promise.resolve(probeOutputByHost[hostname] ?? "");
+      },
+    }),
+  },
+}));
+
+afterAll(() => {
+  mock.module("../../db/repositories/docker-nodes", () => realDockerNodes);
+  mock.module("./docker-node-workloads", () => realDockerNodeWorkloads);
+  mock.module("./docker-ssh", () => realDockerSsh);
+  mock.module("../utils/logger", () => realLogger);
+});
+
+import {
+  admitsRequiredMemory,
+  DockerNodeManager,
+  parseNodeMemorySnapshot,
+  readProbeSection,
+} from "./docker-node-manager";
+
+function node(nodeId: string, hostname: string): DockerNode {
+  return {
+    id: `${nodeId}-uuid`,
+    node_id: nodeId,
+    hostname,
+    ssh_port: 22,
+    capacity: 4,
+    enabled: true,
+    status: "healthy",
+    allocated_count: 0,
+    last_health_check: null,
+    ssh_user: "root",
+    host_key_fingerprint: "SHA256:test",
+    metadata: {},
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    updated_at: new Date("2026-01-01T00:00:00.000Z"),
+  };
+}
+
+/** A node that is alive and not IO-starved, so only memory can refuse it. */
+const HEALTHY_PSI = [
+  "some avg10=1.02 avg60=0.98 avg300=1.11 total=499893023295",
+  "full avg10=0.87 avg60=0.79 avg300=0.81 total=457451749125",
+].join("\n");
+
+function meminfo(totalMib: number, availableMib: number): string {
+  return [
+    `MemTotal:       ${totalMib * 1024} kB`,
+    `MemFree:         ${Math.floor((availableMib * 1024) / 2)} kB`,
+    `MemAvailable:   ${availableMib * 1024} kB`,
+    "Buffers:           81920 kB",
+  ].join("\n");
+}
+
+/** `docker inspect -f '{{.HostConfig.Memory}}'` output: one byte count per line. */
+function ceilings(...mib: number[]): string {
+  return mib.map((value) => String(value * 1024 * 1024)).join("\n");
+}
+
+function probe(opts: { meminfo: string; ceilings: string; psi?: string }): string {
+  return [
+    "GH4Y:2NWO:testdockerid|x86_64",
+    "---IO-PRESSURE---",
+    opts.psi ?? HEALTHY_PSI,
+    "---MEMINFO---",
+    opts.meminfo,
+    "---MEM-COMMITTED---",
+    opts.ceilings,
+  ].join("\n");
+}
+
+/** eliza-core-40661ddb / 2.28.17.235 at the moment it accepted the third agent. */
+const STARVED_NODE_PROBE = probe({
+  meminfo: meminfo(7745, 2058),
+  ceilings: ceilings(3072, 3072),
+});
+
+/** 16 resident agents, each at the default 3072 MiB ceiling. */
+const ROBOT_CEILINGS = ceilings(...Array.from({ length: 16 }, () => 3072));
+
+/** eliza-staging-robot-1 / 88.99.66.168: 16 agents resident, zero OOM kills. */
+const ROBOT_NODE_PROBE = probe({
+  meminfo: meminfo(257626, 205913),
+  ceilings: ROBOT_CEILINGS,
+});
+
+beforeEach(() => {
+  enabledNodes = [];
+  probeOutputByHost = {};
+  execCommands.length = 0;
+  warnings.length = 0;
+});
+
+describe("readProbeSection", () => {
+  test("addresses sections by name, not by position", () => {
+    const output = probe({
+      meminfo: meminfo(7745, 2058),
+      ceilings: ceilings(3072),
+    });
+    expect(readProbeSection(output, null).trim()).toBe("GH4Y:2NWO:testdockerid|x86_64");
+    expect(readProbeSection(output, "---MEMINFO---")).toContain("MemTotal:       7930880 kB");
+    expect(readProbeSection(output, "---MEM-COMMITTED---").trim()).toBe("3221225472");
+  });
+
+  test("returns empty for a section the probe did not emit", () => {
+    const linesOnly = "GH4Y:2NWO:testdockerid|x86_64";
+    expect(readProbeSection(linesOnly, "---MEMINFO---")).toBe("");
+    expect(readProbeSection(linesOnly, null)).toBe(linesOnly);
+  });
+});
+
+describe("parseNodeMemorySnapshot", () => {
+  test("converts the measured node's meminfo and ceilings to MiB", () => {
+    const snapshot = parseNodeMemorySnapshot(meminfo(7745, 2058), ceilings(3072, 3072));
+    expect(snapshot).toEqual({
+      memTotalMb: 7745,
+      memAvailableMb: 2058,
+      declaredCeilingMb: 6144,
+    });
+  });
+
+  test("treats an unbounded container as declaring nothing", () => {
+    const snapshot = parseNodeMemorySnapshot(meminfo(7745, 4398), "0\n0");
+    expect(snapshot?.declaredCeilingMb).toBe(0);
+  });
+
+  test("returns null when the signal is absent or unreadable", () => {
+    expect(parseNodeMemorySnapshot("", "")).toBeNull();
+    expect(parseNodeMemorySnapshot("MemTotal:       7930880 kB", "")).toBeNull();
+    expect(parseNodeMemorySnapshot("nonsense", "3221225472")).toBeNull();
+  });
+});
+
+describe("admitsRequiredMemory", () => {
+  test("refuses the placement that actually OOM-killed the fleet", () => {
+    const snapshot = parseNodeMemorySnapshot(meminfo(7745, 2058), ceilings(3072, 3072));
+    const verdict = admitsRequiredMemory(snapshot!, 3072);
+    expect(verdict.admitted).toBe(false);
+    // 2 x 3072 committed + 3072 requested = 9216 against a 7745 - 1024 budget.
+    expect(verdict.effectiveCommittedMb).toBe(6144);
+    expect(verdict.budgetMb).toBe(6721);
+  });
+
+  test("admits the 251 GiB robot that carried 16 agents with zero kills", () => {
+    const snapshot = parseNodeMemorySnapshot(meminfo(257626, 205913), ROBOT_CEILINGS);
+    expect(admitsRequiredMemory(snapshot!, 3072).admitted).toBe(true);
+  });
+
+  test("free memory alone would NOT have refused it — committed ceilings do", () => {
+    // At selection time the node still had ~4.1 GiB free, which is why a
+    // MemAvailable probe passes and the kernel kills seconds later. Same node,
+    // same commitments, only the instantaneous free memory differs.
+    const atSelection = parseNodeMemorySnapshot(meminfo(7745, 4198), ceilings(3072, 3072));
+    expect(atSelection!.memAvailableMb).toBeGreaterThan(3072);
+    expect(admitsRequiredMemory(atSelection!, 3072).admitted).toBe(false);
+  });
+
+  test("counts unbounded containers through used memory rather than free", () => {
+    // Declares nothing, but occupies 7745 - 1000 = 6745 MiB.
+    const crowded = parseNodeMemorySnapshot(meminfo(7745, 1000), "0\n0");
+    expect(crowded!.declaredCeilingMb).toBe(0);
+    const verdict = admitsRequiredMemory(crowded!, 3072);
+    expect(verdict.effectiveCommittedMb).toBe(6745);
+    expect(verdict.admitted).toBe(false);
+  });
+
+  test("admits a node whose unbounded containers leave real room", () => {
+    const roomy = parseNodeMemorySnapshot(meminfo(7745, 4398), "0\n0");
+    expect(admitsRequiredMemory(roomy!, 3072).admitted).toBe(true);
+  });
+
+  test("admits exactly at the budget and refuses one MiB past it", () => {
+    const snapshot = parseNodeMemorySnapshot(meminfo(7745, 7745), ceilings(3649));
+    expect(admitsRequiredMemory(snapshot!, 3072).admitted).toBe(true);
+    const overBy1 = parseNodeMemorySnapshot(meminfo(7745, 7745), `${(3650 * 1024 + 1) * 1024}`);
+    expect(admitsRequiredMemory(overBy1!, 3072).admitted).toBe(false);
+  });
+});
+
+describe("ensureNodeReady memory gate", () => {
+  test("refuses the starved node for placement", async () => {
+    const target = node("eliza-core-40661ddb", "2.28.17.235");
+    probeOutputByHost["2.28.17.235"] = STARVED_NODE_PROBE;
+
+    const ready = await new DockerNodeManager().ensureNodeReady(target, {
+      enforcePlacementIoPressure: true,
+      requiredMemoryMb: 3072,
+    });
+
+    expect(ready).toBe(false);
+  });
+
+  test("admits the robot for the same request", async () => {
+    const target = node("eliza-staging-robot-1", "88.99.66.168");
+    probeOutputByHost["88.99.66.168"] = ROBOT_NODE_PROBE;
+
+    const ready = await new DockerNodeManager().ensureNodeReady(target, {
+      enforcePlacementIoPressure: true,
+      requiredMemoryMb: 3072,
+    });
+
+    expect(ready).toBe(true);
+  });
+
+  test("does not probe memory when the caller states no requirement", async () => {
+    const target = node("eliza-core-40661ddb", "2.28.17.235");
+    probeOutputByHost["2.28.17.235"] = STARVED_NODE_PROBE;
+
+    const ready = await new DockerNodeManager().ensureNodeReady(target, {
+      enforcePlacementIoPressure: true,
+    });
+
+    // Liveness-only callers (sticky routing, autoscaler bootstrap) must keep
+    // their old verdict, and must not pay for the extra commands.
+    expect(ready).toBe(true);
+    expect(execCommands.join("\n")).not.toContain("/proc/meminfo");
+  });
+
+  test("does not block when the node cannot report its memory, but says so", async () => {
+    const target = node("eliza-core-40661ddb", "2.28.17.235");
+    probeOutputByHost["2.28.17.235"] = probe({ meminfo: "", ceilings: "" });
+
+    const ready = await new DockerNodeManager().ensureNodeReady(target, {
+      enforcePlacementIoPressure: true,
+      requiredMemoryMb: 3072,
+    });
+
+    expect(ready).toBe(true);
+    // Admitting is deliberate, silence is not: this is the one branch that
+    // restores pre-gate behaviour, so a probe regression that turns the gate
+    // into a permanent no-op has to be visible in the logs and here.
+    const skipped = warnings.find((entry) => entry.message.includes("Memory admission skipped"));
+    expect(skipped).toBeDefined();
+    expect(skipped?.context).toMatchObject({
+      nodeId: "eliza-core-40661ddb",
+      requiredMemoryMb: 3072,
+    });
+  });
+
+  test("does not warn about a skip when the gate actually ran", async () => {
+    const target = node("eliza-staging-robot-1", "88.99.66.168");
+    probeOutputByHost["88.99.66.168"] = ROBOT_NODE_PROBE;
+
+    await new DockerNodeManager().ensureNodeReady(target, {
+      enforcePlacementIoPressure: true,
+      requiredMemoryMb: 3072,
+    });
+
+    expect(
+      warnings.filter((entry) => entry.message.includes("Memory admission skipped")),
+    ).toHaveLength(0);
+  });
+});
+
+describe("getAvailableNode", () => {
+  test("skips the starved node and selects one that can hold the ceiling", async () => {
+    const starved = node("eliza-core-40661ddb", "2.28.17.235");
+    const robot = node("eliza-staging-robot-1", "88.99.66.168");
+    enabledNodes = [starved, robot];
+    probeOutputByHost["2.28.17.235"] = STARVED_NODE_PROBE;
+    probeOutputByHost["88.99.66.168"] = ROBOT_NODE_PROBE;
+
+    const selected = await new DockerNodeManager().getAvailableNode({
+      requiredMemoryMb: 3072,
+    });
+
+    expect(selected?.node_id).toBe("eliza-staging-robot-1");
+  });
+
+  test("returns null when every node is oversubscribed", async () => {
+    enabledNodes = [
+      node("eliza-core-40661ddb", "2.28.17.235"),
+      node("eliza-core-600f3d86", "162.55.170.116"),
+    ];
+    probeOutputByHost["2.28.17.235"] = STARVED_NODE_PROBE;
+    // 4 x 3072 of ceilings on 7745 MiB, 466 MiB free: the fullest node measured.
+    probeOutputByHost["162.55.170.116"] = probe({
+      meminfo: meminfo(7745, 466),
+      ceilings: ceilings(3072, 3072, 3072, 3072),
+    });
+
+    // Null is the contract: the caller falls through to autoscaling a node
+    // rather than stacking another ceiling onto a box that cannot hold it.
+    expect(
+      await new DockerNodeManager().getAvailableNode({
+        requiredMemoryMb: 3072,
+      }),
+    ).toBeNull();
+  });
+
+  test("still selects the starved node when no ceiling is requested", async () => {
+    enabledNodes = [node("eliza-core-40661ddb", "2.28.17.235")];
+    probeOutputByHost["2.28.17.235"] = STARVED_NODE_PROBE;
+
+    const selected = await new DockerNodeManager().getAvailableNode({});
+
+    expect(selected?.node_id).toBe("eliza-core-40661ddb");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -213,6 +213,116 @@ export function parseIoPressureFullAvg60(section: string): number | null {
   return Number.isFinite(value) ? value : null;
 }
 
+/**
+ * Memory the host keeps outside every agent ceiling: dockerd, tailscaled, the
+ * page cache, and the embedding sidecar — which is launched with no `--memory`
+ * of its own, so its footprint has to be absorbed here or the reserve is
+ * fiction.
+ */
+const HOST_RESERVE_MB = 1024;
+
+/** Separates the meminfo and committed-ceiling sections in the readiness probe. */
+const READINESS_PROBE_MEMINFO_MARKER = "---MEMINFO---";
+const READINESS_PROBE_COMMITTED_MARKER = "---MEM-COMMITTED---";
+
+/**
+ * Slice one section out of the readiness probe's concatenated output.
+ *
+ * `marker === null` returns everything before the first marker, i.e. the
+ * `docker info` reply. Sections are addressed by name rather than by position
+ * so a probe that omits one (a caller that skips the memory gate) cannot shift
+ * the meaning of the others.
+ */
+export function readProbeSection(output: string, marker: string | null): string {
+  const anyMarker = /---[A-Z-]+---/;
+  if (marker === null) {
+    const first = output.search(anyMarker);
+    return first === -1 ? output : output.slice(0, first);
+  }
+  const start = output.indexOf(marker);
+  if (start === -1) return "";
+  const rest = output.slice(start + marker.length);
+  const next = rest.search(anyMarker);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+export interface NodeMemorySnapshot {
+  memTotalMb: number;
+  memAvailableMb: number;
+  /** Sum of the explicit `--memory` ceilings of the containers resident on the node. */
+  declaredCeilingMb: number;
+}
+
+/**
+ * Read the node's memory facts out of the readiness probe.
+ *
+ * Returns null when the signal is absent or unparseable. Absence must not block
+ * placement — the same policy the IO-pressure gate follows — so a node whose
+ * kernel or Docker output we cannot read stays eligible rather than freezing
+ * the fleet.
+ */
+export function parseNodeMemorySnapshot(
+  meminfoSection: string,
+  committedSection: string,
+): NodeMemorySnapshot | null {
+  const total = meminfoSection.match(/^MemTotal:\s+(\d+)\s+kB/m);
+  const availableMatch = meminfoSection.match(/^MemAvailable:\s+(\d+)\s+kB/m);
+  if (!total || !availableMatch) return null;
+
+  const memTotalMb = Math.floor(Number.parseInt(total[1]!, 10) / 1024);
+  const memAvailableMb = Math.floor(Number.parseInt(availableMatch[1]!, 10) / 1024);
+  if (!Number.isFinite(memTotalMb) || !Number.isFinite(memAvailableMb) || memTotalMb <= 0) {
+    return null;
+  }
+
+  // `docker inspect -f '{{.HostConfig.Memory}}'` prints one byte count per
+  // container; 0 means that container runs unbounded and contributes nothing
+  // measurable here. Unbounded containers are recovered through used memory in
+  // `admitsRequiredMemory`, so they are not silently free.
+  let declaredCeilingMb = 0;
+  for (const line of committedSection.split("\n")) {
+    const trimmed = line.trim();
+    if (!/^\d+$/.test(trimmed)) continue;
+    declaredCeilingMb += Math.floor(Number.parseInt(trimmed, 10) / (1024 * 1024));
+  }
+
+  return { memTotalMb, memAvailableMb, declaredCeilingMb };
+}
+
+export interface MemoryAdmissionVerdict {
+  admitted: boolean;
+  /** The larger of the declared ceilings and what the node is actually using. */
+  effectiveCommittedMb: number;
+  /** Memory the node may commit in total, i.e. `memTotalMb - HOST_RESERVE_MB`. */
+  budgetMb: number;
+}
+
+/**
+ * Decide whether a node can take one more container of `requiredMemoryMb`.
+ *
+ * The gate is the sum of *committed ceilings*, not free memory. Free memory
+ * only collapses once the new agent is already allocating, so a MemAvailable
+ * check passes at the moment of the decision and the kernel OOM-kills seconds
+ * later — which is exactly how a 7745 MiB node accepted a third 3072 MiB
+ * ceiling and then killed the booting agent every ~29s.
+ *
+ * Used memory is taken as a floor for the commitment because a container
+ * launched without a ceiling declares nothing while still occupying the node.
+ */
+export function admitsRequiredMemory(
+  snapshot: NodeMemorySnapshot,
+  requiredMemoryMb: number,
+): MemoryAdmissionVerdict {
+  const usedMb = Math.max(0, snapshot.memTotalMb - snapshot.memAvailableMb);
+  const effectiveCommittedMb = Math.max(snapshot.declaredCeilingMb, usedMb);
+  const budgetMb = snapshot.memTotalMb - HOST_RESERVE_MB;
+  return {
+    admitted: effectiveCommittedMb + requiredMemoryMb <= budgetMb,
+    effectiveCommittedMb,
+    budgetMb,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Embedding-sidecar self-heal bookkeeping
 // ---------------------------------------------------------------------------
@@ -278,6 +388,13 @@ export interface NodeSelectionOptions {
    * stateful routing and autoscaler readiness must remain liveness-only.
    */
   enforcePlacementIoPressure?: boolean;
+  /**
+   * The `--memory` ceiling the caller is about to apply to the container. When
+   * set, a node is refused unless it can still commit that much on top of what
+   * it has already committed. Callers must pass the value they will actually
+   * hand to `docker create`, so the admitted and applied ceilings cannot drift.
+   */
+  requiredMemoryMb?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -754,11 +871,27 @@ export class DockerNodeManager {
       // callers use this method as a liveness probe for sticky stateful routing
       // and autoscaler bootstrap, where transient pressure must not reroute or
       // reject the node.
-      const probeCommand = options.enforcePlacementIoPressure
-        ? `${dockerInfoCommand} && { echo '${READINESS_PROBE_PSI_MARKER}'; cat /proc/pressure/io 2>/dev/null || true; }`
-        : dockerInfoCommand;
+      const extraSections: string[] = [];
+      if (options.enforcePlacementIoPressure) {
+        extraSections.push(
+          `echo '${READINESS_PROBE_PSI_MARKER}'; cat /proc/pressure/io 2>/dev/null || true`,
+        );
+      }
+      // The memory facts ride the same round trip: reading them separately would
+      // race the placement they are meant to gate.
+      if (typeof options.requiredMemoryMb === "number") {
+        extraSections.push(
+          `echo '${READINESS_PROBE_MEMINFO_MARKER}'; cat /proc/meminfo 2>/dev/null || true`,
+          `echo '${READINESS_PROBE_COMMITTED_MARKER}'; docker ps -q | xargs -r docker inspect -f '{{.HostConfig.Memory}}' 2>/dev/null || true`,
+        );
+      }
+      const probeCommand =
+        extraSections.length > 0
+          ? `${dockerInfoCommand} && { ${extraSections.join("; ")}; }`
+          : dockerInfoCommand;
       const probeOutput = await ssh.exec(probeCommand, 10_000);
-      const [dockerSection = "", psiSection = ""] = probeOutput.split(READINESS_PROBE_PSI_MARKER);
+      const dockerSection = readProbeSection(probeOutput, null);
+      const psiSection = readProbeSection(probeOutput, READINESS_PROBE_PSI_MARKER);
       const { dockerId, architecture } = parseDockerInfoProbe(dockerSection);
       if (dockerId.trim()) {
         if (
@@ -785,6 +918,48 @@ export class DockerNodeManager {
             max: PLACEMENT_MAX_IO_PRESSURE_FULL_AVG60,
           });
           return false;
+        }
+        if (typeof options.requiredMemoryMb === "number") {
+          const meminfoSection = readProbeSection(probeOutput, READINESS_PROBE_MEMINFO_MARKER);
+          const committedSection = readProbeSection(probeOutput, READINESS_PROBE_COMMITTED_MARKER);
+          const snapshot = parseNodeMemorySnapshot(meminfoSection, committedSection);
+          if (!snapshot) {
+            // Admitting here is the deliberate direction, but it is the one
+            // branch that restores pre-gate behaviour, so it must never be
+            // silent: an edit to the probe command or the section grammar
+            // would otherwise turn this gate into a permanent no-op that
+            // neither the logs nor CI would notice.
+            logger.warn(
+              "[docker-node-manager] Memory admission skipped: node did not report readable memory facts",
+              {
+                nodeId: node.node_id,
+                requiredMemoryMb: options.requiredMemoryMb,
+                meminfoBytes: meminfoSection.length,
+                committedBytes: committedSection.length,
+              },
+            );
+          }
+          if (snapshot) {
+            const verdict = admitsRequiredMemory(snapshot, options.requiredMemoryMb);
+            if (!verdict.admitted) {
+              // No DB status write, for the same reason as IO: the node is
+              // healthy, it is simply full. Marking it degraded would hide a
+              // capacity problem behind an infrastructure one.
+              logger.warn(
+                "[docker-node-manager] Node refused for placement: memory would be oversubscribed",
+                {
+                  nodeId: node.node_id,
+                  requiredMemoryMb: options.requiredMemoryMb,
+                  effectiveCommittedMb: verdict.effectiveCommittedMb,
+                  budgetMb: verdict.budgetMb,
+                  memTotalMb: snapshot.memTotalMb,
+                  memAvailableMb: snapshot.memAvailableMb,
+                  declaredCeilingMb: snapshot.declaredCeilingMb,
+                },
+              );
+              return false;
+            }
+          }
         }
         await dockerNodesRepository.updateStatus(node.node_id, "healthy");
         return true;

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -1054,9 +1054,16 @@ export class DockerSandboxProvider implements SandboxProvider {
     // getAvailableNode + incrementAllocated + getUsedDockerHostPorts are three sequential
     // DB round-trips without a transaction boundary; the UNIQUE port index and
     // retry logic provide safety against concurrent capacity changes.
+    // The ceiling admitted here is the same value applied to `docker create`
+    // below, so a node can never be accepted against one number and loaded with
+    // another. Zero means the operator disabled ceilings entirely, which opts
+    // this container out of memory admission rather than admitting it for free.
+    const containerMemoryMb =
+      config.container?.memoryMb ?? containersEnv.agentContainerMemoryLimitMb();
     let dbNode = await dockerNodeManager.getAvailableNode({
       requiredPlatform: imagePlatform,
       excludeNodeId: config.excludeNodeId,
+      ...(containerMemoryMb > 0 ? { requiredMemoryMb: containerMemoryMb } : {}),
     });
     if (!dbNode) {
       dbNode = await this.provisionAutoscaledNodeForAgent({
@@ -1455,9 +1462,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         // an explicit per-agent `container.memory` wins; otherwise the
         // env-tunable fleet default applies so a boot-looping agent can never
         // OOM-starve its co-tenants again (staging fleet incident 2026-08-05).
-        ...buildAgentContainerMemoryFlags(
-          config.container?.memoryMb ?? containersEnv.agentContainerMemoryLimitMb(),
-        ),
+        ...buildAgentContainerMemoryFlags(containerMemoryMb),
         // Escape-hardening (#12230/#12302): drop ALL kernel capabilities, forbid
         // privilege escalation, and bound the process count — then, under
         // headscale only, re-add exactly NET_ADMIN + /dev/net/tun for the VPN.
@@ -2443,7 +2448,10 @@ export class DockerSandboxProvider implements SandboxProvider {
         );
       }
       if (unreachable) {
-        outcome = { kind: "not-running-unresolved", reason: "node-unreachable" };
+        outcome = {
+          kind: "not-running-unresolved",
+          reason: "node-unreachable",
+        };
         logger.warn(
           `[docker-sandbox] Node ${meta.hostname} unreachable during stop of ${meta.containerName}; ` +
             `completing delete while retaining its capacity until reconciliation — ` +


### PR DESCRIPTION
# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was loaded for this change`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` @ `c1cf54e04d3`; zero conflicts.
- [x] Package gates run: `packages/cloud/shared` typecheck reports nothing on the touched files, biome clean, 19 new tests plus 51 neighbouring placement tests green.

# Risks

**Low, and the failure direction is deliberate.**

- A node that cannot report readable memory facts is **admitted**, not refused — matching the IO-pressure gate's policy that an unreadable signal must not freeze the fleet. That branch now emits a `logger.warn` naming the node and both section lengths, so it can never become a silent no-op.
- Liveness-only callers (sticky stateful routing, autoscaler bootstrap) pass no `requiredMemoryMb`, so their probe and their verdict are byte-identical to before. Asserted on `execCommands` in the suite.
- The gate only **refuses**; it does not rank. Selection is still least-loaded-by-slots. When every candidate is refused, `getAvailableNode` returns `null` and the existing fall-through to `provisionAutoscaledNodeForAgent` takes over.
- Two concurrent provisions can read the same committed figure. Not closed here — the provisioning worker is a single sequential process today. Atomic reservation is the follow-up.

# Background

## What does this PR do?

Placement decided with two unit-less integers: `available = max(0, node.capacity - allocated)`. Neither the node's RAM nor the ceilings already committed on it entered the decision.

Measured on staging, 2026-08-12. Node `eliza-core-40661ddb` / `2.28.17.235`: **7745 MiB of RAM**, `capacity=4`, two resident agents at a 3072 MiB ceiling each. Placement computed `4 - 2 = 2 > 0` and selected it. `docker create` committed a third 3072 MiB ceiling onto a 7.6 GiB box — **9216 MiB of ceilings**, with a licence for 12 GiB.

The per-container `--memory` bound cannot catch this. No cgroup reaches its own limit, so the kernel fires a **global** OOM and Docker reports `OOMKilled=false` — a false negative, since that flag is only set for a cgroup-limit kill:

```
docker inspect: Status=running OOMKilled=false ExitCode=0 RestartCount=58
                MemLimit=3221225472 Policy=unless-stopped
```

With `restart unless-stopped` the agent relaunched every ~29 s, never reached its HTTP bind, and the provisioning row sat at `status='provisioning'` with a null error indefinitely.

`ensureNodeReady` now reads `/proc/meminfo` and the resident containers' `HostConfig.Memory` **in the SSH round trip that already runs `docker info` and `/proc/pressure/io`** — reading them separately would race the placement they gate. A node is refused unless:

```
max(declared ceilings, used memory) + required  <=  MemTotal - 1024 MiB
```

Used memory is the floor for the commitment because a container launched without a ceiling declares nothing while still occupying the node — one staging node runs two such containers today. The 1024 MiB reserve covers dockerd, tailscaled, the page cache, and the embedding sidecar, which is launched with no `--memory` of its own.

The ceiling admitted is the same value handed to `docker create`, hoisted into one `containerMemoryMb`, so a node can never be accepted against one number and loaded with another.

### Why not free memory alone

A `MemAvailable` probe would **not** have refused this placement: at selection time the node still had ~4.1 GiB free. The shortage only materialises once the new agent is allocating, which is why the kernel kills seconds after a check that passed. The committed-ceiling sum is the only predicate whose arithmetic refuses at the moment of the decision. There is a named test for exactly this.

## What kind of change is this?

Bug fix — control-plane admission control.

# Documentation changes needed?

`packages/cloud/shared/.env.example` shipped `CONTAINERS_HCLOUD_SERVER_TYPE=cpx32` (8 GB) against a code default of `ccx33` (32 GB). At the default capacity of 8 slots that licenses 24 GiB of ceilings on an 8 GB box — the reference config encoded this bug. Corrected, with the invariant stated inline.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/docker-node-manager.ts` — `admitsRequiredMemory`. The whole decision is one pure function; `readProbeSection` and `parseNodeMemorySnapshot` are pure too, following the `parseIoPressureFullAvg60` convention already in the file. The I/O stays in `ensureNodeReady`.

## Detailed testing steps

`bun test packages/cloud/shared/src/lib/services/docker-node-manager-memory-admission.test.ts` — 19 tests, fixtures taken verbatim from the measured fleet.

The suite is mutation-proved, not merely green. Forcing `admitted: true`:

```
(fail) admitsRequiredMemory > refuses the placement that actually OOM-killed the fleet
        Expected: false
        Received: true
(fail) admitsRequiredMemory > free memory alone would NOT have refused it - committed ceilings do
(fail) admitsRequiredMemory > counts unbounded containers through used memory rather than free
(fail) admitsRequiredMemory > admits exactly at the budget and refuses one MiB past it
(fail) ensureNodeReady memory gate > refuses the starved node for placement
(fail) getAvailableNode > skips the starved node and selects one that can hold the ceiling
(fail) getAvailableNode > returns null when every node is oversubscribed
 11 pass, 7 fail
```

Deleting the skip warning alone fails exactly one test (`does not block when the node cannot report its memory, but says so`, `expect(skipped).toBeDefined()` / `Received: undefined`), so the unobservable branch stays observable to CI. Both mutations were reverted against the git object.

Regression: 51/51 across `docker-node-manager-placement-breaker`, `-health-disable`, `-prepull-self-heal`, `-embedding-sidecar`, `docker-sandbox-placement-fallback`, `agent-container-security`, `autoscale-defaults`.

# Evidence Gate

<!-- evidence-head:3a862f83df2d408f42f6484be20dae21a9f6548c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this change lives in the control-plane placement path; no rendered surface exists before or after.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this change lives in the control-plane placement path; no rendered surface exists before or after.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing flow in a node-selection predicate; the observable behaviour is a refusal recorded in the control-plane log.
<!-- evidence-row:backend-logs -->
- [x] Kernel and daemon logs captured live from the staging node that failed, `2.28.17.235`:

```
oom-kill:constraint=CONSTRAINT_NONE,nodemask=(null),global_oom,task_memcg=/system
Out of memory: Killed process 287404 (MainThread) total-vm:54678916kB, anon-rss:2189360kB
Out of memory: Killed process 287699 (MainThread) total-vm:54568640kB, anon-rss:2166248kB
free -m: total 7745  available 2040
docker inspect: Status=running OOMKilled=false ExitCode=0 RestartCount=58 MemLimit=3221225472
```

Two kills 29 seconds apart, 21 in the log. The corresponding control-plane journal shows the consequence — the container is reachable and never answers:

```
[docker-sandbox] Container agent-4961b512-... registered on VPN: 100.64.2.17
[docker-sandbox] Polling tailnet health for agent-4961b512-... at http://100.64.2.17:2138/api/health (timeout: 360s)
[docker-sandbox] Tailnet health probe failed for agent-4961b512-..., retrying: fetch failed
```

The tailnet path was ruled out by measurement rather than assumption: the node is registered in headscale with `tag:agent`, the ACL admits `tag:eliza-proxy -> tag:agent:*`, and a wireguard `tailscale ping` returns `pong ... via 2.28.17.235:57504 in 1ms`.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer code is touched; the user-visible symptom of this defect is tracked separately in #18463.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behaviour is touched by this change.
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is the fleet the predicate is judged against. Measured across all six staging cloud nodes and all six robot nodes, then replayed as test fixtures:
  <details><summary>Fleet measurement matrix (6 cloud + robot nodes)</summary>

| Node | RAM | Free | Agents | Committed | OOM kills | Gate verdict |
|---|---|---|---|---|---|---|
| 2.28.17.235 | 7745 MiB | 2040 | 3 | 9.0 GiB | 21 | refuse |
| 162.55.170.116 | 7745 | 466 | 4 | 12.0 GiB | 8 | refuse |
| 5.75.249.51 | 7745 | 211 | 3 | 9.0 GiB | 18 | refuse |
| 167.233.211.66 | 7745 | 1483 | 2 | 6.0 GiB | 19 | refuse |
| 178.105.210.137 | 7745 | 4398 | 2 | 0 (unbounded) | 20 | admit |
| 178.105.103.121 | 7745 | 3441 | 2 | 3.0 GiB | 0 | admit |
| eliza-staging-robot-1 | 251 GiB | 201 GiB | 16 | 49 GiB | 0 | admit |

86 OOM kills across five of the six cloud nodes; zero across the robot fleet. The gate refuses exactly the nodes that were killing and admits the ones with genuine room, including the node whose containers declare nothing.

Related: #16899 (the OOM, root cause posted there), #18485 (fleet-blind placement — this closes the memory half, not the robot-preference half), #18463 (the spinner this loop surfaces as).

[stan-cloud]

  </details>
