### PR TITLE
test(core): cover the reference-echo safety gate

### DIFF
--- a/packages/core/src/utils/reference-echo.test.ts
+++ b/packages/core/src/utils/reference-echo.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Deterministic unit coverage for the reference-echo safety gate. Both helpers
+ * are pure, so every case is an exact input/output assertion.
+ *
+ * This is a containment boundary, not formatting: a reference that fell back to
+ * `message.content.text` can be an entire rendered prompt including the
+ * external-content security envelope, and quoting it verbatim re-broadcasts
+ * that scaffolding to chat (the 2026-08-02 live leak the module header cites).
+ * The gate is a shape property, so the tests are written around its edges — the
+ * exact 64- and 120-character boundaries, and which whitespace counts as
+ * multi-line — because those are what a refactor moves by one and nothing else
+ * would notice.
+ */
+
+import { describe, expect, it } from "vitest";
+import { describeUserReference, userReferenceLogView } from "./reference-echo";
+
+const FALLBACK = "that item";
+
+describe("describeUserReference", () => {
+	it("quotes a name-shaped reference", () => {
+		expect(describeUserReference("Ada Lovelace", FALLBACK)).toBe(
+			'"Ada Lovelace"',
+		);
+	});
+
+	it("trims before quoting and before measuring", () => {
+		expect(describeUserReference("  Ada  ", FALLBACK)).toBe('"Ada"');
+		// 64 content characters plus surrounding whitespace still passes: the
+		// length gate applies to the trimmed value.
+		const exactly64 = "a".repeat(64);
+		expect(describeUserReference(`  ${exactly64}  `, FALLBACK)).toBe(
+			`"${exactly64}"`,
+		);
+	});
+
+	it("falls back for an empty or whitespace-only reference", () => {
+		expect(describeUserReference("", FALLBACK)).toBe(FALLBACK);
+		expect(describeUserReference("   ", FALLBACK)).toBe(FALLBACK);
+		expect(describeUserReference("\n\t ", FALLBACK)).toBe(FALLBACK);
+	});
+
+	it("holds the 64-character boundary exactly", () => {
+		expect(describeUserReference("a".repeat(64), FALLBACK)).toBe(
+			`"${"a".repeat(64)}"`,
+		);
+		expect(describeUserReference("a".repeat(65), FALLBACK)).toBe(FALLBACK);
+	});
+
+	it("falls back for anything multi-line", () => {
+		// A rendered prompt is never single-line, which is the whole gate.
+		expect(describeUserReference("line one\nline two", FALLBACK)).toBe(
+			FALLBACK,
+		);
+		expect(describeUserReference("line one\rline two", FALLBACK)).toBe(
+			FALLBACK,
+		);
+		expect(describeUserReference("a\r\nb", FALLBACK)).toBe(FALLBACK);
+		expect(describeUserReference("trailing\n", FALLBACK)).toBe('"trailing"');
+	});
+
+	it("treats a horizontal tab as name-shaped", () => {
+		// Only CR and LF are rejected; a tab survives the gate. Pinned because it
+		// is the nearest neighbour to the rejected characters.
+		expect(describeUserReference("a\tb", FALLBACK)).toBe('"a\tb"');
+	});
+
+	it("returns the caller's fallback verbatim", () => {
+		expect(describeUserReference("x".repeat(200), "the requested target")).toBe(
+			"the requested target",
+		);
+	});
+});
+
+describe("userReferenceLogView", () => {
+	it("collapses every whitespace run to a single space and trims", () => {
+		expect(userReferenceLogView("  a \n\t  b \r\n c  ")).toBe("a b c");
+	});
+
+	it("returns a short reference unchanged after collapsing", () => {
+		expect(userReferenceLogView("plain reference")).toBe("plain reference");
+		expect(userReferenceLogView("")).toBe("");
+		expect(userReferenceLogView("   ")).toBe("");
+	});
+
+	it("holds the 120-character boundary exactly", () => {
+		const exactly120 = "a".repeat(120);
+		expect(userReferenceLogView(exactly120)).toBe(exactly120);
+
+		const over = "a".repeat(121);
+		expect(userReferenceLogView(over)).toBe(`${"a".repeat(120)}…`);
+	});
+
+	it("measures the boundary after collapsing, not before", () => {
+		// 150 raw characters that collapse to 89 must survive intact — clamping on
+		// the raw length would truncate this.
+		const spaced = "ab   ".repeat(30);
+		expect(spaced.length).toBeGreaterThan(120);
+
+		const collapsed = userReferenceLogView(spaced);
+		expect(collapsed).toBe(Array.from({ length: 30 }, () => "ab").join(" "));
+		expect(collapsed.length).toBeLessThanOrEqual(120);
+		expect(collapsed).not.toContain("…");
+	});
+
+	it("appends exactly one ellipsis character when clamping", () => {
+		const clamped = userReferenceLogView("b".repeat(500));
+		expect(clamped).toHaveLength(121);
+		expect(clamped.endsWith("…")).toBe(true);
+		expect(clamped.slice(0, 120)).toBe("b".repeat(120));
+	});
+});


### PR DESCRIPTION
# Relates to

No tracking issue — `packages/core/src/utils/reference-echo.ts` had no test file. No behavior is changed by this PR.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused suite, typecheck, and Biome recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passes post-sync; see **Known gaps / failures**.

