### PR TITLE
fix(dev): reject invalid dev health-check port overrides

### DIFF
--- a/packages/scripts/__tests__/dev-health-check.test.mjs
+++ b/packages/scripts/__tests__/dev-health-check.test.mjs
@@ -1,0 +1,89 @@
+/** Exercises dev health-check option validation without starting the dev stack. */
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs, parsePort } from "../dev-health-check.mjs";
+
+const scriptPath = fileURLToPath(
+  new URL("../dev-health-check.mjs", import.meta.url),
+);
+
+describe("dev health-check port options", () => {
+  test("preserves defaults and valid CLI overrides", () => {
+    expect(parseArgs([], {})).toMatchObject({ uiPort: 2138, apiPort: 31337 });
+    expect(parseArgs(["--ui-port=65535", "--api-port=1"], {})).toMatchObject({
+      uiPort: 65535,
+      apiPort: 1,
+    });
+  });
+
+  test("uses validated environment overrides with UI-specific precedence", () => {
+    expect(
+      parseArgs([], {
+        ELIZA_UI_PORT: "4321",
+        ELIZA_PORT: "5432",
+        ELIZA_API_PORT: "6543",
+      }),
+    ).toMatchObject({ uiPort: 4321, apiPort: 6543 });
+    expect(parseArgs([], { ELIZA_PORT: "5432" })).toMatchObject({
+      uiPort: 5432,
+      apiPort: 31337,
+    });
+  });
+
+  test.each([
+    "",
+    "0",
+    "-1",
+    "+1",
+    "1.5",
+    "1junk",
+    "NaN",
+    "Infinity",
+    "65536",
+    "9007199254740992",
+  ])("rejects invalid port %p", (value) => {
+    expect(() => parsePort(value, "--ui-port")).toThrow(
+      "--ui-port must be a decimal TCP port from 1 to 65535",
+    );
+  });
+
+  test("rejects malformed environment ports at their source", () => {
+    expect(() => parseArgs([], { ELIZA_UI_PORT: "0" })).toThrow(
+      "ELIZA_UI_PORT must be a decimal TCP port from 1 to 65535",
+    );
+    expect(() => parseArgs([], { ELIZA_API_PORT: "65536" })).toThrow(
+      "ELIZA_API_PORT must be a decimal TCP port from 1 to 65535",
+    );
+  });
+
+  test("lets explicit CLI ports override malformed environment values", () => {
+    expect(
+      parseArgs(["--ui-port=1234", "--api-port=5678"], {
+        ELIZA_UI_PORT: "invalid",
+        ELIZA_API_PORT: "65536",
+      }),
+    ).toMatchObject({ uiPort: 1234, apiPort: 5678 });
+  });
+
+  test("real CLI rejects before creating output or starting the dev stack", () => {
+    const parent = mkdtempSync(path.join(tmpdir(), "dev-health-check-test-"));
+    const logDir = path.join(parent, "logs");
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, "--ui-port=65536", `--log-dir=${logDir}`],
+      { cwd: parent, encoding: "utf8", env: { PATH: process.env.PATH ?? "" } },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "--ui-port must be a decimal TCP port from 1 to 65535",
+    );
+    expect(result.stdout).not.toContain("starting: bun run dev");
+    expect(existsSync(logDir)).toBe(false);
+  });
+});

