### PR TITLE
fix(cloud): use Docker age for orphan grace

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/orphan-reaper-warm-claim-keys.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/orphan-reaper-warm-claim-keys.test.ts
@@ -158,7 +158,6 @@ describe("orphan reaper key resolution for warm-claimed containers", () => {
           key: cleanupNameId,
           status: "replacement_cleanup_owned",
           nodeId: "node-8",
-          updatedAtMs: expect.any(Number),
         },
       ]);
     },

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.test.ts
@@ -95,12 +95,11 @@ describe("computeOrphanContainersToReap (agent diff)", () => {
 
   test("keeps both primary and replacement placements owned by one sandbox row", () => {
     const rows: LiveContainerRef[] = [
-      { key: "same", status: "running", nodeId: "node-old", updatedAtMs: 1 },
+      { key: "same", status: "running", nodeId: "node-old" },
       {
         key: "same",
         status: "replacement_cleanup_owned",
         nodeId: "node-new",
-        updatedAtMs: 1,
       },
     ];
     const config = { ...AGENT_DIFF, nodeAware: true, nodeMoveGraceMs: 1 };

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -178,10 +178,8 @@ export async function loadSandboxStatusesByIds(
       containerName: agentSandboxes.container_name,
       status: agentSandboxes.status,
       nodeId: agentSandboxes.node_id,
-      updatedAt: agentSandboxes.updated_at,
       replacementNodeId: agentSandboxes.replacement_cleanup_node_id,
       replacementContainerName: agentSandboxes.replacement_cleanup_container_name,
-      replacementCreatedAt: agentSandboxes.replacement_cleanup_created_at,
     })
     .from(agentSandboxes)
     .where(
@@ -211,7 +209,6 @@ export async function loadSandboxStatusesByIds(
         key: row.key,
         status: row.status,
         nodeId: row.nodeId ?? undefined,
-        updatedAtMs: row.updatedAt ? new Date(row.updatedAt).getTime() : undefined,
       },
       row.containerName,
     );
@@ -221,9 +218,6 @@ export async function loadSandboxStatusesByIds(
           key: row.key,
           status: "replacement_cleanup_owned",
           nodeId: row.replacementNodeId,
-          updatedAtMs: row.replacementCreatedAt
-            ? new Date(row.replacementCreatedAt).getTime()
-            : undefined,
         },
         row.replacementContainerName,
       );

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.test.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.test.ts
@@ -224,16 +224,10 @@ describe("node-aware stale-twin classification", () => {
     nodeMoveGraceMs: 5 * 60_000,
   };
   const NOW = 1_000_000_000_000;
-  const onNode = (
-    key: string,
-    status: string,
-    nodeId: string,
-    ageMs: number,
-  ): LiveContainerRef => ({
+  const onNode = (key: string, status: string, nodeId: string): LiveContainerRef => ({
     key,
     status,
     nodeId,
-    updatedAtMs: NOW - ageMs,
   });
   const c = (id: string, containerAgeMs = 60 * 60_000): NodeContainerRef => ({
     name: `agent-${id}`,
@@ -255,7 +249,7 @@ describe("node-aware stale-twin classification", () => {
     expect(
       computeOrphanContainersToReap(
         [tenMinutesOld],
-        [onNode("x", "running", "nodeB", 10 * 60_000)],
+        [onNode("x", "running", "nodeB")],
         independentGrace,
         "nodeA",
         NOW,
@@ -263,10 +257,10 @@ describe("node-aware stale-twin classification", () => {
     ).toEqual([{ name: "agent-x", id: "docker-x", key: "x", reason: "wrong_node" }]);
   });
 
-  test("reaps a stable container whose live row points at a different node", () => {
+  test("reaps an old container whose live row points at a different node", () => {
     const orphans = computeOrphanContainersToReap(
       [c("x")],
-      [onNode("x", "running", "nodeB", 10 * 60_000)],
+      [onNode("x", "running", "nodeB")],
       cfg,
       "nodeA",
       NOW,
@@ -275,64 +269,108 @@ describe("node-aware stale-twin classification", () => {
   });
 
   test("retains a fresh container while placement is in flight", () => {
-    const orphans = computeOrphanContainersToReap(
+    const decisions = classifyContainersForReconciliation(
       [c("x", 29_000)],
-      [onNode("x", "running", "nodeB", 12 * 24 * 60 * 60_000)],
+      [onNode("x", "running", "nodeB")],
       cfg,
       "nodeA",
       NOW,
     );
-    expect(orphans).toEqual([]);
+    expect(decisions).toEqual([
+      {
+        action: "retain",
+        name: "agent-x",
+        id: "docker-x",
+        key: "x",
+        reason: "wrong_node_container_within_grace",
+      },
+    ]);
   });
 
   test("retains a container with unknown age", () => {
-    const orphans = computeOrphanContainersToReap(
+    const decisions = classifyContainersForReconciliation(
       [{ name: "agent-x", id: "docker-x" }],
-      [onNode("x", "running", "nodeB", 10 * 60_000)],
+      [onNode("x", "running", "nodeB")],
       cfg,
       "nodeA",
       NOW,
     );
-    expect(orphans).toEqual([]);
+    expect(decisions).toEqual([
+      {
+        action: "retain",
+        name: "agent-x",
+        id: "docker-x",
+        key: "x",
+        reason: "wrong_node_age_unknown",
+      },
+    ]);
   });
 
   test("retains the container on its canonical node", () => {
-    const orphans = computeOrphanContainersToReap(
+    const decisions = classifyContainersForReconciliation(
       [c("x")],
-      [onNode("x", "running", "nodeA", 10 * 60_000)],
+      [onNode("x", "running", "nodeA")],
       cfg,
       "nodeA",
       NOW,
     );
-    expect(orphans).toEqual([]);
+    expect(decisions).toEqual([
+      {
+        action: "retain",
+        name: "agent-x",
+        id: "docker-x",
+        key: "x",
+        reason: "live_on_node",
+      },
+    ]);
   });
 
-  test("retains a node mismatch within the row grace window", () => {
-    const orphans = computeOrphanContainersToReap(
+  test("reaps an old wrong-node container despite a fresh heartbeat row", () => {
+    const freshHeartbeatRow: LiveContainerRef & { updatedAtMs: number } = {
+      ...onNode("x", "running", "nodeB"),
+      updatedAtMs: NOW - 30_000,
+    };
+    const decisions = classifyContainersForReconciliation(
       [c("x")],
-      [onNode("x", "running", "nodeB", 30_000)],
+      [freshHeartbeatRow],
       cfg,
       "nodeA",
       NOW,
     );
-    expect(orphans).toEqual([]);
+    expect(decisions).toEqual([
+      {
+        action: "reap",
+        name: "agent-x",
+        id: "docker-x",
+        key: "x",
+        reason: "wrong_node",
+      },
+    ]);
   });
 
   test("retains a row whose placement evidence is incomplete", () => {
-    const orphans = computeOrphanContainersToReap(
+    const decisions = classifyContainersForReconciliation(
       [c("x")],
       [{ key: "x", status: "running" }],
       cfg,
       "nodeA",
       NOW,
     );
-    expect(orphans).toEqual([]);
+    expect(decisions).toEqual([
+      {
+        action: "retain",
+        name: "agent-x",
+        id: "docker-x",
+        key: "x",
+        reason: "wrong_node_evidence_incomplete",
+      },
+    ]);
   });
 
   test("terminal row still wins over node logic (reap as terminal_db_row)", () => {
     const orphans = computeOrphanContainersToReap(
       [c("x")],
-      [onNode("x", "error", "nodeB", 10 * 60_000)],
+      [onNode("x", "error", "nodeB")],
       cfg,
       "nodeA",
       NOW,
@@ -343,7 +381,7 @@ describe("node-aware stale-twin classification", () => {
   test("retains when the caller omits node context", () => {
     const orphans = computeOrphanContainersToReap(
       [c("x")],
-      [onNode("x", "running", "nodeB", 10 * 60_000)],
+      [onNode("x", "running", "nodeB")],
       cfg,
       undefined,
       NOW,
@@ -355,7 +393,7 @@ describe("node-aware stale-twin classification", () => {
     const appsCfg = { ...cfg, nodeAware: false };
     const orphans = computeOrphanContainersToReap(
       [c("x")],
-      [onNode("x", "running", "nodeB", 10 * 60_000)],
+      [onNode("x", "running", "nodeB")],
       appsCfg,
       "nodeA",
       NOW,

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
@@ -44,13 +44,6 @@ export interface LiveContainerRef {
    * that moved the workload (see `wrong_node`). Absent for apps.
    */
   nodeId?: string;
-  /**
-   * When this row was last written (epoch ms). Node-aware reaping only trusts a
-   * `nodeId` mismatch once the row has been stable for `nodeMoveGraceMs`, so a
-   * container observed mid-provision (its healthy on node X before the row is
-   * updated to X) is never mistaken for a stale twin. Absent for apps.
-   */
-  updatedAtMs?: number;
 }
 
 /** A container the reconciler has decided to forcibly remove. */
@@ -63,7 +56,7 @@ export interface OrphanContainer {
   key: string;
   /**
    * Why it was flagged: no DB row at all, every row in a terminal state, or —
-   * for node-aware reconcilers — a live row that has stably pointed at a
+   * for node-aware reconcilers — an old container whose live row points at a
    * DIFFERENT node (`wrong_node`, the re-provision-left-a-twin case).
    */
   reason: "no_db_row" | "terminal_db_row" | "wrong_node";
@@ -79,8 +72,7 @@ export type RetainedContainerReason =
   | "live_on_node"
   | "wrong_node_evidence_incomplete"
   | "wrong_node_age_unknown"
-  | "wrong_node_container_within_grace"
-  | "wrong_node_row_within_grace";
+  | "wrong_node_container_within_grace";
 
 /** Complete, observable classification for one container in a node listing. */
 export type ContainerReconcileDecision =
@@ -158,8 +150,8 @@ export interface OrphanReconcilerConfig {
    * Opt in to node-aware reaping: also reap a container on node X when the
    * workload has a live row but every live row points at a DIFFERENT node (a
    * re-provision moved the workload and left this twin behind). Requires
-   * `loadStatuses` to populate `nodeId` + `updatedAtMs`. Agents set this;
-   * apps (which legitimately fan a name across rows) leave it off.
+   * `loadStatuses` to populate `nodeId`. Agents set this; apps (which
+   * legitimately fan a name across rows) leave it off.
    */
   nodeAware?: boolean;
   /**
@@ -170,10 +162,10 @@ export interface OrphanReconcilerConfig {
    */
   rowlessGraceMs?: number;
   /**
-   * How long a `nodeId` mismatch must persist before the twin is reaped
-   * (epoch-ms delta against the row's `updatedAtMs`). Guards the provision race
-   * where a container is healthy on its new node before the DB row catches up.
-   * Defaults to `DEFAULT_NODE_MOVE_GRACE_MS` when node-aware and unset.
+   * How old a wrong-node container must be before the twin is reaped (epoch-ms
+   * delta against its immutable Docker `createdAtMs`). Guards the provision
+   * race where a new container is healthy before the DB row catches up. Defaults
+   * to `DEFAULT_NODE_MOVE_GRACE_MS` when node-aware and unset.
    */
   nodeMoveGraceMs?: number;
 
@@ -189,9 +181,9 @@ export interface OrphanReconcilerConfig {
 }
 
 /**
- * A stale twin must have been "wrong-noded" for at least this long before it is
+ * A wrong-node container must have existed for at least this long before it is
  * reaped — long enough that a normal provision (create container → confirm
- * healthy → update row's node_id) has written the row, so the freshly-healthy
+ * healthy → update row's node_id) has written the row, so the freshly healthy
  * NEW container is never mistaken for the twin during its own creation window.
  */
 export const DEFAULT_NODE_MOVE_GRACE_MS = 5 * 60_000;
@@ -231,11 +223,12 @@ export const DEFAULT_ROWLESS_GRACE_MS = 5 * 60_000;
  * sits on. That is the re-provision-left-a-twin case (#15228): the worker moved
  * the agent to a new node and never tore down the old container, which then
  * holds the headscale identity and makes the new registration flap. We reap the
- * twin ONLY when EVERY live row for the key points elsewhere AND the newest such
- * row has been stable for `nodeMoveGraceMs` — so a container that is merely
- * healthy-before-its-own-row-updates during a normal provision is protected.
- * When any live row points at THIS node, the container is the canonical one and
- * is kept.
+ * twin ONLY when EVERY live row for the key points elsewhere AND the container
+ * itself is older than `nodeMoveGraceMs` — so a newly created container that
+ * is healthy before its own row updates during a normal provision is protected.
+ * Database `updated_at` is deliberately not a clock for this decision because
+ * healthy-agent heartbeats rewrite it continuously. When any live row points at
+ * THIS node, the container is the canonical one and is kept.
  *
  * `nowMs` is injected so classification remains deterministic. Missing time is
  * treated as incomplete evidence and therefore retains the container.
@@ -343,8 +336,9 @@ export function classifyContainersForReconciliation(
 
     // A live (non-terminal) row exists. In node-aware mode, this container is a
     // stale twin iff NONE of the live rows point at this node — the canonical
-    // container lives elsewhere. Require the newest such mismatching row to have
-    // been stable past the grace window before reaping.
+    // container lives elsewhere. The immutable Docker creation time protects a
+    // newly created container while its row catches up; mutable row timestamps
+    // cannot, because healthy-agent heartbeats refresh them indefinitely.
     if (!config.nodeAware) {
       decisions.push({
         action: "retain",
@@ -378,15 +372,7 @@ export function classifyContainersForReconciliation(
       continue;
     }
     const completePlacements = liveRows_.filter(
-      (
-        row,
-      ): row is LiveContainerRef & {
-        nodeId: string;
-        updatedAtMs: number;
-      } =>
-        row.nodeId !== undefined &&
-        row.updatedAtMs !== undefined &&
-        Number.isFinite(row.updatedAtMs),
+      (row): row is LiveContainerRef & { nodeId: string } => row.nodeId !== undefined,
     );
     if (completePlacements.length !== liveRows_.length) {
       decisions.push({
@@ -420,17 +406,6 @@ export function classifyContainersForReconciliation(
         id: container.id,
         key,
         reason: "wrong_node_container_within_grace",
-      });
-      continue;
-    }
-    const newest = Math.max(...completePlacements.map((row) => row.updatedAtMs));
-    if (nowMs - newest < nodeMoveGraceMs) {
-      decisions.push({
-        action: "retain",
-        name: container.name,
-        id: container.id,
-        key,
-        reason: "wrong_node_row_within_grace",
       });
       continue;
     }


### PR DESCRIPTION
# Relates to

Fixes #18051

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` and `bun run verify` were run after the final sync.
- [x] The deterministic decision artifact and exact verification commands below
      let a reviewer confirm the change without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88`; zero conflicts.
- [x] `bun run verify` passes post-sync on `b8593e561b25dfe49308c0a5ed843a9f80b8ba18`.

# Risks

Low. The change narrows one cleanup decision to immutable Docker creation age.
Unknown age, incomplete placement evidence, the canonical node, and a fresh
wrong-node container all remain fail-closed retain decisions. The main risk is
leaving an old wrong-node container behind if Docker cannot report creation
time, which is the deliberate safe failure mode.

# Background

## What does this PR do?

It prevents healthy heartbeat writes to `agent_sandboxes.updated_at` from
permanently resetting the wrong-node cleanup grace window. The agent orphan
reconciler now uses only the observed container's immutable Docker
`CreatedAt` value for that grace decision, while preserving the existing
fail-closed placement and canonical-node protections. The production loader no
longer selects or maps the mutable row timestamp for reconciliation.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is needed. This corrects an internal cleanup
clock and its tests without changing a public API or operator procedure.

# Testing

## Where should a reviewer start?

Start with `packages/cloud/shared/src/lib/services/orphan-container-reconciler.test.ts`,
especially the old-container/fresh-heartbeat regression and the four
fail-closed retention cases beside it. Then inspect the production adapter in
`docker-node-workloads.ts`.

## Detailed testing steps

All commands used Node `v24.15.0` and Bun `1.3.14` after the final rebase:

```text
bun install
# Checked 3459 installs across 3765 packages (no changes)

bun run build:core
# 56 successful, 56 total

bun --config=/dev/null test --reporter=dots \
  packages/cloud/shared/src/lib/services/orphan-container-reconciler.test.ts \
  packages/cloud/shared/src/lib/services/docker-node-workloads.test.ts \
  packages/cloud/shared/src/lib/services/__tests__/orphan-reaper-warm-claim-keys.test.ts
# 50 pass, 0 fail, 78 expect() calls

bun run --cwd packages/cloud/shared lint:check
# Checked 1848 files. No fixes applied.

bun run --cwd packages/cloud/shared typecheck
# exit 0

bun run --cwd packages/cloud/shared test
# 678 files, 162 sequential child-process shards, exit 0; only explicit
# environment-gated integration tests skipped

bun run verify
# 350 successful, 350 total; all follow-up audits passed
# anti-larp: 7906 test files, 0 focused, 0 orphaned skips
```

# Evidence Gate

<!-- evidence-head:9f4a347b9b055037b697c42920afee18a20fabac -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only Docker reconciliation classifier; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only Docker reconciliation classifier; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic server-side decision path with no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] Focused backend/runtime proof from the reviewed head:

<details>
<summary>Node 24.15.0 / Bun 1.3.14 focused test transcript</summary>

```text
v24.15.0
1.3.14
$ bun --config=/dev/null test --reporter=dots orphan-container-reconciler.test.ts docker-node-workloads.test.ts orphan-reaper-warm-claim-keys.test.ts
bun test v1.3.14 (0d9b296a)
50 pass
0 fail
78 expect() calls
Ran 50 tests across 3 files. [1.83s]
process exit: 0
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, state, or code path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic five-case reconciliation decision artifact:

<details>
<summary>Classifier output at fixed nowMs=1000000000000</summary>

```json
{
  "head": "b8593e561b25dfe49308c0a5ed843a9f80b8ba18",
  "cases": {
    "old_wrong_node_fresh_heartbeat": { "action": "reap", "reason": "wrong_node" },
    "unknown_age": { "action": "retain", "reason": "wrong_node_age_unknown" },
    "canonical_node": { "action": "retain", "reason": "live_on_node" },
    "incomplete_placement": { "action": "retain", "reason": "wrong_node_evidence_incomplete" },
    "fresh_wrong_node": { "action": "retain", "reason": "wrong_node_container_within_grace" }
  }
}
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

Focused backend/runtime proof:

```text
bun test v1.3.14 (0d9b296a)
50 pass
0 fail
78 expect() calls
Ran 50 tests across 3 files. [2.06s]
```

Deterministic classifier artifact from the reviewed head (fixed `nowMs`, no
network, database, or production mutation):

```json
{
  "head": "b8593e561b25dfe49308c0a5ed843a9f80b8ba18",
  "nowMs": 1000000000000,
  "cases": {
    "old_wrong_node_fresh_heartbeat": { "action": "reap", "reason": "wrong_node" },
    "unknown_age": { "action": "retain", "reason": "wrong_node_age_unknown" },
    "canonical_node": { "action": "retain", "reason": "live_on_node" },
    "incomplete_placement": { "action": "retain", "reason": "wrong_node_evidence_incomplete" },
    "fresh_wrong_node": { "action": "retain", "reason": "wrong_node_container_within_grace" }
  }
}
```

Frontend logs: N/A - no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - this is a backend-only reconciliation change with no rendered surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- No production Docker container was removed and no deployment or live fleet
  mutation was performed or claimed. Evidence is deterministic host-verifiable
  classifier execution plus the owning package and full repository checks.
- On the pre-fix parent behavior, the same old wrong-node container paired with
  a fresh heartbeat-mutated row was retained as
  `wrong_node_row_within_grace`; on this head it deterministically reaps as
  `wrong_node`. The adjacent safety cases prove unknown age, canonical
  placement, incomplete placement, and a fresh container remain retained.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 52137851 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [marcoworms-issue-18051]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZT97AE41F7RD9VMB5YER9ZX","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T06:05:45.796Z","completed_at":"2026-08-12T06:36:33.831Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":2650463,"output_tokens":60192,"cache_creation_tokens":0,"cache_read_tokens":49427196,"total_tokens":52137851,"cost_micro_usd":"10681777","session_count":10},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAyxbT0XzbIDMGbIz7b-1rBh0lxcEeDNFvJvuru8xiJdU","device_key_id":"0a3ad4f006e672e1ff30dfaf97a587c1ed71ae0bd99c2024aa65485e0b9ed0cd","device_signature":"Cwego3ZhGg1yF8RTsDadmQwSLSLQGjtxwkFPhgK3m3JagIpkK6EWSwmF53zgK3sVcbuGncsIT87TeHXrpC68Aw"}} -->



