### PR TITLE
fix(cloud): classify PGlite-closing snapshot failures as transient/retryable — unwedge agent restarts (backup-500 incident fix)

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -345,6 +345,7 @@ import {
   createAgentSnapshot,
   createLocalAgentBackup,
   listLocalAgentBackups,
+  PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT,
   restoreAgentSnapshot,
   restoreLocalAgentBackup,
 } from "../services/agent-backup.ts";
@@ -1834,13 +1835,20 @@ async function handleRequest(
       const snapshot = await createAgentSnapshot(state.runtime, state.config);
       json(res, snapshot);
     } catch (err) {
-      logger.error(
-        {
-          err: err instanceof Error ? err.message : String(err),
-        },
-        "[agent-backup] Snapshot failed",
-      );
-      error(res, err instanceof Error ? err.message : "Snapshot failed", 500);
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT) {
+        // Transient teardown race (PGlite closing) — 503 so the caller retries
+        // or defers instead of tripping the fail-closed restart gate on a 500
+        // (2026-08-11 fleet incident: 500 here wedged healthy agent restarts).
+        logger.warn(
+          { err: message },
+          "[agent-backup] Snapshot temporarily unavailable",
+        );
+        error(res, message, 503);
+        return;
+      }
+      logger.error({ err: message }, "[agent-backup] Snapshot failed");
+      error(res, message, 500);
     }
     return;
   }

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -346,6 +346,7 @@ import {
   createLocalAgentBackup,
   listLocalAgentBackups,
   PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT,
+  PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT_CODE,
   restoreAgentSnapshot,
   restoreLocalAgentBackup,
 } from "../services/agent-backup.ts";
@@ -1844,7 +1845,14 @@ async function handleRequest(
           { err: message },
           "[agent-backup] Snapshot temporarily unavailable",
         );
-        error(res, message, 503);
+        json(
+          res,
+          {
+            error: message,
+            code: PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT_CODE,
+          },
+          503,
+        );
         return;
       }
       logger.error({ err: message }, "[agent-backup] Snapshot failed");

