### PR TITLE
fix(app): reject invalid measure-anonymous-login-transfer --settle-ms and --timeout

### DIFF
--- a/packages/app/scripts/measure-anonymous-login-transfer.mjs
+++ b/packages/app/scripts/measure-anonymous-login-transfer.mjs
@@ -17,12 +17,15 @@
  *
  *   --url          full login URL (required unless --serve-dist)
  *   --serve-dist   serve packages/app/dist on an ephemeral port and measure /login
- *   --settle-ms    wait after load before sampling (default 6000)
+ *   --settle-ms    wait after load before sampling (default 6000; 0..2^31-1)
+ *   --timeout      navigation timeout in ms (default 90000; 1..2^31-1)
  *   --out          write JSON report
  *   --headed       visible browser
  *   --label        label for this run (e.g. head-sha or develop)
  *
  * Desktop (1280x720) and mobile (390x844) viewports are measured by default.
+ * Numeric overrides must be complete decimal integers; malformed values fail
+ * closed before Chromium launches.
  */
 
 import { execSync } from "node:child_process";
@@ -36,6 +39,9 @@ import { chromium } from "@playwright/test";
 const here = dirname(fileURLToPath(import.meta.url));
 const appDir = resolve(here, "..");
 let distDir = join(appDir, "dist");
