### PR TITLE
fix(core): analyze the current message's image + no ack after a delivered image

### DIFF
--- a/packages/core/src/__tests__/message-answer-clobber-rescue.test.ts
+++ b/packages/core/src/__tests__/message-answer-clobber-rescue.test.ts
@@ -181,6 +181,11 @@ const ANSWERLESS_FINISH: CannedResponse = {
 async function runTurn(opts: {
 	runtime: IAgentRuntime;
 	callback?: HandlerCallback;
+	// Connectors like Discord do not wire an early-reply channel
+	// (message.ts:12122): the stage-0 ack is never delivered early and instead
+	// survives as the post-action ackFallback. Omitting the callback reproduces
+	// that path.
+	noEarlyReply?: boolean;
 }): Promise<{
 	finalText: string | undefined;
 	earlyReplies: string[];
@@ -210,9 +215,13 @@ async function runTurn(opts: {
 		responseId: RESPONSE_ID,
 		...(instrumentedCallback ? { callback: instrumentedCallback } : {}),
 		deliveredVisibleTexts,
-		onResponseHandlerEarlyReply: async ({ text }) => {
-			earlyReplies.push(text);
-		},
+		...(opts.noEarlyReply
+			? {}
+			: {
+					onResponseHandlerEarlyReply: async ({ text }) => {
+						earlyReplies.push(text);
+					},
+				}),
 	});
 	const finalText =
 		result.kind === "planned_reply"
@@ -577,5 +586,176 @@ describe("answer-clobber rescue", () => {
 
 		expect(earlyReplies).toContain(PROGRESS_ACK);
 		expect(finalText).toBe(SUBSTANTIVE_ANSWER);
+	});
+});
+
+describe("media deliverable suppresses the trailing progress ack", () => {
+	const IMAGE_URL = "https://example.test/neon-cat.png";
+
+	function generateMediaAction(): Action {
+		const attachment: Media = {
+			id: "generated-image",
+			url: IMAGE_URL,
+			title: "neon cat",
+			contentType: "image/png",
+			source: "media-generation",
+		};
+		return {
+			name: "GENERATE_MEDIA_TEST",
+			description: "generates an image and delivers it as an attachment",
+			similes: [],
+			examples: [],
+			parameters: [],
+			validate: async () => true,
+			// Mirrors the real GENERATE_MEDIA delivery shape: an attachment-only,
+			// text:"" callback posts the image, and the result carries mediaUrl in
+			// data (which collectMediaDeliveryUrls reads) plus a userFacingText the
+			// media-delivery sanitizer strips to empty.
+			handler: async (_rt, _msg, _state, _opts, cb) => {
+				await cb?.({
+					attachments: [attachment],
+					text: "",
+					actions: ["GENERATE_MEDIA_TEST"],
+					source: "media-generation",
+				});
+				return {
+					success: true,
+					text: "Generated image",
+					userFacingText: "Here's your image.",
+					data: {
+						actionName: "GENERATE_MEDIA_TEST",
+						mediaUrl: IMAGE_URL,
+						imageUrl: IMAGE_URL,
+					},
+				};
+			},
+		} as unknown as Action;
+	}
+
+	it("does not resurrect the stage-1 ack behind an already-posted image", async () => {
+		// BUG 2: GENERATE_MEDIA posts the image through its own attachment-only
+		// callback, then the answerless-final floor resurrected the stage-1
+		// "on it" ack behind it — a redundant, out-of-order second bubble. Once a
+		// media deliverable shipped this turn, the ack must be suppressed.
+		const delivered: Content[] = [];
+		const callback: HandlerCallback = async (content) => {
+			delivered.push(content);
+			return [];
+		};
+		const runtime = makeRuntime({
+			responses: [
+				{
+					expectModelType: String(ModelType.RESPONSE_HANDLER),
+					body: stage1Response({
+						contexts: ["general"],
+						replyText: PROGRESS_ACK,
+						extra: { candidateActionNames: ["GENERATE_MEDIA_TEST"] },
+					}),
+				},
+				{
+					expectModelType: String(ModelType.ACTION_PLANNER),
+					body: {
+						text: "",
+						toolCalls: [
+							{
+								id: "gen-media-1",
+								name: "GENERATE_MEDIA_TEST",
+								arguments: {},
+							},
+						],
+					},
+				},
+				// The post-media evaluator summarizes the delivered image with a bare
+				// completion ack ("Done."), which the media-delivery sanitizer strips
+				// to empty — exactly the answerless-final state where the pre-fix
+				// floor resurrected the stage-1 ack behind the already-posted image.
+				{
+					expectModelType: String(ModelType.RESPONSE_HANDLER),
+					body: JSON.stringify({
+						success: true,
+						decision: "FINISH",
+						thought: "Image delivered.",
+						messageToUser: "Done.",
+					}),
+				},
+			],
+			evaluators: [],
+			actions: [generateMediaAction()],
+		});
+
+		const { finalText } = await runTurn({
+			runtime,
+			callback,
+			noEarlyReply: true,
+		});
+
+		// The image WAS delivered through the action callback.
+		expect(
+			delivered.some((content) =>
+				content.attachments?.some((media) => media.url === IMAGE_URL),
+			),
+		).toBe(true);
+		// No trailing ack after the image.
+		expect(finalText ?? "").toBe("");
+		expect(delivered.map((content) => content.text)).not.toContain(
+			PROGRESS_ACK,
+		);
+	});
+
+	it("does not suppress a non-media action's own reply (the gate keys on media, not on 'an action ran')", async () => {
+		// Regression guard for the fix's blast radius: the new `!mediaDeliverableShipped`
+		// conjunct must alter delivery ONLY when a media URL was actually shipped.
+		// The SAME answerless-finish turn as above, minus the media (no attachment,
+		// no mediaUrl in data), must still surface the action's user-facing text —
+		// nothing is stripped or suppressed when no deliverable shipped.
+		const summary = "Here's the summary you asked for.";
+		const noMediaAction: Action = {
+			name: "SUMMARIZE_TEST",
+			description: "produces a text summary, no media",
+			similes: [],
+			examples: [],
+			parameters: [],
+			validate: async () => true,
+			handler: async () => ({
+				success: true,
+				text: "Summarized",
+				userFacingText: summary,
+				data: { actionName: "SUMMARIZE_TEST" },
+			}),
+		} as unknown as Action;
+		const runtime = makeRuntime({
+			responses: [
+				{
+					expectModelType: String(ModelType.RESPONSE_HANDLER),
+					body: stage1Response({
+						contexts: ["general"],
+						replyText: PROGRESS_ACK,
+						extra: { candidateActionNames: ["SUMMARIZE_TEST"] },
+					}),
+				},
+				{
+					expectModelType: String(ModelType.ACTION_PLANNER),
+					body: {
+						text: "",
+						toolCalls: [
+							{
+								id: "summarize-1",
+								name: "SUMMARIZE_TEST",
+								arguments: {},
+							},
+						],
+					},
+				},
+				ANSWERLESS_FINISH,
+			],
+			evaluators: [],
+			actions: [noMediaAction],
+		});
+
+		const { finalText } = await runTurn({ runtime, noEarlyReply: true });
+
+		// No media shipped: the action's user-facing text is delivered intact,
+		// never collapsed to empty the way the media-delivered turn is.
+		expect(finalText).toBe(summary);
 	});
 });

