### PR TITLE
fix(cloud): validate mock stack port overrides

### DIFF
--- a/scripts/cloud/__tests__/mock-stack-up.test.mjs
+++ b/scripts/cloud/__tests__/mock-stack-up.test.mjs
@@ -60,6 +60,62 @@ describe("mock-stack-up orchestrator", () => {
     expect(combined).toContain("Usage:");
   });
 
+  test.each([
+    ["--port-frontend", "3000junk"],
+    ["--port-api", "0"],
+    ["--port-cp", "-1"],
+    ["--port-hetzner", "65536"],
+  ])("%s rejects an invalid override before boot", async (flag, value) => {
+    const r = await redirectedRun([flag, value, "--help"]);
+    expect(r.code).toBe(1);
+    const combined = r.stdout + r.stderr;
+    expect(combined).toContain(
+      `${flag} requires a decimal port between 1 and 65535`,
+    );
+    expect(combined).toContain("Usage:");
+    expect(combined).not.toContain("Eliza cloud mock stack — ready");
+  });
+
+  test.each([
+    ["non-numeric", ["not-a-port"]],
+    ["empty", [""]],
+    ["trailing junk", ["23456junk"]],
+    ["fractional", ["1.5"]],
+    ["whitespace-padded", [" 1"]],
+    ["oversized", ["999999999999999999999999"]],
+  ])("--port-api rejects %s operands", async (_case, operands) => {
+    const r = await redirectedRun(["--port-api", ...operands, "--help"]);
+    expect(r.code).toBe(1);
+    const combined = r.stdout + r.stderr;
+    expect(combined).toContain(
+      "--port-api requires a decimal port between 1 and 65535",
+    );
+    expect(combined).not.toContain("Eliza cloud mock stack — ready");
+  });
+
+  test("--port-api rejects a missing operand", async () => {
+    const r = await redirectedRun(["--port-api"]);
+    expect(r.code).toBe(1);
+    const combined = r.stdout + r.stderr;
+    expect(combined).toContain(
+      "--port-api requires a decimal port between 1 and 65535",
+    );
+    expect(combined).toContain("Usage:");
+    expect(combined).not.toContain("Eliza cloud mock stack — ready");
+  });
+
+  test.each([
+    ["--port-frontend", "23456"],
+    ["--port-api", "1"],
+    ["--port-api", "65535"],
+    ["--port-cp", "23456"],
+    ["--port-hetzner", "23456"],
+  ])("accepts valid %s override %s", async (flag, port) => {
+    const r = await redirectedRun([flag, port, "--help"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("Usage:");
+  });
+
   test("skip-everything boot reaches ready banner and SIGINT shuts down cleanly", async () => {
     const started = Date.now();
     const r = await redirectedRun(

--- a/scripts/cloud/mock-stack-up.mjs
+++ b/scripts/cloud/mock-stack-up.mjs
@@ -46,6 +46,24 @@ Flags:
   --help                print this usage
 `;
 
+const PORT_FLAG_KEYS = new Map([
+  ["--port-frontend", "portFrontend"],
+  ["--port-api", "portApi"],
+  ["--port-cp", "portCp"],
+  ["--port-hetzner", "portHetzner"],
+]);
+
+function parsePortOverride(flag, value) {
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    return { error: `${flag} requires a decimal port between 1 and 65535` };
+  }
+  const port = Number(value);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+    return { error: `${flag} requires a decimal port between 1 and 65535` };
+  }
+  return { port };
+}
+
 function parseFlags(argv) {
   const flags = {
     noFrontend: false,
@@ -62,6 +80,14 @@ function parseFlags(argv) {
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
+    const portKey = PORT_FLAG_KEYS.get(a);
+    if (portKey) {
+      const parsed = parsePortOverride(a, argv[i + 1]);
+      if (parsed.error) return parsed;
+      flags[portKey] = parsed.port;
+      i += 1;
+      continue;
+    }
     switch (a) {
       case "--no-frontend":
         flags.noFrontend = true;
@@ -84,18 +110,6 @@ function parseFlags(argv) {
       case "--help":
       case "-h":
         flags.help = true;
-        break;
-      case "--port-frontend":
-        flags.portFrontend = Number.parseInt(argv[++i], 10);
-        break;
-      case "--port-api":
-        flags.portApi = Number.parseInt(argv[++i], 10);
-        break;
-      case "--port-cp":
-        flags.portCp = Number.parseInt(argv[++i], 10);
-        break;
-      case "--port-hetzner":
-        flags.portHetzner = Number.parseInt(argv[++i], 10);
         break;
       default:
         return { error: `Unknown flag: ${a}` };


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18566

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change is confined to the local cloud mock-stack command boundary and its real-process tests. Automatic port selection remains unchanged when no explicit override is supplied. Explicit overrides now accept only complete decimal values in the TCP range 1-65535.

# Background

## What does this PR do?

Makes all four `--port-*` overrides fail closed on missing, empty, partial, non-decimal, zero, negative, fractional, unsafe, or out-of-range operands. Previously `Number.parseInt` truncated values such as `23456junk`, while missing or falsy values silently fell through to automatic port selection.

The parser now validates the entire operand before any log directory, database, migration, or service startup work. Real-process coverage exercises every port flag, both valid boundaries, adversarial values, help/error behavior, and the existing boot/SIGINT shutdown path.

## What kind of change is this?

Bug fix (non-breaking local cloud tooling reliability correction).

# Documentation changes needed?

No documentation change is needed. The documented flags and valid decimal port behavior are unchanged; malformed values now produce the expected boundary error.

# Testing

## Where should a reviewer start?

Start with `parsePortOverride` and the shared port-flag map in `scripts/cloud/mock-stack-up.mjs`, then inspect the real-process argument matrix in `scripts/cloud/__tests__/mock-stack-up.test.mjs`.

## Detailed testing steps

Post-sync verification at `63fb6bedc5a2e359b091a231f881e56cd303b767`:

```text
bun install --frozen-lockfile
Checked 3459 installs across 3765 packages (no changes)

bun test scripts/cloud/__tests__/mock-stack-up.test.mjs
19 tests passed; 0 failed; 57 assertions

bunx @biomejs/biome check --diagnostic-level=error scripts/cloud/mock-stack-up.mjs scripts/cloud/__tests__/mock-stack-up.test.mjs
Checked 2 files; PASS

bun run verify
Tasks: 350 successful, 350 total
[audit-build-typecheck] PASS
[audit-turbo-build-deps] PASS
audit-tee-secret-leak: PASS
[hetzner-fleet-routing] verified 62 selectors across 15 workflows
[audit-scripts] OK
[anti-larp] clean
```

Before the fix, the real command accepted a partial operand, performed local database work, and booted on the truncated prefix:

```text
input: --port-api 23456junk
[wrangler:info] Ready on http://127.0.0.1:23456
Cloud API        http://127.0.0.1:23456
```

After the fix, the same command returns before starting any child service:

```text
input: --port-api 23456junk
--port-api requires a decimal port between 1 and 65535
exit: 1
```

# Evidence Gate

<!-- evidence-head:63fb6bedc5a2e359b091a231f881e56cd303b767 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - command-line development tooling only; no rendered UI surface changes`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - command-line development tooling only; no rendered UI surface changes`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no rendered or interactive user flow is changed`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - invalid arguments are rejected before any application backend is started`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - invalid arguments are rejected before any frontend or browser path is started`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent, action, provider, prompt, or model behavior changes`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.).

<details>
<summary>Port override boundary proof</summary>

```text
BEFORE: a partial 23456junk operand ran local database work, started the service, and announced port 23456 as ready.
AFTER: the identical malformed operand exits 1 with a flag-specific 1-65535 diagnostic before any child-service output.
CONTROL: ports 1, 23456, and 65535 remain accepted; all four flags and the existing boot/shutdown path pass in the 19-case process suite.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - this diff changes command-line JavaScript and tests only, with no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

N/A - rejected input returns before application services start. The real pre-fix startup and post-fix diagnostic transcripts are included in **Testing**.

## Screenshots (before / after) + video walkthrough

N/A - no rendered application surface changes.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changes.

## Known gaps / failures

None. Every focused and repository verification command passed on the final synced head. Visual, network, LLM, OCR, and audio artifacts are intentionally N/A because the changed behavior is an early local CLI boundary with no corresponding runtime surface.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 3208187 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [hkc2023-codex]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTEXWCX72MRWQH2CQHR3JBH","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T07:45:27.965Z","completed_at":"2026-08-12T07:51:43.444Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":93414,"output_tokens":10261,"cache_creation_tokens":0,"cache_read_tokens":3104512,"total_tokens":3208187,"cost_micro_usd":"2327156","session_count":1},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAiePG1tPOzrMu-ASR7S9zu658VITXXJQIcWo_RCLcPNg","device_key_id":"efa48975f21fa1dc36e1a917bcfe1737a5329a11ccb709deb6dbae9121164067","device_signature":"qnhEvBxkAk1zbIbtU1L3nwNJ5RTB6yeS7kJIE0YE_N67I_-0gOM5ST6FWwpLUUCUxL-MAvlyR8nzYufmdJScBg"}} -->
