### PR TITLE
fix(evidence): validate evidence-review CLI values

### DIFF
--- a/scripts/evidence-review/evidence-review.test.mjs
+++ b/scripts/evidence-review/evidence-review.test.mjs
@@ -4,15 +4,23 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { parseArgs } from "./generate.mjs";
 import { analyzeImageFile, classifyArtifactPath, inferSource } from "./lib.mjs";
 
 const WHITE_PIXEL_PNG = Buffer.from(
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAADUlEQVQI12P4////fwAJ+wP90YOM8AAAAABJRU5ErkJggg==",
   "base64",
 );
 
@@ -198,6 +206,84 @@ test("--bundle fails fast when a manifest lists a missing file", async () => {
     ]);
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /missing from the bundle/);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("rejects malformed numeric limits before creating output", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "evidence-review-args-"));
+  try {
+    const invalidArguments = [
+      "--max-images=1junk",
+      "--max-images=1.5",
+      "--max-images=-1",
+      "--max-images=+1",
+      "--max-images=01",
+      "--max-images=",
+      "--max-images= ",
+      "--max-images=9007199254740992",
+      "--max-artifacts=99",
+      "--max-artifacts=100oops",
+      "--max-files-per-dir=99",
+      "--max-files-per-dir=100.5",
+    ];
+
+    for (const [index, argument] of invalidArguments.entries()) {
+      const outDir = path.join(tmpDir, `out-${index}`);
+      const result = runGenerate([
+        `--out=${outDir}`,
+        "--source=/definitely/missing",
+        "--ocr=off",
+        "--no-open",
+        argument,
+      ]);
+
+      assert.notEqual(result.status, 0, argument);
+      assert.match(result.stderr, /must be|requires a non-empty value/);
+      await assert.rejects(() => stat(outDir));
+    }
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("rejects empty path options during argument parsing", () => {
+  for (const argument of [
+    "--out=",
+    "--out= ",
+    "--source=",
+    "--source= ",
+    "--bundle=",
+    "--bundle= ",
+  ]) {
+    assert.throws(
+      () => parseArgs([argument]),
+      /requires a non-empty value/,
+      argument,
+    );
+  }
+});
+
+test("preserves valid numeric boundary values", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "evidence-review-args-"));
+  try {
+    const outDir = path.join(tmpDir, "out");
+    const result = runGenerate([
+      `--out=${outDir}`,
+      "--source=/definitely/missing",
+      "--ocr=off",
+      "--no-open",
+      "--max-images=0",
+      "--max-artifacts=100",
+      "--max-files-per-dir=100",
+    ]);
+
+    assert.equal(result.status, 0, result.stderr);
+    const manifest = JSON.parse(
+      await readFile(path.join(outDir, "manifest.json"), "utf8"),
+    );
+    assert.deepEqual(manifest.artifacts, []);
   } finally {
     await rm(tmpDir, { recursive: true, force: true });
   }

--- a/scripts/evidence-review/generate.mjs
+++ b/scripts/evidence-review/generate.mjs
@@ -59,7 +59,31 @@ const SKIP_DIR_NAMES = new Set([
   ".codex-pr-worktrees",
 ]);
 