--- a/packages/core/src/features/working-memory/attachmentContext.test.ts
+++ b/packages/core/src/features/working-memory/attachmentContext.test.ts
@@ -101,3 +101,90 @@ describe("attachmentContext disclosure", () => {
 		expect(records[0]?.content).toBe("");
 	});
 });
+
+function neonCatMessage(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000008" as UUID,
+		entityId: agentId,
+		roomId,
+		createdAt: 1,
+		content: {
+			text: "here's your image",
+			attachments: [
+				{
+					id: "neon-cat",
+					url: "https://example.test/cat.png",
+					title: "Neon Cat",
+					source: "media-generation",
+					contentType: "image",
+					text: "a neon cat sitting on a synthwave grid.",
+				},
+			],
+		},
+	} as Memory;
+}
+
+function currentImageQuestion(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000009" as UUID,
+		entityId: userId,
+		roomId,
+		createdAt: 2,
+		content: {
+			text: "what's in this image? describe it",
+			attachments: [
+				{
+					id: "eliza-pic",
+					url: "https://example.test/eliza.png",
+					title: "Eliza",
+					source: "Image",
+					contentType: "image",
+					text: "an eliza profile picture",
+				},
+			],
+		},
+	} as Memory;
+}
+
+describe("current-message attachment wins over a stale explicit id", () => {
+	it("reads the freshly-attached image, not a prior attachment's cached text", async () => {
+		// BUG 1: the planner named the PRIOR generated image's id (the cheapest
+		// readable candidate — it already carried cached .text). The current
+		// message carries its OWN freshly-attached image, so that attachment must
+		// win over the stale id resolved against room history.
+		const records = await readAttachmentRecords(
+			makeRuntime([neonCatMessage()]),
+			currentImageQuestion(),
+			"neon-cat",
+		);
+
+		expect(records).toHaveLength(1);
+		expect(records[0]?.attachment.id).toBe("eliza-pic");
+		expect(records[0]?.content).toBe("an eliza profile picture");
+		expect(records[0]?.autoSelected).toBe(true);
+	});
+
+	it("still honors a genuine recent read when the current message carries no attachment", async () => {
+		const records = await readAttachmentRecords(
+			makeRuntime([neonCatMessage()]),
+			viewerMessage(),
+			"neon-cat",
+		);
+
+		expect(records).toHaveLength(1);
+		expect(records[0]?.attachment.id).toBe("neon-cat");
+		expect(records[0]?.autoSelected).toBe(false);
+	});
+
+	it("honors an explicit id that names one of the current-message attachments", async () => {
+		const records = await readAttachmentRecords(
+			makeRuntime([neonCatMessage()]),
+			currentImageQuestion(),
+			"eliza-pic",
+		);
+
+		expect(records).toHaveLength(1);
+		expect(records[0]?.attachment.id).toBe("eliza-pic");
+		expect(records[0]?.autoSelected).toBe(false);
+	});
+});

