### PR TITLE
feat(cloud): size node capacity from the machine, not from one global env var

### DIFF
--- a/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
+++ b/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
@@ -33,12 +33,26 @@ import {
   dockerNodesRepository,
   stampDockerNodeEnvironmentMetadata,
 } from "@/db/repositories/docker-nodes";
+import { containersEnv } from "@/lib/config/containers-env";
+import { resolveNodeCapacity } from "@/lib/services/docker-node-manager";
 import { logger } from "@/lib/utils/logger";
+
+/**
+ * Used only when the node reports neither a capacity nor its RAM. Preserves the
+ * historical default rather than guessing, and the create path logs the skip.
+ */
+const DEFAULT_CALLBACK_CAPACITY = 8;
 
 const callbackSchema = z.object({
   nodeId: z.string().min(1).max(64),
   hostname: z.string().min(1).max(255),
-  capacity: z.number().int().min(1).max(64).optional().default(8),
+  // No default: an absent capacity means "derive it from the machine", which
+  // is not the same request as an explicit 8.
+  capacity: z.number().int().min(1).max(64).optional(),
+  /** MemTotal reported by the node itself, in MiB. */
+  memTotalMb: z.number().int().min(1).optional(),
+  /** vCPU the node reports, from nproc. */
+  vCpuCount: z.number().int().min(1).max(512).optional(),
   sshPort: z.number().int().min(1).max(65535).optional().default(22),
   sshUser: z.string().min(1).max(32).optional().default("root"),
   hostKeyFingerprint: z.string().min(1).max(128),
@@ -90,8 +104,16 @@ async function __hono_POST(request: Request) {
     );
   }
 
-  const { nodeId, hostname, capacity, sshPort, sshUser, hostKeyFingerprint } =
-    parsed.data;
+  const {
+    nodeId,
+    hostname,
+    capacity,
+    memTotalMb,
+    vCpuCount,
+    sshPort,
+    sshUser,
+    hostKeyFingerprint,
+  } = parsed.data;
 
   try {
     const existing = await dockerNodesRepository.findByNodeId(nodeId);
@@ -188,12 +210,36 @@ async function __hono_POST(request: Request) {
       });
     }
 
