### PR TITLE
fix(cloud): route messaging Connect CTA straight to ElizaCloud/Steward login

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -451,6 +451,13 @@ ELIZA_APP_URL = "https://eliza.app"
 # Same environment-peer rule as STAGING_ELIZA_APP_ORIGIN in
 # packages/ui/src/utils/cloud-agent-base.ts (#15161).
 ELIZA_ONBOARDING_APP_URL = "https://app-staging.elizacloud.ai"
+# VESTIGIAL as of the CONNECT-DIRECT-STEWARD change: the messaging Connect CTA
+# now targets the Cloud app's own /get-started (ELIZA_ONBOARDING_APP_URL above)
+# for a direct Steward-login handoff, so onboarding-chat.ts no longer reads
+# ELIZA_ONBOARDING_LOGIN_APP_URL. Left in place (not deleted) because the
+# canonical Worker deploy still manages the paired out-of-band secret binding
+# around this key; deleting it here without updating that workflow could break
+# the secret-removal/restore dance. Safe to remove once that workflow drops it.
 # Login CTA base for onboarding DMs (`/get-started?onboardingSession=...`).
 # The staging homepage exists since 2026-08-11: CF Pages project
 # eliza-home-staging serves https://staging.eliza.app built with

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -169,7 +169,10 @@ describe("runOnboardingChat", () => {
     });
 
     const loginUrl = new URL(result.loginUrl);
-    expect(loginUrl.origin).toBe("https://eliza.app");
+    // Same continuation as Discord: straight to the Cloud app's /get-started
+    // (Steward login), never the homepage sign-in card.
+    expect(loginUrl.origin).toBe("https://app.elizacloud.ai");
+    expect(loginUrl.pathname).toBe("/get-started");
     // No legacy method/link hints: those forced the homepage's Telegram
     // widget + phone-number flow instead of the Steward continuation.
     expect(loginUrl.searchParams.get("method")).toBeNull();
@@ -657,8 +660,44 @@ describe("runOnboardingChat", () => {
     expect(result.reply).toContain("$5");
   });
 