--- a/packages/core/src/features/working-memory/attachmentContext.ts
+++ b/packages/core/src/features/working-memory/attachmentContext.ts
@@ -354,30 +354,42 @@ export async function readAttachmentRecords(
 	message: Memory,
 	attachmentId?: string | null,
 ): Promise<ReadAttachmentResult[]> {
-	if (attachmentId?.trim()) {
-		const record = await readAttachmentRecord(runtime, message, attachmentId);
-		return record ? [record] : [];
-	}
-
+	const trimmedId = attachmentId?.trim() || "";
 	const currentAttachments = (message.content.attachments ??
 		[]) as AttachmentWithInlineData[];
+
+	// A "what's in this image" on a message that CARRIES its own attachment must
+	// analyze THAT attachment — never a prior attachment's cached description. The
+	// planner may name a stale id (a previously generated/described image is the
+	// cheapest readable candidate); honoring it against room history returns the
+	// wrong image's cached text. So when the current message has attachments, an
+	// explicit id is honored ONLY if it names one of them; otherwise it is stale
+	// and the current-message attachment(s) win.
 	if (currentAttachments.length > 0) {
 		const createdAt = message.createdAt ?? Date.now();
 		const attachments = await listConversationAttachments(runtime, message);
 		const currentIds = new Set(
 			currentAttachments.map((attachment) => attachment.id),
 		);
+		const explicitIsCurrent = trimmedId.length > 0 && currentIds.has(trimmedId);
+		const targetIds = explicitIsCurrent ? new Set([trimmedId]) : currentIds;
 		return Promise.all(
 			attachments
-				.filter((attachment) => currentIds.has(attachment.id))
+				.filter((attachment) => targetIds.has(attachment.id))
 				.map(async (attachment) => ({
 					attachment: { ...attachment, _createdAt: createdAt },
 					content: await readableAttachmentContent(runtime, attachment),
-					autoSelected: true,
+					autoSelected: !explicitIsCurrent,
 				})),
 		);
 	}
 
+	// No current-message attachment: honor an explicit id against the
+	// conversation window, else auto-select from it.
+	if (trimmedId.length > 0) {
+		const record = await readAttachmentRecord(runtime, message, trimmedId);
+		return record ? [record] : [];
+	}
 	const record = await readAttachmentRecord(runtime, message);
 	return record ? [record] : [];
 }

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -8732,10 +8732,17 @@ export async function runV5MessageRuntimeStage1(args: {
 		// ran NO action must not "fix" its silence into a work-is-underway ack:
 		// no work follows this turn, so the ack would be a lie. Prefer the
 		// preserved stage-0 answer over any ack in every case.
+		// A media deliverable delivered through an action's own callback
+		// (GENERATE_MEDIA posts an attachment-only, text:"" callback) IS the turn's
+		// answer. The answerless-final floor must not then resurrect the Stage-1
+		// "on it" ack behind the image — a redundant, out-of-order second bubble.
+		// deliveredMediaUrls is non-empty only for a SYNCHRONOUSLY delivered media
+		// attachment, so a slow/async generation (nothing delivered yet) still acks.
+		const mediaDeliverableShipped = deliveredMediaUrls.length > 0;
 		const ackFallback =
 			!plannedText && !earlyReplySent && !suppressesPlannerReply
 				? preservedAnswerFallback ||
-					(ranNonSilentAction
+					(ranNonSilentAction && !mediaDeliverableShipped
 						? stageOneAck || "on it, working on that now."
 						: "")
 				: preservedAnswerFallback;


### PR DESCRIPTION
Two image-path bugs found + reproduced live via the Discord test webhook on the running bot (nubilio).

**Bug 1 — analysis describes the WRONG image.** Generate an image ("neon cat") → then attach a *different* image (eliza pfp) and ask "what's in this image?" → the bot replied **"a neon cat sitting on a synthwave grid"** (the prior generated image, not the attached one). Root cause: `readAttachmentRecords` short-circuited an explicit `attachmentId` against merged current+recent history with no current-message constraint; the planner names the prior image's id (cheapest readable candidate, already carrying cached `.text`), so the cached description came back and vision never ran on the fresh attachment. Fix: when the current message carries attachment(s), an explicit id is honored only if it names one of them; otherwise it's stale and the current-message attachment wins.

**Bug 2 — "on it." ack posts AFTER the image.** GENERATE_MEDIA delivers via an attachment-only `text:""` callback, so the answerless-final floor resurrected the Stage-1 ack behind the already-delivered image (a redundant, out-of-order second bubble). Fix: suppress the trailing ack once a media deliverable shipped synchronously this turn; a slow/async generation (nothing delivered yet) still acks.

4 files (2 src + 2 tests). Deterministic regression tests for both, adversarially verified **SAFE + FAITHFUL**.

---

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - core message-loop + attachment-resolution change, no UI surface`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - core change, no UI surface rendered`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - backend change; live repro shown as the Discord transcript in backend-logs below`.

<!-- evidence-row:backend-logs -->
- [x] Backend logs — live Discord repro (both bugs) + deterministic test results:
<details><summary>live Discord transcript + vitest fail-on-revert / pass-with-fix</summary>

```
LIVE (test channel 1490836448755060920):
[03:59:45] user: "what's in this image? describe it" [attached: eliza-app-profile-image.png]
[04:00:00] bot:  "a neon cat sitting on a synthwave grid."   <-- BUG 1: described the PRIOR generated image
[gen turn] bot: [image/png] THEN "on it."                    <-- BUG 2: ack after the image
trajectory tj-20798f6ae4a2dd: ATTACHMENT tool {action:read, attachmentId:346acd66...} returned cached text "a neon cat sitting on a synthwave grid" (prior image)

TESTS:
bug1 (attachmentContext.test.ts) revert-fix -> x expected 'neon-cat' to be 'eliza-pic'; with fix -> 5 passed
bug2 (message-answer-clobber-rescue.test.ts) revert-fix -> x expected 'On it, working on that now.' to be ''; with fix -> 11 passed
existing: readAttachmentAction/generateMedia 32 passed; message service 99 passed; plugin-elizacloud 13 passed
```
</details>

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend or client change`.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory (the live wrong-image analysis):
```json
{
 "trajectoryId": "tj-20798f6ae4a2dd",
 "status": "finished",
 "rootMessage": {
  "text": "what's in this image? describe it [attached: eliza pfp]"
 },
 "stage": {
  "kind": "messageHandler",
  "provider": "cerebras",
  "model": "gemma-4-31b",
  "messages": [
   {
    "role": "system",
    "content": "# remilio nubilio\n\nyou are remilio nubilio \u2014 eliza dev agent on discord: code, ops, app bu\u2026"
   },
   {
    "role": "user",
    "content": "prior_message:agent:\nremilio nubilio: latest beta is v2.0.3-beta.6. <https://github.com/el\u2026"
   }
  ],
  "response": "{\"addressedTo\": [\"1490833425802854491\"], \"candidateActionNames\": [\"ATTACHMENT\"], \"contexts\": [\"media\"], \"emotion\": \"none\", \"facts\": [], \"intents\": [\"describe image\"], \"relationships\": [], \"replyEffect\u2026"
 },
 "toolResult": {
  "tool": "ATTACHMENT",
  "text": "a neon cat sitting on a synthwave grid.",
  "note": "cached text of the PRIOR generated image \u2014 the bug"
 }
}
```

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - message-loop + attachment-resolution change; artifacts are the two regression tests and the trajectory above`.

<!-- evidence-row:ocr-review -->
- [ ] OCR review `N/A - core backend change, no rendered visual surface to OCR`.

<!-- evidence-head:6368ba4cfe65eddc62adfea191df76898f3b01d8 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
