### PR TITLE
fix(app): reject invalid capture-script --duration overrides

### DIFF
--- a/packages/app/scripts/capture-android-emu.mjs
+++ b/packages/app/scripts/capture-android-emu.mjs
@@ -22,6 +22,7 @@ import {
   logFor,
   mirrorToRecordings,
   parseFlags,
+  resolveCaptureDurationSeconds,
   skip,
 } from "./lib/capture-output.mjs";
 
@@ -183,7 +184,7 @@ async function main() {
     slug: flags.slug,
     platform: PLATFORM,
   });
-  const durationSec = Number(flags.duration ?? 6);
+  const durationSec = resolveCaptureDurationSeconds(flags);
 
   const pngPath = evidencePath(base, "png");
   if (captureScreenshot(adb, serial, pngPath)) {

--- a/packages/app/scripts/capture-ios-sim.mjs
+++ b/packages/app/scripts/capture-ios-sim.mjs
@@ -19,6 +19,7 @@ import {
   logFor,
   mirrorToRecordings,
   parseFlags,
+  resolveCaptureDurationSeconds,
   skip,
 } from "./lib/capture-output.mjs";
 import { analyzeScreenshot } from "./lib/visual-qa.mjs";
@@ -99,7 +100,7 @@ async function main() {
     slug: flags.slug,
     platform: PLATFORM,
   });
-  const durationSec = Number(flags.duration ?? 6);
+  const durationSec = resolveCaptureDurationSeconds(flags);
 
   const pngPath = evidencePath(base, "png");
   simctl(["io", udid, "screenshot", "--type=png", pngPath]);

--- a/packages/app/scripts/capture-linux-desktop.mjs
+++ b/packages/app/scripts/capture-linux-desktop.mjs
@@ -18,6 +18,7 @@ import {
   logFor,
   mirrorToRecordings,
   parseFlags,
+  resolveCaptureDurationSeconds,
   skip,
 } from "./lib/capture-output.mjs";
 import { resolveRequiredFfmpeg } from "./lib/ffmpeg.mjs";
@@ -101,7 +102,7 @@ async function main() {
     slug: flags.slug,
     platform: PLATFORM,
   });
-  const durationSec = Number(flags.duration ?? 6);
+  const durationSec = resolveCaptureDurationSeconds(flags);
   const size = screenSize(display);
   log(`capturing X11 desktop ${display} @ ${size}`);
 

--- a/packages/app/scripts/capture-macos-desktop.mjs
+++ b/packages/app/scripts/capture-macos-desktop.mjs
@@ -11,6 +11,7 @@ import {
   logFor,
   mirrorToRecordings,
   parseFlags,
+  resolveCaptureDurationSeconds,
   skip,
 } from "./lib/capture-output.mjs";
 import { resolveRequiredFfmpeg } from "./lib/ffmpeg.mjs";
@@ -72,7 +73,7 @@ async function main() {
     slug: flags.slug,
     platform: PLATFORM,
   });
-  const durationSec = Number(flags.duration ?? 6);
+  const durationSec = resolveCaptureDurationSeconds(flags);
 
   const pngPath = evidencePath(base, "png");
   if (captureScreenshot(pngPath)) {

--- a/packages/app/scripts/capture-windows-desktop.mjs
+++ b/packages/app/scripts/capture-windows-desktop.mjs
@@ -18,6 +18,7 @@ import {
   logFor,
   mirrorToRecordings,
   parseFlags,
+  resolveCaptureDurationSeconds,
   skip,
 } from "./lib/capture-output.mjs";
 import { resolveRequiredFfmpeg } from "./lib/ffmpeg.mjs";
@@ -74,7 +75,7 @@ async function main() {
     slug: flags.slug,
     platform: PLATFORM,
   });
-  const durationSec = Number(flags.duration ?? 6);
+  const durationSec = resolveCaptureDurationSeconds(flags);
   log("capturing windows desktop via gdigrab");
 
   const pngPath = evidencePath(base, "png");

