### PR TITLE
fix(test): reject malformed TEST_SHARD specifications

### DIFF
--- a/packages/scripts/__tests__/test-task-pool.test.ts
+++ b/packages/scripts/__tests__/test-task-pool.test.ts
@@ -181,6 +181,7 @@ describe("parseShardSpec", () => {
     expect(parseShardSpec("2/4")).toEqual({ index: 2, total: 4 });
     expect(parseShardSpec("1/1")).toEqual({ index: 1, total: 1 });
     expect(parseShardSpec("4/4")).toEqual({ index: 4, total: 4 });
+    expect(parseShardSpec("02/04")).toEqual({ index: 2, total: 4 });
   });
 
   test("returns null for absent specs", () => {
@@ -197,9 +198,22 @@ describe("parseShardSpec", () => {
       "5/4", // index > total
       "2/0", // total <= 0
       "-1/4", // negative index
+      "+1/4", // signed index
+      "1/-4", // negative total
+      "1/+4", // signed total
       "1/2/3", // too many parts
       "/4", // empty index
       "2/", // empty total
+      "1junk/2", // partial index
+      "1/2junk", // partial total
+      "1.5/2", // decimal index
+      "1/2.5", // decimal total
+      "1e0/2", // exponent index
+      "1/2e0", // exponent total
+      " 1/2", // leading whitespace
+      "1/2 ", // trailing whitespace
+      "9007199254740992/9007199254740992", // unsafe index and total
+      "1/9007199254740992", // unsafe total
     ]) {
       expect(parseShardSpec(bad)).toBeNull();
     }
@@ -335,6 +349,32 @@ describe("run-all-tests plan mode", () => {
       },
     ]);
     expect(plan.cloudStep).toBeNull();
+  });
+
+  test("warns and preserves the unsharded plan for a partially numeric TEST_SHARD", () => {
+    const result = runPlan(
+      [
+        "--plan=json",
+        "--only=test",
+        "--no-cloud",
+        "--filter=^@elizaos/core \\(packages/core\\)#test$",
+      ],
+      { TEST_SHARD: "1junk/2" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain(
+      'WARN invalid TEST_SHARD "1junk/2" — expected N/M (1-indexed). Ignoring.',
+    );
+    const plan = JSON.parse(result.stdout);
+    expect(plan.summary).toMatchObject({ shard: null, taskCount: 1 });
+    expect(plan.tasks).toEqual([
+      expect.objectContaining({
+        packageName: "@elizaos/core",
+        relativeDir: "packages/core",
+        scriptName: "test",
+      }),
+    ]);
   });
 
   test("routes homepage e2e to its dedicated deployment lane instead of root PR smoke", () => {

--- a/packages/scripts/lib/test-task-pool.mjs
+++ b/packages/scripts/lib/test-task-pool.mjs
@@ -158,14 +158,18 @@ export function parseShardSpec(spec) {
     return null;
   }
   const parts = String(spec).split("/");
-  if (parts.length !== 2) {
+  if (
+    parts.length !== 2 ||
+    !/^\d+$/.test(parts[0]) ||
+    !/^\d+$/.test(parts[1])
+  ) {
     return null;
   }
-  const index = Number.parseInt(parts[0], 10);
-  const total = Number.parseInt(parts[1], 10);
+  const index = Number(parts[0]);
+  const total = Number(parts[1]);
   if (
-    !Number.isInteger(index) ||
-    !Number.isInteger(total) ||
+    !Number.isSafeInteger(index) ||
+    !Number.isSafeInteger(total) ||
     total <= 0 ||
     index < 1 ||
     index > total


### PR DESCRIPTION
# Relates to

Closes #18572

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop\n\n- [x] Rebased onto origin/develop@131a765c3cfac15495f76eaa5f9b3c3b0e80ae63; zero conflicts and zero commits behind.\n- [x] Post-rebase verification at exact head 7ea251fbb7c922ef592e718583caa43d99500900: 27 focused tests passed with 1905 assertions; Biome and git diff --check passed.\n\n# Risks

Low. Canonical CI matrix values such as `1/4` are unchanged. Only malformed manual or environment values now follow the existing warning-and-ignore path. Complete unsigned decimal spellings with leading zeros remain accepted.

# Background

## What does this PR do?

It makes `parseShardSpec` validate both sides of `TEST_SHARD=N/M` as complete unsigned decimal strings and safe integers before accepting them. It also adds adversarial parser coverage and a real `--plan=json` regression proving malformed input cannot silently omit selected test tasks.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No documentation change is needed. The documented `N/M` contract already describes the behavior enforced by this fix.

# Testing

## Where should a reviewer start?

Start with `parseShardSpec` in `packages/scripts/lib/test-task-pool.mjs`, then review the malformed-input table and real planner regression in `packages/scripts/__tests__/test-task-pool.test.ts`.

## Detailed testing steps

1. Run `bun test packages/scripts/__tests__/test-task-pool.test.ts`.
2. Run the planner with `TEST_SHARD=1junk/2`, `--plan=json`, and the core-only filter.
3. Confirm stderr warns that the shard is invalid, the JSON summary reports `shard: null`, and the `@elizaos/core` task remains selected.
4. Run `bun run verify`.

Verified with the repository-pinned Node 24.15.0, Bun 1.3.14, and Biome 2.5.6:

- `bun install --frozen-lockfile`: success, 6,396 packages.
- Focused test: 27 passed, 0 failed, 1,905 assertions.
- Focused Biome check: 2 files checked, no fixes.
- `git diff --check origin/develop...HEAD`: pass.
- `bun run verify`: pass, 350/350 Turbo tasks; 7,906 test files scanned with zero focused or orphaned skips.

Deterministic before/after proof at the real planner boundary:

```text
BEFORE (origin/develop, TEST_SHARD=1junk/2)
stderr: <no invalid-shard warning>
summary.shard: {"index":1,"total":2}
summary.taskCount: 0
summary.tasks: []

AFTER (527f92632a6eff9432f3d2b133d06734bd44fe22, TEST_SHARD=1junk/2)
stderr: [eliza-test] WARN invalid TEST_SHARD "1junk/2" — expected N/M (1-indexed). Ignoring.
summary.shard: null
summary.taskCount: 1
summary.tasks: ["@elizaos/core"]
```

# Evidence Gate

<!-- evidence-head:7ea251fbb7c922ef592e718583caa43d99500900 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - repository test-planner automation has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - repository test-planner automation has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the affected path is deterministic CLI automation, not a user flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - the planner invokes no backend or live service; the exact real-process transcript is included in Testing.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or network path is involved.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - shard parsing generates no external domain artifact; the deterministic planner JSON transcript is included in Testing.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - the planner is local deterministic repository automation and calls no backend or frontend. The exact child-process transcript is included in **Testing**.

## Screenshots (before / after) + video walkthrough

N/A - this two-file JavaScript/test change has no rendered UI surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changed.

## Known gaps / failures

None. UI, backend, frontend, live-LLM, OCR, and audio artifacts are inapplicable because this change is confined to deterministic test-shard parsing and planner selection.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 113261553 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [symbiex-sol-mission]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTEWXFJP545YF7PCC80GFYR","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T07:44:56.307Z","completed_at":"2026-08-12T08:30:00.632Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":2882440,"output_tokens":238953,"cache_creation_tokens":0,"cache_read_tokens":110140160,"total_tokens":113261553,"cost_micro_usd":"75218578","session_count":9},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"e1EaeZIeTAX9aDBBZOu2F0L1QYj4rnp1WzM4v6me-qgxCbv2FcwRP13K7WB4arpYX02ObcD0DPRx0twziupKAw"}} -->
