### PR TITLE
fix(scripts): reject invalid DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS

### DIFF
--- a/packages/scripts/__tests__/dev-all-service-startup-timeout.test.mjs
+++ b/packages/scripts/__tests__/dev-all-service-startup-timeout.test.mjs
@@ -1,0 +1,147 @@
+/**
+ * Focused coverage for `DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS` validation in
+ * dev-all: parser contract plus real CLI boundary rejections before prepare.
+ */
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DEFAULT_SERVICE_STARTUP_TIMEOUT_MS,
+  parsePositiveSafeInteger,
+  resolveServiceStartupTimeoutMs,
+} from "../dev-all.mjs";
+import { spawnSync } from "../lib/spawn-sync-captured.mjs";
+
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "dev-all.mjs",
+);
+
+function runCli(args, env = {}) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS: undefined,
+      ...env,
+    },
+    timeout: 10_000,
+  });
+}
+
+describe("parsePositiveSafeInteger", () => {
+  test("accepts positive safe integers as strings and numbers", () => {
+    expect(parsePositiveSafeInteger("1", "label")).toBe(1);
+    expect(parsePositiveSafeInteger("120000", "label")).toBe(120000);
+    expect(parsePositiveSafeInteger(90, "label")).toBe(90);
+    expect(parsePositiveSafeInteger(" 5000 ", "label")).toBe(5000);
+  });
+
+  test("rejects zero, negative, partial, signed, fractional, and non-decimal forms", () => {
+    const bad = [
+      "0",
+      "-1",
+      "1.5",
+      "1junk",
+      "+120000",
+      "0x10",
+      "1e2",
+      "0120000",
+      "",
+      " ",
+      "NaN",
+      "Infinity",
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      -3,
+      0,
+      1.5,
+    ];
+    for (const value of bad) {
+      expect(() => parsePositiveSafeInteger(value, "label")).toThrow(
+        /must be a positive safe-integer decimal/,
+      );
+    }
+  });
+});
+
+describe("resolveServiceStartupTimeoutMs", () => {
+  test("uses default when unset or empty", () => {
+    expect(resolveServiceStartupTimeoutMs({})).toBe(
+      DEFAULT_SERVICE_STARTUP_TIMEOUT_MS,
+    );
+    expect(
+      resolveServiceStartupTimeoutMs({
+        DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS: "",
+      }),
+    ).toBe(DEFAULT_SERVICE_STARTUP_TIMEOUT_MS);
+    expect(
+      resolveServiceStartupTimeoutMs({
+        DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS: "   ",
+      }),
+    ).toBe(DEFAULT_SERVICE_STARTUP_TIMEOUT_MS);
+  });
+
+  test("accepts a valid explicit timeout", () => {
+    expect(
+      resolveServiceStartupTimeoutMs({
+        DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS: "45000",
+      }),
+    ).toBe(45000);
+  });
+
+  test("fails closed on explicit invalid env values", () => {
+    for (const value of [
+      "0",
+      "1junk",
+      "notanumber",
+      "1.5",
+      "+120000",
+      "-5",
+      "0120000",
+    ]) {
+      expect(() =>
+        resolveServiceStartupTimeoutMs({
+          DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS: value,
+        }),
+      ).toThrow(
+        /DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS must be a positive safe-integer decimal/,
+      );
+    }
+  });
+});
+
+describe("dev-all CLI boundary", () => {
+  test("rejects invalid DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS before plan output", () => {
+    for (const value of ["0", "1junk", "notanumber", "1.5", "+120000"]) {
+      const result = runCli(["--dry-run", "--no-prepare"], {
+        DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS: value,
+      });
+      expect(result.status).not.toBe(0);
+      const combined = `${result.stdout}${result.stderr}`;
+      expect(combined).toMatch(
+        /DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS must be a positive safe-integer decimal/,
+      );
+      expect(combined).not.toContain("[dev:all] local stack");
+      expect(combined).not.toContain("using fast source prepare");
+    }
+  });
+
+  test("accepts default timeout with dry-run and no-prepare", () => {
+    const result = runCli(["--dry-run", "--no-prepare"], {});
+    expect(result.status).toBe(0);
+    const combined = `${result.stdout}${result.stderr}`;
+    expect(combined).toContain("[dev:all] local stack");
+    expect(combined).toContain("skipping prepare steps");
+  });
+
+  test("accepts a valid explicit timeout with dry-run and no-prepare", () => {
+    const result = runCli(["--dry-run", "--no-prepare"], {
+      DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS: "90000",
+    });
+    expect(result.status).toBe(0);
+    const combined = `${result.stdout}${result.stderr}`;
+    expect(combined).toContain("[dev:all] local stack");
+  });
+});

--- a/packages/scripts/dev-all.mjs
+++ b/packages/scripts/dev-all.mjs
@@ -1,10 +1,24 @@
 #!/usr/bin/env node
