### PR TITLE
fix(app-core): reject invalid voice-latency-report --limit

### DIFF
--- a/packages/app-core/scripts/voice-latency-report.mjs
+++ b/packages/app-core/scripts/voice-latency-report.mjs
@@ -12,20 +12,26 @@
  *
  * Exit codes:
  *   0  — payload fetched (regardless of whether any traces exist).
- *   1  — API not reachable / endpoint errored.
+ *   1  — API not reachable / endpoint errored, or invalid CLI input.
  */
 
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
 import {
   fetchAndRenderVoiceLatency,
   renderVoiceLatencyReport,
 } from "./lib/voice-latency-report.mjs";
+
+/** Practical upper bound so overflow/timer-adjacent values fail closed. */
+export const MAX_LIMIT = 2_147_483_647;
 
 function parsePositivePort(value) {
   const n = Number(value);
   return Number.isInteger(n) && n > 0 && n < 65536 ? n : null;
 }
 
-function resolveApiBase(env, argBase) {
+export function resolveApiBase(env, argBase) {
   if (argBase) return argBase.replace(/\/$/, "");
   const port =
     parsePositivePort(env.ELIZA_API_PORT) ??
@@ -35,62 +41,112 @@ function resolveApiBase(env, argBase) {
   return `http://127.0.0.1:${port}`;
 }
 
-const argv = process.argv.slice(2);
-let json = false;
-let limit;
-let base;
-for (let i = 0; i < argv.length; i += 1) {
-  const a = argv[i];
-  if (a === "--json") json = true;
-  else if (a === "--limit") {
-    i += 1;
-    limit = Number(argv[i]);
-  } else if (a === "--base") {
-    i += 1;
-    base = argv[i];
-  } else if (a === "--help" || a === "-h") {
-    console.log(
-      "Usage: node voice-latency-report.mjs [--json] [--limit N] [--base http://127.0.0.1:31337]",
+/**
+ * Accept only a complete positive decimal integer string (>= 1, <= MAX_LIMIT).
+ * Rejects missing, fractional, signed, partial, zero, and non-finite values so
+ * mistyped report flags fail before contacting the API.
+ */
+export function parsePositiveLimit(raw, flag = "--limit") {
+  if (raw === undefined || raw === null) {
+    throw new Error(`${flag} requires a positive integer >= 1`);
+  }
+  const value = String(raw);
+  if (!/^[1-9]\d*$/.test(value)) {
+    throw new Error(
+      `${flag} must be a positive integer >= 1 (received ${JSON.stringify(value)})`,
     );
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > MAX_LIMIT) {
+    throw new Error(
+      `${flag} must be a positive integer from 1 to ${MAX_LIMIT} (received ${JSON.stringify(value)})`,
+    );
+  }
+  return parsed;
+}
+
+export function parseArgs(argv) {
+  let json = false;
+  /** @type {number | undefined} */
+  let limit;
+  /** @type {string | undefined} */
+  let base;
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--json") json = true;
+    else if (a === "--limit") {
+      const value = argv[++i];
+      if (value === undefined || value.startsWith("--")) {
+        throw new Error("--limit requires a positive integer >= 1");
+      }
+      limit = parsePositiveLimit(value, "--limit");
+    } else if (a === "--base") {
+      const value = argv[++i];
+      if (value === undefined || value.startsWith("--")) {
+        throw new Error("--base requires a URL value");
+      }
+      base = value;
+    } else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: node voice-latency-report.mjs [--json] [--limit N] [--base http://127.0.0.1:31337]",
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return { json, limit, base };
+}
+
+export async function main(argv = process.argv.slice(2), env = process.env) {
+  const args = parseArgs(argv);
+  const baseUrl = resolveApiBase(env, args.base);
+
+  const result = await fetchAndRenderVoiceLatency(baseUrl, {
+    limit: args.limit,
+  });
+
+  if (!result.ok) {
+    if (args.json) {
+      console.log(JSON.stringify({ ok: false, baseUrl, error: result.error }));
+    } else {
+      console.error(
+        `[voice-latency-report] could not fetch ${baseUrl}/api/dev/voice-latency: ${result.error}`,
+      );
+      console.error(
+        "[voice-latency-report] is the API running? (bun run dev / dev:desktop)",
+      );
+    }
+    process.exit(1);
+  }
+
+  if (args.json) {
+    // Re-fetch raw JSON for --json mode (the lib renders text). Simpler than
+    // threading the raw payload back through — and this path is for humans
+    // anyway; --json is a convenience.
+    const url = new URL("/api/dev/voice-latency", baseUrl);
+    if (args.limit !== undefined) {
+      url.searchParams.set("limit", String(args.limit));
+    }
+    const res = await fetch(url.toString());
+    const payload = await res.json();
+    console.log(JSON.stringify(payload, null, 2));
+    // Echo the rendered table to stderr so it's still visible.
+    console.error(renderVoiceLatencyReport(payload));
     process.exit(0);
   }
-}
 
-const baseUrl = resolveApiBase(process.env, base);
-
-const result = await fetchAndRenderVoiceLatency(baseUrl, {
-  limit: Number.isInteger(limit) && limit > 0 ? limit : undefined,
-});
-
-if (!result.ok) {
-  if (json) {
-    console.log(JSON.stringify({ ok: false, baseUrl, error: result.error }));
-  } else {
-    console.error(
-      `[voice-latency-report] could not fetch ${baseUrl}/api/dev/voice-latency: ${result.error}`,
-    );
-    console.error(
-      "[voice-latency-report] is the API running? (bun run dev / dev:desktop)",
-    );
-  }
-  process.exit(1);
-}
-
-if (json) {
-  // Re-fetch raw JSON for --json mode (the lib renders text). Simpler than
-  // threading the raw payload back through — and this path is for humans
-  // anyway; --json is a convenience.
-  const url = new URL("/api/dev/voice-latency", baseUrl);
-  if (Number.isInteger(limit) && limit > 0) {
-    url.searchParams.set("limit", String(limit));
-  }
-  const res = await fetch(url.toString());
-  const payload = await res.json();
-  console.log(JSON.stringify(payload, null, 2));
-  // Echo the rendered table to stderr so it's still visible.
-  console.error(renderVoiceLatencyReport(payload));
+  console.log(result.report);
   process.exit(0);
 }
 
-console.log(result.report);
-process.exit(0);
+const isMain =
+  Boolean(process.argv[1]) &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isMain) {
+  main().catch((err) => {
+    console.error(`[voice-latency-report] ${err?.stack || err}`);
+    process.exit(1);
+  });
+}

--- a/packages/app-core/scripts/voice-latency-report.test.ts
+++ b/packages/app-core/scripts/voice-latency-report.test.ts
@@ -1,9 +1,20 @@
 /** Exercises voice latency report behavior with deterministic app-core test fixtures. */
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   fetchAndRenderVoiceLatency,
   renderVoiceLatencyReport,
 } from "./lib/voice-latency-report.mjs";
+import {
+  MAX_LIMIT,
+  parseArgs,
+  parsePositiveLimit,
+} from "./voice-latency-report.mjs";
+
+const SCRIPT_PATH = fileURLToPath(
+  new URL("./voice-latency-report.mjs", import.meta.url),
+);
 
 const SAMPLE_PAYLOAD = {
   generatedAtEpochMs: 1_700_000_000_000,
@@ -173,5 +184,55 @@ describe("fetchAndRenderVoiceLatency", () => {
     });
     expect(seenUrl).toContain("limit=7");
     expect(seenUrl).toContain("/api/dev/voice-latency");
+  });
+});
+
+describe("voice-latency-report CLI --limit validation", () => {
+  it("omitting --limit leaves limit undefined", () => {
+    expect(parseArgs([])).toEqual({
+      json: false,
+      limit: undefined,
+      base: undefined,
+    });
+    expect(parseArgs(["--json"])).toMatchObject({
+      json: true,
+      limit: undefined,
+    });
+  });
+
+  it("parses valid --limit", () => {
+    expect(parseArgs(["--limit", "5"])).toMatchObject({ limit: 5 });
+    expect(parsePositiveLimit("1")).toBe(1);
+    expect(parsePositiveLimit(String(MAX_LIMIT))).toBe(MAX_LIMIT);
+  });
+
+  it.each(["", "0", "-3", "1.5", "10junk", "NaN", "Infinity", "+1"])(
+    "rejects invalid limit %p",
+    (value) => {
+      expect(() => parsePositiveLimit(value)).toThrow(/--limit/);
+      expect(() => parseArgs(["--limit", value])).toThrow(/--limit/);
+    },
+  );
+
+  it("rejects missing --limit value without consuming the next flag", () => {
+    expect(() => parseArgs(["--limit", "--json"])).toThrow(
+      /--limit requires a positive integer/,
+    );
+  });
+
+  it("real CLI rejects before contacting the API", () => {
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT_PATH, "--limit", "junk"],
+      {
+        encoding: "utf8",
+        env: { PATH: process.env.PATH ?? "" },
+      },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/--limit/);
+    expect(result.stdout + result.stderr).not.toMatch(
+      /could not fetch|is the API running/,
+    );
   });
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18630

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused package checks were run after sync; full monorepo `bun run verify`
      is not claimed below.
- [x] A reviewer can confirm the change from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused package checks pass post-sync; full `bun run verify` is not claimed.

# Risks

Low. CLI-boundary validation only for `voice-latency-report.mjs`. Invalid
`--limit` now fails closed before the API fetch. Omit-means-undefined is
preserved. No report rendering or endpoint contract changes for valid input.

# Background

## What does this PR do?

Hardens `packages/app-core/scripts/voice-latency-report.mjs` `--limit` parsing:

- Accept only complete positive decimal integers in `1..2^31-1`
- Keep omit → no limit (previous valid default path)
- Reject missing values without consuming the next flag
- Fail before contacting `/api/dev/voice-latency` with a named diagnostic
- Export parse helpers and extend focused tests with real CLI rejection

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. `packages/app-core/scripts/voice-latency-report.mjs`
2. `packages/app-core/scripts/voice-latency-report.test.ts`

## Detailed testing steps

```bash
export PATH="$HOME/.bun/bin:$PATH"
bun run --cwd packages/app-core test -- scripts/voice-latency-report.test.ts
node packages/app-core/scripts/voice-latency-report.mjs --limit junk
bunx biome check packages/app-core/scripts/voice-latency-report.mjs packages/app-core/scripts/voice-latency-report.test.ts
```

Observed:

- **19 pass / 0 fail** focused tests
- CLI: exit 1, stderr names `--limit`, no API-unreachable message
- Biome clean on touched files

# Evidence Gate

<!-- evidence-head:ff4ec4d9dcd0979e41c8b53de95a2c3558e49774 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface; CLI option validation only`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface; CLI option validation only`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI flow; terminal CLI validation only`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - invalid path never reaches the API`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend path`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/model path`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked
      `N/A - terminal test output is the domain artifact`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model path.

## Backend + frontend logs

N/A - local CLI validation only.

```text
bun run --cwd packages/app-core test -- scripts/voice-latency-report.test.ts
Test Files  1 passed (1)
     Tests  19 passed (19)

node packages/app-core/scripts/voice-latency-report.mjs --limit junk
# exit 1
# [voice-latency-report] Error: --limit must be a positive integer >= 1 (received "junk")
```

## Screenshots (before / after) + video walkthrough

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI flow.

## Audio / voice walkthrough

N/A - no voice path (CLI validation only; does not change the voice loop).

## Known gaps / failures

- Full monorepo `bun run verify` not re-run for this two-file scripts change;
  focused suite + Biome on the touched surface pass. No live API required for
  the acceptance criteria.


AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [hermes-agent-cortex]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTQ84PMF046HN97RVYM4YFE","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T10:10:52.757Z","completed_at":"2026-08-12T11:02:52.207Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEABCQ_La8E3A-mhoOGQAU1JDjb5V6pW0qzF_zrcALUa7w","device_key_id":"2ca15083498fec081db8f2a4bbc2afcd06af5a23f516c26e16441b7fa6261099","device_signature":"QmJwPNun2wLeyRBhA9-fCuW8cHWtL0YzbTFewPEdhvLIAw3pPMWhhd7q2bFhw9khOjlBXa6f-hpciVgayiSeCw"}} -->
