### PR TITLE
feat(core): harden research cancellation tests for AbortSignal support

### DIFF
--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -1258,6 +1258,14 @@ export interface ResearchParams {
 	background?: boolean;
 
 	/**
+	 * Optional cancellation signal for the provider request.
+	 * The first-party research providers combine it with their configured
+	 * request timeout, so either caller cancellation or the deadline aborts the
+	 * underlying request.
+	 */
+	signal?: AbortSignal;
+
+	/**
 	 * Array of tools/data sources for the research model.
 	 * Must include at least one data source: web_search_preview, file_search, or mcp.
 	 * Can also include code_interpreter for data analysis.

--- a/plugins/plugin-elizacloud/README.md
+++ b/plugins/plugin-elizacloud/README.md
@@ -162,6 +162,15 @@ const speech = await runtime.useModel(ModelType.TEXT_TO_SPEECH, {
 // core TranscriptionParams ({ audioUrl }). URL fetches go through the
 // SSRF guard. Requires ELIZAOS_CLOUD_ENABLED=true or ELIZAOS_CLOUD_USE_STT=true.
 const transcript = await runtime.useModel(ModelType.TRANSCRIPTION, audioBuffer);
+
+// Cancel a long-running research request without disabling its provider timeout.
+const researchController = new AbortController();
+const report = await runtime.useModel(ModelType.RESEARCH, {
+  input: "Compare current grid-scale energy storage approaches.",
+  tools: [{ type: "web_search_preview" }],
+  signal: researchController.signal,
+});
+// Call researchController.abort() when the result is no longer needed.
 ```
 
 ## Adding Cloud Calls

--- a/plugins/plugin-elizacloud/__tests__/integration/research-model-contract.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/integration/research-model-contract.test.ts
@@ -7,15 +7,44 @@
  * live-API `*.real.test.ts` lane. Live coverage lives in the post-merge real lane (`TEST_LANE=post-merge`).
  */
 
+import type { IncomingMessage, ServerResponse } from "node:http";
 import * as http from "node:http";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleResearch } from "../../src/models/research";
+
+interface HeldRequest {
+  req: IncomingMessage;
+  res: ServerResponse;
+}
 
 let server: http.Server;
 let baseUrl: string;
 let lastRequestBody = "";
 let nextStatus = 200;
 let nextBody = "{}";
+let holdResponse = false;
+const heldRequests: HeldRequest[] = [];
+
+function releaseHeldRequests(): void {
+  while (heldRequests.length > 0) {
+    const held = heldRequests.pop();
+    if (!held) {
+      continue;
+    }
+    if (!held.res.writableEnded) {
+      held.res.writeHead(499, { "Content-Type": "application/json" });
+      held.res.end(JSON.stringify({ error: "client closed request" }));
+    }
+    held.req.destroy();
+  }
+}
+
+function removeHeldRequest(req: IncomingMessage): void {
+  const index = heldRequests.findIndex((held) => held.req === req);
+  if (index >= 0) {
+    heldRequests.splice(index, 1);
+  }
+}
 
 function createRuntime(overrides: Record<string, string> = {}) {
   return {
@@ -42,8 +71,21 @@ beforeAll(async () => {
     req.on("data", (chunk: Buffer) => chunks.push(chunk));
     req.on("end", () => {
       lastRequestBody = Buffer.concat(chunks).toString("utf8");
+      if (holdResponse) {
+        heldRequests.push({ req, res });
+        req.on("close", () => {
+          removeHeldRequest(req);
+        });
+        return;
+      }
       res.writeHead(nextStatus, { "Content-Type": "application/json" });
       res.end(nextBody);
+    });
+    req.on("aborted", () => {
+      removeHeldRequest(req);
+      if (!res.writableEnded) {
+        res.destroy();
+      }
     });
   });
 
@@ -56,8 +98,36 @@ beforeAll(async () => {
   });
 });
 
