### PR TITLE
fix(cloud): add auth callback recovery actions

### DIFF
--- a/packages/app/test/ui-smoke/auth-callback-recovery.spec.ts
+++ b/packages/app/test/ui-smoke/auth-callback-recovery.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Hosted-browser regression coverage for invalid public authentication
+ * callbacks, including landmark, heading, safe destination, and keyboard
+ * recovery contracts.
+ */
+
+import { expect, test } from "@playwright/test";
+import { installDefaultAppRoutes } from "./helpers";
+
+const INVALID_CALLBACKS = [
+  {
+    name: "CLI login without a session",
+    path: "/auth/cli-login",
+    heading: "Authentication Error",
+  },
+  {
+    name: "email callback without an email",
+    path: "/auth/callback/email?token=email-smoke-token",
+    heading: "Sign-in failed",
+  },
+  {
+    name: "OIDC continuation without a request id",
+    path: "/oidc/continue",
+    heading: "Authentication Error",
+  },
+] as const;
+
+test.beforeEach(async ({ page }) => {
+  await installDefaultAppRoutes(page);
+});
+
+for (const callback of INVALID_CALLBACKS) {
+  test(`${callback.name} provides an accessible recovery action`, async ({
+    page,
+  }) => {
+    await page.goto(callback.path, { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("main")).toHaveCount(1);
+    await expect(
+      page.getByRole("heading", { level: 1, name: callback.heading }),
+    ).toBeVisible();
+    const recovery = page.getByRole("link", { name: "Sign In Again" });
+    await expect(recovery).toHaveAttribute("href", "/login");
+    await page.keyboard.press("Tab");
+    await expect(recovery).toBeFocused();
+    await page.keyboard.press("Enter");
+    await expect(page).toHaveURL(/\/login$/);
+  });
+}

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
@@ -15,6 +15,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- collaborator doubles (hoisted so vi.mock factories can close over them) ---
@@ -351,14 +352,26 @@ describe("CliLoginPage", () => {
     expect(replace).not.toHaveBeenCalled();
   });
 
-  it("renders the error panel when the session id is missing — no POST, no redirect, no dead close button", async () => {
+  it("renders a safe keyboard-reachable recovery action when the session id is missing", async () => {
+    const user = userEvent.setup();
     searchParamsRef.current = new URLSearchParams("");
 
     render(<CliLoginPage />);
 
+    expect(screen.getByRole("main")).toBeTruthy();
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "Authentication Error",
+      }),
+    ).toBeTruthy();
     expect(
       screen.getByText("Invalid authentication link. Missing session ID."),
     ).toBeTruthy();
+    const recovery = screen.getByRole("link", { name: "Sign In Again" });
+    expect(recovery.getAttribute("href")).toBe("/login");
+    await user.tab();
+    expect(document.activeElement).toBe(recovery);
     expect(apiFetchMock).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
     expect(screen.queryByRole("button", { name: "Close Window" })).toBeNull();

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
@@ -169,7 +169,7 @@ function CliLoginPanel({
     // `my-auto` centers when it fits and scrolls-from-top when it overflows.
     // Regressed on short screens (Light Phone III, 1080×1240) where the action
     // buttons fell below an unscrollable fold — see cli-login-page.test.tsx.
-    <div className="theme-cloud relative flex min-h-[100dvh] flex-col items-center overflow-y-auto bg-bg p-4">
+    <main className="theme-cloud relative flex min-h-[100dvh] flex-col items-center overflow-y-auto bg-bg p-4">
       <div className="relative my-auto w-full max-w-md bg-card border border-border p-8">
         <div className="flex flex-col items-center gap-6 text-center">
           <div
@@ -180,14 +180,14 @@ function CliLoginPanel({
             />
           </div>
           <div className="space-y-1">
-            <h2 className="text-xl font-semibold text-txt">{title}</h2>
+            <h1 className="text-xl font-semibold text-txt">{title}</h1>
             <div className="text-sm text-muted">{description}</div>
           </div>
           {children}
           {actions ? <div className="w-full space-y-2">{actions}</div> : null}
         </div>
       </div>
-    </div>
+    </main>
   );
 }
 
@@ -366,15 +366,16 @@ export default function CliLoginPage() {
     return (
       <CliLoginPanel
         actions={
-          sessionId ? (
-            <a href={signInHref} className="w-full">
-              <Button className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground">
-                {t("cloud.cliLogin.signInAgain", {
-                  defaultValue: "Sign In Again",
-                })}
-              </Button>
+          <Button
+            asChild
+            className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
+          >
+            <a href={sessionId ? signInHref : "/login"}>
+              {t("cloud.cliLogin.signInAgain", {
+                defaultValue: "Sign In Again",
+              })}
             </a>
-          ) : null
+          </Button>
         }
         description={pageState.errorMessage}
         icon={AlertCircle}

--- a/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.test.tsx
@@ -10,6 +10,7 @@
 
 import { StewardApiError } from "@stwd/sdk";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -81,6 +82,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.clearAllMocks();
 });
 
 describe("EmailCallbackPage", () => {
@@ -188,9 +190,11 @@ describe("EmailCallbackPage", () => {
     );
   });
 
-  it("rejects an incomplete callback without calling the consume endpoint", async () => {
+  it("rejects an incomplete callback and offers a safe keyboard-reachable recovery action", async () => {
+    const user = userEvent.setup();
+
     render(
-      <MemoryRouter initialEntries={["/auth/callback/email?email=a%40b.co"]}>
+      <MemoryRouter initialEntries={["/auth/callback/email"]}>
         <EmailCallbackPage />
       </MemoryRouter>,
     );
@@ -200,6 +204,14 @@ describe("EmailCallbackPage", () => {
         "This sign-in link is missing its token or email.",
       ),
     ).toBeTruthy();
+    expect(await screen.findByRole("main")).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Sign-in failed" }),
+    ).toBeTruthy();
+    const recovery = screen.getByRole("link", { name: "Sign In Again" });
+    expect(recovery.getAttribute("href")).toBe("/login");
+    await user.tab();
+    expect(document.activeElement).toBe(recovery);
     expect(callbackState.verifyEmailCallback).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.tsx
@@ -13,6 +13,7 @@ import {
   readStoredAppAuthorizeReturnTo,
 } from "../../../../cloud-ui/components/auth/authorize-return";
 import { BrandButton } from "../../../../cloud-ui/components/brand/brand-button";
+import { Button } from "../../../../components/primitives";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
 import {
   LocalStewardAuthContext,
@@ -193,6 +194,13 @@ function EmailCallbackContent() {
           })}
         </h1>
         <p className="max-w-xs text-center text-sm text-muted">{error}</p>
+        <Button asChild className="mt-2">
+          <a href="/login">
+            {t("cloud.cliLogin.signInAgain", {
+              defaultValue: "Sign In Again",
+            })}
+          </a>
+        </Button>
       </Frame>
     );
   }
@@ -235,12 +243,12 @@ function EmailCallbackContent() {
 
 function Frame({ children }: { children: ReactNode }) {
   return (
-    <div className="theme-cloud relative flex min-h-[100dvh] w-full flex-col overflow-hidden bg-bg font-sans text-txt">
+    <main className="theme-cloud relative flex min-h-[100dvh] w-full flex-col overflow-hidden bg-bg font-sans text-txt">
       <div className="relative z-10 flex flex-1 items-center justify-center p-4">
         <div className="w-full max-w-md border border-border bg-card p-8">
           <div className="flex flex-col items-center gap-6">{children}</div>
         </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/packages/ui/src/cloud/public-pages/pages/oidc/oidc-continue-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/oidc/oidc-continue-page.test.tsx
@@ -1,0 +1,44 @@
+/** Verifies invalid OIDC continuation recovery through the public page. */
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? _key,
+}));
+vi.mock("../../lib/use-page-title", () => ({ usePageTitle: () => {} }));
+
+import OidcContinuePage from "./oidc-continue-page";
+
+afterEach(cleanup);
+
+describe("OidcContinuePage", () => {
+  it.each(["/oidc/continue", "/oidc/continue?rid=%20"])(
+    "offers a safe keyboard-reachable recovery action for %s",
+    async (path) => {
+      const user = userEvent.setup();
+
+      render(
+        <MemoryRouter initialEntries={[path]}>
+          <OidcContinuePage />
+        </MemoryRouter>,
+      );
+
+      expect(await screen.findByRole("main")).toBeTruthy();
+      expect(
+        await screen.findByRole("heading", {
+          level: 1,
+          name: "Authentication Error",
+        }),
+      ).toBeTruthy();
+      const recovery = screen.getByRole("link", { name: "Sign In Again" });
+      expect(recovery.getAttribute("href")).toBe("/login");
+      await user.tab();
+      expect(document.activeElement).toBe(recovery);
+    },
+  );
+});

--- a/packages/ui/src/cloud/public-pages/pages/oidc/oidc-continue-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/oidc/oidc-continue-page.tsx
@@ -17,6 +17,7 @@
 
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import { Button } from "../../../../components/primitives";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
 import {
   buildOidcResumeTarget,
@@ -57,31 +58,62 @@ export default function OidcContinuePage() {
   }, [requestId]);
 
   return (
-    <div className="theme-cloud relative flex min-h-[100dvh] items-center justify-center bg-bg p-4">
+    <main className="theme-cloud relative flex min-h-[100dvh] items-center justify-center bg-bg p-4">
       <div className="relative w-full max-w-md bg-card border border-border p-8 text-center">
         {failure === "issuer_unconfigured" ? (
-          <p className="text-fg">
-            {t("cloud.oidcContinue.issuerUnconfigured", {
-              defaultValue:
-                "Single sign-on is not configured for this deployment: {{envVar}} is unset, so there is no identity provider to return to.",
-              envVar: OIDC_ISSUER_ENV_VAR,
-            })}
-          </p>
+          <RecoveryPanel>
+            <p className="text-fg">
+              {t("cloud.oidcContinue.issuerUnconfigured", {
+                defaultValue:
+                  "Single sign-on is not configured for this deployment: {{envVar}} is unset, so there is no identity provider to return to.",
+                envVar: OIDC_ISSUER_ENV_VAR,
+              })}
+            </p>
+            <RecoveryAction />
+          </RecoveryPanel>
         ) : failure ? (
-          <p className="text-fg">
-            {t("cloud.oidcContinue.expired", {
-              defaultValue:
-                "This sign-in request is no longer valid. Return to the application and start sign-in again.",
-            })}
-          </p>
+          <RecoveryPanel>
+            <p className="text-fg">
+              {t("cloud.oidcContinue.expired", {
+                defaultValue:
+                  "This sign-in request is no longer valid. Return to the application and start sign-in again.",
+              })}
+            </p>
+            <RecoveryAction />
+          </RecoveryPanel>
         ) : (
-          <p className="text-muted-fg">
+          <h1 className="text-lg font-semibold text-muted-fg">
             {t("cloud.oidcContinue.redirecting", {
               defaultValue: "Completing sign-in…",
             })}
-          </p>
+          </h1>
         )}
       </div>
-    </div>
+    </main>
   );
+
+  function RecoveryPanel({ children }: { children: React.ReactNode }) {
+    return (
+      <div className="flex flex-col items-center gap-6">
+        <h1 className="text-lg font-semibold text-txt">
+          {t("cloud.cliLogin.authError", {
+            defaultValue: "Authentication Error",
+          })}
+        </h1>
+        {children}
+      </div>
+    );
+  }
+
+  function RecoveryAction() {
+    return (
+      <Button asChild>
+        <a href="/login">
+          {t("cloud.cliLogin.signInAgain", {
+            defaultValue: "Sign In Again",
+          })}
+        </a>
+      </Button>
+    );
+  }
 }


### PR DESCRIPTION
# Relates to

Fixes #18072.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the behavior from the automated browser proof and evidence described below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `4e955327a4`; the overlapping callback test was reconciled with upstream's new one-time-link coverage.
- [x] `bun run verify` passes post-sync: 350/350 Turbo tasks plus all repository audits.

# Risks

Low. The change is limited to invalid/missing-parameter error states on three public auth routes. Valid callback and redirect behavior is unchanged. Recovery links intentionally use the canonical literal `/login` route.

# Background

## What does this PR do?

Adds an accessible **Sign In Again** recovery action to the CLI login, email callback, and OIDC continuation failure states. It also gives each error page one semantic `<main>` landmark and a meaningful `<h1>`, and removes invalid nested interactive markup from the CLI page.

Regression coverage verifies the literal `/login` destination, keyboard focus with Tab, activation with Enter, final navigation, landmarks, and headings.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is needed; this restores recovery behavior on existing routes.

# Testing

## Where should a reviewer start?

Open `/auth/cli`, `/auth/callback/email`, or `/oidc/continue` without required query parameters. Confirm the error panel provides **Sign In Again**, then Tab to it and press Enter to reach `/login`.

## Detailed testing steps

- `bun run verify` — passed, 350/350 Turbo tasks and all repository audits.
- Focused Vitest command for the three auth page suites — 19/19 tests passed.
- Focused Playwright Chromium flow — 3/3 hosted browser journeys passed.
- Targeted cloud aesthetic audit — all six affected desktop/mobile cases passed.
- Full cloud aesthetic audit — 91 passed, 1 skipped, with one unrelated existing `/auth/bridge` desktop expectation failure (`/chat` versus `/`).
- Full app aesthetic audit — 214/215 passed; unrelated existing minimalism baseline failures were confined to untouched built-in browser/plugins/trajectories views.

# Evidence Gate

<!-- evidence-head:9409e5d40c13c2fe13b6c8880fbb77b7a2c56181 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/user-attachments/assets/7802ba2f-58ad-40f0-86ae-22636cba522b)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/user-attachments/assets/a688117b-0dd3-43cb-b037-bc898ad7cc60)
<!-- evidence-row:walkthrough-video -->
- [x] [20a34bc7-3480-4862-9a0c-0cc9e549bedc](https://github.com/user-attachments/assets/20a34bc7-3480-4862-9a0c-0cc9e549bedc)
<!-- evidence-row:backend-logs -->
- [ ] N/A - missing-parameter recovery is entirely client-side and does not invoke a backend
<!-- evidence-row:frontend-logs -->
- [ ] N/A - browser traces were intentionally not published because they can contain local environment metadata; the committed Playwright test verifies landmark, heading, literal href, Tab focus, Enter activation, and final navigation for all three routes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain state or generated artifacts are changed
<!-- evidence-row:ocr-review -->
- [x] [eliza-auth-recovery-ocr.txt](https://github.com/user-attachments/files/30992868/eliza-auth-recovery-ocr.txt)

# Evidence Details

## Backend + frontend logs

Backend: N/A; invalid callback query parameters are handled entirely in the browser before any request.

Frontend: Browser traces were intentionally not published because they can contain local environment metadata. The focused browser test asserts a single `main`, a meaningful `h1`, literal `/login`, Tab focus, Enter activation, and final `/login` navigation for all three routes.

## Screenshots (before / after) + video walkthrough

Evidence is attached above. Before captures use the exact original PR base; after captures and recordings exercise the rebased implementation at commit `9409e5d40c`.

## Known gaps / failures

- `audit:cloud`: all six affected desktop/mobile cases passed. The aggregate command exits nonzero only because the untouched desktop `/auth/bridge` case navigates to `/chat` while its audit expects `/`; this was reproduced independently of this change.
- `audit:app`: 214/215 passed. Existing minimalism baseline failures affect untouched built-in browser/plugins/trajectories views.
- Full UI suite has unrelated sandbox and existing test failures; all changed auth suites pass.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 30481348 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [codex-18072-auth-recovery]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZT7WRRJKC9087SKPNW8C65F","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T05:42:31.443Z","completed_at":"2026-08-12T07:06:47.551Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":1244223,"output_tokens":45189,"cache_creation_tokens":0,"cache_read_tokens":29191936,"total_tokens":30481348,"cost_micro_usd":"22172753","session_count":3},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA5wEnz-MQm4R4ZWoefYOyuAMFvUqTYgnhG6xocZ-jHTo","device_key_id":"6a039230679effa2ab08cf48c4146bcad3abf16cc6390a0417a4706cf14f816b","device_signature":"W1cuaP0qit_WS3iaEzmCnWLibW0eFAvS1PcSKboyCUaMvDzbwiZcKCDXrlViWsR45x6lijVOmOJtdWUlGq_xBw"}} -->
