### PR TITLE
fix(cloud): refresh agent routing key TTL on heartbeat (#18277)

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -2882,6 +2882,229 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
       getClientSpy.mockRestore();
     }
   }, 30_000);
+
+  test("successful heartbeat writes routing registry fallback keys when none exist (#18277)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = customSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
+      async () => sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, updates) => ({ ...sandbox, ...updates }) as AgentSandbox,
+    );
+
+    globalThis.fetch = mock(async () => new Response("ok", { status: 200 }));
+
+    const redisStore = new Map<string, string>();
+    const mockRedis = {
+      set: jest.fn(async (key: string, value: string, _options?: unknown) => {
+        if (redisStore.has(key)) return null;
+        redisStore.set(key, value);
+        return "OK";
+      }),
+      setex: jest.fn(async (key: string, _ttl: number, value: string) => {
+        redisStore.set(key, value);
+        return "OK";
+      }),
+      expire: jest.fn(async () => 1),
+      get: jest.fn(async (key: string) => redisStore.get(key) ?? null),
+      pipeline: jest.fn(() => ({
+        setex: jest.fn().mockReturnThis(),
+        exec: jest.fn(async () => []),
+      })),
+    };
+    const redisFactory = await import("../cache/redis-factory");
+    const buildSpy = spyOn(redisFactory, "buildRedisClient").mockReturnValue(mockRedis as never);
+    const hasRedisSpy = spyOn(redisFactory, "hasRedisConfig").mockReturnValue(true);
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(true);
+
+      const agentServerKey = `agent:${sandbox.id}:server`;
+      const serverUrlKey = `server:sandbox-${sandbox.id}:url`;
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        agentServerKey,
+        `sandbox-${sandbox.id}`,
+        expect.objectContaining({ nx: true }),
+      );
+      expect(redisStore.get(agentServerKey)).toBe(`sandbox-${sandbox.id}`);
+      expect(redisStore.get(serverUrlKey)).toBe(sandbox.bridge_url);
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      buildSpy.mockRestore();
+      hasRedisSpy.mockRestore();
+    }
+  });
+
+  test("subsequent heartbeat refreshes URL and agent key TTL when we own the agent key (#18277)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = customSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
+      async () => sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, updates) => ({ ...sandbox, ...updates }) as AgentSandbox,
+    );
+
+    globalThis.fetch = mock(async () => new Response("ok", { status: 200 }));
+
+    const agentServerKey = `agent:${sandbox.id}:server`;
+    const serverUrlKey = `server:sandbox-${sandbox.id}:url`;
+    const serverName = `sandbox-${sandbox.id}`;
+    const redisStore = new Map<string, string>([
+      [agentServerKey, serverName],
+      [serverUrlKey, "old-url"],
+    ]);
+    const setexCalls: Array<{ key: string; value: string }> = [];
+    const expireCalls: Array<{ key: string; ttl: number }> = [];
+    const mockRedis = {
+      set: jest.fn(async (key: string, _value: string, _options?: unknown) =>
+        redisStore.has(key) ? null : "OK",
+      ),
+      setex: jest.fn(async (key: string, ttl: number, value: string) => {
+        redisStore.set(key, value);
+        setexCalls.push({ key, value });
+        return "OK";
+      }),
+      expire: jest.fn(async (key: string, ttl: number) => {
+        expireCalls.push({ key, ttl });
+        return 1;
+      }),
+      get: jest.fn(async (key: string) => redisStore.get(key) ?? null),
+      pipeline: jest.fn(() => ({
+        setex: jest.fn().mockReturnThis(),
+        exec: jest.fn(async () => []),
+      })),
+    };
+    const redisFactory = await import("../cache/redis-factory");
+    const buildSpy = spyOn(redisFactory, "buildRedisClient").mockReturnValue(mockRedis as never);
+    const hasRedisSpy = spyOn(redisFactory, "hasRedisConfig").mockReturnValue(true);
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(true);
+
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        agentServerKey,
+        serverName,
+        expect.objectContaining({ nx: true }),
+      );
+      expect(mockRedis.get).toHaveBeenCalledWith(agentServerKey);
+      expect(setexCalls).toContainEqual({ key: serverUrlKey, value: sandbox.bridge_url });
+      expect(expireCalls).toContainEqual({
+        key: agentServerKey,
+        ttl: 30 * 24 * 60 * 60,
+      });
+      expect(redisStore.get(serverUrlKey)).toBe(sandbox.bridge_url);
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      buildSpy.mockRestore();
+      hasRedisSpy.mockRestore();
+    }
+  });
+
+  test("successful heartbeat does NOT overwrite routing keys when container already self-registered (#18277)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = customSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
+      async () => sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, updates) => ({ ...sandbox, ...updates }) as AgentSandbox,
+    );
+
+    globalThis.fetch = mock(async () => new Response("ok", { status: 200 }));
+
+    const selfRegisteredServer = "container-own-server-name";
+    const redisStore = new Map<string, string>([
+      [`agent:${sandbox.id}:server`, selfRegisteredServer],
+    ]);
+    const setexCalls: Array<{ key: string; value: string }> = [];
+    const mockRedis = {
+      set: jest.fn(async (key: string, _value: string, _options?: unknown) =>
+        redisStore.has(key) ? null : "OK",
+      ),
+      setex: jest.fn(async (key: string, _ttl: number, value: string) => {
+        setexCalls.push({ key, value });
+        return "OK";
+      }),
+      expire: jest.fn(async () => 1),
+      get: jest.fn(async (key: string) => redisStore.get(key) ?? null),
+      pipeline: jest.fn(() => ({
+        setex: jest.fn().mockReturnThis(),
+        exec: jest.fn(async () => []),
+      })),
+    };
+    const redisFactory = await import("../cache/redis-factory");
+    const buildSpy = spyOn(redisFactory, "buildRedisClient").mockReturnValue(mockRedis as never);
+    const hasRedisSpy = spyOn(redisFactory, "hasRedisConfig").mockReturnValue(true);
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(true);
+
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        `agent:${sandbox.id}:server`,
+        `sandbox-${sandbox.id}`,
+        expect.objectContaining({ nx: true }),
+      );
+      expect(setexCalls).toEqual([]);
+      expect(mockRedis.expire).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      buildSpy.mockRestore();
+      hasRedisSpy.mockRestore();
+    }
+  });
+
+  test("Redis failure during routing fallback does not abort heartbeat (#18277)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = customSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
+      async () => sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, updates) => ({ ...sandbox, ...updates }) as AgentSandbox,
+    );
+
+    globalThis.fetch = mock(async () => new Response("ok", { status: 200 }));
+
+    const mockRedis = {
+      set: jest.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+      setex: jest.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+      expire: jest.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+      get: jest.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+      pipeline: jest.fn(() => ({
+        setex: jest.fn().mockReturnThis(),
+        exec: jest.fn(async () => []),
+      })),
+    };
+    const redisFactory = await import("../cache/redis-factory");
+    const buildSpy = spyOn(redisFactory, "buildRedisClient").mockReturnValue(mockRedis as never);
+    const hasRedisSpy = spyOn(redisFactory, "hasRedisConfig").mockReturnValue(true);
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(true);
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      buildSpy.mockRestore();
+      hasRedisSpy.mockRestore();
+    }
+  });
 });
 
 // The daemon handler for the `agent_resume` job. Covers the branch logic the

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -42,6 +42,7 @@ import { jobs } from "../../db/schemas/jobs";
 import { imageRepo } from "../../db/utils/docker-image-ref";
 import { ApiError } from "../api/cloud-worker-errors";
 import { InsufficientCreditsError as InsufficientCreditsApiError } from "../api/errors";
