### PR TITLE
fix(app): reject invalid host-agent readyAttempts and readyDelayMs

### DIFF
--- a/packages/app/scripts/lib/host-agent.mjs
+++ b/packages/app/scripts/lib/host-agent.mjs
@@ -1,3 +1,8 @@
+/**
+ * Local device-e2e host-agent process helper. Chooses an exclusive API port,
+ * spawns the real local agent (or a caller-supplied command), waits for health,
+ * and returns a stop handle used by iOS/Android device lanes.
+ */
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import net from "node:net";
@@ -6,10 +11,10 @@ import path from "node:path";
 export const DEFAULT_HOST_AGENT_PORT = 31338;
 export const DEFAULT_HOST_AGENT_HOST = "127.0.0.1";
 export const DEFAULT_HOST_AGENT_HEALTH_PATH = "/api/health";
+export const DEFAULT_READY_ATTEMPTS = 90;
+export const DEFAULT_READY_DELAY_MS = 2000;
 
 const SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"];
-const DEFAULT_READY_ATTEMPTS = 90;
-const DEFAULT_READY_DELAY_MS = 2000;
 
 export function parsePort(value, label = "port") {
   const raw = String(value ?? "").trim();
@@ -21,6 +26,68 @@ export function parsePort(value, label = "port") {
     throw new Error(`Invalid ${label}: ${value}`);
   }
   return port;
+}
+
+/**
+ * Parses a non-negative safe integer from a string or number. Rejects partial
+ * numeric strings (`10abc`), fractions, negatives, and empty values so readiness
+ * knobs cannot silently become NaN/truncated via `Number.parseInt`.
+ */
+export function parseNonNegativeSafeInteger(value, label) {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error(`Invalid ${label}: ${value}`);
+    }
+    return value;
+  }
+  const raw = String(value ?? "").trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  return parsed;
+}
+
+/** Like parseNonNegativeSafeInteger but requires a positive value (>= 1). */
+export function parsePositiveSafeInteger(value, label) {
+  const parsed = parseNonNegativeSafeInteger(value, label);
+  if (parsed < 1) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  return parsed;
+}
+
+/**
+ * Resolve readiness knobs from explicit options or env, failing closed on
+ * malformed values so a typo never becomes a zero-iteration health wait.
+ */
+export function resolveReadyOptions({
+  readyAttempts,
+  readyDelayMs,
+  env = process.env,
+} = {}) {
+  const attemptsSource =
+    readyAttempts ??
+    env.ELIZA_HOST_AGENT_READY_ATTEMPTS ??
+    DEFAULT_READY_ATTEMPTS;
+  const delaySource =
+    readyDelayMs ??
+    env.ELIZA_HOST_AGENT_READY_DELAY_MS ??
+    DEFAULT_READY_DELAY_MS;
+
+  return {
+    readyAttempts: parsePositiveSafeInteger(
+      attemptsSource,
+      "host-agent readyAttempts",
+    ),
+    readyDelayMs: parseNonNegativeSafeInteger(
+      delaySource,
+      "host-agent readyDelayMs",
+    ),
+  };
 }
 
 export function hostAgentApiBase(port, host = DEFAULT_HOST_AGENT_HOST) {
@@ -86,6 +153,7 @@ function tailFile(filePath, maxBytes = 12_000) {
       fs.closeSync(fd);
     }
   } catch {
+    // error-policy:J6 best-effort log tail for failure messages
     return "";
   }
 }
@@ -128,7 +196,7 @@ async function waitForHealth({
         return;
       }
     } catch {
-      // Retry until attempts are exhausted or the child exits.
+      // error-policy:J4 health probe retry until attempts exhausted or child exits
     }
 
     await sleep(delayMs);
