### PR TITLE
fix(task-coordinator): restore server import test formatting

### DIFF
--- a/plugins/plugin-task-coordinator/__tests__/unit/server-entry-no-ui-imports.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/server-entry-no-ui-imports.test.ts
@@ -51,7 +51,9 @@ function relativeImportPattern(moduleName: string): RegExp {
 
 function sideEffectImportPattern(moduleName: string): RegExp {
   const escaped = moduleName.replaceAll(".", String.raw`\.`);
-  return new RegExp(String.raw`import\s+["']\.\/${escaped}(?:\.(?:tsx?|jsx?))?["']`);
+  return new RegExp(
+    String.raw`import\s+["']\.\/${escaped}(?:\.(?:tsx?|jsx?))?["']`,
+  );
 }
 
 function starExportPattern(moduleName: string): RegExp {
@@ -96,7 +98,9 @@ describe("server entry — no browser/UI imports (#18031, #18347)", () => {
 
   it("does not import browser-only barrel paths", () => {
     for (const path of BROWSER_ONLY_PATHS) {
-      const escaped = path.replaceAll("/", String.raw`\/`).replaceAll(".", String.raw`\.`);
+      const escaped = path
+        .replaceAll("/", String.raw`\/`)
+        .replaceAll(".", String.raw`\.`);
       expect(source, `import from ${path}`).not.toMatch(
         new RegExp(String.raw`(?:import|export)\s+[^"']*["']${escaped}`),
       );


### PR DESCRIPTION
# What

Restores repository-owned Biome formatting in the task-coordinator server-entry import boundary test. Current `develop` fails `bun run verify` on this file, blocking unrelated PR verification.

# Why

This is a formatting-only repair: it wraps one regular-expression construction and one chained `replaceAll` expression without changing their tokens or behavior.

# Verification

Exact head: `1189343a12cd3748e7d38e28899ceb06eef0c739`

- `bun run --cwd plugins/plugin-task-coordinator test` — 31 files passed, 240 tests passed.
- `bun run --cwd plugins/plugin-task-coordinator lint:check` — 96 files checked, no fixes needed.
- `git diff --check` — passed.

# Evidence Gate

<!-- evidence-head:1189343a12cd3748e7d38e28899ceb06eef0c739 -->

- Before/after screenshots: N/A; test formatting only.
- Walkthrough video: N/A; no runtime or UI behavior.
- Backend/frontend logs: N/A; no runtime path changed.
- LLM trajectory: N/A; no agent behavior changed.
- Domain artifacts: N/A; no domain state changed.

# Contribution provenance

- AI assistance: yes
- Model: OpenAI GPT-5
- Client: Codex
- Maintainer-authored repair discovered while validating first-time-contributor PRs.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test formatting only; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test formatting only; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user flow or runtime behavior changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime path changed; exact-head test and lint results are in the PR body

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, task, wallet, generated-domain, or audio artifacts changed

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual surface or text rendering changed
