### PR TITLE
fix(app): reject invalid audit-views-soak timing env overrides

### DIFF
--- a/packages/app/scripts/audit-views-soak-navigation.test.mjs
+++ b/packages/app/scripts/audit-views-soak-navigation.test.mjs
@@ -26,9 +26,8 @@ test("cleanup navigates through the shell event instead of raw History", () => {
 });
 
 test("navigation uses an independent cold-load timeout with target diagnostics", () => {
-  expect(source).toContain(
-    "const NAV_TIMEOUT_MS = Number(process.env.NAV_TIMEOUT_MS || 10_000);",
-  );
+  expect(source).toContain("resolveSoakTiming");
+  expect(source).toContain("DEFAULT_NAV_TIMEOUT_MS");
   expect(source).toContain(
     "{ timeout: Math.max(NAV_TIMEOUT_MS, NAV_WAIT_MS * 3) }",
   );

--- a/packages/app/scripts/audit-views-soak-timing.test.mjs
+++ b/packages/app/scripts/audit-views-soak-timing.test.mjs
@@ -1,0 +1,133 @@
+/**
+ * Deterministic coverage for audit-views-soak timing env validation: pure
+ * parsers, resolve helpers, and real CLI boundary rejection before Chromium
+ * or the /api/views fetch is reached.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  DEFAULT_NAV_TIMEOUT_MS,
+  DEFAULT_NAV_WAIT_MS,
+  DEFAULT_ROUNDS,
+  MAX_TIMER_DELAY_MS,
+  parsePositiveSafeInteger,
+  resolveSoakTiming,
+} from "./audit-views-soak.mjs";
+
+const SCRIPT = fileURLToPath(
+  new URL("./audit-views-soak.mjs", import.meta.url),
+);
+const NODE_BIN = process.execPath;
+
+function runCli(env = {}, timeoutMs = 8_000) {
+  return spawnSync(NODE_BIN, [SCRIPT], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+    timeout: timeoutMs,
+  });
+}
+
+describe("parsePositiveSafeInteger", () => {
+  it("accepts complete positive safe-integer decimals", () => {
+    expect(parsePositiveSafeInteger("6", "ROUNDS")).toBe(6);
+    expect(parsePositiveSafeInteger(700, "NAV_WAIT_MS")).toBe(700);
+    expect(parsePositiveSafeInteger("1", "ROUNDS")).toBe(1);
+  });
+
+  it("rejects partial, signed, fractional, zero, and out-of-range values", () => {
+    for (const value of [
+      "",
+      "  ",
+      "abc",
+      "6junk",
+      "1.5",
+      "+3",
+      "-1",
+      "0",
+      Number.NaN,
+      1.5,
+      -1,
+    ]) {
+      expect(() => parsePositiveSafeInteger(value, "ROUNDS")).toThrow(
+        /ROUNDS must be a positive safe-integer decimal/,
+      );
+    }
+    expect(() =>
+      parsePositiveSafeInteger(String(MAX_TIMER_DELAY_MS + 1), "NAV_WAIT_MS", {
+        max: MAX_TIMER_DELAY_MS,
+      }),
+    ).toThrow(/NAV_WAIT_MS must be a positive safe-integer decimal/);
+  });
+});
+
+describe("resolveSoakTiming", () => {
+  it("keeps historical defaults when env is unset or blank", () => {
+    expect(resolveSoakTiming({})).toEqual({
+      rounds: DEFAULT_ROUNDS,
+      navWaitMs: DEFAULT_NAV_WAIT_MS,
+      navTimeoutMs: DEFAULT_NAV_TIMEOUT_MS,
+    });
+    expect(
+      resolveSoakTiming({
+        ROUNDS: "",
+        NAV_WAIT_MS: "   ",
+        NAV_TIMEOUT_MS: "",
+      }),
+    ).toEqual({
+      rounds: DEFAULT_ROUNDS,
+      navWaitMs: DEFAULT_NAV_WAIT_MS,
+      navTimeoutMs: DEFAULT_NAV_TIMEOUT_MS,
+    });
+  });
+
+  it("applies valid overrides", () => {
+    expect(
+      resolveSoakTiming({
+        ROUNDS: "3",
+        NAV_WAIT_MS: "500",
+        NAV_TIMEOUT_MS: "12000",
+      }),
+    ).toEqual({ rounds: 3, navWaitMs: 500, navTimeoutMs: 12_000 });
+  });
+
+  it("fails closed on malformed ROUNDS, NAV_WAIT_MS, or NAV_TIMEOUT_MS", () => {
+    expect(() => resolveSoakTiming({ ROUNDS: "6junk" })).toThrow(/ROUNDS/);
+    expect(() => resolveSoakTiming({ ROUNDS: "0" })).toThrow(/ROUNDS/);
+    expect(() => resolveSoakTiming({ NAV_WAIT_MS: "1.5" })).toThrow(
+      /NAV_WAIT_MS/,
+    );
+    expect(() => resolveSoakTiming({ NAV_TIMEOUT_MS: "10s" })).toThrow(
+      /NAV_TIMEOUT_MS/,
+    );
+    expect(() =>
+      resolveSoakTiming({
+        NAV_TIMEOUT_MS: String(MAX_TIMER_DELAY_MS + 1),
+      }),
+    ).toThrow(/NAV_TIMEOUT_MS/);
+  });
+});
+
+describe("audit-views-soak CLI boundary", () => {
+  it("rejects invalid ROUNDS before soak work starts", () => {
+    const result = runCli({ ROUNDS: "6junk" });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/ROUNDS/);
+    expect(result.stdout + result.stderr).not.toMatch(/audit:views soak/);
+    expect(result.stdout + result.stderr).not.toMatch(/\/api\/views/);
+  });
+
+  it("rejects invalid NAV_TIMEOUT_MS before soak work starts", () => {
+    const result = runCli({ NAV_TIMEOUT_MS: "1.5" });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/NAV_TIMEOUT_MS/);
+    expect(result.stdout + result.stderr).not.toMatch(/audit:views soak/);
+  });
+
+  it("rejects zero ROUNDS instead of silently running zero churn", () => {
+    const result = runCli({ ROUNDS: "0" });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/ROUNDS/);
+  });
+});

--- a/packages/app/scripts/audit-views-soak.mjs
+++ b/packages/app/scripts/audit-views-soak.mjs
@@ -11,13 +11,22 @@
  * `usedJSHeapSize`. It fails (non-zero) on a render-storm, an unbounded module
  * cache, or unbounded heap growth across the churn.
  *
+ * Timing and churn env knobs must be complete positive safe-integer decimals.
+ * Bare `Number(...)` previously turned typos into `NaN`: `ROUNDS=NaN` makes the
+ * churn loop iterate zero times (false pass), and NaN navigation timeouts feed
+ * Playwright wait helpers unpredictably. Invalid overrides fail closed before
+ * `/api/views` fetch or Chromium launch.
+ *
  * Assumes the stack is already up (boot it with the dev server). Env:
- *   UI=http://127.0.0.1:2138  API=http://127.0.0.1:31337  ROUNDS=6  OUT=<dir>
+ *   UI=http://127.0.0.1:2138  API=http://127.0.0.1:31337
+ *   ROUNDS=6  NAV_WAIT_MS=700  NAV_TIMEOUT_MS=10000  OUT=<dir>
  *
  * Run under Node on Windows (Playwright's CDP pipe is dead under Bun there).
  */
 import { mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import path, { join } from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
 import { chromium } from "playwright";
 import {
   finalizeSoakEvidence,
@@ -31,16 +40,109 @@ import {
   isExpectedUnavailableBrowserBridgeCompanionsResponse,
 } from "./browser-failure-policy.mjs";
 
+/** Default view-churn rounds when `ROUNDS` is unset. */
+export const DEFAULT_ROUNDS = 6;
+
+/** Default post-navigation settle wait (ms). */
+export const DEFAULT_NAV_WAIT_MS = 700;
+
+/** Default cold-load navigation timeout (ms). */
+export const DEFAULT_NAV_TIMEOUT_MS = 10_000;
+
+/** Node clamps `setTimeout` / Playwright timer delays above this to 1 ms. */
+export const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+/**
+ * Accept only complete positive safe-integer decimal strings (or numbers).
+ * Rejects partial numbers, signed values, fractions, zero, and values above
+ * an optional max (defaults to Number.MAX_SAFE_INTEGER).
+ * @param {string | number} value
+ * @param {string} label
+ * @param {{ max?: number }} [options]
+ * @returns {number}
+ */
+export function parsePositiveSafeInteger(value, label, options = {}) {
+  const max = options.max ?? Number.MAX_SAFE_INTEGER;
+  const rangeHint =
+    max === Number.MAX_SAFE_INTEGER
+      ? "a positive safe-integer decimal"
+      : `a positive safe-integer decimal from 1 to ${max}`;
+  const received = (v) =>
+    typeof v === "number" ? JSON.stringify(v) : JSON.stringify(String(v ?? ""));
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 1 || value > max) {
+      throw new Error(
+        `${label} must be ${rangeHint} (received ${received(value)})`,
+      );
+    }
+    return value;
+  }
+  const raw = String(value ?? "").trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `${label} must be ${rangeHint} (received ${received(value)})`,
+    );
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < 1 ||
+    parsed > max ||
+    String(parsed) !== raw
+  ) {
+    throw new Error(
+      `${label} must be ${rangeHint} (received ${received(value)})`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Resolve soak churn and navigation timing from env. Unset/empty/whitespace
+ * keep historical defaults. Explicit overrides fail closed on typos so a bad
+ * `ROUNDS` cannot silently run zero churn cycles.
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {{ rounds: number, navWaitMs: number, navTimeoutMs: number }}
+ */
+export function resolveSoakTiming(env = process.env) {
+  const roundsRaw = env.ROUNDS;
+  const navWaitRaw = env.NAV_WAIT_MS;
+  const navTimeoutRaw = env.NAV_TIMEOUT_MS;
+
+  const rounds =
+    roundsRaw == null || String(roundsRaw).trim() === ""
+      ? DEFAULT_ROUNDS
+      : parsePositiveSafeInteger(roundsRaw, "ROUNDS");
+
+  const navWaitMs =
+    navWaitRaw == null || String(navWaitRaw).trim() === ""
+      ? DEFAULT_NAV_WAIT_MS
+      : parsePositiveSafeInteger(navWaitRaw, "NAV_WAIT_MS", {
+          max: MAX_TIMER_DELAY_MS,
+        });
+
+  const navTimeoutMs =
+    navTimeoutRaw == null || String(navTimeoutRaw).trim() === ""
+      ? DEFAULT_NAV_TIMEOUT_MS
+      : parsePositiveSafeInteger(navTimeoutRaw, "NAV_TIMEOUT_MS", {
+          max: MAX_TIMER_DELAY_MS,
+        });
+
+  return { rounds, navWaitMs, navTimeoutMs };
+}
+
 const UI = process.env.UI || "http://127.0.0.1:2138";
 const API = process.env.API || "http://127.0.0.1:31337";
-const ROUNDS = Number(process.env.ROUNDS || 6);
-const NAV_WAIT_MS = Number(process.env.NAV_WAIT_MS || 700);
-const NAV_TIMEOUT_MS = Number(process.env.NAV_TIMEOUT_MS || 10_000);
+/** @type {number} */
+let ROUNDS = DEFAULT_ROUNDS;
+/** @type {number} */
+let NAV_WAIT_MS = DEFAULT_NAV_WAIT_MS;
+/** @type {number} */
+let NAV_TIMEOUT_MS = DEFAULT_NAV_TIMEOUT_MS;
 const VIDEO = process.env.VIDEO !== "0";
 const SETUP_FIRST_RUN = process.env.SETUP_FIRST_RUN !== "0";
 const OUT =
   process.env.OUT || join(process.cwd(), "capture-output", "10196-views-state");
-mkdirSync(OUT, { recursive: true });
 
 let fails = 0;
 const checks = [];
@@ -916,12 +1018,37 @@ async function main() {
   }
 }
 
-// error-policy:J1 the process boundary translates any required-check or
-// evidence-finalization failure into cleanup, diagnostics, and a non-zero exit.
-await main().catch(async (error) => {
-  await cleanupAfterFailure();
-  console.error(
-    `[soak] fatal: ${error instanceof Error ? error.stack : error}`,
-  );
-  process.exitCode = 1;
-});
+const isDirectRun =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (isDirectRun) {
+  let timing;
+  try {
+    timing = resolveSoakTiming(process.env);
+  } catch (error) {
+    // error-policy:J1 CLI boundary — invalid soak timing env fails before
+    // output-dir creation, /api/views fetch, or Chromium launch so a typo
+    // cannot silently run zero churn rounds or feed NaN to Playwright waits.
+    console.error(
+      error instanceof Error
+        ? error.message
+        : "[soak] invalid timing environment",
+    );
+    process.exit(1);
+  }
+  ROUNDS = timing.rounds;
+  NAV_WAIT_MS = timing.navWaitMs;
+  NAV_TIMEOUT_MS = timing.navTimeoutMs;
+  mkdirSync(OUT, { recursive: true });
+
+  // error-policy:J1 the process boundary translates any required-check or
+  // evidence-finalization failure into cleanup, diagnostics, and a non-zero exit.
+  await main().catch(async (error) => {
+    await cleanupAfterFailure();
+    console.error(
+      `[soak] fatal: ${error instanceof Error ? error.stack : error}`,
+    );
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
# Relates to

Closes #18648

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused package checks passed after sync (`bun test packages/app/scripts/audit-views-soak-timing.test.mjs packages/app/scripts/audit-views-soak-navigation.test.mjs` + Biome on touched files). Full `bun run verify` was not re-run end-to-end in this session.
- [x] A reviewer can confirm the change from the CLI transcripts and focused test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xAI / grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build` (`grok` client)
<!-- attribution-row:skill-revision -->
- Skill path: `contribute-to-eliza` @ `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77`
<!-- attribution-row:status -->
- Provenance status: `self-reported` + device-signed project receipt (footer below)
- Run id: `run_01KZTYVR1T7EHC7JWM8011QTH5`
- Note: Operator approved Grok for this workstream. Token meter via ccusage is unavailable for Grok (signed zero / unavailable confidence), not fabricated.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync; full monorepo `bun run verify` not claimed here.

# Risks

**Low.** Env validation only for the local/CI `audit:views` soak harness timing knobs. No production API, agent runtime, or UI behavior changes for valid invocations. Invalid `ROUNDS` / navigation timeout overrides now fail closed at the CLI boundary instead of silently running zero churn cycles or feeding NaN into Playwright waits. Oversized timer values cannot clamp to a 1 ms race.

# Background

## What does this PR do?

Validates audit-views-soak timing environment variables before output-dir creation, `/api/views` fetch, or Chromium launch:

- `ROUNDS`: complete positive safe-integer decimals only (default 6).
- `NAV_WAIT_MS`: complete positive safe-integer decimals only, capped at Node's max timer delay `2^31-1` (default 700).
- `NAV_TIMEOUT_MS`: complete positive safe-integer decimals only, capped at Node's max timer delay (default 10000).
- Unset/empty/whitespace keep the historical defaults.
- Parsers + `resolveSoakTiming` are exported for unit coverage; the CLI resolves timing under a direct-run guard before `main`.

Previously bare `Number(...)` turned typos into `NaN`. Because `for (let r = 0; r < NaN; r++)` never iterates, a bad `ROUNDS` could false-pass the soak after zero view churn. Navigation timeouts similarly became non-deterministic Playwright waits.

## What kind of change is this?

Bug fix (non-breaking for valid env use; invalid overrides now fail closed).

# Documentation changes needed?

No project docs change required. The env contract is now enforced by the validator itself (and restated in the script header).

# Testing

## Where should a reviewer start?

1. `packages/app/scripts/audit-views-soak.mjs` — parsers + `resolveSoakTiming` + early CLI boundary
2. `packages/app/scripts/audit-views-soak-timing.test.mjs` — unit + real CLI boundary
3. `packages/app/scripts/audit-views-soak-navigation.test.mjs` — updated source contract for timeout binding

## Detailed testing steps

```bash
bun test packages/app/scripts/audit-views-soak-timing.test.mjs packages/app/scripts/audit-views-soak-navigation.test.mjs
# 20 passed

ROUNDS=6junk node packages/app/scripts/audit-views-soak.mjs
# exit 1, message includes ROUNDS; no audit:views soak cycle summary

NAV_WAIT_MS=1.5 node packages/app/scripts/audit-views-soak.mjs
# exit 1, NAV_WAIT_MS must be a positive safe-integer decimal from 1 to 2147483647

ROUNDS=0 node packages/app/scripts/audit-views-soak.mjs
# exit 1, ROUNDS rejected (zero churn would false-pass)
```

# Evidence Gate

<!-- evidence-head:00868738cec8183cf2dfdc109923fd1ae15ae920 -->

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - terminal-only audit:views soak harness; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - terminal-only audit:views soak harness; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no interactive UI flow; CLI argument rejection is fully captured by transcripts below.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no server/runtime path; rejection happens before `/api/views` fetch or Chromium launch.
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no browser app surface.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent, model, prompt, provider, or action behavior.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: focused bun test output (20 passed) and CLI rejection transcripts proving non-zero exit before soak work for invalid timing env values.

### CLI after (this head `00868738cec8`)

```text
$ bun test packages/app/scripts/audit-views-soak-timing.test.mjs packages/app/scripts/audit-views-soak-navigation.test.mjs
 20 pass
 0 fail
 73 expect() calls
Ran 20 tests across 2 files.

$ ROUNDS=6junk node packages/app/scripts/audit-views-soak.mjs
ROUNDS must be a positive safe-integer decimal (received "6junk")
# exit 1

$ NAV_WAIT_MS=1.5 node packages/app/scripts/audit-views-soak.mjs
NAV_WAIT_MS must be a positive safe-integer decimal from 1 to 2147483647 (received "1.5")
# exit 1

$ ROUNDS=0 node packages/app/scripts/audit-views-soak.mjs
ROUNDS must be a positive safe-integer decimal (received "0")
# exit 1
```

# Known gaps / failures

- Full monorepo `bun run verify` not re-run in this session (scoped harness fix; focused soak unit + CLI boundary tests cover the change).
- Full live `audit:views` soak against a running app stack not re-executed; this PR only hardens fail-closed env validation before that path starts.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [rama0x1-unattended]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTYVR1T7EHC7JWM8011QTH5","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T12:23:55.194Z","completed_at":"2026-08-12T12:28:25.136Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"AIv282AyZ00E-kZ1mm42sKk9KM8OY0Zaa-CuVKyUuWoBAEyx0xRzX6EEY3ja2XSd4WPGlY_iq1boyxVMSAUwDw"}} -->