### PR TITLE
fix(app-core): harden Node runtime probe against NODE_OPTIONS noise (#18500)

### DIFF
--- a/packages/app-core/scripts/run-node-runtime.mjs
+++ b/packages/app-core/scripts/run-node-runtime.mjs
@@ -223,15 +223,15 @@ export function validateNodeExecutable({
   return validateNodeProbeOutput(probe.stdout);
 }
 
-export function probeNodeExecutable(candidate) {
+export function probeNodeExecutable(candidate, env = process.env) {
   try {
     const result = spawnSync(
       candidate,
       [
         "-e",
-        "process.stdout.write(process.versions.bun ? 'bun' : 'node:' + (process.versions.node || ''))",
+        "process.stdout.write('\\n' + (process.versions.bun ? 'bun' : 'node:' + (process.versions.node || '')) + '\\n')",
       ],
-      { encoding: "utf8", env: probeEnv(process.env) },
+      { encoding: "utf8", env: probeEnv(env) },
     );
     return {
       status: result.status ?? 1,

--- a/packages/app-core/scripts/run-node-runtime.mjs
+++ b/packages/app-core/scripts/run-node-runtime.mjs
@@ -8,34 +8,6 @@ import { spawnSync } from "node:child_process";
 
 const KNOWN_UNSTABLE_BUN_LINUX = /^1\.3\.9(?:$|[-+].*)/;
 const MIN_NODE_MAJOR = 24;
-/** Matches a Node version token emitted by the runtime probe anywhere in stdout. */
-const NODE_PROBE_VERSION_PATTERN = /(?:^|[\s\r\n])node:([0-9][^\s\r\n]*)/g;
-
-/**
- * Builds the child-process env for the Node runtime probe. Inherits PATH and
- * other discovery-related vars, but strips NODE_OPTIONS so caller preloads
- * cannot write to stdout and corrupt version detection.
- */
-export function buildNodeProbeEnv(parentEnv = process.env) {
-  const env = { ...parentEnv };
-  delete env.NODE_OPTIONS;
-  return env;
-}
-
-function extractNodeProbeVersion(text) {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return null;
-  }
-  for (const line of trimmed.split(/\r?\n/)) {
-    const exact = /^node:(.+)$/.exec(line.trim());
-    if (exact) {
-      return exact[1];
-    }
-  }
-  const matches = [...trimmed.matchAll(NODE_PROBE_VERSION_PATTERN)];
-  return matches.at(-1)?.[1] ?? null;
-}
 
 /**
  * Bun 1.3.9 has known Linux segfault reports in long-running workloads.
@@ -152,15 +124,63 @@ export function parseNodeMajor(version) {
   return major ? Number.parseInt(major, 10) : null;
 }
 
+/**
+ * Probe child env: inherit caller discovery vars (PATH, etc.) but drop
+ * NODE_OPTIONS so preloads cannot write banners onto the probe stdout channel.
+ */
+export function probeEnv(env = process.env) {
+  const { NODE_OPTIONS: _dropped, ...rest } = env ?? {};
+  return rest;
+}
+
+/**
+ * Collect exact probe markers from non-empty trimmed stdout lines.
+ * A line must be exactly `bun` or `node:<version>` — partial or decorated
+ * lines (preload banners, deprecation notices) are ignored.
+ */
+export function findProbeMarkers(text) {
+  const lines = (text ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  let sawBun = false;
+  /** @type {string[]} */
+  const nodeVersions = [];
+  for (const line of lines) {
+    if (line === "bun") {
+      sawBun = true;
+      continue;
+    }
+    const match = /^node:(.+)$/.exec(line);
+    if (match) {
+      nodeVersions.push(match[1]);
+    }
+  }
+  return { sawBun, nodeVersions };
+}
+
 export function validateNodeProbeOutput(output) {
   const text = output?.trim() ?? "";
-  if (text === "bun") {
+  const { sawBun, nodeVersions } = findProbeMarkers(text);
+
+  // Bun keeps priority so a shimmed Bun behind banner lines is still rejected.
+  if (sawBun) {
     return { ok: false, reason: "resolved to Bun, not Node.js" };
   }
-  const version = extractNodeProbeVersion(text);
-  if (!version) {
+  if (nodeVersions.length === 0) {
     return { ok: false, reason: "did not report a Node.js runtime" };
   }
+
+  const uniqueVersions = [...new Set(nodeVersions)];
+  if (uniqueVersions.length > 1) {
+    return {
+      ok: false,
+      reason: `reported more than one Node.js runtime (${uniqueVersions.join(", ")})`,
+    };
+  }
+
+  const version = uniqueVersions[0];
   const major = parseNodeMajor(version);
   if (major === null) {
     return { ok: false, reason: `could not parse Node.js version ${version}` };
@@ -211,7 +231,7 @@ export function probeNodeExecutable(candidate) {
         "-e",
         "process.stdout.write(process.versions.bun ? 'bun' : 'node:' + (process.versions.node || ''))",
       ],
-      { encoding: "utf8", env: buildNodeProbeEnv() },
+      { encoding: "utf8", env: probeEnv(process.env) },
     );
     return {
       status: result.status ?? 1,

--- a/packages/app-core/scripts/run-node-runtime.test.mjs
+++ b/packages/app-core/scripts/run-node-runtime.test.mjs
@@ -1,10 +1,15 @@
 /** Exercises run node runtime behavior with deterministic app-core test fixtures. */
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, test } from "vitest";
 import {
   chooseElizaRuntime,
   findProbeMarkers,
   parseNodeMajor,
   probeEnv,
+  probeNodeExecutable,
   resolveNodeExecPath,
   resolveNodeExecPathFromCandidates,
   validateNodeExecutable,
@@ -180,6 +185,67 @@ describe("run-node-runtime node validation", () => {
     expect(env.PATH).toBe("/usr/bin");
     expect(env.HOME).toBe("/home/eliza");
   });
+
+  test("strips NODE_OPTIONS from the real probe child", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "eliza-node-probe-"));
+    const preloadPath = path.join(tempDir, "stdout-preload.mjs");
+    writeFileSync(
+      preloadPath,
+      'process.stdout.write("unexpected preload banner");\n',
+    );
+
+    try {
+      const result = probeNodeExecutable(process.execPath, {
+        ...process.env,
+        NODE_OPTIONS: `--import=${pathToFileURL(preloadPath).href}`,
+      });
+      expect(result).toMatchObject({
+        status: 0,
+        stdout: `node:${process.versions.node}`,
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  const testPosix = process.platform === "win32" ? test.skip : test;
+  testPosix(
+    "isolates the marker from a PATH shim banner without a newline",
+    () => {
+      const tempDir = mkdtempSync(path.join(os.tmpdir(), "eliza-node-shim-"));
+      const shimPath = path.join(tempDir, "node-shim.cjs");
+      writeFileSync(
+        shimPath,
+        `#!/usr/bin/env node
+const { spawnSync } = require("node:child_process");
+process.stdout.write("[shim-without-newline]");
+const child = spawnSync(process.execPath, process.argv.slice(2), {
+  encoding: "utf8",
+  env: process.env,
+});
+process.stdout.write(child.stdout ?? "");
+process.stderr.write(child.stderr ?? "");
+process.exit(child.status ?? 1);
+`,
+      );
+      chmodSync(shimPath, 0o755);
+
+      try {
+        expect(probeNodeExecutable(shimPath)).toMatchObject({
+          status: 0,
+          stdout: `[shim-without-newline]\nnode:${process.versions.node}`,
+        });
+        expect(
+          validateNodeExecutable({
+            candidate: shimPath,
+            platform: process.platform,
+          }),
+        ).toEqual({ ok: true, reason: null });
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   test("findProbeMarkers collects exact line markers only", () => {
     expect(

--- a/packages/app-core/scripts/run-node-runtime.test.mjs
+++ b/packages/app-core/scripts/run-node-runtime.test.mjs
@@ -1,9 +1,10 @@
 /** Exercises run node runtime behavior with deterministic app-core test fixtures. */
 import { describe, expect, test } from "vitest";
 import {
-  buildNodeProbeEnv,
   chooseElizaRuntime,
+  findProbeMarkers,
   parseNodeMajor,
+  probeEnv,
   resolveNodeExecPath,
   resolveNodeExecPathFromCandidates,
   validateNodeExecutable,
@@ -117,7 +118,7 @@ describe("run-node-runtime node validation", () => {
     });
   });
 
-  test("accepts probe markers when stdout includes preload or warning noise", () => {
+  test("accepts Node 24 markers when stdout includes preload banners or trailing chatter", () => {
     expect(
       validateNodeProbeOutput(
         "[apm-bootstrap] instrumenting process\nnode:24.4.0",
@@ -131,13 +132,68 @@ describe("run-node-runtime node validation", () => {
     ).toEqual({ ok: true, reason: null });
   });
 
-  test("strips NODE_OPTIONS from the shared probe env without removing PATH", () => {
-    const env = buildNodeProbeEnv({
+  test("reports the version reason for an old Node behind noisy probe stdout", () => {
+    const result = validateNodeProbeOutput(
+      "[apm-bootstrap] instrumenting process\nnode:22.23.0",
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("Node.js 22.23.0 is too old");
+    expect(result.reason).not.toContain("did not report a Node.js runtime");
+  });
+
+  test("rejects bun when preceded by shim or preload output", () => {
+    expect(validateNodeProbeOutput("[nvm-shim] loading\nbun")).toEqual({
+      ok: false,
+      reason: "resolved to Bun, not Node.js",
+    });
+  });
+
+  test("rejects disagreeing node: markers as ambiguous rather than picking one", () => {
+    const result = validateNodeProbeOutput("node:24.4.0\nnode:22.23.0");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(
+      /reported more than one Node\.js runtime \(24\.4\.0, 22\.23\.0\)/,
+    );
+  });
+
+  test("accepts repeated identical node: markers", () => {
+    expect(validateNodeProbeOutput("node:24.4.0\nnode:24.4.0")).toEqual({
+      ok: true,
+      reason: null,
+    });
+  });
+
+  test("still rejects junk-only probe output with no marker", () => {
+    expect(validateNodeProbeOutput("[apm-bootstrap] only noise")).toEqual({
+      ok: false,
+      reason: "did not report a Node.js runtime",
+    });
+  });
+
+  test("strips NODE_OPTIONS from probeEnv without removing PATH", () => {
+    const env = probeEnv({
       PATH: "/usr/bin",
       NODE_OPTIONS: "--require ./apm-bootstrap.js",
+      HOME: "/home/eliza",
     });
     expect(env.NODE_OPTIONS).toBeUndefined();
     expect(env.PATH).toBe("/usr/bin");
+    expect(env.HOME).toBe("/home/eliza");
+  });
+
+  test("findProbeMarkers collects exact line markers only", () => {
+    expect(
+      findProbeMarkers(
+        "[apm-bootstrap] instrumenting process\nnode:24.4.0\nbun\n",
+      ),
+    ).toEqual({
+      sawBun: true,
+      nodeVersions: ["24.4.0"],
+    });
+    expect(findProbeMarkers("(node:123) DeprecationWarning: x")).toEqual({
+      sawBun: false,
+      nodeVersions: [],
+    });
   });
 
   test("rejects Codex-bundled macOS Node", () => {


### PR DESCRIPTION
# Relates to

Closes #18500

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused verification was run on the touched surfaces (see Testing).
- [x] A reviewer can confirm the change from the unit transcripts and live probe output below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `upstream/develop` before push; zero conflicts.
- [x] Focused tests and Biome re-run on the exact head after sync.

<!-- evidence-head:140442f79b4a88bfdc6548eb01c685aa914f0e76 -->

# What this PR does

Hardens the shared Node runtime probe in `packages/app-core/scripts/run-node-runtime.mjs` so a valid Node 24+ executable is no longer rejected when probe stdout contains preload banners, trailing chatter, or deprecation notices, and so the failure reason stays accurate when the runtime is actually too old.

## Changes

1. **`probeEnv`** — builds the probe child environment by dropping `NODE_OPTIONS` while passing the rest of the caller environment through (PATH and discovery vars remain).
2. **`findProbeMarkers`** — splits stdout into non-empty trimmed lines and matches only exact `bun` or `node:<version>` lines.
3. **`validateNodeProbeOutput`** — uses per-line markers; Bun keeps priority (shimmed Bun still fails closed); disagreeing multi-`node:` markers return `reported more than one Node.js runtime (…);` old Node behind noise reports the version reason, not `did not report a Node.js runtime`.
4. **`probeNodeExecutable`** — spawns with `{ env: probeEnv(process.env) }`.

## Scope / non-goals

- App-core probe + unit tests only.
- Does **not** change Playwright lane wiring (#18456 / #18460 / #18504). Those PRs may touch the same files for a broader fail-fast path; this PR is the focused #18500 contract (including multi-marker ambiguity and bun-behind-shim).

# Testing

```bash
bun run --cwd packages/app-core test scripts/run-node-runtime.test.mjs
# 21 passed (13 existing + 8 added)

bunx @biomejs/biome check \
  packages/app-core/scripts/run-node-runtime.mjs \
  packages/app-core/scripts/run-node-runtime.test.mjs
# clean

git diff --check
# clean
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - CLI runtime-resolution helper only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - CLI runtime-resolution helper only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - no interactive flow changed; failure surfaces as a CLI error string.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: live probe drive of shipped exports under clean and noisy stdout, plus parent NODE_OPTIONS pollution check on exact head `44016cd4e5c5b6aa7e7022fb118bd7b1fbf3cc35`.
<details>
<summary>Live probe transcript</summary>

```
clean        ok=true  reason=null
banner       ok=true  reason=null
trailing     ok=true  reason=null
deprecation  ok=true  reason=null
old+noise    ok=false reason=Node.js 22.23.0 is too old; Node.js 24+ is required
bun+shim     ok=false reason=resolved to Bun, not Node.js
two-marker   ok=false reason=reported more than one Node.js runtime (24.4.0, 22.23.0)
junk         ok=false reason=did not report a Node.js runtime
probeEnv NODE_OPTIONS=undefined PATH=/usr/bin FOO=bar
live probe status=0 stdout="node:25.2.1"
live probe polluted_by_NODE_OPTIONS=false
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend runtime or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused vitest run for `packages/app-core/scripts/run-node-runtime.test.mjs` on exact head `44016cd4e5c5b6aa7e7022fb118bd7b1fbf3cc35` (21/21 pass).
<details>
<summary>vitest transcript</summary>

```
$ node ../scripts/run-vitest.mjs run --config vitest.config.ts scripts/run-node-runtime.test.mjs

 RUN  v4.1.5 /home/deepanshu/os/eliza/packages/app-core

 ✓ scripts/run-node-runtime.test.mjs (21 tests) 9ms

 Test Files  1 passed (1)
      Tests  21 passed (21)
   Start at  09:46:38
   Duration  190ms (transform 43ms, setup 0ms, import 57ms, tests 9ms, environment 0ms)
```

</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface changed.

# Risks

Low. Shared probe only used for runtime path validation. Fail-closed behavior preserved for junk, Bun, multi-marker ambiguity, and pre-24 Node. No cloud, auth, or deploy changes.

# Known gaps / failures

- Full monorepo `bun run verify` not re-run here (unrelated install/LFS worktree noise + long wall time); develop-PR gate lint/typecheck/build + focused package tests cover this surface.
- Playwright lane consumers are out of scope; coordinate with #18504 if both land closely.
- Fork `pull_request` workflows are currently `action_required` pending first-time maintainer approval to run Actions on this fork PR (same edge case as prior fork PRs).

# Documentation changes needed?

No - internal runtime probe helper only.



