### PR TITLE
test(cloud): cover normalizeLedgerSourceId

### DIFF
--- a/packages/cloud/shared/src/lib/utils/ledger-source-id.test.ts
+++ b/packages/cloud/shared/src/lib/utils/ledger-source-id.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Deterministic unit coverage for `normalizeLedgerSourceId`. The helper is pure
+ * apart from a SHA-256 digest, so every case is an exact input/output
+ * assertion.
+ *
+ * This is a ledger identity function: `redeemable_earnings_ledger.source_id` is
+ * a `uuid` column, and dedupe keys such as `revenue_split:<paymentIntent>:<user>`
+ * are not UUIDs, so they are folded into one. Two properties are therefore
+ * load-bearing and are asserted directly rather than assumed — the mapping must
+ * be stable across calls (a retry must dedupe against the earlier row) and
+ * injective enough that two distinct keys never collapse onto one id.
+ *
+ * The accepted-UUID gate is narrower than "looks like a UUID": the version
+ * nibble is restricted to 1-5, so a UUIDv7 or the nil UUID is *derived* rather
+ * than passed through. That is pinned below because it is invisible at the call
+ * site and changes which ledger row a key lands on.
+ */
+
+import { describe, expect, it } from "vitest";
+import { normalizeLedgerSourceId } from "./ledger-source-id";
+
+/** The shape the ledger column requires: RFC-4122 version 1-5, variant 8/9/a/b. */
+const UUID_CONTRACT = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+const V4 = "f47ac10b-58cc-4372-a567-0e02b2c3d479";
+const V1 = "b54adc00-67f9-11d9-9669-0800200c9a66";
+const V5 = "886313e1-3b8a-5372-9b90-0c9aee199e5d";
+/** UUIDv7 — valid RFC 9562, but version 7 is outside the accepted 1-5 class. */
+const V7 = "0197b3f1-8c2a-7def-9abc-1234567890ab";
+const NIL = "00000000-0000-0000-0000-000000000000";
+
+describe("canonical UUIDs pass through", () => {
+  it.each([V1, V4, V5])("returns %s unchanged", (uuid) => {
+    expect(normalizeLedgerSourceId(uuid)).toBe(uuid);
+  });
+
+  it("lowercases an upper-case UUID so casing cannot split a dedupe key", () => {
+    expect(normalizeLedgerSourceId(V4.toUpperCase())).toBe(V4);
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    expect(normalizeLedgerSourceId(`  ${V4}\n`)).toBe(V4);
+  });
+});
+
+describe("values outside the accepted UUID class are derived, not passed through", () => {
+  it.each([
+    ["UUIDv7", V7],
+    ["the nil UUID", NIL],
+    ["a UUID with an invalid variant nibble", "f47ac10b-58cc-4372-c567-0e02b2c3d479"],
+    ["a truncated UUID", "f47ac10b-58cc-4372-a567-0e02b2c3d47"],
+  ])("derives a new id for %s", (_label, value) => {
+    const out = normalizeLedgerSourceId(value);
+    expect(out).not.toBe(value.toLowerCase());
+    expect(out).toMatch(UUID_CONTRACT);
+  });
+
+  it("derives an id for the dedupe keys the earnings ledger actually uses", () => {
+    for (const key of [
+      "revenue_split:pi_3PabcdEfGhIjKlMn:11111111-1111-4111-8111-111111111111",
+      "crypto_revenue_split:9f2c:22222222-2222-4222-8222-222222222222",
+      "",
+    ]) {
+      expect(normalizeLedgerSourceId(key)).toMatch(UUID_CONTRACT);
+    }
+  });
+});
+
+describe("identity properties the ledger depends on", () => {
+  const keys = [
+    "revenue_split:pi_1:user_a",
+    "revenue_split:pi_1:user_b",
+    "revenue_split:pi_2:user_a",
+    "app_owner:9",
+    "",
+    " ",
+  ];
+
+  it("is stable across calls, so a retry dedupes against the first row", () => {
+    for (const key of keys) {
+      expect(normalizeLedgerSourceId(key)).toBe(normalizeLedgerSourceId(key));
+    }
+  });
+
+  it("is idempotent — re-normalising a derived id returns it unchanged", () => {
+    // Only holds because the derived id satisfies UUID_CONTRACT itself; if the
+    // forced version/variant nibbles regressed, the second pass would re-hash.
+    for (const key of keys) {
+      const once = normalizeLedgerSourceId(key);
+      expect(normalizeLedgerSourceId(once)).toBe(once);
+    }
+  });
+
+  it("maps distinct keys to distinct ids", () => {
+    // `" "` is excluded: it trims to `""`, so the two are the same key by
+    // design — asserted separately below.
+    const distinct = keys.filter((key) => key.trim() !== "");
+    const ids = distinct.map((key) => normalizeLedgerSourceId(key));
+    expect(new Set(ids).size).toBe(distinct.length);
+  });
+
+  it("treats whitespace-only and empty keys as the same key", () => {
+    // Both trim to "", so they intentionally share one derived id.
+    expect(normalizeLedgerSourceId(" ")).toBe(normalizeLedgerSourceId(""));
+  });
+
+  it("always produces a value the uuid column accepts", () => {
+    for (const key of [...keys, V7, NIL, "x".repeat(512), "🙂 unicode key"]) {
+      expect(normalizeLedgerSourceId(key)).toMatch(UUID_CONTRACT);
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

No tracking issue — `packages/cloud/shared/src/lib/utils/ledger-source-id.ts` had no test file. No behavior is changed by this PR.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused suites, typecheck, and Biome recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passes post-sync; see **Known gaps / failures**.

# Risks

Low. Test-only: one new file, no source file touched, no public surface changed.

# Background

## What does this PR do?

Adds the first test coverage for `normalizeLedgerSourceId`.

This is a ledger identity function rather than a formatting helper: `redeemable_earnings_ledger.source_id` is a `uuid` column, while the dedupe keys callers pass — `revenue_split:<paymentIntent>:<user>` in `queue/stripe-event.ts`, `crypto_revenue_split:<id>:<user>` in `crypto-payments.ts` — are not UUIDs, so they are folded into one. `addEarnings({ dedupeBySourceId: true })` then matches on the folded value, which makes two properties load-bearing:

- **Stability** — the same key must always fold to the same id, or a retry writes a second earnings row instead of deduping against the first.
- **Injectivity** — two distinct keys must not collapse onto one id, or a legitimate second credit is silently swallowed as a duplicate.

Both are asserted directly. The suite also pins that every result satisfies the `uuid` column's contract, which is what makes re-normalising an already-derived id a no-op.

One behaviour is worth a reviewer's eye because it is invisible at the call site: the accepted-UUID gate restricts the **version nibble to 1-5**, so a UUIDv7 (RFC 9562) or the nil UUID does **not** pass through — it is hashed into a different id. Any caller that starts minting v7 ids would silently land on a different ledger row than a reader would expect. I have pinned the current behaviour rather than changed it.

## What kind of change is this?

Improvements — test coverage only, no production code touched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/utils/ledger-source-id.test.ts` is the whole diff. The mutation scorecard below is the argument that it is not vacuous.

## Detailed testing steps

```bash
bun install
bun test --cwd packages/cloud/shared src/lib/utils/ledger-source-id.test.ts
```

# Evidence Gate

<!-- evidence-head:74a9de4cc7f7533b192baf13a471fd99e8ea5351 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only change; the diff adds one .test.ts file under packages/cloud/shared and touches no rendered surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only change; no rendered surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is a unit-test file whose full output is inline below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — full transcript inline below: both test lanes, the mutation runs proving each assertion group fails when its invariant is broken, the restored source back to green, and lint/typecheck.

<details>
<summary>test lanes + mutation scorecard + lint/typecheck</summary>

```text
# Evidence log — test(cloud): cover normalizeLedgerSourceId
# node v24.15.0  bun 1.3.14

===== 1. vitest lane =====
 Test Files  1 passed (1)
      Tests  15 passed (15)

===== 2. the package's own runner (bun test) =====
 15 pass
 0 fail
 40 expect() calls
Ran 15 tests across 1 file. [71.00ms]

===== 3. mutation scorecard (source restored after each) =====
baseline (unmutated)                           Tests  15 passed (15)

M1 drop the trim before matching               Tests  2 failed | 13 passed (15)
M2 stop lowercasing an accepted UUID           Tests  1 failed | 14 passed (15)
M3 forced version nibble 5 -> 0                Tests  7 failed | 8 passed (15)
M4 drop the variant nibble forcing             Tests  6 failed | 9 passed (15)
M5 widen the accepted version class to any hex Tests  2 failed | 13 passed (15)
M6 hash a constant (all keys collide)          Tests  1 failed | 14 passed (15)

restored                                       Tests  15 passed (15)
git diff --stat -> (clean)

===== 4. lint + typecheck =====
Checked 1 file in 9ms. No fixes applied.
Done!
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path is exercised.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model code path changed; no production source file is modified by this PR.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - the helper returns a normalised uuid string; every input/output pair is asserted inline in the test file and visible in the transcript above.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model path changed.`

## Backend + frontend logs

Frontend: `N/A - no frontend path exercised.` Backend: full transcript is inline on the `backend-logs` row above.

### Proof the suite is not vacuous

Each invariant was checked by mutating the source and confirming the matching assertions fail; the source was restored after every run (`git diff --stat` clean, 15/15 green again).

| # | mutation applied to `ledger-source-id.ts` | result |
| --- | --- | --- |
| M1 | drop the `.trim()` before matching | **2 failed** |
| M2 | stop lowercasing an accepted UUID | **1 failed** |
| M3 | forced version nibble `"5"` -> `"0"` | **7 failed** |
| M4 | drop the variant-nibble forcing | **6 failed** |
| M5 | widen the accepted version class to any hex | **2 failed** |
| M6 | hash a constant so every key collides | **1 failed** |

M3 and M4 are the ones that matter most: both break the derived id's own conformance to the `uuid` contract, which is exactly what would make a second `normalizeLedgerSourceId` call re-hash an already-derived id and split a dedupe key across two rows.

## Screenshots (before / after) + video walkthrough

`N/A - test-only change with no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, or STT path involved.`

## Known gaps / failures

- Runner: this package's `test` script is `bun test`, but the immediate siblings in `src/lib/utils/` (`agent-username.test.ts`, `app-url.test.ts`, `cors.test.ts`) import from `vitest`, so this file follows them. It passes under **both** lanes — `bun test` 15 pass / 0 fail and the repo vitest lane 15 passed — and the transcript shows both.
- `bun run --cwd packages/cloud/shared typecheck` and Biome are clean. I did not run the full `bun run verify`; the diff is a single new test file with no production import-graph change.
- Injectivity is asserted over the sampled keys in the suite, not proven in general — it rests on SHA-256 over the trimmed input, so a collision would require a SHA-256 collision.
