### PR TITLE
fix(ui): close 4 authority-isolation gaps left in notification-store after #18495

### DIFF
--- a/packages/ui/src/api/client-base-base-url-change-resilience.test.ts
+++ b/packages/ui/src/api/client-base-base-url-change-resilience.test.ts
@@ -1,0 +1,87 @@
+/**
+ * ElizaClient.onBaseUrlChange resilience (#18542): a throwing listener must
+ * not block delivery to other listeners, must not block repointBaseUrl's
+ * reconnect/token-sync, and a persistence failure in setBaseUrl must not
+ * suppress the notification since the in-memory base already changed.
+ * Dedicated cloud-agent hosts are used throughout so the client is
+ * connected-over-REST and never attempts a real WebSocket. jsdom harness.
+ */
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../config/boot-config";
+import { clearPersistedActiveServer } from "../state/persistence";
+import { ElizaClient } from "./client-base";
+
+const AGENT_BASE_A =
+  "https://11111111-1111-1111-1111-111111111111.staging.elizacloud.ai";
+const AGENT_BASE_B =
+  "https://22222222-2222-2222-2222-222222222222.staging.elizacloud.ai";
+
+describe("ElizaClient.onBaseUrlChange resilience", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+    localStorage.clear();
+    clearPersistedActiveServer();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    clearPersistedActiveServer();
+    vi.restoreAllMocks();
+  });
+
+  it("isolates a throwing listener so a later listener still fires", () => {
+    const client = new ElizaClient(AGENT_BASE_A, "token");
+    const seen: string[] = [];
+    client.onBaseUrlChange(() => {
+      throw new Error("boom");
+    });
+    client.onBaseUrlChange((baseUrl) => {
+      seen.push(baseUrl);
+    });
+
+    client.setBaseUrl(AGENT_BASE_B);
+
+    expect(seen).toEqual([AGENT_BASE_B]);
+  });
+
+  it("repointBaseUrl still reconnects and dispatches token-sync despite a throwing onBaseUrlChange listener", () => {
+    const client = new ElizaClient(AGENT_BASE_A, "token");
+    client.onBaseUrlChange(() => {
+      throw new Error("boom");
+    });
+
+    const tokenSyncHandler = vi.fn();
+    window.addEventListener("steward-token-sync", tokenSyncHandler);
+    try {
+      client.repointBaseUrl(AGENT_BASE_B, "new-token");
+    } finally {
+      window.removeEventListener("steward-token-sync", tokenSyncHandler);
+    }
+
+    expect(client.getBaseUrl()).toBe(AGENT_BASE_B);
+    expect(tokenSyncHandler).toHaveBeenCalledTimes(1);
+    // Connected-over-REST for a dedicated cloud-agent host: reaching
+    // "connected" (rather than getting stuck mid-teardown) proves
+    // connectWs() ran to completion after the throwing listener.
+    expect(client.getConnectionState().state).toBe("connected");
+  });
+
+  it("setBaseUrl still notifies listeners when persistBaseUrl throws (storage failure)", () => {
+    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    const client = new ElizaClient(AGENT_BASE_A, "token");
+    const seen: string[] = [];
+    client.onBaseUrlChange((baseUrl) => {
+      seen.push(baseUrl);
+    });
+
+    client.setBaseUrl(AGENT_BASE_B);
+
+    // The in-memory base is authoritative even though persistence failed.
+    expect(client.getBaseUrl()).toBe(AGENT_BASE_B);
+    expect(seen).toEqual([AGENT_BASE_B]);
+  });
+});

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -938,7 +938,7 @@ export class ElizaClient {
     this._baseUrl = normalized;
     this.disconnectWs();
     if (persist) {
-      this.persistBaseUrl(normalized);
+      this.persistBaseUrlFailClosed(normalized);
     }
     this.notifyBaseUrlChange();
   }
@@ -955,9 +955,40 @@ export class ElizaClient {
     };
   }
 
+  /**
+   * Isolate each listener so one throwing observer cannot swallow the base
+   * change for the rest — critical in {@link repointBaseUrl}, where this
+   * notification runs before `connectWs()` and the token-sync dispatch; an
+   * unguarded throw there would silently break reconnection (#18542).
+   */
   private notifyBaseUrlChange(): void {
     for (const listener of this.baseUrlChangeListeners) {
-      listener(this._baseUrl);
+      try {
+        listener(this._baseUrl);
+      } catch (err) {
+        logger.error(
+          { err },
+          "[ElizaClient] onBaseUrlChange listener threw; other listeners still notified",
+        );
+      }
+    }
+  }
+
+  /**
+   * Persist the base URL, but never let a storage failure (quota, disabled
+   * localStorage, private-mode restrictions) suppress {@link
+   * notifyBaseUrlChange}: `_baseUrl` is already mutated in memory and is the
+   * authoritative value, so dependent per-authority observers must still
+   * learn about the change even when persistence itself failed (#18542).
+   */
+  private persistBaseUrlFailClosed(normalized: string): void {
+    try {
+      this.persistBaseUrl(normalized);
+    } catch (err) {
+      // error-policy:J6 best-effort persistence — the in-memory base is
+      // already authoritative for this process; a storage failure must not
+      // block downstream notification of the change that already happened.
+      logger.warn({ err }, "[ElizaClient] persistBaseUrl failed");
     }
   }
 
