### PR TITLE
fix(app): reject invalid check-startup-budget --tolerance-pct overrides

### DIFF
--- a/packages/app/scripts/check-startup-budget.mjs
+++ b/packages/app/scripts/check-startup-budget.mjs
@@ -207,7 +207,43 @@ export function shouldPassAfterBaselineUpdate(rows, updatedCount) {
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_BUDGETS = path.resolve(HERE, "..", "perf-budgets.json");
 
-function parseArgs(argv) {
+/**
+ * Parse `--tolerance-pct` at the CLI boundary. Accepts only a complete
+ * non-negative decimal (integer or fractional). Partial strings such as
+ * `10junk` and non-finite values must not fall through to the budgets-file
+ * default — that would grade the gate under a different tolerance than the
+ * operator requested.
+ *
+ * @param {string | undefined} raw
+ * @returns {number}
+ */
+export function parseTolerancePct(raw) {
+  if (typeof raw !== "string" || raw.length === 0 || raw.startsWith("--")) {
+    throw new Error(
+      "--tolerance-pct requires a non-negative decimal number (e.g. 0, 15, 12.5)",
+    );
+  }
+  // Full-string match only: Number("10junk") is NaN and previously fell open
+  // to the budgets default via evaluateAll's Number.isFinite guard.
+  if (!/^(?:\d+(?:\.\d+)?|\.\d+)$/.test(raw)) {
+    throw new Error(
+      `--tolerance-pct must be a non-negative decimal number, got "${raw}"`,
+    );
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(
+      `--tolerance-pct must be a non-negative decimal number, got "${raw}"`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Parse CLI argv for the startup-budget gate. Exported for focused unit tests.
+ * @param {string[]} argv process.argv-style array (index 0-1 ignored)
+ */
+export function parseArgs(argv) {
   const args = {
     budgets: DEFAULT_BUDGETS,
     trace: null,
@@ -228,8 +264,9 @@ function parseArgs(argv) {
     else if (a === "--build-timing") args.buildTiming = argv[++i];
     else if (a === "--build-target") args.buildTarget = argv[++i];
     else if (a === "--metric") args.metrics.push(argv[++i]);
-    else if (a === "--tolerance-pct") args.tolerancePct = Number(argv[++i]);
-    else if (a === "--out") args.out = argv[++i];
+    else if (a === "--tolerance-pct") {
+      args.tolerancePct = parseTolerancePct(argv[++i]);
+    } else if (a === "--out") args.out = argv[++i];
     else if (a === "--update-baseline") args.updateBaseline = true;
     else if (a === "--json") args.json = true;
     else throw new Error(`Unknown argument: ${a}`);

--- a/packages/app/scripts/check-startup-budget.test.ts
+++ b/packages/app/scripts/check-startup-budget.test.ts
@@ -18,6 +18,8 @@ import {
   evaluateMetric,
   extractTtiMark,
   METRIC_STATUS,
+  parseArgs,
+  parseTolerancePct,
   selectColdRun,
   shouldPassAfterBaselineUpdate,
 } from "./check-startup-budget.mjs";
@@ -271,6 +273,69 @@ describe("shouldPassAfterBaselineUpdate", () => {
   });
 });
 
+describe("parseTolerancePct", () => {
+  it("accepts non-negative integers and fractional decimals", () => {
+    expect(parseTolerancePct("0")).toBe(0);
+    expect(parseTolerancePct("15")).toBe(15);
+    expect(parseTolerancePct("12.5")).toBe(12.5);
+    expect(parseTolerancePct(".5")).toBe(0.5);
+  });
+
+  it.each([
+    undefined,
+    "",
+    "--json",
+    "junk",
+    "10junk",
+    "-1",
+    "-0.1",
+    "1e2",
+    "Infinity",
+    "NaN",
+    "15%",
+    " 15",
+  ] as Array<string | undefined>)(
+    "rejects invalid input %j at the boundary",
+    (raw) => {
+      expect(() => parseTolerancePct(raw)).toThrow(/--tolerance-pct/);
+    },
+  );
+});
+
+describe("parseArgs --tolerance-pct", () => {
+  it("records a valid override and leaves omission as null", () => {
+    expect(
+      parseArgs(["node", "check-startup-budget.mjs", "--tolerance-pct", "12.5"])
+        .tolerancePct,
+    ).toBe(12.5);
+    expect(
+      parseArgs(["node", "check-startup-budget.mjs"]).tolerancePct,
+    ).toBeNull();
+  });
+
+  it("fails closed when the value is missing or malformed", () => {
+    expect(() =>
+      parseArgs(["node", "check-startup-budget.mjs", "--tolerance-pct"]),
+    ).toThrow(/--tolerance-pct/);
+    expect(() =>
+      parseArgs([
+        "node",
+        "check-startup-budget.mjs",
+        "--tolerance-pct",
+        "10junk",
+      ]),
+    ).toThrow(/10junk/);
+    expect(() =>
+      parseArgs([
+        "node",
+        "check-startup-budget.mjs",
+        "--tolerance-pct",
+        "--json",
+      ]),
+    ).toThrow(/--tolerance-pct/);
+  });
+});
+
 describe("CLI baseline recording", () => {
   it("does not partially write baselines when one requested metric has no budget", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "startup-budget-"));
@@ -306,5 +371,45 @@ describe("CLI baseline recording", () => {
     expect(result.stderr).toContain("Refusing to update baselines");
     const budgets = JSON.parse(readFileSync(budgetsPath, "utf8"));
     expect(budgets.tti["ci-web"].baselineMs).toBeNull();
+  });
+});
+
+describe("CLI --tolerance-pct fail-closed", () => {
+  function runCli(extraArgs: string[]) {
+    return spawnSync(
+      process.execPath,
+      [SCRIPT_PATH, "--metric", "build:rebuild-loop=100", ...extraArgs],
+      { encoding: "utf8" },
+    );
+  }
+
+  it("rejects malformed and missing values with a non-zero exit", () => {
+    for (const args of [
+      ["--tolerance-pct", "junk"],
+      ["--tolerance-pct", "10junk"],
+      ["--tolerance-pct", "-1"],
+      ["--tolerance-pct"],
+      ["--tolerance-pct", "--json"],
+    ]) {
+      const result = runCli(args);
+      expect(result.status, args.join(" ")).not.toBe(0);
+      expect(result.stderr, args.join(" ")).toMatch(/tolerance-pct/i);
+      expect(result.stdout, args.join(" ")).not.toMatch(/Budget gate: PASS/);
+    }
+  });
+
+  it("accepts a valid override and reports it in --json output", () => {
+    const result = runCli(["--tolerance-pct", "12.5", "--json"]);
+    expect(result.status).toBe(0);
+    const report = JSON.parse(result.stdout);
+    expect(report.tolerancePct).toBe(12.5);
+    expect(report.ok).toBe(true);
+  });
+
+  it("keeps the budgets-file default when the flag is omitted", () => {
+    const result = runCli(["--json"]);
+    expect(result.status).toBe(0);
+    const report = JSON.parse(result.stdout);
+    expect(report.tolerancePct).toBe(15);
   });
 });


### PR DESCRIPTION
# Relates to

Fixes #18607

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok (unattended contribution worker)`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** CLI boundary validation only for `--tolerance-pct`. Call sites that
omit the flag or pass a valid non-negative decimal are unchanged. Invalid
overrides now fail closed instead of grading under the budgets-file default.

# Background

## What does this PR do?

`check-startup-budget.mjs` previously parsed `--tolerance-pct` with
`Number(...)`. Malformed, partial (`10junk`), missing, negative, and
non-finite values became `NaN`, and `evaluateAll` silently fell back to the
budgets-file default (or 15). A mistyped performance-gate flag therefore exited
successfully under a different regression tolerance than requested.

This PR adds `parseTolerancePct` that accepts only a complete non-negative
decimal, exports `parseArgs` for unit tests, and fails closed at the CLI
boundary with a non-zero exit.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation. The existing
script header already documents `--tolerance-pct`.

# Testing

## Where should a reviewer start?

1. `packages/app/scripts/check-startup-budget.mjs` — `parseTolerancePct` / `parseArgs`
2. `packages/app/scripts/check-startup-budget.test.ts` — unit + real CLI subprocess cases

## Detailed testing steps

```bash
bun test packages/app/scripts/check-startup-budget.test.ts
# 38 pass

node packages/app/scripts/check-startup-budget.mjs \
  --metric build:rebuild-loop=100 --tolerance-pct junk --json
# expect exit 1, stderr mentions --tolerance-pct

node packages/app/scripts/check-startup-budget.mjs \
  --metric build:rebuild-loop=100 --tolerance-pct 12.5 --json
# expect exit 0, report.tolerancePct === 12.5

node packages/app/scripts/check-startup-budget.mjs \
  --metric build:rebuild-loop=100 --json
# expect exit 0, report.tolerancePct === 15 (file default)
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:53e2a01fa7ffe42047b2380713624a9de924daf8 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - terminal-only CLI/test-runner change; no rendered UI surface`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - terminal-only CLI/test-runner change; no rendered UI surface`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing flow; real CLI transcripts below`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no server/runtime path; CLI stderr/stdout is the complete artifact`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no browser or frontend surface`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, prompt, provider, or model behavior`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused test output and before/after CLI transcripts (below)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model changes`

## Backend + frontend logs

`N/A - no backend or frontend path`

### Before (on origin/develop)

```text
$ node packages/app/scripts/check-startup-budget.mjs --metric build:rebuild-loop=100 --tolerance-pct junk --json
exit:0
{"tolerancePct":15,"ok":true,...}   # silent fallback to file default

$ node packages/app/scripts/check-startup-budget.mjs --metric build:rebuild-loop=100 --tolerance-pct 10junk --json
exit:0
{"tolerancePct":15,"ok":true,...}

$ node packages/app/scripts/check-startup-budget.mjs --metric build:rebuild-loop=100 --tolerance-pct --json
exit:0
# missing value also fell open
```

### After (this PR head `53e2a01f`)

```text
$ node packages/app/scripts/check-startup-budget.mjs --metric build:rebuild-loop=100 --tolerance-pct junk
[startup-budget] --tolerance-pct must be a non-negative decimal number, got "junk"
exit:1

$ node packages/app/scripts/check-startup-budget.mjs --metric build:rebuild-loop=100 --tolerance-pct 10junk
[startup-budget] --tolerance-pct must be a non-negative decimal number, got "10junk"
exit:1

$ node packages/app/scripts/check-startup-budget.mjs --metric build:rebuild-loop=100 --tolerance-pct
[startup-budget] --tolerance-pct requires a non-negative decimal number (e.g. 0, 15, 12.5)
exit:1

$ node packages/app/scripts/check-startup-budget.mjs --metric build:rebuild-loop=100 --tolerance-pct -1
[startup-budget] --tolerance-pct must be a non-negative decimal number, got "-1"
exit:1

$ node packages/app/scripts/check-startup-budget.mjs --metric build:rebuild-loop=100 --tolerance-pct 12.5 --json
exit:0
{"tolerancePct":12.5,"ok":true,...}

$ node packages/app/scripts/check-startup-budget.mjs --metric build:rebuild-loop=100 --json
exit:0
{"tolerancePct":15,"ok":true,...}   # omit flag → budgets-file default
```

### Focused tests

```text
$ bun test packages/app/scripts/check-startup-budget.test.ts
38 pass
0 fail
```

### Biome

```text
$ bunx biome check packages/app/scripts/check-startup-budget.mjs packages/app/scripts/check-startup-budget.test.ts
Checked 2 files. No errors.
```

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface`

## Audio / voice walkthrough

`N/A - no voice/TTS/STT path`

## Known gaps / failures

- Full `bun run verify` was **not** run this cycle (scoped CLI validation fix only).
- Focused proof: `bun test packages/app/scripts/check-startup-budget.test.ts` (38 pass), real CLI before/after exit behavior, Biome on the two touched files.
- `bun install` was not required; working tree already had dependencies.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [rama0x1-unattended]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTTZ814C1B3ANT1F1KNZN5Q","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T11:15:55.556Z","completed_at":"2026-08-12T11:16:22.943Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"8D4YdhAyAM7dn2PTveTymrS4SLjPVtJDA9RyjHVz0scj9FCYoPOqIzKoN6ToMiPY3P5O1cm2gQ651jip_KVSDg"}} -->