### PR TITLE
fix(ui): poll explicit cloud base during handoff

### DIFF
--- a/packages/ui/src/api/client-cloud-handoff-target.test.ts
+++ b/packages/ui/src/api/client-cloud-handoff-target.test.ts
@@ -65,9 +65,21 @@ describe("startCloudAgentHandoff — dedicated migration target", () => {
   beforeEach(() => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
+      vi.fn(async (input: RequestInfo | URL) => ({
         status: 200,
-        json: async () => ({ messages: [] }),
+        json: async () => {
+          const match = String(input).match(
+            /\/api\/v1\/eliza\/agents\/([^/]+)$/,
+          );
+          if (match) {
+            const id = decodeURIComponent(match[1] ?? "");
+            return {
+              success: true,
+              data: { ...runningDedicated({ agent_id: id }), id },
+            };
+          }
+          return { messages: [] };
+        },
       })),
     );
   });
@@ -97,8 +109,14 @@ describe("startCloudAgentHandoff — dedicated migration target", () => {
       log: () => {},
     });
 
-    expect(getCloudCompatAgent).toHaveBeenCalledWith("dedicated-1");
+    expect(getCloudCompatAgent).not.toHaveBeenCalled();
     expect(getCloudCompatAgent).not.toHaveBeenCalledWith("shared-1");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.elizacloud.ai/api/v1/eliza/agents/dedicated-1",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer tok" }),
+      }),
+    );
     expect(onSwitch).toHaveBeenCalledWith("https://dedicated-1.elizacloud.ai");
     expect(
       result.status === "switched" || result.status === "switched-empty",
@@ -126,7 +144,7 @@ describe("startCloudAgentHandoff — dedicated migration target", () => {
       log: () => {},
     });
 
-    expect(getCloudCompatAgent).toHaveBeenCalledWith("agent-self");
+    expect(getCloudCompatAgent).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -3811,10 +3811,32 @@ ElizaClient.prototype.startCloudAgentHandoff = function (
 
   const readiness: AgentReadinessProbe = {
     resolveReadyBase: async () => {
-      const detail = await this.getCloudCompatAgent(readinessAgentId).catch(
-        () => null,
-      );
-      const agent = detail?.success ? detail.data : null;
+      // Handoff already carries an explicit Cloud API base and credential.
+      // Read the target through that canonical route instead of asking the
+      // client to infer direct-vs-proxy mode from its ambient configuration.
+      // Local and self-hosted Cloud bases are intentionally not recognized as
+      // production direct-cloud hosts, so inference would otherwise poll the
+      // app-only `/api/cloud/compat/agents/:id` proxy and time out on 404.
+      const detail = await authedFetch(
+        resolvedCloudApiBase,
+        `/api/v1/eliza/agents/${encodeURIComponent(readinessAgentId)}`,
+      ).catch(() => null);
+      const detailBody = detail?.json as {
+        success?: boolean;
+        data?: DirectCloudAgent;
+      } | null;
+      let agent =
+        detail?.status === 200 && detailBody?.success && detailBody.data
+          ? toCloudCompatAgent(detailBody.data)
+          : null;
+      // Compatibility fallback for older app proxies and injected clients that
+      // do not implement the canonical direct detail envelope.
+      if (!agent) {
+        const compatDetail = await this.getCloudCompatAgent(
+          readinessAgentId,
+        ).catch(() => null);
+        agent = compatDetail?.success ? compatDetail.data : null;
+      }
       if (!agent) return null;
       // The container is "ready" only once the record exposes a dedicated base
       // (bridge/web-ui subdomain) AND reports running — until then the user is


### PR DESCRIPTION
# Relates to

Partial fix for #18475 — resolves the two shared-to-dedicated handoff timeout failures. The onboarding 404 and BlueBubbles payload mismatch remain separately scoped in the issue.

# Summary

- poll the canonical Cloud agent-detail route using the handoff's explicit Cloud API base and bearer credential
- retain the existing compat-client fallback for older app proxies and injected clients
- prevent localhost and self-hosted Cloud APIs from being misclassified as app proxies during handoff readiness
- pin the direct route and authorization contract in focused tests

# Root cause

The handoff accepted an explicit `cloudApiBase` and `authToken`, but readiness delegated to `getCloudCompatAgent()`, which inferred direct-vs-proxy mode from ambient client configuration. A localhost Cloud API was not recognized as a production direct-cloud host, so both E2E paths repeatedly requested the app-only `/api/cloud/compat/agents/:id` route from cloud-api. That route correctly returned 404 until the handoff budget expired.

# Evidence

- Focused unit: `bun run --cwd packages/ui test -- src/api/client-cloud-handoff-target.test.ts` — 6/6 passed.
- UI package: typecheck, lint, and build passed. Lint retained 8 pre-existing `noDocumentCookie` warnings outside this diff.
- Real local full-stack path: `bun run --cwd packages/cloud/e2e test -- tests/app-client-handoff-success.spec.ts tests/shared-to-dedicated-upgrade.spec.ts` — 2/2 passed after rebase; each imported 4/4 messages and switched.
- Root: `bun run verify` — 350/350 Turbo tasks passed plus all repository audits.
- Before: both focused E2Es reached `timed-out`; cloud-api logs showed repeated 404s at `/api/cloud/compat/agents/:id`.
- After: both reach `switched` through the canonical direct detail route.

## Evidence matrix

- Before/after screenshots: N/A — API-client orchestration only; no rendered UI changed.
- MP4 walkthrough: N/A — no rendered interaction changed.
- Frontend console/network logs: N/A — Playwright exercises the client directly without a frontend.
- Backend logs: local cloud-api logs and Playwright output were manually inspected; direct 404 loop removed.
- Real-LLM trajectory: N/A — deterministic mock-backed provisioning and conversation handoff; no model behavior changed.
- Domain artifact: Playwright inspected the dedicated mock control-plane transcript and proved 4/4 ordered messages imported for both flows.

# Risk

Low and bounded to handoff readiness lookup. The canonical direct request uses the same required handoff credential; a compatibility fallback preserves existing injected/proxy clients. The container routability probe and fail-safe timeout behavior are unchanged.

# Contribution provenance

- AI assistance: yes
- AI provider/model: openai / gpt-5.6-sol
- Client / agent tooling: codex
- Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
- Attribution status: self-reported

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [yizhengzhou-daily]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZSZHR5YQ6GW6N9DGG63B7P9","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T03:16:41.791Z","completed_at":"2026-08-12T04:36:20.148Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEABGe4fV_PPi4aKX7l-LF2u0-A5ZUoJEgkLr-PwrXlgEw","device_key_id":"1ef5dc9a7ed9b85d08d30f10597a4600d5dbd4eff9254abeefd0722c483dc368","device_signature":"vBxswiDj-CrBAeAYO6TNFBTR1BPRxzisPZSIOJyEW73X-JbqwQNbOfH-7f1rOq6zJLy4KKAm4m_ue70fo3lLAQ"}} -->
