### PR TITLE
fix(auth): settle Codex device login on early exit

### DIFF
--- a/packages/auth/src/codex-device.test.ts
+++ b/packages/auth/src/codex-device.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Deterministic mocked child-process coverage for the Codex device-login
+ * lifecycle. The harness uses in-memory streams and isolated real temporary
+ * directories; it never invokes Codex, a provider, or the network.
+ */
+
+import { EventEmitter } from "node:events";
+import { existsSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import { ElizaError } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+const rmSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawn: spawnMock };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  rmSyncMock.mockImplementation(actual.rmSync);
+  return { ...actual, rmSync: rmSyncMock };
+});
+
+import { startCodexDeviceLogin } from "./codex-device.ts";
+
+interface FakeChild {
+  process: EventEmitter;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+const temporaryHomes: string[] = [];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function mockChild(): FakeChild {
+  const process = new EventEmitter();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const kill = vi.fn(() => true);
+  Object.assign(process, { stdout, stderr, kill });
+  spawnMock.mockReturnValue(process);
+  return { process, stdout, stderr, kill };
+}
+
+function spawnedCodexHome(): string {
+  const options: unknown = spawnMock.mock.calls[0]?.[2];
+  if (!isRecord(options) || !isRecord(options.env)) {
+    throw new Error("Codex spawn options did not include an environment");
+  }
+  const codexHome = options.env.CODEX_HOME;
+  if (typeof codexHome !== "string") {
+    throw new Error("Codex spawn environment did not include CODEX_HOME");
+  }
+  temporaryHomes.push(codexHome);
+  return codexHome;
+}
+
+function emitPrompt(child: FakeChild): void {
+  child.stdout.write("Visit https://auth.openai.com/codex/device\n");
+  child.stderr.write("Enter code ABCD-12345\n");
+}
+
+function accessToken(exp: number): string {
+  return `header.${Buffer.from(JSON.stringify({ exp })).toString("base64url")}.signature`;
+}
+
+afterEach(() => {
+  for (const temporaryHome of temporaryHomes) {
+    if (existsSync(temporaryHome)) {
+      rmSync(temporaryHome, { recursive: true, force: true });
+    }
+  }
+  temporaryHomes.length = 0;
+  spawnMock.mockReset();
+  rmSyncMock.mockClear();
+});
+
+describe("startCodexDeviceLogin", () => {
+  it("rejects when the CLI closes successfully before emitting the prompt", async () => {
+    const child = mockChild();
+    const start = startCodexDeviceLogin();
+    const codexHome = spawnedCodexHome();
+
+    child.process.emit("close", 0, null);
+
+    await expect(start).rejects.toThrow(
+      "exited with code 0 before emitting a device URL and user code",
+    );
+    await expect(start).rejects.toMatchObject({
+      code: "codex_device.prompt_missing",
+    });
+    expect(existsSync(codexHome)).toBe(false);
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+    expect(rmSyncMock).toHaveBeenCalledWith(codexHome, {
+      recursive: true,
+      force: true,
+      maxRetries: 2,
+      retryDelay: 25,
+    });
+  });
+
+  it("rejects a nonzero close with exit context", async () => {
+    const child = mockChild();
+    const start = startCodexDeviceLogin();
+    const codexHome = spawnedCodexHome();
+
+    child.process.emit("close", 7, null);
+
+    await expect(start).rejects.toThrow("exited with code 7");
+    await expect(start).rejects.toMatchObject({
+      code: "codex_device.process_failed",
+      context: { exitCode: 7, signal: null },
+    });
+    expect(existsSync(codexHome)).toBe(false);
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles once when spawn emits an error before close", async () => {
+    const child = mockChild();
+    const start = startCodexDeviceLogin();
+    const codexHome = spawnedCodexHome();
+    const spawnError = new Error("codex executable unavailable");
+
+    child.process.emit("error", spawnError);
+    child.process.emit("close", -2, null);
+
+    await expect(start).rejects.toMatchObject({
+      code: "codex_device.spawn_failed",
+      cause: spawnError,
+    });
+    expect(existsSync(codexHome)).toBe(false);
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("translates cleanup failure without throwing from an early-close callback", async () => {
+    const child = mockChild();
+    const start = startCodexDeviceLogin();
+    const codexHome = spawnedCodexHome();
+    const cleanupFailure = new Error("simulated cleanup failure");
+    rmSyncMock.mockImplementationOnce(() => {
+      throw cleanupFailure;
+    });
+
+    expect(() => child.process.emit("close", 0, null)).not.toThrow();
+
+    const error = await start.catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(ElizaError);
+    expect(error).toMatchObject({
+      code: "codex_device.cleanup_failed",
+      cause: cleanupFailure,
+      context: {
+        phase: "prompt_missing",
+        maxRetries: 2,
+        retryDelayMs: 25,
+      },
+    });
+    expect(existsSync(codexHome)).toBe(true);
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for complete output and resolves credentials after a normal login", async () => {
+    const child = mockChild();
+    const start = startCodexDeviceLogin();
+    const codexHome = spawnedCodexHome();
+
+    child.process.emit("exit", 0, null);
+    emitPrompt(child);
+    const flow = await start;
+    const exp = 2_000_000_000;
+    writeFileSync(
+      path.join(codexHome, "auth.json"),
+      JSON.stringify({
+        tokens: {
+          access_token: accessToken(exp),
+          refresh_token: "refresh-fixture",
+          id_token: "id-fixture",
+        },
+      }),
+    );
+
+    child.process.emit("close", 0, null);
+
+    await expect(flow.credentials).resolves.toEqual({
+      access: accessToken(exp),
+      refresh: "refresh-fixture",
+      expires: exp * 1000,
+      idToken: "id-fixture",
+    });
+    expect(flow).toMatchObject({
+      authUrl: "https://auth.openai.com/codex/device",
+      userCode: "ABCD-12345",
+    });
+    expect(existsSync(codexHome)).toBe(false);
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects credentials instead of fulfilling them when final cleanup fails", async () => {
+    const child = mockChild();
+    const start = startCodexDeviceLogin();
+    const codexHome = spawnedCodexHome();
+    emitPrompt(child);
+    const flow = await start;
+    const exp = 2_000_000_000;
+    writeFileSync(
+      path.join(codexHome, "auth.json"),
+      JSON.stringify({
+        tokens: {
+          access_token: accessToken(exp),
+          refresh_token: "refresh-fixture",
+        },
+      }),
+    );
+    const cleanupFailure = new Error("simulated cleanup failure");
+    rmSyncMock.mockImplementationOnce(() => {
+      throw cleanupFailure;
+    });
+
+    expect(() => child.process.emit("close", 0, null)).not.toThrow();
+
+    const error = await flow.credentials.catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(ElizaError);
+    expect(error).toMatchObject({
+      code: "codex_device.cleanup_failed",
+      cause: cleanupFailure,
+      context: {
+        phase: "credentials_complete",
+        maxRetries: 2,
+        retryDelayMs: 25,
+      },
+    });
+    expect(String(error)).not.toContain("refresh-fixture");
+    expect(existsSync(codexHome)).toBe(true);
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("kills and rejects credentials when a started flow is cancelled", async () => {
+    const child = mockChild();
+    const start = startCodexDeviceLogin();
+    const codexHome = spawnedCodexHome();
+    emitPrompt(child);
+    const flow = await start;
+
+    flow.close();
+    child.process.emit("close", null, "SIGTERM");
+
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    await expect(flow.credentials).rejects.toThrow("exited with SIGTERM");
+    await expect(flow.credentials).rejects.toMatchObject({
+      code: "codex_device.process_failed",
+      context: { exitCode: null, signal: "SIGTERM" },
+    });
+    expect(existsSync(codexHome)).toBe(false);
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/auth/src/codex-device.test.ts
+++ b/packages/auth/src/codex-device.test.ts
@@ -89,6 +89,7 @@ describe("startCodexDeviceLogin", () => {
     const start = startCodexDeviceLogin();
     const codexHome = spawnedCodexHome();
 
+    child.process.emit("spawn");
     child.process.emit("close", 0, null);
 
     await expect(start).rejects.toThrow(
@@ -112,6 +113,7 @@ describe("startCodexDeviceLogin", () => {
     const start = startCodexDeviceLogin();
     const codexHome = spawnedCodexHome();
 
+    child.process.emit("spawn");
     child.process.emit("close", 7, null);
 
     await expect(start).rejects.toThrow("exited with code 7");
@@ -149,6 +151,7 @@ describe("startCodexDeviceLogin", () => {
       throw cleanupFailure;
     });
 
+    child.process.emit("spawn");
     expect(() => child.process.emit("close", 0, null)).not.toThrow();
 
     const error = await start.catch((cause: unknown) => cause);
@@ -171,6 +174,7 @@ describe("startCodexDeviceLogin", () => {
     const start = startCodexDeviceLogin();
     const codexHome = spawnedCodexHome();
 
+    child.process.emit("spawn");
     child.process.emit("exit", 0, null);
     emitPrompt(child);
     const flow = await start;
@@ -206,6 +210,7 @@ describe("startCodexDeviceLogin", () => {
     const child = mockChild();
     const start = startCodexDeviceLogin();
     const codexHome = spawnedCodexHome();
+    child.process.emit("spawn");
     emitPrompt(child);
     const flow = await start;
     const exp = 2_000_000_000;
@@ -245,6 +250,7 @@ describe("startCodexDeviceLogin", () => {
     const child = mockChild();
     const start = startCodexDeviceLogin();
     const codexHome = spawnedCodexHome();
+    child.process.emit("spawn");
     emitPrompt(child);
     const flow = await start;
 
@@ -253,6 +259,46 @@ describe("startCodexDeviceLogin", () => {
 
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
     await expect(flow.credentials).rejects.toThrow("exited with SIGTERM");
+    await expect(flow.credentials).rejects.toMatchObject({
+      code: "codex_device.process_failed",
+      context: { exitCode: null, signal: "SIGTERM" },
+    });
+    expect(existsSync(codexHome)).toBe(false);
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for close when cancellation emits a post-spawn kill error", async () => {
+    const child = mockChild();
+    const start = startCodexDeviceLogin();
+    const codexHome = spawnedCodexHome();
+    child.process.emit("spawn");
+    emitPrompt(child);
+    const flow = await start;
+    const killError = Object.assign(new Error("operation not permitted"), {
+      code: "EPERM",
+    });
+    child.kill.mockImplementationOnce(() => {
+      child.process.emit("error", killError);
+      return false;
+    });
+
+    flow.close();
+
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(rmSyncMock).not.toHaveBeenCalled();
+    expect(existsSync(codexHome)).toBe(true);
+    await expect(
+      Promise.race([
+        flow.credentials.then(
+          () => "fulfilled",
+          () => "rejected",
+        ),
+        Promise.resolve("pending"),
+      ]),
+    ).resolves.toBe("pending");
+
+    child.process.emit("close", null, "SIGTERM");
+
     await expect(flow.credentials).rejects.toMatchObject({
       code: "codex_device.process_failed",
       context: { exitCode: null, signal: "SIGTERM" },

--- a/packages/auth/src/codex-device.ts
+++ b/packages/auth/src/codex-device.ts
@@ -1,13 +1,56 @@
+/**
+ * Orchestrates headless Codex device login for authentication consumers.
+ *
+ * The flow owns an isolated temporary CODEX_HOME, parses only the public
+ * device prompt, and withholds credentials until the child is terminal and
+ * that temporary state has been removed successfully.
+ */
+
 import { spawn } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { ElizaError } from "@elizaos/core";
 import type { OAuthCredentials } from "./types.ts";
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: strips terminal ANSI color sequences from CLI output.
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
 const DEVICE_URL_RE = /https:\/\/auth\.openai\.com\/codex\/device/;
 const DEVICE_CODE_RE = /\b[A-Z0-9]{4}-[A-Z0-9]{5}\b/;
+const CLEANUP_MAX_RETRIES = 2;
+const CLEANUP_RETRY_DELAY_MS = 25;
+
+type CodexDeviceErrorCode =
+  | "codex_device.cleanup_failed"
+  | "codex_device.credentials_invalid"
+  | "codex_device.invalid_access_token"
+  | "codex_device.process_failed"
+  | "codex_device.prompt_missing"
+  | "codex_device.spawn_failed";
+
+type CleanupPhase =
+  | "credentials_complete"
+  | "credentials_invalid"
+  | "process_failed"
+  | "prompt_missing"
+  | "spawn_failed";
+
+function codexDeviceError(
+  code: CodexDeviceErrorCode,
+  message: string,
+  options: {
+    cause?: unknown;
+    context?: Record<string, unknown>;
+    severity: "ephemeral" | "fatal";
+  },
+): ElizaError {
+  return new ElizaError(message, {
+    code,
+    severity: options.severity,
+    ...(options.context ? { context: options.context } : {}),
+    ...(options.cause !== undefined ? { cause: options.cause } : {}),
+  });
+}
 
 export interface CodexDeviceFlow {
   authUrl: string;
@@ -28,9 +71,11 @@ function expiryFromJwt(token: string): number {
   } catch (cause) {
     // error-policy:J2 context-adding rethrow — fabricating an expiry can make an
     // invalid token look healthy and delay required reauthentication.
-    throw new Error("Codex access token expiry could not be validated", {
-      cause,
-    });
+    throw codexDeviceError(
+      "codex_device.invalid_access_token",
+      "Codex access token expiry could not be validated",
+      { cause, severity: "fatal" },
+    );
   }
 }
 
@@ -43,6 +88,8 @@ export function startCodexDeviceLogin(): Promise<CodexDeviceFlow> {
 
   let output = "";
   let settledStart = false;
+  let settledTerminal = false;
+  let cleanedUp = false;
   let resolveCredentials!: (credentials: OAuthCredentials) => void;
   let rejectCredentials!: (error: Error) => void;
   const credentials = new Promise<OAuthCredentials>((resolve, reject) => {
@@ -53,7 +100,48 @@ export function startCodexDeviceLogin(): Promise<CodexDeviceFlow> {
   // observer prevents a process-level rejection before the flow is consumed.
   void credentials.catch(() => undefined);
 
+  const cleanup = (phase: CleanupPhase): ElizaError | null => {
+    if (cleanedUp) return null;
+    try {
+      rmSync(codexHome, {
+        recursive: true,
+        force: true,
+        maxRetries: CLEANUP_MAX_RETRIES,
+        retryDelay: CLEANUP_RETRY_DELAY_MS,
+      });
+      cleanedUp = true;
+      return null;
+    } catch (cause) {
+      // error-policy:J1 filesystem boundary translation — cleanup is part of
+      // terminal settlement, so its failure becomes a typed promise rejection
+      // instead of escaping a child-process event callback.
+      return codexDeviceError(
+        "codex_device.cleanup_failed",
+        "Codex device login temporary state could not be removed",
+        {
+          cause,
+          context: {
+            phase,
+            maxRetries: CLEANUP_MAX_RETRIES,
+            retryDelayMs: CLEANUP_RETRY_DELAY_MS,
+          },
+          severity: "fatal",
+        },
+      );
+    }
+  };
+
   return new Promise<CodexDeviceFlow>((resolve, reject) => {
+    const rejectStart = (error: Error) => {
+      if (settledStart) return;
+      settledStart = true;
+      reject(error);
+    };
+    const fail = (error: ElizaError, phase: CleanupPhase) => {
+      const terminalError = cleanup(phase) ?? error;
+      rejectStart(terminalError);
+      rejectCredentials(terminalError);
+    };
     const inspect = (chunk: Buffer | string) => {
       output += String(chunk).replace(ANSI_RE, "");
       if (settledStart) return;
@@ -71,20 +159,53 @@ export function startCodexDeviceLogin(): Promise<CodexDeviceFlow> {
     child.stdout.on("data", inspect);
     child.stderr.on("data", inspect);
     child.once("error", (err) => {
-      if (!settledStart) reject(err);
-      rejectCredentials(err);
-      rmSync(codexHome, { recursive: true, force: true });
+      if (settledTerminal) return;
+      settledTerminal = true;
+      fail(
+        codexDeviceError(
+          "codex_device.spawn_failed",
+          "Codex device login process could not be started",
+          {
+            cause: err,
+            context: { command: "codex", mode: "device-auth" },
+            severity: "fatal",
+          },
+        ),
+        "spawn_failed",
+      );
     });
-    child.once("exit", (code, signal) => {
+    // `close` follows the exit event after stdio has closed, so the prompt
+    // parser has observed every output chunk before deciding it was absent.
+    child.once("close", (code, signal) => {
+      if (settledTerminal) return;
+      settledTerminal = true;
       if (code !== 0) {
-        const err = new Error(
+        const err = codexDeviceError(
+          "codex_device.process_failed",
           `Codex device login exited ${signal ? `with ${signal}` : `with code ${code}`}`,
+          {
+            context: { exitCode: code, signal },
+            severity: "ephemeral",
+          },
         );
-        if (!settledStart) reject(err);
-        rejectCredentials(err);
-        rmSync(codexHome, { recursive: true, force: true });
+        fail(err, "process_failed");
         return;
       }
+      if (!settledStart) {
+        fail(
+          codexDeviceError(
+            "codex_device.prompt_missing",
+            "Codex device login exited with code 0 before emitting a device URL and user code",
+            {
+              context: { exitCode: code, signal },
+              severity: "fatal",
+            },
+          ),
+          "prompt_missing",
+        );
+        return;
+      }
+      let parsedCredentials: OAuthCredentials;
       try {
         const parsed = JSON.parse(
           readFileSync(path.join(codexHome, "auth.json"), "utf8"),
@@ -99,21 +220,36 @@ export function startCodexDeviceLogin(): Promise<CodexDeviceFlow> {
         const refresh = parsed.tokens?.refresh_token;
         if (!access || !refresh)
           throw new Error("Codex device login returned no tokens");
-        resolveCredentials({
+        parsedCredentials = {
           access,
           refresh,
           expires: expiryFromJwt(access),
           ...(parsed.tokens?.id_token
             ? { idToken: parsed.tokens.id_token }
             : {}),
-        });
-      } catch (err) {
-        // error-policy:J1 child-process boundary translation — credential-file
-        // failures reject the public flow and never fabricate a token record.
-        rejectCredentials(err instanceof Error ? err : new Error(String(err)));
-      } finally {
-        rmSync(codexHome, { recursive: true, force: true });
+        };
+      } catch (cause) {
+        // error-policy:J2 context-adding translation — credential-file and JWT
+        // failures become a typed terminal flow error with their cause intact.
+        fail(
+          cause instanceof ElizaError
+            ? cause
+            : codexDeviceError(
+                "codex_device.credentials_invalid",
+                "Codex device login credentials could not be validated",
+                { cause, severity: "fatal" },
+              ),
+          "credentials_invalid",
+        );
+        return;
       }
+
+      const cleanupError = cleanup("credentials_complete");
+      if (cleanupError) {
+        rejectCredentials(cleanupError);
+        return;
+      }
+      resolveCredentials(parsedCredentials);
     });
   });
 }

--- a/packages/auth/src/codex-device.ts
+++ b/packages/auth/src/codex-device.ts
@@ -10,7 +10,7 @@ import { spawn } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import type { OAuthCredentials } from "./types.ts";
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: strips terminal ANSI color sequences from CLI output.
@@ -87,6 +87,7 @@ export function startCodexDeviceLogin(): Promise<CodexDeviceFlow> {
   });
 
   let output = "";
+  let spawned = false;
   let settledStart = false;
   let settledTerminal = false;
   let cleanedUp = false;
@@ -143,11 +144,12 @@ export function startCodexDeviceLogin(): Promise<CodexDeviceFlow> {
       rejectCredentials(terminalError);
     };
     const inspect = (chunk: Buffer | string) => {
-      output += String(chunk).replace(ANSI_RE, "");
       if (settledStart) return;
+      output += String(chunk).replace(ANSI_RE, "");
       const url = output.match(DEVICE_URL_RE)?.[0];
       const userCode = output.match(DEVICE_CODE_RE)?.[0];
       if (!url || !userCode) return;
+      output = "";
       settledStart = true;
       resolve({
         authUrl: url,
@@ -158,8 +160,20 @@ export function startCodexDeviceLogin(): Promise<CodexDeviceFlow> {
     };
     child.stdout.on("data", inspect);
     child.stderr.on("data", inspect);
-    child.once("error", (err) => {
+    child.once("spawn", () => {
+      spawned = true;
+    });
+    child.on("error", (err) => {
       if (settledTerminal) return;
+      if (spawned) {
+        // error-policy:J6 a running child can emit `error` when SIGTERM delivery
+        // fails. It is still live, so retain CODEX_HOME and wait for `close`
+        // instead of misclassifying teardown as a failed spawn.
+        logger.debug(
+          "[auth] Codex device login termination signal failed; waiting for process close",
+        );
+        return;
+      }
       settledTerminal = true;
       fail(
         codexDeviceError(


### PR DESCRIPTION
# Relates to

Closes #18585.

Definition of Done: full standard in [CONTRIBUTING.md](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop\n\n- [x] Rebased onto origin/develop@131a765c3cfac15495f76eaa5f9b3c3b0e80ae63; zero conflicts and zero commits behind.\n- [x] Post-rebase verification at exact head 00ea6756d6b54128b19d9a5adc96bb4d5c49eb86: 8 Codex-device Vitest cases passed; auth typecheck and lint passed; git diff --check passed.\n\n# Risks

Low. The change is isolated to the Codex device-login child-process lifecycle. It changes terminal handling from `exit` to `close`, introduces typed errors, and makes credential success conditional on removing the token-bearing temporary home. The main compatibility risk is subprocess event ordering; focused tests cover output between `exit` and `close`, error/close duplication, post-start kill errors, cancellation, and cleanup failure.

# Background

## What does this PR do?

Prevents `startCodexDeviceLogin()` from remaining pending forever when the Codex CLI exits with code 0 before emitting a device URL and user code. It waits for complete stdio at `close`, settles both public promises on terminal failure, removes temporary credential state before success, and returns typed `ElizaError` classifications without raw CLI output or tokens.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is needed. The public API is unchanged; source and test responsibility headers document the lifecycle invariant.

# Testing

## Where should a reviewer start?

Start with `packages/auth/src/codex-device.test.ts`, then inspect the terminal settlement and cleanup ordering in `packages/auth/src/codex-device.ts`.

## Detailed testing steps

1. Run `bun test packages/auth/src/codex-device.test.ts` and expect 8/8 passing.
2. Run `ELIZA_STATE_DIR=<temporary-directory> bun run --cwd packages/auth test` and expect 148/148 passing.
3. Run auth build, typecheck, lint, and format checks.
4. Put a fake `codex` executable that exits 0 first in `PATH`; call `startCodexDeviceLogin()` and verify it rejects with code `codex_device.prompt_missing` instead of remaining pending.
5. Run `bun run verify`.

# Evidence Gate

<!-- evidence-head:00ea6756d6b54128b19d9a5adc96bb4d5c49eb86 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend auth subprocess change has no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend auth subprocess change has no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend auth subprocess change has no interactive visual flow
<!-- evidence-row:backend-logs -->
- [x] Backend logs:
  <details><summary>Node 24 and Bun 1.3.14 terminal-settlement proof</summary>

  ```text
  $ node --version
  v24.15.0
  $ bun --version
  1.3.14
  $ git rev-parse HEAD
  5b361809ea344f67ffce59f5ffb4d87261f79932
  $ bunx vitest run packages/auth/src/codex-device.test.ts
  Test Files 1 passed (1)
  Tests 8 passed (8)
  $ ELIZA_STATE_DIR=<temporary-directory> bun run --cwd packages/auth test
  Test Files 11 passed (11)
  Tests 148 passed (148)
  $ bun run verify
  Tasks: 350 successful, 350 total
  ```
  </details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend or network request path changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, scheduled-task, wallet, audio, or generated domain state changed
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

# Evidence Details

## Real LLM-call trajectory

N/A - this is a local authentication subprocess lifecycle change and performs no LLM call.

## Backend + frontend logs

Before, a fake `codex` executable linked to `/usr/bin/true` left the startup promise pending beyond a 250 ms control deadline:

```json
{"outcome":"STILL_PENDING_AFTER_250MS","nodeVersion":"v24.15.0"}
```

After, the same outside-repository fixture rejects through the real source path:

```json
{"bunVersion":"1.3.14","kind":"rejected","isElizaError":true,"code":"codex_device.prompt_missing","message":"Codex device login exited with code 0 before emitting a device URL and user code","elapsedMs":238}
```

Focused verification:

```text
codex-device.test.ts: 8/8 passed
isolated packages/auth suite: 148/148 passed
packages/auth build: passed
packages/auth typecheck: passed
packages/auth lint:check: passed
packages/auth format:check: passed
bun run verify: 350/350 Turbo tasks plus all follow-on audits passed
```

Frontend logs are N/A because no frontend or network path changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI files or rendered surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changed.

## Known gaps / failures

- A live successful Codex login was not performed because it would require interactive credentials. The normal prompt and credential path is exercised deterministically with real temporary files and in-memory child streams.
- A real operating-system EPERM kill failure was not induced on the host; the deterministic child-process regression emits the documented post-spawn `error` ordering and verifies temporary state survives until `close`.
- No UI, frontend, LLM, domain, audio, or deployment evidence applies to this two-file backend lifecycle fix.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 38617803 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [sol-xhigh-codex-device-review-fix]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTRJ9TJXYKM3JCCS39SYJ45","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T10:33:54.258Z","completed_at":"2026-08-12T10:42:45.376Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":1141596,"output_tokens":109167,"cache_creation_tokens":0,"cache_read_tokens":37367040,"total_tokens":38617803,"cost_micro_usd":"25190774","session_count":9},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"5lf0zZlSFRMtruTAKklXCZOTbfUvY0fw4dx5g-4rC9RCEE_7Wt9XPN006KVu-0yJCifjbb3Xo0phyifiq7bRCQ"}} -->