### PR TITLE
feat(scheduling): route channel-destination dispatches through live message connectors

### DIFF
--- a/plugins/plugin-discord/__tests__/outbound-dm-allowlist-exemption.test.ts
+++ b/plugins/plugin-discord/__tests__/outbound-dm-allowlist-exemption.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Outbound counterpart of the #18419 inbound DM exemption: with CHANNEL_IDS
+ * configured (`allowedChannelIds` set on the account state), the send-path
+ * guild allowlist gate in `handleSendMessage` must not block DM / group-DM
+ * targets — a DM channel id is by definition never in CHANNEL_IDS, so an
+ * allowlisted deployment could receive DMs but never send them (including
+ * scheduled/proactive owner DMs). Guild channels outside the allowlist stay
+ * blocked.
+ */
+import type { AgentRuntime, UUID } from "@elizaos/core";
+import { Collection, ChannelType as DiscordChannelType } from "discord.js";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+	DiscordAccountClientPool,
+	type DiscordAccountClientState,
+} from "../account-client-pool.ts";
+import { DiscordService } from "../service.ts";
+import { createTestRuntime } from "../test/helpers/pglite-runtime.ts";
+
+type MutableDiscordService = DiscordService & {
+	accountPool: DiscordAccountClientPool;
+	defaultAccountId: string;
+	resolveDiscordTargetUserId: (entityId: string) => Promise<string | null>;
+};
+
+const DISCORD_USER_ID = "222222222222222222";
+const DM_CHANNEL_ID = "333333333333333333";
+const GUILD_CHANNEL_ID = "444444444444444444";
+const ALLOWED_GUILD_CHANNEL_ID = "555555555555555000";
+
+function makeDmChannel() {
+	return {
+		id: DM_CHANNEL_ID,
+		type: DiscordChannelType.DM,
+		isTextBased: () => true,
+		isVoiceBased: () => false,
+		isThread: () => false,
+		send: vi.fn(async (payload: { content?: string }) => ({
+			id: "999999999999999999",
+			content: payload.content ?? "",
+			url: `https://discord.test/dm/999999999999999999`,
+			createdTimestamp: Date.now(),
+			attachments: new Collection(),
+		})),
+	};
+}
+
+function makeGuildChannel() {
+	return {
+		id: GUILD_CHANNEL_ID,
+		type: DiscordChannelType.GuildText,
+		isTextBased: () => true,
+		isVoiceBased: () => false,
+		isThread: () => false,
+		send: vi.fn(async () => {
+			throw new Error("guild send must not be reached when disallowed");
+		}),
+	};
+}
+
+describe("handleSendMessage — DM exemption from the guild-channel allowlist", () => {
+	let runtime: AgentRuntime;
+	let cleanup: () => Promise<void>;
+
+	beforeAll(async () => {
+		({ runtime, cleanup } = await createTestRuntime({
+			characterName: "DiscordOutboundDmAllowlist",
+		}));
+	});
+
+	afterAll(async () => {
+		await cleanup();
+	});
+
+	function makeService(opts: {
+		dmChannel: ReturnType<typeof makeDmChannel>;
+		guildChannel: ReturnType<typeof makeGuildChannel>;
+	}) {
+		const user = {
+			id: DISCORD_USER_ID,
+			username: "recipient",
+			displayName: "Recipient",
+			dmChannel: opts.dmChannel,
+			createDM: vi.fn(async () => opts.dmChannel),
+		};
+		const client = {
+			isReady: () => true,
+			user: { id: "111000000000000000", username: "eliza" },
+			channels: {
+				fetch: vi.fn(async (id: string) =>
+					id === GUILD_CHANNEL_ID ? opts.guildChannel : null,
+				),
+			},
+			users: {
+				fetch: vi.fn(async (id: string) =>
+					id === DISCORD_USER_ID ? user : null,
+				),
+			},
+		};
+		const accountPool = new DiscordAccountClientPool("default");
+		accountPool.set({
+			accountId: "default",
+			account: {
+				accountId: "default",
+				name: "Default",
+				token: "test-token",
+				tokenSource: "config",
+				enabled: true,
+				config: {},
+			},
+			client: client as unknown as NonNullable<
+				DiscordAccountClientState["client"]
+			>,
+			settings: {
+				shouldIgnoreBotMessages: true,
+				shouldIgnoreDirectMessages: false,
+				shouldRespondOnlyToMentions: false,
+				dmPolicy: "open",
+				allowFrom: [],
+				syncProfile: false,
+				autoReply: false,
+			},
+			// The gate under test: a configured guild allowlist that contains
+			// neither the DM channel (it never can) nor the guild channel.
+			allowedChannelIds: [ALLOWED_GUILD_CHANNEL_ID],
+			dynamicChannelIds: new Set(),
+			clientReadyPromise: Promise.resolve(),
+			loginFailed: false,
+		});
+		const service = new DiscordService(runtime) as MutableDiscordService;
+		service.accountPool = accountPool;
+		service.defaultAccountId = "default";
+		service.resolveDiscordTargetUserId = vi.fn(async () => DISCORD_USER_ID);
+		return service;
+	}
+
+	it("delivers an entity-targeted DM despite a configured CHANNEL_IDS allowlist", async () => {
+		const dmChannel = makeDmChannel();
+		const guildChannel = makeGuildChannel();
+		const service = makeService({ dmChannel, guildChannel });
+
+		const result = await service.handleSendMessage(
+			runtime,
+			{
+				source: "discord",
+				accountId: "default",
+				entityId: DISCORD_USER_ID as UUID,
+			},
+			{ text: "scheduled morning brief", agentVoiced: true },
+		);
+
+		expect(dmChannel.send).toHaveBeenCalledTimes(1);
+		expect(result).not.toMatchObject({
+			kind: "not_delivered",
+			code: "DISCORD_CHANNEL_NOT_ALLOWED",
+		});
+	});
+
+	it("still blocks a guild channel outside the allowlist", async () => {
+		const dmChannel = makeDmChannel();
+		const guildChannel = makeGuildChannel();
+		const service = makeService({ dmChannel, guildChannel });
+
+		const result = await service.handleSendMessage(
+			runtime,
+			{
+				source: "discord",
+				accountId: "default",
+				channelId: GUILD_CHANNEL_ID,
+			},
+			{ text: "should not go out" },
+		);
+
+		expect(guildChannel.send).not.toHaveBeenCalled();
+		expect(result).toMatchObject({
+			kind: "not_delivered",
+			code: "DISCORD_CHANNEL_NOT_ALLOWED",
+		});
+	});
+});

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -1878,7 +1878,17 @@ export class DiscordService extends Service implements IDiscordService {
 				typeof targetChannel.parentId === "string" &&
 				targetChannel.parentId.length > 0 &&
 				this.isChannelAllowed(targetChannel.parentId, accountId);
+			// DMs (and group DMs) are exempt from the guild-channel allowlist,
+			// mirroring the inbound gate (#18419): CHANNEL_IDS scopes which *guild*
+			// surfaces the bot participates in, while DM access is governed by the
+			// DM policy. A DM channel id is by definition never in CHANNEL_IDS, so
+			// without this exemption an allowlisted deployment could receive DMs
+			// but never send them (including scheduled/proactive owner DMs).
+			const isDmTarget =
+				targetChannel.type === DiscordChannelType.DM ||
+				targetChannel.type === DiscordChannelType.GroupDM;
 			if (
+				!isDmTarget &&
 				state?.allowedChannelIds &&
 				!this.isChannelAllowed(targetChannel.id, accountId) &&
 				!allowedByParentThread

--- a/plugins/plugin-scheduling/src/scheduled-task/connector-dispatch.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/connector-dispatch.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Connector-transport dispatch for the default scheduled-task dispatcher.
+ *
+ * Covers the target grammar, the connector-availability probe, disposition →
+ * DispatchResult translation, and the default dispatcher's routing order
+ * (connector path first for channel destinations, notification fallback for
+ * everything else).
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  dispatchViaMessageConnector,
+  resolveConnectorDispatchTarget,
+  runtimeHasMessageConnector,
+} from "./connector-dispatch.js";
+import type { ScheduledTaskDispatchRecord } from "./runner.js";
+import { ScheduledTaskRunnerService } from "./runner-service.js";
+
+function makeRecord(
+  overrides: Partial<ScheduledTaskDispatchRecord> = {},
+): ScheduledTaskDispatchRecord {
+  return {
+    taskId: "st_test_1",
+    kind: "reminder",
+    firedAtIso: "2026-08-12T09:00:00.000Z",
+    channelKey: "discord",
+    promptInstructions: "Tell the owner good morning.",
+    contextRequest: undefined,
+    output: {
+      destination: "channel",
+      target: "discord:user:308276393450668032",
+    },
+    ...overrides,
+  };
+}
+
+function makeRuntime(opts: {
+  connectors?: string[];
+  sendResult?: unknown;
+  sendError?: Error;
+}): IAgentRuntime & { sends: Array<{ target: unknown; content: unknown }> } {
+  const sends: Array<{ target: unknown; content: unknown }> = [];
+  return {
+    agentId: "00000000-0000-0000-0000-00000000beef",
+    sends,
+    getService: () => null,
+    useModel: async () => "Rendered dispatch message.",
+    reportError: () => undefined,
+    getMessageConnectors: () =>
+      (opts.connectors ?? []).map((source) => ({ source })),
+    sendMessageToTarget: async (target: unknown, content: unknown) => {
+      sends.push({ target, content });
+      if (opts.sendError) throw opts.sendError;
+      return opts.sendResult;
+    },
+  } as unknown as IAgentRuntime & {
+    sends: Array<{ target: unknown; content: unknown }>;
+  };
+}
+
+describe("resolveConnectorDispatchTarget — target grammar", () => {
+  it("parses prefixed user targets into entityId TargetInfo", () => {
+    const resolved = resolveConnectorDispatchTarget(makeRecord());
+    expect(resolved).toEqual({
+      source: "discord",
+      targetInfo: { source: "discord", entityId: "308276393450668032" },
+      rawTarget: "discord:user:308276393450668032",
+    });
+  });
+
+  it("parses channel targets, prefixed and bare", () => {
+    expect(
+      resolveConnectorDispatchTarget(
+        makeRecord({
+          output: { destination: "channel", target: "discord:channel:123" },
+        }),
+      )?.targetInfo,
+    ).toEqual({ source: "discord", channelId: "123" });
+    expect(
+      resolveConnectorDispatchTarget(
+        makeRecord({
+          output: { destination: "channel", target: "discord:123" },
+        }),
+      )?.targetInfo,
+    ).toEqual({ source: "discord", channelId: "123" });
+    // No channelKey prefix at all — still a channel id for that channel key.
+    expect(
+      resolveConnectorDispatchTarget(
+        makeRecord({ output: { destination: "channel", target: "456" } }),
+      )?.targetInfo,
+    ).toEqual({ source: "discord", channelId: "456" });
+  });
+
+  it("returns null for non-channel destinations, in-process keys, and empty targets", () => {
+    expect(
+      resolveConnectorDispatchTarget(
+        makeRecord({ output: { destination: "in_app_card" } }),
+      ),
+    ).toBeNull();
+    expect(
+      resolveConnectorDispatchTarget(
+        makeRecord({
+          channelKey: "in_app",
+          output: { destination: "channel", target: "in_app" },
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      resolveConnectorDispatchTarget(
+        makeRecord({ output: { destination: "channel" } }),
+      ),
+    ).toBeNull();
+    expect(
+      resolveConnectorDispatchTarget(
+        makeRecord({
+          output: { destination: "channel", target: "discord:user:" },
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("runtimeHasMessageConnector", () => {
+  it("requires the transport method and a matching registered source", () => {
+    expect(
+      runtimeHasMessageConnector(
+        makeRuntime({ connectors: ["discord"] }),
+        "discord",
+      ),
+    ).toBe(true);
+    expect(
+      runtimeHasMessageConnector(
+        makeRuntime({ connectors: ["telegram"] }),
+        "discord",
+      ),
+    ).toBe(false);
+    const noTransport = {
+      getMessageConnectors: () => [{ source: "discord" }],
+    } as unknown as IAgentRuntime;
+    expect(runtimeHasMessageConnector(noTransport, "discord")).toBe(false);
+  });
+});
+
+describe("dispatchViaMessageConnector — disposition translation", () => {
+  it("returns null when no connector matches (caller falls through)", async () => {
+    const runtime = makeRuntime({ connectors: ["telegram"] });
+    expect(
+      await dispatchViaMessageConnector(runtime, makeRecord(), "body"),
+    ).toBeNull();
+    expect(runtime.sends).toHaveLength(0);
+  });
+
+  it("delivers the rendered body (agentVoiced) and reports ok with the provider id", async () => {
+    const runtime = makeRuntime({
+      connectors: ["discord"],
+      sendResult: {
+        kind: "delivered",
+        receipt: {
+          providerMessageIds: ["mid-1"],
+          acceptedAt: Date.now(),
+          persistence: { status: "persisted", memoryIds: ["m-1"] },
+        },
+        memories: [],
+      },
+    });
+    const result = await dispatchViaMessageConnector(
+      runtime,
+      makeRecord(),
+      "morning brief body",
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      messageId: "mid-1",
+      channelKey: "discord",
+      target: "discord:user:308276393450668032",
+    });
+    expect(runtime.sends).toHaveLength(1);
+    const { target, content } = runtime.sends[0] as {
+      target: { source: string; entityId: string };
+      content: { text: string; agentVoiced: boolean };
+    };
+    expect(target).toMatchObject({
+      source: "discord",
+      entityId: "308276393450668032",
+    });
+    expect(content.text).toBe("morning brief body");
+    expect(content.agentVoiced).toBe(true);
+  });
+
+  it("treats a legacy Memory return as delivered", async () => {
+    const runtime = makeRuntime({
+      connectors: ["discord"],
+      sendResult: { id: "11111111-2222-3333-4444-555555555555", content: {} },
+    });
+    const result = await dispatchViaMessageConnector(
+      runtime,
+      makeRecord(),
+      "body",
+    );
+    expect(result).toMatchObject({ ok: true });
+  });
+
+  it("maps not_delivered to a typed disconnected failure", async () => {
+    const runtime = makeRuntime({
+      connectors: ["discord"],
+      sendResult: {
+        kind: "not_delivered",
+        code: "client_not_ready",
+        message: "Discord client is not ready.",
+      },
+    });
+    const result = await dispatchViaMessageConnector(
+      runtime,
+      makeRecord(),
+      "body",
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "disconnected",
+      acceptance: "not_accepted",
+      userActionable: true,
+    });
+  });
+
+  it("maps an unknown/no-evidence outcome to a non-retryable-by-default transport error", async () => {
+    const runtime = makeRuntime({
+      connectors: ["discord"],
+      sendResult: undefined,
+    });
+    const result = await dispatchViaMessageConnector(
+      runtime,
+      makeRecord(),
+      "body",
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "transport_error",
+      acceptance: "unknown",
+    });
+  });
+
+  it("translates a transport throw into a typed failure and reports it", async () => {
+    const reportError = vi.fn();
+    const runtime = makeRuntime({
+      connectors: ["discord"],
+      sendError: new Error("socket hang up"),
+    });
+    (runtime as unknown as { reportError: unknown }).reportError = reportError;
+    const result = await dispatchViaMessageConnector(
+      runtime,
+      makeRecord(),
+      "body",
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "transport_error",
+      acceptance: "unknown",
+      message: "socket hang up",
+    });
+    expect(reportError).toHaveBeenCalledWith(
+      "scheduling:scheduled-task:connector-dispatch",
+      expect.any(Error),
+      expect.objectContaining({ taskId: "st_test_1", source: "discord" }),
+    );
+  });
+});
+
+describe("default dispatcher routing — connector path before notification fallback", () => {
+  it("routes a discord channel-destination fire through the connector transport", async () => {
+    const runtime = makeRuntime({
+      connectors: ["discord"],
+      sendResult: {
+        kind: "delivered",
+        receipt: {
+          providerMessageIds: ["mid-2"],
+          acceptedAt: Date.now(),
+          persistence: { status: "persisted", memoryIds: ["m-2"] },
+        },
+        memories: [],
+      },
+    });
+    const service = await ScheduledTaskRunnerService.start(runtime);
+    const runner = service.getRunner({ agentId: runtime.agentId });
+    const task = await runner.schedule({
+      kind: "reminder",
+      promptInstructions: "Morning brief for the owner.",
+      trigger: { kind: "manual" },
+      priority: "low",
+      respectsGlobalPause: false,
+      source: "plugin",
+      createdBy: runtime.agentId,
+      ownerVisible: true,
+      output: {
+        destination: "channel",
+        target: "discord:user:308276393450668032",
+      },
+      escalation: { steps: [{ delayMinutes: 0, channelKey: "discord" }] },
+    });
+    const fired = await runner.fire(task.taskId);
+    expect(fired.state.status).toBe("fired");
+    expect(runtime.sends).toHaveLength(1);
+    expect(fired.metadata?.lastDispatchResult).toMatchObject({
+      ok: true,
+      messageId: "mid-2",
+      channelKey: "discord",
+    });
+    // The delivered text is the model rendering, not the raw instruction.
+    const sent = runtime.sends[0] as { content: { text: string } };
+    expect(sent.content.text).toBe("Rendered dispatch message.");
+  });
+
+  it("keeps the in_app notification fallback for non-connector dispatches", async () => {
+    const runtime = makeRuntime({ connectors: ["discord"] });
+    const service = await ScheduledTaskRunnerService.start(runtime);
+    const runner = service.getRunner({ agentId: runtime.agentId });
+    const task = await runner.schedule({
+      kind: "reminder",
+      promptInstructions: "In-app nudge.",
+      trigger: { kind: "manual" },
+      priority: "low",
+      respectsGlobalPause: false,
+      source: "plugin",
+      createdBy: runtime.agentId,
+      ownerVisible: true,
+      output: { destination: "channel", target: "in_app" },
+    });
+    const fired = await runner.fire(task.taskId);
+    expect(fired.state.status).toBe("fired");
+    expect(runtime.sends).toHaveLength(0);
+    expect(fired.metadata?.lastDispatchResult).toMatchObject({
+      ok: true,
+      messageId: expect.stringContaining("in_app:"),
+    });
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/connector-dispatch.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/connector-dispatch.test.ts
@@ -7,11 +7,12 @@
  * everything else).
  */
 
-import type { IAgentRuntime } from "@elizaos/core";
+import { type IAgentRuntime, ServiceType } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 
 import {
   dispatchViaMessageConnector,
+  isConnectorDispatchIntent,
   resolveConnectorDispatchTarget,
   runtimeHasMessageConnector,
 } from "./connector-dispatch.js";
@@ -40,12 +41,27 @@ function makeRuntime(opts: {
   connectors?: string[];
   sendResult?: unknown;
   sendError?: Error;
-}): IAgentRuntime & { sends: Array<{ target: unknown; content: unknown }> } {
+  notification?: boolean;
+  notificationError?: Error;
+}): IAgentRuntime & {
+  sends: Array<{ target: unknown; content: unknown }>;
+  notifications: unknown[];
+} {
   const sends: Array<{ target: unknown; content: unknown }> = [];
+  const notifications: unknown[] = [];
   return {
     agentId: "00000000-0000-0000-0000-00000000beef",
     sends,
-    getService: () => null,
+    notifications,
+    getService: (serviceType: string) =>
+      opts.notification && serviceType === ServiceType.NOTIFICATION
+        ? {
+            async notify(input: unknown) {
+              notifications.push(input);
+              if (opts.notificationError) throw opts.notificationError;
+            },
+          }
+        : null,
     useModel: async () => "Rendered dispatch message.",
     reportError: () => undefined,
     getMessageConnectors: () =>
@@ -57,6 +73,7 @@ function makeRuntime(opts: {
     },
   } as unknown as IAgentRuntime & {
     sends: Array<{ target: unknown; content: unknown }>;
+    notifications: unknown[];
   };
 }
 
@@ -97,6 +114,20 @@ describe("resolveConnectorDispatchTarget — target grammar", () => {
     expect(
       resolveConnectorDispatchTarget(
         makeRecord({ output: { destination: "in_app_card" } }),
+      ),
+    ).toBeNull();
+    expect(
+      isConnectorDispatchIntent(
+        makeRecord({
+          output: { destination: "channel", target: "telegram:user:123" },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      resolveConnectorDispatchTarget(
+        makeRecord({
+          output: { destination: "channel", target: "telegram:user:123" },
+        }),
       ),
     ).toBeNull();
     expect(
@@ -224,6 +255,63 @@ describe("dispatchViaMessageConnector — disposition translation", () => {
     });
   });
 
+  it("does not fabricate success for a partially delivered provider send", async () => {
+    const reportError = vi.fn();
+    const runtime = makeRuntime({
+      connectors: ["discord"],
+      sendResult: {
+        kind: "partially_delivered",
+        receipt: {
+          providerMessageIds: ["mid-partial"],
+          acceptedAt: Date.now(),
+          persistence: { status: "persisted", memoryIds: ["m-partial"] },
+        },
+        memories: [],
+        code: "CHUNK_SEND_FAILED",
+        message: "Only the first chunk was accepted.",
+      },
+    });
+    (runtime as unknown as { reportError: unknown }).reportError = reportError;
+    await expect(
+      dispatchViaMessageConnector(runtime, makeRecord(), "body"),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: "transport_error",
+      acceptance: "unknown",
+    });
+    expect(reportError).toHaveBeenCalledWith(
+      "scheduling:scheduled-task:partial-delivery",
+      expect.any(Error),
+      expect.objectContaining({ providerMessageId: "mid-partial" }),
+    );
+  });
+
+  it("reuses a persisted dispatch key when a retry has a new firedAt", async () => {
+    const runtime = makeRuntime({
+      connectors: ["discord"],
+      sendResult: { kind: "duplicate", priorDelivery: "in_flight" },
+    });
+    const record = makeRecord({
+      metadata: { dispatchIdempotencyKey: "st_test_1:original-occurrence" },
+    });
+    await dispatchViaMessageConnector(runtime, record, "body");
+    await dispatchViaMessageConnector(
+      runtime,
+      { ...record, firedAtIso: "2026-08-12T09:05:00.000Z" },
+      "body",
+    );
+    expect(
+      runtime.sends.map(
+        ({ content }) =>
+          (content as { metadata: { scheduledDispatchKey: string } }).metadata
+            .scheduledDispatchKey,
+      ),
+    ).toEqual([
+      "st_test_1:original-occurrence",
+      "st_test_1:original-occurrence",
+    ]);
+  });
+
   it("maps an unknown/no-evidence outcome to a non-retryable-by-default transport error", async () => {
     const runtime = makeRuntime({
       connectors: ["discord"],
@@ -306,13 +394,20 @@ describe("default dispatcher routing — connector path before notification fall
       messageId: "mid-2",
       channelKey: "discord",
     });
+    expect(fired.metadata).toMatchObject({
+      dispatchPreparedMessage: "Rendered dispatch message.",
+      dispatchIdempotencyKey: expect.stringContaining(task.taskId),
+    });
     // The delivered text is the model rendering, not the raw instruction.
     const sent = runtime.sends[0] as { content: { text: string } };
     expect(sent.content.text).toBe("Rendered dispatch message.");
   });
 
   it("keeps the in_app notification fallback for non-connector dispatches", async () => {
-    const runtime = makeRuntime({ connectors: ["discord"] });
+    const runtime = makeRuntime({
+      connectors: ["discord"],
+      notification: true,
+    });
     const service = await ScheduledTaskRunnerService.start(runtime);
     const runner = service.getRunner({ agentId: runtime.agentId });
     const task = await runner.schedule({
@@ -329,9 +424,76 @@ describe("default dispatcher routing — connector path before notification fall
     const fired = await runner.fire(task.taskId);
     expect(fired.state.status).toBe("fired");
     expect(runtime.sends).toHaveLength(0);
+    expect(runtime.notifications).toHaveLength(1);
     expect(fired.metadata?.lastDispatchResult).toMatchObject({
       ok: true,
       messageId: expect.stringContaining("in_app:"),
     });
+  });
+
+  it("returns an honest failure when an explicit connector is unavailable", async () => {
+    const runtime = makeRuntime({
+      connectors: ["telegram"],
+      notification: true,
+    });
+    const service = await ScheduledTaskRunnerService.start(runtime);
+    const runner = service.getRunner({ agentId: runtime.agentId });
+    const task = await runner.schedule({
+      kind: "reminder",
+      promptInstructions: "Discord-only nudge.",
+      trigger: { kind: "manual" },
+      priority: "low",
+      respectsGlobalPause: false,
+      source: "plugin",
+      createdBy: runtime.agentId,
+      ownerVisible: true,
+      output: {
+        destination: "channel",
+        target: "discord:user:308276393450668032",
+      },
+    });
+    const fired = await runner.fire(task.taskId);
+    expect(fired.state.status).toBe("failed");
+    expect(fired.metadata?.lastDispatchResult).toMatchObject({
+      ok: false,
+      reason: "disconnected",
+      acceptance: "not_accepted",
+    });
+    expect(runtime.notifications).toHaveLength(0);
+  });
+
+  it("rejects a connector/target mismatch instead of misrouting or falling back", async () => {
+    const runtime = makeRuntime({
+      connectors: ["discord", "telegram"],
+      notification: true,
+    });
+    const service = await ScheduledTaskRunnerService.start(runtime);
+    const runner = service.getRunner({ agentId: runtime.agentId });
+    const task = await runner.schedule({
+      kind: "reminder",
+      promptInstructions: "Do not misroute this.",
+      trigger: { kind: "manual" },
+      priority: "low",
+      respectsGlobalPause: false,
+      source: "plugin",
+      createdBy: runtime.agentId,
+      ownerVisible: true,
+      output: {
+        destination: "channel",
+        target: "telegram:user:123",
+      },
+      escalation: { steps: [{ delayMinutes: 0, channelKey: "discord" }] },
+    });
+    const first = await runner.fire(task.taskId);
+    expect(first.state.status).toBe("scheduled");
+    const escalated = await runner.fire(task.taskId);
+    expect(escalated.state.status).toBe("failed");
+    expect(escalated.metadata?.lastDispatchResult).toMatchObject({
+      ok: false,
+      reason: "unknown_recipient",
+      acceptance: "not_accepted",
+    });
+    expect(runtime.sends).toHaveLength(1);
+    expect(runtime.notifications).toHaveLength(0);
   });
 });

--- a/plugins/plugin-scheduling/src/scheduled-task/connector-dispatch.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/connector-dispatch.ts
@@ -1,0 +1,212 @@
+/**
+ * Connector-transport dispatch for the DEFAULT (no-consumer-host) scheduled
+ * task dispatcher.
+ *
+ * On a standalone runtime — `@elizaos/plugin-scheduling` loaded without
+ * `@elizaos/plugin-personal-assistant` — the default dispatcher previously
+ * routed EVERY fire through the local NOTIFICATION emit, even when the task's
+ * `output` explicitly targeted a live message connector
+ * (`{ destination: "channel", target: "discord:user:<id>" }`) and that
+ * connector was registered and connected on the runtime. The scheduled
+ * message reached the in-app inbox but never the owner's actual channel, so a
+ * standalone boot (e.g. a sol-dev / cloud container without PA) had no way to
+ * deliver proactive scheduled behaviors to Discord/Telegram/etc.
+ *
+ * This module bridges that gap through the runtime's own connector transport:
+ * when a dispatch record's channel key matches a registered message connector
+ * (`runtime.getMessageConnectors()`), the rendered owner-facing body is sent
+ * via `runtime.sendMessageToTarget` — the same chokepoint PA's production
+ * dispatcher uses for bound chat delivery, so the humanness voice gate,
+ * outbound sanitizer, and connector-level durable dedupe all apply. The
+ * provider outcome is translated into the runner's typed `DispatchResult`
+ * contract (mirroring PA's disposition mapping) so retry/escalation policy
+ * keeps working. When the path does not apply (non-channel destination, no
+ * target, no matching connector, no transport) the caller falls through to
+ * the existing notification behavior unchanged.
+ *
+ * Target grammar (the `channelKey:` prefix is optional and stripped):
+ *   - `<channelKey>:user:<providerUserId>`    → DM the user (TargetInfo.entityId)
+ *   - `<channelKey>:channel:<providerChanId>` → post to the channel
+ *   - `<channelKey>:<providerChanId>`         → bare id, treated as a channel
+ */
+
+import {
+  type Content,
+  type IAgentRuntime,
+  inspectSendHandlerResult,
+  type TargetInfo,
+  type UUID,
+} from "@elizaos/core";
+import type { DispatchResult } from "../dispatch-types.js";
+import type { ScheduledTaskDispatchRecord } from "./runner.js";
+
+/**
+ * Channel keys that are in-process delivery surfaces, never message-connector
+ * sources. Skipping them keeps the notification path authoritative for
+ * in-app/push dispatches even if a connector ever registers such a source.
+ */
+const IN_PROCESS_CHANNEL_KEYS: ReadonlySet<string> = new Set([
+  "in_app",
+  "push",
+  "browser",
+]);
+
+/** Backoff for an in-flight duplicate: retry the same step, do not escalate. */
+const IN_FLIGHT_RETRY_MINUTES = 5;
+
+export interface ConnectorDispatchTarget {
+  /** Message-connector source, i.e. the dispatch channel key ("discord"). */
+  source: string;
+  /** Transport target for `runtime.sendMessageToTarget`. */
+  targetInfo: TargetInfo;
+  /** The original `output.target` string, for result reporting. */
+  rawTarget: string;
+}
+
+/**
+ * Resolve a dispatch record into a connector transport target, or `null`
+ * when the record does not describe a channel-destination connector send.
+ */
+export function resolveConnectorDispatchTarget(
+  record: Pick<ScheduledTaskDispatchRecord, "channelKey" | "output">,
+): ConnectorDispatchTarget | null {
+  if (record.output?.destination !== "channel") return null;
+  const source =
+    typeof record.channelKey === "string" ? record.channelKey.trim() : "";
+  if (!source || IN_PROCESS_CHANNEL_KEYS.has(source)) return null;
+  const rawTarget =
+    typeof record.output.target === "string" ? record.output.target.trim() : "";
+  if (!rawTarget) return null;
+  const rest = rawTarget.startsWith(`${source}:`)
+    ? rawTarget.slice(source.length + 1)
+    : rawTarget;
+  if (!rest) return null;
+  let targetInfo: TargetInfo;
+  if (rest.startsWith("user:")) {
+    const userId = rest.slice("user:".length);
+    if (!userId) return null;
+    // Provider user ids ride in `entityId`: connectors (e.g. Discord's
+    // handleSendMessage) route entityId targets through their user→DM
+    // resolution path, which accepts raw provider ids alongside runtime
+    // entity UUIDs.
+    targetInfo = { source, entityId: userId as UUID };
+  } else {
+    const channelId = rest.startsWith("channel:")
+      ? rest.slice("channel:".length)
+      : rest;
+    if (!channelId) return null;
+    targetInfo = { source, channelId };
+  }
+  return { source, targetInfo, rawTarget };
+}
+
+/** Whether this runtime can route the source through a message connector. */
+export function runtimeHasMessageConnector(
+  runtime: IAgentRuntime,
+  source: string,
+): boolean {
+  if (typeof runtime.sendMessageToTarget !== "function") return false;
+  if (typeof runtime.getMessageConnectors !== "function") return false;
+  try {
+    return runtime
+      .getMessageConnectors()
+      .some((connector) => connector.source === source);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Attempt connector-transport delivery for one dispatch. Returns `null` when
+ * the path does not apply (caller falls through to the notification surface);
+ * otherwise returns the typed `DispatchResult` for the runner's policy.
+ *
+ * `body` is the already-rendered owner-facing message — never the raw
+ * `promptInstructions` — and is flagged `agentVoiced` so the transport voice
+ * gate preserves it instead of re-rephrasing model output.
+ */
+export async function dispatchViaMessageConnector(
+  runtime: IAgentRuntime,
+  record: ScheduledTaskDispatchRecord,
+  body: string,
+): Promise<DispatchResult | null> {
+  const resolved = resolveConnectorDispatchTarget(record);
+  if (!resolved) return null;
+  if (!runtimeHasMessageConnector(runtime, resolved.source)) return null;
+
+  const content: Content = {
+    text: body,
+    agentVoiced: true,
+    source: resolved.source,
+    metadata: {
+      taskId: record.taskId,
+      firedAtIso: record.firedAtIso,
+      channelKey: record.channelKey,
+      scheduledDispatchKey: `${record.taskId}:${record.firedAtIso}`,
+    },
+  };
+
+  try {
+    const disposition = inspectSendHandlerResult(
+      await runtime.sendMessageToTarget(resolved.targetInfo, content),
+    );
+    switch (disposition.kind) {
+      case "delivered":
+      case "partially_delivered": {
+        // Provider acceptance is authoritative; degraded local persistence
+        // must not trigger a retry that duplicates the visible message.
+        const providerMessageId = disposition.providerMessageId;
+        return {
+          ok: true,
+          ...(providerMessageId ? { messageId: providerMessageId } : {}),
+          channelKey: record.channelKey,
+          target: resolved.rawTarget,
+        };
+      }
+      case "in_flight":
+        return {
+          ok: false,
+          reason: "transport_error",
+          acceptance: "unknown",
+          retryAfterMinutes: IN_FLIGHT_RETRY_MINUTES,
+          userActionable: false,
+          message: disposition.message,
+        };
+      case "not_delivered":
+        return {
+          ok: false,
+          reason: "disconnected",
+          acceptance: "not_accepted",
+          userActionable: true,
+          message: disposition.message,
+        };
+      default:
+        // "unknown": no delivery evidence either way. `acceptance: "unknown"`
+        // tells the dispatch policy this send must not be blindly retried on
+        // a non-idempotent transport.
+        return {
+          ok: false,
+          reason: "transport_error",
+          acceptance: "unknown",
+          userActionable: false,
+          message: disposition.message,
+        };
+    }
+  } catch (error) {
+    // error-policy:J1 boundary translation — transport throws become the
+    // runner's typed contract; the failure also reaches RECENT_ERRORS via
+    // reportError.
+    runtime.reportError("scheduling:scheduled-task:connector-dispatch", error, {
+      taskId: record.taskId,
+      channelKey: record.channelKey,
+      source: resolved.source,
+    });
+    return {
+      ok: false,
+      reason: "transport_error",
+      acceptance: "unknown",
+      userActionable: false,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/plugins/plugin-scheduling/src/scheduled-task/connector-dispatch.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/connector-dispatch.ts
@@ -54,6 +54,39 @@ const IN_PROCESS_CHANNEL_KEYS: ReadonlySet<string> = new Set([
 /** Backoff for an in-flight duplicate: retry the same step, do not escalate. */
 const IN_FLIGHT_RETRY_MINUTES = 5;
 
+function dispatchIdempotencyKey(record: ScheduledTaskDispatchRecord): string {
+  const persisted = record.metadata?.dispatchIdempotencyKey;
+  return typeof persisted === "string" && persisted.trim().length > 0
+    ? persisted.trim()
+    : `${record.taskId}:${record.firedAtIso}`;
+}
+
+function notDeliveredResult(
+  code: string,
+  message: string,
+): Extract<DispatchResult, { ok: false }> {
+  const normalized = code.toLowerCase();
+  const reason = /rate|throttl/.test(normalized)
+    ? "rate_limited"
+    : /auth|credential|token/.test(normalized)
+      ? "auth_expired"
+      : /recipient|target|user_not_found|channel_not_found/.test(normalized)
+        ? "unknown_recipient"
+        : /disconnect|not_ready|unavailable/.test(normalized)
+          ? "disconnected"
+          : "transport_error";
+  return {
+    ok: false,
+    reason,
+    acceptance: "not_accepted",
+    userActionable:
+      reason === "auth_expired" ||
+      reason === "unknown_recipient" ||
+      reason === "disconnected",
+    message,
+  };
+}
+
 export interface ConnectorDispatchTarget {
   /** Message-connector source, i.e. the dispatch channel key ("discord"). */
   source: string;
@@ -63,6 +96,16 @@ export interface ConnectorDispatchTarget {
   rawTarget: string;
 }
 
+/** Whether the record explicitly requests an out-of-process connector send. */
+export function isConnectorDispatchIntent(
+  record: Pick<ScheduledTaskDispatchRecord, "channelKey" | "output">,
+): boolean {
+  if (record.output?.destination !== "channel") return false;
+  const source =
+    typeof record.channelKey === "string" ? record.channelKey.trim() : "";
+  return Boolean(source) && !IN_PROCESS_CHANNEL_KEYS.has(source);
+}
+
 /**
  * Resolve a dispatch record into a connector transport target, or `null`
  * when the record does not describe a channel-destination connector send.
@@ -70,13 +113,17 @@ export interface ConnectorDispatchTarget {
 export function resolveConnectorDispatchTarget(
   record: Pick<ScheduledTaskDispatchRecord, "channelKey" | "output">,
 ): ConnectorDispatchTarget | null {
-  if (record.output?.destination !== "channel") return null;
+  if (!isConnectorDispatchIntent(record)) return null;
+  const output = record.output;
+  if (!output) return null;
   const source =
     typeof record.channelKey === "string" ? record.channelKey.trim() : "";
   if (!source || IN_PROCESS_CHANNEL_KEYS.has(source)) return null;
   const rawTarget =
-    typeof record.output.target === "string" ? record.output.target.trim() : "";
+    typeof output.target === "string" ? output.target.trim() : "";
   if (!rawTarget) return null;
+  const structuredPrefix = /^([^:]+):(user|channel):/.exec(rawTarget)?.[1];
+  if (structuredPrefix && structuredPrefix !== source) return null;
   const rest = rawTarget.startsWith(`${source}:`)
     ? rawTarget.slice(source.length + 1)
     : rawTarget;
@@ -142,7 +189,7 @@ export async function dispatchViaMessageConnector(
       taskId: record.taskId,
       firedAtIso: record.firedAtIso,
       channelKey: record.channelKey,
-      scheduledDispatchKey: `${record.taskId}:${record.firedAtIso}`,
+      scheduledDispatchKey: dispatchIdempotencyKey(record),
     },
   };
 
@@ -151,18 +198,63 @@ export async function dispatchViaMessageConnector(
       await runtime.sendMessageToTarget(resolved.targetInfo, content),
     );
     switch (disposition.kind) {
-      case "delivered":
-      case "partially_delivered": {
+      case "delivered": {
         // Provider acceptance is authoritative; degraded local persistence
         // must not trigger a retry that duplicates the visible message.
         const providerMessageId = disposition.providerMessageId;
+        const idempotencyKey = dispatchIdempotencyKey(record);
+        if (
+          disposition.receipt?.persistence.status === "partial" ||
+          disposition.receipt?.persistence.status === "failed"
+        ) {
+          runtime.reportError(
+            "scheduling:scheduled-task:delivery-evidence",
+            new Error(
+              `Provider accepted scheduled dispatch but local persistence is ${disposition.receipt.persistence.status}`,
+            ),
+            { taskId: record.taskId, providerMessageId },
+          );
+        }
         return {
           ok: true,
           ...(providerMessageId ? { messageId: providerMessageId } : {}),
           channelKey: record.channelKey,
           target: resolved.rawTarget,
+          ...(providerMessageId && disposition.receipt
+            ? {
+                receipt: {
+                  provider: resolved.source,
+                  providerMessageId,
+                  idempotencyKey,
+                  acceptedAt: new Date(
+                    disposition.receipt.acceptedAt,
+                  ).toISOString(),
+                  metadata: {
+                    replayed: disposition.replayed,
+                    persistence: disposition.receipt.persistence.status,
+                  },
+                },
+              }
+            : {}),
         };
       }
+      case "partially_delivered":
+        runtime.reportError(
+          "scheduling:scheduled-task:partial-delivery",
+          new Error(disposition.message),
+          {
+            taskId: record.taskId,
+            providerMessageId: disposition.providerMessageId,
+            code: disposition.code,
+          },
+        );
+        return {
+          ok: false,
+          reason: "transport_error",
+          acceptance: "unknown",
+          userActionable: false,
+          message: disposition.message,
+        };
       case "in_flight":
         return {
           ok: false,
@@ -173,13 +265,7 @@ export async function dispatchViaMessageConnector(
           message: disposition.message,
         };
       case "not_delivered":
-        return {
-          ok: false,
-          reason: "disconnected",
-          acceptance: "not_accepted",
-          userActionable: true,
-          message: disposition.message,
-        };
+        return notDeliveredResult(disposition.code, disposition.message);
       default:
         // "unknown": no delivery evidence either way. `acceptance: "unknown"`
         // tells the dispatch policy this send must not be blindly retried on

--- a/plugins/plugin-scheduling/src/scheduled-task/index.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/index.ts
@@ -22,6 +22,7 @@ export {
 export {
   type ConnectorDispatchTarget,
   dispatchViaMessageConnector,
+  isConnectorDispatchIntent,
   resolveConnectorDispatchTarget,
   runtimeHasMessageConnector,
 } from "./connector-dispatch.js";

--- a/plugins/plugin-scheduling/src/scheduled-task/index.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/index.ts
@@ -20,6 +20,12 @@ export {
   registerBuiltInCompletionChecks,
 } from "./completion-check-registry.js";
 export {
+  type ConnectorDispatchTarget,
+  dispatchViaMessageConnector,
+  resolveConnectorDispatchTarget,
+  runtimeHasMessageConnector,
+} from "./connector-dispatch.js";
+export {
   type AnchorRegistry,
   type ConsolidationRegistry,
   createAnchorRegistry,

--- a/plugins/plugin-scheduling/src/scheduled-task/runner-service.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner-service.test.ts
@@ -16,7 +16,7 @@
  * failure driving the dispatch policy, and delegation for other channels).
  */
 
-import { type IAgentRuntime, isElizaError } from "@elizaos/core";
+import { type IAgentRuntime, isElizaError, ServiceType } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -36,7 +36,10 @@ import { ScheduledTaskRunnerService } from "./runner-service.js";
 function makeFakeRuntime(): IAgentRuntime {
   return {
     agentId: "00000000-0000-0000-0000-00000000cafe",
-    getService: () => null,
+    getService: (type: string) =>
+      type === ServiceType.NOTIFICATION
+        ? { notify: async () => undefined }
+        : null,
     // The default dispatcher renders promptInstructions through the model
     // before notifying; a deterministic stub keeps fires succeeding so the
     // assertions below stay about the clock.

--- a/plugins/plugin-scheduling/src/scheduled-task/runner-service.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner-service.ts
@@ -44,6 +44,7 @@ import {
   createCompletionCheckRegistry,
   registerBuiltInCompletionChecks,
 } from "./completion-check-registry.js";
+import { dispatchViaMessageConnector } from "./connector-dispatch.js";
 import {
   type AnchorRegistry,
   type ConsolidationRegistry,
@@ -208,10 +209,13 @@ function getNotifier(runtime: IAgentRuntime): NotificationEmitter | null {
 }
 
 /**
- * Default dispatcher with no channel registry: routes everything through a
- * local NOTIFICATION emit (when a notification service is present) and reports
- * delivered. This is the honest "no connector wired" behavior — the in_app
- * notification reaches the device even on a stock mobile boot.
+ * Default dispatcher with no channel registry: channel-destination dispatches
+ * whose channel key matches a live message connector go out through the
+ * runtime's connector transport (`sendMessageToTarget`); everything else
+ * routes through a local NOTIFICATION emit (when a notification service is
+ * present) and reports delivered. The notification path remains the honest
+ * "no connector wired" behavior — the in_app notification reaches the device
+ * even on a stock mobile boot.
  */
 function createDefaultScheduledTaskDispatcher(
   runtime: IAgentRuntime,
@@ -241,6 +245,16 @@ function createDefaultScheduledTaskDispatcher(
         );
         return renderFailureDispatchResult(error);
       }
+      // Channel-destination dispatch through a live message connector (e.g.
+      // `output: { destination: "channel", target: "discord:user:<id>" }` on
+      // a standalone runtime with plugin-discord). Falls through to the
+      // notification surface when the path does not apply.
+      const connectorResult = await dispatchViaMessageConnector(
+        runtime,
+        record,
+        body,
+      );
+      if (connectorResult) return connectorResult;
       const isUrgent = record.intensity === "urgent";
       void getNotifier(runtime)
         ?.notify({

--- a/plugins/plugin-scheduling/src/scheduled-task/runner-service.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner-service.ts
@@ -44,7 +44,12 @@ import {
   createCompletionCheckRegistry,
   registerBuiltInCompletionChecks,
 } from "./completion-check-registry.js";
-import { dispatchViaMessageConnector } from "./connector-dispatch.js";
+import {
+  dispatchViaMessageConnector,
+  isConnectorDispatchIntent,
+  resolveConnectorDispatchTarget,
+  runtimeHasMessageConnector,
+} from "./connector-dispatch.js";
 import {
   type AnchorRegistry,
   type ConsolidationRegistry,
@@ -219,6 +224,7 @@ function getNotifier(runtime: IAgentRuntime): NotificationEmitter | null {
  */
 function createDefaultScheduledTaskDispatcher(
   runtime: IAgentRuntime,
+  store: ScheduledTaskStore,
 ): ScheduledTaskDispatcher {
   return {
     async dispatch(record): Promise<DispatchResult> {
@@ -226,11 +232,39 @@ function createDefaultScheduledTaskDispatcher(
       // notification body must be the model's rendering of it. A model-free
       // runtime receives a neutral deterministic fallback; a present-but-failed
       // model call is a typed, retryable dispatch failure.
+      const connectorTarget = resolveConnectorDispatchTarget(record);
+      if (isConnectorDispatchIntent(record) && !connectorTarget) {
+        return {
+          ok: false,
+          reason: "unknown_recipient",
+          acceptance: "not_accepted",
+          userActionable: true,
+          message: `Channel "${record.channelKey}" has no valid connector target.`,
+        };
+      }
+      if (
+        connectorTarget &&
+        !runtimeHasMessageConnector(runtime, connectorTarget.source)
+      ) {
+        return {
+          ok: false,
+          reason: "disconnected",
+          acceptance: "not_accepted",
+          userActionable: true,
+          message: `Channel "${connectorTarget.source}" has no registered message connector.`,
+        };
+      }
+
       let body: string;
-      let title: string;
       try {
-        body = await renderScheduledDispatchMessage(runtime, record);
-        title = await renderScheduledDispatchTitle(runtime, record, body);
+        const preparedMessage = connectorTarget
+          ? (await store.get(record.taskId))?.metadata?.dispatchPreparedMessage
+          : undefined;
+        body =
+          typeof preparedMessage === "string" &&
+          preparedMessage.trim().length > 0
+            ? preparedMessage
+            : await renderScheduledDispatchMessage(runtime, record);
       } catch (error) {
         // error-policy:J1 boundary translation — dispatch outcomes are the
         // runner's typed contract; the failure also reaches RECENT_ERRORS and
@@ -245,6 +279,39 @@ function createDefaultScheduledTaskDispatcher(
         );
         return renderFailureDispatchResult(error);
       }
+      if (connectorTarget) {
+        const current = await store.get(record.taskId);
+        if (!current) {
+          return {
+            ok: false,
+            reason: "transport_error",
+            acceptance: "not_accepted",
+            userActionable: false,
+            message: "Scheduled task disappeared before connector dispatch.",
+          };
+        }
+        const existingKey = current.metadata?.dispatchIdempotencyKey;
+        const dispatchIdempotencyKey =
+          typeof existingKey === "string" && existingKey.trim().length > 0
+            ? existingKey.trim()
+            : `${record.taskId}:${record.firedAtIso}`;
+        current.metadata = {
+          ...(current.metadata ?? {}),
+          dispatchPreparedMessage: body,
+          dispatchIdempotencyKey,
+          dispatchAttempt: {
+            status: "prepared",
+            preparedAtIso: new Date().toISOString(),
+            firedAtIso: record.firedAtIso,
+          },
+        };
+        await store.upsert(current);
+        if (record.metadata) {
+          Object.assign(record.metadata, current.metadata);
+        } else {
+          record.metadata = current.metadata;
+        }
+      }
       // Channel-destination dispatch through a live message connector (e.g.
       // `output: { destination: "channel", target: "discord:user:<id>" }` on
       // a standalone runtime with plugin-discord). Falls through to the
@@ -255,9 +322,30 @@ function createDefaultScheduledTaskDispatcher(
         body,
       );
       if (connectorResult) return connectorResult;
+      let title: string;
+      try {
+        title = await renderScheduledDispatchTitle(runtime, record, body);
+      } catch (error) {
+        runtime.reportError(
+          "scheduling:scheduled-task:dispatch-render",
+          error,
+          { taskId: record.taskId, channelKey: record.channelKey },
+        );
+        return renderFailureDispatchResult(error);
+      }
       const isUrgent = record.intensity === "urgent";
-      void getNotifier(runtime)
-        ?.notify({
+      const notifier = getNotifier(runtime);
+      if (!notifier) {
+        return {
+          ok: false,
+          reason: "disconnected",
+          acceptance: "not_accepted",
+          userActionable: true,
+          message: "No notification service is registered for in-app delivery.",
+        };
+      }
+      try {
+        await notifier.notify({
           title,
           body,
           category: isUrgent ? "approval" : "reminder",
@@ -270,13 +358,23 @@ function createDefaultScheduledTaskDispatcher(
             firedAtIso: record.firedAtIso,
             channelKey: record.channelKey,
           },
-        })
-        .catch((error: unknown) => {
-          logger.debug(
-            { src: SERVICE_TYPE, error },
-            "Default dispatcher notification emit failed",
-          );
         });
+      } catch (error) {
+        // error-policy:J1 the notification transport boundary returns an
+        // honest typed failure instead of recording a fabricated delivery.
+        runtime.reportError(
+          "scheduling:scheduled-task:notification-dispatch",
+          error,
+          { taskId: record.taskId, channelKey: record.channelKey },
+        );
+        return {
+          ok: false,
+          reason: "transport_error",
+          acceptance: "unknown",
+          userActionable: false,
+          message: error instanceof Error ? error.message : String(error),
+        };
+      }
       return {
         ok: true,
         messageId: `in_app:${record.taskId}:${record.firedAtIso}`,
@@ -337,14 +435,15 @@ function defaultRunnerDeps(
   agentId: string,
 ): ScheduledTaskRunnerDepsBundle {
   const hasRuntimeDb = getRuntimeDb(runtime) !== null;
+  const store = hasRuntimeDb
+    ? createSchedulingSqlScheduledTaskStore({ runtime, agentId })
+    : createInMemoryScheduledTaskStore();
   return {
-    store: hasRuntimeDb
-      ? createSchedulingSqlScheduledTaskStore({ runtime, agentId })
-      : createInMemoryScheduledTaskStore(),
+    store,
     logStore: hasRuntimeDb
       ? createSchedulingSqlScheduledTaskLogStore({ runtime, agentId })
       : createInMemoryScheduledTaskLogStore(),
-    dispatcher: createDefaultScheduledTaskDispatcher(runtime),
+    dispatcher: createDefaultScheduledTaskDispatcher(runtime, store),
     ownerFacts: () => ({}) as OwnerFactsView,
     globalPause: ALWAYS_ALLOW_GLOBAL_PAUSE,
     activity: makeMissingActivityBusView(runtime),

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -1457,6 +1457,19 @@ export function createScheduledTaskRunner(
     // dispatch failure) routes this attempt through its recorded ladder
     // step; a fresh fire starts at the initial channel (cursor -1).
     const pending = readPendingDispatch(claimed);
+    if (!pending && !recoveryClaim) {
+      // A fresh occurrence owns a new durable dispatch identity. Persist it
+      // before rendering/provider egress so retries and crash recovery reuse
+      // the same connector dedupe key and exact prepared payload. Never trust
+      // caller-supplied values in these internal metadata fields.
+      claimed.metadata = {
+        ...(claimed.metadata ?? {}),
+        dispatchIdempotencyKey: `${claimed.taskId}:${fireAtIso}`,
+      };
+      delete claimed.metadata.dispatchPreparedMessage;
+      delete claimed.metadata.dispatchAttempt;
+      delete claimed.metadata.recoveredDispatchAtIso;
+    }
     const ladder = resolveEffectiveLadder(claimed, deps.ladders);
     const pendingStep =
       pending && pending.stepIndex >= 0

--- a/plugins/plugin-scheduling/src/scheduled-task/standalone-tick.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/standalone-tick.test.ts
@@ -15,7 +15,13 @@
  *  - one throwing row does not starve the rest of the tick
  */
 
-import type { IAgentRuntime, Task, TaskWorker, UUID } from "@elizaos/core";
+import {
+  type IAgentRuntime,
+  ServiceType,
+  type Task,
+  type TaskWorker,
+  type UUID,
+} from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -34,7 +40,10 @@ import {
 function makeFakeRuntime(): IAgentRuntime {
   return {
     agentId: "00000000-0000-0000-0000-0000000000t1" as UUID,
-    getService: () => null,
+    getService: (type: string) =>
+      type === ServiceType.NOTIFICATION
+        ? { notify: async () => undefined }
+        : null,
     // Default dispatcher renders promptInstructions through the model before
     // notifying; a deterministic stub keeps fires succeeding.
     useModel: async () => "Rendered dispatch message.",
@@ -45,8 +54,11 @@ function makeFakeRuntime(): IAgentRuntime {
 /** Bind the started service into the runtime's getService lookup. */
 async function startServiceOn(runtime: IAgentRuntime) {
   const service = await ScheduledTaskRunnerService.start(runtime);
+  const previousGetService = runtime.getService.bind(runtime);
   (runtime as { getService: unknown }).getService = (type: string) =>
-    type === ScheduledTaskRunnerService.serviceType ? service : null;
+    type === ScheduledTaskRunnerService.serviceType
+      ? service
+      : previousGetService(type);
   return service;
 }
 


### PR DESCRIPTION
## Problem

The standalone scheduling host sent every fire to the local notification surface even when `output.target` explicitly named a live connector. A real Discord owner-DM receipt showed a nominally successful in-app id while no DM arrived. Once connector routing was added, Discord's outbound guild-channel allowlist also incorrectly rejected DM channels.

## Root fix

- Route explicit channel targets through the runtime connector chokepoint, using the rendered owner-facing message and preserving the outbound voice/sanitization guards.
- Parse user, channel, and bare connector targets; reject source/target mismatches rather than misrouting or silently falling back.
- Return an honest typed failure when an explicit connector or notification service is unavailable.
- Persist the exact rendered payload and a stable per-occurrence dispatch idempotency key before provider egress. Retries and stale-fire recovery reuse both, preventing changed prose from defeating connector dedupe.
- Preserve provider receipts and distinguish delivered, partial, in-flight, refused, unknown, and thrown outcomes. Partial delivery is not fabricated as full success; accepted sends with degraded local evidence are reported but not duplicated.
- Classify definitive connector refusals into rate-limit, auth, unknown-recipient, disconnected, or transport failures so the existing retry/escalation policy does the right thing.
- Exempt Discord DM/group-DM targets from the guild `CHANNEL_IDS` allowlist while retaining the allowlist for guild channels.

`@elizaos/plugin-personal-assistant` remains authoritative when loaded; this changes only the scheduling-owned default host path.

## Critical repair during review

The submitted head changed the idempotency key on each retry, treated partial provider delivery as complete success, recorded unavailable explicit connector targets as successful in-app delivery, and allowed a mismatched structured target to route through the wrong connector. The current head repairs those root defects and adds regression coverage for each.

## Verification

- `bun run --cwd plugins/plugin-scheduling test`: **26 files, 341 tests passed**.
- Focused connector/default-dispatch regression suite: **16/16 passed**.
- Scheduling clock, standalone tick, and routing suites: **30/30 passed**.
- Biome and `git diff --check`: passed.
- Discord's new PGlite test is also covered by clean CI; the linked-worktree local invocation could not resolve its workspace `@elizaos/plugin-sql` entry and is not claimed as a local pass.

## Evidence

<!-- evidence-head:a00e89851c2e6078fedb3a1de1dfdf79a7b8797a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI changes.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changes.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - connector transport and persistence behavior is non-visual.

<!-- evidence-row:backend-logs -->
- [x] [18515-scheduling-tests-v3.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18515-scheduling-tests-v3.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend implementation changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - tests use deterministic rendering and assert provider dispatch directly; no live-model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [18515-dispatch-contract-v3.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18515-dispatch-contract-v3.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or layout changed.

Follow-up to #18382.

Author: 0xSolace. Maintainer repair: Codex / OpenAI GPT-5.
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/repository-review"} -->

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5 (review remediation; system-reported model family, deployment variant unavailable)
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - installed Codex plugin packages do not expose a repository commit SHA
<!-- attribution-row:status -->
- Provenance status: self-reported
