### PR TITLE
fix(cloud): guard deletion of recently live agents

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts
@@ -172,11 +172,14 @@ describe("DELETE /api/v1/eliza/agents/:agentId", () => {
         status: "pending",
       },
     });
-    expect(deleteAgent).toHaveBeenCalledWith("agent-1", "org-1");
+    expect(deleteAgent).toHaveBeenCalledWith("agent-1", "org-1", {
+      authorization: "user_request",
+    });
     expect(enqueueAgentDeleteOnce).toHaveBeenCalledWith({
       agentId: "agent-1",
       organizationId: "org-1",
       userId: "user-1",
+      authorization: "user_request",
     });
     expect(triggerImmediate).toHaveBeenCalledTimes(1);
     expect(loggerWarn).toHaveBeenCalledWith(
@@ -250,6 +253,7 @@ describe("DELETE /api/v1/eliza/agents/:agentId", () => {
       agentId: "agent-1",
       organizationId: "org-1",
       userId: "user-1",
+      authorization: "user_request",
       expectedIdentity: {
         agentName: "Canary Agent",
         createdAt: "2026-07-07T08:00:00.000Z",

--- a/packages/cloud/api/compat/agents/[id]/route.ts
+++ b/packages/cloud/api/compat/agents/[id]/route.ts
@@ -164,12 +164,14 @@ async function __hono_DELETE(
     const deleted = await elizaSandboxService.deleteAgent(
       agentId,
       user.organization_id,
+      { authorization: "user_request" },
     );
     if (!deleted.success) {
       const status =
         deleted.error === "Agent not found"
           ? 404
-          : deleted.error === "Agent provisioning is in progress"
+          : deleted.error === "Agent provisioning is in progress" ||
+              deleted.error === "Agent is running; suspend it before deletion"
             ? 409
             : 500;
       return withCompatCors(

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
@@ -443,12 +443,14 @@ app.delete("/", async (c) => {
       const result = await elizaSandboxService.deleteAgent(
         agentId,
         user.organization_id,
+        { authorization: "user_request" },
       );
       if (!result.success) {
         const status =
           result.error === "Agent not found"
             ? 404
-            : result.error === "Agent provisioning is in progress"
+            : result.error === "Agent provisioning is in progress" ||
+                result.error === "Agent is running; suspend it before deletion"
               ? 409
               : 500;
         if (status !== 500) {
@@ -498,6 +500,7 @@ app.delete("/", async (c) => {
       agentId,
       organizationId: user.organization_id,
       userId: user.id,
+      authorization: "user_request",
       expectedIdentity,
     });
 

--- a/packages/cloud/services/container-control-plane/src/index.ts
+++ b/packages/cloud/services/container-control-plane/src/index.ts
@@ -1051,12 +1051,14 @@ app.delete("/api/compat/agents/:id", (c) =>
     const deleted = await elizaSandboxService.deleteAgent(
       agentId,
       auth.organizationId,
+      { authorization: "user_request" },
     );
     if (!deleted.success) {
       const status =
         deleted.error === "Agent not found"
           ? 404
-          : deleted.error === "Agent provisioning is in progress"
+          : deleted.error === "Agent provisioning is in progress" ||
+              deleted.error === "Agent is running; suspend it before deletion"
             ? 409
             : 500;
       return c.json(errorEnvelope(deleted.error), status);

--- a/packages/cloud/shared/src/lib/services/active-billing.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing.ts
@@ -577,6 +577,7 @@ async function cancelAgentInfrastructure(
         agentId,
         organizationId,
         userId,
+        authorization: "billing_request",
       });
     } else {
       await provisioningJobService.enqueueAgentSuspendOnce({

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -3708,6 +3708,7 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     executeDeletion(
       agentId: string,
       orgId: string,
+      authorization?: "user_request" | "billing_request",
     ): Promise<{
       success: boolean;
       containerStopped: boolean;
@@ -3717,6 +3718,7 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     prepareAgentDelete(
       agentId: string,
       orgId: string,
+      authorization?: "user_request" | "billing_request",
     ): Promise<
       | {
           ok: true;
@@ -3736,7 +3738,7 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     return new ElizaSandboxService() as unknown as Svc;
   }
 
-  test("prepareAgentDelete refuses a running agent with a fresh heartbeat", async () => {
+  test("prepareAgentDelete refuses an unauthorized running agent before deletion intent", async () => {
     const svc = await makeSvc();
     const live = {
       ...customSandbox(),
@@ -3764,9 +3766,44 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     try {
       await expect(svc.prepareAgentDelete(AGENT, ORG)).resolves.toEqual({
         ok: false,
-        error: "Agent is running with a recent heartbeat",
+        error: "Agent is running; suspend it before deletion",
       });
       expect(update).not.toHaveBeenCalled();
+    } finally {
+      upgradeTransactionImpl = null;
+      lockLifecycle.mockRestore();
+      getForMutation.mockRestore();
+      activeProvision.mockRestore();
+      activeReplacement.mockRestore();
+    }
+  });
+
+  test("prepareAgentDelete allows an explicitly authorized running agent", async () => {
+    const svc = await makeSvc();
+    const live = {
+      ...customSandbox(),
+      id: AGENT,
+      organization_id: ORG,
+      last_heartbeat_at: null,
+    };
+    const lockLifecycle = spyOn(svc, "lockLifecycle").mockResolvedValue(undefined);
+    const getForMutation = spyOn(svc, "getAgentForLifecycleMutation").mockResolvedValue(live);
+    const activeProvision = spyOn(svc, "hasActiveProvisionJobTx").mockResolvedValue(false);
+    const activeReplacement = spyOn(svc, "hasActiveReplacementJobTx").mockResolvedValue(false);
+    const update = mock(() => ({
+      set: mock(() => ({
+        where: mock(() => ({
+          returning: mock(async () => [{ ...live, status: "deletion_pending" }]),
+        })),
+      })),
+    }));
+    upgradeTransactionImpl = async (fn) => fn({ execute: async () => ({ rows: [] }), update });
+
+    try {
+      await expect(svc.prepareAgentDelete(AGENT, ORG, "user_request")).resolves.toMatchObject({
+        ok: true,
+      });
+      expect(update).toHaveBeenCalled();
     } finally {
       upgradeTransactionImpl = null;
       lockLifecycle.mockRestore();

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -3793,7 +3793,14 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     const update = mock(() => ({
       set: mock(() => ({
         where: mock(() => ({
-          returning: mock(async () => [{ ...live, status: "deletion_pending" }]),
+          returning: mock(async () => [
+            {
+              id: AGENT,
+              deletionAttemptId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+              deletionStartedAt: new Date("2026-06-04T12:00:00.000Z"),
+              lifecycleRevision: 1,
+            },
+          ]),
         })),
       })),
     }));

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -3736,6 +3736,46 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     return new ElizaSandboxService() as unknown as Svc;
   }
 
+  test("prepareAgentDelete refuses a running agent with a fresh heartbeat", async () => {
+    const svc = await makeSvc();
+    const live = {
+      ...customSandbox(),
+      id: AGENT,
+      organization_id: ORG,
+      last_heartbeat_at: new Date(Date.now() - 30_000),
+    };
+    const lockLifecycle = spyOn(svc, "lockLifecycle").mockResolvedValue(undefined);
+    const getForMutation = spyOn(svc, "getAgentForLifecycleMutation").mockResolvedValue(live);
+    const activeProvision = spyOn(svc, "hasActiveProvisionJobTx").mockResolvedValue(false);
+    const activeReplacement = spyOn(svc, "hasActiveReplacementJobTx").mockResolvedValue(false);
+    const update = mock(() => ({
+      set: mock(() => ({
+        where: mock(() => ({
+          returning: mock(async () => [{ ...live, status: "deletion_pending" }]),
+        })),
+      })),
+    }));
+    upgradeTransactionImpl = async (fn) =>
+      fn({
+        execute: async () => ({ rows: [] }),
+        update,
+      });
+
+    try {
+      await expect(svc.prepareAgentDelete(AGENT, ORG)).resolves.toEqual({
+        ok: false,
+        error: "Agent is running with a recent heartbeat",
+      });
+      expect(update).not.toHaveBeenCalled();
+    } finally {
+      upgradeTransactionImpl = null;
+      lockLifecycle.mockRestore();
+      getForMutation.mockRestore();
+      activeProvision.mockRestore();
+      activeReplacement.mockRestore();
+    }
+  });
+
   test("linked character cleanup waits until the reconciliation tombstone is removed", async () => {
     const svc = await makeSvc();
     const characterId = "44444444-4444-4444-8444-444444444444";

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -20,6 +20,7 @@ import { PgDialect } from "drizzle-orm/pg-core";
 
 import { decryptField, encryptField } from "../../db/crypto/field-crypto";
 import { resetKmsClientForTests } from "../../db/crypto/kms-client";
+import * as realEnsureSchemaNs from "../../db/ensure-agent-sandbox-schema";
 import * as realHelpersNs from "../../db/helpers";
 import { agentBillingRepository } from "../../db/repositories/agent-billing";
 import type { AgentSandbox, AgentSandboxBackup } from "../../db/repositories/agent-sandboxes";
@@ -100,6 +101,12 @@ type UpgradeTransactionOutcome =
 // patch the SHARED live binding — building the restore (or this override's
 // spread) from the live namespace after a mock landed would capture the mock.
 const realHelpers = { ...realHelpersNs };
+// Same VALUE-snapshot rule for the self-healing DDL guard: prepareAgentDelete
+// awaits ensureAgentSandboxSchema() before its transaction, and this file's
+// swapped `dbWrite` forwards `.execute` to the real connection — so the real
+// guard would attempt live DDL here. This is a mocked-database suite; the
+// guard itself is covered by the PGlite tests.
+const realEnsureSchema = { ...realEnsureSchemaNs };
 let upgradeTransactionImpl: (<T>(fn: (tx: UpgradeTx) => Promise<T>) => Promise<T>) | null = null;
 let upgradeTransactionOutcome: UpgradeTransactionOutcome = null;
 const realDbWrite = realHelpers.dbWrite as unknown as object;
@@ -346,6 +353,10 @@ beforeAll(async () => {
     ...realHelpers,
     dbWrite: upgradeDbWrite,
   }));
+  mock.module("../../db/ensure-agent-sandbox-schema", () => ({
+    ...realEnsureSchema,
+    ensureAgentSandboxSchema: async () => {},
+  }));
 
   const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
   const prototype = ElizaSandboxService.prototype as unknown as ReplacementLifecycleHarnessService;
@@ -516,6 +527,7 @@ beforeAll(async () => {
 afterAll(() => {
   restoreReplacementLifecycleHarness?.();
   mock.module("../../db/helpers", () => realHelpers);
+  mock.module("../../db/ensure-agent-sandbox-schema", () => realEnsureSchema);
 });
 
 // provision()'s success path now re-enters the billable set via

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -514,6 +514,15 @@ const HEARTBEAT_PROBE_RETRY_MS = 2_000;
 // on success) is the downtime clock. The ~30s heartbeat itself keeps the
 // WireGuard NAT mapping warm, so a reachable agent never trips this.
 const HEARTBEAT_DISCONNECT_AFTER_MS = 120_000;
+
+/** Returns whether a heartbeat timestamp proves the agent was recently live. */
+export function hasRecentAgentHeartbeat(lastHeartbeatAt: Date | string | null): boolean {
+  if (!lastHeartbeatAt) return false;
+  const heartbeatMs = new Date(lastHeartbeatAt).getTime();
+  const ageMs = Date.now() - heartbeatMs;
+  return Number.isFinite(ageMs) && ageMs >= 0 && ageMs < HEARTBEAT_DISCONNECT_AFTER_MS;
+}
+
 // IP reconciliation (heartbeat + recovery): agent containers do not persist
 // tailscale node state, so a container restart mints a fresh node key and
 // headscale hands out the NEXT sequential IP — the stored headscale_ip /
@@ -2115,6 +2124,9 @@ export class ElizaSandboxService {
       const hasActiveReplacementJob = await this.hasActiveReplacementJobTx(tx, agentId, orgId);
       if (rec.status === "provisioning" || hasActiveProvisionJob || hasActiveReplacementJob) {
         return { ok: false as const, error: "Agent provisioning is in progress" };
+      }
+      if (rec.status === "running" && hasRecentAgentHeartbeat(rec.last_heartbeat_at)) {
+        return { ok: false as const, error: "Agent is running with a recent heartbeat" };
       }
       const deletionAttemptId = rec.deletion_attempt_id ?? crypto.randomUUID();
       // A retry preserves the original audit timestamp while taking a fresh

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -394,6 +394,8 @@ export type DeleteAgentResult =
     }
   | { success: false; error: string };
 
+export type DeleteAuthorization = "user_request" | "billing_request";
+
 /**
  * Outcome of the bounded container teardown attempted during `deleteAgent`:
  * `null` = stop succeeded; `{ error }` = stop failed within the cap (classified
@@ -514,14 +516,6 @@ const HEARTBEAT_PROBE_RETRY_MS = 2_000;
 // on success) is the downtime clock. The ~30s heartbeat itself keeps the
 // WireGuard NAT mapping warm, so a reachable agent never trips this.
 const HEARTBEAT_DISCONNECT_AFTER_MS = 120_000;
-
-/** Returns whether a heartbeat timestamp proves the agent was recently live. */
-export function hasRecentAgentHeartbeat(lastHeartbeatAt: Date | string | null): boolean {
-  if (!lastHeartbeatAt) return false;
-  const heartbeatMs = new Date(lastHeartbeatAt).getTime();
-  const ageMs = Date.now() - heartbeatMs;
-  return Number.isFinite(ageMs) && ageMs >= 0 && ageMs < HEARTBEAT_DISCONNECT_AFTER_MS;
-}
 
 // IP reconciliation (heartbeat + recovery): agent containers do not persist
 // tailscale node state, so a container restart mints a fresh node key and
@@ -1911,7 +1905,11 @@ export class ElizaSandboxService {
     return agentSandboxesRepository.listByOrganization(orgId);
   }
 
-  async deleteAgent(agentId: string, orgId: string): Promise<DeleteAgentResult> {
+  async deleteAgent(
+    agentId: string,
+    orgId: string,
+    options: { authorization?: DeleteAuthorization } = {},
+  ): Promise<DeleteAgentResult> {
     // Phase 1 — short transaction: take the lifecycle lock, validate
     // preconditions, and capture the fields needed for teardown. We deliberately
     // do NOT run the container teardown inside this transaction:
@@ -1920,7 +1918,7 @@ export class ElizaSandboxService {
     // + write transaction + a pooled connection for the full teardown cap (up to
     // SANDBOX_DELETE_STOP_TIMEOUT_MS) would wedge concurrent lifecycle ops on the
     // same agent/org. The lock + transaction are released the moment this returns.
-    const precheck = await this.prepareAgentDelete(agentId, orgId);
+    const precheck = await this.prepareAgentDelete(agentId, orgId, options.authorization);
 
     if (!precheck.ok) {
       return { success: false, error: precheck.error };
@@ -2090,6 +2088,7 @@ export class ElizaSandboxService {
   private async prepareAgentDelete(
     agentId: string,
     orgId: string,
+    authorization?: DeleteAuthorization,
   ): Promise<
     | {
         ok: true;
@@ -2125,8 +2124,19 @@ export class ElizaSandboxService {
       if (rec.status === "provisioning" || hasActiveProvisionJob || hasActiveReplacementJob) {
         return { ok: false as const, error: "Agent provisioning is in progress" };
       }
-      if (rec.status === "running" && hasRecentAgentHeartbeat(rec.last_heartbeat_at)) {
-        return { ok: false as const, error: "Agent is running with a recent heartbeat" };
+      const isSharedRuntime = rec.execution_tier === "shared";
+      const isUnclaimedWarmPoolEntry =
+        rec.organization_id === WARM_POOL_ORG_ID && rec.pool_status === "unclaimed";
+      if (
+        rec.status === "running" &&
+        !isSharedRuntime &&
+        !isUnclaimedWarmPoolEntry &&
+        !authorization
+      ) {
+        return {
+          ok: false as const,
+          error: "Agent is running; suspend it before deletion",
+        };
       }
       const deletionAttemptId = rec.deletion_attempt_id ?? crypto.randomUUID();
       // A retry preserves the original audit timestamp while taking a fresh
@@ -2399,13 +2409,14 @@ export class ElizaSandboxService {
   async executeDeletion(
     agentId: string,
     orgId: string,
+    authorization?: DeleteAuthorization,
   ): Promise<{
     success: boolean;
     containerStopped: boolean;
     rowDeleted: boolean;
     error?: string;
   }> {
-    const result = await this.deleteAgent(agentId, orgId);
+    const result = await this.deleteAgent(agentId, orgId, { authorization });
     if (!result.success) {
       // If the row is already gone, treat as success. This covers the retry
       // case where a prior attempt deleted the row but failed before updating

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
@@ -63,7 +63,7 @@ const txExecute = mock(async () => ({ rows: [] }));
 let txSelectCall = 0;
 let selectedSandbox: Record<string, unknown> = {
   id: "agent",
-  status: "running",
+  status: "stopped",
   lifecycle_revision: 0,
   updated_at: new Date(),
   last_heartbeat_at: null,
@@ -157,7 +157,7 @@ afterEach(() => {
   txSelectCall = 0;
   selectedSandbox = {
     id: "agent",
-    status: "running",
+    status: "stopped",
     lifecycle_revision: 0,
     updated_at: new Date(),
     last_heartbeat_at: null,
@@ -171,9 +171,10 @@ afterAll(() => {
 });
 
 describe("enqueueAgentDeleteOnce.beforeInsert — cancels other pending jobs", () => {
-  test("rejects a running agent with a recent heartbeat before flipping deletion_pending", async () => {
+  test("rejects a running agent before flipping deletion_pending", async () => {
     selectedSandbox = {
       ...selectedSandbox,
+      status: "running",
       last_heartbeat_at: new Date(Date.now() - 30_000),
     };
     const { provisioningJobService } = await import("./provisioning-jobs");
@@ -184,12 +185,29 @@ describe("enqueueAgentDeleteOnce.beforeInsert — cancels other pending jobs", (
         organizationId: "22222222-2222-4222-8222-222222222222",
         userId: "33333333-3333-4333-8333-333333333333",
       }),
-    ).rejects.toThrow("Agent is running with a recent heartbeat");
+    ).rejects.toThrow("Agent is running; suspend it before deletion");
     expect(
       txUpdateSet.mock.calls.some(
         ([values]) => (values as { status?: string }).status === "deletion_pending",
       ),
     ).toBe(false);
+  });
+
+  test("allows an explicitly authorized running-agent delete", async () => {
+    selectedSandbox = {
+      ...selectedSandbox,
+      status: "running",
+    };
+    const { provisioningJobService } = await import("./provisioning-jobs");
+
+    await expect(
+      provisioningJobService.enqueueAgentDeleteOnce({
+        agentId: "agent",
+        organizationId: "22222222-2222-4222-8222-222222222222",
+        userId: "33333333-3333-4333-8333-333333333333",
+        authorization: "user_request",
+      }),
+    ).resolves.toMatchObject({ created: true });
   });
 
   test("marks only the agent's quiescent non-delete pending jobs cancelled", async () => {

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
@@ -61,12 +61,17 @@ const txExecute = mock(async () => ({ rows: [] }));
 // returns cannot move before the enqueue commits, so `for` is part of the
 // chain the enqueue actually walks.
 let txSelectCall = 0;
+let selectedSandbox: Record<string, unknown> = {
+  id: "agent",
+  status: "running",
+  lifecycle_revision: 0,
+  updated_at: new Date(),
+  last_heartbeat_at: null,
+};
 const txSelect = mock(() => {
   txSelectCall += 1;
   const isSandboxLookup = txSelectCall === 1;
-  const rows = isSandboxLookup
-    ? [{ id: "agent", status: "running", lifecycle_revision: 0, updated_at: new Date() }]
-    : [];
+  const rows = isSandboxLookup ? [selectedSandbox] : [];
   const chain = {
     from: () => chain,
     where: () => chain,
@@ -150,6 +155,13 @@ afterEach(() => {
   selectRows = [];
   cancelledReturning = [];
   txSelectCall = 0;
+  selectedSandbox = {
+    id: "agent",
+    status: "running",
+    lifecycle_revision: 0,
+    updated_at: new Date(),
+    last_heartbeat_at: null,
+  };
 });
 
 afterAll(() => {
@@ -159,6 +171,27 @@ afterAll(() => {
 });
 
 describe("enqueueAgentDeleteOnce.beforeInsert — cancels other pending jobs", () => {
+  test("rejects a running agent with a recent heartbeat before flipping deletion_pending", async () => {
+    selectedSandbox = {
+      ...selectedSandbox,
+      last_heartbeat_at: new Date(Date.now() - 30_000),
+    };
+    const { provisioningJobService } = await import("./provisioning-jobs");
+
+    await expect(
+      provisioningJobService.enqueueAgentDeleteOnce({
+        agentId: "agent",
+        organizationId: "22222222-2222-4222-8222-222222222222",
+        userId: "33333333-3333-4333-8333-333333333333",
+      }),
+    ).rejects.toThrow("Agent is running with a recent heartbeat");
+    expect(
+      txUpdateSet.mock.calls.some(
+        ([values]) => (values as { status?: string }).status === "deletion_pending",
+      ),
+    ).toBe(false);
+  });
+
   test("marks only the agent's quiescent non-delete pending jobs cancelled", async () => {
     cancelledReturning = [{ id: "j-restart" }, { id: "j-snapshot" }];
     const orgId = "22222222-2222-4222-8222-222222222222";

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
@@ -617,6 +617,28 @@ describe("executeJob dispatch — failure path per job type retries (increments 
 });
 
 describe("executeJob dispatch — type-specific disposition rules", () => {
+  test("agent_delete preserves billing authorization through worker execution", async () => {
+    const ctx = harness(makeJob(JOB_TYPES.AGENT_DELETE, { authorization: "billing_request" }));
+    const executeDeletionSpy = stub("executeDeletion", {
+      success: true,
+      containerStopped: true,
+      rowDeleted: true,
+    });
+
+    try {
+      const res = await run(JOB_TYPES.AGENT_DELETE);
+      expect(res).toMatchObject({ succeeded: 1, failed: 0, retried: 0 });
+      expect(executeDeletionSpy).toHaveBeenCalledWith(AGENT, ORG, "billing_request");
+    } finally {
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
   test("an unresolved delete completes the hot queue attempt with rowDeleted false", async () => {
     const ctx = harness(makeJob(JOB_TYPES.AGENT_DELETE));
     stub("executeDeletion", {

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
@@ -288,7 +288,9 @@ describe("enqueueScheduledBackups — enqueue behavior", () => {
  * predicate is a red test rather than a silent bad row on the queue.
  */
 describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
-  async function seedAgent(opts: { status?: string; lastHeartbeatAt?: Date | null } = {}): Promise<{
+  async function seedAgent(
+    opts: { status?: string; lastHeartbeatAt?: Date | null; executionTier?: string } = {},
+  ): Promise<{
     agentId: string;
     orgId: string;
     userId: string;
@@ -302,6 +304,7 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
         user_id: userId,
         agent_name: uniq("agent"),
         status: (opts.status ?? "running") as never,
+        execution_tier: (opts.executionTier ?? "shared") as never,
         bridge_url: REACHABLE_BRIDGE,
         last_heartbeat_at: opts.lastHeartbeatAt ?? null,
       })
@@ -549,6 +552,7 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
     const { agentId, orgId, userId } = await seedAgent({
       status: "running",
       lastHeartbeatAt: new Date(Date.now() - 5 * 60_000),
+      executionTier: "dedicated-always",
     });
 
     await expect(

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
@@ -69,6 +69,7 @@ interface SeedOpts {
   bridgeUrl?: string | null;
   poolStatus?: string | null;
   lastBackupAt?: Date | null;
+  lastHeartbeatAt?: Date | null;
 }
 
 async function seedSandbox(opts: SeedOpts = {}): Promise<string> {
@@ -85,6 +86,7 @@ async function seedSandbox(opts: SeedOpts = {}): Promise<string> {
       bridge_url: opts.bridgeUrl === undefined ? REACHABLE_BRIDGE : opts.bridgeUrl,
       pool_status: (opts.poolStatus ?? null) as never,
       last_backup_at: opts.lastBackupAt ?? null,
+      last_heartbeat_at: opts.lastHeartbeatAt ?? null,
     })
     .returning();
   return sandbox.id;
@@ -286,7 +288,7 @@ describe("enqueueScheduledBackups — enqueue behavior", () => {
  * predicate is a red test rather than a silent bad row on the queue.
  */
 describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
-  async function seedAgent(): Promise<{
+  async function seedAgent(opts: { status?: string; lastHeartbeatAt?: Date | null } = {}): Promise<{
     agentId: string;
     orgId: string;
     userId: string;
@@ -299,8 +301,9 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
         organization_id: orgId,
         user_id: userId,
         agent_name: uniq("agent"),
-        status: "running" as never,
+        status: (opts.status ?? "running") as never,
         bridge_url: REACHABLE_BRIDGE,
+        last_heartbeat_at: opts.lastHeartbeatAt ?? null,
       })
       .returning();
     return {
@@ -511,7 +514,7 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
   });
 
   test("delete flips the sandbox to deletion_pending and cancels other in-flight jobs", async () => {
-    const { agentId, orgId, userId } = await seedAgent();
+    const { agentId, orgId, userId } = await seedAgent({ status: "running" });
     // A queued suspend that the delete must supersede.
     await provisioningJobService.enqueueAgentSuspendOnce({
       agentId,
@@ -523,9 +526,11 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
       agentId,
       organizationId: orgId,
       userId,
+      authorization: "user_request",
     });
     expect(del.created).toBe(true);
     expect(del.job.type).toBe(JOB_TYPES.AGENT_DELETE);
+    expect((del.job.data as { authorization?: string }).authorization).toBe("user_request");
 
     const [sandbox] = await dbWrite
       .select()
@@ -538,6 +543,34 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
     expect(suspendRows[0]?.status).toBe("cancelled");
     const deleteRows = await jobsOfType(agentId, JOB_TYPES.AGENT_DELETE);
     expect(deleteRows[0]?.status).toBe("pending");
+  });
+
+  test("delete refuses a running sandbox before recording deletion intent", async () => {
+    const { agentId, orgId, userId } = await seedAgent({
+      status: "running",
+      lastHeartbeatAt: new Date(Date.now() - 5 * 60_000),
+    });
+
+    await expect(
+      provisioningJobService.enqueueAgentDeleteOnce({
+        agentId,
+        organizationId: orgId,
+        userId,
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "session_not_ready",
+      message: "Agent is running; suspend it before deletion",
+    });
+
+    const [sandbox] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, agentId));
+    expect(sandbox?.status).toBe("running");
+    expect(sandbox?.deletion_attempt_id).toBeNull();
+    expect(sandbox?.deletion_started_at).toBeNull();
+    expect(await jobsOfType(agentId, JOB_TYPES.AGENT_DELETE)).toHaveLength(0);
   });
 
   test("conditional delete atomically owns the exact stale provisioning identity", async () => {

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -90,8 +90,8 @@ import {
 } from "./eliza-provision-lock";
 import {
   AdminCanaryCleanupExpectationError,
+  type DeleteAuthorization,
   elizaSandboxService,
-  hasRecentAgentHeartbeat,
   SNAPSHOT_ENDPOINT_UNSUPPORTED,
 } from "./eliza-sandbox";
 import {
@@ -128,6 +128,7 @@ export interface AgentDeleteJobData {
   agentId: string;
   organizationId: string;
   userId: string;
+  authorization?: DeleteAuthorization;
 }
 
 export interface AgentSuspendJobData {
@@ -450,12 +451,19 @@ function isAgentProvisionJobData(value: unknown): value is AgentProvisionJobData
 }
 
 function isAgentDeleteJobData(value: unknown): value is AgentDeleteJobData {
+  const authorization =
+    typeof value === "object" && value !== null
+      ? (value as { authorization?: unknown }).authorization
+      : undefined;
   return (
     typeof value === "object" &&
     value !== null &&
     typeof (value as { agentId?: unknown }).agentId === "string" &&
     typeof (value as { organizationId?: unknown }).organizationId === "string" &&
-    typeof (value as { userId?: unknown }).userId === "string"
+    typeof (value as { userId?: unknown }).userId === "string" &&
+    (authorization === undefined ||
+      authorization === "user_request" ||
+      authorization === "billing_request")
   );
 }
 
@@ -807,6 +815,7 @@ interface LifecycleJobOptions<TData extends object> {
    * provision's lifecycle-revision race check).
    */
   validateSandbox?: (sandbox: LifecycleSandboxRow) => void;
+  deleteAuthorization?: DeleteAuthorization;
   /**
    * Called with the hydrated existing job when an active pending/in_progress
    * job of the same type would be reused instead of inserting a new row.
@@ -1301,9 +1310,10 @@ export class ProvisioningJobService {
     if (
       opts.jobType === JOB_TYPES.AGENT_DELETE &&
       sandbox.status === "running" &&
-      hasRecentAgentHeartbeat(sandbox.last_heartbeat_at)
+      sandbox.execution_tier !== "shared" &&
+      !opts.deleteAuthorization
     ) {
-      throw new ApiError(409, "session_not_ready", "Agent is running with a recent heartbeat");
+      throw new ApiError(409, "session_not_ready", "Agent is running; suspend it before deletion");
     }
 
     const configuredConflicts = opts.mutuallyExclusiveJobTypes ?? [];
@@ -1497,6 +1507,7 @@ export class ProvisioningJobService {
     organizationId: string;
     userId: string;
     webhookUrl?: string;
+    authorization?: DeleteAuthorization;
     expectedIdentity?: {
       agentName: string;
       createdAt: Date | string;
@@ -1518,12 +1529,14 @@ export class ProvisioningJobService {
         agentId: params.agentId,
         organizationId: params.organizationId,
         userId: params.userId,
+        authorization: params.authorization,
       },
       toRecord: agentDeleteJobDataToRecord,
       agentId: params.agentId,
       organizationId: params.organizationId,
       userId: params.userId,
       webhookUrl: params.webhookUrl,
+      deleteAuthorization: params.authorization,
       maxAttempts: 3,
       // SSH stop is fast (~10s graceful + ~5s force kill), DB cascade is
       // sub-second. 30s matches the Docker deletion-stop command timeout.
@@ -4858,7 +4871,11 @@ export class ProvisioningJobService {
     });
 
     await this.assertExecutionMutationLease(job);
-    const delResult = await elizaSandboxService.executeDeletion(data.agentId, data.organizationId);
+    const delResult = await elizaSandboxService.executeDeletion(
+      data.agentId,
+      data.organizationId,
+      data.authorization,
+    );
 
     if (!delResult.success) {
       // Persist a partial result and rethrow so the jobs runner counts an

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -91,6 +91,7 @@ import {
 import {
   AdminCanaryCleanupExpectationError,
   elizaSandboxService,
+  hasRecentAgentHeartbeat,
   SNAPSHOT_ENDPOINT_UNSUPPORTED,
 } from "./eliza-sandbox";
 import {
@@ -1250,6 +1251,7 @@ export class ProvisioningJobService {
         replacement_cleanup_sandbox_id: agentSandboxes.replacement_cleanup_sandbox_id,
         deletion_attempt_id: agentSandboxes.deletion_attempt_id,
         deletion_started_at: agentSandboxes.deletion_started_at,
+        last_heartbeat_at: agentSandboxes.last_heartbeat_at,
       })
       .from(agentSandboxes)
       .where(
@@ -1295,6 +1297,14 @@ export class ProvisioningJobService {
     }
 
     opts.validateSandbox?.(sandbox);
+
+    if (
+      opts.jobType === JOB_TYPES.AGENT_DELETE &&
+      sandbox.status === "running" &&
+      hasRecentAgentHeartbeat(sandbox.last_heartbeat_at)
+    ) {
+      throw new ApiError(409, "session_not_ready", "Agent is running with a recent heartbeat");
+    }
 
     const configuredConflicts = opts.mutuallyExclusiveJobTypes ?? [];
     const symmetricConflicts =

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -46,9 +46,11 @@ import {
 } from "../../db/repositories/jobs";
 import {
   type AgentExecutionTier,
+  type AgentSandboxPoolStatus,
   type AgentSandboxStatus,
   agentSandboxes,
   UPGRADE_FAILURE_TARGET_MARKER_PREFIX,
+  WARM_POOL_ORG_ID,
 } from "../../db/schemas/agent-sandboxes";
 import { apps } from "../../db/schemas/apps";
 import { containers } from "../../db/schemas/containers";
@@ -777,6 +779,7 @@ interface LifecycleSandboxRow {
   replacement_cleanup_sandbox_id: string | null;
   deletion_attempt_id: string | null;
   deletion_started_at: Date | null;
+  pool_status: AgentSandboxPoolStatus | null;
 }
 
 interface LifecycleJobOptions<TData extends object> {
@@ -1260,7 +1263,7 @@ export class ProvisioningJobService {
         replacement_cleanup_sandbox_id: agentSandboxes.replacement_cleanup_sandbox_id,
         deletion_attempt_id: agentSandboxes.deletion_attempt_id,
         deletion_started_at: agentSandboxes.deletion_started_at,
-        last_heartbeat_at: agentSandboxes.last_heartbeat_at,
+        pool_status: agentSandboxes.pool_status,
       })
       .from(agentSandboxes)
       .where(
@@ -1307,10 +1310,18 @@ export class ProvisioningJobService {
 
     opts.validateSandbox?.(sandbox);
 
+    // Mirrors prepareAgentDelete's admission policy in eliza-sandbox.ts: an
+    // unqualified delete of a running dedicated agent fails closed, while
+    // shared-runtime rows and unclaimed warm-pool rows stay deletable by
+    // cleanup paths. The row lookup above is scoped to opts.organizationId,
+    // so that value is the row's organization_id.
+    const isUnclaimedWarmPoolEntry =
+      opts.organizationId === WARM_POOL_ORG_ID && sandbox.pool_status === "unclaimed";
     if (
       opts.jobType === JOB_TYPES.AGENT_DELETE &&
       sandbox.status === "running" &&
       sandbox.execution_tier !== "shared" &&
+      !isUnclaimedWarmPoolEntry &&
       !opts.deleteAuthorization
     ) {
       throw new ApiError(409, "session_not_ready", "Agent is running; suspend it before deletion");


### PR DESCRIPTION
## Relates to

#18517

## Definition of Done

- [x] This PR targets develop and origin/develop is an ancestor of the committed head 5e857434e66fa88d39f243b483d8ba16847802ee; no rebase conflicts were required.
- [ ] bun install and bun run verify passed after sync; exact environment blockers are recorded below.
- [x] The reviewer can inspect the bounded authorization guard, regression tests, and verification results below.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@28417a4faf6fa2a32409dd1fc619d0c9bf4fbda3:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

## Sync with develop

- [x] Fetched origin/develop; git merge-base --is-ancestor origin/develop HEAD passed on the final commit.
- [ ] bun run verify passes post-sync; the exact unrelated environment blockers are listed in Known gaps / failures.

## Risks

Medium. This changes the deletion admission boundary for dedicated agents. Unqualified recovery and cleanup paths now fail closed for running dedicated rows, while authenticated user deletion and billing cancellation carry explicit typed authorization through the queue. Shared-runtime and unclaimed warm-pool cleanup remain available. No live infrastructure or wallet/payment operation was used.

## Background

### What does this PR do?

It makes live-agent deletion policy explicit instead of relying on heartbeat age alone:

- user_request and billing_request authorization is passed from the public/billing callers through AgentDeleteJobData to worker execution.
- Unqualified deletion of a dedicated running agent is rejected before deletion_pending or a delete job is recorded.
- Shared-runtime and unclaimed warm-pool cleanup remain allowed.
- HTTP boundaries map the admission failure to 409 Conflict.
- Recovery and re-enqueue paths remain unqualified and therefore fail closed for dedicated running rows.

### What kind of change is this?

Bug fix.

## Documentation changes needed?

No documentation changes are needed; this is an internal server-side lifecycle authorization guard.

## Testing

### Where should a reviewer start?

- packages/cloud/shared/src/lib/services/eliza-sandbox.ts: lifecycle preparation and authorization policy.
- packages/cloud/shared/src/lib/services/provisioning-jobs.ts: enqueue validation, typed job data, and worker propagation.
- packages/cloud/api/v1/eliza/agents/[agentId]/route.ts and packages/cloud/shared/src/lib/services/active-billing.ts: explicit caller authorization.
- packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts: billing authorization propagation regression.
- packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts: public route call-shape regression.

### Detailed testing steps

- Run bun x tsc --noEmit -p packages/cloud/shared/tsconfig.json.
- Run Biome on the 11 changed files and git diff --check.
- Run bun test packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts.
- Run the focused shared suites: eliza-sandbox.test.ts, provisioning-jobs-delete-enqueue.test.ts, provisioning-jobs-scheduled-backup-sentinel.test.ts, and provisioning-jobs-execute-dispatch.test.ts.
- Confirm an unqualified dedicated running row remains running with no delete job, while explicit user/billing authorization is preserved through queued worker execution.

## Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:39025901c82df7eac43f35d08fa930e813da304a -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing UI flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no live infrastructure was used; local runtime suites were blocked by pre-existing workspace artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend request or rendered state changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no live agent or database was mutated.
<!-- evidence-row:ocr-review -->
- [x] OCR visual review: N/A - no rendered visual surface changed.

## Evidence Details

### Test and verification output

- bun x tsc --noEmit -p packages/cloud/shared/tsconfig.json passed.
- Biome check on all 11 changed files passed.
- git diff --check passed.
- bun test packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts passed: 6 tests.
- Focused shared Bun suites were blocked before test bodies executed by the existing artifact resolver error: Cannot find module './errors' from packages/core/dist/index.d.ts.
- bun run verify passed repository contract checks, including AGENTS/CLAUDE parity, Bun version contract, dependency references, and alias-read guard, then failed in six unrelated package lint tasks because their scripts invoke unavailable bunx on this Windows environment.
- Direct Cloud API and container-control-plane typechecks were attempted separately but the TypeScript process exhausted Windows virtual memory; no code diagnostic was produced.
- bun install --frozen-lockfile --ignore-scripts was previously blocked by Windows EPERM while linking @openai/codex@0.133.0-win32-x64.
- No project-confirmed Eliza receipt tool was available, so no receipt was published.
- Maintainer review, independent verification, and merge remain pending.

### Known gaps / failures

The focused shared runtime proof and full repository verification remain environment-blocked as described above. The committed diff is limited to the 11 Eliza files listed in the commit, contains no private-key or wallet-secret material, and does not perform live infrastructure, payment, wallet, or transaction operations.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@28417a4faf6fa2a32409dd1fc619d0c9bf4fbda3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-live-guard]
<!-- eliza-computer-attribution:v1 {provider:openai,model:gpt-5.6-sol,client:Codex,skill_revision:elizaOS/eliza@28417a4faf6fa2a32409dd1fc619d0c9bf4fbda3:packages/skills/skills/contribute-to-eliza} -->

