### PR TITLE
fix(test): bound isolated script-test numeric options

### DIFF
--- a/packages/scripts/__tests__/run-script-test-files.test.ts
+++ b/packages/scripts/__tests__/run-script-test-files.test.ts
@@ -1,0 +1,70 @@
+/** Verifies the isolated script-test runner rejects invalid bounds before execution. */
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseIsolatedScriptTestArgs } from "../run-script-test-files.mjs";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const driver = path.resolve(scriptDirectory, "..", "run-script-test-files.mjs");
+const testFile = "packages/scripts/example.test.ts";
+
+function parse(...options: string[]) {
+  return parseIsolatedScriptTestArgs([...options, "--", testFile]);
+}
+
+describe("isolated script-test runner arguments", () => {
+  test("preserves defaults and accepts the exact numeric ceilings", () => {
+    expect(parse()).toMatchObject({ concurrency: 4, timeoutMs: 120_000 });
+    expect(parse(`--concurrency=${Number.MAX_SAFE_INTEGER}`)).toMatchObject({
+      concurrency: Number.MAX_SAFE_INTEGER,
+    });
+    expect(parse("--timeout-ms=2147483647")).toMatchObject({
+      timeoutMs: 2_147_483_647,
+    });
+  });
+
+  test.each(["0", "-1", "+1", "1.5", "1e3", "NaN", "Infinity", ""])(
+    "rejects malformed positive integer %p",
+    (value) => {
+      expect(() => parse(`--concurrency=${value}`)).toThrow(
+        "--concurrency requires a positive integer",
+      );
+      expect(() => parse(`--timeout-ms=${value}`)).toThrow(
+        "--timeout-ms requires a positive integer",
+      );
+    },
+  );
+
+  test("rejects unsafe concurrency instead of rounding or accepting Infinity", () => {
+    for (const value of ["9007199254740992", "9".repeat(400)]) {
+      expect(() => parse(`--concurrency=${value}`)).toThrow(
+        "--concurrency requires a positive safe integer",
+      );
+    }
+  });
+
+  test("rejects timeout values that Node would clamp to one millisecond", () => {
+    for (const value of ["2147483648", "9007199254740992", "9".repeat(400)]) {
+      expect(() => parse(`--timeout-ms=${value}`)).toThrow(
+        "--timeout-ms requires a positive integer no greater than 2147483647",
+      );
+    }
+  });
+
+  test("the CLI rejects an overflowing timeout before starting a Bun child", () => {
+    const result = spawnSync(
+      process.execPath,
+      [driver, "--timeout-ms=2147483648", "--", testFile],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "--timeout-ms requires a positive integer no greater than 2147483647",
+    );
+    expect(result.stderr).not.toContain("timed out");
+    expect(result.stderr).not.toContain("TimeoutOverflowWarning");
+  });
+});

--- a/packages/scripts/run-script-test-files.mjs
+++ b/packages/scripts/run-script-test-files.mjs
@@ -19,10 +19,25 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { runPool } from "./lib/test-task-pool.mjs";
 
