### PR TITLE
fix(i18n): add missing cloud login handoff keys to the source catalog

### DIFF
--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -8190,5 +8190,8 @@
   "cloud.security.metaTitle": "Security · Eliza Cloud",
   "cloud.security.pluginPermissionsLink": "Plugin permissions →",
   "browserworkspace.NativeSurfaceUnavailable": "Browser view unavailable",
-  "browserworkspace.NativeSurfaceUnavailableDescription": "The secure browser surface could not connect. Retry without losing your tabs."
+  "browserworkspace.NativeSurfaceUnavailableDescription": "The secure browser surface could not connect. Retry without losing your tabs.",
+  "cloud.login.handoffCompleteTitle": "You're signed in",
+  "cloud.login.handoffCompleteBody": "Return to the Eliza app tab to continue. You can close this window.",
+  "cloud.login.closeWindow": "Close window"
 }


### PR DESCRIPTION
## Problem

Develop's `Tests / Classify changed paths` i18n contract check fails: `en.json missing 3 key(s) used in source` — `cloud.login.handoffCompleteTitle`, `cloud.login.handoffCompleteBody`, `cloud.login.closeWindow`, referenced by `packages/ui/src/cloud/public-pages/pages/login/login-page.tsx:121-142` (handoff-complete state), merged without catalog entries. Same class as #18041.

## Fix

Add the three keys to `packages/ui/src/i18n/locales/en.json` with the component's `defaultValue` strings.

## Verification

At tip 112a73c8eec the checker exits 1 with exactly these 3 keys; with this change `node packages/app-core/scripts/check-i18n.mjs` exits 0; biome clean on the file.

## Evidence

<!-- evidence-head:d417e2ed314e59f5e92bae11b8bb38ed7f031bc6 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - catalog data only; UI already renders these strings via defaultValue.
<!-- evidence-row:after-screenshots -->
- [x] N/A - catalog data only; no visual change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - catalog data only.
<!-- evidence-row:backend-logs -->
- [x] Checker transcript: tip 112a73c8eec → exit 1 (3 keys listed above); with fix → exit 0; biome check clean.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior change (defaultValue already displayed).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM invoked.
<!-- evidence-row:domain-artifacts -->
- [x] The three added catalog entries in this diff; values byte-match the component's defaultValue props.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)