### PR TITLE
fix(ui): alias /dashboard/applications to AppsMovedRoute

### DIFF
--- a/packages/ui/src/cloud/applications/index.ts
+++ b/packages/ui/src/cloud/applications/index.ts
@@ -21,6 +21,10 @@ import {
   type CloudRouteDef,
   registerCloudRoute,
 } from "../shell/cloud-route-registry";
+import {
+  APPLICATIONS_DETAIL_ROUTE_PATH,
+  APPLICATIONS_LIST_ROUTE_PATH,
+} from "./register-moved-routes";
 
 export { default as ApplicationDetailPage } from "./ApplicationDetailPage";
 export { default as ApplicationsPage } from "./ApplicationsPage";
@@ -37,11 +41,15 @@ export {
   useApp,
   useApps,
 } from "./lib/apps";
+export {
+  APPLICATIONS_DETAIL_ROUTE_PATH,
+  APPLICATIONS_LEGACY_DETAIL_ROUTE_PATH,
+  APPLICATIONS_LEGACY_LIST_ROUTE_PATH,
+  APPLICATIONS_LIST_ROUTE_PATH,
+} from "./register-moved-routes";
 
 /** Stable surface label + URL path slugs for the Applications surface. */
 export const APPLICATIONS_SURFACE_LABEL = "Applications";
-export const APPLICATIONS_LIST_ROUTE_PATH = "dashboard/apps";
-export const APPLICATIONS_DETAIL_ROUTE_PATH = "dashboard/apps/:id";
 
 /** Lazy route elements (code-split) for the Applications surfaces. */
 const ApplicationsRouteLazy = lazy(() => import("./ApplicationsPage"));

--- a/packages/ui/src/cloud/applications/register-moved-routes.ts
+++ b/packages/ui/src/cloud/applications/register-moved-routes.ts
@@ -1,0 +1,29 @@
+/**
+ * Registers current and legacy console Applications paths to the retired-Apps
+ * redirect without loading the heavier Applications page barrel.
+ */
+import { lazy } from "react";
+import { registerCloudRoute } from "../shell/cloud-route-registry";
+
+export const APPLICATIONS_LIST_ROUTE_PATH = "dashboard/apps";
+export const APPLICATIONS_DETAIL_ROUTE_PATH = "dashboard/apps/:id";
+export const APPLICATIONS_LEGACY_LIST_ROUTE_PATH = "dashboard/applications";
+export const APPLICATIONS_LEGACY_DETAIL_ROUTE_PATH =
+  "dashboard/applications/:id";
+
+/** Register every console Applications spelling to the moved-route handoff. */
+export function registerMovedApplicationsCloudRoutes(): void {
+  const AppsMovedRoute = lazy(() => import("./AppsMovedRoute"));
+  for (const path of [
+    APPLICATIONS_LIST_ROUTE_PATH,
+    APPLICATIONS_DETAIL_ROUTE_PATH,
+    APPLICATIONS_LEGACY_LIST_ROUTE_PATH,
+    APPLICATIONS_LEGACY_DETAIL_ROUTE_PATH,
+  ]) {
+    registerCloudRoute({
+      path,
+      element: AppsMovedRoute,
+      group: "dashboard",
+    });
+  }
+}

--- a/packages/ui/src/cloud/private-cloud-registration.test.ts
+++ b/packages/ui/src/cloud/private-cloud-registration.test.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import { registerMovedApplicationsCloudRoutes } from "./applications/register-moved-routes";
 import {
   ensurePrivateCloudSurfaces,
   forceNewPrivateCloudGenerationForTests,
@@ -15,6 +16,7 @@ import {
   setPrivateCloudLoadForTests,
   subscribePrivateCloudRegistration,
 } from "./private-cloud-registration";
+import { getCloudRoute } from "./shell/cloud-route-registry";
 
 const appMainSource = readFileSync(
   join(dirname(fileURLToPath(import.meta.url)), "../../../app/src/main.tsx"),
@@ -50,6 +52,23 @@ describe("pathNeedsPrivateCloudSurfaces", () => {
     ]) {
       expect(pathNeedsPrivateCloudSurfaces(path), path).toBe(true);
     }
+  });
+});
+
+describe("private cloud route registration", () => {
+  it("maps legacy Applications URLs to the moved Apps route", () => {
+    registerMovedApplicationsCloudRoutes();
+    const movedAppsRoute = getCloudRoute("dashboard/apps");
+    expect(movedAppsRoute).toBeDefined();
+    expect(getCloudRoute("dashboard/apps/:id")?.element).toBe(
+      movedAppsRoute?.element,
+    );
+    expect(getCloudRoute("dashboard/applications")?.element).toBe(
+      movedAppsRoute?.element,
+    );
+    expect(getCloudRoute("dashboard/applications/:id")?.element).toBe(
+      movedAppsRoute?.element,
+    );
   });
 });
 