-function positiveInteger(value, flag) {
-  if (!/^[1-9]\d*$/.test(value))
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+function positiveInteger(
+  value,
+  flag,
+  { maximum = Number.MAX_SAFE_INTEGER } = {},
+) {
+  if (!/^[1-9]\d*$/.test(value)) {
     throw new Error(`${flag} requires a positive integer`);
-  return Number(value);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed > maximum) {
+    const bound =
+      maximum === Number.MAX_SAFE_INTEGER
+        ? "a positive safe integer"
+        : `a positive integer no greater than ${maximum}`;
+    throw new Error(`${flag} requires ${bound}`);
+  }
+  return parsed;
 }
 
 export function parseIsolatedScriptTestArgs(argv) {
@@ -42,7 +57,9 @@ export function parseIsolatedScriptTestArgs(argv) {
     } else if (arg.startsWith("--junit=")) {
       options.junit = arg.slice(8);
     } else if (arg.startsWith("--timeout-ms=")) {
-      options.timeoutMs = positiveInteger(arg.slice(13), "--timeout-ms");
+      options.timeoutMs = positiveInteger(arg.slice(13), "--timeout-ms", {
+        maximum: MAX_TIMER_DELAY_MS,
+      });
     } else {
       throw new Error(`unknown argument: ${arg}`);
     }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18587

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. This is a strict input-validation change in the isolated script-test runner. Existing valid concurrency values remain accepted, and valid timeout values through Node's maximum timer delay remain accepted. Callers that previously supplied unsafe integers or timeout values Node would silently clamp to 1 ms now receive an immediate diagnostic instead.

# Background

## What does this PR do?

Rejects script-test numeric arguments before they can be rounded, converted to `Infinity`, or silently clamped by Node's timer implementation. `--concurrency` must now fit in JavaScript's safe-integer range, and `--timeout-ms` must additionally be no greater than `2_147_483_647`, Node's maximum supported timer delay.

The regression suite covers both exact ceilings, malformed values, unsafe integers, a 400-digit decimal, the first out-of-range timer value, and the real CLI failure path before any Bun child starts.

## What kind of change is this?

Bug fix (non-breaking test-infrastructure correctness improvement).

# Documentation changes needed?

No project-documentation change is needed. The command-line flags and defaults are unchanged; invalid values now fail with an actionable bound instead of producing a misleading timeout.

# Testing

## Where should a reviewer start?

Start with `positiveInteger` and the `--timeout-ms` branch in `packages/scripts/run-script-test-files.mjs`, then inspect the boundary and process-level cases in `packages/scripts/__tests__/run-script-test-files.test.ts`.

## Detailed testing steps

Post-sync verification at `8c73f4f60b204bfe19fb965755fa3373c90642c5`:

```text
bun install
Checked 3459 installs across 3765 packages (no changes)

bun test packages/scripts/__tests__/run-script-test-files.test.ts packages/scripts/__tests__/script-test-inventory.test.ts
27 tests passed; 0 failed; 499 assertions

npm_config_cache=<isolated-temp-cache> node packages/scripts/run-script-tests.mjs --report reports/script-tests/18587-full-inventory.json --junit reports/script-tests/18587-full-junit.xml
128 suites; 1,382 tests; 27,392 assertions; 0 failures; JUnit SHA-256 11409cc4502e9750dcd0429e0a5838432b79e20a8921f263e6d949c9b4c2f498

bunx @biomejs/biome check packages/scripts/run-script-test-files.mjs packages/scripts/__tests__/run-script-test-files.test.ts
Checked 2 files; PASS

bun run verify
Tasks: 350 successful, 350 total
[audit-build-typecheck] PASS
[audit-turbo-build-deps] PASS
audit-tee-secret-leak: PASS
[hetzner-fleet-routing] verified 62 selectors across 15 workflows
[audit-scripts] OK
[anti-larp] clean
```

Locked Node 24.15.0 boundary proof:

```json
{"node":"v24.15.0","accepted":2147483647,"rejected":"--timeout-ms requires a positive integer no greater than 2147483647","unsafeConcurrency":"--concurrency requires a positive safe integer"}
```

# Evidence Gate

<!-- evidence-head:8c73f4f60b204bfe19fb965755fa3373c90642c5 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - command-line test infrastructure only; no rendered UI surface changes`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - command-line test infrastructure only; no rendered UI surface changes`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no rendered or interactive application flow is changed`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - this standalone test runner does not start an application backend; its real CLI transcript is attached below`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend, browser, or network path is changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent, action, provider, prompt, or model behavior changes`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.).

<details>
<summary>Before/after CLI and timer-bound transcript</summary>

```text
BEFORE (base e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88):
(node:49916) TimeoutOverflowWarning: Infinity does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
[script-tests] timed out after Infinityms: packages/scripts/__tests__/run-with-deadline.test.ts

NODE 24 CONTROL:
setTimeout(2147483648) reported _idleTimeout=1 and emitted TimeoutOverflowWarning.

AFTER (head 8c73f4f60b204bfe19fb965755fa3373c90642c5):
[script-tests] --timeout-ms requires a positive integer no greater than 2147483647
exit: 1; no Bun child, timeout line, or TimeoutOverflowWarning
```

</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - this diff changes command-line JavaScript and tests only, with no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

N/A - no application backend or frontend participates in this path. The executed command-line transcript is included under **Domain artifacts**.

## Screenshots (before / after) + video walkthrough

N/A - no rendered application surface changes.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changes.

## Known gaps / failures

The first complete script-test run encountered `EACCES` in two existing release-fixture tests because this machine's default `~/.npm/_cacache` contains root-owned entries. The two affected suites passed with an isolated npm cache (16 tests, 91 assertions), and the entire 128-suite script-test lane then passed with the same isolated-cache setup (1,382 tests, 27,392 assertions, zero failures). No user cache ownership was changed.

Visual, backend, frontend, network, LLM, OCR, and audio artifacts are intentionally N/A because this change only validates local command-line test-runner arguments. The supported Node 24 timer boundary was exercised in a locked `node:24.15.0-bookworm-slim` container; the repository's remaining verification used its pinned Bun 1.3.14 toolchain.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 12638834 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [hkc2023-codex]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTNRD2JR6YY4900HA0JSYZJ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T09:44:48.466Z","completed_at":"2026-08-12T10:05:12.834Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":303569,"output_tokens":35489,"cache_creation_tokens":0,"cache_read_tokens":12299776,"total_tokens":12638834,"cost_micro_usd":"8732403","session_count":1},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAiePG1tPOzrMu-ASR7S9zu658VITXXJQIcWo_RCLcPNg","device_key_id":"efa48975f21fa1dc36e1a917bcfe1737a5329a11ccb709deb6dbae9121164067","device_signature":"Mg7bppcGM2oRn0SQLxUrNuuLTRjUcnHtaVC8uCwHLnv1cCntjKtImYf7zx-YNrzPYiHoKNhC-7PA_o5V6ZauAQ"}} -->
