### PR TITLE
fix(app): reject invalid Playwright lane port env overrides

### DIFF
--- a/packages/app/playwright.android-browser.config.ts
+++ b/packages/app/playwright.android-browser.config.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { defineConfig } from "@playwright/test";
 import { KNOWN_PHRASE_WAV_DATA_URL } from "../ui/src/voice/voice-selftest/fixtures/known-phrase";
 import { resolvePlaywrightNodeRuntime } from "./scripts/lib/playwright-node-runtime.mjs";
+import { resolvePlaywrightPortEnv } from "./scripts/lib/playwright-port.mjs";
 
 const appDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(appDir, "../..");
@@ -18,8 +19,17 @@ const uiSmokeLiveStack = path.join(
   "scripts",
   "playwright-ui-live-stack.ts",
 );
-const uiSmokeApiPort = Number(process.env.ELIZA_UI_SMOKE_API_PORT || "31337");
-const uiSmokePort = Number(process.env.ELIZA_UI_SMOKE_PORT || "2138");
+// Fail closed on explicit port typos before baseURL/webServer wiring.
+const uiSmokeApiPort = resolvePlaywrightPortEnv(
+  process.env,
+  "ELIZA_UI_SMOKE_API_PORT",
+  31337,
+);
+const uiSmokePort = resolvePlaywrightPortEnv(
+  process.env,
+  "ELIZA_UI_SMOKE_PORT",
+  2138,
+);
 // Fail-fast Node runtime resolution: the shared app-core validator throws at
 // config load — before the webServer command spawns — when ELIZA_NODE_PATH is
 // invalid or no real Node.js 24+ executable can be found.

--- a/packages/app/playwright.dev-smoke.config.ts
+++ b/packages/app/playwright.dev-smoke.config.ts
@@ -6,11 +6,21 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig, devices } from "@playwright/test";
+import { resolvePlaywrightPortEnv } from "./scripts/lib/playwright-port.mjs";
 
 const appDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(appDir, "../..");
-const apiPort = Number(process.env.ELIZA_DEV_SMOKE_API_PORT || "31337");
-const uiPort = Number(process.env.ELIZA_DEV_SMOKE_UI_PORT || "2138");
+// Fail closed on explicit port typos before baseURL/webServer wiring.
+const apiPort = resolvePlaywrightPortEnv(
+  process.env,
+  "ELIZA_DEV_SMOKE_API_PORT",
+  31337,
+);
+const uiPort = resolvePlaywrightPortEnv(
+  process.env,
+  "ELIZA_DEV_SMOKE_UI_PORT",
+  2138,
+);
 const stateDir =
   process.env.ELIZA_DEV_SMOKE_STATE_DIR ||
   path.join(os.tmpdir(), `eliza-dev-smoke-${process.pid}`);

--- a/packages/app/playwright.hmr.config.ts
+++ b/packages/app/playwright.hmr.config.ts
@@ -6,11 +6,21 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig, devices } from "@playwright/test";
+import { resolvePlaywrightPortEnv } from "./scripts/lib/playwright-port.mjs";
 
 const appDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(appDir, "../..");
-const apiPort = Number(process.env.ELIZA_HMR_API_PORT || "41337");
-const uiPort = Number(process.env.ELIZA_HMR_UI_PORT || "42138");
+// Fail closed on explicit port typos before baseURL/webServer wiring.
+const apiPort = resolvePlaywrightPortEnv(
+  process.env,
+  "ELIZA_HMR_API_PORT",
+  41337,
+);
+const uiPort = resolvePlaywrightPortEnv(
+  process.env,
+  "ELIZA_HMR_UI_PORT",
+  42138,
+);
 const stateDir =
   process.env.ELIZA_HMR_STATE_DIR ||
   path.join(os.tmpdir(), `eliza-hmr-${process.pid}`);

--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -16,6 +16,7 @@ import {
   writeAuditProjectPropagation,
 } from "./scripts/lib/playwright-audit-projects.mjs";
 import { resolvePlaywrightNodeRuntime } from "./scripts/lib/playwright-node-runtime.mjs";
