### PR TITLE
fix(ui): reject invalid Story Gate --limit and --shard

### DIFF
--- a/packages/ui/test/story-gate/run-story-gate.mjs
+++ b/packages/ui/test/story-gate/run-story-gate.mjs
@@ -52,7 +52,66 @@ const rmRecursiveScript = resolve(pkgRoot, "../scripts/rm-path-recursive.mjs");
 // ---------------------------------------------------------------------------
 // args
 // ---------------------------------------------------------------------------
-function parseArgs(argv) {
+
+/**
+ * Require a complete unsigned decimal string that is a positive safe integer.
+ * Rejects partial numeric prefixes (`1junk`), fractions, signs, and values
+ * above Number.MAX_SAFE_INTEGER so filters never run with NaN/negative bounds.
+ *
+ * @param {string | undefined} raw
+ * @param {string} flag
+ * @returns {number}
+ */
+export function requirePositiveSafeInteger(raw, flag) {
+  if (raw === undefined) {
+    throw new Error(
+      `story-gate: ${flag} requires a positive integer (received no value)`,
+    );
+  }
+  if (typeof raw !== "string" || !/^[1-9]\d*$/.test(raw)) {
+    throw new Error(
+      `story-gate: ${flag} must be a positive integer (received ${JSON.stringify(raw)})`,
+    );
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(
+      `story-gate: ${flag} must be a positive safe integer (received ${JSON.stringify(raw)})`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate `--shard N/M` (1-indexed). Both sides must be complete positive
+ * safe integers with `1 <= N <= M`.
+ *
+ * @param {string | undefined} raw
+ * @returns {string} canonical `N/M` form
+ */
+export function requireShardSpec(raw) {
+  if (raw === undefined) {
+    throw new Error(
+      `story-gate: --shard requires N/M with positive integers (received no value)`,
+    );
+  }
+  if (typeof raw !== "string" || !/^[1-9]\d*\/[1-9]\d*$/.test(raw)) {
+    throw new Error(
+      `story-gate: --shard must be N/M with positive integers (received ${JSON.stringify(raw)})`,
+    );
+  }
+  const [indexRaw, totalRaw] = raw.split("/");
+  const index = requirePositiveSafeInteger(indexRaw, "--shard index");
+  const total = requirePositiveSafeInteger(totalRaw, "--shard total");
+  if (index > total) {
+    throw new Error(
+      `story-gate: --shard index must be <= total (received ${JSON.stringify(raw)})`,
+    );
+  }
+  return `${index}/${total}`;
+}
+
+export function parseArgs(argv) {
   const a = {
     staticDir: "storybook-static",
     out: "test/story-gate/output",
@@ -72,11 +131,12 @@ function parseArgs(argv) {
     if (arg === "--static-dir") a.staticDir = next();
     else if (arg === "--out") a.out = next();
     else if (arg === "--concurrency") a.concurrency = Number(next());
-    else if (arg === "--shard") a.shard = next();
+    else if (arg === "--shard") a.shard = requireShardSpec(next());
     else if (arg === "--section") a.section = next();
     else if (arg === "--grep") a.grep = next();
-    else if (arg === "--limit") a.limit = Number(next());
-    else if (arg === "--update-baseline") a.updateBaseline = true;
+    else if (arg === "--limit") {
+      a.limit = requirePositiveSafeInteger(next(), "--limit");
+    } else if (arg === "--update-baseline") a.updateBaseline = true;
     else if (arg === "--no-screenshots") a.screenshots = false;
     else if (arg === "--no-a11y") a.a11y = false;
   }

--- a/packages/ui/test/story-gate/story-gate-limit-shard.test.mjs
+++ b/packages/ui/test/story-gate/story-gate-limit-shard.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * Regression tests for Story Gate `--limit` and `--shard` CLI validation
+ * (#18588). Confirms malformed values fail at the parser and process boundary
+ * before filters silently drop stories or produce empty selections.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  parseArgs,
+  requirePositiveSafeInteger,
+  requireShardSpec,
+} from "./run-story-gate.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const runner = join(here, "run-story-gate.mjs");
+const temporaryDirectories = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("Story Gate --limit / --shard validation (#18588)", () => {
+  it("accepts valid limit and shard values", () => {
+    expect(parseArgs([]).limit).toBeNull();
+    expect(parseArgs([]).shard).toBeNull();
+    expect(parseArgs(["--limit", "1"]).limit).toBe(1);
+    expect(parseArgs(["--limit", "42"]).limit).toBe(42);
+    expect(parseArgs(["--shard", "1/4"]).shard).toBe("1/4");
+    expect(parseArgs(["--shard", "3/3"]).shard).toBe("3/3");
+  });
+
+  it.each(["0", "-1", "1.5", "1junk", "NaN", "Infinity", "", "01"])(
+    "rejects invalid limit %j",
+    (value) => {
+      expect(() => parseArgs(["--limit", value])).toThrow(
+        "--limit must be a positive integer",
+      );
+    },
+  );
+
+  it("rejects a missing limit value", () => {
+    expect(() => parseArgs(["--limit"])).toThrow(
+      "--limit requires a positive integer (received no value)",
+    );
+  });
+
+  it.each([
+    "0/1",
+    "1/0",
+    "-1/2",
+    "1/-2",
+    "1.5/2",
+    "1junk/2",
+    "1/2junk",
+    "1",
+    "1/",
+    "/2",
+    "abc",
+    "2/1",
+    "",
+  ])("rejects invalid shard %j", (value) => {
+    expect(() => parseArgs(["--shard", value])).toThrow(/--shard/);
+  });
+
+  it("rejects a missing shard value", () => {
+    expect(() => parseArgs(["--shard"])).toThrow(
+      "--shard requires N/M with positive integers (received no value)",
+    );
+  });
+
+  it("requirePositiveSafeInteger and requireShardSpec match CLI errors", () => {
+    expect(() => requirePositiveSafeInteger("-1", "--limit")).toThrow(
+      "--limit must be a positive integer",
+    );
+    expect(() => requireShardSpec("1junk/2")).toThrow(
+      "--shard must be N/M with positive integers",
+    );
+  });
+
+  it("fails at the real CLI boundary for --limit -1 before creating artifacts", () => {
+    const directory = mkdtempSync(join(tmpdir(), "eliza-story-gate-limit-"));
+    temporaryDirectories.push(directory);
+    const output = join(directory, "output");
+
+    const result = spawnSync(
+      process.execPath,
+      [runner, "--out", output, "--limit", "-1"],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(
+      "story-gate: --limit must be a positive integer",
+    );
+    expect(existsSync(output)).toBe(false);
+  });
+
+  it("fails at the real CLI boundary for --shard 1junk/2 before creating artifacts", () => {
+    const directory = mkdtempSync(join(tmpdir(), "eliza-story-gate-shard-"));
+    temporaryDirectories.push(directory);
+    const output = join(directory, "output");
+
+    const result = spawnSync(
+      process.execPath,
+      [runner, "--out", output, "--shard", "1junk/2"],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(
+      "story-gate: --shard must be N/M with positive integers",
+    );
+    expect(existsSync(output)).toBe(false);
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #18588

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused package checks passed after sync (`packages/ui` story-gate tests +
      Biome on touched files). Full `bun run verify` was not re-run end-to-end in
      this unmeasured session; unrelated existing package lint warnings only.
- [x] A reviewer can confirm the change from the CLI transcripts and focused
      test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xAI / grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build` (`grok` client)
<!-- attribution-row:skill-revision -->
- Skill path: `contribute-to-eliza` @ `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77`
<!-- attribution-row:status -->
- Provenance status: `self-reported` + device-signed project receipt (footer below)
- Run id: `run_01KZTQK1SF3FFRX2CM2KTAB987`
- Note: implementation was done under operator override on Grok; receipt covers a post-hoc measured verification window with re-run tests/CLI proof. Token meter via ccusage is unavailable for Grok (signed zero / unavailable confidence), not fabricated.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync; full monorepo `bun run verify` not claimed here.

# Risks

**Low.** CLI argument validation only for Story Gate harness filters. No production UI, runtime, or Storybook catalog behavior changes for valid invocations. Overlaps file-wise with open #18551 concurrency PR on the same `parseArgs` function; this PR does not change concurrency handling.

# Background

## What does this PR do?

Validates Story Gate `--limit` and `--shard` at the CLI boundary:

- `--limit` must be a positive safe integer (rejects `-1`, `0`, fractions, partial numbers).
- `--shard` must be `N/M` with positive safe integers and `1 <= N <= M` (rejects `1junk/2`, `1/0`, `2/1`, etc.).

Previously `Number()` parsing could silently drop the last story (`--limit -1` → `slice(0, -1)`) or empty the selection on malformed shards, which could look like a filter miss instead of a bad argument.

## What kind of change is this?

Bug fix (non-breaking for valid CLI use; invalid args now fail closed).

# Documentation changes needed?

No project docs change required. Behavior matches the existing README flag intent (`--limit N`, `--shard i/n`) more strictly.

# Testing

## Where should a reviewer start?

1. `packages/ui/test/story-gate/run-story-gate.mjs` — `requirePositiveSafeInteger`, `requireShardSpec`, `parseArgs`
2. `packages/ui/test/story-gate/story-gate-limit-shard.test.mjs` — unit + real CLI boundary

## Detailed testing steps

```bash
bun run --cwd packages/ui test test/story-gate/story-gate-limit-shard.test.mjs
# 27 passed

node packages/ui/test/story-gate/run-story-gate.mjs --out /tmp/sg-out --limit -1
# exit 1, message: story-gate: --limit must be a positive integer (received "-1")
# /tmp/sg-out is not created

node packages/ui/test/story-gate/run-story-gate.mjs --out /tmp/sg-out --shard 1junk/2
# exit 1, message: story-gate: --shard must be N/M with positive integers (received "1junk/2")
```

Also re-ran sibling story-gate unit suites that import the module (classify + log-capture-wiring): 23 passed.

# Evidence Gate

<!-- evidence-head:95dc79eaf746111101f2131468c63e8872b50d0c -->

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - terminal-only Story Gate CLI harness; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - terminal-only Story Gate CLI harness; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no interactive UI flow; CLI argument rejection is fully captured by transcripts below.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no server/runtime path.
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no browser app surface.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent, model, prompt, provider, or action behavior.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: focused vitest output (27 passed) and CLI rejection transcripts proving non-zero exit and no output directory creation for `--limit -1` and `--shard 1junk/2`.

### CLI after (this head)

```text
$ node packages/ui/test/story-gate/run-story-gate.mjs --out /tmp/sg-out-limit --limit -1
Error: story-gate: --limit must be a positive integer (received "-1")
exit:1
# /tmp/sg-out-limit does not exist

$ node packages/ui/test/story-gate/run-story-gate.mjs --out /tmp/sg-out-shard --shard 1junk/2
Error: story-gate: --shard must be N/M with positive integers (received "1junk/2")
exit:1
# /tmp/sg-out-shard does not exist

$ bun run --cwd packages/ui test test/story-gate/story-gate-limit-shard.test.mjs
Test Files  1 passed (1)
     Tests  27 passed (27)
```

### Pre-fix filter shape (why the bug matters)

```text
["a","b","c"].slice(0, Number("-1"))  // => ["a","b"]  — last story dropped
// shard "1junk/2" → NaN index → empty selection
```

# Known gaps / failures

- Full monorepo `bun run verify` not asserted in this unmeasured session after light install (one unrelated package install failure reported by `install:light`; workspace still ran the focused UI tests).
- `--concurrency` validation remains tracked by #18551 / PR #18554; intentionally untouched here to avoid dual ownership of that flag.

# Notes for reviewers

Operator override allowed Grok for this contribution. Device-signed measured receipt is appended below (post-hoc verification window + re-run tests). Independent review and merge remain with maintainers.

# Measured project receipt

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [rama0x1-grok]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTQK1SF3FFRX2CM2KTAB987","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T10:16:50.223Z","completed_at":"2026-08-12T10:17:03.728Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"tk_87dVYE1TdlRiQ3QGqiGbpFWhxzUOSfYMKqqEuYPoRcw69n5qcNeF-uRucqzTUQ713gJEq2fng9RK39EL4Dg"}} -->