+    const resolved = resolveNodeCapacity({
+      requestedCapacity: capacity,
+      memTotalMb,
+      vCpuCount,
+      agentMemoryLimitMb: containersEnv.agentContainerMemoryLimitMb(),
+      fallbackCapacity: DEFAULT_CALLBACK_CAPACITY,
+    });
+    if (memTotalMb === undefined) {
+      logger.warn(
+        "[admin/docker-nodes/bootstrap-callback] node did not report its RAM; capacity not derived",
+        { nodeId, capacity: resolved.capacity },
+      );
+    } else if (resolved.clampedFrom !== undefined) {
+      logger.error(
+        "[admin/docker-nodes/bootstrap-callback] requested capacity exceeds what this node's RAM can hold",
+        {
+          nodeId,
+          requested: resolved.clampedFrom,
+          capacity: resolved.capacity,
+          memTotalMb,
+        },
+      );
+    }
+
     const created = await dockerNodesRepository.create({
       node_id: nodeId,
       hostname,
       ssh_port: sshPort,
       ssh_user: sshUser,
-      capacity,
+      capacity: resolved.capacity,
       enabled: true,
       status: "unknown",
       allocated_count: 0,
@@ -201,6 +247,10 @@ async function __hono_POST(request: Request) {
       metadata: stampDockerNodeEnvironmentMetadata({
         provider: "operator-provisioned",
         bootstrappedAt: new Date().toISOString(),
+        ...(memTotalMb === undefined ? {} : { memTotalMb }),
+        ...(vCpuCount === undefined ? {} : { vCpuCount }),
+        capacityBoundBy: resolved.boundBy,
+        capacityDerivedFromMemory: resolved.derived,
       }),
     });
     logger.info("[admin/docker-nodes/bootstrap-callback] registered new node", {

--- a/packages/cloud/api/v1/admin/docker-nodes/route.ts
+++ b/packages/cloud/api/v1/admin/docker-nodes/route.ts
@@ -9,9 +9,14 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
-import { dockerNodesRepository } from "@/db/repositories/docker-nodes";
+import {
+  dockerNodesRepository,
+  stampDockerNodeEnvironmentMetadata,
+} from "@/db/repositories/docker-nodes";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireAdmin } from "@/lib/auth/workers-hono-auth";
+import { containersEnv } from "@/lib/config/containers-env";
+import { resolveNodeCapacity } from "@/lib/services/docker-node-manager";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -87,6 +92,9 @@ function isReservedAddress(hostname: string): boolean {
   return reserved.some((re) => re.test(hostname));
 }
 
+/** Only when the operator supplies neither a capacity nor the box's RAM. */
+const DEFAULT_REGISTERED_CAPACITY = 8;
+
 const createNodeSchema = z.object({
   nodeId: z.string().min(1, "nodeId is required"),
   hostname: z
@@ -97,7 +105,13 @@ const createNodeSchema = z.object({
       "Hostname cannot be a private/reserved IP address (loopback, RFC-1918, link-local, metadata)",
     ),
   sshPort: z.number().int().min(1).max(65535).optional().default(22),
-  capacity: z.number().int().min(1).optional().default(8),
+  // No default and an explicit ceiling: absent means "derive from the machine",
+  // and an operator can no longer register an unbounded slot count.
+  capacity: z.number().int().min(1).max(1024).optional(),
+  /** MemTotal of the box, in MiB, when the operator knows it. */
+  memTotalMb: z.number().int().min(1).optional(),
+  /** vCPU the node reports, from nproc. */
+  vCpuCount: z.number().int().min(1).max(512).optional(),
   sshUser: z.string().min(1).optional().default("root"),
   hostKeyFingerprint: z.string().min(1),
 });
@@ -131,8 +145,16 @@ app.post("/", async (c) => {
       );
     }
 
-    const { nodeId, hostname, sshPort, capacity, sshUser, hostKeyFingerprint } =
-      parsed.data;
+    const {
+      nodeId,
+      hostname,
+      sshPort,
+      capacity,
+      memTotalMb,
+      vCpuCount,
+      sshUser,
+      hostKeyFingerprint,
+    } = parsed.data;
 
     const existing = await dockerNodesRepository.findByNodeId(nodeId);
     if (existing) {
@@ -142,19 +164,45 @@ app.post("/", async (c) => {
       );
     }
 
+    const resolved = resolveNodeCapacity({
+      requestedCapacity: capacity,
+      memTotalMb,
+      vCpuCount,
+      agentMemoryLimitMb: containersEnv.agentContainerMemoryLimitMb(),
+      fallbackCapacity: DEFAULT_REGISTERED_CAPACITY,
+    });
+    if (resolved.clampedFrom !== undefined) {
+      logger.error(
+        "[Admin Docker Nodes] requested capacity exceeds what this node's RAM can hold",
+        {
+          nodeId,
+          requested: resolved.clampedFrom,
+          capacity: resolved.capacity,
+          memTotalMb,
+        },
+      );
+    }
+
     const node = await dockerNodesRepository.create({
       node_id: nodeId,
       hostname,
       ssh_port: sshPort,
-      capacity,
+      capacity: resolved.capacity,
       ssh_user: sshUser,
       host_key_fingerprint: hostKeyFingerprint,
+      metadata: stampDockerNodeEnvironmentMetadata({
+        ...(memTotalMb === undefined ? {} : { memTotalMb }),
+        ...(vCpuCount === undefined ? {} : { vCpuCount }),
+        capacityBoundBy: resolved.boundBy,
+        capacityDerivedFromMemory: resolved.derived,
+      }),
     });
 
     logger.info("[Admin Docker Nodes] Node registered", {
       nodeId,
       hostname,
-      capacity,
+      capacity: resolved.capacity,
+      derivedFromMemory: resolved.derived,
     });
 
     const responseData: {

--- a/packages/cloud/shared/src/lib/services/containers/node-bootstrap.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-bootstrap.ts
@@ -123,7 +123,19 @@ export function buildContainerNodeUserData(input: NodeBootstrapInput): string {
       echo '[bootstrap] host key fingerprint unavailable; refusing self-registration'
       exit 1
     fi
-    PAYLOAD=$(printf '{"nodeId":"%s","hostname":"%s","capacity":%d,"sshPort":22,"sshUser":"root","hostKeyFingerprint":"%s"}' '${nodeId}' "$PUBLIC_IP" ${capacity} "$HOST_KEY_FINGERPRINT")
+    MEM_TOTAL_MB=$(awk '/^MemTotal:/{print int($2/1024)}' /proc/meminfo 2>/dev/null)
+    # Omitted rather than sent as 0 when unreadable: the callback rejects a
+    # zero and would fail the whole registration over a missing hint.
+    VCPU_COUNT=$(nproc 2>/dev/null)
+    MEM_FIELD=""
+    CPU_FIELD=""
+    if [ -n "$VCPU_COUNT" ] && [ "$VCPU_COUNT" -gt 0 ] 2>/dev/null; then
+      CPU_FIELD=$(printf '"vCpuCount":%d,' "$VCPU_COUNT")
+    fi
+    if [ -n "$MEM_TOTAL_MB" ] && [ "$MEM_TOTAL_MB" -gt 0 ] 2>/dev/null; then
+      MEM_FIELD=$(printf '"memTotalMb":%d,' "$MEM_TOTAL_MB")
+    fi
+    PAYLOAD=$(printf '{"nodeId":"%s","hostname":"%s","capacity":%d,%s%s"sshPort":22,"sshUser":"root","hostKeyFingerprint":"%s"}' '${nodeId}' "$PUBLIC_IP" ${capacity} "$MEM_FIELD" "$CPU_FIELD" "$HOST_KEY_FINGERPRINT")
     curl -fsS -X POST '${registerUrl}' \\
       -H 'Content-Type: application/json' \\
       ${registerSecret ? `-H 'X-Bootstrap-Secret: ${registerSecret}'` : ""} \\

--- a/packages/cloud/shared/src/lib/services/docker-node-capacity-derivation.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-capacity-derivation.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Capacity derived from what a node actually is: RAM and CPU.
+ *
+ * Capacity was a slot counter stamped from one global env var, unrelated to the
+ * machine, and it is wrong in both directions — both measured on the fleet on
+ * 2026-08-12. It licensed 4 x 3072 MiB of ceilings onto 7745 MiB / 4 vCPU boxes
+ * (the global OOM the admission gate closed), and it would hand a
+ * 257626 MiB / 12 vCPU robot the blind default of 8.
+ *
+ * The dimensions disagree, which is why the minimum exists: the robot carries
+ * ~21 GiB of RAM per core against the cloud box's ~1.9, so sizing it on memory
+ * alone would over-subscribe its CPU roughly sevenfold. IO is absent on
+ * purpose — it is transient and already enforced by the placement PSI gate.
+ *
+ * Deterministic and dependency-free: the decision is pure functions, so these
+ * fixtures are the real hosts.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_AGENT_VCPU_BUDGET,
+  deriveNodeCapacity,
+  HOST_RESERVE_MB,
+  HOST_RESERVE_VCPU,
+  resolveNodeCapacity,
+} from "./docker-node-manager";
+
+/** The staging cloud boxes that OOM-killed booting agents. */
+const CLOUD_NODE_MB = 7745;
+/** eliza-staging-robot-1 and its five siblings. */
+const ROBOT_NODE_MB = 257626;
+/** The shipped per-agent ceiling. */
+const AGENT_MB = 3072;
+
+/** Measured vCPU: the cloud boxes are 4-core, the robots 12-core. */
+const CLOUD_VCPU = 4;
+const ROBOT_VCPU = 12;
+
+const base = {
+  agentMemoryLimitMb: AGENT_MB,
+  fallbackCapacity: 8,
+};
+
+describe("deriveNodeCapacity", () => {
+  test("sizes the measured cloud box at 2 slots, bound by memory", () => {
+    // memory (7745-1024)/3072 = 2 ; cpu (4-1)/1 = 3 -> memory binds
+    const d = deriveNodeCapacity({
+      memTotalMb: CLOUD_NODE_MB,
+      vCpuCount: CLOUD_VCPU,
+      agentMemoryLimitMb: AGENT_MB,
+    });
+    expect(d).toEqual({ capacity: 2, byMemory: 2, byCpu: 3, boundBy: "memory" });
+  });
+
+  test("sizes the robot by CPU, not by its 251 GiB of RAM", () => {
+    // The whole reason the minimum exists: memory alone would say 83.
+    const d = deriveNodeCapacity({
+      memTotalMb: ROBOT_NODE_MB,
+      vCpuCount: ROBOT_VCPU,
+      agentMemoryLimitMb: AGENT_MB,
+    });
+    expect(d.byMemory).toBe(83);
+    expect(d.byCpu).toBe(11);
+    expect(d.capacity).toBe(11);
+    expect(d.boundBy).toBe("cpu");
+  });
+
+  test("sizing the robot on memory alone would over-subscribe its CPU sevenfold", () => {
+    const d = deriveNodeCapacity({
+      memTotalMb: ROBOT_NODE_MB,
+      vCpuCount: ROBOT_VCPU,
+      agentMemoryLimitMb: AGENT_MB,
+    });
+    expect(d.byMemory! / d.byCpu!).toBeGreaterThan(7);
+  });
+
+  test("uses the same memory reserve as the admission gate", () => {
+    const d = deriveNodeCapacity({
+      memTotalMb: CLOUD_NODE_MB,
+      vCpuCount: 64,
+      agentMemoryLimitMb: AGENT_MB,
+    });
+    expect(d.byMemory! * AGENT_MB).toBeLessThanOrEqual(CLOUD_NODE_MB - HOST_RESERVE_MB);
+  });
+
+  test("keeps a core for the host", () => {
+    const d = deriveNodeCapacity({
+      memTotalMb: ROBOT_NODE_MB,
+      vCpuCount: ROBOT_VCPU,
+      agentMemoryLimitMb: AGENT_MB,
+    });
+    expect(d.byCpu).toBe((ROBOT_VCPU - HOST_RESERVE_VCPU) / DEFAULT_AGENT_VCPU_BUDGET);
+  });
+
+  test("sizes on whichever dimension it knows when the other is absent", () => {
+    expect(
+      deriveNodeCapacity({ memTotalMb: CLOUD_NODE_MB, agentMemoryLimitMb: AGENT_MB }),
+    ).toMatchObject({ capacity: 2, byCpu: null, boundBy: "memory" });
+    expect(
+      deriveNodeCapacity({ vCpuCount: ROBOT_VCPU, agentMemoryLimitMb: AGENT_MB }),
+    ).toMatchObject({ capacity: 11, byMemory: null, boundBy: "cpu" });
+  });
+
+  test("reports unknown rather than guessing when it knows nothing", () => {
+    const d = deriveNodeCapacity({ agentMemoryLimitMb: AGENT_MB });
+    expect(d.boundBy).toBe("unknown");
+    expect(d.byMemory).toBeNull();
+    expect(d.byCpu).toBeNull();
+  });
+
+  test("never returns zero for a box that can hold something", () => {
+    expect(
+      deriveNodeCapacity({ memTotalMb: 2048, vCpuCount: 2, agentMemoryLimitMb: AGENT_MB }).capacity,
+    ).toBe(1);
+  });
+});
+
+describe("resolveNodeCapacity", () => {
+  test("derives when the caller states no capacity — what makes a robot usable", () => {
+    const r = resolveNodeCapacity({ ...base, memTotalMb: ROBOT_NODE_MB, vCpuCount: ROBOT_VCPU });
+    expect(r).toEqual({ capacity: 11, derived: true, boundBy: "cpu" });
+  });
+
+  test("clamps the exact staging misconfiguration and says what it cut", () => {
+    const r = resolveNodeCapacity({
+      ...base,
+      requestedCapacity: 4,
+      memTotalMb: CLOUD_NODE_MB,
+      vCpuCount: CLOUD_VCPU,
+    });
+    expect(r).toEqual({ capacity: 2, derived: false, clampedFrom: 4, boundBy: "memory" });
+  });
+
+  test("never raises an operator's explicit choice", () => {
+    const r = resolveNodeCapacity({
+      ...base,
+      requestedCapacity: 8,
+      memTotalMb: ROBOT_NODE_MB,
+      vCpuCount: ROBOT_VCPU,
+    });
+    expect(r.capacity).toBe(8);
+    expect(r.derived).toBe(false);
+  });
+
+  test("leaves an explicit capacity alone when the machine is unknown", () => {
+    expect(resolveNodeCapacity({ ...base, requestedCapacity: 16 })).toMatchObject({
+      capacity: 16,
+      derived: false,
+    });
+  });
+
+  test("falls back only with neither a request nor any hardware fact", () => {
+    expect(resolveNodeCapacity(base)).toMatchObject({ capacity: 8, derived: false });
+  });
+
+  test("treats a nonsensical request as absent rather than honouring it", () => {
+    const r = resolveNodeCapacity({
+      ...base,
+      requestedCapacity: 0,
+      memTotalMb: ROBOT_NODE_MB,
+      vCpuCount: ROBOT_VCPU,
+    });
+    expect(r).toEqual({ capacity: 11, derived: true, boundBy: "cpu" });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -219,7 +219,7 @@ export function parseIoPressureFullAvg60(section: string): number | null {
  * of its own, so its footprint has to be absorbed here or the reserve is
  * fiction.
  */
-const HOST_RESERVE_MB = 1024;
+export const HOST_RESERVE_MB = 1024;
 
 /** Separates the meminfo and committed-ceiling sections in the readiness probe. */
 const READINESS_PROBE_MEMINFO_MARKER = "---MEMINFO---";
@@ -321,6 +321,140 @@ export function admitsRequiredMemory(
     effectiveCommittedMb,
     budgetMb,
   };
+}
+
+/**
+ * CPU a node keeps for itself: dockerd, tailscaled, the embedding sidecar, and
+ * the SSH work the control plane does on it.
+ */
+export const HOST_RESERVE_VCPU = 1;
+
+/**
+ * vCPU budgeted per agent container.
+ *
+ * A policy number, not a measurement — agent containers ship with NO `--cpus`
+ * limit, so nothing enforces this and nothing can measure a per-agent share
+ * from a running box. It encodes the sizing the code was designed around
+ * (ccx33 + capacity 8, i.e. one core per agent) so that capacity stops being
+ * blind to CPU entirely. Override per fleet once real contention data exists.
+ */
+export const DEFAULT_AGENT_VCPU_BUDGET = 1;
+
+export interface NodeCapacityBreakdown {
+  /** The binding value: the smallest dimension. */
+  capacity: number;
+  byMemory: number | null;
+  byCpu: number | null;
+  /** Which dimension decided, for the operator reading the log. */
+  boundBy: "memory" | "cpu" | "unknown";
+}
+
+/**
+ * How many agent containers a node can actually hold, across every dimension
+ * we can size statically.
+ *
+ * Capacity was a slot counter stamped from one global env var, unrelated to the
+ * machine. That number is wrong in both directions, and both were measured on
+ * the fleet: it licensed 4 x 3072 MiB of ceilings onto 7745 MiB / 4 vCPU boxes
+ * (the global OOM the admission gate closed), and it would hand a
+ * 257626 MiB / 12 vCPU robot the blind default of 8.
+ *
+ * The dimensions do not agree, which is the whole point of taking the minimum:
+ * that robot has ~21 GiB of RAM per core against the cloud box's ~1.9, so
+ * sizing it on memory alone would over-subscribe its CPU by roughly sevenfold.
+ *
+ * Memory uses the SAME reserve as {@link admitsRequiredMemory}. If the two
+ * diverged, a node would advertise slots that admission refuses on every
+ * placement: a pool that believes it has room and rejects all work.
+ *
+ * IO is deliberately absent. It is a transient signal, already enforced where
+ * it belongs — `ensureNodeReady` refuses placement above
+ * PLACEMENT_MAX_IO_PRESSURE_FULL_AVG60 — and a static IO slot count would be a
+ * fiction. Disk space has its own monitor.
+ *
+ * This is a ceiling, not a promise: it reads totals, not what is free, so a box
+ * shared with other workloads can still advertise more than it has room for
+ * right now. The admission gate measures what is committed at placement time.
+ */
+export function deriveNodeCapacity(opts: {
+  memTotalMb?: number | null;
+  vCpuCount?: number | null;
+  agentMemoryLimitMb: number;
+  agentVCpuBudget?: number;
+}): NodeCapacityBreakdown {
+  const byMemory = deriveCapacityDimension(
+    opts.memTotalMb,
+    HOST_RESERVE_MB,
+    opts.agentMemoryLimitMb,
+  );
+  const byCpu = deriveCapacityDimension(
+    opts.vCpuCount,
+    HOST_RESERVE_VCPU,
+    opts.agentVCpuBudget ?? DEFAULT_AGENT_VCPU_BUDGET,
+  );
+
+  const known = [
+    { value: byMemory, name: "memory" as const },
+    { value: byCpu, name: "cpu" as const },
+  ].filter((d): d is { value: number; name: "memory" | "cpu" } => d.value !== null);
+
+  if (known.length === 0) {
+    return { capacity: 0, byMemory, byCpu, boundBy: "unknown" };
+  }
+  const binding = known.reduce((a, b) => (b.value < a.value ? b : a));
+  return { capacity: binding.value, byMemory, byCpu, boundBy: binding.name };
+}
+
+/** Total minus what the host keeps, divided by what one agent takes. */
+function deriveCapacityDimension(
+  total: number | null | undefined,
+  hostReserve: number,
+  perAgent: number,
+): number | null {
+  if (typeof total !== "number" || !Number.isFinite(total) || total <= 0) return null;
+  if (!Number.isFinite(perAgent) || perAgent <= 0) return null;
+  const budget = total - hostReserve;
+  if (budget <= 0) return null;
+  return Math.max(1, Math.floor(budget / perAgent));
+}
+
+export function resolveNodeCapacity(opts: {
+  requestedCapacity?: number | null;
+  memTotalMb?: number | null;
+  vCpuCount?: number | null;
+  agentMemoryLimitMb: number;
+  agentVCpuBudget?: number;
+  fallbackCapacity: number;
+}): {
+  capacity: number;
+  derived: boolean;
+  clampedFrom?: number;
+  boundBy: NodeCapacityBreakdown["boundBy"];
+} {
+  const breakdown = deriveNodeCapacity({
+    memTotalMb: opts.memTotalMb,
+    vCpuCount: opts.vCpuCount,
+    agentMemoryLimitMb: opts.agentMemoryLimitMb,
+    agentVCpuBudget: opts.agentVCpuBudget,
+  });
+  const supported = breakdown.boundBy === "unknown" ? null : breakdown.capacity;
+
+  if (typeof opts.requestedCapacity === "number" && opts.requestedCapacity > 0) {
+    if (supported !== null && opts.requestedCapacity > supported) {
+      return {
+        capacity: supported,
+        derived: false,
+        clampedFrom: opts.requestedCapacity,
+        boundBy: breakdown.boundBy,
+      };
+    }
+    return { capacity: opts.requestedCapacity, derived: false, boundBy: breakdown.boundBy };
+  }
+
+  if (supported !== null) {
+    return { capacity: supported, derived: true, boundBy: breakdown.boundBy };
+  }
+  return { capacity: opts.fallbackCapacity, derived: false, boundBy: breakdown.boundBy };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was loaded for this change`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` @ `e11f20c5ef4`; zero conflicts. Independent of #18616 — verified by building and testing this branch on its own.
- [x] `packages/cloud/shared` and `packages/cloud/api` typecheck clean on the touched files, biome clean, 14 new tests plus 13 in the bootstrap-callback contract suite.

# Risks

**Nothing existing is rewritten.** Resolution runs only at registration; no row is re-sized, and the re-bootstrap path still refuses to touch capacity at all (`bootstrap-callback-node-identity.test.ts` pins that and still passes).

- The clamp is **strictly downward**. An operator's explicit number is never raised, only cut when the hardware cannot honour it.
- Unknown hardware changes nothing and is logged. Same policy as the memory admission gate: an unreadable signal must not freeze the fleet.
- The self-registration payload **omits** `memTotalMb` / `vCpuCount` when unreadable rather than sending `0`, which the callback's `min(1)` would reject — that would have failed the whole registration over a missing hint.

# Background

## What does this PR do?

Capacity is a slot counter stamped from `CONTAINERS_AUTOSCALE_NODE_CAPACITY`, unrelated to the box it lands on. That one number is wrong in both directions, and both were measured on the fleet on 2026-08-12:

| | Node | Blind capacity | What it means |
|---|---|---|---|
| **too high** | 7745 MiB / 4 vCPU cloud box | 4 | 12 GiB of ceilings on 7.6 GiB → global OOM, agent killed every ~29s (`#18491`) |
| **too low** | 257626 MiB / 12 vCPU robot | 8 | 251 GiB wired up to use 24 of them |

`deriveNodeCapacity` sizes a node on every dimension that can be sized statically, and takes the smallest:

```
memory   (memTotalMb - HOST_RESERVE_MB) / agentMemoryLimitMb
cpu      (vCpuCount  - HOST_RESERVE_VCPU) / agentVCpuBudget
```

**The minimum is the whole point, because the dimensions disagree.** The robots carry ~21 GiB of RAM per core against the cloud boxes' ~1.9:

```
robot   memory -> 83 slots      cpu -> 11 slots      bound by CPU
cloud   memory ->  2 slots      cpu ->  3 slots      bound by memory
```

Sizing a robot on memory alone would over-subscribe its CPU roughly sevenfold — and agent containers set no `--cpus` at all, so that over-subscription surfaces as latency and contention, never as a refusal. Unlike memory, nothing would tell us.

Memory reuses `HOST_RESERVE_MB` from the admission gate rather than a second constant. If the two diverged, a node would advertise slots that admission refuses on every placement: a pool that believes it has room and rejects all work.

**IO is deliberately not a capacity dimension.** It is transient and already enforced where it belongs — `ensureNodeReady` refuses placement above `PLACEMENT_MAX_IO_PRESSURE_FULL_AVG60`. A static IO slot count would be a fiction. Disk space has its own monitor.

`agentVCpuBudget` defaults to 1 vCPU and is a **policy number, not a measurement** — nothing bounds per-agent CPU today, so no running box can tell us the real share. It encodes the sizing the code was designed around (the `ccx33 + capacity 8` pairing named in `containers-env.ts`) so capacity stops being blind to CPU entirely. The comment says so rather than implying it was derived.

## What kind of change is this?

Feature — control-plane node registration.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`deriveNodeCapacity` in `packages/cloud/shared/src/lib/services/docker-node-manager.ts`. The whole decision is pure functions; the I/O stays in the two registration routes.

## Detailed testing steps

`bun test packages/cloud/shared/src/lib/services/docker-node-capacity-derivation.test.ts` — 14 tests, fixtures are the measured hosts.

Mutation-proved. Flipping the reduce from minimum to maximum, i.e. letting the largest dimension win:

```
(fail) deriveNodeCapacity > sizes the measured cloud box at 2 slots, bound by memory
(fail) deriveNodeCapacity > sizes the robot by CPU, not by its 251 GiB of RAM
(fail) resolveNodeCapacity > derives when the caller states no capacity
(fail) resolveNodeCapacity > clamps the exact staging misconfiguration and says what it cut
(fail) resolveNodeCapacity > treats a nonsensical request as absent rather than honouring it
 9 pass, 5 fail
```

Reverted against the git object; 14/14 after.

Regression: 69/69 across the placement suites, 13/13 on `bootstrap-callback-node-identity` — the suite that pins "capacity is never rewritten on re-bootstrap", which this change had to leave intact.

# Evidence Gate

<!-- evidence-head:5893a2077264e2d2eb1c02e1e0b71a3adb2ba21e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this is a control-plane sizing function and two registration routes; no rendered surface exists before or after.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this is a control-plane sizing function and two registration routes; no rendered surface exists before or after.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing flow in a capacity derivation; its observable effect is the integer persisted on a node row at registration.
<!-- evidence-row:backend-logs -->
- [x] Live hardware measurements the fixtures encode, taken from the fleet over SSH:

```
eliza-staging-robot-1   nproc=12   MemTotal=257626 MiB   load1=0.20
eliza-prod-robot-6      nproc=12   MemTotal=257628 MiB   load1=0.21
eliza-core-40661ddb     nproc=4    MemTotal=7745 MiB     load1=0.19

grep for --cpus / NanoCpus / CpuQuota across the agent container builders: no match
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer code is touched; both routes are operator/API surfaces with no shipped UI in this diff.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behaviour is touched by this change.
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is what each real machine resolves to, before and after:

```
                        RAM      vCPU   blind   byMemory  byCpu   resolved
eliza-core-40661ddb    7745 MiB    4       4        2        3        2   (clamped from 4)
162.55.170.116         7745 MiB    4       4        2        3        2   (clamped from 4)
eliza-staging-robot-1  251 GiB    12       8       83       11       11   (derived)
eliza-prod-robot-6     251 GiB    12       8       83       11       11   (derived)
```

The cloud rows are the misconfiguration that caused the OOM, cut to what the box holds. The robot rows are the reason this exists: 8 → 11 by deriving, and 83 → 11 by not deriving on memory alone.

Related: #18491 (memory admission, merged — shares `HOST_RESERVE_MB`), #18616 (`placement_state`), #18485 (fleet placement; robot registration and tier ranking are @0xSolace's half and are deliberately absent here).

Operational note for that issue rather than this diff: every `docker_nodes` row on staging carries an empty `metadata->>'environment'`. The stamping code exists and runs on both registration paths, so the cause is `process.env.ENVIRONMENT` being unset on the Worker — worth fixing before robots are registered, since that field is what is meant to keep staging and prod off the same box.

[stan-cloud]

