### PR TITLE
test(core): cover the synthetic-conversation-artifact classifier

### DIFF
--- a/packages/core/src/utils/synthetic-conversation-artifact.test.ts
+++ b/packages/core/src/utils/synthetic-conversation-artifact.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Deterministic unit coverage for the synthetic-conversation-artifact
+ * classifier. Both predicates are pure, so every case is an exact
+ * input/output assertion.
+ *
+ * This gate keeps runtime-generated compaction/summary records out of paths
+ * that should only see real turns, so both directions cost something: a missed
+ * artifact leaks synthesized state into a real-message path, and a false
+ * positive silently drops a genuine user turn.
+ *
+ * Where a branch can be isolated it is driven with input only that branch
+ * matches, so deleting the branch fails the case. Two branches cannot be
+ * isolated — the `compacted prior planner` prefix and the `Conversation
+ * Summary` heading both also satisfy the loose phrase test by construction —
+ * and the comments say so rather than implying coverage the inputs do not give.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	isSyntheticConversationArtifactMemory,
+	isSyntheticConversationArtifactText,
+} from "./synthetic-conversation-artifact";
+
+const memory = (text: unknown, metadata?: unknown) =>
+	({ content: { text }, metadata }) as never;
+
+describe("isSyntheticConversationArtifactText", () => {
+	describe("bracketed marker prefix", () => {
+		// These carry no loose phrase, so the marker regex is the only branch that
+		// can match them — deleting it fails these cases specifically.
+		it.each([
+			"[system hybrid-ledger]",
+			"[conversation state]",
+			"[conversation hybrid-ledger]",
+			"[system state]",
+			"[conversation state [run-42]]",
+			"[SYSTEM HYBRID-LEDGER] trailing prose",
+		])("matches %j", (text) => {
+			expect(isSyntheticConversationArtifactText(text)).toBe(true);
+		});
+
+		it("trims before anchoring the marker", () => {
+			expect(isSyntheticConversationArtifactText("   [system state]")).toBe(
+				true,
+			);
+		});
+
+		it("requires the marker at the start, not anywhere", () => {
+			expect(
+				isSyntheticConversationArtifactText("prose then [system state]"),
+			).toBe(false);
+		});
+
+		it("does not match an unrelated bracketed prefix", () => {
+			expect(isSyntheticConversationArtifactText("[note] ordinary text")).toBe(
+				false,
+			);
+			expect(
+				isSyntheticConversationArtifactText("[system] ordinary text"),
+			).toBe(false);
+		});
+	});
+
+	describe("compaction prefix and summary heading", () => {
+		// Not isolated: each of these also contains a loose phrase, so they stay
+		// true if their own branch is removed. They pin the documented shapes, not
+		// the individual branches.
+		it.each([
+			"compacted prior planner trajectory steps 1-4",
+			"### Conversation Summary",
+			"# conversation summary",
+		])("matches %j", (text) => {
+			expect(isSyntheticConversationArtifactText(text)).toBe(true);
+		});
+	});
+
+	describe("loose phrase match is deliberately unanchored", () => {
+		// The module header calls this "phrasing" matching. It is worth pinning
+		// because it also classifies ordinary user turns that merely mention the
+		// phrase — the false-positive side of this gate.
+		it.each([
+			"can you give me a conversation summary?",
+			"I switched to summary mode yesterday",
+			"the compactor broke again",
+		])("classifies the ordinary message %j as synthetic", (text) => {
+			expect(isSyntheticConversationArtifactText(text)).toBe(true);
+		});
+	});
+
+	describe("genuine turns are left alone", () => {
+		it.each([
+			"hello world",
+			"let's summarize the conversation",
+			"summary of my day",
+			"conversationsummary",
+			"",
+			"   ",
+		])("does not classify %j", (text) => {
+			expect(isSyntheticConversationArtifactText(text)).toBe(false);
+		});
+	});
+});
+
+describe("isSyntheticConversationArtifactMemory", () => {
+	describe("metadata.source", () => {
+		// Text is deliberately inert here so only the source branch can match.
+		it.each(["compaction", "compactor", "synthetic", "summary", "COMPACTION"])(
+			"matches source %j",
+			(source) => {
+				expect(
+					isSyntheticConversationArtifactMemory(memory("hello", { source })),
+				).toBe(true);
+			},
+		);
+
+		it("matches on a word boundary, not a substring", () => {
+			// "compaction-v2" has a boundary before the word; "recompaction" does not.
+			expect(
+				isSyntheticConversationArtifactMemory(
+					memory("hello", { source: "compaction-v2" }),
+				),
+			).toBe(true);
+			expect(
+				isSyntheticConversationArtifactMemory(
+					memory("hello", { source: "recompaction" }),
+				),
+			).toBe(false);
+		});
+	});
+
+	describe("metadata.tags", () => {
+		it("matches when any tag names a synthetic source", () => {
+			expect(
+				isSyntheticConversationArtifactMemory(
+					memory("hello", { tags: ["chat", "synthetic"] }),
+				),
+			).toBe(true);
+		});
+
+		it("ignores non-string tags without throwing", () => {
+			expect(
+				isSyntheticConversationArtifactMemory(
+					memory("hello", { tags: [123, null, { a: 1 }, "summary"] }),
+				),
+			).toBe(true);
+			expect(
+				isSyntheticConversationArtifactMemory(
+					memory("hello", { tags: [123, null, { a: 1 }] }),
+				),
+			).toBe(false);
+		});
+
+		it("ignores a non-array tags value", () => {
+			expect(
+				isSyntheticConversationArtifactMemory(
+					memory("hello", { tags: "synthetic" }),
+				),
+			).toBe(false);
+		});
+	});
+
+	describe("falls back to the text form", () => {
+		it("matches on content text alone", () => {
+			expect(
+				isSyntheticConversationArtifactMemory(
+					memory("[system hybrid-ledger]", { source: "discord" }),
+				),
+			).toBe(true);
+		});
+	});
+
+	describe("malformed input yields false rather than throwing", () => {
+		it.each([
+			["absent metadata", memory("hello", undefined)],
+			["null metadata", memory("hello", null)],
+			["non-object metadata", memory("hello", "compaction")],
+			["non-string content text", memory(123, {})],
+			["clean memory", memory("hello", { source: "discord", tags: ["chat"] })],
+		])("returns false for %s", (_label, value) => {
+			expect(isSyntheticConversationArtifactMemory(value)).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
# Relates to

No tracking issue — `packages/core/src/utils/synthetic-conversation-artifact.ts` had no test file. No behavior is changed by this PR.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused suite and Biome recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passes post-sync; see **Known gaps / failures**.

# Risks

Low. Test-only: one new file, no source file touched, no public surface changed.

# Background

## What does this PR do?

Adds the first test coverage for `isSyntheticConversationArtifactText` / `isSyntheticConversationArtifactMemory`.

This gate keeps runtime-generated compaction and summary records out of paths that should only see real turns, so **both directions cost something**: a missed artifact leaks synthesized state into a real-message path, and a false positive silently drops a genuine user turn. Both sides are pinned.

Following review feedback on an earlier test PR of mine, each isolable branch is driven with input that **only that branch matches**, so deleting the branch fails those cases rather than leaving them green on a neighbouring branch. The bracketed markers used for the marker regex (`[system hybrid-ledger]`, `[conversation state [run-42]]`) deliberately carry no loose phrase for exactly this reason.

Two things surfaced while writing it, both pinned rather than changed:

**1. The phrase branch is unanchored, so ordinary user turns match it.** These all classify as synthetic today:

```
"can you give me a conversation summary?"   -> true
"I switched to summary mode yesterday"      -> true
"the compactor broke again"                 -> true
```

The module header describes this branch as matching "phrasing", so it reads intentional, but the false-positive cost is not recorded anywhere. If it is intentional, the tests now document it; if not, they will fail loudly when it is tightened.

**2. Two branches are strictly subsumed and cannot be distinguished by any input.** Every string matching `/^compacted prior planner trajectory steps/i` necessarily contains `\bcompacted prior planner\b`, and every string matching `/^#{1,3}\s*Conversation Summary\b/i` necessarily contains `\bconversation summary\b` — both of which the loose phrase test already matches. Deleting either branch leaves the whole suite green (B2/B3 in the scorecard below), and no test could change that. They still document intent, so I have not touched them; flagging it so the surviving mutants are not read as a coverage gap.

## What kind of change is this?

Improvements — test coverage only, no production code touched.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/synthetic-conversation-artifact.test.ts` is the whole diff. The mutation scorecard below is the argument that it is not vacuous.

## Detailed testing steps

```bash
bun install
node packages/scripts/run-vitest.mjs run packages/core/src/utils/synthetic-conversation-artifact.test.ts
```

# Evidence Gate

<!-- evidence-head:98de82d6864abc8c4a7f3d09b5571bc1995fa321 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only change; the diff adds one .test.ts file under packages/core and touches no rendered surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only change; no rendered surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is a unit-test file whose full output is inline below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — full transcript inline below: the suite on this head, eleven mutation runs including per-branch deletion, the restored source back to green, and lint.

<details>
<summary>suite + mutation scorecard + lint</summary>

```text
# Evidence log — test(core): cover the synthetic-conversation-artifact classifier
# node v24.15.0  bun 1.3.14

===== 1. suite on the PR head =====
 Test Files  1 passed (1)
      Tests  36 passed (36)

===== 2. mutation scorecard (source restored after each) =====
baseline (unmutated)                               Tests  36 passed (36)

B1 delete the bracketed-marker branch              Tests  8 failed | 28 passed (36)
B2 delete the compaction-prefix branch             Tests  36 passed (36)
B3 delete the summary-heading branch               Tests  36 passed (36)
B4 delete the loose-phrase branch                  Tests  3 failed | 33 passed (36)
B5 delete the metadata.source branch               Tests  6 failed | 30 passed (36)
B6 delete the tags branch                          Tests  2 failed | 34 passed (36)
B7 delete the text fallback in the memory form     Tests  1 failed | 35 passed (36)
M1 marker regex loses its ^ anchor                 Tests  1 failed | 35 passed (36)
M2 source regex loses its word boundaries          Tests  1 failed | 35 passed (36)
M3 drop the trim before matching                   Tests  1 failed | 35 passed (36)
M4 tags no longer filtered to strings              Tests  2 failed | 34 passed (36)

restored                                           Tests  36 passed (36)
git diff --stat -> (clean)

===== 3. lint =====
Checked 1 file in 24ms. No fixes applied.
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path is exercised.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model code path changed; no production source file is modified by this PR.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - both predicates return a boolean; every input/output pair is asserted inline in the test file and visible in the transcript above.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model path changed.`

## Backend + frontend logs

Frontend: `N/A - no frontend path exercised.` Backend: full transcript is inline on the `backend-logs` row above.

### Proof the suite is not vacuous

Eleven mutants, seven of them **branch deletions** rather than tweaks, since a classifier's real risk is a branch quietly stopping to fire. Source restored after every run (`git diff --stat` clean, 36/36 green again).

| # | mutation | result |
| --- | --- | --- |
| B1 | delete the bracketed-marker branch | **8 failed** |
| B2 | delete the compaction-prefix branch | 36 passed — subsumed, see above |
| B3 | delete the summary-heading branch | 36 passed — subsumed, see above |
| B4 | delete the loose-phrase branch | **3 failed** |
| B5 | delete the `metadata.source` branch | **6 failed** |
| B6 | delete the `metadata.tags` branch | **2 failed** |
| B7 | delete the text fallback in the memory form | **1 failed** |
| M1 | marker regex loses its `^` anchor | **1 failed** |
| M2 | source regex loses its word boundaries | **1 failed** |
| M3 | drop the `.trim()` before matching | **1 failed** |
| M4 | tags no longer filtered to strings | **2 failed** |

## Screenshots (before / after) + video walkthrough

`N/A - test-only change with no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, or STT path involved.`

## Known gaps / failures

- B2 and B3 above are unkillable by construction, not untested. The PR description explains why and the test file says so at the point of use rather than implying coverage the inputs do not give.
- Biome is clean on the new file. I did not run the full `bun run verify`; the diff is a single new test file with no production import-graph change.
