### PR TITLE
test(eliza-code): harden TUI owner session bootstrap tests (#18270)

### DIFF
--- a/packages/examples/code/src/app-session-bootstrap.test.ts
+++ b/packages/examples/code/src/app-session-bootstrap.test.ts
@@ -1,0 +1,44 @@
+/** Verifies that App reuses the session loaded before runtime initialization. */
+import { afterEach, describe, expect, it } from "bun:test";
+import type { AgentRuntime } from "@elizaos/core";
+import { App } from "./App.js";
+import { useStore } from "./lib/store.js";
+
+const ORIGINAL_STATE = useStore.getState();
+
+describe("App session bootstrap", () => {
+  afterEach(() => {
+    useStore.setState(ORIGINAL_STATE, true);
+  });
+
+  it("does not reload a session that the runtime owner bootstrap already loaded", async () => {
+    let reloads = 0;
+    const runtime = {
+      agentId: "30000000-0000-4000-8000-000000000001",
+      character: {},
+      getService: () => null,
+      registerEvent: () => undefined,
+    } as unknown as AgentRuntime;
+    const app = new App(runtime);
+
+    useStore.setState({
+      sessionLoaded: true,
+      loadSessionState: async () => {
+        reloads += 1;
+        throw new Error("loaded session was read twice");
+      },
+    });
+
+    const tui = (
+      app as unknown as { tui: { start: () => void; stop: () => void } }
+    ).tui;
+    tui.start = () => {
+      queueMicrotask(() => {
+        app.stop();
+      });
+    };
+
+    await expect(app.run()).resolves.toBeUndefined();
+    expect(reloads).toBe(0);
+  });
+});

--- a/packages/examples/code/src/lib/tui-owner.test.ts
+++ b/packages/examples/code/src/lib/tui-owner.test.ts
@@ -3,6 +3,9 @@
  * deterministic in-memory session persistence.
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { UUID } from "@elizaos/core";
 import { useStore } from "./store.js";
 import { resolveTuiOwnerUserId } from "./tui-owner.js";
@@ -36,5 +39,61 @@ describe("resolveTuiOwnerUserId", () => {
 
     await expect(resolveTuiOwnerUserId()).resolves.toBe(userId);
     expect(useStore.getState().identity).toBe(identity);
+  });
+});
+
+describe("resolveTuiOwnerUserId persisted session file", () => {
+  const originalCwd = process.cwd();
+  let fixtureRoot = "";
+
+  beforeEach(async () => {
+    delete process.env.ELIZA_CODE_DISABLE_SESSION_PERSISTENCE;
+    fixtureRoot = await mkdtemp(join(tmpdir(), "eliza-code-owner-"));
+    process.chdir(fixtureRoot);
+    useStore.setState({ ...ORIGINAL_STATE, sessionLoaded: false }, true);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(fixtureRoot, { recursive: true, force: true });
+    useStore.setState(ORIGINAL_STATE, true);
+    delete process.env.ELIZA_CODE_DISABLE_SESSION_PERSISTENCE;
+  });
+
+  it("returns the persisted identity from a real session file", async () => {
+    const sessionDir = join(fixtureRoot, ".eliza-code");
+    const identity = {
+      projectId: "10000000-0000-4000-8000-000000000001" as UUID,
+      userId: "10000000-0000-4000-8000-000000000002" as UUID,
+      worldId: "10000000-0000-4000-8000-000000000003" as UUID,
+      messageServerId: "10000000-0000-4000-8000-000000000004" as UUID,
+    };
+
+    await mkdir(sessionDir);
+    await writeFile(
+      join(sessionDir, "session.json"),
+      JSON.stringify({
+        version: 1,
+        savedAt: Date.now(),
+        currentRoomId: "default-main-room",
+        currentTaskId: null,
+        rooms: [
+          {
+            id: "default-main-room",
+            name: "Main",
+            messages: [],
+            createdAt: Date.now(),
+            taskIds: [],
+            elizaRoomId: "20000000-0000-4000-8000-000000000001",
+          },
+        ],
+        cwd: fixtureRoot,
+        ...identity,
+      }),
+    );
+
+    await expect(resolveTuiOwnerUserId()).resolves.toBe(identity.userId);
+    expect(useStore.getState().identity).toEqual(identity);
+    expect(useStore.getState().sessionLoaded).toBe(true);
   });
 });


### PR DESCRIPTION
# Relates to

Relates to #18264. Addresses deep-review findings on #18270.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto current `origin/develop`.
- [x] The branch contains only regression coverage that is still missing on current `develop`.
- [x] Focused tests, package lint, and package build pass on the exact head below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `cursor/composer-2.5`
<!-- attribution-row:client -->
- Agent tooling: `Cursor Cloud Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] Test-only delta covering the two remaining TUI owner session bootstrap gaps.

# Risks

Low. This PR changes tests only. It does not alter runtime behavior, persistence, or the TUI.

# Background

## What does this PR do?

Current `develop` contains `resolveTuiOwnerUserId()` and the guarded `App.run()` session load. Its existing unit tests cover fresh and already-loaded in-memory state.

This PR adds the two remaining regression boundaries requested in review on #18270, with hardened test harnesses:

1. An actual `.eliza-code/session.json` fixture hydrates the shared Zustand identity and returns that persisted user ID to the runtime owner bootstrap. The fixture uses an isolated describe block with `beforeEach`/`afterEach` cwd restoration, matching `session.test.ts`.
2. `App.run()` does not read the session a second time after the owner bootstrap has already loaded it. The stop condition patches `tui.start()` to call `app.stop()` on the next microtask so `exitResolver` is registered before shutdown, avoiding the flaky fixed 10ms timer from the original PR.

## What kind of change is this?

Test-only regression coverage.

# Documentation changes needed?

No. Public behavior and commands are unchanged.

# Testing

## Where should a reviewer start?

- `packages/examples/code/src/lib/tui-owner.test.ts`
- `packages/examples/code/src/app-session-bootstrap.test.ts`

## Detailed testing steps

From `packages/examples/code`:

```bash
bun test --conditions=eliza-source src/lib/tui-owner.test.ts src/app-session-bootstrap.test.ts
bun run lint
bun run build
```

# Evidence Gate

<!-- evidence-head:1546e83c7014991e606e42f409c8a35fce3ef124 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only coverage with no rendered change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only coverage with no rendered change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interaction or layout changed.
<!-- evidence-row:backend-logs -->
- [x] Exact-head verification:

```text
(pass) App session bootstrap > does not reload a session that the runtime owner bootstrap already loaded
(pass) resolveTuiOwnerUserId > returns the identity from the same store after loading it
(pass) resolveTuiOwnerUserId > does not reload and replace an already resolved store identity
(pass) resolveTuiOwnerUserId persisted session file > returns the persisted identity from a real session file

4 pass
0 fail
10 expect() calls
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser or frontend transport changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - test-only regression coverage; the focused test transcript in backend-logs is the verification artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Known gaps / failures

None for the changed package. Root `bun run verify` was not rerun for this test-only delta; package lint, build, and focused tests pass on the exact head above.