### PR TITLE
fix(app): harden Playwright Node-24 runtime probe and fail-fast resolution

### DIFF
--- a/packages/app-core/scripts/run-node-runtime.mjs
+++ b/packages/app-core/scripts/run-node-runtime.mjs
@@ -8,6 +8,34 @@ import { spawnSync } from "node:child_process";
 
 const KNOWN_UNSTABLE_BUN_LINUX = /^1\.3\.9(?:$|[-+].*)/;
 const MIN_NODE_MAJOR = 24;
+/** Matches a Node version token emitted by the runtime probe anywhere in stdout. */
+const NODE_PROBE_VERSION_PATTERN = /(?:^|[\s\r\n])node:([0-9][^\s\r\n]*)/g;
+
+/**
+ * Builds the child-process env for the Node runtime probe. Inherits PATH and
+ * other discovery-related vars, but strips NODE_OPTIONS so caller preloads
+ * cannot write to stdout and corrupt version detection.
+ */
+export function buildNodeProbeEnv(parentEnv = process.env) {
+  const env = { ...parentEnv };
+  delete env.NODE_OPTIONS;
+  return env;
+}
+
+function extractNodeProbeVersion(text) {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return null;
+  }
+  for (const line of trimmed.split(/\r?\n/)) {
+    const exact = /^node:(.+)$/.exec(line.trim());
+    if (exact) {
+      return exact[1];
+    }
+  }
+  const matches = [...trimmed.matchAll(NODE_PROBE_VERSION_PATTERN)];
+  return matches.at(-1)?.[1] ?? null;
+}
 
 /**
  * Bun 1.3.9 has known Linux segfault reports in long-running workloads.
@@ -129,18 +157,18 @@ export function validateNodeProbeOutput(output) {
   if (text === "bun") {
     return { ok: false, reason: "resolved to Bun, not Node.js" };
   }
-  const match = /^node:(.+)$/.exec(text);
-  if (!match) {
+  const version = extractNodeProbeVersion(text);
+  if (!version) {
     return { ok: false, reason: "did not report a Node.js runtime" };
   }
-  const major = parseNodeMajor(match[1]);
+  const major = parseNodeMajor(version);
   if (major === null) {
-    return { ok: false, reason: `could not parse Node.js version ${match[1]}` };
+    return { ok: false, reason: `could not parse Node.js version ${version}` };
   }
   if (major < MIN_NODE_MAJOR) {
     return {
       ok: false,
-      reason: `Node.js ${match[1]} is too old; Node.js ${MIN_NODE_MAJOR}+ is required`,
+      reason: `Node.js ${version} is too old; Node.js ${MIN_NODE_MAJOR}+ is required`,
     };
   }
   return { ok: true, reason: null };
@@ -183,7 +211,7 @@ export function probeNodeExecutable(candidate) {
         "-e",
         "process.stdout.write(process.versions.bun ? 'bun' : 'node:' + (process.versions.node || ''))",
       ],
-      { encoding: "utf8" },
+      { encoding: "utf8", env: buildNodeProbeEnv() },
     );
     return {
       status: result.status ?? 1,

--- a/packages/app-core/scripts/run-node-runtime.test.mjs
+++ b/packages/app-core/scripts/run-node-runtime.test.mjs
@@ -1,6 +1,7 @@
 /** Exercises run node runtime behavior with deterministic app-core test fixtures. */
 import { describe, expect, test } from "vitest";
 import {
+  buildNodeProbeEnv,
   chooseElizaRuntime,
   parseNodeMajor,
   resolveNodeExecPath,
@@ -114,6 +115,29 @@ describe("run-node-runtime node validation", () => {
       ok: true,
       reason: null,
     });
+  });
+
+  test("accepts probe markers when stdout includes preload or warning noise", () => {
+    expect(
+      validateNodeProbeOutput(
+        "[apm-bootstrap] instrumenting process\nnode:24.4.0",
+      ),
+    ).toEqual({ ok: true, reason: null });
+    expect(
+      validateNodeProbeOutput("node:24.4.0\n[apm-bootstrap] done"),
+    ).toEqual({ ok: true, reason: null });
+    expect(
+      validateNodeProbeOutput("(node:123) DeprecationWarning: x\nnode:24.4.0"),
+    ).toEqual({ ok: true, reason: null });
+  });
+
+  test("strips NODE_OPTIONS from the shared probe env without removing PATH", () => {
+    const env = buildNodeProbeEnv({
+      PATH: "/usr/bin",
+      NODE_OPTIONS: "--require ./apm-bootstrap.js",
+    });
+    expect(env.NODE_OPTIONS).toBeUndefined();
+    expect(env.PATH).toBe("/usr/bin");
   });
 
   test("rejects Codex-bundled macOS Node", () => {

--- a/packages/app/playwright.android-browser.config.ts
+++ b/packages/app/playwright.android-browser.config.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "@playwright/test";
 import { KNOWN_PHRASE_WAV_DATA_URL } from "../ui/src/voice/voice-selftest/fixtures/known-phrase";
+import { resolvePlaywrightNodeRuntime } from "./scripts/lib/playwright-node-runtime.mjs";
 
 const appDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(appDir, "../..");
@@ -19,10 +20,10 @@ const uiSmokeLiveStack = path.join(
 );
 const uiSmokeApiPort = Number(process.env.ELIZA_UI_SMOKE_API_PORT || "31337");
 const uiSmokePort = Number(process.env.ELIZA_UI_SMOKE_PORT || "2138");
-const nodeExecutable =
-  process.env.ELIZA_NODE_PATH?.trim() ||
-  process.env.npm_node_execpath?.trim() ||
-  process.execPath;
+// Fail-fast Node runtime resolution: the shared app-core validator throws at
+// config load — before the webServer command spawns — when ELIZA_NODE_PATH is
+// invalid or no real Node.js 24+ executable can be found.
+const nodeExecutable = resolvePlaywrightNodeRuntime();
 
 const fakeAudioWav = path.join(
   appDir,

--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -10,6 +10,7 @@ import { defineConfig, devices } from "@playwright/test";
 // (a real omnivoice.cpp speech clip). Binary .wav fixtures are gitignored, so
 // derive the on-disk WAV from it for Chromium's --use-file-for-fake-audio-capture.
 import { KNOWN_PHRASE_WAV_DATA_URL } from "../ui/src/voice/voice-selftest/fixtures/known-phrase";
+import { resolvePlaywrightNodeRuntime } from "./scripts/lib/playwright-node-runtime.mjs";
 import {
   ASSERTION_GRADE_DASHBOARD_SPECS,
   DASHBOARD_E2E_DEVICE_MATRIX,
@@ -27,10 +28,10 @@ const uiSmokeLiveStack = path.join(
 const uiSmokeApiPort = Number(process.env.ELIZA_UI_SMOKE_API_PORT || "31337");
 const uiSmokePort = Number(process.env.ELIZA_UI_SMOKE_PORT || "2138");
 const reuseExistingServer = process.env.ELIZA_UI_SMOKE_REUSE_SERVER === "1";
-const nodeExecutable =
-  process.env.ELIZA_NODE_PATH?.trim() ||
-  process.env.npm_node_execpath?.trim() ||
-  process.execPath;
+// Fail-fast Node runtime resolution: the shared app-core validator throws at
+// config load — before the webServer command spawns — when ELIZA_NODE_PATH is
+// invalid or no real Node.js 24+ executable can be found.
+const nodeExecutable = resolvePlaywrightNodeRuntime();
 const chromiumExecutablePath =
   process.env.ELIZA_UI_SMOKE_CHROMIUM_EXECUTABLE?.trim();
 // Real audio fed to the browser mic for the voice button-press e2e: Chromium

--- a/packages/app/scripts/lib/playwright-node-runtime.mjs
+++ b/packages/app/scripts/lib/playwright-node-runtime.mjs
@@ -1,0 +1,80 @@
+/**
+ * Resolves the Node.js runtime for the app Playwright lanes through the shared
+ * app-core validator so an invalid ELIZA_NODE_PATH, a Bun executable, or a
+ * pre-24 Node fails fast before Playwright or its webServer spawns. Consumed by
+ * scripts/run-ui-playwright.mjs and the playwright.*.config.ts webServer
+ * commands; candidate priority (explicit ELIZA_NODE_PATH → npm_node_execpath →
+ * process.execPath → PATH node) matches the historical fail-open ladder, but
+ * every candidate must now pass app-core's exists/executable/is-node/version
+ * probe, and the error messages are the resolver's own contract strings.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import {
+  probeNodeExecutable,
+  resolveNodeExecPathFromCandidates,
+} from "../../../app-core/scripts/run-node-runtime.mjs";
+
+/**
+ * Finds an executable on PATH, honoring PATHEXT on Windows. Returns the first
+ * existing absolute candidate or null when the command is not on PATH.
+ */
+export function resolveExecutableFromPath(
+  command,
+  env = process.env,
+  platform = process.platform,
+) {
+  const pathValue = env.PATH ?? env.Path ?? "";
+  if (!pathValue) return null;
+
+  const hasExtension = path.extname(command).length > 0;
+  const pathExts =
+    platform === "win32"
+      ? (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+          .split(";")
+          .map((ext) => ext.trim())
+          .filter(Boolean)
+      : [""];
+  const binaryNames =
+    platform === "win32" && !hasExtension
+      ? pathExts.map((ext) => `${command}${ext.toLowerCase()}`)
+      : [command];
+
+  for (const dir of pathValue.split(path.delimiter)) {
+    if (!dir) continue;
+    for (const binaryName of binaryNames) {
+      const candidate = path.join(dir, binaryName);
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolves the validated Node.js executable for a Playwright lane. An explicit
+ * env.ELIZA_NODE_PATH must validate or this throws app-core's
+ * `Invalid ELIZA_NODE_PATH=...` contract; otherwise the first candidate that
+ * probes as real Node.js 24+ wins, and exhaustion throws app-core's
+ * `No usable Node.js 24+ executable found` contract.
+ */
+export function resolvePlaywrightNodeRuntime({
+  env = process.env,
+  platform = process.platform,
+  execPath = process.execPath,
+  probeNode = probeNodeExecutable,
+} = {}) {
+  const nodeCommand = platform === "win32" ? "node.exe" : "node";
+  return resolveNodeExecPathFromCandidates({
+    explicitNodePath: env.ELIZA_NODE_PATH,
+    candidates: [
+      env.npm_node_execpath?.trim(),
+      execPath,
+      resolveExecutableFromPath(nodeCommand, env, platform),
+      nodeCommand,
+    ],
+    platform,
+    probeNode,
+  });
+}

--- a/packages/app/scripts/run-ui-playwright-node-resolution.test.mjs
+++ b/packages/app/scripts/run-ui-playwright-node-resolution.test.mjs
@@ -1,0 +1,247 @@
+/**
+ * Exercises the Playwright-lane Node runtime resolution shared by
+ * scripts/run-ui-playwright.mjs and the playwright.*.config.ts webServer
+ * commands. Deterministic: candidate probes are injected fixtures mirroring
+ * app-core's run-node-runtime.test.mjs, plus one real-probe acceptance case
+ * against the host runtime when it is a genuine Node.js 24+ process.
+ */
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { parseNodeMajor } from "../../app-core/scripts/run-node-runtime.mjs";
+import {
+  resolveExecutableFromPath,
+  resolvePlaywrightNodeRuntime,
+} from "./lib/playwright-node-runtime.mjs";
+
+const probe = (outputs) => (candidate) =>
+  outputs[candidate] ?? {
+    status: 1,
+    stdout: "",
+    stderr: "missing",
+  };
+
+const tempDirs = [];
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("playwright node runtime resolution", () => {
+  it("throws the exact contract for an invalid explicit ELIZA_NODE_PATH", () => {
+    assert.throws(
+      () =>
+        resolvePlaywrightNodeRuntime({
+          env: { ELIZA_NODE_PATH: "/bad/node" },
+          platform: "darwin",
+          execPath: "/valid/node",
+          probeNode: probe({
+            "/valid/node": { status: 0, stdout: "node:24.0.0", stderr: "" },
+          }),
+        }),
+      /^Error: Invalid ELIZA_NODE_PATH=\/bad\/node: .*\. Set ELIZA_NODE_PATH to a standard Node\.js 24\+ executable\.$/,
+    );
+  });
+
+  it("rejects an explicit ELIZA_NODE_PATH that resolves to Bun", () => {
+    assert.throws(
+      () =>
+        resolvePlaywrightNodeRuntime({
+          env: { ELIZA_NODE_PATH: "/opt/bun/bin/bun" },
+          platform: "linux",
+          execPath: "/valid/node",
+          probeNode: probe({
+            "/opt/bun/bin/bun": { status: 0, stdout: "bun", stderr: "" },
+            "/valid/node": { status: 0, stdout: "node:24.0.0", stderr: "" },
+          }),
+        }),
+      /Invalid ELIZA_NODE_PATH=\/opt\/bun\/bin\/bun: resolved to Bun, not Node\.js/,
+    );
+  });
+
+  it("rejects an explicit ELIZA_NODE_PATH below the Node 24 requirement", () => {
+    assert.throws(
+      () =>
+        resolvePlaywrightNodeRuntime({
+          env: { ELIZA_NODE_PATH: "/old/node" },
+          platform: "linux",
+          execPath: "/valid/node",
+          probeNode: probe({
+            "/old/node": { status: 0, stdout: "node:22.23.0", stderr: "" },
+            "/valid/node": { status: 0, stdout: "node:24.0.0", stderr: "" },
+          }),
+        }),
+      /Invalid ELIZA_NODE_PATH=\/old\/node: Node\.js 22\.23\.0 is too old; Node\.js 24\+ is required/,
+    );
+  });
+
+  it("accepts a valid explicit ELIZA_NODE_PATH and returns it unchanged", () => {
+    assert.equal(
+      resolvePlaywrightNodeRuntime({
+        env: { ELIZA_NODE_PATH: " /explicit/node " },
+        platform: "darwin",
+        execPath: "/other/node",
+        probeNode: probe({
+          "/explicit/node": { status: 0, stdout: "node:24.3.0", stderr: "" },
+        }),
+      }),
+      "/explicit/node",
+    );
+  });
+
+  it("prefers npm_node_execpath when no explicit path is set", () => {
+    assert.equal(
+      resolvePlaywrightNodeRuntime({
+        env: { npm_node_execpath: "/npm/node", PATH: "" },
+        platform: "linux",
+        execPath: "/exec/node",
+        probeNode: probe({
+          "/npm/node": { status: 0, stdout: "node:24.1.0", stderr: "" },
+          "/exec/node": { status: 0, stdout: "node:24.1.0", stderr: "" },
+        }),
+      }),
+      "/npm/node",
+    );
+  });
+
+  it("skips a Bun process.execPath and a pre-24 npm_node_execpath, landing on PATH node", () => {
+    assert.equal(
+      resolvePlaywrightNodeRuntime({
+        env: { npm_node_execpath: "/old/node", PATH: "" },
+        platform: "linux",
+        execPath: "/usr/local/bin/bun",
+        probeNode: probe({
+          "/old/node": { status: 0, stdout: "node:22.12.0", stderr: "" },
+          "/usr/local/bin/bun": { status: 0, stdout: "bun", stderr: "" },
+          node: { status: 0, stdout: "node:24.2.0", stderr: "" },
+        }),
+      }),
+      "node",
+    );
+  });
+
+  it("throws the no-usable-node contract when every candidate fails", () => {
+    assert.throws(
+      () =>
+        resolvePlaywrightNodeRuntime({
+          env: { npm_node_execpath: "/old/node", PATH: "" },
+          platform: "linux",
+          execPath: "/usr/local/bin/bun",
+          probeNode: probe({
+            "/old/node": { status: 0, stdout: "node:22.12.0", stderr: "" },
+            "/usr/local/bin/bun": { status: 0, stdout: "bun", stderr: "" },
+          }),
+        }),
+      /No usable Node\.js 24\+ executable found .*Install Node\.js 24\+ or set ELIZA_NODE_PATH=\/absolute\/path\/to\/node\./,
+    );
+  });
+
+  it("rejects the Codex-bundled macOS Node as an explicit path", () => {
+    assert.throws(
+      () =>
+        resolvePlaywrightNodeRuntime({
+          env: {
+            ELIZA_NODE_PATH: "/Applications/Codex.app/Contents/Resources/node",
+          },
+          platform: "darwin",
+          execPath: "/valid/node",
+          probeNode: probe({
+            "/Applications/Codex.app/Contents/Resources/node": {
+              status: 0,
+              stdout: "node:24.0.0",
+              stderr: "",
+            },
+          }),
+        }),
+      /Invalid ELIZA_NODE_PATH=.*Codex-bundled macOS Node is not supported/,
+    );
+  });
+
+  it("resolves executables from PATH and misses cleanly", () => {
+    assert.equal(
+      resolveExecutableFromPath("definitely-not-a-real-binary-xyz", {
+        PATH: "/nonexistent-dir-for-test",
+      }),
+      null,
+    );
+    assert.equal(resolveExecutableFromPath("node", { PATH: "" }), null);
+  });
+
+  it("resolves node.exe directly on win32 when the command already has an extension", () => {
+    const binDir = makeTempDir("eliza-playwright-path-");
+    const nodeCmd = path.join(binDir, "node.cmd");
+    const nodeExe = path.join(binDir, "node.exe");
+    fs.writeFileSync(nodeCmd, "@echo off\r\n");
+    fs.writeFileSync(nodeExe, "");
+
+    assert.equal(
+      resolveExecutableFromPath(
+        "node.exe",
+        { PATH: binDir, PATHEXT: ".CMD;.EXE" },
+        "win32",
+      ),
+      nodeExe,
+    );
+  });
+
+  it("honors custom PATHEXT ordering when resolving bare node on win32", () => {
+    const binDir = makeTempDir("eliza-playwright-pathext-");
+    const nodeBat = path.join(binDir, "node.bat");
+    const nodeExe = path.join(binDir, "node.exe");
+    fs.writeFileSync(nodeBat, "@echo off\r\n");
+    fs.writeFileSync(nodeExe, "");
+
+    assert.equal(
+      resolveExecutableFromPath(
+        "node",
+        { PATH: binDir, PATHEXT: ".BAT;.EXE" },
+        "win32",
+      ),
+      nodeBat,
+    );
+  });
+
+  it("accepts noisy probe stdout through the shared parser", () => {
+    assert.equal(
+      resolvePlaywrightNodeRuntime({
+        env: { ELIZA_NODE_PATH: "/good/node" },
+        platform: "linux",
+        execPath: "/other/node",
+        probeNode: probe({
+          "/good/node": {
+            status: 0,
+            stdout: "[apm-bootstrap] instrumenting process\nnode:24.4.0",
+            stderr: "",
+          },
+        }),
+      }),
+      "/good/node",
+    );
+  });
+
+  const hostIsNode24 =
+    !process.versions.bun &&
+    (parseNodeMajor(process.versions.node ?? "") ?? 0) >= 24;
+
+  it("accepts the live host Node 24+ runtime via the real probe", {
+    skip: !hostIsNode24,
+  }, () => {
+    assert.equal(
+      resolvePlaywrightNodeRuntime({
+        env: { ELIZA_NODE_PATH: process.execPath },
+        platform: process.platform,
+        execPath: process.execPath,
+      }),
+      process.execPath,
+    );
+  });
+});

--- a/packages/app/scripts/run-ui-playwright.mjs
+++ b/packages/app/scripts/run-ui-playwright.mjs
@@ -10,6 +10,10 @@ import { fileURLToPath } from "node:url";
 import { getFreePort } from "../test/utils/get-free-port.mjs";
 import { resolveAuditAppOutput } from "./lib/audit-output.mjs";
 import { withElizaSourceNodeOptions } from "./lib/playwright-node-options.mjs";
+import {
+  resolveExecutableFromPath,
+  resolvePlaywrightNodeRuntime,
+} from "./lib/playwright-node-runtime.mjs";
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = path.resolve(appDir, "..", "..");
@@ -49,35 +53,6 @@ function resolvePlaywrightCommand() {
     }
   }
   return binaryNames[0];
-}
-
-function resolveExecutableFromPath(command) {
-  const pathValue = process.env.PATH ?? process.env.Path ?? "";
-  if (!pathValue) return null;
-
-  const hasExtension = path.extname(command).length > 0;
-  const pathExts =
-    process.platform === "win32"
-      ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
-          .split(";")
-          .map((ext) => ext.trim())
-          .filter(Boolean)
-      : [""];
-  const binaryNames =
-    process.platform === "win32" && !hasExtension
-      ? pathExts.map((ext) => `${command}${ext.toLowerCase()}`)
-      : [command];
-
-  for (const dir of pathValue.split(path.delimiter)) {
-    if (!dir) continue;
-    for (const binaryName of binaryNames) {
-      const candidate = path.join(dir, binaryName);
-      if (fs.existsSync(candidate)) {
-        return candidate;
-      }
-    }
-  }
-  return null;
 }
 
 function resolveBunCommand() {
@@ -131,32 +106,15 @@ function resolveBunCommand() {
   return process.platform === "win32" ? "bun.exe" : "bun";
 }
 
-function looksLikeBun(command) {
-  const binaryName = path.basename(command).toLowerCase();
-  return binaryName === "bun" || binaryName === "bun.exe";
-}
-
-function resolveNodeCommand() {
-  for (const candidate of [
-    process.env.ELIZA_NODE_PATH?.trim(),
-    process.env.npm_node_execpath?.trim(),
-    process.execPath,
-    resolveExecutableFromPath("node"),
-  ]) {
-    if (candidate && fs.existsSync(candidate) && !looksLikeBun(candidate)) {
-      return candidate;
-    }
-  }
-
-  return process.platform === "win32" ? "node.exe" : "node";
-}
-
 const env = { ...process.env };
 delete env.NO_COLOR;
 delete env.FORCE_COLOR;
 delete env.CLICOLOR_FORCE;
 env.BUN = env.BUN || resolveBunCommand();
-env.ELIZA_NODE_PATH = env.ELIZA_NODE_PATH || resolveNodeCommand();
+// Validated through app-core's shared resolver: an invalid or pre-24
+// ELIZA_NODE_PATH (or an environment with no usable Node 24+) throws here,
+// before Playwright or its webServer spawns, instead of dying late in boot.
+env.ELIZA_NODE_PATH = resolvePlaywrightNodeRuntime({ env });
 
 const bunBinDir = path.dirname(env.BUN);
 const pathDelimiter = process.platform === "win32" ? ";" : ":";


### PR DESCRIPTION
# Relates to

Follow-up to deep-review P2s on #18460 for #18456.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused verification was run on the touched surfaces (see Testing).
- [x] A reviewer can confirm the change from the fail-fast contracts and unit transcripts below.

# Contribution provenance

- AI assistance: `yes`
- Model(s) used: `cursor/composer-2.5`
- Client / agent tooling: `Cursor Cloud Agent`
- Skill revision: `N/A - no contribution skill used`
- Attribution status: `self-reported`

# What this PR does

Implements the Playwright Node-24 fail-fast wiring from #18460 and closes the two deep-review P2s called out on that PR.

## Shared app-core probe hardening

- `probeNodeExecutable` now spawns with `buildNodeProbeEnv()`, which strips inherited `NODE_OPTIONS` so caller preloads cannot corrupt stdout-based version detection.
- `validateNodeProbeOutput` now locates a `node:<version>` marker inside noisy stdout (preload banners, trailing log lines, deprecation warnings) instead of requiring the entire stdout string to match.

## Playwright lane fail-fast resolution (#18460 / #18456)

- Adds `packages/app/scripts/lib/playwright-node-runtime.mjs`, a thin seam over app-core's `resolveNodeExecPathFromCandidates`.
- `scripts/run-ui-playwright.mjs`, `playwright.ui-smoke.config.ts`, and `playwright.android-browser.config.ts` now resolve through the shared validator before Playwright or webServer spawn.
- Candidate priority is unchanged: explicit `ELIZA_NODE_PATH` → `npm_node_execpath` → `process.execPath` → PATH `node` → bare `node`.
- Invalid explicit paths, Bun masquerading as Node, pre-24 Node, and Codex-bundled macOS Node still fail closed with the existing contract strings.

## Windows PATHEXT coverage (P2)

- `run-ui-playwright-node-resolution.test.mjs` exercises `resolveExecutableFromPath` with injected `platform: "win32"`, custom `PATHEXT` ordering, and direct `node.exe` resolution.

# Testing

```bash
bunx vitest run packages/app-core/scripts/run-node-runtime.test.mjs   # 15 pass
node --test packages/app/scripts/run-ui-playwright-node-resolution.test.mjs   # 12 pass, 1 skip (host not Node 24+)
bunx @biomejs/biome check <7 touched files>   # clean
```

# Evidence Gate

- [x] N/A — CLI/test-harness runtime resolution only; no UI surface changes.

# Known gaps

- Live Windows host execution remains an evidence gap; win32 PATHEXT branches are covered by injected platform unit tests.
- Full `bun run verify` was not run in this cloud session after `bun run install:light`; focused package tests above cover the changed contracts.