### PR TITLE
fix(google-workspace): require explicit least-privilege OAuth scopes

### DIFF
--- a/packages/ui/src/components/connectors/ConnectorAccountCard.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountCard.tsx
@@ -35,6 +35,10 @@ import { Spinner } from "../ui/spinner";
 import { StatusBadge } from "../ui/status-badge";
 import { ConnectorAccountPrivacySelector } from "./ConnectorAccountPrivacySelector";
 import { ConnectorAccountPurposeSelector } from "./ConnectorAccountPurposeSelector";
+import {
+  GOOGLE_WORKSPACE_CAPABILITY_OPTIONS,
+  googleWorkspaceCapabilitiesFromAccountMetadata,
+} from "./google-workspace-capabilities";
 
 export interface ConnectorAccountCardProps {
   account: ConnectorAccountRecord;
@@ -165,6 +169,16 @@ export function ConnectorAccountCard({
   const status = deriveStatus(account.status, t);
   const displayHandle = account.handle ?? account.externalId ?? null;
   const enabled = account.enabled !== false;
+  const grantedGoogleCapabilities =
+    account.provider === "google"
+      ? googleWorkspaceCapabilitiesFromAccountMetadata(account.metadata)
+      : [];
+  const grantedGoogleCapabilityLabels = grantedGoogleCapabilities.map((id) => {
+    const option = GOOGLE_WORKSPACE_CAPABILITY_OPTIONS.find(
+      (entry) => entry.id === id,
+    );
+    return option?.label ?? id;
+  });
 
   const handleDelete = () => {
     void deleteModal.submit(() => Promise.resolve(onDelete()));
@@ -228,6 +242,19 @@ export function ConnectorAccountCard({
               </span>
             ) : null}
           </div>
+          {grantedGoogleCapabilityLabels.length > 0 ? (
+            <div className="flex flex-wrap gap-1 pt-1">
+              {grantedGoogleCapabilityLabels.map((label) => (
+                <Badge
+                  key={label}
+                  variant="outline"
+                  className="text-[10px] font-normal"
+                >
+                  {label}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
         </div>
 
         <div className="flex shrink-0 flex-wrap items-center gap-1.5">

--- a/packages/ui/src/components/connectors/ConnectorAccountList.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountList.tsx
@@ -10,6 +10,7 @@ import { Plus } from "lucide-react";
 import { useEffect, useMemo } from "react";
 import type {
   ConnectorAccountCreateInput,
+  ConnectorAccountOAuthStartInput,
   ConnectorAccountRecord,
   ConnectorAccountRole,
 } from "../../api/client-agent";
@@ -69,6 +70,10 @@ export interface ConnectorAccountListProps {
    * before, preserving the legacy single-list behavior.
    */
   externalAccounts?: UseConnectorAccountsResult;
+  /** When false, the OAuth add-account button is disabled. */
+  canStartOAuth?: boolean;
+  /** Optional OAuth body factory merged into the start request. */
+  resolveOAuthStartInput?: () => ConnectorAccountOAuthStartInput;
 }
 
 function sortConnectorAccounts(
@@ -126,6 +131,8 @@ export function ConnectorAccountList({
   onAddAccount,
   accountRole,
   externalAccounts,
+  canStartOAuth = true,
+  resolveOAuthStartInput,
 }: ConnectorAccountListProps) {
   // When the caller hoists the accounts hook (e.g. `OwnerAgentConnectorSetupPanel`),
   // skip the internal polling instance — Rules of Hooks require the call
@@ -181,8 +188,11 @@ export function ConnectorAccountList({
       accountRole && accountRole !== CONNECTOR_UNKNOWN_ROLE_BUCKET
         ? accountRole
         : "OWNER";
+    const oauthStart = resolveOAuthStartInput?.() ?? {};
     const result = await connectorAccounts.startOAuth({
+      ...oauthStart,
       metadata: {
+        ...oauthStart.metadata,
         requestedRole,
         privacy: requestedRole === "OWNER" ? "owner_only" : "team_visible",
       },
@@ -193,6 +203,7 @@ export function ConnectorAccountList({
   const addBusy =
     connectorAccounts.saving.has(`add:${provider}:${connectorId}`) ||
     connectorAccounts.saving.has(`oauth:${provider}:${connectorId}:new`);
+  const addDisabled = addBusy || !canStartOAuth;
 
   return (
     <div
@@ -210,7 +221,7 @@ export function ConnectorAccountList({
             type="button"
             variant="default"
             size="sm"
-            disabled={addBusy}
+            disabled={addDisabled}
             onClick={() => void handleAdd()}
             className="h-8 gap-1 px-2.5 text-xs"
           >

--- a/packages/ui/src/components/connectors/ConnectorSetupPanel.tsx
+++ b/packages/ui/src/components/connectors/ConnectorSetupPanel.tsx
@@ -20,6 +20,7 @@ import {
 import { useConnectorChannelMode } from "./connector-channel-mode";
 import { resolveConnectorSetupPanelToken } from "./connector-setup-panel-registry";
 import { DiscordLocalConnectorPanel } from "./DiscordLocalConnectorPanel";
+import { GoogleConnectorSetupPanel } from "./GoogleConnectorSetupPanel";
 import { IMessageStatusPanel } from "./IMessageStatusPanel";
 import { OwnerAgentConnectorSetupPanel } from "./OwnerAgentConnectorSetupPanel";
 import { SignalQrOverlay } from "./SignalQrOverlay";
@@ -35,6 +36,17 @@ function ConnectorAccountManagementPanel({
   connectorId: string;
 }) {
   const channelMode = useConnectorChannelMode();
+  const isGoogle = provider === "google" || connectorId === "google";
+
+  if (isGoogle) {
+    return (
+      <GoogleConnectorSetupPanel
+        provider={provider}
+        connectorId={connectorId}
+      />
+    );
+  }
+
   const option =
     getConnectorPluginManagedAccountOption(connectorId) ??
     getConnectorPluginManagedAccountOption(provider);

--- a/packages/ui/src/components/connectors/GoogleConnectorSetupPanel.tsx
+++ b/packages/ui/src/components/connectors/GoogleConnectorSetupPanel.tsx
@@ -1,0 +1,66 @@
+/**
+ * Google Workspace connector setup: explicit capability selection before OAuth
+ * and owner/agent account lists that pass the selected capability ids as scopes.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import type { ConnectorAccountOAuthStartInput } from "../../api/client-agent";
+import { useConnectorChannelMode } from "./connector-channel-mode";
+import { GoogleWorkspaceCapabilityPicker } from "./GoogleWorkspaceCapabilityPicker";
+import {
+  type GoogleWorkspaceCapabilityId,
+  normalizeGoogleWorkspaceCapabilitySelection,
+} from "./google-workspace-capabilities";
+import { OwnerAgentConnectorSetupPanel } from "./OwnerAgentConnectorSetupPanel";
+
+export interface GoogleConnectorSetupPanelProps {
+  provider?: string;
+  connectorId?: string;
+  className?: string;
+}
+
+export function GoogleConnectorSetupPanel({
+  provider = "google",
+  connectorId = provider,
+  className,
+}: GoogleConnectorSetupPanelProps) {
+  const channelMode = useConnectorChannelMode();
+  const [selectedCapabilities, setSelectedCapabilities] = useState<
+    GoogleWorkspaceCapabilityId[]
+  >([]);
+
+  const oauthScopes = useMemo(
+    () => normalizeGoogleWorkspaceCapabilitySelection(selectedCapabilities),
+    [selectedCapabilities],
+  );
+
+  const resolveOAuthStartInput = useCallback(
+    (): ConnectorAccountOAuthStartInput => ({
+      scopes: [...oauthScopes],
+      metadata: {
+        requestedCapabilities: [...oauthScopes],
+      },
+    }),
+    [oauthScopes],
+  );
+
+  return (
+    <div className={className}>
+      <GoogleWorkspaceCapabilityPicker
+        selected={oauthScopes}
+        onChange={setSelectedCapabilities}
+        className="mb-3"
+      />
+      <OwnerAgentConnectorSetupPanel
+        provider={provider}
+        connectorId={connectorId}
+        enableOwner={channelMode === "delegate"}
+        enableAgent={channelMode === "bot"}
+        enableTeam
+        description="Connect a Google account with only the capabilities selected above."
+        canStartOAuth={oauthScopes.length > 0}
+        resolveOAuthStartInput={resolveOAuthStartInput}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/connectors/GoogleWorkspaceCapabilityPicker.tsx
+++ b/packages/ui/src/components/connectors/GoogleWorkspaceCapabilityPicker.tsx
@@ -1,0 +1,140 @@
+/**
+ * Explicit Google Workspace capability picker for connector OAuth starts.
+ * The selected capability ids are sent as `scopes` on the OAuth start request.
+ */
+
+import { useMemo } from "react";
+import { cn } from "../../lib/utils";
+import { useTranslation } from "../../state/TranslationContext.hooks";
+import { Checkbox } from "../ui/checkbox";
+import { Label } from "../ui/label";
+import {
+  GOOGLE_WORKSPACE_CAPABILITY_GROUPS,
+  GOOGLE_WORKSPACE_CAPABILITY_OPTIONS,
+  type GoogleWorkspaceCapabilityGroup,
+  type GoogleWorkspaceCapabilityId,
+  googleWorkspaceCapabilityGroupLabel,
+} from "./google-workspace-capabilities";
+
+export interface GoogleWorkspaceCapabilityPickerProps {
+  selected: readonly GoogleWorkspaceCapabilityId[];
+  onChange: (next: GoogleWorkspaceCapabilityId[]) => void;
+  className?: string;
+  disabled?: boolean;
+}
+
+export function GoogleWorkspaceCapabilityPicker({
+  selected,
+  onChange,
+  className,
+  disabled = false,
+}: GoogleWorkspaceCapabilityPickerProps) {
+  const { t } = useTranslation();
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+  const grouped = useMemo(() => {
+    const buckets = new Map<
+      GoogleWorkspaceCapabilityGroup,
+      typeof GOOGLE_WORKSPACE_CAPABILITY_OPTIONS
+    >();
+    for (const group of GOOGLE_WORKSPACE_CAPABILITY_GROUPS) {
+      buckets.set(
+        group,
+        GOOGLE_WORKSPACE_CAPABILITY_OPTIONS.filter(
+          (option) => option.group === group,
+        ),
+      );
+    }
+    return buckets;
+  }, []);
+
+  const toggle = (
+    capabilityId: GoogleWorkspaceCapabilityId,
+    checked: boolean,
+  ) => {
+    if (disabled) return;
+    const next = new Set(selectedSet);
+    if (checked) next.add(capabilityId);
+    else next.delete(capabilityId);
+    onChange([...next]);
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 rounded-sm border border-border/40 bg-card/20 p-3",
+        className,
+      )}
+    >
+      <div className="space-y-1">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-muted">
+          {t("connectors.google.capabilities.title", {
+            defaultValue: "Requested capabilities",
+          })}
+        </h3>
+        <p className="text-xs text-muted">
+          {t("connectors.google.capabilities.description", {
+            defaultValue:
+              "Choose the Google products this connection may access. At least one capability is required before starting OAuth.",
+          })}
+        </p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        {GOOGLE_WORKSPACE_CAPABILITY_GROUPS.map((group) => {
+          const options = grouped.get(group) ?? [];
+          return (
+            <section
+              key={group}
+              className="rounded-sm border border-border/35 bg-bg-accent/30 p-3"
+              aria-label={googleWorkspaceCapabilityGroupLabel(group)}
+            >
+              <h4 className="mb-2 text-xs font-semibold text-foreground">
+                {googleWorkspaceCapabilityGroupLabel(group)}
+              </h4>
+              <ul className="flex flex-col gap-2">
+                {options.map((option) => {
+                  const inputId = `google-capability-${option.id}`;
+                  const checked = selectedSet.has(option.id);
+                  return (
+                    <li key={option.id}>
+                      <div className="flex items-start gap-2">
+                        <Checkbox
+                          id={inputId}
+                          checked={checked}
+                          disabled={disabled}
+                          onCheckedChange={(value) =>
+                            toggle(option.id, value === true)
+                          }
+                        />
+                        <div className="space-y-0.5">
+                          <Label
+                            htmlFor={inputId}
+                            className="text-xs font-medium leading-none"
+                          >
+                            {option.label}
+                          </Label>
+                          <p className="text-[11px] leading-snug text-muted">
+                            {option.description}
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          );
+        })}
+      </div>
+
+      {selected.length === 0 ? (
+        <p className="text-xs text-destructive">
+          {t("connectors.google.capabilities.required", {
+            defaultValue:
+              "Select at least one Gmail, Calendar, Drive, or Meet capability.",
+          })}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/components/connectors/OwnerAgentConnectorSetupPanel.tsx
+++ b/packages/ui/src/components/connectors/OwnerAgentConnectorSetupPanel.tsx
@@ -19,6 +19,7 @@
 
 import type {
   ConnectorAccountCreateInput,
+  ConnectorAccountOAuthStartInput,
   ConnectorAccountRole,
 } from "../../api/client-agent";
 import { useConnectorAccounts } from "../../hooks/useConnectorAccounts";
@@ -50,6 +51,10 @@ export interface OwnerAgentConnectorSetupPanelProps {
   agentTitle?: string;
   /** Optional help text rendered above the two sections. */
   description?: string;
+  /** When false, OAuth add-account buttons stay disabled (e.g. missing scopes). */
+  canStartOAuth?: boolean;
+  /** Optional OAuth body factory merged into the start request (scopes/metadata). */
+  resolveOAuthStartInput?: () => ConnectorAccountOAuthStartInput;
 }
 
 export function OwnerAgentConnectorSetupPanel({
@@ -64,6 +69,8 @@ export function OwnerAgentConnectorSetupPanel({
   ownerTitle,
   agentTitle,
   description,
+  canStartOAuth = true,
+  resolveOAuthStartInput,
 }: OwnerAgentConnectorSetupPanelProps) {
   // Hoist the accounts hook to the panel so both the OWNER and AGENT lists
   // share a single polling instance + cache, instead of each calling the
@@ -92,6 +99,8 @@ export function OwnerAgentConnectorSetupPanel({
           title={ownerTitle}
           externalAccounts={accountsHook}
           onAddAccount={onAddAccount ? () => onAddAccount("OWNER") : undefined}
+          canStartOAuth={canStartOAuth}
+          resolveOAuthStartInput={resolveOAuthStartInput}
         />
       ) : null}
       {enableAgent ? (
@@ -102,6 +111,8 @@ export function OwnerAgentConnectorSetupPanel({
           title={agentTitle}
           externalAccounts={accountsHook}
           onAddAccount={onAddAccount ? () => onAddAccount("AGENT") : undefined}
+          canStartOAuth={canStartOAuth}
+          resolveOAuthStartInput={resolveOAuthStartInput}
         />
       ) : null}
       {enableTeam ? (
@@ -111,6 +122,8 @@ export function OwnerAgentConnectorSetupPanel({
           accountRole="TEAM"
           externalAccounts={accountsHook}
           onAddAccount={onAddAccount ? () => onAddAccount("TEAM") : undefined}
+          canStartOAuth={canStartOAuth}
+          resolveOAuthStartInput={resolveOAuthStartInput}
         />
       ) : null}
       {hasUnknownRoleAccounts ? (

--- a/packages/ui/src/components/connectors/google-workspace-capabilities.test.ts
+++ b/packages/ui/src/components/connectors/google-workspace-capabilities.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Contract tests for the browser-safe Google Workspace capability catalog used
+ * by connector OAuth UI.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  GOOGLE_WORKSPACE_CAPABILITY_OPTIONS,
+  googleWorkspaceCapabilitiesFromAccountMetadata,
+  normalizeGoogleWorkspaceCapabilitySelection,
+} from "./google-workspace-capabilities";
+
+describe("google-workspace-capabilities", () => {
+  it("deduplicates and ignores unknown capability ids", () => {
+    expect(
+      normalizeGoogleWorkspaceCapabilitySelection([
+        "gmail.read",
+        "gmail.read",
+        "calendar.read",
+        "unknown.capability",
+      ]),
+    ).toEqual(["gmail.read", "calendar.read"]);
+  });
+
+  it("reads granted capabilities from connected account metadata", () => {
+    expect(
+      googleWorkspaceCapabilitiesFromAccountMetadata({
+        grantedCapabilities: ["gmail.read", "calendar.read", "drive.write"],
+      }),
+    ).toEqual(["gmail.read", "calendar.read", "drive.write"]);
+  });
+
+  it("covers every supported Google Workspace capability id", () => {
+    expect(
+      GOOGLE_WORKSPACE_CAPABILITY_OPTIONS.map((option) => option.id),
+    ).toEqual([
+      "gmail.read",
+      "gmail.send",
+      "gmail.manage",
+      "calendar.read",
+      "calendar.write",
+      "drive.read",
+      "drive.write",
+      "meet.create",
+      "meet.read",
+    ]);
+  });
+});

--- a/packages/ui/src/components/connectors/google-workspace-capabilities.ts
+++ b/packages/ui/src/components/connectors/google-workspace-capabilities.ts
@@ -1,0 +1,140 @@
+/**
+ * Browser-safe Google Workspace capability catalog for connector OAuth UI.
+ * Capability ids mirror `@elizaos/plugin-google-workspace` `GOOGLE_CAPABILITIES`.
+ */
+
+export const GOOGLE_WORKSPACE_CAPABILITY_GROUPS = [
+  "gmail",
+  "calendar",
+  "drive",
+  "meet",
+] as const;
+
+export type GoogleWorkspaceCapabilityGroup =
+  (typeof GOOGLE_WORKSPACE_CAPABILITY_GROUPS)[number];
+
+export type GoogleWorkspaceCapabilityId =
+  | "gmail.read"
+  | "gmail.send"
+  | "gmail.manage"
+  | "calendar.read"
+  | "calendar.write"
+  | "drive.read"
+  | "drive.write"
+  | "meet.create"
+  | "meet.read";
+
+export interface GoogleWorkspaceCapabilityOption {
+  id: GoogleWorkspaceCapabilityId;
+  group: GoogleWorkspaceCapabilityGroup;
+  label: string;
+  description: string;
+}
+
+export const GOOGLE_WORKSPACE_CAPABILITY_OPTIONS: readonly GoogleWorkspaceCapabilityOption[] =
+  [
+    {
+      id: "gmail.read",
+      group: "gmail",
+      label: "Read Gmail",
+      description: "Search and read Gmail message metadata and bodies.",
+    },
+    {
+      id: "gmail.send",
+      group: "gmail",
+      label: "Send Gmail",
+      description: "Send email through Gmail for the selected account.",
+    },
+    {
+      id: "gmail.manage",
+      group: "gmail",
+      label: "Manage Gmail",
+      description:
+        "Modify Gmail labels, message state, and basic mail settings.",
+    },
+    {
+      id: "calendar.read",
+      group: "calendar",
+      label: "Read Calendar",
+      description: "List Google Calendar events for the selected account.",
+    },
+    {
+      id: "calendar.write",
+      group: "calendar",
+      label: "Write Calendar",
+      description: "Create and update Google Calendar events.",
+    },
+    {
+      id: "drive.read",
+      group: "drive",
+      label: "Read Drive",
+      description: "Search and read Google Drive file metadata.",
+    },
+    {
+      id: "drive.write",
+      group: "drive",
+      label: "Write Drive",
+      description:
+        "Create or update files opened or created by this integration.",
+    },
+    {
+      id: "meet.create",
+      group: "meet",
+      label: "Create Meet Spaces",
+      description:
+        "Create Google Meet spaces and end active conferences created by the user.",
+    },
+    {
+      id: "meet.read",
+      group: "meet",
+      label: "Read Meet Artifacts",
+      description:
+        "Read Google Meet spaces, conference records, participants, transcripts, and recordings.",
+    },
+  ];
+
+const GROUP_LABELS: Record<GoogleWorkspaceCapabilityGroup, string> = {
+  gmail: "Gmail",
+  calendar: "Calendar",
+  drive: "Drive",
+  meet: "Meet",
+};
+
+export function googleWorkspaceCapabilityGroupLabel(
+  group: GoogleWorkspaceCapabilityGroup,
+): string {
+  return GROUP_LABELS[group];
+}
+
+export function isGoogleWorkspaceCapabilityId(
+  value: unknown,
+): value is GoogleWorkspaceCapabilityId {
+  return (
+    typeof value === "string" &&
+    GOOGLE_WORKSPACE_CAPABILITY_OPTIONS.some((option) => option.id === value)
+  );
+}
+
+export function normalizeGoogleWorkspaceCapabilitySelection(
+  capabilities: Iterable<unknown>,
+): GoogleWorkspaceCapabilityId[] {
+  const normalized: GoogleWorkspaceCapabilityId[] = [];
+  const seen = new Set<GoogleWorkspaceCapabilityId>();
+  for (const candidate of capabilities) {
+    if (!isGoogleWorkspaceCapabilityId(candidate) || seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    normalized.push(candidate);
+  }
+  return normalized;
+}
+
+export function googleWorkspaceCapabilitiesFromAccountMetadata(
+  metadata: Record<string, unknown> | undefined,
+): GoogleWorkspaceCapabilityId[] {
+  if (!metadata) return [];
+  const granted = metadata.grantedCapabilities;
+  if (!Array.isArray(granted)) return [];
+  return normalizeGoogleWorkspaceCapabilitySelection(granted);
+}

--- a/plugins/plugin-google-workspace/src/connector-account-provider.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.ts
@@ -6,11 +6,11 @@
  * can list, create, patch, delete, and run the OAuth flow for Google accounts
  * using a single consolidated grant covering Gmail, Calendar, Drive, and Meet.
  *
- * Single OAuth grant per account: callers may pass `scopes` to the manager's
- * startOAuth to limit which capabilities are requested. By default all
- * capabilities (gmail.read+send+manage, calendar.read+write, drive.read+write,
- * meet.create+read) are requested; granted capabilities are recorded on the
- * returned account so downstream consumers know which surfaces are usable.
+ * Single OAuth grant per account: callers must pass an explicit `scopes`
+ * capability subset to the manager's startOAuth. Omitted or empty scope lists
+ * fail closed instead of expanding to every supported capability. Granted
+ * capabilities are recorded on the returned account so downstream consumers
+ * know which surfaces are usable.
  */
 
 import { createHash, randomBytes } from "node:crypto";
@@ -126,7 +126,14 @@ function readClientConfig(runtime: IAgentRuntime): {
 
 function normalizeRequestedCapabilities(scopes: readonly string[] | undefined): GoogleCapability[] {
   if (!scopes || scopes.length === 0) {
-    return [...GOOGLE_CAPABILITIES];
+    throw new ElizaError(
+      "Google OAuth requires an explicit Gmail, Calendar, Drive, or Meet capability selection.",
+      {
+        code: "GOOGLE_OAUTH_CAPABILITY_REQUIRED",
+        context: { scopes: scopes ?? null },
+        severity: "fatal",
+      }
+    );
   }
   // The caller passes either capability identifiers (e.g. "gmail.read") OR raw
   // OAuth scope URLs. Both shapes are accepted so the manager's startOAuth API

--- a/plugins/plugin-google-workspace/src/index.test.ts
+++ b/plugins/plugin-google-workspace/src/index.test.ts
@@ -153,6 +153,98 @@ describe("google plugin", () => {
     );
   });
 
+  it.each([
+    {
+      label: "omitted scopes",
+      scopes: undefined,
+    },
+    {
+      label: "empty scopes",
+      scopes: [],
+    },
+  ])("fails closed when OAuth start receives $label", async ({ scopes }) => {
+    const runtime = {
+      getSetting: (key: string) =>
+        ({
+          GOOGLE_CLIENT_ID: "google-client",
+          GOOGLE_CLIENT_SECRET: "google-secret",
+          GOOGLE_REDIRECT_URI: "http://localhost/oauth/google/callback",
+        })[key],
+      getService: () => null,
+    } as never;
+    const provider = createGoogleConnectorAccountProvider(runtime);
+
+    await expect(
+      provider.startOAuth?.(
+        {
+          provider: "google",
+          scopes,
+          flow: {
+            id: "flow-missing-capabilities",
+            provider: "google",
+            state: "state-missing-capabilities",
+            status: "pending",
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        },
+        {} as never
+      )
+    ).rejects.toThrow(
+      "Google OAuth requires an explicit Gmail, Calendar, Drive, or Meet capability selection."
+    );
+  });
+
+  it("derives a least-privilege connector OAuth URL from gmail.read and calendar.read", async () => {
+    const runtime = {
+      getSetting: (key: string) =>
+        ({
+          GOOGLE_CLIENT_ID: "google-client",
+          GOOGLE_CLIENT_SECRET: "google-secret",
+          GOOGLE_REDIRECT_URI: "http://localhost/oauth/google/callback",
+        })[key],
+      getService: () => null,
+    } as never;
+    const provider = createGoogleConnectorAccountProvider(runtime);
+
+    const result = await provider.startOAuth?.(
+      {
+        provider: "google",
+        scopes: ["gmail.read", "calendar.read"],
+        flow: {
+          id: "flow-gmail-calendar-read",
+          provider: "google",
+          state: "state-gmail-calendar-read",
+          status: "pending",
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      },
+      {} as never
+    );
+    const url = new URL(result?.authUrl ?? "");
+    const requestedScopes = new Set(
+      (url.searchParams.get("scope") ?? "").split(" ").filter(Boolean)
+    );
+
+    expect(requestedScopes).toEqual(
+      new Set([
+        GOOGLE_OAUTH_SCOPES.profile.openid,
+        GOOGLE_OAUTH_SCOPES.profile.email,
+        GOOGLE_OAUTH_SCOPES.profile.profile,
+        GOOGLE_OAUTH_SCOPES.gmail.read,
+        GOOGLE_OAUTH_SCOPES.calendar.read,
+      ])
+    );
+    expect(requestedScopes).not.toContain(GOOGLE_OAUTH_SCOPES.drive.read);
+    expect(requestedScopes).not.toContain(GOOGLE_OAUTH_SCOPES.drive.write);
+    expect(requestedScopes).not.toContain(GOOGLE_OAUTH_SCOPES.meet.create);
+    expect(requestedScopes).not.toContain(GOOGLE_OAUTH_SCOPES.meet.read);
+    expect(result?.metadata).toMatchObject({
+      requestedCapabilities: ["gmail.read", "calendar.read"],
+    });
+  });
+
   it("derives a least-privilege connector OAuth URL from calendar.read", async () => {
     const runtime = {
       getSetting: (key: string) =>


### PR DESCRIPTION
# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5 (maintainer verification and CI repair; original author model undeclared)
<!-- attribution-row:client -->
- Agent tooling: unknown - not declared by author
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

## Summary

Google Workspace OAuth connect no longer treats omitted or empty scope lists as authority expansion. Settings → Google now requires an explicit capability selection before starting OAuth, and the connector provider fails closed when scopes are missing.

Fixes #18454

## Problem

Settings → Google → Add account sent no scope subset. `normalizeRequestedCapabilities` in the Google connector provider returned every supported capability when `scopes` was omitted or empty, expanding Gmail + Calendar into Gmail, Calendar, Drive, and Meet.

## Changes

### Server (`@elizaos/plugin-google-workspace`)
- `startOAuth` rejects omitted/empty `scopes` with `GOOGLE_OAUTH_CAPABILITY_REQUIRED` instead of defaulting to all capabilities.
- Unknown scope values continue to be rejected; identity-only requests continue to fail closed.

### UI (`@elizaos/ui`)
- New Google connector setup panel with grouped capability checkboxes (Gmail, Calendar, Drive, Meet).
- Add account stays disabled until at least one capability is selected.
- OAuth start sends the selected capability ids as explicit `scopes` plus `requestedCapabilities` metadata.
- Connected Google accounts show granted capability badges on account cards.

## Tests

- `plugin-google-workspace`: fails closed on omitted and empty OAuth scopes; verifies Gmail + Calendar selection produces an authorization URL without Drive/Meet scopes.
- `packages/ui`: capability catalog normalization and metadata parsing.

## Verification

```bash
bun run --cwd plugins/plugin-google-workspace test
bun run --cwd packages/ui test -- src/components/connectors/google-workspace-capabilities.test.ts
bun run --cwd packages/ui typecheck
```

## Out of scope

- OAuth callback URL work tracked separately (#18455).
- No Google Console / secret / production changes.

<!-- evidence-head:69806f9864c68eed9d3ee03255a50ed61e71b574 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18522-google-panel-BEFORE-chromium.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18522-google-panel-chromium.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18522-walkthrough-fs.mp4

<!-- evidence-row:backend-logs -->
- [x] [18522-backend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18522-backend-logs.txt)

<!-- evidence-row:frontend-logs -->
- [x] [18522-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18522-frontend-logs.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-behavior change; the contract is enforced structurally server-side and pinned by deterministic tests

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the domain artifact is the Google authorization URL, asserted scope-by-scope in the backend test transcript

<!-- evidence-row:ocr-review -->
- [x] [18522-ocr.jsonl](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18522-ocr.jsonl)

