### PR TITLE
fix(app): reject invalid iOS voice selftest poll env overrides

### DIFF
--- a/packages/app/scripts/ios-voice-selftest-lib.mjs
+++ b/packages/app/scripts/ios-voice-selftest-lib.mjs
@@ -1,20 +1,120 @@
 /**
- * Pure verdict logic for the iOS simulator voice round-trip lane
- * (`ios-voice-selftest-smoke.mjs`). Kept dependency-free so it is the single
- * source of truth for "did the REAL mic->ASR->agent->TTS loop pass?" shared by
- * the in-app WKWebView verifier (which mirrors this check to signal early) and
- * the host-side orchestrator (which re-derives the verdict from the raw report
- * as the authoritative hard gate), and unit-tested by
- * `ios-voice-selftest-lib.test.mjs`.
+ * Pure verdict and poll-policy helpers for the iOS simulator voice round-trip
+ * lane (`ios-voice-selftest-smoke.mjs`). Kept dependency-free so it is the
+ * single source of truth for "did the REAL mic->ASR->agent->TTS loop pass?"
+ * shared by the in-app WKWebView verifier (which mirrors this check to signal
+ * early) and the host-side orchestrator (which re-derives the verdict from the
+ * raw report as the authoritative hard gate), plus safe-integer parsing for
+ * host poll knobs. Unit-tested by `ios-voice-selftest-lib.test.mjs`.
  *
  * The no-false-green contract matches `voice-selftest.android.spec.ts`: overall
  * must be `pass` AND each of the asr/send/tts stages must be `pass`. A `skipped`
  * stage (e.g. local-inference ASR not provisioned) is NOT a pass — it fails the
  * lane loudly so "can't run here" never reads as "verified working".
+ *
+ * Poll env overrides (`IOS_VOICE_SELFTEST_ATTEMPTS` / `_DELAY_MS`) must be
+ * complete safe-integer decimals. Partial `Number.parseInt` forms cannot
+ * silently shrink the budget (e.g. `"30junk"` → 30) before the host times out.
  */
 
 /** The three stages every real voice round-trip must clear, in order. */
 export const REQUIRED_VOICE_STAGES = ["asr", "send", "tts"];
+
+/** Default host-side Preferences poll budget when env overrides are unset. */
+export const DEFAULT_VOICE_SELFTEST_ATTEMPTS = 300;
+
+/** Default delay between Preferences polls when env overrides are unset. */
+export const DEFAULT_VOICE_SELFTEST_DELAY_MS = 1000;
+
+/**
+ * Accept only complete positive safe-integer decimal strings (or numbers).
+ * Rejects partial numbers, signed values, fractions, and non-positive values.
+ * @param {string | number} value
+ * @param {string} label
+ * @returns {number}
+ */
+export function parsePositiveSafeInteger(value, label) {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 1) {
+      throw new Error(
+        `${label} must be a positive safe-integer decimal (received ${JSON.stringify(value)})`,
+      );
+    }
+    return value;
+  }
+  const raw = String(value ?? "").trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `${label} must be a positive safe-integer decimal (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || String(parsed) !== raw) {
+    throw new Error(
+      `${label} must be a positive safe-integer decimal (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Accept only complete non-negative safe-integer decimal strings (or numbers),
+ * including zero. Same reject set as {@link parsePositiveSafeInteger} except 0.
+ * @param {string | number} value
+ * @param {string} label
+ * @returns {number}
+ */
+export function parseNonNegativeSafeInteger(value, label) {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error(
+        `${label} must be a non-negative safe-integer decimal (received ${JSON.stringify(value)})`,
+      );
+    }
+    return value;
+  }
+  const raw = String(value ?? "").trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `${label} must be a non-negative safe-integer decimal (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 0 || String(parsed) !== raw) {
+    throw new Error(
+      `${label} must be a non-negative safe-integer decimal (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  }
+  return parsed;
+}
+
+function isUnsetEnv(value) {
+  return value === undefined || value === null || String(value).trim() === "";
+}
+
+/**
+ * Resolve host-side Preferences poll policy from env. Unset/empty overrides
+ * keep the historical defaults (300 attempts / 1000 ms). Any other explicit
+ * value must be a complete safe-integer decimal or the lane fails closed
+ * before simulator boot or host-agent spawn.
+ * @param {{ env?: NodeJS.ProcessEnv }} [options]
+ * @returns {{ attempts: number, delayMs: number }}
+ */
+export function resolveVoiceSelfTestPollPolicy({ env = process.env } = {}) {
+  const attempts = isUnsetEnv(env.IOS_VOICE_SELFTEST_ATTEMPTS)
+    ? DEFAULT_VOICE_SELFTEST_ATTEMPTS
+    : parsePositiveSafeInteger(
+        String(env.IOS_VOICE_SELFTEST_ATTEMPTS).trim(),
+        "IOS_VOICE_SELFTEST_ATTEMPTS",
+      );
+  const delayMs = isUnsetEnv(env.IOS_VOICE_SELFTEST_DELAY_MS)
+    ? DEFAULT_VOICE_SELFTEST_DELAY_MS
+    : parseNonNegativeSafeInteger(
+        String(env.IOS_VOICE_SELFTEST_DELAY_MS).trim(),
+        "IOS_VOICE_SELFTEST_DELAY_MS",
+      );
+  return { attempts, delayMs };
+}
 
 /**
  * Reduce a {@link VoiceSelfTestReport}-shaped object to a hard pass/fail verdict

--- a/packages/app/scripts/ios-voice-selftest-lib.test.mjs
+++ b/packages/app/scripts/ios-voice-selftest-lib.test.mjs
@@ -1,15 +1,42 @@
 /**
- * Unit tests for the pure verdict logic of the iOS voice round-trip lane
- * (`evaluateVoiceSelfTestReport`). Deterministic — no simulator, no device, no
- * model; exercises the no-false-green contract (skipped != pass, transcript +
- * reply presence) that gates `ios-voice-selftest-smoke.mjs`. Runs in the
- * packages/app vitest suite (root `test:client` lane).
+ * Unit tests for the pure verdict logic and poll-policy parsers of the iOS
+ * voice round-trip lane. Deterministic — no simulator, no device, no model;
+ * exercises the no-false-green contract (skipped != pass, transcript + reply
+ * presence) and fail-closed poll env validation that gates
+ * `ios-voice-selftest-smoke.mjs`. Runs in the packages/app vitest suite
+ * (root `test:client` lane).
  */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_VOICE_SELFTEST_ATTEMPTS,