# Risks

Low. Test-only: one new file, no source file touched, no public surface changed.

# Background

## What does this PR do?

Adds the first test coverage for `describeUserReference` / `userReferenceLogView`.

This one is a containment boundary rather than formatting, which is why it seemed worth covering: as the module header records, a reference that fell back to `message.content.text` can be an entire rendered prompt — including the external-content security envelope — and quoting it verbatim re-broadcasts that scaffolding to chat (the 2026-08-02 live leak). The gate is a shape property, so the only thing standing between a name and a leaked prompt is two numeric bounds and a newline test, none of which had a test.

The suite is written around those edges, because they are what a refactor moves by one while everything else still looks correct:

- the **64-character** name-shape bound, asserted at exactly 64 (quoted) and 65 (fallback)
- trimming happening **before** measuring, so a 64-character value with surrounding whitespace still passes
- which whitespace counts as multi-line — CR and LF are rejected, a horizontal tab is not
- the **120-character** log clamp, asserted at exactly 120 (unchanged) and 121 (clamped)
- the clamp measuring the **collapsed** length, not the raw one — 150 raw characters that collapse to 89 must survive intact
- exactly one `…` appended, so a clamped value is 121 characters

## What kind of change is this?

Improvements — test coverage only, no production code touched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/reference-echo.test.ts` is the whole diff. The mutation scorecard below is the argument that it is not vacuous.

## Detailed testing steps

```bash
bun install
node packages/scripts/run-vitest.mjs run packages/core/src/utils/reference-echo.test.ts
```

# Evidence Gate

<!-- evidence-head:bdd22f6cf746879b8a0f649a9bfb288a17be06ae -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only change; the diff adds one .test.ts file under packages/core and touches no rendered surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only change; no rendered surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is a unit-test file whose full output is inline below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — full transcript inline below: the suite on this head, the mutation runs proving each assertion group fails when its invariant is broken, the restored source back to green, and lint/typecheck.

<details>
<summary>suite + mutation scorecard + lint/typecheck</summary>

```text
# Evidence log — test(core): cover the reference-echo safety gate
# node v24.15.0  bun 1.3.14

===== 1. suite on the PR head =====
 Test Files  1 passed (1)
      Tests  12 passed (12)

===== 2. mutation scorecard (source restored after each) =====
baseline (unmutated)                                 Tests  12 passed (12)

M1 name-shape length bound 64 -> 65 (off-by-one)     Tests  1 failed | 11 passed (12)
M2 drop the multi-line rejection                     Tests  1 failed | 11 passed (12)
M3 reject only LF, allow CR                          Tests  1 failed | 11 passed (12)
M4 skip the trim before shape check                  Tests  3 failed | 9 passed (12)
M5 drop the empty-reference guard                    Tests  1 failed | 11 passed (12)
M6 log clamp 120 -> 121 (off-by-one)                 Tests  1 failed | 11 passed (12)
M7 log view stops collapsing whitespace              Tests  2 failed | 10 passed (12)
M8 log view clamps without the ellipsis              Tests  2 failed | 10 passed (12)

restored                                             Tests  12 passed (12)
git diff --stat -> (clean)

===== 3. lint + typecheck =====
Checked 1 file in 4ms. No fixes applied.
Done!
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path is exercised.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model code path changed; no production source file is modified by this PR.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - the helpers return rendered strings; every input/output pair is asserted inline in the test file and visible in the transcript above.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model path changed.`

## Backend + frontend logs

Frontend: `N/A - no frontend path exercised.` Backend: full transcript is inline on the `backend-logs` row above.

### Proof the suite is not vacuous

Each invariant was checked by mutating the source and confirming the matching assertions fail; the source was restored after every run (`git diff --stat` clean, 12/12 green again).

| # | mutation applied to `reference-echo.ts` | result |
| --- | --- | --- |
| M1 | name-shape bound `<= 64` -> `<= 65` | **1 failed** |
| M2 | drop the multi-line rejection entirely | **1 failed** |
| M3 | reject only LF, allow CR | **1 failed** |
| M4 | skip the `.trim()` before the shape check | **3 failed** |
| M5 | drop the empty-reference guard | **1 failed** |
| M6 | log clamp `> 120` -> `> 121` | **1 failed** |
| M7 | log view stops collapsing whitespace | **2 failed** |
| M8 | log view clamps without appending the ellipsis | **2 failed** |

M1 and M6 are the point of the exercise: both are single-character off-by-one edits to the two bounds that decide whether a rendered prompt is echoed, and both are caught.

## Screenshots (before / after) + video walkthrough

`N/A - test-only change with no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, or STT path involved.`

## Known gaps / failures

- `bun run --cwd packages/core typecheck` and Biome are clean. I did not run the full `bun run verify`; the diff is a single new test file with no production import-graph change.
- Lengths are measured in UTF-16 code units by `String.prototype.length`, so an astral character counts twice against both bounds and the 120-clamp can split a surrogate pair. That is pre-existing behaviour of the helper rather than something this PR introduces, and pinning it would freeze a rough edge rather than a contract, so I left it uncovered and am noting it here instead. `packages/core/src/utils/well-formed.ts` already exists if that is ever worth tightening.
