### PR TITLE
fix(scripts): reject invalid ELIZA_PACKAGE_BUILD_LOCK_STALE_MS overrides

### DIFF
--- a/packages/scripts/__tests__/with-package-build-lock-stale-ms.test.mjs
+++ b/packages/scripts/__tests__/with-package-build-lock-stale-ms.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  parsePositiveSafeInteger,
+  resolveStaleAfterMs,
+} from "../with-package-build-lock.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const scriptPath = path.resolve(
+  __dirname,
+  "../with-package-build-lock.mjs",
+);
+
+describe("with-package-build-lock ELIZA_PACKAGE_BUILD_LOCK_STALE_MS validation", () => {
+  it("uses default 1800000 ms when env var is unset or empty", () => {
+    assert.equal(resolveStaleAfterMs(undefined), 1800000);
+    assert.equal(resolveStaleAfterMs(""), 1800000);
+  });
+
+  it("parses valid positive safe integers", () => {
+    assert.equal(resolveStaleAfterMs("1800000"), 1800000);
+    assert.equal(resolveStaleAfterMs("600000"), 600000);
+    assert.equal(resolveStaleAfterMs("1"), 1);
+  });
+
+  it("rejects malformed, non-numeric, signed, fractional, zero, and negative inputs", () => {
+    const invalidInputs = [
+      "1800000junk",
+      "invalid",
+      "1800000.5",
+      "+1800000",
+      "0",
+      "-500",
+      "  ",
+    ];
+
+    for (const input of invalidInputs) {
+      assert.throws(
+        () => resolveStaleAfterMs(input),
+        (err) => {
+          assert.match(
+            err.message,
+            /\[with-package-build-lock\] ELIZA_PACKAGE_BUILD_LOCK_STALE_MS must be a positive safe-integer decimal/,
+          );
+          return true;
+        },
+        `Expected input "${input}" to throw validation error`,
+      );
+    }
+  });
+
+  it("fails closed in CLI subprocess execution when ELIZA_PACKAGE_BUILD_LOCK_STALE_MS is malformed", () => {
+    assert.throws(
+      () => {
+        execFileSync(
+          process.execPath,
+          [scriptPath, "packages/core", "--", "echo", "hello"],
+          {
+            env: {
+              ...process.env,
+              ELIZA_PACKAGE_BUILD_LOCK_STALE_MS: "1800000junk",
+            },
+            encoding: "utf8",
+            stdio: "pipe",
+          },
+        );
+      },
+      (err) => {
+        assert.equal(err.status, 1);
+        assert.match(
+          err.stderr,
+          /\[with-package-build-lock\] ELIZA_PACKAGE_BUILD_LOCK_STALE_MS must be a positive safe-integer decimal/,
+        );
+        return true;
+      },
+    );
+  });
+
+  it("prints usage and exits 1 when CLI arguments are incomplete", () => {
+    assert.throws(
+      () => {
+        execFileSync(process.execPath, [scriptPath, "--help"], {
+          env: process.env,
+          encoding: "utf8",
+          stdio: "pipe",
+        });
+      },
+      (err) => {
+        assert.equal(err.status, 1);
+        assert.match(
+          err.stderr,
+          /Usage: node packages\/scripts\/with-package-build-lock.mjs/,
+        );
+        return true;
+      },
+    );
+  });
+});

