### PR TITLE
ci: avoid duplicate privileged work for fork pull requests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -34,6 +34,24 @@ the `pr.yaml` title check cover narrower contracts. None replaces the
 - `ui-e2e-gate.yml` and `ui-fixture-e2e.yml` run the packages/ui Chromium and
   WebKit fixture gates when `packages/ui/src/**` changes.
 
+### Outside contributors
+
+Untrusted pull requests—forks and same-repository Dependabot heads—run the
+canonical `ci.yml` workflow on ephemeral GitHub-hosted runners with read-only
+permissions. Cloud integration/E2E, UI fixture, and PR-policy workflows remain
+enabled because they add coverage that canonical CI does not provide. The jobs
+in `develop-pr.yml` and the standalone `gitleaks.yml` job are skipped for these
+PRs because canonical CI already supplies their lint, format, typecheck,
+plugin-test, build-core, and diff-scoped secret-scan contracts; running both
+copies only delays feedback and consumes capacity. Their `pull_request`
+triggers still create workflow runs, whose guarded jobs settle as skipped.
+
+Repository variables are not an authorization boundary for fork events. Any
+fork-capable workflow with optional Hetzner placement must default to hosted
+when `HETZNER_FLEET_ONLINE` is unavailable, using the fail-safe `!= 'true'`
+test. GitHub's outside-collaborator approval remains an abuse/cost-control
+policy, not the mechanism that protects secrets or persistent runners.
+
 ## Manual operations
 
 - `live-smoke.yml` is the general credential-backed dispatcher. Its input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
       # --ignore-scripts install never builds them. Turbo builds core plus its
       # dependency graph, matching the prelude in dev-smoke.yml.
       - name: Build @elizaos/core and workspace deps
-        if: needs.changes.outputs.desktop == 'true' && needs.changes.outputs.cloud != 'true'
+        if: needs.changes.outputs.desktop == 'true' && needs.changes.outputs.cloud != 'true' && needs.changes.outputs.zero_key != 'true'
         run: bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
 
       # test:cloud reaches further than the desktop prelude: cloud service suites
@@ -333,7 +333,7 @@ jobs:
       # build:core is a superset of the desktop prelude, so it replaces the
       # narrow build rather than running alongside it.
       - name: Build core contract
-        if: needs.changes.outputs.cloud == 'true'
+        if: needs.changes.outputs.cloud == 'true' || needs.changes.outputs.zero_key == 'true'
         run: bun run build:core
 
       - name: Desktop startup smoke

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -22,6 +22,10 @@ permissions:
 
 jobs:
   lint:
+    # Canonical CI already gives untrusted PRs the same lint/format contract
+    # plus the broader repository verification lane. Dependabot heads live in
+    # this repository but GitHub applies fork-equivalent trust restrictions.
+    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -73,6 +77,7 @@ jobs:
           .github/workflows/test.yml
 
   typecheck:
+    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     # 35 not 20: at --concurrency=4 a near-total affected cone (~250 packages)
     # needs headroom — the one green full-cone run spent 11 minutes in the
@@ -119,6 +124,7 @@ jobs:
           TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
 
   build:
+    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -154,6 +160,7 @@ jobs:
   # a sharded post-merge lane and is far too slow for a per-PR gate.
   plugin-tests:
     name: plugin-tests
+    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     # Rust-backed plugin suites can compile their native test harness on a cold
     # hosted runner. The cache keeps normal runs short; the cap prevents a

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -31,6 +31,10 @@ permissions:
 jobs:
   gitleaks:
     name: gitleaks
+    # ci.yml owns the same diff-scoped scan for untrusted PRs. Dependabot heads
+    # are same-repository branches but receive GitHub's fork-equivalent trust.
+    # Protected pushes and trusted PRs retain this visible SOC2 lane.
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]')
     runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-24.04"]' || vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout

