### PR TITLE
fix(notes): require structural confirmation for clear-notes (#18383)

### DIFF
--- a/plugins/plugin-notes/src/__tests__/backend.test.ts
+++ b/plugins/plugin-notes/src/__tests__/backend.test.ts
@@ -478,7 +478,11 @@ describe("Notes capabilities", () => {
 
     await interact("create-note", { content: "One", color: "slate" }, service);
     await interact("create-note", { content: "Two", color: "rose" }, service);
-    const clearedNotes = await interact("clear-notes", {}, service);
+    const clearedNotes = await interact(
+      "clear-notes",
+      { confirm: true, expectedRevision: service.snapshot().revision },
+      service,
+    );
     expect(clearedNotes).toMatchObject({
       success: true,
       data: { cleared: 2 },
@@ -487,6 +491,143 @@ describe("Notes capabilities", () => {
       kind: "notes.note-collection",
       id: "notes",
     });
+  });
+
+  it("requires structural confirmation before clear-notes mutates the collection", async () => {
+    const service = await serviceFor(await temporaryStateFile());
+    await interact(
+      "create-note",
+      { content: "Keep me", color: "yellow" },
+      service,
+    );
+    const revision = service.snapshot().revision;
+
+    await expect(interact("clear-notes", {}, service)).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_VALIDATION_FAILED" },
+    });
+    await expect(
+      interact(
+        "clear-notes",
+        { confirm: false, expectedRevision: revision },
+        service,
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_VALIDATION_FAILED" },
+    });
+    await expect(
+      interact(
+        "clear-notes",
+        { confirm: "true", expectedRevision: revision },
+        service,
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_VALIDATION_FAILED" },
+    });
+    await expect(
+      interact("clear-notes", { confirm: true }, service),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_VALIDATION_FAILED" },
+    });
+    await expect(
+      interact(
+        "clear-notes",
+        { confirm: true, expectedRevision: revision - 1 },
+        service,
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_VALIDATION_FAILED" },
+    });
+    await expect(
+      interact(
+        "clear-notes",
+        { confirm: true, expectedRevision: revision, query: "Keep" },
+        service,
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_VALIDATION_FAILED" },
+    });
+    expect(service.listNotes()).toHaveLength(1);
+
+    const cleared = await interact(
+      "clear-notes",
+      { confirm: true, expectedRevision: revision },
+      service,
+    );
+    expect(cleared).toMatchObject({
+      success: true,
+      data: { cleared: 1 },
+    });
+    expectAppliedMutationReceipt(cleared, "clear-notes", {
+      kind: "notes.note-collection",
+      id: "notes",
+    });
+    expect(service.listNotes()).toEqual([]);
+  });
+
+  it("rejects stale clear-notes confirmation after another mutation", async () => {
+    const service = await serviceFor(await temporaryStateFile());
+    await interact(
+      "create-note",
+      { content: "First", color: "yellow" },
+      service,
+    );
+    const staleRevision = service.snapshot().revision;
+    await interact(
+      "create-note",
+      { content: "Second", color: "green" },
+      service,
+    );
+
+    await expect(
+      interact(
+        "clear-notes",
+        { confirm: true, expectedRevision: staleRevision },
+        service,
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      error: { code: "NOTES_VALIDATION_FAILED" },
+    });
+    expect(service.listNotes()).toHaveLength(2);
+
+    const cleared = await interact(
+      "clear-notes",
+      { confirm: true, expectedRevision: service.snapshot().revision },
+      service,
+    );
+    expect(cleared).toMatchObject({
+      success: true,
+      data: { cleared: 2 },
+    });
+    expect(service.listNotes()).toEqual([]);
+  });
+
+  it("persists intentional clear-notes across service restart", async () => {
+    const filePath = await temporaryStateFile();
+    const first = await serviceFor(filePath);
+    await interact(
+      "create-note",
+      { content: "Persisted", color: "slate" },
+      first,
+    );
+    const revision = first.snapshot().revision;
+    await interact(
+      "clear-notes",
+      { confirm: true, expectedRevision: revision },
+      first,
+    );
+    await first.stop();
+
+    const restarted = await serviceFor(filePath);
+    expect(restarted.snapshot()).toMatchObject({ revision: revision + 1 });
+    expect(restarted.listNotes()).toEqual([]);
+    await restarted.stop();
   });
 
   it("fails closed when a title lookup is missing or ambiguous", async () => {

--- a/plugins/plugin-notes/src/capabilities.ts
+++ b/plugins/plugin-notes/src/capabilities.ts
@@ -29,6 +29,22 @@ const COLOR_PARAM: ViewCapabilityParameter = {
   enum: ["yellow", "green", "rose", "slate"],
 };
 
+const CONFIRM_PARAM: ViewCapabilityParameter = {
+  type: "boolean",
+  description:
+    "Must be true after the user explicitly confirms deleting every note.",
+  required: true,
+  enum: [true],
+};
+
+const EXPECTED_REVISION_PARAM: ViewCapabilityParameter = {
+  type: "integer",
+  description:
+    "Current notes revision from the latest snapshot; must match at execution time.",
+  required: true,
+  minimum: 0,
+};
+
 const ID_PARAM = {
   id: {
     type: "string",
@@ -96,6 +112,11 @@ export const NOTES_CAPABILITIES: ViewCapability[] = [
   },
   {
     id: "clear-notes",
-    description: "Delete every sticky note.",
+    description:
+      "Delete every sticky note. Requires explicit confirmation and the current notes revision from the latest snapshot.",
+    params: {
+      confirm: CONFIRM_PARAM,
+      expectedRevision: EXPECTED_REVISION_PARAM,
+    },
   },
 ];

--- a/plugins/plugin-notes/src/interact.ts
+++ b/plugins/plugin-notes/src/interact.ts
@@ -106,6 +106,66 @@ type NoteSelector =
   | { selector: "id"; value: string }
   | { selector: "query"; value: string };
 
+function parseClearNotesConfirmation(
+  params: Record<string, unknown>,
+  currentRevision: number,
+): void {
+  assertOnlyParams(params, ["confirm", "expectedRevision"]);
+  if (!Object.hasOwn(params, "confirm")) {
+    throw new ElizaError("clear-notes requires confirm: true.", {
+      code: "NOTES_VALIDATION_FAILED",
+      context: { field: "confirm" },
+      severity: "ephemeral",
+    });
+  }
+  if (params.confirm !== true) {
+    throw new ElizaError("clear-notes confirm must be the boolean true.", {
+      code: "NOTES_VALIDATION_FAILED",
+      context: { field: "confirm", value: params.confirm },
+      severity: "ephemeral",
+    });
+  }
+  if (!Object.hasOwn(params, "expectedRevision")) {
+    throw new ElizaError(
+      "clear-notes requires expectedRevision matching the current notes revision.",
+      {
+        code: "NOTES_VALIDATION_FAILED",
+        context: { field: "expectedRevision" },
+        severity: "ephemeral",
+      },
+    );
+  }
+  const expectedRevision = params.expectedRevision;
+  if (
+    typeof expectedRevision !== "number" ||
+    !Number.isSafeInteger(expectedRevision) ||
+    expectedRevision < 0
+  ) {
+    throw new ElizaError(
+      "clear-notes expectedRevision must be a non-negative integer.",
+      {
+        code: "NOTES_VALIDATION_FAILED",
+        context: { field: "expectedRevision", value: expectedRevision },
+        severity: "ephemeral",
+      },
+    );
+  }
+  if (expectedRevision !== currentRevision) {
+    throw new ElizaError(
+      "clear-notes expectedRevision is stale; refresh the notes snapshot and try again.",
+      {
+        code: "NOTES_VALIDATION_FAILED",
+        context: {
+          field: "expectedRevision",
+          expectedRevision,
+          currentRevision,
+        },
+        severity: "ephemeral",
+      },
+    );
+  }
+}
+
 function parseLookupTarget(
   params: Record<string, unknown>,
   capability: string,
@@ -279,7 +339,7 @@ async function dispatchCapability(
     );
   }
   if (capability === "clear-notes") {
-    assertOnlyParams(params, []);
+    parseClearNotesConfirmation(params, service.snapshot().revision);
     const { value: cleared, snapshot } = await service.clearNotesWithCommit();
     return mutationSuccess(
       snapshot,


### PR DESCRIPTION
# Relates to

Closes #18383

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused `plugin-notes` tests were run after sync (`37/37` pass).
- [x] A reviewer can confirm the change works without reading the code from the testing steps below.

# Contribution provenance

- AI assistance: `yes`
- Model(s) used: `Cursor / composer-2.5`
- Client / agent tooling: `Cursor Cloud Agent`
- Skill revision: `N/A - no contribution skill used`
- Attribution status: `self-reported`

# Sync with develop

- [x] Branch created from current `origin/develop`; zero conflicts.
- [ ] Full `bun run verify` not executed end-to-end in this environment (heavy install/build). Focused `plugin-notes` tests pass.

# Risks

Low. Changes are isolated to `plugins/plugin-notes` capability metadata and the `interact` broker. `clear-notes` now fails closed without `confirm: true` and a matching `expectedRevision`. `delete-note` and other capabilities are unchanged.

# Background

## What does this PR do?

Fixes #18383 by adding a structural confirmation contract on the Notes capability/backend boundary:

- `clear-notes` now declares required `confirm` (boolean, must be `true`) and `expectedRevision` (non-negative integer matching the current snapshot).
- `interact.ts` enforces the contract before calling `clearNotesWithCommit`, including when invoked outside VIEWS.
- Absent, false, malformed, stale, ambiguous, or extra params fail with `NOTES_VALIDATION_FAILED` and zero mutation.

A planner that selects `clear-notes` with `{}` for a single-note deletion request no longer reaches a destructive mutation.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-notes/src/capabilities.ts` — `CONFIRM_PARAM`, `EXPECTED_REVISION_PARAM`, updated `clear-notes` declaration
- `plugins/plugin-notes/src/interact.ts` — `parseClearNotesConfirmation` and enforcement in the `clear-notes` handler
- `plugins/plugin-notes/src/__tests__/backend.test.ts` — rejection, intentional clear, stale revision, and restart persistence coverage

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-notes test
```

- `interact("clear-notes", {}, service)` → `NOTES_VALIDATION_FAILED`, notes unchanged
- `interact("clear-notes", { confirm: false, expectedRevision })` → same
- `interact("clear-notes", { confirm: "true", expectedRevision })` → same
- `interact("clear-notes", { confirm: true })` → same
- `interact("clear-notes", { confirm: true, expectedRevision: stale })` after another mutation → same
- `interact("clear-notes", { confirm: true, expectedRevision, query })` → same (unsupported field)
- `interact("clear-notes", { confirm: true, expectedRevision: current })` → clears with durable receipt

# Evidence Gate

- [x] N/A - no frontend visual surface; Notes capability/server handler fix.
- [x] N/A - no frontend visual surface.
- [x] N/A - no user-visible walkthrough beyond durable note lifecycle; handler receipts and before/after counts are the proof.
- [x] Backend verification is `plugin-notes` test suite (`37/37` pass on this head).
- [x] N/A - no frontend web path beyond the Notes view broker envelope.
- [x] N/A - deterministic handler probes and durable tests cover the contract; original issue trajectories are the oracle.
- [x] Domain artifacts are durable Notes receipts and before/after `listNotes()` counts in `backend.test.ts`.
- [x] N/A - no rendered visual surface to OCR.

## Known gaps / failures

- Full repository `bun run verify` not run in this cloud environment after `install:light`. Change is scoped to `plugin-notes` with passing focused tests.

— felirami

# Evidence

<!-- evidence-head:49ef346f401ba3f806129df2eb37db0e64170e6e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend capability-contract change only; the Notes view renderer is untouched.

<!-- evidence-row:after-screenshots -->
- [x] N/A - nothing renders differently; the change is broker-side validation of clear-notes params.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no on-screen flow changes; the observable behavior is the interact broker failing closed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - maintainer-verified run of the full plugin-notes backend suite at this head, including the three new structural-confirmation tests.

<details><summary>plugin-notes backend.test.ts (16/16)</summary>

```text
$ bunx vitest run src/__tests__/backend.test.ts --reporter=verbose
 ✓ NotesStore > persists one document and restores notes after restart 22ms
 ✓ NotesStore > serializes concurrent writes without losing a mutation 44ms
 ✓ NotesStore > scopes default stores per agent and shares serialization for duplicate runtime construction 98ms
 ✓ NotesStore > keeps unscoped workbench state outside the agent-scoped durable store 18ms
 ✓ NotesStore > ignores malformed unscoped workbench state instead of importing it 7ms
 ✓ NotesStore > surfaces corrupt persisted bytes as an error instead of healthy empty state 3ms
 ✓ Notes capabilities > dispatches server capabilities to the owning runtime service 18ms
 ✓ Notes capabilities > drives full note CRUD against the durable service 21ms
 ✓ Notes capabilities > requires structural confirmation before clear-notes mutates the collection 17ms
 ✓ Notes capabilities > rejects stale clear-notes confirmation after another mutation 9ms
 ✓ Notes capabilities > persists intentional clear-notes across service restart 14ms
 ✓ Notes capabilities > fails closed when a title lookup is missing or ambiguous 10ms
 ✓ Notes capabilities > returns explicit failures for invalid input and rejects undeclared capabilities 4ms
 ✓ Notes authenticated routes > keeps every state route behind the central auth gate 1ms
 ✓ Notes authenticated routes > returns the authoritative durable snapshot 34ms
 ✓ Notes authenticated routes > returns unavailable instead of fabricating an empty snapshot 8ms
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code is touched; the Notes view calls the same broker endpoint.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - issue #18383 explicitly requires a structural (typed) contract, not model-behavior tuning; the fail-closed paths a mistaken planner can hit (missing confirm, non-boolean confirm, missing/stale expectedRevision, extra params) are pinned deterministically in the backend suite above, and the stale-revision error returns currentRevision so a live planner self-corrects.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - the domain artifact is the durable notes store state, which the persistence test above asserts across service restart (intentional clear survives, revision increments).
