### PR TITLE
fix(app-core): reject invalid dev-startup-smoke timing env overrides

### DIFF
--- a/packages/app-core/scripts/dev-startup-smoke.mjs
+++ b/packages/app-core/scripts/dev-startup-smoke.mjs
@@ -1,32 +1,117 @@
 #!/usr/bin/env node
-// CI smoke test: boot `bun run dev` and assert the full dev stack reaches a
-// usable state (API runtime ready AND Vite UI serving) within a hard time
-// budget. Exits non-zero if the budget is exceeded or the dev process dies.
-//
-// Runs on freshly-allocated ports and a throwaway state dir so it never
-// collides with a developer's running dev server or mutates ~/.eliza.
-//
-// Env:
-//   ELIZA_DEV_STARTUP_BUDGET_MS  hard ceiling, default 60000 (the "1 minute" gate)
-//   ELIZA_DEV_STARTUP_HARD_KILL_MS  grace before SIGKILL on teardown, default 8000
-//
-// Emits one compact machine-readable line prefixed with:
-//   [dev-startup-smoke:metrics]
+/**
+ * CI smoke: boot `bun run dev` and assert the full dev stack reaches a usable
+ * state (API runtime ready AND Vite UI serving) within a hard time budget.
+ * Exits non-zero if the budget is exceeded or the dev process dies.
+ *
+ * Runs on freshly-allocated ports and a throwaway state dir so it never
+ * collides with a developer's running dev server or mutates ~/.eliza.
+ *
+ * Env timing knobs must be complete positive safe-integer decimals. Bare
+ * `Number(...)` previously turned typos into NaN, and `Date.now() > NaN` is
+ * always false, so a bad `ELIZA_DEV_STARTUP_BUDGET_MS` could hang the smoke
+ * forever instead of failing closed before spawn.
+ *
+ * Env:
+ *   ELIZA_DEV_STARTUP_BUDGET_MS     hard ceiling, default 60000
+ *   ELIZA_DEV_STARTUP_HARD_KILL_MS  grace before SIGKILL on teardown, default 8000
+ *                                   (capped at Node's max timer delay)
+ *
+ * Emits one compact machine-readable line prefixed with:
+ *   [dev-startup-smoke:metrics]
+ */
 
 import { spawn } from "node:child_process";
 import { createConnection, createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { signalSpawnedProcessTree } from "./lib/kill-process-tree.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "../../..");
-const BUDGET_MS = Number(process.env.ELIZA_DEV_STARTUP_BUDGET_MS || "60000");
-const HARD_KILL_MS = Number(
-  process.env.ELIZA_DEV_STARTUP_HARD_KILL_MS || "8000",
-);
+
+/** Default hard ceiling for the full stack reaching ready (1 minute gate). */
+export const DEFAULT_BUDGET_MS = 60_000;
+
+/** Default SIGTERM→SIGKILL grace during teardown. */
+export const DEFAULT_HARD_KILL_MS = 8_000;
+
+/** Node clamps `setTimeout` delays above this to 1 ms. */
+export const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+/**
+ * Accept only complete positive safe-integer decimal strings (or numbers).
+ * Rejects partial numbers, signed values, fractions, zero, and values above
+ * an optional max (defaults to Number.MAX_SAFE_INTEGER).
+ * @param {string | number} value
+ * @param {string} label
+ * @param {{ max?: number }} [options]
+ * @returns {number}
+ */
+export function parsePositiveSafeInteger(value, label, options = {}) {
+  const max = options.max ?? Number.MAX_SAFE_INTEGER;
+  const rangeHint =
+    max === Number.MAX_SAFE_INTEGER
+      ? "a positive safe-integer decimal"
+      : `a positive safe-integer decimal from 1 to ${max}`;
+  const received = (v) =>
+    typeof v === "number" ? JSON.stringify(v) : JSON.stringify(String(v ?? ""));
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 1 || value > max) {
+      throw new Error(
+        `${label} must be ${rangeHint} (received ${received(value)})`,
+      );
+    }
+    return value;
+  }
+  const raw = String(value ?? "").trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `${label} must be ${rangeHint} (received ${received(value)})`,
+    );
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < 1 ||
+    parsed > max ||
+    String(parsed) !== raw
+  ) {
+    throw new Error(
+      `${label} must be ${rangeHint} (received ${received(value)})`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Resolve budget and hard-kill timing from env. Unset/empty/whitespace keep
+ * historical defaults. Explicit overrides fail closed on typos.
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {{ budgetMs: number, hardKillMs: number }}
+ */
+export function resolveStartupSmokeTiming(env = process.env) {
+  const budgetRaw = env.ELIZA_DEV_STARTUP_BUDGET_MS;
+  const hardKillRaw = env.ELIZA_DEV_STARTUP_HARD_KILL_MS;
+
+  const budgetMs =
+    budgetRaw == null || String(budgetRaw).trim() === ""
+      ? DEFAULT_BUDGET_MS
+      : parsePositiveSafeInteger(budgetRaw, "ELIZA_DEV_STARTUP_BUDGET_MS");
+
+  const hardKillMs =
+    hardKillRaw == null || String(hardKillRaw).trim() === ""
+      ? DEFAULT_HARD_KILL_MS
+      : parsePositiveSafeInteger(
+          hardKillRaw,
+          "ELIZA_DEV_STARTUP_HARD_KILL_MS",
+          { max: MAX_TIMER_DELAY_MS },
+        );
+
+  return { budgetMs, hardKillMs };
+}
 
 function getFreePort() {
   return new Promise((resolve, reject) => {
@@ -92,7 +177,11 @@ async function waitForUiServing(port, deadline) {
   throw new Error(`Vite UI never served HTML on port ${port}`);
 }
 
-async function main() {
+/**
+ * @param {{ budgetMs: number, hardKillMs: number }} timing
+ */
+async function main(timing) {
+  const { budgetMs: BUDGET_MS, hardKillMs: HARD_KILL_MS } = timing;
   const apiPort = await getFreePort();
   let uiPort = await getFreePort();
   if (uiPort === apiPort) uiPort = await getFreePort();
@@ -241,7 +330,26 @@ async function main() {
   process.exit(0);
 }
 
-main().catch((err) => {
-  console.error(`[dev-startup-smoke] unexpected error: ${err?.stack || err}`);
-  process.exit(1);
-});
+const isDirectRun =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (isDirectRun) {
+  let timing;
+  try {
+    timing = resolveStartupSmokeTiming(process.env);
+  } catch (error) {
+    // error-policy:J1 CLI boundary — invalid timing env fails before port
+    // allocation or `bun run dev` spawn, so a typo cannot hang the CI job.
+    console.error(
+      error instanceof Error
+        ? error.message
+        : "[dev-startup-smoke] invalid timing environment",
+    );
+    process.exit(1);
+  }
+  main(timing).catch((err) => {
+    console.error(`[dev-startup-smoke] unexpected error: ${err?.stack || err}`);
+    process.exit(1);
+  });
+}

--- a/packages/app-core/scripts/dev-startup-smoke.test.mjs
+++ b/packages/app-core/scripts/dev-startup-smoke.test.mjs
@@ -1,0 +1,138 @@
+/**
+ * Deterministic coverage for dev-startup-smoke timing env validation: pure
+ * parsers, resolve helpers, and real CLI boundary rejection before `bun run
+ * dev` is ever spawned.
+ */
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_BUDGET_MS,
+  DEFAULT_HARD_KILL_MS,
+  MAX_TIMER_DELAY_MS,
+  parsePositiveSafeInteger,
+  resolveStartupSmokeTiming,
+} from "./dev-startup-smoke.mjs";
+
+const SCRIPT = fileURLToPath(
+  new URL("./dev-startup-smoke.mjs", import.meta.url),
+);
+const NODE_BIN = process.execPath;
+
+function runCli(env = {}, timeoutMs = 5_000) {
+  return spawnSync(NODE_BIN, [SCRIPT], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+    timeout: timeoutMs,
+  });
+}
+
+describe("parsePositiveSafeInteger", () => {
+  it("accepts complete positive safe-integer decimals", () => {
+    expect(parsePositiveSafeInteger("60000", "budget")).toBe(60_000);
+    expect(parsePositiveSafeInteger(8_000, "hard-kill")).toBe(8_000);
+    expect(parsePositiveSafeInteger("1", "budget")).toBe(1);
+  });
+
+  it("rejects partial, signed, fractional, zero, and out-of-range values", () => {
+    for (const value of [
+      "",
+      "  ",
+      "abc",
+      "60junk",
+      "1.5",
+      "+1000",
+      "-3",
+      "0",
+      NaN,
+      1.5,
+      -1,
+    ]) {
+      expect(() => parsePositiveSafeInteger(value, "budget")).toThrow(
+        /budget must be a positive safe-integer decimal/,
+      );
+    }
+    expect(() =>
+      parsePositiveSafeInteger(String(MAX_TIMER_DELAY_MS + 1), "hard-kill", {
+        max: MAX_TIMER_DELAY_MS,
+      }),
+    ).toThrow(/hard-kill must be a positive safe-integer decimal/);
+  });
+});
+
+describe("resolveStartupSmokeTiming", () => {
+  it("keeps historical defaults when env is unset or blank", () => {
+    expect(resolveStartupSmokeTiming({})).toEqual({
+      budgetMs: DEFAULT_BUDGET_MS,
+      hardKillMs: DEFAULT_HARD_KILL_MS,
+    });
+    expect(
+      resolveStartupSmokeTiming({
+        ELIZA_DEV_STARTUP_BUDGET_MS: "",
+        ELIZA_DEV_STARTUP_HARD_KILL_MS: "   ",
+      }),
+    ).toEqual({
+      budgetMs: DEFAULT_BUDGET_MS,
+      hardKillMs: DEFAULT_HARD_KILL_MS,
+    });
+  });
+
+  it("applies valid overrides", () => {
+    expect(
+      resolveStartupSmokeTiming({
+        ELIZA_DEV_STARTUP_BUDGET_MS: "45000",
+        ELIZA_DEV_STARTUP_HARD_KILL_MS: "2500",
+      }),
+    ).toEqual({ budgetMs: 45_000, hardKillMs: 2_500 });
+  });
+
+  it("fails closed on malformed budget or hard-kill overrides", () => {
+    expect(() =>
+      resolveStartupSmokeTiming({
+        ELIZA_DEV_STARTUP_BUDGET_MS: "60junk",
+      }),
+    ).toThrow(/ELIZA_DEV_STARTUP_BUDGET_MS/);
+    expect(() =>
+      resolveStartupSmokeTiming({
+        ELIZA_DEV_STARTUP_HARD_KILL_MS: "1.5",
+      }),
+    ).toThrow(/ELIZA_DEV_STARTUP_HARD_KILL_MS/);
+    expect(() =>
+      resolveStartupSmokeTiming({
+        ELIZA_DEV_STARTUP_BUDGET_MS: "0",
+      }),
+    ).toThrow(/ELIZA_DEV_STARTUP_BUDGET_MS/);
+    expect(() =>
+      resolveStartupSmokeTiming({
+        ELIZA_DEV_STARTUP_HARD_KILL_MS: String(MAX_TIMER_DELAY_MS + 1),
+      }),
+    ).toThrow(/ELIZA_DEV_STARTUP_HARD_KILL_MS/);
+  });
+});
+
+describe("dev-startup-smoke CLI boundary", () => {
+  it("rejects invalid budget env before spawning the dev stack", () => {
+    const result = runCli({ ELIZA_DEV_STARTUP_BUDGET_MS: "60junk" });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/ELIZA_DEV_STARTUP_BUDGET_MS/);
+    expect(result.stdout + result.stderr).not.toMatch(
+      /\[dev-startup-smoke\] budget=/,
+    );
+    expect(result.stdout + result.stderr).not.toMatch(/process spawned/);
+  });
+
+  it("rejects invalid hard-kill env before spawning the dev stack", () => {
+    const result = runCli({ ELIZA_DEV_STARTUP_HARD_KILL_MS: "8s" });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/ELIZA_DEV_STARTUP_HARD_KILL_MS/);
+    expect(result.stdout + result.stderr).not.toMatch(
+      /\[dev-startup-smoke\] budget=/,
+    );
+  });
+
+  it("rejects zero budget instead of hanging with a NaN/zero deadline", () => {
+    const result = runCli({ ELIZA_DEV_STARTUP_BUDGET_MS: "0" });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/ELIZA_DEV_STARTUP_BUDGET_MS/);
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #18644

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused package checks passed after sync (`bun run --cwd packages/app-core test scripts/dev-startup-smoke.test.mjs` + Biome on touched files). Full `bun run verify` was not re-run end-to-end in this session.
- [x] A reviewer can confirm the change from the CLI transcripts and focused test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xAI / grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build` (`grok` client)
<!-- attribution-row:skill-revision -->
- Skill path: `contribute-to-eliza` @ `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77`
<!-- attribution-row:status -->
- Provenance status: `self-reported` + device-signed project receipt (footer below)
- Run id: `run_01KZTYG4M74ED60YC017FNHQES`
- Note: Operator approved Grok for this workstream. Token meter via ccusage is unavailable for Grok (signed zero / unavailable confidence), not fabricated.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync; full monorepo `bun run verify` not claimed here.

# Risks

**Low.** Env validation only for the local/CI `dev-startup-smoke` harness timing knobs. No production API, agent runtime, or UI behavior changes for valid invocations. Invalid budget/hard-kill overrides now fail closed at the CLI boundary instead of hanging on a NaN deadline or clamping oversized `setTimeout` delays to 1 ms.

# Background

## What does this PR do?

Validates dev-startup-smoke timing environment variables before free-port allocation or `bun run dev` spawn:

- `ELIZA_DEV_STARTUP_BUDGET_MS`: complete positive safe-integer decimals only (default 60000).
- `ELIZA_DEV_STARTUP_HARD_KILL_MS`: complete positive safe-integer decimals only, capped at Node's max timer delay `2^31-1` (default 8000).
- Unset/empty/whitespace keep the historical defaults.
- Parsers + `resolveStartupSmokeTiming` are exported for unit coverage; the CLI resolves timing under a direct-run guard before `main`.

Previously bare `Number(...)` turned typos into `NaN`. Because `Date.now() > NaN` is always false, a bad budget could hang the CI smoke forever instead of failing the gate. Oversized hard-kill values could also clamp `setTimeout` to 1 ms and race teardown.

## What kind of change is this?

Bug fix (non-breaking for valid env use; invalid overrides now fail closed).

# Documentation changes needed?

No project docs change required. The env contract is now enforced by the validator itself (and restated in the script header).

# Testing

## Where should a reviewer start?

1. `packages/app-core/scripts/dev-startup-smoke.mjs` — parsers + `resolveStartupSmokeTiming` + early CLI boundary
2. `packages/app-core/scripts/dev-startup-smoke.test.mjs` — unit + real CLI boundary

## Detailed testing steps

```bash
bun run --cwd packages/app-core test scripts/dev-startup-smoke.test.mjs
# 8 passed

ELIZA_DEV_STARTUP_BUDGET_MS=60junk node packages/app-core/scripts/dev-startup-smoke.mjs
# exit 1, message includes ELIZA_DEV_STARTUP_BUDGET_MS; no budget= / process spawn lines

ELIZA_DEV_STARTUP_HARD_KILL_MS=1.5 node packages/app-core/scripts/dev-startup-smoke.mjs
# exit 1, hard-kill must be a positive safe-integer decimal from 1 to 2147483647
```

# Evidence Gate

<!-- evidence-head:f85a1e846fb57b769251ce930f51b117dbf5411d -->

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - terminal-only CI dev-startup-smoke harness; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - terminal-only CI dev-startup-smoke harness; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no interactive UI flow; CLI argument rejection is fully captured by transcripts below.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no server/runtime path; rejection happens before free-port allocation or `bun run dev` spawn.
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no browser app surface.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent, model, prompt, provider, or action behavior.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: focused vitest output (8 passed) and CLI rejection transcripts proving non-zero exit before dev stack spawn for invalid timing env values.

### CLI after (this head `f85a1e846f`)

```text
$ bun run --cwd packages/app-core test scripts/dev-startup-smoke.test.mjs
 Test Files  1 passed (1)
      Tests  8 passed (8)

$ ELIZA_DEV_STARTUP_BUDGET_MS=60junk node packages/app-core/scripts/dev-startup-smoke.mjs
ELIZA_DEV_STARTUP_BUDGET_MS must be a positive safe-integer decimal (received "60junk")
exit:1

$ ELIZA_DEV_STARTUP_HARD_KILL_MS=1.5 node packages/app-core/scripts/dev-startup-smoke.mjs
ELIZA_DEV_STARTUP_HARD_KILL_MS must be a positive safe-integer decimal from 1 to 2147483647 (received "1.5")
exit:1

$ ELIZA_DEV_STARTUP_BUDGET_MS=0 node packages/app-core/scripts/dev-startup-smoke.mjs
ELIZA_DEV_STARTUP_BUDGET_MS must be a positive safe-integer decimal (received "0")
exit:1

$ ELIZA_DEV_STARTUP_HARD_KILL_MS=+8000 node packages/app-core/scripts/dev-startup-smoke.mjs
ELIZA_DEV_STARTUP_HARD_KILL_MS must be a positive safe-integer decimal from 1 to 2147483647 (received "+8000")
exit:1
```

### Pre-fix failure shape (why the bug matters)

```text
Number("60junk")              // => NaN  — Date.now() > NaN never trips → hang
Number("0")                   // => 0    — zero budget / zero teardown grace
Number("1.5")                 // => 1.5  — fractional timer delay
Number("+8000")               // => 8000 — signed form accepted
Number("2147483648")          // => large — setTimeout clamps to 1 ms
```

# Known gaps / failures

- Full monorepo `bun run verify` not asserted in this session; focused vitest + Biome on touched files were run.
- No live full-stack `bun run dev` smoke was executed; this change only hardens offline timing-policy parsing at the CLI/unit boundary before spawn.

# Notes for reviewers

Operator override allowed Grok for this contribution. Device-signed measured receipt is appended below. Independent review and merge remain with maintainers.

# Measured project receipt

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-rama0x1]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTYG4M74ED60YC017FNHQES","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T12:17:34.856Z","completed_at":"2026-08-12T12:22:46.990Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"H794Bv40cGQhgDzktg2LFUM8LDmf4L39SHfatw4jpoNTAVNzo2SBvU1fVP6HqtCPoL2Opj13bu1T3QN_RhIHDQ"}} -->