### PR TITLE
fix(ui): single-flight email magic-link verification (#18627)

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.test.tsx
@@ -8,17 +8,20 @@
  * authorize-return/brand-button are doubled to isolate the mount.
  */
 
+import { StewardApiError } from "@stwd/sdk";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// A never-resolving verify keeps the page in its "verifying" state — we only
-// need to observe the verify was REACHED, not its outcome.
-const { verifyEmailCallback } = vi.hoisted(() => ({
-  verifyEmailCallback: vi.fn(
-    (_token: string, _email: string) => new Promise(() => {}),
-  ),
+const callbackState = vi.hoisted(() => ({
+  verifyEmailCallback:
+    vi.fn<
+      (
+        token: string,
+        email: string,
+      ) => Promise<{ token: string; refreshToken?: string }>
+    >(),
 }));
 
 // Stub StewardAuthProvider with a marker that ALSO supplies the Steward context
@@ -42,7 +45,7 @@ vi.mock("../../../shell/StewardProvider", async () => {
             session: null,
             signOut: () => {},
             getToken: () => "",
-            verifyEmailCallback,
+            verifyEmailCallback: callbackState.verifyEmailCallback,
           }}
         >
           {children}
@@ -72,12 +75,20 @@ vi.mock("../../../../cloud-ui/components/brand/brand-button", () => ({
 
 import EmailCallbackPage from "./email-callback-page";
 
+beforeEach(() => {
+  callbackState.verifyEmailCallback.mockReset();
+});
+
 afterEach(() => {
   cleanup();
 });
 
 describe("EmailCallbackPage", () => {
   it("mounts the callback inside StewardAuthProvider so the magic-link verify runs (not the 'unavailable' dead-end)", async () => {
+    callbackState.verifyEmailCallback.mockImplementation(
+      () => new Promise(() => {}),
+    );
+
     render(
       <MemoryRouter
         initialEntries={["/auth/callback/email?token=tok&email=a%40b.co"]}
@@ -94,7 +105,101 @@ describe("EmailCallbackPage", () => {
     // token/email. Without the wrapper `auth` is null and this never fires —
     // the page dead-ends on "Sign-in is unavailable".
     await waitFor(() =>
-      expect(verifyEmailCallback).toHaveBeenCalledWith("tok", "a@b.co"),
+      expect(callbackState.verifyEmailCallback).toHaveBeenCalledWith(
+        "tok",
+        "a@b.co",
+      ),
     );
+  });
+
+  it("keeps one-time verification single-flight across provider remounts", async () => {
+    callbackState.verifyEmailCallback.mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    const firstMount = render(
+      <MemoryRouter
+        initialEntries={[
+          "/auth/callback/email?token=strict-token&email=strict%40example.com",
+        ]}
+      >
+        <EmailCallbackPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(callbackState.verifyEmailCallback).toHaveBeenCalledTimes(1),
+    );
+    firstMount.unmount();
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/auth/callback/email?token=strict-token&email=strict%40example.com",
+        ]}
+      >
+        <EmailCallbackPage />
+      </MemoryRouter>,
+    );
+
+    expect(callbackState.verifyEmailCallback).toHaveBeenCalledTimes(1);
+    expect(callbackState.verifyEmailCallback).toHaveBeenCalledWith(
+      "strict-token",
+      "strict@example.com",
+    );
+  });
+
+  it("identifies an upstream one-time-link rejection as expired or already used", async () => {
+    callbackState.verifyEmailCallback.mockRejectedValue(
+      new StewardApiError("Invalid or expired magic link", 410),
+    );
+
+    const firstMount = render(
+      <MemoryRouter
+        initialEntries={[
+          "/auth/callback/email?token=used-token&email=used%40example.com",
+        ]}
+      >
+        <EmailCallbackPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "That sign-in link expired or was already used. Please sign in again.",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(screen.queryByText("Invalid or expired magic link")).toBeNull();
+
+    firstMount.unmount();
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/auth/callback/email?token=used-token&email=used%40example.com",
+        ]}
+      >
+        <EmailCallbackPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(callbackState.verifyEmailCallback).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it("rejects an incomplete callback without calling the consume endpoint", async () => {
+    render(
+      <MemoryRouter initialEntries={["/auth/callback/email?email=a%40b.co"]}>
+        <EmailCallbackPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText(
+        "This sign-in link is missing its token or email.",
+      ),
+    ).toBeTruthy();
+    expect(callbackState.verifyEmailCallback).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.tsx
@@ -24,6 +24,60 @@ import { usePageTitle } from "../../lib/use-page-title";
 
 type CallbackStatus = "verifying" | "success" | "error";
 
+type EmailVerificationResult = {
+  token: string;
+  refreshToken?: string;
+};
+
+const pendingEmailVerifications = new Map<
+  string,
+  Promise<EmailVerificationResult>
+>();
+
+function verifyEmailCallbackSingleFlight(
+  verify: (token: string, email: string) => Promise<EmailVerificationResult>,
+  token: string,
+  email: string,
+): Promise<EmailVerificationResult> {
+  const key = `${email}\0${token}`;
+  const pending = pendingEmailVerifications.get(key);
+  if (pending) return pending;
+
+  // Deferring the call lets us publish the promise before a non-conforming
+  // verifier can throw synchronously. Entries live only while the upstream
+  // consume is in flight, so a later deliberate replay still reaches Steward.
+  const verification = Promise.resolve()
+    .then(() => verify(token, email))
+    .finally(() => {
+      if (pendingEmailVerifications.get(key) === verification) {
+        pendingEmailVerifications.delete(key);
+      }
+    });
+  pendingEmailVerifications.set(key, verification);
+  return verification;
+}
+
+function describeVerificationError(
+  error: unknown,
+  t: ReturnType<typeof useCloudT>,
+): string {
+  const status =
+    error !== null && typeof error === "object" && "status" in error
+      ? Reflect.get(error, "status")
+      : undefined;
+  if (status === 401 || status === 403 || status === 410) {
+    return t("cloud.login.callback.codeRejected", {
+      defaultValue:
+        "That sign-in link expired or was already used. Please sign in again.",
+    });
+  }
+  return error instanceof Error
+    ? error.message
+    : t("cloud.emailCallback.verifyFailed", {
+        defaultValue: "Could not verify this sign-in link.",
+      });
+}
+
 // `public: true` routes render WITHOUT the per-route Steward wrapper (see
 // `CloudRouteElement` / `app-authorize-page` #9881), so this page must mount the
 // shell's `StewardAuthProvider` itself. Otherwise the magic-link verify has no
@@ -104,18 +158,21 @@ function EmailCallbackContent() {
       try {
         // The Steward context's verifyEmailCallback already throws on MFA, so
         // the result here is always a completed { token, refreshToken? }.
-        const result = await auth.verifyEmailCallback(token, email);
+        // The module-level single-flight survives StrictMode/provider remounts;
+        // a component-local ref does not, and two concurrent POSTs can consume
+        // the same one-time link before either mount observes authentication.
+        const result = await verifyEmailCallbackSingleFlight(
+          auth.verifyEmailCallback,
+          token,
+          email,
+        );
         await syncStewardSessionCookie(result.token, result.refreshToken);
         finishSuccess();
       } catch (err) {
+        // error-policy:J4 expected rejected/expired one-time links render a
+        // distinct recovery message; unexpected failures retain their detail.
         setStatus("error");
-        setError(
-          err instanceof Error
-            ? err.message
-            : t("cloud.emailCallback.verifyFailed", {
-                defaultValue: "Could not verify this sign-in link.",
-              }),
-        );
+        setError(describeVerificationError(err, t));
       }
     })();
 

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts
@@ -63,4 +63,13 @@ export function useAuthStatus(): {
  * authenticated snapshot (never the `loading` phase the real probe races), so
  * priming is inherently a no-op.
  */
+/**
+ * Non-hook full snapshot read used by the notification store (#18391).
+ * The fixture is a fixed authenticated snapshot, so return that constant;
+ * the export must exist here or the aliased e2e bundle fails to resolve it.
+ */
+export function getAuthStatusSnapshot(): typeof AUTHENTICATED_STATE {
+  return AUTHENTICATED_STATE;
+}
+
 export function primeAuthStatusProbe(): void {}

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts
@@ -63,6 +63,8 @@ export function useAuthStatus(): {
  * authenticated snapshot (never the `loading` phase the real probe races), so
  * priming is inherently a no-op.
  */
+export function primeAuthStatusProbe(): void {}
+
 /**
  * Non-hook full snapshot read used by the notification store (#18391).
  * The fixture is a fixed authenticated snapshot, so return that constant;
@@ -71,5 +73,3 @@ export function useAuthStatus(): {
 export function getAuthStatusSnapshot(): typeof AUTHENTICATED_STATE {
   return AUTHENTICATED_STATE;
 }
-
-export function primeAuthStatusProbe(): void {}


### PR DESCRIPTION
# Relates to

Fixes #18627

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package verification was run after sync; broader unrelated blockers are recorded below.
- [x] A reviewer can confirm the changed behavior from the tests and evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `cursor/grok-4.5`, `cursor/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `cursor`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88:packages/skills/skills/contribute-to-eliza`
- Lane: `[sayo]`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] Focused tests, UI typecheck, UI build, UI lint, and the affected browser fixture pass.
- [ ] Root `bun run verify` was not practical locally because several concurrent worktrees left limited disk; required CI checks are running on this head.

# Risks

**Medium**, scoped to `/auth/callback/email`: single-flight keying must coalesce StrictMode/provider remounts without suppressing a later retry after a failed request. The in-flight entry is removed on settlement. Google OAuth `invalid_client` is an ops/secrets-rotation item; no credential is committed here.

# Background

## What does this PR do?

- Makes email magic-link verification single-flight across StrictMode/provider remounts, preventing duplicate one-time Steward consume requests in Chromium/Brave.
- Maps Steward 401/403/410 consume rejections to an explicit expired-or-already-used recovery message.
- Rejects incomplete callbacks before calling the consume endpoint.
- Keeps the home-screen E2E auth stub aligned with the auth-status module's non-hook snapshot export so the real fixture bundle remains verifiable.

## What kind of change is this?

Bug fix (non-breaking) for staging email magic-link browser-dependent failures.

# Google OAuth diagnosis

The staging `invalid_client` is not fixed in code. The Cloud API reads `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` from the deployed Worker environment in `packages/cloud/api/src/steward/embedded.ts`; no real secret is stored in this repository. A 401 `invalid_client` during token exchange requires the staging operator to rotate/re-provision the matching Google client secret (and confirm the configured client ID/redirect URI pair) in the staging secret store, then redeploy/restart the Steward/Worker path.

# Documentation changes needed?

No user-facing documentation change is required.

# Testing

## Where should a reviewer start?

1. `packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.tsx` — module-level single-flight and error translation.
2. `packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.test.tsx` — remount coalescing, expired/used messaging, and incomplete callback coverage.

## Commands and results

- `bun run --cwd packages/ui test -- src/cloud/public-pages/pages/auth/email-callback-page.test.tsx` — **1 file, 4 tests passed**.
- `bun run --cwd packages/ui typecheck` — **passed**.
- `bun run --cwd packages/ui build` — **passed**.
- `bun run --cwd packages/ui lint:check` — **passed**, with 8 pre-existing `noDocumentCookie` warnings.
- `bun run --cwd packages/ui test:home-screen-e2e` — **passed**.
- `bun run --cwd packages/app audit:app` with pinned Node 24.15.0 — capture completed; OCR reported **212 views / 191 verified / 20 needs-eyeball / 1 unrelated broken** (`builtin-tasks`, iPad portrait, missing `Tasks`).
- Full UI suite — exited nonzero after about eight minutes in broad pre-existing notification-store/fuzz coverage; the focused callback file remained green.

Manual staging follow-up: request a fresh link, open it once in Brave Private/Chromium and Safari, then replay it and confirm the already-used recovery message.

# Evidence Gate

<!-- evidence-head:85f725acb6ed5549547a4d64cff6c20b154ef089 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18641-before-email-callback-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18641-after-email-callback-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18641-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - client-side magic-link verification single-flight; Steward API contract unchanged
<!-- evidence-row:frontend-logs -->
- [ ] N/A - focused Vitest callback coverage is 4/4 and includes the remount race
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - auth callback has no LLM path
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database or media artifacts; session-cookie sync only
<!-- evidence-row:ocr-review -->
- [x] [18641-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18641-ocr-review.txt)

# Known gaps / follow-ups

- **Ops-only:** rotate/re-provision the staging Google OAuth client secret; no secret belongs in this PR.
- Stale CSS preload warnings and empty Agents table rows are separate defects and are not changed here.
- The unrelated app-audit `builtin-tasks` iPad OCR regression remains outside this auth PR.