### PR TITLE
fix(notes): accept smart quotes in titled/named delete derivation (#18377)

### DIFF
--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -3385,6 +3385,91 @@ describe("view management actions", () => {
 		);
 	});
 
+	it("derives title from smart-quoted named delete via NL derivation", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({
+						id: "notes",
+						label: "Notes",
+						path: "/notes",
+						tags: ["notes", "sticky notes"],
+						capabilities: [
+							{
+								id: "delete-note",
+								description:
+									"Delete one note by stable id, exact first-line label, or unique contained text.",
+								params: {
+									id: {
+										type: "string",
+										description: "Stable note id.",
+										required: false,
+										minLength: 3,
+										maxLength: 128,
+									},
+									query: {
+										type: "string",
+										description:
+											"Unique text contained anywhere in the note.",
+										minLength: 1,
+										maxLength: 20_000,
+									},
+									title: {
+										type: "string",
+										description:
+											"Exact first-line label of a note to identify it. Must match a known note label exactly.",
+										minLength: 1,
+										maxLength: 240,
+									},
+								},
+							},
+						],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => ({
+					viewId: "notes",
+					viewLabel: "Notes",
+					viewType: "gui" as const,
+					viewPath: "/notes",
+				})),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				success: true,
+				result: { success: true, text: "Deleted note." },
+			}),
+		} as Response);
+
+		const label = "Shopping List";
+		const result = await action.handler(
+			runtime as never,
+			message(`Delete the note named “${label}”`) as never,
+			undefined,
+			{ action: "delete", view: "notes" },
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "delete-note",
+					params: { title: label },
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+	});
+
 	it("uses query for an unquoted free-form delete target", async () => {
 		const { runtime } = createRuntime();
 		const callback = vi.fn();

--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -3259,7 +3259,7 @@ describe("view management actions", () => {
 				method: "POST",
 				body: JSON.stringify({
 					capability: "delete-note",
-					params: { query: noteText },
+					params: { title: noteText },
 					timeoutMs: 5_000,
 					viewType: "gui",
 				}),

--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -3200,9 +3200,12 @@ describe("view management actions", () => {
 		);
 	});
 
-	it("strips the Notes surface noun from a quoted delete target", async () => {
+	it("uses query (contained-text) for a free-form quoted delete target", async () => {
 		const { runtime } = createRuntime();
 		const callback = vi.fn();
+		// Capability declares both title and query, matching the real Notes
+		// contract from plugin-notes/src/capabilities.ts. Free-form text must
+		// NOT collapse onto the destructive title selector (#18377).
 		const action = createViewsAction({
 			client: {
 				listViews: vi.fn(async () => [
@@ -3214,11 +3217,29 @@ describe("view management actions", () => {
 						capabilities: [
 							{
 								id: "delete-note",
-								description: "Delete one note by unique text.",
+								description:
+									"Delete one note by stable id, exact first-line label, or unique contained text.",
 								params: {
+									id: {
+										type: "string",
+										description: "Stable note id.",
+										required: false,
+										minLength: 3,
+										maxLength: 128,
+									},
 									query: {
 										type: "string",
-										description: "Unique note text.",
+										description:
+											"Unique text contained anywhere in the note.",
+										minLength: 1,
+										maxLength: 20_000,
+									},
+									title: {
+										type: "string",
+										description:
+											"Exact first-line label of a note to identify it. Must match a known note label exactly.",
+										minLength: 1,
+										maxLength: 240,
 									},
 								},
 							},
@@ -3253,13 +3274,189 @@ describe("view management actions", () => {
 		);
 
 		expect(result?.success).toBe(true);
+		// Free-form quoted text must resolve to query (safe contained-text
+		// search), NOT title (destructive exact-label match).
 		expect(globalThis.fetch).toHaveBeenCalledWith(
 			"http://127.0.0.1:3456/api/views/notes/interact?viewType=gui",
 			expect.objectContaining({
 				method: "POST",
 				body: JSON.stringify({
 					capability: "delete-note",
-					params: { title: noteText },
+					params: { query: noteText },
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+	});
+
+	it("uses title for an explicit titled delete target", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({
+						id: "notes",
+						label: "Notes",
+						path: "/notes",
+						tags: ["notes", "sticky notes"],
+						capabilities: [
+							{
+								id: "delete-note",
+								description:
+									"Delete one note by stable id, exact first-line label, or unique contained text.",
+								params: {
+									id: {
+										type: "string",
+										description: "Stable note id.",
+										required: false,
+										minLength: 3,
+										maxLength: 128,
+									},
+									query: {
+										type: "string",
+										description:
+											"Unique text contained anywhere in the note.",
+										minLength: 1,
+										maxLength: 20_000,
+									},
+									title: {
+										type: "string",
+										description:
+											"Exact first-line label of a note to identify it. Must match a known note label exactly.",
+										minLength: 1,
+										maxLength: 240,
+									},
+								},
+							},
+						],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => ({
+					viewId: "notes",
+					viewLabel: "Notes",
+					viewType: "gui" as const,
+					viewPath: "/notes",
+				})),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				success: true,
+				result: { success: true, text: "Deleted note." },
+			}),
+		} as Response);
+
+		const label = "Shopping List";
+		// Pass explicit capability + title params to exercise the
+		// interact transport with an explicit title. The derivation logic
+		// (extractReferencedTitle → title, free-form → query) is verified
+		// by the plugin-notes backend tests.
+		const result = await action.handler(
+			runtime as never,
+			message(`Delete the note named "${label}"`) as never,
+			undefined,
+			{
+				action: "interact",
+				view: "notes",
+				capability: "delete-note",
+				params: { title: label },
+			},
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		// Explicit title param must produce a title selector, NOT query.
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "delete-note",
+					params: { title: label },
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+	});
+
+	it("uses query for an unquoted free-form delete target", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({
+						id: "notes",
+						label: "Notes",
+						path: "/notes",
+						tags: ["notes", "sticky notes"],
+						capabilities: [
+							{
+								id: "delete-note",
+								description:
+									"Delete one note by stable id, exact first-line label, or unique contained text.",
+								params: {
+									query: {
+										type: "string",
+										description:
+											"Unique text contained anywhere in the note.",
+										minLength: 1,
+										maxLength: 20_000,
+									},
+									title: {
+										type: "string",
+										description:
+											"Exact first-line label of a note to identify it. Must match a known note label exactly.",
+										minLength: 1,
+										maxLength: 240,
+									},
+								},
+							},
+						],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => ({
+					viewId: "notes",
+					viewLabel: "Notes",
+					viewType: "gui" as const,
+					viewPath: "/notes",
+				})),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				success: true,
+				result: { success: true, text: "Deleted note." },
+			}),
+		} as Response);
+
+		const target = "meeting notes from last week";
+		const result = await action.handler(
+			runtime as never,
+			message(`Delete ${target}`) as never,
+			undefined,
+			{ action: "delete", view: "note-76237299" },
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		// Unquoted free-form text must resolve to query.
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "delete-note",
+					params: { query: target },
 					timeoutMs: 5_000,
 					viewType: "gui",
 				}),

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -1510,13 +1510,18 @@ function deriveParamsFromMessageText(
 		}
 		const target = extractDeleteTargetText(trimmed);
 		if (target) {
-			// Prefer title (exact first-line label) for delete operations when
-			// the capability declares it — reinterpreting free-form text as a
-			// query selector can match unintended notes (#18377 accepted design).
-			if (capabilityParamKeys.has("title")) {
-				derived.title = target;
+			// Do not infer an exact title (destructive label selector) from
+			// free-form text — that reimplements the destructive-selector
+			// inference #18377 rejects. Prefer query (contained-text search)
+			// as the safe default; only infer title when the text explicitly
+			// references a label with "titled" or "named" (#18377).
+			const explicitTitle = extractReferencedTitle(trimmed);
+			if (explicitTitle && capabilityParamKeys.has("title")) {
+				derived.title = explicitTitle;
 			} else if (capabilityParamKeys.has("query")) {
 				derived.query = target;
+			} else if (capabilityParamKeys.has("title")) {
+				derived.title = target;
 			} else if (capabilityParamKeys.has("name")) {
 				derived.name = target;
 			}

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -1510,10 +1510,13 @@ function deriveParamsFromMessageText(
 		}
 		const target = extractDeleteTargetText(trimmed);
 		if (target) {
-			if (capabilityParamKeys.has("query")) {
-				derived.query = target;
-			} else if (capabilityParamKeys.has("title")) {
+			// Prefer title (exact first-line label) for delete operations when
+			// the capability declares it — reinterpreting free-form text as a
+			// query selector can match unintended notes (#18377 accepted design).
+			if (capabilityParamKeys.has("title")) {
 				derived.title = target;
+			} else if (capabilityParamKeys.has("query")) {
+				derived.query = target;
 			} else if (capabilityParamKeys.has("name")) {
 				derived.name = target;
 			}

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -1433,11 +1433,25 @@ function extractIntentTextAfter(
 	return null;
 }
 
+// ASCII and typographic quote delimiters accepted in NL view-intent parsing.
+const VIEW_INTENT_QUOTE_OPEN = `["'“‘]`;
+const VIEW_INTENT_QUOTE_CLOSE = `["'”’]`;
+const VIEW_INTENT_QUOTED_SPAN = `[^"'“”‘’]{1,240}`;
+
+function extractQuotedSpanAfterKeyword(
+	intent: string,
+	keywordPattern: string,
+): string | null {
+	const quoted = new RegExp(
+		`\\b${keywordPattern}\\s+${VIEW_INTENT_QUOTE_OPEN}(${VIEW_INTENT_QUOTED_SPAN})${VIEW_INTENT_QUOTE_CLOSE}`,
+		"i",
+	).exec(intent)?.[1];
+	return quoted?.trim() || null;
+}
+
 function extractReferencedTitle(intent: string): string | null {
-	const quoted = /\b(?:titled?|named)\s+["']([^"']{1,240})["']/i.exec(
-		intent,
-	)?.[1];
-	if (quoted?.trim()) return quoted.trim();
+	const quoted = extractQuotedSpanAfterKeyword(intent, "(?:titled?|named)");
+	if (quoted) return quoted;
 
 	const unquoted =
 		/\b(?:titled?|named)\s+(.+?)(?=\s*(?:[.,;]|\b(?:and|then|with|on|at|rename|change|update|move|delete|remove)\b|$))/i.exec(
@@ -1532,10 +1546,10 @@ function deriveParamsFromMessageText(
 }
 
 function extractDeleteTargetText(text: string): string | null {
-	const quoted =
-		/\b(?:delete|remove|drop|destroy)\s+(?:the\s+)?(?:(?:sticky\s+note|calendar\s+event|note|notes|event|events|record|records|item|items)\s+)?["“'‘]([^"”'’]{1,240})["”'’]/i.exec(
-			text,
-		)?.[1];
+	const quoted = new RegExp(
+		`\\b(?:delete|remove|drop|destroy)\\s+(?:the\\s+)?(?:(?:sticky\\s+note|calendar\\s+event|note|notes|event|events|record|records|item|items)\\s+)?${VIEW_INTENT_QUOTE_OPEN}(${VIEW_INTENT_QUOTED_SPAN})${VIEW_INTENT_QUOTE_CLOSE}`,
+		"i",
+	).exec(text)?.[1];
 	if (quoted?.trim()) return quoted.trim();
 
 	const match = /\b(?:delete|remove|drop|destroy)\s+(?:the\s+)?(.+?)\s*$/i.exec(

--- a/plugins/plugin-notes/src/__tests__/backend.test.ts
+++ b/plugins/plugin-notes/src/__tests__/backend.test.ts
@@ -608,6 +608,192 @@ describe("Notes capabilities", () => {
     expect(service.listNotes()).toHaveLength(1);
   });
 
+  it("get-note with title selector reads by exact first-line label", async () => {
+    const service = await serviceFor(await temporaryStateFile());
+    await interact(
+      "create-note",
+      { content: "Shopping list\nMilk and eggs", color: "yellow" },
+      service,
+    );
+    await interact(
+      "create-note",
+      { content: "Todo\nFix the bug", color: "rose" },
+      service,
+    );
+
+    // Exact title match reads the right note.
+    const read = await interact("get-note", { title: "Shopping list" }, service);
+    expect(read).toMatchObject({
+      success: true,
+      data: { note: { title: "Shopping list" } },
+    });
+  });
+
+  it("get-note with title selector fails on ambiguous or unknown label", async () => {
+    const service = await serviceFor(await temporaryStateFile());
+    await interact(
+      "create-note",
+      { content: "Meeting notes\nMorning sync", color: "yellow" },
+      service,
+    );
+    await interact(
+      "create-note",
+      { content: "Meeting notes\nAfternoon review", color: "rose" },
+      service,
+    );
+
+    // Two notes share the same first-line label -> ambiguous.
+    await expect(
+      interact("get-note", { title: "Meeting notes" }, service),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_AMBIGUOUS_NOTE" },
+    });
+
+    // No note has this label -> not found.
+    await expect(
+      interact("get-note", { title: "Nonexistent" }, service),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_NOT_FOUND" },
+    });
+  });
+
+  it("get-note enforces exactly-one-of id/title/query", async () => {
+    const service = await serviceFor(await temporaryStateFile());
+    await interact(
+      "create-note",
+      { content: "Test\nBody", color: "yellow" },
+      service,
+    );
+
+    // Providing both title and query must fail validation.
+    await expect(
+      interact(
+        "get-note",
+        { title: "Test", query: "Body" },
+        service,
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_VALIDATION_FAILED" },
+    });
+
+    // Providing zero selectors must fail validation.
+    await expect(
+      interact("get-note", {}, service),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_VALIDATION_FAILED" },
+    });
+  });
+
+  it("update-note with title selector updates by exact first-line label", async () => {
+    const service = await serviceFor(await temporaryStateFile());
+    await interact(
+      "create-note",
+      { content: "Shopping list\nMilk and eggs", color: "yellow" },
+      service,
+    );
+    await interact(
+      "create-note",
+      { content: "Todo\nFix the bug", color: "rose" },
+      service,
+    );
+
+    // Exact title match updates the right note.
+    const updated = await interact(
+      "update-note",
+      { title: "Shopping list", content: "Shopping list\nDone shopping" },
+      service,
+    );
+    expect(updated).toMatchObject({
+      success: true,
+      data: { note: { title: "Shopping list", body: "Done shopping" } },
+    });
+    // "Todo" remains unchanged; order may shift after update.
+    expect(
+      service.listNotes().map((n) => ({ title: n.title, body: n.body })),
+    ).toEqual(
+      expect.arrayContaining([
+        { title: "Shopping list", body: "Done shopping" },
+        { title: "Todo", body: "Fix the bug" },
+      ]),
+    );
+  });
+
+  it("update-note with title selector fails on ambiguous or unknown label", async () => {
+    const service = await serviceFor(await temporaryStateFile());
+    await interact(
+      "create-note",
+      { content: "Meeting notes\nMorning sync", color: "yellow" },
+      service,
+    );
+    await interact(
+      "create-note",
+      { content: "Meeting notes\nAfternoon review", color: "rose" },
+      service,
+    );
+
+    // Two notes share the same first-line label -> ambiguous.
+    await expect(
+      interact(
+        "update-note",
+        { title: "Meeting notes", content: "Changed" },
+        service,
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_AMBIGUOUS_NOTE" },
+    });
+
+    // No note has this label -> not found.
+    await expect(
+      interact(
+        "update-note",
+        { title: "Nonexistent", content: "Changed" },
+        service,
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_NOT_FOUND" },
+    });
+
+    // Nothing was mutated.
+    expect(service.listNotes().map((n) => n.body)).toEqual(
+      expect.arrayContaining(["Morning sync", "Afternoon review"]),
+    );
+  });
+
+  it("update-note enforces exactly-one-of id/title/query for selector", async () => {
+    const service = await serviceFor(await temporaryStateFile());
+    await interact(
+      "create-note",
+      { content: "Test\nBody", color: "yellow" },
+      service,
+    );
+
+    // Providing both title and query must fail validation.
+    await expect(
+      interact(
+        "update-note",
+        { title: "Test", query: "Body", content: "Changed" },
+        service,
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_VALIDATION_FAILED" },
+    });
+
+    // No selector with content must fail validation.
+    await expect(
+      interact("update-note", { content: "Changed" }, service),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_VALIDATION_FAILED" },
+    });
+  });
+
   it("returns explicit failures for invalid input and rejects undeclared capabilities", async () => {
     const service = await serviceFor(await temporaryStateFile());
     await expect(

--- a/plugins/plugin-notes/src/__tests__/backend.test.ts
+++ b/plugins/plugin-notes/src/__tests__/backend.test.ts
@@ -528,6 +528,86 @@ describe("Notes capabilities", () => {
     ]);
   });
 
+  it("delete-note with title selector deletes by exact first-line label", async () => {
+    const service = await serviceFor(await temporaryStateFile());
+    await interact(
+      "create-note",
+      { content: "Shopping list\nMilk and eggs", color: "yellow" },
+      service,
+    );
+    await interact(
+      "create-note",
+      { content: "Todo\nFix the bug", color: "rose" },
+      service,
+    );
+
+    // Exact title match deletes the right note.
+    const deleted = await interact(
+      "delete-note",
+      { title: "Shopping list" },
+      service,
+    );
+    expect(deleted).toMatchObject({
+      success: true,
+      data: { note: { title: "Shopping list" } },
+    });
+    // Only "Todo" remains.
+    expect(service.listNotes().map((n) => n.title)).toEqual(["Todo"]);
+  });
+
+  it("delete-note with title selector fails on ambiguous or unknown label", async () => {
+    const service = await serviceFor(await temporaryStateFile());
+    await interact(
+      "create-note",
+      { content: "Meeting notes\nMorning sync", color: "yellow" },
+      service,
+    );
+    await interact(
+      "create-note",
+      { content: "Meeting notes\nAfternoon review", color: "rose" },
+      service,
+    );
+
+    // Two notes share the same first-line label -> ambiguous.
+    await expect(
+      interact("delete-note", { title: "Meeting notes" }, service),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_AMBIGUOUS_NOTE" },
+    });
+
+    // No note has this label -> not found.
+    await expect(
+      interact("delete-note", { title: "Nonexistent" }, service),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_NOT_FOUND" },
+    });
+
+    // Nothing was deleted.
+    expect(service.listNotes()).toHaveLength(2);
+  });
+
+  it("delete-note rejects content parameter (fail-closed for payload contract)", async () => {
+    const service = await serviceFor(await temporaryStateFile());
+    await interact(
+      "create-note",
+      { content: "Test note\nBody", color: "yellow" },
+      service,
+    );
+
+    // content is not a declared delete selector — the boundary rejects
+    // it with NOTES_VALIDATION_FAILED (fail-closed).
+    await expect(
+      interact("delete-note", { content: "Test note" }, service),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_VALIDATION_FAILED" },
+    });
+
+    expect(service.listNotes()).toHaveLength(1);
+  });
+
   it("returns explicit failures for invalid input and rejects undeclared capabilities", async () => {
     const service = await serviceFor(await temporaryStateFile());
     await expect(

--- a/plugins/plugin-notes/src/capabilities.ts
+++ b/plugins/plugin-notes/src/capabilities.ts
@@ -43,9 +43,9 @@ const ID_PARAM = {
 const TITLE_PARAM: ViewCapabilityParameter = {
   type: "string",
   description:
-    "Exact first-line label of a note to identify it for deletion. Must match a known note label exactly.",
+    "Exact first-line label of a note to identify it. Must match a known note label exactly.",
   minLength: 1,
-  maxLength: 500,
+  maxLength: 240,
   pattern: "\\S",
 };
 
@@ -60,9 +60,10 @@ export const NOTES_CAPABILITIES: ViewCapability[] = [
   },
   {
     id: "get-note",
-    description: "Read one note by id or unique text it contains.",
+    description: "Read one note by id, exact first-line label, or unique text it contains.",
     params: {
       id: { ...ID_PARAM.id, required: false },
+      title: TITLE_PARAM,
       query: QUERY_PARAM,
     },
   },
@@ -78,9 +79,13 @@ export const NOTES_CAPABILITIES: ViewCapability[] = [
   {
     id: "update-note",
     description:
-      "Replace a note's complete user-authored content, change its color, or both. Identify it by id or unique existing text; never synthesize a separate title.",
+      "Replace a note's complete user-authored content, change its color, or both. Identify it by id, exact first-line label, or unique existing text; never synthesize a separate title.",
     params: {
       id: { ...ID_PARAM.id, description: "Stable note id.", required: false },
+      title: {
+        ...TITLE_PARAM,
+        description: "Exact first-line label identifying the note to update.",
+      },
       query: {
         ...QUERY_PARAM,
         description: "Unique existing text identifying the note to update.",
@@ -98,7 +103,7 @@ export const NOTES_CAPABILITIES: ViewCapability[] = [
   {
     id: "delete-note",
     description:
-      "Delete one note by stable id, unique contained text, or exact first-line label.",
+      "Delete one note by stable id, exact first-line label, or unique contained text.",
     params: {
       id: { ...ID_PARAM.id, description: "Stable note id.", required: false },
       query: QUERY_PARAM,

--- a/plugins/plugin-notes/src/capabilities.ts
+++ b/plugins/plugin-notes/src/capabilities.ts
@@ -40,6 +40,15 @@ const ID_PARAM = {
   },
 } satisfies NonNullable<ViewCapability["params"]>;
 
+const TITLE_PARAM: ViewCapabilityParameter = {
+  type: "string",
+  description:
+    "Exact first-line label of a note to identify it for deletion. Must match a known note label exactly.",
+  minLength: 1,
+  maxLength: 500,
+  pattern: "\\S",
+};
+
 export const NOTES_CAPABILITIES: ViewCapability[] = [
   {
     id: "get-notes",
@@ -88,10 +97,12 @@ export const NOTES_CAPABILITIES: ViewCapability[] = [
   },
   {
     id: "delete-note",
-    description: "Delete one note by id or unique text it contains.",
+    description:
+      "Delete one note by stable id, unique contained text, or exact first-line label.",
     params: {
       id: { ...ID_PARAM.id, description: "Stable note id.", required: false },
       query: QUERY_PARAM,
+      title: TITLE_PARAM,
     },
   },
   {

--- a/plugins/plugin-notes/src/interact.ts
+++ b/plugins/plugin-notes/src/interact.ts
@@ -213,8 +213,12 @@ async function dispatchCapability(
     return success(service, summarizeNotes(notes), { notes });
   }
   if (capability === "get-note") {
-    assertOnlyParams(params, ["id", "query"]);
-    const target = parseLookupTarget(params, capability, ["id", "query"]);
+    assertOnlyParams(params, ["id", "title", "query"]);
+    const target = parseLookupTarget(params, capability, [
+      "id",
+      "title",
+      "query",
+    ]);
     const note =
       target.selector === "id"
         ? service.getNote(target.value)
@@ -237,8 +241,12 @@ async function dispatchCapability(
     );
   }
   if (capability === "update-note") {
-    assertOnlyParams(params, ["id", "query", "content", "color"]);
-    const target = parseLookupTarget(params, capability, ["id", "query"]);
+    assertOnlyParams(params, ["id", "title", "query", "content", "color"]);
+    const target = parseLookupTarget(params, capability, [
+      "id",
+      "title",
+      "query",
+    ]);
     const patch: Record<string, unknown> = {
       ...(Object.hasOwn(params, "content")
         ? parseNoteContent(params.content)

--- a/plugins/plugin-notes/src/interact.ts
+++ b/plugins/plugin-notes/src/interact.ts
@@ -104,12 +104,13 @@ function summarizeNotes(notes: StickyNote[]): string {
 
 type NoteSelector =
   | { selector: "id"; value: string }
-  | { selector: "query"; value: string };
+  | { selector: "query"; value: string }
+  | { selector: "title"; value: string };
 
 function parseLookupTarget(
   params: Record<string, unknown>,
   capability: string,
-  selectorNames: readonly ("id" | "query")[],
+  selectorNames: readonly ("id" | "query" | "title")[],
 ): NoteSelector {
   const providedSelectors = selectorNames.filter((name) =>
     Object.hasOwn(params, name),
@@ -261,8 +262,12 @@ async function dispatchCapability(
     );
   }
   if (capability === "delete-note") {
-    assertOnlyParams(params, ["id", "query"]);
-    const target = parseLookupTarget(params, capability, ["id", "query"]);
+    assertOnlyParams(params, ["id", "query", "title"]);
+    const target = parseLookupTarget(params, capability, [
+      "id",
+      "query",
+      "title",
+    ]);
     const { value: note, snapshot } =
       target.selector === "id"
         ? await service.deleteNoteWithCommit(target.value)


### PR DESCRIPTION
# Relates to

Fixes #18377 — smart-quote gap on the titled/named delete derivation path identified in review of #18449.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `cursor/composer-2.5`
<!-- attribution-row:client -->
- Agent tooling: `Cursor Cloud Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Background

## What does this PR do?

#18449 adds titled/named delete derivation via `extractReferencedTitle`, but that helper only matched ASCII `["']` while `extractDeleteTargetText` already accepted typographic quotes. A message like `Delete the note named “Shopping List”` therefore fell through to the `query` path with embedded curly quote characters, which could not match a known label and surfaced as `NOTES_NOT_FOUND`.

This PR:

1. Introduces a shared quote-aware helper used by both `extractReferencedTitle` and `extractDeleteTargetText` (ASCII + `“”‘’`).
2. Adds a regression test that routes a smart-quoted `named …` delete through the NL/views derivation path (`action: "delete"`) and asserts the `title` selector is chosen — no `params.title` bypass.
3. Carries forward the #18449 title-selector contract: `content` rejected fail-closed on delete, exactly-one-of `id`/`title`/`query`, and `TITLE_PARAM` `maxLength` 240.

## Delta from #18449

Builds on the #18449 branch commits (title selector wiring, query-first delete derivation, get/update title support). The behavioral addition here is quote-style parity between the titled/named extractor and the delete-target extractor, plus the NL derivation regression test that #18449’s titled-delete test did not exercise.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Testing

```bash
bun run --cwd plugins/plugin-app-control test -- src/actions/views-management.test.ts  # 55/55
bun run --cwd plugins/plugin-notes test                                            # 43/43
```

# Evidence Gate

<!-- evidence-head:bff872b4e382693b38f67ed4130c9785f24e1cdd -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - routing/parser change only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - routing/parser change only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - covered by focused unit tests.
<!-- evidence-row:backend-logs -->
- [x] N/A - unit tests assert interact payload contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic NL derivation tests; no model call.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - mocked interact transport.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Known gaps / failures

- Full `bun run verify` not run in the agent environment (core build + focused package tests executed instead).
