### PR TITLE
fix: bind payment callbacks to room agents

### DIFF
--- a/packages/cloud/shared/src/db/repositories/eliza-room-characters.ts
+++ b/packages/cloud/shared/src/db/repositories/eliza-room-characters.ts
@@ -1,5 +1,5 @@
 // Persists eliza room characters records for cloud services through the shared DB boundary.
-import { count, eq, inArray, sql } from "drizzle-orm";
+import { and, count, eq, inArray } from "drizzle-orm";
 import { logger } from "../../lib/utils/logger";
 import { sqlRows } from "../execute-helpers";
 import { dbRead, dbWrite } from "../helpers";
@@ -99,22 +99,23 @@ export const elizaRoomCharactersRepository = {
   },
 
   /**
-   * Resolves the owning organization of a room via its mapped character.
-   *
-   * `eliza_room_characters.room_id → character_id → user_characters.organization_id`
-   * is the authority for which org a conversation room belongs to. Used to
-   * confirm a payment-callback channel targets a room the charge creator owns
-   * before writing an agent message into it (cross-tenant guard, #10253).
-   *
-   * Returns `undefined` when the room has no character mapping (callers must
-   * treat that as unverifiable and fail closed).
+   * Resolves a room's organization only when it is mapped to the requested
+   * character. Callback channels must authorize the room and agent as a pair.
    */