@@ -1055,7 +1086,7 @@ export class ElizaClient {
     if (installsToken) this.installToken(token ?? null, false);
     this._userSetBase = normalized.length > 0;
     this._baseUrl = normalized;
-    this.persistBaseUrl(normalized);
+    this.persistBaseUrlFailClosed(normalized);
     this.notifyBaseUrlChange();
 
     // Reconnect immediately against the new base. connectWs() derives the WS
@@ -1913,6 +1944,45 @@ export class ElizaClient {
     return () => {
       this.resyncListeners.delete(listener);
     };
+  }
+
+  /**
+   * Force-close and immediately re-establish the live WebSocket against the
+   * SAME base — `_baseUrl`, persistence, and the token are untouched. Unlike
+   * {@link resetConnection}, which leaves an already-open socket alone, this
+   * always tears the socket down first, nulling its handlers before `close()`
+   * exactly like {@link repointBaseUrl}'s teardown, so nothing already in
+   * flight on it can be delivered afterward.
+   *
+   * For an authority-scoped observer (e.g. the notification store, #18542)
+   * whose authority changed WITHOUT a base URL change (an in-place identity
+   * switch or logout), neither {@link setBaseUrl} nor {@link repointBaseUrl}
+   * runs, so the socket would otherwise stay open across the switch — the one
+   * transport gap {@link onBaseUrlChange} does not cover. This closes it.
+   */
+  rotateConnection(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      this.ws.onopen = null;
+      this.ws.onclose = null;
+      this.ws.onerror = null;
+      this.ws.onmessage = null;
+      try {
+        this.ws.close();
+      } catch {
+        /* already closing */
+      }
+      this.ws = null;
+    }
+    this.wsSendQueue = [];
+    this.wsEventBacklog.clear();
+    this.backoffMs = 500;
+    this.reconnectAttempt = 0;
+    this.disconnectedAt = null;
+    this.connectWs();
   }
 
   /** Reset connection state and restart reconnection attempts. */

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -19,6 +19,8 @@ const seedDevNotificationsApi = vi.fn();
 const onWsEvent = vi.fn();
 const getBaseUrl = vi.fn((..._args: unknown[]) => "http://mock.local");
 const onBaseUrlChange = vi.fn((..._args: unknown[]) => () => {});
