### PR TITLE
test(core): cover text-normalize helpers

### DIFF
--- a/packages/core/src/utils/text-normalize.test.ts
+++ b/packages/core/src/utils/text-normalize.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Deterministic unit coverage for the prompt/context text-normalization
+ * helpers. Both functions are pure, so every case is an exact input/output
+ * assertion.
+ *
+ * These build the text blocks that reach model prompts, so the coercion rules
+ * are the contract: which values survive, which are silently dropped, and how a
+ * nested value is rendered. The drops are the part worth pinning — a value that
+ * disappears here disappears from the prompt with no error, and the rule is
+ * "empty after coercion", not "falsy": `0` and `false` are kept while `{}`,
+ * `null` and a whitespace-only string are not.
+ */
+
+import { describe, expect, it } from "vitest";
+import { flattenTextValues, toMultilineText } from "./text-normalize";
+
+describe("flattenTextValues", () => {
+	describe("strings", () => {
+		it("trims and keeps a non-empty string", () => {
+			expect(flattenTextValues("  hello  ")).toEqual(["hello"]);
+		});
+
+		it("drops an empty or whitespace-only string", () => {
+			expect(flattenTextValues("")).toEqual([]);
+			expect(flattenTextValues("   \n\t ")).toEqual([]);
+		});
+	});
+
+	describe("nullish", () => {
+		it("drops null and undefined, keeping their siblings", () => {
+			expect(flattenTextValues(null)).toEqual([]);
+			expect(flattenTextValues(undefined)).toEqual([]);
+			expect(flattenTextValues([null, "a", undefined, "b"])).toEqual([
+				"a",
+				"b",
+			]);
+		});
+	});
+
+	describe("scalars", () => {
+		it("keeps falsy-but-present scalars", () => {
+			// The rule is "empty after coercion", not "falsy" — dropping these would
+			// silently remove a real 0 or false from a prompt.
+			expect(flattenTextValues(0)).toEqual(["0"]);
+			expect(flattenTextValues(false)).toEqual(["false"]);
+			expect(flattenTextValues([0, false])).toEqual(["0", "false"]);
+		});
+
+		it("stringifies other scalars", () => {
+			expect(flattenTextValues(42)).toEqual(["42"]);
+			expect(flattenTextValues(Number.NaN)).toEqual(["NaN"]);
+			expect(flattenTextValues(true)).toEqual(["true"]);
+		});
+	});
+
+	describe("arrays", () => {
+		it("flattens arbitrarily nested arrays in order", () => {
+			expect(flattenTextValues(["a", ["b", ["c", ["d"]]]])).toEqual([
+				"a",
+				"b",
+				"c",
+				"d",
+			]);
+		});
+
+		it("yields nothing for an empty array or an array of empties", () => {
+			expect(flattenTextValues([])).toEqual([]);
+			expect(flattenTextValues([null, "", [], "  "])).toEqual([]);
+		});
+	});
+
+	describe("objects", () => {
+		it("renders each entry as `key: value`", () => {
+			expect(flattenTextValues({ a: "1", b: "2" })).toEqual(["a: 1", "b: 2"]);
+		});
+
+		it("joins a nested collection into one entry with `, `", () => {
+			expect(flattenTextValues({ tags: ["x", "y"] })).toEqual(["tags: x, y"]);
+			expect(flattenTextValues({ outer: { inner: "v" } })).toEqual([
+				"outer: inner: v",
+			]);
+		});
+
+		it("drops an entry whose value coerces to nothing", () => {
+			expect(flattenTextValues({ a: {}, b: null, c: "  ", d: [] })).toEqual([]);
+			expect(flattenTextValues({ kept: "v", dropped: null })).toEqual([
+				"kept: v",
+			]);
+		});
+
+		it("keeps an entry whose value is a falsy scalar", () => {
+			expect(flattenTextValues({ count: 0, on: false })).toEqual([
+				"count: 0",
+				"on: false",
+			]);
+		});
+	});
+
+	describe("non-plain objects have no enumerable own entries and are dropped", () => {
+		// Worth pinning: these coerce to nothing rather than to their toString(),
+		// so a Date or Map handed to prompt assembly vanishes without an error.
+		it.each([
+			["a Date", new Date("2026-01-01T00:00:00.000Z")],
+			["a Map", new Map([["k", "v"]])],
+			["a Set", new Set(["a"])],
+		])("drops %s", (_label, value) => {
+			expect(flattenTextValues(value)).toEqual([]);
+		});
+	});
+});
+
+describe("toMultilineText", () => {
+	it("joins the flattened fragments with newlines", () => {
+		expect(toMultilineText({ a: "1", b: "2" })).toBe("a: 1\nb: 2");
+		expect(toMultilineText(["x", ["y", "z"]])).toBe("x\ny\nz");
+	});
+
+	it("returns an empty string when nothing survives", () => {
+		expect(toMultilineText(null)).toBe("");
+		expect(toMultilineText([null, "  ", {}])).toBe("");
+	});
+});


### PR DESCRIPTION
# Relates to