--- a/packages/scripts/dev-health-check.mjs
+++ b/packages/scripts/dev-health-check.mjs
@@ -26,6 +26,7 @@ import {
 import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 
 const DEFAULT_SECONDS = 90;
 const DEFAULT_UI_PORT = 2138;
@@ -36,13 +37,21 @@ const FETCH_TIMEOUT_MS = 10000;
 const FINAL_PROBE_RETRIES = 3;
 const FINAL_PROBE_RETRY_DELAY_MS = 1000;
 
-function parseArgs(argv) {
+function parseArgs(argv, env = process.env) {
+  let [uiPortValue, uiPortLabel] =
+    env.ELIZA_UI_PORT !== undefined
+      ? [env.ELIZA_UI_PORT, "ELIZA_UI_PORT"]
+      : env.ELIZA_PORT !== undefined
+        ? [env.ELIZA_PORT, "ELIZA_PORT"]
+        : [DEFAULT_UI_PORT, "--ui-port"];
+  let [apiPortValue, apiPortLabel] =
+    env.ELIZA_API_PORT !== undefined
+      ? [env.ELIZA_API_PORT, "ELIZA_API_PORT"]
+      : [DEFAULT_API_PORT, "--api-port"];
   const options = {
     seconds: DEFAULT_SECONDS,
-    uiPort:
-      Number(process.env.ELIZA_UI_PORT || process.env.ELIZA_PORT) ||
-      DEFAULT_UI_PORT,
-    apiPort: Number(process.env.ELIZA_API_PORT) || DEFAULT_API_PORT,
+    uiPort: DEFAULT_UI_PORT,
+    apiPort: DEFAULT_API_PORT,
     initialProbeDelayMs: DEFAULT_INITIAL_PROBE_DELAY_MS,
     logDir: path.join(process.cwd(), "logs"),
   };
@@ -61,9 +70,11 @@ function parseArgs(argv) {
     } else if (key === "--duration-ms") {
       options.seconds = parsePositiveNumber(value, "--duration-ms") / 1000;
     } else if (key === "--ui-port") {
-      options.uiPort = parsePositiveInteger(value, "--ui-port");
+      uiPortValue = value;
+      uiPortLabel = "--ui-port";
     } else if (key === "--api-port") {
-      options.apiPort = parsePositiveInteger(value, "--api-port");
+      apiPortValue = value;
+      apiPortLabel = "--api-port";
     } else if (key === "--initial-probe-delay-ms") {
       options.initialProbeDelayMs = parsePositiveNumber(
         value,
@@ -76,6 +87,8 @@ function parseArgs(argv) {
     }
   }
 
+  options.uiPort = parsePort(uiPortValue, uiPortLabel);
+  options.apiPort = parsePort(apiPortValue, apiPortLabel);
   return options;
 }
 
@@ -146,14 +159,14 @@ function parsePositiveNumber(value, label) {
   return parsed;
 }
 
-function parsePositiveInteger(value, label) {
-  const parsed = Number.parseInt(value, 10);
-  if (
-    !Number.isFinite(parsed) ||
-    parsed <= 0 ||
-    String(parsed) !== String(value)
-  ) {
-    throw new Error(`${label} must be a positive integer`);
+function parsePort(value, label) {
+  const raw = String(value);
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`${label} must be a decimal TCP port from 1 to 65535`);
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed > 65535) {
+    throw new Error(`${label} must be a decimal TCP port from 1 to 65535`);
   }
   return parsed;
 }
@@ -749,7 +762,14 @@ async function run() {
   console.log("[dev-health-check] PASS");
 }
 
-run().catch((error) => {
-  console.error(`[dev-health-check] ${error?.stack || error}`);
-  process.exit(1);
-});
+export { parseArgs, parsePort };
+
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
+  run().catch((error) => {
+    console.error(`[dev-health-check] ${error?.stack || error}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18593

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and focused package checks were run after sync; full
      `bun run verify` status is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused package checks pass post-sync; full `bun run verify` status is
      documented in **Known gaps / failures** below.

# Risks

Low. Command-boundary validation only for local `dev-health-check.mjs`.
Failure mode shifts from late probe/log failure to early labeled rejection.
No runtime probe, logging, or process-teardown behavior changes.

# Background

## What does this PR do?

Hardens `packages/scripts/dev-health-check.mjs` port option parsing:

- Accept only canonical decimal TCP ports in `1..65535` for `--ui-port`,
  `--api-port`, `ELIZA_UI_PORT`, `ELIZA_PORT`, and `ELIZA_API_PORT`.
- Keep defaults (`2138` / `31337`) when env overrides are absent.
- Keep `ELIZA_UI_PORT` precedence over `ELIZA_PORT`.
- Let explicit CLI port flags override env after argv is fully parsed, so a
  valid CLI flag is not blocked by a stale invalid env value.
- Fail before log-directory creation or `bun run dev` startup with a
  source-specific diagnostic.
- Export `parseArgs` / `parsePort` for focused unit tests and add a real CLI
  rejection test.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. `packages/scripts/dev-health-check.mjs` — `parseArgs` / `parsePort`
2. `packages/scripts/__tests__/dev-health-check.test.mjs`

## Detailed testing steps

```bash
export PATH="$HOME/.bun/bin:$PATH"
bun test packages/scripts/__tests__/dev-health-check.test.mjs
node packages/scripts/audit-scripts.mjs
bunx biome check packages/scripts/__tests__/dev-health-check.test.mjs
bunx biome format packages/scripts/dev-health-check.mjs
```

Observed:

- 15 pass / 0 fail focused tests (defaults, env precedence, invalid values,
  CLI override of bad env, real CLI rejects before log dir / dev start)
- `[audit-scripts] OK`
- Biome check/format clean on the new test and format-clean on the script
  (pre-existing control-character regex lint in untouched `stripAnsi`)

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:49252b55a4610bd50992a8f9fca524a8c3ed75df -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface; CLI option validation only`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface; CLI option validation only`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI flow; terminal CLI validation only`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - no backend server path; local script boundary only`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend path`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/model path`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - terminal test output is the domain artifact`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model path.

## Backend + frontend logs

N/A - local command-line validation only. Focused test/command output:

```text
bun test packages/scripts/__tests__/dev-health-check.test.mjs
15 pass
0 fail
[audit-scripts] OK — no orphan/no-op/broken scripts.
```

## Screenshots (before / after) + video walkthrough

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI flow.

## Audio / voice walkthrough

N/A - no voice path.

## Known gaps / failures

- Full-repo `bun run verify` was started after install; if still incomplete at
  PR open time, the blocker is monorepo-wide duration on this host, not the
  touched script surface. Focused checks for the changed path all pass:
  `bun test packages/scripts/__tests__/dev-health-check.test.mjs`,
  `node packages/scripts/audit-scripts.mjs`, and Biome format/check on the
  touched test file.
- Pre-existing Biome `noControlCharactersInRegex` warning remains on untouched
  `stripAnsi` in `dev-health-check.mjs`; left alone to avoid drive-by churn.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [hermes-agent-cortex]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTQ84PMF046HN97RVYM4YFE","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T10:10:52.757Z","completed_at":"2026-08-12T11:02:52.207Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEABCQ_La8E3A-mhoOGQAU1JDjb5V6pW0qzF_zrcALUa7w","device_key_id":"2ca15083498fec081db8f2a4bbc2afcd06af5a23f516c26e16441b7fa6261099","device_signature":"QmJwPNun2wLeyRBhA9-fCuW8cHWtL0YzbTFewPEdhvLIAw3pPMWhhd7q2bFhw9khOjlBXa6f-hpciVgayiSeCw"}} -->
