### PR TITLE
fix(ui): restore Knowledge availability on hosted web (KNOW-001)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -183,12 +183,14 @@
       },
       "peerDependencies": {
         "@elizaos/plugin-calendar": "workspace:*",
+        "@elizaos/plugin-documents": "workspace:*",
         "@elizaos/plugin-e2b-sandbox": "*",
         "@elizaos/plugin-inbox": "workspace:*",
         "@elizaos/plugin-x402": "*",
       },
       "optionalPeers": [
         "@elizaos/plugin-calendar",
+        "@elizaos/plugin-documents",
         "@elizaos/plugin-e2b-sandbox",
         "@elizaos/plugin-inbox",
         "@elizaos/plugin-x402",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -385,6 +385,7 @@
   "peerDependencies": {
     "@elizaos/plugin-e2b-sandbox": "*",
     "@elizaos/plugin-calendar": "workspace:*",
+    "@elizaos/plugin-documents": "workspace:*",
     "@elizaos/plugin-inbox": "workspace:*",
     "@elizaos/plugin-x402": "*"
   },
@@ -393,6 +394,9 @@
       "optional": true
     },
     "@elizaos/plugin-calendar": {
+      "optional": true
+    },
+    "@elizaos/plugin-documents": {
       "optional": true
     },
     "@elizaos/plugin-inbox": {

--- a/packages/agent/src/runtime/core-plugins.test.ts
+++ b/packages/agent/src/runtime/core-plugins.test.ts
@@ -13,6 +13,11 @@ import {
 } from "./core-plugins.ts";
 
 describe("CORE_PLUGINS", () => {
+  it("loads the documents route plugin for web and hosted agent defaults", () => {
+    expect(CORE_PLUGINS).toContain("@elizaos/plugin-documents");
+    expect(DEFERRED_CORE_PLUGINS).toContain("@elizaos/plugin-documents");
+  });
+
   it("does not load plugin-google-workspace or plugin-personal-assistant by default", () => {
     // These two plugins pull in heavy native/cloud deps (googleapis and
     // @capacitor/core) that the slim Docker runtime image intentionally does

--- a/packages/agent/src/runtime/core-plugins.ts
+++ b/packages/agent/src/runtime/core-plugins.ts
@@ -280,6 +280,7 @@ export const CORE_PLUGINS: readonly string[] = [
   "@elizaos/plugin-commands", // slash command handling (skills auto-register as /commands)
   "@elizaos/plugin-browser", // Browser workspace and Chrome/Safari companion bridge.
   "@elizaos/plugin-scheduling", // always-loaded ScheduledTask runtime primitive (runner host + REST surface + seed registry); personal-assistant enriches it when present
+  "@elizaos/plugin-documents", // Knowledge CRUD/search routes required by the web and desktop Knowledge surface
   // Built-in runtime capabilities (no longer external plugins):
   // - experience, todos, personality: advanced capabilities (advancedCapabilities: true)
   // - form: standalone @elizaos/plugin-form
@@ -306,6 +307,7 @@ export const LEAN_CHAT_PLUGINS: readonly string[] = [
   "@elizaos/plugin-local-inference", // text + embeddings + voice — required for memory + generation
   "@elizaos/plugin-app-control", // VIEWS navigation in the app chat surface
   "@elizaos/plugin-notes", // managed Cloud Notes data and capabilities
+  "@elizaos/plugin-documents", // Knowledge CRUD/search routes exposed to hosted web clients
   // ScheduledTask primitive. Calendar is already always selected on lean-chat
   // via MOBILE_VIEW_PLUGINS (viewEveryPlatform) and declares a hard dependency
   // on scheduling in plugin-calendar. Seeding it here is not a new surface:

--- a/packages/agent/src/runtime/optional-plugin-imports.generated.ts
+++ b/packages/agent/src/runtime/optional-plugin-imports.generated.ts
@@ -18,19 +18,25 @@ export const OPTIONAL_PLUGIN_IMPORTERS: Record<string, () => Promise<unknown>> =
     "@elizaos/plugin-commands": () => import("@elizaos/plugin-commands"),
     "@elizaos/plugin-video": () => import("@elizaos/plugin-video"),
     "@elizaos/plugin-vision": () => import("@elizaos/plugin-vision"),
-    // biome-ignore lint/suspicious/noTsIgnore: optional literal imports may be unbuilt in sibling source typechecks.
-    // @ts-ignore: optional mobile bundle plugin is outside sibling typecheck build graph; runtime import is guarded.
     "@elizaos/plugin-native-filesystem": () =>
+      // biome-ignore lint/suspicious/noTsIgnore: optional literal imports may be unbuilt in sibling source typechecks.
+      // @ts-ignore: optional mobile bundle plugin is outside sibling typecheck build graph; runtime import is guarded.
       import("@elizaos/plugin-native-filesystem"),
     "@elizaos/plugin-scheduling": () => import("@elizaos/plugin-scheduling"),
-    // biome-ignore lint/suspicious/noTsIgnore: optional literal imports may be unbuilt in sibling source typechecks.
-    // @ts-ignore: runtime subpath export is intentional; not every package tsconfig resolves its declaration condition.
-    "@elizaos/plugin-inbox": () => import("@elizaos/plugin-inbox/plugin"),
+    "@elizaos/plugin-inbox": () =>
+      // biome-ignore lint/suspicious/noTsIgnore: optional literal imports may be unbuilt in sibling source typechecks.
+      // @ts-ignore: runtime subpath export is intentional; not every package tsconfig resolves its declaration condition.
+      import("@elizaos/plugin-inbox/plugin"),
     "@elizaos/plugin-app-control": () => import("@elizaos/plugin-app-control"),
     "@elizaos/plugin-notes": () => import("@elizaos/plugin-notes/plugin"),
-    // biome-ignore lint/suspicious/noTsIgnore: optional literal imports may be unbuilt in sibling source typechecks.
-    // @ts-ignore: calendar is peer-linked to avoid the calendar -> agent runtime dependency cycle; the deferred import runs after agent module initialization.
-    "@elizaos/plugin-calendar": () => import("@elizaos/plugin-calendar/plugin"),
+    "@elizaos/plugin-documents": () =>
+      // biome-ignore lint/suspicious/noTsIgnore: optional literal imports may be unbuilt in sibling source typechecks.
+      // @ts-ignore: documents is peer-linked to avoid the documents -> agent runtime dependency cycle; the deferred import runs after agent module initialization.
+      import("@elizaos/plugin-documents/plugin"),
+    "@elizaos/plugin-calendar": () =>
+      // biome-ignore lint/suspicious/noTsIgnore: optional literal imports may be unbuilt in sibling source typechecks.
+      // @ts-ignore: calendar is peer-linked to avoid the calendar -> agent runtime dependency cycle; the deferred import runs after agent module initialization.
+      import("@elizaos/plugin-calendar/plugin"),
     "@elizaos/plugin-anthropic": () => import("@elizaos/plugin-anthropic"),
     "@elizaos/plugin-openai": () => import("@elizaos/plugin-openai"),
   };

--- a/packages/agent/src/runtime/optional-plugins.test.ts
+++ b/packages/agent/src/runtime/optional-plugins.test.ts
@@ -35,11 +35,19 @@ function readSource(file: string): string {
  * check reads the source and asserts on the literal `"pkg": () => import("pkg")`
  * entries instead.
  */
-function generatedImporterEntries(): { key: string; specifier: string }[] {
-  const source = readSource("optional-plugin-imports.generated.ts");
+function importerEntries(source: string): {
+  key: string;
+  specifier: string;
+}[] {
   return [
-    ...source.matchAll(/"([^"]+)":\s*\(\)\s*=>\s*import\(\s*"([^"]+)"\s*\)/g),
+    ...source.matchAll(
+      /"([^"]+)":\s*\(\)\s*=>\s*(?:\/\/[^\n]*\n\s*)*import\(\s*"([^"]+)"\s*\)/g,
+    ),
   ].map((m) => ({ key: m[1], specifier: m[2] }));
+}
+
+function generatedImporterEntries(): { key: string; specifier: string }[] {
+  return importerEntries(readSource("optional-plugin-imports.generated.ts"));
 }
 
 /**
@@ -77,11 +85,12 @@ describe("optional-plugin literal-import codegen", () => {
     const rendered = renderOptionalPluginImportsModule(
       OPTIONAL_STATIC_PLUGIN_PACKAGES,
     );
-    for (const pkg of OPTIONAL_STATIC_PLUGIN_PACKAGES) {
-      expect(rendered, pkg).toContain(
-        `"${pkg}": () => import("${optionalPluginImportSpecifier(pkg)}")`,
-      );
-    }
+    expect(importerEntries(rendered)).toEqual(
+      OPTIONAL_STATIC_PLUGIN_PACKAGES.map((key) => ({
+        key,
+        specifier: optionalPluginImportSpecifier(key),
+      })),
+    );
   });
 
   it("bundled and unbundled optional lists are disjoint", () => {

--- a/packages/agent/src/runtime/optional-plugins.ts
+++ b/packages/agent/src/runtime/optional-plugins.ts
@@ -55,6 +55,7 @@ export const OPTIONAL_STATIC_PLUGIN_PACKAGES: readonly string[] = [
   "@elizaos/plugin-inbox",
   "@elizaos/plugin-app-control",
   "@elizaos/plugin-notes",
+  "@elizaos/plugin-documents",
   "@elizaos/plugin-calendar",
   "@elizaos/plugin-anthropic",
   "@elizaos/plugin-openai",
@@ -177,6 +178,11 @@ export const OPTIONAL_STATIC_PLUGIN_OVERRIDES: Readonly<
   "@elizaos/plugin-notes": {
     importSubpath: "./plugin",
   },
+  "@elizaos/plugin-documents": {
+    importSubpath: "./plugin",
+    suppressTypeResolutionReason:
+      "documents is peer-linked to avoid the documents -> agent runtime dependency cycle; the deferred import runs after agent module initialization.",
+  },
   "@elizaos/plugin-calendar": {
     importSubpath: "./plugin",
     suppressTypeResolutionReason:
@@ -216,10 +222,13 @@ export function renderOptionalPluginImportsModule(
       const specifier = optionalPluginImportSpecifier(pkg);
       const suppression =
         OPTIONAL_STATIC_PLUGIN_OVERRIDES[pkg]?.suppressTypeResolutionReason;
-      const comments = suppression
-        ? `  // biome-ignore lint/suspicious/noTsIgnore: optional literal imports may be unbuilt in sibling source typechecks.\n  // @ts-ignore: ${suppression}\n`
-        : "";
-      return `${comments}  "${pkg}": () => import("${specifier}"),`;
+      if (suppression) {
+        return `  "${pkg}": () =>
+    // biome-ignore lint/suspicious/noTsIgnore: optional literal imports may be unbuilt in sibling source typechecks.
+    // @ts-ignore: ${suppression}
+    import("${specifier}"),`;
+      }
+      return `  "${pkg}": () => import("${specifier}"),`;
     })
     .join("\n");
   return `/**

--- a/packages/agent/src/runtime/plugin-collector-lean-chat.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-lean-chat.test.ts
@@ -63,6 +63,7 @@ describe("collectPluginNames lean-chat plugin set (#8434)", () => {
     expect(names.has("@elizaos/plugin-sql")).toBe(true);
     expect(names.has("@elizaos/plugin-app-control")).toBe(true);
     expect(names.has("@elizaos/plugin-notes")).toBe(true);
+    expect(names.has("@elizaos/plugin-documents")).toBe(true);
     expect(names.has("@elizaos/plugin-commands")).toBe(true);
     expect(names.has("@elizaos/plugin-agent-skills")).toBe(true);
     // Calendar tile (viewEveryPlatform) needs scheduling; Google Workspace is

--- a/packages/agent/src/runtime/plugin-resolver.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver.test.ts
@@ -31,6 +31,9 @@ describe("resolveRuntimePluginImportSpecifier", () => {
     expect(resolveRuntimePluginImportSpecifier("@elizaos/plugin-notes")).toBe(
       "@elizaos/plugin-notes/plugin",
     );
+    expect(
+      resolveRuntimePluginImportSpecifier("@elizaos/plugin-documents"),
+    ).toBe("@elizaos/plugin-documents/plugin");
   });
 
   it("keeps regular plugin package roots unchanged", () => {

--- a/packages/agent/src/runtime/plugin-resolver.ts
+++ b/packages/agent/src/runtime/plugin-resolver.ts
@@ -82,6 +82,7 @@ const RUNTIME_APP_PLUGIN_SUBPATHS = new Set([
   "@elizaos/plugin-personal-assistant",
   "@elizaos/plugin-phone",
   "@elizaos/plugin-notes",
+  "@elizaos/plugin-documents",
   "@elizaos/plugin-wifi",
 ]);
 

--- a/packages/ui/src/components/pages/DocumentsView.availability.test.tsx
+++ b/packages/ui/src/components/pages/DocumentsView.availability.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Component coverage for Knowledge availability states on web and native
+ * mobile when the documents route is absent. The harness uses the real
+ * DocumentsView state machine with only its transport and app context mocked.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../../api/client-types-core";
+import { __resetResourceCache } from "../../hooks/resource-cache";
+
+const appMock = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
+const platformMock = vi.hoisted(() => ({ isNative: false }));
+const clientMock = vi.hoisted(() => ({
+  getDocumentFacetCounts: vi.fn(),
+  listDocuments: vi.fn(),
+}));
+
+vi.mock("../../state", () => ({
+  useAppSelector: (selector: (value: Record<string, unknown>) => unknown) =>
+    selector(appMock.value),
+  useTranslation: () => ({ t: appMock.value.t }),
+}));
+vi.mock("../../api/client", () => ({ client: clientMock }));
+vi.mock("../../platform", () => ({
+  get isNative() {
+    return platformMock.isNative;
+  },
+}));
+vi.mock("../../state/view-chat-binding", () => ({
+  useRegisterViewChatBinding: () => {},
+}));
+
+import { DocumentsView } from "./DocumentsView";
+
+function t(key: string, options?: { defaultValue?: string }) {
+  return options?.defaultValue ?? key;
+}
+
+function missingDocumentsRoute(): ApiError {
+  return new ApiError({
+    kind: "http",
+    path: "/api/documents",
+    message: "Not Found",
+    status: 404,
+  });
+}
+
+beforeEach(() => {
+  __resetResourceCache();
+  platformMock.isNative = false;
+  appMock.value = { t, setActionNotice: vi.fn() };
+  clientMock.listDocuments.mockReset();
+  clientMock.getDocumentFacetCounts.mockReset();
+  clientMock.listDocuments.mockRejectedValue(missingDocumentsRoute());
+  clientMock.getDocumentFacetCounts.mockRejectedValue(missingDocumentsRoute());
+});
+
+afterEach(() => cleanup());
+
+describe("DocumentsView availability", () => {
+  it("shows a retryable service error on web without empty-state CTAs", async () => {
+    render(<DocumentsView fileInputId="knowledge-upload" />);
+
+    expect(
+      await screen.findByText(
+        "Knowledge service is unavailable. Please try again.",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText(/Knowledge isn't available on this device/i),
+    ).toBeNull();
+    expect(screen.queryByText("No knowledge yet")).toBeNull();
+    expect(screen.queryByTestId("knowledge-add")).toBeNull();
+    expect(screen.getByRole("button", { name: "common.retry" })).toBeTruthy();
+  });
+
+  it("keeps the device-unavailable state for native mobile only", async () => {
+    platformMock.isNative = true;
+    render(<DocumentsView fileInputId="knowledge-upload" />);
+
+    expect(
+      await screen.findByText(
+        "Knowledge isn't available on this device. Manage documents from the desktop or web app.",
+      ),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByText("No knowledge yet")).toBeNull();
+      expect(screen.queryByTestId("knowledge-add")).toBeNull();
+    });
+    expect(
+      screen.queryByText("Knowledge service is unavailable. Please try again."),
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "common.retry" })).toBeNull();
+  });
+});

--- a/packages/ui/src/components/pages/DocumentsView.tsx
+++ b/packages/ui/src/components/pages/DocumentsView.tsx
@@ -46,6 +46,7 @@ import type {
 } from "../../api/client-types-chat";
 import { isApiError } from "../../api/client-types-core";
 import { getCached, setCached } from "../../hooks/resource-cache";
+import { isNative } from "../../platform";
 import { useAppSelector, useTranslation } from "../../state";
 import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import { confirmDesktopAction } from "../../utils/desktop-dialogs";
@@ -393,9 +394,9 @@ export function DocumentsView({
     { documentId: string; startMs: number } | undefined
   >();
   const [loadError, setLoadError] = useState<string | null>(null);
-  // Set when GET /api/documents 404s — the documents plugin isn't mounted on
-  // this surface (e.g. the mobile/Android agent). Degrade to a calm
-  // "unavailable here" panel instead of a red error + Retry loop (J4).
+  // Set only when a native mobile agent omits the documents route. Web and
+  // desktop treat the same 404 as a service failure because Knowledge is a
+  // supported surface there.
   const [documentsUnavailable, setDocumentsUnavailable] = useState(false);
   const [isServiceLoading, setIsServiceLoading] = useState(false);
   const serviceRetryRef = useRef(0);
@@ -463,25 +464,30 @@ export function DocumentsView({
         setDocumentsUnavailable(false);
         serviceRetryRef.current = 0;
       } catch (err) {
-        // error-policy:J4 — a 404 means the documents plugin isn't mounted on
-        // this surface (the mobile/Android agent omits it); degrade to a calm
-        // "unavailable here" panel, not a red error + Retry loop.
-        if (isApiError(err) && err.status === 404) {
+        // error-policy:J4 — native mobile intentionally omits the documents
+        // route, so only that platform gets the device-unavailable state.
+        if (isApiError(err) && err.status === 404 && isNative) {
           setIsServiceLoading(false);
           setDocumentsUnavailable(true);
           return;
         }
+        setDocumentsUnavailable(false);
         const status = (err as { status?: number }).status;
         if (status === 503) {
           setIsServiceLoading(true);
         } else {
           setIsServiceLoading(false);
           const msg =
-            err instanceof Error
-              ? err.message
-              : tRef.current("documentsview.FailedToLoadDocumentsData", {
-                  defaultValue: "Failed to load Knowledge data",
-                });
+            isApiError(err) && err.status === 404
+              ? tRef.current("documentsview.ServiceUnavailable", {
+                  defaultValue:
+                    "Knowledge service is unavailable. Please try again.",
+                })
+              : err instanceof Error
+                ? err.message
+                : tRef.current("documentsview.FailedToLoadDocumentsData", {
+                    defaultValue: "Failed to load Knowledge data",
+                  });
           setLoadError(msg);
           setActionNoticeRef.current(msg, "error");
         }
@@ -1095,7 +1101,9 @@ export function DocumentsView({
   ) : null;
 
   let listBody: ReactNode;
-  if (isShowingSearchResults) {
+  if (documentsUnavailable || loadError) {
+    listBody = null;
+  } else if (isShowingSearchResults) {
     listBody =
       visibleSearchResults.length === 0 ? (
         <PagePanel.Empty
@@ -1264,7 +1272,7 @@ export function DocumentsView({
         </PagePanel.Notice>
       )}
 
-      {!documentsUnavailable && (
+      {!documentsUnavailable && !loadError && (
         <div className="flex shrink-0 flex-col gap-0.5">
           <div className="flex items-center justify-between gap-2">
             {isShowingSearchResults ? <span aria-hidden /> : facetStrip}

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts
@@ -63,4 +63,13 @@ export function useAuthStatus(): {
  * authenticated snapshot (never the `loading` phase the real probe races), so
  * priming is inherently a no-op.
  */
+/**
+ * Non-hook full snapshot read used by the notification store (#18391).
+ * The fixture is a fixed authenticated snapshot, so return that constant;
+ * the export must exist here or the aliased e2e bundle fails to resolve it.
+ */
+export function getAuthStatusSnapshot(): typeof AUTHENTICATED_STATE {
+  return AUTHENTICATED_STATE;
+}
+
 export function primeAuthStatusProbe(): void {}

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -2840,6 +2840,7 @@
   "documentsview.SearchTips": "Try a filename, topic, or phrase from the document body.",
   "documentsview.ServiceDidNotBecomeAvailable": "Knowledge service did not become available. Please reload the page.",
   "documentsview.ServiceIsLoading": "Knowledge service is loading...",
+  "documentsview.ServiceUnavailable": "Knowledge service is unavailable. Please try again.",
   "documentsview.TitleOptional": "Title (optional)",
   "documentsview.Type": "Type:",
   "documentsview.UnknownDeleteError": "Unknown delete error",


### PR DESCRIPTION
Fixes #18625

# Relates to

- https://github.com/elizaOS/eliza/issues/18625 (KNOW-001)

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused UI and agent checks pass; the exact repository-wide infrastructure blocker is recorded below.
- [x] A reviewer can confirm the web/native branching from the focused component tests.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `cursor`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
- Lane: `[sayo]`

# Sync with develop

- [x] `git fetch origin develop && git rebase origin/develop` completed with zero conflicts.
- [x] `bun run verify` reached 203/204 tasks; the remaining task failed on local `ENOSPC`, documented below.

# Risks

**Medium.** The documents plugin becomes part of the default hosted/core and lean-chat agent composition. The optional peer and deferred `./plugin` import preserve the existing agent↔documents dependency boundary. If the route is still absent on web, the UI now presents an honest retryable service error rather than mobile-only copy.

# Background

## What does this PR do?

- Loads `@elizaos/plugin-documents` in core and lean-chat hosted agent defaults so `/api/documents` is mounted.
- Resolves the plugin through its runtime `./plugin` subpath and optional peer/deferred-import path.
- Restricts “Knowledge isn't available on this device” to native clients.
- Makes unavailable, error, and empty states mutually exclusive, so a failed route cannot render upload/chat CTAs beneath an error.
- Adds component coverage for web and native 404 behavior plus agent plugin-selection/import coverage.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

No documentation change is required.

# Testing

## Where should a reviewer start?

1. `packages/ui/src/components/pages/DocumentsView.availability.test.tsx`
2. `packages/ui/src/components/pages/DocumentsView.tsx`
3. `packages/agent/src/runtime/core-plugins.ts`
4. `packages/agent/src/runtime/optional-plugins.ts`

## Detailed testing steps

Passed:

```bash
bun run --cwd packages/ui test src/components/pages/DocumentsView.availability.test.tsx
bun test packages/agent/src/runtime/core-plugins.test.ts \
  packages/agent/src/runtime/optional-plugins.test.ts \
  packages/agent/src/runtime/plugin-collector-lean-chat.test.ts \
  packages/agent/src/runtime/plugin-resolver.test.ts
bunx tsc --noEmit -p packages/agent/tsconfig.json
bunx @biomejs/biome check <changed TypeScript files>
ELIZA_NODE_PATH=<node-24.15.0> bun run --cwd packages/app audit:app
```

Results:

- UI availability component tests: 2 passed (web retryable service error; native device-unavailable state).
- Agent plugin selection, optional-import generation, lean-chat, and resolver tests: passed.
- Agent TypeScript and focused Biome checks: passed.
- App audit: passed. Affected `builtin-documents` desktop/mobile and `plugin-documents-gui` reports were `good`, with zero console, render-state, hover, overflow, or banned-color findings.

Repository gate:

```bash
bun run verify
```

- Reached 203 successful tasks out of 204.
- `@elizaos/ui#build` then failed while writing generated `dist` files with `TS5033: ENOSPC: no space left on device`.
- This is a local capacity blocker (filesystem at 100%), not a source, test, type, or lint failure.

# Evidence Gate

<!-- evidence-head:a83fd5ad9c5a1e659d0d46ae48db70e25b726f2f -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18650-before-documents-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18650-after-documents-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18650-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - documents plugin wiring + UI degrade path; staging 404 observed pre-fix in QA notes
<!-- evidence-row:frontend-logs -->
- [ ] N/A - focused DocumentsView.availability 2/2 and agent documents wiring tests passed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - Knowledge availability fix does not change model trajectories
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no new domain records in this PR; restores hosted availability path
<!-- evidence-row:ocr-review -->
- [x] [18650-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18650-ocr-review.txt)

# Known gaps / failures

- Live staging upload and chat-save visibility must be rechecked after deployment.
- Full `bun run verify` could not finish its final build task because the local disk filled; all preceding 203 tasks completed.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [sayo]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTXHNCEEMNW13TP6SBW59MR","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T12:00:56.206Z","completed_at":"2026-08-12T12:27:50.512Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAOm9EJBcDQVqaeeQ_EVlZPRfooKEY2vQKKb1oG-pwoJE","device_key_id":"4e4ed288b7930e30e97413822230c4cb736b5a035ebd793307508ef3ecf81a61","device_signature":"LQV6nq-DnO0vEwGREBIZeI35713X74gFfkcoo5vQ0ziApO2EV4luNXxZjhzCdwGoCdB5F7NJAkhOYHcxTco1Cw"}} -->

