### PR TITLE
fix(scripts): reject run-with-deadline values above Node timer limit

### DIFF
--- a/packages/scripts/__tests__/run-with-deadline.test.ts
+++ b/packages/scripts/__tests__/run-with-deadline.test.ts
@@ -1,8 +1,17 @@
-// Exercises the run-with-deadline wrapper against real child processes: exit-code passthrough, deadline group kill, and usage validation.
+/**
+ * Exercises the run-with-deadline wrapper against real child processes: exit-
+ * code passthrough, deadline group kill, usage validation, and Node timer
+ * ceiling rejection before spawn.
+ */
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  MAX_TIMER_DELAY_MS,
+  parseArgs,
+  parseDeadlineMs,
+} from "../run-with-deadline.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const WRAPPER = path.resolve(SCRIPT_DIR, "..", "run-with-deadline.mjs");
@@ -14,6 +23,69 @@ function runWrapper(args: string[], timeoutMs = 30_000) {
     timeout: timeoutMs,
   });
 }
+
+describe("parseDeadlineMs", () => {
+  test("accepts positive integers through the Node timer ceiling", () => {
+    expect(parseDeadlineMs("1")).toBe(1);
+    expect(parseDeadlineMs("500")).toBe(500);
+    expect(parseDeadlineMs(String(MAX_TIMER_DELAY_MS))).toBe(
+      MAX_TIMER_DELAY_MS,
+    );
+  });
+
+  test("rejects zero, fractional, signed, partial, and non-decimal forms", () => {
+    for (const value of [
+      "0",
+      "-1",
+      "+1",
+      "1.5",
+      "1e3",
+      "0x10",
+      "500ms",
+      "500junk",
+      "",
+      " ",
+      "NaN",
+      "Infinity",
+      "08",
+    ]) {
+      expect(() => parseDeadlineMs(value)).toThrow(
+        `deadline-ms must be a positive decimal integer from 1 to ${MAX_TIMER_DELAY_MS}`,
+      );
+    }
+  });
+
+  test("rejects values Node would clamp to one millisecond", () => {
+    for (const value of [
+      String(MAX_TIMER_DELAY_MS + 1),
+      "9007199254740992",
+      "9".repeat(400),
+    ]) {
+      expect(() => parseDeadlineMs(value)).toThrow(
+        `deadline-ms must be a positive decimal integer from 1 to ${MAX_TIMER_DELAY_MS}`,
+      );
+    }
+  });
+});
+
+describe("parseArgs", () => {
+  test("returns deadline and command for valid argv", () => {
+    expect(parseArgs(["1200", "--", "node", "-e", "0"])).toEqual({
+      deadlineMs: 1200,
+      command: "node",
+      args: ["-e", "0"],
+    });
+  });
+
+  test("rejects missing separator or command", () => {
+    expect(() => parseArgs(["1000", "node", "-e", "0"])).toThrow(/usage:/);
+    expect(() => parseArgs(["1000", "--"])).toThrow(/usage:/);
+    expect(() => parseArgs(["--", "node", "-e", "0"])).toThrow(/usage:/);
+    expect(() => parseArgs(["", "--", "node", "-e", "0"])).toThrow(
+      /deadline-ms must be a positive decimal integer/,
+    );
+  });
+});
 
 describe("run-with-deadline", () => {
   test("passes through the child's exit code when it finishes in time", () => {
@@ -58,5 +130,33 @@ describe("run-with-deadline", () => {
       "definitely-not-a-real-binary-xyz",
     ]);
     expect(result.status).toBe(127);
+  });
+
+  test("rejects an overflowing deadline before spawning the child", () => {
+    const result = runWrapper([
+      String(MAX_TIMER_DELAY_MS + 1),
+      "--",
+      NODE_BIN,
+      "-e",
+      "console.log('should-not-run')",
+    ]);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain(
+      `deadline-ms must be a positive decimal integer from 1 to ${MAX_TIMER_DELAY_MS}`,
+    );
+    expect(result.stderr).not.toContain("TimeoutOverflowWarning");
+    expect(result.stdout).not.toContain("should-not-run");
+  });
+
+  test("accepts the exact Node timer ceiling without overflow warnings", () => {
+    const result = runWrapper([
+      String(MAX_TIMER_DELAY_MS),
+      "--",
+      NODE_BIN,
+      "-e",
+      "process.exit(0)",
+    ]);
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("TimeoutOverflowWarning");
   });
 });

