### PR TITLE
refactor(core): passive-connector default branches on typed plugin capability

### DIFF
--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -15,7 +15,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import {
   isGoogleChatConfigured,
-  lifeOpsPassiveConnectorsEnabled,
+  lifeOpsPassiveConnectorsSetting,
 } from "@elizaos/core";
 import channelPluginMap from "@elizaos/registry/first-party/channel-plugin-map.json" with {
   type: "json",
@@ -151,10 +151,14 @@ function gitpathologistRequested(config: ElizaConfig): boolean {
 function telegramStandaloneRequested(
   pluginNames: ReadonlySet<string>,
 ): boolean {
-  const resolvedPlugins = Array.from(pluginNames, (name) => ({ name }));
-  if (
-    lifeOpsPassiveConnectorsEnabled({ plugins: resolvedPlugins }, process.env)
-  ) {
+  // Host loading policy: before runtime construction only resolved package
+  // names exist, and the personal-assistant package is the one whose Plugin
+  // declares `passiveConnectorsByDefault`. An explicit operator setting wins;
+  // otherwise the presence of that package predicts the runtime-time gate.
+  const passive =
+    lifeOpsPassiveConnectorsSetting(null, process.env) ??
+    pluginNames.has("@elizaos/plugin-personal-assistant");
+  if (passive) {
     return false;
   }
   const raw = process.env.ELIZA_TELEGRAM_STANDALONE_BOT?.trim().toLowerCase();

--- a/packages/app-core/src/services/trigger-event-bridge.test.ts
+++ b/packages/app-core/src/services/trigger-event-bridge.test.ts
@@ -91,7 +91,12 @@ function makeRuntime(
   >();
   const settings = new Map<string, unknown>();
   const plugins = options.lifeOpsPluginLoaded
-    ? [{ name: "@elizaos/plugin-personal-assistant" }]
+    ? [
+        {
+          name: "@elizaos/plugin-personal-assistant",
+          passiveConnectorsByDefault: true,
+        },
+      ]
     : [];
 
   const runtime = {

--- a/packages/core/src/__tests__/lifeops-passive-connectors.test.ts
+++ b/packages/core/src/__tests__/lifeops-passive-connectors.test.ts
@@ -5,10 +5,16 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { lifeOpsPassiveConnectorsEnabled } from "../lifeops-passive-connectors";
 
-const LIFEOPS_PLUGIN = "@elizaos/plugin-personal-assistant";
-const OTHER_PLUGIN = "@elizaos/plugin-discord";
+const LIFEOPS_PLUGIN = {
+	name: "@elizaos/plugin-personal-assistant",
+	passiveConnectorsByDefault: true,
+};
+const OTHER_PLUGIN = { name: "@elizaos/plugin-discord" };
 
-function makeRuntime(opts: { setting?: string | boolean; plugins?: string[] }) {
+function makeRuntime(opts: {
+	setting?: string | boolean;
+	plugins?: Array<{ name: string; passiveConnectorsByDefault?: boolean }>;
+}) {
 	return {
 		getSetting: (key: string) => {
 			if (
@@ -20,7 +26,7 @@ function makeRuntime(opts: { setting?: string | boolean; plugins?: string[] }) {
 			}
 			return undefined;
 		},
-		plugins: (opts.plugins ?? []).map((name) => ({ name })),
+		plugins: opts.plugins ?? [],
 	};
 }
 
@@ -69,7 +75,7 @@ describe("lifeOpsPassiveConnectorsEnabled", () => {
 			).toBe(false);
 		});
 
-		it("returns true when plugin-personal-assistant is loaded", () => {
+		it("returns true when a plugin declares passiveConnectorsByDefault", () => {
 			expect(
 				lifeOpsPassiveConnectorsEnabled(
 					makeRuntime({ plugins: [LIFEOPS_PLUGIN] }),
@@ -77,7 +83,7 @@ describe("lifeOpsPassiveConnectorsEnabled", () => {
 			).toBe(true);
 		});
 
-		it("returns true when plugin-personal-assistant is among other plugins", () => {
+		it("returns true when a passive-declaring plugin is among other plugins", () => {
 			expect(
 				lifeOpsPassiveConnectorsEnabled(
 					makeRuntime({ plugins: [OTHER_PLUGIN, LIFEOPS_PLUGIN] }),
@@ -86,7 +92,7 @@ describe("lifeOpsPassiveConnectorsEnabled", () => {
 		});
 	});
 
-	describe("explicit runtime setting overrides plugin detection", () => {
+	describe("explicit runtime setting overrides capability detection", () => {
 		it("returns false when setting is 'false' even with LifeOps plugin loaded", () => {
 			expect(
 				lifeOpsPassiveConnectorsEnabled(
@@ -116,7 +122,7 @@ describe("lifeOpsPassiveConnectorsEnabled", () => {
 		});
 	});
 
-	describe("env var overrides plugin detection", () => {
+	describe("env var overrides capability detection", () => {
 		it("returns false when env ELIZA_LIFEOPS_PASSIVE_CONNECTORS=false even with plugin loaded", () => {
 			expect(
 				lifeOpsPassiveConnectorsEnabled(

--- a/packages/core/src/lifeops-passive-connectors.ts
+++ b/packages/core/src/lifeops-passive-connectors.ts
@@ -1,21 +1,23 @@
 /**
  * Passive-connector gate for LifeOps deployments.
  *
- * When `plugin-personal-assistant` is loaded the runtime operates in passive
- * mode: connectors ingest inbound messages into memory but do not auto-reply
- * (the LifeOps pipeline drives responses instead). Standalone agents that do
- * not load that plugin default to active-reply mode.
+ * A runtime is passive when a loaded plugin declares the typed
+ * `passiveConnectorsByDefault` capability (the LifeOps personal-assistant
+ * plugin does): connectors ingest inbound messages into memory but do not
+ * auto-reply, because the LifeOps pipeline drives responses instead. Agents
+ * without such a plugin default to active-reply mode. Core never branches on
+ * plugin names — only on the declared capability.
  *
  * Explicit env vars (`ELIZA_LIFEOPS_PASSIVE_CONNECTORS` / `LIFEOPS_PASSIVE_CONNECTORS`)
- * and runtime settings always take precedence over plugin-presence detection.
- * Callers that run before `AgentRuntime` construction must supply the plugin
- * set they have resolved from configuration. An absent runtime or plugin list
- * means no LifeOps deployment was identified and therefore defaults active.
+ * and runtime settings always take precedence over capability detection.
+ * Pre-runtime hosts that only know resolved plugin names should call
+ * {@link lifeOpsPassiveConnectorsSetting} and apply their own loading policy
+ * when it returns undefined.
  */
 
 type SettingsReader = {
 	getSetting?: (key: string) => unknown;
-	plugins?: Array<{ name: string }>;
+	plugins?: Array<{ name: string; passiveConnectorsByDefault?: boolean }>;
 };
 
 type EnvLike = Record<string, string | undefined>;
@@ -24,8 +26,6 @@ const PASSIVE_CONNECTOR_SETTING_KEYS = [
 	"ELIZA_LIFEOPS_PASSIVE_CONNECTORS",
 	"LIFEOPS_PASSIVE_CONNECTORS",
 ] as const;
-
-const LIFEOPS_PLUGIN_NAME = "@elizaos/plugin-personal-assistant";
 
 function readFirstSetting(
 	runtime: SettingsReader | null | undefined,
@@ -68,31 +68,47 @@ function isExplicitFalse(value: unknown): boolean {
 	);
 }
 
-function isLifeOpsPluginLoaded(
+function hasPassiveConnectorPlugin(
 	runtime: SettingsReader | null | undefined,
 ): boolean {
 	return (
 		Array.isArray(runtime?.plugins) &&
-		runtime.plugins.some((p) => p.name === LIFEOPS_PLUGIN_NAME)
+		runtime.plugins.some((p) => p.passiveConnectorsByDefault === true)
 	);
 }
 
 /**
- * Returns whether LifeOps passive-connector mode is active for this runtime.
+ * Resolves only the explicit operator-configured passive-connector setting
+ * (runtime setting first, then env). Returns undefined when nothing explicit
+ * is configured, so pre-runtime callers can fall back to their own policy.
+ */
+export function lifeOpsPassiveConnectorsSetting(
+	runtime?: SettingsReader | null,
+	env: EnvLike = defaultEnv(),
+): boolean | undefined {
+	const value = readFirstSetting(runtime, env);
+	if (value === undefined) {
+		return undefined;
+	}
+	return !isExplicitFalse(value);
+}
+
+/**
+ * Returns whether passive-connector mode is active for this runtime.
  *
- * **Default flip:** prior to this function the default was always `true` (passive).
- * It is now `false` for agents that do not load `plugin-personal-assistant` and
- * do not set either env var. Any existing deployment without that plugin will
- * begin auto-replying on connectors where it previously only ingested.
+ * **Default flip:** prior to this function the default was always `true`
+ * (passive). It now defaults from the typed `passiveConnectorsByDefault`
+ * plugin capability; agents without such a plugin and without either env var
+ * auto-reply on connectors where they previously only ingested.
  */
 export function lifeOpsPassiveConnectorsEnabled(
 	runtime?: SettingsReader | null,
 	env: EnvLike = defaultEnv(),
 ): boolean {
-	const value = readFirstSetting(runtime, env);
-	if (value !== undefined) {
-		// Explicit setting always wins — higher priority than plugin detection.
-		return !isExplicitFalse(value);
+	const explicit = lifeOpsPassiveConnectorsSetting(runtime, env);
+	if (explicit !== undefined) {
+		// Explicit setting always wins — higher priority than capability detection.
+		return explicit;
 	}
-	return isLifeOpsPluginLoaded(runtime);
+	return hasPassiveConnectorPlugin(runtime);
 }

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -1385,6 +1385,16 @@ export interface Plugin {
 	remote?: RemotePluginConfig;
 
 	/**
+	 * Declares that loading this plugin puts messaging connectors into passive
+	 * (ingest-only) mode by default, because the plugin owns the reply pipeline
+	 * (e.g. the LifeOps personal assistant). Connector gates read this typed
+	 * capability via `lifeOpsPassiveConnectorsEnabled` instead of matching
+	 * plugin names. Explicit `ELIZA_LIFEOPS_PASSIVE_CONNECTORS` settings
+	 * override the declared default in either direction.
+	 */
+	passiveConnectorsByDefault?: boolean;
+
+	/**
 	 * Optional pre-initialization hook invoked by the plugin resolver once the
 	 * plugin module has loaded, before `init` runs. Use it to prepare a
 	 * plugin-owned load-time dependency that must exist before the plugin's

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -684,6 +684,9 @@ const rawPersonalAssistantPlugin: Plugin = {
   // always-loaded (CORE + MOBILE), but declaring the dependency guarantees the
   // runner host is registered before PA's init injects deps + seeds.
   dependencies: [GOOGLE_CONNECTOR_PLUGIN_PACKAGE, "@elizaos/plugin-scheduling"],
+  // LifeOps owns the reply pipeline: connectors ingest but do not auto-reply
+  // unless the operator explicitly disables passive mode.
+  passiveConnectorsByDefault: true,
   schema: lifeOpsSchema,
   actions: [
     // Canonical owner-operation umbrellas. Each umbrella registers itself + its

--- a/plugins/plugin-telegram/src/standalone/service.test.ts
+++ b/plugins/plugin-telegram/src/standalone/service.test.ts
@@ -38,7 +38,10 @@ function fakeRuntime(
 ): Parameters<typeof TelegramStandaloneService.start>[0] {
   return {
     agentId: "agent-standalone",
-    plugins: plugins.map((name) => ({ name })),
+    plugins: plugins.map((name) => ({
+      name,
+      passiveConnectorsByDefault: name === "@elizaos/plugin-personal-assistant",
+    })),
     getService: vi.fn(() => null),
     reportError: vi.fn(),
   } as unknown as Parameters<typeof TelegramStandaloneService.start>[0];


### PR DESCRIPTION
# Root issue

#18322 fixed the passive-connector default by detecting the LifeOps deployment, but it did so by hardcoding the `@elizaos/plugin-personal-assistant` package name inside `packages/core`. Core branching on a plugin's name violates the repository's typed-capability rule (behavior must branch on typed fields, not identity sniffing) and couples core to one plugin's identity: any rename, fork, or second reply-pipeline plugin silently breaks the policy.

# Fix

- Adds a typed `Plugin.passiveConnectorsByDefault` capability to the core plugin contract. A plugin that owns the reply pipeline declares it; `@elizaos/plugin-personal-assistant` now does.
- `lifeOpsPassiveConnectorsEnabled` branches only on the declared capability plus the explicit `ELIZA_LIFEOPS_PASSIVE_CONNECTORS` / `LIFEOPS_PASSIVE_CONNECTORS` override. The plugin-name constant is gone from core.
- Exports `lifeOpsPassiveConnectorsSetting` (explicit-setting-only resolver) so pre-runtime hosts can compose their own default.
- The agent host's `telegramStandaloneRequested` keeps package-name knowledge where it already legitimately lives — the host's plugin loading policy — instead of fabricating a fake runtime shim around name objects.

# Behavior

No behavior change for any real deployment: the personal-assistant plugin declares the capability, so LifeOps stays passive by default, plain agents stay active, and explicit settings still win in both directions. The change is where the decision is encoded, not what it decides.

# Validation

All four affected suites pass at this head:

- `packages/core` lifeops-passive-connectors: 17/17
- `packages/agent` plugin-collector standalone Telegram: 3/3
- `plugins/plugin-telegram` standalone service lifecycle: 9/9
- `packages/app-core` trigger-event-bridge: 12/12

Core package builds and typechecks clean; Biome passes on all touched files.

<!-- evidence-head:df8c08228847ae4018db2010f7912c211eaa576e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - connector/runtime policy refactor only; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [x] N/A - connector/runtime policy refactor only; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible behavior change; policy suites below exercise the contract

<!-- evidence-row:backend-logs -->
- [x] Exact-head vitest runs for all four affected suites:

```
packages/core src/__tests__/lifeops-passive-connectors.test.ts
 Test Files  1 passed (1)   Tests  17 passed (17)
packages/agent src/runtime/plugin-collector-telegram-standalone.test.ts
 Test Files  1 passed (1)   Tests  3 passed (3)
plugins/plugin-telegram src/standalone/service.test.ts
 Test Files  1 passed (1)   Tests  9 passed (9)
packages/app-core src/services/trigger-event-bridge.test.ts
 Test Files  1 passed (1)   Tests  12 passed (12)
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider path changed

<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifact beyond the policy test matrix already covered by backend logs

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill was used
<!-- attribution-row:status -->
- Provenance status: self-reported