+  DEFAULT_VOICE_SELFTEST_DELAY_MS,
   evaluateVoiceSelfTestReport,
+  parseNonNegativeSafeInteger,
+  parsePositiveSafeInteger,
   REQUIRED_VOICE_STAGES,
+  resolveVoiceSelfTestPollPolicy,
 } from "./ios-voice-selftest-lib.mjs";
+
+const SMOKE_SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "ios-voice-selftest-smoke.mjs",
+);
+
+function runSmokeCli(env = {}) {
+  return spawnSync(process.execPath, [SMOKE_SCRIPT], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      IOS_VOICE_SELFTEST_ATTEMPTS: undefined,
+      IOS_VOICE_SELFTEST_DELAY_MS: undefined,
+      ...env,
+    },
+    timeout: 15_000,
+  });
+}
 
 function stage(name, status) {
   return { stage: name, status, durationMs: 1, detail: {} };
@@ -137,5 +164,157 @@ describe("evaluateVoiceSelfTestReport", () => {
     );
     expect(verdict.pass).toBe(false);
     expect(verdict.reasons).toContain('stage "tts" is "fail", expected "pass"');
+  });
+});
+
+describe("parsePositiveSafeInteger", () => {
+  it("accepts positive safe integers as strings and numbers", () => {
+    expect(parsePositiveSafeInteger("1", "label")).toBe(1);
+    expect(parsePositiveSafeInteger("300", "label")).toBe(300);
+    expect(parsePositiveSafeInteger(90, "label")).toBe(90);
+    expect(parsePositiveSafeInteger(" 15 ", "label")).toBe(15);
+  });
+
+  it("rejects zero, negative, partial, signed, fractional, and non-decimal forms", () => {
+    const bad = [
+      "0",
+      "-1",
+      "1.5",
+      "30junk",
+      "+300",
+      "0x10",
+      "1e2",
+      "0300",
+      "",
+      " ",
+      "NaN",
+      "Infinity",
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      -3,
+      0,
+      1.5,
+    ];
+    for (const value of bad) {
+      expect(() => parsePositiveSafeInteger(value, "label")).toThrow(
+        /must be a positive safe-integer decimal/,
+      );
+    }
+  });
+});
+
+describe("parseNonNegativeSafeInteger", () => {
+  it("accepts zero and positive safe integers", () => {
+    expect(parseNonNegativeSafeInteger("0", "label")).toBe(0);
+    expect(parseNonNegativeSafeInteger(0, "label")).toBe(0);
+    expect(parseNonNegativeSafeInteger("1000", "label")).toBe(1000);
+    expect(parseNonNegativeSafeInteger(" 10 ", "label")).toBe(10);
+  });
+
+  it("rejects negative, partial, signed, fractional, and non-decimal forms", () => {
+    const bad = [
+      "-1",
+      "1.5",
+      "10junk",
+      "+1000",
+      "0x10",
+      "1e2",
+      "01000",
+      "",
+      " ",
+      "NaN",
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      -3,
+      1.5,
+    ];
+    for (const value of bad) {
+      expect(() => parseNonNegativeSafeInteger(value, "label")).toThrow(
+        /must be a non-negative safe-integer decimal/,
+      );
+    }
+  });
+});
+
+describe("resolveVoiceSelfTestPollPolicy", () => {
+  it("uses defaults when unset or empty", () => {
+    expect(resolveVoiceSelfTestPollPolicy({ env: {} })).toEqual({
+      attempts: DEFAULT_VOICE_SELFTEST_ATTEMPTS,
+      delayMs: DEFAULT_VOICE_SELFTEST_DELAY_MS,
+    });
+    expect(
+      resolveVoiceSelfTestPollPolicy({
+        env: {
+          IOS_VOICE_SELFTEST_ATTEMPTS: "",
+          IOS_VOICE_SELFTEST_DELAY_MS: "   ",
+        },
+      }),
+    ).toEqual({
+      attempts: DEFAULT_VOICE_SELFTEST_ATTEMPTS,
+      delayMs: DEFAULT_VOICE_SELFTEST_DELAY_MS,
+    });
+  });
+
+  it("accepts valid explicit overrides", () => {
+    expect(
+      resolveVoiceSelfTestPollPolicy({
+        env: {
+          IOS_VOICE_SELFTEST_ATTEMPTS: "45",
+          IOS_VOICE_SELFTEST_DELAY_MS: "0",
+        },
+      }),
+    ).toEqual({ attempts: 45, delayMs: 0 });
+  });
+
+  it("fails closed on explicit invalid attempts", () => {
+    for (const value of ["0", "30junk", "notanumber", "1.5", "+300", "0300"]) {
+      expect(() =>
+        resolveVoiceSelfTestPollPolicy({
+          env: { IOS_VOICE_SELFTEST_ATTEMPTS: value },
+        }),
+      ).toThrow(
+        /IOS_VOICE_SELFTEST_ATTEMPTS must be a positive safe-integer decimal/,
+      );
+    }
+  });
+
+  it("fails closed on explicit invalid delay", () => {
+    for (const value of ["-1", "10junk", "1.5", "+1000", "01000"]) {
+      expect(() =>
+        resolveVoiceSelfTestPollPolicy({
+          env: { IOS_VOICE_SELFTEST_DELAY_MS: value },
+        }),
+      ).toThrow(
+        /IOS_VOICE_SELFTEST_DELAY_MS must be a non-negative safe-integer decimal/,
+      );
+    }
+  });
+});
+
+describe("ios-voice-selftest-smoke CLI boundary", () => {
+  it("rejects invalid IOS_VOICE_SELFTEST_ATTEMPTS before simulator work", () => {
+    for (const value of ["0", "30junk", "notanumber", "1.5", "+300"]) {
+      const result = runSmokeCli({ IOS_VOICE_SELFTEST_ATTEMPTS: value });
+      expect(result.status).not.toBe(0);
+      const combined = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+      expect(combined).toMatch(
+        /IOS_VOICE_SELFTEST_ATTEMPTS must be a positive safe-integer decimal/,
+      );
+      expect(combined).not.toMatch(/\[ios-voice-selftest\]/);
+      expect(combined).not.toMatch(/xcrun|simctl|simulator/i);
+    }
+  });
+
+  it("rejects invalid IOS_VOICE_SELFTEST_DELAY_MS before simulator work", () => {
+    for (const value of ["-1", "10junk", "1.5", "+1000"]) {
+      const result = runSmokeCli({ IOS_VOICE_SELFTEST_DELAY_MS: value });
+      expect(result.status).not.toBe(0);
+      const combined = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+      expect(combined).toMatch(
+        /IOS_VOICE_SELFTEST_DELAY_MS must be a non-negative safe-integer decimal/,
+      );
+      expect(combined).not.toMatch(/\[ios-voice-selftest\]/);
+      expect(combined).not.toMatch(/xcrun|simctl|simulator/i);
+    }
   });
 });