--- a/packages/scripts/run-with-deadline.mjs
+++ b/packages/scripts/run-with-deadline.mjs
@@ -7,68 +7,125 @@
  * Exit codes: the child's own code on normal completion, 124 on deadline
  * kill, 127 when the command cannot start, 2 on usage errors.
  *
+ * The deadline must be a positive decimal integer no greater than Node's
+ * maximum timer delay (`2^31 - 1` ms). Larger values would clamp to 1 ms and
+ * kill the child immediately.
+ *
  * usage: node packages/scripts/run-with-deadline.mjs <deadline-ms> -- <command> [args...]
  */
 import { spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
-const argv = process.argv.slice(2);
-const deadlineRaw = argv[0] ?? "";
-const deadlineMs = /^\d+$/.test(deadlineRaw) ? Number(deadlineRaw) : NaN;
-if (
-  argv[1] !== "--" ||
-  !Number.isSafeInteger(deadlineMs) ||
-  deadlineMs <= 0 ||
-  argv.length < 3
-) {
-  console.error(
-    "usage: node packages/scripts/run-with-deadline.mjs <deadline-ms> -- <command> [args...]",
-  );
-  process.exit(2);
-}
-const [command, ...args] = argv.slice(2);
+/** Node clamps `setTimeout` delays above this to 1 ms. */
+export const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
-// detached: the child leads its own process group, so the deadline kill
-// reaches grandchildren (per-file test workers, spawned engines) too.
-const child = spawn(command, args, { stdio: "inherit", detached: true });
-
-const killGroup = (signal) => {
-  try {
-    process.kill(-child.pid, signal);
-  } catch {
-    // error-policy:J6 group teardown fallback — the group leader may already
-    // have exited; direct-kill the child instead and let 'close' settle.
-    try {
-      child.kill(signal);
-    } catch {
-      // error-policy:J6 child already gone; 'close' has fired or will fire.
-    }
+/**
+ * Parse a wall-clock deadline for the CLI boundary.
+ * @param {string} raw
+ * @returns {number}
+ */
+export function parseDeadlineMs(raw) {
+  if (typeof raw !== "string" || !/^[1-9]\d*$/.test(raw)) {
+    throw new Error(
+      `deadline-ms must be a positive decimal integer from 1 to ${MAX_TIMER_DELAY_MS}`,
+    );
   }
-};
-
-let timedOut = false;
-const timer = setTimeout(() => {
-  timedOut = true;
-  console.error(
-    `[run-with-deadline] wall-clock deadline of ${deadlineMs}ms exceeded; killing "${command}" process group`,
-  );
-  killGroup("SIGTERM");
-  const escalation = setTimeout(() => killGroup("SIGKILL"), 10_000);
-  escalation.unref();
-}, deadlineMs);
-
-for (const signal of ["SIGINT", "SIGTERM"]) {
-  process.on(signal, () => killGroup(signal));
+  const deadlineMs = Number(raw);
+  if (
+    !Number.isSafeInteger(deadlineMs) ||
+    deadlineMs < 1 ||
+    deadlineMs > MAX_TIMER_DELAY_MS
+  ) {
+    throw new Error(
+      `deadline-ms must be a positive decimal integer from 1 to ${MAX_TIMER_DELAY_MS}`,
+    );
+  }
+  return deadlineMs;
 }
 
-child.on("error", (error) => {
-  clearTimeout(timer);
-  console.error(
-    `[run-with-deadline] failed to start "${command}": ${error.message}`,
-  );
-  process.exit(127);
-});
-child.on("close", (code, signal) => {
-  clearTimeout(timer);
-  if (timedOut) process.exit(124);
-  process.exit(code ?? (signal ? 1 : 0));
-});
+/**
+ * Parse CLI argv into deadline and command. Exported for focused tests.
+ * @param {string[]} argv process.argv slice after the script path
+ * @returns {{ deadlineMs: number, command: string, args: string[] }}
+ */
+export function parseArgs(argv) {
+  const deadlineRaw = argv[0] ?? "";
+  if (argv[1] !== "--" || argv.length < 3) {
+    throw new Error(
+      "usage: node packages/scripts/run-with-deadline.mjs <deadline-ms> -- <command> [args...]",
+    );
+  }
+  const deadlineMs = parseDeadlineMs(deadlineRaw);
+  const [command, ...args] = argv.slice(2);
+  return { deadlineMs, command, args };
+}
+
+function main(argv) {
+  let options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    // error-policy:J1 CLI boundary — invalid deadline/usage fails before spawn
+    console.error(
+      error instanceof Error
+        ? error.message
+        : "usage: node packages/scripts/run-with-deadline.mjs <deadline-ms> -- <command> [args...]",
+    );
+    process.exit(2);
+  }
+
+  const { deadlineMs, command, args } = options;
+
+  // detached: the child leads its own process group, so the deadline kill
+  // reaches grandchildren (per-file test workers, spawned engines) too.
+  const child = spawn(command, args, { stdio: "inherit", detached: true });
+
+  const killGroup = (signal) => {
+    try {
+      process.kill(-child.pid, signal);
+    } catch {
+      // error-policy:J6 group teardown fallback — the group leader may already
+      // have exited; direct-kill the child instead and let 'close' settle.
+      try {
+        child.kill(signal);
+      } catch {
+        // error-policy:J6 child already gone; 'close' has fired or will fire.
+      }
+    }
+  };
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    console.error(
+      `[run-with-deadline] wall-clock deadline of ${deadlineMs}ms exceeded; killing "${command}" process group`,
+    );
+    killGroup("SIGTERM");
+    const escalation = setTimeout(() => killGroup("SIGKILL"), 10_000);
+    escalation.unref();
+  }, deadlineMs);
+
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.on(signal, () => killGroup(signal));
+  }
+
+  child.on("error", (error) => {
+    clearTimeout(timer);
+    console.error(
+      `[run-with-deadline] failed to start "${command}": ${error.message}`,
+    );
+    process.exit(127);
+  });
+  child.on("close", (code, signal) => {
+    clearTimeout(timer);
+    if (timedOut) process.exit(124);
+    process.exit(code ?? (signal ? 1 : 0));
+  });
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main(process.argv.slice(2));
+}