+const hasToken = vi.fn((..._args: unknown[]) => true);
+const rotateConnection = vi.fn((..._args: unknown[]) => {});
 
 vi.mock("../../api/client", () => ({
   client: {
@@ -34,6 +36,8 @@ vi.mock("../../api/client", () => ({
     onWsEvent: (...args: unknown[]) => onWsEvent(...args),
     getBaseUrl: (...args: unknown[]) => getBaseUrl(...args),
     onBaseUrlChange: (...args: unknown[]) => onBaseUrlChange(...args),
+    hasToken: (...args: unknown[]) => hasToken(...args),
+    rotateConnection: (...args: unknown[]) => rotateConnection(...args),
   },
 }));
 
@@ -960,6 +964,8 @@ describe("notification-store — authority isolation (#18391)", () => {
     onWsEvent.mockReset().mockReturnValue(() => {});
     getBaseUrl.mockReset().mockReturnValue("http://agent-a.local");
     onBaseUrlChange.mockReset().mockReturnValue(() => {});
+    hasToken.mockReset().mockReturnValue(true);
+    rotateConnection.mockReset();
     invokeDesktopBridgeRequest.mockReset().mockResolvedValue(null);
   });
 
@@ -1065,7 +1071,14 @@ describe("notification-store — authority isolation (#18391)", () => {
     expect(__getStateForTests().notifications[0]?.id).toBe("b-row");
   });
 
-  it("drops a stale WS event captured before the authority switched", async () => {
+  // A defense-in-depth guard, not the primary protection: real dispatch
+  // always calls whichever handler is currently bound, so this only
+  // matters if something holds and invokes an orphaned handler reference
+  // directly (client-base.ts never does, for "agent_event" today). The real
+  // protection against a message delivered through the CURRENT handler
+  // after an auth-only switch is the connection rotation covered by the
+  // "rotates the connection" tests below (#18542, review finding 2).
+  it("an orphaned handler reference self-drops after rebind, even if invoked directly", async () => {
     initNotifications();
     await vi.waitFor(() => expect(agentEventHandlers()).toHaveLength(1));
     const handlerA = agentEventHandlers()[0];
@@ -1113,5 +1126,225 @@ describe("notification-store — authority isolation (#18391)", () => {
     expect(listNotifications).toHaveBeenCalledTimes(1);
     expect(__getStateForTests().notifications).toHaveLength(1);
     expect(__getStateForTests().notifications[0]?.id).toBe("a-row");
+  });
+
+  // #18542 review finding 2: neither setBaseUrl nor repointBaseUrl runs for
+  // an auth-only switch, so nothing else closes the socket that could still
+  // deliver a message from the outgoing authority through the freshly-bound
+  // (and therefore current-looking) handler. rotateConnection() closes it.
+  it("rotates the connection on a subsequent auth-only switch (same base)", async () => {
+    __setAuthStatusForTests(authenticated("user-a", "session-a"));
+    initNotifications();
+    await vi.waitFor(() => expect(listNotifications).toHaveBeenCalledTimes(1));
+    expect(rotateConnection).not.toHaveBeenCalled();
+
+    __setAuthStatusForTests(authenticated("user-b", "session-b"));
+    expect(rotateConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not rotate the connection on the first resolution from boot", async () => {
+    // No auth status set before init: the store seeds from the boot-time
+    // "anon" snapshot, which never hydrated anything worth protecting.
+    initNotifications();
+    await vi.waitFor(() => expect(listNotifications).toHaveBeenCalledTimes(1));
+
+    __setAuthStatusForTests(authenticated("user-a", "session-a"));
+    await vi.waitFor(() => expect(listNotifications).toHaveBeenCalledTimes(2));
+    expect(rotateConnection).not.toHaveBeenCalled();
+  });
+
+  it("rotates the connection on logout even though the base is unchanged", async () => {
+    __setAuthStatusForTests(authenticated("user-a", "session-a"));
+    initNotifications();
+    await vi.waitFor(() => expect(listNotifications).toHaveBeenCalledTimes(1));
+
+    hasToken.mockReturnValue(false);
+    window.dispatchEvent(new Event("steward-token-sync"));
+    expect(rotateConnection).toHaveBeenCalledTimes(1);
+  });
+
+  // #18542 review finding 3: useAuthStatus intentionally keeps the previous
+  // authenticated snapshot until the async /api/auth/me probe resolves, so a
+  // real logout would otherwise be invisible to reconcileAuthority (which
+  // only reacts to that eventual publish) for the whole round-trip.
+  // steward-token-sync fires synchronously on the token clear itself.
+  describe("credential-sync invalidation ahead of the async auth probe", () => {
+    it("clears immediately on a cleared token, before the auth-status probe catches up", async () => {
+      __setAuthStatusForTests(authenticated("user-a", "session-a"));
+      const notifA = makeNotification({ id: "a-row", title: "A's row" });
+      listNotifications.mockResolvedValueOnce({
+        notifications: [notifA],
+        unreadCount: 1,
+      });
+      initNotifications();
+      await vi.waitFor(() =>
+        expect(__getStateForTests().notifications).toHaveLength(1),
+      );
+
+      // The token is cleared, but the auth-status snapshot has NOT been
+      // updated yet — this is exactly the gap useAuthStatus leaves open.
+      // Invalidation deliberately does not fetch (identity is unknown), so
+      // no response needs to be queued for it.
+      hasToken.mockReturnValue(false);
+      window.dispatchEvent(new Event("steward-token-sync"));
+
+      // Synchronous: no await before this assertion.
+      expect(__getStateForTests().notifications).toHaveLength(0);
+      expect(__getStateForTests().hydrationStatus).toBe("idle");
+      // Identity is unknown at this point, so no fetch is started yet.
+      expect(listNotifications).toHaveBeenCalledTimes(1);
+
+      // The probe eventually resolves — the real reconcile runs normally.
+      const notifB = makeNotification({ id: "b-row", title: "B's row" });
+      listNotifications.mockResolvedValueOnce({
+        notifications: [notifB],
+        unreadCount: 1,
+      });
+      __setAuthStatusForTests({ phase: "unauthenticated" });
+      await vi.waitFor(() =>
+        expect(__getStateForTests().notifications).toHaveLength(1),
+      );
+      expect(__getStateForTests().notifications[0]?.id).toBe("b-row");
+    });
+
+    it("drops a stale WS event delivered during the credential-invalidated window", async () => {
+      __setAuthStatusForTests(authenticated("user-a", "session-a"));
+      initNotifications();
+      await vi.waitFor(() => expect(agentEventHandlers()).toHaveLength(1));
+      const handlerA = agentEventHandlers()[0];
+
+      hasToken.mockReturnValue(false);
+      window.dispatchEvent(new Event("steward-token-sync"));
+
+      handlerA({
+        stream: "notification",
+        payload: {
+          notification: makeNotification({ id: "stale", title: "Stale" }),
+          unreadCount: 9,
+        },
+      });
+      expect(__getStateForTests().notifications).toHaveLength(0);
+    });
+
+    it("a token install (login/refresh/handoff) is a harmless no-op when the base already reconciled", async () => {
+      __setAuthStatusForTests(authenticated("user-a", "session-a"));
+      initNotifications();
+      await vi.waitFor(() =>
+        expect(listNotifications).toHaveBeenCalledTimes(1),
+      );
+
+      // Simulates repointBaseUrl: onBaseUrlChange fires first (same tick, a
+      // real handoff) and already reconciles to the new base correctly;
+      // steward-token-sync fires afterward with a present token.
+      getBaseUrl.mockReturnValue("http://agent-b.local");
+      const baseUrlHandler = onBaseUrlChange.mock.calls[0][0] as () => void;
+      baseUrlHandler();
+      await vi.waitFor(() =>
+        expect(listNotifications).toHaveBeenCalledTimes(2),
+      );
+      rotateConnection.mockClear();
+
+      hasToken.mockReturnValue(true);
+      window.dispatchEvent(new Event("steward-token-sync"));
+      await Promise.resolve();
+
+      // No extra clear/refetch/rotation beyond what the base change already did.
+      expect(listNotifications).toHaveBeenCalledTimes(2);
+      expect(rotateConnection).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("notification-store mutations — authority-scoped rollback (#18542)", () => {
+  function authenticated(userId: string, sessionId: string): AuthStatusState {
+    return {
+      phase: "authenticated",
+      identity: { id: userId, displayName: userId, kind: "owner" },
+      session: { id: sessionId, kind: "browser", expiresAt: null },
+      access: {
+        mode: "session",
+        passwordConfigured: true,
+        ownerConfigured: true,
+        role: "OWNER",
+      },
+    };
+  }
+
+  beforeEach(() => {
+    __resetNotificationStoreForTests();
+    __resetAuthStatusForTests();
+    listNotifications
+      .mockReset()
+      .mockResolvedValue({ notifications: [], unreadCount: 0 });
+    onWsEvent.mockReset().mockReturnValue(() => {});
+    getBaseUrl.mockReset().mockReturnValue("http://agent-a.local");
+    onBaseUrlChange.mockReset().mockReturnValue(() => {});
+    hasToken.mockReset().mockReturnValue(true);
+    rotateConnection.mockReset();
+    markNotificationReadApi.mockReset();
+    invokeDesktopBridgeRequest.mockReset().mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    __resetNotificationStoreForTests();
+    __resetAuthStatusForTests();
+  });
+
+  it("discards a stale-authority optimistic rollback instead of overwriting the new authority's rows", async () => {
+    __setAuthStatusForTests(authenticated("user-a", "session-a"));
+    const notifA = makeNotification({ id: "a-row", title: "A's row" });
+    listNotifications.mockResolvedValueOnce({
+      notifications: [notifA],
+      unreadCount: 1,
+    });
+    initNotifications();
+    await vi.waitFor(() =>
+      expect(__getStateForTests().notifications).toHaveLength(1),
+    );
+
+    // Start a mutation against A's row, but hold its HTTP response open.
+    let rejectMarkRead!: (err: unknown) => void;
+    markNotificationReadApi.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectMarkRead = reject;
+      }),
+    );
+    const mutationPromise = markNotificationRead("a-row");
+
+    // Authority switches to B before the mutation settles.
+    const notifB = makeNotification({ id: "b-row", title: "B's row" });
+    listNotifications.mockResolvedValueOnce({
+      notifications: [notifB],
+      unreadCount: 1,
+    });
+    __setAuthStatusForTests(authenticated("user-b", "session-b"));
+    await vi.waitFor(() =>
+      expect(__getStateForTests().notifications[0]?.id).toBe("b-row"),
+    );
+
+    // A's mutation now fails — its optimistic-rollback snapshot belongs to a
+    // superseded authority and must not overwrite B's freshly-hydrated rows.
+    rejectMarkRead(new Error("network"));
+    await mutationPromise;
+    expect(__getStateForTests().notifications).toHaveLength(1);
+    expect(__getStateForTests().notifications[0]?.id).toBe("b-row");
+  });
+
+  it("still reverts normally when the mutation fails within the same authority", async () => {
+    __setAuthStatusForTests(authenticated("user-a", "session-a"));
+    const notifA = makeNotification({ id: "a-row", title: "A's row" });
+    listNotifications.mockResolvedValueOnce({
+      notifications: [notifA],
+      unreadCount: 1,
+    });
+    initNotifications();
+    await vi.waitFor(() =>
+      expect(__getStateForTests().notifications).toHaveLength(1),
+    );
+
+    markNotificationReadApi.mockRejectedValueOnce(new Error("network"));
+    await markNotificationRead("a-row");
+
+    expect(__getStateForTests().notifications[0]?.readAt).toBeNull();
   });
 });

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -94,6 +94,11 @@ const notificationCleanups: Array<() => void> = [];
 // so an agent/base switch is still isolated even with nobody signed in (e.g.
 // a local, non-Cloud origin). Null until initNotifications() seeds it.
 let currentAuthorityKey: string | null = null;
+// The base URL component of currentAuthorityKey, tracked separately so
+// reconcileAuthority can tell an auth-only switch (base unchanged) from a
+// base switch (already handled by client.onBaseUrlChange's own transport
+// teardown) — see reconcileAuthority (#18542).
+let currentAuthorityBaseUrl: string | null = null;
 // Unsubscribes the currently-bound live WS notification handler; rebound on
 // every authority change so a handler closure from a superseded authority can
 // never reach ingest(), even if a message is somehow still in flight.
@@ -394,20 +399,17 @@ function computeAuthorityKey(
   return `${baseUrl}::${identityPart}`;
 }
 
-/**
- * Re-key the store to the authority implied by the latest auth status and the
- * client's current base URL. A no-op when the authority is unchanged (e.g. a
- * same-session background auth refresh). On a real change: rebind the live WS
- * handler, cancel retry/hydration ownership so a stale in-flight response is
- * discarded by {@link runHydrationAttempt}'s generation check, synchronously
- * clear rows/unread state, and hydrate fresh for the new authority.
- */
-function reconcileAuthority(authStatus: AuthStatusState): void {
-  const nextKey = computeAuthorityKey(authStatus, client.getBaseUrl());
-  if (nextKey === currentAuthorityKey) return;
-  currentAuthorityKey = nextKey;
-  bindLiveNotificationStream(nextKey);
+/** Whether a computed authority key's identity component is the "anon"
+ *  placeholder — i.e. nothing was ever confirmed-authenticated under it, so
+ *  there is no real prior data a leaving message could leak (#18542). */
+function isAnonAuthorityKey(key: string | null): boolean {
+  return Boolean(key?.endsWith("::anon"));
+}
 
+/** Cancel retry/hydration ownership and clear rows/unread state for a new
+ *  authority. Shared by {@link reconcileAuthority} and {@link
+ *  invalidateAuthorityForCredentialChange} (#18542). */
+function clearForAuthorityChange(): void {
   if (hydrationRetryTimer) {
     clearTimeout(hydrationRetryTimer);
     hydrationRetryTimer = null;
@@ -425,8 +427,81 @@ function reconcileAuthority(authStatus: AuthStatusState): void {
     hydrationError: null,
   });
   ephemeralNotificationIds.clear();
+}
 
+/**
+ * Re-key the store to the authority implied by the latest auth status and the
+ * client's current base URL. A no-op when the authority is unchanged (e.g. a
+ * same-session background auth refresh). On a real change: rebind the live WS
+ * handler, cancel retry/hydration ownership so a stale in-flight response is
+ * discarded by {@link runHydrationAttempt}'s generation check, synchronously
+ * clear rows/unread state, and hydrate fresh for the new authority.
+ *
+ * A subsequent switch that keeps the same base URL (an in-place identity
+ * change) rotates the underlying connection too: `setBaseUrl`/
+ * `repointBaseUrl` already close-before-reopen for a base change, but nothing
+ * else touches the transport for an auth-only one, so a message already in
+ * flight on the still-open socket could otherwise reach the freshly-rebound
+ * (and therefore current-looking) WS handler and be accepted as the new
+ * authority's data (#18542).
+ */
+function reconcileAuthority(authStatus: AuthStatusState): void {
+  const baseUrl = client.getBaseUrl();
+  const nextKey = computeAuthorityKey(authStatus, baseUrl);
+  if (nextKey === currentAuthorityKey) return;
+  // Only rotate when the authority being LEFT had a real, hydration-worthy
+  // identity — not the boot-time "anon" seed or placeholder, which never
+  // held anything worth protecting — and the base is unchanged (a base
+  // change already gets its own transport teardown from setBaseUrl /
+  // repointBaseUrl, so rotating again here would be redundant).
+  const isSubsequentAuthOnlySwitch =
+    !isAnonAuthorityKey(currentAuthorityKey) &&
+    currentAuthorityBaseUrl === baseUrl;
+  currentAuthorityKey = nextKey;
+  currentAuthorityBaseUrl = baseUrl;
+  bindLiveNotificationStream(nextKey);
+  clearForAuthorityChange();
+  if (isSubsequentAuthOnlySwitch) {
+    client.rotateConnection();
+  }
   void requestHydration();
+}
+
+// Cannot equal any real `computeAuthorityKey` result (those are always
+// `<baseUrl>::<identityPart>`), so it always compares unequal and forces a
+// real reconcile once the next authority is confirmed.
+const INVALIDATED_AUTHORITY_KEY = "credential-invalidated";
+
+/**
+ * `useAuthStatus` deliberately keeps the previous authenticated snapshot
+ * until the async `/api/auth/me` probe resolves, so a real logout is
+ * invisible to {@link reconcileAuthority} for the duration of that
+ * round-trip — the inbox and live delivery would keep serving the outgoing
+ * authority's data (#18542). `client`'s synchronous `steward-token-sync`
+ * event fires immediately on any credential change; when it reflects a
+ * cleared token (`!client.hasToken()`), that is logout-shaped and cannot wait
+ * for the probe, so invalidate to a sentinel that can never equal a real
+ * computed key — clearing rows/unread and unbinding live delivery — without
+ * hydrating (identity is unknown until the probe's eventual publish runs the
+ * real reconcile). A non-empty token (login, refresh, or an agent handoff's
+ * repointBaseUrl token swap) is not logout-shaped: recompute from whatever
+ * the auth snapshot currently says, which is a no-op if a same-tick base
+ * change already reconciled correctly (e.g. the handoff path) and otherwise
+ * catches up once the snapshot is fresh.
+ */
+function onCredentialSync(): void {
+  if (client.hasToken()) {
+    reconcileAuthority(getAuthStatusSnapshot());
+    return;
+  }
+  if (currentAuthorityKey === INVALIDATED_AUTHORITY_KEY) return;
+  currentAuthorityKey = INVALIDATED_AUTHORITY_KEY;
+  bindLiveNotificationStream(currentAuthorityKey);
+  clearForAuthorityChange();
+  // Logout is a same-base identity change, so nothing else rotates the
+  // socket; do it here for the same reason reconcileAuthority does for a
+  // subsequent auth-only switch (#18542).
+  client.rotateConnection();
 }
 
 function mergeHydratedNotifications(
@@ -621,9 +696,10 @@ export function retryNotificationHydration(): Promise<void> {
 export function initNotifications(): void {
   if (initialized) return;
   initialized = true;
+  currentAuthorityBaseUrl = client.getBaseUrl();
   currentAuthorityKey = computeAuthorityKey(
     getAuthStatusSnapshot(),
-    client.getBaseUrl(),
+    currentAuthorityBaseUrl,
   );
   bindLiveNotificationStream(currentAuthorityKey);
   notificationCleanups.push(
@@ -635,6 +711,10 @@ export function initNotifications(): void {
     client.onBaseUrlChange(() => reconcileAuthority(getAuthStatusSnapshot())),
   );
   if (typeof window !== "undefined") {
+    window.addEventListener("steward-token-sync", onCredentialSync);
+    notificationCleanups.push(() =>
+      window.removeEventListener("steward-token-sync", onCredentialSync),
+    );
     const retryOnline = () => void retryNotificationHydration();
     window.addEventListener("online", retryOnline);
     notificationCleanups.push(() =>
@@ -685,27 +765,51 @@ export async function seedDevNotificationsIfEmpty(): Promise<void> {
 
 // ── Mutations (optimistic; backed by the HTTP API) ──────────────────────────
 
+/** An optimistic mutation's pre-write state, tagged with the authority it was
+ *  captured under so a response that settles after an authority switch can
+ *  recognize its snapshot is stale (#18542). */
+interface MutationSnapshot {
+  authorityKey: string | null;
+  state: NotificationState;
+}
+
+function snapshotForMutation(): MutationSnapshot {
+  return { authorityKey: currentAuthorityKey, state };
+}
+
 /**
- * Roll the optimistic state back to `previous` and log at error level when a
+ * Roll the optimistic state back to the snapshot and log at error level when a
  * mutation's HTTP write fails. Reverting is the user-visible surfacing: a
  * failed "mark read" returns the item to unread and a failed delete makes it
  * reappear, so the inbox never silently diverges from server truth. Callers
  * fire-and-forget (`void`), so this never rethrows.
+ *
+ * If the authority has changed since the snapshot was captured (the request
+ * that failed belonged to a prior authority A, but the store has since
+ * switched to and hydrated authority B), applying the snapshot would overwrite
+ * B's rows with A's — discard the rollback instead (#18542).
  */
 function revertMutation(
-  previous: NotificationState,
+  snapshot: MutationSnapshot,
   op: string,
   err: unknown,
 ): void {
+  if (snapshot.authorityKey !== currentAuthorityKey) {
+    logger.warn(
+      { err },
+      `[notification-store] ${op} failed after an authority switch; stale rollback discarded`,
+    );
+    return;
+  }
   setState({
-    notifications: previous.notifications,
-    unreadCount: previous.unreadCount,
+    notifications: snapshot.state.notifications,
+    unreadCount: snapshot.state.unreadCount,
   });
   logger.error({ err }, `[notification-store] ${op} failed; reverted`);
 }
 
 export async function markNotificationRead(id: string): Promise<void> {
-  const previous = state;
+  const snapshot = snapshotForMutation();
   const now = Date.now();
   const notifications = state.notifications.map((n) =>
     n.id === id && !n.readAt ? { ...n, readAt: now } : n,
@@ -714,12 +818,12 @@ export async function markNotificationRead(id: string): Promise<void> {
   try {
     await client.markNotificationRead(id);
   } catch (err) {
-    revertMutation(previous, "markNotificationRead", err);
+    revertMutation(snapshot, "markNotificationRead", err);
   }
 }
 
 export async function markAllNotificationsRead(): Promise<void> {
-  const previous = state;
+  const snapshot = snapshotForMutation();
   const now = Date.now();
   const notifications = state.notifications.map((n) =>
     n.readAt ? n : { ...n, readAt: now },
@@ -728,19 +832,19 @@ export async function markAllNotificationsRead(): Promise<void> {
   try {
     await client.markAllNotificationsRead();
   } catch (err) {
-    revertMutation(previous, "markAllNotificationsRead", err);
+    revertMutation(snapshot, "markAllNotificationsRead", err);
   }
 }
 
 export async function removeNotification(id: string): Promise<void> {
-  const previous = state;
+  const snapshot = snapshotForMutation();
   const notifications = state.notifications.filter((n) => n.id !== id);
   setState({ notifications, unreadCount: countUnread(notifications) });
   if (ephemeralNotificationIds.delete(id)) return;
   try {
     await client.removeNotification(id);
   } catch (err) {
-    revertMutation(previous, "removeNotification", err);
+    revertMutation(snapshot, "removeNotification", err);
   }
 }
 
@@ -750,7 +854,7 @@ export async function removeNotifications(
 ): Promise<void> {
   if (ids.length === 0) return;
   const idSet = new Set(ids);
-  const previous = state;
+  const snapshot = snapshotForMutation();
   const notifications = state.notifications.filter((n) => !idSet.has(n.id));
   setState({ notifications, unreadCount: countUnread(notifications) });
   const ephemeralIds = ids.filter((id) => ephemeralNotificationIds.delete(id));
@@ -760,21 +864,28 @@ export async function removeNotifications(
   try {
     await Promise.all(persistedIds.map((id) => client.removeNotification(id)));
   } catch (err) {
-    for (const id of ephemeralIds) ephemeralNotificationIds.add(id);
-    revertMutation(previous, "removeNotifications", err);
+    // Re-adding these ephemeral IDs into a superseded authority's set would
+    // let its stray local-only rows resurface under the new authority — only
+    // restore them when the authority that owned them is still current.
+    if (snapshot.authorityKey === currentAuthorityKey) {
+      for (const id of ephemeralIds) ephemeralNotificationIds.add(id);
+    }
+    revertMutation(snapshot, "removeNotifications", err);
   }
 }
 
 export async function clearNotifications(): Promise<void> {
-  const previous = state;
+  const snapshot = snapshotForMutation();
   const previousEphemeralIds = [...ephemeralNotificationIds];
   setState({ notifications: [], unreadCount: 0 });
   ephemeralNotificationIds.clear();
   try {
     await client.clearNotifications();
   } catch (err) {
-    for (const id of previousEphemeralIds) ephemeralNotificationIds.add(id);
-    revertMutation(previous, "clearNotifications", err);
+    if (snapshot.authorityKey === currentAuthorityKey) {
+      for (const id of previousEphemeralIds) ephemeralNotificationIds.add(id);
+    }
+    revertMutation(snapshot, "clearNotifications", err);
   }
 }
 
@@ -802,6 +913,7 @@ export function __resetNotificationStoreForTests(): void {
   hydrationInFlight = null;
   hydrationReadinessDeadlineAt = 0;
   currentAuthorityKey = null;
+  currentAuthorityBaseUrl = null;
   notificationEventUnsub?.();
   notificationEventUnsub = null;
   liveEventRevision = 0;


### PR DESCRIPTION
## Summary

PR #18495 (merged) added per-authority isolation to the notification store. An independent post-merge review from `@fadhelcarlos` on that PR found the isolation was incomplete — 4 P1 findings, tracked and reproduced in #18542 (this PR fixes it).

**1. Optimistic mutation rollback could restore a prior authority's rows after a switch.** `markNotificationRead`/`markAllNotificationsRead`/`removeNotification`/`removeNotifications`/`clearNotifications` captured `previous = state` before an awaited request with no authority tag. If authority A started a mutation, the store switched to and hydrated B, and A's request then rejected, the catch handler overwrote B's fresh rows with A's stale snapshot (the batch path also re-added A's ephemeral IDs into B's set). Mutations now snapshot the authority alongside state (`snapshotForMutation()`), and `revertMutation`/the ephemeral-restore paths discard themselves when the authority has since changed.

**2. The stale-WS-event guard didn't protect the real path.** `createWsAgentEventHandler`'s self-check only matters if something invokes an *orphaned* handler reference directly — real dispatch (`client-base.ts`'s `dispatchWsData`) always calls whichever handler is *currently* bound, whose captured key always equals the current authority by construction. The actual gap: an auth-only switch (no base URL change) doesn't rotate the underlying WebSocket at all, so a message on that still-open socket after the switch reaches the current, valid-looking handler and gets accepted. Added `ElizaClient.rotateConnection()` (force-close + reconnect on the same base, mirroring `repointBaseUrl`'s teardown) and call it on a *subsequent* auth-only authority change — not on the very first resolution from the boot-time "anon" seed, since nothing was hydrated under that placeholder to leak. The existing test is relabeled to describe what it actually covers (a defense-in-depth guard on a directly-invoked orphaned reference), and new tests cover the real rotation behavior.

**3. Logout wasn't synchronous.** `useAuthStatus` intentionally keeps the previous authenticated snapshot until the async `/api/auth/me` probe resolves, so `reconcileAuthority` (which only reacts to that eventual publish) doesn't fire until the round-trip completes — a real logout could leave the prior authority's inbox and live delivery active for the duration. The store now also listens for the synchronous `steward-token-sync` signal `client.setToken`/`installToken` already dispatches: when it reflects a cleared token (`!client.hasToken()`), invalidate immediately to a sentinel authority key (clearing rows, unbinding WS, rotating the connection) without hydrating — identity is unknown until the probe's eventual publish runs the real reconcile. A present token (login/refresh/handoff) just recomputes from the current snapshot, which is a no-op if a same-tick base change (e.g. the dedicated-agent handoff `repointBaseUrl` path) already reconciled correctly.

**4. `notifyBaseUrlChange` had no exception isolation.** One throwing `onBaseUrlChange` listener aborted delivery to every listener registered after it, and in `repointBaseUrl` the notification runs *before* `connectWs()` and the token-sync dispatch, so a throwing listener could block reconnection entirely. `setBaseUrl` also called the (fallible) `persistBaseUrl` before notifying, so a storage failure could leave `_baseUrl` mutated in memory while dependent observers never learned about it. Both are now fail-closed: each listener runs in its own try/catch, and persistence failures are logged and swallowed rather than suppressing the notification.

Fixes #18542

## Test plan

- [x] `bunx vitest run --config packages/ui/vitest.config.ts src/state/notifications/notification-store.test.ts` — 58/58 pass, including new coverage: stale-authority mutation rollback discarded vs. still-reverts-normally-within-authority; connection rotation on a subsequent auth-only switch but not on first-boot resolution or on a redundant token-sync after a same-tick base reconcile; synchronous credential-invalidation clearing/dropping-stale-WS ahead of the auth probe.
- [x] `bunx vitest run --config packages/ui/vitest.config.ts src/api/client-base-base-url-change-resilience.test.ts` (new file) — 3/3 pass: listener exception isolation, `repointBaseUrl` still reconnects + dispatches token-sync past a throwing listener, `setBaseUrl` still notifies past a storage failure.
- [x] Full `setBaseUrl`/`repointBaseUrl`-touching suite (11 files, 119 tests total including the above) — all pass, no regressions from `rotateConnection`/exception-isolation changes.
- [x] `bunx @biomejs/biome check` on the four changed files — clean.
- [x] `bun run --cwd packages/ui typecheck` — only the pre-existing baseline failure unrelated to this change (`@elizaos/cloud-routing` missing package in this checkout, confirmed pre-existing in the prior #18495 PR too).

## Scope

Client-side cache/connection-lifecycle isolation only, matching #18391's original scope boundary — server-side WebSocket session-scoped delivery remains a separate, out-of-scope concern (noted explicitly in #18542).