### PR TITLE
feat(registry): add plugin-pulsenetwork

### DIFF
--- a/packages/registry/entries/third-party/plugin-pulsenetwork.json
+++ b/packages/registry/entries/third-party/plugin-pulsenetwork.json
@@ -1,0 +1,18 @@
+{
+  "package": "plugin-pulsenetwork",
+  "repository": "github:GTCC777/plugin-pulsenetwork",
+  "kind": "plugin",
+  "description": "Pulse Network paid data for agents: free catalog search across the x402 fleet (finance, crypto, macro, travel, sports, health, legal), pre-trade token safety scans ($0.015), and capped pay-per-call fetches — USDC on Base, no API keys. Spend caps and recipient/asset pins enforced in code.",
+  "homepage": "https://pulse.theaslangroupllc.com",
+  "version": "0.1.0",
+  "tags": [
+    "x402",
+    "micropayments",
+    "paid-data",
+    "token-safety",
+    "usdc",
+    "base",
+    "finance",
+    "crypto-data"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1516,6 +1516,54 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "plugin-pulsenetwork": {
+      "git": {
+        "repo": "GTCC777/plugin-pulsenetwork",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "plugin-pulsenetwork",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Pulse Network paid data for agents: free catalog search across the x402 fleet (finance, crypto, macro, travel, sports, health, legal), pre-trade token safety scans ($0.015), and capped pay-per-call fetches — USDC on Base, no API keys. Spend caps and recipient/asset pins enforced in code.",
+      "homepage": "https://pulse.theaslangroupllc.com",
+      "topics": [
+        "x402",
+        "micropayments",
+        "paid-data",
+        "token-safety",
+        "usdc",
+        "base",
+        "finance",
+        "crypto-data"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "plugin-raven-verify": {
       "git": {
         "repo": "billybotticelli4u-collab/plugin-raven-verify",


### PR DESCRIPTION
## What

Adds `plugin-pulsenetwork` to the third-party registry: free catalog search over Pulse Network's x402 paid-data fleet (77 verticals — finance, crypto, macro, travel, sports, health, legal), a pre-trade EVM token safety scan action ($0.015/call), and a capped generic paid-GET action. All payments are x402 v2, USDC on Base, from the agent operator's own `EVM_PRIVATE_KEY` (the same setting the official EVM plugin uses) — no API keys or signups.

Payment safety is enforced in code, not prompts: the x402 client registers a policy that refuses any 402 challenge that is not exact-scheme USDC on Base to Pulse Network's published wallet within a per-call cap (`PULSE_MAX_PAYMENT_USD`, default $0.60), and every outbound request (free or paid) is restricted to `*.theaslangroupllc.com` over HTTPS with redirects disabled.

## Checklist

- [x] Package live on npm: https://www.npmjs.com/package/plugin-pulsenetwork (v0.1.0, exact version in the entry)
- [x] Public repository: https://github.com/GTCC777/plugin-pulsenetwork
- [x] `bun run validate` passes (40 third-party entries)
- [x] `bun run generate` run twice — deterministic, committed
- [x] Diff is exactly 2 files (entry + regenerated registry), no lockfiles
- [x] Trailing newline on the entry file

## Verify without installing

- Catalog search (free, what `SEARCH_PULSE_CATALOG` calls): `curl "https://pulse.theaslangroupllc.com/api/catalog?q=token%20safety"`
- Live 402 challenge the plugin's policy is pinned against (no payment occurs): `curl -i "https://onchainpulse.theaslangroupllc.com/api/evmtoken?address=0x532f27101965dd16442E59d40670FaF5eBB142E4&chain=base"` — note `exact` / `eip155:8453` / USDC `0x8335…2913` / payTo `0x50ab…12fc`, which are the values pinned in `src/client.ts`
- Full endpoint index: https://pulse.theaslangroupllc.com/llms-full.txt
- The paid path was exercised end-to-end before publishing: one real $0.015 scan settled on Base through the exact client code in the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
