### PR TITLE
fix(scripts): reject invalid prune-turbo-cache --max-gb overrides

### DIFF
--- a/packages/scripts/__tests__/prune-turbo-cache.test.mjs
+++ b/packages/scripts/__tests__/prune-turbo-cache.test.mjs
@@ -1,0 +1,200 @@
+/**
+ * Focused coverage for prune-turbo-cache --max-gb validation: parser contract
+ * plus real CLI boundary rejections before any cache eviction.
+ */
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DEFAULT_MAX_GB,
+  maxBytesFromGb,
+  parseArgs,
+  parseMaxGb,
+  pruneTurboCache,
+  resolveCacheDir,
+} from "../prune-turbo-cache.mjs";
+import { spawnSync } from "../lib/spawn-sync-captured.mjs";
+
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "prune-turbo-cache.mjs",
+);
+
+function runCli(args, env = {}) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...env,
+    },
+    timeout: 5_000,
+  });
+}
+
+describe("parseMaxGb", () => {
+  test("accepts positive finite values including fractions", () => {
+    expect(parseMaxGb("20")).toBe(20);
+    expect(parseMaxGb("1.5")).toBe(1.5);
+    expect(parseMaxGb(" 2 ")).toBe(2);
+    expect(parseMaxGb(String(DEFAULT_MAX_GB))).toBe(DEFAULT_MAX_GB);
+  });
+
+  test("rejects empty, non-positive, non-finite, and non-numeric forms", () => {
+    const bad = [
+      "",
+      " ",
+      "0",
+      "-1",
+      "-0.1",
+      "abc",
+      "NaN",
+      "Infinity",
+      "-Infinity",
+      "20gb",
+      "1.2.3",
+    ];
+    for (const value of bad) {
+      expect(() => parseMaxGb(value, "--max-gb")).toThrow(
+        /must be a positive finite number of gigabytes/,
+      );
+    }
+  });
+});
+
+describe("parseArgs", () => {
+  test("defaults to 20 GB when --max-gb is omitted", () => {
+    const options = parseArgs(["--dry-run"]);
+    expect(options.dryRun).toBe(true);
+    expect(options.maxGb).toBe(DEFAULT_MAX_GB);
+    expect(options.maxBytes).toBe(maxBytesFromGb(DEFAULT_MAX_GB));
+  });
+
+  test("accepts a valid --max-gb override", () => {
+    const options = parseArgs(["--max-gb=1.5"]);
+    expect(options.dryRun).toBe(false);
+    expect(options.maxGb).toBe(1.5);
+    expect(options.maxBytes).toBe(maxBytesFromGb(1.5));
+  });
+
+  test("fails closed on invalid --max-gb overrides", () => {
+    for (const arg of [
+      "--max-gb=",
+      "--max-gb=0",
+      "--max-gb=-1",
+      "--max-gb=abc",
+      "--max-gb=NaN",
+      "--max-gb=Infinity",
+    ]) {
+      expect(() => parseArgs([arg])).toThrow(
+        /must be a positive finite number of gigabytes/,
+      );
+    }
+  });
+});
+
+describe("resolveCacheDir", () => {
+  test("prefers TURBO_CACHE_DIR over the default relative path", () => {
+    expect(resolveCacheDir({ TURBO_CACHE_DIR: "/tmp/custom-turbo" }, "/repo")).toBe(
+      path.resolve("/tmp/custom-turbo"),
+    );
+    expect(resolveCacheDir({}, "/repo")).toBe(
+      path.resolve("/repo", ".turbo/cache"),
+    );
+  });
+});
+
+describe("pruneTurboCache", () => {
+  test("reports missing cache without throwing", () => {
+    const cacheDir = path.join(
+      os.tmpdir(),
+      `eliza-prune-missing-${process.pid}-${Date.now()}`,
+    );
+    const result = pruneTurboCache({
+      cacheDir,
+      maxBytes: maxBytesFromGb(1),
+      dryRun: true,
+    });
+    expect(result.missing).toBe(true);
+  });
+
+  test("evicts oldest entries when over the byte cap", () => {
+    const cacheDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza-prune-turbo-"),
+    );
+    try {
+      const older = path.join(cacheDir, "aaa.tar.zst");
+      const newer = path.join(cacheDir, "bbb.tar.zst");
+      fs.writeFileSync(older, "x".repeat(100));
+      fs.writeFileSync(newer, "y".repeat(100));
+      const olderTime = Date.now() - 60_000;
+      const newerTime = Date.now();
+      fs.utimesSync(older, olderTime / 1000, olderTime / 1000);
+      fs.utimesSync(newer, newerTime / 1000, newerTime / 1000);
+
+      const result = pruneTurboCache({
+        cacheDir,
+        maxBytes: 150,
+        dryRun: false,
+      });
+      expect(result.missing).toBe(false);
+      expect(result.evictedCount).toBe(1);
+      expect(fs.existsSync(older)).toBe(false);
+      expect(fs.existsSync(newer)).toBe(true);
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("prune-turbo-cache CLI", () => {
+  test("exits 0 when the cache directory is missing", () => {
+    const missing = path.join(
+      os.tmpdir(),
+      `eliza-prune-cli-missing-${process.pid}-${Date.now()}`,
+    );
+    const result = runCli([], { TURBO_CACHE_DIR: missing });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("No cache at");
+  });
+
+  test("accepts a valid --max-gb dry-run", () => {
+    const missing = path.join(
+      os.tmpdir(),
+      `eliza-prune-cli-valid-${process.pid}-${Date.now()}`,
+    );
+    const result = runCli(["--max-gb=1.5", "--dry-run"], {
+      TURBO_CACHE_DIR: missing,
+    });
+    expect(result.status).toBe(0);
+  });
+
+  test("rejects invalid --max-gb overrides before pruning", () => {
+    const cacheDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza-prune-cli-bad-"),
+    );
+    try {
+      const keep = path.join(cacheDir, "keep.tar.zst");
+      fs.writeFileSync(keep, "payload");
+      for (const arg of [
+        "--max-gb=",
+        "--max-gb=0",
+        "--max-gb=-1",
+        "--max-gb=abc",
+        "--max-gb=NaN",
+        "--max-gb=Infinity",
+      ]) {
+        const result = runCli([arg], { TURBO_CACHE_DIR: cacheDir });
+        expect(result.status).toBe(2);
+        expect(result.stderr).toMatch(
+          /must be a positive finite number of gigabytes/,
+        );
+        expect(fs.existsSync(keep)).toBe(true);
+      }
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/scripts/prune-turbo-cache.mjs
+++ b/packages/scripts/prune-turbo-cache.mjs
@@ -1,97 +1,221 @@
 #!/usr/bin/env node
-// Bounds the local turbo cache so it cannot grow without limit.
-//
-// Turbo's local cache is content-addressed (each task hash maps to a fixed set
-// of filenames), so lookups stay O(1) regardless of cache size — a large cache
-// does not slow builds. The only real costs of an unbounded cache are disk
-// space and orphaned fragments left behind by interrupted writes. This script
-// addresses both:
-//   1. Deletes orphaned `*.tmp` write fragments.
-//   2. Enforces a max total size by evicting the oldest complete entries
-//      (each entry = `<hash>.tar.zst` + `<hash>-meta.json` + `<hash>-manifest.json`)
-//      until the cache is under the cap.
-//
-// Usage:
-//   node packages/scripts/prune-turbo-cache.mjs [--max-gb=20] [--dry-run]
+/**
+ * Bounds the local turbo cache so it cannot grow without limit.
+ *
+ * Turbo's local cache is content-addressed (each task hash maps to a fixed set
+ * of filenames), so lookups stay O(1) regardless of cache size — a large cache
+ * does not slow builds. The only real costs of an unbounded cache are disk
+ * space and orphaned fragments left behind by interrupted writes. This script
+ * addresses both:
+ *   1. Deletes orphaned `*.tmp` write fragments.
+ *   2. Enforces a max total size by evicting the oldest complete entries
+ *      (each entry = `<hash>.tar.zst` + `<hash>-meta.json` + `<hash>-manifest.json`)
+ *      until the cache is under the cap.
+ *
+ * `--max-gb` must be a positive finite number of gigabytes when provided.
+ * Invalid overrides fail closed before any eviction so a typo cannot either
+ * skip pruning (NaN cap) or wipe the cache (zero/negative cap).
+ *
+ * Usage:
+ *   node packages/scripts/prune-turbo-cache.mjs [--max-gb=20] [--dry-run]
+ */
 
 import fs from "node:fs";
 import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
 
-const CACHE_DIR = path.resolve(
-  process.cwd(),
-  process.env.TURBO_CACHE_DIR || ".turbo/cache",
-);
+export const DEFAULT_MAX_GB = 20;
+const BYTES_PER_GB = 1024 ** 3;
 
-const args = process.argv.slice(2);
-const dryRun = args.includes("--dry-run");
-const maxGbArg = args.find((a) => a.startsWith("--max-gb="));
-const maxBytes = Math.round(
-  (maxGbArg ? Number(maxGbArg.split("=")[1]) : 20) * 1024 ** 3,
-);
-
-if (!fs.existsSync(CACHE_DIR)) {
-  console.log(`[prune-turbo-cache] No cache at ${CACHE_DIR}; nothing to do.`);
-  process.exit(0);
-}
-
-const fmt = (bytes) => `${(bytes / 1024 ** 3).toFixed(2)} GB`;
-const rm = (p) => {
-  if (dryRun) return;
-  fs.rmSync(p, { force: true });
-};
-
-const dirents = fs.readdirSync(CACHE_DIR, { withFileTypes: true });
-
-// 1. Orphaned write fragments.
-let tmpFreed = 0;
-let tmpCount = 0;
-for (const d of dirents) {
-  if (!d.isFile() || !d.name.endsWith(".tmp")) continue;
-  const full = path.join(CACHE_DIR, d.name);
-  tmpFreed += fs.statSync(full).size;
-  tmpCount += 1;
-  rm(full);
-}
-
-// 2. Group remaining files into entries keyed by hash, tracking newest mtime
-// and total size per entry. A hash is the leading filename segment before the
-// first `.` (tarball) or `-` (meta/manifest).
-const entries = new Map();
-let totalSize = 0;
-for (const d of dirents) {
-  if (!d.isFile() || d.name.endsWith(".tmp")) continue;
-  const name = d.name;
-  const hash = name.includes(".")
-    ? name.slice(0, name.indexOf("."))
-    : name.slice(0, name.indexOf("-") === -1 ? name.length : name.indexOf("-"));
-  const full = path.join(CACHE_DIR, name);
-  const st = fs.statSync(full);
-  totalSize += st.size;
-  const entry = entries.get(hash) ?? { hash, files: [], size: 0, mtime: 0 };
-  entry.files.push(full);
-  entry.size += st.size;
-  entry.mtime = Math.max(entry.mtime, st.mtimeMs);
-  entries.set(hash, entry);
-}
-
-let evicted = 0;
-let evictedCount = 0;
-if (totalSize > maxBytes) {
-  const oldestFirst = [...entries.values()].sort((a, b) => a.mtime - b.mtime);
-  let running = totalSize;
-  for (const entry of oldestFirst) {
-    if (running <= maxBytes) break;
-    for (const f of entry.files) rm(f);
-    running -= entry.size;
-    evicted += entry.size;
-    evictedCount += 1;
+/**
+ * Parse a positive finite gigabyte cap for `--max-gb`.
+ * @param {string} value
+ * @param {string} [label]
+ * @returns {number}
+ */
+export function parseMaxGb(value, label = "--max-gb") {
+  const raw = String(value ?? "").trim();
+  if (raw === "") {
+    throw new Error(
+      `${label} must be a positive finite number of gigabytes (received ${JSON.stringify(String(value ?? ""))})`,
+    );
   }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(
+      `${label} must be a positive finite number of gigabytes (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  return parsed;
 }
 
-console.log(
-  `[prune-turbo-cache]${dryRun ? " (dry-run)" : ""} ` +
-    `start=${fmt(totalSize + tmpFreed)} cap=${fmt(maxBytes)} | ` +
-    `tmp: removed ${tmpCount} (${fmt(tmpFreed)}), ` +
-    `evicted ${evictedCount} entr${evictedCount === 1 ? "y" : "ies"} (${fmt(evicted)}), ` +
-    `end=${fmt(totalSize - evicted)}`,
-);
+/**
+ * Convert a gigabyte cap to a whole-byte budget.
+ * @param {number} maxGb
+ * @returns {number}
+ */
+export function maxBytesFromGb(maxGb) {
+  return Math.round(maxGb * BYTES_PER_GB);
+}
+
+/**
+ * Parse CLI argv into dry-run and max-size options.
+ * @param {string[]} argv
+ */
+export function parseArgs(argv) {
+  const dryRun = argv.includes("--dry-run");
+  const maxGbArg = argv.find((a) => a.startsWith("--max-gb="));
+  let maxGb = DEFAULT_MAX_GB;
+  if (maxGbArg !== undefined) {
+    maxGb = parseMaxGb(maxGbArg.slice("--max-gb=".length), "--max-gb");
+  }
+  return {
+    dryRun,
+    maxGb,
+    maxBytes: maxBytesFromGb(maxGb),
+  };
+}
+
+/**
+ * Resolve the turbo cache directory from env and cwd.
+ * @param {NodeJS.ProcessEnv} [env]
+ * @param {string} [cwd]
+ */
+export function resolveCacheDir(env = process.env, cwd = process.cwd()) {
+  return path.resolve(cwd, env.TURBO_CACHE_DIR || ".turbo/cache");
+}
+
+/**
+ * Prune orphaned tmp fragments and oldest entries until under the byte cap.
+ * @param {{ cacheDir: string, maxBytes: number, dryRun?: boolean }} options
+ */
+export function pruneTurboCache(options) {
+  const { cacheDir, maxBytes, dryRun = false } = options;
+  if (!fs.existsSync(cacheDir)) {
+    return {
+      missing: true,
+      cacheDir,
+      totalSize: 0,
+      tmpCount: 0,
+      tmpFreed: 0,
+      evictedCount: 0,
+      evicted: 0,
+      endSize: 0,
+    };
+  }
+
+  const rm = (p) => {
+    if (dryRun) return;
+    fs.rmSync(p, { force: true });
+  };
+
+  const dirents = fs.readdirSync(cacheDir, { withFileTypes: true });
+
+  // 1. Orphaned write fragments.
+  let tmpFreed = 0;
+  let tmpCount = 0;
+  for (const d of dirents) {
+    if (!d.isFile() || !d.name.endsWith(".tmp")) continue;
+    const full = path.join(cacheDir, d.name);
+    tmpFreed += fs.statSync(full).size;
+    tmpCount += 1;
+    rm(full);
+  }
+
+  // 2. Group remaining files into entries keyed by hash, tracking newest mtime
+  // and total size per entry. A hash is the leading filename segment before the
+  // first `.` (tarball) or `-` (meta/manifest).
+  const entries = new Map();
+  let totalSize = 0;
+  for (const d of dirents) {
+    if (!d.isFile() || d.name.endsWith(".tmp")) continue;
+    const name = d.name;
+    const hash = name.includes(".")
+      ? name.slice(0, name.indexOf("."))
+      : name.slice(
+          0,
+          name.indexOf("-") === -1 ? name.length : name.indexOf("-"),
+        );
+    const full = path.join(cacheDir, name);
+    const st = fs.statSync(full);
+    totalSize += st.size;
+    const entry = entries.get(hash) ?? { hash, files: [], size: 0, mtime: 0 };
+    entry.files.push(full);
+    entry.size += st.size;
+    entry.mtime = Math.max(entry.mtime, st.mtimeMs);
+    entries.set(hash, entry);
+  }
+
+  let evicted = 0;
+  let evictedCount = 0;
+  if (totalSize > maxBytes) {
+    const oldestFirst = [...entries.values()].sort((a, b) => a.mtime - b.mtime);
+    let running = totalSize;
+    for (const entry of oldestFirst) {
+      if (running <= maxBytes) break;
+      for (const f of entry.files) rm(f);
+      running -= entry.size;
+      evicted += entry.size;
+      evictedCount += 1;
+    }
+  }
+
+  return {
+    missing: false,
+    cacheDir,
+    totalSize,
+    tmpCount,
+    tmpFreed,
+    evictedCount,
+    evicted,
+    endSize: totalSize - evicted,
+  };
+}
+
+function fmt(bytes) {
+  return `${(bytes / BYTES_PER_GB).toFixed(2)} GB`;
+}
+
+function main(argv = process.argv.slice(2), env = process.env) {
+  let options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    // error-policy:J1 CLI boundary — invalid --max-gb fails closed before prune
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`[prune-turbo-cache] ${message}\n`);
+    process.exit(2);
+  }
+
+  const cacheDir = resolveCacheDir(env);
+  const result = pruneTurboCache({
+    cacheDir,
+    maxBytes: options.maxBytes,
+    dryRun: options.dryRun,
+  });
+
+  if (result.missing) {
+    console.log(
+      `[prune-turbo-cache] No cache at ${cacheDir}; nothing to do.`,
+    );
+    return;
+  }
+
+  console.log(
+    `[prune-turbo-cache]${options.dryRun ? " (dry-run)" : ""} ` +
+      `start=${fmt(result.totalSize + result.tmpFreed)} cap=${fmt(options.maxBytes)} | ` +
+      `tmp: removed ${result.tmpCount} (${fmt(result.tmpFreed)}), ` +
+      `evicted ${result.evictedCount} entr${result.evictedCount === 1 ? "y" : "ies"} (${fmt(result.evicted)}), ` +
+      `end=${fmt(result.endSize)}`,
+  );
+}
+
+const isDirectRun =
+  import.meta.main === true ||
+  (typeof process.argv[1] === "string" &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href);
+
+if (isDirectRun) {
+  main();
+}


### PR DESCRIPTION
# Relates to

Closes #18602

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `grok`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** Scripts-only CLI boundary validation for local turbo cache pruning.
Invalid `--max-gb` now exits 2 before any eviction. Valid default (20 GB) and
positive finite overrides keep the prior prune algorithm.

# Background

## What does this PR do?

`packages/scripts/prune-turbo-cache.mjs` parsed `--max-gb=` with bare
`Number(...)`. Invalid values failed open:

- non-numeric / `NaN` → byte cap became `NaN`, so `totalSize > maxBytes` was
  always false and the script never pruned while printing a nonsense cap
- `0` / negative → cap became zero or negative, so the script could delete the
  entire local turbo cache

This change fails closed on empty, non-numeric, non-positive, and non-finite
overrides (exit 2, stderr names `--max-gb`) before any eviction. Positive
finite values including fractional GB remain accepted. The prune algorithm is
unchanged beyond validating the cap first. Exports and a focused test file
cover the parser, CLI boundary, and eviction behavior.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation. The script
header documents the fail-closed `--max-gb` contract.

# Testing

## Where should a reviewer start?

1. `packages/scripts/prune-turbo-cache.mjs` — `parseMaxGb` / `parseArgs` /
   CLI exit 2 path
2. `packages/scripts/__tests__/prune-turbo-cache.test.mjs`

## Detailed testing steps

```bash
bun test packages/scripts/__tests__/prune-turbo-cache.test.mjs
node packages/scripts/prune-turbo-cache.mjs --max-gb=abc   # exit 2
node packages/scripts/prune-turbo-cache.mjs --max-gb=0     # exit 2
TURBO_CACHE_DIR=$(mktemp -d) node packages/scripts/prune-turbo-cache.mjs --max-gb=1.5 --dry-run
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:9eb45c661c951dc24f7b167619bb898588b50f81 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - scripts-only CLI; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - scripts-only CLI; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - scripts-only CLI; no user-facing UI flow
<!-- evidence-row:backend-logs -->
- [ ] N/A - CLI stderr/stdout captured inline in Evidence Details (real script process)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model path changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - focused bun test output and CLI rejection logs captured inline in Evidence Details
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

`N/A - scripts-only numeric CLI validation; no live model path`

## Backend + frontend logs

<details>
<summary>CLI fail-closed + dry-run smoke (HEAD 9eb45c66)</summary>

```text
$ node packages/scripts/prune-turbo-cache.mjs --max-gb=abc; echo exit:$?
[prune-turbo-cache] --max-gb must be a positive finite number of gigabytes (received "abc")
exit:2

$ node packages/scripts/prune-turbo-cache.mjs --max-gb=0; echo exit:$?
[prune-turbo-cache] --max-gb must be a positive finite number of gigabytes (received "0")
exit:2

$ TMP=$(mktemp -d) && TURBO_CACHE_DIR="$TMP" node packages/scripts/prune-turbo-cache.mjs --max-gb=1.5 --dry-run; echo exit:$?
[prune-turbo-cache] (dry-run) start=0.00 GB cap=1.50 GB | tmp: removed 0 (0.00 GB), evicted 0 entries (0.00 GB), end=0.00 GB
exit:0
```

</details>

<details>
<summary>Focused tests</summary>

```text
$ bun test packages/scripts/__tests__/prune-turbo-cache.test.mjs
bun test v1.3.14 (0d9b296a)

 11 pass
 0 fail
 55 expect() calls
Ran 11 tests across 1 file. [368.00ms]
```

</details>

Frontend: `N/A - no frontend surface`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - scripts-only CLI; no rendered UI`

### After

`N/A - scripts-only CLI; no rendered UI`

### Walkthrough video

`N/A - scripts-only CLI; no user-facing UI flow`

## Audio / voice walkthrough

`N/A - no voice/TTS/STT path`

## Known gaps / failures

- Did **not** run full-repo `bun run verify` / `bun install` for this cycle.
  Scope is a single scripts package CLI validator with focused `bun test`
  coverage (11/11 pass). Reviewer can expand verification as needed.
- Root `origin/develop` at branch creation: `e11f20c5`.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [rama0x1-unattended]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTT08JYS4KTCMYN34DK7Q8T","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T10:59:00.319Z","completed_at":"2026-08-12T11:00:51.286Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"G5d5E91i18s8cBa0MYn2UjUjtr3aScouc1iB6vTfw5Zq612fkwvSYGb4CVEA14pSzUqJ8Ms-scJdH_H2AxlTBw"}} -->