-// Drives repo automation dev all with explicit CLI and CI behavior.
+/**
+ * Local full-stack developer launcher (`bun run dev:all`). Spawns agent API,
+ * frontend, homepage, and cloud services with a shared prepare path, then waits
+ * for readiness using `DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS` before treating a
+ * port as failed to start.
+ *
+ * Timeout overrides must be complete positive safe-integer decimals. Partial
+ * `Number.parseInt` accepts (`1junk` → 1) previously shortened readiness waits
+ * into false timeouts that looked like service startup failures.
+ */
 import { execFileSync, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import net from "node:net";
+import path from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 import { resolveDevAllSkipPlugins } from "./lib/script-metadata.mjs";
+
+/** Default wall-clock budget for each service readiness wait (ms). */
+export const DEFAULT_SERVICE_STARTUP_TIMEOUT_MS = 120_000;
 
 const args = new Set(process.argv.slice(2));
 const dryRun = args.has("--dry-run");
@@ -41,6 +55,56 @@ function envDefault(key, value) {
   return process.env[key]?.trim() || value;
 }
 
+/**
+ * Accept only complete positive safe-integer decimal strings (or numbers).
+ * Rejects partial numbers, signed values, fractions, leading zeros, and
+ * non-positive values so a typo cannot silently become a 1 ms readiness wait.
+ * @param {string | number} value
+ * @param {string} label
+ * @returns {number}
+ */
+export function parsePositiveSafeInteger(value, label) {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 1) {
+      throw new Error(
+        `${label} must be a positive safe-integer decimal (received ${JSON.stringify(value)})`,
+      );
+    }
+    return value;
+  }
+  const raw = String(value ?? "").trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `${label} must be a positive safe-integer decimal (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || String(parsed) !== raw) {
+    throw new Error(
+      `${label} must be a positive safe-integer decimal (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Resolve `DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS`: unset/empty keeps the default;
+ * any other explicit value must be a positive safe integer or the command
+ * fails closed.
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number}
+ */
+export function resolveServiceStartupTimeoutMs(env = process.env) {
+  const raw = env.DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS;
+  if (raw === undefined || String(raw).trim() === "") {
+    return DEFAULT_SERVICE_STARTUP_TIMEOUT_MS;
+  }
+  return parsePositiveSafeInteger(
+    String(raw).trim(),
+    "DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS",
+  );
+}
+
 const ports = {
   agentApi: envDefault("DEV_ALL_AGENT_API_PORT", "31337"),
   frontend: envDefault("DEV_ALL_FRONTEND_PORT", "2138"),
@@ -62,10 +126,6 @@ const urls = {
 const localTestAuthSecret = envDefault(
   "PLAYWRIGHT_TEST_AUTH_SECRET",
   "playwright-local-auth-secret",
-);
-const serviceStartupTimeoutMs = Number.parseInt(
-  envDefault("DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS", "120000"),
-  10,
 );
 
 const packagedCloudAvailable = existsSync(
@@ -377,9 +437,9 @@ function canConnect(host, port) {
   });
 }
 
-async function waitForPort(label, host, port) {
+async function waitForPort(label, host, port, timeoutMs) {
   const startedAt = Date.now();
-  while (Date.now() - startedAt < serviceStartupTimeoutMs) {
+  while (Date.now() - startedAt < timeoutMs) {
     if (await canConnect(host, port)) return;
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
@@ -538,6 +598,10 @@ function stopChildrenAndExit(children, code) {
 }
 
 async function main() {
+  // Validate before any prepare or spawn so a typo cannot start services under
+  // a 1 ms / NaN readiness budget that looks like a stack failure.
+  const serviceStartupTimeoutMs = resolveServiceStartupTimeoutMs(process.env);
+
   printPlan();
   if (!dryRun) await assertPortsAvailable();
 
@@ -570,7 +634,12 @@ async function main() {
     const cloudDb = startService(cloudDbService);
     if (cloudDb) children.push(cloudDb);
     console.log(`[dev:all] waiting for cloud DB on 127.0.0.1:${ports.cloudDb}`);
-    await waitForPort("cloud DB", "127.0.0.1", ports.cloudDb);
+    await waitForPort(
+      "cloud DB",
+      "127.0.0.1",
+      ports.cloudDb,
+      serviceStartupTimeoutMs,
+    );
   }
 
   for (const service of services) {
@@ -607,9 +676,16 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(
-    `[dev:all] ${error instanceof Error ? error.message : String(error)}`,
-  );
-  process.exit(1);
-});
+const isDirectRun =
+  import.meta.main === true ||
+  (typeof process.argv[1] === "string" &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href);
+
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error(
+      `[dev:all] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
# Relates to

Closes #18635

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused package checks passed after sync (`packages/scripts` dev-all timeout tests + Biome on touched files). Full `bun run verify` was not re-run end-to-end in this session.
- [x] A reviewer can confirm the change from the CLI transcripts and focused test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xAI / grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build` (`grok` client)
<!-- attribution-row:skill-revision -->
- Skill path: `contribute-to-eliza` @ `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77`
<!-- attribution-row:status -->
- Provenance status: `self-reported` + device-signed project receipt (footer below)
- Run id: `run_01KZTXKFQJH6FH62ETCGHHW0X3`
- Note: Operator approved Grok for this workstream. Token meter via ccusage is unavailable for Grok (signed zero / unavailable confidence), not fabricated.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync; full monorepo `bun run verify` not claimed here.

# Risks

**Low.** Env validation only for the local `dev:all` service readiness budget. No production API, agent runtime, or UI behavior changes for valid invocations. Invalid timeouts now fail closed at the command boundary instead of silently becoming a 1 ms / NaN wait that looks like a stack failure.

# Background

## What does this PR do?

Validates `DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS` at the `dev-all` command boundary:

- Accepts only complete positive safe-integer decimals (rejects `0`, `1junk`, `1.5`, `+120000`, leading zeros, signed/fractional forms).
- Unset/empty keeps the existing 120000 ms default.
- Validation runs before plan print / prepare / spawn so a typo cannot start services under a wrong readiness budget.
- Exports `parsePositiveSafeInteger` / `resolveServiceStartupTimeoutMs` for unit coverage; direct-run guard keeps imports from launching the stack.

Previously `Number.parseInt("1junk", 10)` became `1` and `notanumber` became `NaN`, so `waitForPort` either waited 1 ms or failed immediately with a misleading "did not start" error.

## What kind of change is this?

Bug fix (non-breaking for valid env use; invalid overrides now fail closed).

# Documentation changes needed?

No project docs change required. The env contract is now enforced by the launcher itself.

# Testing

## Where should a reviewer start?

1. `packages/scripts/dev-all.mjs` — `parsePositiveSafeInteger`, `resolveServiceStartupTimeoutMs`, early validation in `main`
2. `packages/scripts/__tests__/dev-all-service-startup-timeout.test.mjs` — unit + real CLI boundary

## Detailed testing steps

```bash
bun test packages/scripts/__tests__/dev-all-service-startup-timeout.test.mjs
# 8 passed

DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS=1junk node packages/scripts/dev-all.mjs --dry-run --no-prepare
# exit 1, message includes DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS must be a positive safe-integer decimal
# does not print "[dev:all] local stack"

DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS=90000 node packages/scripts/dev-all.mjs --dry-run --no-prepare
# exit 0, prints local stack plan
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - terminal-only dev-all CLI harness; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - terminal-only dev-all CLI harness; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no interactive UI flow; CLI argument rejection is fully captured by transcripts below.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no server/runtime path; rejection happens before prepare or spawn.
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no browser app surface.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent, model, prompt, provider, or action behavior.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: focused bun test output (8 passed) and CLI rejection transcripts proving non-zero exit and no plan print for invalid `DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS`.

### CLI after (this head)

```text
$ bun test packages/scripts/__tests__/dev-all-service-startup-timeout.test.mjs
 8 pass
 0 fail

$ DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS=1junk node packages/scripts/dev-all.mjs --dry-run --no-prepare
[dev:all] DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS must be a positive safe-integer decimal (received "1junk")
exit:1

$ DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS=0 node packages/scripts/dev-all.mjs --dry-run --no-prepare
[dev:all] DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS must be a positive safe-integer decimal (received "0")
exit:1

$ DEV_ALL_SERVICE_STARTUP_TIMEOUT_MS=90000 node packages/scripts/dev-all.mjs --dry-run --no-prepare
[dev:all] local stack
  agent API:  http://127.0.0.1:31337
  ...
exit:0
```

### Pre-fix failure shape (why the bug matters)

```text
Number.parseInt("1junk", 10)        // => 1      — 1 ms readiness wait
Number.parseInt("notanumber", 10)   // => NaN    — waitForPort fails immediately
// Date.now() - startedAt < NaN is always false
```

# Known gaps / failures

- Full monorepo `bun run verify` not asserted in this session; focused script tests and Biome on touched files were run.
- Other `DEV_ALL_*_PORT` string overrides retain their prior string-to-URL behavior; only the service startup timeout was hardened in this PR.

# Notes for reviewers

Operator override allowed Grok for this contribution. Device-signed measured receipt is appended below. Independent review and merge remain with maintainers.

# Measured project receipt

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [rama0x1-grok]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTXKFQJH6FH62ETCGHHW0X3","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T12:01:55.955Z","completed_at":"2026-08-12T12:05:57.338Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"BiCAO3sysxVgWLPvcTfH3qbYiO5LFVt4fDjUz8btYqSxfbE7b5cRMgmjoITr0AxzBcnypAPdjl3ReZUEK4DfCw"}} -->