### PR TITLE
fix(ci): bound cloud test batch execution

### DIFF
--- a/.github/ci-windows-command-inventory.json
+++ b/.github/ci-windows-command-inventory.json
@@ -1,6 +1,7 @@
 {
   "$comment": "Coverage floor for the Windows lane (#13402). The dedicated windows-ci.yml workflow was consolidated away; the surviving Windows proof is the jobs.platform-smoke windows matrix entry in .github/workflows/nightly.yml. Every command here must stay wired as a run: step in that job. Enforced by packages/scripts/ci-windows-command-coverage-contract.mjs: adding a command is always allowed (this is a floor, not an exact match); to intentionally retire one, delete it from the workflow AND from this list in the SAME PR so the reduction is reviewable in the diff.",
   "commands": [
+    "node packages/scripts/test-cloud-run-watchdog.self-test.mjs",
     "bun run build:core",
     "bun run test:core"
   ]

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -19,9 +19,11 @@ on:
       - "packages/cloud/scripts/**"
       - "packages/scripts/test-cloud-run.mjs"
       - "packages/scripts/test-cloud-run-helpers.mjs"
+      - "packages/scripts/__tests__/test-cloud-run.test.mjs"
       - "packages/scripts/test-cloud-run-flush.self-test.mjs"
       - "packages/scripts/test-cloud-run-helpers.self-test.mjs"
       - "packages/scripts/test-cloud-run-preflight.self-test.mjs"
+      - "packages/scripts/test-cloud-run-watchdog.self-test.mjs"
       - "package.json"
       - "bun.lock"
       - ".github/workflows/cloud-tests.yml"
@@ -38,9 +40,11 @@ on:
       - "packages/cloud/scripts/**"
       - "packages/scripts/test-cloud-run.mjs"
       - "packages/scripts/test-cloud-run-helpers.mjs"
+      - "packages/scripts/__tests__/test-cloud-run.test.mjs"
       - "packages/scripts/test-cloud-run-flush.self-test.mjs"
       - "packages/scripts/test-cloud-run-helpers.self-test.mjs"
       - "packages/scripts/test-cloud-run-preflight.self-test.mjs"
+      - "packages/scripts/test-cloud-run-watchdog.self-test.mjs"
       - "package.json"
       - "bun.lock"
       - ".github/workflows/cloud-tests.yml"
@@ -104,6 +108,12 @@ jobs:
         run: node packages/scripts/test-cloud-run-flush.self-test.mjs
       - name: Batch runner helper self-test
         run: node packages/scripts/test-cloud-run-helpers.self-test.mjs
+      - name: Batch runner unit tests
+        run: bun test packages/scripts/__tests__/test-cloud-run.test.mjs
+      # Guards the wall-clock watchdog (#17245): a wedged child and its
+      # descendants must be terminated without stalling the remaining batches.
+      - name: Batch runner process-tree watchdog self-test
+        run: node packages/scripts/test-cloud-run-watchdog.self-test.mjs
       # Guards the clean-install preflight (#16187): `bun run test:cloud` must
       # build the missing @elizaos/core dist / generated keyword modules itself
       # instead of dying in `Cannot find module` cascades after a frozen

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           node-version: "24.15.0"
 
+      - name: Run batch watchdog process-tree self-test
+        run: node packages/scripts/test-cloud-run-watchdog.self-test.mjs
+
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 

--- a/packages/scripts/__tests__/test-cloud-run.test.mjs
+++ b/packages/scripts/__tests__/test-cloud-run.test.mjs
@@ -7,6 +7,7 @@
  * lane instead.
  */
 import { describe, expect, it } from "bun:test";
+import { EventEmitter } from "node:events";
 import {
   mkdirSync,
   mkdtempSync,
@@ -17,7 +18,9 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
 import {
+  appendClassificationOutput,
   buildTestEnv,
   chunkByBudget,
   computeRequiredRuntimeArtifacts,
@@ -26,11 +29,17 @@ import {
   ensureCloudTestRuntime,
   findMissingRoots,
   formatBatchFiles,
+  MAX_CLASSIFICATION_OUTPUT_CHARS,
   MAX_FILES_PER_BATCH_WIN32,
   PREFLIGHT_STEPS,
+  parseBatchTimeoutArg,
+  parsePositiveDuration,
   runBatches,
+  runCommandWithWatchdog,
   runPreflightStep,
+  terminateProcessTree,
   walkTests,
+  windowsTaskkillInvocation,
   writeSyncAll,
 } from "../test-cloud-run.mjs";
 
@@ -325,58 +334,84 @@ describe("runBatches", () => {
     return { lines, write: (text) => lines.push(text) };
   }
 
-  it("returns false and keeps going when every batch passes", () => {
+  it("prints the exact manifest before spawning and keeps going when every batch passes", async () => {
     const out = collector();
     const err = collector();
     const calls = [];
-    const anyFailed = runBatches([["a.test.ts"], ["b.test.ts"]], {
-      spawnBatch: (batch) => {
-        calls.push(batch);
-        return { status: 0, signal: null, stdout: "ok\n", stderr: "" };
+    const events = [];
+    const anyFailed = await runBatches(
+      [["/repo/a.test.ts"], ["/repo/b.test.ts"]],
+      {
+        spawnBatch: (batch) => {
+          events.push(`spawn:${batch[0]}`);
+          calls.push(batch);
+          return { status: 0, signal: null, stdout: "ok\n", stderr: "" };
+        },
+        stagingDir: "/staging",
+        env: {},
+        repoRoot: "/repo",
+        writeOut: (text) => {
+          events.push(`out:${text}`);
+          out.write(text);
+        },
+        writeErr: err.write,
       },
-      stagingDir: "/staging",
-      env: {},
-      repoRoot: "/repo",
-      writeOut: out.write,
-      writeErr: err.write,
-    });
+    );
     expect(anyFailed).toBe(false);
-    expect(calls).toEqual([["a.test.ts"], ["b.test.ts"]]);
+    expect(calls).toEqual([["/repo/a.test.ts"], ["/repo/b.test.ts"]]);
     expect(out.lines.join("")).toContain("batch 1/2");
+    expect(out.lines.join("")).toContain("files in batch:\n  - a.test.ts");
     expect(out.lines.join("")).toContain("ok\n");
+    expect(
+      events.findIndex((event) => event.includes("  - a.test.ts")),
+    ).toBeLessThan(events.indexOf("spawn:/repo/a.test.ts"));
   });
 
-  it("marks the gate failed and reports the offending files on a real failure", () => {
+  it("collects ordinary failures and reports the offending files", async () => {
     const out = collector();
     const err = collector();
-    const anyFailed = runBatches([["/repo/packages/x/a.test.ts"]], {
-      spawnBatch: () => ({
-        status: 1,
-        signal: null,
-        stdout: "1 fail\n",
-        stderr: "(fail) something broke\n",
-      }),
-      stagingDir: "/staging",
-      env: {},
-      repoRoot: "/repo",
-      writeOut: out.write,
-      writeErr: err.write,
-    });
+    const calls = [];
+    const anyFailed = await runBatches(
+      [["/repo/packages/x/a.test.ts"], ["/repo/packages/y/b.test.ts"]],
+      {
+        spawnBatch: (batch) => {
+          calls.push(batch);
+          return calls.length === 1
+            ? {
+                status: 1,
+                signal: null,
+                stdout: "1 fail\n",
+                stderr: "(fail) something broke\n",
+              }
+            : { status: 0, signal: null };
+        },
+        stagingDir: "/staging",
+        env: {},
+        repoRoot: "/repo",
+        writeOut: out.write,
+        writeErr: err.write,
+      },
+    );
     expect(anyFailed).toBe(true);
+    expect(calls).toHaveLength(2);
     expect(err.lines.join("")).toContain("exited non-zero");
     expect(err.lines.join("")).toContain(join("packages", "x", "a.test.ts"));
   });
 
-  it("normalizes the known Bun/PGlite status-99 pollution as a pass", () => {
+  it("normalizes the known Bun/PGlite status-99 pollution from complete streamed output", async () => {
     const out = collector();
     const err = collector();
-    const anyFailed = runBatches([["a.test.ts"]], {
-      spawnBatch: () => ({
-        status: 99,
-        signal: null,
-        stdout: "Ran 3 tests across 1 file.\n",
-        stderr: "",
-      }),
+    const anyFailed = await runBatches([["a.test.ts"]], {
+      spawnBatch: (_batch, { writeOut }) => {
+        writeOut("Ran 3 tests across 1 file.\n");
+        return {
+          status: 99,
+          signal: null,
+          stdout: "Ran 3 tests across 1 file.\n",
+          stderr: "",
+          streamed: true,
+        };
+      },
       stagingDir: "/staging",
       env: {},
       repoRoot: "/repo",
@@ -387,11 +422,18 @@ describe("runBatches", () => {
     expect(err.lines.join("")).toContain("treating as pass");
   });
 
-  it("stops immediately and reports a spawn error", () => {
+  it("does not normalize status 99 when bounded classification output was truncated", async () => {
     const out = collector();
     const err = collector();
-    const anyFailed = runBatches([["a.test.ts"], ["b.test.ts"]], {
-      spawnBatch: () => ({ error: new Error("spawn bun ENOENT") }),
+    const anyFailed = await runBatches([["a.test.ts"]], {
+      spawnBatch: () => ({
+        status: 99,
+        signal: null,
+        stdout: "Ran 3 tests across 1 file.\n",
+        stderr: "",
+        streamed: true,
+        outputTruncated: true,
+      }),
       stagingDir: "/staging",
       env: {},
       repoRoot: "/repo",
@@ -399,7 +441,336 @@ describe("runBatches", () => {
       writeErr: err.write,
     });
     expect(anyFailed).toBe(true);
+    expect(err.lines.join("")).toContain("exited non-zero");
+    expect(err.lines.join("")).not.toContain("treating as pass");
+  });
+
+  it("stops when process-tree teardown fails", async () => {
+    const out = collector();
+    const err = collector();
+    const calls = [];
+    const anyFailed = await runBatches([["a.test.ts"], ["b.test.ts"]], {
+      spawnBatch: (batch) => {
+        calls.push(batch);
+        return { terminationError: new Error("taskkill failed") };
+      },
+      stagingDir: "/staging",
+      env: {},
+      repoRoot: "/repo",
+      writeOut: out.write,
+      writeErr: err.write,
+    });
+    expect(anyFailed).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(err.lines.join("")).toContain("process-tree teardown failed");
+  });
+
+  it("continues after a successfully reaped timeout and reports its deadline and files", async () => {
+    const out = collector();
+    const err = collector();
+    const calls = [];
+    const anyFailed = await runBatches(
+      [["/repo/a.test.ts"], ["/repo/b.test.ts"]],
+      {
+        spawnBatch: (batch, { onTimeout }) => {
+          calls.push(batch);
+          if (calls.length === 1) {
+            onTimeout();
+            return { timedOut: true, status: null, signal: "SIGKILL" };
+          }
+          return { status: 0, signal: null };
+        },
+        stagingDir: "/staging",
+        env: {},
+        repoRoot: "/repo",
+        writeOut: out.write,
+        writeErr: err.write,
+        timeoutMs: 4321,
+      },
+    );
+    expect(anyFailed).toBe(true);
+    expect(calls).toHaveLength(2);
+    expect(err.lines.join("")).toContain("4321 ms wall-clock deadline");
+    expect(err.lines.join("")).toContain(
+      "files in timed-out batch:\n  - a.test.ts",
+    );
+  });
+
+  it("stops immediately and reports a spawn error", async () => {
+    const out = collector();
+    const err = collector();
+    const calls = [];
+    const anyFailed = await runBatches([["a.test.ts"], ["b.test.ts"]], {
+      spawnBatch: (batch) => {
+        calls.push(batch);
+        return { error: new Error("spawn bun ENOENT") };
+      },
+      stagingDir: "/staging",
+      env: {},
+      repoRoot: "/repo",
+      writeOut: out.write,
+      writeErr: err.write,
+    });
+    expect(anyFailed).toBe(true);
+    expect(calls).toHaveLength(1);
     expect(err.lines.join("")).toContain("spawn error");
     expect(err.lines.join("")).toContain("ENOENT");
+  });
+});
+
+describe("watchdog configuration", () => {
+  it("accepts positive millisecond values and rejects invalid timers", () => {
+    expect(parsePositiveDuration(undefined, "TIMEOUT", 50)).toBe(50);
+    expect(parsePositiveDuration("250", "TIMEOUT", 50)).toBe(250);
+    for (const value of ["0", "-1", "1.5", "1e3", " 10", "2147483648"]) {
+      expect(() => parsePositiveDuration(value, "TIMEOUT", 50)).toThrow(
+        /TIMEOUT must be/,
+      );
+    }
+  });
+
+  it("parses the optional batch timeout CLI argument", () => {
+    expect(parseBatchTimeoutArg([])).toBe(600_000);
+    expect(parseBatchTimeoutArg(["--batch-timeout-ms=250"])).toBe(250);
+    expect(() =>
+      parseBatchTimeoutArg([
+        "--batch-timeout-ms=250",
+        "--batch-timeout-ms=500",
+      ]),
+    ).toThrow(/only once/);
+    expect(() => parseBatchTimeoutArg(["--unknown"])).toThrow(
+      /unexpected argument/,
+    );
+    expect(() => parseBatchTimeoutArg(["--batch-timeout-ms="])).toThrow(
+      /must include a positive integer value/,
+    );
+  });
+
+  it("builds soft and forced Windows whole-tree taskkill commands", () => {
+    expect(windowsTaskkillInvocation(321, false)).toEqual({
+      command: "taskkill",
+      args: ["/PID", "321", "/T"],
+    });
+    expect(windowsTaskkillInvocation(321, true)).toEqual({
+      command: "taskkill",
+      args: ["/PID", "321", "/T", "/F"],
+    });
+  });
+
+  it("signals the POSIX process group with TERM then KILL", async () => {
+    const signals = [];
+    await terminateProcessTree(321, {
+      platform: "darwin",
+      graceMs: 1,
+      signalFn: (pid, signal) => signals.push([pid, signal]),
+      delayFn: async () => {},
+    });
+    expect(signals).toEqual([
+      [-321, "SIGTERM"],
+      [-321, "SIGKILL"],
+    ]);
+  });
+
+  it("normalizes Windows taskkill races when the tree is already gone", async () => {
+    const runWithCodes = async (codes) => {
+      const invocations = [];
+      await terminateProcessTree(321, {
+        platform: "win32",
+        graceMs: 1,
+        delayFn: async () => {},
+        spawnFn: (command, args) => {
+          invocations.push([command, args]);
+          const killer = new EventEmitter();
+          killer.kill = () => {};
+          queueMicrotask(() => killer.emit("close", codes.shift(), null));
+          return killer;
+        },
+      });
+      return invocations;
+    };
+
+    expect(await runWithCodes([128, 128])).toHaveLength(2);
+    expect(await runWithCodes([0, 128])).toHaveLength(2);
+    expect(await runWithCodes([5, 0])).toHaveLength(2);
+  });
+
+  it("fails closed when forced Windows tree termination fails", async () => {
+    const codes = [0, 5];
+    await expect(
+      terminateProcessTree(321, {
+        platform: "win32",
+        graceMs: 1,
+        delayFn: async () => {},
+        spawnFn: () => {
+          const killer = new EventEmitter();
+          killer.kill = () => {};
+          queueMicrotask(() => killer.emit("close", codes.shift(), null));
+          return killer;
+        },
+      }),
+    ).rejects.toThrow(/failed to terminate Windows process tree/);
+  });
+
+  it("tears down the active child and removes listeners on a parent signal", async () => {
+    const signalSource = new EventEmitter();
+    const child = new EventEmitter();
+    child.pid = 321;
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    const terminations = [];
+    const resultPromise = runCommandWithWatchdog("bun", ["test"], {
+      timeoutMs: 10_000,
+      writeOut: () => {},
+      writeErr: () => {},
+      signalSource,
+      spawnFn: () => child,
+      terminateTree: async (pid) => {
+        terminations.push(pid);
+        child.emit("close", null, "SIGTERM");
+      },
+    });
+
+    signalSource.emit("SIGTERM");
+    const result = await resultPromise;
+
+    expect(result.parentSignal).toBe("SIGTERM");
+    expect(terminations).toEqual([321]);
+    expect(signalSource.listenerCount("SIGINT")).toBe(0);
+    expect(signalSource.listenerCount("SIGTERM")).toBe(0);
+  });
+
+  it("keeps the first termination cause when a parent signal races a timeout", async () => {
+    const signalSource = new EventEmitter();
+    const child = new EventEmitter();
+    child.pid = 321;
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    let releaseTermination;
+    const terminationStarted = new Promise((resolve) => {
+      releaseTermination = resolve;
+    });
+    let unblockTermination;
+    const terminationBlocked = new Promise((resolve) => {
+      unblockTermination = resolve;
+    });
+    const resultPromise = runCommandWithWatchdog("bun", ["test"], {
+      timeoutMs: 1,
+      writeOut: () => {},
+      writeErr: () => {},
+      signalSource,
+      spawnFn: () => child,
+      terminateTree: async () => {
+        releaseTermination();
+        await terminationBlocked;
+        child.emit("close", null, "SIGKILL");
+      },
+    });
+
+    await terminationStarted;
+    signalSource.emit("SIGTERM");
+    unblockTermination();
+    const result = await resultPromise;
+
+    expect(result.timedOut).toBe(true);
+    expect(result.parentSignal).toBeUndefined();
+  });
+
+  it("keeps a parent signal as the cause when its teardown crosses the deadline", async () => {
+    const signalSource = new EventEmitter();
+    const child = new EventEmitter();
+    child.pid = 321;
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    let unblockTermination;
+    const terminationBlocked = new Promise((resolve) => {
+      unblockTermination = resolve;
+    });
+    const resultPromise = runCommandWithWatchdog("bun", ["test"], {
+      timeoutMs: 1,
+      writeOut: () => {},
+      writeErr: () => {},
+      signalSource,
+      spawnFn: () => child,
+      terminateTree: async () => {
+        await terminationBlocked;
+        child.emit("close", null, "SIGTERM");
+      },
+    });
+
+    signalSource.emit("SIGTERM");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    unblockTermination();
+    const result = await resultPromise;
+
+    expect(result.parentSignal).toBe("SIGTERM");
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("terminates a POSIX group when an exited leader leaves descendant stdio open", async () => {
+    const signalSource = new EventEmitter();
+    const child = new EventEmitter();
+    child.pid = 321;
+    child.exitCode = 0;
+    child.signalCode = null;
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    let terminationCalls = 0;
+    const resultPromise = runCommandWithWatchdog("bun", ["test"], {
+      timeoutMs: 1,
+      writeOut: () => {},
+      writeErr: () => {},
+      platform: "darwin",
+      signalSource,
+      spawnFn: () => child,
+      terminateTree: async () => {
+        terminationCalls += 1;
+        child.emit("close", 0, null);
+      },
+    });
+
+    const result = await resultPromise;
+
+    expect(terminationCalls).toBe(1);
+    expect(result.timedOut).toBe(true);
+    expect(result.status).toBe(0);
+  });
+
+  it("fails closed instead of taskkilling a reused Windows leader PID", async () => {
+    const signalSource = new EventEmitter();
+    const child = new EventEmitter();
+    child.pid = 321;
+    child.exitCode = 0;
+    child.signalCode = null;
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    let terminationCalls = 0;
+    const result = await runCommandWithWatchdog("bun", ["test"], {
+      timeoutMs: 1,
+      writeOut: () => {},
+      writeErr: () => {},
+      platform: "win32",
+      signalSource,
+      spawnFn: () => child,
+      terminateTree: async () => {
+        terminationCalls += 1;
+      },
+    });
+
+    expect(terminationCalls).toBe(0);
+    expect(result.timedOut).toBe(true);
+    expect(result.terminationError?.message).toContain(
+      "process-tree teardown cannot be proven safely",
+    );
+  });
+
+  it("retains only a bounded output tail for status classification", () => {
+    const oversized = "x".repeat(MAX_CLASSIFICATION_OUTPUT_CHARS + 20);
+    const retained = appendClassificationOutput(
+      "prefix",
+      `${oversized}STATUS99`,
+    );
+    expect(retained).toHaveLength(MAX_CLASSIFICATION_OUTPUT_CHARS);
+    expect(retained.endsWith("STATUS99")).toBe(true);
+    expect(retained.startsWith("prefix")).toBe(false);
   });
 });

--- a/packages/scripts/__tests__/test-cloud-run.test.mjs
+++ b/packages/scripts/__tests__/test-cloud-run.test.mjs
@@ -714,6 +714,19 @@ describe("watchdog configuration", () => {
     child.pid = 321;
     child.stdout = new PassThrough();
     child.stderr = new PassThrough();
+    const supervisorStatus = new PassThrough();
+    const supervisorControl = new PassThrough();
+    child.stdio = [
+      null,
+      child.stdout,
+      child.stderr,
+      supervisorStatus,
+      supervisorControl,
+    ];
+    let supervisorRelease = "";
+    supervisorControl.on("data", (chunk) => {
+      supervisorRelease += chunk.toString("utf8");
+    });
     let spawned;
     const resultPromise = runCommandWithWatchdog("bun", ["test", "a.ts"], {
       timeoutMs: 10_000,
@@ -728,6 +741,13 @@ describe("watchdog configuration", () => {
       },
     });
 
+    supervisorStatus.end("0\n");
+    child.stdout.end();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(supervisorRelease).toBe("");
+    child.stderr.end();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(supervisorRelease).toBe("release\n");
     child.emit("close", 0, null);
     const result = await resultPromise;
 
@@ -735,7 +755,9 @@ describe("watchdog configuration", () => {
     expect(spawned.args.slice(-3)).toEqual(["bun", "test", "a.ts"]);
     expect(spawned.args[0]).toBe("-c");
     expect(spawned.args[1]).toContain("trap 'terminating=1' TERM INT");
+    expect(spawned.args[1]).toContain("read -r release <&4");
     expect(spawned.options.detached).toBe(true);
+    expect(spawned.options.stdio).toHaveLength(5);
     expect(result.status).toBe(0);
   });
 
@@ -852,14 +874,25 @@ describe("watchdog configuration", () => {
     expect(result.timedOut).toBe(false);
   });
 
-  it("terminates a POSIX group when an exited leader leaves descendant stdio open", async () => {
+  it("retains the POSIX supervisor until completed-command output drains", async () => {
     const signalSource = new EventEmitter();
     const child = new EventEmitter();
     child.pid = 321;
-    child.exitCode = 0;
-    child.signalCode = null;
     child.stdout = new PassThrough();
     child.stderr = new PassThrough();
+    const supervisorStatus = new PassThrough();
+    const supervisorControl = new PassThrough();
+    child.stdio = [
+      null,
+      child.stdout,
+      child.stderr,
+      supervisorStatus,
+      supervisorControl,
+    ];
+    let supervisorRelease = "";
+    supervisorControl.on("data", (chunk) => {
+      supervisorRelease += chunk.toString("utf8");
+    });
     let terminationCalls = 0;
     const resultPromise = runCommandWithWatchdog("bun", ["test"], {
       timeoutMs: 1,
@@ -870,15 +903,19 @@ describe("watchdog configuration", () => {
       spawnFn: () => child,
       terminateTree: async () => {
         terminationCalls += 1;
-        child.emit("close", 0, null);
+        child.emit("close", null, "SIGKILL");
       },
     });
 
+    supervisorStatus.end("0\n");
+    child.stdout.end();
     const result = await resultPromise;
 
     expect(terminationCalls).toBe(1);
     expect(result.timedOut).toBe(true);
-    expect(result.status).toBe(0);
+    expect(result.status).toBeNull();
+    expect(result.signal).toBe("SIGKILL");
+    expect(supervisorRelease).toBe("");
   });
 
   it("fails closed instead of taskkilling a reused Windows leader PID", async () => {

--- a/packages/scripts/__tests__/test-cloud-run.test.mjs
+++ b/packages/scripts/__tests__/test-cloud-run.test.mjs
@@ -564,6 +564,7 @@ describe("watchdog configuration", () => {
       graceMs: 1,
       signalFn: (pid, signal) => signals.push([pid, signal]),
       delayFn: async () => {},
+      identityFn: () => "original-process",
     });
     expect(signals).toEqual([
       [-321, "SIGTERM"],
@@ -578,6 +579,7 @@ describe("watchdog configuration", () => {
         platform: "win32",
         graceMs: 1,
         delayFn: async () => {},
+        identityFn: () => "original-process",
         spawnFn: (command, args) => {
           invocations.push([command, args]);
           const killer = new EventEmitter();
@@ -594,6 +596,42 @@ describe("watchdog configuration", () => {
     expect(await runWithCodes([5, 0])).toHaveLength(2);
   });
 
+  it("does not force-kill a replacement Windows PID after a soft pass", async () => {
+    const identities = ["original-process", "replacement-process"];
+    const invocations = [];
+    await expect(
+      terminateProcessTree(321, {
+        platform: "win32",
+        graceMs: 1,
+        delayFn: async () => {},
+        identityFn: () => identities.shift(),
+        spawnFn: (command, args) => {
+          invocations.push([command, args]);
+          const killer = new EventEmitter();
+          killer.kill = () => {};
+          queueMicrotask(() => killer.emit("close", 0, null));
+          return killer;
+        },
+      }),
+    ).rejects.toMatchObject({ code: "PROCESS_IDENTITY_UNPROVEN" });
+    expect(invocations).toEqual([["taskkill", ["/PID", "321", "/T"]]]);
+  });
+
+  it("does not force-kill a replacement POSIX process group after TERM", async () => {
+    const identities = ["original-group", "replacement-group"];
+    const signals = [];
+    await expect(
+      terminateProcessTree(321, {
+        platform: "darwin",
+        graceMs: 1,
+        delayFn: async () => {},
+        identityFn: () => identities.shift(),
+        signalFn: (pid, signal) => signals.push([pid, signal]),
+      }),
+    ).rejects.toMatchObject({ code: "PROCESS_IDENTITY_UNPROVEN" });
+    expect(signals).toEqual([[-321, "SIGTERM"]]);
+  });
+
   it("fails closed when forced Windows tree termination fails", async () => {
     const codes = [0, 5];
     await expect(
@@ -601,6 +639,7 @@ describe("watchdog configuration", () => {
         platform: "win32",
         graceMs: 1,
         delayFn: async () => {},
+        identityFn: () => "original-process",
         spawnFn: () => {
           const killer = new EventEmitter();
           killer.kill = () => {};

--- a/packages/scripts/__tests__/test-cloud-run.test.mjs
+++ b/packages/scripts/__tests__/test-cloud-run.test.mjs
@@ -565,8 +565,10 @@ describe("watchdog configuration", () => {
       signalFn: (pid, signal) => signals.push([pid, signal]),
       delayFn: async () => {},
       identityFn: () => "original-process",
+      processGroupFn: () => 321,
     });
     expect(signals).toEqual([
+      [321, "SIGSTOP"],
       [-321, "SIGTERM"],
       [-321, "SIGKILL"],
     ]);
@@ -617,8 +619,12 @@ describe("watchdog configuration", () => {
     expect(invocations).toEqual([["taskkill", ["/PID", "321", "/T"]]]);
   });
 
-  it("does not force-kill a replacement POSIX process group after TERM", async () => {
-    const identities = ["original-group", "replacement-group"];
+  it("does not force-kill a POSIX group after the supervisor identity changes", async () => {
+    const identities = [
+      "original-group",
+      "original-group",
+      "replacement-group",
+    ];
     const signals = [];
     await expect(
       terminateProcessTree(321, {
@@ -626,10 +632,111 @@ describe("watchdog configuration", () => {
         graceMs: 1,
         delayFn: async () => {},
         identityFn: () => identities.shift(),
+        processGroupFn: () => 321,
         signalFn: (pid, signal) => signals.push([pid, signal]),
       }),
     ).rejects.toMatchObject({ code: "PROCESS_IDENTITY_UNPROVEN" });
-    expect(signals).toEqual([[-321, "SIGTERM"]]);
+    expect(signals).toEqual([
+      [321, "SIGSTOP"],
+      [-321, "SIGTERM"],
+    ]);
+  });
+
+  it("fails closed when supervisor PGID ownership changes during grace", async () => {
+    const processGroups = [321, 321, 999];
+    const signals = [];
+    await expect(
+      terminateProcessTree(321, {
+        platform: "darwin",
+        graceMs: 1,
+        delayFn: async () => {},
+        identityFn: () => "original-process",
+        processGroupFn: () => processGroups.shift(),
+        signalFn: (pid, signal) => signals.push([pid, signal]),
+      }),
+    ).rejects.toMatchObject({ code: "PROCESS_GROUP_UNPROVEN" });
+    expect(signals).toEqual([
+      [321, "SIGSTOP"],
+      [-321, "SIGTERM"],
+    ]);
+  });
+
+  it("fails closed when supervisor identity changes as it is stopped", async () => {
+    const identities = ["original-process", "replacement-process"];
+    const signals = [];
+    await expect(
+      terminateProcessTree(321, {
+        platform: "darwin",
+        graceMs: 1,
+        delayFn: async () => {},
+        identityFn: () => identities.shift(),
+        processGroupFn: () => 321,
+        signalFn: (pid, signal) => signals.push([pid, signal]),
+      }),
+    ).rejects.toMatchObject({ code: "PROCESS_IDENTITY_UNPROVEN" });
+    expect(signals).toEqual([[321, "SIGSTOP"]]);
+  });
+
+  it("fails closed when supervisor PGID ownership changes as it is stopped", async () => {
+    const processGroups = [321, 999];
+    const signals = [];
+    await expect(
+      terminateProcessTree(321, {
+        platform: "darwin",
+        graceMs: 1,
+        delayFn: async () => {},
+        identityFn: () => "original-process",
+        processGroupFn: () => processGroups.shift(),
+        signalFn: (pid, signal) => signals.push([pid, signal]),
+      }),
+    ).rejects.toMatchObject({ code: "PROCESS_GROUP_UNPROVEN" });
+    expect(signals).toEqual([[321, "SIGSTOP"]]);
+  });
+
+  it("never stops a process that is not the detached group leader", async () => {
+    const signals = [];
+    await expect(
+      terminateProcessTree(321, {
+        platform: "darwin",
+        graceMs: 1,
+        delayFn: async () => {},
+        identityFn: () => "original-process",
+        processGroupFn: () => 999,
+        signalFn: (pid, signal) => signals.push([pid, signal]),
+      }),
+    ).rejects.toMatchObject({ code: "PROCESS_GROUP_UNPROVEN" });
+    expect(signals).toEqual([]);
+  });
+
+  it("spawns POSIX commands behind an owned process-group supervisor", async () => {
+    const signalSource = new EventEmitter();
+    const child = new EventEmitter();
+    child.pid = 321;
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    let spawned;
+    const resultPromise = runCommandWithWatchdog("bun", ["test", "a.ts"], {
+      timeoutMs: 10_000,
+      writeOut: () => {},
+      writeErr: () => {},
+      platform: "darwin",
+      signalSource,
+      identityFn: () => "supervisor",
+      spawnFn: (command, args, options) => {
+        spawned = { command, args, options };
+        return child;
+      },
+    });
+
+    child.emit("close", 0, null);
+    const result = await resultPromise;
+
+    expect(spawned.command).toBe("/bin/sh");
+    expect(spawned.args.slice(-3)).toEqual(["bun", "test", "a.ts"]);
+    expect(spawned.args[0]).toBe("-c");
+    expect(spawned.args[1]).toContain("trap 'terminating=1' TERM INT");
+    expect(spawned.options.detached).toBe(true);
+    expect(result.status).toBe(0);
   });
 
   it("fails closed when forced Windows tree termination fails", async () => {

--- a/packages/scripts/test-cloud-run-watchdog.self-test.mjs
+++ b/packages/scripts/test-cloud-run-watchdog.self-test.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+// End-to-end regression proof for #17245. A parent and its descendant both
+// ignore graceful termination and keep native event-loop handles open. The
+// batch watchdog must still return promptly and remove the whole process tree.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { runCommandWithWatchdog } from "./test-cloud-run.mjs";
+
+const descendantSource = `
+process.on("SIGTERM", () => {});
+setInterval(() => {}, 1000);
+`;
+const parentSource = `
+import { spawn } from "node:child_process";
+const descendant = spawn(process.execPath, ["--input-type=module", "-e", ${JSON.stringify(descendantSource)}], {
+  stdio: "ignore",
+});
+process.stdout.write("DESCENDANT_PID=" + descendant.pid + "\\n");
+process.on("SIGTERM", () => {});
+setInterval(() => {}, 1000);
+`;
+
+let stdout = "";
+let timeoutObserved = false;
+let childPid;
+let descendantPid;
+
+function isAlive(pid) {
+  if (!Number.isInteger(pid)) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+function bestEffortKillTree(pid, { processGroup = false } = {}) {
+  if (!Number.isInteger(pid)) return;
+  try {
+    if (process.platform === "win32") {
+      spawnSync("taskkill", ["/PID", String(pid), "/T", "/F"], {
+        stdio: "ignore",
+        windowsHide: true,
+        timeout: 2000,
+      });
+    } else if (processGroup) {
+      // A descendant may keep the detached group alive after its leader exits,
+      // so target the group even when the leader PID itself is already gone.
+      process.kill(-pid, "SIGKILL");
+    } else if (isAlive(pid)) {
+      process.kill(pid, "SIGKILL");
+    }
+  } catch (error) {
+    if (error?.code !== "ESRCH") {
+      process.stderr.write(
+        `[test-cloud-run-watchdog] cleanup warning for PID ${pid}: ${String(error)}\n`,
+      );
+    }
+  }
+}
+
+try {
+  const startedAt = Date.now();
+  const result = await runCommandWithWatchdog(
+    process.execPath,
+    ["--input-type=module", "-e", parentSource],
+    {
+      timeoutMs: 250,
+      terminationGraceMs: 400,
+      forceKillSettleMs: 500,
+      writeOut: (text) => {
+        stdout += text;
+      },
+      writeErr: () => {},
+      onTimeout: () => {
+        timeoutObserved = true;
+      },
+    },
+  );
+  const elapsedMs = Date.now() - startedAt;
+  childPid = result.pid;
+  descendantPid = Number(stdout.match(/DESCENDANT_PID=(\d+)/)?.[1]);
+
+  assert.equal(timeoutObserved, true, "watchdog must announce the deadline");
+  assert.equal(
+    result.timedOut,
+    true,
+    "non-exiting child must fail as timed out",
+  );
+  assert.equal(
+    result.terminationError,
+    undefined,
+    "successful escalation must not report a teardown error",
+  );
+  assert.ok(
+    elapsedMs < 5000,
+    `watchdog took too long to return (${elapsedMs} ms)`,
+  );
+  assert.ok(
+    Number.isInteger(descendantPid),
+    "child must report its descendant PID live",
+  );
+  assert.ok(
+    Number.isInteger(childPid),
+    "watchdog result must retain the child PID",
+  );
+
+  const descendantDeadline = Date.now() + 1500;
+  while (
+    (isAlive(childPid) || isAlive(descendantPid)) &&
+    Date.now() < descendantDeadline
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  assert.equal(isAlive(childPid), false, "watchdog must terminate the child");
+  assert.equal(
+    isAlive(descendantPid),
+    false,
+    "watchdog must terminate the descendant",
+  );
+
+  console.log(
+    `[test-cloud-run-watchdog] self-test passed (${elapsedMs} ms, platform=${process.platform})`,
+  );
+} finally {
+  bestEffortKillTree(childPid, { processGroup: true });
+  bestEffortKillTree(descendantPid);
+}

--- a/packages/scripts/test-cloud-run-watchdog.self-test.mjs
+++ b/packages/scripts/test-cloud-run-watchdog.self-test.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 /**
- * Exercises the Cloud batch watchdog against a real parent and descendant.
- * The parent exits on graceful termination while the descendant resists it;
- * the watchdog must anchor the group and remove the complete tree promptly.
+ * Exercises the Cloud batch watchdog against real parent/descendant trees.
+ * It covers both a parent that exits on graceful termination and a command
+ * that exits before timeout while a resistant descendant retains its pipes.
  */
 
 import assert from "node:assert/strict";
@@ -26,12 +26,23 @@ process.on("SIGTERM", () => {
 });
 setInterval(() => {}, 1000);
 `;
+const exitedParentSource = `
+import { spawn } from "node:child_process";
+const descendant = spawn(process.execPath, ["--input-type=module", "-e", ${JSON.stringify(descendantSource)}], {
+  stdio: ["ignore", "inherit", "inherit"],
+});
+process.stdout.write("EXITED_PARENT_PID=" + process.pid + "\\n");
+process.stdout.write("RETAINING_DESCENDANT_PID=" + descendant.pid + "\\n", () => process.exit(0));
+`;
 
 let stdout = "";
 let timeoutObserved = false;
 let supervisorPid;
 let parentPid;
 let descendantPid;
+let exitedSupervisorPid;
+let exitedParentPid;
+let retainingDescendantPid;
 
 function isAlive(pid) {
   if (!Number.isInteger(pid)) return false;
@@ -145,10 +156,113 @@ try {
   );
 
   console.log(
-    `[test-cloud-run-watchdog] self-test passed (${elapsedMs} ms, platform=${process.platform})`,
+    `[test-cloud-run-watchdog] TERM-exit scenario passed (${elapsedMs} ms, platform=${process.platform})`,
   );
+
+  if (process.platform !== "win32") {
+    let exitedStdout = "";
+    let exitedTimeoutObserved = false;
+    let exitedParentGoneAtTimeout = false;
+    const exitedStartedAt = Date.now();
+    const exitedResult = await runCommandWithWatchdog(
+      process.execPath,
+      ["--input-type=module", "-e", exitedParentSource],
+      {
+        timeoutMs: 250,
+        terminationGraceMs: 400,
+        forceKillSettleMs: 500,
+        writeOut: (text) => {
+          exitedStdout += text;
+        },
+        writeErr: () => {},
+        onTimeout: () => {
+          exitedTimeoutObserved = true;
+          const reportedParentPid = Number(
+            exitedStdout.match(/EXITED_PARENT_PID=(\d+)/)?.[1],
+          );
+          exitedParentGoneAtTimeout =
+            Number.isInteger(reportedParentPid) && !isAlive(reportedParentPid);
+        },
+      },
+    );
+    const exitedElapsedMs = Date.now() - exitedStartedAt;
+    exitedSupervisorPid = exitedResult.pid;
+    exitedParentPid = Number(
+      exitedStdout.match(/EXITED_PARENT_PID=(\d+)/)?.[1],
+    );
+    retainingDescendantPid = Number(
+      exitedStdout.match(/RETAINING_DESCENDANT_PID=(\d+)/)?.[1],
+    );
+
+    assert.equal(
+      exitedTimeoutObserved,
+      true,
+      "retained descendant pipes must keep the watchdog armed",
+    );
+    assert.equal(
+      exitedResult.timedOut,
+      true,
+      "an exited command with retained descendant pipes must time out",
+    );
+    assert.equal(
+      exitedParentGoneAtTimeout,
+      true,
+      "the command must already be gone when the watchdog fires",
+    );
+    assert.equal(
+      exitedResult.terminationError,
+      undefined,
+      "the retained supervisor anchor must make teardown provable",
+    );
+    assert.ok(
+      Number.isInteger(exitedSupervisorPid),
+      "watchdog must retain the second supervisor PID",
+    );
+    assert.ok(
+      Number.isInteger(exitedParentPid),
+      "exited command must report its PID",
+    );
+    assert.ok(
+      Number.isInteger(retainingDescendantPid),
+      "pipe-retaining descendant must report its PID",
+    );
+    assert.equal(
+      isAlive(exitedParentPid),
+      false,
+      "command must have exited before watchdog teardown",
+    );
+
+    const retainedPipeDeadline = Date.now() + 1500;
+    while (
+      (isAlive(exitedSupervisorPid) || isAlive(retainingDescendantPid)) &&
+      Date.now() < retainedPipeDeadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.equal(
+      isAlive(exitedSupervisorPid),
+      false,
+      "watchdog must terminate the retained supervisor anchor",
+    );
+    assert.equal(
+      isAlive(retainingDescendantPid),
+      false,
+      "watchdog must terminate the pipe-retaining descendant",
+    );
+    assert.ok(
+      exitedElapsedMs < 5000,
+      `retained-pipe watchdog took too long (${exitedElapsedMs} ms)`,
+    );
+
+    console.log(
+      `[test-cloud-run-watchdog] exited-command scenario passed (${exitedElapsedMs} ms, platform=${process.platform})`,
+    );
+  }
 } finally {
   bestEffortKillTree(supervisorPid, { processGroup: true });
   bestEffortKillTree(parentPid);
   bestEffortKillTree(descendantPid);
+  bestEffortKillTree(exitedSupervisorPid, { processGroup: true });
+  bestEffortKillTree(exitedParentPid);
+  bestEffortKillTree(retainingDescendantPid);
 }

--- a/packages/scripts/test-cloud-run-watchdog.self-test.mjs
+++ b/packages/scripts/test-cloud-run-watchdog.self-test.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 
-// End-to-end regression proof for #17245. A parent and its descendant both
-// ignore graceful termination and keep native event-loop handles open. The
-// batch watchdog must still return promptly and remove the whole process tree.
+/**
+ * Exercises the Cloud batch watchdog against a real parent and descendant.
+ * The parent exits on graceful termination while the descendant resists it;
+ * the watchdog must anchor the group and remove the complete tree promptly.
+ */
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
@@ -17,14 +19,18 @@ import { spawn } from "node:child_process";
 const descendant = spawn(process.execPath, ["--input-type=module", "-e", ${JSON.stringify(descendantSource)}], {
   stdio: "ignore",
 });
+process.stdout.write("PARENT_PID=" + process.pid + "\\n");
 process.stdout.write("DESCENDANT_PID=" + descendant.pid + "\\n");
-process.on("SIGTERM", () => {});
+process.on("SIGTERM", () => {
+  process.stdout.write("PARENT_TERM_EXIT\\n", () => process.exit(0));
+});
 setInterval(() => {}, 1000);
 `;
 
 let stdout = "";
 let timeoutObserved = false;
-let childPid;
+let supervisorPid;
+let parentPid;
 let descendantPid;
 
 function isAlive(pid) {
@@ -82,7 +88,8 @@ try {
     },
   );
   const elapsedMs = Date.now() - startedAt;
-  childPid = result.pid;
+  supervisorPid = result.pid;
+  parentPid = Number(stdout.match(/PARENT_PID=(\d+)/)?.[1]);
   descendantPid = Number(stdout.match(/DESCENDANT_PID=(\d+)/)?.[1]);
 
   assert.equal(timeoutObserved, true, "watchdog must announce the deadline");
@@ -105,18 +112,32 @@ try {
     "child must report its descendant PID live",
   );
   assert.ok(
-    Number.isInteger(childPid),
-    "watchdog result must retain the child PID",
+    Number.isInteger(supervisorPid),
+    "watchdog result must retain the supervisor PID",
+  );
+  assert.ok(
+    Number.isInteger(parentPid),
+    "supervised command must report its PID live",
+  );
+  assert.match(
+    stdout,
+    /PARENT_TERM_EXIT/,
+    "parent must handle TERM and exit before forced group teardown",
   );
 
   const descendantDeadline = Date.now() + 1500;
   while (
-    (isAlive(childPid) || isAlive(descendantPid)) &&
+    (isAlive(supervisorPid) || isAlive(parentPid) || isAlive(descendantPid)) &&
     Date.now() < descendantDeadline
   ) {
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
-  assert.equal(isAlive(childPid), false, "watchdog must terminate the child");
+  assert.equal(
+    isAlive(supervisorPid),
+    false,
+    "watchdog must terminate the supervisor",
+  );
+  assert.equal(isAlive(parentPid), false, "watchdog must terminate the parent");
   assert.equal(
     isAlive(descendantPid),
     false,
@@ -127,6 +148,7 @@ try {
     `[test-cloud-run-watchdog] self-test passed (${elapsedMs} ms, platform=${process.platform})`,
   );
 } finally {
-  bestEffortKillTree(childPid, { processGroup: true });
+  bestEffortKillTree(supervisorPid, { processGroup: true });
+  bestEffortKillTree(parentPid);
   bestEffortKillTree(descendantPid);
 }

--- a/packages/scripts/test-cloud-run.mjs
+++ b/packages/scripts/test-cloud-run.mjs
@@ -1,17 +1,11 @@
 #!/usr/bin/env node
 
-// Cross-platform replacement for the previous `test:cloud` shell pipeline,
-// which used `printf '...\n'` (broken under bun's embedded shell on Windows
-// — outputs literal `n` instead of newlines) and required POSIX-shell
-// `$OLDPWD` semantics.
-//
-// The pure helpers below (walkTests, chunkByBudget, formatBatchFiles,
-// writeSyncAll, ensureCloudTestRuntime) are exported so
-// test-cloud-run.test.mjs and the *.self-test.mjs files can exercise them
-// directly; the batch-orchestration side effects (spawning `bun test`,
-// writing bunfig.toml, building missing runtime artifacts) only run when this
-// file is invoked as the entry script, guarded by the `main()` call at the
-// bottom.
+/**
+ * Runs the cross-platform Cloud test batches with bounded process lifetimes,
+ * streamed diagnostics, and whole-tree teardown. Pure helpers are exported
+ * for unit and self-test coverage; spawning tests and preparing runtime
+ * artifacts occur only when this module is invoked as the entry script.
+ */
 
 import { spawn, spawnSync } from "node:child_process";
 import {
@@ -67,6 +61,21 @@ export const DEFAULT_BATCH_TIMEOUT_MS = 10 * 60 * 1000;
 export const DEFAULT_BATCH_KILL_GRACE_MS = 2000;
 export const MAX_CLASSIFICATION_OUTPUT_CHARS = 1024 * 1024;
 const MAX_TIMER_MS = 2_147_483_647;
+const POSIX_PROCESS_GROUP_SUPERVISOR = `
+terminating=0
+trap 'terminating=1' TERM INT
+"$@" &
+child_pid=$!
+wait "$child_pid"
+status=$?
+if [ "$terminating" -ne 0 ]; then
+  while :; do
+    sleep 3600 &
+    wait $!
+  done
+fi
+exit "$status"
+`;
 
 export function chunkByBudget(files, maxFilesPerBatch, maxArgsChars) {
   const batches = [];
@@ -238,6 +247,40 @@ function readPosixProcessIdentity(pid, spawnSyncFn) {
   return startTime ? `ps-start:${startTime}` : undefined;
 }
 
+function readPosixProcessGroup(pid, spawnSyncFn) {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const endOfCommand = stat.lastIndexOf(")");
+    if (endOfCommand > 0) {
+      const fields = stat
+        .slice(endOfCommand + 1)
+        .trim()
+        .split(/\s+/);
+      const processGroup = Number(fields[2]);
+      if (Number.isInteger(processGroup) && processGroup > 0) {
+        return processGroup;
+      }
+    }
+  } catch {
+    // macOS and other POSIX systems do not expose Linux's /proc stat file.
+  }
+
+  let result;
+  try {
+    result = spawnSyncFn("ps", ["-p", String(pid), "-o", "pgid="], {
+      encoding: "utf8",
+      maxBuffer: 4096,
+    });
+  } catch {
+    return undefined;
+  }
+  if (result?.error || result?.status !== 0) return undefined;
+  const processGroup = Number(result.stdout?.trim());
+  return Number.isInteger(processGroup) && processGroup > 0
+    ? processGroup
+    : undefined;
+}
+
 function readWindowsProcessIdentity(pid, spawnSyncFn) {
   const command = [
     `$process = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"`,
@@ -274,6 +317,16 @@ export function readProcessIdentity(
     : readPosixProcessIdentity(pid, spawnSyncFn);
 }
 
+export function readProcessGroup(
+  pid,
+  { platform = process.platform, spawnSyncFn = spawnSync } = {},
+) {
+  if (!Number.isInteger(pid) || pid <= 0 || platform === "win32") {
+    return undefined;
+  }
+  return readPosixProcessGroup(pid, spawnSyncFn);
+}
+
 function processIdentityError(pid, platform, expected, actual) {
   const error = new Error(
     `${platform === "win32" ? "Windows PID" : "POSIX process-group"} ${pid} ` +
@@ -283,6 +336,18 @@ function processIdentityError(pid, platform, expected, actual) {
   error.pid = pid;
   error.expectedIdentity = expected;
   error.actualIdentity = actual;
+  return error;
+}
+
+function processGroupError(pid, actual) {
+  const error = new Error(
+    `POSIX process ${pid} no longer owns detached process group ${pid} ` +
+      "before forced termination",
+  );
+  error.code = "PROCESS_GROUP_UNPROVEN";
+  error.pid = pid;
+  error.expectedProcessGroup = pid;
+  error.actualProcessGroup = actual;
   return error;
 }
 
@@ -331,6 +396,7 @@ export async function terminateProcessTree(
     delayFn = delay,
     identityFn = (identityPid) =>
       readProcessIdentity(identityPid, { platform }),
+    processGroupFn = (groupPid) => readProcessGroup(groupPid, { platform }),
     expectedIdentity,
     identityCaptured = false,
   } = {},
@@ -420,6 +486,27 @@ export async function terminateProcessTree(
     return forceResult;
   }
 
+  const requireOwnedProcessGroup = async () => {
+    const actualProcessGroup = await processGroupFn(pid);
+    if (actualProcessGroup !== pid) {
+      throw processGroupError(pid, actualProcessGroup);
+    }
+  };
+
+  // runCommandWithWatchdog makes an owned supervisor the detached group
+  // leader. Stop that supervisor before signaling its group, then recheck its
+  // immutable identity and group ownership. SIGSTOP is uncatchable, so the
+  // supervisor pins the original PGID while the actual command and descendants
+  // remain runnable and receive TERM. Recheck the stopped anchor before KILL so
+  // the forced negative-PID target can never silently become a reused group.
+  await requireOwnedProcessGroup();
+  try {
+    signalFn(pid, "SIGSTOP");
+  } catch (error) {
+    throw processIdentityError(pid, platform, stableIdentity, error);
+  }
+  await requireStableProcessIdentity(pid, platform, stableIdentity, identityFn);
+  await requireOwnedProcessGroup();
   let softError;
   try {
     signalPosixProcessGroup(pid, "SIGTERM", signalFn);
@@ -428,6 +515,7 @@ export async function terminateProcessTree(
   }
   await delayFn(graceMs);
   await requireStableProcessIdentity(pid, platform, stableIdentity, identityFn);
+  await requireOwnedProcessGroup();
   try {
     signalPosixProcessGroup(pid, "SIGKILL", signalFn);
   } catch (forceError) {
@@ -475,7 +563,18 @@ export function runCommandWithWatchdog(
   return new Promise((resolve) => {
     let child;
     try {
-      child = spawnFn(command, args, {
+      const spawnCommand = platform === "win32" ? command : "/bin/sh";
+      const spawnArgs =
+        platform === "win32"
+          ? args
+          : [
+              "-c",
+              POSIX_PROCESS_GROUP_SUPERVISOR,
+              "test-cloud-run-supervisor",
+              command,
+              ...args,
+            ];
+      child = spawnFn(spawnCommand, spawnArgs, {
         cwd,
         env,
         shell,

--- a/packages/scripts/test-cloud-run.mjs
+++ b/packages/scripts/test-cloud-run.mjs
@@ -13,7 +13,7 @@
 // file is invoked as the entry script, guarded by the `main()` call at the
 // bottom.
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -55,13 +55,17 @@ export function walkTests(dir, excluded) {
 // Batch size bounds per-process memory. Windows uses a smaller process lifetime
 // because native/PGlite state from a large mixed suite can keep Bun alive after
 // the tests finish; fresh processes make that state reclaimable. The char cap
-// also keeps each argv under Windows' ~8 KiB cmd.exe command-line ceiling (the
-// spawn goes through cmd.exe there — `shell: true` below — to resolve bun's
-// `.cmd` shim). Whichever limit a file hits first closes the current batch.
+// also keeps each argv below conservative Windows command-line limits.
+// setup-bun installs bun.exe, so the runner invokes it directly with no shell.
+// Whichever limit a file hits first closes the current batch.
 export const MAX_FILES_PER_BATCH = 80;
 export const MAX_FILES_PER_BATCH_WIN32 = 16;
 export const MAX_ARGS_CHARS_WIN32 = 6000;
 export const MAX_ARGS_CHARS_POSIX = 100000;
+export const DEFAULT_BATCH_TIMEOUT_MS = 10 * 60 * 1000;
+export const DEFAULT_BATCH_KILL_GRACE_MS = 2000;
+export const MAX_CLASSIFICATION_OUTPUT_CHARS = 1024 * 1024;
+const MAX_TIMER_MS = 2_147_483_647;
 
 export function chunkByBudget(files, maxFilesPerBatch, maxArgsChars) {
   const batches = [];
@@ -109,6 +113,357 @@ export function writeSyncAll(fd, text) {
       throw error;
     }
   }
+}
+
+export function parsePositiveDuration(value, name, fallback) {
+  if (value === undefined || value === "") return fallback;
+  if (!/^\d+$/.test(value)) {
+    throw new Error(
+      `[test:cloud] ${name} must be a positive integer in milliseconds`,
+    );
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed > MAX_TIMER_MS) {
+    throw new Error(
+      `[test:cloud] ${name} must be between 1 and ${MAX_TIMER_MS} milliseconds`,
+    );
+  }
+  return parsed;
+}
+
+export function parseBatchTimeoutArg(argv) {
+  const prefix = "--batch-timeout-ms=";
+  const timeoutArgs = argv.filter((arg) => arg.startsWith(prefix));
+  if (timeoutArgs.length > 1) {
+    throw new Error(
+      "[test:cloud] --batch-timeout-ms may be provided only once",
+    );
+  }
+  const unexpected = argv.filter((arg) => !arg.startsWith(prefix));
+  if (unexpected.length > 0) {
+    throw new Error(`[test:cloud] unexpected argument: ${unexpected[0]}`);
+  }
+  if (timeoutArgs.length === 0) return DEFAULT_BATCH_TIMEOUT_MS;
+  const value = timeoutArgs[0].slice(prefix.length);
+  if (value === "") {
+    throw new Error(
+      "[test:cloud] --batch-timeout-ms must include a positive integer value",
+    );
+  }
+  return parsePositiveDuration(
+    value,
+    "--batch-timeout-ms",
+    DEFAULT_BATCH_TIMEOUT_MS,
+  );
+}
+
+export function windowsTaskkillInvocation(pid, force) {
+  return {
+    command: "taskkill",
+    args: ["/PID", String(pid), "/T", ...(force ? ["/F"] : [])],
+  };
+}
+
+function runTreeKillCommand(pid, force, spawnFn, commandTimeoutMs) {
+  const { command, args } = windowsTaskkillInvocation(pid, force);
+  return new Promise((resolve, reject) => {
+    let killer;
+    try {
+      killer = spawnFn(command, args, {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+    } catch (error) {
+      reject(error);
+      return;
+    }
+    let settled = false;
+    let timer;
+    const finish = (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve();
+    };
+    killer.once("error", finish);
+    killer.once("close", (code, signal) => {
+      if (code === 0) finish();
+      else {
+        const error = new Error(
+          `taskkill ${force ? "/F " : ""}/T failed ` +
+            `(status=${code ?? "null"}, signal=${signal ?? "none"})`,
+        );
+        error.exitCode = code;
+        finish(error);
+      }
+    });
+    timer = setTimeout(() => {
+      killer.kill?.("SIGKILL");
+      finish(
+        new Error(`taskkill did not settle within ${commandTimeoutMs} ms`),
+      );
+    }, commandTimeoutMs);
+  });
+}
+
+function signalPosixProcessGroup(pid, signal, signalFn) {
+  try {
+    signalFn(-pid, signal);
+  } catch (error) {
+    if (error?.code === "ESRCH") return;
+    // Detached children must own a process group with their PID. Falling back
+    // to the direct child could strand descendants, so fail closed instead.
+    throw error;
+  }
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// A timed-out batch owns a complete process tree. POSIX children are spawned
+// in their own process group, so negative-PID signals reach every descendant.
+// Windows uses taskkill /T, escalating to /F after the same bounded grace.
+export async function terminateProcessTree(
+  pid,
+  {
+    platform = process.platform,
+    graceMs = DEFAULT_BATCH_KILL_GRACE_MS,
+    spawnFn = spawn,
+    signalFn = process.kill,
+    delayFn = delay,
+  } = {},
+) {
+  if (!Number.isInteger(pid) || pid <= 0) return;
+  if (platform === "win32") {
+    let softError;
+    try {
+      await runTreeKillCommand(pid, false, spawnFn, graceMs);
+    } catch (error) {
+      softError = error;
+    }
+    await delayFn(graceMs);
+    let forceError;
+    try {
+      await runTreeKillCommand(pid, true, spawnFn, graceMs);
+    } catch (error) {
+      forceError = error;
+    }
+    // taskkill exits 128 when the process tree disappeared between the child
+    // state check and either termination pass. Normalize each pass before
+    // deciding whether teardown failed; this race means the desired state was
+    // already reached.
+    if (softError?.exitCode === 128) softError = undefined;
+    if (forceError?.exitCode === 128) forceError = undefined;
+    if (forceError) {
+      throw new AggregateError(
+        [softError, forceError].filter(Boolean),
+        `failed to terminate Windows process tree rooted at PID ${pid}`,
+      );
+    }
+    // A soft-pass error followed by a successful forced pass still proves the
+    // complete tree was removed, so it is not a teardown failure.
+    return;
+  }
+
+  let softError;
+  try {
+    signalPosixProcessGroup(pid, "SIGTERM", signalFn);
+  } catch (error) {
+    softError = error;
+  }
+  await delayFn(graceMs);
+  try {
+    signalPosixProcessGroup(pid, "SIGKILL", signalFn);
+  } catch (forceError) {
+    throw new AggregateError(
+      [softError, forceError].filter(Boolean),
+      `failed to terminate POSIX process group ${pid}`,
+    );
+  }
+  if (softError) {
+    throw new AggregateError(
+      [softError],
+      `POSIX process group ${pid} required forced termination`,
+    );
+  }
+}
+
+export function appendClassificationOutput(current, chunk) {
+  const combined = current + chunk;
+  return combined.length <= MAX_CLASSIFICATION_OUTPUT_CHARS
+    ? combined
+    : combined.slice(-MAX_CLASSIFICATION_OUTPUT_CHARS);
+}
+
+export function runCommandWithWatchdog(
+  command,
+  args,
+  {
+    cwd,
+    env,
+    shell = false,
+    timeoutMs = DEFAULT_BATCH_TIMEOUT_MS,
+    terminationGraceMs = DEFAULT_BATCH_KILL_GRACE_MS,
+    forceKillSettleMs = 1000,
+    writeOut,
+    writeErr,
+    onTimeout = () => {},
+    platform = process.platform,
+    spawnFn = spawn,
+    terminateTree = terminateProcessTree,
+    signalSource = process,
+  },
+) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawnFn(command, args, {
+        cwd,
+        env,
+        shell,
+        detached: true,
+        windowsHide: platform === "win32",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      resolve({ error, stdout: "", stderr: "", streamed: true });
+      return;
+    }
+
+    let stdout = "";
+    let stderr = "";
+    let outputTruncated = false;
+    let timedOut = false;
+    let terminationFinished = false;
+    let terminationError;
+    let terminationPromise;
+    let terminationReason;
+    let parentSignal;
+    let closeResult;
+    let settled = false;
+    let forceSettleTimer;
+    let watchdog;
+
+    const parentSignalHandlers = new Map();
+    const removeParentSignalHandlers = () => {
+      for (const [signal, handler] of parentSignalHandlers) {
+        signalSource.removeListener(signal, handler);
+      }
+      parentSignalHandlers.clear();
+    };
+
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(watchdog);
+      clearTimeout(forceSettleTimer);
+      removeParentSignalHandlers();
+      resolve({
+        ...result,
+        pid: child.pid,
+        stdout,
+        stderr,
+        outputTruncated,
+        streamed: true,
+        timedOut,
+        parentSignal,
+        terminationError,
+      });
+    };
+
+    const finishAfterTermination = () => {
+      terminationFinished = true;
+      if (closeResult) {
+        finish(closeResult);
+        return;
+      }
+      forceSettleTimer = setTimeout(() => {
+        child.stdout?.destroy();
+        child.stderr?.destroy();
+        child.unref?.();
+        finish({ status: null, signal: null });
+      }, forceKillSettleMs);
+    };
+
+    const beginTermination = (reason) => {
+      if (settled || terminationReason) {
+        return terminationPromise ?? Promise.resolve();
+      }
+      terminationReason = reason;
+      if (reason === "timeout") {
+        timedOut = true;
+        onTimeout();
+      } else {
+        parentSignal = reason;
+        clearTimeout(watchdog);
+      }
+      const leaderExited =
+        (child.exitCode !== undefined && child.exitCode !== null) ||
+        (child.signalCode !== undefined && child.signalCode !== null);
+      if (platform === "win32" && leaderExited) {
+        // Windows tree termination is rooted in a live PID. After `exit` but
+        // before `close`, inherited pipes may still be held by descendants,
+        // while the leader PID is already eligible for reuse. Never taskkill a
+        // possibly unrelated process: bound the drain, fail closed, and let the
+        // CI runner's job boundary reap any orphan.
+        terminationError = new Error(
+          `batch leader PID ${child.pid} exited before its stdio closed; ` +
+            "Windows process-tree teardown cannot be proven safely",
+        );
+        child.stdout?.destroy();
+        child.stderr?.destroy();
+        child.unref?.();
+        finish({ status: child.exitCode ?? null, signal: child.signalCode });
+        terminationPromise = Promise.resolve();
+        return terminationPromise;
+      }
+      if (!terminationPromise) {
+        terminationPromise = terminateTree(child.pid, {
+          platform,
+          graceMs: terminationGraceMs,
+        })
+          .catch((error) => {
+            terminationError = error;
+          })
+          .finally(finishAfterTermination);
+      }
+      return terminationPromise;
+    };
+
+    child.stdout?.on("data", (chunk) => {
+      const text = chunk.toString("utf8");
+      if (stdout.length + text.length > MAX_CLASSIFICATION_OUTPUT_CHARS) {
+        outputTruncated = true;
+      }
+      stdout = appendClassificationOutput(stdout, text);
+      writeOut(text);
+    });
+    child.stderr?.on("data", (chunk) => {
+      const text = chunk.toString("utf8");
+      if (stderr.length + text.length > MAX_CLASSIFICATION_OUTPUT_CHARS) {
+        outputTruncated = true;
+      }
+      stderr = appendClassificationOutput(stderr, text);
+      writeErr(text);
+    });
+    child.once("error", (error) => finish({ error }));
+    child.once("close", (status, signal) => {
+      closeResult = { status, signal };
+      if ((!timedOut && !parentSignal) || terminationFinished) {
+        finish(closeResult);
+      }
+    });
+
+    for (const signal of ["SIGINT", "SIGTERM"]) {
+      const handler = () => void beginTermination(signal);
+      parentSignalHandlers.set(signal, handler);
+      signalSource.once(signal, handler);
+    }
+
+    watchdog = setTimeout(() => void beginTermination("timeout"), timeoutMs);
+  });
 }
 
 // The unit lane runs with NO database service (Cloud Tests → unit-tests calls
@@ -311,23 +666,49 @@ export function ensureCloudTestRuntime({
 // (status/signal handling, the pglite status-99 normalization, spawn errors)
 // without shelling out to a real `bun test` run. Returns true if any batch's
 // failure should fail the overall gate.
-export function runBatches(
+export async function runBatches(
   batches,
-  { spawnBatch, stagingDir, env, repoRoot, writeOut, writeErr },
+  {
+    spawnBatch,
+    stagingDir,
+    env,
+    repoRoot,
+    writeOut,
+    writeErr,
+    timeoutMs = DEFAULT_BATCH_TIMEOUT_MS,
+    terminationGraceMs = DEFAULT_BATCH_KILL_GRACE_MS,
+  },
 ) {
   let anyFailed = false;
   for (let i = 0; i < batches.length; i++) {
     const batch = batches[i];
+    const files = formatBatchFiles(batch, repoRoot);
     writeOut(
-      `[test:cloud] batch ${i + 1}/${batches.length} — ${batch.length} files\n`,
+      `[test:cloud] batch ${i + 1}/${batches.length} — ${batch.length} files\n` +
+        `[test:cloud] files in batch:\n${files}\n`,
     );
-    const result = spawnBatch(batch, { cwd: stagingDir, env });
+    let timeoutReported = false;
+    const reportTimeout = () => {
+      if (timeoutReported) return;
+      timeoutReported = true;
+      writeErr(
+        `[test:cloud] batch ${i + 1}/${batches.length} exceeded its ${timeoutMs} ms wall-clock deadline; ` +
+          `terminating the process tree\n[test:cloud] files in timed-out batch:\n${files}\n`,
+      );
+    };
+    const result = await spawnBatch(batch, {
+      cwd: stagingDir,
+      env,
+      writeOut,
+      writeErr,
+      timeoutMs,
+      terminationGraceMs,
+      onTimeout: reportTimeout,
+    });
     const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
-    if (result.stdout) writeOut(result.stdout);
-    if (result.stderr) writeErr(result.stderr);
+    if (!result.streamed && result.stdout) writeOut(result.stdout);
+    if (!result.streamed && result.stderr) writeErr(result.stderr);
     if (result.error) {
-      // spawnSync failure (e.g. ENOBUFS from maxBuffer, spawn ENOENT). Surface it
-      // and keep the exit deferred so the drained batch output is not truncated.
       writeErr(
         `[test:cloud] batch ${i + 1}/${batches.length} spawn error: ${
           result.error.stack ?? String(result.error)
@@ -335,12 +716,34 @@ export function runBatches(
       );
       return true;
     }
+    if (result.terminationError) {
+      writeErr(
+        `[test:cloud] batch ${i + 1}/${batches.length} process-tree teardown failed: ` +
+          `${result.terminationError.stack ?? String(result.terminationError)}\n`,
+      );
+      return true;
+    }
+    if (result.parentSignal) {
+      writeErr(
+        `[test:cloud] batch ${i + 1}/${batches.length} interrupted by parent ${result.parentSignal}; ` +
+          "the process tree was terminated\n",
+      );
+      return true;
+    }
+    if (result.timedOut) {
+      reportTimeout();
+      anyFailed = true;
+      continue;
+    }
     // Run every batch even after a failure so one broken suite doesn't mask the
     // rest; aggregate into a single non-zero exit for the gate.
     const status = result.status;
     const signal = result.signal;
     if ((status ?? 1) !== 0 || signal) {
-      if (shouldNormalizeBunStatus99({ status, signal, output })) {
+      if (
+        !result.outputTruncated &&
+        shouldNormalizeBunStatus99({ status, signal, output })
+      ) {
         writeErr(
           `[test:cloud] batch ${i + 1}/${batches.length} exited with Bun status ${status} ` +
             "after reporting no failed tests; treating as pass (known Bun/PGlite exitCode pollution).\n",
@@ -358,7 +761,8 @@ export function runBatches(
   return anyFailed;
 }
 
-function main() {
+async function main() {
+  const timeoutMs = parseBatchTimeoutArg(process.argv.slice(2));
   try {
     ensureCloudTestRuntime({
       requiredArtifacts: computeRequiredRuntimeArtifacts(repoRoot),
@@ -463,24 +867,41 @@ function main() {
 
   const writeOut = (text) => writeSyncAll(1, text);
   const writeErr = (text) => writeSyncAll(2, text);
-
-  const spawnBatch = (batch, { cwd, env: batchEnv }) =>
-    spawnSync("bun", ["test", ...batch, "--timeout", "120000", "--isolate"], {
+  const spawnBatch = (
+    batch,
+    {
       cwd,
       env: batchEnv,
-      encoding: "utf8",
-      maxBuffer: 128 * 1024 * 1024,
-      stdio: ["ignore", "pipe", "pipe"],
-      shell: process.platform === "win32",
-    });
+      writeOut,
+      writeErr,
+      timeoutMs,
+      terminationGraceMs,
+      onTimeout,
+    },
+  ) =>
+    runCommandWithWatchdog(
+      "bun",
+      ["test", ...batch, "--timeout", "120000", "--isolate"],
+      {
+        cwd,
+        env: batchEnv,
+        shell: false,
+        timeoutMs,
+        terminationGraceMs,
+        writeOut,
+        writeErr,
+        onTimeout,
+      },
+    );
 
-  const anyFailed = runBatches(batches, {
+  const anyFailed = await runBatches(batches, {
     spawnBatch,
     stagingDir,
     env,
     repoRoot,
     writeOut,
     writeErr,
+    timeoutMs,
   });
 
   // Use process.exitCode + natural return instead of process.exit(): the latter
@@ -492,5 +913,10 @@ function main() {
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-  main();
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
 }

--- a/packages/scripts/test-cloud-run.mjs
+++ b/packages/scripts/test-cloud-run.mjs
@@ -18,6 +18,7 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  readFileSync,
   statSync,
   writeFileSync,
   writeSync,
@@ -179,16 +180,16 @@ function runTreeKillCommand(pid, force, spawnFn, commandTimeoutMs) {
     }
     let settled = false;
     let timer;
-    const finish = (error) => {
+    const finish = (error, result) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
       if (error) reject(error);
-      else resolve();
+      else resolve(result);
     };
     killer.once("error", finish);
     killer.once("close", (code, signal) => {
-      if (code === 0) finish();
+      if (code === 0) finish(undefined, { exitCode: code, signal });
       else {
         const error = new Error(
           `taskkill ${force ? "/F " : ""}/T failed ` +
@@ -205,6 +206,101 @@ function runTreeKillCommand(pid, force, spawnFn, commandTimeoutMs) {
       );
     }, commandTimeoutMs);
   });
+}
+
+function readPosixProcessIdentity(pid, spawnSyncFn) {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const endOfCommand = stat.lastIndexOf(")");
+    if (endOfCommand > 0) {
+      const fields = stat
+        .slice(endOfCommand + 1)
+        .trim()
+        .split(/\s+/);
+      const startTime = fields[19];
+      if (startTime) return `proc-start:${startTime}`;
+    }
+  } catch {
+    // macOS and other POSIX systems do not expose Linux's /proc stat file.
+  }
+
+  let result;
+  try {
+    result = spawnSyncFn("ps", ["-p", String(pid), "-o", "lstart="], {
+      encoding: "utf8",
+      maxBuffer: 4096,
+    });
+  } catch {
+    return undefined;
+  }
+  if (result?.error || result?.status !== 0) return undefined;
+  const startTime = result.stdout?.trim();
+  return startTime ? `ps-start:${startTime}` : undefined;
+}
+
+function readWindowsProcessIdentity(pid, spawnSyncFn) {
+  const command = [
+    `$process = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"`,
+    "if ($null -eq $process) { exit 3 }",
+    "[Console]::Write($process.CreationDate.ToUniversalTime().Ticks)",
+  ].join("; ");
+  let result;
+  try {
+    result = spawnSyncFn(
+      "powershell.exe",
+      ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command],
+      {
+        encoding: "utf8",
+        windowsHide: true,
+        timeout: 1000,
+        maxBuffer: 4096,
+      },
+    );
+  } catch {
+    return undefined;
+  }
+  if (result?.error || result?.status !== 0) return undefined;
+  const creationTicks = result.stdout?.trim();
+  return creationTicks ? `win-creation:${creationTicks}` : undefined;
+}
+
+export function readProcessIdentity(
+  pid,
+  { platform = process.platform, spawnSyncFn = spawnSync } = {},
+) {
+  if (!Number.isInteger(pid) || pid <= 0) return undefined;
+  return platform === "win32"
+    ? readWindowsProcessIdentity(pid, spawnSyncFn)
+    : readPosixProcessIdentity(pid, spawnSyncFn);
+}
+
+function processIdentityError(pid, platform, expected, actual) {
+  const error = new Error(
+    `${platform === "win32" ? "Windows PID" : "POSIX process-group"} ${pid} ` +
+      "identity changed or could not be proven before forced termination",
+  );
+  error.code = "PROCESS_IDENTITY_UNPROVEN";
+  error.pid = pid;
+  error.expectedIdentity = expected;
+  error.actualIdentity = actual;
+  return error;
+}
+
+async function requireStableProcessIdentity(
+  pid,
+  platform,
+  expectedIdentity,
+  identityFn,
+) {
+  const actualIdentity = await identityFn(pid);
+  if (
+    !expectedIdentity ||
+    !actualIdentity ||
+    actualIdentity !== expectedIdentity
+  ) {
+    throw processIdentityError(pid, platform, expectedIdentity, actualIdentity);
+  }
+  return actualIdentity;
 }
 
 function signalPosixProcessGroup(pid, signal, signalFn) {
@@ -233,20 +329,77 @@ export async function terminateProcessTree(
     spawnFn = spawn,
     signalFn = process.kill,
     delayFn = delay,
+    identityFn = (identityPid) =>
+      readProcessIdentity(identityPid, { platform }),
+    expectedIdentity,
+    identityCaptured = false,
   } = {},
 ) {
   if (!Number.isInteger(pid) || pid <= 0) return;
+
+  // A numeric PID/PGID is not an ownership handle. Capture a stable process
+  // creation identity before the graceful pass so a reused identifier can
+  // never receive the forced escalation below. If the platform cannot prove
+  // identity, fail closed before sending any destructive signal.
+  const stableIdentity = identityCaptured
+    ? expectedIdentity
+    : await identityFn(pid);
+  if (!stableIdentity) {
+    throw processIdentityError(pid, platform, stableIdentity, undefined);
+  }
+  if (identityCaptured) {
+    await requireStableProcessIdentity(
+      pid,
+      platform,
+      stableIdentity,
+      identityFn,
+    );
+  }
+
   if (platform === "win32") {
     let softError;
+    let softResult;
     try {
-      await runTreeKillCommand(pid, false, spawnFn, graceMs);
+      softResult = await runTreeKillCommand(pid, false, spawnFn, graceMs);
     } catch (error) {
       softError = error;
     }
+
+    // taskkill reports success (0) or an already-gone process (128) when a
+    // forced pass may be unnecessary. Wait through the same bounded grace and
+    // re-check identity for every result: if the original process is still
+    // present, force escalation is safe; if it disappeared, never issue a
+    // second PID-only command because the number may already be reusable.
+    const softExitCode = softResult?.exitCode ?? softError?.exitCode;
     await delayFn(graceMs);
-    let forceError;
+    let currentIdentity;
     try {
-      await runTreeKillCommand(pid, true, spawnFn, graceMs);
+      currentIdentity = await identityFn(pid);
+    } catch (error) {
+      throw processIdentityError(pid, platform, stableIdentity, error);
+    }
+    if (currentIdentity !== stableIdentity) {
+      // A successful/already-gone soft pass plus an absent PID proves there is
+      // no safe forced target. A different live identity is an active reuse
+      // race and must fail closed so the replacement is never touched.
+      if (
+        currentIdentity === undefined &&
+        (softExitCode === 0 || softExitCode === 128)
+      ) {
+        return;
+      }
+      throw processIdentityError(
+        pid,
+        platform,
+        stableIdentity,
+        currentIdentity,
+      );
+    }
+
+    let forceError;
+    let forceResult;
+    try {
+      forceResult = await runTreeKillCommand(pid, true, spawnFn, graceMs);
     } catch (error) {
       forceError = error;
     }
@@ -264,7 +417,7 @@ export async function terminateProcessTree(
     }
     // A soft-pass error followed by a successful forced pass still proves the
     // complete tree was removed, so it is not a teardown failure.
-    return;
+    return forceResult;
   }
 
   let softError;
@@ -274,6 +427,7 @@ export async function terminateProcessTree(
     softError = error;
   }
   await delayFn(graceMs);
+  await requireStableProcessIdentity(pid, platform, stableIdentity, identityFn);
   try {
     signalPosixProcessGroup(pid, "SIGKILL", signalFn);
   } catch (forceError) {
@@ -314,6 +468,8 @@ export function runCommandWithWatchdog(
     spawnFn = spawn,
     terminateTree = terminateProcessTree,
     signalSource = process,
+    identityFn = (identityPid) =>
+      readProcessIdentity(identityPid, { platform }),
   },
 ) {
   return new Promise((resolve) => {
@@ -330,6 +486,13 @@ export function runCommandWithWatchdog(
     } catch (error) {
       resolve({ error, stdout: "", stderr: "", streamed: true });
       return;
+    }
+
+    let childIdentity;
+    try {
+      childIdentity = identityFn(child.pid);
+    } catch {
+      childIdentity = undefined;
     }
 
     let stdout = "";
@@ -423,6 +586,9 @@ export function runCommandWithWatchdog(
         terminationPromise = terminateTree(child.pid, {
           platform,
           graceMs: terminationGraceMs,
+          expectedIdentity: childIdentity,
+          identityCaptured: true,
+          identityFn,
         })
           .catch((error) => {
             terminationError = error;
@@ -916,7 +1082,9 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   try {
     await main();
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
+    const message =
+      error instanceof Error ? (error.stack ?? error.message) : String(error);
+    writeSyncAll(2, `${message}\n`);
     process.exitCode = 1;
   }
 }

--- a/packages/scripts/test-cloud-run.mjs
+++ b/packages/scripts/test-cloud-run.mjs
@@ -64,10 +64,16 @@ const MAX_TIMER_MS = 2_147_483_647;
 const POSIX_PROCESS_GROUP_SUPERVISOR = `
 terminating=0
 trap 'terminating=1' TERM INT
-"$@" &
+"$@" 3>&- 4>&- &
 child_pid=$!
 wait "$child_pid"
 status=$?
+printf '%s\\n' "$status" >&3
+exec 3>&- 1>&- 2>&-
+if [ "$terminating" -eq 0 ]; then
+  IFS= read -r release <&4 || true
+fi
+exec 4>&-
 if [ "$terminating" -ne 0 ]; then
   while :; do
     sleep 3600 &
@@ -577,10 +583,13 @@ export function runCommandWithWatchdog(
       child = spawnFn(spawnCommand, spawnArgs, {
         cwd,
         env,
-        shell,
+        shell: platform === "win32" ? shell : false,
         detached: true,
         windowsHide: platform === "win32",
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio:
+          platform === "win32"
+            ? ["ignore", "pipe", "pipe"]
+            : ["ignore", "pipe", "pipe", "pipe", "pipe"],
       });
     } catch (error) {
       resolve({ error, stdout: "", stderr: "", streamed: true });
@@ -607,6 +616,15 @@ export function runCommandWithWatchdog(
     let settled = false;
     let forceSettleTimer;
     let watchdog;
+    const supervisorStatus =
+      platform === "win32" ? undefined : child.stdio?.[3];
+    const supervisorControl =
+      platform === "win32" ? undefined : child.stdio?.[4];
+    let supervisorStatusOutput = "";
+    let commandCompletionObserved = platform === "win32";
+    let stdoutEnded = !child.stdout;
+    let stderrEnded = !child.stderr;
+    let supervisorReleased = false;
 
     const parentSignalHandlers = new Map();
     const removeParentSignalHandlers = () => {
@@ -614,6 +632,21 @@ export function runCommandWithWatchdog(
         signalSource.removeListener(signal, handler);
       }
       parentSignalHandlers.clear();
+    };
+
+    const releaseDrainedSupervisor = () => {
+      if (
+        platform === "win32" ||
+        supervisorReleased ||
+        terminationReason ||
+        !commandCompletionObserved ||
+        !stdoutEnded ||
+        !stderrEnded
+      ) {
+        return;
+      }
+      supervisorReleased = true;
+      supervisorControl?.end("release\n");
     };
 
     const finish = (result) => {
@@ -705,6 +738,10 @@ export function runCommandWithWatchdog(
       stdout = appendClassificationOutput(stdout, text);
       writeOut(text);
     });
+    child.stdout?.once("end", () => {
+      stdoutEnded = true;
+      releaseDrainedSupervisor();
+    });
     child.stderr?.on("data", (chunk) => {
       const text = chunk.toString("utf8");
       if (stderr.length + text.length > MAX_CLASSIFICATION_OUTPUT_CHARS) {
@@ -712,6 +749,20 @@ export function runCommandWithWatchdog(
       }
       stderr = appendClassificationOutput(stderr, text);
       writeErr(text);
+    });
+    child.stderr?.once("end", () => {
+      stderrEnded = true;
+      releaseDrainedSupervisor();
+    });
+    supervisorStatus?.on("data", (chunk) => {
+      supervisorStatusOutput += chunk.toString("utf8");
+    });
+    supervisorStatus?.once("end", () => {
+      commandCompletionObserved = /^\d+\n$/.test(supervisorStatusOutput);
+      releaseDrainedSupervisor();
+    });
+    supervisorControl?.once("error", (error) => {
+      terminationError ??= error;
     });
     child.once("error", (error) => finish({ error }));
     child.once("close", (status, signal) => {


### PR DESCRIPTION
# Relates to

Relates to #17245 (the August 9 unbounded Windows batch-runner delta). The original drizzle schema failure was already repaired; this PR deliberately does not claim the remaining exact-Windows 60-batch proof is complete.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun run verify` was attempted after sync and is blocked by unrelated existing `plugin-registry` Biome import-order errors on the current base; bounded runner, Cloud, and script gates pass below.
- [x] A reviewer can confirm the changed runner contract from the focused unit and real-process evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop\n\n- [x] Rebased onto origin/develop@131a765c3cfac15495f76eaa5f9b3c3b0e80ae63; zero conflicts and zero commits behind.\n- [x] Post-rebase verification at exact head 9d0c5991f8122c7529f29a33ad0feb093f85382e: 48 focused Bun tests passed with 118 assertions; the real POSIX watchdog self-test passed; Biome and git diff --check passed.\n\n# Risks

Medium. This changes the process-lifecycle and output-streaming behavior of the broad Cloud test runner. It preserves collect-all semantics for ordinary assertion failures and the existing Bun/PGlite status-99 normalization, while timeout, spawn, interruption, and unproven teardown states fail closed. The real Windows `taskkill /T` then `/F` behavior still requires the newly wired `windows-2025` job.

# Background

## What does this PR do?

- Prints the exact repo-relative manifest before each Cloud test batch starts and streams child output live.
- Replaces unbounded `spawnSync` capture with a direct-Bun asynchronous supervisor and a configurable 10-minute wall-clock deadline.
- Runs POSIX commands behind a detached supervisor that owns and pins the process group through TERM/KILL escalation. Private status/control pipes keep that anchor alive after the foreground command exits until inherited stdout/stderr drain; immutable identity and `PGID === PID` are revalidated before every group signal. Windows retains bounded `taskkill /T` then `/T /F` with spawn-time PID identity and fail-closed reuse handling.
- Retains only bounded output tails for exit classification and refuses status-99 normalization after truncation.
- Adds focused concurrency, timeout, malformed-input, signal-race, teardown, and Windows command tests.
- Adds Windows PID and POSIX process-group identity-reuse regressions proving replacements are never force-targeted, including ownership changes immediately after the supervisor is stopped and during the grace period.
- Adds real teardown regressions for both a parent that exits on TERM and a foreground command that exits 0 before timeout while a TERM-resistant descendant retains inherited pipes; the watchdog returns only after every owned process is gone.

## What kind of change is this?

Bug fix (non-breaking CI/test infrastructure hardening).

# Documentation changes needed?

No user-facing documentation change is required. The runner's optional `--batch-timeout-ms=<positive-ms>` override is self-describing and covered by its focused contract tests.

# Testing

## Where should a reviewer start?

Start with `runCommandWithWatchdog` and `terminateProcessTree` in `packages/scripts/test-cloud-run.mjs`, then run the focused unit file and the real-process watchdog self-test.

## Detailed testing steps

Pinned toolchain: Node 24.15.0 and Bun 1.3.14.

```bash
bun test packages/scripts/__tests__/test-cloud-run.test.mjs
node packages/scripts/test-cloud-run-watchdog.self-test.mjs
node packages/scripts/test-cloud-run-flush.self-test.mjs
node packages/scripts/test-cloud-run-helpers.self-test.mjs
node packages/scripts/test-cloud-run-preflight.self-test.mjs
node packages/scripts/ci-windows-command-coverage-contract.mjs
node packages/scripts/ci-bun-version-contract.mjs
bun run test:cloud
RUN_TURBO_CONCURRENCY=4 bun run verify
```

Observed on the exact reviewed head:

- Focused runner suite: 48 passed, 0 failed, 118 assertions.
- Real POSIX watchdog: both the TERM-exiting-parent case and the already-exited-command/retained-pipe case passed five consecutive runs; supervisors, parents, and descendants were all absent before return.
- Existing flush, helper, and preflight self-tests: passed.
- Windows command inventory and Bun-version contracts: passed.
- Full Cloud suite: all 13/13 batches executed through the new supervisor. Batch 13 reported two reproducible pre-existing missing-build-artifact errors (`@elizaos/plugin-sql` from agent-server tests); the same two errors reproduce when that batch is invoked directly outside the watchdog.
- Repository verification: attempted; blocked only by unrelated existing `plugin-registry` Biome import-order failures on the current base.

# Evidence Gate

<!-- evidence-head:9d0c5991f8122c7529f29a33ad0feb093f85382e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI or rendered surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI or rendered surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a CI process supervisor with no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] Real-process and repository verification transcript:
<details><summary>Runner verification</summary>

```text
bun test packages/scripts/__tests__/test-cloud-run.test.mjs
48 pass, 0 fail, 118 assertions
RUN_TURBO_CONCURRENCY=4 bun run verify: blocked outside this diff by existing plugin-registry Biome import-order failures
bun run test:cloud: all 13/13 batches executed; batch 13 exposed two direct-reproducible missing @elizaos/plugin-sql artifact errors outside this diff
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, console, or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this CI process supervisor produces no persistent domain artifact; its real parent-and-descendant liveness proof is captured in the backend transcript and assertions.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changed.

## Backend + frontend logs

```text
bun test packages/scripts/__tests__/test-cloud-run.test.mjs
48 pass, 0 fail, 118 assertions

node packages/scripts/test-cloud-run-watchdog.self-test.mjs
[test-cloud-run-watchdog] self-test passed (platform=darwin)

RUN_TURBO_CONCURRENCY=4 bun run verify
Blocked outside this diff by existing plugin-registry Biome import-order failures
```

No frontend path exists for this change.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice change.

## Known gaps / failures

- Local macOS proves real POSIX process-group cleanup, including the already-exited foreground command with retained descendant pipes, and all platform-neutral state-machine contracts. Real Windows `taskkill /T` then `/F` execution remains a CI gate; this PR wires the teardown self-test into `nightly.yml`'s `windows-2025` matrix. Local verification used Bun 1.4.0 canary and Node 26.5.0 because the pinned Bun 1.3.14 / Node 24.15.0 toolchain was unavailable on this host.
- This bounded contribution resolves the runner hang/diagnostic failure mode. It does not claim to identify or repair a specific Windows-only open handle in the issue's 16-file batch, so #17245 should remain open until its exact Windows batch proof is complete.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 56778611 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [pr-18591-watchdog]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZV9QYP7AJ9FY7WMHA44A071","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T15:34:05.255Z","completed_at":"2026-08-12T16:00:51.190Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":2228390,"output_tokens":146381,"cache_creation_tokens":0,"cache_read_tokens":54403840,"total_tokens":56778611,"cost_micro_usd":"34517988","session_count":10},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"LqqrffD9xKFjlUqgYHXQgU_5UI5ZZ1PN1xjSkGbJzjMSNEWimu4ODWQRmX9Oh2iaW9itaXb7yMmgXyq5DAEgAA"}} -->
