### PR TITLE
fix(voice): reject malformed voice-preset --dim and --concurrency

### DIFF
--- a/packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs
+++ b/packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs
@@ -34,6 +34,10 @@
  *                    if `--bundle` is given, else `./voice-preset-default.bin`.
  *   --concurrency N  Parallel TTS dispatches when synthesizing phrases. Default 2.
  *
+ * `--dim` and `--concurrency` accept only complete positive safe-integer
+ * decimals. Suffixes, fractions, signs, zero, and missing/flag-shaped values
+ * fail at the CLI boundary before any output path is created.
+ *
  * Run with `bun` (it resolves the `.ts` imports):
  *   bun packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs --placeholder
  */
@@ -43,7 +47,58 @@ import path from "node:path";
 
 const PLACEHOLDER_DEFAULT_DIM = 256;
 
-function parseArgs(argv) {
+/**
+ * Accept only complete positive safe-integer decimals (1..MAX_SAFE_INTEGER).
+ * Rejects suffixes (`1junk`), fractions, signs, zero, leading zeros, whitespace,
+ * empty values, and non-decimal forms so the CLI never silently truncates or
+ * falls back to a different dimension/concurrency than the operator requested.
+ *
+ * @param {unknown} value
+ * @param {string} flag
+ * @returns {number}
+ */
+export function parsePositiveSafeInteger(value, flag) {
+  if (value === undefined || value === null) {
+    throw new Error(`${flag} requires a positive safe integer value`);
+  }
+  const raw = String(value);
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(
+      `${flag} must be a positive safe integer (received ${JSON.stringify(raw)})`,
+    );
+  }
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(n) || n < 1 || String(n) !== raw) {
+    throw new Error(
+      `${flag} must be a positive safe integer (received ${JSON.stringify(raw)})`,
+    );
+  }
+  return n;
+}
+
+/**
+ * Read the next argv token for a value-taking flag. Missing values and the next
+ * flag (tokens starting with `-` that are not a pure decimal) fail closed.
+ *
+ * @param {string[]} argv
+ * @param {number} index current flag index; advanced to the value index
+ * @param {string} flag
+ * @returns {{ value: string, nextIndex: number }}
+ */
+function takeFlagValue(argv, index, flag) {
+  const nextIndex = index + 1;
+  const value = argv[nextIndex];
+  // Missing, empty, or another long option — not a value for this flag.
+  if (value === undefined || value === "" || value.startsWith("--")) {
+    throw new Error(`${flag} requires a positive safe integer value`);
+  }
+  return { value, nextIndex };
+}
+
+/**
+ * @param {string[]} argv
+ */
+export function parseArgs(argv) {
   const args = {
     placeholder: false,
     embeddingPath: null,
@@ -71,12 +126,21 @@ function parseArgs(argv) {
       case "--out":
         args.out = argv[++i];
         break;
-      case "--dim":
-        args.dim = Number.parseInt(argv[++i], 10);
+      case "--dim": {
+        const taken = takeFlagValue(argv, i, "--dim");
+        i = taken.nextIndex;
+        args.dim = parsePositiveSafeInteger(taken.value, "--dim");
         break;
-      case "--concurrency":
-        args.concurrency = Number.parseInt(argv[++i], 10);
+      }
+      case "--concurrency": {
+        const taken = takeFlagValue(argv, i, "--concurrency");
+        i = taken.nextIndex;
+        args.concurrency = parsePositiveSafeInteger(
+          taken.value,
+          "--concurrency",
+        );
         break;
+      }
       case "-h":
       case "--help":
         printUsageAndExit(0);
@@ -95,6 +159,9 @@ function printUsageAndExit(code) {
       "  build-default-voice-preset.mjs --placeholder [--dim N] [--out PATH]",
       "  build-default-voice-preset.mjs --embedding PATH [--bundle ROOT] [--no-phrases]",
       "                                 [--out PATH] [--concurrency N]",
+      "",
+      "  --dim N           Placeholder embedding dimension (positive safe integer, default 256).",
+      "  --concurrency N   Parallel TTS phrase synthesis workers (positive safe integer, default 2).",
       "",
     ].join("\n"),
   );
@@ -202,14 +269,11 @@ async function main() {
   let phrases = [];
 
   if (args.placeholder) {
-    const dim =
-      Number.isFinite(args.dim) && args.dim > 0
-        ? args.dim
-        : PLACEHOLDER_DEFAULT_DIM;
-    embedding = new Float32Array(dim); // all zeros
+    // args.dim is always a validated positive safe integer (or the default).
+    embedding = new Float32Array(args.dim); // all zeros
     phrases = []; // N=0 — a placeholder preset carries no audio
     process.stdout.write(
-      `[voice-preset] PLACEHOLDER mode: zero embedding dim=${dim}, 0 phrases. This is a dev placeholder, NOT the default voice.\n`,
+      `[voice-preset] PLACEHOLDER mode: zero embedding dim=${args.dim}, 0 phrases. This is a dev placeholder, NOT the default voice.\n`,
     );
   } else {
     embedding = readFloat32Vector(args.embeddingPath);

--- a/plugins/plugin-local-inference/src/services/voice/voice-preset-generator.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-preset-generator.test.ts
@@ -1,4 +1,8 @@
-/** Covers the default voice-preset build script's preset format output. Deterministic. */
+/**
+ * Covers the default voice-preset build script: format-valid placeholder
+ * output and fail-closed CLI parsing for --dim / --concurrency. Real
+ * subprocess harness (deterministic; no network or model load).
+ */
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -27,6 +31,34 @@ function runGenerator(args: string[]): string {
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "pipe"],
 	});
+}
+
+type CliFailure = {
+	status: number | null;
+	stdout: string;
+	stderr: string;
+};
+
+function runGeneratorExpectFailure(args: string[]): CliFailure {
+	try {
+		const stdout = execFileSync("bun", [SCRIPT, ...args], {
+			cwd: APP_CORE_ROOT,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		return { status: 0, stdout, stderr: "" };
+	} catch (err) {
+		const e = err as {
+			status?: number | null;
+			stdout?: string;
+			stderr?: string;
+		};
+		return {
+			status: e.status ?? null,
+			stdout: e.stdout ?? "",
+			stderr: e.stderr ?? "",
+		};
+	}
 }
 
 describe("build-default-voice-preset.mjs", () => {
@@ -63,6 +95,21 @@ describe("build-default-voice-preset.mjs", () => {
 		expect(parsed.embedding.length).toBe(64);
 	});
 
+	it("accepts explicit valid --concurrency with --placeholder (unused but validated)", () => {
+		const out = path.join(dir, "c.bin");
+		const stdout = runGenerator([
+			"--placeholder",
+			"--concurrency",
+			"4",
+			"--out",
+			out,
+		]);
+		expect(stdout).toMatch(/PLACEHOLDER/);
+		expect(existsSync(out)).toBe(true);
+		const parsed = readVoicePresetFile(new Uint8Array(readFileSync(out)));
+		expect(parsed.embedding.length).toBe(256);
+	});
+
 	it("refuses to build a real preset without an embedding (exit 2, guidance message)", () => {
 		let threw = false;
 		try {
@@ -86,5 +133,138 @@ describe("build-default-voice-preset.mjs", () => {
 		expect(() => readVoicePresetFile(new Uint8Array([1, 2, 3]))).toThrow(
 			VoicePresetFormatError,
 		);
+	});
+
+	describe("fail-closed --dim / --concurrency (issue #18613)", () => {
+		const malformedCases: Array<{
+			name: string;
+			/** Full argv after SCRIPT; must include --out pointing at a nested path. */
+			buildArgs: (out: string) => string[];
+			flag: "--dim" | "--concurrency";
+		}> = [
+			{
+				name: "suffix on --dim",
+				buildArgs: (out) => ["--placeholder", "--dim", "1junk", "--out", out],
+				flag: "--dim",
+			},
+			{
+				name: "suffix on --concurrency",
+				buildArgs: (out) => [
+					"--placeholder",
+					"--concurrency",
+					"2junk",
+					"--out",
+					out,
+				],
+				flag: "--concurrency",
+			},
+			{
+				name: "fraction on --dim",
+				buildArgs: (out) => ["--placeholder", "--dim", "2.5", "--out", out],
+				flag: "--dim",
+			},
+			{
+				name: "fraction on --concurrency",
+				buildArgs: (out) => [
+					"--placeholder",
+					"--concurrency",
+					"1.5",
+					"--out",
+					out,
+				],
+				flag: "--concurrency",
+			},
+			{
+				name: "signed --dim",
+				buildArgs: (out) => ["--placeholder", "--dim", "-4", "--out", out],
+				flag: "--dim",
+			},
+			{
+				name: "zero --dim",
+				buildArgs: (out) => ["--placeholder", "--dim", "0", "--out", out],
+				flag: "--dim",
+			},
+			{
+				name: "zero --concurrency",
+				buildArgs: (out) => [
+					"--placeholder",
+					"--concurrency",
+					"0",
+					"--out",
+					out,
+				],
+				flag: "--concurrency",
+			},
+			{
+				name: "leading zeros on --dim",
+				buildArgs: (out) => ["--placeholder", "--dim", "08", "--out", out],
+				flag: "--dim",
+			},
+			{
+				name: "non-numeric --dim",
+				buildArgs: (out) => ["--placeholder", "--dim", "abc", "--out", out],
+				flag: "--dim",
+			},
+			{
+				name: "unsafe integer --dim",
+				buildArgs: (out) => [
+					"--placeholder",
+					"--dim",
+					"9007199254740992",
+					"--out",
+					out,
+				],
+				flag: "--dim",
+			},
+			{
+				name: "missing --dim value (trailing)",
+				// --out first so the missing --dim is truly at argv end.
+				buildArgs: (out) => ["--placeholder", "--out", out, "--dim"],
+				flag: "--dim",
+			},
+			{
+				name: "flag-shaped --dim value",
+				buildArgs: (out) => [
+					"--placeholder",
+					"--out",
+					out,
+					"--dim",
+					"--no-phrases",
+				],
+				flag: "--dim",
+			},
+			{
+				name: "missing --concurrency value (trailing)",
+				buildArgs: (out) => ["--placeholder", "--out", out, "--concurrency"],
+				flag: "--concurrency",
+			},
+			{
+				name: "flag-shaped --concurrency value",
+				buildArgs: (out) => [
+					"--placeholder",
+					"--out",
+					out,
+					"--concurrency",
+					"--no-phrases",
+				],
+				flag: "--concurrency",
+			},
+		];
+
+		for (const { name, buildArgs, flag } of malformedCases) {
+			it(`rejects ${name} before creating output`, () => {
+				const nested = path.join(dir, "nested-out");
+				const out = path.join(nested, "malformed.bin");
+				const result = runGeneratorExpectFailure(buildArgs(out));
+				expect(result.status, result.stderr || result.stdout).not.toBe(0);
+				expect(result.status).toBe(1);
+				const combined = `${result.stderr}\n${result.stdout}`;
+				expect(combined).toMatch(new RegExp(flag));
+				expect(combined).toMatch(/positive safe integer/i);
+				// Rejection must happen before mkdirSync / writeFileSync.
+				expect(existsSync(out)).toBe(false);
+				expect(existsSync(nested)).toBe(false);
+			});
+		}
 	});
 });


### PR DESCRIPTION
# Relates to

Closes #18613

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused package checks passed after sync (`bun test plugins/plugin-local-inference/src/services/voice/voice-preset-generator.test.ts` — 19 pass; Biome on the two touched files). Full `bun run verify` was not re-run end-to-end in this session.
- [x] A reviewer can confirm the change from the CLI transcripts and focused test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xAI / grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build` (`grok` client)
<!-- attribution-row:skill-revision -->
- Skill path: `contribute-to-eliza` @ `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77`
<!-- attribution-row:status -->
- Provenance status: `self-reported` + device-signed project receipt (footer below)
- Run id: `run_01KZTVQAM867XYNK2SFSWNX37Y`
- Note: Operator approved Grok for this workstream. Token meter via ccusage is unavailable for Grok (signed zero / unavailable confidence), not fabricated.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync; full monorepo `bun run verify` not claimed here.

# Risks

**Low.** CLI boundary validation only for the offline `build-default-voice-preset.mjs` helper. No voice model, audio, GPU, network, runtime service, or rendered UI behavior changes for valid invocations. Invalid `--dim` / `--concurrency` now fail closed before any output path is created instead of silently truncating (`1junk` → dim 1) or falling back to defaults (`abc` → dim 256).

# Background

## What does this PR do?

Validates `--dim` and `--concurrency` on the default voice-preset build CLI at the command boundary:

- Both flags accept only complete positive safe-integer decimals (`1..Number.MAX_SAFE_INTEGER`).
- Rejects suffixes (`1junk`), fractions, signs, zero, leading zeros, non-numeric tokens, unsafe integers, missing values, and flag-shaped next tokens.
- Rejection happens in `parseArgs` before `mkdirSync` / `writeFileSync`, so a nested `--out` path is not created on failure.
- Valid explicit integers and existing defaults still generate format-valid placeholder presets.

Previously `Number.parseInt(\"1junk\", 10)` accepted a truncated dimension and wrote a successful one-dim preset, and non-numeric `--dim` values fell back to the default 256 embedding with exit 0.

## What kind of change is this?

Bug fix (non-breaking for valid CLI use; invalid args now fail closed).

# Documentation changes needed?

No project docs change required. Help text now states that `--dim` and `--concurrency` require positive safe integers.

# Testing

## Where should a reviewer start?

1. `packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs` — `parsePositiveSafeInteger`, `takeFlagValue`, `parseArgs`
2. `plugins/plugin-local-inference/src/services/voice/voice-preset-generator.test.ts` — real subprocess boundary tests

## Detailed testing steps

```bash
bun test plugins/plugin-local-inference/src/services/voice/voice-preset-generator.test.ts
# 19 passed

tmp=$(mktemp -d)
bun packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs \
  --placeholder --dim 1junk --out \"$tmp/nested/malformed.bin\"
# exit 1; nested path not created

bun packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs \
  --placeholder --dim 64 --out \"$tmp/ok.bin\"
# exit 0; format-valid 64-dim placeholder
```

# Evidence Gate

<!-- evidence-head:e5e58785b7359c96d68b21d96407721dca8c806a -->

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - terminal-only voice-preset build CLI; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - terminal-only voice-preset build CLI; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no interactive UI flow; CLI argument rejection is fully captured by transcripts below.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no server/runtime path; rejection happens in parseArgs before any file or TTS work.
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no browser app surface.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent, model, prompt, provider, or action behavior.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: focused bun test output (19 passed) and CLI rejection transcripts proving non-zero exit and no output file creation for invalid `--dim` / `--concurrency`.

### Pre-fix failure shape (why the bug matters)

```text
$ bun packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs \
    --placeholder --dim 1junk --concurrency 2junk --out <temp>/malformed.bin
[voice-preset] PLACEHOLDER mode: zero embedding dim=1, 0 phrases.
[voice-preset] Wrote 32 bytes -> <temp>/malformed.bin
exit: 0
# Number.parseInt silently truncates; operator asked for \"1junk\", got dim=1
```

### CLI after (this head)

```text
$ bun packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs \
    --placeholder --dim 1junk --out /tmp/.../nested/malformed.bin
[voice-preset] Error: --dim must be a positive safe integer (received \"1junk\")
exit:1
# nested parent directory not created

$ bun packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs \
    --placeholder --dim abc --out /tmp/.../x.bin
[voice-preset] Error: --dim must be a positive safe integer (received \"abc\")
exit:1

$ bun packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs \
    --placeholder --concurrency 0 --out /tmp/.../x.bin
[voice-preset] Error: --concurrency must be a positive safe integer (received \"0\")
exit:1

$ bun packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs \
    --placeholder --dim 64 --concurrency 3 --out /tmp/.../ok.bin
[voice-preset] PLACEHOLDER mode: zero embedding dim=64, 0 phrases. ...
[voice-preset] Wrote 284 bytes -> .../ok.bin
exit:0

$ bun test plugins/plugin-local-inference/src/services/voice/voice-preset-generator.test.ts
 19 pass
 0 fail
```

# Known gaps / failures

- Full monorepo `bun run verify` not asserted in this session; focused generator subprocess tests and Biome on the two touched files were run.
- Real fused TTS / embedding paths are unchanged; validation is exercised on the placeholder path and shared `parseArgs` contract (same parser used for both flags).

# Notes for reviewers

Operator override allowed Grok for this contribution. Device-signed measured receipt is appended below. Independent review and merge remain with maintainers.

# Measured project receipt

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-rama0x1]
<!-- elizaos-contribution-attribution:v2 {\"provider\":\"xai\",\"model\":\"grok-4.5\",\"client\":\"grok\",\"skill_revision\":\"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza\",\"run\":{\"schema_version\":\"1\",\"run_id\":\"run_01KZTVQAM867XYNK2SFSWNX37Y\",\"project\":\"eliza\",\"repository\":\"elizaOS/eliza\",\"started_at\":\"2026-08-12T11:29:04.649Z\",\"completed_at\":\"2026-08-12T11:33:36.335Z\",\"skill_sha256\":\"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6\",\"usage\":{\"source\":\"ccusage-session-v20\",\"confidence\":\"unavailable\",\"input_tokens\":0,\"output_tokens\":0,\"cache_creation_tokens\":0,\"cache_read_tokens\":0,\"total_tokens\":0,\"cost_micro_usd\":\"0\",\"session_count\":0},\"trajectory_sha256\":null,\"signature_algorithm\":\"ed25519\",\"device_public_key\":\"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI\",\"device_key_id\":\"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea\",\"device_signature\":\"k3ghrb--2vmY0Owf-t5McQrxBsVb7ce0JdzQDqWBi0ahux-O3i4CO4UTspKWYvhZn9nX3xPZvNACsE36hVDcDQ\"}} -->