### PR TITLE
fix(test): terminate live artifact process trees on timeout

### DIFF
--- a/packages/scripts/__tests__/run-live-test-with-artifacts.test.ts
+++ b/packages/scripts/__tests__/run-live-test-with-artifacts.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Exercises the live-test artifact runner with real child processes, including
+ * non-zero completion and a signal-resistant process tree that requires the
+ * deadline's forced-termination path.
+ */
+import { describe, expect, test } from "bun:test";
+import { spawn, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const RUNNER = path.resolve(
+  SCRIPT_DIR,
+  "..",
+  "run-live-test-with-artifacts.mjs",
+);
+const NODE_BIN = "node";
+const posixTest = process.platform === "win32" ? test.skip : test;
+
+function runWithArtifacts(reportRoot: string, args: string[]) {
+  return spawnSync(NODE_BIN, [RUNNER, "--report-root", reportRoot, ...args], {
+    encoding: "utf8",
+    timeout: 20_000,
+  });
+}
+
+function onlyRunDirectory(reportRoot: string): string {
+  const entries = readdirSync(reportRoot, { withFileTypes: true }).filter(
+    (entry) => entry.isDirectory(),
+  );
+  expect(entries).toHaveLength(1);
+  return path.join(reportRoot, entries[0].name);
+}
+
+function readReport(runDirectory: string) {
+  return JSON.parse(
+    readFileSync(path.join(runDirectory, "report.json"), "utf8"),
+  );
+}
+
+function expectCompleteBundle(runDirectory: string) {
+  for (const file of [
+    "data.js",
+    "index.html",
+    "llm-calls.jsonl",
+    "report.json",
+    "stderr.log",
+    "stdout.log",
+    "trajectory.jsonl",
+  ]) {
+    expect(existsSync(path.join(runDirectory, file))).toBe(true);
+  }
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("run-live-test-with-artifacts", () => {
+  test("preserves a completed child's exit and fully drained output", () => {
+    const reportRoot = mkdtempSync(path.join(tmpdir(), "live-artifacts-"));
+    try {
+      const result = runWithArtifacts(reportRoot, [
+        "--label",
+        "normal-exit",
+        "--",
+        NODE_BIN,
+        "-e",
+        'process.stdout.write("stdout-tail"); process.stderr.write("stderr-tail"); process.exitCode = 7;',
+      ]);
+      expect(result.status).toBe(7);
+      const runDirectory = onlyRunDirectory(reportRoot);
+      const report = readReport(runDirectory);
+      expect(report.exitCode).toBe(7);
+      expect(report.timedOut).toBe(false);
+      expect(report.stdout).toBe("stdout-tail");
+      expect(report.stderr).toBe("stderr-tail");
+      expect(report.processEvents.at(-1)).toMatchObject({
+        type: "exit",
+        code: 7,
+      });
+      expectCompleteBundle(runDirectory);
+    } finally {
+      rmSync(reportRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("records a command-start failure and still finalizes the bundle", () => {
+    const reportRoot = mkdtempSync(path.join(tmpdir(), "live-artifacts-"));
+    try {
+      const result = runWithArtifacts(reportRoot, [
+        "--label",
+        "spawn-error",
+        "--",
+        "definitely-not-a-real-binary-live-artifacts",
+      ]);
+      expect(result.status).toBe(1);
+      const runDirectory = onlyRunDirectory(reportRoot);
+      const report = readReport(runDirectory);
+      expect(report.exitCode).toBe(1);
+      expect(report.timedOut).toBe(false);
+      expect(
+        report.processEvents.map((event: { type: string }) => event.type),
+      ).toEqual(["start", "error", "exit"]);
+      expect(report.processEvents[1].error).toContain(
+        "definitely-not-a-real-binary-live-artifacts",
+      );
+      expectCompleteBundle(runDirectory);
+    } finally {
+      rmSync(reportRoot, { recursive: true, force: true });
+    }
+  });
+
+  posixTest(
+    "returns 124 after graceful deadline termination without waiting for escalation",
+    () => {
+      const reportRoot = mkdtempSync(path.join(tmpdir(), "live-artifacts-"));
+      try {
+        const startedAt = Date.now();
+        const result = runWithArtifacts(reportRoot, [
+          "--label",
+          "graceful-timeout",
+          "--timeout-ms",
+          "100",
+          "--",
+          NODE_BIN,
+          "-e",
+          "setInterval(() => {}, 1000);",
+        ]);
+        expect(result.status).toBe(124);
+        expect(Date.now() - startedAt).toBeLessThan(2_000);
+        const runDirectory = onlyRunDirectory(reportRoot);
+        const report = readReport(runDirectory);
+        expect(
+          report.processEvents.map((event: { type: string }) => event.type),
+        ).toEqual(["start", "timeout", "exit"]);
+        expect(report.processEvents.at(-1)).toMatchObject({
+          type: "exit",
+          code: 124,
+          signal: "SIGTERM",
+        });
+        expectCompleteBundle(runDirectory);
+      } finally {
+        rmSync(reportRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  posixTest(
+    "forwards a parent interrupt to the timed process tree and finalizes artifacts",
+    async () => {
+      const reportRoot = mkdtempSync(path.join(tmpdir(), "live-artifacts-"));
+      try {
+        const runner = spawn(
+          NODE_BIN,
+          [
+            RUNNER,
+            "--report-root",
+            reportRoot,
+            "--label",
+            "parent-interrupt",
+            "--timeout-ms",
+            "30000",
+            "--",
+            NODE_BIN,
+            "-e",
+            'process.stdout.write("READY\\n"); setInterval(() => {}, 1000);',
+          ],
+          { stdio: ["ignore", "pipe", "pipe"] },
+        );
+        let stdout = "";
+        let interrupted = false;
+        const result = await new Promise<{
+          code: number | null;
+          signal: string | null;
+        }>((resolve, reject) => {
+          const failsafe = setTimeout(() => {
+            runner.kill("SIGKILL");
+            reject(new Error("runner did not stop after SIGINT"));
+          }, 10_000);
+          runner.once("error", (error) => {
+            clearTimeout(failsafe);
+            reject(error);
+          });
+          runner.stdout.on("data", (chunk) => {
+            stdout += chunk.toString();
+            if (!interrupted && stdout.includes("READY")) {
+              interrupted = true;
+              runner.kill("SIGINT");
+            }
+          });
+          runner.once("close", (code, signal) => {
+            clearTimeout(failsafe);
+            resolve({ code, signal });
+          });
+        });
+        expect(result).toEqual({ code: 1, signal: null });
+        const runDirectory = onlyRunDirectory(reportRoot);
+        const report = readReport(runDirectory);
+        expect(report.timedOut).toBe(false);
+        expect(
+          report.processEvents.map((event: { type: string }) => event.type),
+        ).toEqual(["start", "stdout", "parent_signal", "exit"]);
+        expect(report.processEvents.at(-1)).toMatchObject({
+          type: "exit",
+          code: 1,
+          signal: "SIGINT",
+        });
+        expectCompleteBundle(runDirectory);
+      } finally {
+        rmSync(reportRoot, { recursive: true, force: true });
+      }
+    },
+    15_000,
+  );
+
+  posixTest(
+    "returns 124, finalizes artifacts, and leaves no signal-resistant descendant",
+    () => {
+      const reportRoot = mkdtempSync(path.join(tmpdir(), "live-artifacts-"));
+      try {
+        const childScript = `
+          const { spawn } = require("node:child_process");
+          process.on("SIGTERM", () => {});
+          const grandchild = spawn(process.execPath, [
+            "-e",
+            "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+          ], { stdio: "ignore" });
+          process.stdout.write("GRANDCHILD_PID=" + grandchild.pid + "\\n");
+          setInterval(() => {}, 1000);
+        `;
+        const startedAt = Date.now();
+        const result = runWithArtifacts(reportRoot, [
+          "--label",
+          "resistant-tree",
+          "--timeout-ms",
+          "100",
+          "--",
+          NODE_BIN,
+          "-e",
+          childScript,
+        ]);
+        expect(result.status).toBe(124);
+        expect(Date.now() - startedAt).toBeLessThan(10_000);
+
+        const runDirectory = onlyRunDirectory(reportRoot);
+        const report = readReport(runDirectory);
+        expect(report.exitCode).toBe(124);
+        expect(report.timedOut).toBe(true);
+        expect(
+          report.processEvents.map((event: { type: string }) => event.type),
+        ).toEqual(["start", "stdout", "timeout", "timeout_escalation", "exit"]);
+        const pidMatch = report.stdout.match(/GRANDCHILD_PID=(\d+)/);
+        expect(pidMatch).not.toBeNull();
+        expect(processIsAlive(Number(pidMatch?.[1]))).toBe(false);
+        expectCompleteBundle(runDirectory);
+      } finally {
+        rmSync(reportRoot, { recursive: true, force: true });
+      }
+    },
+    20_000,
+  );
+});

--- a/packages/scripts/run-live-test-with-artifacts.mjs
+++ b/packages/scripts/run-live-test-with-artifacts.mjs
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
-// Exercises run live test with artifacts automation behavior with deterministic script fixtures.
+/**
+ * Runs a live test command and writes a self-contained evidence bundle with
+ * streamed output, process events, structured LLM calls, and a local viewer.
+ * Timed runs own a process tree so a wedged descendant cannot block artifact
+ * finalization after the configured deadline.
+ */
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,6 +17,7 @@ const REPO_ROOT = path.resolve(
   "..",
 );
 const DEFAULT_REPORT_ROOT = path.join(REPO_ROOT, "reports", "live-test-runs");
+const TERMINATION_GRACE_MS = 5_000;
 
 function timestampId() {
   return new Date().toISOString().replace(/[:.]/g, "-");
@@ -208,6 +214,28 @@ function readStructuredLlmCalls(filePath) {
     });
 }
 
+function signalProcessTree(child, signal) {
+  if (!Number.isInteger(child.pid) || child.pid <= 0) return;
+  if (process.platform === "win32") {
+    const args = ["/pid", String(child.pid), "/t"];
+    if (signal === "SIGKILL") args.push("/f");
+    const result = spawnSync("taskkill", args, { stdio: "ignore" });
+    if (result.status === 0) return;
+  } else {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // error-policy:J6 The process group may have exited between observation and teardown.
+    }
+  }
+  try {
+    child.kill(signal);
+  } catch {
+    // error-policy:J6 The direct child also may have exited during group teardown.
+  }
+}
+
 function structuredLlmSummary(records) {
   const calls = records.filter((record) => record.type === "llm_call");
   return calls.reduce(
@@ -261,6 +289,7 @@ async function main() {
   ];
   const child = spawn(options.command[0], options.command.slice(1), {
     cwd: REPO_ROOT,
+    detached: options.timeoutMs > 0 && process.platform !== "win32",
     env: {
       ...process.env,
       ELIZA_LIVE_TEST_RUN_DIR: runDir,
@@ -285,7 +314,35 @@ async function main() {
     events.push({ type: "stderr", timestamp: new Date().toISOString(), text });
   });
   let timedOut = false;
-  const timer =
+  let timer = null;
+  let escalationTimer = null;
+  const parentSignalHandlers = new Map();
+  if (options.timeoutMs > 0 && process.platform !== "win32") {
+    for (const signal of ["SIGINT", "SIGTERM"]) {
+      const handler = () => {
+        if (timer) clearTimeout(timer);
+        events.push({
+          type: "parent_signal",
+          timestamp: new Date().toISOString(),
+          signal,
+        });
+        signalProcessTree(child, signal);
+        if (!escalationTimer) {
+          escalationTimer = setTimeout(() => {
+            events.push({
+              type: "signal_escalation",
+              timestamp: new Date().toISOString(),
+              signal: "SIGKILL",
+            });
+            signalProcessTree(child, "SIGKILL");
+          }, TERMINATION_GRACE_MS);
+        }
+      };
+      parentSignalHandlers.set(signal, handler);
+      process.once(signal, handler);
+    }
+  }
+  timer =
     options.timeoutMs > 0
       ? setTimeout(() => {
           timedOut = true;
@@ -294,28 +351,43 @@ async function main() {
             timestamp: new Date().toISOString(),
             timeoutMs: options.timeoutMs,
           });
-          child.kill("SIGTERM");
+          signalProcessTree(child, "SIGTERM");
+          escalationTimer = setTimeout(() => {
+            events.push({
+              type: "timeout_escalation",
+              timestamp: new Date().toISOString(),
+              signal: "SIGKILL",
+            });
+            signalProcessTree(child, "SIGKILL");
+          }, TERMINATION_GRACE_MS);
         }, options.timeoutMs)
       : null;
   const exitCode = await new Promise((resolve) => {
+    let spawnError = null;
     child.on("error", (error) => {
       if (timer) clearTimeout(timer);
+      if (escalationTimer) clearTimeout(escalationTimer);
+      spawnError = error;
       events.push({
         type: "error",
         timestamp: new Date().toISOString(),
         error: error instanceof Error ? error.message : String(error),
       });
-      resolve(1);
     });
-    child.on("exit", (code, signal) => {
+    child.on("close", (code, signal) => {
       if (timer) clearTimeout(timer);
+      if (escalationTimer) clearTimeout(escalationTimer);
+      for (const [parentSignal, handler] of parentSignalHandlers) {
+        process.removeListener(parentSignal, handler);
+      }
+      const finalCode = timedOut ? 124 : spawnError ? 1 : (code ?? 1);
       events.push({
         type: "exit",
         timestamp: new Date().toISOString(),
-        code: timedOut ? 124 : (code ?? 1),
+        code: finalCode,
         signal,
       });
-      resolve(timedOut ? 124 : (code ?? 1));
+      resolve(finalCode);
     });
   });
   const completedAt = new Date();


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18569

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Medium-low. The change is confined to the live-test artifact runner and its process-level tests. Timed POSIX commands now run in a dedicated process group so teardown can reach descendants; no-timeout commands retain their existing non-detached behavior. Windows uses the platform `taskkill` tree operation, but that platform-specific branch was not executed on this macOS host.

# Background

## What does this PR do?

Makes timed live-test runs terminate the complete spawned process tree while preserving artifact finalization. The runner now forwards parent `SIGINT`/`SIGTERM`, sends a graceful tree-wide `SIGTERM` at the deadline, escalates to tree-wide `SIGKILL` after five seconds, waits for piped output to close, and consistently returns timeout status 124.

It also records command-start failures in a complete artifact bundle instead of failing before finalization. Process-level coverage exercises normal non-zero completion, startup failure, graceful timeout, parent interrupt forwarding, and a signal-resistant child/grandchild tree.

## What kind of change is this?

Bug fix (non-breaking test-infrastructure reliability correction).

# Documentation changes needed?

No documentation change is needed. The runner's command-line interface, timeout flag, output layout, and documented exit semantics remain unchanged; teardown now fulfills the existing timeout contract.

# Testing

## Where should a reviewer start?

Start with `signalProcessTree` and the timeout/signal lifecycle in `packages/scripts/run-live-test-with-artifacts.mjs`, then inspect the real child-process scenarios in `packages/scripts/__tests__/run-live-test-with-artifacts.test.ts`.

## Detailed testing steps

Post-sync verification at `8d0acffe7ff290a8765a9fc6c90c6b570dcb9d1f`:

```text
bun install --frozen-lockfile
Checked 3459 installs across 3765 packages (no changes)

bun test packages/scripts/__tests__/run-live-test-with-artifacts.test.ts
5 tests passed; 0 failed; 66 assertions

bunx @biomejs/biome check --diagnostic-level=error packages/scripts/run-live-test-with-artifacts.mjs packages/scripts/__tests__/run-live-test-with-artifacts.test.ts
Checked 2 files; PASS

bun run verify
Tasks: 350 successful, 350 total
[audit-build-typecheck] PASS
[audit-turbo-build-deps] PASS
audit-tee-secret-leak: PASS
[hetzner-fleet-routing] verified 62 selectors across 15 workflows
[audit-scripts] OK
[anti-larp] clean
```

Pre-fix reproduction with a 100 ms deadline:

```text
child: acknowledged SIGTERM and remained alive
runner after 2 seconds: still alive
artifact files: none
```

Post-fix reproduction of the same resistant process tree:

```text
deadline: 100 ms
grace period: 5 seconds
elapsed: 5.113 seconds
exit: 124
report events: start -> stdout -> timeout(SIGTERM) -> timeout_escalation(SIGKILL) -> exit(124, SIGKILL)
recorded grandchild after completion: absent
```

# Evidence Gate

<!-- evidence-head:8d0acffe7ff290a8765a9fc6c90c6b570dcb9d1f -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - command-line test infrastructure only; no rendered UI surface changes`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - command-line test infrastructure only; no rendered UI surface changes`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no rendered or interactive application flow is changed`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - this local process runner does not start an application backend; its complete lifecycle transcript is included below`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend, browser, or network path is changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent, action, provider, prompt, or model behavior changes`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.).

<details>
<summary>Artifact bundle and descendant-termination proof</summary>

```text
BEFORE: a 100 ms deadline sent SIGTERM once; the resistant child acknowledged it and the runner was still alive after two seconds, with no artifact files.
AFTER: the same resistant process tree escalates after five seconds, exits 124, and writes all seven artifact files with timeout/escalation/exit events.
CONTROL: recorded grandchild PID is absent after completion; normal exit tails, command-start errors, graceful deadlines, and parent interrupts all preserve complete bundles.

Opened artifact inventory:
data.js
index.html
llm-calls.jsonl (empty because the command made no model calls)
report.json
stderr.log
stdout.log
trajectory.jsonl

report.json event order:
start
stdout
timeout: SIGTERM
timeout_escalation: SIGKILL
exit: code 124, signal SIGKILL

Viewer data check: data.js contains the same final report and event sequence.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - this diff changes command-line JavaScript and process tests only, with no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

N/A - no application backend or frontend runs in this path. The real child-process lifecycle transcript and final artifact event order are included in **Testing** and **Domain artifacts**.

## Screenshots (before / after) + video walkthrough

N/A - no rendered application surface changes.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changes.

## Known gaps / failures

The focused test suite skips POSIX process-group scenarios on Windows, so the `taskkill` fallback was reviewed statically but not executed on this macOS host. This is not a blocker for the verified POSIX timeout fix; direct-child termination remains as a fallback if the Windows tree command cannot start. All focused and repository verification commands passed on the final synced head. Visual, network, LLM, OCR, and audio artifacts are intentionally N/A because the change has no corresponding runtime surface.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 6985457 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [hkc2023-codex]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTFKYA4TS2QJNRSZCXQFXTE","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T07:57:30.820Z","completed_at":"2026-08-12T08:08:28.813Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":116187,"output_tokens":18198,"cache_creation_tokens":0,"cache_read_tokens":6851072,"total_tokens":6985457,"cost_micro_usd":"4552411","session_count":1},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAiePG1tPOzrMu-ASR7S9zu658VITXXJQIcWo_RCLcPNg","device_key_id":"efa48975f21fa1dc36e1a917bcfe1737a5329a11ccb709deb6dbae9121164067","device_signature":"aG6v4ynBpynP1h6RHj92x4WXU7pDGQeY6ZdfPijTKJpUqEQRCigfOf7FJdO7SfwboM6Ya4ogfE1ClmrOnbkKAg"}} -->
