### PR TITLE
fix(notes): restore Biome formatting after structural confirmation

### DIFF
--- a/plugins/plugin-notes/src/__tests__/backend.test.ts
+++ b/plugins/plugin-notes/src/__tests__/backend.test.ts
@@ -763,7 +763,11 @@ describe("Notes capabilities", () => {
     );
 
     // Exact title match reads the right note.
-    const read = await interact("get-note", { title: "Shopping list" }, service);
+    const read = await interact(
+      "get-note",
+      { title: "Shopping list" },
+      service,
+    );
     expect(read).toMatchObject({
       success: true,
       data: { note: { title: "Shopping list" } },
@@ -810,20 +814,14 @@ describe("Notes capabilities", () => {
 
     // Providing both title and query must fail validation.
     await expect(
-      interact(
-        "get-note",
-        { title: "Test", query: "Body" },
-        service,
-      ),
+      interact("get-note", { title: "Test", query: "Body" }, service),
     ).resolves.toMatchObject({
       success: false,
       error: { code: "NOTES_VALIDATION_FAILED" },
     });
 
     // Providing zero selectors must fail validation.
-    await expect(
-      interact("get-note", {}, service),
-    ).resolves.toMatchObject({
+    await expect(interact("get-note", {}, service)).resolves.toMatchObject({
       success: false,
       error: { code: "NOTES_VALIDATION_FAILED" },
     });

--- a/plugins/plugin-notes/src/capabilities.ts
+++ b/plugins/plugin-notes/src/capabilities.ts
@@ -76,7 +76,8 @@ export const NOTES_CAPABILITIES: ViewCapability[] = [
   },
   {
     id: "get-note",
-    description: "Read one note by id, exact first-line label, or unique text it contains.",
+    description:
+      "Read one note by id, exact first-line label, or unique text it contains.",
     params: {
       id: { ...ID_PARAM.id, required: false },
       title: TITLE_PARAM,


### PR DESCRIPTION
# Relates to

Repairs the `develop` lint regression introduced by #18516.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI / GPT-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d30ea161074be295a2c6d7f0ad8f02191ea75e13:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What this PR does

Runs the repository-pinned Biome formatter over the two unformatted files merged by #18516. This is a mechanical formatting repair only: it changes no condition, value, assertion, or runtime behavior.

<!-- evidence-head:fa3d11fe9d46e33935dff56b0aaee6ea3312e33d -->

# Testing

```text
bunx @biomejs/biome check plugins/plugin-notes
Checked 28 files. No fixes applied.

bun run --cwd plugins/plugin-notes test
6 files passed; 46 tests passed.

git diff --check
clean
```

The package typecheck reaches an unrelated existing base error in `packages/ui/src/bridge/electrobun-rpc.ts`: `ExistingElizaInstallInfo` is not exported. This formatting-only diff does not touch that surface.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - formatter-only source repair; no rendered pixels change.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - formatter-only source repair; no rendered pixels change.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - no interactive behavior changes.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no runtime path changes.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend runtime behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [18536-domain-exact-head-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18536-domain-exact-head-v2.txt)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface changes.

# Documentation changes needed?

No - this only restores the repository formatter contract.

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@d30ea161074be295a2c6d7f0ad8f02191ea75e13:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5","client":"Codex","skill_revision":"elizaOS/eliza@d30ea161074be295a2c6d7f0ad8f02191ea75e13:packages/skills/skills/contribute-to-eliza"} -->