--- a/packages/scripts/__tests__/fork-pr-workflow-contract.test.ts
+++ b/packages/scripts/__tests__/fork-pr-workflow-contract.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Guards the fork pull-request CI boundary: outside code stays on disposable
+ * runners, receives every distinct validation surface, and does not pay for
+ * checks already supplied by canonical CI.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repositoryRoot = join(import.meta.dir, "../../..");
+const workflow = (name: string): string =>
+  readFileSync(join(repositoryRoot, ".github/workflows", name), "utf8");
+
+const trustedPullRequest =
+  "github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'";
+const trustedPullRequestOrPush =
+  `github.event_name != 'pull_request' || (${trustedPullRequest})`;
+
+function jobCondition(contents: string, jobName: string): string {
+  const lines = contents.split("\n");
+  const jobStart = lines.findIndex((line) => line === `  ${jobName}:`);
+  expect(jobStart).toBeGreaterThanOrEqual(0);
+
+  for (const line of lines.slice(jobStart + 1)) {
+    if (/^  \S/u.test(line)) break;
+    const condition = line.match(/^    if: (.+)$/u)?.[1];
+    if (condition) return condition;
+  }
+
+  throw new Error(`job ${jobName} has no condition`);
+}
+
+type WorkflowEvent = {
+  eventName: "pull_request" | "push";
+  actor: string;
+  headRepositoryFork?: boolean;
+};
+
+function trustedPullRequestJobRuns(event: WorkflowEvent): boolean {
+  return (
+    event.eventName === "pull_request" &&
+    event.headRepositoryFork === false &&
+    event.actor !== "dependabot[bot]"
+  );
+}
+
+function gitleaksJobRuns(event: WorkflowEvent): boolean {
+  return (
+    event.eventName !== "pull_request" || trustedPullRequestJobRuns(event)
+  );
+}
+
+describe("fork pull-request workflow policy", () => {
+  test("canonical CI is entirely GitHub-hosted and read-only", () => {
+    const canonical = workflow("ci.yml");
+
+    expect(canonical).toContain("permissions:\n  contents: read");
+    expect(canonical).not.toContain("self-hosted");
+    expect(
+      canonical.match(/runs-on: ubuntu-24\.04/g)?.length,
+    ).toBeGreaterThanOrEqual(7);
+  });
+
+  test("each duplicate develop PR job uses the complete trust predicate", () => {
+    const developPr = workflow("develop-pr.yml");
+
+    for (const job of ["lint", "typecheck", "build", "plugin-tests"]) {
+      expect(jobCondition(developPr, job)).toBe(trustedPullRequest);
+    }
+  });
+
+  test("standalone gitleaks uses the same trust boundary and preserves pushes", () => {
+    const gitleaks = workflow("gitleaks.yml");
+
+    expect(jobCondition(gitleaks, "gitleaks")).toBe(trustedPullRequestOrPush);
+    expect(gitleaks).toContain('push:\n    branches: ["main", "develop"]');
+  });
+
+  test("trust truth table separates forks, Dependabot, trusted PRs, and pushes", () => {
+    const cases: Array<{
+      event: WorkflowEvent;
+      developPr: boolean;
+      gitleaks: boolean;
+    }> = [
+      {
+        event: {
+          eventName: "pull_request",
+          actor: "outside-contributor",
+          headRepositoryFork: true,
+        },
+        developPr: false,
+        gitleaks: false,
+      },
+      {
+        event: {
+          eventName: "pull_request",
+          actor: "dependabot[bot]",
+          headRepositoryFork: false,
+        },
+        developPr: false,
+        gitleaks: false,
+      },
+      {
+        event: {
+          eventName: "pull_request",
+          actor: "trusted-contributor",
+          headRepositoryFork: false,
+        },
+        developPr: true,
+        gitleaks: true,
+      },
+      {
+        event: { eventName: "push", actor: "maintainer" },
+        developPr: false,
+        gitleaks: true,
+      },
+    ];
+
+    for (const scenario of cases) {
+      expect(trustedPullRequestJobRuns(scenario.event)).toBe(
+        scenario.developPr,
+      );
+      expect(gitleaksJobRuns(scenario.event)).toBe(scenario.gitleaks);
+    }
+  });
+
+  test("distinct fork checks remain available", () => {
+    for (const name of [
+      "cloud-tests.yml",
+      "pr.yaml",
+      "ui-e2e-gate.yml",
+      "ui-fixture-e2e.yml",
+    ]) {
+      const contents = workflow(name);
+      expect(contents).toContain("pull_request:");
+      expect(contents).not.toContain(trustedPullRequest);
+    }
+  });
+
+  test("fork-capable optional fleet jobs fail safe to hosted runners", () => {
+    for (const name of ["cloud-tests.yml", "gitleaks.yml", "ui-e2e-gate.yml"]) {
+      const contents = workflow(name);
+      expect(contents).toContain("vars.HETZNER_FLEET_ONLINE != 'true'");
+      expect(contents).not.toContain("vars.HETZNER_FLEET_ONLINE == 'false'");
+    }
+  });
+});

--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -32,6 +32,8 @@ const smokeLanesE2eCommand =
   "bun run test:e2e --filter='^(?!.*packages/app\\)#test:e2e)'";
 
 const zeroKeyCondition = "needs.changes.outputs.zero_key == 'true'";