-afterAll(() => {
-  server.close();
+afterAll(async () => {
+  releaseHeldRequests();
+  if (typeof server.closeAllConnections === "function") {
+    server.closeAllConnections();
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+});
+
+beforeEach(() => {
+  nextStatus = 200;
+  nextBody = "{}";
+  holdResponse = false;
+});
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  releaseHeldRequests();
+  holdResponse = false;
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+  expect(heldRequests).toHaveLength(0);
 });
 
 describe("handleResearch", () => {
@@ -145,5 +215,40 @@ describe("handleResearch", () => {
     ).rejects.toThrow(
       "Eliza Cloud /responses rejected deep-research tool types; the provider currently only accepts function tools on this route"
     );
+  });
+
+  it("aborts the in-flight cloud request when the caller cancels", async () => {
+    holdResponse = true;
+    const controller = new AbortController();
+    const request = handleResearch(createRuntime() as never, {
+      input: "Research cancellation behavior.",
+      signal: controller.signal,
+    });
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    controller.abort(new DOMException("Research cancelled", "AbortError"));
+
+    await expect(request).rejects.toMatchObject({ name: "AbortError" });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(heldRequests).toHaveLength(0);
+  });
+
+  it("retains the configured cloud timeout when no caller signal fires", async () => {
+    holdResponse = true;
+    vi.stubEnv("ELIZAOS_CLOUD_RESEARCH_TIMEOUT_MS", "5");
+
+    const request = handleResearch(createRuntime() as never, {
+      input: "Research timeout behavior.",
+    });
+
+    await expect(request).rejects.toMatchObject({ name: "TimeoutError" });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(heldRequests).toHaveLength(0);
   });
 });

--- a/plugins/plugin-elizacloud/src/models/research.ts
+++ b/plugins/plugin-elizacloud/src/models/research.ts
@@ -225,12 +225,19 @@ export async function handleResearch(
     requestBody.reasoning = { summary: params.reasoningSummary };
   }
 
