### PR TITLE
docs(security): restore GitHub-discoverable SECURITY.md (#18446)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@ contact_links:
     url: https://github.com/orgs/elizaOS/projects/15
     about: The active kanban. MVP work items live here; workstream design docs are under packages/docs/ongoing-development/.
   - name: Security vulnerability
-    url: https://github.com/elizaOS/eliza/blob/develop/packages/docs/security.md
-    about: Do not open a public issue for security bugs. Read the security policy for private reporting instructions.
+    url: https://github.com/elizaOS/eliza/blob/develop/SECURITY.md
+    about: Do not open a public issue for security bugs. Read SECURITY.md for private reporting instructions.
   - name: Discord community
     url: https://discord.gg/ai16z
     about: Chat with the team and other contributors (see the development-feed channel).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,16 +272,19 @@ frontend logs) is [#15171](https://github.com/elizaOS/eliza/pull/15171).
 
 ## Security Reporting
 
-The canonical security policy — reporting channel, disclosure window, and
-remediation SLAs — is [`packages/docs/security.md`](packages/docs/security.md). In short: report
-vulnerabilities privately to `security@elizalabs.ai`; do not open a public
-GitHub issue for a live vulnerability, credential leak, exploit path, or
-embargoed dependency issue. Include affected versions or commits, reproduction
-steps, impact, and any safe proof of exploitability. Agents that encounter a
-secret or suspected vulnerability must stop exposing details publicly and route
-the finding to that mailbox or a maintainer-owned private channel.
+The canonical security policy — reporting channels, disclosure window, and
+remediation SLAs — is [`SECURITY.md`](SECURITY.md). In short: report
+vulnerabilities privately through [GitHub Security Advisories](https://github.com/elizaOS/eliza/security/advisories/new)
+or `security@elizalabs.ai`; do not open a public GitHub issue for a live
+vulnerability, credential leak, exploit path, or embargoed dependency issue.
+Include affected versions or commits, reproduction steps, impact, and any safe
+proof of exploitability. Contributors who encounter a secret or suspected
+vulnerability must stop exposing details publicly and route the finding through
+those private channels.
 
-Security, SOC2, and incident-response reference material lives under
+Security architecture and hardening notes live in
+[`packages/docs/security.md`](packages/docs/security.md). SOC2 and
+incident-response reference material lives under
 [`packages/docs/security/`](packages/docs/security/). Package-specific security
 implementation notes live in the relevant package docs.
 

--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ testing, synchronization, and human-verifiable evidence requirements.
 - [Feature request](.github/ISSUE_TEMPLATE/feature_request.md)
 - [Agent work item](.github/ISSUE_TEMPLATE/agent_work_item.md)
 - [Windows setup](WINDOWS.md)
-- [Product security documentation](packages/docs/security.md)
+- [Security policy](SECURITY.md)
+- [Security architecture documentation](packages/docs/security.md)
 
-Report vulnerabilities privately through
-[GitHub Security Advisories](https://github.com/elizaOS/eliza/security/advisories/new),
+Report vulnerabilities privately through the [security policy](SECURITY.md),
 not a public issue.
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+The elizaOS team takes the security of our software seriously. This document
+describes how to report vulnerabilities and our remediation commitments.
+
+For security architecture, hardening measures, and implementation notes, see
+[`packages/docs/security.md`](packages/docs/security.md).
+
+## Reporting a Vulnerability
+
+**Do not open public GitHub issues for security bugs.**
+
+Report vulnerabilities privately through one of these channels:
+
+- **GitHub Security Advisories:**
+  [elizaOS/eliza private vulnerability reporting](https://github.com/elizaOS/eliza/security/advisories/new)
+- **Email:** **security@elizalabs.ai**
+
+Include a description of the issue, steps to reproduce, the affected versions
+or packages, and any proof-of-concept you have. If you need to share especially
+sensitive material, say so in your first message and we will arrange a secure
+channel before you send it.
+
+We will acknowledge receipt within **2 business days** and provide an initial
+triage assessment within **5 business days**.
+
+## Responsible Disclosure
+
+We follow a **90-day** coordinated-disclosure window from initial report to
+public disclosure. We may extend this for complex issues by mutual agreement
+with the reporter. Researchers who report in good faith and follow this policy
+will not be subject to legal action under our vulnerability-disclosure terms.
+
+## Remediation SLA
+
+Once a vulnerability is confirmed:
+
+| Severity (CVSS v3) | Remediation Target  | Notes                                            |
+| ------------------ | ------------------- | ------------------------------------------------ |
+| Critical (9.0–10)  | **7 calendar days** | Includes hotfix release where applicable.        |
+| High (7.0–8.9)     | **30 days**         | Patched in next minor release.                   |
+| Medium (4.0–6.9)   | **90 days**         | Patched in next minor release or bundled bugfix. |
+| Low (< 4.0)        | Next planned release| Tracked but not separately released.             |
+
+These targets apply to first-party code in this repository and to direct
+dependencies under our control. Transitive vulnerabilities that depend on
+upstream maintainers may take longer; we document any extended exposure in
+this file and in dependabot ignore rules.
+
+## Supported Versions
+
+Security patches are applied to the **`latest` and `beta` dist-tag releases**
+on npm and PyPI. Versions older than the current `latest` minor are end-of-life
+and will not receive patches.
+
+## Scope
+
+In-scope:
+
+- Source code in this repository.
+- Official installer scripts shipped from this repository, including
+  `packages/homepage/public/install.sh` and `packages/homepage/public/install.ps1`.
+- Officially published packages on npm and PyPI.
+
+Out-of-scope:
+
+- Third-party plugins not maintained by the elizaOS organization.
+- Social engineering against contributors.
+- Denial of service via resource exhaustion of a self-hosted deployment.
+
+## Public Advisories
+
+Confirmed and remediated vulnerabilities are published as GitHub Security
+Advisories on this repository.

--- a/packages/docs/security.md
+++ b/packages/docs/security.md
@@ -6,7 +6,12 @@ description: "Security layers, hardening measures, and review notes for the Eliz
 
 # Security Architecture
 
-This document describes the security architecture and hardening measures implemented in the Eliza codebase. It is intended for developers, auditors, and contributors who want to understand the defensive layers in place.
+This document describes the security architecture and hardening measures
+implemented in the Eliza codebase. It is intended for developers, auditors, and
+contributors who want to understand the defensive layers in place.
+
+To report a vulnerability, follow the reporter-facing policy in the root
+[`SECURITY.md`](../../SECURITY.md) — do not open a public GitHub issue.
 
 ---
 
@@ -220,7 +225,6 @@ Only known top-level configuration keys are accepted (`CONFIG_WRITE_ALLOWED_TOP_
 
 ## Reporting Security Issues
 
-If you discover a security vulnerability, please report it responsibly through a **private channel** — do **not** open a public GitHub issue, as this risks 0-day disclosure. Use one of:
-
-- **GitHub private vulnerability reporting** via the repository's Security tab
-- **Direct contact** with the maintainers
+Report vulnerabilities through the root [`SECURITY.md`](../../SECURITY.md) policy
+— private GitHub Security Advisories or `security@elizalabs.ai`. Do not open a
+public GitHub issue for a live vulnerability.

--- a/packages/scripts/launch-qa/check-docs.mjs
+++ b/packages/scripts/launch-qa/check-docs.mjs
@@ -21,7 +21,16 @@ const SKIP_DIRS = new Set([
   "node_modules",
   "target",
 ]);
-const ROOT_DOCS = ["README.md", "CONTRIBUTING.md", "WINDOWS.md"];
+const ROOT_DOCS = [
+  "README.md",
+  "CONTRIBUTING.md",
+  "SECURITY.md",
+  "WINDOWS.md",
+];
+const ISSUE_TEMPLATE_CONFIG = ".github/ISSUE_TEMPLATE/config.yml";
+const SECURITY_POLICY_FILE = "SECURITY.md";
+const SECURITY_POLICY_CONTACT_URL =
+  "https://github.com/elizaOS/eliza/blob/develop/SECURITY.md";
 
 function rel(repoRoot, filePath) {
   return path.relative(repoRoot, filePath).split(path.sep).join("/");
@@ -477,6 +486,62 @@ function checkCommands({ repoRoot, docFiles, contentByFile, scriptsByDir }) {
   return errors;
 }
 
+function readIssueTemplateSecurityContactUrl(configPath) {
+  try {
+    const content = fs.readFileSync(configPath, "utf8");
+    const match = content.match(
+      /name:\s*Security vulnerability\s*\n\s*url:\s*([^\n#]+)/i,
+    );
+    return match?.[1]?.trim() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function checkSecurityPolicy(repoRoot) {
+  const errors = [];
+  const securityPolicyPath = path.join(repoRoot, SECURITY_POLICY_FILE);
+  if (!exists(securityPolicyPath)) {
+    errors.push({
+      type: "missing-security-policy",
+      file: SECURITY_POLICY_FILE,
+      message: `missing root ${SECURITY_POLICY_FILE} required for GitHub security-policy discovery`,
+    });
+    return errors;
+  }
+
+  const configPath = path.join(repoRoot, ISSUE_TEMPLATE_CONFIG);
+  if (!exists(configPath)) {
+    errors.push({
+      type: "missing-issue-template-config",
+      file: ISSUE_TEMPLATE_CONFIG,
+      message: `missing ${ISSUE_TEMPLATE_CONFIG} required for security contact validation`,
+    });
+    return errors;
+  }
+
+  const securityContactUrl = readIssueTemplateSecurityContactUrl(configPath);
+  if (!securityContactUrl) {
+    errors.push({
+      type: "missing-security-contact",
+      file: ISSUE_TEMPLATE_CONFIG,
+      message: "missing Security vulnerability contact link in issue template config",
+    });
+    return errors;
+  }
+
+  if (securityContactUrl !== SECURITY_POLICY_CONTACT_URL) {
+    errors.push({
+      type: "stale-security-contact",
+      file: ISSUE_TEMPLATE_CONFIG,
+      target: securityContactUrl,
+      message: `Security vulnerability contact must target ${SECURITY_POLICY_CONTACT_URL}`,
+    });
+  }
+
+  return errors;
+}
+
 export function checkDocs(options = {}) {
   const repoRoot = path.resolve(options.repoRoot ?? defaultRepoRoot);
   const docFiles =
@@ -488,6 +553,7 @@ export function checkDocs(options = {}) {
   }
   const scriptsByDir = collectPackageScripts(repoRoot);
   const errors = [
+    ...checkSecurityPolicy(repoRoot),
     ...checkLinks({ repoRoot, docFiles, contentByFile }),
     ...checkCommands({ repoRoot, docFiles, contentByFile, scriptsByDir }),
   ];

--- a/packages/scripts/launch-qa/check-docs.test.ts
+++ b/packages/scripts/launch-qa/check-docs.test.ts
@@ -12,6 +12,9 @@ async function makeRepo() {
   tempRoots.push(repoRoot);
   await fs.mkdir(path.join(repoRoot, "docs"), { recursive: true });
   await fs.mkdir(path.join(repoRoot, "packages", "demo"), { recursive: true });
+  await fs.mkdir(path.join(repoRoot, ".github", "ISSUE_TEMPLATE"), {
+    recursive: true,
+  });
   await fs.writeFile(
     path.join(repoRoot, "package.json"),
     JSON.stringify({ scripts: { dev: "echo dev" } }),
@@ -19,6 +22,15 @@ async function makeRepo() {
   await fs.writeFile(
     path.join(repoRoot, "packages", "demo", "package.json"),
     JSON.stringify({ scripts: { test: "echo test" } }),
+  );
+  await fs.writeFile(path.join(repoRoot, "SECURITY.md"), "# Security Policy\n");
+  await fs.writeFile(
+    path.join(repoRoot, ".github", "ISSUE_TEMPLATE", "config.yml"),
+    `contact_links:
+  - name: Security vulnerability
+    url: https://github.com/elizaOS/eliza/blob/develop/SECURITY.md
+    about: Report privately.
+`,
   );
   return repoRoot;
 }
@@ -166,6 +178,47 @@ describe("docs gate", () => {
     expect(result.ok).toBe(true);
     expect(result.checkedFiles).toContain("README.md");
     expect(result.checkedFiles).not.toContain("packages/demo/README.md");
+  });
+
+  it("fails when the root security policy is missing", async () => {
+    const repoRoot = await makeRepo();
+    await fs.rm(path.join(repoRoot, "SECURITY.md"));
+
+    const result = checkDocs({ repoRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        type: "missing-security-policy",
+        file: "SECURITY.md",
+      }),
+    );
+  });
+
+  it("fails when the issue template security contact is stale", async () => {
+    const repoRoot = await makeRepo();
+    await fs.mkdir(path.join(repoRoot, ".github", "ISSUE_TEMPLATE"), {
+      recursive: true,
+    });
+    await fs.writeFile(path.join(repoRoot, "SECURITY.md"), "# Security Policy\n");
+    await fs.writeFile(
+      path.join(repoRoot, ".github", "ISSUE_TEMPLATE", "config.yml"),
+      `contact_links:
+  - name: Security vulnerability
+    url: https://github.com/elizaOS/eliza/blob/develop/packages/docs/security.md
+    about: stale
+`,
+    );
+
+    const result = checkDocs({ repoRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        type: "stale-security-contact",
+        file: ".github/ISSUE_TEMPLATE/config.yml",
+      }),
+    );
   });
 
   it("resolves moved relative docs links under packages/docs", async () => {


### PR DESCRIPTION
Restores the reporter-facing root `SECURITY.md` removed during #17695 so GitHub recognizes the repository security policy again.

Closes #18446.

## Changes

- Add root `SECURITY.md` with private reporting channels (GitHub Security Advisories and `security@elizalabs.ai`), report-content guidance, supported-version policy, scope, response expectations, coordinated-disclosure window, and remediation targets validated against current repository practice
- Keep `packages/docs/security.md` focused on security architecture and link it to the root reporter policy
- Update `CONTRIBUTING.md`, `README.md`, and `.github/ISSUE_TEMPLATE/config.yml` so canonical policy links and ownership boundaries match
- Extend the launch-qa docs gate to fail when root `SECURITY.md` is missing or the issue-template security contact targets a stale path

## Verification

- `bun test packages/scripts/launch-qa/check-docs.test.ts`
- `node scripts/check-markdown-links.mjs`
- Security-policy slice of `node packages/scripts/launch-qa/check-docs.mjs --scope=docs` (no security-policy errors)
- `git diff --check`

# Evidence

<!-- evidence-head:0d6973ad4e78df636db126d0e1be0dee565454df -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - documentation and docs-gate script change; no rendered UI surface is touched.

<!-- evidence-row:after-screenshots -->
- [x] N/A - nothing renders; the deliverable is a root SECURITY.md file plus a docs-gate check.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no on-screen user flow; the observable behavior is GitHub security-policy discovery and a passing docs gate.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - maintainer-verified local run of the changed gate and link checker at this head.

<details><summary>check-docs vitest run (9/9 incl. both new security-policy tests) + markdown link gate</summary>

```text
$ bunx vitest run packages/scripts/launch-qa/check-docs.test.ts --reporter=verbose
 ✓ launch-qa/check-docs.test.ts > docs gate > fails missing local markdown file links 24ms
 ✓ launch-qa/check-docs.test.ts > docs gate > fails missing root and package bun scripts 5ms
 ✓ launch-qa/check-docs.test.ts > docs gate > checks launchdocs under the package docs tree 3ms
 ✓ launch-qa/check-docs.test.ts > docs gate > fails launchdocs scope when no launch files are present 2ms
 ✓ launch-qa/check-docs.test.ts > docs gate > resolves docs-site absolute links under packages/docs 4ms
 ✓ launch-qa/check-docs.test.ts > docs gate > limits docs scope to site docs, repo docs, and root docs 5ms
 ✓ launch-qa/check-docs.test.ts > docs gate > fails when the root security policy is missing 4ms
 ✓ launch-qa/check-docs.test.ts > docs gate > fails when the issue template security contact is stale 3ms
 ✓ launch-qa/check-docs.test.ts > docs gate > resolves moved relative docs links under packages/docs 3ms
 Test Files  1 passed (1)
      Tests  9 passed (9)

$ node scripts/check-markdown-links.mjs
[check-markdown-links] PASS: relative Markdown links resolve.
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code path exists for this change.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent-visible behavior changes; this is reporter-facing policy documentation and a repo gate.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact - restored policy content verified against the pre-#17695 published policy.

<details><summary>History verification</summary>

```text
$ git log --oneline --all -- SECURITY.md | head -2
3623ceb246b release: promote develop to main ... (#17865)
d04deb98f9f Shaw refactor (#17695)        <- removal commit
$ git show d04deb98f9f^:SECURITY.md   # pre-removal policy
Sections and commitments (2-business-day ack, 5-day triage, 90-day window,
CVSS SLA table, npm/PyPI supported versions, scope incl. homepage installers)
match the restored root SECURITY.md; deltas are deliberate: adds the GitHub
Security Advisories channel and drops the removed packages/deploy/systemd path.
```

</details>
