### PR TITLE
test(cloud): cover BlueBubbles target recovery

### DIFF
--- a/packages/cloud/e2e/tests/bluebubbles-gateway.spec.ts
+++ b/packages/cloud/e2e/tests/bluebubbles-gateway.spec.ts
@@ -44,6 +44,8 @@ interface FakeBlueBubblesServer {
   url: string;
   sends: JsonRecord[];
   webhookCreates: JsonRecord[];
+  messageTargets: Map<string, string | null>;
+  messageLookups: string[];
 }
 
 function json(res: ServerResponse, status: number, body: unknown): void {
@@ -61,6 +63,8 @@ async function readJson(req: IncomingMessage): Promise<JsonRecord> {
 async function startFakeBlueBubbles(): Promise<FakeBlueBubblesServer> {
   const sends: JsonRecord[] = [];
   const webhookCreates: JsonRecord[] = [];
+  const messageTargets = new Map<string, string | null>();
+  const messageLookups: string[] = [];
   const server = createServer((req, res) => {
     void (async () => {
       const url = new URL(req.url ?? "/", "http://127.0.0.1");
@@ -73,6 +77,24 @@ async function startFakeBlueBubbles(): Promise<FakeBlueBubblesServer> {
       }
       if (req.method === "GET" && url.pathname === "/api/v1/webhook") {
         json(res, 200, { status: 200, data: [] });
+        return;
+      }
+      const messageMatch = url.pathname.match(/^\/api\/v1\/message\/(.+)$/);
+      if (req.method === "GET" && messageMatch) {
+        const guid = decodeURIComponent(messageMatch[1] ?? "");
+        messageLookups.push(guid);
+        if (!messageTargets.has(guid)) {
+          json(res, 404, { error: "message not found" });
+          return;
+        }
+        const target = messageTargets.get(guid);
+        json(res, 200, {
+          status: 200,
+          data: {
+            guid,
+            chats: target ? [{ lastAddressedHandle: target }] : [],
+          },
+        });
         return;
       }
       if (req.method === "POST" && url.pathname === "/api/v1/webhook") {
@@ -105,6 +127,8 @@ async function startFakeBlueBubbles(): Promise<FakeBlueBubblesServer> {
     url: `http://127.0.0.1:${address.port}`,
     sends,
     webhookCreates,
+    messageTargets,
+    messageLookups,
   };
 }
 
@@ -245,6 +269,11 @@ test.describe("registered BlueBubbles gateway", () => {
 
     try {
       await waitForRelay(relayBaseUrl);
+      const onboardingGuid = `inbound-${crypto.randomUUID()}`;
+      fakeBlueBubbles.messageTargets.set(
+        onboardingGuid,
+        registration.phoneNumber,
+      );
       const onboardingInboundResponse = await fetch(
         `${relayBaseUrl}/webhooks/bluebubbles`,
         {
@@ -253,7 +282,7 @@ test.describe("registered BlueBubbles gateway", () => {
           body: JSON.stringify({
             type: "new-message",
             data: {
-              guid: `inbound-${crypto.randomUUID()}`,
+              guid: onboardingGuid,
               text: "My name is Casey",
               isFromMe: false,
               handle: { address: senderPhone, service: "iMessage" },
@@ -261,10 +290,6 @@ test.describe("registered BlueBubbles gateway", () => {
                 {
                   guid: `iMessage;-;${senderPhone}`,
                   chatIdentifier: senderPhone,
-                  // The relay fail-closes unless the event proves which local
-                  // account received it. Real BlueBubbles payloads carry this
-                  // field; keep the fixture on the routed onboarding path.
-                  lastAddressedHandle: registration.phoneNumber,
                 },
               ],
             },
@@ -284,6 +309,7 @@ test.describe("registered BlueBubbles gateway", () => {
         replied: true,
         replyQueued: false,
       });
+      expect(fakeBlueBubbles.messageLookups).toEqual([onboardingGuid]);
       expect(stack.mocks.mockLlm?.requestCount()).toBe(0);
       expect(fakeBlueBubbles.sends).toHaveLength(1);
       const onboardingReply = String(fakeBlueBubbles.sends[0]?.message ?? "");
@@ -345,6 +371,30 @@ test.describe("registered BlueBubbles gateway", () => {
       if (!agentId)
         throw new Error("Onboarding returned no provisioned agent id");
 
+      const configureAgentResponse = await fetch(
+        `${stack.urls.api}/api/v1/eliza/agents/${agentId}`,
+        {
+          method: "PATCH",
+          headers: {
+            ...authHeaders(senderUser.apiKey),
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            agentConfig: {
+              character: {
+                name: "Phone Eliza",
+                system: "Reply helpfully to messages arriving by phone.",
+                model: MODEL,
+              },
+            },
+          }),
+        },
+      );
+      expect(
+        configureAgentResponse.status,
+        `agent config returned ${configureAgentResponse.status}: ${await configureAgentResponse.clone().text()}`,
+      ).toBe(200);
+
       const { usersRepository } = await import(
         "@elizaos/cloud-shared/db/repositories/users"
       );
@@ -390,13 +440,10 @@ test.describe("registered BlueBubbles gateway", () => {
         replied: true,
         replyQueued: false,
       });
+      expect(stack.mocks.mockLlm?.requestCount()).toBe(1);
       expect(fakeBlueBubbles.sends[1]).toMatchObject({
         chatGuid: `iMessage;-;${senderPhone}`,
-        // The onboarding-created shared agent intentionally has no model
-        // override in this credential-free lane. Prove the linked turn reached
-        // that agent and its deterministic fail-closed reply was relayed.
-        message:
-          "Eliza is temporarily unavailable (no shared model configured).",
+        message: "PONG",
         method: "apple-script",
       });
 
@@ -418,6 +465,76 @@ test.describe("registered BlueBubbles gateway", () => {
         replied: true,
         replyQueued: false,
       });
+
+      const mismatchedGuid = `mismatched-${crypto.randomUUID()}`;
+      fakeBlueBubbles.messageTargets.set(mismatchedGuid, "+14155559999");
+      const mismatchedTargetResponse = await fetch(
+        `${relayBaseUrl}/webhooks/bluebubbles`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            type: "new-message",
+            data: {
+              guid: mismatchedGuid,
+              text: "This belongs to a different local number.",
+              isFromMe: false,
+              handle: { address: senderPhone, service: "iMessage" },
+              chats: [
+                {
+                  guid: `iMessage;-;${senderPhone}`,
+                  chatIdentifier: senderPhone,
+                },
+              ],
+            },
+          }),
+        },
+      );
+      expect(mismatchedTargetResponse.status).toBe(200);
+      await expect(mismatchedTargetResponse.json()).resolves.toMatchObject({
+        success: true,
+        skipped: "gateway_target_mismatch",
+        replied: false,
+        replyQueued: false,
+      });
+
+      const unverifiedGuid = `unverified-${crypto.randomUUID()}`;
+      const unverifiedTargetResponse = await fetch(
+        `${relayBaseUrl}/webhooks/bluebubbles`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            type: "new-message",
+            data: {
+              guid: unverifiedGuid,
+              text: "This target cannot be proven.",
+              isFromMe: false,
+              handle: { address: senderPhone, service: "iMessage" },
+              chats: [
+                {
+                  guid: `iMessage;-;${senderPhone}`,
+                  chatIdentifier: senderPhone,
+                },
+              ],
+            },
+          }),
+        },
+      );
+      expect(unverifiedTargetResponse.status).toBe(200);
+      await expect(unverifiedTargetResponse.json()).resolves.toMatchObject({
+        success: true,
+        skipped: "gateway_target_unverified",
+        replied: false,
+        replyQueued: false,
+      });
+      expect(fakeBlueBubbles.messageLookups).toEqual([
+        onboardingGuid,
+        mismatchedGuid,
+        unverifiedGuid,
+      ]);
+      expect(fakeBlueBubbles.sends).toHaveLength(2);
+      expect(stack.mocks.mockLlm?.requestCount()).toBe(1);
 
       await expect.poll(() => fakeBlueBubbles.webhookCreates.length).toBe(1);
       expect(fakeBlueBubbles.webhookCreates[0]).toEqual({
@@ -477,7 +594,7 @@ test.describe("registered BlueBubbles gateway", () => {
         }),
       });
       expect(rejectedResponse.status).toBe(401);
-      expect(stack.mocks.mockLlm?.requestCount()).toBe(0);
+      expect(stack.mocks.mockLlm?.requestCount()).toBe(1);
     } finally {
       // error-policy:J6 test teardown must release the relay and loopback server.
       await stopChild(relay);

--- a/packages/cloud/e2e/tests/bluebubbles-gateway.spec.ts
+++ b/packages/cloud/e2e/tests/bluebubbles-gateway.spec.ts
@@ -81,6 +81,13 @@ async function startFakeBlueBubbles(): Promise<FakeBlueBubblesServer> {
       }
       const messageMatch = url.pathname.match(/^\/api\/v1\/message\/(.+)$/);
       if (req.method === "GET" && messageMatch) {
+        if (
+          url.searchParams.get("password") !== "e2e-password" ||
+          url.searchParams.get("with") !== "chats"
+        ) {
+          json(res, 401, { error: "invalid message lookup" });
+          return;
+        }
         const guid = decodeURIComponent(messageMatch[1] ?? "");
         messageLookups.push(guid);
         if (!messageTargets.has(guid)) {
@@ -405,6 +412,8 @@ test.describe("registered BlueBubbles gateway", () => {
         organization_id: senderUser.organizationId,
       });
 
+      const linkedGuid = `linked-${crypto.randomUUID()}`;
+      fakeBlueBubbles.messageTargets.set(linkedGuid, registration.phoneNumber);
       const linkedInboundResponse = await fetch(
         `${relayBaseUrl}/webhooks/bluebubbles`,
         {
@@ -413,7 +422,7 @@ test.describe("registered BlueBubbles gateway", () => {
           body: JSON.stringify({
             type: "new-message",
             data: {
-              guid: `linked-${crypto.randomUUID()}`,
+              guid: linkedGuid,
               text: "Reply through my linked phone gateway.",
               isFromMe: false,
               handle: { address: senderPhone, service: "iMessage" },
@@ -421,7 +430,6 @@ test.describe("registered BlueBubbles gateway", () => {
                 {
                   guid: `iMessage;-;${senderPhone}`,
                   chatIdentifier: senderPhone,
-                  lastAddressedHandle: registration.phoneNumber,
                 },
               ],
             },
@@ -530,6 +538,7 @@ test.describe("registered BlueBubbles gateway", () => {
       });
       expect(fakeBlueBubbles.messageLookups).toEqual([
         onboardingGuid,
+        linkedGuid,
         mismatchedGuid,
         unverifiedGuid,
       ]);


### PR DESCRIPTION
## Summary

Adds the bounded post-merge coverage requested by the #18510 audit without changing production behavior.

- emulate BlueBubbles `GET /api/v1/message/:guid?with=chats` target-identity recovery
- prove a recovered gateway target can complete onboarding
- configure the onboarding-provisioned shared agent with the deterministic mock model and prove model → cloud router → relay → BlueBubbles delivery (`PONG`)
- prove recovered target mismatch and unavailable lookup both fail closed without model calls or outbound replies

Follow-up to #18510. Relates to #18475; does not close the broader issue.

## Verification

- `bun run --cwd packages/cloud/e2e test -- tests/bluebubbles-gateway.spec.ts` — 1 passed (repeated twice)
- `bun run --cwd packages/cloud/e2e typecheck` — passed
- `bunx @biomejs/biome check packages/cloud/e2e/tests/bluebubbles-gateway.spec.ts` — passed
- `git diff --check` — passed
- regression proof: temporarily disabled the fake message-lookup endpoint; the focused Playwright spec failed as expected (`exit 1`), then the source was restored and the spec passed again
- related BlueBubbles route/registered-relay tests: 14 assertions passed; the direct command exits nonzero only because the repository enables global coverage thresholds for a two-file subset

## Scope

Test-only, one file. No credentials, live Apple device, or production services required.

## Contribution attribution

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [hermesagent270]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZT684EYA6FPGMNGBD9QYV9D","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T05:13:46.718Z","completed_at":"2026-08-12T05:23:17.897Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAYYY9QlvLKi2EbkM-n3_gQRwvkoYS-LS-t35mChI2fr4","device_key_id":"726a1932c3eaa04ebc56539b0e80212d34f02aefc208f9106847de86fab835fa","device_signature":"2kJA_GbqeHIkncpPfnlWOSUzHSr_5R6cgoW4dKHNu-E_2ASuTl1R1hVJBfFRygzT6inAp0IBxeUz_DCbtmhGBQ"}} -->

<!-- evidence-head:ed6f0f8d434f7b64c6d4b61675b6970799fc9318 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only transport/security contract coverage; no rendered UI changes

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only transport/security contract coverage; no rendered UI changes

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI or manual flow changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - Focused Playwright passed after review hardening; lookup fake requires the production password and with=chats query contract

<!-- evidence-row:frontend-logs -->
- [ ] N/A - frontend is disabled for this API/relay E2E stack

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - linked successful model-to-relay path now also obtains its gateway identity through message-detail lookup and sends exactly PONG

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - E2E typecheck, Biome, and diff check pass; external read-only review found no blocking findings

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or rendered text