### PR TITLE
fix(ui): preserve app-origin Cloud binding after Cloud console navigation (NAV-001)

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts
@@ -63,4 +63,13 @@ export function useAuthStatus(): {
  * authenticated snapshot (never the `loading` phase the real probe races), so
  * priming is inherently a no-op.
  */
+/**
+ * Non-hook full snapshot read used by the notification store (#18391).
+ * The fixture is a fixed authenticated snapshot, so return that constant;
+ * the export must exist here or the aliased e2e bundle fails to resolve it.
+ */
+export function getAuthStatusSnapshot(): typeof AUTHENTICATED_STATE {
+  return AUTHENTICATED_STATE;
+}
+
 export function primeAuthStatusProbe(): void {}

--- a/packages/ui/src/state/cloud-session-refresh-for-repair.app-origin.test.ts
+++ b/packages/ui/src/state/cloud-session-refresh-for-repair.app-origin.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment jsdom
+ * @vitest-environment-options {"url":"https://app-staging.elizacloud.ai/apps"}
+ *
+ * Exercises app-origin Cloud session repair through the real cookie probe,
+ * token store, and staging API endpoint resolver with an HTTP-bound refresh
+ * double.
+ */
+import {
+  hasStewardAuthedCookie,
+  STEWARD_REFRESH_ENDPOINT,
+  STEWARD_TOKEN_KEY,
+} from "@elizaos/shared/steward-session-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api/client-cloud", () => ({
+  refreshCloudStewardSession: async (options?: { endpoint?: string }) => {
+    const response = await fetch(
+      options?.endpoint ?? STEWARD_REFRESH_ENDPOINT,
+      {
+        method: "POST",
+        credentials: "include",
+      },
+    );
+    if (!response.ok) return null;
+    return (await response.json()) as { token?: string };
+  },
+}));
+
+import { ensureCloudSessionForRepair } from "./cloud-session-refresh-for-repair";
+
+const STAGING_AUTHED_COOKIE = "steward-authed-staging";
+
+function writeTestCookie(value: string): void {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom must drive the browser marker read by production.
+  document.cookie = value;
+}
+
+describe("app-origin Cloud session repair", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    writeTestCookie(`${STAGING_AUTHED_COOKIE}=1; Domain=elizacloud.ai; Path=/`);
+  });
+
+  afterEach(() => {
+    writeTestCookie(
+      `${STAGING_AUTHED_COOKIE}=; Max-Age=0; Domain=elizacloud.ai; Path=/`,
+    );
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("recovers an empty app-origin token mirror from the shared staging Cloud cookie", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({ token: "recovered-staging-token", expiresIn: 900 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(hasStewardAuthedCookie()).toBe(true);
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+
+    await expect(ensureCloudSessionForRepair()).resolves.toBe(
+      "recovered-staging-token",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api-staging.elizacloud.ai/api/auth/steward-refresh",
+      {
+        method: "POST",
+        credentials: "include",
+      },
+    );
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(
+      "recovered-staging-token",
+    );
+  });
+});

--- a/packages/ui/src/state/cloud-session-refresh-for-repair.ts
+++ b/packages/ui/src/state/cloud-session-refresh-for-repair.ts
@@ -32,9 +32,11 @@
 import {
   hasStewardAuthedCookie,
   readStoredStewardToken,
+  STEWARD_REFRESH_ENDPOINT,
   writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
 import { refreshCloudStewardSession } from "../api/client-cloud";
+import { DIRECT_ELIZA_CLOUD_API_BY_HOST } from "../api/direct-cloud-endpoints";
 
 /** Bounded so the recovery gate can never hang on a slow refresh. */
 export const CLOUD_REPAIR_REFRESH_TIMEOUT_MS = 6_000;
@@ -62,6 +64,14 @@ function defaultRaceTimeout<T>(p: Promise<T>, ms: number): Promise<T | null> {
   return Promise.race([p, timeout]).finally(() => {
     if (timer) clearTimeout(timer);
   });
+}
+
+function resolveRepairRefreshEndpoint(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  const apiBase = DIRECT_ELIZA_CLOUD_API_BY_HOST.get(
+    window.location.hostname.toLowerCase(),
+  );
+  return apiBase ? `${apiBase}${STEWARD_REFRESH_ENDPOINT}` : undefined;
 }
 
 /**
@@ -103,7 +113,7 @@ export async function ensureCloudSessionForRepair(
     // error-policy:J4 a failed/absent cookie refresh yields null → the caller
     // keeps the wall; it NEVER fabricates a session.
     recovered = await raceTimeout(
-      refreshFn().catch(() => null),
+      refreshFn({ endpoint: resolveRepairRefreshEndpoint() }).catch(() => null),
       timeoutMs,
     );
   } catch {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Fixes #18624 (NAV-001)

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Cursor`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@9f8be8af4d8383edc2cf55b229d6cc39babcdd06:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** Scoped to app-origin Cloud session repair refresh endpoint resolution. Failure mode remains the existing null recovery path (caller keeps the wall); no fabricated session is introduced. Non-app-origin hosts keep the prior relative refresh behavior.

# Background

## What does this PR do?

When repairing an empty app-origin Cloud token mirror from the shared HttpOnly Cloud cookie, `ensureCloudSessionForRepair` now resolves the host-mapped direct Eliza Cloud API steward-refresh URL (`DIRECT_ELIZA_CLOUD_API_BY_HOST` + `STEWARD_REFRESH_ENDPOINT`) instead of posting to a same-origin relative path that cannot see the shared cookie flow correctly on app-origin hosts.

This preserves secure Cloud binding when users pair / recover after browsing the Cloud console and returning to `app-staging.elizacloud.ai` (and production app-origin equivalents).

## What kind of change is this?

Bug fix (non-breaking) for NAV-001 app-origin Cloud session repair.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. `packages/ui/src/state/cloud-session-refresh-for-repair.ts` — `resolveRepairRefreshEndpoint()` and the `refreshFn({ endpoint })` call.
2. `packages/ui/src/state/cloud-session-refresh-for-repair.app-origin.test.ts` — staging app-origin jsdom coverage asserting the direct staging API refresh URL.

## Detailed testing steps

- [x] `bun run --cwd packages/ui test -- cloud-session-refresh-for-repair` — **2 files, 8 tests passed** (includes the new app-origin staging cookie recovery case).
- [ ] Staging QA: sign in on app-origin → browse Cloud console → return to `/apps` or `/settings` and confirm the agent wall does not stick when the shared Cloud cookie is valid (or one-click recovery restores the app-origin mirror).
- [ ] Full `packages/app` aesthetic `audit:app` was not re-run locally (prior run was killed mid-flight). Focused unit tests above passed; full `audit:app` can be run in CI / follow-up — no rendered `.tsx`/`.css` surface changed in this PR.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:36370d1b8f87650f4172310fb8e728ff04d33e40 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface; only packages/ui state helper .ts changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface; only packages/ui state helper .ts changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI surface; only packages/ui state helper .ts changed
<!-- evidence-row:backend-logs -->
- [ ] N/A - client-side repair routing only; no server log path changed
<!-- evidence-row:frontend-logs -->
- [ ] N/A - see Testing section: focused vitest cloud-session-refresh-for-repair passed 8/8; no browser console surface for this .ts-only change
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/agent trajectory in this binding repair change
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain DB/media/scheduled artifacts produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered UI surface; OCR not applicable to .ts state helper

# Evidence Details

## Known gaps / failures

- Full `bun run verify` and `bun run --cwd packages/app audit:app` were intentionally not run in this worktree per scoped finish instructions; a prior `audit:app` attempt was killed mid-run and was not restarted.
- Focused unit proof: `bun run --cwd packages/ui test -- cloud-session-refresh-for-repair` → 2 files / 8 tests passed.
- End-to-end staging Safari reproduction from #18624 remains a useful CI/manual follow-up for acceptance criteria beyond the unit contract.

— [nav-001]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"Cursor","skill_revision":"elizaOS/eliza@9f8be8af4d8383edc2cf55b229d6cc39babcdd06:packages/skills/skills/contribute-to-eliza"} -->

Made with [Cursor](https://cursor.com)