+import { buildRedisClient, hasRedisConfig } from "../cache/redis-factory";
 import { containersEnv } from "../config/containers-env";
 import { getElizaAgentPublicWebUiUrl } from "../eliza-agent-web-ui";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
@@ -503,6 +504,13 @@ const RECONCILE_SSH_CMD_TIMEOUT_MS = 15_000;
 // still fires — an unreachable paid agent must never look "running" forever.
 const IP_RECONCILE_MAX_UNRESOLVED_CYCLES = 3;
 const DB_LIVENESS_RESTART_MARKER = "[db-liveness-restart]";
+// TTLs for the server-side routing key fallback written during heartbeat.
+// The agent→server mapping is long-lived (30 days) to match the gateway
+// contract in server-router.ts:154-159 (a booted container writes it with a
+// 30-day TTL). The server→URL key is heartbeat-backed and short so a dead
+// pod's URL expires quickly (the ~30s heartbeat cycle refreshes it).
+const ROUTING_AGENT_KEY_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days = 2592000
+const ROUTING_SERVER_URL_KEY_TTL_SECONDS = 90;
 const DB_LIVENESS_RESTART_BUDGET = 3;
 const DB_LIVENESS_RESTART_COOLDOWN_MS = 10 * 60_000;
 const DB_LIVENESS_RESTART_BUDGET_WINDOW_MS = 60 * 60_000;
