### PR TITLE
fix(lifeops): apply brief engagement history

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/brief.ts
+++ b/plugins/plugin-personal-assistant/src/actions/brief.ts
@@ -33,11 +33,15 @@ import {
 } from "@elizaos/core";
 import { FinancesService } from "@elizaos/plugin-finances/finances-service";
 import { hasLifeOpsAccess } from "../lifeops/access.js";
-import { buildBriefEditorialContract } from "../lifeops/briefing/editorial-judgment.js";
+import {
+  buildBriefEditorialContract,
+  type LifeOpsBriefItemEngagementSummary,
+} from "../lifeops/briefing/editorial-judgment.js";
 import {
   BRIEF_NARRATIVE_INSTRUCTIONS,
   MEETING_PREP_INSTRUCTIONS,
 } from "../lifeops/optimized-prompt-instructions.js";
+import { LifeOpsRepository } from "../lifeops/repository.js";
 import type {
   LifeOpsBriefing,
   LifeOpsBriefingCalendarItem,
@@ -370,6 +374,24 @@ async function loadMoneyFromPayments(args: {
   }
 }
 
+async function loadEngagementSummariesFromLifeOps(args: {
+  runtime: IAgentRuntime;
+}): Promise<readonly LifeOpsBriefItemEngagementSummary[]> {
+  try {
+    return await new LifeOpsRepository(
+      args.runtime,
+    ).summarizeBriefItemEngagements(args.runtime.agentId);
+  } catch (error) {
+    // error-policy:J4 engagement history improves editorial ranking but is not
+    // required to render a brief. Keep the degradation observable instead of
+    // presenting the missing history as a successful database read.
+    args.runtime.reportError("Brief.loadEngagementSummaries", error, {
+      surface: "brief-editorial-engagement",
+    });
+    return [];
+  }
+}
+
 /**
  * Composer hooks — overridable for tests. Defaults compose from LifeOps'
  * structural services: calendar feed, MESSAGE triage, overview reminders, and
@@ -396,6 +418,10 @@ export interface BriefComposers {
   loadCompletedToday: (args: {
     runtime: IAgentRuntime;
   }) => Promise<readonly LifeOpsBriefingLifeItem[]>;
+  /** Persisted owner response signals that influence editorial ranking. */
+  loadEngagementSummaries: (args: {
+    runtime: IAgentRuntime;
+  }) => Promise<readonly LifeOpsBriefItemEngagementSummary[]>;
 }
 
 const defaultComposers: BriefComposers = {
@@ -404,6 +430,7 @@ const defaultComposers: BriefComposers = {
   loadLife: loadLifeFromOverview,
   loadMoney: loadMoneyFromPayments,
   loadCompletedToday: loadCompletedTodayFromService,
+  loadEngagementSummaries: loadEngagementSummariesFromLifeOps,
 };
 
 let activeComposers: BriefComposers = defaultComposers;
@@ -610,7 +637,13 @@ async function assembleBriefing(args: {
   optimizationTask: BriefOptimizationTask;
 }): Promise<LifeOpsBriefing> {
   const composers = activeComposers;
-  const [calendarItems, inboxItems, lifeItems, moneyItems] = await Promise.all([
+  const [
+    calendarItems,
+    inboxItems,
+    lifeItems,
+    moneyItems,
+    engagementSummaries,
+  ] = await Promise.all([
     args.include.calendar
       ? composers.loadCalendar({ runtime: args.runtime, period: args.period })
       : Promise.resolve([] as readonly LifeOpsBriefingCalendarItem[]),
@@ -623,6 +656,7 @@ async function assembleBriefing(args: {
     args.include.money
       ? composers.loadMoney({ runtime: args.runtime, period: args.period })
       : Promise.resolve([] as readonly LifeOpsBriefingMoneyItem[]),
+    composers.loadEngagementSummaries({ runtime: args.runtime }),
   ]);
 
   const kind = SUBACTION_TO_KIND[args.subaction];
@@ -642,7 +676,10 @@ async function assembleBriefing(args: {
     ...(args.include.money ? { money: moneyItems } : {}),
   };
 
-  const editorial = buildBriefEditorialContract({ sections });
+  const editorial = buildBriefEditorialContract({
+    sections,
+    engagementSummaries,
+  });
   let narrative: string | undefined;
   if (args.format === "narrative") {
     narrative = await composeNarrative({

--- a/plugins/plugin-personal-assistant/test/brief-action.test.ts
+++ b/plugins/plugin-personal-assistant/test/brief-action.test.ts
@@ -24,7 +24,8 @@ const mocks = vi.hoisted(() => ({
   hasOwnerAccess: vi.fn(async () => true),
 }));
 
-vi.mock("@elizaos/agent", () => ({
+vi.mock("@elizaos/agent", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@elizaos/agent")>()),
   hasOwnerAccess: mocks.hasOwnerAccess,
 }));
 
@@ -33,6 +34,8 @@ import {
   briefAction,
   setBriefComposers,
 } from "../src/actions/brief.js";
+import { LifeOpsRepository } from "../src/lifeops/repository.js";
+import { createLifeOpsTestRuntime } from "./helpers/runtime.ts";
 
 function makeRuntime(
   options: {
@@ -87,6 +90,7 @@ async function callBrief(
 describe("BRIEF umbrella action — Daily Operations", () => {
   beforeEach(() => {
     __resetBriefComposersForTests();
+    setBriefComposers({ loadEngagementSummaries: async () => [] });
     mocks.hasOwnerAccess.mockReset().mockResolvedValue(true);
   });
 
@@ -133,6 +137,108 @@ describe("BRIEF umbrella action — Daily Operations", () => {
   });
 
   describe("compose_morning", () => {
+    it("uses persisted ignored-item history to demote that class in the next brief", async () => {
+      const runtimeResult = await createLifeOpsTestRuntime();
+      try {
+        await LifeOpsRepository.bootstrapSchema(runtimeResult.runtime);
+        const repository = new LifeOpsRepository(runtimeResult.runtime);
+        for (let day = 1; day <= 5; day += 1) {
+          await repository.recordBriefItemEngagement({
+            agentId: runtimeResult.runtime.agentId,
+            briefingId: `brief-${day}`,
+            itemId: "inbox:newsletter-1",
+            source: "inbox",
+            kind: "message",
+            sourceId: "newsletter-1",
+            itemClass: "inbox:newsletter-digest",
+            eventType: "ignored",
+            eventAt: `2026-07-0${day}T12:00:00.000Z`,
+            weight: -1,
+            metadata: { scenario: "ignore-pattern" },
+          });
+        }
+
+        // Restore the production engagement loader while keeping unrelated
+        // source reads deterministic for this action-level database contract.
+        __resetBriefComposersForTests();
+        setBriefComposers({
+          loadCalendar: async () => [],
+          loadInbox: async () => [
+            {
+              id: "newsletter-1",
+              channel: "gmail",
+              senderName: "Weekly Digest",
+              snippet: "Your weekly newsletter roundup",
+              urgency: "low",
+              classification: "unread",
+            },
+          ],
+          loadLife: async () => [],
+          loadMoney: async () => [],
+          loadCompletedToday: async () => [],
+        });
+
+        const result = await callBrief(runtimeResult.runtime, makeMessage(), {
+          subaction: "compose_morning",
+          format: "json",
+        });
+
+        expect(result.success).toBe(true);
+        const data = result.data as {
+          briefing: {
+            editorial: {
+              demotedItemClasses: readonly string[];
+              decisions: readonly {
+                itemId: string;
+                action: string;
+                reason: string;
+              }[];
+            };
+          };
+        };
+        expect(data.briefing.editorial.demotedItemClasses).toEqual([
+          "inbox:newsletter-digest",
+        ]);
+        expect(data.briefing.editorial.decisions).toContainEqual({
+          itemId: "inbox:newsletter-1",
+          action: "demote",
+          reason:
+            "inbox:newsletter-digest has repeated ignore history with no acted-on signal",
+        });
+      } finally {
+        await runtimeResult.cleanup();
+      }
+    });
+
+    it("reports unavailable engagement history without blocking the structured brief", async () => {
+      const reportError = vi.fn();
+      __resetBriefComposersForTests();
+      setBriefComposers({
+        loadCalendar: async () => [],
+        loadInbox: async () => [],
+        loadLife: async () => [],
+        loadMoney: async () => [],
+        loadCompletedToday: async () => [],
+      });
+
+      const result = await callBrief(
+        makeRuntime({ reportError }),
+        makeMessage(),
+        {
+          subaction: "compose_morning",
+          format: "json",
+        },
+      );
+
+      expect(result.success).toBe(true);
+      expect(reportError).toHaveBeenCalledTimes(1);
+      expect(reportError).toHaveBeenCalledWith(
+        "Brief.loadEngagementSummaries",
+        expect.anything(),
+        { surface: "brief-editorial-engagement" },
+      );
+    });
+
     it("feeds the loader payload to the model and returns the trimmed narrative", async () => {
       // Padded model reply: the pipeline must return the TRIMMED narrative,
       // so a straight echo of the stub cannot satisfy the assertion.

--- a/plugins/plugin-personal-assistant/test/lifeops-llm-consumer-robustness.test.ts
+++ b/plugins/plugin-personal-assistant/test/lifeops-llm-consumer-robustness.test.ts
@@ -60,6 +60,7 @@ function runtimeWithModel(
     logger: { warn: vi.fn(), debug: vi.fn(), error: vi.fn(), info: vi.fn() },
     getService: () => null,
     getMemories: vi.fn(async () => []),
+    reportError: vi.fn(),
     useModel: vi.fn(useModel),
   } as unknown as IAgentRuntime;
 }


### PR DESCRIPTION
# Relates to

Refs #14872. This is the bounded persisted-engagement feedback slice; production event capture, the owner-facing recalibrate verb, optimization rewards, and live scenario evidence remain open on the issue.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the changed contract from the PGlite-backed regression evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `e11f20c5ef`; zero conflicts.
- [x] `bun run verify` passed post-sync: 350/350 Turbo tasks plus repository audits.

# Risks

Low. The new database read is auxiliary to brief composition: expected persistence failure is reported through `runtime.reportError` and produces a structured brief without engagement-based demotion. The primary risk is an extra read during BRIEF assembly.

# Background

## What does this PR do?

The engagement ledger and editorial demotion policy already existed, but production BRIEF assembly never connected them. This change loads the current agent's persisted brief-item engagement summary and supplies it to `buildBriefEditorialContract`.

An action-level PGlite regression inserts five ignored events for `inbox:newsletter-digest`, invokes `compose_morning` in JSON mode, and proves the next brief demotes the matching inbox item. A second regression proves unavailable engagement persistence is reported without fabricating failure for the otherwise valid structured brief.

## What kind of change is this?

Bug fix (non-breaking change that connects two existing production contracts).

# Documentation changes needed?

No. This connects existing documented LifeOps repository and editorial behavior without changing a public API or operator workflow.

# Testing

## Where should a reviewer start?

Run the first command below and inspect the test named `uses persisted ignored-item history to demote that class in the next brief`.

## Detailed testing steps

```text
bun run --cwd plugins/plugin-personal-assistant test -- test/brief-action.test.ts --reporter=verbose
  Test Files  1 passed (1)
  Tests       18 passed (18)

bun run --cwd plugins/plugin-personal-assistant test
  Test Files  213 passed (213)
  Tests       1738 passed | 6 skipped

bun run --cwd plugins/plugin-personal-assistant typecheck
  exit 0

bun run --cwd plugins/plugin-personal-assistant lint
  Checked 1632 files; no fixes

bun run --cwd plugins/plugin-personal-assistant build
  exit 0

bun run check:agents-claude
  PASS: 154 mirrored AGENTS.md/CLAUDE.md pairs

bun run verify
  Tasks: 350 successful, 350 total
  repository audits: passed

git diff --check
  exit 0
```

# Evidence Gate

Evidence matches commit `dfc9c10e84ac37f418b2af177738705eeb254bbb`.
<!-- evidence-head:dfc9c10e84ac37f418b2af177738705eeb254bbb -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this domain/action change has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this domain/action change has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no frontend or native interaction flow in this slice.
<!-- evidence-row:backend-logs -->
- [x] N/A - the slice is proven at the action/domain boundary with a real PGlite repository; it does not add a transport or deployed backend route.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, console, or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no live model credentials are present in this shell. This slice changes deterministic editorial-contract assembly and is fully exercised with `format: json`; live seeded scenario evidence remains explicitly open on #14872.
<!-- evidence-row:domain-artifacts -->
- [x] PGlite-backed domain artifact: five persisted `ignored` rows for class `inbox:newsletter-digest` produce `demotedItemClasses: ["inbox:newsletter-digest"]` and a `demote` decision for `inbox:newsletter-1` in the next BRIEF result.

```text
persisted rows: 5 x eventType=ignored, itemClass=inbox:newsletter-digest, weight=-1
next BRIEF artifact: demotedItemClasses=["inbox:newsletter-digest"]
editorial decision: itemId=inbox:newsletter-1 action=demote reason="inbox:newsletter-digest has repeated ignore history with no acted-on signal"
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model credentials are available. The test deliberately uses structured JSON output so the persisted-row-to-editorial-decision contract is observed without substituting a fake model call for live evidence. The broader live-model scenario remains unclaimed by this PR.

## Backend + frontend logs

N/A - no transport/frontend surface changed. The verbose focused run above records the exact action-level PGlite test passing.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Known gaps / failures

- Live-model trajectory: unavailable because the current shell exposes no live model credentials; this PR does not claim that remaining issue acceptance row.
- A separate `bun run build` attempt completed 123/124 workspace build tasks and then correctly stopped at the `@elizaos/electrobun` 4 GiB free-disk safety guard (about 0.8 GiB was available). The owning package build and required root `bun run verify` both pass; no safety override was used.
- An initial direct `bun test ... --reporter=verbose` invocation was invalid because Bun's built-in reporter only accepts `dots` or `junit`; the repository's supported `bun run test -- ... --reporter=verbose` command then passed 18/18 tests.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 48121129 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [megabyte0x-issue]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTHQNWK8ZP3W0Z22BJ6A6Z0","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T08:34:30.419Z","completed_at":"2026-08-12T09:15:53.024Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":2164440,"output_tokens":95185,"cache_creation_tokens":0,"cache_read_tokens":45861504,"total_tokens":48121129,"cost_micro_usd":"30188113","session_count":6},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEApSLIUWEFmTSYKxqSp8nFoU1VGhF9sxn0kfLd8YHWst0","device_key_id":"da4b81cc016ef5b094291cf4ae70b64b688d405deec44331eebd5ac3a0a612b4","device_signature":"BpE7JgZHkCZAF2CHkglmdvwyRTqePAFbt8Apge0YhHoYTXWdnAO3F8TA9_mjG1z_051kUEgr02I7m7k_Gs_rAw"}} -->
