### PR TITLE
fix(google): unify LifeOps and Settings OAuth callback URL

### DIFF
--- a/packages/core/src/connectors/account-manager.test.ts
+++ b/packages/core/src/connectors/account-manager.test.ts
@@ -270,6 +270,25 @@ describe("ConnectorAccountManager", () => {
 		).rejects.toThrow(/already used|unknown|expired/i);
 	});
 
+	it("persists the canonical redirect URI selected by an OAuth provider", async () => {
+		const runtime = makeRuntime();
+		const manager = getConnectorAccountManager(runtime);
+		manager.registerProvider({
+			provider: "oauth-canonical",
+			startOAuth: () => ({
+				authUrl: "https://auth.example/start",
+				redirectUri:
+					"http://127.0.0.1:31437/api/connectors/example/oauth/callback",
+			}),
+		});
+
+		const flow = await manager.startOAuth("oauth-canonical");
+
+		expect(flow.redirectUri).toBe(
+			"http://127.0.0.1:31437/api/connectors/example/oauth/callback",
+		);
+	});
+
 	it("requires a verified owner-binding lookup for owner-bound policies", async () => {
 		const runtime = makeRuntime();
 		const manager = getConnectorAccountManager(runtime);

--- a/packages/core/src/connectors/account-manager.ts
+++ b/packages/core/src/connectors/account-manager.ts
@@ -113,6 +113,8 @@ export interface ConnectorOAuthStartRequest {
 
 export interface ConnectorOAuthStartResult {
 	authUrl: string;
+	/** Canonical callback selected by the provider when callers do not own it. */
+	redirectUri?: string;
 	expiresAt?: number;
 	codeVerifier?: string;
 	metadata?: Metadata;
@@ -1603,11 +1605,18 @@ export class ConnectorAccountManager extends Service {
 		}
 		const updated = await this.storage.updateOAuthFlow(providerId, flow.id, {
 			authUrl: result.authUrl,
+			redirectUri: result.redirectUri ?? flow.redirectUri,
 			expiresAt: result.expiresAt,
 			codeVerifier: result.codeVerifier,
 			metadata: result.metadata ?? flow.metadata,
 		});
-		return updated ?? { ...flow, authUrl: result.authUrl };
+		return (
+			updated ?? {
+				...flow,
+				authUrl: result.authUrl,
+				redirectUri: result.redirectUri ?? flow.redirectUri,
+			}
+		);
 	}
 
 	async getOAuthFlow(

--- a/plugins/plugin-google-workspace/src/connector-account-provider.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.ts
@@ -30,6 +30,10 @@ import {
   logger,
 } from "@elizaos/core";
 import { GOOGLE_OAUTH_PROVIDER_METADATA } from "./auth.js";
+import {
+  assertCanonicalGoogleOAuthRedirectUri,
+  resolveGoogleConnectorOAuthCallbackUrl,
+} from "./google-oauth-callback.js";
 import { persistConnectorCredentialRefs } from "./connector-credential-refs.js";
 import { createGmailMessageConnector } from "./gmail-message-connector.js";
 import {
@@ -115,8 +119,8 @@ function readClientConfig(runtime: IAgentRuntime): {
 } {
   const clientId = readSetting(runtime, "GOOGLE_CLIENT_ID");
   const clientSecret = readSetting(runtime, "GOOGLE_CLIENT_SECRET");
-  const redirectUri = readSetting(runtime, "GOOGLE_REDIRECT_URI");
-  if (!clientId || !clientSecret || !redirectUri) {
+  const redirectUri = resolveGoogleConnectorOAuthCallbackUrl(runtime);
+  if (!clientId || !clientSecret) {
     throw new Error(
       "Google OAuth requires GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and GOOGLE_REDIRECT_URI to be configured."
     );
@@ -415,7 +419,11 @@ export function createGoogleConnectorAccountProvider(
       _manager: ConnectorAccountManager
     ): Promise<ConnectorOAuthStartResult> => {
       const config = readClientConfig(runtime);
-      const redirectUri = request.redirectUri ?? config.redirectUri;
+      assertCanonicalGoogleOAuthRedirectUri(
+        config.redirectUri,
+        request.redirectUri,
+      );
+      const redirectUri = config.redirectUri;
       const capabilities = normalizeRequestedCapabilities(request.scopes);
       const oauthScopes = scopesForGoogleCapabilities(capabilities);
       const codeVerifier = createCodeVerifier();

--- a/plugins/plugin-google-workspace/src/connector-account-provider.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.ts
@@ -30,12 +30,9 @@ import {
   logger,
 } from "@elizaos/core";
 import { GOOGLE_OAUTH_PROVIDER_METADATA } from "./auth.js";
-import {
-  assertCanonicalGoogleOAuthRedirectUri,
-  resolveGoogleConnectorOAuthCallbackUrl,
-} from "./google-oauth-callback.js";
 import { persistConnectorCredentialRefs } from "./connector-credential-refs.js";
 import { createGmailMessageConnector } from "./gmail-message-connector.js";
+import { resolveGoogleConnectorOAuthCallbackUrl } from "./google-oauth-callback.js";
 import {
   GOOGLE_CAPABILITIES,
   GOOGLE_IDENTITY_SCOPES,
@@ -419,10 +416,6 @@ export function createGoogleConnectorAccountProvider(
       _manager: ConnectorAccountManager
     ): Promise<ConnectorOAuthStartResult> => {
       const config = readClientConfig(runtime);
-      assertCanonicalGoogleOAuthRedirectUri(
-        config.redirectUri,
-        request.redirectUri,
-      );
       const redirectUri = config.redirectUri;
       const capabilities = normalizeRequestedCapabilities(request.scopes);
       const oauthScopes = scopesForGoogleCapabilities(capabilities);
@@ -444,6 +437,7 @@ export function createGoogleConnectorAccountProvider(
 
       return {
         authUrl: `${GOOGLE_OAUTH_PROVIDER_METADATA.authorizationEndpoint}?${params.toString()}`,
+        redirectUri,
         codeVerifier,
         metadata: {
           ...request.metadata,

--- a/plugins/plugin-google-workspace/src/google-oauth-callback.test.ts
+++ b/plugins/plugin-google-workspace/src/google-oauth-callback.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression tests for the canonical Google connector OAuth callback contract:
+ * shared redirect URI between chat and Settings, and rejection of portless
+ * loopback INTERNAL_URL-style defaults.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  assessGoogleOAuthCallbackConfig,
+  assertCanonicalGoogleOAuthRedirectUri,
+  GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH,
+  isPortlessLoopbackRedirectUrl,
+  resolveGoogleConnectorOAuthCallbackUrl,
+} from "./google-oauth-callback.js";
+
+const CANONICAL =
+  "http://127.0.0.1:31437/api/connectors/google/oauth/callback";
+
+function runtimeWithRedirect(uri?: string) {
+  return {
+    getSetting: (key: string) =>
+      key === "GOOGLE_REDIRECT_URI" ? uri : undefined,
+  };
+}
+
+describe("google oauth callback contract", () => {
+  it("accepts a loopback callback with an explicit port", () => {
+    const assessment = assessGoogleOAuthCallbackConfig(
+      runtimeWithRedirect(CANONICAL),
+    );
+    expect(assessment.configured).toBe(true);
+    expect(assessment.redirectUri).toBe(CANONICAL);
+    expect(assessment.issues).toEqual([]);
+    expect(resolveGoogleConnectorOAuthCallbackUrl(runtimeWithRedirect(CANONICAL)))
+      .toBe(CANONICAL);
+  });
+
+  it("rejects a portless loopback callback derived from INTERNAL_URL", () => {
+    const portless =
+      "http://127.0.0.1/api/connectors/google/oauth/callback";
+    const assessment = assessGoogleOAuthCallbackConfig(
+      runtimeWithRedirect(portless),
+    );
+    expect(assessment.configured).toBe(false);
+    expect(assessment.issues.some((issue) => issue.code === "portless_loopback"))
+      .toBe(true);
+    expect(isPortlessLoopbackRedirectUrl(new URL(portless))).toBe(true);
+    expect(() =>
+      resolveGoogleConnectorOAuthCallbackUrl(runtimeWithRedirect(portless)),
+    ).toThrow(/portless loopback/i);
+  });
+
+  it("rejects a missing redirect URI", () => {
+    const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect());
+    expect(assessment.configured).toBe(false);
+    expect(assessment.issues[0]?.code).toBe("missing");
+  });
+
+  it("rejects a callback on the wrong path", () => {
+    const assessment = assessGoogleOAuthCallbackConfig(
+      runtimeWithRedirect("http://127.0.0.1:31437/oauth/google/callback"),
+    );
+    expect(assessment.configured).toBe(false);
+    expect(assessment.issues.some((issue) => issue.code === "wrong_path"))
+      .toBe(true);
+    expect(GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH).toBe(
+      "/api/connectors/google/oauth/callback",
+    );
+  });
+
+  it("allows production https callbacks without an explicit port", () => {
+    const production =
+      "https://eliza.example/api/connectors/google/oauth/callback";
+    const assessment = assessGoogleOAuthCallbackConfig(
+      runtimeWithRedirect(production),
+    );
+    expect(assessment.configured).toBe(true);
+    expect(isPortlessLoopbackRedirectUrl(new URL(production))).toBe(false);
+  });
+
+  it("rejects a requested redirect URI that disagrees with the canonical value", () => {
+    expect(() =>
+      assertCanonicalGoogleOAuthRedirectUri(
+        CANONICAL,
+        "http://127.0.0.1/api/connectors/google/oauth/callback",
+      ),
+    ).toThrow(/redirect uri mismatch/i);
+    assertCanonicalGoogleOAuthRedirectUri(CANONICAL, CANONICAL);
+    assertCanonicalGoogleOAuthRedirectUri(CANONICAL, undefined);
+  });
+});

--- a/plugins/plugin-google-workspace/src/google-oauth-callback.test.ts
+++ b/plugins/plugin-google-workspace/src/google-oauth-callback.test.ts
@@ -6,47 +6,37 @@
 import { describe, expect, it } from "vitest";
 import {
   assessGoogleOAuthCallbackConfig,
-  assertCanonicalGoogleOAuthRedirectUri,
   GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH,
   isPortlessLoopbackRedirectUrl,
   resolveGoogleConnectorOAuthCallbackUrl,
 } from "./google-oauth-callback.js";
 
-const CANONICAL =
-  "http://127.0.0.1:31437/api/connectors/google/oauth/callback";
+const CANONICAL = "http://127.0.0.1:31437/api/connectors/google/oauth/callback";
 
 function runtimeWithRedirect(uri?: string) {
   return {
-    getSetting: (key: string) =>
-      key === "GOOGLE_REDIRECT_URI" ? uri : undefined,
+    getSetting: (key: string) => (key === "GOOGLE_REDIRECT_URI" ? uri : undefined),
   };
 }
 
 describe("google oauth callback contract", () => {
   it("accepts a loopback callback with an explicit port", () => {
-    const assessment = assessGoogleOAuthCallbackConfig(
-      runtimeWithRedirect(CANONICAL),
-    );
+    const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(CANONICAL));
     expect(assessment.configured).toBe(true);
     expect(assessment.redirectUri).toBe(CANONICAL);
     expect(assessment.issues).toEqual([]);
-    expect(resolveGoogleConnectorOAuthCallbackUrl(runtimeWithRedirect(CANONICAL)))
-      .toBe(CANONICAL);
+    expect(resolveGoogleConnectorOAuthCallbackUrl(runtimeWithRedirect(CANONICAL))).toBe(CANONICAL);
   });
 
   it("rejects a portless loopback callback derived from INTERNAL_URL", () => {
-    const portless =
-      "http://127.0.0.1/api/connectors/google/oauth/callback";
-    const assessment = assessGoogleOAuthCallbackConfig(
-      runtimeWithRedirect(portless),
-    );
+    const portless = "http://127.0.0.1/api/connectors/google/oauth/callback";
+    const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(portless));
     expect(assessment.configured).toBe(false);
-    expect(assessment.issues.some((issue) => issue.code === "portless_loopback"))
-      .toBe(true);
+    expect(assessment.issues.some((issue) => issue.code === "portless_loopback")).toBe(true);
     expect(isPortlessLoopbackRedirectUrl(new URL(portless))).toBe(true);
-    expect(() =>
-      resolveGoogleConnectorOAuthCallbackUrl(runtimeWithRedirect(portless)),
-    ).toThrow(/portless loopback/i);
+    expect(() => resolveGoogleConnectorOAuthCallbackUrl(runtimeWithRedirect(portless))).toThrow(
+      /portless loopback/i
+    );
   });
 
   it("rejects a missing redirect URI", () => {
@@ -57,34 +47,17 @@ describe("google oauth callback contract", () => {
 
   it("rejects a callback on the wrong path", () => {
     const assessment = assessGoogleOAuthCallbackConfig(
-      runtimeWithRedirect("http://127.0.0.1:31437/oauth/google/callback"),
+      runtimeWithRedirect("http://127.0.0.1:31437/oauth/google/callback")
     );
     expect(assessment.configured).toBe(false);
-    expect(assessment.issues.some((issue) => issue.code === "wrong_path"))
-      .toBe(true);
-    expect(GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH).toBe(
-      "/api/connectors/google/oauth/callback",
-    );
+    expect(assessment.issues.some((issue) => issue.code === "wrong_path")).toBe(true);
+    expect(GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH).toBe("/api/connectors/google/oauth/callback");
   });
 
   it("allows production https callbacks without an explicit port", () => {
-    const production =
-      "https://eliza.example/api/connectors/google/oauth/callback";
-    const assessment = assessGoogleOAuthCallbackConfig(
-      runtimeWithRedirect(production),
-    );
+    const production = "https://eliza.example/api/connectors/google/oauth/callback";
+    const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(production));
     expect(assessment.configured).toBe(true);
     expect(isPortlessLoopbackRedirectUrl(new URL(production))).toBe(false);
-  });
-
-  it("rejects a requested redirect URI that disagrees with the canonical value", () => {
-    expect(() =>
-      assertCanonicalGoogleOAuthRedirectUri(
-        CANONICAL,
-        "http://127.0.0.1/api/connectors/google/oauth/callback",
-      ),
-    ).toThrow(/redirect uri mismatch/i);
-    assertCanonicalGoogleOAuthRedirectUri(CANONICAL, CANONICAL);
-    assertCanonicalGoogleOAuthRedirectUri(CANONICAL, undefined);
   });
 });

--- a/plugins/plugin-google-workspace/src/google-oauth-callback.ts
+++ b/plugins/plugin-google-workspace/src/google-oauth-callback.ts
@@ -6,15 +6,13 @@
  */
 import type { IAgentRuntime } from "@elizaos/core";
 
-export const GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH =
-  "/api/connectors/google/oauth/callback";
+export const GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH = "/api/connectors/google/oauth/callback";
 
 export type GoogleOAuthCallbackConfigIssueCode =
   | "missing"
   | "malformed"
   | "portless_loopback"
-  | "wrong_path"
-  | "mismatch";
+  | "wrong_path";
 
 export interface GoogleOAuthCallbackConfigIssue {
   code: GoogleOAuthCallbackConfigIssueCode;
@@ -55,7 +53,7 @@ export function isPortlessLoopbackRedirectUrl(url: URL): boolean {
 }
 
 export function assessGoogleOAuthCallbackConfig(
-  runtime: RuntimeWithSettings,
+  runtime: RuntimeWithSettings
 ): GoogleOAuthCallbackConfigAssessment {
   const raw = readRedirectUriSetting(runtime);
   if (!raw) {
@@ -122,31 +120,14 @@ export function assessGoogleOAuthCallbackConfig(
   };
 }
 
-export function resolveGoogleConnectorOAuthCallbackUrl(
-  runtime: RuntimeWithSettings,
-): string {
+export function resolveGoogleConnectorOAuthCallbackUrl(runtime: RuntimeWithSettings): string {
   const assessment = assessGoogleOAuthCallbackConfig(runtime);
   if (!assessment.configured || !assessment.redirectUri) {
     const detail = assessment.issues.map((issue) => issue.message).join(" ");
     throw new Error(
       detail ||
-        "Google OAuth requires GOOGLE_REDIRECT_URI to be configured for /api/connectors/google/oauth/callback.",
+        "Google OAuth requires GOOGLE_REDIRECT_URI to be configured for /api/connectors/google/oauth/callback."
     );
   }
   return assessment.redirectUri;
-}
-
-export function assertCanonicalGoogleOAuthRedirectUri(
-  canonicalRedirectUri: string,
-  requestedRedirectUri: string | undefined,
-): void {
-  const requested = nonEmptyString(requestedRedirectUri);
-  if (!requested) return;
-  const canonical = new URL(canonicalRedirectUri).toString();
-  const normalizedRequested = new URL(requested).toString();
-  if (canonical !== normalizedRequested) {
-    throw new Error(
-      `Google OAuth redirect URI mismatch. Use the configured GOOGLE_REDIRECT_URI (${canonical}) instead of ${normalizedRequested}.`,
-    );
-  }
 }

--- a/plugins/plugin-google-workspace/src/google-oauth-callback.ts
+++ b/plugins/plugin-google-workspace/src/google-oauth-callback.ts
@@ -1,0 +1,152 @@
+/**
+ * Canonical Google connector OAuth callback resolution. Chat, Settings, and the
+ * connector-account provider must agree on `GOOGLE_REDIRECT_URI` for
+ * `/api/connectors/google/oauth/callback`; portless loopback origins are
+ * rejected because they cannot reach the served local API port.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+
+export const GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH =
+  "/api/connectors/google/oauth/callback";
+
+export type GoogleOAuthCallbackConfigIssueCode =
+  | "missing"
+  | "malformed"
+  | "portless_loopback"
+  | "wrong_path"
+  | "mismatch";
+
+export interface GoogleOAuthCallbackConfigIssue {
+  code: GoogleOAuthCallbackConfigIssueCode;
+  message: string;
+}
+
+export interface GoogleOAuthCallbackConfigAssessment {
+  configured: boolean;
+  redirectUri: string | null;
+  issues: GoogleOAuthCallbackConfigIssue[];
+}
+
+type RuntimeWithSettings = Pick<IAgentRuntime, "getSetting">;
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readRedirectUriSetting(runtime: RuntimeWithSettings): string | undefined {
+  return nonEmptyString(runtime.getSetting?.("GOOGLE_REDIRECT_URI"));
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
+}
+
+/**
+ * Loopback callbacks must name an explicit port (for example `31437`). A
+ * portless `http://127.0.0.1/...` origin targets implicit port 80, not the
+ * served local API.
+ */
+export function isPortlessLoopbackRedirectUrl(url: URL): boolean {
+  if (!isLoopbackHost(url.hostname)) return false;
+  return url.port === "";
+}
+
+export function assessGoogleOAuthCallbackConfig(
+  runtime: RuntimeWithSettings,
+): GoogleOAuthCallbackConfigAssessment {
+  const raw = readRedirectUriSetting(runtime);
+  if (!raw) {
+    return {
+      configured: false,
+      redirectUri: null,
+      issues: [
+        {
+          code: "missing",
+          message:
+            "GOOGLE_REDIRECT_URI is not configured. Set it to the served connector callback, for example http://127.0.0.1:31437/api/connectors/google/oauth/callback.",
+        },
+      ],
+    };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return {
+      configured: false,
+      redirectUri: null,
+      issues: [
+        {
+          code: "malformed",
+          message: "GOOGLE_REDIRECT_URI is not a valid URL.",
+        },
+      ],
+    };
+  }
+
+  const issues: GoogleOAuthCallbackConfigIssue[] = [];
+  const normalizedPath =
+    parsed.pathname.endsWith("/") && parsed.pathname.length > 1
+      ? parsed.pathname.slice(0, -1)
+      : parsed.pathname;
+  if (normalizedPath !== GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH) {
+    issues.push({
+      code: "wrong_path",
+      message: `GOOGLE_REDIRECT_URI must end with ${GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH}.`,
+    });
+  }
+  if (isPortlessLoopbackRedirectUrl(parsed)) {
+    issues.push({
+      code: "portless_loopback",
+      message:
+        "GOOGLE_REDIRECT_URI uses a portless loopback origin. Include the served API port, for example http://127.0.0.1:31437/api/connectors/google/oauth/callback.",
+    });
+  }
+
+  if (issues.length > 0) {
+    return {
+      configured: false,
+      redirectUri: parsed.toString(),
+      issues,
+    };
+  }
+
+  return {
+    configured: true,
+    redirectUri: parsed.toString(),
+    issues: [],
+  };
+}
+
+export function resolveGoogleConnectorOAuthCallbackUrl(
+  runtime: RuntimeWithSettings,
+): string {
+  const assessment = assessGoogleOAuthCallbackConfig(runtime);
+  if (!assessment.configured || !assessment.redirectUri) {
+    const detail = assessment.issues.map((issue) => issue.message).join(" ");
+    throw new Error(
+      detail ||
+        "Google OAuth requires GOOGLE_REDIRECT_URI to be configured for /api/connectors/google/oauth/callback.",
+    );
+  }
+  return assessment.redirectUri;
+}
+
+export function assertCanonicalGoogleOAuthRedirectUri(
+  canonicalRedirectUri: string,
+  requestedRedirectUri: string | undefined,
+): void {
+  const requested = nonEmptyString(requestedRedirectUri);
+  if (!requested) return;
+  const canonical = new URL(canonicalRedirectUri).toString();
+  const normalizedRequested = new URL(requested).toString();
+  if (canonical !== normalizedRequested) {
+    throw new Error(
+      `Google OAuth redirect URI mismatch. Use the configured GOOGLE_REDIRECT_URI (${canonical}) instead of ${normalizedRequested}.`,
+    );
+  }
+}

--- a/plugins/plugin-google-workspace/src/index.test.ts
+++ b/plugins/plugin-google-workspace/src/index.test.ts
@@ -91,7 +91,7 @@ describe("google plugin", () => {
         ({
           GOOGLE_CLIENT_ID: "google-client",
           GOOGLE_CLIENT_SECRET: "google-secret",
-          GOOGLE_REDIRECT_URI: "http://localhost/oauth/google/callback",
+          GOOGLE_REDIRECT_URI: "http://localhost:31437/api/connectors/google/oauth/callback",
         })[key],
       getService: () => null,
     } as never;
@@ -122,7 +122,7 @@ describe("google plugin", () => {
         ({
           GOOGLE_CLIENT_ID: "google-client",
           GOOGLE_CLIENT_SECRET: "google-secret",
-          GOOGLE_REDIRECT_URI: "http://localhost/oauth/google/callback",
+          GOOGLE_REDIRECT_URI: "http://localhost:31437/api/connectors/google/oauth/callback",
         })[key],
       getService: () => null,
     } as never;
@@ -159,7 +159,7 @@ describe("google plugin", () => {
         ({
           GOOGLE_CLIENT_ID: "google-client",
           GOOGLE_CLIENT_SECRET: "google-secret",
-          GOOGLE_REDIRECT_URI: "http://localhost/oauth/google/callback",
+          GOOGLE_REDIRECT_URI: "http://localhost:31437/api/connectors/google/oauth/callback",
         })[key],
       getService: () => null,
     } as never;
@@ -265,7 +265,7 @@ describe("google plugin", () => {
       credentialStore,
       clientId: "google-client",
       clientSecret: "google-secret",
-      redirectUri: "http://localhost/oauth/google/callback",
+      redirectUri: "http://localhost:31437/api/connectors/google/oauth/callback",
     });
 
     const request = {
@@ -405,7 +405,7 @@ describe("google plugin", () => {
         ({
           GOOGLE_CLIENT_ID: "google-client",
           GOOGLE_CLIENT_SECRET: "google-secret",
-          GOOGLE_REDIRECT_URI: "http://localhost/oauth/google/callback",
+          GOOGLE_REDIRECT_URI: "http://localhost:31437/api/connectors/google/oauth/callback",
         })[key],
       getService: (serviceType: string) =>
         serviceType === "vault"
@@ -493,7 +493,7 @@ describe("google plugin", () => {
         ({
           GOOGLE_CLIENT_ID: "google-client",
           GOOGLE_CLIENT_SECRET: "google-secret",
-          GOOGLE_REDIRECT_URI: "http://localhost/oauth/google/callback",
+          GOOGLE_REDIRECT_URI: "http://localhost:31437/api/connectors/google/oauth/callback",
         })[key],
       getService: (serviceType: string) =>
         serviceType === "vault"
@@ -580,7 +580,7 @@ describe("google plugin", () => {
         ({
           GOOGLE_CLIENT_ID: "google-client",
           GOOGLE_CLIENT_SECRET: "google-secret",
-          GOOGLE_REDIRECT_URI: "http://localhost/oauth/google/callback",
+          GOOGLE_REDIRECT_URI: "http://localhost:31437/api/connectors/google/oauth/callback",
         })[key],
       getService: () => null,
     } as never;
@@ -668,7 +668,7 @@ describe("google plugin", () => {
         ({
           GOOGLE_CLIENT_ID: "google-client",
           GOOGLE_CLIENT_SECRET: "google-secret",
-          GOOGLE_REDIRECT_URI: "http://localhost/oauth/google/callback",
+          GOOGLE_REDIRECT_URI: "http://localhost:31437/api/connectors/google/oauth/callback",
         })[key],
       getService: () => null,
     } as never;
@@ -727,7 +727,7 @@ describe("google plugin", () => {
         ({
           GOOGLE_CLIENT_ID: "google-client",
           GOOGLE_CLIENT_SECRET: "google-secret",
-          GOOGLE_REDIRECT_URI: "http://localhost/oauth/google/callback",
+          GOOGLE_REDIRECT_URI: "http://localhost:31437/api/connectors/google/oauth/callback",
         })[key],
       getService: () => null,
     } as never;

--- a/plugins/plugin-google-workspace/src/index.ts
+++ b/plugins/plugin-google-workspace/src/index.ts
@@ -23,7 +23,6 @@ import { GoogleWorkspaceService } from "./service.js";
 import { GOOGLE_SERVICE_NAME } from "./types.js";
 
 export * from "./auth.js";
-export * from "./google-oauth-callback.js";
 export * from "./calendar.js";
 export * from "./chat/accounts.js";
 export type {
@@ -41,6 +40,7 @@ export * from "./credential-resolver.js";
 export * from "./drive.js";
 export * from "./gmail.js";
 export * from "./gmail-message-connector.js";
+export * from "./google-oauth-callback.js";
 export { GoogleGmailAdapter } from "./lifeops-message-adapter.js";
 export * from "./meet.js";
 export * from "./scopes.js";

--- a/plugins/plugin-google-workspace/src/index.ts
+++ b/plugins/plugin-google-workspace/src/index.ts
@@ -23,6 +23,7 @@ import { GoogleWorkspaceService } from "./service.js";
 import { GOOGLE_SERVICE_NAME } from "./types.js";
 
 export * from "./auth.js";
+export * from "./google-oauth-callback.js";
 export * from "./calendar.js";
 export * from "./chat/accounts.js";
 export type {

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.oauth-callback.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.oauth-callback.test.ts
@@ -1,0 +1,58 @@
+/**
+ * LifeOps Google OAuth start must use the canonical GOOGLE_REDIRECT_URI instead
+ * of deriving a portless callback from INTERNAL_URL.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { GoogleDomain } from "./google-service.js";
+
+const CANONICAL =
+  "http://127.0.0.1:31437/api/connectors/google/oauth/callback";
+
+describe("GoogleDomain OAuth callback parity", () => {
+  it("starts OAuth with GOOGLE_REDIRECT_URI, not a portless INTERNAL_URL origin", async () => {
+    const startOAuth = vi.fn(
+      async (_provider: string, input: { redirectUri?: string }) => ({
+        redirectUri: input.redirectUri,
+        authUrl: "https://accounts.google.com/o/oauth2/v2/auth?client_id=test",
+      }),
+    );
+    const runtime = {
+      getSetting: (key: string) =>
+        ({
+          GOOGLE_CLIENT_ID: "client-id",
+          GOOGLE_CLIENT_SECRET: "client-secret",
+          GOOGLE_REDIRECT_URI: CANONICAL,
+        })[key],
+    };
+    const manager = {
+      getProvider: () => ({ provider: "google" }),
+      startOAuth,
+    };
+    const ctx = {
+      runtime,
+      agentId: () => "agent-1",
+      repository: {
+        listCalendarEvents: vi.fn(async () => []),
+        deleteCalendarEventsForProvider: vi.fn(async () => undefined),
+        deleteCalendarSyncState: vi.fn(async () => undefined),
+        deleteGmailSyncState: vi.fn(async () => undefined),
+        deleteGmailMessagesForProvider: vi.fn(async () => undefined),
+      },
+    };
+    const domain = new GoogleDomain(ctx as never);
+    vi.spyOn(domain as never, "googleConnectorManager").mockReturnValue(
+      manager as never,
+    );
+
+    const response = await domain.startGoogleConnector(
+      { side: "owner" },
+      new URL("http://127.0.0.1/"),
+    );
+
+    expect(startOAuth).toHaveBeenCalledWith(
+      "google",
+      expect.objectContaining({ redirectUri: CANONICAL }),
+    );
+    expect(response.redirectUri).toBe(CANONICAL);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.oauth-callback.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.oauth-callback.test.ts
@@ -5,17 +5,14 @@
 import { describe, expect, it, vi } from "vitest";
 import { GoogleDomain } from "./google-service.js";
 
-const CANONICAL =
-  "http://127.0.0.1:31437/api/connectors/google/oauth/callback";
+const CANONICAL = "http://127.0.0.1:31437/api/connectors/google/oauth/callback";
 
 describe("GoogleDomain OAuth callback parity", () => {
   it("starts OAuth with GOOGLE_REDIRECT_URI, not a portless INTERNAL_URL origin", async () => {
-    const startOAuth = vi.fn(
-      async (_provider: string, input: { redirectUri?: string }) => ({
-        redirectUri: input.redirectUri,
-        authUrl: "https://accounts.google.com/o/oauth2/v2/auth?client_id=test",
-      }),
-    );
+    const startOAuth = vi.fn(async () => ({
+      redirectUri: CANONICAL,
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth?client_id=test",
+    }));
     const runtime = {
       getSetting: (key: string) =>
         ({
@@ -51,7 +48,7 @@ describe("GoogleDomain OAuth callback parity", () => {
 
     expect(startOAuth).toHaveBeenCalledWith(
       "google",
-      expect.objectContaining({ redirectUri: CANONICAL }),
+      expect.not.objectContaining({ redirectUri: expect.anything() }),
     );
     expect(response.redirectUri).toBe(CANONICAL);
   });

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts
@@ -7,6 +7,7 @@ import {
   type ConnectorAccount,
   getConnectorAccountManager,
 } from "@elizaos/core";
+import { assessGoogleOAuthCallbackConfig, resolveGoogleConnectorOAuthCallbackUrl } from "@elizaos/plugin-google-workspace";
 import type {
   DisconnectLifeOpsGoogleConnectorRequest,
   LifeOpsConnectorGrant,
@@ -72,6 +73,38 @@ function assertLocalMode(mode?: LifeOpsConnectorMode): void {
       "LifeOps no longer manages cloud or legacy Google modes. Use @elizaos/plugin-google-workspace connector accounts.",
     );
   }
+}
+
+function googleOAuthCallbackMisconfigStatus(
+  side: LifeOpsConnectorSide,
+  assessment: ReturnType<typeof assessGoogleOAuthCallbackConfig>,
+): LifeOpsGoogleConnectorStatus {
+  return {
+    provider: "google",
+    side,
+    mode: "local",
+    defaultMode: "local",
+    availableModes: ["local"],
+    executionTarget: "local",
+    sourceOfTruth: "connector_account",
+    configured: false,
+    connected: false,
+    reason: "config_missing",
+    preferredByAgent: false,
+    cloudConnectionId: null,
+    identity: null,
+    grantedCapabilities: [],
+    grantedScopes: [],
+    expiresAt: null,
+    hasRefreshToken: false,
+    grant: null,
+    degradations: assessment.issues.map((issue) => ({
+      axis: "disconnected",
+      code: `google_oauth_callback_${issue.code}`,
+      message: issue.message,
+      retryable: true,
+    })),
+  };
 }
 
 function googlePluginUnavailableStatus(
@@ -336,6 +369,10 @@ export class GoogleDomain {
     if (!manager?.getProvider?.("google")) {
       return googlePluginUnavailableStatus(side);
     }
+    const callbackAssessment = assessGoogleOAuthCallbackConfig(this.ctx.runtime);
+    if (!callbackAssessment.configured) {
+      return googleOAuthCallbackMisconfigStatus(side, callbackAssessment);
+    }
     const account = await resolveGoogleConnectorAccount({
       runtime: this.ctx.runtime,
       requestedSide: side,
@@ -403,10 +440,7 @@ export class GoogleDomain {
     }
 
     const requestedAccountId = googleAccountIdFromGrantId(request.grantId);
-    const redirectUri = new URL(
-      "/api/connectors/google/oauth/callback",
-      requestUrl.origin,
-    ).toString();
+    const redirectUri = resolveGoogleConnectorOAuthCallbackUrl(this.ctx.runtime);
     const flow = await manager.startOAuth("google", {
       redirectUri,
       accountId: requestedAccountId ?? undefined,

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts
@@ -7,7 +7,7 @@ import {
   type ConnectorAccount,
   getConnectorAccountManager,
 } from "@elizaos/core";
-import { assessGoogleOAuthCallbackConfig, resolveGoogleConnectorOAuthCallbackUrl } from "@elizaos/plugin-google-workspace";
+import { assessGoogleOAuthCallbackConfig } from "@elizaos/plugin-google-workspace";
 import type {
   DisconnectLifeOpsGoogleConnectorRequest,
   LifeOpsConnectorGrant,
@@ -369,7 +369,9 @@ export class GoogleDomain {
     if (!manager?.getProvider?.("google")) {
       return googlePluginUnavailableStatus(side);
     }
-    const callbackAssessment = assessGoogleOAuthCallbackConfig(this.ctx.runtime);
+    const callbackAssessment = assessGoogleOAuthCallbackConfig(
+      this.ctx.runtime,
+    );
     if (!callbackAssessment.configured) {
       return googleOAuthCallbackMisconfigStatus(side, callbackAssessment);
     }
@@ -422,7 +424,7 @@ export class GoogleDomain {
 
   async startGoogleConnector(
     request: StartLifeOpsGoogleConnectorRequest,
-    requestUrl: URL,
+    _requestUrl: URL,
   ): Promise<StartLifeOpsGoogleConnectorResponse> {
     const mode = normalizeOptionalConnectorMode(request.mode, "mode");
     assertLocalMode(mode);
@@ -440,9 +442,7 @@ export class GoogleDomain {
     }
 
     const requestedAccountId = googleAccountIdFromGrantId(request.grantId);
-    const redirectUri = resolveGoogleConnectorOAuthCallbackUrl(this.ctx.runtime);
     const flow = await manager.startOAuth("google", {
-      redirectUri,
       accountId: requestedAccountId ?? undefined,
       scopes: requestedScopesForCapabilities(requestedCapabilities),
       metadata: {
@@ -460,7 +460,9 @@ export class GoogleDomain {
       side: requestedSide,
       mode: "local",
       requestedCapabilities: requestedCapabilities ?? [],
-      redirectUri: flow.redirectUri ?? redirectUri,
+      redirectUri:
+        flow.redirectUri ??
+        fail(500, "Google OAuth provider did not select a callback URI."),
       authUrl: flow.authUrl ?? "",
     };
   }

--- a/plugins/plugin-personal-assistant/test/stubs/plugin-google-workspace.ts
+++ b/plugins/plugin-personal-assistant/test/stubs/plugin-google-workspace.ts
@@ -17,7 +17,6 @@ import { Service } from "@elizaos/core";
 
 export {
   assessGoogleOAuthCallbackConfig,
-  assertCanonicalGoogleOAuthRedirectUri,
   GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH,
   isPortlessLoopbackRedirectUrl,
   resolveGoogleConnectorOAuthCallbackUrl,

--- a/plugins/plugin-personal-assistant/test/stubs/plugin-google-workspace.ts
+++ b/plugins/plugin-personal-assistant/test/stubs/plugin-google-workspace.ts
@@ -15,6 +15,14 @@ import type {
 } from "@elizaos/core";
 import { Service } from "@elizaos/core";
 
+export {
+  assessGoogleOAuthCallbackConfig,
+  assertCanonicalGoogleOAuthRedirectUri,
+  GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH,
+  isPortlessLoopbackRedirectUrl,
+  resolveGoogleConnectorOAuthCallbackUrl,
+} from "../../../plugin-google-workspace/src/google-oauth-callback.ts";
+
 export class GoogleWorkspaceTestService extends Service {
   static serviceType = "google";
 


### PR DESCRIPTION
# Relates to

Fixes #18455.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun run install:light` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the contract from the focused deterministic regressions and package validation recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low-to-medium. The change alters Google OAuth callback selection across connector-account and LifeOps entry points. Risk is constrained by provider-owned validation, persisted provider-selected callback state, and regressions covering valid and invalid callback configuration.

# Background

## What does this PR do?

Google OAuth previously had two authorities for its callback URI: Settings used provider configuration, while LifeOps could derive and submit a competing request-level redirect. This made OAuth state depend on the entry point and could produce callback mismatches.

This repair makes the Google provider the sole owner of the canonical callback URI, returns that selected URI in the generic connector OAuth start result, persists it with OAuth state, removes LifeOps' competing redirect derivation, validates callback configuration, and corrects the regression fixtures to use valid configured callbacks.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No user-facing documentation change is needed. This aligns existing OAuth entry points with the provider contract and is covered by source-level contract tests.

# Testing

## Where should a reviewer start?

- `plugins/plugin-google-workspace/src/google-oauth-callback.ts`
- `packages/core/src/connectors/account-manager.ts`
- `plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts`

## Detailed testing steps

- `bun run --cwd packages/core test -- src/connectors/account-manager.test.ts` — 14 passed.
- `bun run --cwd plugins/plugin-google-workspace test -- src/google-oauth-callback.test.ts src/index.test.ts` — 29 passed.
- `bun run --cwd plugins/plugin-personal-assistant test -- src/lifeops/domains/google-service.oauth-callback.test.ts` — 1 passed.
- `bun run --cwd plugins/plugin-google-workspace test` — 114 passed across 14 files.
- `bun run --cwd packages/core typecheck` — passed.
- `bun run --cwd plugins/plugin-google-workspace typecheck` — passed.
- `bun run --cwd plugins/plugin-personal-assistant typecheck` — passed.
- `bun run --cwd packages/core lint:check` — passed (one unrelated informational warning).
- `bun run --cwd plugins/plugin-google-workspace lint:check` — passed.
- `bun run --cwd plugins/plugin-personal-assistant lint:check` — passed.
- `bun run verify` — passed.

# Evidence Gate

<!-- evidence-head:d768019c12cef7cef1c47fc8274c1223da3b77cf -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - live Google credentials and an external OAuth callback endpoint are not available in this repair environment; deterministic contract regressions exercise callback selection and persistence.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the changed artifact is ephemeral OAuth state; its persisted redirect URI is asserted by the account-manager regression.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - this change does not alter LLM behavior.

## Backend + frontend logs

N/A - no frontend path changed, and a live third-party OAuth round trip requires credentials unavailable in this environment. The focused tests validate the provider-selected URI, state persistence, callback validation, and both entry points.

## Screenshots (before / after) + video walkthrough

N/A - no UI files or rendered surfaces changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

No validation failures remain. A live Google OAuth round trip was not performed because external credentials and callback infrastructure are unavailable; deterministic regressions cover the changed contract and all repository verification gates pass.

— [PR repair]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Codex","skill_revision":"N/A - no contribution skill used"} -->