-  async findOrganizationIdByRoomId(roomId: string): Promise<string | undefined> {
+  async findOrganizationIdByRoomAndCharacterId(
+    roomId: string,
+    characterId: string,
+  ): Promise<string | undefined> {
     const [row] = await dbRead
       .select({ organizationId: userCharacters.organization_id })
       .from(elizaRoomCharactersTable)
       .innerJoin(userCharacters, eq(userCharacters.id, elizaRoomCharactersTable.character_id))
-      .where(eq(elizaRoomCharactersTable.room_id, roomId))
+      .where(
+        and(
+          eq(elizaRoomCharactersTable.room_id, roomId),
+          eq(elizaRoomCharactersTable.character_id, characterId),
+        ),
+      )
       .limit(1);
 
     return row?.organizationId ?? undefined;

--- a/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-cross-tenant.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-cross-tenant.test.ts
@@ -37,7 +37,7 @@ const CHAR_A = "00000000-0000-0000-0000-0000000000a3";
 const CHAR_B = "00000000-0000-0000-0000-0000000000b3";
 const ROOM_A = "00000000-0000-0000-0000-0000000000a4";
 const ROOM_B = "00000000-0000-0000-0000-0000000000b4";
-const AGENT_A = "00000000-0000-0000-0000-0000000000a5";
+const WRONG_AGENT = "00000000-0000-0000-0000-0000000000a5";
 const APP_ID = "00000000-0000-0000-0000-00000000ff01";
 const CHARGE_ID = "00000000-0000-0000-0000-00000000ff02";
 const UNMAPPED_ROOM = "00000000-0000-0000-0000-00000000dead";
@@ -50,14 +50,14 @@ let memoriesRepository: typeof import("../../../db/repositories/agents/memories"
 let createSpy: ReturnType<typeof spyOn> | undefined;
 let pgliteReady = true;
 
-async function seedCharge(creatorOrg: string, roomId: string): Promise<void> {
+async function seedCharge(creatorOrg: string, roomId: string, agentId = CHAR_A): Promise<void> {
   await dbWrite.execute(`DELETE FROM crypto_payments WHERE id = '${CHARGE_ID}';`);
   const metadata = JSON.stringify({
     kind: "app_charge_request",
     app_id: APP_ID,
     amount_usd: 5,
     payment_context: "any_payer",
-    callback_channel: { roomId, agentId: AGENT_A, source: "payment" },
+    callback_channel: { roomId, agentId, source: "payment" },
   }).replace(/'/g, "''");
   await dbWrite.execute(
     `INSERT INTO crypto_payments
@@ -145,6 +145,7 @@ describe("callbackRoomBelongsToOrganization — room→org authority", () => {
     expect(
       await callbackRoomBelongsToOrganization({
         roomId: ROOM_A,
+        agentId: CHAR_A,
         chargeOrganizationId: ORG_A,
         logContext: "test",
       }),
@@ -156,6 +157,7 @@ describe("callbackRoomBelongsToOrganization — room→org authority", () => {
     expect(
       await callbackRoomBelongsToOrganization({
         roomId: ROOM_A,
+        agentId: CHAR_A,
         chargeOrganizationId: ORG_B,
         logContext: "test",
       }),
@@ -167,6 +169,19 @@ describe("callbackRoomBelongsToOrganization — room→org authority", () => {
     expect(
       await callbackRoomBelongsToOrganization({
         roomId: UNMAPPED_ROOM,
+        agentId: CHAR_A,
+        chargeOrganizationId: ORG_A,
+        logContext: "test",
+      }),
+    ).toBe(false);
+  });
+
+  test("same-tenant room with a different agent → refused", async () => {
+    if (!pgliteReady) return;
+    expect(
+      await callbackRoomBelongsToOrganization({
+        roomId: ROOM_A,
+        agentId: WRONG_AGENT,
         chargeOrganizationId: ORG_A,
         logContext: "test",
       }),
@@ -199,7 +214,23 @@ describe("appChargeCallbacksService.dispatch — settlement memory write is gate
     expect(createSpy).toHaveBeenCalledTimes(1);
     const [memory] = createSpy.mock.calls[0] as [{ roomId: string; agentId: string }];
     expect(memory.roomId).toBe(ROOM_A);
-    expect(memory.agentId).toBe(AGENT_A);
+    expect(memory.agentId).toBe(CHAR_A);
+  });
+
+  test("same-tenant room with a mismatched callback agent → NO memory is written", async () => {
+    if (!pgliteReady) return;
+    await seedCharge(ORG_A, ROOM_A, WRONG_AGENT);
+
+    const result = await appChargeCallbacksService.dispatch({
+      appId: APP_ID,
+      chargeRequestId: CHARGE_ID,
+      status: "paid",
+      provider: "stripe",
+      providerPaymentId: "pi_wrong_agent",
+    });
+
+    expect(result.roomMessageCreated).toBe(false);
+    expect(createSpy).not.toHaveBeenCalled();
   });
 
   test("cross-tenant charge → NO memory is written into the victim's room", async () => {

--- a/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
@@ -323,6 +323,7 @@ export class AppChargeCallbacksService {
     // otherwise a forged settlement message could be injected cross-tenant.
     const authorized = await callbackRoomBelongsToOrganization({
       roomId,
+      agentId,
       chargeOrganizationId,
       logContext: "AppChargeCallbacks",
     });

--- a/packages/cloud/shared/src/lib/services/callback-channel-authz.ts
+++ b/packages/cloud/shared/src/lib/services/callback-channel-authz.ts
@@ -3,8 +3,8 @@ import { elizaRoomCharactersRepository } from "../../db/repositories/eliza-room-
 import { logger } from "../utils/logger";
 
 /**
- * Confirms the room a payment-settlement callback would post into belongs to
- * the organization that created the charge.
+ * Confirms the room and agent a payment-settlement callback would post into
+ * belong to the organization that created the charge.
  *
  * A charge's `callback_channel.{roomId, agentId}` is attacker-controlled — it is
  * supplied by whoever created the charge and stored verbatim. Without this check
@@ -20,17 +20,19 @@ import { logger } from "../utils/logger";
  */
 export async function callbackRoomBelongsToOrganization(params: {
   roomId: string;
+  agentId: string;
   chargeOrganizationId: string;
   logContext: string;
 }): Promise<boolean> {
-  const { roomId, chargeOrganizationId, logContext } = params;
+  const { roomId, agentId, chargeOrganizationId, logContext } = params;
 
-  const roomOrganizationId = await elizaRoomCharactersRepository.findOrganizationIdByRoomId(roomId);
+  const roomOrganizationId =
+    await elizaRoomCharactersRepository.findOrganizationIdByRoomAndCharacterId(roomId, agentId);
 
   if (!roomOrganizationId) {
     logger.warn(
       `[${logContext}] refusing callback room-message: room has no organization mapping`,
-      { roomId, chargeOrganizationId },
+      { roomId, agentId, chargeOrganizationId },
     );
     return false;
   }
@@ -38,6 +40,7 @@ export async function callbackRoomBelongsToOrganization(params: {
   if (roomOrganizationId !== chargeOrganizationId) {
     logger.warn(`[${logContext}] refusing cross-tenant callback room-message`, {
       roomId,
+      agentId,
       roomOrganizationId,
       chargeOrganizationId,
     });

--- a/packages/cloud/shared/src/lib/services/x402-payment-requests.ts
+++ b/packages/cloud/shared/src/lib/services/x402-payment-requests.ts
@@ -386,6 +386,7 @@ async function triggerChannelCallback(
   // org — otherwise a forged settlement message could be injected cross-tenant.
   const authorized = await callbackRoomBelongsToOrganization({
     roomId,
+    agentId,
     chargeOrganizationId: payment.organization_id,
     logContext: "x402-payment-requests",
   });


### PR DESCRIPTION
Summary:
- Authorize payment room callbacks only when the supplied (roomId, agentId) pair maps to the same cloud character and organization.
- Apply the exact-pair guard to app-charge and x402 payment callbacks.
- Add regression coverage for same-tenant callbacks with a mismatched agent.

Verification:
- git diff --cached --check: passed before commit.
- Bun parser/build checks for all five changed files with external dependencies: passed.
- Focused integration test: assertions pass, but the suite is blocked by missing drizzle-orm/node-postgres in the checkout; dependency installation then failed with ENOSPC.
- No secrets detected in the staged diff; no wallet, receipt, or transaction actions performed.

Model attribution: openai/gpt-5.6-sol