### PR TITLE
fix(ui): reject invalid check-stories --limit and --settle

### DIFF
--- a/packages/ui/stories/check-stories.mjs
+++ b/packages/ui/stories/check-stories.mjs
@@ -1,148 +1,288 @@
+#!/usr/bin/env node
 /**
  * Headless checker: loads every Storybook story in isolation and captures
  * render errors (SB error overlay, page errors, console.error).
  *
+ * Numeric CLI overrides fail closed before Playwright launches so a typo or
+ * negative bound cannot silently drop stories or rewrite settle timing.
+ *
  * Usage:
- *   node stories/check-stories.mjs [--base http://localhost:6006] [--limit N] [--filter substr] [--globals theme:light]
+ *   node stories/check-stories.mjs [--base http://localhost:6006] [--limit N]
+ *     [--filter substr] [--globals theme:light] [--settle MS] [--ids-file path]
  */
 import { chromium } from "playwright";
+import { pathToFileURL } from "node:url";
 
-const arg = (name, def) => {
-  const i = process.argv.indexOf(name);
-  return i >= 0 ? process.argv[i + 1] : def;
-};
-const base = arg("--base", "http://localhost:6006");
-const limit = Number(arg("--limit", "0")) || 0;
-const filter = arg("--filter", "");
-const globals = arg("--globals", "");
+export const DEFAULT_SETTLE_MS = 600;
 
