### PR TITLE
fix(discord): cordon inbound turns during shutdown

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -5911,10 +5911,10 @@ export async function startEliza(
 
   bootContext.enterPhase("attach-host");
   const processLifecycle = createAgentProcessLifecycle({
-    disposeRuntime: (reason) =>
-      shutdownRuntime(runtime, reason, {
-        fast: true,
-      }),
+    // Signal shutdown must honor connector drain contracts. The supervisor's
+    // bounded escalation remains the hard ceiling; using the runtime's 500 ms
+    // fast service-stop cap here cut Discord's 10 s in-flight drain short.
+    disposeRuntime: (reason) => shutdownRuntime(runtime, reason),
     disposeSandbox: sandboxManager
       ? async () => {
           await sandboxManager?.stop();

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -153,6 +153,7 @@ import {
   MESSAGE_SOURCE_CLIENT_CHAT,
   type Plugin,
   type Provider,
+  type RuntimeStopOptions,
   requireConfirmedSendHandlerDelivery,
   type ServiceClass,
   stringToUuid,
@@ -1603,6 +1604,12 @@ type RuntimeAdapterWithClose = {
   close?: () => Promise<void> | void;
 };
 
+// Discord's bounded connector teardown may use 10 s for turn drain and 2 s
+// for reaction reconciliation. Keep signal shutdown fast/concurrent while
+// granting that contract a small cleanup margin under the dev supervisor's
+// 15 s hard ceiling.
+const SIGNAL_SERVICE_STOP_TIMEOUT_MS = 13_000;
+
 /**
  * Best-effort runtime shutdown that also closes the database adapter.
  *
@@ -1613,7 +1620,7 @@ type RuntimeAdapterWithClose = {
 export async function shutdownRuntime(
   runtime: AgentRuntime | null | undefined,
   context: string,
-  options: { fast?: boolean } = {},
+  options: RuntimeStopOptions = {},
 ): Promise<void> {
   let firstError: unknown = null;
 
@@ -1651,7 +1658,7 @@ export async function shutdownRuntime(
   try {
     // Interactive/signal teardown asks for the capped fast path so Ctrl-C does
     // not block on a slow deferred service start or a long embedding drain.
-    await runtime.stop(options.fast ? { fast: true } : undefined);
+    await runtime.stop(options.fast ? options : undefined);
   } catch (err) {
     if (!firstError) firstError = err;
     logger.warn(`[eliza] ${context}: runtime stop failed: ${formatError(err)}`);
@@ -5911,10 +5918,11 @@ export async function startEliza(
 
   bootContext.enterPhase("attach-host");
   const processLifecycle = createAgentProcessLifecycle({
-    // Signal shutdown must honor connector drain contracts. The supervisor's
-    // bounded escalation remains the hard ceiling; using the runtime's 500 ms
-    // fast service-stop cap here cut Discord's 10 s in-flight drain short.
-    disposeRuntime: (reason) => shutdownRuntime(runtime, reason),
+    disposeRuntime: (reason) =>
+      shutdownRuntime(runtime, reason, {
+        fast: true,
+        serviceStopTimeoutMs: SIGNAL_SERVICE_STOP_TIMEOUT_MS,
+      }),
     disposeSandbox: sandboxManager
       ? async () => {
           await sandboxManager?.stop();

--- a/packages/core/src/__tests__/runtime-stop.test.ts
+++ b/packages/core/src/__tests__/runtime-stop.test.ts
@@ -131,7 +131,7 @@ describe("AgentRuntime.stop", () => {
 	});
 
 	it("fast shutdown caps already-started service stop waits", async () => {
-		process.env.ELIZA_SHUTDOWN_SERVICE_STOP_TIMEOUT_MS = "5";
+		process.env.ELIZA_SHUTDOWN_SERVICE_STOP_TIMEOUT_MS = "500";
 		const runtime = new AgentRuntime({ logLevel: "fatal" });
 		await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
 		let stopCalls = 0;
@@ -154,7 +154,9 @@ describe("AgentRuntime.stop", () => {
 		await runtime.getServiceLoadPromise(HangingStopService.serviceType);
 
 		const stopResult = await Promise.race([
-			runtime.stop({ fast: true }).then(() => "stopped"),
+			runtime
+				.stop({ fast: true, serviceStopTimeoutMs: 5 })
+				.then(() => "stopped"),
 			delay(500),
 		]);
 
@@ -198,6 +200,51 @@ describe("AgentRuntime.stop", () => {
 		await lease.release();
 		await stop;
 		expect(events).toEqual(["prepare:runtime-stop", "stop"]);
+	});
+
+	it("makes reentrant and concurrent stop callers await one teardown", async () => {
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+		await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+		const stopStarted = createDeferred<void>();
+		const finishStop = createDeferred<void>();
+		let stopCalls = 0;
+		let reentrantStop: Promise<void> | null = null;
+
+		class DeferredStopService extends Service {
+			static override serviceType = "shutdown-concurrent-stop-service";
+			capabilityDescription = "service that exposes concurrent stop ordering";
+
+			static override async start(): Promise<DeferredStopService> {
+				return new DeferredStopService();
+			}
+
+			override prepareStop(): void {
+				reentrantStop = runtime.stop();
+			}
+
+			override async stop(): Promise<void> {
+				stopCalls += 1;
+				stopStarted.resolve();
+				await finishStop.promise;
+			}
+		}
+
+		await runtime.registerService(DeferredStopService);
+		await runtime.getServiceLoadPromise(DeferredStopService.serviceType);
+		const first = runtime.stop();
+		await stopStarted.promise;
+		expect(reentrantStop).not.toBeNull();
+		let secondSettled = false;
+		const second = runtime.stop().then(() => {
+			secondSettled = true;
+		});
+		await Promise.resolve();
+		expect(secondSettled).toBe(false);
+
+		finishStop.resolve();
+		await Promise.all([first, second, reentrantStop]);
+		expect(stopCalls).toBe(1);
+		expect(secondSettled).toBe(true);
 	});
 
 	it("fails fast without stopping resources beneath a noncooperative room owner", async () => {

--- a/packages/core/src/__tests__/runtime-stop.test.ts
+++ b/packages/core/src/__tests__/runtime-stop.test.ts
@@ -97,6 +97,39 @@ describe("AgentRuntime.stop", () => {
 		);
 	});
 
+	it("rejects a service whose start settles after the shutdown cordon", async () => {
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+		await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+		const start = createDeferred<LateService>();
+		let stopCalls = 0;
+
+		class LateService extends Service {
+			static override serviceType = "shutdown-late-service";
+			capabilityDescription = "service that settles during shutdown";
+
+			static override async start(): Promise<LateService> {
+				return start.promise;
+			}
+
+			override async stop(): Promise<void> {
+				stopCalls += 1;
+			}
+		}
+
+		await runtime.registerService(LateService);
+		const load = runtime
+			.getServiceLoadPromise(LateService.serviceType)
+			.catch((error: unknown) => error);
+		await Promise.resolve();
+		const stop = runtime.stop();
+		start.resolve(new LateService());
+
+		await stop;
+		expect(await load).toMatchObject({ code: "SERVICE_START_FAILED" });
+		expect(stopCalls).toBe(1);
+		expect(runtime.getService(LateService.serviceType)).toBeNull();
+	});
+
 	it("fast shutdown caps already-started service stop waits", async () => {
 		process.env.ELIZA_SHUTDOWN_SERVICE_STOP_TIMEOUT_MS = "5";
 		const runtime = new AgentRuntime({ logLevel: "fatal" });
@@ -128,6 +161,43 @@ describe("AgentRuntime.stop", () => {
 		expect(stopResult).toBe("stopped");
 		expect(stopCalls).toBe(1);
 		expect(process.env.ELIZA_FAST_SHUTDOWN).toBe(previousFastShutdown);
+	});
+
+	it("cordons service admissions before waiting for the room drain", async () => {
+		process.env.ELIZA_FAST_ROOM_DRAIN_TIMEOUT_MS = "50";
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+		await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+		const events: string[] = [];
+
+		class AdmissionAwareService extends Service {
+			static override serviceType = "shutdown-admission-aware-service";
+			capabilityDescription = "observes the pre-drain shutdown cordon";
+
+			static override async start(): Promise<AdmissionAwareService> {
+				return new AdmissionAwareService();
+			}
+
+			override prepareStop(reason: string): void {
+				events.push(`prepare:${reason}`);
+			}
+
+			override async stop(): Promise<void> {
+				events.push("stop");
+			}
+		}
+
+		await runtime.registerService(AdmissionAwareService);
+		await runtime.getServiceLoadPromise(AdmissionAwareService.serviceType);
+		const lease = await runtime.roomHandlerQueue.acquire(
+			"00000000-0000-4000-8000-000000000098",
+		);
+
+		const stop = runtime.stop();
+		await Promise.resolve();
+		expect(events).toEqual(["prepare:runtime-stop"]);
+		await lease.release();
+		await stop;
+		expect(events).toEqual(["prepare:runtime-stop", "stop"]);
 	});
 
 	it("fails fast without stopping resources beneath a noncooperative room owner", async () => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1412,8 +1412,10 @@ export class AgentRuntime implements IAgentRuntime {
 	private currentRoomId?: UUID; // Track the current room for logging
 	public messageService: IMessageService | null = null; // Lazily initialized
 	public companionUrl?: string;
-	/** Set when stop() has been called; prevents new service starts and use-after-stop. */
+	/** Set when stop() has completed service teardown. */
 	private stopped = false;
+	/** Set synchronously at stop entry, before any drain can yield. */
+	private stopping = false;
 
 	constructor(opts: {
 		conversationLength?: number;
@@ -2599,12 +2601,36 @@ export class AgentRuntime implements IAgentRuntime {
 	 * For full teardown (including DB/adapter connection), call close() after stop().
 	 */
 	async stop(options?: RuntimeStopOptions): Promise<void> {
-		if (this.stopped) {
+		if (this.stopped || this.stopping) {
 			this.logger.debug(
 				{ src: "agent", agentId: this.agentId },
-				"Runtime already stopped",
+				"Runtime already stopping or stopped",
 			);
 			return;
+		}
+		this.stopping = true;
+		// Freeze connector/service ingress before the first shutdown await. Without
+		// this phase, a gateway delivery can begin a new turn while the runtime is
+		// already waiting for its room-owner drain, behind the eventual service-stop
+		// snapshot. Hooks are synchronous by contract to make that boundary atomic.
+		for (const [serviceType, services] of this.services) {
+			for (const service of services) {
+				try {
+					service?.prepareStop?.("runtime-stop");
+				} catch (err) {
+					// error-policy:J6 admission preparation is best-effort so one broken
+					// connector cannot deny every service its teardown opportunity.
+					this.logger.warn(
+						{
+							src: "agent",
+							agentId: this.agentId,
+							serviceType,
+							error: err instanceof Error ? err.message : String(err),
+						},
+						"Service prepareStop() threw; continuing",
+					);
+				}
+			}
 		}
 		this.roomHandlerQueue.closeAdmissions("runtime-stop");
 		this.turnControllers.abortAllTurns("runtime-stop");
@@ -2632,6 +2658,7 @@ export class AgentRuntime implements IAgentRuntime {
 					pendingRooms: this.roomHandlerQueue.pendingTotal(),
 					timeoutMs,
 				});
+				this.stopping = false;
 				throw error;
 			}
 		} else {
@@ -5658,7 +5685,7 @@ export class AgentRuntime implements IAgentRuntime {
 			});
 		}
 		try {
-			if (this.stopped) {
+			if (this.stopped || this.stopping) {
 				throw new Error(
 					`Runtime stopped before service ${String(serviceType)} could start`,
 				);
@@ -5671,7 +5698,7 @@ export class AgentRuntime implements IAgentRuntime {
 					context: { serviceType },
 				});
 			}
-			if (this.stopped) {
+			if (this.stopped || this.stopping) {
 				await this._stopServiceInstance(
 					key,
 					serviceInstance,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1414,8 +1414,10 @@ export class AgentRuntime implements IAgentRuntime {
 	public companionUrl?: string;
 	/** Set when stop() has completed service teardown. */
 	private stopped = false;
-	/** Set synchronously at stop entry, before any drain can yield. */
-	private stopping = false;
+	/** Set permanently at the first stop request, before any drain can yield. */
+	private stopRequested = false;
+	/** The active stop attempt; concurrent callers await the same teardown. */
+	private stopPromise: Promise<void> | null = null;
 
 	constructor(opts: {
 		conversationLength?: number;
@@ -2333,9 +2335,9 @@ export class AgentRuntime implements IAgentRuntime {
 			throw new Error(`registerPlugin: ${errorMsg}`);
 		}
 		const assertRuntimeActive = (): void => {
-			if (!this.stopped) return;
+			if (!this.stopRequested) return;
 			throw new ElizaError(
-				`Cannot register plugin "${plugin.name}" on a stopped runtime`,
+				`Cannot register plugin "${plugin.name}" after runtime stop was requested`,
 				{
 					code: "RUNTIME_STOPPED_DURING_PLUGIN_REGISTRATION",
 					severity: "ephemeral",
@@ -2601,37 +2603,72 @@ export class AgentRuntime implements IAgentRuntime {
 	 * For full teardown (including DB/adapter connection), call close() after stop().
 	 */
 	async stop(options?: RuntimeStopOptions): Promise<void> {
-		if (this.stopped || this.stopping) {
+		if (this.stopPromise) {
 			this.logger.debug(
 				{ src: "agent", agentId: this.agentId },
-				"Runtime already stopping or stopped",
+				"Runtime stop already in progress",
+			);
+			await this.stopPromise;
+			return;
+		}
+		if (this.stopped) {
+			this.logger.debug(
+				{ src: "agent", agentId: this.agentId },
+				"Runtime already stopped",
 			);
 			return;
 		}
-		this.stopping = true;
-		// Freeze connector/service ingress before the first shutdown await. Without
-		// this phase, a gateway delivery can begin a new turn while the runtime is
-		// already waiting for its room-owner drain, behind the eventual service-stop
-		// snapshot. Hooks are synchronous by contract to make that boundary atomic.
-		for (const [serviceType, services] of this.services) {
-			for (const service of services) {
-				try {
-					service?.prepareStop?.("runtime-stop");
-				} catch (err) {
-					// error-policy:J6 admission preparation is best-effort so one broken
-					// connector cannot deny every service its teardown opportunity.
-					this.logger.warn(
-						{
-							src: "agent",
-							agentId: this.agentId,
-							serviceType,
-							error: err instanceof Error ? err.message : String(err),
-						},
-						"Service prepareStop() threw; continuing",
-					);
+
+		let resolveStop!: () => void;
+		let rejectStop!: (reason?: unknown) => void;
+		const stopAttempt = new Promise<void>((resolve, reject) => {
+			resolveStop = resolve;
+			rejectStop = reject;
+		});
+		// Publish single-flight ownership before invoking a service hook. A hook is
+		// synchronous but may itself request shutdown; that reentrant call must join
+		// this attempt instead of starting a second teardown.
+		this.stopPromise = stopAttempt;
+		if (!this.stopRequested) {
+			this.stopRequested = true;
+			// Freeze connector/service ingress before the first shutdown await. Without
+			// this phase, a gateway delivery can begin a new turn while the runtime is
+			// already waiting for its room-owner drain, behind the eventual service-stop
+			// snapshot. Hooks are synchronous by contract to make that boundary atomic.
+			for (const [serviceType, services] of this.services) {
+				for (const service of services) {
+					try {
+						service?.prepareStop?.("runtime-stop");
+					} catch (err) {
+						// error-policy:J6 admission preparation is best-effort so one broken
+						// connector cannot deny every service its teardown opportunity.
+						this.logger.warn(
+							{
+								src: "agent",
+								agentId: this.agentId,
+								serviceType,
+								error: err instanceof Error ? err.message : String(err),
+							},
+							"Service prepareStop() threw; continuing",
+						);
+					}
 				}
 			}
 		}
+
+		void this._stopAfterAdmissionCordon(options).then(resolveStop, rejectStop);
+		try {
+			await stopAttempt;
+		} finally {
+			if (this.stopPromise === stopAttempt) {
+				this.stopPromise = null;
+			}
+		}
+	}
+
+	private async _stopAfterAdmissionCordon(
+		options?: RuntimeStopOptions,
+	): Promise<void> {
 		this.roomHandlerQueue.closeAdmissions("runtime-stop");
 		this.turnControllers.abortAllTurns("runtime-stop");
 		const fast = options?.fast === true;
@@ -2658,7 +2695,6 @@ export class AgentRuntime implements IAgentRuntime {
 					pendingRooms: this.roomHandlerQueue.pendingTotal(),
 					timeoutMs,
 				});
-				this.stopping = false;
 				throw error;
 			}
 		} else {
@@ -2679,7 +2715,7 @@ export class AgentRuntime implements IAgentRuntime {
 			process.env.ELIZA_FAST_SHUTDOWN = "1";
 		}
 		try {
-			await this._stopServices(fast);
+			await this._stopServices(fast, options?.serviceStopTimeoutMs);
 		} finally {
 			if (fast) {
 				if (previousFastShutdown === undefined) {
@@ -2691,7 +2727,10 @@ export class AgentRuntime implements IAgentRuntime {
 		}
 	}
 
-	private async _stopServices(fast: boolean): Promise<void> {
+	private async _stopServices(
+		fast: boolean,
+		serviceStopTimeoutMs?: number,
+	): Promise<void> {
 		this.stopped = true;
 		this.logger.debug(
 			{ src: "agent", agentId: this.agentId, fast },
@@ -2769,10 +2808,15 @@ export class AgentRuntime implements IAgentRuntime {
 			}
 		}
 		if (fast && fastStopTasks.length > 0) {
-			const timeoutMs = resolveShutdownTimeoutMs(
-				"ELIZA_SHUTDOWN_SERVICE_STOP_TIMEOUT_MS",
-				DEFAULT_FAST_SERVICE_STOP_TIMEOUT_MS,
-			);
+			const timeoutMs =
+				serviceStopTimeoutMs !== undefined &&
+				Number.isFinite(serviceStopTimeoutMs) &&
+				serviceStopTimeoutMs >= 0
+					? Math.floor(serviceStopTimeoutMs)
+					: resolveShutdownTimeoutMs(
+							"ELIZA_SHUTDOWN_SERVICE_STOP_TIMEOUT_MS",
+							DEFAULT_FAST_SERVICE_STOP_TIMEOUT_MS,
+						);
 			if (timeoutMs > 0) {
 				await Promise.race([
 					Promise.allSettled(fastStopTasks),
@@ -5561,7 +5605,7 @@ export class AgentRuntime implements IAgentRuntime {
 	private async _ensureServiceStarted(
 		serviceType: ServiceTypeName | string,
 	): Promise<Service | null> {
-		if (this.stopped) return null;
+		if (this.stopRequested) return null;
 		if (!this.isNativeFeatureServiceEnabled(serviceType)) return null;
 		const key = this.resolveServiceTypeAlias(serviceType) as ServiceTypeName;
 		// Fast path: a service that is already registered and running is returned
@@ -5571,7 +5615,7 @@ export class AgentRuntime implements IAgentRuntime {
 		const alreadyRunning = this.services.get(key)?.[0];
 		if (alreadyRunning && this.initResolver) return alreadyRunning;
 		await this.initPromise;
-		if (this.stopped) return null;
+		if (this.stopRequested) return null;
 		const classes = this.serviceTypes.get(key);
 		if (!classes || classes.length === 0) {
 			return null;
@@ -5685,9 +5729,9 @@ export class AgentRuntime implements IAgentRuntime {
 			});
 		}
 		try {
-			if (this.stopped || this.stopping) {
+			if (this.stopped || this.stopRequested) {
 				throw new Error(
-					`Runtime stopped before service ${String(serviceType)} could start`,
+					`Runtime stop requested before service ${String(serviceType)} could start`,
 				);
 			}
 			const serviceInstance = await serviceDef.start(this);
@@ -5698,14 +5742,14 @@ export class AgentRuntime implements IAgentRuntime {
 					context: { serviceType },
 				});
 			}
-			if (this.stopped || this.stopping) {
+			if (this.stopped || this.stopRequested) {
 				await this._stopServiceInstance(
 					key,
 					serviceInstance,
 					"late service start after runtime stop",
 				);
 				throw new Error(
-					`Runtime stopped while service ${String(serviceType)} was starting`,
+					`Runtime stop requested while service ${String(serviceType)} was starting`,
 				);
 			}
 			this.serviceInstancesByClass.set(serviceDef, serviceInstance);
@@ -5885,6 +5929,16 @@ export class AgentRuntime implements IAgentRuntime {
 				code: "SERVICE_TYPE_MISSING",
 				context: { serviceName },
 			});
+		}
+		if (this.stopRequested) {
+			throw new ElizaError(
+				`Cannot register service ${String(serviceType)} after runtime stop was requested`,
+				{
+					code: "RUNTIME_STOPPED_DURING_SERVICE_REGISTRATION",
+					severity: "ephemeral",
+					context: { agentId: this.agentId, serviceType },
+				},
+			);
 		}
 		this.logger.debug(
 			{ src: "agent", agentId: this.agentId, serviceType },

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -151,6 +151,12 @@ export interface RuntimeStopOptions {
 	 * for signal handlers, reset/restart paths, and development shutdown.
 	 */
 	fast?: boolean;
+	/**
+	 * Override the aggregate service-stop ceiling used by fast shutdown. A value
+	 * of zero waits without a runtime-level cap; callers should supply a positive
+	 * bound when an outer supervisor cannot guarantee escalation.
+	 */
+	serviceStopTimeoutMs?: number;
 }
 
 export const ConnectorAccountPurpose = {

--- a/packages/core/src/types/service.ts
+++ b/packages/core/src/types/service.ts
@@ -181,6 +181,13 @@ export abstract class Service {
 
 	abstract stop(): Promise<void>;
 
+	/**
+	 * Optional synchronous shutdown-admission hook. Runtime invokes this for all
+	 * services before awaiting any drain, so connectors can reject new inbound
+	 * work while allowing already-admitted work to settle.
+	 */
+	prepareStop?(_reason: string): void;
+
 	/** Service type */
 	static serviceType: string;
 

--- a/plugins/plugin-discord/__tests__/discord-events-mute-gate.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-events-mute-gate.test.ts
@@ -74,6 +74,7 @@ function makeService() {
 	};
 	const service = {
 		accountId: "test",
+		admitInboundMessage: vi.fn(() => true),
 		allowAllSlashCommands: new Set(),
 		allowedChannelIds: undefined,
 		buildMemoryFromMessage: vi.fn(),
@@ -137,6 +138,24 @@ describe("messageCreate — persisted mute gate before ingestion", () => {
 		service.client.emit("messageCreate", makeChannelMessage("chan-1"));
 		await tick();
 
+		expect(debouncerState.channelEnqueue).not.toHaveBeenCalled();
+		expect(service.messageManager.handleMessage).not.toHaveBeenCalled();
+	});
+
+	it("drops a post-cordon delivery before ingestion or dispatch", async () => {
+		const { service } = makeService();
+		service.admitInboundMessage.mockReturnValue(false);
+		wire(service);
+
+		const message = makeChannelMessage("chan-shutdown");
+		service.client.emit("messageCreate", message);
+		await tick();
+
+		expect(service.admitInboundMessage).toHaveBeenCalledWith(
+			message.id,
+			message.channel.id,
+		);
+		expect(service.buildMemoryFromMessage).not.toHaveBeenCalled();
 		expect(debouncerState.channelEnqueue).not.toHaveBeenCalled();
 		expect(service.messageManager.handleMessage).not.toHaveBeenCalled();
 	});

--- a/plugins/plugin-discord/__tests__/service-shutdown-drain.test.ts
+++ b/plugins/plugin-discord/__tests__/service-shutdown-drain.test.ts
@@ -77,6 +77,53 @@ describe("DiscordService#stop shutdown drain", () => {
 		);
 	});
 
+	it("cordons new ingress before waiting for an admitted turn to drain", async () => {
+		const runtime = makeRuntime();
+		const service = makeService(runtime);
+		let finishTurn: () => void = () => {};
+		const turn = new Promise<void>((resolve) => {
+			finishTurn = resolve;
+		});
+		service.trackInFlightTurn("msg-admitted", turn);
+
+		const stopPromise = service.stop();
+		expect(
+			service.admitInboundMessage("msg-after-cordon", "channel-1", "test"),
+		).toBe(false);
+		const directCaller = {
+			client: { user: { id: "bot" } },
+			discordSettings: { shouldIgnoreBotMessages: false },
+			admitInboundMessage: (messageId: string, channelId: string): boolean =>
+				service.admitInboundMessage(messageId, channelId, "test"),
+			trackInFlightTurn: vi.fn(),
+		};
+		const { MessageManager } = await import("../messages.ts");
+		const manager = Object.create(MessageManager.prototype) as {
+			discordService: typeof directCaller;
+			runMessageTurn: ReturnType<typeof vi.fn>;
+			handleMessage: (message: unknown) => Promise<void>;
+		};
+		manager.discordService = directCaller;
+		manager.runMessageTurn = vi.fn();
+		await manager.handleMessage({
+			id: "msg-direct-after-cordon",
+			channel: { id: "channel-1" },
+		});
+		expect(manager.runMessageTurn).not.toHaveBeenCalled();
+		expect(directCaller.trackInFlightTurn).not.toHaveBeenCalled();
+		expect(runtime.logger.info).toHaveBeenCalledWith(
+			expect.objectContaining({
+				messageId: "msg-after-cordon",
+				channelId: "channel-1",
+				reason: "shutdown-cordon",
+			}),
+			"discord: drop shutdown-cordon target=channel-1",
+		);
+
+		finishTurn();
+		await stopPromise;
+	});
+
 	it("drains an in-flight turn before completing, without abandoning its reaction", async () => {
 		const runtime = makeRuntime();
 		const service = makeService(runtime);

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -72,6 +72,8 @@ export interface DiscordServiceInternals {
 	slashCommands: DiscordSlashCommand[];
 	timeouts: ReturnType<typeof setTimeout>[];
 	clientReadyPromise?: Promise<void> | null;
+	/** Atomically accept an inbound delivery or record its shutdown drop. */
+	admitInboundMessage?(messageId: string, channelId: string): boolean;
 
 	// Methods
 	isChannelAllowed(channelId: string): boolean;
@@ -214,6 +216,12 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 
 			const botAddressed = anchor !== undefined;
 			anchor ??= messages[messages.length - 1];
+			if (
+				!anchor ||
+				service.admitInboundMessage?.(anchor.id, anchor.channel.id) === false
+			) {
+				return;
+			}
 			if (messageCoalesce.enabled) {
 				const combined = makeCoalescedDiscordMessage(
 					messages,
@@ -298,6 +306,12 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 		const run = prior
 			.catch(() => undefined)
 			.then(() => {
+				if (
+					service.admitInboundMessage?.(message.id, message.channel.id) ===
+					false
+				) {
+					return;
+				}
 				// Re-read at dispatch time: the manager can be torn down between
 				// enqueue and this deferred run (service stop). If it's gone, skip
 				// rather than throw.
@@ -324,6 +338,14 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 
 	// ── messageCreate ──────────────────────────────────────────────────
 	service.client.on("messageCreate", async (message) => {
+		// This must be the first gate in the listener: `stop()` closes admissions
+		// synchronously before taking its drain snapshot. Deliveries arriving after
+		// that point are designed-ignore drops, not new turns racing teardown.
+		if (
+			service.admitInboundMessage?.(message.id, message.channel.id) === false
+		) {
+			return;
+		}
 		const clientUser = service.client?.user;
 		if (
 			(clientUser && message.author.id === clientUser.id) ||
@@ -357,6 +379,14 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 					channelId: message.channel.id,
 				},
 			);
+			return;
+		}
+		// Readiness and every later policy lookup cross await boundaries. Recheck
+		// here, and again at dispatch below, so a message accepted just before the
+		// cordon cannot start a turn behind the shutdown snapshot.
+		if (
+			service.admitInboundMessage?.(message.id, message.channel.id) === false
+		) {
 			return;
 		}
 
@@ -436,6 +466,11 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 		}
 
 		if (listenCids.includes(message.channel.id) && message) {
+			if (
+				service.admitInboundMessage?.(message.id, message.channel.id) === false
+			) {
+				return;
+			}
 			const newMessage = await service.buildMemoryFromMessage(message);
 
 			if (!newMessage) {
@@ -537,6 +572,11 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 
 		try {
 			if (!service.messageManager) {
+				return;
+			}
+			if (
+				service.admitInboundMessage?.(message.id, message.channel.id) === false
+			) {
 				return;
 			}
 

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -1275,6 +1275,17 @@ export class MessageManager {
 	 * @param {DiscordMessage} message - The Discord message to be handled
 	 */
 	async handleMessage(message: DiscordMessage): Promise<void> {
+		// Choke point for gateway, direct/replay, and coordination-sweeper turns.
+		// Event-listener gates avoid wasted preprocessing, but only this check can
+		// guarantee no alternate caller registers work behind the drain snapshot.
+		if (
+			this.discordService.admitInboundMessage?.(
+				message.id,
+				message.channel.id,
+			) === false
+		) {
+			return;
+		}
 		const turn = this.runMessageTurn(message);
 		this.discordService.trackInFlightTurn?.(message.id, turn);
 		return turn;

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -17,6 +17,7 @@ import {
 	type EventPayload,
 	getConnectorAdminWhitelist,
 	type IAgentRuntime,
+	logInboundDrop,
 	type Media,
 	type Memory,
 	MemoryType,
@@ -196,6 +197,7 @@ type DiscordAccountServiceFacade = IDiscordService &
 	ReactionServiceInternals & {
 		client: DiscordJsClient;
 		discordSettings: DiscordSettingsForEvents;
+		admitInboundMessage(messageId: string, channelId: string): boolean;
 		commandRegistrationQueue: Promise<void>;
 		addAllowedChannel(channelId: string): boolean;
 		removeAllowedChannel(channelId: string): boolean;
@@ -614,6 +616,12 @@ export class DiscordService extends Service implements IDiscordService {
 	 * reaction left showing "in progress" instead of tearing down mid-turn.
 	 */
 	private readonly turnDrainRegistry = createTurnDrainRegistry();
+	/**
+	 * Shared across every account facade. `stop()` closes this synchronously
+	 * before it awaits the turn drain, so gateway deliveries racing shutdown can
+	 * never start a new message turn behind the drain snapshot.
+	 */
+	private ingressClosedReason: string | null = null;
 	client: DiscordJsClient | null = null;
 	character: Character;
 	discordSettings: DiscordSettings;
@@ -1346,6 +1354,8 @@ export class DiscordService extends Service implements IDiscordService {
 			get clientReadyPromise() {
 				return state?.clientReadyPromise ?? parent.clientReadyPromise;
 			},
+			admitInboundMessage: (messageId: string, channelId: string) =>
+				parent.admitInboundMessage(messageId, channelId, accountId()),
 			accountToken: state?.account.token,
 		};
 		return facade;
@@ -4035,10 +4045,54 @@ export class DiscordService extends Service implements IDiscordService {
 	}
 
 	/**
+	 * Admission gate for Discord gateway messages. The check is synchronous so
+	 * a delivery either owns admission before shutdown begins or is observably
+	 * rejected; there is no await boundary where it can slip behind the drain.
+	 */
+	public admitInboundMessage(
+		messageId: string,
+		channelId: string,
+		accountId = this.accountId,
+	): boolean {
+		if (this.ingressClosedReason === null) {
+			return true;
+		}
+		const context = {
+			src: "plugin:discord",
+			agentId: this.runtime.agentId,
+			accountId,
+			messageId,
+			channelId,
+			reason: this.ingressClosedReason,
+		};
+		logInboundDrop({
+			log: (message) => this.runtime.logger.info(context, message),
+			channel: "discord",
+			reason: this.ingressClosedReason,
+			target: channelId,
+		});
+		return false;
+	}
+
+	/** Close inbound admissions exactly once while allowing admitted turns to drain. */
+	public cordonIngress(reason = "shutdown-cordon"): void {
+		this.ingressClosedReason ??= reason;
+	}
+
+	/** Runtime-level pre-drain hook; intentionally synchronous. */
+	public override prepareStop(_reason: string): void {
+		this.cordonIngress();
+	}
+
+	/**
 	 * Stops the Discord service and cleans up resources.
 	 */
 	public async stop(): Promise<void> {
 		this.runtime.logger.info("Stopping Discord service");
+		// Cordon before the first await and before taking the drain snapshot. New
+		// gateway deliveries are rejected by the messageCreate gate below, while
+		// turns admitted before this point remain tracked and may finish normally.
+		this.cordonIngress();
 
 		// Drain before any teardown below: in-flight turns depend on the
 		// debouncers, message managers, and client this method is about to

--- a/plugins/plugin-discord/shutdown-drain.ts
+++ b/plugins/plugin-discord/shutdown-drain.ts
@@ -17,13 +17,9 @@
  * to `drain` — without the shared lifetime (#17749 review, @wtfsayo then
  * @lalalune).
  *
- * Scope note: this registry drains turns that were already in flight when
- * `drain` is called. It does not stop new inbound messages from starting a
- * new turn while the drain is in progress — discord.js keeps delivering
- * gateway events until the client is destroyed, and this connector has no
- * ingress cordon (elizaOS/eliza#16318 scopes an inbound cordon to the
- * runtime-level shutdown path, outside this plugin). A turn that starts
- * after `drain` begins is not covered by that call.
+ * `DiscordService#stop` closes the gateway admission gate before calling
+ * `drain`, so the snapshot is stable: already-admitted turns may finish while
+ * later messageCreate deliveries are rejected observably (#16318).
  */
 import type { StatusReactionController } from "./status-reactions";
 

--- a/plugins/plugin-discord/types.ts
+++ b/plugins/plugin-discord/types.ts
@@ -238,6 +238,8 @@ export interface IDiscordService {
 		message: Message,
 		options?: BuildMemoryFromMessageOptions,
 	) => Promise<Memory | null>;
+	/** Synchronous inbound admission check used by every turn-start path. */
+	admitInboundMessage?: (messageId: string, channelId: string) => boolean;
 	getVoiceTargets?: (query?: {
 		accountId?: string | null;
 		guildId?: string | null;


### PR DESCRIPTION
# Relates to

Partial implementation of #16318: runtime-level inbound Discord ingress cordoning and bounded drain coordination. This PR does not close the parent issue; credentialed Discord restart evidence and the remaining supervisor/startup work stay in that issue.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Contributor model: `openai/gpt-5.6-sol`
- Maintainer review and repair: `OpenAI GPT-5`
<!-- attribution-row:client -->
- Contributor tooling: `Codex`
- Maintainer tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Contributor skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `contributor self-reported; maintainer work recorded during review`

# Reviewed revision

- Base: `1cad4b7e82d1f42698c258bfe533880bce59a8b1`
- Head: `6d5c9c6d107b9af5aa63950fd3912fb0c327fabd`
- Pinned `bun install`, focused validation, and the full repository gate completed after the final rebase.

# What this changes

- Adds the optional synchronous `Service.prepareStop(reason)` lifecycle hook and calls it before the runtime's first shutdown await.
- Permanently closes plugin/service admission when shutdown begins and rejects services that finish starting after the cordon.
- Uses one published `stopPromise`, so concurrent and reentrant `stop()` callers observe the same teardown instead of returning early.
- Cordons Discord gateway, delayed debouncer, DM queue, direct/replay, and coordination-sweeper turn starts through shared ingress state.
- Records post-cordon arrivals through `logInboundDrop` with `shutdown-cordon` context while allowing already-admitted turns to drain.
- Keeps signal shutdown bounded: the fast path applies a 13-second aggregate service-stop ceiling, covering Discord's 10-second turn drain and 2-second reaction reconciliation beneath the 15-second supervisor escalation window.
- Exposes a validated `RuntimeStopOptions.serviceStopTimeoutMs` override; zero deliberately means no runtime aggregate cap.

# Maintainer review and repair

The original change had the right cordon architecture but made signal shutdown unbounded, let concurrent `stop()` callers return before teardown, reopened admissions after a stop-time failure, and exposed a reentrant window before teardown ownership existed. The reviewed head repairs those lifecycle invariants and adds regression coverage for them.

# Risk

**Medium.** This changes core shutdown ordering and Discord connector admission. The hook is additive; teardown remains bounded at the process-signal boundary, failure is observable, and the exact concurrency contracts are pinned by deterministic tests.

# Verification

- `bun install`: completed with the pinned toolchain and artifact sync.
- Focused lifecycle/Discord suite: **8 files passed; 71 tests passed**.
- `packages/core`, `packages/agent`, and `plugins/plugin-discord` lint: passed.
- `bun run verify`: **350/350 tasks passed** after the final rebase.
- Tests exercise the real `AgentRuntime`, `DiscordService`, listener, queue, and `MessageManager` admission boundaries with fake external Discord transport.

# Evidence Gate

<!-- evidence-head:6d5c9c6d107b9af5aa63950fd3912fb0c327fabd -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend lifecycle change with no rendered UI surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend lifecycle change with no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic shutdown coordination has no interactive UI flow.

<!-- evidence-row:backend-logs -->
- [x] [18492-backend-logs-exact-head.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18492-backend-logs-exact-head.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request, console, or network behavior changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model, planner, provider, action, or evaluator behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [18492-domain-artifacts-exact-head.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18492-domain-artifacts-exact-head.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed.

# Evidence boundary

No live Discord credential was used. The exact-head artifacts prove the in-process admission, singleflight teardown, timeout, and drain contracts deterministically; they do not claim credentialed reconnect/restart evidence. That broader evidence remains explicitly open on #16318.

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->

