### PR TITLE
fix(app-core): reject malformed CDN retry-policy overrides

### DIFF
--- a/packages/app-core/scripts/validate-cdn-assets.mjs
+++ b/packages/app-core/scripts/validate-cdn-assets.mjs
@@ -3,6 +3,10 @@
  * Validates that published release assets are reachable on the CDN: reads the
  * static asset manifest, builds asset URLs for the resolved release tag, and
  * probes them with a retry/concurrency policy tuned for CI flakiness.
+ *
+ * Retry-policy env overrides must be complete safe-integer decimals. Partial
+ * `Number.parseInt` accepts (`1junk` → 1) previously applied a different
+ * attempts/delay/concurrency budget than the operator requested.
  */
 
 import { execFileSync } from "node:child_process";
@@ -23,45 +27,122 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "../../..");
 const CI_RETRYABLE_STATUSES = new Set([0, 429, 500, 502, 503, 504]);
 
+/** Local defaults when CI is not set. */
+export const DEFAULT_LOCAL_RETRY_POLICY = Object.freeze({
+  attempts: 1,
+  delayMs: 0,
+  concurrency: 2,
+});
+
+/** CI defaults: more retries and parallel probes for flaky CDN edges. */
+export const DEFAULT_CI_RETRY_POLICY = Object.freeze({
+  attempts: 3,
+  delayMs: 5000,
+  concurrency: 4,
+});
+
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function getValidationRetryPolicy({ env = process.env } = {}) {
-  const explicitAttempts = Number.parseInt(
-    env.ELIZA_CDN_VALIDATE_ATTEMPTS ?? "",
-    10,
-  );
-  const explicitDelayMs = Number.parseInt(
-    env.ELIZA_CDN_VALIDATE_DELAY_MS ?? "",
-    10,
-  );
-  const explicitConcurrency = Number.parseInt(
-    env.ELIZA_CDN_VALIDATE_CONCURRENCY ?? "",
-    10,
-  );
-  const inCi = String(env.CI ?? "").toLowerCase() === "true";
+function isUnsetEnv(value) {
+  return value === undefined || String(value).trim() === "";
+}
 
-  return {
-    attempts:
-      Number.isFinite(explicitAttempts) && explicitAttempts > 0
-        ? explicitAttempts
-        : inCi
-          ? 3
-          : 1,
-    delayMs:
-      Number.isFinite(explicitDelayMs) && explicitDelayMs >= 0
-        ? explicitDelayMs
-        : inCi
-          ? 5000
-          : 0,
-    concurrency:
-      Number.isFinite(explicitConcurrency) && explicitConcurrency > 0
-        ? explicitConcurrency
-        : inCi
-          ? 4
-          : 2,
-  };
+/**
+ * Accept only complete positive safe-integer decimal strings (or numbers).
+ * Rejects partial numbers, signed values, fractions, leading zeros, and
+ * non-positive values so a typo cannot silently become a 1-attempt policy.
+ * @param {string | number} value
+ * @param {string} label
+ * @returns {number}
+ */
+export function parsePositiveSafeInteger(value, label) {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 1) {
+      throw new Error(
+        `${label} must be a positive safe-integer decimal (received ${JSON.stringify(value)})`,
+      );
+    }
+    return value;
+  }
+  const raw = String(value ?? "").trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `${label} must be a positive safe-integer decimal (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || String(parsed) !== raw) {
+    throw new Error(
+      `${label} must be a positive safe-integer decimal (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Accept only complete non-negative safe-integer decimal strings (or numbers),
+ * including zero. Same reject set as {@link parsePositiveSafeInteger} except 0.
+ * @param {string | number} value
+ * @param {string} label
+ * @returns {number}
+ */
+export function parseNonNegativeSafeInteger(value, label) {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error(
+        `${label} must be a non-negative safe-integer decimal (received ${JSON.stringify(value)})`,
+      );
+    }
+    return value;
+  }
+  const raw = String(value ?? "").trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `${label} must be a non-negative safe-integer decimal (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 0 || String(parsed) !== raw) {
+    throw new Error(
+      `${label} must be a non-negative safe-integer decimal (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Resolve CDN validation retry policy from env. Unset/empty overrides keep the
+ * current CI or local defaults; any other explicit value must be a complete
+ * safe-integer decimal or the command fails closed before probes.
+ * @param {{ env?: NodeJS.ProcessEnv }} [options]
+ * @returns {{ attempts: number, delayMs: number, concurrency: number }}
+ */
+export function getValidationRetryPolicy({ env = process.env } = {}) {
+  const inCi = String(env.CI ?? "").toLowerCase() === "true";
+  const defaults = inCi ? DEFAULT_CI_RETRY_POLICY : DEFAULT_LOCAL_RETRY_POLICY;
+
+  const attempts = isUnsetEnv(env.ELIZA_CDN_VALIDATE_ATTEMPTS)
+    ? defaults.attempts
+    : parsePositiveSafeInteger(
+        String(env.ELIZA_CDN_VALIDATE_ATTEMPTS).trim(),
+        "ELIZA_CDN_VALIDATE_ATTEMPTS",
+      );
+  const delayMs = isUnsetEnv(env.ELIZA_CDN_VALIDATE_DELAY_MS)
+    ? defaults.delayMs
+    : parseNonNegativeSafeInteger(
+        String(env.ELIZA_CDN_VALIDATE_DELAY_MS).trim(),
+        "ELIZA_CDN_VALIDATE_DELAY_MS",
+      );
+  const concurrency = isUnsetEnv(env.ELIZA_CDN_VALIDATE_CONCURRENCY)
+    ? defaults.concurrency
+    : parsePositiveSafeInteger(
+        String(env.ELIZA_CDN_VALIDATE_CONCURRENCY).trim(),
+        "ELIZA_CDN_VALIDATE_CONCURRENCY",
+      );
+
+  return { attempts, delayMs, concurrency };
 }
 
 async function headManagedAssetUrl(url) {
@@ -234,6 +315,10 @@ export function resolveValidationGitRef({
 }
 
 export async function main({ cwd = repoRoot, env = process.env } = {}) {
+  // Fail closed on bad policy before manifest I/O or network probes so a typo
+  // cannot start validation under a different budget than requested.
+  const retryPolicy = getValidationRetryPolicy({ env });
+
   const releaseTag = resolveElizaReleaseTag({ env });
   const gitSha = resolveCurrentGitSha({ cwd, env });
   const explicitValidationRef = env.ELIZA_CDN_VALIDATION_REF?.trim();
@@ -279,7 +364,6 @@ export async function main({ cwd = repoRoot, env = process.env } = {}) {
     }
   }
 
-  const retryPolicy = getValidationRetryPolicy();
   const appAssetRoot = env.ELIZA_CDN_APP_ASSET_ROOT || "packages/app/public";
   const homepageAssetRoot =
     env.ELIZA_CDN_HOMEPAGE_ASSET_ROOT || "packages/homepage/public";
@@ -317,5 +401,16 @@ if (
   path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
 ) {
   const overrideRoot = process.env.ELIZA_CDN_ROOT_DIR;
-  await main({ cwd: overrideRoot ? path.resolve(overrideRoot) : repoRoot });
+  try {
+    await main({
+      cwd: overrideRoot ? path.resolve(overrideRoot) : repoRoot,
+      env: process.env,
+    });
+  } catch (error) {
+    // error-policy:J1 boundary translation — CLI exits non-zero with message
+    console.error(
+      `validate-cdn-assets: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  }
 }

--- a/packages/app-core/scripts/validate-cdn-assets.test.mjs
+++ b/packages/app-core/scripts/validate-cdn-assets.test.mjs
@@ -1,0 +1,220 @@
+/**
+ * Focused coverage for CDN validation retry-policy env parsing: unit contract
+ * plus a real CLI boundary that rejects malformed overrides before root I/O.
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_CI_RETRY_POLICY,
+  DEFAULT_LOCAL_RETRY_POLICY,
+  getValidationRetryPolicy,
+  parseNonNegativeSafeInteger,
+  parsePositiveSafeInteger,
+} from "./validate-cdn-assets.mjs";
+
+const SCRIPT = fileURLToPath(
+  new URL("./validate-cdn-assets.mjs", import.meta.url),
+);
+const MISSING_ROOT = path.join(
+  path.dirname(SCRIPT),
+  "__missing_cdn_root_for_policy_validation__",
+);
+
+function runCli(env = {}) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      // Clear policy knobs unless the test injects them.
+      ELIZA_CDN_VALIDATE_ATTEMPTS: undefined,
+      ELIZA_CDN_VALIDATE_DELAY_MS: undefined,
+      ELIZA_CDN_VALIDATE_CONCURRENCY: undefined,
+      ELIZA_CDN_ROOT_DIR: undefined,
+      CI: undefined,
+      ...env,
+    },
+    timeout: 15_000,
+  });
+}
+
+describe("parsePositiveSafeInteger", () => {
+  it("accepts positive safe integers as strings and numbers", () => {
+    expect(parsePositiveSafeInteger("1", "label")).toBe(1);
+    expect(parsePositiveSafeInteger("120", "label")).toBe(120);
+    expect(parsePositiveSafeInteger(4, "label")).toBe(4);
+    expect(parsePositiveSafeInteger(" 3 ", "label")).toBe(3);
+  });
+
+  it("rejects zero, negative, partial, signed, fractional, and non-decimal forms", () => {
+    const bad = [
+      "0",
+      "-1",
+      "1.5",
+      "1junk",
+      "+2",
+      "0x10",
+      "1e2",
+      "012",
+      "",
+      " ",
+      "NaN",
+      "Infinity",
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      -3,
+      0,
+      1.5,
+    ];
+    for (const value of bad) {
+      expect(() => parsePositiveSafeInteger(value, "label")).toThrow(
+        /must be a positive safe-integer decimal/,
+      );
+    }
+  });
+});
+
+describe("parseNonNegativeSafeInteger", () => {
+  it("accepts zero and positive safe integers", () => {
+    expect(parseNonNegativeSafeInteger("0", "label")).toBe(0);
+    expect(parseNonNegativeSafeInteger(0, "label")).toBe(0);
+    expect(parseNonNegativeSafeInteger("5000", "label")).toBe(5000);
+    expect(parseNonNegativeSafeInteger(" 10 ", "label")).toBe(10);
+  });
+
+  it("rejects negative, partial, signed, fractional, and non-decimal forms", () => {
+    const bad = [
+      "-1",
+      "1.5",
+      "1junk",
+      "+0",
+      "0x10",
+      "1e2",
+      "00",
+      "012",
+      "",
+      " ",
+      "NaN",
+      Number.NaN,
+      -1,
+      1.5,
+    ];
+    for (const value of bad) {
+      expect(() => parseNonNegativeSafeInteger(value, "label")).toThrow(
+        /must be a non-negative safe-integer decimal/,
+      );
+    }
+  });
+});
+
+describe("getValidationRetryPolicy", () => {
+  it("uses local defaults when unset or empty outside CI", () => {
+    expect(getValidationRetryPolicy({ env: {} })).toEqual(
+      DEFAULT_LOCAL_RETRY_POLICY,
+    );
+    expect(
+      getValidationRetryPolicy({
+        env: {
+          ELIZA_CDN_VALIDATE_ATTEMPTS: "",
+          ELIZA_CDN_VALIDATE_DELAY_MS: "   ",
+          ELIZA_CDN_VALIDATE_CONCURRENCY: "",
+        },
+      }),
+    ).toEqual(DEFAULT_LOCAL_RETRY_POLICY);
+  });
+
+  it("uses CI defaults when CI=true and overrides are unset", () => {
+    expect(getValidationRetryPolicy({ env: { CI: "true" } })).toEqual(
+      DEFAULT_CI_RETRY_POLICY,
+    );
+  });
+
+  it("accepts valid explicit overrides", () => {
+    expect(
+      getValidationRetryPolicy({
+        env: {
+          ELIZA_CDN_VALIDATE_ATTEMPTS: "5",
+          ELIZA_CDN_VALIDATE_DELAY_MS: "0",
+          ELIZA_CDN_VALIDATE_CONCURRENCY: "8",
+        },
+      }),
+    ).toEqual({ attempts: 5, delayMs: 0, concurrency: 8 });
+  });
+
+  it("fails closed on explicit invalid env values", () => {
+    expect(() =>
+      getValidationRetryPolicy({
+        env: { ELIZA_CDN_VALIDATE_ATTEMPTS: "1junk" },
+      }),
+    ).toThrow(
+      /ELIZA_CDN_VALIDATE_ATTEMPTS must be a positive safe-integer decimal/,
+    );
+
+    expect(() =>
+      getValidationRetryPolicy({
+        env: { ELIZA_CDN_VALIDATE_DELAY_MS: "1.5" },
+      }),
+    ).toThrow(
+      /ELIZA_CDN_VALIDATE_DELAY_MS must be a non-negative safe-integer decimal/,
+    );
+
+    expect(() =>
+      getValidationRetryPolicy({
+        env: { ELIZA_CDN_VALIDATE_CONCURRENCY: "+2" },
+      }),
+    ).toThrow(
+      /ELIZA_CDN_VALIDATE_CONCURRENCY must be a positive safe-integer decimal/,
+    );
+
+    expect(() =>
+      getValidationRetryPolicy({
+        env: { ELIZA_CDN_VALIDATE_ATTEMPTS: "0" },
+      }),
+    ).toThrow(
+      /ELIZA_CDN_VALIDATE_ATTEMPTS must be a positive safe-integer decimal/,
+    );
+  });
+});
+
+describe("validate-cdn-assets CLI boundary", () => {
+  it("rejects malformed retry policy before inspecting a missing root", () => {
+    for (const [key, value] of [
+      ["ELIZA_CDN_VALIDATE_ATTEMPTS", "1junk"],
+      ["ELIZA_CDN_VALIDATE_DELAY_MS", "1.5"],
+      ["ELIZA_CDN_VALIDATE_CONCURRENCY", "+2"],
+      ["ELIZA_CDN_VALIDATE_ATTEMPTS", "0"],
+    ]) {
+      const result = runCli({
+        [key]: value,
+        ELIZA_CDN_ROOT_DIR: MISSING_ROOT,
+      });
+      expect(result.status, `${key}=${value}`).not.toBe(0);
+      const combined = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+      expect(combined).toMatch(new RegExp(key));
+      expect(combined).toMatch(/safe-integer decimal/);
+      // Must not proceed into manifest / missing-root diagnostics.
+      expect(combined).not.toMatch(/Static asset manifest/i);
+      expect(combined).not.toMatch(/missing CDN files/i);
+      expect(combined).not.toMatch(/ENOENT/i);
+      expect(combined).not.toMatch(/verified \d+ managed asset/i);
+    }
+  });
+
+  it("does not treat a missing root as success when policy is valid", () => {
+    const result = runCli({
+      ELIZA_CDN_VALIDATE_ATTEMPTS: "1",
+      ELIZA_CDN_VALIDATE_DELAY_MS: "0",
+      ELIZA_CDN_VALIDATE_CONCURRENCY: "1",
+      ELIZA_CDN_ROOT_DIR: MISSING_ROOT,
+    });
+    expect(result.status).not.toBe(0);
+    const combined = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    // With a valid policy, main proceeds and fails later (missing root has no
+    // git SHA / release tag and no static asset manifest).
+    expect(combined).not.toMatch(/safe-integer decimal/);
+    expect(combined).toMatch(
+      /Could not resolve release tag|Static asset manifest|manifest is missing|ENOENT|no such file/i,
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #18634

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused package checks passed after sync (`validate-cdn-assets` tests + Biome on touched files). Full `bun run verify` was not re-run end-to-end in this session.
- [x] A reviewer can confirm the change from the CLI transcripts and focused test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xAI / grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build` (`grok` client)
<!-- attribution-row:skill-revision -->
- Skill path: `contribute-to-eliza` @ `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77`
<!-- attribution-row:status -->
- Provenance status: `self-reported` + device-signed project receipt (footer below)
- Run id: `run_01KZTXYQ8K3K44ZXWPJJPCYRT9`
- Note: Operator approved Grok for this workstream. Token meter via ccusage is unavailable for Grok (signed zero / unavailable confidence), not fabricated.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync; full monorepo `bun run verify` not claimed here.

# Risks

**Low.** Env validation only for the local/CI `validate-cdn-assets` retry policy. No production API, agent runtime, or UI behavior changes for valid invocations. Invalid attempts/delay/concurrency overrides now fail closed at the command boundary instead of silently applying a different policy via partial `Number.parseInt`.

# Background

## What does this PR do?

Validates CDN retry-policy environment variables at the `validate-cdn-assets` boundary:

- `ELIZA_CDN_VALIDATE_ATTEMPTS` / `ELIZA_CDN_VALIDATE_CONCURRENCY`: complete positive safe-integer decimals only.
- `ELIZA_CDN_VALIDATE_DELAY_MS`: complete non-negative safe-integer decimals only (zero allowed).
- Unset/empty keep the existing local (`1/0/2`) and CI (`3/5000/4`) defaults.
- Validation runs before manifest reads or network probes.
- `main({ env })` consults the injected environment for policy resolution (previously always read `process.env`).
- Exports parsers + `getValidationRetryPolicy` for unit coverage; CLI wraps thrown errors with a clear non-zero exit.

Previously `Number.parseInt(\"1junk\", 10)` became `1`, `1.5` delay became `1`, and `+2` concurrency became `2`, so operators could think they set one policy while a different budget ran.

## What kind of change is this?

Bug fix (non-breaking for valid env use; invalid overrides now fail closed).

# Documentation changes needed?

No project docs change required. The env contract is now enforced by the validator itself.

# Testing

## Where should a reviewer start?

1. `packages/app-core/scripts/validate-cdn-assets.mjs` — parsers, `getValidationRetryPolicy`, early validation in `main`
2. `packages/app-core/scripts/validate-cdn-assets.test.mjs` — unit + real CLI boundary

## Detailed testing steps

```bash
node packages/scripts/run-vitest.mjs run --config packages/app-core/vitest.config.ts packages/app-core/scripts/validate-cdn-assets.test.mjs
# 10 passed

ELIZA_CDN_VALIDATE_ATTEMPTS=1junk ELIZA_CDN_ROOT_DIR=/tmp/missing-cdn-root \
  node packages/app-core/scripts/validate-cdn-assets.mjs
# exit 1, message includes ELIZA_CDN_VALIDATE_ATTEMPTS must be a positive safe-integer decimal
# does not mention Static asset manifest

ELIZA_CDN_VALIDATE_DELAY_MS=1.5 ELIZA_CDN_ROOT_DIR=/tmp/missing-cdn-root \
  node packages/app-core/scripts/validate-cdn-assets.mjs
# exit 1, delay must be a non-negative safe-integer decimal
```

# Evidence Gate

<!-- evidence-head:3fa504c22251d0929ee29b968b17ed0f98c7aa8f -->

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - terminal-only CDN validation CLI harness; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - terminal-only CDN validation CLI harness; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no interactive UI flow; CLI argument rejection is fully captured by transcripts below.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no server/runtime path; rejection happens before manifest I/O or network probes.
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no browser app surface.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent, model, prompt, provider, or action behavior.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no DB/memory/wallet/on-chain/audio artifacts; behavior is proven by the offline vitest suite (10 passed) and CLI rejection transcripts in the Testing section (non-zero exit before missing-root/manifest diagnostics for invalid retry-policy env values).

### CLI after (this head `3fa504c22251`)

```text
$ node packages/scripts/run-vitest.mjs run --config packages/app-core/vitest.config.ts packages/app-core/scripts/validate-cdn-assets.test.mjs
 Test Files  1 passed (1)
      Tests  10 passed (10)

$ ELIZA_CDN_VALIDATE_ATTEMPTS=1junk ELIZA_CDN_ROOT_DIR=/tmp/missing-cdn-root node packages/app-core/scripts/validate-cdn-assets.mjs
validate-cdn-assets: ELIZA_CDN_VALIDATE_ATTEMPTS must be a positive safe-integer decimal (received \"1junk\")
exit:1

$ ELIZA_CDN_VALIDATE_DELAY_MS=1.5 ELIZA_CDN_ROOT_DIR=/tmp/missing-cdn-root node packages/app-core/scripts/validate-cdn-assets.mjs
validate-cdn-assets: ELIZA_CDN_VALIDATE_DELAY_MS must be a non-negative safe-integer decimal (received \"1.5\")
exit:1

$ ELIZA_CDN_VALIDATE_CONCURRENCY=+2 ELIZA_CDN_ROOT_DIR=/tmp/missing-cdn-root node packages/app-core/scripts/validate-cdn-assets.mjs
validate-cdn-assets: ELIZA_CDN_VALIDATE_CONCURRENCY must be a positive safe-integer decimal (received \"+2\")
exit:1

$ ELIZA_CDN_VALIDATE_ATTEMPTS=0 ELIZA_CDN_ROOT_DIR=/tmp/missing-cdn-root node packages/app-core/scripts/validate-cdn-assets.mjs
validate-cdn-assets: ELIZA_CDN_VALIDATE_ATTEMPTS must be a positive safe-integer decimal (received \"0\")
exit:1

# Valid policy proceeds past the gate (then fails on missing root/git, as expected):
$ ELIZA_CDN_VALIDATE_ATTEMPTS=2 ELIZA_CDN_VALIDATE_DELAY_MS=0 ELIZA_CDN_VALIDATE_CONCURRENCY=1 ELIZA_CDN_ROOT_DIR=/tmp/missing-cdn-root node packages/app-core/scripts/validate-cdn-assets.mjs
validate-cdn-assets: Could not resolve release tag or git SHA for CDN validation. ...
exit:1
```

### Pre-fix failure shape (why the bug matters)

```text
Number.parseInt(\"1junk\", 10)   // => 1   — silent 1-attempt policy
Number.parseInt(\"1.5\", 10)     // => 1   — 1 ms delay instead of rejecting
Number.parseInt(\"+2\", 10)      // => 2   — signed form accepted
// main({ env }) previously called getValidationRetryPolicy() without env
```

# Known gaps / failures

- Full monorepo `bun run verify` not asserted in this session; focused vitest + Biome on touched files were run.
- No live CDN probes were executed; this change only hardens offline policy parsing at the CLI/unit boundary.

# Notes for reviewers

Operator override allowed Grok for this contribution. Device-signed measured receipt is appended below. Independent review and merge remain with maintainers. Issue #18634 had an implementation CLAIM note from another worker but no linked PR at start time; this PR implements the stated acceptance criteria.

# Measured project receipt

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [rama0x1-grok]
<!-- elizaos-contribution-attribution:v2 {\"provider\":\"xai\",\"model\":\"grok-4.5\",\"client\":\"grok\",\"skill_revision\":\"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza\",\"run\":{\"schema_version\":\"1\",\"run_id\":\"run_01KZTXYQ8K3K44ZXWPJJPCYRT9\",\"project\":\"eliza\",\"repository\":\"elizaOS/eliza\",\"started_at\":\"2026-08-12T12:08:04.116Z\",\"completed_at\":\"2026-08-12T12:10:40.645Z\",\"skill_sha256\":\"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6\",\"usage\":{\"source\":\"ccusage-session-v20\",\"confidence\":\"unavailable\",\"input_tokens\":0,\"output_tokens\":0,\"cache_creation_tokens\":0,\"cache_read_tokens\":0,\"total_tokens\":0,\"cost_micro_usd\":\"0\",\"session_count\":0},\"trajectory_sha256\":null,\"signature_algorithm\":\"ed25519\",\"device_public_key\":\"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI\",\"device_key_id\":\"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea\",\"device_signature\":\"K57R1IiNMWe2_UVS-h8srqoLXjptXeYco1dkbTkIJqg9NL49AisvxRJNLMBvDLFMkYchNqE6ET-G3I8RcRu4Bg\"}} -->