@@ -6325,7 +6333,89 @@ export class ElizaSandboxService {
       // the last healthy beat, not a stale prior error_count from an old episode.
       error_count: 0,
     });
+    // Write the routing registry fallback after a successful heartbeat so the
+    // gateway can route inbound platform messages to this sandbox even when
+    // the container did not self-register (#18277). Errors are swallowed inside
+    // ensureRoutingRegistryKeys so Redis failures never flip the heartbeat result.
+    if (updated) {
+      await this.ensureRoutingRegistryKeys(rec);
+    }
     return Boolean(updated);
+  }
+
+  /**
+   * Server-side fallback for the gateway routing registry. A booted container
+   * self-registers by writing `agent:<id>:server` + `server:<name>:url` keys to
+   * the shared Redis via `SandboxRegistry` (built from `SANDBOX_REGISTRY_*` env
+   * vars injected by the Docker provisioner). When those env vars are absent or
+   * the container fails to self-register, no routing key ever appears and the
+   * webhook gateway resolves `unregistered` forever — re-onboarding the user on
+   * every message even though the agent is alive and heartbeating (#18277).
+   *
+   * This method writes the keys from the control-plane side when the heartbeat
+   * confirms the container is reachable. On the first heartbeat it claims the
+   * agent→server mapping atomically with SET NX (so a container that
+   * self-registers is never clobbered). On subsequent heartbeats it refreshes
+   * both TTLs when we own the pair — without this refresh the URL key expires
+   * after ~90s and the agent mapping expires after ~30 days, making the gateway
+   * resolve "unreachable" or "unregistered" for a healthy agent. If the agent
+   * key is owned by a different server name (container self-registered), both
+   * keys are left untouched. Best-effort: failures are logged and swallowed so a
+   * Redis outage does not abort the heartbeat.
+   */
+  private async ensureRoutingRegistryKeys(
+    rec: Pick<AgentSandbox, "id" | "bridge_url">,
+  ): Promise<void> {
+    if (!rec.bridge_url) return;
+    if (!hasRedisConfig()) return;
+
+    try {
+      const redis = buildRedisClient();
+      if (!redis) return;
+
+      const agentServerKey = `agent:${rec.id}:server`;
+      const serverName = `sandbox-${rec.id}`;
+      const serverUrlKey = `server:${serverName}:url`;
+
+      // Try to claim the agent→server mapping atomically. SET NX is atomic in
+      // Redis — unlike a GET-then-SET, there is no window for a self-registering
+      // container to write between our check and our write.
+      const claimed = await redis.set(agentServerKey, serverName, {
+        ex: ROUTING_AGENT_KEY_TTL_SECONDS,
+        nx: true,
+      });
+
+      if (claimed) {
+        // First heartbeat: we claimed the agent key. Write the URL key with a
+        // short TTL so a dead pod's URL expires before the agent mapping does.
+        await redis.setex(serverUrlKey, ROUTING_SERVER_URL_KEY_TTL_SECONDS, rec.bridge_url);
+        logger.info(
+          `[agent-sandbox] Wrote routing registry fallback for agent ${rec.id} -> ${rec.bridge_url}`,
+        );
+        return;
+      }
+
+      // The agent key already exists. Check whether WE own it (a prior
+      // heartbeat wrote it) or a container self-registered under a different
+      // name. Only refresh TTLs if we own the pair.
+      const owner = await redis.get<string>(agentServerKey);
+      if (owner !== serverName) return;
+
+      // We own the pair from a prior heartbeat — refresh both TTLs so the
+      // mapping survives until the next heartbeat cycle.
+      await Promise.all([
+        redis.expire(agentServerKey, ROUTING_AGENT_KEY_TTL_SECONDS),
+        redis.setex(serverUrlKey, ROUTING_SERVER_URL_KEY_TTL_SECONDS, rec.bridge_url),
+      ]);
+    } catch (err) {
+      // error-policy:J7 — diagnostics must not kill the loop: the routing
+      // fallback is a non-critical optimization layered on the heartbeat cycle.
+      // A Redis outage or transient failure here must not abort the heartbeat or
+      // mark the agent unhealthy; the next heartbeat cycle retries the write.
+      logger.warn(
+        `[agent-sandbox] Routing registry fallback failed for agent ${rec.id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
Relates to #18277 and addresses deep-review nits on #18329.

## Summary

Dedicated sandboxes that rely on the server-side routing registry fallback (when container self-registration via `SANDBOX_REGISTRY_*` is absent) must keep **both** Redis keys alive across the full agent lifetime:

- `agent:<id>:server` — 30-day TTL (matches gateway / agent-server contract)
- `server:sandbox-<id>:url` — 90s TTL, refreshed each ~30s heartbeat

#18329 fixed subsequent-heartbeat refresh for the URL key but still left the agent→server mapping to expire after ~30 days. This PR adds `EXPIRE` on the agent key when GET confirms we own `sandbox-<id>`, preserving SET NX first-writer semantics.

## Design

1. **Absent key** → `SET NX` agent mapping (30d) + `SETEX` URL (90s)
2. **Present and owned by us** (`sandbox-${rec.id}`) → `EXPIRE` agent key + `SETEX` URL key
3. **Present with different owner** (container self-registered) → no writes

Redis failures are caught with `error-policy:J7` and do not change the heartbeat boolean result.

`bridge_url` vs public-proxy URL: unchanged — fallback continues to write the tailnet bridge URL, which is what the webhook gateway path resolves for dedicated sandboxes. No routing redesign.

## Verification

```bash
bun run --cwd packages/cloud/shared typecheck   # clean
bun run --cwd packages/cloud/shared lint:check   # clean
bun test src/lib/services/eliza-sandbox.test.ts -t "#18277"   # 4/4 pass
```

### New / updated tests

1. First heartbeat claims both keys when absent
2. Subsequent heartbeat refreshes URL **and** agent key TTL when we own the mapping
3. Self-registered container keys are not clobbered
4. Redis failure during fallback does not abort heartbeat

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `cursor/composer-2.5`
<!-- attribution-row:client -->
- Agent tooling: `Cursor Cloud Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

Author: felirami

# Evidence Gate

<!-- evidence-head:7dd21dccc6b3550ab6209f4b12947670c09d77e4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend heartbeat/Redis routing change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend heartbeat/Redis routing change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - covered by focused service unit tests (4/4) and full eliza-sandbox suite (188/188).
<!-- evidence-row:backend-logs -->
- [x] N/A - unit tests assert Redis key writes, ownership skip, and J7 failure isolation.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - Redis writes asserted in tests; no DB schema/on-chain artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.