--- a/packages/scripts/with-package-build-lock.mjs
+++ b/packages/scripts/with-package-build-lock.mjs
@@ -3,52 +3,45 @@
 import { execFile, spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { findWorkspaceRoot } from "./lib/repo-root.mjs";
 
 const execFileAsync = promisify(execFile);
 
-const [packageDirArg, separator, ...command] = process.argv.slice(2);
-
-if (!packageDirArg || separator !== "--" || command.length === 0) {
-  console.error(
-    "Usage: node packages/scripts/with-package-build-lock.mjs <package-dir> -- <command...>",
-  );
-  process.exit(1);
+export function parsePositiveSafeInteger(value, name) {
+  if (value === undefined || value === "") return null;
+  const str = String(value).trim();
+  if (!/^[1-9]\d*$/.test(str)) {
+    throw new Error(
+      `[with-package-build-lock] ${name} must be a positive safe-integer decimal (received "${value}")`,
+    );
+  }
+  const num = Number(str);
+  if (!Number.isSafeInteger(num) || num <= 0) {
+    throw new Error(
+      `[with-package-build-lock] ${name} must be a positive safe-integer decimal (received "${value}")`,
+    );
+  }
+  return num;
 }
 
-const root = findWorkspaceRoot(process.cwd());
-const packageDir = path.resolve(root, packageDirArg);
-// Keep transient lock state out of package directories so cancelled Turbo builds
-// do not leave untracked `.build-lock` folders across the workspace.
-const lockRoot = path.join(root, ".turbo", "build-locks");
-const packageLockName = path
-  .relative(root, packageDir)
-  .replaceAll(path.sep, "__")
-  .replaceAll(/[^a-zA-Z0-9._-]/g, "_");
-const lockDir = path.join(lockRoot, packageLockName);
-const cleanupHelper = path.join(
-  root,
-  "packages",
-  "scripts",
-  "rm-path-recursive.mjs",
-);
-const staleAfterMs = Number.parseInt(
-  process.env.ELIZA_PACKAGE_BUILD_LOCK_STALE_MS ?? "1800000",
-  10,
-);
+export function resolveStaleAfterMs(
+  envValue = process.env.ELIZA_PACKAGE_BUILD_LOCK_STALE_MS,
+  defaultValue = 1800000,
+) {
+  if (envValue === undefined || envValue === "") {
+    return defaultValue;
+  }
+  const parsed = parsePositiveSafeInteger(
+    envValue,
+    "ELIZA_PACKAGE_BUILD_LOCK_STALE_MS",
+  );
+  return parsed ?? defaultValue;
+}
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function readLockMetadata() {
-  try {
-    const raw = await fs.readFile(path.join(lockDir, "metadata.json"), "utf8");
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
 }
 
 function isProcessAlive(pid) {
@@ -63,89 +56,150 @@ function isProcessAlive(pid) {
   }
 }
 
-async function removeLockDir() {
-  await execFileAsync(process.execPath, [cleanupHelper, lockDir], {
-    cwd: root,
-  });
-}
+export async function runWithLock(
+  args = process.argv.slice(2),
+  env = process.env,
+) {
+  const [packageDirArg, separator, ...command] = args;
 
-async function removeStaleLock() {
-  const metadata = await readLockMetadata();
-  const createdAt = Date.parse(metadata?.createdAt ?? "");
-  const pid = Number(metadata?.pid);
-  const isStaleByAge =
-    Number.isFinite(createdAt) && Date.now() - createdAt > staleAfterMs;
-  const isStaleByPid = Number.isInteger(pid) && !isProcessAlive(pid);
-
-  if (isStaleByAge || isStaleByPid) {
-    await removeLockDir();
-    return true;
+  if (!packageDirArg || separator !== "--" || command.length === 0) {
+    console.error(
+      "Usage: node packages/scripts/with-package-build-lock.mjs <package-dir> -- <command...>",
+    );
+    return 1;
   }
-  return false;
-}
 
-async function acquireLock() {
-  let waitMs = 100;
-  await fs.mkdir(lockRoot, { recursive: true });
-  while (true) {
+  const staleAfterMs = resolveStaleAfterMs(
+    env.ELIZA_PACKAGE_BUILD_LOCK_STALE_MS,
+  );
+  const root = findWorkspaceRoot(process.cwd());
+  const packageDir = path.resolve(root, packageDirArg);
+  // Keep transient lock state out of package directories so cancelled Turbo builds
+  // do not leave untracked `.build-lock` folders across the workspace.
+  const lockRoot = path.join(root, ".turbo", "build-locks");
+  const packageLockName = path
+    .relative(root, packageDir)
+    .replaceAll(path.sep, "__")
+    .replaceAll(/[^a-zA-Z0-9._-]/g, "_");
+  const lockDir = path.join(lockRoot, packageLockName);
+  const cleanupHelper = path.join(
+    root,
+    "packages",
+    "scripts",
+    "rm-path-recursive.mjs",
+  );
+
+  async function readLockMetadata() {
     try {
-      await fs.mkdir(lockDir);
-      await fs.writeFile(
+      const raw = await fs.readFile(
         path.join(lockDir, "metadata.json"),
-        `${JSON.stringify(
-          {
-            pid: process.pid,
-            command,
-            createdAt: new Date().toISOString(),
-          },
-          null,
-          2,
-        )}\n`,
+        "utf8",
       );
-      return;
-    } catch (error) {
-      if (error?.code !== "EEXIST") {
-        throw error;
-      }
-      if (await removeStaleLock()) {
-        continue;
-      }
-      await sleep(waitMs);
-      waitMs = Math.min(waitMs * 1.5, 1_000);
+      return JSON.parse(raw);
+    } catch {
+      return null;
     }
   }
-}
 
-await acquireLock();
+  async function removeLockDir() {
+    await execFileAsync(process.execPath, [cleanupHelper, lockDir], {
+      cwd: root,
+    });
+  }
 
-const child = spawn(command[0], command.slice(1), {
-  stdio: "inherit",
-  shell: process.platform === "win32",
-});
+  async function removeStaleLock() {
+    const metadata = await readLockMetadata();
+    const createdAt = Date.parse(metadata?.createdAt ?? "");
+    const pid = Number(metadata?.pid);
+    const isStaleByAge =
+      Number.isFinite(createdAt) && Date.now() - createdAt > staleAfterMs;
+    const isStaleByPid = Number.isInteger(pid) && !isProcessAlive(pid);
 
-let cleaningUp = false;
-async function cleanupLock() {
-  if (cleaningUp) return;
-  cleaningUp = true;
-  await removeLockDir();
-}
-
-for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
-  process.once(signal, () => {
-    child.kill(signal);
-  });
-}
-
-const exitCode = await new Promise((resolve) => {
-  child.on("exit", (code, signal) => {
-    if (signal) {
-      console.error(`Command terminated by ${signal}`);
-      resolve(1);
-      return;
+    if (isStaleByAge || isStaleByPid) {
+      await removeLockDir();
+      return true;
     }
-    resolve(code ?? 1);
-  });
-});
+    return false;
+  }
 
-await cleanupLock();
-process.exit(exitCode);
+  async function acquireLock() {
+    let waitMs = 100;
+    await fs.mkdir(lockRoot, { recursive: true });
+    while (true) {
+      try {
+        await fs.mkdir(lockDir);
+        await fs.writeFile(
+          path.join(lockDir, "metadata.json"),
+          `${JSON.stringify(
+            {
+              pid: process.pid,
+              command,
+              createdAt: new Date().toISOString(),
+            },
+            null,
+            2,
+          )}\n`,
+        );
+        return;
+      } catch (error) {
+        if (error?.code !== "EEXIST") {
+          throw error;
+        }
+        if (await removeStaleLock()) {
+          continue;
+        }
+        await sleep(waitMs);
+        waitMs = Math.min(waitMs * 1.5, 1_000);
+      }
+    }
+  }
+
+  await acquireLock();
+
+  const child = spawn(command[0], command.slice(1), {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  let cleaningUp = false;
+  async function cleanupLock() {
+    if (cleaningUp) return;
+    cleaningUp = true;
+    await removeLockDir();
+  }
+
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+    process.once(signal, () => {
+      child.kill(signal);
+    });
+  }
+
+  const exitCode = await new Promise((resolve) => {
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        console.error(`Command terminated by ${signal}`);
+        resolve(1);
+        return;
+      }
+      resolve(code ?? 1);
+    });
+  });
+
+  await cleanupLock();
+  return exitCode;
+}
+
+const invokedDirectly =
+  import.meta.main ||
+  (Boolean(process.argv[1]) &&
+    path.resolve(process.argv[1]) === fileURLToPath(import.meta.url));
+
+if (invokedDirectly) {
+  try {
+    const exitCode = await runWithLock();
+    process.exit(exitCode);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
# Relates to

Closes #18643

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun test packages/scripts/__tests__/with-package-build-lock-stale-ms.test.mjs` and `bunx biome format` were run post-sync.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Antigravity / Gemini 3.6 Flash (High)`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun test packages/scripts/__tests__/with-package-build-lock-stale-ms.test.mjs` passes post-sync.

# Risks

Low. Validation only for `ELIZA_PACKAGE_BUILD_LOCK_STALE_MS` environment variable parsing in `packages/scripts/with-package-build-lock.mjs`. Unset or valid positive integers behave identically. Invalid inputs fail closed before acquiring locks.

# Background

## What does this PR do?

Validates `ELIZA_PACKAGE_BUILD_LOCK_STALE_MS` at the `with-package-build-lock` script boundary:
- Accepts only complete positive safe-integer decimal strings (e.g. `1800000`, `600000`).
- Unset or empty environment variable falls back to the default 1800000 ms (30 minutes).
- Invalid, malformed, signed, fractional, zero, negative, or partial numeric strings fail closed before lock acquisition.
- Exports `parsePositiveSafeInteger` and `resolveStaleAfterMs` for unit testing.
- Direct execution guard (`invokedDirectly`) prevents script side-effects when imported into tests.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. `packages/scripts/with-package-build-lock.mjs`: `parsePositiveSafeInteger`, `resolveStaleAfterMs`, `runWithLock`
2. `packages/scripts/__tests__/with-package-build-lock-stale-ms.test.mjs`: unit + CLI integration tests

## Detailed testing steps

```bash
bun test packages/scripts/__tests__/with-package-build-lock-stale-ms.test.mjs
# 5 pass, 0 fail

ELIZA_PACKAGE_BUILD_LOCK_STALE_MS=1800000junk node packages/scripts/with-package-build-lock.mjs packages/core -- echo "test"
# Exits 1 with error: [with-package-build-lock] ELIZA_PACKAGE_BUILD_LOCK_STALE_MS must be a positive safe-integer decimal (received "1800000junk")

ELIZA_PACKAGE_BUILD_LOCK_STALE_MS=600000 node packages/scripts/with-package-build-lock.mjs packages/core -- echo "lock test ok"
# Exits 0, prints "lock test ok"
```

# Evidence Gate

<!-- evidence-head:85bb203621065483dd0f1a4e0255cf0a56a4541c -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface: N/A - terminal-only build script utility; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface: N/A - terminal-only build script utility; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached: N/A - offline build tooling script; CLI rejection fully demonstrated below.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end: N/A - offline script tool; execution occurs before any service spawn.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change: N/A - no frontend UI surface.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes: N/A - no LLM, agent, prompt, or provider logic touched.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable: focused bun test output (5 passed) and CLI error transcripts.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes: N/A - no visual surface.

# Evidence Details

### CLI transcripts & Test Output

```text
$ bun test packages/scripts/__tests__/with-package-build-lock-stale-ms.test.mjs
bun test v1.3.14 (0d9b296a)

packages/scripts/__tests__/with-package-build-lock-stale-ms.test.mjs:
✓ with-package-build-lock ELIZA_PACKAGE_BUILD_LOCK_STALE_MS validation > uses default 1800000 ms when env var is unset or empty [0.19ms]
✓ with-package-build-lock ELIZA_PACKAGE_BUILD_LOCK_STALE_MS validation > parses valid positive safe integers [0.16ms]
✓ with-package-build-lock ELIZA_PACKAGE_BUILD_LOCK_STALE_MS validation > rejects malformed, non-numeric, signed, fractional, zero, and negative inputs [0.83ms]
✓ with-package-build-lock ELIZA_PACKAGE_BUILD_LOCK_STALE_MS validation > fails closed in CLI subprocess execution when ELIZA_PACKAGE_BUILD_LOCK_STALE_MS is malformed [34.06ms]
✓ with-package-build-lock ELIZA_PACKAGE_BUILD_LOCK_STALE_MS validation > prints usage and exits 1 when CLI arguments are incomplete [31.94ms]

 5 pass
 0 fail
Ran 5 tests across 1 file. [185.00ms]

$ ELIZA_PACKAGE_BUILD_LOCK_STALE_MS=1800000junk node packages/scripts/with-package-build-lock.mjs packages/core -- echo "test"
[with-package-build-lock] ELIZA_PACKAGE_BUILD_LOCK_STALE_MS must be a positive safe-integer decimal (received "1800000junk")
exit code: 1

$ ELIZA_PACKAGE_BUILD_LOCK_STALE_MS=600000 node packages/scripts/with-package-build-lock.mjs packages/core -- echo "lock test ok"
lock test ok
exit code: 0
```

## Known gaps / failures

Full monorepo `bun run verify` was not run; focused script tests and Biome formatting were executed on touched files.