### PR TITLE
fix(ci): regreen develop zero-key and unit lanes (apt-lock installer gap, flick-clock determinism, loaded-runner budgets)

### DIFF
--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -101,7 +101,7 @@ jobs:
           no-vision-deps: "true"
 
       - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Generate shared i18n assets
         run: bun run --cwd packages/shared build:i18n
@@ -184,7 +184,7 @@ jobs:
           no-vision-deps: "true"
 
       - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Install ffmpeg (recording stitch)
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
@@ -271,7 +271,7 @@ jobs:
           no-vision-deps: "true"
 
       - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Generate shared i18n assets
         run: bun run --cwd packages/shared build:i18n
@@ -403,7 +403,7 @@ jobs:
           no-vision-deps: "true"
 
       - name: Install Playwright runner
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       # Build the packaged desktop app (catches build/packaging breaks). Run from
       # the repo root so desktop-build.mjs resolves packages/app.

--- a/.github/workflows/monetized-loop-nightly.yml
+++ b/.github/workflows/monetized-loop-nightly.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: ./.github/actions/cloud-setup-test-env
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Run monetization lifecycle
         run: >-

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -165,7 +165,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Actual app onboarding-to-home browser coverage
         run: bun run --cwd packages/app test:e2e test/ui-smoke/onboarding-to-home.spec.ts --project=chromium
@@ -226,7 +226,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Actual app plugin view browser coverage
         run: bun run --cwd packages/app test:e2e test/ui-smoke/plugin-views-visual.spec.ts test/ui-smoke/plugin-views-interaction.spec.ts --project=chromium
@@ -286,7 +286,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Actual app all-pages render + click-safety browser coverage
         run: bun run --cwd packages/app test:e2e test/ui-smoke/all-pages-clicksafe.spec.ts test/ui-smoke/builtin-views-visual.spec.ts test/ui-smoke/documents-view.spec.ts --project=chromium
@@ -331,7 +331,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Actual app feature interaction browser coverage
         run: bun run --cwd packages/app test:e2e test/ui-smoke/apps-utility-interactions.spec.ts test/ui-smoke/apps-model-training-interactions.spec.ts test/ui-smoke/apps-comms-device-interactions.spec.ts test/ui-smoke/apps-diagnostics-interactions.spec.ts test/ui-smoke/apps-builtin-pages-interactions.spec.ts test/ui-smoke/settings-sections-interactions.spec.ts test/ui-smoke/settings-mobile-load.spec.ts test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts test/ui-smoke/vault-modal-interactions.spec.ts test/ui-smoke/desktop-workspace-interactions.spec.ts test/ui-smoke/settings-chat-control.spec.ts test/ui-smoke/routing-matrix-dispatch.spec.ts test/ui-smoke/chat-overlay-controls-interactions.spec.ts test/ui-smoke/task-widget-in-chat.spec.ts test/ui-smoke/chat-attachment.spec.ts test/ui-smoke/chat-3d-model.spec.ts test/ui-smoke/chat-large-paste.spec.ts test/ui-smoke/chat-clear-swipe.spec.ts test/ui-smoke/files-view.spec.ts test/ui-smoke/files-view-crud.spec.ts test/ui-smoke/conversation-management.spec.ts test/ui-smoke/chat-cloud-routed.spec.ts test/ui-smoke/slash-commands.spec.ts test/ui-smoke/model-download-deferral.spec.ts test/ui-smoke/home-widget-priority.spec.ts test/ui-smoke/settings-background.spec.ts --project=chromium
@@ -376,7 +376,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Actual app cloud keyless browser coverage
         run: bun run --cwd packages/app test:e2e test/ui-smoke/cloud-provisioning-startup.spec.ts test/ui-smoke/cloud-agent-lifecycle.spec.ts test/ui-smoke/cloud-wallet-import.spec.ts test/ui-smoke/live-agent-chat.spec.ts test/ui-smoke/remote-capability-view.spec.ts --project=chromium