--- a/packages/ui/src/cloud/private-cloud-registration.ts
+++ b/packages/ui/src/cloud/private-cloud-registration.ts
@@ -12,12 +12,7 @@
  * successful one.
  */
 
-import { lazy } from "react";
-import { registerCloudRoute } from "./shell/cloud-route-registry";
-
-/** Stable Applications paths (console no longer hosts Apps; see override below). */
-const APPLICATIONS_LIST_ROUTE_PATH = "dashboard/apps";
-const APPLICATIONS_DETAIL_ROUTE_PATH = "dashboard/apps/:id";
+import { registerMovedApplicationsCloudRoutes } from "./applications/register-moved-routes";
 
 export type PrivateCloudRegistrationStatus =
   | "idle"
@@ -97,20 +92,10 @@ async function loadPrivateCloudDomains(): Promise<void> {
   registerApprovalsCloudRoute();
 
   // The console no longer surfaces Apps — management moved into the Eliza
-  // app. Override both paths (later same-path registration wins) so a stale
-  // /dashboard/apps link redirects to the dashboard. Do not import the
-  // Applications barrel: it eagerly re-exports heavy page modules.
-  const AppsMovedRoute = lazy(() => import("./applications/AppsMovedRoute"));
-  registerCloudRoute({
-    path: APPLICATIONS_LIST_ROUTE_PATH,
-    element: AppsMovedRoute,
-    group: "dashboard",
-  });
-  registerCloudRoute({
-    path: APPLICATIONS_DETAIL_ROUTE_PATH,
-    element: AppsMovedRoute,
-    group: "dashboard",
-  });
+  // app. Override the current paths and retain the older plural aliases so
+  // stale links redirect to the dashboard. Do not import the Applications
+  // barrel: it eagerly re-exports heavy page modules.
+  registerMovedApplicationsCloudRoutes();
 
   registerAdminCloudRoutes();
   registerMcpsCloudRoute();

--- a/packages/ui/src/cloud/register-all.test.ts
+++ b/packages/ui/src/cloud/register-all.test.ts
@@ -60,6 +60,9 @@ describe("registerAllCloudSurfaces (sync public API contract)", () => {
       "dashboard/organization",
       "dashboard/api-explorer",
       "dashboard/apps",
+      "dashboard/apps/:id",
+      "dashboard/applications",
+      "dashboard/applications/:id",
       "dashboard/admin",
       "approve/:approvalId",
       "ballot/:ballotId",
@@ -72,6 +75,21 @@ describe("registerAllCloudSurfaces (sync public API contract)", () => {
     ]) {
       expect(paths, `missing route ${p}`).toContain(p);
     }
+  });
+
+  it("maps legacy Applications URLs to the moved Apps route", () => {
+    registerAllCloudSurfaces();
+    const movedAppsRoute = getCloudRoute("dashboard/apps");
+    expect(movedAppsRoute).toBeDefined();
+    expect(getCloudRoute("dashboard/apps/:id")?.element).toBe(
+      movedAppsRoute?.element,
+    );
+    expect(getCloudRoute("dashboard/applications")?.element).toBe(
+      movedAppsRoute?.element,
+    );
+    expect(getCloudRoute("dashboard/applications/:id")?.element).toBe(
+      movedAppsRoute?.element,
+    );
   });
 
   it("leaves the web Cloud Apps handoff in the tab/view app", () => {

--- a/packages/ui/src/cloud/register-all.ts
+++ b/packages/ui/src/cloud/register-all.ts
@@ -44,20 +44,16 @@ import "./account-security/routes";
 import "./monetization/routes";
 import "./connectors/routes";
 import "./organization/routes";
+import "./applications";
 
-import { lazy } from "react";
 import { registerAdminCloudRoutes } from "./admin";
 import { registerApiExplorerCloudRoute } from "./api-explorer";
-import {
-  APPLICATIONS_DETAIL_ROUTE_PATH,
-  APPLICATIONS_LIST_ROUTE_PATH,
-} from "./applications";
+import { registerMovedApplicationsCloudRoutes } from "./applications/register-moved-routes";
 import { registerApprovalsCloudRoute } from "./approvals";
 import { registerJoinFlow } from "./join/register";
 import { registerMcpsCloudRoute } from "./mcps";
 import { registerPublicPages } from "./public-pages/register";
 import { registerCloudSettingsSections } from "./settings";
-import { registerCloudRoute } from "./shell/cloud-route-registry";
 
 let registered = false;
 
@@ -75,19 +71,9 @@ export function registerAllCloudSurfaces(): void {
 
   registerApiExplorerCloudRoute();
   registerApprovalsCloudRoute();
-  // The Applications module self-registers at import time; override both paths
-  // so stale /dashboard/apps links redirect to the dashboard.
-  const AppsMovedRoute = lazy(() => import("./applications/AppsMovedRoute"));
-  registerCloudRoute({
-    path: APPLICATIONS_LIST_ROUTE_PATH,
-    element: AppsMovedRoute,
-    group: "dashboard",
-  });
-  registerCloudRoute({
-    path: APPLICATIONS_DETAIL_ROUTE_PATH,
-    element: AppsMovedRoute,
-    group: "dashboard",
-  });
+  // The Applications module self-registers at import time; override its paths
+  // and retain the older plural aliases so stale links reach the dashboard.
+  registerMovedApplicationsCloudRoutes();
   registerAdminCloudRoutes();
   registerMcpsCloudRoute();
 

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts
@@ -63,4 +63,13 @@ export function useAuthStatus(): {
  * authenticated snapshot (never the `loading` phase the real probe races), so
  * priming is inherently a no-op.
  */
+/**
+ * Non-hook full snapshot read used by the notification store (#18391).
+ * The fixture is a fixed authenticated snapshot, so return that constant;
+ * the export must exist here or the aliased e2e bundle fails to resolve it.
+ */
+export function getAuthStatusSnapshot(): typeof AUTHENTICATED_STATE {
+  return AUTHENTICATED_STATE;
+}
+
 export function primeAuthStatusProbe(): void {}


### PR DESCRIPTION
# Relates to

Fixes #18626

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact verification blocker is recorded below.
- [x] A reviewer can confirm the route mapping through the focused registry tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88`; zero conflicts.
- [x] `bun run verify` was attempted post-sync; the disk-space blocker is documented below.

# Risks

Low. The change adds two compatibility route keys and reuses the existing `AppsMovedRoute`; canonical `/dashboard/apps` behavior is unchanged.

# Background

## What does this PR do?

Registers `dashboard/applications` and `dashboard/applications/:id` in both synchronous and progressive private Cloud registration. All current and legacy Applications paths share the existing moved-Apps redirect to `/dashboard`.

## What kind of change is this?

Bug fix (non-breaking compatibility alias).

# Documentation changes needed?

No documentation change is needed; this restores compatibility for stale URLs.

# Testing

## Where should a reviewer start?

`packages/ui/src/cloud/applications/register-moved-routes.ts` and the route assertions in `packages/ui/src/cloud/register-all.test.ts`.

## Detailed testing steps

- `bun run --cwd packages/ui test -- src/cloud/register-all.test.ts src/cloud/private-cloud-registration.test.ts` — 2 files, 20 tests passed.
- `bun run --cwd packages/ui typecheck` — passed after building the required `@elizaos/cloud-routing` workspace output.
- `bun run --cwd packages/ui lint:check` — passed with 8 pre-existing cookie API warnings.
- Confirmed all four paths resolve to the same route element: `dashboard/apps`, `dashboard/apps/:id`, `dashboard/applications`, and `dashboard/applications/:id`.

# Evidence Gate

<!-- evidence-head:e2cdb6608646608d7ff4e2051caca9456f6ef57a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface; route registration .ts only
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface; route registration .ts only
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI surface; route registration .ts only
<!-- evidence-row:backend-logs -->
- [ ] N/A - client route table alias only; no server log path changed
<!-- evidence-row:frontend-logs -->
- [ ] N/A - focused vitest register-all 8/8 and private-cloud-registration 12/12 passed; no browser console surface for .ts-only change
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/agent trajectory in this route alias change
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain DB/media/scheduled artifacts produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered UI surface; OCR not applicable to route alias .ts

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

N/A - no backend request path changed and no staging deployment was available. Focused Vitest registry assertions passed 20/20.

## Screenshots (before / after) + video walkthrough

N/A - the change only adds route registry aliases and reuses the existing redirect component.

## Audio / voice walkthrough

N/A - no audio or voice behavior changed.

## Known gaps / failures

- Full `packages/ui` test run encountered an unrelated existing failure in `ChatView.render-window.test.tsx` (`reveals the full loaded set...`) and the environment ended the run after about ten minutes. The focused changed-route tests passed.
- `bun run verify` completed 203/204 tasks, then `@elizaos/ui#build` failed with `ENOSPC: no space left on device`; no source/type/lint failure was reported before disk exhaustion.
- Repository-pinned Node 24.15.0 was unavailable on the host; verification used Node 24.19.0 with pinned Bun 1.3.14.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [sayo]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTXB55RSBC5FZDACVQRX6GB","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T11:57:23.000Z","completed_at":"2026-08-12T12:27:21.741Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAOm9EJBcDQVqaeeQ_EVlZPRfooKEY2vQKKb1oG-pwoJE","device_key_id":"4e4ed288b7930e30e97413822230c4cb736b5a035ebd793307508ef3ecf81a61","device_signature":"bhbwlgv0yxk6biFJVZdzajEUOCJiRNbLHZBSRJqQ30M-wNdXyVDjvGWYDHpbnAaU3IdPWWiTOALvvTnGknovDA"}} -->

