### PR TITLE
fix(plugin-task-coordinator): harden server-entry UI import guard (#18031)

### DIFF
--- a/plugins/plugin-task-coordinator/__tests__/unit/server-entry-no-ui-imports.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/server-entry-no-ui-imports.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression contract: the server-side plugin entry (`src/index.ts` →
+ * `dist/index.js`) must not statically import any browser-only React components
+ * or `@elizaos/ui` modules. The headless cloud agent image loads
+ * `dist/index.js` in Node, and the Dockerfile deliberately excludes the
+ * `@elizaos/ui` radix/three/recharts tree from the runtime-dep closure. A
+ * transitive `@radix-ui/react-slot` import through a re-exported GUI component
+ * crashes the plugin at boot with `Cannot find package '@radix-ui/react-slot'`
+ * (issues #18031, #18347).
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ENTRY_PATH = resolve(__dirname, "../../src/index.ts");
+
+/** Browser-only modules that must stay out of the server entry static graph. */
+const BROWSER_ONLY_MODULES = [
+  "ProjectSwitcher",
+  "CodingAgentTasksPanel",
+  "CodingAgentControlChip",
+  "CodingAgentSettingsSection",
+  "OrchestratorView",
+  "OrchestratorWorkbench",
+  "CockpitRoute",
+  "CockpitSessionPane",
+  "CockpitInteractiveTerminal",
+  "TaskCoordinatorView",
+  "PtyConsoleBase",
+  "register-slots",
+  "register",
+  "ui",
+  "task-coordinator-view-bundle",
+] as const;
+
+/** Side-effect or barrel imports that pull browser UI into the server entry. */
+const BROWSER_ONLY_PATHS = [
+  "./components/",
+  "./register-slots",
+  "./register",
+  "./ui",
+  "./task-coordinator-view-bundle",
+] as const;
+
+function relativeImportPattern(moduleName: string): RegExp {
+  const escaped = moduleName.replaceAll(".", String.raw`\.`);
+  return new RegExp(
+    String.raw`(?:import|export)\s+(?:\*|\{[^}]*\})?\s*(?:type\s+)?(?:[^"'\n]*\s+from\s+)?["']\.\/${escaped}(?:\.(?:tsx?|jsx?))?["']`,
+  );
+}
+
+function sideEffectImportPattern(moduleName: string): RegExp {
+  const escaped = moduleName.replaceAll(".", String.raw`\.`);
+  return new RegExp(String.raw`import\s+["']\.\/${escaped}(?:\.(?:tsx?|jsx?))?["']`);
+}
+
+function starExportPattern(moduleName: string): RegExp {
+  const escaped = moduleName.replaceAll(".", String.raw`\.`);
+  return new RegExp(
+    String.raw`export\s+\*\s+from\s+["']\.\/${escaped}(?:\.(?:tsx?|jsx?))?["']`,
+  );
+}
+
+describe("server entry — no browser/UI imports (#18031, #18347)", () => {
+  const source = readFileSync(ENTRY_PATH, "utf8");
+
+  it("does not re-export browser-only components by name", () => {
+    for (const moduleName of BROWSER_ONLY_MODULES) {
+      expect(source, `named re-export of ${moduleName}`).not.toMatch(
+        relativeImportPattern(moduleName),
+      );
+    }
+  });
+
+  it("does not star-export browser-only modules", () => {
+    for (const moduleName of BROWSER_ONLY_MODULES) {
+      expect(source, `export * from ./${moduleName}`).not.toMatch(
+        starExportPattern(moduleName),
+      );
+    }
+  });
+
+  it("does not side-effect import browser-only modules", () => {
+    for (const moduleName of BROWSER_ONLY_MODULES) {
+      expect(source, `import "./${moduleName}"`).not.toMatch(
+        sideEffectImportPattern(moduleName),
+      );
+    }
+  });
+
+  it("does not import or export .tsx view components from relative paths", () => {
+    expect(source).not.toMatch(
+      /(?:import|export)\s+(?:\*|\{[^}]*\})?\s*(?:type\s+)?(?:[^"'\n]*\s+from\s+)?["']\.\/[^"']+\.tsx["']/,
+    );
+  });
+
+  it("does not import browser-only barrel paths", () => {
+    for (const path of BROWSER_ONLY_PATHS) {
+      const escaped = path.replaceAll("/", String.raw`\/`).replaceAll(".", String.raw`\.`);
+      expect(source, `import from ${path}`).not.toMatch(
+        new RegExp(String.raw`(?:import|export)\s+[^"']*["']${escaped}`),
+      );
+    }
+  });
+
+  it("does not import from @elizaos/ui", () => {
+    expect(source).not.toMatch(/from\s+["']@elizaos\/ui/);
+  });
+
+  it("does not import React or react-dom", () => {
+    expect(source).not.toMatch(/from\s+["']react(?:-dom)?["']/);
+  });
+});

--- a/plugins/plugin-task-coordinator/src/index.ts
+++ b/plugins/plugin-task-coordinator/src/index.ts
@@ -1,6 +1,6 @@
 /**
- * Plugin definition for the coding-agent task coordinator: the view manifest,
- * the orchestrator view's typed capability descriptors, and `init()`.
+ * Server-side plugin definition for the coding-agent task coordinator: the view
+ * manifest, the orchestrator view's typed capability descriptors, and `init()`.
  *
  * Declares three GUI views (`task-coordinator`, `orchestrator`, `cockpit`) with
  * their bundle path + component exports, and the capability list remote/control
@@ -9,6 +9,12 @@
  * registry; the deterministic handler action is the only server-side runtime
  * contribution. All task/session state is owned by
  * `@elizaos/plugin-agent-orchestrator` — this plugin is display + control only.
+ *
+ * GUI components (ProjectSwitcher, CodingAgentTasksPanel, …) live in the view
+ * bundle (`task-coordinator-view-bundle.ts`) or are reached via slot-registry
+ * lazy imports. They must NOT be re-exported from this entry: the headless cloud
+ * agent image loads `dist/index.js` in Node, and any `@elizaos/ui` transitives
+ * (e.g. `@radix-ui/react-slot`) are pruned from the Docker runtime-dep closure.
  */
 import type { Plugin, ViewCapability } from "@elizaos/core";
 import {
@@ -333,4 +339,3 @@ export {
   orchestratorStatusCommandAction,
   registerOrchestratorCommands,
 } from "./orchestrator-command";
-export { ProjectSwitcher } from "./ProjectSwitcher";


### PR DESCRIPTION
# Relates to

Fixes #18031. Hardens the regression guard requested in review of #18347.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `composer-2.5`
<!-- attribution-row:client -->
- Agent tooling: `Cursor Cloud Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branch created from current `develop`.
- [ ] `bun run verify` — not run end-to-end in cloud agent VM (workspace packages not fully built); focused package tests below.

# Risks

Low. Server entry export removal matches #18347 intent; test-only expansion otherwise. No runtime behavior change beyond severing the accidental `ProjectSwitcher` re-export.

# Background

## What does this PR do?

The cloud agent Docker image fails to load `@elizaos/plugin-task-coordinator` when the server entry (`src/index.ts` → `dist/index.js`) statically reaches browser-only React components. The original bug was a `ProjectSwitcher` re-export pulling `@elizaos/ui` → `@radix-ui/react-slot`, which the pruned container dep tree omits (#18031).

This PR:

1. **Production fix** — removes `export { ProjectSwitcher } from "./ProjectSwitcher"` from `src/index.ts` (same change as open #18347, which is not yet on `develop`).
2. **Hardened regression test** — adds `__tests__/unit/server-entry-no-ui-imports.test.ts` with broader guards than #18347's initial version:
   - named re-exports of browser-only modules (`ProjectSwitcher`, `CodingAgentTasksPanel`, …)
   - `export * from "./…"` star re-exports
   - side-effect `import "./…"` imports
   - relative `.tsx` import/export paths
   - browser-only barrel paths (`./register-slots`, `./ui`, view bundle)
   - direct `@elizaos/ui`, `react`, and `react-dom` imports

## What kind of change is this?

Bug fix (non-breaking) + test hardening.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

```bash
bun run --cwd plugins/plugin-task-coordinator test -- __tests__/unit/server-entry-no-ui-imports.test.ts
```

Result: **7/7 pass**.

# Evidence Gate

<!-- evidence-head:61001e06e34fd3d74153eef47c06e5fa5bab6b0e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend plugin entry + unit test only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend plugin entry + unit test only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend plugin entry + unit test only.
<!-- evidence-row:backend-logs -->
- [x] N/A - unit test guards source text; no runtime boot exercised.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB/on-chain/generated artifact changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Known gaps / failures

- Full `bun run verify` not executed — cloud VM lacked a complete workspace build (`@elizaos/core` dist artifacts missing for sibling tests). The new guard test and targeted test invocation above pass independently.
