### PR TITLE
fix(cloud): flush snapshot error-body excerpt decode and add tests (#18228)

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -6205,6 +6205,13 @@ describe("isUnrecoverableSnapshotError (permanent-vs-transient classification)",
     expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 429 "))).toBe(false);
     expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 500"))).toBe(false);
     expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 503"))).toBe(false);
+    // #18228: a diagnostic body suffix must not change transient-vs-permanent
+    // classification — the regex is anchored at the status prefix.
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error("Snapshot fetch failed: HTTP 500 Durable Object storage quota exceeded"),
+      ),
+    ).toBe(false);
   });
 
   test("matches only this file's snapshot throw shapes — anchored, exact status", async () => {
@@ -8696,6 +8703,108 @@ describe("ElizaSandboxService updateAgentProfile / updateAgentEnvironment", () =
       mint.mockRestore();
       revoke.mockRestore();
     }
+  });
+});
+
+// Snapshot fetch error-body excerpt (#18228 / #18336).
+describe("readErrorBodyExcerpt (snapshot transfer diagnostics)", () => {
+  function errorResponse(
+    body: string,
+    init?: { contentType?: string; splitAtBytes?: number[] },
+  ): Response {
+    const bytes = new TextEncoder().encode(body);
+    const splitAt = init?.splitAtBytes ?? [bytes.length];
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        let offset = 0;
+        for (const end of splitAt) {
+          if (offset >= bytes.length) break;
+          controller.enqueue(bytes.subarray(offset, Math.min(end, bytes.length)));
+          offset = end;
+        }
+        if (offset < bytes.length) {
+          controller.enqueue(bytes.subarray(offset));
+        }
+        controller.close();
+      },
+    });
+    const headers = new Headers();
+    if (init?.contentType) {
+      headers.set("content-type", init.contentType);
+    }
+    return new Response(stream, { status: 500, headers });
+  }
+
+  test("returns null for an empty body", async () => {
+    const { readErrorBodyExcerpt } = await import("./eliza-sandbox.ts?actual");
+    expect(await readErrorBodyExcerpt(errorResponse(""))).toBeNull();
+    expect(await readErrorBodyExcerpt(new Response(null, { status: 500 }))).toBeNull();
+  });
+
+  test("returns null for whitespace-only bodies", async () => {
+    const { readErrorBodyExcerpt } = await import("./eliza-sandbox.ts?actual");
+    expect(await readErrorBodyExcerpt(errorResponse("   \n\t  "))).toBeNull();
+  });
+
+  test("extracts JSON {error} and {message} fields from short bodies", async () => {
+    const { readErrorBodyExcerpt } = await import("./eliza-sandbox.ts?actual");
+    expect(
+      await readErrorBodyExcerpt(
+        errorResponse('{"error":"Durable Object storage quota exceeded"}', {
+          contentType: "application/json",
+        }),
+      ),
+    ).toBe("Durable Object storage quota exceeded");
+    expect(
+      await readErrorBodyExcerpt(
+        errorResponse('{"message":"Internal agent error during snapshot serialization"}', {
+          contentType: "application/json",
+        }),
+      ),
+    ).toBe("Internal agent error during snapshot serialization");
+  });
+
+  test("returns trimmed plain-text and proxy error pages", async () => {
+    const { readErrorBodyExcerpt } = await import("./eliza-sandbox.ts?actual");
+    expect(
+      await readErrorBodyExcerpt(
+        errorResponse("  Worker exceeded CPU time limit  ", { contentType: "text/plain" }),
+      ),
+    ).toBe("Worker exceeded CPU time limit");
+    expect(
+      await readErrorBodyExcerpt(
+        errorResponse("<html>Bad Gateway: upstream timeout</html>", {
+          contentType: "text/html",
+        }),
+      ),
+    ).toBe("<html>Bad Gateway: upstream timeout</html>");
+  });
+
+  test("truncates bodies past the 512-byte excerpt budget", async () => {
+    const { readErrorBodyExcerpt } = await import("./eliza-sandbox.ts?actual");
+    const body = "y".repeat(600);
+    const excerpt = await readErrorBodyExcerpt(
+      errorResponse(body, { contentType: "text/plain", splitAtBytes: [256, 512, 700] }),
+    );
+    expect(excerpt).toBe("y".repeat(512));
+    expect(Buffer.byteLength(excerpt ?? "", "utf-8")).toBe(512);
+  });
+
+  test("flushes a multi-byte UTF-8 character split across stream chunks", async () => {
+    const { readErrorBodyExcerpt } = await import("./eliza-sandbox.ts?actual");
+    const excerpt = await readErrorBodyExcerpt(
+      errorResponse("😀", { contentType: "text/plain", splitAtBytes: [2] }),
+    );
+    expect(excerpt).toBe("😀");
+  });
+
+  test("truncates at the byte budget without a garbled trailing character", async () => {
+    const { readErrorBodyExcerpt } = await import("./eliza-sandbox.ts?actual");
+    const body = `${"x".repeat(510)}😀`;
+    const excerpt = await readErrorBodyExcerpt(
+      errorResponse(body, { contentType: "text/plain", splitAtBytes: [512] }),
+    );
+    expect(excerpt).toBe("x".repeat(510));
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -524,6 +524,14 @@ const DB_LIVENESS_RESTART_COOLDOWN_MS = 10 * 60_000;
 const DB_LIVENESS_RESTART_BUDGET_WINDOW_MS = 60 * 60_000;
 const SNAPSHOT_FETCH_TIMEOUT_MS = 120_000;
 /**
+ * Maximum bytes to read from a snapshot-fetch error response body for
+ * diagnostic logging (#18228). The body distinguishes an agent-side 500
+ * (carries the thrown error message) from a bridge/proxy-hop 500 (proxy
+ * error page or empty). Bounded so a malicious or misconfigured upstream
+ * cannot exhaust Worker memory.
+ */
+const SNAPSHOT_ERROR_BODY_EXCERPT_BYTES = 512;
+/**
  * Hydration budgets (#16639): the worker heap died buffering unbounded
  * snapshot bodies (`res.json()` retained everything, then a re-stringify
  * doubled it). The raw budget is enforced WHILE streaming — bytes past it are
@@ -990,6 +998,91 @@ class ManagedLaunchOwnershipLost extends Error {
     super("Managed launch lost its agent ownership CAS");
     this.name = "ManagedLaunchOwnershipLost";
   }
+}
+
+/**
+ * Read a bounded excerpt of an error response body for diagnostic logging.
+ * Returns a trimmed string or null when the body is empty. Used by
+ * `fetchSnapshotState` (#18228) so an agent-side 500 (carrying the thrown
+ * error message) is distinguishable from a bridge/proxy-hop 500 (proxy error
+ * page or empty body) in Worker logs.
+ *
+ * Streams the body via a ReadableStream reader and stops after
+ * SNAPSHOT_ERROR_BODY_EXCERPT_BYTES of UTF-8, cancelling the remainder —
+ * never buffering the full response (a malicious upstream could OOM the
+ * Worker with an unbounded body).
+ */
+export async function readErrorBodyExcerpt(
+  res: Pick<Response, "body" | "headers">,
+): Promise<string | null> {
+  // error-policy:J2 non-blocking diagnostic — a body-read failure degrades to
+  // a null excerpt (status-only message) without aborting the snapshot path.
+  try {
+    if (!res.body) return null;
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder("utf-8", { fatal: false });
+    const chunks: string[] = [];
+    let totalBytes = 0;
+    try {
+      // error-policy:J2 stream cancellation after the byte budget is reached.
+      while (totalBytes < SNAPSHOT_ERROR_BODY_EXCERPT_BYTES) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const remaining = SNAPSHOT_ERROR_BODY_EXCERPT_BYTES - totalBytes;
+        const sliced = value.length >= remaining ? truncateUtf8Bytes(value, remaining) : value;
+        chunks.push(decoder.decode(sliced, { stream: true }));
+        totalBytes += sliced.length;
+      }
+    } finally {
+      // Cancel the reader to release the connection even if the body is larger.
+      await reader.cancel().catch(() => {});
+    }
+    // Flush any trailing multi-byte UTF-8 sequence held by the stream decoder.
+    chunks.push(decoder.decode());
+    const body = chunks.join("");
+    if (!body.trim()) return null;
+    const contentType = res.headers.get("content-type") ?? "";
+    // JSON error bodies carry structured diagnostics — try to extract a message.
+    if (contentType.includes("application/json")) {
+      try {
+        const data = JSON.parse(body) as { error?: unknown; message?: unknown };
+        const msg = data.error ?? data.message;
+        if (typeof msg === "string" && msg.trim()) {
+          return msg.trim();
+        }
+      } catch {
+        // Not valid JSON — fall through to raw excerpt.
+      }
+    }
+    return body.trim();
+  } catch {
+    return null;
+  }
+}
+
+/** Truncate UTF-8 bytes without splitting a multi-byte code point. */
+function truncateUtf8Bytes(bytes: Uint8Array, maxBytes: number): Uint8Array {
+  const limit = Math.min(bytes.length, maxBytes);
+  let safeEnd = limit;
+  while (safeEnd > 0) {
+    const byte = bytes[safeEnd - 1]!;
+    if ((byte & 0x80) === 0) {
+      return bytes.slice(0, safeEnd);
+    }
+    if ((byte & 0xc0) === 0x80) {
+      safeEnd--;
+      continue;
+    }
+    let sequenceLength = 1;
+    if ((byte & 0xf8) === 0xf0) sequenceLength = 4;
+    else if ((byte & 0xf0) === 0xe0) sequenceLength = 3;
+    else if ((byte & 0xe0) === 0xc0) sequenceLength = 2;
+    if (safeEnd - 1 + sequenceLength <= limit) {
+      return bytes.slice(0, limit);
+    }
+    return bytes.slice(0, safeEnd - 1);
+  }
+  return bytes.slice(0, 0);
 }
 
 export class ElizaSandboxService {
@@ -9865,7 +9958,17 @@ export class ElizaSandboxService {
       throw new Error(SNAPSHOT_ENDPOINT_UNSUPPORTED);
     }
     if (!res.ok) {
-      throw new Error(`Snapshot fetch failed: HTTP ${res.status}`);
+      // #18228: the snapshot transfer failed somewhere between the agent's HTTP
+      // handler and this fetch — an agent-side 500 carries a diagnostic body
+      // (the thrown message), while a bridge/proxy hop 500 carries a proxy
+      // error page or an empty body. The Worker log previously reported only
+      // the status code and discarded the body, making the two indistinguishable.
+      // Read a bounded excerpt of the body and include it after the canonical
+      // `Snapshot fetch failed: HTTP <status>` prefix so the existing
+      // SNAPSHOT_HTTP_ERROR_SHAPE regex (anchored at the status) still classifies
+      // it, while the operator sees where the hop failed.
+      const excerpt = await readErrorBodyExcerpt(res);
+      throw new Error(`Snapshot fetch failed: HTTP ${res.status}${excerpt ? ` ${excerpt}` : ""}`);
     }
 
     // Bounded hydration (#16639): stream and count — bytes past the raw


### PR DESCRIPTION
# Relates to

- Follow-up to #18336 (snapshot transfer error-body diagnostics)
- Fixes nits from deep review of #18336 for #18228

# Contribution provenance

- AI assistance: `yes`
- Model(s) used: `cursor/composer-2.5`
- Client / agent tooling: `Cursor Cloud Agent`
- Skill revision: `N/A - no contribution skill used`
- Attribution status: `self-reported`

# Sync with develop

- [x] Branch created from current `develop`
- [x] Targeted package tests and lint pass (`bun test … -t readErrorBodyExcerpt`, `bun run --cwd packages/cloud/shared lint`)

# Risks

Low — diagnostic-only error-body excerpt path in snapshot fetch failure handling. No change to success paths, 512-byte bound, or `SNAPSHOT_HTTP_ERROR_SHAPE` classification semantics.

# Background

## What does this PR do?

Addresses deep-review nits on #18336:

1. **TextDecoder flush** — `readErrorBodyExcerpt` now finalizes stream decoding (`decoder.decode()` after chunked `{ stream: true }` reads) so multi-byte UTF-8 split across chunks is not dropped.
2. **UTF-8-safe truncation** — when the 512-byte budget lands mid-codepoint, truncate on a code-point boundary instead of emitting a garbled replacement character.
3. **Committed unit tests** — covers empty/whitespace bodies, JSON `{error}`/`{message}` extraction, plain text/HTML, >512 truncation, stream-chunk UTF-8 flush, and budget-boundary truncation.
4. **Classification regression** — confirms `isUnrecoverableSnapshotError` still treats `Snapshot fetch failed: HTTP 500 <body>` as transient.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/eliza-sandbox.ts` (`readErrorBodyExcerpt`, `fetchSnapshotState` error path) and the new `readErrorBodyExcerpt` describe block in `eliza-sandbox.test.ts`.

## Detailed testing steps

```bash
bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts -t "readErrorBodyExcerpt|isUnrecoverableSnapshotError"
bun run --cwd packages/cloud/shared lint
bun run --cwd packages/cloud/shared typecheck
```

# Evidence Gate

- [x] N/A - backend snapshot error-body helper change, no UI surface (all evidence rows)

# Evidence Details

```
bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts -t "readErrorBodyExcerpt|isUnrecoverableSnapshotError"
(pass) readErrorBodyExcerpt … (7 tests)
(pass) isUnrecoverableSnapshotError … (6 tests, includes #18228 body-suffix case)

bun run --cwd packages/cloud/shared lint
Checked 1810 files …
```

## Known gaps / failures

Full `bun run verify` not run in this cloud agent session; targeted package lint/tests above are green.