### PR TITLE
fix(logger): isolate listener failures

### DIFF
--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -60,6 +60,128 @@ describe("logger", () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
+  it("isolates listener failures and continues fan-out", () => {
+    const logger = bufferLogger();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const throwingListener = vi.fn<(entry: LogEntry) => void>(() => {
+      throw new Error("listener-failed");
+    });
+    const laterListener = vi.fn<(entry: LogEntry) => void>();
+    const unsubscribeThrowing = addLogListener(throwingListener);
+    const unsubscribeLater = addLogListener(laterListener);
+
+    try {
+      expect(() => {
+        logger.info("isolated-entry");
+        logger.warn("second-isolated-entry");
+      }).not.toThrow();
+
+      expect(throwingListener.mock.calls.length).toBeGreaterThan(0);
+      expect(laterListener).toHaveBeenCalledTimes(
+        throwingListener.mock.calls.length,
+      );
+      expect(laterListener.mock.calls).toContainEqual([
+        expect.objectContaining({ msg: "isolated-entry" }),
+      ]);
+      expect(laterListener.mock.calls).toContainEqual([
+        expect.objectContaining({ msg: "second-isolated-entry" }),
+      ]);
+      expect(recentLogs()).toContain("isolated-entry");
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalledWith(
+        "[logger] log listener failed; continuing fan-out and suppressing further errors from this listener",
+      );
+    } finally {
+      unsubscribeThrowing();
+      unsubscribeLater();
+    }
+  });
+
+  it("does not rethrow when the fallback warning sink fails", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {
+      throw new Error("console-failed");
+    });
+    const unsubscribeThrowing = addLogListener(() => {
+      throw new Error("listener-failed");
+    });
+    const laterListener = vi.fn<(entry: LogEntry) => void>();
+    const unsubscribeLater = addLogListener(laterListener);
+
+    try {
+      expect(() => bufferLogger().info("sink-failure-entry")).not.toThrow();
+      expect(laterListener.mock.calls.length).toBeGreaterThan(0);
+    } finally {
+      unsubscribeThrowing();
+      unsubscribeLater();
+    }
+  });
+
+  it("invokes a listener at most once per entry when it re-registers itself", () => {
+    const logger = bufferLogger();
+    const mutatingListener = vi.fn<(entry: LogEntry) => void>(() => {
+      removeLogListener(mutatingListener);
+      addLogListener(mutatingListener);
+    });
+    const laterListener = vi.fn<(entry: LogEntry) => void>();
+    addLogListener(mutatingListener);
+    addLogListener(laterListener);
+
+    try {
+      expect(() => logger.info("mutating-listener-entry")).not.toThrow();
+      const deliveredEntries = mutatingListener.mock.calls.map(
+        ([entry]) => entry,
+      );
+      expect(new Set(deliveredEntries).size).toBe(deliveredEntries.length);
+      expect(laterListener).toHaveBeenCalledTimes(deliveredEntries.length);
+    } finally {
+      removeLogListener(mutatingListener);
+      removeLogListener(laterListener);
+    }
+  });
+
+  it("does not reset warning suppression for a duplicate active listener", () => {
+    const logger = bufferLogger();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const throwingListener = () => {
+      throw new Error("listener-failed");
+    };
+    const unsubscribe = addLogListener(throwingListener);
+
+    try {
+      logger.info("first-failure");
+      addLogListener(throwingListener);
+      logger.info("second-failure");
+      expect(consoleError).toHaveBeenCalledTimes(1);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("resets warning suppression after unsubscribe and re-register", () => {
+    const logger = bufferLogger();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const throwingListener = () => {
+      throw new Error("listener-failed");
+    };
+    const unsubscribeFirst = addLogListener(throwingListener);
+
+    try {
+      logger.info("first-registration-failure");
+      unsubscribeFirst();
+      addLogListener(throwingListener);
+      logger.info("second-registration-failure");
+      expect(consoleError).toHaveBeenCalledTimes(2);
+    } finally {
+      removeLogListener(throwingListener);
+    }
+  });
+
   it("preserves forced browser mode for child loggers", () => {
     const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => {});
     const logger = createLogger({

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -141,6 +141,26 @@ describe("logger", () => {
     }
   });
 
+  it("skips a later listener removed during the current delivery", () => {
+    const logger = bufferLogger();
+    const laterListener = vi.fn<(entry: LogEntry) => void>();
+    const removingListener = vi.fn<(entry: LogEntry) => void>(() => {
+      removeLogListener(laterListener);
+    });
+    addLogListener(removingListener);
+    addLogListener(laterListener);
+
+    try {
+      logger.info("removed-before-turn");
+
+      expect(removingListener.mock.calls.length).toBeGreaterThan(0);
+      expect(laterListener).not.toHaveBeenCalled();
+    } finally {
+      removeLogListener(removingListener);
+      removeLogListener(laterListener);
+    }
+  });
+
   it("does not reset warning suppression for a duplicate active listener", () => {
     const logger = bufferLogger();
     const consoleError = vi

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -102,6 +102,7 @@ export type LogListener = (entry: LogEntry) => void;
 
 // Global log listeners for streaming
 const logListeners: Set<LogListener> = new Set();
+const warnedLogListeners: WeakSet<LogListener> = new WeakSet();
 
 /**
  * Add a listener for real-time log entries (used for WebSocket streaming)
@@ -109,7 +110,10 @@ const logListeners: Set<LogListener> = new Set();
  * @returns Function to remove the listener
  */
 export function addLogListener(listener: LogListener): () => void {
-  logListeners.add(listener);
+  if (!logListeners.has(listener)) {
+    warnedLogListeners.delete(listener);
+    logListeners.add(listener);
+  }
   return () => logListeners.delete(listener);
 }
 
@@ -721,9 +725,26 @@ function createInMemoryDestination(maxLogs = 100): InMemoryDestination {
       if (logs.length > maxLogs) {
         logs.shift();
       }
-      // Notify all listeners for real-time streaming
-      for (const listener of logListeners) {
-        listener(entry);
+      if (logListeners.size === 0) return;
+      // Snapshot so registration changes during a callback apply only to the
+      // next entry and cannot revisit the current listener indefinitely.
+      for (const listener of [...logListeners]) {
+        try {
+          listener(entry);
+        } catch {
+          // error-policy:J7 the logger is the diagnostics boundary, so report
+          // directly without recursively invoking it or exposing the entry.
+          if (!warnedLogListeners.has(listener)) {
+            warnedLogListeners.add(listener);
+            try {
+              console.error(
+                "[logger] log listener failed; continuing fan-out and suppressing further errors from this listener",
+              );
+            } catch {
+              // error-policy:J7 a failed console sink cannot be re-reported.
+            }
+          }
+        }
       }
     },
     clear(): void {

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -729,6 +729,10 @@ function createInMemoryDestination(maxLogs = 100): InMemoryDestination {
       // Snapshot so registration changes during a callback apply only to the
       // next entry and cannot revisit the current listener indefinitely.
       for (const listener of [...logListeners]) {
+        // A listener earlier in the snapshot may unsubscribe a later one.
+        // Honor that removal immediately without letting new registrations
+        // join the current delivery.
+        if (!logListeners.has(listener)) continue;
         try {
           listener(entry);
         } catch {


### PR DESCRIPTION
# Relates to

Closes #18595.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` with zero conflicts.
- [x] Frozen dependency validation and `bun run verify` were run after the final sync.
- [x] A reviewer can confirm the changed behavior from the exact-source evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop\n\n- [x] Rebased onto origin/develop@131a765c3cfac15495f76eaa5f9b3c3b0e80ae63; zero conflicts and zero commits behind.\n- [x] Post-rebase verification at exact head 0d9b86bccdb05a9c48f5c5446c540a7eca1918b1: 15 logger tests passed; logger typecheck and lint passed; git diff --check passed.\n\n# Risks

Low. This changes only the in-memory listener fan-out in `@elizaos/logger` and its deterministic tests. Dispatch now snapshots the active listener set only when listeners exist, so callback registration changes apply to the next entry. A failing listener produces one constant stderr warning per genuine registration. No log-entry contents or callback error text are included in that warning.

# Background

## What does this PR do?

- Prevents a public `addLogListener()` callback exception from escaping an ordinary logger call.
- Continues delivery to listeners later in the same dispatch.
- Uses a start-of-entry listener snapshot so a callback that removes and re-adds itself cannot be revisited indefinitely.
- Suppresses repeated listener warnings while resetting suppression after a genuine unsubscribe/re-register lifecycle.
- Keeps warning fallback failure non-throwing and non-recursive.

## What kind of change is this?

Bug fix (non-breaking change).

# Documentation changes needed?

No documentation change is required. The existing public listener API is preserved; this repair enforces its diagnostics boundary and adds regression coverage.

# Testing

## Where should a reviewer start?

- `packages/logger/src/logger.ts`: `addLogListener()` and `createInMemoryDestination().write()`.
- `packages/logger/src/logger.test.ts`: listener failure, warning lifecycle, console fallback, and mutation/re-registration regressions.

## Detailed testing steps

All commands used Node 24.15.0 and Bun 1.3.14 on exact head `c8f6f1fb2ac83dc535709ac08638518a5ff581be`.

1. `bunx bun@1.3.14 install --frozen-lockfile --ignore-scripts` — exit 0; 3,459 installs checked, no changes.
2. `bunx bun@1.3.14 test packages/logger/src/logger.test.ts` — 14 passed, 0 failed.
3. `bunx bun@1.3.14 run --cwd packages/logger test` — 14 passed, 0 failed.
4. Package `typecheck`, `lint`, `format`, and `build` — all exit 0.
5. `bunx bun@1.3.14 run verify` — exit 0 in 132 seconds; 350/350 Turbo tasks successful and all trailing audits passed.
6. Exact-source before/after probe — baseline and final source blobs were verified against their Git object IDs before execution.

# Evidence Gate

<!-- evidence-head:0d9b86bccdb05a9c48f5c5446c540a7eca1918b1 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - the changed logger listener path has no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - the changed logger listener path has no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - this deterministic leaf-library change has no user interaction flow
<!-- evidence-row:backend-logs -->
- [ ] N/A - no deployed backend is required; exact committed-source probe output is inline in the PR body
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, request, network path, or browser state changes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, schedule, wallet, generated-file, or persistent domain state changes
<!-- evidence-row:ocr-review -->
- [ ] N/A - the change has no rendered visual or textual UI surface

# Evidence Details

## Exact-source before/after probe

The baseline source is the Git blob from `origin/develop` at `e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88`; the final source is the Git blob from this PR head. The mutation probes used a 2-second `SIGKILL` watchdog.

```text
--- baseline failure-isolation probe ---
{"escaped":"listener-failed","laterCalls":0,"buffered":true,"warningCalls":0,"warningExposesEntry":false,"warningExposesListenerError":false}
baseline_failure_exit=0

--- final failure-isolation probe ---
{"escaped":"","laterCalls":2,"buffered":true,"warningCalls":1,"warningExposesEntry":false,"warningExposesListenerError":false}
final_failure_exit=0

--- baseline self-reregister mutation probe (2s hard watchdog) ---
baseline_mutation_exit=137

--- final self-reregister mutation probe (2s hard watchdog) ---
{"selfCalls":2,"uniqueEntries":2,"laterCalls":2}
final_mutation_exit=0
```

The inspected complete output is stored locally outside the repository at `/tmp/eliza-army-18595-c8f6f1fb/probe-output.txt` with SHA-256:

```text
d8cd2dea32f21e8a754febc3fa482980c3ee0ea1f485b133d2ca2b8b35728808
```

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

N/A - no deployed backend or frontend path is required for this leaf logger contract. The exact committed-source runtime output is included above.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

- GitHub denied self-assignment and label mutation for issue #18595, and the token lacks Project read/write scope. The attributable `CLAIMING:` comment records ownership; these repository-permission limitations do not affect code or verification.
- The original full repository verify completed successfully. The post-rebase maintenance rerun reached the current develop lint gate and then failed on an unrelated pre-existing formatter violation in packages/ui/src/cloud/connectors/discord-gateway-connection.tsx; the logger package tests, typecheck, lint, and diff check remain green.
- Screenshots, video, OCR, frontend/backend service logs, LLM trajectories, and domain artifacts are inapplicable for this non-UI deterministic logger-library repair, as recorded in every stable evidence row above.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 49708251 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [symbiex-open-pr-maintenance]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZVAR4C4EX3HNRWY22AHCBVJ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T15:51:39.652Z","completed_at":"2026-08-12T16:08:53.193Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":1178400,"output_tokens":106939,"cache_creation_tokens":0,"cache_read_tokens":48422912,"total_tokens":49708251,"cost_micro_usd":"28228252","session_count":8},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"YJSd37HQd9hKNDcs8CMKWHwFCyBmNVtugKxiRQb0ymQpc-WWaAuhZgzK205575ymj0HM2a-rV_DcvONr2UVbBg"}} -->