+import { resolvePlaywrightPortEnv } from "./scripts/lib/playwright-port.mjs";
 import {
   parseUiSmokeShard,
   UI_SMOKE_SHARD_ENV,
@@ -34,8 +35,17 @@ const uiSmokeLiveStack = path.join(
   "scripts",
   "playwright-ui-live-stack.ts",
 );
-const uiSmokeApiPort = Number(process.env.ELIZA_UI_SMOKE_API_PORT || "31337");
-const uiSmokePort = Number(process.env.ELIZA_UI_SMOKE_PORT || "2138");
+// Fail closed on explicit port typos before baseURL/webServer wiring.
+const uiSmokeApiPort = resolvePlaywrightPortEnv(
+  process.env,
+  "ELIZA_UI_SMOKE_API_PORT",
+  31337,
+);
+const uiSmokePort = resolvePlaywrightPortEnv(
+  process.env,
+  "ELIZA_UI_SMOKE_PORT",
+  2138,
+);
 const reuseExistingServer = process.env.ELIZA_UI_SMOKE_REUSE_SERVER === "1";
 // Fail-fast Node runtime resolution: the shared app-core validator throws at
 // config load — before the webServer command spawns — when ELIZA_NODE_PATH is

--- a/packages/app/scripts/lib/playwright-port.mjs
+++ b/packages/app/scripts/lib/playwright-port.mjs
@@ -1,0 +1,60 @@
+/**
+ * Canonical TCP-port parsing for Playwright lane environment overrides.
+ *
+ * Lane configs previously used `Number(process.env.X || default)`, which
+ * accepts `0`, negatives, fractions, and turns typos like `2138junk` into
+ * `NaN` that only fail later inside webServer bind or baseURL construction.
+ * Explicit invalid overrides must fail closed at config/preflight load with
+ * the env-var name in the message.
+ */
+
+export const MIN_TCP_PORT = 1;
+export const MAX_TCP_PORT = 65535;
+
+/**
+ * Accept only full-string decimal TCP ports in the range 1..65535.
+ * Rejects partial numbers, signed values, fractions, leading zeros beyond a
+ * single digit, and out-of-range integers so a typo never selects a different
+ * bind target than the operator requested.
+ *
+ * @param {unknown} value
+ * @param {string} label
+ * @returns {number}
+ */
+export function parsePlaywrightPort(value, label) {
+  const raw = String(value ?? "").trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `${label} must be a TCP port integer from ${MIN_TCP_PORT} to ${MAX_TCP_PORT} (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  const port = Number.parseInt(raw, 10);
+  if (
+    !Number.isSafeInteger(port) ||
+    port < MIN_TCP_PORT ||
+    port > MAX_TCP_PORT ||
+    String(port) !== raw
+  ) {
+    throw new Error(
+      `${label} must be a TCP port integer from ${MIN_TCP_PORT} to ${MAX_TCP_PORT} (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  return port;
+}
+
+/**
+ * Resolve a port from env: unset/empty keeps `defaultPort`; any other explicit
+ * value must be a canonical TCP port or the command fails closed.
+ *
+ * @param {NodeJS.ProcessEnv | Record<string, string | undefined>} env
+ * @param {string} envName
+ * @param {number} defaultPort
+ * @returns {number}
+ */
+export function resolvePlaywrightPortEnv(env, envName, defaultPort) {
+  const raw = env?.[envName];
+  if (raw === undefined || raw === null || String(raw).trim() === "") {
+    return defaultPort;
+  }
+  return parsePlaywrightPort(raw, envName);
+}

--- a/packages/app/scripts/lib/playwright-port.test.mjs
+++ b/packages/app/scripts/lib/playwright-port.test.mjs
@@ -1,0 +1,121 @@
+/**
+ * Deterministic unit tests for Playwright lane TCP-port parsing. Covers the
+ * real exported helpers: accept path, default-when-unset, and every fail-closed
+ * invalid override that must abort before webServer or baseURL wiring.
+ */
+import { describe, expect, it } from "bun:test";
+import {
+  MAX_TCP_PORT,
+  MIN_TCP_PORT,
+  parsePlaywrightPort,
+  resolvePlaywrightPortEnv,
+} from "./playwright-port.mjs";
+
+describe("parsePlaywrightPort", () => {
+  it("accepts canonical ports at the range boundaries", () => {
+    expect(parsePlaywrightPort("1", "PORT")).toBe(1);
+    expect(parsePlaywrightPort(String(MAX_TCP_PORT), "PORT")).toBe(
+      MAX_TCP_PORT,
+    );
+    expect(parsePlaywrightPort("2138", "ELIZA_UI_SMOKE_PORT")).toBe(2138);
+    expect(parsePlaywrightPort("31337", "ELIZA_UI_SMOKE_API_PORT")).toBe(31337);
+  });
+
+  it("trims surrounding whitespace from operator env interpolation", () => {
+    expect(parsePlaywrightPort("  2138\n", "PORT")).toBe(2138);
+  });
+
+  it("rejects partial parses, fractions, signed values, and non-digits", () => {
+    for (const bad of [
+      "2138junk",
+      "junk",
+      "21.38",
+      "-1",
+      "+2138",
+      "0x84a",
+      "2e3",
+      "1_000",
+    ]) {
+      expect(() => parsePlaywrightPort(bad, "PORT")).toThrow(
+        /must be a TCP port integer from 1 to 65535/,
+      );
+    }
+  });
+
+  it("rejects zero, out-of-range, empty, and leading-zero padded values", () => {
+    for (const bad of ["0", "65536", "999999", "", "   ", "01", "02138"]) {
+      expect(() => parsePlaywrightPort(bad, "ELIZA_UI_SMOKE_PORT")).toThrow(
+        /ELIZA_UI_SMOKE_PORT must be a TCP port integer/,
+      );
+    }
+  });
+
+  it("names the label in the error for preflight diagnostics", () => {
+    expect(() => parsePlaywrightPort("abc", "ELIZA_HMR_UI_PORT")).toThrow(
+      'ELIZA_HMR_UI_PORT must be a TCP port integer from 1 to 65535 (received "abc")',
+    );
+  });
+});
+
+describe("resolvePlaywrightPortEnv", () => {
+  const DEFAULT = 2138;
+
+  it("keeps the documented default when the env var is unset or empty", () => {
+    expect(resolvePlaywrightPortEnv({}, "ELIZA_UI_SMOKE_PORT", DEFAULT)).toBe(
+      DEFAULT,
+    );
+    expect(
+      resolvePlaywrightPortEnv(
+        { ELIZA_UI_SMOKE_PORT: "" },
+        "ELIZA_UI_SMOKE_PORT",
+        DEFAULT,
+      ),
+    ).toBe(DEFAULT);
+    expect(
+      resolvePlaywrightPortEnv(
+        { ELIZA_UI_SMOKE_PORT: "   " },
+        "ELIZA_UI_SMOKE_PORT",
+        DEFAULT,
+      ),
+    ).toBe(DEFAULT);
+  });
+
+  it("accepts a valid explicit override", () => {
+    expect(
+      resolvePlaywrightPortEnv(
+        { ELIZA_UI_SMOKE_PORT: "42138" },
+        "ELIZA_UI_SMOKE_PORT",
+        DEFAULT,
+      ),
+    ).toBe(42138);
+  });
+
+  it("fails closed on an explicit invalid override instead of falling back", () => {
+    expect(() =>
+      resolvePlaywrightPortEnv(
+        { ELIZA_UI_SMOKE_API_PORT: "31337junk" },
+        "ELIZA_UI_SMOKE_API_PORT",
+        31337,
+      ),
+    ).toThrow(/ELIZA_UI_SMOKE_API_PORT/);
+    expect(() =>
+      resolvePlaywrightPortEnv(
+        { ELIZA_DEV_SMOKE_API_PORT: "0" },
+        "ELIZA_DEV_SMOKE_API_PORT",
+        31337,
+      ),
+    ).toThrow(/ELIZA_DEV_SMOKE_API_PORT/);
+    expect(() =>
+      resolvePlaywrightPortEnv(
+        { ELIZA_HMR_UI_PORT: String(MAX_TCP_PORT + 1) },
+        "ELIZA_HMR_UI_PORT",
+        42138,
+      ),
+    ).toThrow(/ELIZA_HMR_UI_PORT/);
+  });
+
+  it("exports the TCP range constants used by callers and docs", () => {
+    expect(MIN_TCP_PORT).toBe(1);
+    expect(MAX_TCP_PORT).toBe(65535);
+  });
+});

--- a/packages/app/scripts/run-ui-playwright.mjs
+++ b/packages/app/scripts/run-ui-playwright.mjs
@@ -18,6 +18,7 @@ import {
   resolveExecutableFromPath,
   resolvePlaywrightNodeRuntime,
 } from "./lib/playwright-node-runtime.mjs";
+import { parsePlaywrightPort } from "./lib/playwright-port.mjs";
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = path.resolve(appDir, "..", "..");
@@ -360,13 +361,23 @@ if (hasPlaywrightConfig("playwright.ui-smoke.config.ts")) {
     const apiPort = await getDistinctFreePort(reservedPorts);
     env.ELIZA_UI_SMOKE_API_PORT = String(apiPort);
     env.ELIZA_API_PORT = env.ELIZA_API_PORT || String(apiPort);
+    reservedPorts.add(apiPort);
+  } else {
+    // Pre-set overrides must be canonical ports before reservation/spawn.
+    reservedPorts.add(
+      parsePlaywrightPort(
+        env.ELIZA_UI_SMOKE_API_PORT,
+        "ELIZA_UI_SMOKE_API_PORT",
+      ),
+    );
   }
-  reservedPorts.add(Number(env.ELIZA_UI_SMOKE_API_PORT));
 
   if (!env.ELIZA_UI_SMOKE_PORT) {
     const uiPort = await getDistinctFreePort(reservedPorts);
     env.ELIZA_UI_SMOKE_PORT = String(uiPort);
     env.ELIZA_PORT = env.ELIZA_PORT || String(uiPort);
+  } else {
+    parsePlaywrightPort(env.ELIZA_UI_SMOKE_PORT, "ELIZA_UI_SMOKE_PORT");
   }
 }
 


### PR DESCRIPTION
# Relates to

Fixes #18618

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xAI/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build (unattended worker)`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** Fail-closed validation at Playwright config load / runner preflight only.
Valid environments (unset/empty or a canonical 1..65535 port) are unchanged.
Invalid explicit overrides that previously produced `NaN` or out-of-range ports
now throw early with the env-var name — intentional behavior change.

# Background

## What does this PR do?

Playwright lane configs parsed port env overrides with `Number(process.env.X || default)`, which accepts `0`, negatives, fractions, and turns typos like `2138junk` into `NaN` that only fail later inside webServer bind or baseURL construction.

This PR adds a shared helper (`parsePlaywrightPort` / `resolvePlaywrightPortEnv`) and wires:

- `playwright.ui-smoke.config.ts` — `ELIZA_UI_SMOKE_API_PORT`, `ELIZA_UI_SMOKE_PORT`
- `playwright.android-browser.config.ts` — same UI-smoke ports
- `playwright.hmr.config.ts` — `ELIZA_HMR_API_PORT`, `ELIZA_HMR_UI_PORT`
- `playwright.dev-smoke.config.ts` — `ELIZA_DEV_SMOKE_API_PORT`, `ELIZA_DEV_SMOKE_UI_PORT`
- `run-ui-playwright.mjs` — validates pre-set UI-smoke ports before reservation/spawn

Unset/empty keeps the documented defaults. Explicit invalid values throw with the env-var name.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation. Error messages name the env vars; defaults are unchanged.

# Testing

## Where should a reviewer start?

1. `packages/app/scripts/lib/playwright-port.mjs` — parser contract
2. `packages/app/scripts/lib/playwright-port.test.mjs` — accept/reject matrix
3. Config call sites listed above

## Detailed testing steps

```bash
bun test packages/app/scripts/lib/playwright-port.test.mjs
bun test packages/app/scripts/lib/playwright-shard.test.mjs packages/app/scripts/lib/playwright-port.test.mjs
```

Direct probe of fail-closed path:

```bash
node --input-type=module -e '
import { resolvePlaywrightPortEnv } from "./packages/app/scripts/lib/playwright-port.mjs";
console.log(resolvePlaywrightPortEnv({}, "ELIZA_UI_SMOKE_PORT", 2138));
try { resolvePlaywrightPortEnv({ELIZA_UI_SMOKE_PORT:"2138junk"}, "ELIZA_UI_SMOKE_PORT", 2138); }
catch (e) { console.log(e.message); }
'
```

# Evidence Gate

<!-- evidence-head:318feff985ac97ba04681fc484fa7381e65427e7 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: **N/A - non-UI CLI/config validation only; no rendered surface.**
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: **N/A - non-UI CLI/config validation only; no rendered surface.**
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: **N/A - non-UI CLI/config validation only; no user-visible flow.**
<!-- evidence-row:backend-logs -->
- [x] Backend logs: focused unit-test + helper probe output below (parser boundary, not a server path).
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: **N/A - no frontend request/response path; config preflight only.**
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: **N/A - no agent, action, prompt, provider, or model behavior changes.**
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: **N/A - no DB rows, memories, tasks, wallet, or generated domain state.**
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: **N/A - no rendered visual surface.**

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changes.

## Backend + frontend logs

<details>
<summary>Focused unit tests (9 pass) + sibling shard regression (16 pass total)</summary>

```
bun test packages/app/scripts/lib/playwright-port.test.mjs
# 9 pass, 0 fail, 100% lines on playwright-port.mjs

bun test packages/app/scripts/lib/playwright-shard.test.mjs packages/app/scripts/lib/playwright-port.test.mjs
# 16 pass, 0 fail
```

</details>

<details>
<summary>Direct fail-closed probe</summary>

```
default 2138
valid 42138
reject: ELIZA_UI_SMOKE_PORT must be a TCP port integer from 1 to 65535 (received "2138junk")
all defaults ok
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - non-UI CLI/config validation only.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT path.

## Known gaps / failures

- Full `bun run verify` was **not** run this cycle (scoped CLI/config validation; focused package tests only).
- Device-signed project token receipt was **not** emitted: the bundled receipt script only accepts codex/claude-code model identities, and this run used operator-approved Grok — lying on the receipt would violate the workstream rule.
- Biome check on the 7 touched files: clean (no fixes applied).