### PR TITLE
fix(ui): recover app-origin Cloud binding from shared session

### DIFF
--- a/packages/ui/src/state/cloud-session-refresh-for-repair.app-origin.test.ts
+++ b/packages/ui/src/state/cloud-session-refresh-for-repair.app-origin.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment jsdom
+ * @vitest-environment-options {"url":"https://app-staging.elizacloud.ai/apps"}
+ *
+ * Exercises app-origin Cloud session repair through the real cookie probe,
+ * token store, and staging API endpoint resolver with an HTTP-bound refresh
+ * double.
+ */
+import {
+  hasStewardAuthedCookie,
+  STEWARD_REFRESH_ENDPOINT,
+  STEWARD_TOKEN_KEY,
+} from "@elizaos/shared/steward-session-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api/client-cloud", () => ({
+  refreshCloudStewardSession: async (options?: { endpoint?: string }) => {
+    const response = await fetch(
+      options?.endpoint ?? STEWARD_REFRESH_ENDPOINT,
+      {
+        method: "POST",
+        credentials: "include",
+      },
+    );
+    if (!response.ok) return null;
+    return (await response.json()) as { token?: string };
+  },
+}));
+
+import { ensureCloudSessionForRepair } from "./cloud-session-refresh-for-repair";
+
+const STAGING_AUTHED_COOKIE = "steward-authed-staging";
+
+function writeTestCookie(value: string): void {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom must drive the browser marker read by production.
+  document.cookie = value;
+}
+
+describe("app-origin Cloud session repair", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    writeTestCookie(`${STAGING_AUTHED_COOKIE}=1; Domain=elizacloud.ai; Path=/`);
+  });
+
+  afterEach(() => {
+    writeTestCookie(
+      `${STAGING_AUTHED_COOKIE}=; Max-Age=0; Domain=elizacloud.ai; Path=/`,
+    );
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("recovers an empty app-origin token mirror from the shared staging Cloud cookie", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({ token: "recovered-staging-token", expiresIn: 900 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(hasStewardAuthedCookie()).toBe(true);
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+
+    await expect(ensureCloudSessionForRepair()).resolves.toBe(
+      "recovered-staging-token",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api-staging.elizacloud.ai/api/auth/steward-refresh",
+      {
+        method: "POST",
+        credentials: "include",
+      },
+    );
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(
+      "recovered-staging-token",
+    );
+  });
+});

--- a/packages/ui/src/state/cloud-session-refresh-for-repair.ts
+++ b/packages/ui/src/state/cloud-session-refresh-for-repair.ts
@@ -32,9 +32,11 @@
 import {
   hasStewardAuthedCookie,
   readStoredStewardToken,
+  STEWARD_REFRESH_ENDPOINT,
   writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
 import { refreshCloudStewardSession } from "../api/client-cloud";
+import { DIRECT_ELIZA_CLOUD_API_BY_HOST } from "../api/direct-cloud-endpoints";
 
 /** Bounded so the recovery gate can never hang on a slow refresh. */
 export const CLOUD_REPAIR_REFRESH_TIMEOUT_MS = 6_000;
@@ -62,6 +64,14 @@ function defaultRaceTimeout<T>(p: Promise<T>, ms: number): Promise<T | null> {
   return Promise.race([p, timeout]).finally(() => {
     if (timer) clearTimeout(timer);
   });
+}
+
+function resolveRepairRefreshEndpoint(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  const apiBase = DIRECT_ELIZA_CLOUD_API_BY_HOST.get(
+    window.location.hostname.toLowerCase(),
+  );
+  return apiBase ? `${apiBase}${STEWARD_REFRESH_ENDPOINT}` : undefined;
 }
 
 /**
@@ -103,7 +113,7 @@ export async function ensureCloudSessionForRepair(
     // error-policy:J4 a failed/absent cookie refresh yields null → the caller
     // keeps the wall; it NEVER fabricates a session.
     recovered = await raceTimeout(
-      refreshFn().catch(() => null),
+      refreshFn({ endpoint: resolveRepairRefreshEndpoint() }).catch(() => null),
       timeoutMs,
     );
   } catch {


### PR DESCRIPTION
# Relates to

Fixes #18624.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the unrelated verification storage failure is recorded below.
- [x] A reviewer can confirm the changed recovery contract from the deterministic regression test and focused package checks below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` did not complete because the host filesystem reached `ENOSPC` after 195/201 tasks; details are below.

# Risks

Low. The change only selects the already-canonical direct Cloud API host for Steward cookie refresh on recognized Eliza Cloud hosts. Unknown/local hosts retain the existing relative endpoint, and failed refresh still returns `null` without weakening the auth wall.

# Background

## What does this PR do?

When an app-origin Steward token mirror is empty but the shared environment-scoped Cloud cookie is present, session repair now posts to the host-mapped direct Cloud API endpoint. On `app-staging.elizacloud.ai`, that is `https://api-staging.elizacloud.ai/api/auth/steward-refresh`, allowing the server-validated HttpOnly session to restore the token mirror and continue the existing silent re-pair flow.

The regression test starts at the staging app origin with the real cookie probe and token store, an empty local mirror, and an HTTP-bound refresh double. It verifies the direct staging endpoint, credentialed POST, recovered token, and persisted mirror.

## What kind of change is this?

Bug fix (non-breaking).

## Reproduction

1. Authenticate on `app-staging.elizacloud.ai`.
2. Visit `staging.elizacloud.ai`, then return to the app origin.
3. Before this patch, repair used the relative app-origin refresh route and could fall through permanently to “Open this agent from Eliza Cloud”.
4. With this patch, a valid shared staging Cloud session refreshes through `api-staging.elizacloud.ai`, restoring the app-origin mirror so the existing recovery hook can silently re-pair.

# Documentation changes needed?

N/A - this corrects an internal authentication recovery route without changing a public API or user workflow.

# Testing

## Where should a reviewer start?

- `packages/ui/src/state/cloud-session-refresh-for-repair.ts`
- `packages/ui/src/state/cloud-session-refresh-for-repair.app-origin.test.ts`

## Detailed testing steps

```bash
bun run --cwd packages/ui test src/state/cloud-session-refresh-for-repair.app-origin.test.ts src/state/cloud-session-refresh-for-repair.test.ts src/hooks/useAgentSessionRecovery.test.tsx
bun run --cwd packages/ui typecheck
bun run --cwd packages/ui lint:check
```

Results:
- Focused recovery suite: 3 files passed, 29 tests passed.
- UI typecheck: passed.
- UI lint: passed with 8 pre-existing `document.cookie` warnings in unrelated SSO tests; changed files are warning-free.

# Evidence Gate

<!-- evidence-head:9f8be8af4d8383edc2cf55b229d6cc39babcdd06 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered component or visual styling changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered component or visual styling changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the staging verification lever was already claimed; this state/transport-only fix is covered deterministically without changing pixels.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code changed, and live staging was unavailable to this lane.
<!-- evidence-row:frontend-logs -->
- [x] N/A - live staging was unavailable to this lane; the regression test asserts the exact credentialed request and persisted state transition.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain data artifact is produced by session-token mirror recovery.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

N/A - no backend path changed; live staging was unavailable. The deterministic integration-style test records the exact request contract and state recovery.

## Screenshots (before / after) + video walkthrough

N/A - this patch changes only state/transport routing and does not alter rendered UI.

## Known gaps / failures

- `bun run verify`: infrastructure-blocked after 195/201 tasks because the host filesystem reached 100% capacity (`ENOSPC`) while `plugin-meetings` generated declarations. No changed-package failure preceded it.
- `bun run --cwd packages/app audit:app`: the execution harness terminated the long-running audit after 148/215 passing cases with no observed test failure, so it is reported as incomplete rather than passed. The diff does not touch a rendered view.
- Live staging Cloud→app proof: N/A because the staging lever was already claimed for verification. The new regression test covers the requested Cloud-cookie-present + empty-app-origin-mirror recovery contract.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [sayo]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88:packages/skills/skills/contribute-to-eliza"} -->

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [sayo]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTXB55RSBC5FZDACVQRX6GB","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T11:57:23.000Z","completed_at":"2026-08-12T12:27:21.741Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAOm9EJBcDQVqaeeQ_EVlZPRfooKEY2vQKKb1oG-pwoJE","device_key_id":"4e4ed288b7930e30e97413822230c4cb736b5a035ebd793307508ef3ecf81a61","device_signature":"bhbwlgv0yxk6biFJVZdzajEUOCJiRNbLHZBSRJqQ30M-wNdXyVDjvGWYDHpbnAaU3IdPWWiTOALvvTnGknovDA"}} -->

Made with [Cursor](https://cursor.com)