### PR TITLE
fix(shared): resolve terminal palette from source

### DIFF
--- a/packages/app/test/vite-source-resolution.test.ts
+++ b/packages/app/test/vite-source-resolution.test.ts
@@ -2,7 +2,12 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { type ConfigEnv, createServer, defaultClientConditions } from "vite";
+import {
+  type ConfigEnv,
+  createServer,
+  defaultClientConditions,
+  normalizePath,
+} from "vite";
 import { describe, expect, test } from "vitest";
 import appViteConfig from "../vite.config";
 
@@ -53,7 +58,9 @@ describe("workspace package resolution", () => {
           path.resolve(appRoot, "../ui/src/terminal/palette.ts"),
         );
       expect(resolved?.id).toBe(
-        path.resolve(appRoot, "../shared/src/terminal/palette.ts"),
+        normalizePath(
+          path.resolve(appRoot, "../shared/src/terminal/palette.ts"),
+        ),
       );
     } finally {
       await server.close();

--- a/packages/app/test/vite-source-resolution.test.ts
+++ b/packages/app/test/vite-source-resolution.test.ts
@@ -35,6 +35,31 @@ describe("workspace package resolution", () => {
     expect(buildConfig.resolve?.conditions).toBeUndefined();
   });
 
+  test("resolves the shared terminal palette from workspace source while serving", async () => {
+    const serveConfig = await resolveAppViteConfig("serve");
+    const server = await createServer({
+      configFile: false,
+      root: appRoot,
+      logLevel: "silent",
+      optimizeDeps: { noDiscovery: true },
+      resolve: { conditions: serveConfig.resolve?.conditions },
+      server: { middlewareMode: true },
+    });
+
+    try {
+      const resolved =
+        await server.environments.client.pluginContainer.resolveId(
+          "@elizaos/shared/terminal/palette",
+          path.resolve(appRoot, "../ui/src/terminal/palette.ts"),
+        );
+      expect(resolved?.id).toBe(
+        path.resolve(appRoot, "../shared/src/terminal/palette.ts"),
+      );
+    } finally {
+      await server.close();
+    }
+  });
+
   test("keeps browser conditional exports on their browser entry", async () => {
     const serveConfig = await resolveAppViteConfig("serve");
     const server = await createServer({

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -428,6 +428,16 @@
       "import": "./dist/audio-redaction-verify.js",
       "default": "./dist/audio-redaction-verify.js"
     },
+    "./terminal/palette": {
+      "types": "./dist/terminal/palette.d.ts",
+      "eliza-source": {
+        "types": "./src/terminal/palette.ts",
+        "import": "./src/terminal/palette.ts",
+        "default": "./src/terminal/palette.ts"
+      },
+      "import": "./dist/terminal/palette.js",
+      "default": "./dist/terminal/palette.js"
+    },
     "./*.css": "./dist/*.css",
     "./*": {
       "types": "./dist/*.d.ts",


### PR DESCRIPTION
# Relates to

Relates to #18134.

- [x] This PR targets `develop` and is rebased onto exact `origin/develop@e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88` with zero conflicts.
- [x] `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the changed resolver contract from the automated regression and cold startup evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branch is one commit above exact `origin/develop@e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88`; zero conflicts.
- [x] `bun run verify` passed post-sync with exit code 0.

# Risks

Low. This adds one explicit package export and one integration regression. The existing wildcard export is unchanged, normal imports still target built `dist`, and only development with the `eliza-source` condition selects TypeScript source.

# Background

## What does this PR do?

- Adds an explicit `@elizaos/shared/terminal/palette` export with an `eliza-source` branch.
- Keeps the normal type/import/default targets on `dist/terminal/palette`.
- Adds a real Vite client resolver test using the production development conditions and the actual UI importer.
- Completes the cold-source path that remained broken after `bcb1899e8a747b9391a77a3bac9054c444f2e4b5`.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is needed. The public subpath already exists through the wildcard export; this patch makes its development source condition match the repository's documented source-resolution contract.

# Testing

## Where should a reviewer start?

1. `packages/app/test/vite-source-resolution.test.ts`
2. `packages/shared/package.json`
3. The cold-start metrics below.

## Detailed testing steps

### TDD resolver proof

Before the manifest change, the new real resolver test failed as intended:

~~~text
FAIL test/vite-source-resolution.test.ts
expected undefined to be
/Users/mac/Desktop/elizamoney/packages/shared/src/terminal/palette.ts
Tests: 1 failed | 2 passed
~~~

After the explicit export:

~~~text
Test Files  1 passed (1)
Tests       3 passed (3)
~~~

Direct source-condition import with `packages/shared/dist/terminal/palette.js` absent:

~~~text
node v24.15.0
bun 1.3.14
source_condition_import=#FF5A2D
~~~

Built package contract:

~~~text
bun run --cwd packages/shared build
built_import=#FF5A2D
npm pack --dry-run: terminal/palette.{js,d.ts} included
~~~

### Focused/package checks

- `bunx @biomejs/biome check packages/shared/package.json packages/app/test/vite-source-resolution.test.ts` - passed.
- `bun run --cwd packages/shared lint:check` - 379 files, no fixes.
- `bun run --cwd packages/shared typecheck` - passed after the required cloud-routing declaration dependency was built.
- `NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/app --concurrency=8 --cache=local:rw --output-logs=errors-only` - passed.
- `bun run --cwd packages/app test` - 653 passed, 1 skipped, 0 failed.
- `bun run verify` - passed, exit 0.

### Real frozen cold-start acceptance

After a frozen light install with no package/lock changes, all of these were absent:

~~~text
packages/cloud/routing/dist/index.js
packages/core/dist/index.js
packages/shared/dist/terminal/palette.js
packages/ui/dist/index.js
packages/app-core/dist/index.js
packages/app/dist/index.html
~~~

The real `bun run test:dev-startup` passed:

~~~json
{"status":"pass","budgetMs":60000,"ports":{"api":56124,"ui":56125},"milestonesMs":{"processSpawn":3,"apiListen":3790,"healthReady":32513,"uiServed":5252,"total":32514},"segmentsMs":{"processSpawnToApiListen":3787,"apiListenToHealthReady":28723,"processSpawnToUiServed":5249}}
~~~

The base revision previously emitted:

~~~text
Pre-transform error: Failed to resolve import "@elizaos/shared/terminal/palette"
from "../ui/src/terminal/palette.ts"
~~~

The fixed cold run contains no `Pre-transform error`, `Failed to resolve import`, or `ERR_MODULE_NOT_FOUND`, and finishes with:

~~~text
[dev-startup-smoke] PASS: dev stack ready in 32.5s (budget 60s)
~~~

# Evidence Gate

<!-- evidence-head:f23b8eae050eb9e22a8c19167761f64116bc245a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - package export and non-rendered startup behavior; no pixels change
<!-- evidence-row:after-screenshots -->
- [ ] N/A - package export and non-rendered startup behavior; no pixels change
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - automated non-rendered resolver and startup path has no user interaction
<!-- evidence-row:backend-logs -->
- [x] Backend cold-start logs:
  <details><summary>backend log output</summary>

  ```text
  [dev-startup-smoke] budget=60000ms api=56124 ui=56125
  [dev-startup-smoke] API listen: 3790ms
  [dev-startup-smoke] /api/health.ready: 32513ms
  [dev-startup-smoke:metrics] {"status":"pass","budgetMs":60000,"ports":{"api":56124,"ui":56125},"milestonesMs":{"processSpawn":3,"apiListen":3790,"healthReady":32513,"uiServed":5252,"total":32514},"segmentsMs":{"processSpawnToApiListen":3787,"apiListenToHealthReady":28723,"processSpawnToUiServed":5249}}
  [dev-startup-smoke] PASS: dev stack ready in 32.5s (budget 60s)
  [eliza] Draining 2 child processes (up to 15000 ms)…
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend Vite cold-source logs:
  <details><summary>frontend log output</summary>

  ```text
  [dev-startup-smoke] budget=60000ms api=56124 ui=56125
  [dev-startup-smoke] process spawned: 3ms
  [eliza][vite] @elizaos/core has no built dist/; falling back to the browser SOURCE entry (src/index.browser.ts).
  [dev-startup-smoke] UI served: 5252ms
  [dev-startup-smoke] PASS: dev stack ready in 32.5s (budget 60s)
  Pre-transform error=0; Failed to resolve import=0; ERR_MODULE_NOT_FOUND=0
  ```

  </details>
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, wallet, scheduled-task, generated-domain, audio, or device state changes
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changes

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

The same captured real cold-start log contains the Vite source-graph output, API readiness, UI serving milestone, terminal metrics JSON, and clean child-process drain. It will be attached to the evidence rows immediately after PR creation.

## Screenshots (before / after) + video walkthrough

N/A - this two-file diff changes a package export map and resolver regression only; it changes no rendered source, CSS, SVG, layout, interaction, or pixels.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changes.

## Known gaps / failures

`bun run --cwd packages/shared test` is not green on exact `origin/develop`: 121/122 Vitest files and 1,377 tests pass, while newly merged `packages/shared/src/utils/trajectory-format.test.ts` imports `bun:test`, which Vitest cannot resolve. The file is byte-identical to `origin/develop` and outside this diff. Running that file under Bun produces 14 passes and one unrelated locale wording mismatch (`"Aug 9 at 08:49 AM"` versus a regex that omits `at`). The repository-required `bun run verify` passes. No part of this PR touches trajectory formatting or its test.

No deploy, production change, secret, wallet, database, or staging infrastructure is involved.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 34929744 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [rndrntwrk-codex-implement-18134-terminal-palette]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTJ6486SA7CDESWSF4ET3TR","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T08:42:23.878Z","completed_at":"2026-08-12T09:10:57.260Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":1757727,"output_tokens":124721,"cache_creation_tokens":0,"cache_read_tokens":33047296,"total_tokens":34929744,"cost_micro_usd":"24422289","session_count":5},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAca_bmgW70vt_4YdSWBk9O4OcExXrUczaWSsxNRnwtrw","device_key_id":"fb0b00036edfe4c6ff8630ecd4b1182ddf807c431da450ca4064fa05dec7ebe1","device_signature":"V--I7faE1Hn0XReIrGfk70hQVUq9lqhduw7cmeutc1bmZS0IkLCIAsVJMpX-DsucE0LiIZ1FmQaNJYzO8fLmAQ"}} -->