### PR TITLE
fix(skills): bound contributor live-report GitHub reads

### DIFF
--- a/packages/skills/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/packages/skills/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -87,6 +87,7 @@ const CLOCK_SKEW_MS = 5 * 60 * 1000;
 const FULL_COMMIT_RE = /^[a-f0-9]{40}$/i;
 const GH_READ_MAX_ATTEMPTS = 3;
 const GH_READ_RETRY_BASE_DELAY_MS = 250;
+const GH_READ_TIMEOUT_MS = 15_000;
 // Rate limits are intentionally excluded: HTTP 403/429 require honoring the
 // server's retry window, while this short transport backoff would amplify them.
 const RETRYABLE_GH_READ_FAILURE_RE =
@@ -326,6 +327,12 @@ function waitSynchronously(durationMs) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, durationMs);
 }
 
+function isTimeoutError(error) {
+  return (
+    error instanceof Error && "code" in error && error.code === "ETIMEDOUT"
+  );
+}
+
 export function readGhPages(
   endpoint,
   spawn = spawnSync,
@@ -350,9 +357,21 @@ export function readGhPages(
   while (true) {
     const result = spawn("gh", args, {
       encoding: "utf8",
+      // A synchronous child that handles SIGTERM can keep the caller blocked
+      // after its timeout. SIGKILL makes the per-read limit a hard boundary.
+      killSignal: "SIGKILL",
       maxBuffer: 64 * 1024 * 1024,
+      timeout: GH_READ_TIMEOUT_MS,
       windowsHide: true,
     });
+    if (isTimeoutError(result.error)) {
+      // A timed-out paginated read may contain only a prefix of the inventory.
+      // Fail immediately instead of multiplying the full timeout budget.
+      throw new Error(
+        `gh api timed out for ${endpoint} on attempt ${attempt} after ${GH_READ_TIMEOUT_MS}ms; timeout failures are not retried and partial output was discarded`,
+        { cause: result.error },
+      );
+    }
     if (result.error) {
       throw new Error(`gh api could not start for ${endpoint}`, {
         cause: result.error,

--- a/packages/skills/test/contribute-to-eliza.test.ts
+++ b/packages/skills/test/contribute-to-eliza.test.ts
@@ -334,10 +334,7 @@ describe("live report parsing", () => {
         '{"number":1,"body":"first\\nrecord"}\n{"number":2}\n',
         "repos/elizaOS/eliza/issues",
       ),
-      [
-        { number: 1, body: "first\nrecord" },
-        { number: 2 },
-      ],
+      [{ number: 1, body: "first\nrecord" }, { number: 2 }],
     );
     assert.deepStrictEqual(parsePaginatedJson("\n\r\n"), []);
   });
@@ -732,9 +729,54 @@ describe("live report behavior", () => {
       ".[]",
       "repos/elizaOS/eliza/issues?state=open&per_page=100",
     ]);
+    assert.deepStrictEqual(invocation?.options, {
+      encoding: "utf8",
+      killSignal: "SIGKILL",
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: 15_000,
+      windowsHide: true,
+    });
     assert.ok(
       !invocation?.args.some((argument) => /POST|PATCH|DELETE/.test(argument)),
     );
+  });
+
+  it("fails timed-out reads once with endpoint and attempt context", () => {
+    const endpoint = "repos/elizaOS/eliza/issues/1/comments?per_page=100";
+    const timeoutError = Object.assign(new Error("spawnSync gh ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+    let invocations = 0;
+    const delays: number[] = [];
+
+    assert.throws(
+      () =>
+        readGhPages(
+          endpoint,
+          (_command, _args, options) => {
+            invocations += 1;
+            assert.strictEqual(options.timeout, 15_000);
+            assert.strictEqual(options.killSignal, "SIGKILL");
+            return {
+              error: timeoutError,
+              signal: "SIGKILL",
+              status: null,
+              stderr: "",
+              stdout: '{"number":999,"partial":true}\n',
+            };
+          },
+          (durationMs) => delays.push(durationMs),
+        ),
+      (error: unknown) =>
+        error instanceof Error &&
+        error.message.includes(`timed out for ${endpoint}`) &&
+        error.message.includes("on attempt 1") &&
+        error.message.includes("after 15000ms") &&
+        error.message.includes("partial output was discarded") &&
+        error.cause === timeoutError,
+    );
+    assert.strictEqual(invocations, 1);
+    assert.deepStrictEqual(delays, []);
   });
 
   it("fails command and spawn errors with endpoint context", () => {


### PR DESCRIPTION
# Relates to

Fixes #18580.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code from the
      deterministic timeout proof below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop\n\n- [x] Rebased onto origin/develop@131a765c3cfac15495f76eaa5f9b3c3b0e80ae63; zero conflicts and zero commits behind.\n- [x] Post-rebase verification at exact head b0f08e09a5ad311ab4411b75c001a9f622e4528b: 24 contribute-to-eliza tests passed; Biome and git diff --check passed.\n\n# Risks

Low. The change affects only the contribution skill's read-only GitHub CLI
pagination helper. A timed-out call now stops after 15 seconds instead of
blocking indefinitely. Existing non-timeout retry behavior and GET-only
pagination arguments are unchanged.

# Background

## What does this PR do?

- Gives every `gh api` subprocess a 15-second timeout with `SIGKILL`.
- Fails immediately on `ETIMEDOUT`, before parsing any partial output.
- Reports endpoint, attempt, and timeout duration without echoing partial data.
- Adds regression coverage for exact `gh` arguments/options and timeout
  behavior.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This is an internal reliability guard with regression coverage and no
public interface change.

# Testing

## Where should a reviewer start?

- `packages/skills/skills/contribute-to-eliza/scripts/live-report.mjs`
- `packages/skills/test/contribute-to-eliza.test.ts`

## Detailed testing steps

```bash
bunx bun@1.3.14 install --frozen-lockfile
bunx bun@1.3.14 run build:core
bunx bun@1.3.14 run --cwd packages/skills typecheck
bunx bun@1.3.14 test packages/skills/test/contribute-to-eliza.test.ts
bunx bun@1.3.14 x @biomejs/biome check \
  packages/skills/skills/contribute-to-eliza/scripts/live-report.mjs \
  packages/skills/test/contribute-to-eliza.test.ts
bunx bun@1.3.14 run verify
```

Results:

- Focused tests: 24 passed, 0 failed.
- Skills package typecheck: passed.
- Pinned Biome check: passed.
- Core build: 56/56 tasks passed.
- Root verify: 350/350 Turbo tasks plus repository audits passed.
- `git diff --check`: passed.

# Evidence Gate

Evidence matches the exact reviewed commit.
<!-- evidence-head:b0f08e09a5ad311ab4411b75c001a9f622e4528b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-UI contributor CLI reliability change
<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-UI contributor CLI reliability change
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered or interactive UI flow changed
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend service changed; direct end-to-end CLI output is included in the PR body
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or network flow changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, scheduled-task, wallet, generated-media, or other domain state changed
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

The final synced commit was exercised with a fake `gh` executable that writes
partial JSON, traps `SIGTERM`, and stays alive. Node 24.15.0 ran the real
`live-report.mjs` CLI against that fixture:

```text
contribute-to-eliza report failed: gh api timed out for repos/elizaOS/eliza/issues?state=open&per_page=100&sort=created&direction=asc on attempt 1 after 15000ms; timeout failures are not retried and partial output was discarded
real 15.03
user 0.04
sys 0.01
```

The command exited 1, emitted no partial JSON, and left no fixture or
`live-report.mjs` process behind.

## Screenshots (before / after) + video walkthrough

N/A - this diff has no UI surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio code changed.

## Known gaps / failures

- No Windows host was available for a direct runtime probe. Node 24.15.0's
  cross-platform timeout tests and libuv Windows `TerminateProcess` path cover
  the same `spawnSync` contract; the macOS adversarial proof used the exact
  final commit.
- GitHub Project `Status` / `Claimed-by` fields could not be inspected or
  updated because the current CLI token lacks `read:project`. Issue #18580 was
  raised and claimed by this contributor, has no assignee or competing claim,
  and a final scan found no changed-file overlap across all 29 open PRs.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [sol-xhigh-unclaimed-issue]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTHF7HG8BK3WHJ6ZTK01BD2","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T08:29:53.584Z","completed_at":"2026-08-12T09:10:54.836Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"Xz_36yYxokTxBi62ZSUsPSkHZo81yRPjGGtktjKdnZRZ6Xr_8ynnlXDLs2HPTSxNVaPo6y70H9eK1zo-UO7QCg"}} -->