@@ -421,7 +421,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Actual app ratcheted keyless browser coverage
         run: bun run --cwd packages/app test:e2e test/ui-smoke/ai-qa-capture.spec.ts test/ui-smoke/android-system-apps.spec.ts test/ui-smoke/apps-session.spec.ts test/ui-smoke/apps-session-direct-a.spec.ts test/ui-smoke/apps-session-direct-b.spec.ts test/ui-smoke/auth-startup.spec.ts test/ui-smoke/automations.spec.ts test/ui-smoke/browser-workspace.spec.ts test/ui-smoke/character-editor.spec.ts test/ui-smoke/wallet-inventory.spec.ts test/ui-smoke/workflow-editor.spec.ts test/ui-smoke/computer-use.spec.ts test/ui-smoke/connectors.spec.ts test/ui-smoke/first-run-startup.spec.ts test/ui-smoke/model-download-deferral.spec.ts test/ui-smoke/history-navigation.spec.ts test/ui-smoke/orchestrator-gui-workbench.spec.ts test/ui-smoke/reset-returns-to-onboarding.spec.ts test/ui-smoke/tutorial-chat.spec.ts test/ui-smoke/warming-shell-startup.spec.ts test/ui-smoke/runtime-configurability.spec.ts test/ui-smoke/perf-load-kpi.spec.ts test/ui-smoke/perf-reduced-motion.spec.ts test/ui-smoke/task-coordinator-gui-interactions.spec.ts test/ui-smoke/titlebar-navigation.spec.ts test/ui-smoke/ui-smoke.spec.ts --project=chromium
@@ -473,7 +473,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Actual app interaction frame-rate KPI browser coverage
         run: bun run --cwd packages/app test:e2e test/ui-smoke/perf-interaction-kpi.spec.ts --project=chromium
@@ -526,7 +526,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Actual app auto-discovered ui-smoke browser coverage
         run: |
@@ -586,7 +586,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       # The assertion-grade dashboard specs (browser-workspace, character-editor,
       # wallet-inventory, workflow-editor) across mobile-portrait/-landscape,
@@ -634,7 +634,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       # Pixel 7 (hasTouch, isMobile) lane: the decomposed personal-assistant
       # views + the real-CDP-touch chat gesture/fuzz specs at the WebView
@@ -692,7 +692,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright browsers (WebKit)
-        run: bunx playwright install --with-deps webkit
+        run: .github/scripts/install-playwright-browsers.sh webkit
 
       - name: Real-WebKit dashboard + shell + input-modality browser coverage
         run: bun run --cwd packages/app test:e2e --project=desktop-webkit
@@ -744,7 +744,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright browsers (Chromium)
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Accounts UI browser e2e — real AccountList + real accounts routes + real AccountPool
         env:
@@ -792,7 +792,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Install ffmpeg (recording stitch)
         run: sudo apt-get update && sudo apt-get install -y ffmpeg

--- a/packages/cloud/scripts/bluebubbles-local-bridge.registered-e2e.test.ts
+++ b/packages/cloud/scripts/bluebubbles-local-bridge.registered-e2e.test.ts
@@ -565,5 +565,5 @@ describe("registered BlueBubbles local bridge E2E", () => {
         },
       ],
     });
-  }, 15_000);
+  }, 180_000);
 });