### PR DESCRIPTION
# Relates to

Fixes #18605

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok (unattended contribution worker)`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - local contribute-to-eliza skill archive; operator-approved Grok workstream (receipt script only accepts codex/claude-code models, so no signed zero-receipt was fabricated)`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** CLI boundary validation only. Call sites that already pass positive
deadlines under ~24.8 days are unchanged. Deadlines above Node's timer ceiling
now fail closed instead of silently becoming a 1 ms kill.

# Background

## What does this PR do?

Rejects `run-with-deadline` wall-clock values that Node would clamp to 1 ms
(`> 2^31 - 1`), and tightens the parser to positive canonical decimal integers.
Adds focused parser + real-process CLI regressions.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation. The script
header documents the Node timer ceiling constraint.

# Testing

## Where should a reviewer start?

1. `packages/scripts/run-with-deadline.mjs` — `parseDeadlineMs` / `parseArgs`
2. `packages/scripts/__tests__/run-with-deadline.test.ts`

## Detailed testing steps

```bash
bun test packages/scripts/__tests__/run-with-deadline.test.ts
node packages/scripts/run-with-deadline.mjs 2147483648 -- node -e 'console.log(\"should-not-run\")'
# expect exit 2, no TimeoutOverflowWarning, no child output
node packages/scripts/run-with-deadline.mjs 2147483647 -- node -e 'console.log(\"ceiling-ok\")'
# expect exit 0
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:49aa08a8aea289ef61d0329bb95713732519e725 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - terminal-only CLI/test-runner change; no rendered UI surface`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - terminal-only CLI/test-runner change; no rendered UI surface`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing flow; real CLI transcripts below`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no server/runtime path; CLI stderr/stdout is the complete artifact`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no browser or frontend surface`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, prompt, provider, or model behavior`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused test output and before/after CLI transcripts (below)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model changes`

## Backend + frontend logs

`N/A - no backend or frontend path`

### Before (on origin/develop)

```text
$ node packages/scripts/run-with-deadline.mjs 2147483648 -- node -e 'console.log("ok"); setTimeout(()=>{}, 5000)'
(node) TimeoutOverflowWarning: 2147483648 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
[run-with-deadline] wall-clock deadline of 2147483648ms exceeded; killing "node" process group
```

