### PR TITLE
fix(scripts): reject invalid seed-message-corpus API ports

### DIFF
--- a/packages/scripts/__tests__/seed-message-corpus.test.mjs
+++ b/packages/scripts/__tests__/seed-message-corpus.test.mjs
@@ -1,0 +1,140 @@
+/**
+ * Focused coverage for seed-message-corpus API port validation: parser contract
+ * plus real CLI boundary rejections before any network request.
+ */
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "../lib/spawn-sync-captured.mjs";
+import {
+  DEFAULT_API_PORT,
+  parseArgs,
+  parseTcpPort,
+  resolveApiPortFromEnv,
+} from "../seed-message-corpus.mjs";
+
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "seed-message-corpus.mjs",
+);
+
+function runCli(args, env = {}) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      // Drop inherited API port so CLI/env cases are isolated.
+      ELIZA_API_PORT: undefined,
+      ...env,
+    },
+    timeout: 5_000,
+  });
+}
+
+describe("parseTcpPort", () => {
+  test("accepts boundary and default ports", () => {
+    expect(parseTcpPort("1", "--api-port")).toBe(1);
+    expect(parseTcpPort("65535", "--api-port")).toBe(65535);
+    expect(parseTcpPort(String(DEFAULT_API_PORT), "--api-port")).toBe(
+      DEFAULT_API_PORT,
+    );
+    expect(parseTcpPort(" 31337 ", "ELIZA_API_PORT")).toBe(31337);
+  });
+
+  test("rejects zero, out-of-range, partial, signed, and non-decimal forms", () => {
+    const bad = [
+      "0",
+      "65536",
+      "99999",
+      "-1",
+      "1.5",
+      "31337junk",
+      "0x10",
+      "1e2",
+      "031337",
+      "",
+      " ",
+      "NaN",
+      "Infinity",
+    ];
+    for (const value of bad) {
+      expect(() => parseTcpPort(value, "--api-port")).toThrow(
+        /must be a TCP port integer from 1 to 65535/,
+      );
+    }
+  });
+});
+
+describe("resolveApiPortFromEnv", () => {
+  test("uses default when unset or empty", () => {
+    expect(resolveApiPortFromEnv({})).toBe(DEFAULT_API_PORT);
+    expect(resolveApiPortFromEnv({ ELIZA_API_PORT: "" })).toBe(
+      DEFAULT_API_PORT,
+    );
+  });
+
+  test("accepts a valid explicit env port", () => {
+    expect(resolveApiPortFromEnv({ ELIZA_API_PORT: "41234" })).toBe(41234);
+  });
+
+  test("fails closed on explicit invalid env values", () => {
+    for (const value of ["0", "notaport", "31337junk", "99999", "65536"]) {
+      expect(() => resolveApiPortFromEnv({ ELIZA_API_PORT: value })).toThrow(
+        /ELIZA_API_PORT must be a TCP port integer from 1 to 65535/,
+      );
+    }
+  });
+});
+
+describe("parseArgs port wiring", () => {
+  test("CLI --api-port overrides env and default", () => {
+    const options = parseArgs(["--api-port=44444"], {
+      ELIZA_API_PORT: "40000",
+    });
+    expect(options.apiPort).toBe(44444);
+  });
+
+  test("env port applies when CLI port is omitted", () => {
+    const options = parseArgs([], { ELIZA_API_PORT: "40001" });
+    expect(options.apiPort).toBe(40001);
+  });
+
+  test("default applies when CLI and env are omitted", () => {
+    const options = parseArgs([], {});
+    expect(options.apiPort).toBe(DEFAULT_API_PORT);
+  });
+});
+
+describe("seed-message-corpus CLI boundary", () => {
+  test("--help prints usage and exits 0", () => {
+    const result = runCli(["--help"]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Usage:");
+    expect(result.stdout).toContain("--api-port");
+  });
+
+  test("rejects invalid --api-port before any seed request", () => {
+    for (const value of ["0", "99999", "65536", "31337junk", "-1", "1.5"]) {
+      const result = runCli([`--api-port=${value}`]);
+      expect(result.status).not.toBe(0);
+      const combined = `${result.stdout}${result.stderr}`;
+      expect(combined).toMatch(
+        /--api-port must be a TCP port integer from 1 to 65535/,
+      );
+      expect(combined).not.toContain("Seeding backdated message corpus");
+    }
+  });
+
+  test("rejects invalid ELIZA_API_PORT before any seed request", () => {
+    for (const value of ["0", "notaport", "31337junk", "99999"]) {
+      const result = runCli([], { ELIZA_API_PORT: value });
+      expect(result.status).not.toBe(0);
+      const combined = `${result.stdout}${result.stderr}`;
+      expect(combined).toMatch(
+        /ELIZA_API_PORT must be a TCP port integer from 1 to 65535/,
+      );
+      expect(combined).not.toContain("Seeding backdated message corpus");
+    }
+  });
+});

--- a/packages/scripts/seed-message-corpus.mjs
+++ b/packages/scripts/seed-message-corpus.mjs
@@ -14,20 +14,31 @@
  * operator can see that a relevant hit older than any recency window is still
  * found and that the `since`/`until` window narrows the result set.
  *
+ * Port overrides (`--api-port`, `ELIZA_API_PORT`) must be canonical TCP ports
+ * in `1..65535`. Explicit invalid environment values fail closed rather than
+ * silently selecting the default.
+ *
  * Usage:
  *   node packages/scripts/seed-message-corpus.mjs
  *   node packages/scripts/seed-message-corpus.mjs --conversations=24 --messages=60 --span-months=18
  *   node packages/scripts/seed-message-corpus.mjs --api-port=31337 --seed=99
  */
+import path from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 
-const DEFAULT_API_PORT = 31337;
+export const DEFAULT_API_PORT = 31337;
 const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
 
-function parseArgs(argv) {
+/**
+ * Parse CLI argv and optional env into seed options.
+ * @param {string[]} argv
+ * @param {NodeJS.ProcessEnv} [env]
+ */
+export function parseArgs(argv, env = process.env) {
   const options = {
-    apiPort: Number(process.env.ELIZA_API_PORT) || DEFAULT_API_PORT,
-    host: process.env.ELIZA_API_HOST || "127.0.0.1",
+    apiPort: resolveApiPortFromEnv(env),
+    host: env.ELIZA_API_HOST || "127.0.0.1",
     body: {},
   };
   for (const arg of argv) {
@@ -41,7 +52,7 @@ function parseArgs(argv) {
     }
     switch (key) {
       case "--api-port":
-        options.apiPort = parsePositiveInt(value, key);
+        options.apiPort = parseTcpPort(value, "--api-port");
         break;
       case "--host":
         options.host = value;
@@ -66,6 +77,48 @@ function parseArgs(argv) {
     }
   }
   return options;
+}
+
+/**
+ * Resolve `ELIZA_API_PORT`: unset/empty keeps the default; any other explicit
+ * value must be a canonical TCP port or the command fails closed.
+ * @param {NodeJS.ProcessEnv} env
+ */
+export function resolveApiPortFromEnv(env = process.env) {
+  const raw = env.ELIZA_API_PORT;
+  if (raw === undefined || raw === "") {
+    return DEFAULT_API_PORT;
+  }
+  return parseTcpPort(raw, "ELIZA_API_PORT");
+}
+
+/**
+ * Accept only canonical decimal TCP ports in the range 1..65535.
+ * Rejects partial numbers, signed values, fractions, leading zeros, and
+ * out-of-range integers so the seeder never probes a different port than the
+ * operator requested.
+ * @param {string} value
+ * @param {string} label
+ */
+export function parseTcpPort(value, label) {
+  const raw = String(value ?? "").trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `${label} must be a TCP port integer from 1 to 65535 (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  const port = Number.parseInt(raw, 10);
+  if (
+    !Number.isSafeInteger(port) ||
+    port < 1 ||
+    port > 65535 ||
+    String(port) !== raw
+  ) {
+    throw new Error(
+      `${label} must be a TCP port integer from 1 to 65535 (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  return port;
 }
 
 function parseIntStrict(value, flag) {
@@ -94,7 +147,7 @@ Usage:
   node packages/scripts/seed-message-corpus.mjs [flags]
 
 Flags:
-  --api-port=N        Agent API port (default ${DEFAULT_API_PORT}; env ELIZA_API_PORT)
+  --api-port=N        Agent API TCP port 1-65535 (default ${DEFAULT_API_PORT}; env ELIZA_API_PORT)
   --host=HOST         Agent API host (default 127.0.0.1; env ELIZA_API_HOST)
   --conversations=N   Conversations to generate (1-200, default 12)
   --messages=N        Messages per conversation (1-500, default 40)
@@ -211,7 +264,16 @@ async function main() {
   process.stdout.write("Time window honored by the store. Done.\n");
 }
 
-main().catch((err) => {
-  process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
-  process.exitCode = 1;
-});
+const isDirectRun =
+  import.meta.main === true ||
+  (typeof process.argv[1] === "string" &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href);
+
+if (isDirectRun) {
+  main().catch((err) => {
+    process.stderr.write(
+      `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
# Relates to

Closes #18596

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused package checks passed after sync (`packages/scripts` seed-message-corpus tests + Biome on touched files). Full `bun run verify` was not re-run end-to-end in this session.
- [x] A reviewer can confirm the change from the CLI transcripts and focused test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xAI / grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build` (`grok` client)
<!-- attribution-row:skill-revision -->
- Skill path: `contribute-to-eliza` @ `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77`
<!-- attribution-row:status -->
- Provenance status: `self-reported` + device-signed project receipt (footer below)
- Run id: `run_01KZTRY411DB88FNF2DXRREBFG`
- Note: Operator approved Grok for this workstream. Token meter via ccusage is unavailable for Grok (signed zero / unavailable confidence), not fabricated.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync; full monorepo `bun run verify` not claimed here.

# Risks

**Low.** CLI and environment port validation only for the manual message-corpus seeder. No production API, agent runtime, or UI behavior changes for valid invocations. Invalid ports now fail closed at the command boundary instead of probing a wrong or impossible endpoint.

# Background

## What does this PR do?

Validates seed-message-corpus API port overrides at the command boundary:

- `--api-port` must be a canonical decimal TCP port in `1..65535` (rejects `0`, `99999`, `65536`, partial numbers, signed/fractional forms, leading zeros).
- `ELIZA_API_PORT` uses the same contract when set; explicit invalid values fail closed instead of silently falling back to `31337` via `Number(...) || default`.
- Unset/empty env keeps the existing default.

Previously `--api-port=99999` reached URL construction (`Failed to parse URL`) and `ELIZA_API_PORT=0` / `notaport` / `31337junk` silently selected the default agent port.

## What kind of change is this?

Bug fix (non-breaking for valid CLI/env use; invalid args now fail closed).

# Documentation changes needed?

No project docs change required. Help text now states the TCP port range explicitly.

# Testing

## Where should a reviewer start?

1. `packages/scripts/seed-message-corpus.mjs` — `parseTcpPort`, `resolveApiPortFromEnv`, `parseArgs`
2. `packages/scripts/__tests__/seed-message-corpus.test.mjs` — unit + real CLI boundary

## Detailed testing steps

```bash
bun test packages/scripts/__tests__/seed-message-corpus.test.mjs
# 11 passed

node packages/scripts/seed-message-corpus.mjs --api-port=99999
# exit 1, message: --api-port must be a TCP port integer from 1 to 65535 (received \"99999\")
# does not print \"Seeding backdated message corpus\"

ELIZA_API_PORT=notaport node packages/scripts/seed-message-corpus.mjs
# exit 1, message: ELIZA_API_PORT must be a TCP port integer from 1 to 65535 (received \"notaport\")
```

# Evidence Gate

<!-- evidence-head:c79ae2c65615130319ab45a66f4f66882ab8349c -->

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - terminal-only seed-message-corpus CLI harness; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - terminal-only seed-message-corpus CLI harness; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no interactive UI flow; CLI argument rejection is fully captured by transcripts below.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no server/runtime path; rejection happens before any fetch.
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no browser app surface.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent, model, prompt, provider, or action behavior.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: focused bun test output (11 passed) and CLI rejection transcripts proving non-zero exit and no seed request for invalid `--api-port` / `ELIZA_API_PORT`.

### CLI after (this head)

```text
$ node packages/scripts/seed-message-corpus.mjs --api-port=99999
--api-port must be a TCP port integer from 1 to 65535 (received \"99999\")
exit:1

$ ELIZA_API_PORT=0 node packages/scripts/seed-message-corpus.mjs
ELIZA_API_PORT must be a TCP port integer from 1 to 65535 (received \"0\")
exit:1

$ ELIZA_API_PORT=notaport node packages/scripts/seed-message-corpus.mjs
ELIZA_API_PORT must be a TCP port integer from 1 to 65535 (received \"notaport\")
exit:1

$ bun test packages/scripts/__tests__/seed-message-corpus.test.mjs
 11 pass
 0 fail
```

### Pre-fix failure shape (why the bug matters)

```text
Number(\"notaport\") || 31337  // => 31337  — silent wrong target
Number(\"0\") || 31337         // => 31337  — explicit 0 ignored
// --api-port=99999 accepted → late \"Failed to parse URL\"
```

# Known gaps / failures

- Full monorepo `bun run verify` not asserted in this session; focused script tests and Biome on touched files were run.
- Other numeric flags (`--conversations`, etc.) retain their prior integer parsers; only API port validation was hardened in this PR.

# Notes for reviewers

Operator override allowed Grok for this contribution. Device-signed measured receipt is appended below. Independent review and merge remain with maintainers.

# Measured project receipt

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-rama0x1]
<!-- elizaos-contribution-attribution:v2 {\"provider\":\"xai\",\"model\":\"grok-4.5\",\"client\":\"grok\",\"skill_revision\":\"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza\",\"run\":{\"schema_version\":\"1\",\"run_id\":\"run_01KZTRY411DB88FNF2DXRREBFG\",\"project\":\"eliza\",\"repository\":\"elizaOS/eliza\",\"started_at\":\"2026-08-12T10:40:21.537Z\",\"completed_at\":\"2026-08-12T10:45:57.454Z\",\"skill_sha256\":\"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6\",\"usage\":{\"source\":\"ccusage-session-v20\",\"confidence\":\"unavailable\",\"input_tokens\":0,\"output_tokens\":0,\"cache_creation_tokens\":0,\"cache_read_tokens\":0,\"total_tokens\":0,\"cost_micro_usd\":\"0\",\"session_count\":0},\"trajectory_sha256\":null,\"signature_algorithm\":\"ed25519\",\"device_public_key\":\"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI\",\"device_key_id\":\"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea\",\"device_signature\":\"ta2HZFr30IC75W5muMuwD6k_E5FeGWxgfeSvGH7m2FmswhjsYaSbgpQustrQPqlrPvuIiyswxdGpBHfBKEX7CA\"}} -->