-const idsFile = arg("--ids-file", "");
-const settle = Number(arg("--settle", "600")) || 600;
+/**
+ * Require a complete unsigned decimal string that is a positive safe integer.
+ * Rejects partial numeric prefixes (`1junk`), fractions, signs, and zero so a
+ * limit never becomes NaN/negative and silently changes which stories run.
+ *
+ * @param {string | undefined} raw
+ * @param {string} flag
+ * @returns {number}
+ */
+export function requirePositiveSafeInteger(raw, flag) {
+  if (raw === undefined) {
+    throw new Error(
+      `check-stories: ${flag} requires a positive integer (received no value)`,
+    );
+  }
+  if (typeof raw !== "string" || !/^[1-9]\d*$/.test(raw)) {
+    throw new Error(
+      `check-stories: ${flag} must be a positive integer (received ${JSON.stringify(raw)})`,
+    );
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(
+      `check-stories: ${flag} must be a positive safe integer (received ${JSON.stringify(raw)})`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Require a complete unsigned decimal string that is a non-negative safe
+ * integer. Zero is allowed so operators can disable the post-navigation settle.
+ *
+ * @param {string | undefined} raw
+ * @param {string} flag
+ * @returns {number}
+ */
+export function requireNonNegativeSafeInteger(raw, flag) {
+  if (raw === undefined) {
+    throw new Error(
+      `check-stories: ${flag} requires a non-negative integer (received no value)`,
+    );
+  }
+  if (typeof raw !== "string" || !/^\d+$/.test(raw)) {
+    throw new Error(
+      `check-stories: ${flag} must be a non-negative integer (received ${JSON.stringify(raw)})`,
+    );
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 0 || String(value) !== raw) {
+    throw new Error(
+      `check-stories: ${flag} must be a non-negative safe integer (received ${JSON.stringify(raw)})`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Parse CLI argv into checker options. Unknown flags are ignored for backward
+ * compatibility with ad-hoc local invocations; numeric flags fail closed.
+ *
+ * @param {string[]} argv
+ */
+export function parseArgs(argv) {
+  const options = {
+    base: "http://localhost:6006",
+    limit: 0,
+    filter: "",
+    globals: "",
+    idsFile: "",
+    settle: DEFAULT_SETTLE_MS,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const next = () => argv[++i];
+    if (flag === "--base") {
+      const value = next();
+      if (value === undefined) {
+        throw new Error("check-stories: --base requires a URL value");
+      }
+      options.base = value;
+    } else if (flag === "--limit") {
+      options.limit = requirePositiveSafeInteger(next(), "--limit");
+    } else if (flag === "--filter") {
+      const value = next();
+      if (value === undefined) {
+        throw new Error("check-stories: --filter requires a value");
+      }
+      options.filter = value;
+    } else if (flag === "--globals") {
+      const value = next();
+      if (value === undefined) {
+        throw new Error("check-stories: --globals requires a value");
+      }
+      options.globals = value;
+    } else if (flag === "--ids-file") {
+      const value = next();
+      if (value === undefined) {
+        throw new Error("check-stories: --ids-file requires a path value");
+      }
+      options.idsFile = value;
+    } else if (flag === "--settle") {
+      options.settle = requireNonNegativeSafeInteger(next(), "--settle");
+    }
+  }
+  return options;
+}
+
 const isTransientNavigationError = (message) =>
   /net::ERR_(ABORTED|CONNECTION_REFUSED)|Execution context was destroyed/i.test(
     message,
   );
-let ids;
-if (idsFile) {
-  const fsmod = await import("node:fs");
-  ids = fsmod
-    .readFileSync(idsFile, "utf8")
-    .split("\n")
-    .map((s) => s.trim())
-    .filter(Boolean);
-} else {
-  const index = await (await fetch(`${base}/index.json`)).json();
-  ids = Object.values(index.entries)
-    .filter((e) => e.type === "story")
-    .map((e) => e.id);
-}
-if (filter) ids = ids.filter((id) => id.includes(filter));
-if (limit) ids = ids.slice(0, limit);
 
-console.log(`Checking ${ids.length} stories at ${base}`);
-
-const browser = await chromium.launch();
-const ctx = await browser.newContext({
-  viewport: { width: 1024, height: 768 },
-});
-const page = await ctx.newPage();
-
-const bad = [];
-let n = 0;
-for (const id of ids) {
-  n++;
-  const errs = [];
-  const onConsole = (msg) => {
-    if (msg.type() === "error") errs.push("console: " + msg.text());
-  };
-  const onPageErr = (e) => errs.push("pageerror: " + (e?.message || String(e)));
-  page.on("console", onConsole);
-  page.on("pageerror", onPageErr);
-  let overlay = "";
-  for (let storyAttempt = 0; storyAttempt < 2; storyAttempt++) {
-    errs.length = 0;
-    overlay = "";
-    try {
-      const url = new URL(`${base}/iframe.html`);
-      url.searchParams.set("id", id);
-      url.searchParams.set("viewMode", "story");
-      if (globals) url.searchParams.set("globals", globals);
-      let lastGotoError;
-      for (let attempt = 0; attempt < 2; attempt++) {
-        try {
-          await page.goto(url.toString(), {
-            waitUntil: "load",
-            timeout: 30000,
-          });
-          lastGotoError = undefined;
-          break;
-        } catch (e) {
-          lastGotoError = e;
-          if (!isTransientNavigationError(e.message)) break;
-          await page.waitForTimeout(500);
-        }
-      }
-      if (lastGotoError) throw lastGotoError;
-      // Let the story render / Vite compile settle.
-      await page.waitForTimeout(settle);
-      overlay = await page.evaluate(() => {
-        const body = document.body;
-        if (body && body.classList.contains("sb-show-errordisplay")) {
-          const m = document.querySelector("#error-message, .sb-errordisplay");
-          return (m?.textContent || "error overlay").trim().slice(0, 400);
-        }
-        return "";
-      });
-      break;
-    } catch (e) {
-      if (storyAttempt === 0 && isTransientNavigationError(e.message)) {
-        await page.waitForTimeout(500);
-        continue;
-      }
-      errs.push("goto: " + e.message);
-      break;
-    }
-  }
-  page.off("console", onConsole);
-  page.off("pageerror", onPageErr);
-  // Filter benign noise.
-  const realErrs = errs.filter(
-    (e) =>
-      !/Failed to load resource.*favicon/i.test(e) &&
-      !/Download the React DevTools/i.test(e) &&
-      !/\[vite\] connect(ing|ed)/i.test(e) &&
-      !/Error loading story index/i.test(e) &&
-      !/Failed to fetch.*PreviewWeb\.getStoryIndexFromServer/is.test(e) &&
-      !/Preview\.onStoriesChanged\(\)`? before initialization/i.test(e) &&
-      // ErrorBoundary stories deliberately throw to demonstrate the fallback.
-      !/Simulated render failure/i.test(e) &&
-      !/The above error occurred in the <Boom>/i.test(e),
-  );
-  if (overlay || realErrs.length) {
-    bad.push({ id, overlay, errs: realErrs.slice(0, 4) });
-    process.stdout.write("X");
+/**
+ * Run the headless story checker with already-validated options.
+ *
+ * @param {{
+ *   base: string;
+ *   limit: number;
+ *   filter: string;
+ *   globals: string;
+ *   idsFile: string;
+ *   settle: number;
+ * }} options
+ */
+export async function runCheckStories(options) {
+  const { base, limit, filter, globals, idsFile, settle } = options;
+  let ids;
+  if (idsFile) {
+    const fsmod = await import("node:fs");
+    ids = fsmod
+      .readFileSync(idsFile, "utf8")
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
   } else {
-    process.stdout.write(".");
+    const index = await (await fetch(`${base}/index.json`)).json();
+    ids = Object.values(index.entries)
+      .filter((e) => e.type === "story")
+      .map((e) => e.id);
   }
-  if (n % 50 === 0) process.stdout.write(` ${n}\n`);
-  // Gentle pacing so the dev server's on-demand compiler isn't overwhelmed.
-  await page.waitForTimeout(150);
+  if (filter) ids = ids.filter((id) => id.includes(filter));
+  if (limit) ids = ids.slice(0, limit);
+
+  console.log(`Checking ${ids.length} stories at ${base}`);
+
+  const browser = await chromium.launch();
+  const ctx = await browser.newContext({
+    viewport: { width: 1024, height: 768 },
+  });
+  const page = await ctx.newPage();
+
+  const bad = [];
+  let n = 0;
+  for (const id of ids) {
+    n++;
+    const errs = [];
+    const onConsole = (msg) => {
+      if (msg.type() === "error") errs.push("console: " + msg.text());
+    };
+    const onPageErr = (e) =>
+      errs.push("pageerror: " + (e?.message || String(e)));
+    page.on("console", onConsole);
+    page.on("pageerror", onPageErr);
+    let overlay = "";
+    for (let storyAttempt = 0; storyAttempt < 2; storyAttempt++) {
+      errs.length = 0;
+      overlay = "";
+      try {
+        const url = new URL(`${base}/iframe.html`);
+        url.searchParams.set("id", id);
+        url.searchParams.set("viewMode", "story");
+        if (globals) url.searchParams.set("globals", globals);
+        let lastGotoError;
+        for (let attempt = 0; attempt < 2; attempt++) {
+          try {
+            await page.goto(url.toString(), {
+              waitUntil: "load",
+              timeout: 30000,
+            });
+            lastGotoError = undefined;
+            break;
+          } catch (e) {
+            lastGotoError = e;
+            if (!isTransientNavigationError(e.message)) break;
+            await page.waitForTimeout(500);
+          }
+        }
+        if (lastGotoError) throw lastGotoError;
+        // Let the story render / Vite compile settle.
+        await page.waitForTimeout(settle);
+        overlay = await page.evaluate(() => {
+          const body = document.body;
+          if (body && body.classList.contains("sb-show-errordisplay")) {
+            const m = document.querySelector("#error-message, .sb-errordisplay");
+            return (m?.textContent || "error overlay").trim().slice(0, 400);
+          }
+          return "";
+        });
+        break;
+      } catch (e) {
+        if (storyAttempt === 0 && isTransientNavigationError(e.message)) {
+          await page.waitForTimeout(500);
+          continue;
+        }
+        errs.push("goto: " + e.message);
+        break;
+      }
+    }
+    page.off("console", onConsole);
+    page.off("pageerror", onPageErr);
+    // Filter benign noise.
+    const realErrs = errs.filter(
+      (e) =>
+        !/Failed to load resource.*favicon/i.test(e) &&
+        !/Download the React DevTools/i.test(e) &&
+        !/\[vite\] connect(ing|ed)/i.test(e) &&
+        !/Error loading story index/i.test(e) &&
+        !/Failed to fetch.*PreviewWeb\.getStoryIndexFromServer/is.test(e) &&
+        !/Preview\.onStoriesChanged\(\)`? before initialization/i.test(e) &&
+        // ErrorBoundary stories deliberately throw to demonstrate the fallback.
+        !/Simulated render failure/i.test(e) &&
+        !/The above error occurred in the <Boom>/i.test(e),
+    );
+    if (overlay || realErrs.length) {
+      bad.push({ id, overlay, errs: realErrs.slice(0, 4) });
+      process.stdout.write("X");
+    } else {
+      process.stdout.write(".");
+    }
+    if (n % 50 === 0) process.stdout.write(` ${n}\n`);
+    // Gentle pacing so the dev server's on-demand compiler isn't overwhelmed.
+    await page.waitForTimeout(150);
+  }
+  process.stdout.write("\n");
+
+  await browser.close();
+
+  console.log(`\n=== ${bad.length}/${ids.length} stories with issues ===\n`);
+  for (const b of bad) {
+    console.log(`\n## ${b.id}`);
+    if (b.overlay) console.log("  OVERLAY: " + b.overlay.replace(/\n/g, " ⏎ "));
+    for (const e of b.errs) console.log("  " + e.replace(/\n/g, " ⏎ "));
+  }
+
+  const fs = await import("node:fs");
+  fs.writeFileSync(
+    new URL("./check-stories-report.json", import.meta.url),
+    JSON.stringify(bad, null, 2),
+  );
+  console.log(`\nReport: stories/check-stories-report.json`);
+  return bad;
 }
-process.stdout.write("\n");
 
-await browser.close();
-
-console.log(`\n=== ${bad.length}/${ids.length} stories with issues ===\n`);
-for (const b of bad) {
-  console.log(`\n## ${b.id}`);
-  if (b.overlay) console.log("  OVERLAY: " + b.overlay.replace(/\n/g, " ⏎ "));
-  for (const e of b.errs) console.log("  " + e.replace(/\n/g, " ⏎ "));
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  await runCheckStories(options);
 }
 
-import fs from "node:fs";
-
-fs.writeFileSync(
-  new URL("./check-stories-report.json", import.meta.url),
-  JSON.stringify(bad, null, 2),
-);
-console.log(`\nReport: stories/check-stories-report.json`);
+// Only auto-run as a CLI; importing this module for unit tests must not launch
+// a browser. pathToFileURL comparison is required on Windows where argv[1] is
+// backslash-separated and drive-lettered.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });
+}

--- a/packages/ui/test/check-stories-cli.test.mjs
+++ b/packages/ui/test/check-stories-cli.test.mjs
@@ -1,0 +1,103 @@
+/**
+ * Regression tests for check-stories `--limit` and `--settle` CLI validation
+ * (#18628). Confirms malformed values fail at the parser and process boundary
+ * before Playwright launches or stories are silently mis-filtered.
+ */
+
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SETTLE_MS,
+  parseArgs,
+  requireNonNegativeSafeInteger,
+  requirePositiveSafeInteger,
+} from "../stories/check-stories.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const runner = join(here, "../stories/check-stories.mjs");
+
+describe("check-stories --limit / --settle validation (#18628)", () => {
+  it("accepts omitted and valid limit/settle values", () => {
+    expect(parseArgs([])).toEqual({
+      base: "http://localhost:6006",
+      limit: 0,
+      filter: "",
+      globals: "",
+      idsFile: "",
+      settle: DEFAULT_SETTLE_MS,
+    });
+    expect(parseArgs(["--limit", "1"]).limit).toBe(1);
+    expect(parseArgs(["--limit", "42"]).limit).toBe(42);
+    expect(parseArgs(["--settle", "0"]).settle).toBe(0);
+    expect(parseArgs(["--settle", "250"]).settle).toBe(250);
+  });
+
+  it.each(["0", "-1", "1.5", "1junk", "NaN", "Infinity", "", "01"])(
+    "rejects invalid limit %j",
+    (value) => {
+      expect(() => parseArgs(["--limit", value])).toThrow(
+        "--limit must be a positive integer",
+      );
+    },
+  );
+
+  it("rejects a missing limit value", () => {
+    expect(() => parseArgs(["--limit"])).toThrow(
+      "--limit requires a positive integer (received no value)",
+    );
+  });
+
+  it.each(["-1", "1.5", "1junk", "NaN", "Infinity", "", "01", "00"])(
+    "rejects invalid settle %j",
+    (value) => {
+      expect(() => parseArgs(["--settle", value])).toThrow(
+        "--settle must be a non-negative",
+      );
+    },
+  );
+
+  it("rejects a missing settle value", () => {
+    expect(() => parseArgs(["--settle"])).toThrow(
+      "--settle requires a non-negative integer (received no value)",
+    );
+  });
+
+  it("validators match CLI error text", () => {
+    expect(() => requirePositiveSafeInteger("-1", "--limit")).toThrow(
+      "--limit must be a positive integer",
+    );
+    expect(() => requireNonNegativeSafeInteger("1junk", "--settle")).toThrow(
+      "--settle must be a non-negative integer",
+    );
+  });
+
+  it("fails at the real CLI boundary for --limit -1 before browser work", () => {
+    const result = spawnSync(
+      process.execPath,
+      [runner, "--limit", "-1"],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(
+      "check-stories: --limit must be a positive integer",
+    );
+    expect(`${result.stdout}\n${result.stderr}`).not.toMatch(/Checking \d+ stories/);
+  });
+
+  it("fails at the real CLI boundary for --settle 1junk before browser work", () => {
+    const result = spawnSync(
+      process.execPath,
+      [runner, "--settle", "1junk"],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(
+      "check-stories: --settle must be a non-negative integer",
+    );
+    expect(`${result.stdout}\n${result.stderr}`).not.toMatch(/Checking \d+ stories/);
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18628

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli` / Grok Build unattended worker
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported` (operator-approved Grok workstream; contribution receipt tooling only accepts Codex/Claude model IDs, so no device-signed v2 marker is attached rather than a false model claim)

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** Scoped to the headless Storybook checker CLI in `packages/ui/stories/check-stories.mjs`. Valid invocations with omitted flags or well-formed `--limit` / `--settle` keep prior defaults. Only malformed numeric overrides that previously failed open now exit non-zero before Playwright launches.

# Background

## What does this PR do?

Fails closed on invalid `--limit` and `--settle` for the lightweight `check-stories.mjs` runner (the live-Storybook headless checker, distinct from Story Gate).

Previously:

| Input | Behavior |
| --- | --- |
| `--limit -1` | `ids.slice(0, -1)` silently dropped the last story |
| `--limit 1junk` | Became unlimited (`NaN || 0`) |
| `--settle 0` | Silently rewritten to 600 ms |
| `--settle 1junk` | Became 600 ms via `||` fallback |

Now those invalid values throw at the CLI boundary with actionable messages, and `--settle 0` is preserved.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation. The script header documents the validated flags.

# Testing

## Where should a reviewer start?

1. `packages/ui/stories/check-stories.mjs` — exported validators + `parseArgs`
2. `packages/ui/test/check-stories-cli.test.mjs` — unit + real process-boundary tests

## Detailed testing steps

```bash
bun run --cwd packages/ui test -- test/check-stories-cli.test.mjs
# 22 passed

node packages/ui/stories/check-stories.mjs --limit -1
# exit 1: check-stories: --limit must be a positive integer (received "-1")

node packages/ui/stories/check-stories.mjs --settle 1junk
# exit 1: check-stories: --settle must be a non-negative integer (received "1junk")
```

Omitted flags keep defaults (unlimited limit, settle 600 ms). Valid `--limit 3 --settle 0` parses as limit 3 and settle 0.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:439aa05ece5b99d6bbf7799b44cd8af4db0c0ca8 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CLI validation only; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - CLI validation only; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI flow; process-boundary CLI tests are the proof path.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no server/runtime path; local CLI parser only.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend app surface.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain state mutated.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model changes.

## Backend + frontend logs

<details>
<summary>Focused test + CLI boundary output</summary>

```
$ bun run --cwd packages/ui test -- test/check-stories-cli.test.mjs
 Test Files  1 passed (1)
      Tests  22 passed (22)

$ node packages/ui/stories/check-stories.mjs --limit -1
check-stories: --limit must be a positive integer (received "-1")
exit:1

$ node packages/ui/stories/check-stories.mjs --settle 1junk
check-stories: --settle must be a non-negative integer (received "1junk")
exit:1
```

</details>

## Screenshots (before / after) + video walkthrough

### Before

N/A - CLI validation only.

### After

N/A - CLI validation only.

### Walkthrough video

N/A - no interactive UI flow.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT changes.

## Known gaps / failures

- Full `bun run verify` was **not** run this cycle (scoped CLI fix; focused package tests + CLI smoke only).
- Device-signed contribution receipt was **not** attached: receipt tooling only accepts Codex/Claude approved model IDs; this run used operator-approved Grok and does not fabricate a false model identity.