+const smokeLanesCoreBuildCondition =
+  "needs.changes.outputs.cloud == 'true' || needs.changes.outputs.zero_key == 'true'";
 
 function assertJobBrowserBootstrap(
   steps: WorkflowStep[],
@@ -77,6 +79,30 @@ function assertSmokeE2eBrowserBootstrap(source: string): void {
     install: smokeLanesBrowserInstallCommand,
     e2e: smokeLanesE2eCommand,
   });
+}
+
+function assertSmokeLanesCoreBootstrap(source: string): void {
+  const workflow = Bun.YAML.parse(source) as {
+    jobs?: { smoke_lanes?: { steps?: WorkflowStep[] } };
+  };
+  const steps = workflow.jobs?.smoke_lanes?.steps ?? [];
+  const buildIndex = steps.findIndex(
+    (step) =>
+      step.name === "Build core contract" && step.run === "bun run build:core",
+  );
+  const e2eIndex = steps.findIndex((step) => step.run === smokeLanesE2eCommand);
+
+  if (
+    buildIndex < 0 ||
+    steps[buildIndex]?.if !== smokeLanesCoreBuildCondition
+  ) {
+    throw new Error(
+      "Smoke lanes must build the core contract for cloud and zero-key work",
+    );
+  }
+  if (e2eIndex < 0 || buildIndex >= e2eIndex) {
+    throw new Error("Smoke lanes must build the core contract before E2E");
+  }
 }
 
 function collectYamlFiles(directory: string): string[] {
@@ -233,6 +259,25 @@ describe("GitHub action supply-chain references", () => {
       );
     expect(() => assertSmokeE2eBrowserBootstrap(afterE2e)).toThrow(
       "Smoke must install browsers before running E2E",
+    );
+  });
+
+  test("builds workspace contracts before unshardable smoke E2E", () => {
+    const source = readFileSync(
+      join(githubRoot, "workflows", "ci.yml"),
+      "utf8",
+    );
+
+    expect(() => assertSmokeLanesCoreBootstrap(source)).not.toThrow();
+    expect(() =>
+      assertSmokeLanesCoreBootstrap(
+        source.replace(
+          `        if: ${smokeLanesCoreBuildCondition}\n        run: bun run build:core`,
+          `        if: ${zeroKeyCondition}\n        run: bun run build:core`,
+        ),
+      ),
+    ).toThrow(
+      "Smoke lanes must build the core contract for cloud and zero-key work",
     );
   });
 


### PR DESCRIPTION
# Relates to

Closes #18443.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused workflow contract tests pass locally.
- [x] A reviewer can confirm the change without reading the code from the evidence below.

# Contribution provenance

- AI assistance: yes
- Model(s) used: Composer
- Agent tooling: Cursor Cloud Agent
- Provenance status: self-reported

# Risks

Low. Fork pull requests retain canonical hosted, read-only CI via `ci.yml`; same-repository PRs retain `develop-pr.yml` and standalone Gitleaks coverage; protected-branch pushes keep the SOC2 secret-scan lane.

# Background

## What does this PR do?

Skips duplicate `develop-pr.yml` jobs and the standalone `gitleaks.yml` job for untrusted pull requests (forks and same-repository Dependabot heads). Workflow runs are still created; guarded jobs settle as skipped. Documents the outside-contributor policy and Hetzner fail-safe routing. Adds a contract test with a four-event trust truth table.

## What kind of change is this?

Improvement: CI dispatch policy and workflow documentation.

## Why are we doing this? Any context or related work?

Canonical `ci.yml` is read-only and safe for forks. Running approval-gated duplicate jobs wastes runner capacity and delays feedback without adding distinct validation.

# Documentation changes needed?

Updated `.github/workflows/README.md` with the durable outside-contributor policy.

# Testing

## Where should a reviewer start?

`.github/workflows/README.md`, then guards in `develop-pr.yml` and `gitleaks.yml`; the contract test states the expected boundaries.

## Detailed testing steps

1. `bun test packages/scripts/__tests__/fork-pr-workflow-contract.test.ts`
2. `bun test packages/scripts/__tests__/github-action-pinning.test.ts`

# Evidence Gate

- [x] N/A - workflow-only change; no rendered UI surface
- [x] N/A - workflow-only change; no rendered UI surface
- [x] N/A - workflow-only change; no user-exercisable UI flow
- [x] N/A - no application runtime path changed
- [x] N/A - no frontend surface or request flow changed
- [x] N/A - no agent, action, provider, prompt, or model behavior changed
- [x] N/A - no database, memory, scheduled task, wallet, generated-domain artifact, or device behavior changed
- [x] N/A - workflow-only change has no rendered visual surface

# Evidence Details

- Focused workflow contract tests: 18 pass locally (`fork-pr-workflow-contract.test.ts`, `github-action-pinning.test.ts`).
- Full `bun run verify` not run locally; GitHub CI is the execution proof for the full gate.