### PR TITLE
fix(shared): promote trajectory format units at rounding boundaries (#18527)

### DIFF
--- a/packages/shared/src/utils/trajectory-format.test.ts
+++ b/packages/shared/src/utils/trajectory-format.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Boundary coverage for the trajectory display formatters (#18527): values
+ * whose rounded display reaches a unit boundary must promote to the next unit
+ * ("1.0m", never "60.0s"; "1.0M", never "1000.0k"), while every value below
+ * the rounding boundary keeps its original unit. Deterministic, no clock.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  formatTrajectoryDuration,
+  formatTrajectoryTokenCount,
+} from "./trajectory-format";
+
+describe("formatTrajectoryDuration", () => {
+  it("keeps sub-boundary values in their original unit", () => {
+    expect(formatTrajectoryDuration(null)).toBe("—");
+    expect(formatTrajectoryDuration(0)).toBe("0ms");
+    expect(formatTrajectoryDuration(999)).toBe("999ms");
+    expect(formatTrajectoryDuration(1000)).toBe("1.0s");
+    expect(formatTrajectoryDuration(59_949)).toBe("59.9s");
+  });
+
+  it("promotes to minutes when rounding reaches the 60s boundary", () => {
+    expect(formatTrajectoryDuration(59_950)).toBe("1.0m");
+    expect(formatTrajectoryDuration(59_994)).toBe("1.0m");
+    expect(formatTrajectoryDuration(59_999)).toBe("1.0m");
+    expect(formatTrajectoryDuration(60_000)).toBe("1.0m");
+    expect(formatTrajectoryDuration(90_000)).toBe("1.5m");
+  });
+});
+
+describe("formatTrajectoryTokenCount", () => {
+  const options = { emptyLabel: "—" };
+
+  it("keeps sub-boundary values in their original unit", () => {
+    expect(formatTrajectoryTokenCount(undefined, options)).toBe("—");
+    expect(formatTrajectoryTokenCount(0, options)).toBe("—");
+    expect(formatTrajectoryTokenCount(999, options)).toBe("999");
+    expect(formatTrajectoryTokenCount(1000, options)).toBe("1.0k");
+    expect(formatTrajectoryTokenCount(999_500, options)).toBe("999.5k");
+    expect(formatTrajectoryTokenCount(999_949, options)).toBe("999.9k");
+  });
+
+  it("promotes to the M tier when rounding reaches the 1000k boundary", () => {
+    expect(formatTrajectoryTokenCount(999_950, options)).toBe("1.0M");
+    expect(formatTrajectoryTokenCount(1_000_000, options)).toBe("1.0M");
+    expect(formatTrajectoryTokenCount(2_500_000, options)).toBe("2.5M");
+  });
+});

--- a/packages/shared/src/utils/trajectory-format.ts
+++ b/packages/shared/src/utils/trajectory-format.ts
@@ -2,7 +2,12 @@
 export function formatTrajectoryDuration(ms: number | null): string {
   if (ms === null) return "—";
   if (ms < 1000) return `${ms}ms`;
-  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  if (ms < 60000) {
+    const seconds = (ms / 1000).toFixed(1);
+    // Rounding can reach the unit boundary ("60.0"); promote to minutes
+    // instead of rendering an impossible seconds value.
+    if (Number(seconds) < 60) return `${seconds}s`;
+  }
   return `${(ms / 60000).toFixed(1)}m`;
 }
 
@@ -47,5 +52,11 @@ export function formatTrajectoryTokenCount(
 ): string {
   if (count === undefined || count === 0) return options.emptyLabel;
   if (count < 1000) return String(count);
-  return `${(count / 1000).toFixed(1)}k`;
+  if (count < 1_000_000) {
+    const thousands = (count / 1000).toFixed(1);
+    // Same boundary promotion as durations: a rounded "1000.0k" is promoted
+    // to the M tier rather than displayed.
+    if (Number(thousands) < 1000) return `${thousands}k`;
+  }
+  return `${(count / 1_000_000).toFixed(1)}M`;
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18527

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; verify passes green on this head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes on this head.

# Risks

Low: two pure display formatters in `packages/shared/src/utils/trajectory-format.ts`; `packages/ui`'s copy is a re-export, so this is the single fix site. No behavior change below each rounding boundary (proven by the sub-boundary test cases).

# Background

## What does this PR do?

`formatTrajectoryDuration` rendered impossible values like `"60.0s"` when `toFixed(1)` rounding reached the minute boundary (`59_950–59_999ms`), and `formatTrajectoryTokenCount` had no `M` tier at all, so `1_000_000+` tokens rendered as `"1000.0k"` (and `2_500_000` as `"2500.0k"`) in the trajectory viewer. Values whose rounded display reaches a unit boundary now promote to the next unit (`59_950ms+ → "1.0m"`, `999_950+ tokens → "1.0M"`).

One divergence from the issue text, called out in my claim comment: the `999_500 → "1000.0k"` repro in the issue was an arithmetic slip (`999_500/1000 = 999.5` renders fine as `"999.5k"` and still does); the round-promote boundary is `999_950`, which is implemented and tested exactly there.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/shared/src/utils/trajectory-format.ts` (the two boundary promotions) and `packages/shared/src/utils/trajectory-format.test.ts` (both sides of each threshold).

## Detailed testing steps

```bash
bun run --cwd packages/shared test -- src/utils/trajectory-format.test.ts
```

# Evidence Gate

<!-- evidence-head:25d3b70fe6757ea79255a52be63c8a14f6e7cb84 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - pure string formatter; the before/after repro transcript below shows the exact rendered labels`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - pure string formatter; see repro transcript below`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user flow change; boundary label fix`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — before/after repro against the shipped module, generated by importing it on develop vs this head:

  <details><summary>before/after repro transcript</summary>

  ```
=== BEFORE (develop) ===
{
 "d59950": "60.0s",
 "d59999": "60.0s",
 "d60000": "1.0m",
 "t999950": "1000.0k",
 "t1M": "1000.0k",
 "t2_5M": "2500.0k"
}
=== AFTER (this PR) ===
{
 "d59950": "1.0m",
 "d59999": "1.0m",
 "d60000": "1.0m",
 "t999950": "1.0M",
 "t1M": "1.0M",
 "t2_5M": "2.5M"
}
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs — deterministic vitest run of the boundary suite:

  <details><summary>vitest run</summary>

  ```
$ node ../scripts/run-vitest.mjs run --config ./vitest.config.ts src/utils/trajectory-format.test.ts

 RUN  v4.1.5 /Users/home/slop-cash/eliza/packages/shared


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  02:05:58
   Duration  202ms (transform 52ms, setup 68ms, import 10ms, tests 4ms, environment 0ms)
  ```

  </details>

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - pure display formatter; no model, prompt, provider, or action behavior involved`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — exact rendered labels at every boundary, before and after:

  <details><summary>rendered-label transcript</summary>

  ```
=== BEFORE (develop) ===
{
 "d59950": "60.0s",
 "d59999": "60.0s",
 "d60000": "1.0m",
 "t999950": "1000.0k",
 "t1M": "1000.0k",
 "t2_5M": "2500.0k"
}
=== AFTER (this PR) ===
{
 "d59950": "1.0m",
 "d59999": "1.0m",
 "d60000": "1.0m",
 "t999950": "1.0M",
 "t1M": "1.0M",
 "t2_5M": "2.5M"
}
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface change beyond the string values proven above`.

# Evidence Details

All evidence is inline above.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZT93NTM9E7XCF86Q316S04V","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T06:03:46.388Z","completed_at":"2026-08-12T06:05:58.959Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"NO_eX48on6muxwjfen5sTHPy0NQbsRQjj2cHQcExxR_7fBdqLuLF2Ki76nApQOJvIwLA_TN0cXUWneWg6fvXCQ"}} -->