+
+/** Node clamps `setTimeout` delays above this to 1 ms; Playwright waits share that bound. */
+export const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 const MIME = {
   ".html": "text/html; charset=utf-8",
@@ -59,7 +65,48 @@ const VIEWPORTS = [
   { id: "mobile", width: 390, height: 844 },
 ];
 
-function parseArgs(argv) {
+/**
+ * Parse a non-negative decimal integer CLI override (allows 0).
+ * Full-string match only: bare `Number("10junk")` is NaN and previously
+ * launched Chromium under an unintended settle/timeout budget.
+ *
+ * @param {string | undefined} raw
+ * @param {string} flag flag name for error messages (e.g. `--settle-ms`)
+ * @param {{ max?: number, min?: number }} [opts]
+ * @returns {number}
+ */
+export function parseDecimalInt(raw, flag, opts = {}) {
+  const min = opts.min ?? 0;
+  const max = opts.max ?? Number.MAX_SAFE_INTEGER;
+  if (typeof raw !== "string" || raw.length === 0 || raw.startsWith("--")) {
+    throw new Error(`${flag} requires a decimal integer from ${min} to ${max}`);
+  }
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `${flag} must be a decimal integer from ${min} to ${max}, got "${raw}"`,
+    );
+  }
+  // Leading zeros like "08" are rejected so the canonical decimal form is
+  // unambiguous (matches other CLI gates in packages/app scripts).
+  if (raw.length > 1 && raw.startsWith("0")) {
+    throw new Error(
+      `${flag} must be a decimal integer from ${min} to ${max}, got "${raw}"`,
+    );
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new Error(
+      `${flag} must be a decimal integer from ${min} to ${max}, got "${raw}"`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Parse CLI argv for the login-transfer harness. Exported for focused unit tests.
+ * @param {string[]} argv process.argv-style array (index 0-1 ignored)
+ */
+export function parseArgs(argv) {
   const args = {
     url: null,
     serveDist: false,
@@ -69,31 +116,79 @@ function parseArgs(argv) {
     headed: false,
     label: null,
     timeout: 90_000,
+    help: false,
   };
   for (let i = 2; i < argv.length; i += 1) {
     const a = argv[i];
-    if (a === "--url") args.url = argv[++i];
-    else if (a === "--serve-dist") args.serveDist = true;
-    else if (a === "--dist-dir") args.distDir = argv[++i];
-    else if (a === "--settle-ms") args.settleMs = Number(argv[++i]);
-    else if (a === "--out") args.out = argv[++i];
-    else if (a === "--timeout") args.timeout = Number(argv[++i]);
-    else if (a === "--label") args.label = argv[++i];
-    else if (a === "--headed") args.headed = true;
+    if (a === "--url") {
+      const next = argv[++i];
+      if (
+        typeof next !== "string" ||
+        next.length === 0 ||
+        next.startsWith("--")
+      ) {
+        throw new Error("--url requires a login URL value");
+      }
+      args.url = next;
+    } else if (a === "--serve-dist") args.serveDist = true;
+    else if (a === "--dist-dir") {
+      const next = argv[++i];
+      if (
+        typeof next !== "string" ||
+        next.length === 0 ||
+        next.startsWith("--")
+      ) {
+        throw new Error("--dist-dir requires a path value");
+      }
+      args.distDir = next;
+    } else if (a === "--settle-ms") {
+      args.settleMs = parseDecimalInt(argv[++i], "--settle-ms", {
+        min: 0,
+        max: MAX_TIMER_DELAY_MS,
+      });
+    } else if (a === "--out") {
+      const next = argv[++i];
+      if (
+        typeof next !== "string" ||
+        next.length === 0 ||
+        next.startsWith("--")
+      ) {
+        throw new Error("--out requires a file path value");
+      }
+      args.out = next;
+    } else if (a === "--timeout") {
+      args.timeout = parseDecimalInt(argv[++i], "--timeout", {
+        min: 1,
+        max: MAX_TIMER_DELAY_MS,
+      });
+    } else if (a === "--label") {
+      const next = argv[++i];
+      if (
+        typeof next !== "string" ||
+        next.length === 0 ||
+        next.startsWith("--")
+      ) {
+        throw new Error("--label requires a name value");
+      }
+      args.label = next;
+    } else if (a === "--headed") args.headed = true;
     else if (a === "--help" || a === "-h") {
-      console.log(`Usage: node scripts/measure-anonymous-login-transfer.mjs [options]
-  --url <url>       Login URL (default with --serve-dist: http://127.0.0.1:<port>/login)
-  --serve-dist      Serve packages/app/dist and measure /login
-  --dist-dir <path> Override dist directory (default: packages/app/dist)
-  --settle-ms <n>   Settle time after navigation (default 6000)
-  --out <path>      Write JSON report
-  --label <name>    Label this measurement (e.g. git sha)
-  --headed          Visible browser
-  --timeout <ms>    Navigation timeout (default 90000)`);
-      process.exit(0);
+      args.help = true;
     }
   }
   return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/measure-anonymous-login-transfer.mjs [options]
+  --url <url>       Login URL (default with --serve-dist: http://127.0.0.1:<port>/login)
+  --serve-dist      Serve packages/app/dist and measure /login
+  --dist-dir <path> Override dist directory (default: packages/app/dist)
+  --settle-ms <n>   Settle time after navigation (default 6000; 0..${MAX_TIMER_DELAY_MS})
+  --out <path>      Write JSON report
+  --label <name>    Label this measurement (e.g. git sha)
+  --headed          Visible browser
+  --timeout <ms>    Navigation timeout (default 90000; 1..${MAX_TIMER_DELAY_MS})`);
 }
 
 function gitHead() {
@@ -249,8 +344,12 @@ function printSample(sample) {
   }
 }
 
-async function main() {
-  const args = parseArgs(process.argv);
+async function main(argv = process.argv) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
   let server = null;
   let baseUrl = null;
   let loginUrl = args.url;
@@ -337,7 +436,17 @@ async function main() {
   process.exit(0);
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+const isMain =
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  // error-policy:J1 CLI boundary — invalid flags and measure failures exit
+  // non-zero with a legible message instead of an unhandled rejection.
+  main().catch((err) => {
+    console.error(
+      `[login-transfer] ${err instanceof Error ? err.message : err}`,
+    );
+    process.exit(1);
+  });
+}

--- a/packages/app/scripts/measure-anonymous-login-transfer.test.ts
+++ b/packages/app/scripts/measure-anonymous-login-transfer.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit and CLI-boundary tests for the login-transfer measurement argument
+ * parser. The harness is deterministic here: invalid flags must fail closed
+ * before Chromium launches, so subprocess cases never need a renderer or
+ * browser.
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  MAX_TIMER_DELAY_MS,
+  parseArgs,
+  parseDecimalInt,
+} from "./measure-anonymous-login-transfer.mjs";
+
+// Resolve the CLI relative to this test file (a sibling .mjs), not
+// process.cwd(): the client test lane runs vitest from packages/app, so a
+// cwd-relative "packages/app/..." path doubles into
+// packages/app/packages/app/... and the spawned Node can't find the module.
+const SCRIPT_PATH = path.join(
+  import.meta.dirname,
+  "measure-anonymous-login-transfer.mjs",
+);
+
+describe("parseDecimalInt", () => {
+  it("accepts non-negative decimal integers through an explicit max", () => {
+    expect(parseDecimalInt("0", "--settle-ms", { min: 0 })).toBe(0);
+    expect(parseDecimalInt("1", "--timeout", { min: 1 })).toBe(1);
+    expect(parseDecimalInt("6000", "--settle-ms")).toBe(6000);
+    expect(
+      parseDecimalInt(String(MAX_TIMER_DELAY_MS), "--timeout", {
+        min: 1,
+        max: MAX_TIMER_DELAY_MS,
+      }),
+    ).toBe(MAX_TIMER_DELAY_MS);
+  });
+
+  it.each([
+    undefined,
+    "",
+    "junk",
+    "10junk",
+    "-1",
+    "1.5",
+    "1e3",
+    "+2",
+    " 3",
+    "08",
+    "NaN",
+    "Infinity",
+    "--url",
+  ] as Array<string | undefined>)(
+    "rejects invalid input %j at the boundary",
+    (raw) => {
+      expect(() => parseDecimalInt(raw, "--settle-ms")).toThrow(/--settle-ms/);
+    },
+  );
+
+  it("rejects values below min or above max", () => {
+    expect(() =>
+      parseDecimalInt("0", "--timeout", { min: 1, max: MAX_TIMER_DELAY_MS }),
+    ).toThrow(/--timeout/);
+    expect(() =>
+      parseDecimalInt(String(MAX_TIMER_DELAY_MS + 1), "--timeout", {
+        min: 1,
+        max: MAX_TIMER_DELAY_MS,
+      }),
+    ).toThrow(/--timeout/);
+  });
+});
+
+describe("parseArgs --settle-ms / --timeout", () => {
+  it("keeps defaults when flags are omitted", () => {
+    const args = parseArgs(["node", "measure-anonymous-login-transfer.mjs"]);
+    expect(args.settleMs).toBe(6000);
+    expect(args.timeout).toBe(90_000);
+  });
+
+  it("records valid overrides including zero settle", () => {
+    const args = parseArgs([
+      "node",
+      "measure-anonymous-login-transfer.mjs",
+      "--settle-ms",
+      "0",
+      "--timeout",
+      "5000",
+      "--url",
+      "http://127.0.0.1:4173/login",
+    ]);
+    expect(args.settleMs).toBe(0);
+    expect(args.timeout).toBe(5000);
+    expect(args.url).toBe("http://127.0.0.1:4173/login");
+  });
+
+  it("fails closed when --settle-ms is missing or malformed", () => {
+    expect(() =>
+      parseArgs([
+        "node",
+        "measure-anonymous-login-transfer.mjs",
+        "--settle-ms",
+      ]),
+    ).toThrow(/--settle-ms/);
+    expect(() =>
+      parseArgs([
+        "node",
+        "measure-anonymous-login-transfer.mjs",
+        "--settle-ms",
+        "junk",
+      ]),
+    ).toThrow(/junk/);
+    expect(() =>
+      parseArgs([
+        "node",
+        "measure-anonymous-login-transfer.mjs",
+        "--settle-ms",
+        "-3",
+      ]),
+    ).toThrow(/--settle-ms/);
+    expect(() =>
+      parseArgs([
+        "node",
+        "measure-anonymous-login-transfer.mjs",
+        "--settle-ms",
+        "1.5",
+      ]),
+    ).toThrow(/--settle-ms/);
+    expect(() =>
+      parseArgs([
+        "node",
+        "measure-anonymous-login-transfer.mjs",
+        "--settle-ms",
+        "--url",
+        "http://example",
+      ]),
+    ).toThrow(/--settle-ms/);
+  });
+
+  it("fails closed when --timeout is missing or malformed", () => {
+    expect(() =>
+      parseArgs(["node", "measure-anonymous-login-transfer.mjs", "--timeout"]),
+    ).toThrow(/--timeout/);
+    expect(() =>
+      parseArgs([
+        "node",
+        "measure-anonymous-login-transfer.mjs",
+        "--timeout",
+        "10junk",
+      ]),
+    ).toThrow(/10junk/);
+    expect(() =>
+      parseArgs([
+        "node",
+        "measure-anonymous-login-transfer.mjs",
+        "--timeout",
+        "0",
+      ]),
+    ).toThrow(/--timeout/);
+    expect(() =>
+      parseArgs([
+        "node",
+        "measure-anonymous-login-transfer.mjs",
+        "--timeout",
+        String(MAX_TIMER_DELAY_MS + 1),
+      ]),
+    ).toThrow(/--timeout/);
+  });
+
+  it("accepts the exact Node timer ceiling for both flags", () => {
+    const args = parseArgs([
+      "node",
+      "measure-anonymous-login-transfer.mjs",
+      "--settle-ms",
+      String(MAX_TIMER_DELAY_MS),
+      "--timeout",
+      String(MAX_TIMER_DELAY_MS),
+    ]);
+    expect(args.settleMs).toBe(MAX_TIMER_DELAY_MS);
+    expect(args.timeout).toBe(MAX_TIMER_DELAY_MS);
+  });
+});
+
+describe("measure-anonymous-login-transfer CLI", () => {
+  it("exits non-zero on invalid --settle-ms without launching Chromium", () => {
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT_PATH, "--settle-ms", "abc", "--url", "http://127.0.0.1:9/login"],
+      { encoding: "utf8", timeout: 15_000 },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/--settle-ms/);
+    expect(result.stderr).not.toMatch(/playwright|chromium|browser/i);
+    expect(result.stdout).not.toMatch(/Measuring cold/);
+  });
+
+  it("exits non-zero on invalid --timeout without launching Chromium", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        SCRIPT_PATH,
+        "--timeout",
+        String(MAX_TIMER_DELAY_MS + 1),
+        "--url",
+        "http://127.0.0.1:9/login",
+      ],
+      { encoding: "utf8", timeout: 15_000 },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/--timeout/);
+    expect(result.stdout).not.toMatch(/Measuring cold/);
+  });
+
+  it("prints help and exits 0", () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, "--help"], {
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/--settle-ms/);
+    expect(result.stdout).toMatch(/--timeout/);
+  });
+});


### PR DESCRIPTION
# Relates to

Fixes #18611

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok (unattended contribution worker)`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - local contribute-to-eliza skill archive; operator-approved Grok workstream (receipt script only accepts codex/claude-code models, so no signed zero-receipt was fabricated)`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** CLI boundary validation only for the login-transfer measurement harness.
Call sites that omit flags keep the same defaults (6000 / 90000). Malformed
overrides now fail closed before Chromium launches instead of measuring under
NaN or clamped timer budgets.

# Background

## What does this PR do?

Rejects invalid `--settle-ms` and `--timeout` overrides on
`measure-anonymous-login-transfer.mjs` at parse time. Values must be complete
decimal integers within the Node timer ceiling. `--settle-ms` allows 0 (no
settle wait); `--timeout` requires at least 1. Adds focused unit + real-process
CLI regressions.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation. The script
header and `--help` text document the accepted numeric ranges.

# Testing

## Where should a reviewer start?

1. `packages/app/scripts/measure-anonymous-login-transfer.mjs` — `parseDecimalInt` / `parseArgs`
2. `packages/app/scripts/measure-anonymous-login-transfer.test.ts`

## Detailed testing steps

```bash
bun test packages/app/scripts/measure-anonymous-login-transfer.test.ts
node packages/app/scripts/measure-anonymous-login-transfer.mjs --settle-ms abc --url http://127.0.0.1:9/login
# expect exit 1, clear --settle-ms error, no Chromium launch
node packages/app/scripts/measure-anonymous-login-transfer.mjs --timeout 2147483648 --url http://127.0.0.1:9/login
# expect exit 1
node packages/app/scripts/measure-anonymous-login-transfer.mjs --help
# expect exit 0 with range docs
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:2c9a024d047da171a1d866e82479b7b52253444a -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - terminal-only CLI/test-runner change; no rendered UI surface`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - terminal-only CLI/test-runner change; no rendered UI surface`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing flow; real CLI transcripts below`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no server/runtime path; CLI stderr/stdout is the complete artifact`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no browser or frontend surface`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, prompt, provider, or model behavior`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused test output and before/after CLI transcripts (below)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model changes`

## Backend + frontend logs

`N/A - no backend or frontend path`

### Before (on origin/develop)

Bare `Number(...)` accepted garbage and overflow without failing closed:

```text
--settle-ms abc     => settleMs: NaN
--timeout 0         => timeout: 0
--timeout 2147483648 => timeout: 2147483648
```

Those values would reach Chromium launch / Playwright navigation under the wrong
budget (or with an immediate 0 ms timeout).

### After (this PR head `2c9a024d`)

```text
$ node packages/app/scripts/measure-anonymous-login-transfer.mjs --settle-ms abc --url http://127.0.0.1:9/login
[login-transfer] --settle-ms must be a decimal integer from 0 to 2147483647, got \"abc\"
exit:1

$ node packages/app/scripts/measure-anonymous-login-transfer.mjs --timeout 0 --url http://127.0.0.1:9/login
[login-transfer] --timeout must be a decimal integer from 1 to 2147483647, got \"0\"
exit:1

$ node packages/app/scripts/measure-anonymous-login-transfer.mjs --timeout 2147483648 --url http://127.0.0.1:9/login
[login-transfer] --timeout must be a decimal integer from 1 to 2147483647, got \"2147483648\"
exit:1
```

### Focused tests

```text
bun test packages/app/scripts/measure-anonymous-login-transfer.test.ts
23 pass
0 fail
45 expect() calls
Ran 23 tests across 1 file. [2.02s]
```

Also:

```text
bunx biome check --diagnostic-level=error \
  packages/app/scripts/measure-anonymous-login-transfer.mjs \
  packages/app/scripts/measure-anonymous-login-transfer.test.ts
Checked 2 files. No fixes applied.
```

### Screenshots / Walkthrough video

`N/A - terminal-only tooling; no UI`

## Audio / voice walkthrough

`N/A - no voice/TTS/STT surface`

## Known gaps / failures

- Full `bun run verify` was **not** run this cycle. Focused coverage:
  - `bun test packages/app/scripts/measure-anonymous-login-transfer.test.ts` (23 pass)
  - `bunx biome check` on the two touched files (clean)
  - Real CLI probes for invalid settle/timeout rejection and `--help`
- Signed contribute-to-eliza run receipt omitted: operator approved Grok for this
  workstream, and the receipt script only accepts codex/claude-code models.
  Fabricating an approved model id would violate provenance rules.