### PR TITLE
fix(app-core): supervisor test fails fast when child never spawns

### DIFF
--- a/packages/app-core/scripts/lib/run-node-supervisor-spawn-count.mjs
+++ b/packages/app-core/scripts/lib/run-node-supervisor-spawn-count.mjs
@@ -1,0 +1,31 @@
+/**
+ * Spawn-counter reader for the `run-node.mjs` supervisor integration test.
+ *
+ * The fake child writes `spawn-count.txt` on every launch. When the supervisor
+ * aborts before spawning, that file is never created and an unguarded read would
+ * throw inside an `EventEmitter` callback, leaving the test promise unsettled
+ * until vitest's timeout. This helper fails fast and surfaces captured stderr.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * @param {string} counterFile - Absolute path to the fake child's spawn counter.
+ * @param {{ code: number | null, stderr: string }} context - Supervisor exit metadata.
+ * @returns {number} Parsed spawn count from the counter file.
+ */
+export function readSpawnCountForSupervisorTest(counterFile, { code, stderr }) {
+  try {
+    return Number(fs.readFileSync(counterFile, "utf8").trim() || "0");
+  } catch (error) {
+    const errCode =
+      error && typeof error === "object" && "code" in error
+        ? error.code
+        : "unknown";
+    throw new Error(
+      `supervisor exited with code ${code} without spawning the child ` +
+        `(${path.basename(counterFile)} was never written: ${errCode}).\n` +
+        `--- supervisor stderr ---\n${stderr || "(empty)"}`,
+    );
+  }
+}

--- a/packages/app-core/scripts/lib/run-node-supervisor-spawn-count.test.mjs
+++ b/packages/app-core/scripts/lib/run-node-supervisor-spawn-count.test.mjs
@@ -1,0 +1,52 @@
+/** Unit tests for the supervisor integration test spawn-counter reader. */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readSpawnCountForSupervisorTest } from "./run-node-supervisor-spawn-count.mjs";
+
+let workDir;
+
+afterEach(() => {
+  if (workDir) {
+    fs.rmSync(workDir, { recursive: true, force: true });
+    workDir = undefined;
+  }
+});
+
+describe("readSpawnCountForSupervisorTest", () => {
+  it("returns the trimmed counter value when the file exists", () => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-spawn-count-"));
+    const counterFile = path.join(workDir, "spawn-count.txt");
+    fs.writeFileSync(counterFile, " 3\n");
+
+    expect(
+      readSpawnCountForSupervisorTest(counterFile, { code: 0, stderr: "" }),
+    ).toBe(3);
+  });
+
+  it("fails fast with supervisor stderr when the counter file was never written", () => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-spawn-count-"));
+    const counterFile = path.join(workDir, "spawn-count.txt");
+    const stderr = "Error: No usable Node.js 24+ executable found";
+
+    expect(() =>
+      readSpawnCountForSupervisorTest(counterFile, { code: 1, stderr }),
+    ).toThrow(
+      /supervisor exited with code 1 without spawning the child.*spawn-count\.txt was never written: ENOENT/s,
+    );
+    expect(() =>
+      readSpawnCountForSupervisorTest(counterFile, { code: 1, stderr }),
+    ).toThrow(stderr);
+  });
+
+  it("labels empty stderr explicitly in the missing-counter error", () => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-spawn-count-"));
+    const counterFile = path.join(workDir, "spawn-count.txt");
+
+    expect(() =>
+      readSpawnCountForSupervisorTest(counterFile, { code: 1, stderr: "" }),
+    ).toThrow(/--- supervisor stderr ---\n\(empty\)/);
+  });
+});

--- a/packages/app-core/scripts/run-node-supervisor.test.mjs
+++ b/packages/app-core/scripts/run-node-supervisor.test.mjs
@@ -17,6 +17,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import restartExitCodeDefinition from "../../shared/src/restart-exit-code.json" with {
   type: "json",
 };
+import { readSpawnCountForSupervisorTest } from "./lib/run-node-supervisor-spawn-count.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const RUN_NODE = path.join(SCRIPT_DIR, "run-node.mjs");
@@ -82,24 +83,24 @@ function runSupervisor(restartUntil) {
     });
     child.on("error", reject);
     child.on("exit", (code) => {
-      const spawnCount = Number(
-        fs.readFileSync(counterFile, "utf8").trim() || "0",
-      );
-      resolve({ code, spawnCount, stdout, stderr });
+      try {
+        const spawnCount = readSpawnCountForSupervisorTest(counterFile, {
+          code,
+          stderr,
+        });
+        resolve({ code, spawnCount, stdout, stderr });
+      } catch (error) {
+        reject(error);
+      }
     });
   });
 }
 
