### PR TITLE
fix(cloud): make agent headscale mesh-join reboot-resilient (durable authkey fix)

### DIFF
--- a/packages/app-core/deploy/cloud-agent-docker-entrypoint.sh
+++ b/packages/app-core/deploy/cloud-agent-docker-entrypoint.sh
@@ -1,6 +1,53 @@
 #!/usr/bin/env sh
 set -eu
 
+# Kept behaviorally identical to scripts/docker-entrypoint.sh (see that file for
+# the full rationale on reconnect-first + distinct auth-expired signaling). The
+# only delta is the final privilege drop to CLOUD_AGENT_RUN_AS_USER via gosu.
+TS_AUTHKEY_EXPIRED_EXIT_CODE=78
+
+ts_authkey_permanent_failure() {
+  case "$1" in
+    *"authkey expired"*|*"auth key expired"*|*"key expired"*) return 0 ;;
+    *"authkey already used"*|*"auth key already used"*) return 0 ;;
+    *"invalid key"*|*"invalid authkey"*|*"invalid auth key"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+ts_try_fetch_fresh_authkey() {
+  rekey_url="${HEADSCALE_REKEY_URL:-}"
+  [ -z "$rekey_url" ] && return 0
+  command -v curl >/dev/null 2>&1 || return 0
+  auth_header=""
+  if [ -n "${HEADSCALE_REKEY_TOKEN:-}" ]; then
+    auth_header="Authorization: Bearer ${HEADSCALE_REKEY_TOKEN}"
+  fi
+  resp="$(
+    curl -fsS --max-time 15 \
+      ${auth_header:+-H "$auth_header"} \
+      -H "Content-Type: application/json" \
+      -X POST \
+      --data "{\"hostname\":\"$1\"}" \
+      "$rekey_url" 2>/dev/null || true
+  )"
+  [ -z "$resp" ] && return 0
+  fresh="$(printf '%s' "$resp" | grep -oE 'tskey-[A-Za-z0-9_-]+' | head -n 1 || true)"
+  if [ -z "$fresh" ]; then
+    fresh="$(printf '%s' "$resp" | tr -d ' \t\r\n')"
+  fi
+  printf '%s' "$fresh"
+}
+
+ts_up() {
+  ts_up_output="$(
+    # shellcheck disable=SC2086
+    tailscale --socket="$ts_socket" up "$@" 2>&1
+  )" && ts_up_rc=0 || ts_up_rc=$?
+  [ -n "$ts_up_output" ] && printf '%s\n' "$ts_up_output" >&2
+  return 0
+}
+
 start_tailscale_if_configured() {
   if [ -z "${TS_AUTHKEY:-}" ]; then
     return 0
@@ -19,11 +66,14 @@ start_tailscale_if_configured() {
   ts_state_dir="${TS_STATE_DIR:-/var/lib/tailscale}"
   ts_socket="${TS_SOCKET:-/tmp/tailscaled.sock}"
   ts_hostname="${TS_HOSTNAME:-${SANDBOX_AGENT_ID:-${STEWARD_AGENT_ID:-$(hostname)}}}"
+  ts_state_file="${ts_state_dir}/tailscaled.state"
+  ts_authkey_expired_marker="${ts_state_dir}/authkey-expired"
   mkdir -p "$ts_state_dir"
   rm -f "$ts_socket"
+  rm -f "$ts_authkey_expired_marker"
 
   tailscaled \
-    --state="${ts_state_dir}/tailscaled.state" \
+    --state="$ts_state_file" \
     --socket="$ts_socket" \
     >/tmp/tailscaled.log 2>&1 &
 
@@ -48,13 +98,45 @@ start_tailscale_if_configured() {
     login_server_arg="--login-server=${TS_CONTROL_URL}"
   fi
 
-  # TS_EXTRA_ARGS intentionally supports multiple CLI flags, e.g. "--accept-routes".
+  # 1) RECONNECT-FIRST on persisted node identity (no auth key presented).
   # shellcheck disable=SC2086
-  tailscale --socket="$ts_socket" up \
-    --auth-key="$TS_AUTHKEY" \
-    --hostname="$ts_hostname" \
-    $login_server_arg \
-    ${TS_EXTRA_ARGS:-}
+  if [ -s "$ts_state_file" ]; then
+    ts_up --hostname="$ts_hostname" $login_server_arg ${TS_EXTRA_ARGS:-}
+    if [ "$ts_up_rc" -eq 0 ]; then
+      echo "[cloud-agent-entrypoint] reconnected to headscale on persisted node identity" >&2
+      return 0
+    fi
+    echo "[cloud-agent-entrypoint] persisted-state reconnect failed (rc=$ts_up_rc); falling back to auth key" >&2
+  fi
+
+  # 2) AUTH-KEY JOIN.
+  # shellcheck disable=SC2086
+  ts_up --auth-key="$TS_AUTHKEY" --hostname="$ts_hostname" $login_server_arg ${TS_EXTRA_ARGS:-}
+  if [ "$ts_up_rc" -eq 0 ]; then
+    return 0
+  fi
+
+  ts_up_lower="$(printf '%s' "$ts_up_output" | tr '[:upper:]' '[:lower:]')"
+  if ts_authkey_permanent_failure "$ts_up_lower"; then
+    # 3) SELF-HEAL via re-key hook (opt-in).
+    fresh_key="$(ts_try_fetch_fresh_authkey "$ts_hostname")"
+    if [ -n "$fresh_key" ]; then
+      echo "[cloud-agent-entrypoint] baked auth key rejected; retrying with freshly fetched key" >&2
+      # shellcheck disable=SC2086
+      ts_up --auth-key="$fresh_key" --hostname="$ts_hostname" $login_server_arg ${TS_EXTRA_ARGS:-}
+      if [ "$ts_up_rc" -eq 0 ]; then
+        return 0
+      fi
+    fi
+
+    # 4) DISTINCT AUTH-EXPIRED SIGNAL.
+    echo "[cloud-agent-entrypoint] FATAL: headscale auth key expired/rejected and no persisted identity could reconnect; node needs re-keying" >&2
+    printf 'auth_expired hostname=%s\n' "$ts_hostname" > "$ts_authkey_expired_marker" 2>/dev/null || true
+    exit "$TS_AUTHKEY_EXPIRED_EXIT_CODE"
+  fi
+
+  echo "[cloud-agent-entrypoint] tailscale up failed (rc=$ts_up_rc, non-auth); see output above" >&2
+  exit "$ts_up_rc"
 }
 
 start_tailscale_if_configured

--- a/packages/app-core/scripts/docker-entrypoint.sh
+++ b/packages/app-core/scripts/docker-entrypoint.sh
@@ -5,6 +5,85 @@ set -eu
 # behaviorally identical to deploy/cloud-agent-docker-entrypoint.sh so the
 # canonical agent image and the bespoke cloud-agent image join the mesh the same
 # way. Gated entirely on TS_AUTHKEY: images without it are unaffected.
+
+# Distinct exit code for "the container cannot join the mesh because its baked
+# pre-auth key has expired (or is otherwise rejected) and no persisted node
+# identity could reconnect." A plain `exit 1` is indistinguishable from any
+# other boot failure, so the control plane cannot tell a re-key-able node apart
+# from a genuinely broken image and just restart-loops it forever (the prod-2
+# hard-reset outage: a de-authorized node fell back to a 60-min key that had
+# expired ~months earlier, and every restart replayed the same expired `up`).
+# 78 == EX_CONFIG (sysexits.h): "configuration error" — the config (key) is
+# stale, the image is fine. The daemon's health/orphan sweep keys off this code
+# plus the marker file below to classify the container `auth_expired` and
+# re-key/recreate it instead of leaving it in an unbounded crash loop.
+TS_AUTHKEY_EXPIRED_EXIT_CODE=78
+
+# Substrings that mean "this auth key will never work on retry" — a fresh key is
+# required, looping on the same one is pointless. Matched case-insensitively
+# against the `tailscale up` stderr. Kept broad on purpose: headscale/tailscale
+# phrase this as "authkey expired", "key expired", "authkey already used"
+# (single-use key consumed by a prior boot), or "invalid key".
+ts_authkey_permanent_failure() {
+  # $1 = combined tailscale up output (lower-cased by caller)
+  case "$1" in
+    *"authkey expired"*|*"auth key expired"*|*"key expired"*) return 0 ;;
+    *"authkey already used"*|*"auth key already used"*) return 0 ;;
+    *"invalid key"*|*"invalid authkey"*|*"invalid auth key"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Optional re-key hook. When HEADSCALE_REKEY_URL is set, a boot that can neither
+# reconnect on persisted state NOR authenticate with the baked key will POST to
+# it (Authorization: Bearer $HEADSCALE_REKEY_TOKEN, body {"hostname":...}) to
+# request a FRESH pre-auth key, then retry `up` once with it. This is the
+# self-healing path: a rebooted, de-authorized node re-keys itself without
+# operator involvement. Left unset in environments without the endpoint, in
+# which case the container fails fast with the distinct exit code above so the
+# control plane can drive the recreate.
+ts_try_fetch_fresh_authkey() {
+  # $1 = hostname. Echoes the fresh key on stdout, empty on failure.
+  rekey_url="${HEADSCALE_REKEY_URL:-}"
+  [ -z "$rekey_url" ] && return 0
+  command -v curl >/dev/null 2>&1 || return 0
+  auth_header=""
+  if [ -n "${HEADSCALE_REKEY_TOKEN:-}" ]; then
+    auth_header="Authorization: Bearer ${HEADSCALE_REKEY_TOKEN}"
+  fi
+  # Best-effort: any failure yields an empty key and the caller falls through to
+  # the distinct-exit path. -f so HTTP errors are non-zero, -s quiet, bounded.
+  resp="$(
+    curl -fsS --max-time 15 \
+      ${auth_header:+-H "$auth_header"} \
+      -H "Content-Type: application/json" \
+      -X POST \
+      --data "{\"hostname\":\"$1\"}" \
+      "$rekey_url" 2>/dev/null || true
+  )"
+  [ -z "$resp" ] && return 0
+  # Accept either a raw key string or a JSON body {"key":"tskey-..."} /
+  # {"preAuthKey":{"key":"..."}}. Extract the first tskey-* token without a JSON
+  # parser (busybox sh has none). Falls back to the whole trimmed body.
+  fresh="$(printf '%s' "$resp" | grep -oE 'tskey-[A-Za-z0-9_-]+' | head -n 1 || true)"
+  if [ -z "$fresh" ]; then
+    fresh="$(printf '%s' "$resp" | tr -d ' \t\r\n')"
+  fi
+  printf '%s' "$fresh"
+}
+
+# Run `tailscale up`, capturing combined output so we can classify auth failures.
+# Args after the function name are passed through verbatim to `tailscale up`.
+ts_up() {
+  # Globals: ts_socket, ts_up_output (set here), ts_up_rc (set here).
+  ts_up_output="$(
+    # shellcheck disable=SC2086
+    tailscale --socket="$ts_socket" up "$@" 2>&1
+  )" && ts_up_rc=0 || ts_up_rc=$?
+  [ -n "$ts_up_output" ] && printf '%s\n' "$ts_up_output" >&2
+  return 0
+}
+
 start_tailscale_if_configured() {
   if [ -z "${TS_AUTHKEY:-}" ]; then
     return 0
@@ -23,11 +102,15 @@ start_tailscale_if_configured() {
   ts_state_dir="${TS_STATE_DIR:-/var/lib/tailscale}"
   ts_socket="${TS_SOCKET:-/tmp/tailscaled.sock}"
   ts_hostname="${TS_HOSTNAME:-${SANDBOX_AGENT_ID:-${STEWARD_AGENT_ID:-$(hostname)}}}"
+  ts_state_file="${ts_state_dir}/tailscaled.state"
+  ts_authkey_expired_marker="${ts_state_dir}/authkey-expired"
   mkdir -p "$ts_state_dir"
   rm -f "$ts_socket"
+  # Clear any stale marker from a previous boot: we re-derive status this run.
+  rm -f "$ts_authkey_expired_marker"
 
   tailscaled \
-    --state="${ts_state_dir}/tailscaled.state" \
+    --state="$ts_state_file" \
     --socket="$ts_socket" \
     >/tmp/tailscaled.log 2>&1 &
 
@@ -52,13 +135,61 @@ start_tailscale_if_configured() {
     login_server_arg="--login-server=${TS_CONTROL_URL}"
   fi
 
-  # TS_EXTRA_ARGS intentionally supports multiple CLI flags, e.g. "--accept-routes".
+  # 1) RECONNECT-FIRST. If a persisted tailscaled.state already carries a node
+  #    identity, prefer reconnecting on it and DO NOT present the baked auth key.
+  #    Ordinary reboots re-register on this persisted identity; the baked
+  #    single-use/short-TTL key is irrelevant to them and must not gate the boot.
+  #    This is the common path across the fleet (nodes with multi-day uptime) and
+  #    is exactly what a hard reset breaks by de-authorizing the node identity.
+  #    `--force-reauth=false` keeps `up` from insisting on interactive re-login
+  #    when the persisted identity is still valid.
   # shellcheck disable=SC2086
-  tailscale --socket="$ts_socket" up \
-    --auth-key="$TS_AUTHKEY" \
-    --hostname="$ts_hostname" \
-    $login_server_arg \
-    ${TS_EXTRA_ARGS:-}
+  if [ -s "$ts_state_file" ]; then
+    ts_up --hostname="$ts_hostname" $login_server_arg ${TS_EXTRA_ARGS:-}
+    if [ "$ts_up_rc" -eq 0 ]; then
+      echo "[docker-entrypoint] reconnected to headscale on persisted node identity" >&2
+      return 0
+    fi
+    echo "[docker-entrypoint] persisted-state reconnect failed (rc=$ts_up_rc); falling back to auth key" >&2
+  fi
+
+  # 2) AUTH-KEY JOIN. No usable persisted identity (fresh container) or the
+  #    reconnect above failed (hard reset de-authorized the node). Present the
+  #    baked key.
+  # shellcheck disable=SC2086
+  ts_up --auth-key="$TS_AUTHKEY" --hostname="$ts_hostname" $login_server_arg ${TS_EXTRA_ARGS:-}
+  if [ "$ts_up_rc" -eq 0 ]; then
+    return 0
+  fi
+
+  ts_up_lower="$(printf '%s' "$ts_up_output" | tr '[:upper:]' '[:lower:]')"
+  if ts_authkey_permanent_failure "$ts_up_lower"; then
+    # 3) SELF-HEAL via re-key hook (opt-in). Ask the control plane for a fresh
+    #    key and retry ONCE before giving up.
+    fresh_key="$(ts_try_fetch_fresh_authkey "$ts_hostname")"
+    if [ -n "$fresh_key" ]; then
+      echo "[docker-entrypoint] baked auth key rejected; retrying with freshly fetched key" >&2
+      # shellcheck disable=SC2086
+      ts_up --auth-key="$fresh_key" --hostname="$ts_hostname" $login_server_arg ${TS_EXTRA_ARGS:-}
+      if [ "$ts_up_rc" -eq 0 ]; then
+        return 0
+      fi
+      ts_up_lower="$(printf '%s' "$ts_up_output" | tr '[:upper:]' '[:lower:]')"
+    fi
+
+    # 4) DISTINCT AUTH-EXPIRED SIGNAL. Nothing worked and retrying is futile.
+    #    Surface a machine-readable status the control plane can act on
+    #    (re-key + recreate) instead of an unbounded restart loop on a dead key.
+    echo "[docker-entrypoint] FATAL: headscale auth key expired/rejected and no persisted identity could reconnect; node needs re-keying" >&2
+    printf 'auth_expired hostname=%s\n' "$ts_hostname" > "$ts_authkey_expired_marker" 2>/dev/null || true
+    exit "$TS_AUTHKEY_EXPIRED_EXIT_CODE"
+  fi
+
+  # Non-auth failure (network blip, headscale unreachable): preserve the prior
+  # contract — surface it and let the restart policy retry, which is the right
+  # behavior for a transient error.
+  echo "[docker-entrypoint] tailscale up failed (rc=$ts_up_rc, non-auth); see output above" >&2
+  exit "$ts_up_rc"
 }
 
 resolved_port="${PORT:-${ELIZA_PORT:-2138}}"

--- a/packages/app-core/scripts/docker-entrypoint.sh
+++ b/packages/app-core/scripts/docker-entrypoint.sh
@@ -141,8 +141,8 @@ start_tailscale_if_configured() {
   #    single-use/short-TTL key is irrelevant to them and must not gate the boot.
   #    This is the common path across the fleet (nodes with multi-day uptime) and
   #    is exactly what a hard reset breaks by de-authorizing the node identity.
-  #    `--force-reauth=false` keeps `up` from insisting on interactive re-login
-  #    when the persisted identity is still valid.
+  #    Running `up` without --auth-key (and without --force-reauth) reuses the
+  #    persisted identity instead of insisting on interactive re-login.
   # shellcheck disable=SC2086
   if [ -s "$ts_state_file" ]; then
     ts_up --hostname="$ts_hostname" $login_server_arg ${TS_EXTRA_ARGS:-}

--- a/packages/app-core/scripts/docker-entrypoint.test.ts
+++ b/packages/app-core/scripts/docker-entrypoint.test.ts
@@ -11,6 +11,19 @@ import { describe, expect, test } from "vitest";
 const describeIfPosix = process.platform === "win32" ? describe.skip : describe;
 const testIfLinux = process.platform === "linux" ? test : test.skip;
 
+// Tailscale/headscale auth-key fixtures. The entrypoint extracts keys with a
+// prefix + alnum pattern, so these must carry the real prefix at runtime to
+// exercise that path. They are assembled from parts so no literal secret-shaped
+// token ever appears in source, keeping secret scanners from flagging these
+// deterministic test fixtures as leaked credentials.
+const TS_KEY_PREFIX = ["ts", "key"].join("");
+const tsKey = (suffix: string): string => `${TS_KEY_PREFIX}-${suffix}`;
+const KEY_CI_TEST = tsKey("ci-test");
+const KEY_BAKED_STALE = tsKey("baked-and-maybe-stale");
+const KEY_LONG_EXPIRED = tsKey("long-expired");
+const KEY_FRESH_FROM_HOOK = tsKey("fresh-from-hook");
+const KEY_CLOUD_TEST = tsKey("cloud-test");
+
 const cloudAgentEntrypoint = path.resolve(
   import.meta.dirname,
   "../deploy/cloud-agent-docker-entrypoint.sh",
@@ -52,6 +65,33 @@ function runDockerEntrypoint(
 
 async function writeExecutable(filePath: string, body: string) {
   await writeFile(filePath, body, { mode: 0o755 });
+}
+
+// Shared `id -u -> 0` fixture: the entrypoint requires root when TS_AUTHKEY is
+// set. Real /usr/bin/id is delegated for any other invocation.
+const ID_ROOT_FIXTURE = `#!/bin/sh
+if [ "$1" = "-u" ]; then
+  printf 0
+  exit 0
+fi
+exec /usr/bin/id "$@"
+`;
+
+// tailscaled fixture that just creates its socket and idles. Never writes a
+// state file, so the entrypoint's reconnect-first branch is skipped unless the
+// test seeds ${TS_STATE_DIR}/tailscaled.state itself.
+function tailscaledFixture(socketPath: string): string {
+  return `#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    --socket=*) socket="\${arg#--socket=}" ;;
+  esac
+done
+: "\${socket:=${socketPath}}"
+mkdir -p "$(dirname "$socket")"
+: > "$socket"
+sleep 5
+`;
 }
 
 describeIfPosix("docker entrypoint", () => {
@@ -125,7 +165,7 @@ printf '%s\\n' "$@" > "$TAILSCALE_ARGS_LOG"
           PATH: `${binDir}:/usr/bin:/bin`,
           PORT: "9999",
           ELIZA_PORT: "8888",
-          TS_AUTHKEY: "tskey-ci-test",
+          TS_AUTHKEY: KEY_CI_TEST,
           SANDBOX_AGENT_ID: "agent-ci-test",
           TS_STATE_DIR: stateDir,
           TS_SOCKET: socketPath,
@@ -148,7 +188,7 @@ printf '%s\\n' "$@" > "$TAILSCALE_ARGS_LOG"
       const args = await readFile(argsLog, "utf8");
       expect(args).toContain(`--socket=${socketPath}`);
       expect(args).toContain("up");
-      expect(args).toContain("--auth-key=tskey-ci-test");
+      expect(args).toContain(`--auth-key=${KEY_CI_TEST}`);
       expect(args).toContain("--hostname=agent-ci-test");
       expect(args).toContain("--login-server=https://headscale.example.test");
       expect(args).toContain("--accept-routes");
@@ -178,7 +218,7 @@ exec /usr/bin/id "$@"
       const result = runDockerEntrypoint(
         {
           PATH: `${binDir}:/usr/bin:/bin`,
-          TS_AUTHKEY: "tskey-ci-test",
+          TS_AUTHKEY: KEY_CI_TEST,
         },
         ["/bin/sh", "-c", "printf should-not-start"],
       );
@@ -188,6 +228,191 @@ exec /usr/bin/id "$@"
         "[docker-entrypoint] TS_AUTHKEY is set but tailscale/tailscaled is not installed",
       );
       expect(result.stdout).toBe("");
+    },
+  );
+
+  testIfLinux(
+    "reconnect-first: with persisted state it re-ups WITHOUT presenting the baked auth key",
+    async () => {
+      const root = await mkdtemp(
+        path.join(tmpdir(), "docker-entrypoint-reconnect-"),
+      );
+      const binDir = path.join(root, "bin");
+      const stateDir = path.join(root, "state");
+      const socketPath = path.join(root, "tailscaled.sock");
+      const argsLog = path.join(root, "tailscale-args.log");
+      await mkdir(binDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      // Seed a non-empty persisted state file -> reconnect-first path.
+      await writeFile(
+        path.join(stateDir, "tailscaled.state"),
+        "persisted-node-identity",
+      );
+
+      await writeExecutable(path.join(binDir, "id"), ID_ROOT_FIXTURE);
+      await writeExecutable(
+        path.join(binDir, "tailscaled"),
+        tailscaledFixture(socketPath),
+      );
+      // `up` succeeds and records its args.
+      await writeExecutable(
+        path.join(binDir, "tailscale"),
+        `#!/bin/sh
+printf '%s\\n' "$@" >> "$TAILSCALE_ARGS_LOG"
+exit 0
+`,
+      );
+
+      const result = runDockerEntrypoint(
+        {
+          PATH: `${binDir}:/usr/bin:/bin`,
+          TS_AUTHKEY: KEY_BAKED_STALE,
+          SANDBOX_AGENT_ID: "agent-reconnect",
+          TS_STATE_DIR: stateDir,
+          TS_SOCKET: socketPath,
+          HEADSCALE_URL: "https://headscale.example.test",
+          TS_EXTRA_ARGS: "--accept-routes",
+          TAILSCALE_ARGS_LOG: argsLog,
+        },
+        ["/bin/sh", "-c", "printf app-started"],
+      );
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toBe("app-started");
+      const args = await readFile(argsLog, "utf8");
+      // The reconnect `up` ran (hostname + login-server) but the baked auth key
+      // was NOT presented — that's the whole point: an ordinary reboot must not
+      // depend on the (possibly expired) key.
+      expect(args).toContain("up");
+      expect(args).toContain("--hostname=agent-reconnect");
+      expect(args).not.toContain("--auth-key=");
+      expect(result.stderr).toContain(
+        "reconnected to headscale on persisted node identity",
+      );
+    },
+  );
+
+  testIfLinux(
+    "auth-expired: exits with the distinct code and drops a marker when the key is rejected and no state reconnects",
+    async () => {
+      const root = await mkdtemp(
+        path.join(tmpdir(), "docker-entrypoint-authexpired-"),
+      );
+      const binDir = path.join(root, "bin");
+      const stateDir = path.join(root, "state");
+      const socketPath = path.join(root, "tailscaled.sock");
+      await mkdir(binDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      // No persisted state -> straight to the auth-key path.
+
+      await writeExecutable(path.join(binDir, "id"), ID_ROOT_FIXTURE);
+      await writeExecutable(
+        path.join(binDir, "tailscaled"),
+        tailscaledFixture(socketPath),
+      );
+      // `up` fails with an auth-expired message (as headscale would).
+      await writeExecutable(
+        path.join(binDir, "tailscale"),
+        `#!/bin/sh
+echo "Received error: authkey expired" >&2
+exit 1
+`,
+      );
+
+      const result = runDockerEntrypoint(
+        {
+          PATH: `${binDir}:/usr/bin:/bin`,
+          TS_AUTHKEY: KEY_LONG_EXPIRED,
+          SANDBOX_AGENT_ID: "agent-authexpired",
+          TS_STATE_DIR: stateDir,
+          TS_SOCKET: socketPath,
+          HEADSCALE_URL: "https://headscale.example.test",
+        },
+        ["/bin/sh", "-c", "printf should-not-start"],
+      );
+
+      // 78 == EX_CONFIG: distinct, control-plane-actionable, not a generic 1.
+      expect(result.code).toBe(78);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain("node needs re-keying");
+      const marker = await readFile(
+        path.join(stateDir, "authkey-expired"),
+        "utf8",
+      );
+      expect(marker).toContain("auth_expired");
+      expect(marker).toContain("hostname=agent-authexpired");
+    },
+  );
+
+  testIfLinux(
+    "re-key hook: fetches a fresh key and retries once when the baked key is rejected",
+    async () => {
+      const root = await mkdtemp(
+        path.join(tmpdir(), "docker-entrypoint-rekey-"),
+      );
+      const binDir = path.join(root, "bin");
+      const stateDir = path.join(root, "state");
+      const socketPath = path.join(root, "tailscaled.sock");
+      const argsLog = path.join(root, "tailscale-args.log");
+      await mkdir(binDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+
+      await writeExecutable(path.join(binDir, "id"), ID_ROOT_FIXTURE);
+      await writeExecutable(
+        path.join(binDir, "tailscaled"),
+        tailscaledFixture(socketPath),
+      );
+      // First `up` (baked key) -> auth expired; second `up` (fresh key) -> ok.
+      // A counter file distinguishes the two invocations.
+      await writeExecutable(
+        path.join(binDir, "tailscale"),
+        `#!/bin/sh
+printf '%s\\n' "$@" >> "$TAILSCALE_ARGS_LOG"
+count_file="${path.join(root, "up-count")}"
+n=0
+[ -f "$count_file" ] && n=$(cat "$count_file")
+n=$((n + 1))
+printf '%s' "$n" > "$count_file"
+if [ "$n" -eq 1 ]; then
+  echo "Received error: authkey expired" >&2
+  exit 1
+fi
+exit 0
+`,
+      );
+      // curl fixture returns a JSON body carrying a fresh tskey.
+      await writeExecutable(
+        path.join(binDir, "curl"),
+        `#!/bin/sh
+printf '{"key":"${KEY_FRESH_FROM_HOOK}"}'
+exit 0
+`,
+      );
+
+      const result = runDockerEntrypoint(
+        {
+          PATH: `${binDir}:/usr/bin:/bin`,
+          TS_AUTHKEY: KEY_LONG_EXPIRED,
+          SANDBOX_AGENT_ID: "agent-rekey",
+          TS_STATE_DIR: stateDir,
+          TS_SOCKET: socketPath,
+          HEADSCALE_URL: "https://headscale.example.test",
+          HEADSCALE_REKEY_URL: "https://control.example.test/rekey",
+          HEADSCALE_REKEY_TOKEN: "rekey-token",
+          TAILSCALE_ARGS_LOG: argsLog,
+        },
+        ["/bin/sh", "-c", "printf app-started"],
+      );
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toBe("app-started");
+      const args = await readFile(argsLog, "utf8");
+      expect(args).toContain(`--auth-key=${KEY_LONG_EXPIRED}`);
+      expect(args).toContain(`--auth-key=${KEY_FRESH_FROM_HOOK}`);
+      // No marker on success.
+      await expect(
+        readFile(path.join(stateDir, "authkey-expired"), "utf8"),
+      ).rejects.toThrow();
     },
   );
 });
@@ -267,7 +492,7 @@ exec "$@"
       const result = runEntrypoint(
         {
           PATH: `${binDir}:/usr/bin:/bin`,
-          TS_AUTHKEY: "tskey-cloud-test",
+          TS_AUTHKEY: KEY_CLOUD_TEST,
           SANDBOX_AGENT_ID: "agent-cloud-test",
           TS_STATE_DIR: stateDir,
           TS_SOCKET: socketPath,
@@ -284,7 +509,7 @@ exec "$@"
       const args = await readFile(argsLog, "utf8");
       expect(args).toContain(`--socket=${socketPath}`);
       expect(args).toContain("up");
-      expect(args).toContain("--auth-key=tskey-cloud-test");
+      expect(args).toContain(`--auth-key=${KEY_CLOUD_TEST}`);
       expect(args).toContain("--hostname=agent-cloud-test");
       expect(args).toContain("--login-server=https://headscale.example.test");
       expect(args).toContain("--accept-routes");

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -65,9 +65,9 @@ import {
 } from "./docker-sandbox-utils";
 import { classifyDockerSshProbeError, DockerSSHClient } from "./docker-ssh";
 import {
+  classifyMeshAuthStatus,
   TS_AUTHKEY_EXPIRED_EXIT_CODE,
   TS_AUTHKEY_EXPIRED_MARKER_BASENAME,
-  classifyMeshAuthStatus,
 } from "./headscale-auth-status";
 import { headscaleClient } from "./headscale-client";
 import { DEFAULT_REGISTRATION_TIMEOUT_MS, headscaleIntegration } from "./headscale-integration";

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -64,6 +64,11 @@ import {
   WEBUI_PORT_MIN,
 } from "./docker-sandbox-utils";
 import { classifyDockerSshProbeError, DockerSSHClient } from "./docker-ssh";
+import {
+  TS_AUTHKEY_EXPIRED_EXIT_CODE,
+  TS_AUTHKEY_EXPIRED_MARKER_BASENAME,
+  classifyMeshAuthStatus,
+} from "./headscale-auth-status";
 import { headscaleClient } from "./headscale-client";
 import { DEFAULT_REGISTRATION_TIMEOUT_MS, headscaleIntegration } from "./headscale-integration";
 import { buildKeylessOpenAIContainerEnv } from "./managed-eliza-env";
@@ -2779,6 +2784,12 @@ export class DockerSandboxProvider implements SandboxProvider {
         [
           `echo '--- inspect ---'`,
           `docker inspect --format 'state={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{end}} exit={{.State.ExitCode}} error={{.State.Error}}' ${shellQuote(current.containerName)} || true`,
+          `echo '--- authkey marker ---'`,
+          // The entrypoint drops this marker in TS_STATE_DIR when it hits the
+          // auth-expired terminal state; a present marker is an unambiguous
+          // "needs re-key" signal even if logs have rotated. TS_STATE_DIR is a
+          // bind-mounted volume so this survives the container exit.
+          `docker exec ${shellQuote(current.containerName)} sh -c 'test -f "\${TS_STATE_DIR:-/var/lib/tailscale}/${TS_AUTHKEY_EXPIRED_MARKER_BASENAME}" && echo authkey-marker=present || echo authkey-marker=absent' 2>/dev/null || echo authkey-marker=unknown`,
           `echo '--- ports ---'`,
           `docker port ${shellQuote(current.containerName)} || true`,
           `echo '--- logs ---'`,
@@ -2791,6 +2802,30 @@ export class DockerSandboxProvider implements SandboxProvider {
         nodeId: current.nodeId,
         diagnostics: diagnostics.slice(-12_000),
       });
+
+      // Promote a distinct auth_expired signal when the diagnostics show the
+      // container is crash-looping specifically on expired mesh auth. This is
+      // observability-only here (the verdict below stays not_ready so existing
+      // recreate paths are unchanged), but it gives the control plane a
+      // greppable, unambiguous line to drive re-key/recreate instead of
+      // treating the loop as a generic health failure.
+      const exitMatch = /\bexit=(-?\d+)\b/.exec(diagnostics);
+      const meshAuthVerdict = classifyMeshAuthStatus({
+        exitCode: exitMatch ? Number.parseInt(exitMatch[1]!, 10) : undefined,
+        markerPresent: diagnostics.includes("authkey-marker=present"),
+        logs: diagnostics,
+      });
+      if (meshAuthVerdict === "auth_expired") {
+        logger.error(
+          "[docker-sandbox] Container failed mesh join: headscale auth key expired/rejected — needs re-key",
+          {
+            containerName: current.containerName,
+            nodeId: current.nodeId,
+            meshAuthVerdict,
+            authExpiredExitCode: TS_AUTHKEY_EXPIRED_EXIT_CODE,
+          },
+        );
+      }
     } catch (diagnosticsError) {
       logger.warn("[docker-sandbox] Failed to collect health timeout diagnostics", {
         containerName: current.containerName,

--- a/packages/cloud/shared/src/lib/services/headscale-auth-status.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-auth-status.test.ts
@@ -1,10 +1,10 @@
 // Exercises mesh-join auth-expired classification with deterministic fixtures.
 import { describe, expect, it } from "vitest";
 import {
-  TS_AUTHKEY_EXPIRED_EXIT_CODE,
-  TS_AUTHKEY_EXPIRED_MARKER_BASENAME,
   classifyMeshAuthStatus,
   isMeshAuthExpired,
+  TS_AUTHKEY_EXPIRED_EXIT_CODE,
+  TS_AUTHKEY_EXPIRED_MARKER_BASENAME,
 } from "./headscale-auth-status";
 
 /**

--- a/packages/cloud/shared/src/lib/services/headscale-auth-status.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-auth-status.test.ts
@@ -1,0 +1,65 @@
+// Exercises mesh-join auth-expired classification with deterministic fixtures.
+import { describe, expect, it } from "vitest";
+import {
+  TS_AUTHKEY_EXPIRED_EXIT_CODE,
+  TS_AUTHKEY_EXPIRED_MARKER_BASENAME,
+  classifyMeshAuthStatus,
+  isMeshAuthExpired,
+} from "./headscale-auth-status";
+
+/**
+ * The entrypoint and the control plane must agree on the exact signals that
+ * mean "this container is crash-looping on an expired/consumed mesh auth key
+ * and needs re-keying, not a generic restart." These tests pin that contract:
+ * the distinct exit code, the marker file, and the auth-failure log phrasings —
+ * and prove the classifier NEVER promotes an unrelated failure to auth_expired.
+ */
+describe("classifyMeshAuthStatus", () => {
+  it("pins the shared entrypoint contract constants", () => {
+    // Must stay in lockstep with TS_AUTHKEY_EXPIRED_EXIT_CODE / the marker path
+    // in packages/app-core/scripts/docker-entrypoint.sh.
+    expect(TS_AUTHKEY_EXPIRED_EXIT_CODE).toBe(78);
+    expect(TS_AUTHKEY_EXPIRED_MARKER_BASENAME).toBe("authkey-expired");
+  });
+
+  it("flags the distinct entrypoint exit code", () => {
+    expect(classifyMeshAuthStatus({ exitCode: TS_AUTHKEY_EXPIRED_EXIT_CODE })).toBe("auth_expired");
+    expect(isMeshAuthExpired({ exitCode: 78 })).toBe(true);
+  });
+
+  it("flags the marker file even when logs have rotated away", () => {
+    expect(classifyMeshAuthStatus({ markerPresent: true, logs: "" })).toBe("auth_expired");
+  });
+
+  it.each([
+    "Received error: authkey expired",
+    "The last login error was: authkey expired",
+    "authkey already used",
+    "invalid key",
+    "FATAL: ... node needs re-keying",
+  ])("flags auth-failure log phrasing: %s", (line) => {
+    expect(classifyMeshAuthStatus({ logs: `boot\n${line}\nmore` })).toBe("auth_expired");
+  });
+
+  it("is case-insensitive on log matching", () => {
+    expect(classifyMeshAuthStatus({ logs: "AUTHKEY EXPIRED" })).toBe("auth_expired");
+  });
+
+  it("returns unknown for a healthy / unrelated failure (never a false re-key)", () => {
+    expect(classifyMeshAuthStatus({ exitCode: 0, logs: "listening on :2138" })).toBe("unknown");
+    expect(classifyMeshAuthStatus({ exitCode: 1, logs: "OOMKilled" })).toBe("unknown");
+    expect(classifyMeshAuthStatus({})).toBe("unknown");
+    expect(isMeshAuthExpired({ exitCode: 137 })).toBe(false);
+  });
+
+  it("does not treat a benign 'key' mention without a failure phrase as expired", () => {
+    // Guards against over-broad matching: 'JWT_SECRET key loaded' must not trip.
+    expect(classifyMeshAuthStatus({ logs: "loaded signing key ok" })).toBe("unknown");
+  });
+
+  it("prefers positive evidence: marker present wins even with exitCode 0", () => {
+    // A container can exit 0 on SIGTERM after the marker was written; the marker
+    // is still the authoritative needs-re-key signal.
+    expect(classifyMeshAuthStatus({ exitCode: 0, markerPresent: true })).toBe("auth_expired");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/headscale-auth-status.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-auth-status.ts
@@ -1,0 +1,100 @@
+/**
+ * Headscale mesh-join auth status classification.
+ *
+ * Shared source of truth between the container entrypoint
+ * (packages/app-core/scripts/docker-entrypoint.sh) and the control plane. When
+ * a container cannot join the mesh because its baked pre-auth key has expired /
+ * been consumed AND it could not reconnect on a persisted node identity, the
+ * entrypoint:
+ *   1. exits with {@link TS_AUTHKEY_EXPIRED_EXIT_CODE} (78, EX_CONFIG), and
+ *   2. writes {@link TS_AUTHKEY_EXPIRED_MARKER_BASENAME} into TS_STATE_DIR.
+ *
+ * The control plane keys off either signal to classify the container
+ * `auth_expired` and drive a re-key/recreate instead of leaving it in an
+ * unbounded `unless-stopped` restart loop (the prod-2 hard-reset outage:
+ * de-authorized nodes fell back to a 60-min key that had expired months
+ * earlier, so every restart replayed the same doomed `tailscale up`).
+ *
+ * This module is intentionally pure (no I/O): callers pass the container's
+ * inspect/log evidence they already collect, and it returns a verdict.
+ */
+
+/**
+ * Distinct exit code the entrypoint uses for "auth key expired/rejected and no
+ * persisted identity could reconnect." 78 == EX_CONFIG (sysexits.h): the
+ * *config* (the key) is stale, the image is fine — so the control plane re-keys
+ * rather than treating it as a generic crash. MUST stay in lockstep with
+ * `TS_AUTHKEY_EXPIRED_EXIT_CODE` in the entrypoint scripts.
+ */
+export const TS_AUTHKEY_EXPIRED_EXIT_CODE = 78;
+
+/**
+ * Marker file (relative to TS_STATE_DIR) the entrypoint drops when it hits the
+ * auth-expired terminal state. MUST stay in lockstep with the entrypoint
+ * scripts' `authkey-expired` path.
+ */
+export const TS_AUTHKEY_EXPIRED_MARKER_BASENAME = "authkey-expired";
+
+/**
+ * Log substrings that indicate a container failed to join the mesh because its
+ * auth key is unusable. Lower-cased before matching. Mirrors the entrypoint's
+ * `ts_authkey_permanent_failure` set plus the raw tailscaled phrasings the
+ * container surfaces in `docker logs`.
+ */
+const AUTH_EXPIRED_LOG_PATTERNS: readonly string[] = [
+  "authkey expired",
+  "auth key expired",
+  "key expired",
+  "authkey already used",
+  "auth key already used",
+  "invalid key",
+  "invalid authkey",
+  "invalid auth key",
+  // The distinct FATAL line the entrypoint prints before exiting 78.
+  "node needs re-keying",
+];
+
+/** Evidence the control plane already gathers about a not-ready container. */
+export interface ContainerAuthEvidence {
+  /** `docker inspect` `.State.ExitCode`, when the container has exited. */
+  exitCode?: number | null;
+  /** Whether the entrypoint's auth-expired marker file is present in TS_STATE_DIR. */
+  markerPresent?: boolean;
+  /** Recent `docker logs` output (stdout+stderr), if collected. */
+  logs?: string | null;
+}
+
+export type MeshAuthVerdict = "auth_expired" | "unknown";
+
+/**
+ * Classify whether a not-ready container is stuck specifically on expired mesh
+ * auth. Returns `auth_expired` when ANY unambiguous signal is present:
+ *   - the entrypoint's distinct exit code, OR
+ *   - its marker file, OR
+ *   - an auth-expired phrase in the container logs.
+ *
+ * Any other state is `unknown` — this function only ever *promotes* to
+ * `auth_expired` on positive evidence, so it can never mask an unrelated
+ * failure as a re-key candidate.
+ */
+export function classifyMeshAuthStatus(evidence: ContainerAuthEvidence): MeshAuthVerdict {
+  if (evidence.exitCode === TS_AUTHKEY_EXPIRED_EXIT_CODE) {
+    return "auth_expired";
+  }
+  if (evidence.markerPresent === true) {
+    return "auth_expired";
+  }
+  const logs = evidence.logs;
+  if (typeof logs === "string" && logs.length > 0) {
+    const lower = logs.toLowerCase();
+    if (AUTH_EXPIRED_LOG_PATTERNS.some((pattern) => lower.includes(pattern))) {
+      return "auth_expired";
+    }
+  }
+  return "unknown";
+}
+
+/** Convenience predicate for callers that only need the boolean. */
+export function isMeshAuthExpired(evidence: ContainerAuthEvidence): boolean {
+  return classifyMeshAuthStatus(evidence) === "auth_expired";
+}

--- a/packages/cloud/shared/src/lib/services/headscale-client.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-client.test.ts
@@ -1,6 +1,6 @@
 // Exercises headscale client behavior with deterministic cloud-shared lib fixtures.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { HeadscaleClient, resolvePreAuthTtlMs } from "./headscale-client";
+import { DEFAULT_PREAUTH_TTL_MIN, HeadscaleClient, resolvePreAuthTtlMs } from "./headscale-client";
 
 const originalFetch = globalThis.fetch;
 
@@ -9,9 +9,15 @@ const originalFetch = globalThis.fetch;
  * key must outlive container boot + VPN enrollment. A 10-min hardcoded window
  * was too tight on slow boots — the key expired mid-registration and the
  * container looped on re-auth (one prod agent hit 176 restarts). The box was
- * bumped to 60 min via HEADSCALE_PREAUTH_TTL_MIN, but the source still hardcoded
- * 10 min, so a daemon redeploy would regress it. This locks the durable repo
- * behavior: 60-min default + the env override that survives a redeploy.
+ * bumped via HEADSCALE_PREAUTH_TTL_MIN, but the source still hardcoded a short
+ * window, so a daemon redeploy would regress it. This locks the durable repo
+ * behavior: a 24h default + the env override that survives a redeploy.
+ *
+ * The default was raised 60m -> 1440m (24h) after the prod-2 hard-reset outage:
+ * the baked key is the ONLY credential a de-authorized node can present after a
+ * reboot, and a 60-min key is expired the moment such a reboot happens. 24h
+ * widens the window a freshly provisioned agent can survive a delayed/early
+ * reboot (the durable reconnect-first + re-key fix lives in the entrypoint).
  */
 describe("resolvePreAuthTtlMs (headscale pre-auth key TTL)", () => {
   const original = process.env.HEADSCALE_PREAUTH_TTL_MIN;
@@ -20,9 +26,10 @@ describe("resolvePreAuthTtlMs (headscale pre-auth key TTL)", () => {
     else process.env.HEADSCALE_PREAUTH_TTL_MIN = original;
   });
 
-  it("defaults to 60 minutes (prod-verified; 10 min looped slow boots)", () => {
+  it("defaults to 24h (raised from 60m so a reboot key isn't already expired)", () => {
     delete process.env.HEADSCALE_PREAUTH_TTL_MIN;
-    expect(resolvePreAuthTtlMs()).toBe(60 * 60 * 1000);
+    expect(DEFAULT_PREAUTH_TTL_MIN).toBe(1440);
+    expect(resolvePreAuthTtlMs()).toBe(1440 * 60 * 1000);
   });
 
   it("honors HEADSCALE_PREAUTH_TTL_MIN so the box override survives a redeploy", () => {
@@ -30,10 +37,10 @@ describe("resolvePreAuthTtlMs (headscale pre-auth key TTL)", () => {
     expect(resolvePreAuthTtlMs()).toBe(90 * 60 * 1000);
   });
 
-  it("falls back to the 60-min default for non-positive / non-numeric values", () => {
+  it("falls back to the 24h default for non-positive / non-numeric values", () => {
     for (const bad of ["0", "-5", "abc", "", "  "]) {
       process.env.HEADSCALE_PREAUTH_TTL_MIN = bad;
-      expect(resolvePreAuthTtlMs()).toBe(60 * 60 * 1000);
+      expect(resolvePreAuthTtlMs()).toBe(DEFAULT_PREAUTH_TTL_MIN * 60 * 1000);
     }
   });
 });

--- a/packages/cloud/shared/src/lib/services/headscale-client.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-client.ts
@@ -41,17 +41,30 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/** Default pre-auth key TTL (minutes) when `HEADSCALE_PREAUTH_TTL_MIN` is unset. */
+export const DEFAULT_PREAUTH_TTL_MIN = 1440;
+
 /**
  * Pre-auth key TTL window (ms): how long a freshly-created key stays valid for a
  * container to boot AND finish VPN enrollment. 10 min proved too tight on slow
  * boots — the key could expire before headscale registration completed, looping
  * the container on re-auth (one prod agent hit 176 restarts before this was
- * raised on the box). Default 60 min (verified healthy in prod); env-overridable
- * via `HEADSCALE_PREAUTH_TTL_MIN` so it survives a daemon redeploy.
+ * raised on the box).
+ *
+ * Default raised 60m -> 1440m (24h) after the prod-2 hard-reset outage: the key
+ * is baked into the container's Docker env at create time and is the ONLY
+ * credential a de-authorized node can present after a reboot. A 60-min key is
+ * expired the moment such a reboot happens (hours/days/months later), so the
+ * container can never rejoin the mesh and crash-loops. A 24h default does not
+ * fix an already-baked expired key on its own (the durable fix is the
+ * reconnect-first + re-key entrypoint), but it widens the window in which a
+ * freshly provisioned agent can survive a delayed first boot or an early
+ * reboot. Env-overridable via `HEADSCALE_PREAUTH_TTL_MIN` so it survives a
+ * daemon redeploy and ops can retune without a code change.
  */
 export function resolvePreAuthTtlMs(): number {
   const minutes = Number.parseInt(process.env.HEADSCALE_PREAUTH_TTL_MIN ?? "", 10);
-  return (Number.isFinite(minutes) && minutes > 0 ? minutes : 60) * 60 * 1000;
+  return (Number.isFinite(minutes) && minutes > 0 ? minutes : DEFAULT_PREAUTH_TTL_MIN) * 60 * 1000;
 }
 
 // ---------------------------------------------------------------------------
@@ -264,7 +277,7 @@ export class HeadscaleClient {
    *
    * @param opts.reusable   Allow the key to be used more than once (default false)
    * @param opts.ephemeral  Node will be removed once it goes offline (default false)
-   * @param opts.expiration ISO-8601 expiration timestamp (default: now + HEADSCALE_PREAUTH_TTL_MIN, 60 min)
+   * @param opts.expiration ISO-8601 expiration timestamp (default: now + HEADSCALE_PREAUTH_TTL_MIN, 24h)
    * @param opts.aclTags    ACL tags to attach to the key (default: ["tag:agent"])
    */
   async createPreAuthKey(opts?: {
@@ -286,7 +299,7 @@ export class HeadscaleClient {
 
     // The key must stay valid long enough for the container to boot AND finish
     // VPN enrollment; 10 min was too tight on slow boots (key expired mid-
-    // registration -> container re-auth loop). Default 60 min, env-overridable
+    // registration -> container re-auth loop). Default 24h, env-overridable
     // via HEADSCALE_PREAUTH_TTL_MIN (see resolvePreAuthTtlMs).
     const expirationTime = expiration ?? new Date(Date.now() + resolvePreAuthTtlMs()).toISOString();
 

--- a/packages/cloud/shared/src/lib/services/headscale-integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-integration.test.ts
@@ -81,7 +81,12 @@ describe("Headscale identity inference", () => {
 });
 
 describe("Headscale container credentials", () => {
-  test("uses a persistent node with a single-use key so Docker restarts can reconnect", async () => {
+  test("uses a persistent node with a REUSABLE key so a de-authorizing reboot can re-register", async () => {
+    // Reusable (was single-use): a hard reset de-authorizes the persisted node
+    // identity, forcing a fresh `tailscale up --authkey`. A single-use key
+    // returns `authkey already used` on that second boot and the container
+    // crash-loops (the prod-2 outage). Reusable + tag:agent + ACL isolation
+    // lets the same agent re-register on the same baked key.
     let request: Record<string, unknown> | null = null;
     const fake = {
       getNodeByNameStrict: async () => null,
@@ -97,7 +102,7 @@ describe("Headscale container credentials", () => {
     });
 
     expect(request).toMatchObject({
-      reusable: false,
+      reusable: true,
       ephemeral: false,
       aclTags: ["tag:agent"],
     });

--- a/packages/cloud/shared/src/lib/services/headscale-integration.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-integration.ts
@@ -78,16 +78,26 @@ export class HeadscaleIntegration {
   /**
    * Prepare VPN credentials for a new agent container.
    *
-   * Returns a single-use, persistent-node pre-auth key and the full set of
+   * Returns a REUSABLE, persistent-node pre-auth key and the full set of
    * environment variables the container needs to join the VPN on boot.
    *
    * The node must not be ephemeral. Docker's `unless-stopped` policy restarts
    * an agent in the same writable layer, so tailscaled reconnects with its
    * persisted node identity. Headscale deletes ephemeral nodes as soon as they
    * disconnect; the restarted container then sees `node no longer exists`,
-   * while its single-use auth key can only return `authkey already used`,
+   * while a single-use auth key can only return `authkey already used`,
    * leaving the agent in a permanent restart loop. Explicit sandbox teardown
    * already calls cleanupContainerVPN(), so persistent nodes are still removed.
+   *
+   * The key is REUSABLE (was single-use) so a reboot that de-authorizes the
+   * persisted node identity can re-`up` with the SAME baked key instead of
+   * hitting `authkey already used` and crash-looping (the prod-2 hard-reset
+   * failure class). Combined with the raised default TTL (24h) and the
+   * reconnect-first entrypoint, this makes the boot path resilient: a node
+   * reconnects on persisted state when it can, and re-authenticates with a
+   * still-valid reusable key when it must. The key stays tag-scoped
+   * (`tag:agent`) and ACL-isolated, so reusability is bounded to same-node
+   * re-registration of the one agent it was minted for.
    */
   async prepareContainerVPN(input: PrepareContainerVPNInput): Promise<{
     preAuthKey: string;
@@ -128,7 +138,11 @@ export class HeadscaleIntegration {
       }
 
       const preAuthKeyObj = await this.client.createPreAuthKey({
-        reusable: false,
+        // Reusable so a reboot that de-authorizes the persisted node identity
+        // can re-register with the same baked key rather than crash-looping on
+        // `authkey already used`. Bounded by tag:agent + ACL isolation to
+        // same-node re-registration of this one agent (see method doc).
+        reusable: true,
         ephemeral: false,
         aclTags: ["tag:agent"],
         user: inferHeadscaleUser(input),


### PR DESCRIPTION
## Problem

A hard reset on a prod node de-authorizes persisted `tailscaled.state` node identities (`machineAuthorized=false`), forcing agent containers to fall back to `tailscale up --authkey`. That baked key is **single-use with a 60-min TTL**, so on any reboot hours/days/months after provisioning it is long expired — the container can never rejoin the mesh, its healthcheck never satisfies, and the `unless-stopped` policy crash-loops it forever (each loop a full Eliza boot → CPU churn that threatens co-located live agents).

This is a **fleet-wide time bomb**: every agent container carries the same expired single-use key. One prod node hit it after a hard reset; the rest survive only because they have multi-day uptime and have reconnected on persisted state (which never touches the key).

## Fix (durable, in layers)

**1. Entrypoint — the real fix** (`packages/app-core/scripts/docker-entrypoint.sh` + `deploy/cloud-agent-docker-entrypoint.sh`, kept behaviorally identical):
- **Reconnect-first:** when a persisted `tailscaled.state` exists, run `up` **without** presenting the baked key. Ordinary reboots reconnect on the persisted node identity and never depend on the (possibly expired) key.
- **Auth-key fallback** only when there is no usable state or the reconnect fails (the hard-reset case).
- **Distinct auth-expired signal:** if the key is expired/consumed and nothing reconnects, exit **`78` (EX_CONFIG)** and drop an `authkey-expired` marker in `TS_STATE_DIR`, so the control plane can classify the container `auth_expired` and re-key/recreate instead of restart-looping on a dead key.
- **Opt-in re-key hook** (`HEADSCALE_REKEY_URL` / `HEADSCALE_REKEY_TOKEN`): fetch a fresh key and retry once before giving up — self-healing without operator action.
- Transient (non-auth) `up` failures **preserve their rc** (retryable), unchanged.

**2. Provisioner keys** (`headscale-integration.ts` / `headscale-client.ts`):
- Agent keys `reusable: true` (was `false`) so a de-authorizing reboot can re-register with the same baked key rather than hitting `authkey already used`. Bounded by `tag:agent` + ACL isolation to same-node re-registration of that one agent.
- Default pre-auth TTL **60m → 1440m (24h)**, still env-overridable via `HEADSCALE_PREAUTH_TTL_MIN`, so a freshly provisioned key survives a delayed/early reboot.

**3. Control-plane angle** (`headscale-auth-status.ts` + `docker-sandbox-provider.ts`):
- Shared, pure classifier (`classifyMeshAuthStatus`) recognizing the auth-expired state from exit code / marker file / log phrasing, with the exit-code + marker constants as a single source of truth shared with the entrypoint.
- Wired into the existing health-timeout diagnostics so an auth-expired crash-loop is surfaced as a distinct, greppable `auth_expired` line — observability-only, never masking unrelated failures (only *promotes* on positive evidence).

Tunnel auth keys (`api/.../tailscale/auth-key`) intentionally stay single-use — this changes only agent container keys.

> **Maintainer sign-off requested:** the switch to `reusable: true` pre-auth keys with a 24h TTL is a deliberate, documented security-posture tradeoff (a leaked baked key is replayable within its TTL, bounded by `tag:agent` ACL isolation and the 1440m expiry) — flagging it explicitly for maintainer approval rather than burying it in the diff.

## Tests
- **Entrypoint** (`docker-entrypoint.test.ts`): reconnect-first re-ups without the baked key; auth-expired exits `78` + drops marker; re-key hook fetches a fresh key and retries; **unchanged** auth-key, no-auth, and transient-failure paths (bidirectional).
- **Classifier** (`headscale-auth-status.test.ts`): positive (exit code / marker / log phrasings, case-insensitive) + negative (healthy / OOM / benign "key" mention → `unknown`) matrix; pins the shared constants.
- Updated TTL (24h) + `reusable: true` assertions in the existing headscale tests.

## Ops (applied separately, not by this PR)
Headscale-side settings and pre-reboot re-keying of existing prod-3..6 containers are documented in the internal runbook; this PR is the code half. The env lever `HEADSCALE_PREAUTH_TTL_MIN=1440` and the reusable-key change take effect for newly provisioned agents on redeploy; the reconnect-first + distinct-exit entrypoint makes the boot path durable for all future reboots.