--- a/packages/app/scripts/ios-voice-selftest-smoke.mjs
+++ b/packages/app/scripts/ios-voice-selftest-smoke.mjs
@@ -24,7 +24,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { evaluateVoiceSelfTestReport } from "./ios-voice-selftest-lib.mjs";
+import {
+  evaluateVoiceSelfTestReport,
+  resolveVoiceSelfTestPollPolicy,
+} from "./ios-voice-selftest-lib.mjs";
 import {
   DEFAULT_HOST_AGENT_PORT,
   startDeviceE2eHostAgent,
@@ -373,15 +376,7 @@ async function stopVideo(recording) {
   return recording.stop();
 }
 
-async function pollResult(udid, appId) {
-  const attempts = Number.parseInt(
-    process.env.IOS_VOICE_SELFTEST_ATTEMPTS ?? "300",
-    10,
-  );
-  const delayMs = Number.parseInt(
-    process.env.IOS_VOICE_SELFTEST_DELAY_MS ?? "1000",
-    10,
-  );
+async function pollResult(udid, appId, { attempts, delayMs }) {
   let lastRaw = "";
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     lastRaw = defaultsReadString(udid, appId, VOICE_RESULT_KEY) ?? "";
@@ -417,6 +412,10 @@ async function pollResult(udid, appId) {
 }
 
 async function main() {
+  // Validate poll knobs before simulator boot or host-agent spawn so a typo
+  // cannot silently shrink the Preferences wait budget via partial parseInt.
+  const pollPolicy = resolveVoiceSelfTestPollPolicy({ env: process.env });
+
   const { appId } = readAppIdentity();
   let apiBase = val("--api-base");
   const udid = ensureSimulatorBooted();
@@ -487,7 +486,7 @@ async function main() {
       `armed in-app first-run remote connect + voice self-test for ${apiBase}`,
     );
 
-    const result = await pollResult(udid, appId);
+    const result = await pollResult(udid, appId, pollPolicy);
     const screenshot = takeScreenshot(udid, "voice-selftest-result");
     const video = await stopVideo(recording);
 


### PR DESCRIPTION
# Relates to

Closes #18638

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused package checks passed after sync (`bun test packages/app/scripts/ios-voice-selftest-lib.test.mjs` + Biome on touched files). Full `bun run verify` was not re-run end-to-end in this session.
- [x] A reviewer can confirm the change from the CLI transcripts and focused test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xAI / grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build` (`grok` client)
<!-- attribution-row:skill-revision -->
- Skill path: `contribute-to-eliza` @ `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77`
<!-- attribution-row:status -->
- Provenance status: `self-reported` + device-signed project receipt (footer below)
- Run id: `run_01KZTY78815WRR4BCGXTJVT9W6`
- Note: Operator approved Grok for this workstream. Token meter via ccusage is unavailable for Grok (signed zero / unavailable confidence), not fabricated.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync; full monorepo `bun run verify` not claimed here.

# Risks

**Low.** Env validation only for the local/CI iOS voice selftest smoke harness poll knobs. No production API, agent runtime, or UI behavior changes for valid invocations. Invalid attempts/delay overrides now fail closed at the CLI boundary instead of silently applying a different Preferences poll budget via partial `Number.parseInt`.

# Background

## What does this PR do?

Validates iOS voice selftest poll environment variables before simulator boot or host-agent spawn:

- `IOS_VOICE_SELFTEST_ATTEMPTS`: complete positive safe-integer decimals only (default 300).
- `IOS_VOICE_SELFTEST_DELAY_MS`: complete non-negative safe-integer decimals only, zero allowed (default 1000).
- Unset/empty/whitespace keep the historical defaults.
- Parsers + `resolveVoiceSelfTestPollPolicy` live in `ios-voice-selftest-lib.mjs` for unit coverage; the smoke CLI resolves policy at the start of `main` and passes the resolved budget into `pollResult`.

Previously `Number.parseInt("30junk", 10)` became `30`, `1.5` delay became `1`, and `+1000` delay became `1000`, so operators could think they set one poll policy while a different budget ran (or `NaN` made the wait loop misbehave).

## What kind of change is this?

Bug fix (non-breaking for valid env use; invalid overrides now fail closed).

# Documentation changes needed?

No project docs change required. The env contract is now enforced by the validator itself.

# Testing

## Where should a reviewer start?

1. `packages/app/scripts/ios-voice-selftest-lib.mjs` — parsers + `resolveVoiceSelfTestPollPolicy`
2. `packages/app/scripts/ios-voice-selftest-smoke.mjs` — early validation in `main`, `pollResult` takes resolved policy
3. `packages/app/scripts/ios-voice-selftest-lib.test.mjs` — unit + real CLI boundary

## Detailed testing steps

```bash
bun test packages/app/scripts/ios-voice-selftest-lib.test.mjs
# 19 passed

IOS_VOICE_SELFTEST_ATTEMPTS=30junk node packages/app/scripts/ios-voice-selftest-smoke.mjs
# exit 1, message includes IOS_VOICE_SELFTEST_ATTEMPTS must be a positive safe-integer decimal
# does not mention [ios-voice-selftest] or simctl

IOS_VOICE_SELFTEST_DELAY_MS=1.5 node packages/app/scripts/ios-voice-selftest-smoke.mjs
# exit 1, delay must be a non-negative safe-integer decimal
```

# Evidence Gate

<!-- evidence-head:b3d8ea99b72f002957746644a04f4aeb4da7522a -->

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - terminal-only iOS voice selftest CLI harness; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - terminal-only iOS voice selftest CLI harness; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no interactive UI flow; CLI argument rejection is fully captured by transcripts below.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no server/runtime path; rejection happens before simulator boot or host-agent spawn.
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no browser app surface.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent, model, prompt, provider, or action behavior.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: focused bun test output (19 passed) and CLI rejection transcripts proving non-zero exit before simulator diagnostics for invalid poll env values.

### CLI after (this head `b3d8ea99b72f`)

```text
$ bun test packages/app/scripts/ios-voice-selftest-lib.test.mjs
 19 pass
 0 fail
 112 expect() calls

$ IOS_VOICE_SELFTEST_ATTEMPTS=30junk node packages/app/scripts/ios-voice-selftest-smoke.mjs
IOS_VOICE_SELFTEST_ATTEMPTS must be a positive safe-integer decimal (received "30junk")
exit:1

$ IOS_VOICE_SELFTEST_DELAY_MS=1.5 node packages/app/scripts/ios-voice-selftest-smoke.mjs
IOS_VOICE_SELFTEST_DELAY_MS must be a non-negative safe-integer decimal (received "1.5")
exit:1

$ IOS_VOICE_SELFTEST_ATTEMPTS=0 node packages/app/scripts/ios-voice-selftest-smoke.mjs
IOS_VOICE_SELFTEST_ATTEMPTS must be a positive safe-integer decimal (received "0")
exit:1

$ IOS_VOICE_SELFTEST_DELAY_MS=+1000 node packages/app/scripts/ios-voice-selftest-smoke.mjs
IOS_VOICE_SELFTEST_DELAY_MS must be a non-negative safe-integer decimal (received "+1000")
exit:1
```

### Pre-fix failure shape (why the bug matters)

```text
Number.parseInt("30junk", 10)   // => 30   — silent smaller attempt budget
Number.parseInt("1.5", 10)      // => 1    — 1 ms delay instead of rejecting
Number.parseInt("+1000", 10)    // => 1000 — signed form accepted
Number.parseInt("notanumber", 10) // => NaN — wait loop misbehaves
```

# Known gaps / failures

- Full monorepo `bun run verify` not asserted in this session; focused bun test + Biome on touched files were run.
- No live iOS simulator voice round-trip was executed; this change only hardens offline poll-policy parsing at the CLI/unit boundary.

# Notes for reviewers

Operator override allowed Grok for this contribution. Device-signed measured receipt is appended below. Independent review and merge remain with maintainers.

# Measured project receipt

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [rama0x1-unattended]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTY78815WRR4BCGXTJVT9W6","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T12:12:43.649Z","completed_at":"2026-08-12T12:16:03.147Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"9UI5mgx1oyBZ6y_xVZrA8iCXlgYHtP8moL7njr_ZX4mUaMzOyvgVQ0-o_74sDereOtoh88tSL1az97O_EA8ICA"}} -->