@@ -151,16 +219,8 @@ export async function startDeviceE2eHostAgent({
   preferredPort = process.env.ELIZA_IOS_HOST_AGENT_PORT ??
     DEFAULT_HOST_AGENT_PORT,
   host = DEFAULT_HOST_AGENT_HOST,
-  readyAttempts = Number.parseInt(
-    process.env.ELIZA_HOST_AGENT_READY_ATTEMPTS ??
-      String(DEFAULT_READY_ATTEMPTS),
-    10,
-  ),
-  readyDelayMs = Number.parseInt(
-    process.env.ELIZA_HOST_AGENT_READY_DELAY_MS ??
-      String(DEFAULT_READY_DELAY_MS),
-    10,
-  ),
+  readyAttempts,
+  readyDelayMs,
   log = null,
   command = process.execPath,
   args = [
@@ -173,6 +233,16 @@ export async function startDeviceE2eHostAgent({
   if (!artifactDir) {
     throw new Error("startDeviceE2eHostAgent requires artifactDir.");
   }
+
+  // Validate before spawn so a bad env typo cannot start a child that is then
+  // immediately torn down after a zero-iteration readiness wait. Readiness
+  // knobs come from the parent process env (or explicit options), not the child
+  // spawn env bag.
+  const resolvedReady = resolveReadyOptions({
+    readyAttempts,
+    readyDelayMs,
+    env: process.env,
+  });
 
   const port = await chooseHostAgentPort({
     preferredPort,
@@ -211,7 +281,7 @@ export async function startDeviceE2eHostAgent({
         try {
           fs.closeSync(logFd);
         } catch {
-          // Already closed by the platform.
+          // error-policy:J6 log fd may already be closed by the platform
         }
         resolve();
       };
@@ -261,11 +331,12 @@ export async function startDeviceE2eHostAgent({
       child,
       getChildError: () => childError,
       logPath,
-      attempts: readyAttempts,
-      delayMs: readyDelayMs,
+      attempts: resolvedReady.readyAttempts,
+      delayMs: resolvedReady.readyDelayMs,
       log,
     });
   } catch (error) {
+    // error-policy:J2 stop child then rethrow readiness/spawn failure
     await stop();
     throw error;
   }

--- a/packages/app/scripts/lib/host-agent.test.mjs
+++ b/packages/app/scripts/lib/host-agent.test.mjs
@@ -1,3 +1,8 @@
+/**
+ * Deterministic unit coverage for the device-e2e host-agent helper: port
+ * selection exclusivity, readiness knob validation, health wait + stop lifecycle,
+ * and spawn failure cleanup.
+ */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
@@ -7,9 +12,14 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   chooseHostAgentPort,
   DEFAULT_HOST_AGENT_PORT,
+  DEFAULT_READY_ATTEMPTS,
+  DEFAULT_READY_DELAY_MS,
   hostAgentApiBase,
   isPortAvailable,
+  parseNonNegativeSafeInteger,
   parsePort,
+  parsePositiveSafeInteger,
+  resolveReadyOptions,
   startDeviceE2eHostAgent,
 } from "./host-agent.mjs";
 
@@ -64,6 +74,76 @@ describe("host-agent helper", () => {
     for (const value of ["", "0", "-1", "123abc", "70000"]) {
       expect(() => parsePort(value)).toThrow(/Invalid/);
     }
+  });
+
+  it("parses positive and non-negative safe integers without partial coercion", () => {
+    expect(parsePositiveSafeInteger("90", "attempts")).toBe(90);
+    expect(parsePositiveSafeInteger(50, "attempts")).toBe(50);
+    expect(parseNonNegativeSafeInteger("0", "delay")).toBe(0);
+    expect(parseNonNegativeSafeInteger(2000, "delay")).toBe(2000);
+
+    for (const value of ["", "abc", "10abc", "1.5", "-1", "0", NaN, 1.5]) {
+      expect(() => parsePositiveSafeInteger(value, "attempts")).toThrow(
+        /Invalid attempts/,
+      );
+    }
+    for (const value of ["", "abc", "10abc", "1.5", "-1", NaN, -3]) {
+      expect(() => parseNonNegativeSafeInteger(value, "delay")).toThrow(
+        /Invalid delay/,
+      );
+    }
+  });
+
+  it("resolves readiness knobs from options and env, failing closed on typos", () => {
+    expect(resolveReadyOptions({})).toEqual({
+      readyAttempts: DEFAULT_READY_ATTEMPTS,
+      readyDelayMs: DEFAULT_READY_DELAY_MS,
+    });
+    expect(
+      resolveReadyOptions({
+        readyAttempts: 12,
+        readyDelayMs: 0,
+      }),
+    ).toEqual({ readyAttempts: 12, readyDelayMs: 0 });
+    expect(
+      resolveReadyOptions({
+        env: {
+          ELIZA_HOST_AGENT_READY_ATTEMPTS: "7",
+          ELIZA_HOST_AGENT_READY_DELAY_MS: "25",
+        },
+      }),
+    ).toEqual({ readyAttempts: 7, readyDelayMs: 25 });
+
+    expect(() =>
+      resolveReadyOptions({
+        env: { ELIZA_HOST_AGENT_READY_ATTEMPTS: "abc" },
+      }),
+    ).toThrow(/Invalid host-agent readyAttempts/);
+    expect(() =>
+      resolveReadyOptions({
+        env: { ELIZA_HOST_AGENT_READY_DELAY_MS: "10ms" },
+      }),
+    ).toThrow(/Invalid host-agent readyDelayMs/);
+    expect(() => resolveReadyOptions({ readyAttempts: "0" })).toThrow(
+      /Invalid host-agent readyAttempts/,
+    );
+  });
+
+  it("rejects invalid readyAttempts before spawning a host agent child", async () => {
+    const artifactDir = makeTmpDir();
+    await expect(
+      startDeviceE2eHostAgent({
+        repoRoot: process.cwd(),
+        artifactDir,
+        requestedPort: await chooseHostAgentPort(),
+        readyAttempts: "10abc",
+        readyDelayMs: 20,
+        command: process.execPath,
+        args: ["-e", "process.exit(0)"],
+        env: {},
+      }),
+    ).rejects.toThrow(/Invalid host-agent readyAttempts/);
+    expect(fs.existsSync(path.join(artifactDir, "host-agent.log"))).toBe(false);
   });
 
   it("keeps explicit requested ports exclusive", async () => {


### PR DESCRIPTION
# Relates to

Closes #18632

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xAI / grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build` (`grok` client)
<!-- attribution-row:skill-revision -->
- Skill path: `contribute-to-eliza` @ `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77`
<!-- attribution-row:status -->
- Provenance status: `self-reported` + device-signed project receipt (footer below)
- Run id: `run_01KZTX6NY15A69KHXBT80EVCHX`
- Note: Operator override approved Grok for this workstream. Token meter via ccusage is unavailable for Grok (signed zero / unavailable confidence), not fabricated.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] Full monorepo `bun run verify` not claimed; focused host-agent tests + Biome on touched files passed.

# Risks

**Low.** CLI/env validation only for device-e2e host-agent readiness knobs. Valid defaults and explicit overrides are unchanged. Invalid typos now fail before spawn instead of presenting as false readiness timeouts.

# Background

## What does this PR do?

Validates host-agent readiness knobs at the boundary:

- `readyAttempts` / `ELIZA_HOST_AGENT_READY_ATTEMPTS` must be a positive safe integer (`>= 1`)
- `readyDelayMs` / `ELIZA_HOST_AGENT_READY_DELAY_MS` must be a non-negative safe integer (`>= 0`)

Previously bare `Number.parseInt` accepted partial strings (`10abc` → `10`) and turned `abc` / `0` into empty health-wait loops (`attempt <= NaN` / `attempt <= 0`), so CI typos looked like “host agent never became healthy.”

Validation runs **before spawn**, so a bad value does not start a child process.

## What kind of change is this?

Bug fix (non-breaking for valid invocations; invalid args now fail closed).

# Documentation changes needed?

No project docs change required. Env var names and intent are unchanged; invalid values are rejected instead of coerced.

# Testing

## Where should a reviewer start?

1. `packages/app/scripts/lib/host-agent.mjs` — `parsePositiveSafeInteger`, `parseNonNegativeSafeInteger`, `resolveReadyOptions`, `startDeviceE2eHostAgent`
2. `packages/app/scripts/lib/host-agent.test.mjs` — unit + spawn-guard coverage

## Detailed testing steps

```bash
bun test packages/app/scripts/lib/host-agent.test.mjs
# 8 passed

# Pre-fix failure shape (why the bug matters)
node -e 'const a=Number.parseInt("abc",10); let n=0; for(let i=1;i<=a;i++) n++; console.log({a,n})'
# { a: NaN, n: 0 }  — empty wait loop, then false timeout
```

# Evidence Gate

<!-- evidence-head:66b8b7e8571d2bdade14f96cc11e7e524c2c5916 -->

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - terminal/library helper for device-e2e host-agent startup; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - terminal/library helper; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no interactive UI flow; rejection is fully captured by unit tests and the pre-fix empty-loop probe below.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no server/runtime path beyond the isolated fake host-agent child used in unit tests.
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no browser app surface.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent, model, prompt, provider, or action behavior.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: focused bun test output (8 passed) proving invalid readyAttempts are rejected before `host-agent.log` is created, plus parse/resolve unit cases for partial strings, zero attempts, and defaults.

### Focused tests (this head)

```text
$ bun test packages/app/scripts/lib/host-agent.test.mjs
✓ host-agent helper > validates ports without coercing malformed values
✓ host-agent helper > parses positive and non-negative safe integers without partial coercion
✓ host-agent helper > resolves readiness knobs from options and env, failing closed on typos
✓ host-agent helper > rejects invalid readyAttempts before spawning a host agent child
✓ host-agent helper > keeps explicit requested ports exclusive
✓ host-agent helper > falls back to a free port when the preferred default is occupied
✓ host-agent helper > starts a child host agent, waits for health, writes logs, and stops it
✓ host-agent helper > fails fast and closes the log fd when the child cannot spawn
 8 pass
 0 fail
```

### Pre-fix empty readiness loop shape

```text
Number.parseInt("abc", 10) // NaN
// for (let attempt = 1; attempt <= NaN; attempt++) never iterates
// → immediate false "Timed out waiting for host agent health"
```

# Known gaps / failures

- Full monorepo `bun run verify` was not run in this cycle (unattended, focused scope).
- Host environment Node is 22.23.2; repository pin is Node 24.15.0. Focused host-agent tests run under Bun and do not require the Playwright Node 24 probe path.
- Package-wide `bun run --cwd packages/app test` also runs unrelated Playwright audit project tests that fail here solely due to missing Node 24+; not caused by this change.

# Notes for reviewers

Operator override allowed Grok for this contribution. Device-signed measured receipt is appended below. Independent review and merge remain with maintainers.

# Measured project receipt

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-rama0x1]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTX6NY15A69KHXBT80EVCHX","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T11:54:56.322Z","completed_at":"2026-08-12T11:59:37.402Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"XOgXCV8b4s25t-llDeVUZUew9h8s2iM7AxPIUWgI3KjMlCbZm85AlLvkSIUxT63r2lnFVfcsUYotRxhzaguDBg"}} -->