--- a/packages/scripts/__tests__/audit-scripts-inventory.test.ts
+++ b/packages/scripts/__tests__/audit-scripts-inventory.test.ts
@@ -212,7 +212,9 @@ describe("script inventory: packages/app surface (issue #10200)", () => {
       fs.rmSync(root, { force: true, recursive: true });
       fs.rmSync(outside, { force: true, recursive: true });
     }
-  });
+    // Symlink fixtures hit real disk; a loaded CI host has pushed this past
+    // the 5s default (11.4s observed on the scenario-runner lane).
+  }, 60_000);
 
   test("workflow execution seeds come only from structural run steps", () => {
     const steps = workflowExecutionSteps(`

--- a/packages/scripts/__tests__/biome-version-consistency.test.ts
+++ b/packages/scripts/__tests__/biome-version-consistency.test.ts
@@ -79,16 +79,22 @@ describe("Biome version consistency", () => {
     expect(collectBiomeVersionProblems(REPO_ROOT)).toEqual([]);
   });
 
-  it("accepts an aligned synthetic repository", () => {
-    const root = makeFixture();
-    expect(
-      collectBiomeVersionProblems(root, {
-        packageFiles: ["package.json", "nested/package.json"],
-        configFiles: ["biome.json"],
-        lockFiles: ["bun.lock", "nested/bun.lock"],
-      }),
-    ).toEqual([]);
-  });
+  it(
+    "accepts an aligned synthetic repository",
+    () => {
+      const root = makeFixture();
+      expect(
+        collectBiomeVersionProblems(root, {
+          packageFiles: ["package.json", "nested/package.json"],
+          configFiles: ["biome.json"],
+          lockFiles: ["bun.lock", "nested/bun.lock"],
+        }),
+      ).toEqual([]);
+    },
+    // Fixture writes hit real disk; a loaded CI host has pushed this past the
+    // 5s default (11.7s observed on the scenario-runner lane).
+    60_000,
+  );
 
   it("accepts a CRLF lockfile from a Windows checkout", () => {
     const root = makeFixture();

--- a/packages/scripts/__tests__/release-git.integration.test.ts
+++ b/packages/scripts/__tests__/release-git.integration.test.ts
@@ -203,7 +203,7 @@ describe("atomic release refs", () => {
     expect(remoteRefs(fixture.repoRoot, fixture.remote)).not.toContain(
       "refs/tags/",
     );
-  }, 30_000);
+  }, 120_000);
 
   test("one rejected ref rejects the entire atomic push and no unrelated tag follows", () => {
     const fixture = makeScenario();
@@ -259,7 +259,7 @@ describe("atomic release refs", () => {
     expect(remoteRefs(fixture.repoRoot, fixture.remote)).not.toContain(
       "refs/tags/v1.0.1",
     );
-  }, 30_000);
+  }, 120_000);
 
   test("tag-only finalization leaves the release branch untouched and retries exactly", () => {
     const fixture = makeScenario();
@@ -343,7 +343,7 @@ describe("atomic release refs", () => {
       ]),
       finalState: loadReleaseState(fixture.candidateDirectory),
     });
-  }, 30_000);
+  }, 120_000);
 
   test("tag-only rejection and a mismatched planned tag fail without ref mutation", () => {
     const fixture = makeScenario();
@@ -381,7 +381,7 @@ describe("atomic release refs", () => {
     expect(remoteRefs(fixture.repoRoot, fixture.remote)).not.toContain(
       "refs/tags/v1.0.1",
     );
-  }, 30_000);
+  }, 120_000);
 
   test("a post-push interruption binds retry intent before remote mutation", async () => {
     const fixture = makeScenario();
@@ -485,7 +485,7 @@ describe("atomic release refs", () => {
     expect(loadReleaseState(fixture.candidateDirectory).state.phase).toBe(
       "git-tagged",
     );
-  }, 30_000);
+  }, 120_000);
 
   test("refuses to publish an ambient lightweight local release tag", () => {
     const fixture = makeScenario();
@@ -506,7 +506,7 @@ describe("atomic release refs", () => {
     expect(remoteRefs(fixture.repoRoot, fixture.remote)).not.toContain(
       "refs/tags/v1.0.0",
     );
-  }, 30_000);
+  }, 120_000);
 
   test("remote source movement fails without an implicit rebase", () => {
     const fixture = makeScenario();
@@ -534,7 +534,7 @@ describe("atomic release refs", () => {
     expect(remoteRefs(fixture.repoRoot, fixture.remote)).not.toContain(
       "refs/tags/v1.0.0",
     );
-  }, 30_000);
+  }, 120_000);
 
   test("same-commit annotated tag with a noncanonical message is a conflict", () => {
     const fixture = makeScenario();
@@ -565,7 +565,7 @@ describe("atomic release refs", () => {
     expect(loadReleaseState(fixture.candidateDirectory).state.phase).toBe(
       "git-bound",
     );
-  }, 30_000);
+  }, 120_000);
 
   test("same-commit lightweight remote tag is a conflict", () => {
     const fixture = makeScenario();
@@ -589,7 +589,7 @@ describe("atomic release refs", () => {
     expect(loadReleaseState(fixture.candidateDirectory).state.phase).toBe(
       "git-bound",
     );
-  }, 30_000);
+  }, 120_000);
 
   test("conflicting and reserved tags fail", () => {
     const fixture = makeScenario();
@@ -614,5 +614,5 @@ describe("atomic release refs", () => {
         "reserved failed-release residue",
       );
     }
-  }, 30_000);
+  }, 120_000);
 });

--- a/packages/scripts/script-test-isolation.test.mjs
+++ b/packages/scripts/script-test-isolation.test.mjs
@@ -11,7 +11,12 @@ import path from "node:path";
 import test from "node:test";
 import { spawnSync } from "./lib/spawn-sync-captured.mjs";
 
-test("parallel script suites run in isolated worker processes", () => {
+// The four spawned suites do real subprocess work with a 20s exec budget; the
+// runner's 5s default test timeout undercut that on a loaded CI host (10.9s
+// observed on the scenario-runner lane).
+test("parallel script suites run in isolated worker processes", {
+  timeout: 60_000,
+}, () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "script-test-isolation-"));
   try {
     fs.mkdirSync(path.join(root, "changed-cwd"));

--- a/packages/ui/src/components/shell/HomeLauncherSurface.composed.test.tsx
+++ b/packages/ui/src/components/shell/HomeLauncherSurface.composed.test.tsx
@@ -102,6 +102,8 @@ const HIDDEN_VIEWS = [
 const ALL_VIEWS = [...DOCK_VIEWS, ...PAGE_VIEWS, ...HIDDEN_VIEWS];
 
 beforeEach(() => {
+  clock = 1000;
+  vi.spyOn(performance, "now").mockImplementation(() => clock);
   resetShellSurfaceForTests();
   window.localStorage.clear();
   window.history.replaceState(null, "", "/");
@@ -133,6 +135,12 @@ function renderComposed() {
   return screen.getByTestId("home-launcher-surface");
 }
 
+// The pager reads flick velocity from performance.now() deltas, so gestures
+// ride the pinned clock (advanced explicitly here) instead of wall-clock time;
+// on a loaded CI host a real-time gap between fireEvent calls reads as a slow
+// drag and the flick snaps back.
+let clock = 1000;
+
 function flick(testid: string, dx: number, dy = 4): void {
   const el = screen.getByTestId(testid);
   fireEvent.pointerDown(el, {
@@ -141,12 +149,14 @@ function flick(testid: string, dx: number, dy = 4): void {
     clientX: 260,
     clientY: 300,
   });
+  clock += 10;
   fireEvent.pointerMove(el, {
     isPrimary: true,
     pointerId: 1,
     clientX: 260 + dx,
     clientY: 300 + dy,
   });
+  clock += 10;
   fireEvent.pointerUp(el, {
     isPrimary: true,
     pointerId: 1,

--- a/packages/ui/src/components/shell/HomeLauncherSurface.test.tsx
+++ b/packages/ui/src/components/shell/HomeLauncherSurface.test.tsx
@@ -13,7 +13,7 @@ import {
   screen,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { goHome, goLauncher } from "../../state/shell-surface-store";
 import { HomeLauncherSurface } from "./HomeLauncherSurface";
 
@@ -22,6 +22,13 @@ function LauncherProbe() {
 }
 
 const originalMatchMedia = window.matchMedia;
+
+// The pager derives flick velocity from performance.now() deltas between
+// pointer events. Real wall-clock time makes the flick tests load-sensitive
+// (a GC/scheduler stall between two fireEvent calls on a busy CI host reads as
+// a slow drag and snaps back), so the suite pins the gesture clock the same
+// way useHorizontalPager.test.tsx does and advances it explicitly.
+let clock = 1000;
 
 function mockDesktopPagingMedia({
   finePointer,
@@ -43,8 +50,14 @@ function mockDesktopPagingMedia({
   })) as unknown as typeof window.matchMedia;
 }
 
+beforeEach(() => {
+  clock = 1000;
+  vi.spyOn(performance, "now").mockImplementation(() => clock);
+});
+
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   Object.defineProperty(window, "matchMedia", {
     configurable: true,
     writable: true,
@@ -70,11 +83,13 @@ describe("HomeLauncherSurface", () => {
       clientX: 260,
       clientY: 100,
     });
+    clock += 10;
     fireEvent.pointerMove(homePage, {
       isPrimary: true,
       clientX: 150,
       clientY: 104,
     });
+    clock += 10;
     fireEvent.pointerUp(homePage, {
       isPrimary: true,
       clientX: 150,
@@ -107,11 +122,13 @@ describe("HomeLauncherSurface", () => {
       clientX: 120,
       clientY: 300,
     });
+    clock += 10;
     fireEvent.pointerMove(launcherPage, {
       isPrimary: true,
       clientX: 260,
       clientY: 304,
     });
+    clock += 10;
     fireEvent.pointerUp(launcherPage, {
       isPrimary: true,
       clientX: 260,


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Anthropic / Claude Fable 5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: N/A - direct CI-remediation task, no packaged skill
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What this PR does

Regreens the red develop push-CI lanes (`Tests`, `Scenario PR E2E`) reported at tip 112a73c8eec and re-attributed against the current tip 539ae4150a2. Every fix below is tied to a specific failing job log; per-job attribution is in the table.

## Per-job attribution

| Red job | Runs (develop) | Root cause | Fix here |
| --- | --- | --- | --- |
| Tests / Classify changed paths, Plugin Tests, Zero-Key Deterministic E2E, ci-ok (run 31285789876 @ 112a73c8eec) | one cascade | `Classify changed paths` failed on the i18n catalog gap (3 missing `cloud.login.*` keys). The plugin shard matrix and every zero-key job are `needs:`-downstream of classify, so they were **skipped**, and both aggregators treat skipped-on-push as failure. | Root already fixed by merged #18526. This PR removes the fatal side effect #18526 introduced: it appended the 3 keys to the end of `packages/ui/src/i18n/locales/en.json` while identical keys already existed in the sorted block → `lint/suspicious/noDuplicateObjectKeys` **errors** under the repo-pinned Biome 2.5.6, which reds `@elizaos/ui#lint:check` (root `verify` / Quality lane) at the current tip. The dedup landed upstream while this branch was in flight (verified single-copy at the rebase base); this PR carries no en.json change. Root `bun run verify` was run green on this branch with the dedup applied. |
| Scenario / Zero-Key app browser auto-discovered specs (31552743524), dashboard device matrix (31532160747, 31488222526, 31482830881), cloud keyless & Pixel-7 & view lifecycle installs | ≥5 runs, rotating lanes | `bunx playwright install --with-deps` shells out to apt-get and races the other concurrent lanes / unattended-upgrades on the shared self-hosted hosts: `E: Could not get lock /var/lib/apt/lists/lock … exit code 100`. The repo already has a hardened installer (`.github/scripts/install-playwright-browsers.sh`, added by #17910) that configures the dpkg lock timeout and retries — but `scenario-pr.yml` (13 steps), `app-live-e2e.yml` (4), and `monetized-loop-nightly.yml` (1) still call the raw command. The #18396 ui-smoke sharding multiplied concurrent installs per host and made this the dominant zero-key red. | Route all 18 remaining raw installs through the hardened script. |
| Tests / Client Tests (run 31488222516 @ aa6677ea69) | deterministic mechanism, load-triggered | `packages/ui/src/components/shell/HomeLauncherSurface.test.tsx` › "flips to Launcher on a left flick": the pager computes flick velocity from real `performance.now()` deltas; in jsdom the distance path needs 307 px (innerWidth fallback × 0.3) so the 110 px test gesture rides the velocity path, and any ≥ ~245 ms stall between two `fireEvent` calls (the failing run's UI suite took 1486 s) drops velocity below `PAGER_FLICK_VELOCITY` and the flick snaps home — exactly the CI assertion `expected 'home' to be 'launcher'`. | Pin the gesture clock (`vi.spyOn(performance, "now")` + explicit advances), the same pattern `useHorizontalPager.test.tsx` already uses; applied to both HomeLauncherSurface suites. Red→green proven locally (see evidence). |
| Scenario / Zero-Key scenario runner E2E (31547762048, 31544159998, 31504925719) → Zero-Key Deterministic E2E aggregator | rotating tests, one class | Loaded-runner timeouts: real-subprocess/disk tests exceeded small explicit or default budgets (44.9 s vs 30 s in `release-git.integration.test.ts`; 97.9 s vs 15 s BlueBubbles bridge e2e; 10.9–11.7 s vs 5 s defaults in `script-test-isolation`, `audit-scripts-inventory` symlink test, `biome-version-consistency`). The sibling `release-github.integration.test.ts` was already hardened to 120 s — `release-git` was left behind. | Align `release-git.integration.test.ts` to 120 s and give the four observed casualties explicit budgets. The underlying host oversubscription is infra and also mitigated by the apt-lock fix removing 30 s-backoff retry storms. |
| Scenario / Zero-Key app browser dashboard device matrix (31547762048 ipad-portrait, 31552743524 desktop-landscape) | 2 of 3 recent runs, different projects | `browser-workspace.spec.ts:178`: after switching to the example.com tab via the switcher, `fill("docs.elizaos.ai")` is clobbered back to `https://example.com/`. Reported, not fixed: 12/12 local runs green (real harness, both projects, plus a CPU-stress rerun), all dirty-draft reset paths in `BrowserWorkspaceView.tsx` were audited without a provable in-component overwrite, and the two CI hits coincide with the post-#18396 host saturation. Watching; needs a trace artifact from a failing CI run to attribute further. | none (documented flake) |

## Verification

- Red→green for the flick suite: original spec + injected 300 ms stall between `pointerMove`/`pointerUp` fails with the exact CI signature (`AssertionError: expected 'home' to be 'launcher'`); pinned-clock version passes with the same stall injected. Both suites (26 tests) green.
- `bun test packages/scripts/__tests__/release-git.integration.test.ts` (10 pass), `script-test-isolation` under both `node --test` and `bun test`, `audit-scripts-inventory` (14 pass), `biome-version-consistency` (5 pass), BlueBubbles registered e2e (1 pass).
- `packages/app` browser-workspace spec: 12/12 green locally on the failing device projects (idle + CPU-stress).
- `actionlint` clean on all three touched workflows; `biome check` clean on every touched file; `packages/ui` and `packages/scripts` typecheck green; `node packages/app-core/scripts/check-i18n.mjs` exit 0; root `bun run verify` green on this branch (pre-rebase head cebd23c; the en.json dedup it validated has since landed upstream).

<!-- evidence-head:cebd23c394a178a44ce609e2987ace607af97889 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow + test-harness determinism changes; no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] CI job logs cited per row above (runs 31285789876, 31552743524, 31547762048, 31544159998, 31532160747, 31530003175, 31509427772, 31504925719, 31488222516/31488222526, 31482830881); local red→green transcripts in the PR discussion below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - jsdom unit suites and Playwright runs above are the frontend evidence.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM invoked by the changed code.
<!-- evidence-row:domain-artifacts -->
- [x] The 18 workflow install steps now calling `.github/scripts/install-playwright-browsers.sh` (13 scenario-pr + 4 app-live-e2e + 1 monetized-loop-nightly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
