### PR TITLE
fix(scripts): reject invalid dev-health-check port overrides

### DIFF
--- a/packages/scripts/__tests__/dev-health-check.test.mjs
+++ b/packages/scripts/__tests__/dev-health-check.test.mjs
@@ -1,0 +1,227 @@
+/**
+ * Focused coverage for dev-health-check TCP port validation: parser contract
+ * plus real CLI boundary rejections before log/output directory creation or
+ * `bun run dev` startup.
+ */
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DEFAULT_API_PORT,
+  DEFAULT_UI_PORT,
+  parseArgs,
+  parseTcpPort,
+  resolveApiPortFromEnv,
+  resolveUiPortFromEnv,
+} from "../dev-health-check.mjs";
+import { spawnSync } from "../lib/spawn-sync-captured.mjs";
+
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "dev-health-check.mjs",
+);
+
+function runCli(args, env = {}) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      // Drop inherited ports so CLI/env cases are isolated.
+      ELIZA_UI_PORT: undefined,
+      ELIZA_PORT: undefined,
+      ELIZA_API_PORT: undefined,
+      ...env,
+    },
+    timeout: 5_000,
+  });
+}
+
+describe("parseTcpPort", () => {
+  test("accepts boundary and default ports", () => {
+    expect(parseTcpPort("1", "--ui-port")).toBe(1);
+    expect(parseTcpPort("65535", "--api-port")).toBe(65535);
+    expect(parseTcpPort(String(DEFAULT_UI_PORT), "--ui-port")).toBe(
+      DEFAULT_UI_PORT,
+    );
+    expect(parseTcpPort(String(DEFAULT_API_PORT), "--api-port")).toBe(
+      DEFAULT_API_PORT,
+    );
+    expect(parseTcpPort(" 31337 ", "ELIZA_API_PORT")).toBe(31337);
+  });
+
+  test("rejects zero, out-of-range, partial, signed, and non-decimal forms", () => {
+    const bad = [
+      "0",
+      "65536",
+      "99999",
+      "-1",
+      "1.5",
+      "31337junk",
+      "0x10",
+      "1e2",
+      "031337",
+      "",
+      " ",
+      "NaN",
+      "Infinity",
+    ];
+    for (const value of bad) {
+      expect(() => parseTcpPort(value, "--ui-port")).toThrow(
+        /must be a TCP port integer from 1 to 65535/,
+      );
+    }
+  });
+});
+
+describe("resolveUiPortFromEnv", () => {
+  test("uses default when unset or empty", () => {
+    expect(resolveUiPortFromEnv({})).toBe(DEFAULT_UI_PORT);
+    expect(resolveUiPortFromEnv({ ELIZA_UI_PORT: "" })).toBe(DEFAULT_UI_PORT);
+    expect(resolveUiPortFromEnv({ ELIZA_PORT: "" })).toBe(DEFAULT_UI_PORT);
+  });
+
+  test("ELIZA_UI_PORT takes precedence over ELIZA_PORT", () => {
+    expect(
+      resolveUiPortFromEnv({ ELIZA_UI_PORT: "41234", ELIZA_PORT: "40000" }),
+    ).toBe(41234);
+    expect(resolveUiPortFromEnv({ ELIZA_PORT: "40001" })).toBe(40001);
+  });
+
+  test("fails closed on explicit invalid env values", () => {
+    for (const value of ["0", "notaport", "2138junk", "99999", "65536"]) {
+      expect(() => resolveUiPortFromEnv({ ELIZA_UI_PORT: value })).toThrow(
+        /ELIZA_UI_PORT must be a TCP port integer from 1 to 65535/,
+      );
+      expect(() => resolveUiPortFromEnv({ ELIZA_PORT: value })).toThrow(
+        /ELIZA_PORT must be a TCP port integer from 1 to 65535/,
+      );
+    }
+  });
+});
+
+describe("resolveApiPortFromEnv", () => {
+  test("uses default when unset or empty", () => {
+    expect(resolveApiPortFromEnv({})).toBe(DEFAULT_API_PORT);
+    expect(resolveApiPortFromEnv({ ELIZA_API_PORT: "" })).toBe(
+      DEFAULT_API_PORT,
+    );
+  });
+
+  test("accepts a valid explicit env port", () => {
+    expect(resolveApiPortFromEnv({ ELIZA_API_PORT: "41234" })).toBe(41234);
+  });
+
+  test("fails closed on explicit invalid env values", () => {
+    for (const value of ["0", "notaport", "31337junk", "99999", "65536"]) {
+      expect(() => resolveApiPortFromEnv({ ELIZA_API_PORT: value })).toThrow(
+        /ELIZA_API_PORT must be a TCP port integer from 1 to 65535/,
+      );
+    }
+  });
+});
+
+describe("parseArgs port wiring", () => {
+  test("CLI ports override env and defaults", () => {
+    const options = parseArgs(["--ui-port=44444", "--api-port=45555"], {
+      ELIZA_UI_PORT: "40000",
+      ELIZA_API_PORT: "40001",
+    });
+    expect(options.uiPort).toBe(44444);
+    expect(options.apiPort).toBe(45555);
+  });
+
+  test("env ports apply when CLI ports are omitted", () => {
+    const options = parseArgs([], {
+      ELIZA_UI_PORT: "40002",
+      ELIZA_API_PORT: "40003",
+    });
+    expect(options.uiPort).toBe(40002);
+    expect(options.apiPort).toBe(40003);
+  });
+
+  test("defaults apply when CLI and env are omitted", () => {
+    const options = parseArgs([], {});
+    expect(options.uiPort).toBe(DEFAULT_UI_PORT);
+    expect(options.apiPort).toBe(DEFAULT_API_PORT);
+  });
+
+  test("rejects invalid CLI ports", () => {
+    expect(() => parseArgs(["--ui-port=99999"], {})).toThrow(
+      /--ui-port must be a TCP port integer from 1 to 65535/,
+    );
+    expect(() => parseArgs(["--api-port=0"], {})).toThrow(
+      /--api-port must be a TCP port integer from 1 to 65535/,
+    );
+  });
+});
+
+describe("dev-health-check CLI boundary", () => {
+  test("--help prints usage and exits 0", () => {
+    const result = runCli(["--help"]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Usage:");
+    expect(result.stdout).toContain("--ui-port");
+    expect(result.stdout).toContain("--api-port");
+    expect(result.stdout).toContain("1-65535");
+  });
+
+  test("rejects invalid --ui-port before log/output or dev startup", () => {
+    for (const value of ["0", "99999", "65536", "2138junk", "-1", "1.5"]) {
+      const result = runCli([`--ui-port=${value}`]);
+      expect(result.status).not.toBe(0);
+      const combined = `${result.stdout}${result.stderr}`;
+      expect(combined).toMatch(
+        /--ui-port must be a TCP port integer from 1 to 65535/,
+      );
+      expect(combined).not.toContain("[dev-health-check] starting:");
+      expect(combined).not.toContain("bun run dev");
+    }
+  });
+
+  test("rejects invalid --api-port before log/output or dev startup", () => {
+    for (const value of ["0", "99999", "65536", "31337junk", "-1", "1.5"]) {
+      const result = runCli([`--api-port=${value}`]);
+      expect(result.status).not.toBe(0);
+      const combined = `${result.stdout}${result.stderr}`;
+      expect(combined).toMatch(
+        /--api-port must be a TCP port integer from 1 to 65535/,
+      );
+      expect(combined).not.toContain("[dev-health-check] starting:");
+    }
+  });
+
+  test("rejects invalid ELIZA_UI_PORT before log/output or dev startup", () => {
+    for (const value of ["0", "notaport", "2138junk", "99999"]) {
+      const result = runCli([], { ELIZA_UI_PORT: value });
+      expect(result.status).not.toBe(0);
+      const combined = `${result.stdout}${result.stderr}`;
+      expect(combined).toMatch(
+        /ELIZA_UI_PORT must be a TCP port integer from 1 to 65535/,
+      );
+      expect(combined).not.toContain("[dev-health-check] starting:");
+    }
+  });
+
+  test("rejects invalid ELIZA_PORT when ELIZA_UI_PORT is unset", () => {
+    const result = runCli([], { ELIZA_PORT: "notaport" });
+    expect(result.status).not.toBe(0);
+    const combined = `${result.stdout}${result.stderr}`;
+    expect(combined).toMatch(
+      /ELIZA_PORT must be a TCP port integer from 1 to 65535/,
+    );
+    expect(combined).not.toContain("[dev-health-check] starting:");
+  });
+
+  test("rejects invalid ELIZA_API_PORT before log/output or dev startup", () => {
+    for (const value of ["0", "notaport", "31337junk", "99999"]) {
+      const result = runCli([], { ELIZA_API_PORT: value });
+      expect(result.status).not.toBe(0);
+      const combined = `${result.stdout}${result.stderr}`;
+      expect(combined).toMatch(
+        /ELIZA_API_PORT must be a TCP port integer from 1 to 65535/,
+      );
+      expect(combined).not.toContain("[dev-health-check] starting:");
+    }
+  });
+});

--- a/packages/scripts/dev-health-check.mjs
+++ b/packages/scripts/dev-health-check.mjs
@@ -9,6 +9,10 @@
  * - Logs do not contain fatal/error/timeout signatures
  * - The dev process does not exit before the observation window completes
  *
+ * Port overrides (`--ui-port`, `--api-port`, and the matching environment
+ * variables) must be canonical TCP ports in `1..65535`. Explicit invalid
+ * environment values fail closed rather than silently selecting a default.
+ *
  * Usage:
  *   node packages/scripts/dev-health-check.mjs
  *   node packages/scripts/dev-health-check.mjs --seconds=120
@@ -26,23 +30,27 @@ import {
 import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 
 const DEFAULT_SECONDS = 90;
-const DEFAULT_UI_PORT = 2138;
-const DEFAULT_API_PORT = 31337;
+export const DEFAULT_UI_PORT = 2138;
+export const DEFAULT_API_PORT = 31337;
 const DEFAULT_INITIAL_PROBE_DELAY_MS = 8000;
 const POLL_INTERVAL_MS = 1000;
 const FETCH_TIMEOUT_MS = 10000;
 const FINAL_PROBE_RETRIES = 3;
 const FINAL_PROBE_RETRY_DELAY_MS = 1000;
 
-function parseArgs(argv) {
+/**
+ * Parse CLI argv and optional env into health-check options.
+ * @param {string[]} argv
+ * @param {NodeJS.ProcessEnv} [env]
+ */
+export function parseArgs(argv, env = process.env) {
   const options = {
     seconds: DEFAULT_SECONDS,
-    uiPort:
-      Number(process.env.ELIZA_UI_PORT || process.env.ELIZA_PORT) ||
-      DEFAULT_UI_PORT,
-    apiPort: Number(process.env.ELIZA_API_PORT) || DEFAULT_API_PORT,
+    uiPort: resolveUiPortFromEnv(env),
+    apiPort: resolveApiPortFromEnv(env),
     initialProbeDelayMs: DEFAULT_INITIAL_PROBE_DELAY_MS,
     logDir: path.join(process.cwd(), "logs"),
   };
@@ -61,9 +69,9 @@ function parseArgs(argv) {
     } else if (key === "--duration-ms") {
       options.seconds = parsePositiveNumber(value, "--duration-ms") / 1000;
     } else if (key === "--ui-port") {
-      options.uiPort = parsePositiveInteger(value, "--ui-port");
+      options.uiPort = parseTcpPort(value, "--ui-port");
     } else if (key === "--api-port") {
-      options.apiPort = parsePositiveInteger(value, "--api-port");
+      options.apiPort = parseTcpPort(value, "--api-port");
     } else if (key === "--initial-probe-delay-ms") {
       options.initialProbeDelayMs = parsePositiveNumber(
         value,
@@ -77,6 +85,65 @@ function parseArgs(argv) {
   }
 
   return options;
+}
+
+/**
+ * Resolve UI port: `ELIZA_UI_PORT` wins over `ELIZA_PORT`; unset/empty keeps
+ * the default. Any other explicit value must be a canonical TCP port.
+ * @param {NodeJS.ProcessEnv} env
+ */
+export function resolveUiPortFromEnv(env = process.env) {
+  const uiRaw = env.ELIZA_UI_PORT;
+  if (uiRaw !== undefined && uiRaw !== "") {
+    return parseTcpPort(uiRaw, "ELIZA_UI_PORT");
+  }
+  const portRaw = env.ELIZA_PORT;
+  if (portRaw !== undefined && portRaw !== "") {
+    return parseTcpPort(portRaw, "ELIZA_PORT");
+  }
+  return DEFAULT_UI_PORT;
+}
+
+/**
+ * Resolve `ELIZA_API_PORT`: unset/empty keeps the default; any other explicit
+ * value must be a canonical TCP port or the command fails closed.
+ * @param {NodeJS.ProcessEnv} env
+ */
+export function resolveApiPortFromEnv(env = process.env) {
+  const raw = env.ELIZA_API_PORT;
+  if (raw === undefined || raw === "") {
+    return DEFAULT_API_PORT;
+  }
+  return parseTcpPort(raw, "ELIZA_API_PORT");
+}
+
+/**
+ * Accept only canonical decimal TCP ports in the range 1..65535.
+ * Rejects partial numbers, signed values, fractions, leading zeros, and
+ * out-of-range integers so the health check never probes a different port
+ * than the operator requested.
+ * @param {string} value
+ * @param {string} label
+ */
+export function parseTcpPort(value, label) {
+  const raw = String(value ?? "").trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `${label} must be a TCP port integer from 1 to 65535 (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  const port = Number.parseInt(raw, 10);
+  if (
+    !Number.isSafeInteger(port) ||
+    port < 1 ||
+    port > 65535 ||
+    String(port) !== raw
+  ) {
+    throw new Error(
+      `${label} must be a TCP port integer from 1 to 65535 (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  return port;
 }
 
 function prependPath(env, entries) {
@@ -131,29 +198,22 @@ function printHelp() {
 Options:
   --seconds=N       Observation window in seconds, default ${DEFAULT_SECONDS}
   --duration-ms=N   Observation window in milliseconds
-  --ui-port=N       UI port to probe, default ${DEFAULT_UI_PORT}
-  --api-port=N      API port to probe, default ${DEFAULT_API_PORT}
+  --ui-port=N       UI port to probe (1-65535), default ${DEFAULT_UI_PORT}
+  --api-port=N      API port to probe (1-65535), default ${DEFAULT_API_PORT}
   --initial-probe-delay-ms=N
                     Startup delay before probing, default ${DEFAULT_INITIAL_PROBE_DELAY_MS}
-  --log-dir=PATH    Directory for captured logs, default ./logs`);
+  --log-dir=PATH    Directory for captured logs, default ./logs
+
+Environment:
+  ELIZA_UI_PORT / ELIZA_PORT  UI probe port when --ui-port is omitted
+                              (ELIZA_UI_PORT takes precedence)
+  ELIZA_API_PORT              API probe port when --api-port is omitted`);
 }
 
 function parsePositiveNumber(value, label) {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) {
     throw new Error(`${label} must be a positive number`);
-  }
-  return parsed;
-}
-
-function parsePositiveInteger(value, label) {
-  const parsed = Number.parseInt(value, 10);
-  if (
-    !Number.isFinite(parsed) ||
-    parsed <= 0 ||
-    String(parsed) !== String(value)
-  ) {
-    throw new Error(`${label} must be a positive integer`);
   }
   return parsed;
 }
@@ -749,7 +809,14 @@ async function run() {
   console.log("[dev-health-check] PASS");
 }
 
-run().catch((error) => {
-  console.error(`[dev-health-check] ${error?.stack || error}`);
-  process.exit(1);
-});
+const isDirectRun =
+  import.meta.main === true ||
+  (typeof process.argv[1] === "string" &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href);
+
+if (isDirectRun) {
+  run().catch((error) => {
+    console.error(`[dev-health-check] ${error?.stack || error}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
# Relates to

Closes #18593

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused package checks passed after sync (`packages/scripts` dev-health-check tests + Biome on the new test file). Full `bun run verify` was not re-run end-to-end in this session.
- [x] A reviewer can confirm the change from the CLI transcripts and focused test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xAI / grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build` (`grok` client)
<!-- attribution-row:skill-revision -->
- Skill path: `contribute-to-eliza` @ `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77`
<!-- attribution-row:status -->
- Provenance status: `self-reported` + device-signed project receipt (footer below)
- Run id: `run_01KZTSS4ME5FZHXZ6MZC1FBNMK`
- Note: Operator approved Grok for this workstream. Token meter via ccusage is unavailable for Grok (signed zero / unavailable confidence), not fabricated.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync; full monorepo `bun run verify` not claimed here.

# Risks

**Low.** CLI and environment port validation only for the local `dev-health-check` harness. No production API, agent runtime, or UI behavior changes for valid invocations. Invalid ports now fail closed at the command boundary instead of probing a wrong or impossible endpoint, or spending the observation window on a silent default.

# Background

## What does this PR do?

Validates dev-health-check UI/API port overrides at the command boundary:

- `--ui-port` and `--api-port` must be canonical decimal TCP ports in `1..65535` (rejects `0`, `99999`, `65536`, partial numbers, signed/fractional forms, leading zeros).
- `ELIZA_UI_PORT`, `ELIZA_PORT`, and `ELIZA_API_PORT` use the same contract when set; explicit invalid values fail closed instead of silently falling back via `Number(...) || default`.
- `ELIZA_UI_PORT` keeps precedence over `ELIZA_PORT`.
- Unset/empty env keeps the existing defaults (`2138` UI / `31337` API).

Previously `--ui-port=99999` was accepted by a positive-integer parser and only failed later through `curl`/`nc`, and env values such as `0` / `notaport` silently selected the default probe port.

## What kind of change is this?

Bug fix (non-breaking for valid CLI/env use; invalid args now fail closed).

# Documentation changes needed?

No project docs change required. Help text now states the TCP port range and environment override names explicitly.

# Testing

## Where should a reviewer start?

1. `packages/scripts/dev-health-check.mjs` — `parseTcpPort`, `resolveUiPortFromEnv`, `resolveApiPortFromEnv`, `parseArgs`
2. `packages/scripts/__tests__/dev-health-check.test.mjs` — unit + real CLI boundary

## Detailed testing steps

```bash
bun test packages/scripts/__tests__/dev-health-check.test.mjs
# 18 passed

node packages/scripts/dev-health-check.mjs --ui-port=99999
# exit 1, message: --ui-port must be a TCP port integer from 1 to 65535 (received "99999")
# does not print "[dev-health-check] starting:"

ELIZA_API_PORT=0 node packages/scripts/dev-health-check.mjs
# exit 1, message: ELIZA_API_PORT must be a TCP port integer from 1 to 65535 (received "0")
```

# Evidence Gate

<!-- evidence-head:1c98e3bf3871b162f4e9eb1dbb361ebcae79f588 -->

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - terminal-only dev-health-check CLI harness; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - terminal-only dev-health-check CLI harness; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no interactive UI flow; CLI argument rejection is fully captured by transcripts below.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no server/runtime path; rejection happens before log directory creation or `bun run dev` spawn.
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no browser app surface.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent, model, prompt, provider, or action behavior.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: focused bun test output (18 passed) and CLI rejection transcripts proving non-zero exit and no dev startup for invalid `--ui-port` / `--api-port` / env ports.

### CLI after (this head)

```text
$ node packages/scripts/dev-health-check.mjs --ui-port=99999
--ui-port must be a TCP port integer from 1 to 65535 (received "99999")
exit:1

$ ELIZA_API_PORT=0 node packages/scripts/dev-health-check.mjs
ELIZA_API_PORT must be a TCP port integer from 1 to 65535 (received "0")
exit:1

$ ELIZA_UI_PORT=notaport node packages/scripts/dev-health-check.mjs
ELIZA_UI_PORT must be a TCP port integer from 1 to 65535 (received "notaport")
exit:1

$ ELIZA_PORT=65536 node packages/scripts/dev-health-check.mjs
ELIZA_PORT must be a TCP port integer from 1 to 65535 (received "65536")
exit:1

$ bun test packages/scripts/__tests__/dev-health-check.test.mjs
 18 pass
 0 fail
```

### Pre-fix failure shape (why the bug matters)

```text
Number("notaport") || 2138   // => 2138  — silent wrong UI target
Number("0") || 31337         // => 31337 — explicit 0 ignored for API
// --ui-port=99999 accepted by parsePositiveInteger → late curl/nc failure
```

# Known gaps / failures

- Full monorepo `bun run verify` not asserted in this session; focused script tests and Biome on the new test file were run.
- Pre-existing Biome findings in `dev-health-check.mjs` (`stripAnsi` control-character regex and an optional-chain warning) are unchanged and exist on `origin/develop`.
- Non-port options (`--seconds`, `--initial-probe-delay-ms`) retain their prior positive-number parsers; only TCP port validation was hardened in this PR.

# Notes for reviewers

Operator override allowed Grok for this contribution. Device-signed measured receipt is appended below. Independent review and merge remain with maintainers.

# Measured project receipt

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-rama0x1]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTSS4ME5FZHXZ6MZC1FBNMK","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T10:55:06.894Z","completed_at":"2026-08-12T10:56:47.289Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"sEKGHEUkLw3PWIKqFr2G55g4nasuQunZrCllVBKv5S5X5JXaYYfGC9-7x_PwLtzkpSvu8PIQgLNU9xFKs_hTDA"}} -->