--- a/packages/agent/src/api/snapshot-route-transient.test.ts
+++ b/packages/agent/src/api/snapshot-route-transient.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Proves the POST /api/snapshot HTTP boundary's transient/terminal split
+ * against a real AgentRuntime and TCP API host: a PGlite closing-race failure
+ * (the PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT sentinel) maps to 503 with the
+ * structured transient code the cloud restart orchestrator keys on, while a
+ * genuine dump failure stays a terminal 500. Only the database adapter is a
+ * stub; server, routes, and snapshot capture are real.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { AgentRuntime, InMemoryDatabaseAdapter } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT,
+  PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT_CODE,
+} from "../services/agent-backup.ts";
+import { startApiServer } from "./server.ts";
+
+type ApiServer = Awaited<ReturnType<typeof startApiServer>>;
+
+const API_TOKEN = "snapshot-transient-route-token";
+
+const originalEnv = new Map<string, string | undefined>();
+const touchedEnv = [
+  "DATABASE_URL",
+  "ELIZA_API_AUTH_TOKEN",
+  "ELIZA_API_BIND_HOST",
+  "ELIZA_API_PORT",
+  "ELIZA_API_TOKEN",
+  "ELIZA_CONFIG_PATH",
+  "ELIZA_PERSIST_CONFIG_PATH",
+  "ELIZA_PORT",
+  "ELIZA_STATE_DIR",
+  "PGLITE_DATA_DIR",
+  "POSTGRES_URL",
+] as const;
+
+function snapshotEnvironment(): void {
+  originalEnv.clear();
+  for (const key of touchedEnv) originalEnv.set(key, process.env[key]);
+}
+
+function restoreEnvironment(): void {
+  for (const key of touchedEnv) {
+    const original = originalEnv.get(key);
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
+  originalEnv.clear();
+}
+
+async function seedState(root: string): Promise<void> {
+  const stateDir = path.join(root, "state");
+  const pgliteDir = path.join(stateDir, "pglite");
+  await mkdir(pgliteDir, { recursive: true });
+  const configPath = path.join(stateDir, "eliza.json");
+  await writeFile(
+    configPath,
+    JSON.stringify({ logging: { level: "error" } }),
+    "utf8",
+  );
+
+  process.env.ELIZA_STATE_DIR = stateDir;
+  process.env.PGLITE_DATA_DIR = pgliteDir;
+  process.env.ELIZA_CONFIG_PATH = configPath;
+  process.env.ELIZA_PERSIST_CONFIG_PATH = configPath;
+  process.env.ELIZA_API_BIND_HOST = "127.0.0.1";
+  process.env.ELIZA_API_TOKEN = API_TOKEN;
+  delete process.env.ELIZA_API_AUTH_TOKEN;
+  delete process.env.POSTGRES_URL;
+  delete process.env.DATABASE_URL;
+}
+
+/**
+ * Real in-memory adapter widened with the PGlite raw-connection surface the
+ * snapshot capture path reads; `dumpDataDir` behavior is injected per test.
+ */
+class PgliteFacadeAdapter extends InMemoryDatabaseAdapter {
+  constructor(private readonly dumpDataDir: () => Promise<unknown>) {
+    super();
+  }
+
+  getRawConnection(): unknown {
+    return { dumpDataDir: this.dumpDataDir };
+  }
+}
+
+async function withSnapshotServer(
+  dumpDataDir: () => Promise<unknown>,
+  run: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+  snapshotEnvironment();
+  const root = await mkdtemp(path.join(tmpdir(), "eliza-snapshot-route-"));
+  let runtime: AgentRuntime | null = null;
+  let api: ApiServer | null = null;
+  try {
+    await seedState(root);
+    runtime = new AgentRuntime({ logLevel: "fatal", plugins: [] });
+    // Register before initialize() so the runtime does not fall back to a
+    // plain in-memory adapter without the raw-connection facade.
+    runtime.registerDatabaseAdapter(new PgliteFacadeAdapter(dumpDataDir));
+    await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+
+    api = await startApiServer({
+      port: 0,
+      runtime,
+      skipDeferredStartupWork: true,
+    });
+    process.env.ELIZA_PORT = String(api.port);
+    process.env.ELIZA_API_PORT = String(api.port);
+
+    await run(`http://127.0.0.1:${api.port}`);
+  } finally {
+    if (api) await api.close();
+    if (runtime) {
+      await runtime.stop({ fast: true });
+      await runtime.close();
+    }
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function postSnapshot(baseUrl: string): Promise<Response> {
+  return fetch(`${baseUrl}/api/snapshot`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${API_TOKEN}` },
+  });
+}
+
+afterEach(restoreEnvironment);
+
+describe("POST /api/snapshot transient/terminal mapping", () => {
+  it("maps a PGlite closing race to 503 with the structured transient code", async () => {
+    await withSnapshotServer(
+      async () => {
+        // Exact phrasing PGlite throws when dumpDataDir races a close.
+        throw new Error("PGlite is closing");
+      },
+      async (baseUrl) => {
+        const res = await postSnapshot(baseUrl);
+        expect(res.status).toBe(503);
+        await expect(res.json()).resolves.toEqual(
+          expect.objectContaining({
+            error: PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT,
+            code: PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT_CODE,
+          }),
+        );
+      },
+    );
+  }, 120_000);
+
+  it("keeps a genuine dump failure a terminal 500 without the transient code", async () => {
+    await withSnapshotServer(
+      async () => {
+        throw new Error("tar write failed: disk I/O error");
+      },
+      async (baseUrl) => {
+        const res = await postSnapshot(baseUrl);
+        expect(res.status).toBe(500);
+        const body = (await res.json()) as Record<string, unknown>;
+        expect(body).toEqual(
+          expect.objectContaining({
+            error: "tar write failed: disk I/O error",
+          }),
+        );
+        expect(body.code).toBeUndefined();
+      },
+    );
+  }, 120_000);
+});

--- a/packages/agent/src/services/agent-backup.test.ts
+++ b/packages/agent/src/services/agent-backup.test.ts
@@ -16,6 +16,7 @@ import {
   createLocalAgentBackup,
   fetchAgentScopedRowsBatched,
   listLocalAgentBackups,
+  PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT,
   restoreAgentSnapshot,
   restoreLocalAgentBackup,
   SnapshotBudget,
@@ -307,6 +308,61 @@ describe("agent backup manifest", () => {
       dumpBytes,
     );
     expect(snapshot.manifest.components.database.pglite).toBeUndefined();
+  });
+
+  test("captures through the adapter's lifecycle-serialized PGlite operation", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "eliza-agent-backup-"),
+    );
+    process.env.ELIZA_STATE_DIR = root;
+    delete process.env.POSTGRES_URL;
+    delete process.env.DATABASE_URL;
+
+    let captures = 0;
+    const runtime = {
+      ...runtimeStub("55555555-5555-4555-8555-555555555555"),
+      adapter: {
+        close: async () => undefined,
+        dumpPgliteDataDir: async () => {
+          captures += 1;
+          return new Blob(["captured"], { type: "application/gzip" });
+        },
+      },
+    } as unknown as AgentRuntime;
+
+    const snapshot = await createAgentSnapshot(runtime, {} as never);
+
+    expect(captures).toBe(1);
+    expect(snapshot.manifest.components.database.kind).toBe("pglite-dump");
+  });
+
+  test("surfaces repeated closing errors as transient without masking other failures", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "eliza-agent-backup-"),
+    );
+    process.env.ELIZA_STATE_DIR = root;
+    delete process.env.POSTGRES_URL;
+    delete process.env.DATABASE_URL;
+
+    const snapshotWithError = (message: string) => {
+      const runtime = {
+        ...runtimeStub("66666666-6666-4666-8666-666666666666"),
+        adapter: {
+          close: async () => undefined,
+          dumpPgliteDataDir: async () => {
+            throw new Error(message);
+          },
+        },
+      } as unknown as AgentRuntime;
+      return createAgentSnapshot(runtime, {} as never);
+    };
+
+    await expect(snapshotWithError("connection is closing")).rejects.toThrow(
+      PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT,
+    );
+    await expect(
+      snapshotWithError("failed while closing corrupted WAL segment"),
+    ).rejects.toThrow("failed while closing corrupted WAL segment");
   });
 
   test("writes encrypted local backup files and restores them", async () => {

--- a/packages/agent/src/services/agent-backup.ts
+++ b/packages/agent/src/services/agent-backup.ts
@@ -936,6 +936,8 @@ function isBlobLike(value: unknown): value is {
  */
 export const PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT =
   "PGlite snapshot temporarily unavailable (connection closing)";
+export const PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT_CODE =
+  "PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT";
 
 /**
  * A PGlite handle that is mid-close throws with these shapes. Kept narrow so a
@@ -943,68 +945,46 @@ export const PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT =
  * silently treated as transient.
  */
 function isPgliteClosingError(err: unknown): boolean {
-  const message = (
-    err instanceof Error ? err.message : String(err)
-  ).toLowerCase();
+  const message = (err instanceof Error ? err.message : String(err))
+    .trim()
+    .toLowerCase();
   return (
-    message.includes("pglite is closed") ||
-    message.includes("database is closed") ||
-    message.includes("connection is closed") ||
-    message.includes("closing")
+    message === "closing" ||
+    /\b(?:pglite|database|connection)\s+(?:is\s+)?(?:closed|closing)\b/.test(
+      message,
+    )
   );
-}
-
-async function runDumpDataDir(connection: {
-  dumpDataDir?: (compression?: "gzip") => Promise<unknown>;
-  runExclusive?: <T>(operation: () => Promise<T>) => Promise<T>;
-}): Promise<unknown> {
-  const dumpDataDir = connection.dumpDataDir;
-  if (typeof dumpDataDir !== "function") {
-    throw new Error("PGlite connection does not expose dumpDataDir()");
-  }
-  // runExclusive serializes against an in-flight close, so routing the dump
-  // through it both avoids and detects the teardown race deterministically.
-  return connection.runExclusive
-    ? connection.runExclusive(() => dumpDataDir.call(connection, "gzip"))
-    : dumpDataDir.call(connection, "gzip");
 }
 
 async function capturePgliteDump(
   runtime: IAgentRuntime | AgentRuntime,
   budget?: SnapshotBudget,
 ): Promise<AgentBackupPgliteDump | null> {
-  const raw = (
-    runtime.adapter as
-      | {
-          getRawConnection?: () => unknown;
-        }
-      | undefined
-  )?.getRawConnection?.();
-  if (!raw || typeof raw !== "object") return null;
-  const connection = raw as {
-    dumpDataDir?: (compression?: "gzip") => Promise<unknown>;
-    runExclusive?: <T>(operation: () => Promise<T>) => Promise<T>;
-  };
-  if (typeof connection.dumpDataDir !== "function") return null;
+  const adapter = runtime.adapter as
+    | {
+        dumpPgliteDataDir?: (compression?: "gzip") => Promise<unknown>;
+        getRawConnection?: () => unknown;
+      }
+    | undefined;
+  const managedDump = adapter?.dumpPgliteDataDir;
+  const raw = adapter?.getRawConnection?.();
+  const rawDump =
+    raw && typeof raw === "object"
+      ? (raw as { dumpDataDir?: (compression?: "gzip") => Promise<unknown> })
+          .dumpDataDir
+      : undefined;
+  if (typeof managedDump !== "function" && typeof rawDump !== "function") {
+    return null;
+  }
 
   let dump: unknown;
   try {
-    dump = await runDumpDataDir(connection);
+    dump = managedDump
+      ? await managedDump.call(adapter, "gzip")
+      : await rawDump?.call(raw, "gzip");
   } catch (err) {
     if (isPgliteClosingError(err)) {
-      // Transient teardown race: re-check once through runExclusive (serialized
-      // behind the close), then surface a recognizable sentinel so the snapshot
-      // endpoint returns a retryable/deferrable condition instead of an opaque
-      // 500 that wedges restarts (2026-08-11 fleet incident). Fail-closed on any
-      // NON-transient dump error still applies (rethrown below).
-      try {
-        dump = await runDumpDataDir(connection);
-      } catch (retryErr) {
-        if (isPgliteClosingError(retryErr)) {
-          throw new Error(PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT);
-        }
-        throw retryErr;
-      }
+      throw new Error(PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT);
     } else {
       throw err;
     }

--- a/packages/agent/src/services/agent-backup.ts
+++ b/packages/agent/src/services/agent-backup.ts
@@ -924,6 +924,51 @@ function isBlobLike(value: unknown): value is {
   );
 }
 
+/**
+ * Recognizable sentinel for a snapshot that failed because the underlying
+ * PGlite connection was closing/closed while `dumpDataDir()` ran — a TRANSIENT
+ * teardown-race condition, not data corruption. The 2026-08-11 fleet incident
+ * wedged agent restarts because a `dumpDataDir()` against a closing PGlite
+ * threw an opaque error that surfaced as `POST /api/snapshot` → HTTP 500,
+ * which tripped the cloud restart's fail-closed "Refusing to stop without a
+ * current backup" gate and left healthy agents unrestartable. Surfacing this as
+ * a distinct condition lets the caller degrade/retry instead of hard-failing.
+ */
+export const PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT =
+  "PGlite snapshot temporarily unavailable (connection closing)";
+
+/**
+ * A PGlite handle that is mid-close throws with these shapes. Kept narrow so a
+ * genuine dump failure (corruption, OOM) still hard-fails rather than being
+ * silently treated as transient.
+ */
+function isPgliteClosingError(err: unknown): boolean {
+  const message = (
+    err instanceof Error ? err.message : String(err)
+  ).toLowerCase();
+  return (
+    message.includes("pglite is closed") ||
+    message.includes("database is closed") ||
+    message.includes("connection is closed") ||
+    message.includes("closing")
+  );
+}
+
+async function runDumpDataDir(connection: {
+  dumpDataDir?: (compression?: "gzip") => Promise<unknown>;
+  runExclusive?: <T>(operation: () => Promise<T>) => Promise<T>;
+}): Promise<unknown> {
+  const dumpDataDir = connection.dumpDataDir;
+  if (typeof dumpDataDir !== "function") {
+    throw new Error("PGlite connection does not expose dumpDataDir()");
+  }
+  // runExclusive serializes against an in-flight close, so routing the dump
+  // through it both avoids and detects the teardown race deterministically.
+  return connection.runExclusive
+    ? connection.runExclusive(() => dumpDataDir.call(connection, "gzip"))
+    : dumpDataDir.call(connection, "gzip");
+}
+
 async function capturePgliteDump(
   runtime: IAgentRuntime | AgentRuntime,
   budget?: SnapshotBudget,
@@ -940,12 +985,30 @@ async function capturePgliteDump(
     dumpDataDir?: (compression?: "gzip") => Promise<unknown>;
     runExclusive?: <T>(operation: () => Promise<T>) => Promise<T>;
   };
-  const dumpDataDir = connection.dumpDataDir;
-  if (typeof dumpDataDir !== "function") return null;
+  if (typeof connection.dumpDataDir !== "function") return null;
 
-  const dump = connection.runExclusive
-    ? await connection.runExclusive(() => dumpDataDir.call(connection, "gzip"))
-    : await dumpDataDir.call(connection, "gzip");
+  let dump: unknown;
+  try {
+    dump = await runDumpDataDir(connection);
+  } catch (err) {
+    if (isPgliteClosingError(err)) {
+      // Transient teardown race: re-check once through runExclusive (serialized
+      // behind the close), then surface a recognizable sentinel so the snapshot
+      // endpoint returns a retryable/deferrable condition instead of an opaque
+      // 500 that wedges restarts (2026-08-11 fleet incident). Fail-closed on any
+      // NON-transient dump error still applies (rethrown below).
+      try {
+        dump = await runDumpDataDir(connection);
+      } catch (retryErr) {
+        if (isPgliteClosingError(retryErr)) {
+          throw new Error(PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT);
+        }
+        throw retryErr;
+      }
+    } else {
+      throw err;
+    }
+  }
   if (!isBlobLike(dump)) {
     throw new Error("PGlite dumpDataDir() did not return a Blob/File");
   }

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -1601,6 +1601,42 @@ describe("ElizaSandboxService shutdown fails closed without a current capture (#
       fetchSnap.mockRestore();
     }
   });
+
+  test("a transient capture refusal is retryable and leaves the agent running", async () => {
+    const { ElizaSandboxService, SNAPSHOT_CAPTURE_TRANSIENT } = await import(
+      "./eliza-sandbox.ts?actual"
+    );
+    const rec = customSandbox();
+    const provider: SandboxProvider = {
+      create: mock(async () => {
+        throw new Error("must not create");
+      }),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
+      checkHealth: mock(async () => true),
+    };
+    const svc = new ElizaSandboxService(provider);
+    const getForWrite = spyOn(
+      svc as unknown as { getAgentForWrite: () => Promise<unknown> },
+      "getAgentForWrite",
+    ).mockResolvedValue(rec);
+    const fetchSnap = spyOn(
+      svc as unknown as { fetchSnapshotState: () => Promise<never> },
+      "fetchSnapshotState",
+    ).mockRejectedValue(new Error(SNAPSHOT_CAPTURE_TRANSIENT));
+    try {
+      await expect(svc.shutdown(rec.id, rec.organization_id)).resolves.toEqual({
+        success: false,
+        retryable: true,
+        error: `Refusing to stop without a current backup: ${SNAPSHOT_CAPTURE_TRANSIENT}`,
+      });
+      expect(provider.stopForDeletion).not.toHaveBeenCalled();
+      expect(provider.stopForReplacement).not.toHaveBeenCalled();
+    } finally {
+      getForWrite.mockRestore();
+      fetchSnap.mockRestore();
+    }
+  });
 });
 
 describe("ElizaSandboxService sleep refuses an unproven fallback backup (#17180 §3)", () => {
@@ -1969,6 +2005,62 @@ describe("ElizaSandboxService snapshot — endpoint capability", () => {
     } finally {
       findRunningSpy.mockRestore();
       createBackupSpy.mockRestore();
+    }
+  });
+
+  test("a 503 from /api/snapshot remains a retryable transient sentinel", async () => {
+    const { ElizaSandboxService, SNAPSHOT_CAPTURE_TRANSIENT } = await import(
+      "./eliza-sandbox.ts?actual"
+    );
+    const rec = customSandbox();
+    const findRunningSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
+      rec,
+    );
+    const createBackupSpy = spyOn(agentSandboxesRepository, "createBackup");
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: "PGlite snapshot temporarily unavailable (connection closing)",
+            code: "PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT",
+          }),
+          { status: 503, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    try {
+      await expect(
+        new ElizaSandboxService().snapshot(rec.id, rec.organization_id, "auto"),
+      ).resolves.toEqual({
+        success: false,
+        error: SNAPSHOT_CAPTURE_TRANSIENT,
+        retryable: true,
+      });
+      expect(createBackupSpy).not.toHaveBeenCalled();
+    } finally {
+      findRunningSpy.mockRestore();
+      createBackupSpy.mockRestore();
+    }
+  });
+
+  test("an unrelated 503 remains an ordinary snapshot failure", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const rec = customSandbox();
+    const findRunningSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
+      rec,
+    );
+    globalThis.fetch = mock(
+      async () =>
+        new Response(JSON.stringify({ error: "Runtime not ready" }), {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    try {
+      await expect(
+        new ElizaSandboxService().snapshot(rec.id, rec.organization_id, "auto"),
+      ).rejects.toThrow("Snapshot fetch failed: HTTP 503");
+    } finally {
+      findRunningSpy.mockRestore();
     }
   });
 });
@@ -3054,6 +3146,36 @@ describe("ElizaSandboxService deletion-state guards (resume/wake/restart)", () =
       }
     });
   }
+
+  test("executeRestart propagates a transient fail-closed snapshot result", async () => {
+    const { ElizaSandboxService, SNAPSHOT_CAPTURE_TRANSIENT } = await import(
+      "./eliza-sandbox.ts?actual"
+    );
+    const svc = new ElizaSandboxService();
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(
+      row("running"),
+    );
+    const shutdownSpy = spyOn(svc, "shutdown").mockResolvedValue({
+      success: false,
+      retryable: true,
+      error: `Refusing to stop without a current backup: ${SNAPSHOT_CAPTURE_TRANSIENT}`,
+    });
+    const provisionSpy = spyOn(svc, "provision");
+    try {
+      const res = await svc.executeRestart(AGENT, ORG);
+      expect(res).toMatchObject({
+        success: false,
+        retryable: true,
+        containerStopped: false,
+        containerStarted: false,
+      });
+      expect(provisionSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      shutdownSpy.mockRestore();
+      provisionSpy.mockRestore();
+    }
+  });
 });
 
 describe("replacement lifecycle teardown is absence-proof", () => {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -492,6 +492,14 @@ export interface SnapshotResult {
  */
 export const SNAPSHOT_ENDPOINT_UNSUPPORTED = "Snapshot endpoint not supported by agent image";
 
+/**
+ * Transient pre-stop snapshot failure (agent returned 503 because its PGlite
+ * connection was closing while dumpDataDir() ran). Distinct from a hard 500 so
+ * a state-preserving restart can defer rather than permanently refuse to stop
+ * (2026-08-11 fleet incident: a 500 here wedged healthy agent restarts).
+ */
+export const SNAPSHOT_CAPTURE_TRANSIENT = "Snapshot capture temporarily unavailable";
+
 const MAX_BACKUPS = 10;
 const SHARED_RUNTIME_HISTORY_MAX_MESSAGES = 40;
 // Heartbeat probes the agent over the headscale tailnet. When idle the path
@@ -7264,7 +7272,10 @@ export class ElizaSandboxService {
 
   // Shutdown
 
-  async shutdown(agentId: string, orgId: string): Promise<{ success: boolean; error?: string }> {
+  async shutdown(
+    agentId: string,
+    orgId: string,
+  ): Promise<{ success: boolean; error?: string; retryable?: boolean }> {
     let snapshotAgentId: string | null = null;
     let captureUnsupported = false;
     let preShutdownSnapshot: {
@@ -7289,6 +7300,22 @@ export class ElizaSandboxService {
             "[agent-sandbox] Shutdown proceeding without capture: image has no snapshot endpoint",
             { agentId },
           );
+        } else if (message === SNAPSHOT_CAPTURE_TRANSIENT) {
+          // TRANSIENT (PGlite closing race): do NOT weaken the fail-closed
+          // guarantee — still refuse to stop — but mark the failure RETRYABLE so
+          // the restart/shutdown job re-attempts instead of treating a healthy
+          // agent as permanently un-capturable. On the next attempt PGlite is no
+          // longer mid-close and the capture succeeds (2026-08-11 fleet
+          // incident: opaque 500 here wedged healthy agents indefinitely).
+          logger.warn(
+            "[agent-sandbox] Shutdown deferred: pre-stop capture transiently unavailable, will retry",
+            { agentId },
+          );
+          return {
+            success: false,
+            retryable: true,
+            error: `Refusing to stop without a current backup: ${message}`,
+          };
         } else {
           // Fail CLOSED: stopping the container without a current capture
           // silently discards everything since the last backup. A shutdown
@@ -7894,6 +7921,7 @@ export class ElizaSandboxService {
     bridgeUrl?: string;
     healthUrl?: string;
     error?: string;
+    retryable?: boolean;
   }> {
     // Bail before shutdown()+provision() if the row is being deleted — restart
     // would otherwise flip a deletion_pending row to `stopped` and rebuild a
@@ -7920,6 +7948,10 @@ export class ElizaSandboxService {
         success: false,
         containerStopped: false,
         containerStarted: false,
+        // Propagate retryability: a transient pre-stop capture failure (PGlite
+        // closing race) must re-queue the restart, not permanently wedge a
+        // healthy agent (2026-08-11 fleet incident).
+        retryable: shutdownResult.retryable,
         error: shutdownResult.error ?? "Failed to stop sandbox before restart",
       };
     }
@@ -9956,6 +9988,14 @@ export class ElizaSandboxService {
       // cloud-agent template image does). Surface a recognizable sentinel so an
       // auto snapshot is skipped, not hard-failed-and-retried.
       throw new Error(SNAPSHOT_ENDPOINT_UNSUPPORTED);
+    }
+    if (res.status === 503) {
+      // TRANSIENT: the agent's PGlite was closing while dumpDataDir() ran (a
+      // teardown race, not corruption). Surface a recognizable sentinel so a
+      // state-preserving restart DEFERS instead of tripping the fail-closed
+      // "Refusing to stop without a current backup" gate on an opaque 500 and
+      // wedging a healthy agent (2026-08-11 fleet incident).
+      throw new Error(SNAPSHOT_CAPTURE_TRANSIENT);
     }
     if (!res.ok) {
       // #18228: the snapshot transfer failed somewhere between the agent's HTTP

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -480,6 +480,7 @@ export interface SnapshotResult {
   success: boolean;
   backup?: AgentSandboxBackup;
   error?: string;
+  retryable?: boolean;
 }
 
 /**
@@ -499,6 +500,7 @@ export const SNAPSHOT_ENDPOINT_UNSUPPORTED = "Snapshot endpoint not supported by
  * (2026-08-11 fleet incident: a 500 here wedged healthy agent restarts).
  */
 export const SNAPSHOT_CAPTURE_TRANSIENT = "Snapshot capture temporarily unavailable";
+const AGENT_SNAPSHOT_CAPTURE_TRANSIENT_CODE = "PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT";
 
 const MAX_BACKUPS = 10;
 const SHARED_RUNTIME_HISTORY_MAX_MESSAGES = 40;
@@ -6383,6 +6385,13 @@ export class ElizaSandboxService {
       if (message === SNAPSHOT_ENDPOINT_UNSUPPORTED) {
         return { success: false, error: SNAPSHOT_ENDPOINT_UNSUPPORTED };
       }
+      if (message === SNAPSHOT_CAPTURE_TRANSIENT) {
+        return {
+          success: false,
+          error: SNAPSHOT_CAPTURE_TRANSIENT,
+          retryable: true,
+        };
+      }
       throw error;
     }
 
@@ -9990,12 +9999,20 @@ export class ElizaSandboxService {
       throw new Error(SNAPSHOT_ENDPOINT_UNSUPPORTED);
     }
     if (res.status === 503) {
-      // TRANSIENT: the agent's PGlite was closing while dumpDataDir() ran (a
-      // teardown race, not corruption). Surface a recognizable sentinel so a
-      // state-preserving restart DEFERS instead of tripping the fail-closed
-      // "Refusing to stop without a current backup" gate on an opaque 500 and
-      // wedging a healthy agent (2026-08-11 fleet incident).
-      throw new Error(SNAPSHOT_CAPTURE_TRANSIENT);
+      let payload: { code?: unknown } | null = null;
+      try {
+        payload = (await res.clone().json()) as { code?: unknown };
+      } catch {
+        // error-policy:J3 an invalid upstream error body is not the structured
+        // transient signal and therefore follows the ordinary HTTP failure.
+        payload = null;
+      }
+      if (payload?.code === AGENT_SNAPSHOT_CAPTURE_TRANSIENT_CODE) {
+        // TRANSIENT: only the agent's structured PGlite-closing code defers a
+        // state-preserving restart. Unrelated runtime/proxy 503 responses keep
+        // the ordinary failure path and bounded attempt policy.
+        throw new Error(SNAPSHOT_CAPTURE_TRANSIENT);
+      }
     }
     if (!res.ok) {
       // #18228: the snapshot transfer failed somewhere between the agent's HTTP

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
@@ -668,6 +668,33 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
     }
   });
 
+  test("agent_restart transient snapshot failure → requeued without burning an attempt", async () => {
+    const ctx = harness(makeJob(JOB_TYPES.AGENT_RESTART));
+    stub("executeRestart", {
+      success: false,
+      retryable: true,
+      containerStopped: false,
+      containerStarted: false,
+      error: "Refusing to stop without a current backup: Snapshot capture temporarily unavailable",
+    });
+    try {
+      const res = await run(JOB_TYPES.AGENT_RESTART);
+      expect(res).toMatchObject({ retried: 1, failed: 0 });
+      expect(ctx.retryLaterSpy).toHaveBeenCalledTimes(1);
+      expect(ctx.retryLaterSpy.mock.calls[0]?.[1]).toContain(
+        "Snapshot capture temporarily unavailable",
+      );
+      expect(ctx.incrementSpy).not.toHaveBeenCalled();
+    } finally {
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
   test("retryable transport lost to another worker is not reported as requeued", async () => {
     const ctx = harness(makeJob(JOB_TYPES.AGENT_PROVISION));
     ctx.retryLaterSpy.mockResolvedValue(undefined);
@@ -734,6 +761,33 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
         skipped: true,
         reason: "Sandbox is not running",
       });
+      expect(ctx.incrementSpy).not.toHaveBeenCalled();
+    } finally {
+      disarmGate();
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
+  test("agent_snapshot transient capture failure → requeued without burning an attempt", async () => {
+    const ctx = harness(makeJob(JOB_TYPES.AGENT_SNAPSHOT, { snapshotType: "auto" }));
+    const disarmGate = armSnapshotGateFor(JOB_TYPES.AGENT_SNAPSHOT);
+    stub("executeSnapshot", {
+      success: false,
+      retryable: true,
+      error: "Snapshot capture temporarily unavailable",
+    });
+    try {
+      const res = await run(JOB_TYPES.AGENT_SNAPSHOT);
+      expect(res).toMatchObject({ retried: 1, failed: 0 });
+      expect(ctx.retryLaterSpy).toHaveBeenCalledTimes(1);
+      expect(ctx.retryLaterSpy.mock.calls[0]?.[1]).toContain(
+        "Snapshot capture temporarily unavailable",
+      );
       expect(ctx.incrementSpy).not.toHaveBeenCalled();
     } finally {
       disarmGate();

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -3997,6 +3997,11 @@ export class ProvisioningJobService {
           error: result.error,
         }),
       });
+      if (result.retryable) {
+        throw new RetryableProvisionTransportError(
+          result.error ?? "Snapshot capture temporarily unavailable",
+        );
+      }
       throw new Error(result.error ?? "Unknown agent_restart failure");
     }
 
@@ -4793,6 +4798,11 @@ export class ProvisioningJobService {
           error: result.error,
         }),
       });
+      if (result.retryable) {
+        throw new RetryableProvisionTransportError(
+          result.error ?? "Snapshot capture temporarily unavailable",
+        );
+      }
       throw new Error(result.error ?? "Unknown agent_snapshot failure");
     }
 

--- a/plugins/plugin-sql/src/__tests__/pglite-adapter-liveness.test.ts
+++ b/plugins/plugin-sql/src/__tests__/pglite-adapter-liveness.test.ts
@@ -35,6 +35,7 @@ function makeAdapter() {
   };
   const manager = {
     close: vi.fn(async () => undefined),
+    dumpDataDir: vi.fn(async () => new Blob(["snapshot"])),
     ensureSync: vi.fn(async () => undefined),
     getConnection: vi.fn(() => rawConnection),
     initialize: vi.fn(async () => undefined),
@@ -78,6 +79,8 @@ describe("PgliteDatabaseAdapter liveness", () => {
     await expect(adapter.init()).resolves.toBeUndefined();
     await expect(adapter.getConnection()).resolves.toBe(db);
     expect(adapter.getRawConnection()).toBe(rawConnection);
+    await expect(adapter.dumpPgliteDataDir("gzip")).resolves.toBeInstanceOf(Blob);
+    expect(manager.dumpDataDir).toHaveBeenCalledWith("gzip");
     await expect(
       adapter.withEntityContext(null, async (tx) => {
         expect(tx).toBe(db);

--- a/plugins/plugin-sql/src/__tests__/pglite-lifecycle-serialization.test.ts
+++ b/plugins/plugin-sql/src/__tests__/pglite-lifecycle-serialization.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Proves the production PGlite manager serializes data-directory snapshots
+ * with client teardown so neither operation can observe a half-closed handle.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PGliteClientManager } from "../pglite/manager";
+
+describe("PGlite snapshot lifecycle serialization", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lets an admitted dump finish before close reaches the client", async () => {
+    const manager = new PGliteClientManager({ dataDir: "memory://" });
+    const client = manager.getConnection();
+    let releaseDump!: (value: Blob) => void;
+    const dumpSpy = vi.spyOn(client, "dumpDataDir").mockImplementation(
+      async () =>
+        await new Promise<Blob>((resolve) => {
+          releaseDump = resolve;
+        })
+    );
+    const closeSpy = vi.spyOn(client, "close").mockResolvedValue(undefined);
+
+    const dumpPromise = manager.dumpDataDir("gzip");
+    const closePromise = manager.close();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(dumpSpy).toHaveBeenCalledTimes(1);
+    expect(closeSpy).not.toHaveBeenCalled();
+
+    releaseDump(new Blob(["snapshot"]));
+    await expect(dumpPromise).resolves.toBeInstanceOf(Blob);
+    await expect(closePromise).resolves.toBeUndefined();
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a dump admitted after close without touching the client", async () => {
+    const manager = new PGliteClientManager({ dataDir: "memory://" });
+    const client = manager.getConnection();
+    const dumpSpy = vi.spyOn(client, "dumpDataDir");
+    const closeSpy = vi.spyOn(client, "close").mockResolvedValue(undefined);
+
+    const closePromise = manager.close();
+    await expect(manager.dumpDataDir("gzip")).rejects.toThrow("PGlite is closing");
+    await expect(closePromise).resolves.toBeUndefined();
+    expect(dumpSpy).not.toHaveBeenCalled();
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-sql/src/pglite/adapter.ts
+++ b/plugins/plugin-sql/src/pglite/adapter.ts
@@ -152,6 +152,10 @@ export class PgliteDatabaseAdapter extends BaseDrizzleAdapter {
     return this.manager.getConnection();
   }
 
+  async dumpPgliteDataDir(compression: "gzip" = "gzip"): Promise<File | Blob> {
+    return await this.manager.dumpDataDir(compression);
+  }
+
   // ── Electric write-back notification overrides ─────────────────────────
   // Each override calls super[method] then fires manager.notifyWrite() so the
   // WriteBackService (Pattern 1 — Online Writes) can forward the change to the

--- a/plugins/plugin-sql/src/pglite/manager.ts
+++ b/plugins/plugin-sql/src/pglite/manager.ts
@@ -132,6 +132,8 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
   private shuttingDown = false;
   private initialized = false;
   private initializePromise: Promise<void> | null = null;
+  private lifecycleTail: Promise<void> = Promise.resolve();
+  private closePromise: Promise<void> | null = null;
   private lockFd: number | null = null;
   private lockPath: string | null = null;
   private syncUrl: string | null;
@@ -184,6 +186,32 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
 
   public getConnection(): PGlite {
     return this.client;
+  }
+
+  /**
+   * Capture the live PGlite data directory without racing client teardown.
+   * Once close has begun, new captures fail explicitly instead of touching a
+   * monotonically closing handle.
+   */
+  public async dumpDataDir(compression: "gzip" = "gzip"): Promise<File | Blob> {
+    if (this.shuttingDown) {
+      throw new Error("PGlite is closing");
+    }
+    return await this.withLifecycleLock(async () => await this.client.dumpDataDir(compression));
+  }
+
+  private async withLifecycleLock<T>(operation: () => Promise<T>): Promise<T> {
+    const predecessor = this.lifecycleTail;
+    let release!: () => void;
+    this.lifecycleTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await predecessor;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
   }
 
   /**
@@ -254,7 +282,16 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
   }
 
   public async close(): Promise<void> {
-    this.shuttingDown = true;
+    if (!this.closePromise) {
+      this.shuttingDown = true;
+      this.closePromise = this.withLifecycleLock(async () => {
+        await this.closeInternal();
+      });
+    }
+    await this.closePromise;
+  }
+
+  private async closeInternal(): Promise<void> {
     // Flush pending write-backs before tearing down.
     if (this.writeBack.enabled) {
       try {


### PR DESCRIPTION
## Problem

During restart/teardown churn, PGlite `dumpDataDir()` could race the production manager's `close()`. The agent returned an opaque 500, cloud shutdown correctly refused to stop without a current capture, but both restart and scheduled-snapshot jobs consumed their finite attempts and became permanently failed.

The original PR recognized the PGlite error and propagated a `retryable` field through `executeRestart()`, but the durable job consumer discarded that field. It also retried the same monotonically closing raw PGlite object through an optional `runExclusive` method that the production adapter does not expose, and treated every snapshot HTTP 503 as this incident.

## Root fix

- add a production `PGliteClientManager.dumpDataDir()` operation guarded by the same lifecycle lock as `close()`
- if capture enters first, close waits until the dump completes; if close enters first, capture refuses without touching the closing client
- expose that operation through `PgliteDatabaseAdapter` and make agent backup use it instead of inventing a method on the raw PGlite handle
- narrow the closing-error matcher so unrelated errors containing “closing” remain hard failures
- return a structured `PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT` code from the agent; cloud classifies only that code, while unrelated/runtime/proxy 503s remain ordinary failures
- preserve the fail-closed invariant: transient pre-stop capture failure never stops the container
- translate retryable restart **and scheduled snapshot** results into the queue's recognized retryable transport error, returning each job to `pending` without incrementing attempts
- prove the `POST /api/snapshot` transient/terminal split at the real HTTP boundary: a booted `AgentRuntime` + TCP API server returns 503 with the structured transient code for the closing race and a terminal 500 (no transient code) for a genuine dump failure

## Validation

Exact head: `5321a26c45ea3b086baf4edcd67749d4c86c6ffd` (validation runs recorded at pre-rebase content-identical head `0460e4c8665`)

- agent backup suite: **25/25 pass**
- `POST /api/snapshot` real-server HTTP boundary suite (`snapshot-route-transient.test.ts`): **2/2 pass**
- cloud structured-503, shutdown, restart, and snapshot-job suites (`eliza-sandbox.test.ts` + `provisioning-jobs-execute-dispatch.test.ts`): **224/224 pass**
- production PGlite manager/adapter lifecycle tests: **5/5 pass**
- `packages/agent` typecheck: pass
- `packages/cloud/shared` typecheck: pass
- `plugins/plugin-sql` typecheck: pass
- Biome on all touched files: pass
- `git diff --check`: clean

The concurrency tests control both orderings and prove dump and client close never overlap. Queue tests prove neither restart nor scheduled-snapshot transient failures call `incrementAttempt`. The HTTP-boundary suite boots the real server (only the database adapter is a stub) and asserts both the retryable and the fail-closed response shapes end to end.

## Evidence

<!-- evidence-head:5321a26c45ea3b086baf4edcd67749d4c86c6ffd -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - backend lifecycle and queue repair has no user interface.

<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - backend lifecycle and queue repair has no user interface.

<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - deterministic backend tests provide the relevant concurrency proof; no interactive surface exists.

<!-- evidence-row:backend-logs -->
- [x] [exact-head root-cause test report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18521-pr18521-root-cause-tests-v3.txt); fresh runs at content-identical head `0460e4c8665` (rebased to `5321a26c45e` before merge with no PR-file changes):

  <details><summary>agent-backup + HTTP-boundary suites (vitest, packages/agent)</summary>

  ```text
  $ bunx vitest run src/services/agent-backup.test.ts
   Test Files  1 passed (1)
        Tests  25 passed (25)
     Start at  22:33:48
     Duration  9.01s (transform 6.77s, setup 83ms, import 8.60s, tests 140ms, environment 0ms)

  $ bunx vitest run src/api/snapshot-route-transient.test.ts
   Test Files  1 passed (1)
        Tests  2 passed (2)
     Start at  22:32:14
     Duration  14.58s (transform 11.00s, setup 102ms, import 13.97s, tests 326ms, environment 0ms)
  ```

  </details>

  <details><summary>cloud sandbox + provisioning-job suites (bun test, packages/cloud/shared)</summary>

  ```text
  $ node scripts/run-bun-tests.mjs src/lib/services/eliza-sandbox.test.ts src/lib/services/provisioning-jobs-execute-dispatch.test.ts
   224 pass
   0 fail
   1599 expect() calls
  Ran 224 tests across 2 files. [58.40s]
  ```

  </details>

  <details><summary>PGlite lifecycle tests (vitest, plugins/plugin-sql) + typechecks</summary>

  ```text
  $ bunx vitest run src/__tests__/pglite-adapter-liveness.test.ts src/__tests__/pglite-lifecycle-serialization.test.ts
   Test Files  2 passed (2)
        Tests  5 passed (5)
     Start at  22:33:37
     Duration  9.68s

  $ bun run --cwd packages/agent typecheck        # exit 0
  $ bun run --cwd packages/cloud/shared typecheck # exit 0
  $ bun run --cwd plugins/plugin-sql typecheck    # exit 0
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend implementation changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - snapshot and provisioning lifecycle code does not invoke a model.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no generated domain artifact is produced by this lifecycle repair.

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no visual artifact exists for this backend-only repair.

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS repository review workflow
Attribution status: maintainer review and root-cause remediation recorded
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/repository-review"} -->

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5 (maintainer remediation; system-reported model family, deployment variant unavailable); Anthropic / Claude Fable 5 (review-fix application and HTTP-boundary test)
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop; Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: N/A - installed Codex plugin packages do not expose a repository commit SHA
<!-- attribution-row:status -->
- Provenance status: self-reported
