### PR TITLE
fix(app): reject invalid capture-startup-trace --runs and --timeout

### DIFF
--- a/packages/app/scripts/capture-startup-trace.mjs
+++ b/packages/app/scripts/capture-startup-trace.mjs
@@ -31,9 +31,50 @@
  */
 
 import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 
-function parseArgs(argv) {
+/** Node clamps `setTimeout` delays above this to 1 ms; Playwright waits share that bound. */
+export const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+/**
+ * Parse a positive decimal integer CLI override.
+ * Full-string match only: `Number("10junk")` is NaN and previously fell through
+ * so `--runs` / `--timeout` typos launched Chromium under a different budget
+ * than the operator requested (or skipped all runs silently).
+ *
+ * @param {string | undefined} raw
+ * @param {string} flag flag name for error messages (e.g. `--runs`)
+ * @param {{ max?: number }} [opts]
+ * @returns {number}
+ */
+export function parsePositiveInt(raw, flag, opts = {}) {
+  const max = opts.max ?? Number.MAX_SAFE_INTEGER;
+  if (typeof raw !== "string" || raw.length === 0 || raw.startsWith("--")) {
+    throw new Error(
+      `${flag} requires a positive decimal integer from 1 to ${max}`,
+    );
+  }
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(
+      `${flag} must be a positive decimal integer from 1 to ${max}, got "${raw}"`,
+    );
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1 || value > max) {
+    throw new Error(
+      `${flag} must be a positive decimal integer from 1 to ${max}, got "${raw}"`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Parse CLI argv for the startup-trace harness. Exported for focused unit tests.
+ * @param {string[]} argv process.argv-style array (index 0-1 ignored)
+ */
+export function parseArgs(argv) {
   const args = {
     url:
       process.env.ELIZA_STARTUP_TRACE_URL ||
@@ -46,11 +87,33 @@ function parseArgs(argv) {
   };
   for (let i = 2; i < argv.length; i += 1) {
     const a = argv[i];
-    if (a === "--url") args.url = argv[++i];
-    else if (a === "--runs") args.runs = Number(argv[++i]);
-    else if (a === "--out") args.out = argv[++i];
-    else if (a === "--timeout") args.timeout = Number(argv[++i]);
-    else if (a === "--wait-ready") args.waitReady = true;
+    if (a === "--url") {
+      const next = argv[++i];
+      if (
+        typeof next !== "string" ||
+        next.length === 0 ||
+        next.startsWith("--")
+      ) {
+        throw new Error("--url requires a renderer URL value");
+      }
+      args.url = next;
+    } else if (a === "--runs") {
+      args.runs = parsePositiveInt(argv[++i], "--runs");
+    } else if (a === "--out") {
+      const next = argv[++i];
+      if (
+        typeof next !== "string" ||
+        next.length === 0 ||
+        next.startsWith("--")
+      ) {
+        throw new Error("--out requires a file path value");
+      }
+      args.out = next;
+    } else if (a === "--timeout") {
+      args.timeout = parsePositiveInt(argv[++i], "--timeout", {
+        max: MAX_TIMER_DELAY_MS,
+      });
+    } else if (a === "--wait-ready") args.waitReady = true;
     else if (a === "--headed") args.headed = true;
   }
   return args;
@@ -140,8 +203,8 @@ function printRun(run) {
   }
 }
 
-async function main() {
-  const args = parseArgs(process.argv);
+async function main(argv = process.argv) {
+  const args = parseArgs(argv);
   // Renderer-only default: first-paint is gated behind STARTUP_SPLASH_DELAY_MS
   // and never fires on boots faster than the gate, so the unconditional
   // startup-shell:mounted mark also satisfies the wait. --wait-ready still
@@ -190,7 +253,17 @@ async function main() {
   process.exit(anyOk ? 0 : 1);
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  // error-policy:J1 CLI boundary — invalid flags and capture failures exit
+  // non-zero with a legible message instead of an unhandled rejection.
+  main().catch((err) => {
+    console.error(
+      `[startup-trace] ${err instanceof Error ? err.message : err}`,
+    );
+    process.exit(1);
+  });
+}

--- a/packages/app/scripts/capture-startup-trace.test.ts
+++ b/packages/app/scripts/capture-startup-trace.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Unit and CLI-boundary tests for the startup-trace harness argument parser.
+ * The harness is deterministic here: invalid flags must fail closed before
+ * Chromium launches, so subprocess cases never need a renderer or browser.
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  MAX_TIMER_DELAY_MS,
+  parseArgs,
+  parsePositiveInt,
+} from "./capture-startup-trace.mjs";
+
+// Resolve the CLI relative to this test file (a sibling .mjs), not
+// process.cwd(): the client test lane runs vitest from packages/app, so a
+// cwd-relative "packages/app/..." path doubles into
+// packages/app/packages/app/... and the spawned Node can't find the module.
+const SCRIPT_PATH = path.join(import.meta.dirname, "capture-startup-trace.mjs");
+
+describe("parsePositiveInt", () => {
+  it("accepts positive decimal integers", () => {
+    expect(parsePositiveInt("1", "--runs")).toBe(1);
+    expect(parsePositiveInt("42", "--runs")).toBe(42);
+    expect(parsePositiveInt("60000", "--timeout")).toBe(60_000);
+  });
+
+  it.each([
+    undefined,
+    "",
+    "junk",
+    "10junk",
+    "0",
+    "-1",
+    "1.5",
+    "1e3",
+    "+2",
+    " 3",
+    "--url",
+  ] as Array<string | undefined>)(
+    "rejects invalid input %j at the boundary",
+    (raw) => {
+      expect(() => parsePositiveInt(raw, "--runs")).toThrow(/--runs/);
+    },
+  );
+
+  it("rejects values above an explicit max", () => {
+    expect(() =>
+      parsePositiveInt(String(MAX_TIMER_DELAY_MS + 1), "--timeout", {
+        max: MAX_TIMER_DELAY_MS,
+      }),
+    ).toThrow(/--timeout/);
+    expect(
+      parsePositiveInt(String(MAX_TIMER_DELAY_MS), "--timeout", {
+        max: MAX_TIMER_DELAY_MS,
+      }),
+    ).toBe(MAX_TIMER_DELAY_MS);
+  });
+});
+
+describe("parseArgs --runs / --timeout", () => {
+  it("keeps defaults when flags are omitted", () => {
+    const args = parseArgs(["node", "capture-startup-trace.mjs"]);
+    expect(args.runs).toBe(1);
+    expect(args.timeout).toBe(60_000);
+  });
+
+  it("records valid overrides", () => {
+    const args = parseArgs([
+      "node",
+      "capture-startup-trace.mjs",
+      "--runs",
+      "3",
+      "--timeout",
+      "5000",
+      "--url",
+      "http://127.0.0.1:2138",
+    ]);
+    expect(args.runs).toBe(3);
+    expect(args.timeout).toBe(5000);
+    expect(args.url).toBe("http://127.0.0.1:2138");
+  });
+
+  it("fails closed when --runs is missing or malformed", () => {
+    expect(() =>
+      parseArgs(["node", "capture-startup-trace.mjs", "--runs"]),
+    ).toThrow(/--runs/);
+    expect(() =>
+      parseArgs(["node", "capture-startup-trace.mjs", "--runs", "junk"]),
+    ).toThrow(/junk/);
+    expect(() =>
+      parseArgs(["node", "capture-startup-trace.mjs", "--runs", "0"]),
+    ).toThrow(/--runs/);
+    expect(() =>
+      parseArgs(["node", "capture-startup-trace.mjs", "--runs", "-3"]),
+    ).toThrow(/--runs/);
+    expect(() =>
+      parseArgs([
+        "node",
+        "capture-startup-trace.mjs",
+        "--runs",
+        "--url",
+        "http://example",
+      ]),
+    ).toThrow(/--runs/);
+  });
+
+  it("fails closed when --timeout is missing or malformed", () => {
+    expect(() =>
+      parseArgs(["node", "capture-startup-trace.mjs", "--timeout"]),
+    ).toThrow(/--timeout/);
+    expect(() =>
+      parseArgs(["node", "capture-startup-trace.mjs", "--timeout", "10junk"]),
+    ).toThrow(/10junk/);
+    expect(() =>
+      parseArgs(["node", "capture-startup-trace.mjs", "--timeout", "0"]),
+    ).toThrow(/--timeout/);
+    expect(() =>
+      parseArgs([
+        "node",
+        "capture-startup-trace.mjs",
+        "--timeout",
+        String(MAX_TIMER_DELAY_MS + 1),
+      ]),
+    ).toThrow(/--timeout/);
+  });
+});
+
+describe("CLI --runs / --timeout fail-closed", () => {
+  function runCli(extraArgs: string[]) {
+    return spawnSync(process.execPath, [SCRIPT_PATH, ...extraArgs], {
+      encoding: "utf8",
+    });
+  }
+
+  it("rejects malformed and missing values before launching a capture", () => {
+    for (const args of [
+      ["--runs", "junk"],
+      ["--runs", "10junk"],
+      ["--runs", "0"],
+      ["--runs", "-3"],
+      ["--runs"],
+      ["--runs", "--url", "http://127.0.0.1:1"],
+      ["--timeout", "junk"],
+      ["--timeout", "10junk"],
+      ["--timeout", "0"],
+      ["--timeout"],
+      ["--timeout", String(MAX_TIMER_DELAY_MS + 1)],
+    ]) {
+      const result = runCli(args);
+      expect(result.status, args.join(" ")).not.toBe(0);
+      expect(result.stderr, args.join(" ")).toMatch(/startup-trace/i);
+      // Must not reach the capture banner that prints after successful parse.
+      expect(result.stdout, args.join(" ")).not.toMatch(
+        /Capturing startup trace:/,
+      );
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

Fixes #18609

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok (unattended contribution worker)`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** CLI boundary validation only for `--runs`, `--timeout`, and missing
`--url` / `--out` values. Call sites that omit the flags or pass valid positive
integers are unchanged. Invalid overrides now fail closed before Chromium
launches instead of capturing under `NaN` budgets or zero-iteration loops.

# Background

## What does this PR do?

`capture-startup-trace.mjs` previously parsed `--runs` and `--timeout` with
bare `Number(...)`. Malformed, partial (`10junk`), missing, zero, and negative
values became `NaN` or non-positive integers. The harness then launched Chromium
and either skipped all runs (`runs=NaN` / `0` / negative) or handed `NaN` to
Playwright waits. A mistyped performance-capture flag therefore did not fail at
the CLI boundary with a clear error.

This PR adds `parsePositiveInt` (full-string positive decimal integers), exports
`parseArgs` for unit tests, bounds `--timeout` to Node's maximum timer delay
(`2^31 - 1` ms), and fails closed with a non-zero exit before launch.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation. The existing
script header already documents `--runs` and `--timeout`.

# Testing

## Where should a reviewer start?

1. `packages/app/scripts/capture-startup-trace.mjs` — `parsePositiveInt` / `parseArgs`
2. `packages/app/scripts/capture-startup-trace.test.ts` — unit + real CLI subprocess cases

## Detailed testing steps

```bash
bun test packages/app/scripts/capture-startup-trace.test.ts
# 18 pass

node packages/app/scripts/capture-startup-trace.mjs --runs junk
# expect exit 1, stderr mentions --runs; no "Capturing startup trace:" banner

node packages/app/scripts/capture-startup-trace.mjs --timeout 10junk
# expect exit 1, stderr mentions --timeout

node packages/app/scripts/capture-startup-trace.mjs --runs 0
# expect exit 1
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:bb3627d96f58533ec098c38283b6b2e70a575796 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - terminal-only CLI/test-runner change; no rendered UI surface`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - terminal-only CLI/test-runner change; no rendered UI surface`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing flow; real CLI transcripts below`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no server/runtime path; CLI stderr/stdout is the complete artifact`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no browser or frontend surface`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, prompt, provider, or model behavior`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused test output and before/after CLI transcripts (below)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model changes`

## Backend + frontend logs

`N/A - no backend or frontend path`

### Before (on origin/develop)

```text
$ node packages/app/scripts/capture-startup-trace.mjs --runs junk --url http://127.0.0.1:1
Capturing startup trace: url=http://127.0.0.1:1 runs=NaN waitFor=startup-shell:first-paint|startup-shell:mounted
# Chromium still launches; loop body never runs
exit:1   # only because zero usable runs, not because of CLI validation

$ node packages/app/scripts/capture-startup-trace.mjs --runs 0 --url http://127.0.0.1:1
Capturing startup trace: url=http://127.0.0.1:1 runs=0 waitFor=...
# silent zero-iteration capture path

$ node packages/app/scripts/capture-startup-trace.mjs --timeout junk --url http://127.0.0.1:1
Capturing startup trace: ... runs=1 ...
# Playwright receives NaN timeout and fails late inside navigation
```

### After (this PR head `bb3627d9`)

```text
$ node packages/app/scripts/capture-startup-trace.mjs --runs junk
[startup-trace] --runs must be a positive decimal integer from 1 to 9007199254740991, got "junk"
exit:1

$ node packages/app/scripts/capture-startup-trace.mjs --timeout 10junk
[startup-trace] --timeout must be a positive decimal integer from 1 to 2147483647, got "10junk"
exit:1

$ node packages/app/scripts/capture-startup-trace.mjs --runs 0
[startup-trace] --runs must be a positive decimal integer from 1 to 9007199254740991, got "0"
exit:1

$ node packages/app/scripts/capture-startup-trace.mjs --runs --url http://127.0.0.1:1
[startup-trace] --runs requires a positive decimal integer from 1 to 9007199254740991
exit:1

$ node packages/app/scripts/capture-startup-trace.mjs --timeout 2147483648
[startup-trace] --timeout must be a positive decimal integer from 1 to 2147483647, got "2147483648"
exit:1
```

### Focused tests

```text
$ bun test packages/app/scripts/capture-startup-trace.test.ts
18 pass
0 fail
```

### Biome

```text
$ bunx biome check packages/app/scripts/capture-startup-trace.mjs packages/app/scripts/capture-startup-trace.test.ts
Checked 2 files. No errors.
```

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface`

## Audio / voice walkthrough

`N/A - no voice/TTS/STT path`

## Known gaps / failures

- Full `bun run verify` was **not** run this cycle (scoped CLI validation fix only).
- Focused proof: `bun test packages/app/scripts/capture-startup-trace.test.ts` (18 pass), real CLI before/after exit behavior, Biome on the two touched files.
- `bun install` was not required; working tree already had dependencies.
- Valid end-to-end capture against a live renderer was not re-run; parse-level acceptance of valid integers is covered by unit tests, and capture semantics are unchanged.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [rama0x1-unattended]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTV4TRZZ3EEX82JNB9AZPPQ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T11:18:58.592Z","completed_at":"2026-08-12T11:22:02.351Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"0s_GYbfGxomXWGkyYr5Y1Nr9I7eRqCxvQGMMf5fRynmmvf2yXoJgsgki_ejsxNjDTClQA1A2h2PixDCvcVs7Dw"}} -->