### PR TITLE
feat(registry): add plugin-pulsenetwork@0.2.0 (supersedes #18493)

### DIFF
--- a/packages/registry/entries/third-party/plugin-pulsenetwork.json
+++ b/packages/registry/entries/third-party/plugin-pulsenetwork.json
@@ -1,0 +1,18 @@
+{
+  "package": "plugin-pulsenetwork",
+  "repository": "github:GTCC777/plugin-pulsenetwork",
+  "kind": "plugin",
+  "description": "Pulse Network paid data for agents: free catalog search across the x402 fleet (finance, crypto, macro, travel, sports, health, legal), pre-trade token safety scans, and pay-per-call fetches — USDC on Base, no API keys. Quote-first: every paid call previews its exact price, asset, and recipient and executes only on a content-bound user confirmation, under a per-call cap, a daily budget, and an execute-once ledger.",
+  "homepage": "https://pulse.theaslangroupllc.com",
+  "version": "0.2.0",
+  "tags": [
+    "x402",
+    "micropayments",
+    "paid-data",
+    "token-safety",
+    "usdc",
+    "base",
+    "finance",
+    "crypto-data"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1516,6 +1516,54 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "plugin-pulsenetwork": {
+      "git": {
+        "repo": "GTCC777/plugin-pulsenetwork",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "plugin-pulsenetwork",
+        "v0": null,
+        "v1": null,
+        "v2": "0.2.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Pulse Network paid data for agents: free catalog search across the x402 fleet (finance, crypto, macro, travel, sports, health, legal), pre-trade token safety scans, and pay-per-call fetches — USDC on Base, no API keys. Quote-first: every paid call previews its exact price, asset, and recipient and executes only on a content-bound user confirmation, under a per-call cap, a daily budget, and an execute-once ledger.",
+      "homepage": "https://pulse.theaslangroupllc.com",
+      "topics": [
+        "x402",
+        "micropayments",
+        "paid-data",
+        "token-safety",
+        "usdc",
+        "base",
+        "finance",
+        "crypto-data"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "plugin-raven-verify": {
       "git": {
         "repo": "billybotticelli4u-collab/plugin-raven-verify",


### PR DESCRIPTION
Fresh registry entry for `plugin-pulsenetwork`, pinned to the newly published **0.2.0**. This supersedes #18493 and directly addresses every point from @lalalune's review there. Thank you for the thorough read of the tarball — it was exactly right, and 0.2.0 is a genuine redesign of the money path, not a patch.

The prior finding was precise: pinning the recipient, asset, network, and per-call amount answers *what* may be paid, but nothing authorized *whether* a given charge should happen — so planner-selected content could spend repeatedly up to the cap. 0.2.0 fixes that.

### How 0.2.0 addresses each requirement

**1. Preview exact URL, amount, asset, network, recipient.** `CHECK_TOKEN_SAFETY` and `PULSE_PAID_GET` no longer pay. They fetch the 402 challenge with **no signer in scope** (`fetch402Preview`) and reply with a quote showing all five fields. Nothing is signed at this step.

**2. Content-bound user authorization; planner confirmation rejected.** A new `PULSE_CONFIRM_PAYMENT` action is the only code path that signs. The confirmation code is the first six hex of `sha256(url, amount, asset, network, payTo, scheme, nonce)` — the exact operation bytes from the quote. The handler re-derives that hash from the stored charge and refuses if it no longer matches the code, so a tampered pending record can't be paid. Confirmations are accepted only from a **user-authored** message (`entityId !== agentId`, checked in both `validate()` and the handler) by the **same user in the same room**, within a 10-minute TTL. Agent/planner text can never satisfy it.

**3. Durable cumulative budget + idempotency/replay.** New `PULSE_BUDGET_USD_PER_DAY` (default $2, UTC days) on top of the per-call cap, both fail-closed on invalid values. Each authorization is consumed before execution and written to an execute-once charge ledger keyed by the operation hash; a global payment lock serializes execution so duplicate or concurrent confirmations pay at most once. Budget refunds key off a **typed structured signal** from the x402 client's `onAfterPaymentCreation` hook (did a payload get signed?), never off error-message text.

**4. Reject untrusted-context execution.** Financial actions refuse agent/system-authored messages. There is an explicit `PULSE_AUTOPAY=true` opt-in for headless single-operator deployments — documented as unsafe in shared rooms — and even it refuses non-human-authored triggers; cap, budget, ledger, and pins still apply.

**5. Sanitized live evidence.** A real quote → confirm → $0.015 settle → replay-refused run is in [`EVIDENCE.md`](https://github.com/GTCC777/plugin-pulsenetwork/blob/main/EVIDENCE.md). Abbreviated:

```
User:  is 0x532f…42E4 safe to buy on base?
Agent: 💸 Payment required — nothing has been paid yet.
       • Price: $0.015 (15000 atomic USDC)
       • Asset: USDC on Base (eip155:8453, 0x8335…2913)
       • Recipient: 0x50ab…12fc (Pulse Network fleet wallet)
       Reply "pay EAAEFB" within 10 minutes to authorize exactly this charge.
User:  pay EAAEFB
Agent: Paid $0.015 to 0x50ab…12fc … **CLEAR** …
User:  pay EAAEFB          # replay
Agent: There is no pending quote for you in this room.
```
Resulting state: ledger `status: settled`, daily budget `spentAtomic: 15000`.

### Verification
- `plugin-pulsenetwork@0.2.0` on npm — integrity `sha512-Xv87XlnyvRYR4VKUhEGJzcFfuoJA3/4cPYzE9Ing+byt53GB4mHn1ctaj1tYmqUeJC00wmtWTzR1d0KlHzdOqg==`
- Source: https://github.com/GTCC777/plugin-pulsenetwork (79 unit tests incl. confirmation binding, cross-user/cross-room refusal, replay, budget accounting, tampered-charge integrity)
- `bun run validate` and `bun run generate` clean; diff is this entry only.

The free `SEARCH_PULSE_CATALOG` action remains independent and needs no wallet, per your note.