--- a/packages/app/scripts/lib/capture-output.mjs
+++ b/packages/app/scripts/lib/capture-output.mjs
@@ -2,9 +2,10 @@
 //
 // One place owns: resolving the repo root, choosing the generated capture
 // output directory, the `<issue#>-<slug>-<platform>.<ext>` naming convention,
-// CLI flag parsing, the skip-with-reason exit, and a best-effort backend-log
-// pull. The iOS and Android capture helpers both build on this so the path math
-// and conventions live here, not duplicated per platform.
+// CLI flag parsing, fail-closed `--duration` resolution, the skip-with-reason
+// exit, and a best-effort backend-log pull. The iOS and Android capture helpers
+// both build on this so the path math and conventions live here, not
+// duplicated per platform.
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -113,6 +114,55 @@ export function parseFlags(argv = process.argv.slice(2)) {
     }
   }
   return flags;
+}
+
+/** Default recording length (seconds) when `--duration` is omitted. */
+export const DEFAULT_CAPTURE_DURATION_SECONDS = 6;
+
+/**
+ * Largest whole-second duration whose millisecond delay stays inside Node's
+ * signed 32-bit timer range (`setTimeout` / `delay(ms)` clamp above 2^31-1).
+ */
+export const MAX_CAPTURE_DURATION_SECONDS = Math.floor(2_147_483_647 / 1000);
+
+/**
+ * Resolve capture `--duration` from parsed flags. Unset keeps the documented
+ * default; an explicit value must be a complete positive integer whose
+ * millisecond form still fits a Node timer. Rejects bare `--duration` (boolean
+ * true), fractions, partial numbers, zero, negatives, and overflows so device
+ * / ffmpeg work never starts with NaN or a silent wrong length.
+ *
+ * @param {Record<string, unknown>} flags output of {@link parseFlags}
+ * @returns {number} recording length in whole seconds
+ */
+export function resolveCaptureDurationSeconds(flags = {}) {
+  const raw = flags?.duration;
+  if (raw === undefined || raw === null) {
+    return DEFAULT_CAPTURE_DURATION_SECONDS;
+  }
+  // parseFlags sets true for a bare `--duration` with no value.
+  if (raw === true) {
+    throw new Error(
+      `--duration requires an integer from 1 to ${MAX_CAPTURE_DURATION_SECONDS}`,
+    );
+  }
+  const value = String(raw);
+  if (!/^[1-9]\d*$/.test(value)) {
+    throw new Error(
+      `--duration must be an integer from 1 to ${MAX_CAPTURE_DURATION_SECONDS} (received ${JSON.stringify(value)})`,
+    );
+  }
+  const parsed = Number(value);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < 1 ||
+    parsed > MAX_CAPTURE_DURATION_SECONDS
+  ) {
+    throw new Error(
+      `--duration must be an integer from 1 to ${MAX_CAPTURE_DURATION_SECONDS} (received ${JSON.stringify(value)})`,
+    );
+  }
+  return parsed;
 }
 
 function timestamp() {

--- a/packages/app/scripts/lib/capture-output.test.mjs
+++ b/packages/app/scripts/lib/capture-output.test.mjs
@@ -9,9 +9,83 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, describe, expect, it } from "vitest";
-import { resolveRequireEvidence } from "./capture-output.mjs";
+import {
+  DEFAULT_CAPTURE_DURATION_SECONDS,
+  MAX_CAPTURE_DURATION_SECONDS,
+  parseFlags,
+  resolveCaptureDurationSeconds,
+  resolveRequireEvidence,
+} from "./capture-output.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
+
+describe("resolveCaptureDurationSeconds (#18622)", () => {
+  it("defaults to 6 seconds when --duration is omitted", () => {
+    expect(resolveCaptureDurationSeconds({})).toBe(
+      DEFAULT_CAPTURE_DURATION_SECONDS,
+    );
+    expect(resolveCaptureDurationSeconds(parseFlags([]))).toBe(
+      DEFAULT_CAPTURE_DURATION_SECONDS,
+    );
+    expect(DEFAULT_CAPTURE_DURATION_SECONDS).toBe(6);
+  });
+
+  it("accepts complete positive integers in the safe timer range", () => {
+    expect(resolveCaptureDurationSeconds({ duration: "1" })).toBe(1);
+    expect(resolveCaptureDurationSeconds({ duration: "6" })).toBe(6);
+    expect(resolveCaptureDurationSeconds({ duration: "180" })).toBe(180);
+    expect(
+      resolveCaptureDurationSeconds({
+        duration: String(MAX_CAPTURE_DURATION_SECONDS),
+      }),
+    ).toBe(MAX_CAPTURE_DURATION_SECONDS);
+    expect(
+      resolveCaptureDurationSeconds(parseFlags(["--duration", "30"])),
+    ).toBe(30);
+  });
+
+  it("rejects bare --duration (boolean true from parseFlags)", () => {
+    expect(() =>
+      resolveCaptureDurationSeconds(parseFlags(["--duration"])),
+    ).toThrow(/--duration requires an integer/);
+    expect(() => resolveCaptureDurationSeconds({ duration: true })).toThrow(
+      /--duration requires an integer/,
+    );
+  });
+
+  it("rejects zero, negative, fractional, partial, and non-numeric values", () => {
+    for (const bad of [
+      "0",
+      "-1",
+      "-3",
+      "1.5",
+      "6junk",
+      "junk",
+      "NaN",
+      "Infinity",
+      "",
+      " 6",
+      "6 ",
+      "+6",
+      "0x10",
+      "1e2",
+    ]) {
+      expect(() => resolveCaptureDurationSeconds({ duration: bad })).toThrow(
+        /--duration must be an integer/,
+      );
+    }
+  });
+
+  it("rejects values that would overflow a Node millisecond timer", () => {
+    const over = String(MAX_CAPTURE_DURATION_SECONDS + 1);
+    expect(() => resolveCaptureDurationSeconds({ duration: over })).toThrow(
+      /--duration must be an integer/,
+    );
+    expect(MAX_CAPTURE_DURATION_SECONDS * 1000).toBeLessThanOrEqual(
+      2_147_483_647,
+    );
+  });
+});
 
 describe("resolveRequireEvidence (#13624)", () => {
   it("defaults to false for a local ad-hoc run (no flag, no env, no CI)", () => {


### PR DESCRIPTION
# Relates to

Fixes #18622

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xAI/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build (unattended worker)`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** Fail-closed validation of `--duration` at the shared capture helper only.
Unset duration still defaults to 6 seconds. Explicit invalid values that previously
became `NaN`, `1` (bare flag), or silent clamps now throw before device/ffmpeg work.
Intentional behavior change for mistyped CLI only.

# Background

## What does this PR do?

Platform capture scripts resolved recording length with `Number(flags.duration ?? 6)`,
which accepts `0`, negatives, fractions, partial numbers (`6junk`), and treats a bare
`--duration` as boolean `true` → `Number(true) === 1`.

This PR adds `resolveCaptureDurationSeconds` in `packages/app/scripts/lib/capture-output.mjs`
and wires it into:

- `capture-android-emu.mjs`
- `capture-ios-sim.mjs`
- `capture-macos-desktop.mjs`
- `capture-windows-desktop.mjs`
- `capture-linux-desktop.mjs`

Unset keeps default `6`. Explicit values must be complete positive integers whose
millisecond form fits Node's max timer (`MAX_CAPTURE_DURATION_SECONDS`).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation. Error messages
name `--duration`; defaults are unchanged.

# Testing

## Where should a reviewer start?

1. `packages/app/scripts/lib/capture-output.mjs` — `resolveCaptureDurationSeconds`
2. `packages/app/scripts/lib/capture-output.test.mjs` — accept/reject matrix
3. The five `capture-*.mjs` call sites

## Detailed testing steps

```bash
bun test packages/app/scripts/lib/capture-output.test.mjs
```

Direct probe:

```bash
node --input-type=module -e '
import { parseFlags, resolveCaptureDurationSeconds } from "./packages/app/scripts/lib/capture-output.mjs";
console.log(resolveCaptureDurationSeconds({}));
console.log(resolveCaptureDurationSeconds(parseFlags(["--duration","42"])));
try { resolveCaptureDurationSeconds({duration:"6junk"}); } catch (e) { console.log(e.message); }
'
```

# Evidence Gate

<!-- evidence-head:015e1083083589703c38974ca320c4226524ee88 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: **N/A - non-UI CLI/helper validation only; no rendered surface.**
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: **N/A - non-UI CLI/helper validation only; no rendered surface.**
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: **N/A - non-UI CLI/helper validation only; no user-visible flow.**
<!-- evidence-row:backend-logs -->
- [x] Backend logs: focused unit-test + helper probe output below (parser boundary, not a server path).
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: **N/A - no frontend request/response path; capture preflight only.**
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: **N/A - no agent, action, prompt, provider, or model behavior changes.**
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: **N/A - no DB rows, memories, tasks, wallet, or generated domain state.**
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: **N/A - no rendered visual surface.**

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changes.

## Backend + frontend logs

<details>
<summary>Focused unit tests (21 pass)</summary>

```
[0m[1mbun test [0m[2mv1.3.14 (0d9b296a)[0m
[0m
packages/app/scripts/lib/capture-output.test.mjs:
[0m[32m✓[0m [0mresolveCaptureDurationSeconds (#18622)[2m >[0m[1m defaults to 6 seconds when --duration is omitted[0m [0m[2m[0.23ms[0m[2m][0m
[0m[32m✓[0m [0mresolveCaptureDurationSeconds (#18622)[2m >[0m[1m accepts complete positive integers in the safe timer range[0m [0m[2m[0.13ms[0m[2m][0m
[0m[32m✓[0m [0mresolveCaptureDurationSeconds (#18622)[2m >[0m[1m rejects bare --duration (boolean true from parseFlags)[0m [0m[2m[0.15ms[0m[2m][0m
[0m[32m✓[0m [0mresolveCaptureDurationSeconds (#18622)[2m >[0m[1m rejects zero, negative, fractional, partial, and non-numeric values[0m [0m[2m[0.19ms[0m[2m][0m
[0m[32m✓[0m [0mresolveCaptureDurationSeconds (#18622)[2m >[0m[1m rejects values that would overflow a Node millisecond timer[0m [0m[2m[0.09ms[0m[2m][0m
[0m[32m✓[0m [0mresolveRequireEvidence (#13624)[2m >[0m[1m defaults to false for a local ad-hoc run (no flag, no env, no CI)[0m [0m[2m[0.15ms[0m[2m][0m
[0m[32m✓[0m [0mresolveRequireEvidence (#13624)[2m >[0m[1m is true with a bare --require-evidence flag[0m [0m[2m[0.07ms[0m[2m][0m
[0m[32m✓[0m [0mresolveRequireEvidence (#13624)[2m >[0m[1m honors --require-evidence <value> (space form)[0m [0m[2m[0.04ms[0m[2m][0m
[0m[32m✓[0m [0mresolveRequireEvidence (#13624)[2m >[0m[1m honors --require-evidence=<value> (equals form)[0m [0m[2m[0.03ms[0m[2m][0m
[0m[32m✓[0m [0mresolveRequireEvidence (#13624)[2m >[0m[1m a bare --require-evidence followed by another flag is a true opt-in[0m [0m[2m[0.02ms[0m[2m][0m
[0m[32m✓[0m [0mresolveRequireEvidence (#13624)[2m >[0m[1m --no-require-evidence is an explicit opt-out that beats CI[0m [0m[2m[0.02ms[0m[2m][0m
[0m[32m✓[0m [0mresolveRequireEvidence (#13624)[2m >[0m[1m an explicit --require-evidence false beats a truthy CI env[0m [0m[2m[0.02ms[0m[2m][0m
[0m[32m✓[0m [0mresolveRequireEvidence (#13624)[2m >[0m[1m last flag occurrence wins (explicit off after on)[0m [0m[2m[0.03ms[0m[2m][0m
[0m[32m✓[0m [0mresolveRequireEvidence (#13624)[2m >[0m[1m auto-on under CI=true / CI=1[0m [0m[2m[0.03ms[0m[2m][0m
[0m[32m✓[0m [0mresolveRequireEvidence (#13624)[2m >[0m[1m does NOT arm on falsey CI spellings (0/false/off/empty)[0m [0m[2m[0.06ms[0m[2m][0m
[0m[32m✓[0m [0mresolveRequireEvidence (#13624)[2m >[0m[1m env opt-in E2E_REQUIRE_EVIDENCE / ELIZA_REQUIRE_EVIDENCE[0m [0m[2m[0.04ms[0m[2m][0m
[0m[32m✓[0m [0mresolveRequireEvidence (#13624)[2m >[0m[1m REGRESSION: an explicit --require-evidence must not silently degrade to a soft skip[0m [0m[2m[0.02ms[0m[2m][0m
[0m[32m✓[0m [0mskip() exit contract (#13624)[2m >[0m[1m exits 0 with a [skip] line when evidence is NOT required (local default)[0m [0m[2m[[1m41.55ms[0m[2m][0m
[0m[32m✓[0m [0mskip() exit contract (#13624)[2m >[0m[1m exits NON-ZERO with a [require-evidence] line under --require-evidence[0m [0m[2m[[1m38.93ms[0m[2m][0m
[0m[32m✓[0m [0mskip() exit contract (#13624)[2m >[0m[1m exits NON-ZERO under CI=true (auto-on) even without the flag[0m [0m[2m[[1m36.23ms[0m[2m][0m
[0m[32m✓[0m [0mskip() exit contract (#13624)[2m >[0m[1m stays a soft skip (exit 0) with an explicit --no-require-evidence even under CI[0m [0m[2m[[1m36.41ms[0m[2m][0m
[0m[2m---------------------------------------------|---------|---------|-------------------[0m
File                                         [2m|[0m % Funcs [2m|[0m % Lines [2m|[0m Uncovered Line #s
[2m---------------------------------------------|---------|---------|-------------------[0m
[0m[1m[31mAll files                                   [0m[2m | [0m[1m[31m  33.33[0m[2m | [0m[1m[31m  63.69[0m[2m |[0m
[0m[1m[31m packages/app/scripts/lib/capture-output.mjs[0m[2m | [0m[1m[31m  33.33[0m[2m | [0m[1m[31m  63.69[0m[2m | [0m[31m168[0m[2m,[0m[31m177-184[0m[2m,[0m[31m189-190[0m[2m,[0m[31m199-210[0m[2m,[0m[31m237-250[0m[2m,[0m[31m264-274[0m[2m,[0m[31m296-307
[0m[2m---------------------------------------------|---------|---------|-------------------[0m

[0m[32m 21 pass[0m
[0m[2m 0 fail[0m
 61 expect() calls
Ran 21 tests across 1 file. [0m[2m[[1m309.00ms[0m[2m][0m
```

</details>

<details>
<summary>Direct fail-closed probe</summary>

```
default [33m6[39m
valid [33m42[39m
reject: --duration must be an integer from 1 to 2147483 (received "6junk")
bare: --duration requires an integer from 1 to 2147483
(node:142704) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - non-UI CLI/helper validation only.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT path.

## Known gaps / failures

- Full `bun run verify` was **not** run this cycle (scoped capture CLI validation; focused package tests only).
- Device-signed project token receipt was **not** emitted: the bundled receipt script only accepts codex/claude-code model identities, and this run used operator-approved Grok — lying on the receipt would violate the workstream rule.
- Biome check on the 7 touched files: clean (no fixes applied).
- No device/ffmpeg capture run was required; validation is pure helper logic.