### PR TITLE
fix(app): serialize renderer service teardown and native activity capture

### DIFF
--- a/packages/ui/src/platform/renderer-services.test.ts
+++ b/packages/ui/src/platform/renderer-services.test.ts
@@ -152,30 +152,72 @@ describe("teardown", () => {
     expect(getRendererServiceStates().hostShell).toBeNull();
   });
 
-  it("disposes on a real pagehide but survives a bfcache round trip", async () => {
+  it("suspends every instance on a persisted pagehide (bfcache) and restarts them on pageshow", async () => {
     const svc = makeService("a.bfcache");
     registerRendererService(svc.definition);
     startRendererServiceHost({ shell: "main" });
     await settleRendererServices();
 
-    // bfcache entry: persisted=true (iOS Safari back-nav) — the page can come
-    // back via pageshow, so the host must keep every service alive.
+    // bfcache entry: persisted=true (iOS Safari back-nav). The page can come
+    // back via pageshow, so the host itself survives, but every instance's
+    // owned native resources must be suspended now — the freeze can happen
+    // mid-flight, so only *initiating* teardown needs to be synchronous.
     const persisted = new Event("pagehide") as Event & { persisted: boolean };
     Object.defineProperty(persisted, "persisted", { value: true });
     window.dispatchEvent(persisted);
-    expect(svc.cleanup).not.toHaveBeenCalled();
-    expect(stateOf("a.bfcache")).toBe("running");
+    expect(svc.cleanup).toHaveBeenCalledTimes(1);
+    expect(stateOf("a.bfcache")).toBe("stopped");
     expect(getRendererServiceStates().hostShell).toBe("main");
 
-    // Restore from bfcache, then a real teardown: persisted=false disposes.
+    // Restore from bfcache: pageshow restarts the suspended service through
+    // the same serialized queue.
     const pageshow = new Event("pageshow") as Event & { persisted: boolean };
     Object.defineProperty(pageshow, "persisted", { value: true });
     window.dispatchEvent(pageshow);
+    await settleRendererServices();
+    expect(svc.start).toHaveBeenCalledTimes(2);
     expect(stateOf("a.bfcache")).toBe("running");
 
+    // A real teardown (persisted=false) still fully disposes the host.
     window.dispatchEvent(new Event("pagehide"));
-    expect(svc.cleanup).toHaveBeenCalledTimes(1);
+    expect(svc.cleanup).toHaveBeenCalledTimes(2);
     expect(getRendererServiceStates().hostShell).toBeNull();
+  });
+
+  it("restarted suspended service waits for a still-pending suspension cleanup", async () => {
+    let releaseCleanup: (() => void) | undefined;
+    const start = vi.fn(
+      () => () =>
+        new Promise<void>((resolve) => {
+          releaseCleanup = resolve;
+        }),
+    );
+    registerRendererService({
+      id: "a.slow-suspend",
+      shells: ["main"],
+      start,
+    });
+    startRendererServiceHost({ shell: "main" });
+    await settleRendererServices();
+    expect(start).toHaveBeenCalledTimes(1);
+
+    const persisted = new Event("pagehide") as Event & { persisted: boolean };
+    Object.defineProperty(persisted, "persisted", { value: true });
+    window.dispatchEvent(persisted);
+
+    const pageshow = new Event("pageshow") as Event & { persisted: boolean };
+    Object.defineProperty(pageshow, "persisted", { value: true });
+    window.dispatchEvent(pageshow);
+
+    // The restart is queued but must not run until the pending suspension
+    // cleanup settles.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(start).toHaveBeenCalledTimes(1);
+
+    releaseCleanup?.();
+    await settleRendererServices();
+    expect(start).toHaveBeenCalledTimes(2);
   });
 
   it("stops the previous host's instances on host replacement", async () => {
@@ -231,6 +273,135 @@ describe("teardown", () => {
       expect.any(Error),
       "cleanup",
     );
+  });
+});
+
+describe("async cleanup serialization (#17110)", () => {
+  it("awaits an async cleanup before starting the successor on re-registration", async () => {
+    let releaseCleanup: (() => void) | undefined;
+    const firstStart = vi.fn(
+      () => () =>
+        new Promise<void>((resolve) => {
+          releaseCleanup = resolve;
+        }),
+    );
+    const secondStart = vi.fn(() => () => {});
+    registerRendererService({
+      id: "a.async-hmr",
+      shells: ["main"],
+      start: firstStart,
+    });
+    startRendererServiceHost({ shell: "main" });
+    await settleRendererServices();
+    expect(firstStart).toHaveBeenCalledTimes(1);
+
+    registerRendererService({
+      id: "a.async-hmr",
+      shells: ["main"],
+      start: secondStart,
+    });
+
+    // The old instance's cleanup is still pending — the successor must not
+    // have started yet.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(secondStart).not.toHaveBeenCalled();
+
+    releaseCleanup?.();
+    await settleRendererServices();
+    expect(secondStart).toHaveBeenCalledTimes(1);
+    expect(stateOf("a.async-hmr")).toBe("running");
+  });
+
+  it("awaits the prior host's full disposal before the replacement host's services start", async () => {
+    let releaseCleanup: (() => void) | undefined;
+    const start = vi.fn(
+      () => () =>
+        new Promise<void>((resolve) => {
+          releaseCleanup = resolve;
+        }),
+    );
+    registerRendererService({
+      id: "a.async-host-replace",
+      shells: ["main"],
+      start,
+    });
+    startRendererServiceHost({ shell: "main" });
+    await settleRendererServices();
+    expect(start).toHaveBeenCalledTimes(1);
+
+    // Host replacement (shell HMR, repeated test boots) while the old
+    // instance's cleanup is still pending — the new host's instance must not
+    // start until the old host has fully disposed.
+    startRendererServiceHost({ shell: "main" });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(start).toHaveBeenCalledTimes(1);
+
+    releaseCleanup?.();
+    await settleRendererServices();
+    expect(start).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports a rejecting async cleanup and still unblocks the successor", async () => {
+    const reportError = vi.fn();
+    let rejectCleanup: ((error: Error) => void) | undefined;
+    registerRendererService({
+      id: "a.async-reject-cleanup",
+      shells: ["main"],
+      start: () => () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectCleanup = reject;
+        }),
+    });
+    startRendererServiceHost({ shell: "main", reportError });
+    await settleRendererServices();
+
+    const second = makeService("a.async-reject-cleanup");
+    registerRendererService(second.definition);
+    rejectCleanup?.(new Error("cleanup rejected"));
+
+    await settleRendererServices();
+    expect(reportError).toHaveBeenCalledWith(
+      "a.async-reject-cleanup",
+      expect.any(Error),
+      "cleanup",
+    );
+    expect(second.start).toHaveBeenCalledTimes(1);
+    expect(stateOf("a.async-reject-cleanup")).toBe("running");
+  });
+
+  it("a late-completing predecessor cleanup cannot stop the running successor", async () => {
+    let releaseCleanup: (() => void) | undefined;
+    registerRendererService({
+      id: "a.late-cleanup-safety",
+      shells: ["main"],
+      start: () => () =>
+        new Promise<void>((resolve) => {
+          releaseCleanup = resolve;
+        }),
+    });
+    startRendererServiceHost({ shell: "main" });
+    await settleRendererServices();
+
+    const successor = makeService("a.late-cleanup-safety");
+    registerRendererService(successor.definition);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(successor.start).not.toHaveBeenCalled();
+
+    releaseCleanup?.();
+    await settleRendererServices();
+    expect(successor.start).toHaveBeenCalledTimes(1);
+    expect(stateOf("a.late-cleanup-safety")).toBe("running");
+
+    // The predecessor's long-settled cleanup resolving even later must not
+    // retroactively stop or clean up the now-running successor.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(successor.cleanup).not.toHaveBeenCalled();
+    expect(stateOf("a.late-cleanup-safety")).toBe("running");
   });
 });
 

--- a/packages/ui/src/platform/renderer-services.test.ts
+++ b/packages/ui/src/platform/renderer-services.test.ts
@@ -372,6 +372,42 @@ describe("async cleanup serialization (#17110)", () => {
     expect(stateOf("a.async-reject-cleanup")).toBe("running");
   });
 
