### PR TITLE
fix(cloud): scope payment requests to owned agents

### DIFF
--- a/packages/cloud/api/v1/payment-requests/route.test.ts
+++ b/packages/cloud/api/v1/payment-requests/route.test.ts
@@ -1,0 +1,115 @@
+// Exercises payment-request agent ownership at the authenticated API boundary.
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-a",
+  organization_id: "org-a",
+}));
+const getAgentForWrite = mock(
+  async (): Promise<{ id: string; organization_id: string } | undefined> => ({
+    id: "agent-a",
+    organization_id: "org-a",
+  }),
+);
+const createPaymentRequest = mock(async (input: Record<string, unknown>) => ({
+  paymentRequest: {
+    id: "payment-request-a",
+    organizationId: input.organizationId,
+    agentId: input.agentId,
+  },
+  hostedUrl: "https://pay.example/request-a",
+}));
+const listPaymentRequests = mock(async () => []);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: { getAgentForWrite },
+}));
+
+mock.module("@/lib/services/payment-requests-default", () => ({
+  getPaymentRequestsService: () => ({
+    create: createPaymentRequest,
+    list: listPaymentRequests,
+  }),
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    error: mock(() => undefined),
+  },
+}));
+
+const { default: paymentRequestsRoute } = await import("./route");
+const app = new Hono();
+app.route("/api/v1/payment-requests", paymentRequestsRoute);
+
+function createRequest(agentId: string): Request {
+  return new Request("https://api.example.test/api/v1/payment-requests", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      provider: "oxapay",
+      amountCents: 100,
+      paymentContext: "any_payer",
+      agentId,
+    }),
+  });
+}
+
+describe("POST /api/v1/payment-requests agent ownership", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockReset();
+    requireUserOrApiKeyWithOrg.mockResolvedValue({ id: "user-a", organization_id: "org-a" });
+    getAgentForWrite.mockReset();
+    getAgentForWrite.mockResolvedValue({ id: "agent-a", organization_id: "org-a" });
+    createPaymentRequest.mockReset();
+    createPaymentRequest.mockResolvedValue({
+      paymentRequest: {
+        id: "payment-request-a",
+        organizationId: "org-a",
+        agentId: "agent-a",
+      },
+      hostedUrl: "https://pay.example/request-a",
+    });
+  });
+
+  test("allows an agent owned by the caller's organization", async () => {
+    const response = await app.fetch(createRequest("agent-a"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ success: true });
+    expect(getAgentForWrite).toHaveBeenCalledWith("agent-a", "org-a");
+    expect(createPaymentRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: "org-a", agentId: "agent-a" }),
+    );
+  });
+
+  test.each(["foreign-agent", "missing-agent"])(
+    "rejects a %s before creating a payment request",
+    async (agentId) => {
+      getAgentForWrite.mockResolvedValueOnce(undefined);
+
+      const response = await app.fetch(createRequest(agentId));
+
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toMatchObject({
+        success: false,
+        error: "Agent not found",
+        code: "resource_not_found",
+      });
+      expect(getAgentForWrite).toHaveBeenCalledWith(agentId, "org-a");
+      expect(createPaymentRequest).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/payment-requests/route.test.ts
+++ b/packages/cloud/api/v1/payment-requests/route.test.ts
@@ -1,4 +1,9 @@
-// Exercises payment-request agent ownership at the authenticated API boundary.
+/**
+ * Exercises payment-request agent ownership at the authenticated API boundary.
+ * Bun test with mocked auth, sandbox, and payment-request service modules; the
+ * real Hono route under test must reject foreign/missing agents with 404
+ * before any provider intent is created.
+ */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 
@@ -70,9 +75,15 @@ function createRequest(agentId: string): Request {
 describe("POST /api/v1/payment-requests agent ownership", () => {
   beforeEach(() => {
     requireUserOrApiKeyWithOrg.mockReset();
-    requireUserOrApiKeyWithOrg.mockResolvedValue({ id: "user-a", organization_id: "org-a" });
+    requireUserOrApiKeyWithOrg.mockResolvedValue({
+      id: "user-a",
+      organization_id: "org-a",
+    });
     getAgentForWrite.mockReset();
-    getAgentForWrite.mockResolvedValue({ id: "agent-a", organization_id: "org-a" });
+    getAgentForWrite.mockResolvedValue({
+      id: "agent-a",
+      organization_id: "org-a",
+    });
     createPaymentRequest.mockReset();
     createPaymentRequest.mockResolvedValue({
       paymentRequest: {

--- a/packages/cloud/api/v1/payment-requests/route.ts
+++ b/packages/cloud/api/v1/payment-requests/route.ts
@@ -13,12 +13,13 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
-import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { failureResponse, NotFoundError } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { getPaymentRequestsService } from "@/lib/services/payment-requests-default";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -106,6 +107,16 @@ app.post("/", async (c) => {
         },
         400,
       );
+    }
+
+    if (parsed.data.agentId) {
+      const agent = await elizaSandboxService.getAgentForWrite(
+        parsed.data.agentId,
+        user.organization_id,
+      );
+      if (!agent) {
+        throw NotFoundError("Agent not found");
+      }
     }
 
     const { successUrl, cancelUrl, metadata } = paymentMetadata(parsed.data);


### PR DESCRIPTION
## Relates to

Direct bounded fix for payment-request creation: an optional `agentId` is now verified against the authenticated organization before a provider intent or payment row can be created. No existing issue was found for this exact scope during read-only GitHub coordination; this PR is intentionally limited to the authorization regression.

## Definition of Done

- [x] Targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were not runnable in this clean worktree because dependencies are absent and prior installation was blocked by `ENOSPC`; parser/build checks and `git diff --check` pass.
- [x] Focused regression coverage is included for same-org, foreign-org, and missing agents.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@4d57248577903bac93ac9652c2eb78a95e32b64c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Risks

Low: requests that reference a missing or foreign-organization managed agent now fail closed with the same 404 response, avoiding an organization-membership existence oracle. Requests without `agentId` are unchanged.

## Background

### What does this PR do?

Validates `agentId` through the primary database ownership lookup before invoking the payment-request service.

### What kind of change is this?

Bug fix (authorization boundary).

## Documentation changes needed?

No documentation changes are needed; this is an internal authorization guard with regression tests.

## Testing

### Where should a reviewer start?

- `packages/cloud/api/v1/payment-requests/route.ts`
- `packages/cloud/api/v1/payment-requests/route.test.ts`

### Detailed testing steps

```text
bun build packages/cloud/api/v1/payment-requests/route.ts --outdir .tmp/payment-request-route-build-final --external '*'
bun build packages/cloud/api/v1/payment-requests/route.test.ts --outdir .tmp/payment-request-test-build-final --external '*'
git diff origin/develop...HEAD --check
git diff --no-ext-diff --no-textconv origin/develop...HEAD | secret-pattern scan
```

Focused runtime test attempted:

```text
bun test packages/cloud/api/v1/payment-requests/route.test.ts
-> blocked: Cannot find package 'hono' in the clean worktree.
```

Package typecheck attempted:

```text
bun run --cwd packages/cloud/api typecheck
-> blocked: `tsc` is not installed in the clean worktree.
```

## Evidence Gate

<!-- evidence-head:c3b3de8837f281b1abbd9a080a72d96a96f6ed7c -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - server/API-only change; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - server/API-only change; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - server/API-only change; no rendered UI surface.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - runtime integration test is blocked by missing worktree dependencies; parser/build evidence is attached in the testing section.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - server/API-only change; no frontend request surface is changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior is changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no live database mutation was performed; regression tests are deterministic and runtime execution is dependency-blocked.`
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - no rendered visual surface.`

## Known gaps / failures

- `bun install` was not rerun because prior dependency installation in session-created worktrees failed with `ENOSPC`; no dependency files were changed.
- The focused Bun test could not start because `hono` is unavailable in this worktree.
- Cloud package typecheck could not start because `tsc` is unavailable.
- No receipt was produced: the checkout contains the Eliza live-report helper but no project-validated `run-receipt.mjs`; the only discovered receipt script belongs to a Delta Star skill and was not used.

## Maintainer review

Pending independent maintainer review and CI.

AI provider/model: OpenAI / openai/gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@4d57248577903bac93ac9652c2eb78a95e32b64c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
- [fix-payment-request-agent-ownership-clean]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"openai/gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@4d57248577903bac93ac9652c2eb78a95e32b64c:packages/skills/skills/contribute-to-eliza"} -->