-// Windows-ci only: the supervisor-spawned fake child never writes its
-// `spawn-count.txt`, so this test's own `child.on("exit")` handler throws
-// `ENOENT` reading it and the run Promise never resolves → both cases hit the
-// 30s timeout. The spawn (`spawn(<full node exec path>, ["fake-child.mjs"],
-// { cwd: workDir, stdio: "inherit" })`) and the child's absolute-path
-// `fs.writeFileSync` are Windows-portable and pass on Linux (2/2, ~1.2s); the
-// runner-specific failure (the child process never runs/writes) is not
-// reproducible off the GitHub-hosted Windows runner. Gated there pending a
-// Windows-box root-cause — a likely hardening is pinning `ELIZA_NODE_PATH` to
-// the current node so the supervisor skips runtime-resolution/PATH probing.
+// Windows-ci only: when the supervisor aborts before spawning, the fake child
+// never writes `spawn-count.txt`. The exit handler now rejects immediately with
+// captured stderr via `readSpawnCountForSupervisorTest` instead of hanging on a
+// missing-file `ENOENT` inside the `exit` callback. Gated on Windows pending a
+// runner-specific root-cause for why the child never runs there.
 describe.skipIf(process.platform === "win32")(
   "run-node.mjs supervisor (real processes)",
   () => {


### PR DESCRIPTION
# Relates to

Fixes #18512.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package tests and lint checks were run on the touched files; full `bun run verify` was not run in this environment (Node 22 host; see **Known gaps**).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: cursor/composer-2.5
<!-- attribution-row:client -->
- Agent tooling: Cursor Cloud Agent
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `develop` synced with `upstream/develop`; zero conflicts.
- [x] Focused tests and Biome checks pass on touched files; full verify deferred (see **Known gaps**).

# Risks

Low — test-harness only. No production runtime behavior changes. The helper is consumed solely by the supervisor integration test.

# Background

## What does this PR do?

When `run-node-supervisor.test.mjs` drives the real `run-node.mjs` supervisor and the supervisor aborts before spawning the fake child, `spawn-count.txt` is never written. The previous `child.on("exit")` handler called `fs.readFileSync` unguarded; `ENOENT` inside the `EventEmitter` callback left the promise unsettled, so both cases burned the full 30s vitest timeout and reported an uncaught temp-path `ENOENT` instead of the supervisor's stderr.

This PR:

1. Extracts `readSpawnCountForSupervisorTest` (`scripts/lib/run-node-supervisor-spawn-count.mjs`) to read the counter or reject immediately with captured stderr.
2. Wires the integration test's exit handler through that helper (try/catch → `reject`).
3. Adds three focused unit tests for the helper (happy path, missing file with stderr, empty stderr).
4. Updates the Windows gate comment to describe the new fast-fail behavior.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue) — test infrastructure.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/app-core/scripts/lib/run-node-supervisor-spawn-count.mjs` — the fast-fail reader.
- `packages/app-core/scripts/lib/run-node-supervisor-spawn-count.test.mjs` — focused unit coverage.
- `packages/app-core/scripts/run-node-supervisor.test.mjs` — integration test exit handler.

## Detailed testing steps

```bash
bun run --cwd packages/app-core test scripts/lib/run-node-supervisor-spawn-count.test.mjs
bun run --cwd packages/app-core test scripts/run-node-supervisor.test.mjs
```

On Node 24+ (CI floor), both integration cases pass in ~1s. On Node <24, they now fail in ~170ms with the supervisor stderr (`No usable Node.js 24+ executable found...`) instead of hanging 2×30s.

# Evidence Gate

- [x] N/A - test-runner behavior only; no rendered UI.
- [x] N/A - test-runner behavior only; no rendered UI.
- [x] N/A - no UI flow to record.
- [x] Console output — unit tests green; integration tests fail fast with stderr on Node 22 host.
- [x] N/A - no frontend surface.
- [x] N/A - no model-facing behavior changed.
- [x] Focused test output — see below.
- [x] N/A - no rendered visual surface.

## Backend + frontend logs

<details><summary>Unit tests (3/3 pass)</summary>

```
bun run --cwd packages/app-core test scripts/lib/run-node-supervisor-spawn-count.test.mjs
 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  140ms
```

</details>

<details><summary>Integration tests on Node 22 — fast fail (~170ms vs 60s)</summary>

```
bun run --cwd packages/app-core test scripts/run-node-supervisor.test.mjs
 Test Files  1 failed (1)
      Tests  2 failed (2)
   Duration  426ms (tests 175ms)

Error: supervisor exited with code 1 without spawning the child (spawn-count.txt was never written: ENOENT).
--- supervisor stderr ---
Error: No usable Node.js 24+ executable found (Node.js 22.14.0 is too old; Node.js 24+ is required)...
```

</details>

## Known gaps / failures

- Full `bun run verify` not run in this Cloud Agent environment (Node 22.14.0; repo requires Node 24+). CI with the pinned Node 24 floor should run the integration cases green.
- Integration tests correctly fail on this host; the fix makes the failure legible rather than making incorrect environments pass.