+  const timeoutMs = resolveCloudTimeoutMs(
+    "ELIZAOS_CLOUD_RESEARCH_TIMEOUT_MS",
+    DEFAULT_RESEARCH_TIMEOUT_MS
+  );
+  const timeoutSignal = timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined;
+  const signal =
+    params.signal && timeoutSignal
+      ? AbortSignal.any([params.signal, timeoutSignal])
+      : (params.signal ?? timeoutSignal);
+
   const response = await createCloudApiClient(runtime).requestRaw("POST", "/responses", {
     json: requestBody,
-    timeoutMs: resolveCloudTimeoutMs(
-      "ELIZAOS_CLOUD_RESEARCH_TIMEOUT_MS",
-      DEFAULT_RESEARCH_TIMEOUT_MS
-    ),
+    signal,
   });
 
   if (!response.ok) {

--- a/plugins/plugin-openai/README.md
+++ b/plugins/plugin-openai/README.md
@@ -167,10 +167,13 @@ const audio = await runtime.useModel(ModelType.TEXT_TO_SPEECH, {
 });
 
 // Deep research (may take minutes)
+const researchController = new AbortController();
 const report = await runtime.useModel(ModelType.RESEARCH, {
   input: "What are the latest advances in fusion energy?",
   tools: [{ type: "web_search_preview" }],
+  signal: researchController.signal,
 });
+// Call researchController.abort() when the result is no longer needed.
 console.log(report.text, report.annotations);
 ```
 

--- a/plugins/plugin-openai/__tests__/research-cancellation.test.ts
+++ b/plugins/plugin-openai/__tests__/research-cancellation.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Deterministic cancellation tests for the OpenAI research handler. A mocked
+ * fetch waits on the real request signal so caller aborts and provider
+ * deadlines exercise the transport boundary without spending API quota.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleResearch } from "../models/research";
+
+function createRuntime(settings: Record<string, string> = {}): IAgentRuntime {
+  return {
+    character: { name: "Research test" },
+    getSetting(key: string) {
+      const values: Record<string, string> = {
+        OPENAI_API_KEY: "test-key",
+        OPENAI_RESEARCH_TIMEOUT: "10000",
+        ...settings,
+      };
+      return values[key];
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function abortableFetch(): typeof fetch {
+  return vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+    return new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) {
+        reject(new Error("Research request did not include an abort signal"));
+        return;
+      }
+
+      const rejectWithReason = () => reject(signal.reason);
+      if (signal.aborted) {
+        rejectWithReason();
+        return;
+      }
+      signal.addEventListener("abort", rejectWithReason, { once: true });
+    });
+  }) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("OpenAI research cancellation", () => {
+  it("aborts the in-flight provider request when the caller cancels", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(abortableFetch());
+    const controller = new AbortController();
+
+    const request = handleResearch(createRuntime(), {
+      input: "Research cancellation behavior.",
+      signal: controller.signal,
+    });
+    controller.abort(new DOMException("Research cancelled", "AbortError"));
+
+    await expect(request).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("retains the configured provider timeout when no caller signal fires", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(abortableFetch());
+
+    await expect(
+      handleResearch(createRuntime({ OPENAI_RESEARCH_TIMEOUT: "5" }), {
+        input: "Research timeout behavior.",
+      })
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+});

--- a/plugins/plugin-openai/models/research.ts
+++ b/plugins/plugin-openai/models/research.ts
@@ -299,6 +299,9 @@ export async function handleResearch(
   const modelName = params.model ?? getResearchModel(runtime);
   const timeout = getResearchTimeout(runtime);
 
+  const timeoutSignal = AbortSignal.timeout(timeout);
+  const signal = params.signal ? AbortSignal.any([params.signal, timeoutSignal]) : timeoutSignal;
+
   logger.debug(`[OpenAI] Starting deep research with model: ${modelName}`);
   logger.debug(`[OpenAI] Research input: ${params.input.substring(0, 100)}...`);
 
@@ -359,7 +362,7 @@ export async function handleResearch(
         "Content-Type": "application/json",
       },
       body: JSON.stringify(requestBody),
-      signal: AbortSignal.timeout(timeout),
+      signal,
     });
 
     if (!response.ok) {


### PR DESCRIPTION
# Relates to

Addresses deep-review nits on #18195 (research request cancellation / `AbortSignal`).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun run verify` passes post-sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

- AI assistance: `yes`
- Model(s) used: `Cursor/composer-2.5`
- Client / agent tooling: `Cursor Cloud Agent`
- Skill revision: `N/A - no contribution skill used`
- Attribution status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. The core contract change is additive, and only the two first-party research handlers change runtime behavior. Caller cancellation and the existing provider deadline are composed, so the first abort reason is preserved while successful requests and timeout-only requests keep their prior behavior.

# Background

## What does this PR do?

Implements and hardens the research cancellation contract from #18195:

- Adds optional `ResearchParams.signal` to the core research model-call contract.
- Composes caller cancellation with provider timeouts in the OpenAI and Eliza Cloud `ModelType.RESEARCH` handlers via `AbortSignal.any`.
- Makes Eliza Cloud loopback cancellation tests deterministic and leak-free by tracking held requests, releasing them on client abort/close, and tearing down stragglers in `afterEach`/`afterAll` so the mock HTTP server does not retain aborted connections until suite shutdown.
- Adds focused OpenAI transport cancellation tests and updates provider README examples.

## What kind of change is this?

Feature + test hardening: a non-breaking extension to the research model-call contract with deterministic cancellation coverage.

# Documentation changes needed?

Yes. OpenAI and Eliza Cloud provider READMEs now show cancellable research requests.

# Testing

## Where should a reviewer start?

1. `packages/core/src/types/model.ts` — `ResearchParams.signal`
2. `plugins/plugin-openai/models/research.ts` and `plugins/plugin-elizacloud/src/models/research.ts` — composed abort signals
3. `plugins/plugin-elizacloud/__tests__/integration/research-model-contract.test.ts` — leak-free `holdResponse` cleanup

## Detailed testing steps

```bash
bun run --cwd packages/core build
bun run --cwd plugins/plugin-openai test -- __tests__/research-cancellation.test.ts
bun run --cwd plugins/plugin-elizacloud test -- __tests__/integration/research-model-contract.test.ts
bun run --cwd packages/core typecheck
bun run --cwd plugins/plugin-openai typecheck
bun run --cwd plugins/plugin-elizacloud typecheck
```

Observed results on this branch:

- OpenAI cancellation contract: 1 file / 2 tests passed
- Eliza Cloud loopback contract: 1 file / 4 tests passed (including caller abort + timeout paths)
- Core, OpenAI, and Eliza Cloud typechecks passed

# Evidence Gate

- [ ] N/A - no UI or rendered surface changes.
- [ ] N/A - no UI or rendered surface changes.
- [ ] N/A - transport-level SDK contract change with no user flow.
- [ ] N/A - deterministic fetch and loopback HTTP tests exercise the real provider-handler abort paths.
- [ ] N/A - no frontend code changed.
- [ ] N/A - no live provider credential in this worktree; deterministic transport tests prove cancellation without quota spend.
- [ ] N/A - no database, memory, scheduled-task, wallet, generated-file, or media artifact is created.
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic transport tests prove the abort path without quota spend.

## Backend + frontend logs

```text
OpenAI research cancellation: 1 file / 2 tests passed
Eliza Cloud research contract: 1 file / 4 tests passed
```

## Screenshots / video / audio

N/A - no UI or voice changes.

## Known gaps / failures

- Root `bun run verify` was not run in this cloud worktree; focused package tests and typechecks listed above passed.
- No live provider trajectory attached; cancellation behavior is covered by deterministic transport tests.