No tracking issue — `packages/core/src/utils/text-normalize.ts` had no test file. No behavior is changed by this PR.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused suite, typecheck, and Biome recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passes post-sync; see **Known gaps / failures**.

# Risks

Low. Test-only: one new file, no source file touched, no public surface changed.

# Background

## What does this PR do?

Adds the first test coverage for `flattenTextValues` / `toMultilineText`. Both are pure, so every case is an exact input/output assertion.

These build text blocks that reach model prompts, which makes the coercion rules the actual contract — and the **drops** are the part worth pinning, because a value that disappears here disappears from the prompt with no error anywhere.

The rule is "empty after coercion", not "falsy". The suite asserts that distinction directly:

- `0` and `false` survive (as `"0"` / `"false"`), including as object values
- `null`, `undefined`, `""`, a whitespace-only string, `[]` and `{}` are dropped
- an object entry whose value coerces to nothing is dropped, while its siblings survive

It also pins one behaviour that is invisible at the call site: a `Date`, `Map`, or `Set` reaches the `typeof value === "object"` branch, has no enumerable own entries, and is therefore **dropped rather than stringified**. Handing prompt assembly a `Date` silently contributes nothing. I have pinned the current behaviour rather than changed it — if stringifying those is wanted, that is a separate change with real prompt-output consequences.

## What kind of change is this?

Improvements — test coverage only, no production code touched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/text-normalize.test.ts` is the whole diff. The mutation scorecard below is the argument that it is not vacuous.

## Detailed testing steps

```bash
bun install
node packages/scripts/run-vitest.mjs run packages/core/src/utils/text-normalize.test.ts
```

# Evidence Gate

<!-- evidence-head:4c257e09fc63f455c6a5fd101b25509a0cc950a3 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only change; the diff adds one .test.ts file under packages/core and touches no rendered surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only change; no rendered surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is a unit-test file whose full output is inline below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — full transcript inline below: the suite on this head, the mutation runs proving each assertion group fails when its invariant is broken, the restored source back to green, and lint/typecheck.

<details>
<summary>suite + mutation scorecard + lint/typecheck</summary>

```text
# Evidence log — test(core): cover text-normalize helpers
# node v24.15.0  bun 1.3.14

===== 1. suite on the PR head =====
 Test Files  1 passed (1)
      Tests  16 passed (16)

===== 2. mutation scorecard (source restored after each) =====
baseline (unmutated)                             Tests  16 passed (16)

M1 drop the string trim                          Tests  5 failed | 11 passed (16)
M2 nullish check == becomes ===                  Tests  1 failed | 15 passed (16)
M3 keep empty strings                            Tests  2 failed | 14 passed (16)
M4 object entries joined with newline not ', '   Tests  1 failed | 15 passed (16)
M5 keep entries whose value is empty             Tests  1 failed | 15 passed (16)
M6 arrays no longer recurse                      Tests  5 failed | 11 passed (16)
M7 toMultilineText joins with space              Tests  1 failed | 15 passed (16)

restored                                         Tests  16 passed (16)
git diff --stat -> (clean)

===== 3. lint + typecheck =====
Checked 1 file in 4ms. No fixes applied.
Done!
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path is exercised.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model code path changed; no production source file is modified by this PR. The helpers feed prompt assembly, but they are pure functions and every input/output pair is asserted deterministically.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - the helpers return string fragments; every input/output pair is asserted inline in the test file and visible in the transcript above.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model path changed.`

## Backend + frontend logs

Frontend: `N/A - no frontend path exercised.` Backend: full transcript is inline on the `backend-logs` row above.

### Proof the suite is not vacuous

Each invariant was checked by mutating the source and confirming the matching assertions fail; the source was restored after every run (`git diff --stat` clean, 16/16 green again).

| # | mutation applied to `text-normalize.ts` | result |
| --- | --- | --- |
| M1 | drop the string `.trim()` | **5 failed** |
| M2 | nullish check `== null` -> `=== null` (undefined leaks through) | **1 failed** |
| M3 | keep empty strings instead of dropping them | **2 failed** |
| M4 | join nested object entries with a newline instead of `", "` | **1 failed** |
| M5 | keep object entries whose value coerces to nothing | **1 failed** |
| M6 | arrays no longer recurse | **5 failed** |
| M7 | `toMultilineText` joins with a space instead of `\n` | **1 failed** |

## Screenshots (before / after) + video walkthrough

`N/A - test-only change with no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, or STT path involved.`

## Known gaps / failures

- Exact rebased-head focused Vitest is 16/16 and changed-file Biome/diff check are clean. A disposable-worktree rerun of package typecheck reached only an unchanged missing `fast-redact` declaration in the linked logger dependency; the original exact-head package typecheck was clean. I did not run the full `bun run verify`; the diff is a single new test file with no production import-graph change.
- Circular structures are not covered: `flattenTextValues` recurses without a seen-set, so a self-referencing object overflows the stack. That is pre-existing behaviour and asserting it would pin a crash rather than a contract, so I left it out and am noting it here instead.