### After (this PR head `49aa08a8`)

```text
$ node packages/scripts/run-with-deadline.mjs 2147483648 -- node -e 'console.log(\"should-not-run\")'
deadline-ms must be a positive decimal integer from 1 to 2147483647
exit:2

$ node packages/scripts/run-with-deadline.mjs 2147483647 -- node -e 'console.log(\"ceiling-ok\")'
ceiling-ok
exit:0
```

### Focused tests

```text
[0m[1mbun test [0m[2mv1.3.14 (0d9b296a)[0m
[0m
packages/scripts/__tests__/run-with-deadline.test.ts:
[0m[32m✓[0m [0mparseDeadlineMs[2m >[0m[1m accepts positive integers through the Node timer ceiling[0m [0m[2m[0.63ms[0m[2m][0m
[0m[32m✓[0m [0mparseDeadlineMs[2m >[0m[1m rejects zero, fractional, signed, partial, and non-decimal forms[0m [0m[2m[0.25ms[0m[2m][0m
[0m[32m✓[0m [0mparseDeadlineMs[2m >[0m[1m rejects values Node would clamp to one millisecond[0m [0m[2m[0.18ms[0m[2m][0m
[0m[32m✓[0m [0mparseArgs[2m >[0m[1m returns deadline and command for valid argv[0m [0m[2m[0.11ms[0m[2m][0m
[0m[32m✓[0m [0mparseArgs[2m >[0m[1m rejects missing separator or command[0m [0m[2m[0.16ms[0m[2m][0m
[0m[32m✓[0m [0mrun-with-deadline[2m >[0m[1m passes through the child's exit code when it finishes in time[0m [0m[2m[[1m36.62ms[0m[2m][0m
[0m[32m✓[0m [0mrun-with-deadline[2m >[0m[1m kills a wedged child at the deadline and exits 124[0m [0m[2m[[1m534.88ms[0m[2m][0m
[0m[32m✓[0m [0mrun-with-deadline[2m >[0m[1m fails usage when the separator or deadline is missing[0m [0m[2m[[1m68.98ms[0m[2m][0m
[0m[32m✓[0m [0mrun-with-deadline[2m >[0m[1m exits 127 when the command cannot start[0m [0m[2m[[1m22.94ms[0m[2m][0m
[0m[32m✓[0m [0mrun-with-deadline[2m >[0m[1m rejects an overflowing deadline before spawning the child[0m [0m[2m[[1m20.46ms[0m[2m][0m
[0m[32m✓[0m [0mrun-with-deadline[2m >[0m[1m accepts the exact Node timer ceiling without overflow warnings[0m [0m[2m[[1m35.78ms[0m[2m][0m
[0m[2m----------------------------------------|---------|---------|-------------------[0m
File                                    [2m|[0m % Funcs [2m|[0m % Lines [2m|[0m Uncovered Line #s
[2m----------------------------------------|---------|---------|-------------------[0m
[0m[1m[31mAll files                              [0m[2m | [0m[1m[31m  66.67[0m[2m | [0m[1m[31m  35.42[0m[2m |[0m
[0m[1m[31m packages/scripts/run-with-deadline.mjs[0m[2m | [0m[1m[31m  66.67[0m[2m | [0m[1m[31m  35.42[0m[2m | [0m[31m63-122[0m[2m,[0m[31m129-130
[0m[2m----------------------------------------|---------|---------|-------------------[0m

[0m[32m 11 pass[0m
[0m[2m 0 fail[0m
 38 expect() calls
Ran 11 tests across 1 file. [0m[2m[[1m839.00ms[0m[2m][0m
```

### Screenshots / Walkthrough video

`N/A - terminal-only tooling; no UI`

## Audio / voice walkthrough

`N/A - no voice/TTS/STT surface`

## Known gaps / failures

- Full `bun run verify` was **not** run this cycle. Focused coverage:
  - `bun test packages/scripts/__tests__/run-with-deadline.test.ts` (11 pass)
  - `bunx biome check` on the two touched files (clean)
  - Real CLI probes for overflow rejection and exact ceiling acceptance
- Signed contribute-to-eliza run receipt omitted: operator approved Grok for this
  workstream, and the receipt script only accepts codex/claude-code models.
  Fabricating an approved model id would violate provenance rules.