+  test("discord Connect CTA targets the Cloud app /get-started directly, not the homepage", async () => {
+    // Shadow spec 2026-08-11/12: the Discord DM Connect button must open the
+    // ElizaCloud/Steward login flow directly. The Cloud app's authenticated
+    // /get-started bounces signed-out users to /login?returnTo=/get-started,
+    // so it IS the Steward login entry — no intermediate homepage sign-in card.
+    const result = await runOnboardingChat({
+      message: "call me Sam",
+      platform: "discord",
+      platformUserId: "discord-user-direct",
+      sessionId: "platform:discord:discord-user-direct",
+      trustedPlatformIdentity: true,
+    });
+
+    const loginUrl = new URL(result.loginUrl);
+    // Default cloud env => the Cloud *app* host, never the homepage (eliza.app).
+    expect(loginUrl.origin).toBe("https://app.elizacloud.ai");
+    expect(loginUrl.pathname).toBe("/get-started");
+    expect(loginUrl.searchParams.get("onboardingSession")).toBeTruthy();
+    expect(result.cta).toEqual({ label: "Connect", url: result.loginUrl });
+  });
+
+  test("discord Connect CTA follows ELIZA_ONBOARDING_APP_URL to the staging app host", async () => {
+    cloudEnv = { ELIZA_ONBOARDING_APP_URL: "https://app-staging.elizacloud.ai" };
+    const result = await runOnboardingChat({
+      message: "call me Sam",
+      platform: "discord",
+      platformUserId: "discord-user-staging",
+      sessionId: "platform:discord:discord-user-staging",
+      trustedPlatformIdentity: true,
+    });
+
+    const loginUrl = new URL(result.loginUrl);
+    expect(loginUrl.origin).toBe("https://app-staging.elizacloud.ai");
+    expect(loginUrl.pathname).toBe("/get-started");
+  });
+
   test("discord handoff falls back to the inline-URL copy when the login URL cannot be a button (http scheme)", async () => {
-    cloudEnv = { ELIZA_ONBOARDING_LOGIN_APP_URL: "http://localhost:3000" };
+    cloudEnv = { ELIZA_ONBOARDING_APP_URL: "http://localhost:3000" };
     const result = await runOnboardingChat({
       message: "call me Sam",
       platform: "discord",
@@ -678,7 +717,7 @@ describe("runOnboardingChat", () => {
 
   test("discord handoff falls back to the inline-URL copy when the login URL exceeds Discord's 512-char button bound", async () => {
     cloudEnv = {
-      ELIZA_ONBOARDING_LOGIN_APP_URL: `https://example.com/${"a".repeat(520)}`,
+      ELIZA_ONBOARDING_APP_URL: `https://example.com/${"a".repeat(520)}`,
     };
     const result = await runOnboardingChat({
       message: "call me Sam",
@@ -842,7 +881,7 @@ describe("runOnboardingChat", () => {
   test("stays deterministic and model-free even when a Cerebras key is configured", async () => {
     cloudEnv = {
       CEREBRAS_API_KEY: "test-key",
-      ELIZA_ONBOARDING_LOGIN_APP_URL: "https://elizaos-homepage.pages.dev",
+      ELIZA_ONBOARDING_APP_URL: "https://elizaos-homepage.pages.dev",
     };
     const first = await runOnboardingChat({
       message: "My name is Sam",

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -141,11 +141,10 @@ const MAX_HISTORY_MESSAGES = 200;
  * raw connector payloads, so the session store enforces its own bound.
  */
 const MAX_MESSAGE_LENGTH = 4000;
+// The Cloud app host. Serves the authenticated `/get-started` continuation
+// landing (Steward login -> identity confirm -> back-to-Discord handoff) that
+// the messaging Connect CTA now targets directly, plus dashboard/billing links.
 const DEFAULT_ONBOARDING_APP_URL = "https://app.elizacloud.ai";
-// `/get-started` belongs to the homepage, while dashboard and billing links
-// belong to the Cloud app. Keep these origins separate so fixing one route
-// cannot silently break the other surface.
-const DEFAULT_ONBOARDING_LOGIN_APP_URL = "https://eliza.app";
 const ELIZA_APP_INITIAL_CREDIT_USD = "$5";
 /** Label for platforms that render the login link as a UI affordance. */
 const ONBOARDING_CTA_LABEL = "Connect";
@@ -920,11 +919,27 @@ function onboardingAppPath(path: string): string {
   return `${getOnboardingAppUrl()}${path.startsWith("/") ? path : `/${path}`}`;
 }
 
-function onboardingLoginAppPath(path: string): string {
-  const configured =
-    getCloudAwareEnv().ELIZA_ONBOARDING_LOGIN_APP_URL || DEFAULT_ONBOARDING_LOGIN_APP_URL;
-  const baseUrl = configured.replace(/\/+$/, "");
-  return `${baseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+/**
+ * The messaging-continuation Connect CTA target: the Cloud app's own
+ * `/get-started` (ELIZA_ONBOARDING_APP_URL — app.elizacloud.ai /
+ * app-staging.elizacloud.ai), NOT the homepage.
+ *
+ * That Cloud-app route is authenticated, so a signed-out visitor is bounced
+ * straight to `/login?returnTo=/get-started` (the Steward auth flow) with the
+ * continuation token preserved in storage, and after auth lands on the
+ * identity preview -> confirm redeem -> "head back to Discord" handoff
+ * (packages/ui/src/cloud/join/GetStartedPage.tsx). Sending the CTA here instead
+ * of the homepage removes the intermediate homepage sign-in card so the DM
+ * Connect button opens ElizaCloud/Steward login with zero detours, per Shadow's
+ * spec (2026-08-11/12). The Cloud-app page resolves the platform identity
+ * server-side from the gateway-attested session, so no URL method hints are
+ * needed for any platform.
+ *
+ * The homepage `/get-started` route (eliza.app) stays intact for organic,
+ * non-continuation visitors; only the messaging CTA moves.
+ */
+function onboardingContinuationLoginPath(path: string): string {
+  return onboardingAppPath(path);
 }
 
 /**
@@ -1368,7 +1383,8 @@ export async function runOnboardingChatWithStore(
   const loginParams = new URLSearchParams({
     onboardingSession: session.continuationToken ?? session.id,
   });
-  const loginUrl = onboardingLoginAppPath(`/get-started/?${loginParams.toString()}`);
+  // Cloud-app route is `/get-started` (no trailing slash), query appended.
+  const loginUrl = onboardingContinuationLoginPath(`/get-started?${loginParams.toString()}`);
   const panelUrl = controlPanelUrl(session.agentId);
   // The CTA is derived FIRST and the copy chosen from whether it exists, so
   // "tap below" text without a button is unrepresentable: the button CTA is

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-host-contract.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-host-contract.test.ts
@@ -1,6 +1,9 @@
 /**
- * Deployment contract for the two onboarding frontend origins: `/get-started`
- * belongs to the homepage, dashboard and billing links belong to the Cloud app.
+ * Deployment contract for the onboarding frontend origins. The messaging
+ * continuation Connect CTA (`/get-started`) and the dashboard/billing links now
+ * both live on the Cloud app: the CTA opens the app's authenticated
+ * `/get-started`, which sends signed-out users straight into Steward login and
+ * hands back to Discord, so there is no intermediate homepage sign-in card.
  *
  * The contract is checked through effective resolution, not string presence.
  * Each case parses one deployed environment's complete `[vars]` block out of the
@@ -98,10 +101,13 @@ async function resolveOnboardingOrigins(
  * Pages domain, same environment-peer rule as STAGING_ELIZA_APP_ORIGIN in
  * packages/ui/src/utils/cloud-agent-base.ts).
  *
- * `loginOrigin` is the homepage. Production resolves the public homepage while
- * staging resolves the dedicated staging homepage whose bundle redeems
- * continuation tokens against the staging API. Keeping this explicit prevents
- * a plain Worker redeploy from silently restoring the production fallback.
+ * `loginOrigin` is the messaging-continuation Connect CTA target. It now equals
+ * the Cloud *app* host: the CTA points at the app's authenticated
+ * `/get-started`, which bounces signed-out users straight to Steward login
+ * (`/login?returnTo=/get-started`) and hands back to Discord — no intermediate
+ * homepage sign-in card. Both origins therefore resolve to the same app host,
+ * per environment, and staging must resolve its own app peer so a staging token
+ * is redeemed against the staging endpoint.
  */
 const ONBOARDING_HOST_CONTRACT: ReadonlyArray<{
   section: string;
@@ -110,17 +116,17 @@ const ONBOARDING_HOST_CONTRACT: ReadonlyArray<{
 }> = [
   {
     section: "vars",
-    loginOrigin: "https://eliza.app",
+    loginOrigin: "https://app.elizacloud.ai",
     appOrigin: "https://app.elizacloud.ai",
   },
   {
     section: "env.production.vars",
-    loginOrigin: "https://eliza.app",
+    loginOrigin: "https://app.elizacloud.ai",
     appOrigin: "https://app.elizacloud.ai",
   },
   {
     section: "env.staging.vars",
-    loginOrigin: "https://staging.eliza.app",
+    loginOrigin: "https://app-staging.elizacloud.ai",
     appOrigin: "https://app-staging.elizacloud.ai",
   },
 ];
@@ -138,16 +144,25 @@ describe("onboarding host deployment contract", () => {
   );
 
   test.each(ONBOARDING_HOST_CONTRACT)(
-    "$section keeps the login origin off the dashboard origin",
-    async ({ section }) => {
+    "$section routes the continuation Connect CTA into the Cloud app /get-started, not the homepage",
+    async ({ section, appOrigin }) => {
       const resolved = await resolveOnboardingOrigins(section);
-      expect(resolved.loginOrigin).not.toBe(resolved.appOrigin);
+      // The Steward-login handoff lives on the Cloud app, so login and app
+      // origins coincide by design; neither is the homepage (eliza.app).
+      expect(resolved.loginOrigin).toBe(appOrigin);
+      expect(resolved.loginOrigin).not.toBe("https://eliza.app");
+      expect(resolved.loginOrigin).not.toBe("https://staging.eliza.app");
     },
   );
 
   test("staging never resolves a production dashboard origin", async () => {
     const resolved = await resolveOnboardingOrigins("env.staging.vars");
     expect(PRODUCTION_APP_ORIGINS).not.toContain(resolved.appOrigin);
+  });
+
+  test("staging never resolves a production login origin for the continuation CTA", async () => {
+    const resolved = await resolveOnboardingOrigins("env.staging.vars");
+    expect(PRODUCTION_APP_ORIGINS).not.toContain(resolved.loginOrigin);
   });
 
   test("the staging section pins the app origin instead of inheriting one", () => {


### PR DESCRIPTION
## Problem

The onboarding **Connect** button (Discord DM today; Telegram/SMS ride the same continuation since #18161) points at the **homepage** `/get-started` (`ELIZA_ONBOARDING_LOGIN_APP_URL` → `eliza.app` / `staging.eliza.app`). That lands the user on an intermediate homepage sign-in card *before any auth*.

Shadow's spec (2026-08-11, reaffirmed 2026-08-12 during staging QA): the DM Connect button should open the **ElizaCloud/Steward login flow directly**, then hand back to Discord, with **zero** homepage detour. Right now clicking Connect from a Discord DM still routes through `staging.eliza.app` instead of the Steward auth flow at `staging.elizacloud.ai`.

## Fix

Point the messaging CTA at the **Cloud app's own** `/get-started` (`ELIZA_ONBOARDING_APP_URL` → `app.elizacloud.ai` / `app-staging.elizacloud.ai`) instead of the homepage.

That Cloud-app route (`packages/ui/src/cloud/join/GetStartedPage.tsx`) is **authenticated**, so a signed-out visitor is bounced straight to `/login?returnTo=/get-started` (the Steward auth flow) with the continuation token preserved in storage. After auth it lands on the existing **identity preview → confirm redeem → "head back to Discord"** handoff.

- **Confused-deputy guard preserved:** the page still does a read-only GET preview before the mutating confirm POST.
- **#18353 proactive-DM seam untouched:** the confirm turn is exactly where the proactive greeting already fires; not reimplemented here.
- **Platform-agnostic:** the Cloud-app page resolves the platform identity server-side from the gateway-attested session, so no URL method hints are needed (Discord + Telegram both go straight to Steward login now).
- **Homepage `/get-started` stays intact** for organic, non-continuation visitors; only the messaging CTA moves.
- `ELIZA_ONBOARDING_LOGIN_APP_URL` is now vestigial (noted in `wrangler.toml`, left in place because the canonical Worker deploy still manages its paired out-of-band secret binding; safe to remove once that workflow drops it).

## Tests

- `onboarding-chat.test.ts`: locks the Discord **and** Telegram CTA origin/path (`app.elizacloud.ai` `/get-started`, `app-staging.elizacloud.ai` under the staging override) and the `ELIZA_ONBOARDING_APP_URL` env override; the http-scheme and 512-char Discord button-eligibility fallbacks now key off `ELIZA_ONBOARDING_APP_URL`.
- `onboarding-host-contract.test.ts`: per-environment contract that the continuation CTA resolves the Cloud app host, **never the homepage** (`eliza.app` / `staging.eliza.app`), and **never a production origin on staging**.

All: `bun test` 87/87 pass, `tsc --noEmit` ✅, biome ✅.

## Deploy note

The CTA is generated by the **cloud API worker** (`/api/eliza-app/onboarding/chat`), so this ships to staging via the normal `cloud-cf-deploy.yml` develop path (approval-gated). No homepage rebuild is required for the Discord flow anymore — the button bypasses `staging.eliza.app` entirely. Staging homepage build-time vars (`VITE_DISCORD_CLIENT_ID`, `VITE_ELIZACLOUD_API_URL`) requirement noted for the pending staging-deploy workflow (#18442).

🔗 Continuation of #18461 (which added the homepage sign-in step); this supersedes that hop with a direct-to-Steward route.
