### PR TITLE
fix(evidence): reject invalid AI-QA reviewer arguments

### DIFF
--- a/packages/app/test/audit/ai-qa-reviewer-args.test.ts
+++ b/packages/app/test/audit/ai-qa-reviewer-args.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Verifies the real AI-QA reviewer entrypoints reject ambiguous CLI input
+ * before credential checks while preserving their valid keyless path.
+ */
+
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseReviewerArgs } from "../../../../scripts/ai-qa/reviewer-args.mjs";
+
+const reviewerScripts = [
+  {
+    label: "screenshot reviewer",
+    path: resolve(
+      import.meta.dirname,
+      "../../../../scripts/ai-qa/review-screenshots.mjs",
+    ),
+  },
+  {
+    label: "walkthrough reviewer",
+    path: resolve(
+      import.meta.dirname,
+      "../../../../scripts/ai-qa/review-walkthrough.mjs",
+    ),
+  },
+];
+
+const {
+  AI_QA_VISION_BACKEND: _backend,
+  ANTHROPIC_API_KEY: _anthropicKey,
+  OPENAI_API_KEY: _openAiKey,
+  ...keylessEnvironment
+} = process.env;
+
+describe("AI-QA reviewer arguments", () => {
+  it("preserves defaults and supported screenshot options", () => {
+    expect(parseReviewerArgs([])).toEqual({
+      runDir: null,
+      concurrency: 4,
+      strict: false,
+      updateDebt: false,
+    });
+    expect(
+      parseReviewerArgs([
+        "--run-dir",
+        "reports/example",
+        "--concurrency",
+        "8",
+        "--strict",
+        "--update-debt",
+      ]),
+    ).toEqual({
+      runDir: "reports/example",
+      concurrency: 8,
+      strict: true,
+      updateDebt: true,
+    });
+  });
+
+  it("supports the walkthrough-only verdict destination", () => {
+    expect(
+      parseReviewerArgs(["--verdict-md", "reports/verdict.md"], {
+        defaultVerdictMd: "default.md",
+      }).verdictMd,
+    ).toBe("reports/verdict.md");
+    expect(() =>
+      parseReviewerArgs(["--verdict-md", "reports/verdict.md"]),
+    ).toThrow("unknown argument: --verdict-md");
+  });
+
+  it.each([
+    [["--strcit"], "unknown argument: --strcit"],
+    [["positional"], "unknown argument: positional"],
+    [["--strict", "--strict"], "--strict may be specified only once"],
+    [
+      ["--concurrency", "2", "--concurrency", "3"],
+      "--concurrency may be specified only once",
+    ],
+    [["--run-dir"], "--run-dir requires a value"],
+    [["--run-dir", "--strict"], "--run-dir requires a value"],
+    [["--concurrency"], "--concurrency requires a value"],
+    [["--concurrency", "--strict"], "--concurrency requires a value"],
+  ])("rejects ambiguous arguments %j", (argv, message) => {
+    expect(() => parseReviewerArgs(argv)).toThrow(message);
+  });
+
+  it.each(["0", "-1", "1.5", "NaN", "Infinity", "9007199254740992"])(
+    "rejects invalid concurrency %j",
+    (value) => {
+      expect(() => parseReviewerArgs(["--concurrency", value])).toThrow(
+        "--concurrency must be a positive safe integer",
+      );
+    },
+  );
+
+  it.each(reviewerScripts)(
+    "rejects a misspelled strict flag at the real $label boundary",
+    ({ path }) => {
+      const result = spawnSync(process.execPath, [path, "--strcit"], {
+        encoding: "utf8",
+        env: keylessEnvironment,
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("unknown argument: --strcit");
+      expect(result.stdout).not.toContain("skipping");
+      expect(result.stdout).not.toContain("PASSED");
+    },
+  );
+
+  it.each(reviewerScripts)(
+    "preserves the valid keyless skip for the $label",
+    ({ path }) => {
+      const result = spawnSync(process.execPath, [path, "--strict"], {
+        encoding: "utf8",
+        env: keylessEnvironment,
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("skipping");
+      expect(result.stderr).toBe("");
+    },
+  );
+});

--- a/scripts/ai-qa/review-screenshots.mjs
+++ b/scripts/ai-qa/review-screenshots.mjs
@@ -33,22 +33,11 @@ import {
   imageBlock,
   parseVisionVerdict,
 } from "./review-lib.mjs";
+import { parseReviewerArgs } from "./reviewer-args.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const MODEL = process.env.AI_QA_VISION_MODEL || "claude-haiku-4-5-20251001";
 const ANTHROPIC_VERSION = "2023-06-01";
-
-function parseArgs(argv) {
-  const a = { runDir: null, concurrency: 4, strict: false, updateDebt: false };
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (arg === "--run-dir") a.runDir = argv[++i];
-    else if (arg === "--concurrency") a.concurrency = Number(argv[++i]);
-    else if (arg === "--strict") a.strict = true;
-    else if (arg === "--update-debt") a.updateDebt = true;
-  }
-  return a;
-}
 
 async function latestRunDir() {
   const base = join(REPO_ROOT, "reports", "ai-qa");
@@ -148,7 +137,7 @@ async function mapPool(items, n, fn) {
 }
 
 async function main() {
-  const args = parseArgs(process.argv.slice(2));
+  const args = parseReviewerArgs(process.argv.slice(2));
   if (!process.env.ANTHROPIC_API_KEY) {
     console.log(
       "[vision-review] ANTHROPIC_API_KEY not set — skipping (CI-safe no-op). Set it to run the content review.",

--- a/scripts/ai-qa/review-walkthrough.mjs
+++ b/scripts/ai-qa/review-walkthrough.mjs
@@ -32,6 +32,7 @@ import {
   imageBlock,
   parseVisionVerdict,
 } from "./review-lib.mjs";
+import { parseReviewerArgs } from "./reviewer-args.mjs";
 import { resolveReviewerBackend } from "./reviewer-preflight.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
@@ -44,26 +45,6 @@ const DEFAULT_VERDICT_MD = join(
   REPO_ROOT,
   "packages/app/test/ui-smoke/walkthrough/WALKTHROUGH_VERDICTS.md",
 );
-
-function parseArgs(argv) {
-  const a = {
-    runDir: null,
-    concurrency: 4,
-    strict: false,
-    updateDebt: false,
-    verdictMd: DEFAULT_VERDICT_MD,
-  };
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (arg === "--run-dir") a.runDir = argv[++i];
-    else if (arg === "--concurrency") a.concurrency = Number(argv[++i]);
-    else if (arg === "--strict") a.strict = true;
-    else if (arg === "--update-debt") a.updateDebt = true;
-    else if (arg === "--verdict-md")
-      a.verdictMd = resolve(REPO_ROOT, argv[++i]);
-  }
-  return a;
-}
 
 async function latestRunDir() {
   const base = join(REPO_ROOT, "reports", "walkthrough");
@@ -280,7 +261,13 @@ function buildVerdictMarkdown({ runId, model, lane, totals, results }) {
 }
 
 async function main() {
-  const args = parseArgs(process.argv.slice(2));
+  const parsedArgs = parseReviewerArgs(process.argv.slice(2), {
+    defaultVerdictMd: DEFAULT_VERDICT_MD,
+  });
+  const args = {
+    ...parsedArgs,
+    verdictMd: resolve(REPO_ROOT, parsedArgs.verdictMd),
+  };
   const providerKey =
     BACKEND === "openai"
       ? process.env.OPENAI_API_KEY

--- a/scripts/ai-qa/reviewer-args.mjs
+++ b/scripts/ai-qa/reviewer-args.mjs
@@ -1,0 +1,66 @@
+/**
+ * Defines the fail-closed command-line contract shared by AI-QA reviewer
+ * entrypoints before they inspect credentials, call a model, or write evidence.
+ */
+
+function requireUnique(seen, argument) {
+  if (seen.has(argument)) {
+    throw new Error(`${argument} may be specified only once`);
+  }
+  seen.add(argument);
+}
+
+function takeValue(argv, index, argument) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${argument} requires a value`);
+  }
+  return value;
+}
+
+export function parseReviewerArgs(argv, { defaultVerdictMd } = {}) {
+  const supportsVerdictMd = defaultVerdictMd !== undefined;
+  const options = {
+    runDir: null,
+    concurrency: 4,
+    strict: false,
+    updateDebt: false,
+    ...(supportsVerdictMd ? { verdictMd: defaultVerdictMd } : {}),
+  };
+  const seen = new Set();
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--strict" || argument === "--update-debt") {
+      requireUnique(seen, argument);
+      options[argument === "--strict" ? "strict" : "updateDebt"] = true;
+      continue;
+    }
+    if (
+      argument === "--run-dir" ||
+      argument === "--concurrency" ||
+      (supportsVerdictMd && argument === "--verdict-md")
+    ) {
+      requireUnique(seen, argument);
+      const value = takeValue(argv, index, argument);
+      index += 1;
+      if (argument === "--run-dir") {
+        options.runDir = value;
+      } else if (argument === "--verdict-md") {
+        options.verdictMd = value;
+      } else {
+        const concurrency = Number(value);
+        if (!Number.isSafeInteger(concurrency) || concurrency < 1) {
+          throw new Error(
+            `--concurrency must be a positive safe integer (received ${JSON.stringify(value)})`,
+          );
+        }
+        options.concurrency = concurrency;
+      }
+      continue;
+    }
+    throw new Error(`unknown argument: ${argument}`);
+  }
+
+  return options;
+}


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18557

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change is limited to command-line parsing for the two AI-QA reviewer scripts and regression tests. Valid options, default concurrency, and the credential-free CI skip remain unchanged. Invalid or ambiguous input now stops before credential checks, model requests, or evidence writes.

# Background

## What does this PR do?

Adds one shared, fail-closed parser for the screenshot and walkthrough AI-QA reviewers. It rejects unknown or positional arguments, duplicate flags, missing values, and concurrency values that are not positive safe integers. The real CLI boundaries are tested to prove a misspelled `--strcit` flag can no longer silently disable strict mode.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No documentation change is needed. Supported arguments and defaults are unchanged; this corrects invalid-input handling.

# Testing

## Where should a reviewer start?

Start with `packages/app/test/audit/ai-qa-reviewer-args.test.ts`, then inspect `scripts/ai-qa/reviewer-args.mjs` and its use by the two reviewer entrypoints.

## Detailed testing steps

Post-sync verification at `ace863011e80fff053f7fd59b1e780616e1feec9`:

```text
bun install --frozen-lockfile
Checked 3459 installs across 3765 packages (no changes)

bunx vitest run packages/app/test/audit/ai-qa-reviewer-args.test.ts
1 file, 20 tests passed

node --test scripts/ai-qa/reviewer-preflight.test.mjs
10 tests passed

bun run --cwd packages/app test
Bun suite: 653 passed, 1 expected platform skip
Vitest: 84 files, 653 tests passed

bun run --cwd packages/app typecheck
PASS

bun run --cwd packages/app lint:check
Checked 284 files; PASS

bun run --cwd packages/app build:web
9003 modules transformed; build PASS
[verify-chunk-safety] PASS
[verify-viewport-meta] PASS

bunx @biomejs/biome check <four changed files>
PASS with 8 pre-existing undeclared-environment warnings in the existing reviewer scripts

bun run verify
Tasks: 350 successful, 350 total
[audit-build-typecheck] PASS
[audit-turbo-build-deps] PASS
audit-tee-secret-leak: PASS
[hetzner-fleet-routing] verified 62 selectors across 15 workflows
[audit-scripts] OK
[anti-larp] clean
```

Before the fix, both real CLIs ignored a misspelled strict flag. A deterministic one-item fixture returned one `needs-work` verdict, but the processes still reported success and wrote evidence:

```text
$ node scripts/ai-qa/review-screenshots.mjs --run-dir <fixture> --strcit
[vision-review] reviewing 1 screenshots with claude-haiku-4-5-20251001 (concurrency 4)
total=1 | needs-work=1 | strict=false | undebted failures=0
PASSED
exit: 0; vision-review.json and vision-review.md written

$ node scripts/ai-qa/review-walkthrough.mjs --run-dir <fixture> --strcit
total=1 | needs-work=1 | strict=false | undebted failures=0
PASSED
exit: 0; vision-review.json, vision-review.md, and verdict markdown written
```

After the fix, the same typo fails before any evidence artifact is created:

```text
$ node scripts/ai-qa/review-screenshots.mjs --run-dir <fixture> --strcit
fatal Error: unknown argument: --strcit
exit: 1; vision-review.json absent; vision-review.md absent

$ node scripts/ai-qa/review-walkthrough.mjs --run-dir <fixture> --strcit
fatal Error: unknown argument: --strcit
exit: 1; vision-review.json absent; vision-review.md absent; verdict markdown absent
```

# Evidence Gate

<!-- evidence-head:ace863011e80fff053f7fd59b1e780616e1feec9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - command-line scripts and tests only; this diff changes no rendered UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - command-line scripts and tests only; this diff changes no rendered UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no rendered or interactive user flow is changed`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - parsing rejects invalid input locally before credentials, network calls, or a server path`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - these reviewer CLIs have no frontend request or browser state path`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent, action, provider, prompt, or model behavior changes`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.).

<details>
<summary>AI-QA evidence artifact proof</summary>

```text
BEFORE: both real CLIs accepted --strcit, printed strict=false, exited 0 after a needs-work verdict, and wrote reviewer evidence files.
AFTER: both real CLIs reject "unknown argument: --strcit" and exit 1 before credential checks or model requests.
AFTER: vision-review.json, vision-review.md, and the walkthrough verdict markdown are all absent from the requested run output.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - this diff changes only .mjs command-line code and a test file, with no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - argument parsing changes only; no agent, action, provider, prompt, or model behavior changes. The rejection path intentionally runs before any LLM call.

## Backend + frontend logs

N/A - the real CLI diagnostics, exit codes, and artifact results are included in **Testing**; rejected input reaches neither a backend nor a frontend path.

## Screenshots (before / after) + video walkthrough

N/A - this is a command-line tooling change with no rendered UI surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changes.

## Known gaps / failures

The native-inclusive `bun run --cwd packages/app build` reached the existing macOS alarm Swift helper and failed because this host's Command Line Tools compiler (`swiftc` 6.0.3, build `.1.10`) does not match its installed SDK modules (build `.1.5`). No native or Swift file is changed by this PR. The relevant web production build, chunk-safety check, viewport check, app test/typecheck/lint suites, and root `bun run verify` all passed, so the host toolchain mismatch does not block this command-line JavaScript fix.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 7167161 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [hkc2023-codex]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTBCSEPMQZK58Y2DHX5E5EW","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T06:43:42.167Z","completed_at":"2026-08-12T07:00:12.517Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":281358,"output_tokens":23467,"cache_creation_tokens":0,"cache_read_tokens":6862336,"total_tokens":7167161,"cost_micro_usd":"5541968","session_count":1},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAiePG1tPOzrMu-ASR7S9zu658VITXXJQIcWo_RCLcPNg","device_key_id":"efa48975f21fa1dc36e1a917bcfe1737a5329a11ccb709deb6dbae9121164067","device_signature":"yV5vBGNrHHeJqDZMx7DApo_05Ls7eFaJd-64rVXGb3XK-BnBUvuwCfi1eGMvPtp_Hipo912mxLhe9xuq-37hAw"}} -->