+  it("a stop during a disposal-gated start cannot poison the id's teardown queue (self-await)", async () => {
+    // Host A's instance has a slow async cleanup, so host B's replacement
+    // instance parks awaiting A's disposal. Re-registering the id then stops
+    // that still-waiting B instance, parking its own `settled` as the id's
+    // pending teardown. When A's disposal finally resolves, the stopped B
+    // instance must resolve promptly instead of awaiting its own parked
+    // promise — a self-await would deadlock this id (and every later host
+    // generation) forever.
+    let releaseCleanup: (() => void) | undefined;
+    registerRendererService({
+      id: "a.self-await",
+      shells: ["main"],
+      start: () => () =>
+        new Promise<void>((resolve) => {
+          releaseCleanup = resolve;
+        }),
+    });
+    startRendererServiceHost({ shell: "main" });
+    await settleRendererServices();
+
+    // Replace the host while A's cleanup is pending: B's instance now waits
+    // on A's full disposal before it may start.
+    startRendererServiceHost({ shell: "main" });
+
+    // Stop the waiting B instance via re-registration and enqueue a successor.
+    const successor = makeService("a.self-await");
+    registerRendererService(successor.definition);
+
+    releaseCleanup?.();
+    for (let i = 0; i < 12; i += 1) {
+      await Promise.resolve();
+    }
+    expect(successor.start).toHaveBeenCalledTimes(1);
+    expect(stateOf("a.self-await")).toBe("running");
+  });
+
   it("a late-completing predecessor cleanup cannot stop the running successor", async () => {
     let releaseCleanup: (() => void) | undefined;
     registerRendererService({

--- a/packages/ui/src/platform/renderer-services.ts
+++ b/packages/ui/src/platform/renderer-services.ts
@@ -275,6 +275,14 @@ function startInstance(
     if (waitFor) {
       await waitFor;
     }
+    // Check supersession BEFORE consulting pendingCleanup: a stop that landed
+    // while this instance awaited the prior generation's disposal parked this
+    // instance's own `settled` there, and awaiting it from inside itself
+    // would deadlock the id (and every later host generation) forever.
+    // Nothing started yet, so resolving immediately is the correct teardown.
+    if (host.instances.get(definition.id) !== instance) {
+      return;
+    }
     const pendingSameId = host.pendingCleanup.get(definition.id);
     if (pendingSameId) {
       await pendingSameId;

--- a/packages/ui/src/platform/renderer-services.ts
+++ b/packages/ui/src/platform/renderer-services.ts
@@ -16,6 +16,31 @@
  * definitions registered later (side-effect modules load on the idle path)
  * start immediately.
  *
+ * Cleanup is allowed to be asynchronous (owned native resources — listeners,
+ * monitors — stop asynchronously), so every id-scoped transition (stop then
+ * replacement start, whether triggered by re-registration or host
+ * replacement) is serialized: a successor's `start` never runs until the
+ * predecessor's cleanup promise has settled, resolved or rejected. A
+ * rejecting cleanup is reported through the host's `reportError` and still
+ * unblocks the successor — teardown never deadlocks the registry, and a
+ * failure is always surfaced, never swallowed. `disposeHost` returns a
+ * promise that resolves once every instance it stopped has fully settled;
+ * `startRendererServiceHost` makes every newly started instance await that
+ * promise before it starts, so a replaced generation's in-flight teardown
+ * (e.g. a native `stopMonitoring()` call) can never land after the
+ * replacement's `start` and clobber it (#17110). Each instance keeps its own
+ * `AbortController`/generation identity, so a stale instance's late
+ * completion (a delayed start, or cleanup settling long after a successor is
+ * already running) can only ever act on itself — it is discarded rather than
+ * mutating the successor's state.
+ *
+ * A `pagehide` with `persisted=true` (bfcache entry, e.g. iOS Safari
+ * back-nav) suspends every instance through the same serialized stop path
+ * instead of disposing the host outright — the page may come back via
+ * `pageshow`, which restarts every eligible definition through the same
+ * serialized start path (awaiting a still-in-flight suspension first). Only a
+ * real `pagehide` (`persisted=false`) fully disposes the host.
+ *
  * The store lives on `globalThis` so duplicated module evaluations (HMR, mixed
  * chunk graphs) share one registry — two copies of this module must never each
  * believe they own the running instances. Stop is race-safe against pending
@@ -50,7 +75,8 @@ export interface RendererServiceContext {
   signal: AbortSignal;
 }
 
-export type RendererServiceCleanup = () => void;
+/** May resolve asynchronously — the registry awaits it before starting a successor. */
+export type RendererServiceCleanup = () => void | Promise<void>;
 
 export interface RendererServiceDefinition {
   /** Globally unique, stable id, e.g. "personal-assistant.lifeops-activity-signals". */
@@ -89,8 +115,12 @@ export type RendererServiceErrorReporter = (
 
 export interface RendererServiceHostHandle {
   shell: RendererShellKind;
-  /** Stop every running/starting instance and detach the pagehide hook. */
-  dispose: () => void;
+  /**
+   * Stop every running/starting instance and detach the pagehide/pageshow
+   * hooks. Returns a promise that settles once every instance's cleanup has
+   * fully run; callers that only need to enqueue the stop may ignore it.
+   */
+  dispose: () => void | Promise<void>;
 }
 
 interface ServiceInstance {
@@ -98,7 +128,12 @@ interface ServiceInstance {
   controller: AbortController;
   status: "starting" | "running" | "failed" | "stopped";
   cleanup: RendererServiceCleanup | null;
-  /** Settles when a pending start has fully resolved its cleanup handling. */
+  /**
+   * Settles once this instance's `start` (if still pending) and any cleanup
+   * it triggers have both fully resolved — the single signal a successor
+   * (same id re-registration, or the next host generation) awaits before it
+   * is allowed to start.
+   */
   settled: Promise<void>;
 }
 
@@ -106,7 +141,9 @@ interface HostState {
   shell: RendererShellKind;
   reportError: RendererServiceErrorReporter;
   instances: Map<string, ServiceInstance>;
-  detachPagehide: (() => void) | null;
+  /** Id-scoped teardown in flight; a same-id start awaits this before running. */
+  pendingCleanup: Map<string, Promise<void>>;
+  detachLifecycleHooks: (() => void) | null;
   disposed: boolean;
 }
 
@@ -150,33 +187,79 @@ const defaultReportError: RendererServiceErrorReporter = (
   });
 };
 
-function runCleanup(host: HostState, instance: ServiceInstance): void {
+/**
+ * Invoke a retained cleanup and return a promise that settles once it (sync
+ * or async) has fully run. Never rejects: a throwing/rejecting cleanup is
+ * reported through the host's reporter instead, so a failed teardown can
+ * never deadlock a successor waiting on it.
+ */
+function runCleanup(host: HostState, instance: ServiceInstance): Promise<void> {
   const cleanup = instance.cleanup;
   instance.cleanup = null;
-  if (!cleanup) return;
-  try {
-    cleanup();
-  } catch (error) {
-    // error-policy:J6 best-effort teardown — a throwing cleanup must not block
-    // the remaining services' teardown; it is reported, never swallowed.
+  if (!cleanup) return Promise.resolve();
+  const reportFailure = (error: unknown): void => {
+    // error-policy:J6 best-effort teardown — a throwing/rejecting cleanup
+    // must not block the remaining services' teardown or a waiting
+    // successor's start; it is reported, never swallowed.
     host.reportError(instance.definition.id, error, "cleanup");
+  };
+  try {
+    const result = cleanup();
+    if (result && typeof (result as Promise<void>).then === "function") {
+      return (result as Promise<void>).catch(reportFailure);
+    }
+    return Promise.resolve();
+  } catch (error) {
+    reportFailure(error);
+    return Promise.resolve();
   }
 }
 
-function stopInstance(host: HostState, instance: ServiceInstance): void {
-  if (instance.status === "stopped") return;
+/**
+ * Mark an instance stopped, invoke (or arrange) its cleanup, and register the
+ * settling promise under the instance's id so a same-id `startInstance` call
+ * — from re-registration or the next host generation — waits for it. Returns
+ * that same promise.
+ */
+function stopInstance(
+  host: HostState,
+  instance: ServiceInstance,
+): Promise<void> {
+  if (instance.status === "stopped") {
+    return host.pendingCleanup.get(instance.definition.id) ?? Promise.resolve();
+  }
   const id = instance.definition.id;
+  const wasStarting = instance.status === "starting";
   instance.status = "stopped";
   instance.controller.abort();
-  // If start is still pending, cleanup is null here; the start continuation in
-  // startInstance sees the aborted signal and runs the late cleanup itself.
-  runCleanup(host, instance);
-  host.instances.delete(id);
+  // If start is still pending, `instance.settled`'s continuation sees the
+  // aborted signal and runs (and awaits) the late cleanup itself once the
+  // start resolves; that same promise is what a waiting successor needs.
+  // Otherwise the retained cleanup runs now.
+  const settled = wasStarting ? instance.settled : runCleanup(host, instance);
+  if (host.instances.get(id) === instance) {
+    host.instances.delete(id);
+  }
+  host.pendingCleanup.set(id, settled);
+  void settled.finally(() => {
+    if (host.pendingCleanup.get(id) === settled) {
+      host.pendingCleanup.delete(id);
+    }
+  });
+  return settled;
 }
 
+/**
+ * Start a new instance for `definition`. If `waitFor` is given (the prior
+ * host generation's full disposal) or a same-id teardown is already pending
+ * on this host (re-registration), `start` is not invoked until that teardown
+ * has settled — this is the serialization guarantee (#17110): a predecessor's
+ * async cleanup always finishes before its successor starts.
+ */
 function startInstance(
   host: HostState,
   definition: RendererServiceDefinition,
+  waitFor?: Promise<void>,
 ): void {
   const controller = new AbortController();
   const instance: ServiceInstance = {
@@ -189,6 +272,19 @@ function startInstance(
   host.instances.set(definition.id, instance);
 
   instance.settled = (async () => {
+    if (waitFor) {
+      await waitFor;
+    }
+    const pendingSameId = host.pendingCleanup.get(definition.id);
+    if (pendingSameId) {
+      await pendingSameId;
+    }
+    // A later stop (or another re-registration) may have already superseded
+    // this instance while we waited — do not start an instance nobody wants.
+    if (host.instances.get(definition.id) !== instance) {
+      return;
+    }
+
     let cleanup: RendererServiceCleanup;
     try {
       cleanup = await definition.start({
@@ -226,9 +322,11 @@ function startInstance(
 
     if (controller.signal.aborted) {
       // Stopped while start was awaited: run the late cleanup now so no
-      // listener/interval installed by the finished start survives the stop.
+      // listener/interval installed by the finished start survives the stop,
+      // and await it so this instance's `settled` remains the single signal
+      // a waiting successor needs.
       instance.cleanup = cleanup;
-      runCleanup(host, instance);
+      await runCleanup(host, instance);
       return;
     }
 
@@ -249,8 +347,9 @@ function isEligible(
  * entries call this at import time. If a host is active and the definition's
  * shells include the host's shell, the service starts immediately.
  * Re-registering an id replaces the definition: the old instance is stopped
- * (its cleanup runs) before the new definition starts — this is what makes dev
- * HMR of a plugin registration module safe.
+ * (its cleanup runs, and is fully awaited before the replacement starts) —
+ * this is what makes dev HMR of a plugin registration module safe even when
+ * the old instance's cleanup is asynchronous.
  */
 export function registerRendererService(
   definition: RendererServiceDefinition,
@@ -276,47 +375,73 @@ export function registerRendererService(
 /**
  * Install the per-window service host. The app shell calls this once per
  * renderer window with the window's resolved shell kind; every already
- * registered eligible definition starts, later registrations start on arrival,
- * and a non-bfcache `pagehide` (real page teardown, including mobile app
- * kill) disposes everything — a bfcache round trip keeps services alive.
- * Calling again replaces the previous host — its instances are
- * stopped first — which keeps repeated boots (tests, HMR of the shell) from
- * stacking duplicate instances.
+ * registered eligible definition starts, later registrations start on
+ * arrival. A non-bfcache `pagehide` (real page teardown, including mobile app
+ * kill) disposes everything; a bfcache round trip (`persisted=true`) instead
+ * suspends every instance — their cleanup runs, but the host and its
+ * definitions survive — and a matching `pageshow` restarts them. Calling
+ * again replaces the previous host: its disposal is awaited before any of the
+ * new host's instances start, so a stale generation's in-flight teardown can
+ * never land after (and clobber) the replacement.
  */
 export function startRendererServiceHost(options: {
   shell: RendererShellKind;
   reportError?: RendererServiceErrorReporter;
 }): RendererServiceHostHandle {
   const store = getStore();
-  if (store.host) disposeHost(store.host);
+  const priorDisposal = store.host ? disposeHost(store.host) : undefined;
 
   const host: HostState = {
     shell: options.shell,
     reportError: options.reportError ?? defaultReportError,
     instances: new Map(),
-    detachPagehide: null,
+    pendingCleanup: new Map(),
+    detachLifecycleHooks: null,
     disposed: false,
   };
   store.host = host;
 
   if (typeof window !== "undefined") {
-    // Real page teardown disposes everything; a bfcache round trip
-    // (persisted=true — iOS Safari back-nav is the common case) must NOT: the
-    // page can come back via `pageshow`, and a dispose here would permanently
-    // kill every renderer service until a hard reload. While the page sits in
-    // bfcache no JS runs, so keeping instances alive is safe — their timers
-    // and listeners freeze with the page and resume on restore, which is why
-    // no `pageshow` revival hook is needed.
     const onPagehide = (event: PageTransitionEvent) => {
-      if (!event.persisted) disposeHost(host);
+      if (event.persisted) {
+        // bfcache entry: suspend every instance's owned resources now — the
+        // page can come back via pageshow, so the host and its definitions
+        // must survive. The page may freeze mid-flight; only *initiating*
+        // every instance's stop needs to be synchronous, which it is (each
+        // stopInstance call below invokes cleanup() synchronously).
+        for (const instance of [...host.instances.values()]) {
+          stopInstance(host, instance);
+        }
+        return;
+      }
+      disposeHost(host);
+    };
+    const onPageshow = (event: PageTransitionEvent) => {
+      if (!event.persisted || host.disposed) return;
+      // Restore from bfcache: restart every eligible definition that isn't
+      // already running through the same serialized start path, so a restart
+      // racing a still-in-flight suspension cleanup waits for it.
+      for (const definition of store.definitions.values()) {
+        if (
+          isEligible(definition, host.shell) &&
+          !host.instances.has(definition.id)
+        ) {
+          startInstance(host, definition);
+        }
+      }
     };
     window.addEventListener("pagehide", onPagehide);
-    host.detachPagehide = () =>
+    window.addEventListener("pageshow", onPageshow);
+    host.detachLifecycleHooks = () => {
       window.removeEventListener("pagehide", onPagehide);
+      window.removeEventListener("pageshow", onPageshow);
+    };
   }
 
   for (const definition of store.definitions.values()) {
-    if (isEligible(definition, host.shell)) startInstance(host, definition);
+    if (isEligible(definition, host.shell)) {
+      startInstance(host, definition, priorDisposal);
+    }
   }
 
   return {
@@ -325,16 +450,24 @@ export function startRendererServiceHost(options: {
   };
 }
 
-function disposeHost(host: HostState): void {
-  if (host.disposed) return;
+/**
+ * Stop every instance and detach the lifecycle hooks. Returns a promise that
+ * settles once every instance's cleanup has fully run (idempotent — a second
+ * call resolves immediately). The next host generation's `startInstance`
+ * calls await this so a replaced generation's in-flight teardown can never
+ * land after the replacement starts.
+ */
+function disposeHost(host: HostState): Promise<void> {
+  if (host.disposed) return Promise.resolve();
   host.disposed = true;
-  host.detachPagehide?.();
-  host.detachPagehide = null;
-  for (const instance of [...host.instances.values()]) {
-    stopInstance(host, instance);
-  }
+  host.detachLifecycleHooks?.();
+  host.detachLifecycleHooks = null;
+  const settling = [...host.instances.values()].map((instance) =>
+    stopInstance(host, instance),
+  );
   const store = getStore();
   if (store.host === host) store.host = null;
+  return Promise.all(settling).then(() => undefined);
 }
 
 /**

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
@@ -44,6 +44,7 @@ const h = vi.hoisted(() => {
       healthSnapshot: null,
     })),
     scheduleBackgroundRefresh: vi.fn(async () => ({ scheduled: true })),
+    cancelBackgroundRefresh: vi.fn(async () => ({ cancelled: true })),
   };
   return {
     // The client-lifeops / client-calendar extension modules (side-effect
@@ -288,6 +289,7 @@ describe("startLifeOpsActivitySignalCapture", () => {
       healthSnapshot: null,
     });
     h.mobile.scheduleBackgroundRefresh.mockResolvedValue({ scheduled: true });
+    h.mobile.cancelBackgroundRefresh.mockResolvedValue({ cancelled: true });
     h.mobile.listenerCb = null;
   });
 
@@ -1009,5 +1011,119 @@ describe("startLifeOpsActivitySignalCapture", () => {
     removeDoc.mockRestore();
     removeWin.mockRestore();
     clearIntervalSpy.mockRestore();
+  });
+
+  it("rolls back the listener when startMonitoring resolves enabled:false, allowing a later retry (#17110)", async () => {
+    mockNativeMobile();
+    const remove = vi.fn(async () => {});
+    h.mobile.addListener.mockImplementation(
+      async (_event: string, cb: (signal: unknown) => void) => {
+        h.mobile.listenerCb = cb;
+        return { remove };
+      },
+    );
+    h.mobile.startMonitoring.mockResolvedValueOnce({
+      enabled: false,
+      supported: true,
+      platform: "ios",
+      snapshot: null,
+      healthSnapshot: null,
+    });
+
+    stop = startLifeOpsActivitySignalCapture(true);
+    await settle();
+
+    expect(h.mobile.startMonitoring).toHaveBeenCalledTimes(1);
+    // Never committed: the rejected/disabled handle is rolled back instead of
+    // wedging the guard for every later retry.
+    expect(remove).toHaveBeenCalledTimes(1);
+
+    h.mobile.startMonitoring.mockResolvedValue({
+      enabled: true,
+      supported: true,
+      platform: "ios",
+      snapshot: null,
+      healthSnapshot: null,
+    });
+    document.dispatchEvent(new Event("eliza:app-resume"));
+    await settle();
+
+    expect(h.mobile.startMonitoring).toHaveBeenCalledTimes(2);
+  });
+
+  it("rolls back the listener when startMonitoring rejects, allowing a later retry (#17110)", async () => {
+    mockNativeMobile();
+    const remove = vi.fn(async () => {});
+    h.mobile.addListener.mockImplementation(
+      async (_event: string, cb: (signal: unknown) => void) => {
+        h.mobile.listenerCb = cb;
+        return { remove };
+      },
+    );
+    h.mobile.startMonitoring.mockRejectedValueOnce(
+      new Error("native start failed"),
+    );
+
+    stop = startLifeOpsActivitySignalCapture(true);
+    await settle();
+
+    expect(remove).toHaveBeenCalledTimes(1);
+
+    h.mobile.startMonitoring.mockResolvedValue({
+      enabled: true,
+      supported: true,
+      platform: "ios",
+      snapshot: null,
+      healthSnapshot: null,
+    });
+    document.dispatchEvent(new Event("eliza:app-resume"));
+    await settle();
+
+    expect(h.mobile.startMonitoring).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels the scheduled background refresh on stop (#17110)", async () => {
+    mockNativeMobile();
+    h.mobile.scheduleBackgroundRefresh.mockResolvedValue({ scheduled: true });
+
+    stop = startLifeOpsActivitySignalCapture(true);
+    await settle();
+    expect(h.mobile.scheduleBackgroundRefresh).toHaveBeenCalled();
+
+    stop();
+    stop = undefined;
+
+    expect(h.mobile.cancelBackgroundRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("discards a late in-flight capture-signal failure after stop instead of publishing it (#17110)", async () => {
+    let rejectCapture: ((error: unknown) => void) | undefined;
+    h.captureLifeOpsActivitySignal.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectCapture = reject;
+        }),
+    );
+
+    stop = startLifeOpsActivitySignalCapture(true);
+    await settle();
+    expect(h.captureLifeOpsActivitySignal).toHaveBeenCalled();
+    const callsBeforeStop = h.captureLifeOpsActivitySignal.mock.calls.length;
+
+    stop();
+    stop = undefined;
+
+    // The in-flight call resolves late, after stop.
+    rejectCapture?.(new Error("late failure after stop"));
+    await settle();
+
+    // No new client call was made because of the stop, and the late failure
+    // was discarded rather than published as a capture_error.
+    expect(h.captureLifeOpsActivitySignal.mock.calls.length).toBe(
+      callsBeforeStop,
+    );
+    expect(h.dispatchStatus).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "capture_error" }),
+    );
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
@@ -1096,6 +1096,87 @@ describe("startLifeOpsActivitySignalCapture", () => {
     expect(h.mobile.cancelBackgroundRefresh).toHaveBeenCalledTimes(1);
   });
 
+  it("stop() awaits an in-flight native startup's rollback before resolving (#17110)", async () => {
+    mockNativeMobile();
+    const remove = vi.fn(async () => {});
+    h.mobile.addListener.mockImplementation(
+      async (_event: string, cb: (signal: unknown) => void) => {
+        h.mobile.listenerCb = cb;
+        return { remove };
+      },
+    );
+    let releaseStartMonitoring: ((value: unknown) => void) | undefined;
+    h.mobile.startMonitoring.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseStartMonitoring = resolve;
+        }),
+    );
+
+    const stopFn = startLifeOpsActivitySignalCapture(true);
+    stop = stopFn;
+    await settle();
+    expect(h.mobile.startMonitoring).toHaveBeenCalledTimes(1);
+
+    let stopSettled = false;
+    const stopPromise = Promise.resolve(stopFn()).then(() => {
+      stopSettled = true;
+    });
+    stop = undefined;
+    await settle();
+    // The in-flight startup (startMonitoring pending) is owned teardown
+    // work: stop() must not resolve until its rollback has completed, or the
+    // registry would start a successor the late rollback can then disable.
+    expect(stopSettled).toBe(false);
+
+    releaseStartMonitoring?.({
+      enabled: true,
+      supported: true,
+      platform: "ios",
+      snapshot: null,
+      healthSnapshot: null,
+    });
+    await settle();
+    await stopPromise;
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(h.mobile.stopMonitoring).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-cancels a background refresh that resolves after stop (#17110)", async () => {
+    mockNativeMobile();
+    let releaseSchedule: ((value: unknown) => void) | undefined;
+    h.mobile.scheduleBackgroundRefresh.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseSchedule = resolve;
+        }),
+    );
+
+    const stopFn = startLifeOpsActivitySignalCapture(true);
+    stop = stopFn;
+    await settle();
+    expect(h.mobile.scheduleBackgroundRefresh).toHaveBeenCalledTimes(1);
+
+    let stopSettled = false;
+    const stopPromise = Promise.resolve(stopFn()).then(() => {
+      stopSettled = true;
+    });
+    stop = undefined;
+    await settle();
+    expect(h.mobile.cancelBackgroundRefresh).toHaveBeenCalledTimes(1);
+    // The pending schedule is owned work: stop() may not resolve while a
+    // late `{ scheduled: true }` can still create a background job that no
+    // live generation owns.
+    expect(stopSettled).toBe(false);
+
+    releaseSchedule?.({ scheduled: true });
+    await settle();
+    await stopPromise;
+    // The late schedule landed after stop's cancel — it must be cancelled
+    // again before cleanup resolves.
+    expect(h.mobile.cancelBackgroundRefresh).toHaveBeenCalledTimes(2);
+  });
+
   it("discards a late in-flight capture-signal failure after stop instead of publishing it (#17110)", async () => {
     let rejectCapture: ((error: unknown) => void) | undefined;
     h.captureLifeOpsActivitySignal.mockImplementation(

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
@@ -563,6 +563,13 @@ export function startLifeOpsActivitySignalCapture(
   let mobileSignalsHandle: { remove: () => Promise<void> } | null = null;
   let mobileSignalsStarted = false;
   let mobileSignalsStarting = false;
+  // The whole native startup run (permissions → listener → startMonitoring →
+  // snapshots → background refresh), including every unmounted-rollback path
+  // inside it, is owned teardown work: stop() awaits it so a predecessor's
+  // late rollback (listener removal, stopMonitoring of a just-engaged
+  // monitor, re-cancel of a late-scheduled refresh) always lands before the
+  // renderer-service registry may start a successor (#17110).
+  let mobileSignalsInFlight: Promise<void> | null = null;
   let mobileHealthPoller: number | null = null;
 
   const refreshMobileHealthSnapshot = async (reason: string): Promise<void> => {
@@ -583,12 +590,12 @@ export function startLifeOpsActivitySignalCapture(
     }
   };
 
-  const startMobileSignals = async (): Promise<void> => {
+  const startMobileSignals = (): Promise<void> => {
     // The starting flag closes the concurrency window two callers (initial
     // ready check + ready poller + resume) would otherwise race through: the
     // handle/started guards below are only assigned after awaits.
     if (mobileSignalsStarting || mobileSignalsHandle || mobileSignalsStarted) {
-      return;
+      return Promise.resolve();
     }
     if (
       !mobileSignals ||
@@ -597,10 +604,28 @@ export function startLifeOpsActivitySignalCapture(
       typeof mobileSignals.startMonitoring !== "function" ||
       typeof mobileSignals.stopMonitoring !== "function"
     ) {
-      return;
+      return Promise.resolve();
     }
 
     mobileSignalsStarting = true;
+    const run = runMobileSignalsStartup();
+    mobileSignalsInFlight = run;
+    const clearInFlight = (): void => {
+      if (mobileSignalsInFlight === run) {
+        mobileSignalsInFlight = null;
+      }
+    };
+    // error-policy:J5 a startup rejection is observed by every call site's
+    // `.catch(reportCaptureError)` on the returned promise; this derived
+    // promise exists only to clear the in-flight slot on settlement.
+    void run.then(clearInFlight, clearInFlight);
+    return run;
+  };
+
+  const runMobileSignalsStartup = async (): Promise<void> => {
+    if (!mobileSignals) {
+      return;
+    }
     try {
       const permissions = await mobileSignals.checkPermissions();
       if (!mounted) return;
@@ -669,6 +694,23 @@ export function startLifeOpsActivitySignalCapture(
       if (typeof mobileSignals.scheduleBackgroundRefresh === "function") {
         try {
           const result = await mobileSignals.scheduleBackgroundRefresh();
+          if (!mounted) {
+            // Stopped while scheduling was in flight: stop()'s
+            // cancelBackgroundRefresh may have raced ahead of this schedule,
+            // so a successful late schedule must be cancelled again — no
+            // background job may outlive its generation. stop() awaits this
+            // whole startup run, so the re-cancel lands before cleanup
+            // resolves (#17110).
+            if (
+              result.scheduled &&
+              typeof mobileSignals.cancelBackgroundRefresh === "function"
+            ) {
+              await mobileSignals
+                .cancelBackgroundRefresh()
+                .catch(reportTeardownFailure);
+            }
+            return;
+          }
           if (!result.scheduled && result.reason) {
             dispatchLifeOpsActivitySignalsStatus({
               status: "background_refresh_unavailable",
@@ -789,6 +831,15 @@ export function startLifeOpsActivitySignalCapture(
     window.removeEventListener("blur", handleBlur);
 
     const pending: Promise<unknown>[] = [];
+    if (mobileSignalsInFlight) {
+      // The in-flight startup run performs its own unmounted rollback
+      // (listener removal, stopMonitoring, background-refresh re-cancel)
+      // once each pending native call settles; owning it here is what keeps
+      // that rollback ahead of a successor's start.
+      // error-policy:J5 a startup rejection is observed by the launch call
+      // sites' `.catch(reportCaptureError)`; stop() needs only settlement.
+      pending.push(mobileSignalsInFlight.catch(() => {}));
+    }
     if (mobileSignalsHandle) {
       const handle = mobileSignalsHandle;
       mobileSignalsHandle = null;

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
@@ -7,9 +7,10 @@
  * resume.
  *
  * The renderer-service host starts this via `../register.ts`
- * (`registerRendererService`), scoped to main app windows only — never
- * popouts, detached shells, the phone companion, app windows, or the model
- * tester. The controller upholds three hard guarantees (#16504):
+ * (`registerRendererService`), passing its per-instance context through, scoped
+ * to main app windows only — never popouts, detached shells, the phone
+ * companion, app windows, or the model tester. The controller upholds four
+ * hard guarantees (#16504, #17110):
  *
  * - **Idempotent start.** One capture per renderer: a second start while one
  *   is active returns the active capture's stop function instead of installing
@@ -24,6 +25,27 @@
  *   prompts — requesting permission is the settings UI's job — and a denial
  *   is surfaced as a `permission_unavailable` status event, then re-checked on
  *   each app resume so a grant made in Settings activates without a restart.
+ * - **Commit-after-success teardown.** `stop()` is async-capable: it removes
+ *   the native listener, stops monitoring, cancels any scheduled background
+ *   refresh, and awaits all of it before resolving, so the renderer-service
+ *   registry can serialize a successor's start behind it (defect #2 of
+ *   #17110 — a stale generation's in-flight `stopMonitoring()` can no longer
+ *   land after the replacement's `startMonitoring()`). Symmetrically, native
+ *   monitoring only *commits* its listener handle once `startMonitoring()`
+ *   resolves `{ enabled: true }`; a rejection or `enabled: false` rolls the
+ *   listener back instead of wedging the retry guard forever. The optional
+ *   `context` (the registry's per-instance shell/signal) is accepted so this
+ *   module's `start()` matches the renderer-service contract, but `signal` is
+ *   deliberately not independently observed via an `abort` listener: the
+ *   registry always calls this returned `stop` as the instance's cleanup in
+ *   the same synchronous tick as aborting the signal, and a second listener
+ *   racing that call would see `mounted` already false and hand back an
+ *   already-resolved promise — silently orphaning the real, still in-flight
+ *   teardown and defeating the serialization this fix exists to provide.
+ *   `mounted` alone is the race-free source of truth every async
+ *   continuation re-checks after its await, so a late completion (a
+ *   resolved/rejected in-flight request, a delayed native event) discards
+ *   itself instead of publishing after stop.
  *
  * Canonical auth state gates runtime readiness: a signed-out renderer makes no
  * protected status requests, and the capture arms immediately when the app's
@@ -35,7 +57,10 @@
  * Capability-specific 503s use a bounded retry interval because the global
  * runtime status cannot prove that this optional plugin route is active.
  * Anything else is surfaced observably: a `capture_error` status event plus a
- * prefixed console.error.
+ * prefixed console.error — but only while still mounted; a failure that lands
+ * after stop is discarded rather than published. Teardown's own failures are
+ * the exception: they always report (J6), since they are this instance's own
+ * teardown, not a stale generation's late noise.
  */
 import { Capacitor } from "@capacitor/core";
 import {
@@ -216,10 +241,33 @@ function mapMobileSignal(
 // One capture per renderer window. The active stop function doubles as the
 // idempotency token: repeated starts hand back the same stop instead of
 // duplicating listeners/pollers, and stop releases it so re-init works.
-let activeCaptureStop: (() => void) | null = null;
+let activeCaptureStop: (() => void | Promise<void>) | null = null;
 
-export function startLifeOpsActivitySignalCapture(enabled = true): () => void {
-  if (!enabled || typeof window === "undefined") {
+/**
+ * Minimal shape of the renderer-service host context (`RendererServiceContext`
+ * from `@elizaos/ui/platform/renderer-services`) this module needs. Kept
+ * local instead of importing the full type so this headless capture chunk
+ * never pulls in the registry module at runtime — only structural typing.
+ */
+export interface LifeOpsActivitySignalCaptureContext {
+  signal?: AbortSignal;
+}
+
+export function startLifeOpsActivitySignalCapture(
+  enabled = true,
+  context?: LifeOpsActivitySignalCaptureContext,
+): () => void | Promise<void> {
+  // A signal that is already aborted at call time (an instance the registry
+  // stopped before its start settled — see `startInstance`'s own late-abort
+  // check) must never install listeners/pollers that would then need a
+  // second, redundant teardown. This one-time synchronous read is the safe
+  // way to consume the signal: unlike an `abort` event listener, it cannot
+  // race the registry's own paired abort()+cleanup() call (see `stop`).
+  if (
+    !enabled ||
+    typeof window === "undefined" ||
+    context?.signal?.aborted === true
+  ) {
     return () => {};
   }
   if (activeCaptureStop) {
@@ -272,7 +320,24 @@ export function startLifeOpsActivitySignalCapture(enabled = true): () => void {
     error.kind === "http" &&
     (error.status === 401 || error.status === 403);
 
+  // error-policy:J6 best-effort teardown — a failing disposer (native listener
+  // removal, stopMonitoring, background-refresh cancellation) must not block
+  // the rest of stop(), but unlike reportCaptureError this always reports:
+  // it is this instance's OWN teardown, not a stale generation's late noise,
+  // so it must stay observable even though `mounted` is already false by the
+  // time these calls settle (#17110).
+  const reportTeardownFailure = (error: unknown): void => {
+    dispatchLifeOpsActivitySignalsStatus({
+      status: "capture_error",
+      message: errorMessage(error),
+    });
+  };
+
   const reportCaptureError = (error: unknown): void => {
+    // A completion that lands after stop() belongs to a torn-down instance —
+    // discard it rather than mutate state or publish a status event nobody
+    // owns anymore (#17110 generation safety).
+    if (!mounted) return;
     if (isSessionUnavailableError(error)) {
       suspendForUnavailableSession();
       return;
@@ -505,6 +570,9 @@ export function startLifeOpsActivitySignalCapture(enabled = true): () => void {
       return;
     }
     const snapshot = await mobileSignals.getSnapshot();
+    // Discard a late resolution: a snapshot poll that outlives stop() must
+    // not publish a status event for an instance nobody owns anymore.
+    if (!mounted) return;
     if (snapshot.supported) {
       await sendSnapshotResult(snapshot);
     } else {
@@ -556,26 +624,45 @@ export function startLifeOpsActivitySignalCapture(enabled = true): () => void {
         },
       );
       if (!mounted) {
-        // Stopped while the listener registered: remove the late handle.
-        void handle.remove().catch(() => {
-          // error-policy:J6 best-effort removal of a just-created listener on
-          // a torn-down capture; nothing observes this handle anymore.
-        });
+        // Stopped while the listener registered: nothing was ever committed,
+        // so remove the late handle and leave the retry guard clear.
+        await handle.remove().catch(reportTeardownFailure);
         return;
       }
-      mobileSignalsHandle = handle;
 
-      const initial = await mobileSignals.startMonitoring({
-        emitInitial: true,
-      });
+      // Commit-after-success (#17110): the handle is NOT committed to
+      // `mobileSignalsHandle` yet — a rejecting or disabled startMonitoring
+      // below must not leave a committed handle behind, or every later retry
+      // (resume, permission grant) would wedge forever behind the guard at
+      // the top of this function.
+      let initial: Awaited<ReturnType<typeof mobileSignals.startMonitoring>>;
+      try {
+        initial = await mobileSignals.startMonitoring({ emitInitial: true });
+      } catch (error) {
+        await handle.remove().catch(reportTeardownFailure);
+        throw error;
+      }
+
       if (!mounted) {
-        // Stopped while monitoring engaged: stand the native monitor down.
+        // Stopped while monitoring engaged: stand the native monitor down
+        // and remove the never-committed listener.
         if (initial.enabled) {
-          void mobileSignals.stopMonitoring().catch(reportCaptureError);
+          await mobileSignals.stopMonitoring().catch(reportTeardownFailure);
         }
+        await handle.remove().catch(reportTeardownFailure);
         return;
       }
-      mobileSignalsStarted = initial.enabled;
+
+      if (!initial.enabled) {
+        // Monitoring never actually engaged: roll back instead of committing
+        // a handle for a monitor that isn't running.
+        await handle.remove().catch(reportTeardownFailure);
+        return;
+      }
+
+      // Commit only now that native monitoring is confirmed running.
+      mobileSignalsHandle = handle;
+      mobileSignalsStarted = true;
       await sendSnapshotResult(initial);
       await refreshMobileHealthSnapshot("start");
       if (!mounted) return;
@@ -677,8 +764,17 @@ export function startLifeOpsActivitySignalCapture(enabled = true): () => void {
     void emitDesktopSnapshot("poll");
   }, DESKTOP_POWER_POLL_MS);
 
-  const stop = (): void => {
-    if (!mounted) return;
+  // Full teardown ownership (#17110): every synchronous release below (event
+  // listeners, intervals) happens before any await, so a caller that invokes
+  // `stop()` without awaiting it still observes those side effects
+  // immediately. The native calls below are also *initiated* synchronously
+  // (their in-flight promises are only collected, not chained behind each
+  // other), but the returned promise resolves only once every one of them has
+  // settled — the renderer-service registry awaits this before starting a
+  // successor, so a stale generation's in-flight `stopMonitoring()` can never
+  // land after (and disable) the replacement's `startMonitoring()`.
+  const stop = (): Promise<void> => {
+    if (!mounted) return Promise.resolve();
     mounted = false;
     if (activeCaptureStop === stop) {
       activeCaptureStop = null;
@@ -691,16 +787,21 @@ export function startLifeOpsActivitySignalCapture(enabled = true): () => void {
     document.removeEventListener(APP_PAUSE_EVENT, handlePause);
     window.removeEventListener("focus", handleFocus);
     window.removeEventListener("blur", handleBlur);
+
+    const pending: Promise<unknown>[] = [];
     if (mobileSignalsHandle) {
-      void mobileSignalsHandle.remove().catch(() => {
-        // error-policy:J6 best-effort native listener removal on teardown; the
-        // capture is already stopped and nothing consumes the handle.
-      });
+      const handle = mobileSignalsHandle;
       mobileSignalsHandle = null;
+      pending.push(handle.remove().catch(reportTeardownFailure));
     }
-    if (mobileSignalsStarted) {
-      void mobileSignals?.stopMonitoring().catch(reportCaptureError);
+    if (mobileSignalsStarted && mobileSignals) {
       mobileSignalsStarted = false;
+      pending.push(mobileSignals.stopMonitoring().catch(reportTeardownFailure));
+      if (typeof mobileSignals.cancelBackgroundRefresh === "function") {
+        pending.push(
+          mobileSignals.cancelBackgroundRefresh().catch(reportTeardownFailure),
+        );
+      }
     }
     if (mobileHealthPoller !== null) {
       window.clearInterval(mobileHealthPoller);
@@ -708,6 +809,8 @@ export function startLifeOpsActivitySignalCapture(enabled = true): () => void {
     }
     window.clearInterval(pageHeartbeat);
     window.clearInterval(desktopPoller);
+
+    return Promise.all(pending).then(() => undefined);
   };
 
   activeCaptureStop = stop;

--- a/plugins/plugin-personal-assistant/src/register.test.ts
+++ b/plugins/plugin-personal-assistant/src/register.test.ts
@@ -25,6 +25,31 @@ const h = vi.hoisted(() => ({
   subscribeAuthStatus: vi.fn(() => () => undefined),
   isElectrobunRuntime: vi.fn(() => false),
   loadDesktopWorkspaceSnapshot: vi.fn(async () => ({ supported: false })),
+  capacitorGetPlatform: vi.fn(() => "web"),
+  capacitorIsNative: vi.fn(() => false),
+  mobile: {
+    checkPermissions: vi.fn(async () => ({ status: "granted" })),
+    addListener: vi.fn(
+      async (_event: string, _cb: (signal: unknown) => void) => ({
+        remove: vi.fn(async () => {}),
+      }),
+    ),
+    startMonitoring: vi.fn(async () => ({
+      enabled: true,
+      supported: true,
+      platform: "ios",
+      snapshot: null,
+      healthSnapshot: null,
+    })),
+    stopMonitoring: vi.fn(async () => ({ stopped: true })),
+    getSnapshot: vi.fn(async () => ({
+      supported: false,
+      snapshot: null,
+      healthSnapshot: null,
+    })),
+    scheduleBackgroundRefresh: vi.fn(async () => ({ scheduled: false })),
+    cancelBackgroundRefresh: vi.fn(async () => ({ cancelled: true })),
+  },
 }));
 
 // The four @elizaos/ui subpath specifiers (/api, /bridge, /browser, /events)
@@ -90,23 +115,48 @@ vi.mock("@elizaos/ui/browser", () => ({
 
 vi.mock("@capacitor/core", () => ({
   Capacitor: {
-    getPlatform: vi.fn(() => "web"),
-    isNativePlatform: vi.fn(() => false),
+    getPlatform: h.capacitorGetPlatform,
+    isNativePlatform: h.capacitorIsNative,
   },
 }));
 
-// Web-platform run: the capture never touches MobileSignals, but the module
-// must still resolve without the Capacitor plugin registry.
-vi.mock("@elizaos/capacitor-mobile-signals", () => ({ MobileSignals: {} }));
+// Web-platform tests never touch MobileSignals beyond this stub; the
+// inter-instance and abort-propagation tests below switch the platform to
+// native and drive `h.mobile` directly.
+vi.mock("@elizaos/capacitor-mobile-signals", () => ({
+  MobileSignals: h.mobile,
+}));
+
+// Spy on (never replace) the real capture entry point so one test can assert
+// on the arguments register.ts's own `start` callback passes it, without
+// losing real behavior for every other test in this file.
+vi.mock("./lifeops/activity-signals-capture.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("./lifeops/activity-signals-capture.js")
+    >();
+  return {
+    ...actual,
+    startLifeOpsActivitySignalCapture: vi.fn(
+      actual.startLifeOpsActivitySignalCapture,
+    ),
+  };
+});
 
 import {
   getRendererServiceStates,
+  registerRendererService,
   settleRendererServices,
   startRendererServiceHost,
 } from "@elizaos/ui/platform/renderer-services";
-import { isLifeOpsActivitySignalCaptureActive } from "./lifeops/activity-signals-capture.js";
+import {
+  isLifeOpsActivitySignalCaptureActive,
+  startLifeOpsActivitySignalCapture,
+} from "./lifeops/activity-signals-capture.js";
 // Side-effect import under test: registers the renderer service definition.
 import "./register.js";
+
+const spiedStartCapture = vi.mocked(startLifeOpsActivitySignalCapture);
 
 const SERVICE_ID = "personal-assistant.lifeops-activity-signals";
 
@@ -127,6 +177,28 @@ describe("personal-assistant renderer registration entry", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     h.getStatus.mockResolvedValue({ state: "running" });
+    h.capacitorGetPlatform.mockReturnValue("web");
+    h.capacitorIsNative.mockReturnValue(false);
+    h.mobile.checkPermissions.mockResolvedValue({ status: "granted" });
+    h.mobile.addListener.mockImplementation(
+      async (_event: string, _cb: (signal: unknown) => void) => ({
+        remove: vi.fn(async () => {}),
+      }),
+    );
+    h.mobile.startMonitoring.mockResolvedValue({
+      enabled: true,
+      supported: true,
+      platform: "ios",
+      snapshot: null,
+      healthSnapshot: null,
+    });
+    h.mobile.getSnapshot.mockResolvedValue({
+      supported: false,
+      snapshot: null,
+      healthSnapshot: null,
+    });
+    h.mobile.scheduleBackgroundRefresh.mockResolvedValue({ scheduled: false });
+    h.mobile.cancelBackgroundRefresh.mockResolvedValue({ cancelled: true });
   });
 
   afterEach(async () => {
@@ -205,5 +277,110 @@ describe("personal-assistant renderer registration entry", () => {
     window.dispatchEvent(new Event("pagehide"));
     expect(isLifeOpsActivitySignalCaptureActive()).toBe(false);
     host = undefined;
+  });
+
+  it("serializes host replacement so a slow old-generation stopMonitoring cannot land after the new generation's startMonitoring (#17110)", async () => {
+    h.capacitorIsNative.mockReturnValue(true);
+    h.capacitorGetPlatform.mockReturnValue("ios");
+
+    host = startRendererServiceHost({ shell: "main" });
+    await settleRendererServices();
+    for (let i = 0; i < 8; i += 1) {
+      await settle();
+    }
+    expect(h.mobile.startMonitoring).toHaveBeenCalledTimes(1);
+
+    let releaseStopMonitoring: (() => void) | undefined;
+    h.mobile.stopMonitoring.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseStopMonitoring = () => resolve({ stopped: true });
+        }),
+    );
+
+    // Host replacement (shell HMR / repeated boot) while the old
+    // generation's native stopMonitoring call is still in flight.
+    host = startRendererServiceHost({ shell: "main" });
+
+    // Give the replacement generation ample opportunity to race ahead if it
+    // is not actually serialized behind the old generation's teardown.
+    for (let i = 0; i < 12; i += 1) {
+      await settle();
+    }
+    // The replacement is serialized behind the old generation's still-
+    // pending stop — its own startMonitoring must not have run yet.
+    expect(h.mobile.startMonitoring).toHaveBeenCalledTimes(1);
+
+    releaseStopMonitoring?.();
+    await settleRendererServices();
+    for (let i = 0; i < 8; i += 1) {
+      await settle();
+    }
+
+    expect(h.mobile.startMonitoring).toHaveBeenCalledTimes(2);
+    expect(isLifeOpsActivitySignalCaptureActive()).toBe(true);
+  });
+
+  it("awaits the real capture's async cleanup before a re-registered instance starts (HMR) (#17110)", async () => {
+    h.capacitorIsNative.mockReturnValue(true);
+    h.capacitorGetPlatform.mockReturnValue("ios");
+
+    host = startRendererServiceHost({ shell: "main" });
+    await settleRendererServices();
+    for (let i = 0; i < 8; i += 1) {
+      await settle();
+    }
+    expect(h.mobile.startMonitoring).toHaveBeenCalledTimes(1);
+
+    let releaseStopMonitoring: (() => void) | undefined;
+    h.mobile.stopMonitoring.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseStopMonitoring = () => resolve({ stopped: true });
+        }),
+    );
+
+    // Simulate dev HMR re-evaluating register.ts: the same id re-registers
+    // with the same start wiring while the old instance's native
+    // stopMonitoring call is still in flight.
+    registerRendererService({
+      id: SERVICE_ID,
+      shells: ["main"],
+      start: (context) => startLifeOpsActivitySignalCapture(true, context),
+    });
+
+    for (let i = 0; i < 12; i += 1) {
+      await settle();
+    }
+    // The re-registered instance is serialized behind the old instance's
+    // still-pending native stopMonitoring call.
+    expect(h.mobile.startMonitoring).toHaveBeenCalledTimes(1);
+
+    releaseStopMonitoring?.();
+    await settleRendererServices();
+    for (let i = 0; i < 8; i += 1) {
+      await settle();
+    }
+    expect(h.mobile.startMonitoring).toHaveBeenCalledTimes(2);
+  });
+
+  it("register.ts threads the host's per-instance context (shell + abort signal) into the capture's start()", async () => {
+    // Drives register.ts's REAL `start` wiring (only the capture entry point
+    // is spied, not replaced), proving the registration entry itself passes
+    // the context through rather than dropping it (#17110).
+    host = startRendererServiceHost({ shell: "main" });
+    await settleRendererServices();
+
+    expect(spiedStartCapture).toHaveBeenCalledTimes(1);
+    const [enabledArg, contextArg] = spiedStartCapture.mock.calls[0] ?? [];
+    expect(enabledArg).toBe(true);
+    expect(contextArg?.shell).toBe("main");
+    expect(contextArg?.signal).toBeInstanceOf(AbortSignal);
+    expect(contextArg?.signal?.aborted).toBe(false);
+
+    host.dispose();
+    host = undefined;
+    await settle();
+    expect(contextArg?.signal?.aborted).toBe(true);
   });
 });

--- a/plugins/plugin-personal-assistant/src/register.test.ts
+++ b/plugins/plugin-personal-assistant/src/register.test.ts
@@ -185,6 +185,12 @@ describe("personal-assistant renderer registration entry", () => {
         remove: vi.fn(async () => {}),
       }),
     );
+    // vi.clearAllMocks() clears calls but not implementations, so a test
+    // that pauses a native call must not leak its unreleased promise into
+    // the next test.
+    h.mobile.stopMonitoring.mockImplementation(async () => ({
+      stopped: true,
+    }));
     h.mobile.startMonitoring.mockResolvedValue({
       enabled: true,
       supported: true,
@@ -362,6 +368,53 @@ describe("personal-assistant renderer registration entry", () => {
       await settle();
     }
     expect(h.mobile.startMonitoring).toHaveBeenCalledTimes(2);
+  });
+
+  it("serializes host replacement behind an in-flight native startup's rollback (#17110)", async () => {
+    h.capacitorIsNative.mockReturnValue(true);
+    h.capacitorGetPlatform.mockReturnValue("ios");
+
+    let releaseStartMonitoring: ((value: unknown) => void) | undefined;
+    h.mobile.startMonitoring.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseStartMonitoring = resolve;
+        }),
+    );
+
+    host = startRendererServiceHost({ shell: "main" });
+    await settleRendererServices();
+    for (let i = 0; i < 8; i += 1) {
+      await settle();
+    }
+    expect(h.mobile.startMonitoring).toHaveBeenCalledTimes(1);
+
+    // Replace the host while the predecessor's startMonitoring is still in
+    // flight — nothing is committed yet, so a stop() that only awaits
+    // committed resources would resolve immediately and let the successor's
+    // monitor race the predecessor's late rollback.
+    host = startRendererServiceHost({ shell: "main" });
+    for (let i = 0; i < 12; i += 1) {
+      await settle();
+    }
+    expect(h.mobile.startMonitoring).toHaveBeenCalledTimes(1);
+
+    releaseStartMonitoring?.({
+      enabled: true,
+      supported: true,
+      platform: "ios",
+      snapshot: null,
+      healthSnapshot: null,
+    });
+    await settleRendererServices();
+    for (let i = 0; i < 12; i += 1) {
+      await settle();
+    }
+    // Predecessor rollback (stopMonitoring) completed, then — and only
+    // then — the successor engaged its own monitor.
+    expect(h.mobile.stopMonitoring).toHaveBeenCalled();
+    expect(h.mobile.startMonitoring).toHaveBeenCalledTimes(2);
+    expect(isLifeOpsActivitySignalCaptureActive()).toBe(true);
   });
 
   it("register.ts threads the host's per-instance context (shell + abort signal) into the capture's start()", async () => {

--- a/plugins/plugin-personal-assistant/src/register.ts
+++ b/plugins/plugin-personal-assistant/src/register.ts
@@ -6,8 +6,12 @@
  * activity-signal capture as a lifecycle-scoped renderer service: the host
  * starts it only in main app windows (never popouts, detached shells, the
  * phone companion, app windows, or the model tester), retains the returned
- * stop function, and invokes it on page teardown, host replacement, and HMR
- * re-registration (#16504).
+ * (now async-capable) stop, and invokes it on page teardown, host
+ * replacement, and HMR re-registration (#16504). The host's per-instance
+ * context (shell/abort signal) is passed straight through so the capture
+ * matches the renderer-service `start` contract and the registry can
+ * serialize a successor's start behind this instance's async cleanup
+ * (#17110).
  */
 import { registerRendererService } from "@elizaos/ui/platform/renderer-services";
 import { startLifeOpsActivitySignalCapture } from "./lifeops/activity-signals-capture.js";
@@ -15,5 +19,5 @@ import { startLifeOpsActivitySignalCapture } from "./lifeops/activity-signals-ca
 registerRendererService({
   id: "personal-assistant.lifeops-activity-signals",
   shells: ["main"],
-  start: () => startLifeOpsActivitySignalCapture(),
+  start: (context) => startLifeOpsActivitySignalCapture(true, context),
 });


### PR DESCRIPTION
# Relates to

Closes #17110

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop` — branch is 0 behind).
- [x] `bun install` and `bun run verify` were run after sync; verify exits 0 (details in Testing).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5` (orchestration, design, final review, verification), `anthropic/claude-sonnet-5` (implementation subagent)
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop\n\n- [x] Rebased onto origin/develop@131a765c3cfac15495f76eaa5f9b3c3b0e80ae63; zero conflicts and zero commits behind.\n- [x] Post-rebase verification at exact head 178565175e5981e6eab4e7c6a0da8858035f579b: 73 focused lifecycle tests passed across UI and personal-assistant; Biome checked all 6 changed files; git diff --check passed.\n\n# Risks

Medium-low. This changes lifecycle timing in every renderer window: renderer-service cleanup may now be asynchronous, replacement starts are serialized behind predecessor teardown, and a persisted `pagehide` now suspends services (with `pageshow` restart) instead of leaving them running into bfcache. The registry never deadlocks on a failed teardown (rejections report via `reportError` and still unblock the successor), the web-only path (no native platform) is unchanged, and the entry points remain synchronous, so boot order is unaffected. Blast radius is bounded to `registerRendererService`/`startRendererServiceHost` consumers — currently one production service (LifeOps activity capture) plus the app-shell host install.

# Background

## What does this PR do?

Fixes the five teardown defects #17110 enumerates in the renderer-service registry and the LifeOps native activity capture:

1. **Async cleanup contract** — `RendererServiceCleanup` may now return a `Promise<void>`; `runCleanup` awaits it and reports (never swallows) rejections via the host's `reportError`.
2. **Serialized replacement** — per-id pending-teardown tracking (`HostState.pendingCleanup`) plus a host-generation disposal promise gate every successor `start`, so HMR re-registration and host replacement can no longer let a stale generation's in-flight native `stopMonitoring()` land after the replacement's `startMonitoring()`.
3. **Commit-after-success** — the capture commits its native listener handle only after `startMonitoring()` resolves `{ enabled: true }`; rejection or `enabled: false` rolls the listener back so resume/permission-grant retries are never wedged behind a stale handle.
4. **bfcache suspend/resume** — a persisted `pagehide` synchronously initiates suspension of every instance's owned native resources; a persisted `pageshow` restarts eligible services through the same serialized queue (a restart racing a still-pending suspension waits for it). A real `pagehide` still fully disposes the host.
5. **Abort/teardown ownership** — `register.ts` threads the host's per-instance context (shell + `AbortSignal`) into the capture; the capture's `stop()` is async-capable and owns full teardown (listener removal, `stopMonitoring()`, `cancelBackgroundRefresh()`), awaited before resolving, with teardown failures kept observable while post-stop in-flight completions are discarded instead of published.

One deliberate design note for reviewers: the capture consumes the host's `AbortSignal` via a one-time synchronous `aborted` check at start rather than an `abort` event listener. The registry always pairs `abort()` with the `cleanup()` call in the same synchronous tick, so an event listener calling `stop()` would win that race, hand the registry an already-resolved promise, and silently orphan the real in-flight teardown — defeating the serialization this fix exists to provide. This is documented in the module header.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue). The only public-surface changes are additive widenings: `RendererServiceCleanup` return type, `RendererServiceHostHandle.dispose` return type, and an optional `context` parameter on `startLifeOpsActivitySignalCapture`.

# Documentation changes needed?

No project-documentation change is needed; the lifecycle contract is documented in the affected module headers, which this PR updates in place.

# Testing

## Where should a reviewer start?

`packages/ui/src/platform/renderer-services.ts` (serialization + bfcache), then `plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts` (commit-after-success + teardown ownership), then the inter-instance race tests in `plugins/plugin-personal-assistant/src/register.test.ts`, which drive the REAL registry and REAL capture together with only the native Capacitor boundary faked.

## Detailed testing steps

1. `cd packages/ui && bunx vitest run src/platform/renderer-services.test.ts` → 22/22 pass.
2. `cd plugins/plugin-personal-assistant && bunx vitest run src/lifeops/activity-signals-capture.test.ts src/register.test.ts src/register.loader-contract.test.ts src/lifeops/activity-signals-capture.client-extension.test.ts` → 49/49 pass.
3. `cd packages/app && bunx vitest run src/renderer-shell-scope.test.ts src/plugin-registrations.test.ts src/main.web-entrypoint.test.ts src/main.android-entrypoint.test.ts src/main.ios-full-bun-entrypoint.test.ts src/main.ios-interactive-entrypoint.test.ts` → 16/16 pass.
4. `bun run --cwd packages/ui typecheck`, `bun run --cwd packages/app typecheck`, `bun run --cwd plugins/plugin-personal-assistant typecheck` → all clean.
5. `bunx biome check` on the six changed files → clean, no fixes.
6. `bun run verify` at root → exit 0 (7,906 test files scanned; 0 focused, 0 orphaned skips).

**Review follow-up (head 8047d9e7a)** — a review finding on the first head identified a self-await deadlock: an instance stopped while awaiting the prior host generation's disposal parked its own `settled` promise as the id's pending teardown, then awaited itself once disposal resolved, wedging the id permanently. Fixed by checking supersession before consulting the pending-teardown map; reproduced red-control first (successor `start` never fired), 23/23 after the fix.

**Review follow-up 2 (head 7f01dbd97)** — the second review identified two further lifecycle races, both confirmed and repaired: (1) a stop landing while `addListener()`/`startMonitoring()` was still pending saw no committed resources and resolved immediately, so the predecessor's late unmounted-rollback `stopMonitoring()` could disable the successor's monitor — the whole native startup run is now tracked as an in-flight promise that `stop()` awaits; (2) a `scheduleBackgroundRefresh()` resolving `{ scheduled: true }` after stop's `cancelBackgroundRefresh()` left an orphaned background job — the run now re-checks `mounted` after scheduling resolves and cancels again before cleanup resolves. Three new red-control tests (two capture, one real-registry host-replacement race pausing `startMonitoring`) all failed pre-fix; 52/52 plugin, 23/23 registry after.

**Red-control evidence** — the original 13 new tests were written first and verified to FAIL against the unfixed code, so each passes only because of this fix:

- `renderer-services.test.ts` (6): persisted-pagehide suspension → `expected "vi.fn()" to be called 1 times, but got 0`; rejecting-cleanup reporting → unhandled rejection, `reportError` never called; both serialization tests → successor `start` fired immediately instead of waiting; late-cleanup generation safety and pageshow-queue tests likewise red.
- `activity-signals-capture.test.ts` (4): rollback tests → `remove` called 0 times instead of 1; background-refresh cancellation → `cancelBackgroundRefresh` never called; late-failure-after-stop → `capture_error` was published when it should have been discarded.
- `register.test.ts` (3): host-replacement and HMR races → `startMonitoring` called 2 times instead of 1 (old generation's native stop not awaited); context threading → `enabledArg` was `undefined` (old `register.ts` dropped the context entirely).

# Evidence Gate

<!-- evidence-head:178565175e5981e6eab4e7c6a0da8858035f579b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - pure `.ts` lifecycle/teardown change with no rendered visual surface; no `.tsx`/`.css`/`.svg` touched, pixels are identical.
<!-- evidence-row:after-screenshots -->
- [x] N/A - pure `.ts` lifecycle/teardown change with no rendered visual surface; no `.tsx`/`.css`/`.svg` touched, pixels are identical.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the affected paths (HMR re-registration, host replacement, bfcache freeze, native teardown ordering) have no user-visible flow to record; they are proven by the deterministic adversarial suites in Testing.
<!-- evidence-row:backend-logs -->
- [x] N/A - the change is renderer-window client lifecycle only; no backend code path is involved.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no request/response or rendered state change exists to trace; the full vitest transcripts driving the real registry + real capture are the executable equivalent (Testing, steps 1–3).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic vitest transcripts for all three focused suites — the domain artifact for a lifecycle/teardown change — are pasted inline below; `bun run verify` exits 0 on the same head.

<details><summary>vitest transcripts @ 7f01dbd97 — packages/ui 23/23, plugin-personal-assistant 52/52, packages/app 16/16</summary>

```text
=== packages/ui: renderer-services.test.ts ===

 RUN  v4.1.5 /Users/symbiex/dev/shaw/.claude/worktrees/fix-17110-renderer-teardown/packages/ui

(node:63664) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)

 Test Files  1 passed (1)
      Tests  23 passed (23)
   Start at  09:03:49
   Duration  476ms (transform 58ms, setup 29ms, import 54ms, tests 6ms, environment 331ms)

=== plugin-personal-assistant: capture + register suites ===

 RUN  v4.1.5 /Users/symbiex/dev/shaw/.claude/worktrees/fix-17110-renderer-teardown

(node:63722) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
(node:63783) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
(node:63784) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
(node:63785) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)

 Test Files  4 passed (4)
      Tests  52 passed (52)
   Start at  09:03:50
   Duration  5.26s (transform 2.59s, setup 132ms, import 122ms, tests 3.98s, environment 765ms)

=== packages/app: entrypoint + shell-scope suites ===

 RUN  v4.1.5 /Users/symbiex/dev/shaw/.claude/worktrees/fix-17110-renderer-teardown/packages/app

(node:63788) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
(node:63789) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
(node:63790) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
(node:63791) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
(node:63804) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
(node:63843) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)

 Test Files  6 passed (6)
      Tests  16 passed (16)
   Start at  09:03:55
   Duration  5.49s (transform 5.99s, setup 116ms, import 104ms, tests 9.15s, environment 1.27s)
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - renderer-window client lifecycle change with no backend path and no network/request state change; the deterministic suites in Testing exercise the real registry and capture end to end.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI change (no `.tsx`/`.css`/`.svg` in the diff); behavior is timing/ordering of service teardown, invisible to pixels.

## Audio / voice walkthrough

N/A - no voice/audio path involved.

## Known gaps / failures

- Real-device native evidence (one monitor, one background job across an app kill/resume on physical iOS) is not included: this environment has no iOS device/simulator build available. The inter-instance native ordering, rollback, and cancellation guarantees are instead proven by integration tests that drive the real renderer-service registry and the real capture controller together, faking only the `@elizaos/capacitor-mobile-signals` native boundary (the package's established harness convention).
- The worktree's local `bun` 1.4.0 regenerated `bun.lock` to lockfileVersion 2, which the pinned Turbo cannot parse; the lockfile was restored to the committed version (the repo pins Bun 1.3.14) before running `bun run verify`. No lockfile change is part of this PR.



