### PR TITLE
fix(shared): reject non-finite uptime values

### DIFF
--- a/packages/shared/src/utils/format.test.ts
+++ b/packages/shared/src/utils/format.test.ts
@@ -21,6 +21,13 @@ describe("formatUptime", () => {
     expect(formatUptime(90000)).toBe("1d 1h");
   });
 
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "falls back for non-finite uptime %s",
+    (seconds) => {
+      expect(formatUptime(seconds)).toBe("—");
+    },
+  );
+
   it("verbose mode lists each non-zero unit", () => {
     expect(formatUptime(3661, true)).toBe("1h 1m");
     expect(formatUptime(30, true)).toBe("30s");

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -9,7 +9,7 @@
  * Otherwise the two most-significant units are returned (e.g. "2d 3h").
  */
 export function formatUptime(seconds?: number, verbose?: boolean): string {
-  if (seconds == null || seconds < 0) return "—";
+  if (seconds == null || !Number.isFinite(seconds) || seconds < 0) return "—";
   const d = Math.floor(seconds / 86400);
   const h = Math.floor((seconds % 86400) / 3600);
   const m = Math.floor((seconds % 3600) / 60);


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

N/A - original, narrowly scoped defect in `packages/shared`; GitHub searches found no existing `formatUptime` issue or active PR addressing this behavior.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

The contribution branch was created from `origin/develop` at
`e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88`. GitHub's branch API confirmed
that SHA was still the latest `elizaOS/eliza:develop` during final verification.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

Low. The change only extends the formatter's existing unavailable-value guard.
Outputs for all finite non-negative values are unchanged. Undefined, negative,
and non-finite values consistently return the existing `—` placeholder.

# Background

## What does this PR do?

Prevents `formatUptime` from generating malformed labels such as `NaNs` and
`Infinityd NaNh` when it receives non-finite numeric values. It adds a finite
number guard and deterministic regression coverage for `NaN`, positive
infinity, and negative infinity.

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

Bug fix (non-breaking change which fixes an issue).

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

## Why are we doing this? Any context or related work?

`formatUptime` accepted any JavaScript `number`, but its existing guard only
handled missing and negative values. Non-finite inputs therefore flowed into
the duration arithmetic and produced user-facing nonsense instead of the
formatter's established unavailable placeholder.

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

My changes do not require a change to the project documentation. This restores
the formatter's existing unavailable-value behavior without changing a
supported interface.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

Start with `packages/shared/src/utils/format.test.ts`, especially the
parameterized non-finite input test, then inspect the one-line guard in
`packages/shared/src/utils/format.ts`.

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

Tests used Node `v24.15.0` and Bun `1.3.14`.

Before changing the production implementation, the new regression test
produced:

```text
formatUptime(NaN): expected "—", received "NaNs"
formatUptime(Infinity): expected "—", received "Infinityd NaNh"

Test Files  1 failed
Tests       2 failed | 11 passed
```

After the production fix:

```text
Focused formatter suite: 1 file passed, 13/13 tests passed
Shared package typecheck: PASS
Shared package build: PASS
Shared dependency build graph: 84/84 tasks successful
Touched-file Biome check: PASS
git diff --check: PASS
```

The broader shared package run produced:

```text
Tests:       1380 passed
Test files:  121 passed | 1 failed to collect
```

The one collection failure and all incomplete root-level checks are documented
in **Known gaps / failures** below. Removing the new `Number.isFinite` guard
restores the two deterministic focused-test failures shown above, demonstrating
that the regression test detects the original faulty implementation.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:8b862a309a0cc8056847944b00787142a98a71db -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - pure formatter utility change with no rendered UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - pure formatter utility change with no rendered UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no interactive user flow is changed`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - deterministic synchronous utility with no backend request or logging path`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend request, network activity, or state transition is changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent, action, provider, prompt, or model behavior is changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifact is produced; deterministic before/after formatter outputs are included above`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface or visual text is changed` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

N/A - no agent, action, provider, prompt, or model behavior is changed.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

N/A - the changed contract is a synchronous formatter with no backend,
frontend, network, state-transition, or structured-logging path. Its real path
is exercised directly by the deterministic regression test.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

N/A - no UI files or rendered surfaces are changed.

### After

N/A - no UI files or rendered surfaces are changed.

### Walkthrough video

N/A - no visual or interactive user flow is changed.

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

N/A - no audio, voice, transcript, TTS, or STT behavior is changed.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

- The shared package test run reached 1,380 passing tests and 121 passing test
  files. One existing test file could not be collected by Vitest because it
  imports `bun:test`.
- Running that existing file directly with Bun produced 14 passing tests and
  one locale-sensitive failure: the test expects an English abbreviated month,
  while the `Asia/Shanghai` Windows host returned a Chinese date such as
  `8月9日 09:08`. This test and formatter are not touched by this PR.
- The full root typecheck stopped in unrelated `@elizaos/cloud-api` code because
  `@elevenlabs/elevenlabs-js` was unavailable after the incomplete dependency
  installation. Turbo reported 47 successful tasks before that failure.
- `bun install` downloaded dependencies but failed when the `ffmpeg-static`
  install step timed out while connecting to GitHub. A subsequent
  `bun install --ignore-scripts` encountered optional/mobile package `ENOENT`
  errors and did not complete.
- `bun run verify` passed its preliminary repository checks, including
  AGENTS/CLAUDE parity, Biome version consistency, Bun version contracts,
  workspace dependency references, plugin test conventions, and alias-read
  auditing. Turbo then failed with `Unable to find package manager binary:
  cannot find binary path` because the workspace installation was incomplete.
- The full root build stopped for the same missing package-manager binary
  condition. It is not reported as passing.
- These environment failures do not affect the focused proof: the changed
  `@elizaos/shared` package independently passed its 13/13 focused tests,
  typecheck, build, touched-file Biome check, `git diff --check`, and the
  84/84-task shared dependency build graph.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [FLAVIEN66-codex]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTF90F8YZ8BKZ5AW6DD5Y01","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T07:51:32.585Z","completed_at":"2026-08-12T09:12:59.608Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAD7jv7oqpBwvubQi-bPTN8A8AyLBLhayFXOlWsigArWU","device_key_id":"1d623e65e246b5803a5f62b4afb00c132103b2ad890c97345f8313797cfffe58","device_signature":"sN_1-s3S8SHLf6JIDjQpVS8B_mgg8XGpqycmLMN0NfIDIqIUGE3VF_5wwnkitnZODt4hx2trYFXowvaf2IBIBQ"}} -->