-function parseArgs(argv) {
+function requireOptionValue(argument, prefix) {
+  const value = argument.slice(prefix.length);
+  if (value.trim().length === 0) {
+    throw new Error(`${prefix.slice(0, -1)} requires a non-empty value`);
+  }
+  return value;
+}
+
+function parseIntegerOption(argument, prefix, minimum) {
+  const value = requireOptionValue(argument, prefix);
+  if (!/^(?:0|[1-9]\d*)$/u.test(value)) {
+    throw new Error(`${prefix.slice(0, -1)} must be a decimal integer`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    const constraint =
+      minimum === 0
+        ? "a non-negative safe integer"
+        : `a safe integer of at least ${minimum}`;
+    throw new Error(`${prefix.slice(0, -1)} must be ${constraint}`);
+  }
+  return parsed;
+}
+
+export function parseArgs(argv) {
   const options = {
     outputDir: DEFAULT_OUTPUT_DIR,
     open: false,
@@ -74,30 +98,28 @@ function parseArgs(argv) {
     if (arg === "--open") options.open = true;
     else if (arg === "--no-open") options.open = false;
     else if (arg.startsWith("--out=")) {
-      options.outputDir = path.resolve(REPO_ROOT, arg.slice("--out=".length));
+      options.outputDir = path.resolve(
+        REPO_ROOT,
+        requireOptionValue(arg, "--out="),
+      );
     } else if (arg.startsWith("--ocr=")) {
       options.ocr = arg.slice("--ocr=".length);
     } else if (arg.startsWith("--max-images=")) {
-      options.maxImages = Number.parseInt(
-        arg.slice("--max-images=".length),
-        10,
-      );
+      options.maxImages = parseIntegerOption(arg, "--max-images=", 0);
     } else if (arg.startsWith("--max-artifacts=")) {
-      options.maxArtifacts = Number.parseInt(
-        arg.slice("--max-artifacts=".length),
-        10,
-      );
+      options.maxArtifacts = parseIntegerOption(arg, "--max-artifacts=", 100);
     } else if (arg.startsWith("--max-files-per-dir=")) {
-      options.maxFilesPerDir = Number.parseInt(
-        arg.slice("--max-files-per-dir=".length),
-        10,
+      options.maxFilesPerDir = parseIntegerOption(
+        arg,
+        "--max-files-per-dir=",
+        100,
       );
     } else if (arg.startsWith("--source=")) {
-      options.scanDirs.push(arg.slice("--source=".length));
+      options.scanDirs.push(requireOptionValue(arg, "--source="));
     } else if (arg.startsWith("--bundle=")) {
       options.bundleDir = path.resolve(
         REPO_ROOT,
-        arg.slice("--bundle=".length),
+        requireOptionValue(arg, "--bundle="),
       );
     } else if (arg === "--help" || arg === "-h") {
       printHelp();
@@ -106,20 +128,8 @@ function parseArgs(argv) {
       throw new Error(`unknown argument: ${arg}`);
     }
   }
-  if (!Number.isFinite(options.maxImages) || options.maxImages < 0) {
-    throw new Error("--max-images must be a non-negative number");
-  }
-  if (!Number.isFinite(options.maxArtifacts) || options.maxArtifacts < 100) {
-    throw new Error("--max-artifacts must be at least 100");
-  }
   if (!["auto", "on", "off"].includes(options.ocr)) {
     throw new Error("--ocr must be auto, on, or off");
-  }
-  if (
-    !Number.isFinite(options.maxFilesPerDir) ||
-    options.maxFilesPerDir < 100
-  ) {
-    throw new Error("--max-files-per-dir must be at least 100");
   }
   return options;
 }
@@ -696,12 +706,14 @@ async function main() {
   if (options.open) openFile(indexPath);
 }
 
-main()
-  .catch((error) => {
-    console.error(error?.stack || error?.message || String(error));
-    process.exitCode = 1;
-  })
-  .finally(async () => {
-    await closeOcrEngines();
-    if (process.exitCode) process.exit(process.exitCode);
-  });
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main()
+    .catch((error) => {
+      console.error(error?.stack || error?.message || String(error));
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await closeOcrEngines();
+      if (process.exitCode) process.exit(process.exitCode);
+    });
+}


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18559

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change is confined to the local evidence-review CLI and its tests. Valid defaults and documented options are unchanged. Invalid numeric/path values now fail before directory creation or scanning. The test fixture byte change preserves its declared one-white-pixel semantics while making it readable by the pinned Sharp/libpng stack.

# Background

## What does this PR do?

Makes evidence-review limits and paths fail closed at the CLI boundary. Numeric limits now require canonical non-negative decimal safe integers and retain the existing minimums; empty output, source, and bundle values are rejected. The parser is exported without auto-running the dashboard when imported, enabling side-effect-free boundary tests.

While running the complete owning suite, the pinned image stack rejected its pre-existing embedded PNG and broke both image tests. This PR replaces only those fixture bytes with a verified 1×1 RGBA white PNG (`[255, 255, 255, 255]`), restoring the test's stated contract.

## What kind of change is this?

Bug fix (non-breaking change which fixes invalid-input false greens and restores the focused test fixture).

# Documentation changes needed?

No documentation change is needed. Supported CLI syntax, defaults, and minimums are unchanged.

# Testing

## Where should a reviewer start?

Start with the real-process argument cases in `scripts/evidence-review/evidence-review.test.mjs`, then inspect `parseArgs` in `scripts/evidence-review/generate.mjs`.

## Detailed testing steps

Post-sync verification at `953b7b820e8102f9a3811e69e01707a968fd7490`:

```text
bun install --frozen-lockfile
Checked 3459 installs across 3765 packages (no changes)

node --test scripts/evidence-review/*.test.mjs
26 tests passed; 0 failed

bunx @biomejs/biome check scripts/evidence-review/generate.mjs scripts/evidence-review/evidence-review.test.mjs
Checked 2 files; PASS

bun run verify
Tasks: 350 successful, 350 total
[audit-build-typecheck] PASS
[audit-turbo-build-deps] PASS
audit-tee-secret-leak: PASS
[hetzner-fleet-routing] verified 62 selectors across 15 workflows
[audit-scripts] OK
[anti-larp] clean
```

Before the fix, a malformed limit was silently truncated and the real CLI generated success artifacts:

```text
$ node scripts/evidence-review/generate.mjs --out=/tmp/eliza-evidence-review-before --source=/tmp/empty --ocr=off --no-open --max-images=1junk
Evidence manifest: /tmp/eliza-evidence-review-before/manifest.json
Evidence dashboard: /tmp/eliza-evidence-review-before/index.html
Artifacts: 0 total, 0 screenshots, 0 videos, 0 trajectories, 0 logs.
exit: 0
```

After the fix, rejection occurs before the requested output path exists:

```text
$ node scripts/evidence-review/generate.mjs --out=/tmp/eliza-evidence-review-after-18559 --source=/tmp/empty --ocr=off --no-open --max-images=1junk
Error: --max-images must be a decimal integer
exit: 1
output path exists: no
```

The replacement image fixture was opened through the pinned Sharp implementation and inspected as:

```text
format=raw width=1 height=1 channels=4 depth=uchar hasAlpha=true size=4
pixel bytes=[255,255,255,255]
evidence-review image heuristic: dominant color #ffffff; one-color/near-solid checks exercised
```

# Evidence Gate

<!-- evidence-head:953b7b820e8102f9a3811e69e01707a968fd7490 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - command-line tooling and test-fixture bytes only; no rendered UI surface changes`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - command-line tooling and test-fixture bytes only; no rendered UI surface changes`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no rendered or interactive user flow is changed`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - argument parsing runs in a local CLI before any server or network path`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - the local evidence generator has no frontend request or browser-state path for rejected input`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent, action, provider, prompt, or model behavior changes`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.).

<details>
<summary>Evidence-review artifact and fixture proof</summary>

```text
BEFORE: --max-images=1junk exited 0 and wrote manifest.json plus index.html under a silently truncated limit.
AFTER: the same real CLI exits 1 with "--max-images must be a decimal integer" before the requested output path exists.
IMAGE: pinned Sharp decodes the replacement as one 1x1 RGBA pixel with bytes [255,255,255,255], and all 26 owning tests pass.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - this diff changes a local .mjs CLI and test fixture only, with no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

N/A - the real CLI diagnostic, exit code, output-path check, and owning-suite transcript are included in **Testing**; no backend or frontend path runs.

## Screenshots (before / after) + video walkthrough

N/A - no rendered application surface changes. The embedded PNG is an automated one-pixel heuristic fixture, not product UI evidence.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changes.

## Known gaps / failures

None. Every applicable focused and repository verification command passed on the final synced head. Visual, network, LLM, OCR, and audio artifacts are intentionally N/A because this is local command-line boundary validation with no corresponding runtime surface.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 4764879 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [hkc2023-codex]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTD5HWF0N6XF9RQM0ETRMWB","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T07:14:42.191Z","completed_at":"2026-08-12T07:21:28.555Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":48042,"output_tokens":13349,"cache_creation_tokens":0,"cache_read_tokens":4703488,"total_tokens":4764879,"cost_micro_usd":"2992424","session_count":1},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAiePG1tPOzrMu-ASR7S9zu658VITXXJQIcWo_RCLcPNg","device_key_id":"efa48975f21fa1dc36e1a917bcfe1737a5329a11ccb709deb6dbae9121164067","device_signature":"sIVvHaNJ-j4EFL1X_7PoYPY2m2PvjnvWZDBXgNUeVi0GUMFKjh8kRituQvkk-JVNQ_8IiGKvRSelvrVAJbCMDg"}} -->
