### PR TITLE
fix(scripts): add CLI parameter validation and unit tests for release-set-public-access

### DIFF
--- a/scripts/release-set-public-access.mjs
+++ b/scripts/release-set-public-access.mjs
@@ -15,22 +15,85 @@ const DEFAULT_REPO_ROOT = path.resolve(
   "..",
 );
 
-function argumentValue(args, name) {
-  const index = args.indexOf(name);
-  if (index < 0) return null;
-  if (!args[index + 1]) throw new Error(`${name} requires a value`);
-  return args[index + 1];
+export function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    repoRoot: DEFAULT_REPO_ROOT,
+    cohort: null,
+    dryRun: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg.startsWith("--repo-root=")) {
+      const val = arg.slice("--repo-root=".length).trim();
+      if (!val) {
+        throw new Error(
+          "[release-manifests] --repo-root requires a directory path",
+        );
+      }
+      options.repoRoot = path.resolve(val);
+    } else if (arg === "--repo-root") {
+      const next = argv[index + 1];
+      if (!next || next.startsWith("-")) {
+        throw new Error(
+          "[release-manifests] --repo-root requires a directory path",
+        );
+      }
+      options.repoRoot = path.resolve(next);
+      index += 1;
+    } else if (arg.startsWith("--cohort=")) {
+      const val = arg.slice("--cohort=".length).trim();
+      if (!val) {
+        throw new Error(
+          "[release-manifests] --cohort requires a file path",
+        );
+      }
+      options.cohort = path.resolve(val);
+    } else if (arg === "--cohort") {
+      const next = argv[index + 1];
+      if (!next || next.startsWith("-")) {
+        throw new Error(
+          "[release-manifests] --cohort requires a file path",
+        );
+      }
+      options.cohort = path.resolve(next);
+      index += 1;
+    } else {
+      throw new Error(`[release-manifests] Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+export function printHelp() {
+  console.log(`Usage: node scripts/release-set-public-access.mjs [options]
+
+Options:
+  --repo-root=<path>  Repository root directory (default: workspace root)
+  --cohort=<path>     Path to release cohort file
+  --dry-run           Preview changes without modifying package.json files
+  --help, -h          Show this help message`);
 }
 
 export function main(args = process.argv.slice(2)) {
-  const repoRoot = path.resolve(
-    argumentValue(args, "--repo-root") || DEFAULT_REPO_ROOT,
-  );
-  const cohortPath = argumentValue(args, "--cohort");
-  const packageNames = cohortPath
-    ? loadReleaseCohort(path.resolve(cohortPath))
+  const options = parseArgs(args);
+  if (options.help) {
+    printHelp();
+    return { changedFiles: 0, help: true };
+  }
+
+  const repoRoot = options.repoRoot;
+  const packageNames = options.cohort
+    ? loadReleaseCohort(options.cohort)
     : undefined;
-  const dryRun = args.includes("--dry-run");
+  const dryRun = options.dryRun;
   const result = setPublicAccess({ repoRoot, packageNames, dryRun });
   console.log(
     `[release-manifests] ${dryRun ? "would set" : "set"} publishConfig.access=public on ${result.changedFiles} package(s)`,
@@ -38,8 +101,38 @@ export function main(args = process.argv.slice(2)) {
   return result;
 }
 
+export function runCli(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printHelp();
+    return 0;
+  }
+
+  const packageNames = options.cohort
+    ? loadReleaseCohort(options.cohort)
+    : undefined;
+  const result = setPublicAccess({
+    repoRoot: options.repoRoot,
+    packageNames,
+    dryRun: options.dryRun,
+  });
+  console.log(
+    `[release-manifests] ${options.dryRun ? "would set" : "set"} publishConfig.access=public on ${result.changedFiles} package(s)`,
+  );
+  return 0;
+}
+
 const invokedDirectly =
   import.meta.main ||
   (Boolean(process.argv[1]) &&
     path.resolve(process.argv[1]) === fileURLToPath(import.meta.url));
-if (invokedDirectly) main();
+if (invokedDirectly) {
+  try {
+    process.exitCode = runCli();
+  } catch (error) {
+    console.error(
+      error instanceof Error ? error.message : "[release-manifests] failed",
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release-set-public-access.test.mjs
+++ b/scripts/release-set-public-access.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import tmp from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import {
+  main,
+  parseArgs,
+  printHelp,
+  runCli,
+} from "./release-set-public-access.mjs";
+
+describe("release-set-public-access CLI option parsing", () => {
+  it("defaults to standard configuration", () => {
+    const opts = parseArgs([]);
+    assert.equal(opts.help, false);
+    assert.equal(opts.dryRun, false);
+    assert.equal(opts.cohort, null);
+    assert.ok(typeof opts.repoRoot === "string" && opts.repoRoot.length > 0);
+  });
+
+  it("parses --help and -h flags", () => {
+    assert.equal(parseArgs(["--help"]).help, true);
+    assert.equal(parseArgs(["-h"]).help, true);
+  });
+
+  it("parses --dry-run flag", () => {
+    const opts = parseArgs(["--dry-run"]);
+    assert.equal(opts.dryRun, true);
+  });
+
+  it("parses --repo-root=<dir> and --repo-root <dir>", () => {
+    assert.equal(
+      parseArgs(["--repo-root=/tmp/test-repo"]).repoRoot,
+      path.resolve("/tmp/test-repo"),
+    );
+    assert.equal(
+      parseArgs(["--repo-root", "/tmp/test-repo"]).repoRoot,
+      path.resolve("/tmp/test-repo"),
+    );
+  });
+
+  it("parses --cohort=<file> and --cohort <file>", () => {
+    assert.equal(
+      parseArgs(["--cohort=/tmp/cohort.json"]).cohort,
+      path.resolve("/tmp/cohort.json"),
+    );
+    assert.equal(
+      parseArgs(["--cohort", "/tmp/cohort.json"]).cohort,
+      path.resolve("/tmp/cohort.json"),
+    );
+  });
+
+  it("rejects --repo-root without a value", () => {
+    assert.throws(
+      () => parseArgs(["--repo-root="]),
+      /\[release-manifests\] --repo-root requires a directory path/,
+    );
+    assert.throws(
+      () => parseArgs(["--repo-root"]),
+      /\[release-manifests\] --repo-root requires a directory path/,
+    );
+    assert.throws(
+      () => parseArgs(["--repo-root", "--dry-run"]),
+      /\[release-manifests\] --repo-root requires a directory path/,
+    );
+  });
+
+  it("rejects --cohort without a value", () => {
+    assert.throws(
+      () => parseArgs(["--cohort="]),
+      /\[release-manifests\] --cohort requires a file path/,
+    );
+    assert.throws(
+      () => parseArgs(["--cohort"]),
+      /\[release-manifests\] --cohort requires a file path/,
+    );
+    assert.throws(
+      () => parseArgs(["--cohort", "--dry-run"]),
+      /\[release-manifests\] --cohort requires a file path/,
+    );
+  });
+
+  it("rejects unknown options", () => {
+    assert.throws(
+      () => parseArgs(["--unknown-option"]),
+      /\[release-manifests\] Unknown option: --unknown-option/,
+    );
+  });
+});
+
+describe("release-set-public-access execution and help", () => {
+  it("runCli returns 0 for --help", () => {
+    let output = "";
+    const origLog = console.log;
+    console.log = (msg) => {
+      output += msg;
+    };
+    try {
+      const code = runCli(["--help"]);
+      assert.equal(code, 0);
+      assert.ok(output.includes("Usage: node scripts/release-set-public-access.mjs"));
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it("main returns help result when --help flag is set", () => {
+    const res = main(["--help"]);
+    assert.equal(res.changedFiles, 0);
+    assert.equal(res.help, true);
+  });
+
+  it("executes setPublicAccess dryRun against a mock workspace", () => {
+    const fixtureDir = path.join(
+      tmp.tmpdir(),
+      `rel-pub-access-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(path.join(fixtureDir, "packages", "pkg-a"), { recursive: true });
+    writeFileSync(
+      path.join(fixtureDir, "package.json"),
+      JSON.stringify({ name: "root", workspaces: ["packages/*"] }, null, 2),
+    );
+    writeFileSync(
+      path.join(fixtureDir, "lerna.json"),
+      JSON.stringify({ packages: ["packages/*"] }, null, 2),
+    );
+    writeFileSync(
+      path.join(fixtureDir, "packages", "pkg-a", "package.json"),
+      JSON.stringify({ name: "@elizaos/pkg-a", version: "1.0.0" }, null, 2),
+    );
+
+    try {
+      const result = main(["--repo-root", fixtureDir, "--dry-run"]);
+      assert.equal(result.changedFiles, 1);
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

Refactoring and defensive CLI parameter validation for release tools.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Google / Antigravity / Gemini 3.6 Flash (High)`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Refactors CLI argument parsing and error handling in `scripts/release-set-public-access.mjs` and adds unit tests without altering package manifest modification logic.

# Background

## What does this PR do?

Adds structured CLI argument parsing (`parseArgs`), help output (`printHelp`), safe exit handling (`runCli`), and comprehensive unit test coverage for `scripts/release-set-public-access.mjs`.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review [`scripts/release-set-public-access.mjs`](file:///home/dak/src/eliza-agy/scripts/release-set-public-access.mjs) and [`scripts/release-set-public-access.test.mjs`](file:///home/dak/src/eliza-agy/scripts/release-set-public-access.test.mjs).

## Detailed testing steps

Run `bun test scripts/release-set-public-access.test.mjs` to execute unit tests.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:5ed6a44405fd3f761b5a53026ee3271de8795a3d -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - CLI script refactoring with no UI component`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - CLI script refactoring with no UI component`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - CLI script refactoring with no UI flow`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test coverage for CLI script`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - CLI script refactoring with no frontend component`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - non-LLM CLI script change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable, or marked `N/A - unit test execution verifies script behavior`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - CLI script change with no visual output`.

# Evidence Details

## Real LLM-call trajectory

N/A - non-LLM CLI script change.

## Backend + frontend logs

```text
bun test v1.3.14 (0d9b296a)

scripts/release-set-public-access.test.mjs:
✓ release-set-public-access CLI option parsing > defaults to standard configuration [0.34ms]
✓ release-set-public-access CLI option parsing > parses --help and -h flags [0.06ms]
✓ release-set-public-access CLI option parsing > parses --dry-run flag [0.04ms]
✓ release-set-public-access CLI option parsing > parses --repo-root=<dir> and --repo-root <dir> [0.08ms]
✓ release-set-public-access CLI option parsing > parses --cohort=<file> and --cohort <file> [0.06ms]
✓ release-set-public-access CLI option parsing > rejects --repo-root without a value [0.73ms]
✓ release-set-public-access CLI option parsing > rejects --cohort without a value [0.17ms]
✓ release-set-public-access CLI option parsing > rejects unknown options [0.11ms]
✓ release-set-public-access execution and help > runCli returns 0 for --help [0.20ms]
✓ release-set-public-access execution and help > main returns help result when --help flag is set [0.14ms]
✓ release-set-public-access execution and help > executes setPublicAccess dryRun against a mock workspace [2.63ms]

 11 pass
 0 fail
Ran 11 tests across 1 file. [134.00ms]
```

## Screenshots (before / after) + video walkthrough

N/A - CLI script change.

## Audio / voice walkthrough

N/A - non-audio change.

## Known gaps / failures

None.
