### PR TITLE
fix(discord): never let the startup reaction scan eat the current process's markers

### DIFF
--- a/plugins/plugin-discord/__tests__/shutdown-drain.test.ts
+++ b/plugins/plugin-discord/__tests__/shutdown-drain.test.ts
@@ -63,6 +63,24 @@ describe("createTurnDrainRegistry", () => {
 		expect(registry.pendingCount()).toBe(0);
 	});
 
+	it("reports a message id pending while either half is outstanding, and not after", async () => {
+		const registry = createTurnDrainRegistry();
+		const controller = makeController();
+		const turn = delay(5).then(() => {
+			controller.setDone();
+		});
+
+		expect(registry.isPending("msg-1")).toBe(false);
+		registry.trackTurn("msg-1", turn);
+		registry.trackStatusReaction("msg-1", controller);
+		expect(registry.isPending("msg-1")).toBe(true);
+		expect(registry.isPending("msg-other")).toBe(false);
+
+		await registry.drain(200);
+
+		expect(registry.isPending("msg-1")).toBe(false);
+	});
+
 	it("returns promptly when nothing is in flight", async () => {
 		const registry = createTurnDrainRegistry();
 

--- a/plugins/plugin-discord/__tests__/startup-reaction-reconcile.test.ts
+++ b/plugins/plugin-discord/__tests__/startup-reaction-reconcile.test.ts
@@ -2,13 +2,16 @@
  * Covers the startup stranded-reaction scan (elizaOS/eliza#16318): the bot's
  * own in-progress markers (⏳/🤔) left by a hard kill are removed from recent
  * messages, terminal/others' reactions are untouched, every dimension of the
- * scan is hard-capped, and failures are counted and logged, never thrown.
- * Uses plain-object discord.js fakes, matching service-shutdown-drain.test.ts.
+ * scan is hard-capped, failures are counted and logged, never thrown, and the
+ * scan never eats a marker belonging to the CURRENT process (post-scan-start
+ * messages and registry-active turns are excluded). Uses plain-object
+ * discord.js fakes, matching service-shutdown-drain.test.ts.
  */
 import { describe, expect, it, vi } from "vitest";
 import {
 	reconcileStrandedStatusReactions,
 	STARTUP_SCAN_MAX_AGE_MS,
+	STARTUP_SCAN_STARTED_AT_SKEW_MS,
 } from "../startup-reaction-reconcile.ts";
 
 const BOT_ID = "bot-user-1";
@@ -25,8 +28,10 @@ function makeReaction(me: boolean) {
 function makeMessage({
 	ageMs = 60_000,
 	reactions = {} as Record<string, ReturnType<typeof makeReaction>>,
+	id = `message-${Math.random().toString(36).slice(2, 8)}`,
 } = {}) {
 	return {
+		id,
 		createdTimestamp: NOW - ageMs,
 		reactions: {
 			resolve: (emoji: string) => reactions[emoji],
@@ -123,12 +128,69 @@ describe("reconcileStrandedStatusReactions", () => {
 
 	it("never asks for the terminal ❌ marker", async () => {
 		const resolve = vi.fn(() => undefined);
-		const message = { createdTimestamp: NOW - 1000, reactions: { resolve } };
+		const message = {
+			id: "message-terminal",
+			createdTimestamp: NOW - STARTUP_SCAN_STARTED_AT_SKEW_MS - 1000,
+			reactions: { resolve },
+		};
 		await scan(makeClient([makeChannel([message as never])]));
 
 		const askedFor = resolve.mock.calls.map((call) => call[0]);
 		expect(askedFor).not.toContain("❌");
 		expect(askedFor).toEqual(expect.arrayContaining(["⏳", "🤔"]));
+	});
+
+	it("never removes a marker from a message created at or after scan start", async () => {
+		// The current process's listeners bind before login: a marker on a
+		// message newer than the scan's start is live state, not crash residue.
+		const liveExact = makeReaction(true);
+		const liveWithinSkew = makeReaction(true);
+		const residue = makeReaction(true);
+		const atScanStart = makeMessage({
+			ageMs: 0,
+			reactions: { "🤔": liveExact },
+		});
+		const withinSkew = makeMessage({
+			ageMs: STARTUP_SCAN_STARTED_AT_SKEW_MS - 1,
+			reactions: { "⏳": liveWithinSkew },
+		});
+		const beforeSkew = makeMessage({
+			ageMs: STARTUP_SCAN_STARTED_AT_SKEW_MS + 1,
+			reactions: { "🤔": residue },
+		});
+		const summary = await scan(
+			makeClient([makeChannel([atScanStart, withinSkew, beforeSkew])]),
+		);
+
+		expect(liveExact.users.remove).not.toHaveBeenCalled();
+		expect(liveWithinSkew.users.remove).not.toHaveBeenCalled();
+		expect(residue.users.remove).toHaveBeenCalledWith(BOT_ID);
+		expect(summary.reactionsCleared).toBe(1);
+	});
+
+	it("leaves markers whose message id is active in the turn-drain registry", async () => {
+		const live = makeReaction(true);
+		const residue = makeReaction(true);
+		const activeMessage = makeMessage({
+			id: "message-active-turn",
+			reactions: { "🤔": live },
+		});
+		const idleMessage = makeMessage({
+			id: "message-idle",
+			reactions: { "🤔": residue },
+		});
+		const isTurnActive = vi.fn(
+			(messageId: string) => messageId === "message-active-turn",
+		);
+		const summary = await scan(
+			makeClient([makeChannel([activeMessage, idleMessage])]),
+			{ isTurnActive },
+		);
+
+		expect(isTurnActive).toHaveBeenCalledWith("message-active-turn");
+		expect(live.users.remove).not.toHaveBeenCalled();
+		expect(residue.users.remove).toHaveBeenCalledWith(BOT_ID);
+		expect(summary.reactionsCleared).toBe(1);
 	});
 
 	it("skips messages older than the age cap", async () => {

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -3379,7 +3379,15 @@ export class DiscordService extends Service implements IDiscordService {
 			void reconcileStrandedStatusReactions({
 				client: readyClient,
 				logger: this.runtime.logger,
+				// Listeners bind before login, so a turn started by THIS process
+				// can already be in flight (with a live ⏳/🤔) when the scan runs;
+				// the registry marks those markers as current, not crash residue.
+				isTurnActive: (messageId) =>
+					this.turnDrainRegistry.isPending(messageId),
 			}).catch((error) => {
+				// error-policy:J7 the scan is detached diagnostics/cleanup off the
+				// ready path; a failure is warned here and must never surface as a
+				// terminal login failure for the account.
 				this.runtime.logger.warn(
 					`[DiscordService] Startup reaction scan failed for account ${accountId}: ${
 						error instanceof Error ? error.message : String(error)

--- a/plugins/plugin-discord/shutdown-drain.ts
+++ b/plugins/plugin-discord/shutdown-drain.ts
@@ -77,6 +77,12 @@ export interface DiscordTurnDrainRegistry {
 	/** Count of message ids with either half still outstanding. */
 	pendingCount: () => number;
 	/**
+	 * True while either half (turn promise or reaction controller) of this
+	 * message id is still outstanding. The startup reaction scan uses this to
+	 * leave live turns' markers alone (startup-reaction-reconcile.ts).
+	 */
+	isPending: (messageId: string) => boolean;
+	/**
 	 * Wait for every turn tracked at call time to settle, bounded by
 	 * `timeoutMs`. Turns still pending when the bound elapses are abandoned:
 	 * their status-reaction controller (if any) is forced to its terminal
@@ -132,6 +138,9 @@ export function createTurnDrainRegistry(): DiscordTurnDrainRegistry {
 	];
 
 	const pendingCount = (): number => pendingIds().length;
+
+	const isPending = (messageId: string): boolean =>
+		handlers.has(messageId) || reactions.has(messageId);
 
 	const drain = async (timeoutMs: number): Promise<DiscordDrainResult> => {
 		// Snapshot both halves per id. Holding the promise and controller
@@ -236,5 +245,5 @@ export function createTurnDrainRegistry(): DiscordTurnDrainRegistry {
 		};
 	};
 
-	return { trackTurn, trackStatusReaction, pendingCount, drain };
+	return { trackTurn, trackStatusReaction, pendingCount, isPending, drain };
 }

--- a/plugins/plugin-discord/startup-reaction-reconcile.ts
+++ b/plugins/plugin-discord/startup-reaction-reconcile.ts
@@ -16,6 +16,13 @@
  * every failure is counted and logged with channel context, never thrown:
  * this runs detached from the ready path, where a rejection would be treated
  * as a terminal login failure.
+ *
+ * The scan must never eat a marker the CURRENT process just placed: message
+ * listeners bind before login resolves, so a turn can start (and stamp ⏳/🤔)
+ * before this scan runs. Two guards enforce that: messages created at or
+ * after the scan started (minus a small clock-skew allowance) are skipped,
+ * and the caller may pass `isTurnActive` so message ids tracked in the live
+ * turn-drain registry are excluded regardless of timestamp.
  */
 import type { Client, Message, TextBasedChannel } from "discord.js";
 import { IN_PROGRESS_STATUS_EMOJIS } from "./status-reactions";
@@ -39,6 +46,14 @@ export const STARTUP_SCAN_MAX_AGE_MS = 24 * 60 * 60 * 1000;
  */
 export const STARTUP_SCAN_TIME_BUDGET_MS = 30_000;
 
+/**
+ * Messages created at or after `startedAt - skew` are never touched: they
+ * postdate this process's message listeners, so any in-progress marker on
+ * them belongs to a live turn, not a crashed predecessor. The skew absorbs
+ * drift between the local clock and Discord's snowflake timestamps.
+ */
+export const STARTUP_SCAN_STARTED_AT_SKEW_MS = 5_000;
+
 export interface StartupReconcileSummary {
 	channelsScanned: number;
 	messagesInspected: number;
@@ -59,10 +74,17 @@ interface ReconcileOptions {
 	logger: ScanLogger;
 	/** Injected clock for tests. */
 	now?: () => number;
+	/**
+	 * Live-turn probe (the service passes the turn-drain registry). A message
+	 * id reported active belongs to a turn this process is running right now;
+	 * its marker is current state, not crash residue, and is skipped.
+	 */
+	isTurnActive?: (messageId: string) => boolean;
 	maxChannels?: number;
 	messagesPerChannel?: number;
 	maxAgeMs?: number;
 	timeBudgetMs?: number;
+	startedAtSkewMs?: number;
 }
 
 function channelLabel(channel: { id?: string }): string {
@@ -108,10 +130,12 @@ export async function reconcileStrandedStatusReactions(
 		client,
 		logger,
 		now = Date.now,
+		isTurnActive,
 		maxChannels = STARTUP_SCAN_MAX_CHANNELS,
 		messagesPerChannel = STARTUP_SCAN_MESSAGES_PER_CHANNEL,
 		maxAgeMs = STARTUP_SCAN_MAX_AGE_MS,
 		timeBudgetMs = STARTUP_SCAN_TIME_BUDGET_MS,
+		startedAtSkewMs = STARTUP_SCAN_STARTED_AT_SKEW_MS,
 	} = options;
 
 	const summary: StartupReconcileSummary = {
@@ -145,6 +169,9 @@ export async function reconcileStrandedStatusReactions(
 			});
 			messages = fetched.values();
 		} catch (error) {
+			// error-policy:J6 best-effort residue cleanup; a channel we cannot
+			// read is counted, warned with its id, and skipped — one revoked
+			// channel must not abort the scan of the rest.
 			summary.failures += 1;
 			logger.warn(
 				`[DiscordService] Startup reaction scan could not fetch messages in channel ${channelLabel(channel)}: ${
@@ -157,6 +184,12 @@ export async function reconcileStrandedStatusReactions(
 			summary.messagesInspected += 1;
 			const age = now() - message.createdTimestamp;
 			if (age > maxAgeMs) continue;
+			// Never touch a message this process could have marked itself:
+			// listeners bind before login, so a turn (and its ⏳/🤔) can exist
+			// before this scan runs. Crash residue is by definition older than
+			// this process.
+			if (message.createdTimestamp >= startedAt - startedAtSkewMs) continue;
+			if (isTurnActive?.(message.id) === true) continue;
 			for (const emoji of IN_PROGRESS_STATUS_EMOJIS) {
 				const reaction = message.reactions?.resolve(emoji);
 				// `me` is populated on fetched messages; only the bot's own
@@ -167,6 +200,9 @@ export async function reconcileStrandedStatusReactions(
 					await reaction.users.remove(botId);
 					summary.reactionsCleared += 1;
 				} catch (error) {
+					// error-policy:J6 best-effort residue cleanup; a failed removal
+					// (deleted message, revoked permission) is counted and warned,
+					// and the scan keeps going — the marker simply stays stranded.
 					summary.failures += 1;
 					logger.warn(
 						`[DiscordService] Startup reaction scan could not remove ${emoji} in channel ${channelLabel(channel)}: ${


### PR DESCRIPTION
# Relates to

Follow-up to #18470 (startup reconciliation slice of #16318). These are the review fixes for that PR; it merged before they could be pushed to the contributor's fork (`wbaxterh:fix/discord-startup-reaction-reconcile` rejected the maintainer push), so they land as this follow-up instead. Must NOT close #16318.

# Risks

Low. Two additional skip-guards in the startup scan (it now removes strictly fewer reactions than before), one read-only probe on the turn-drain registry, and error-policy annotations on already-existing catches.

# Background

## What does this PR do?

Review of #18470 found a real race: Discord message listeners bind before login resolves, and the startup scan runs detached after `onReadyForAccount`, so a turn started by the CURRENT process can already hold a live ⏳/🤔 when the scan walks recent messages. The only filter was age > 24h, so the scan could delete a marker the current process had just placed. Two guards close it:

1. **Scan-start cutoff.** Messages created at or after the scan started — minus a 5s clock-skew allowance (`STARTUP_SCAN_STARTED_AT_SKEW_MS`, absorbing drift between the local clock and Discord snowflake timestamps) — are never touched. Crash residue is by definition older than this process.
2. **Live-turn exclusion.** The service passes `isTurnActive` backed by the new `DiscordTurnDrainRegistry.isPending(messageId)` probe, so a message id with a turn or status-reaction controller still outstanding is skipped regardless of timestamp.

It also annotates the retained catches per the repository error policy: `// error-policy:J6` on the scan's fetch-failure and removal-failure catches (best-effort residue cleanup, counted and warned, never thrown) and `// error-policy:J7` on the detached `.catch` in `onReadyForAccount` (the scan is detached diagnostics/cleanup; its failure must never surface as a terminal login failure).

**Honest coverage note (also applies to the merged #18470):** `collectChannels` sees only DMs already present in `client.channels.cache`. On a cold restart that cache is empty until a DM event repopulates it, so a marker stranded in a DM is typically NOT cleaned by the startup scan — DM cleanup effectively covers warm reconnects, not cold restarts. Guild text channels, the common case for the stranded-marker complaint in #16318, are fully covered.

## What kind of change is this?

Bug fix (non-breaking) — closes a self-inflicted-deletion race in the feature merged by #18470.

# Documentation changes needed?

None. The guards and the skew constant are documented at their definition sites.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-discord/startup-reaction-reconcile.ts` — the two skip-guards in the message loop and the `startedAtSkewMs` / `isTurnActive` options.
2. `plugins/plugin-discord/shutdown-drain.ts` — `isPending` on the registry.
3. `plugins/plugin-discord/service.ts` — the `isTurnActive` wiring and the J7-annotated `.catch`.
4. Tests: `__tests__/startup-reaction-reconcile.test.ts` gains a deterministic test that a marker on a message created at/after scan start (including inside the skew window) is never removed while genuinely older residue still is, and one that registry-active message ids are skipped; `__tests__/shutdown-drain.test.ts` gains coverage that `isPending` reports true while either half is outstanding and false after the drain.

Commands run at this head:

```bash
bun run --cwd plugins/plugin-discord test        # 74 files, 594/594
bun run --cwd plugins/plugin-discord typecheck   # 0 errors
bun x biome check <touched files>                # clean
git diff --check                                 # clean
```

# Evidence Gate

<!-- evidence-head:689ca0b9dd0929537571d2f9295af591a27f8957 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: `N/A - deterministic race-guard change with no UI surface; the live Discord captures for the underlying feature remain with the author of #18470`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: `N/A - same as above`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no app UI flow is involved`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end: full plugin test transcript at this head pasted below.

<details>
<summary>Plugin-discord test transcript at 689ca0b9dd0 (74 files, 594/594): full per-test detail for touched files, per-file results for the rest</summary>

```
Per-test detail for the two test files this PR touches:

 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > exposes the shutdown drain timeout as an explicit bounded constant 3ms
 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > drains an in-flight turn that resolves before the timeout 8ms
 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > reports a message id pending while either half is outstanding, and not after 6ms
 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > returns promptly when nothing is in flight 1ms
 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > abandons and reconciles a turn that outlives the drain timeout, without hanging 21ms
 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > reports a timeout for a hung turn that has no status-reaction controller (#17749 review) 21ms
 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > reports a clean drain as not timed out, so the caller can log success on that alone 2ms
 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > separates dropped work from reconciled reactions when both occur 21ms
 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > leaves no permanent residue when a turn dies without driving its reaction terminal (#17749 review) 31ms
 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > does not let an older promise retire a re-registered turn under the same id (#17749 review) 31ms
 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > tracks a status reaction registered before the turn promise itself 21ms
 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > only reports turns still pending at the timeout, not ones that settled just in time 51ms
 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > clears the drain timer once the turns settle, so a clean drain does not hold the event loop (#17749 review) 1ms
 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > waits for the status reaction to settle, not just the handler promise (#17749 review) 21ms
 ✓ __tests__/shutdown-drain.test.ts > createTurnDrainRegistry > abandons a reaction still mid-transition even after its handler untracked the entry (#17749 review) 41ms
 ✓ __tests__/startup-reaction-reconcile.test.ts > reconcileStrandedStatusReactions > removes the bot's own stranded in-progress markers and reports them 7ms
 ✓ __tests__/startup-reaction-reconcile.test.ts > reconcileStrandedStatusReactions > leaves other users' identical emojis untouched 1ms
 ✓ __tests__/startup-reaction-reconcile.test.ts > reconcileStrandedStatusReactions > never asks for the terminal ❌ marker 2ms
 ✓ __tests__/startup-reaction-reconcile.test.ts > reconcileStrandedStatusReactions > never removes a marker from a message created at or after scan start 1ms
 ✓ __tests__/startup-reaction-reconcile.test.ts > reconcileStrandedStatusReactions > leaves markers whose message id is active in the turn-drain registry 1ms
 ✓ __tests__/startup-reaction-reconcile.test.ts > reconcileStrandedStatusReactions > skips messages older than the age cap 1ms
 ✓ __tests__/startup-reaction-reconcile.test.ts > reconcileStrandedStatusReactions > honors the channel cap and per-channel message limit 1ms
 ✓ __tests__/startup-reaction-reconcile.test.ts > reconcileStrandedStatusReactions > stops between channels when the time budget elapses and says so 1ms
 ✓ __tests__/startup-reaction-reconcile.test.ts > reconcileStrandedStatusReactions > counts a failed channel fetch, logs it, and continues 1ms
 ✓ __tests__/startup-reaction-reconcile.test.ts > reconcileStrandedStatusReactions > counts a failed removal and keeps scanning 1ms
 ✓ __tests__/startup-reaction-reconcile.test.ts > reconcileStrandedStatusReactions > skips non-viewable and non-text channels, includes cached DMs 1ms
 ✓ __tests__/startup-reaction-reconcile.test.ts > reconcileStrandedStatusReactions > skips entirely and warns when the client has no user id 0ms

Per-file results for the rest of the suite (every file green):

 ✓ __tests__/dm-gate-handle-message.test.ts (4 tests)
 ✓ __tests__/outbound-dm-participation.harness.test.ts (1 tests)
 ✓ test/messages-group-coordination-pglite.test.ts (8 tests)
 ✓ test/group-coordination-pglite.test.ts (20 tests)
 ✓ __tests__/draft-stream.test.ts (4 tests)
 ✓ __tests__/outbound-dm-allowlist-exemption.test.ts (2 tests)
 ✓ __tests__/shutdown-drain.test.ts (15 tests)
 ✓ __tests__/draft-stream-components.test.ts (2 tests)
 ✓ __tests__/local-routes-e2e.test.ts (12 tests)
 ✓ __tests__/service-account-pool.test.ts (14 tests)
 ✓ actions/messageConnector.outbound-media.test.ts (6 tests)
 ✓ __tests__/slash-commands.test.ts (13 tests)
 ✓ __tests__/catalog-commands.test.ts (57 tests)
 ✓ __tests__/gateway-replay-reconnect.harness.test.ts (5 tests)
 ✓ __tests__/messages-url.test.ts (13 tests)
 ✓ __tests__/messages-durable-turn.test.ts (6 tests)
 ✓ __tests__/messages-inbound-idempotency.test.ts (5 tests)
 ✓ __tests__/generation-timeout-dispatch.test.ts (5 tests)
 ✓ __tests__/interaction-dispatch-coverage.test.ts (7 tests)
 ✓ __tests__/voice-meetings.test.ts (22 tests)
 ✓ __tests__/outbound-attachment.test.ts (6 tests)
 ✓ __tests__/debouncer-recent-context.test.ts (28 tests)
 ✓ __tests__/messages-component-delivery.test.ts (5 tests)
 ✓ __tests__/ask-command-and-groupdm.test.ts (16 tests)
 ✓ __tests__/login-retry.test.ts (10 tests)
 ✓ __tests__/service-shutdown-drain.test.ts (4 tests)
 ✓ __tests__/interaction-replay-render.test.ts (3 tests)
 ✓ __tests__/help-status-commands.test.ts (5 tests)
 ✓ __tests__/slash-command-dispatch-cooldown-and-errors.test.ts (11 tests)
 ✓ __tests__/interactions.test.ts (13 tests)
 ✓ __tests__/group-coordination.test.ts (24 tests)
 ✓ actions/messageConnector.test.ts (6 tests)
 ✓ __tests__/component-interaction-cleanup.test.ts (4 tests)
 ✓ __tests__/startup-reaction-reconcile.test.ts (12 tests)
 ✓ __tests__/inbound-envelope.test.ts (3 tests)
 ✓ __tests__/environment-defaults.test.ts (5 tests)
 ✓ __tests__/discord-events-dm-dispatch.test.ts (10 tests)
 ✓ __tests__/readiness.test.ts (2 tests)
 ✓ __tests__/turn-state.test.ts (14 tests)
 ✓ __tests__/identity.test.ts (15 tests)
 ✓ __tests__/message-coalesce.test.ts (4 tests)
 ✓ __tests__/discord-target-source.test.ts (10 tests)
 ✓ __tests__/owner-pairing-service.test.ts (6 tests)
 ✓ __tests__/slash-command-registration-scope.test.ts (8 tests)
 ✓ __tests__/data-routes.test.ts (4 tests)
 ✓ __tests__/connector-rooms.test.ts (3 tests)
 ✓ __tests__/discord-events-mute-gate.test.ts (7 tests)
 ✓ __tests__/dm-access.test.ts (5 tests)
 ✓ __tests__/list-servers-persisted-world.test.ts (2 tests)
 ✓ __tests__/register-slash-commands-guards.test.ts (5 tests)
 ✓ __tests__/attachments.test.ts (4 tests)
 ✓ __tests__/generation-abort.test.ts (7 tests)
 ✓ __tests__/triage-adapter.test.ts (15 tests)
 ✓ __tests__/sensitive-request-adapter.test.ts (10 tests)
 ✓ __tests__/staleness.test.ts (4 tests)
 ✓ __tests__/channel-allowlist.test.ts (9 tests)
 ✓ __tests__/dm-policy.test.ts (2 tests)
 ✓ __tests__/slash-command-registry.test.ts (7 tests)
 ✓ __tests__/discord-events-config.test.ts (4 tests)
 ✓ __tests__/owner-refresh.test.ts (1 tests)
 ✓ __tests__/discord-audio-sink.test.ts (2 tests)
 ✓ __tests__/banner-reply-warning.test.ts (9 tests)
 ✓ __tests__/dm-widget-components.test.ts (2 tests)
 ✓ __tests__/allowlist.test.ts (2 tests)
 ✓ __tests__/messaging-format.test.ts (8 tests)
 ✓ __tests__/voice-target-registry.test.ts (1 tests)
 ✓ __tests__/service-account-config-resolution.test.ts (9 tests)
 ✓ __tests__/thread-target-parent-mute.test.ts (1 tests)
 ✓ __tests__/extract-content-metadata.test.ts (7 tests)
 ✓ __tests__/numeric-fact-dedup.test.ts (7 tests)
 ✓ __tests__/addressing.test.ts (5 tests)
 ✓ __tests__/voice.test.ts (1 tests)
 ✓ __tests__/audio-lanes.test.ts (2 tests)
 ✓ __tests__/generation-timeout.test.ts (4 tests)

 Test Files  74 passed (74)
      Tests  594 passed (594)
   Start at  22:45:26
   Duration  76.26s (transform 16.78s, setup 2.79s, import 111.75s, tests 24.58s, environment 11ms)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend involvement`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the deterministic tests above encode the exact adversarial sequence (post-scan-start marker, in-skew marker, registry-active turn) and prove none is removed while genuine residue still is.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered app surface`.

# Known gaps

- The DM cold-restart coverage gap described above is inherent to `client.channels.cache` and is documented, not fixed, here.
- Live-Discord screenshot evidence for the underlying feature lives with #18470's author; this follow-up is deterministic-test-verified only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
