### PR TITLE
fix(scripts): add CLI parameter validation, dry-run/check modes, and unit tests for generate-view-heroes

### DIFF
--- a/plugins/plugin-documents/assets/hero.svg
+++ b/plugins/plugin-documents/assets/hero.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024" role="img" aria-label="Documents">
+  <defs>
+    <linearGradient id="bg-documents" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#152528"/>
+      <stop offset="1" stop-color="#0b1319"/>
+    </linearGradient>
+    <radialGradient id="blobA-documents" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#2fbeda" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#2fbeda" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="blobB-documents" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#2861c3" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#2861c3" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="vig-documents" cx="0.5" cy="0.42" r="0.75">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="0.72" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.5"/>
+    </radialGradient>
+    <linearGradient id="label-documents" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.55"/>
+    </linearGradient>
+    <filter id="soft-documents" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="46"/>
+    </filter>
+    <filter id="iglow-documents" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="14" flood-color="#45d1ed" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+
+  <rect width="1024" height="1024" fill="url(#bg-documents)"/>
+
+  <g opacity="0.9">
+    <circle cx="232" cy="220" r="300" fill="url(#blobA-documents)" filter="url(#soft-documents)"/>
+    <circle cx="840" cy="800" r="340" fill="url(#blobB-documents)" filter="url(#soft-documents)"/>
+  </g>
+
+  <g stroke="#d7e7ea" stroke-width="1.4" opacity="0.06">
+    <line x1="0" y1="256" x2="1024" y2="256"/>
+    <line x1="0" y1="512" x2="1024" y2="512"/>
+    <line x1="0" y1="768" x2="1024" y2="768"/>
+    <line x1="256" y1="0" x2="256" y2="1024"/>
+    <line x1="512" y1="0" x2="512" y2="1024"/>
+    <line x1="768" y1="0" x2="768" y2="1024"/>
+  </g>
+
+  <g opacity="0.5">
+    <path d="M120 470 A 400 400 0 0 1 904 470" fill="none" stroke="#45d1ed" stroke-width="3" opacity="0.35"/>
+  </g>
+
+  <g transform="translate(512 432)" filter="url(#iglow-documents)"
+     color="#d7e7ea" stroke="#d7e7ea" stroke-width="20"
+     stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <rect x="-150" y="-150" width="300" height="300" rx="36"/>
+    <polyline points="-92,-6 -36,52 92,-78" fill="none"/>
+  </g>
+
+  <rect x="0" y="784" width="1024" height="240" fill="url(#label-documents)"/>
+  <text x="512" y="892" text-anchor="middle"
+        font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+        font-size="76" font-weight="600" letter-spacing="0.5"
+        fill="#d7e7ea">Documents</text>
+  <rect x="460" y="924" width="104" height="6" rx="3" fill="#45d1ed"/>
+
+  <rect width="1024" height="1024" fill="url(#vig-documents)"/>
+</svg>

--- a/plugins/plugin-form/assets/hero.svg
+++ b/plugins/plugin-form/assets/hero.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024" role="img" aria-label="Form">
+  <defs>
+    <linearGradient id="bg-form" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#281d15"/>
+      <stop offset="1" stop-color="#19140b"/>
+    </linearGradient>
+    <radialGradient id="blobA-form" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#da762f" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#da762f" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="blobB-form" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#c3b128" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#c3b128" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="vig-form" cx="0.5" cy="0.42" r="0.75">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="0.72" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.5"/>
+    </radialGradient>
+    <linearGradient id="label-form" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.55"/>
+    </linearGradient>
+    <filter id="soft-form" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="46"/>
+    </filter>
+    <filter id="iglow-form" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="14" flood-color="#ed8b45" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+
+  <rect width="1024" height="1024" fill="url(#bg-form)"/>
+
+  <g opacity="0.9">
+    <circle cx="232" cy="220" r="300" fill="url(#blobA-form)" filter="url(#soft-form)"/>
+    <circle cx="840" cy="800" r="340" fill="url(#blobB-form)" filter="url(#soft-form)"/>
+  </g>
+
+  <g stroke="#eadfd7" stroke-width="1.4" opacity="0.06">
+    <line x1="0" y1="256" x2="1024" y2="256"/>
+    <line x1="0" y1="512" x2="1024" y2="512"/>
+    <line x1="0" y1="768" x2="1024" y2="768"/>
+    <line x1="256" y1="0" x2="256" y2="1024"/>
+    <line x1="512" y1="0" x2="512" y2="1024"/>
+    <line x1="768" y1="0" x2="768" y2="1024"/>
+  </g>
+
+  <g opacity="0.5">
+    <path d="M120 470 A 400 400 0 0 1 904 470" fill="none" stroke="#ed8b45" stroke-width="3" opacity="0.35"/>
+  </g>
+
+  <g transform="translate(512 432)" filter="url(#iglow-form)"
+     color="#eadfd7" stroke="#eadfd7" stroke-width="20"
+     stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <rect x="-150" y="-150" width="300" height="300" rx="36"/>
+    <polyline points="-92,-6 -36,52 92,-78" fill="none"/>
+  </g>
+
+  <rect x="0" y="784" width="1024" height="240" fill="url(#label-form)"/>
+  <text x="512" y="892" text-anchor="middle"
+        font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+        font-size="76" font-weight="600" letter-spacing="0.5"
+        fill="#eadfd7">Form</text>
+  <rect x="460" y="924" width="104" height="6" rx="3" fill="#ed8b45"/>
+
+  <rect width="1024" height="1024" fill="url(#vig-form)"/>
+</svg>

--- a/plugins/plugin-personal-assistant/assets/hero.svg
+++ b/plugins/plugin-personal-assistant/assets/hero.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024" role="img" aria-label="Assistant">
+  <defs>
+    <linearGradient id="bg-assistant" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#221528"/>
+      <stop offset="1" stop-color="#180b19"/>
+    </linearGradient>
+    <radialGradient id="blobA-assistant" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#a12fda" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#a12fda" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="blobB-assistant" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#c328ae" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#c328ae" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="vig-assistant" cx="0.5" cy="0.42" r="0.75">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="0.72" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.5"/>
+    </radialGradient>
+    <linearGradient id="label-assistant" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.55"/>
+    </linearGradient>
+    <filter id="soft-assistant" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="46"/>
+    </filter>
+    <filter id="iglow-assistant" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="14" flood-color="#b545ed" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+
+  <rect width="1024" height="1024" fill="url(#bg-assistant)"/>
+
+  <g opacity="0.9">
+    <circle cx="232" cy="220" r="300" fill="url(#blobA-assistant)" filter="url(#soft-assistant)"/>
+    <circle cx="840" cy="800" r="340" fill="url(#blobB-assistant)" filter="url(#soft-assistant)"/>
+  </g>
+
+  <g stroke="#e3d7ea" stroke-width="1.4" opacity="0.06">
+    <line x1="0" y1="256" x2="1024" y2="256"/>
+    <line x1="0" y1="512" x2="1024" y2="512"/>
+    <line x1="0" y1="768" x2="1024" y2="768"/>
+    <line x1="256" y1="0" x2="256" y2="1024"/>
+    <line x1="512" y1="0" x2="512" y2="1024"/>
+    <line x1="768" y1="0" x2="768" y2="1024"/>
+  </g>
+
+  <g opacity="0.5">
+    <path d="M120 470 A 400 400 0 0 1 904 470" fill="none" stroke="#b545ed" stroke-width="3" opacity="0.35"/>
+  </g>
+
+  <g transform="translate(512 432)" filter="url(#iglow-assistant)"
+     color="#e3d7ea" stroke="#e3d7ea" stroke-width="20"
+     stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <rect x="-150" y="-150" width="130" height="130" rx="18"/>
+    <rect x="20" y="-150" width="130" height="130" rx="18"/>
+    <rect x="-150" y="20" width="130" height="130" rx="18"/>
+    <rect x="20" y="20" width="130" height="130" rx="18"/>
+  </g>
+
+  <rect x="0" y="784" width="1024" height="240" fill="url(#label-assistant)"/>
+  <text x="512" y="892" text-anchor="middle"
+        font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+        font-size="76" font-weight="600" letter-spacing="0.5"
+        fill="#e3d7ea">Assistant</text>
+  <rect x="460" y="924" width="104" height="6" rx="3" fill="#b545ed"/>
+
+  <rect width="1024" height="1024" fill="url(#vig-assistant)"/>
+</svg>

--- a/scripts/generate-view-heroes.mjs
+++ b/scripts/generate-view-heroes.mjs
@@ -21,10 +21,64 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { renderViewHeroSvg, VIEW_HERO_ICONS } from "@elizaos/shared";
 
-const repoRoot = path.resolve(
+export const DEFAULT_REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
 );
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    repoRoot: DEFAULT_REPO_ROOT,
+    dryRun: false,
+    check: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg === "--check") {
+      options.check = true;
+    } else if (arg.startsWith("--repo-root=")) {
+      const val = arg.slice("--repo-root=".length).trim();
+      if (!val) {
+        throw new Error(
+          "[generate-view-heroes] --repo-root requires a directory path",
+        );
+      }
+      options.repoRoot = path.resolve(val);
+    } else if (arg === "--repo-root") {
+      const next = argv[index + 1];
+      if (!next || next.startsWith("-")) {
+        throw new Error(
+          "[generate-view-heroes] --repo-root requires a directory path",
+        );
+      }
+      options.repoRoot = path.resolve(next);
+      index += 1;
+    } else {
+      throw new Error(`[generate-view-heroes] Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+export function printHelp() {
+  console.log(`Usage: node scripts/generate-view-heroes.mjs [options]
+
+Generate clean, brand-consistent SVG hero images for plugin views.
+
+Options:
+  --repo-root=<path>  Repository root directory (default: workspace root)
+  --dry-run           Preview SVG generation without modifying files on disk
+  --check             Verify all app plugins ship a hero asset without generating
+  --help, -h          Show this help message`);
+}
 
 /**
  * Discover every plugin that declares an Eliza app surface (`elizaos.app` in its
@@ -32,7 +86,7 @@ const repoRoot = path.resolve(
  * catalog reads — so the generator can never silently omit a view-bearing
  * plugin. Returns the plugin dir names (e.g. "plugin-calendar").
  */
-function scanAppPluginDirs() {
+export function scanAppPluginDirs(repoRoot = DEFAULT_REPO_ROOT) {
   const pluginsRoot = path.join(repoRoot, "plugins");
   if (!existsSync(pluginsRoot)) return [];
   const dirs = [];
@@ -50,7 +104,7 @@ function scanAppPluginDirs() {
 }
 
 /** True when a plugin dir already ships a hero asset (svg or png). */
-function pluginHasHeroAsset(pluginDir) {
+export function pluginHasHeroAsset(pluginDir, repoRoot = DEFAULT_REPO_ROOT) {
   const assetsDir = path.join(repoRoot, "plugins", pluginDir, "assets");
   if (!existsSync(assetsDir)) return false;
   return readdirSync(assetsDir).some((f) => /^hero.*\.(svg|png)$/.test(f));
@@ -61,7 +115,7 @@ function pluginHasHeroAsset(pluginDir) {
  * truth for completeness; this list controls generated art for app plugins that
  * need a committed fallback hero.
  */
-const views = [
+export const views = [
   {
     out: "plugins/plugin-app-control/assets/hero.svg",
     id: "views",
@@ -84,11 +138,11 @@ const views = [
     icon: VIEW_HERO_ICONS.calendar,
   },
   {
-    out: "plugins/plugin-native-settings/assets/hero.svg",
-    id: "device-settings",
-    label: "Device Settings",
-    hue: 96,
-    icon: VIEW_HERO_ICONS.views,
+    out: "plugins/plugin-documents/assets/hero.svg",
+    id: "documents",
+    label: "Documents",
+    hue: 190,
+    icon: VIEW_HERO_ICONS.todos,
   },
   {
     out: "plugins/plugin-finances/assets/hero.svg",
@@ -96,6 +150,13 @@ const views = [
     label: "Finances",
     hue: 150,
     icon: VIEW_HERO_ICONS.finances,
+  },
+  {
+    out: "plugins/plugin-form/assets/hero.svg",
+    id: "form",
+    label: "Form",
+    hue: 25,
+    icon: VIEW_HERO_ICONS.todos,
   },
   {
     out: "plugins/plugin-goals/assets/hero.svg",
@@ -126,6 +187,20 @@ const views = [
     icon: VIEW_HERO_ICONS.messages,
   },
   {
+    out: "plugins/plugin-native-settings/assets/hero.svg",
+    id: "device-settings",
+    label: "Device Settings",
+    hue: 96,
+    icon: VIEW_HERO_ICONS.views,
+  },
+  {
+    out: "plugins/plugin-personal-assistant/assets/hero.svg",
+    id: "assistant",
+    label: "Assistant",
+    hue: 280,
+    icon: VIEW_HERO_ICONS.views,
+  },
+  {
     out: "plugins/plugin-relationships/assets/hero.svg",
     id: "relationships",
     label: "Relationships",
@@ -141,37 +216,48 @@ const views = [
   },
 ];
 
-async function main() {
+export async function main(args = process.argv.slice(2)) {
+  const options = parseArgs(args);
+  if (options.help) {
+    printHelp();
+    return { writtenCount: 0, missingCount: 0, help: true };
+  }
+
+  const repoRoot = options.repoRoot;
   const written = [];
-  for (const view of views) {
-    const svg = renderViewHeroSvg({
-      id: view.id,
-      hue: view.hue,
-      iconSvg: view.icon,
-      label: view.label,
-    });
-    const absPath = path.resolve(repoRoot, view.out);
-    await mkdir(path.dirname(absPath), { recursive: true });
-    await writeFile(absPath, svg, "utf8");
-    written.push({ path: view.out, bytes: Buffer.byteLength(svg, "utf8") });
+
+  if (!options.check) {
+    for (const view of views) {
+      const svg = renderViewHeroSvg({
+        id: view.id,
+        hue: view.hue,
+        iconSvg: view.icon,
+        label: view.label,
+      });
+      const absPath = path.resolve(repoRoot, view.out);
+      if (!options.dryRun) {
+        await mkdir(path.dirname(absPath), { recursive: true });
+        await writeFile(absPath, svg, "utf8");
+      }
+      written.push({ path: view.out, bytes: Buffer.byteLength(svg, "utf8") });
+    }
+
+    for (const entry of written) {
+      console.log(`${String(entry.bytes).padStart(6)}  ${entry.path}`);
+    }
+    console.log(
+      `\n${options.dryRun ? "Would write" : "Wrote"} ${written.length} hero SVG files.`,
+    );
   }
 
-  for (const entry of written) {
-    console.log(`${String(entry.bytes).padStart(6)}  ${entry.path}`);
-  }
-  console.log(`\nWrote ${written.length} hero SVG files.`);
-
-  // Coverage, sourced from the manifest scan (#8796): every plugin that
-  // declares an Eliza app surface must ship a hero asset — either generated
-  // above (curated hue/icon) or committed directly. A plugin without one is a
-  // gap the catalog would render as an icon-only fallback.
   const curatedDirs = new Set(
     views.map((v) => v.out.split("/")[1]).filter(Boolean),
   );
-  const appPlugins = scanAppPluginDirs();
+  const appPlugins = scanAppPluginDirs(repoRoot);
   const missing = appPlugins.filter(
-    (dir) => !pluginHasHeroAsset(dir) && !curatedDirs.has(dir),
+    (dir) => !pluginHasHeroAsset(dir, repoRoot) && !curatedDirs.has(dir),
   );
+
   console.log(
     `\nManifest scan: ${appPlugins.length} app plugins, ${appPlugins.length - missing.length} with a hero asset.`,
   );
@@ -183,11 +269,37 @@ async function main() {
           "\n",
         )}\nAdd a curated entry above or commit plugins/<name>/assets/hero.svg.`,
     );
-    process.exitCode = 1;
+    return { writtenCount: written.length, missingCount: missing.length, missing };
   }
+
+  return { writtenCount: written.length, missingCount: 0 };
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+export async function runCli(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printHelp();
+    return 0;
+  }
+  const result = await main(argv);
+  return result.missingCount > 0 ? 1 : 0;
+}
+
+const invokedDirectly =
+  import.meta.main ||
+  (Boolean(process.argv[1]) &&
+    path.resolve(process.argv[1]) === fileURLToPath(import.meta.url));
+
+if (invokedDirectly) {
+  runCli().then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (error) => {
+      console.error(
+        error instanceof Error ? error.message : "[generate-view-heroes] failed",
+      );
+      process.exitCode = 1;
+    },
+  );
+}

--- a/scripts/generate-view-heroes.test.mjs
+++ b/scripts/generate-view-heroes.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import tmp from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import {
+  main,
+  parseArgs,
+  pluginHasHeroAsset,
+  runCli,
+  scanAppPluginDirs,
+} from "./generate-view-heroes.mjs";
+
+describe("generate-view-heroes CLI option parsing", () => {
+  it("defaults to standard configuration", () => {
+    const options = parseArgs([]);
+    assert.equal(options.dryRun, false);
+    assert.equal(options.check, false);
+    assert.equal(options.help, false);
+    assert.ok(typeof options.repoRoot === "string" && options.repoRoot.length > 0);
+  });
+
+  it("parses --help and -h flags", () => {
+    assert.equal(parseArgs(["--help"]).help, true);
+    assert.equal(parseArgs(["-h"]).help, true);
+  });
+
+  it("parses --dry-run and --check flags", () => {
+    assert.equal(parseArgs(["--dry-run"]).dryRun, true);
+    assert.equal(parseArgs(["--check"]).check, true);
+  });
+
+  it("parses --repo-root=<dir> and --repo-root <dir>", () => {
+    const opts1 = parseArgs(["--repo-root=/tmp/test-repo"]);
+    assert.equal(opts1.repoRoot, path.resolve("/tmp/test-repo"));
+
+    const opts2 = parseArgs(["--repo-root", "/tmp/test-repo"]);
+    assert.equal(opts2.repoRoot, path.resolve("/tmp/test-repo"));
+  });
+
+  it("rejects --repo-root without a value", () => {
+    assert.throws(
+      () => parseArgs(["--repo-root"]),
+      /\[generate-view-heroes\] --repo-root requires a directory path/,
+    );
+    assert.throws(
+      () => parseArgs(["--repo-root="]),
+      /\[generate-view-heroes\] --repo-root requires a directory path/,
+    );
+  });
+
+  it("rejects unknown options", () => {
+    assert.throws(
+      () => parseArgs(["--invalid-flag"]),
+      /\[generate-view-heroes\] Unknown option: --invalid-flag/,
+    );
+  });
+});
+
+describe("generate-view-heroes app plugin scan and hero detection", () => {
+  it("scans app plugins and detects hero assets accurately", () => {
+    const mockRoot = path.join(tmp.tmpdir(), `test-heroes-${Date.now()}`);
+    mkdirSync(path.join(mockRoot, "plugins", "plugin-a", "assets"), {
+      recursive: true,
+    });
+    mkdirSync(path.join(mockRoot, "plugins", "plugin-b"), { recursive: true });
+
+    writeFileSync(
+      path.join(mockRoot, "plugins", "plugin-a", "package.json"),
+      JSON.stringify({ elizaos: { app: { displayName: "App A" } } }),
+    );
+    writeFileSync(
+      path.join(mockRoot, "plugins", "plugin-b", "package.json"),
+      JSON.stringify({ elizaos: { app: { displayName: "App B" } } }),
+    );
+    writeFileSync(
+      path.join(mockRoot, "plugins", "plugin-a", "assets", "hero.svg"),
+      "<svg></svg>",
+    );
+
+    try {
+      const appDirs = scanAppPluginDirs(mockRoot);
+      assert.deepEqual(appDirs, ["plugin-a", "plugin-b"]);
+
+      assert.equal(pluginHasHeroAsset("plugin-a", mockRoot), true);
+      assert.equal(pluginHasHeroAsset("plugin-b", mockRoot), false);
+    } finally {
+      rmSync(mockRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("generate-view-heroes execution", () => {
+  it("runCli returns 0 for --help", async () => {
+    const code = await runCli(["--help"]);
+    assert.equal(code, 0);
+  });
+
+  it("main returns help result when --help flag is set", async () => {
+    const result = await main(["--help"]);
+    assert.equal(result.help, true);
+    assert.equal(result.writtenCount, 0);
+  });
+
+  it("main supports --dry-run mode", async () => {
+    const result = await main(["--dry-run"]);
+    assert.ok(result.writtenCount > 0);
+    assert.equal(result.missingCount, 0);
+  });
+});


### PR DESCRIPTION
# Relates to

Refactoring and defensive CLI parameter validation for script tools.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Google / Antigravity / Gemini 3.6 Flash (High)`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Adds CLI argument parsing (`--dry-run`, `--check`, `--repo-root`, `--help`), error handling, curated view hero fallback entries for newly added app plugins, and unit tests in `scripts/generate-view-heroes.mjs` without altering generator art rendering logic.

# Background

## What does this PR do?

Adds structured CLI argument parsing (`parseArgs`), help output (`printHelp`), safe exit handling (`runCli`), `--dry-run` and `--check` modes, curated fallback entries for documents, form, and personal assistant app plugins, and unit test coverage (`scripts/generate-view-heroes.test.mjs`).

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review [`scripts/generate-view-heroes.mjs`](file:///home/dak/src/eliza-agy/scripts/generate-view-heroes.mjs) and [`scripts/generate-view-heroes.test.mjs`](file:///home/dak/src/eliza-agy/scripts/generate-view-heroes.test.mjs).

## Detailed testing steps

Run `bun test scripts/generate-view-heroes.test.mjs` to execute unit tests.
Run `bun scripts/generate-view-heroes.mjs --dry-run` or `--check` to verify CLI behavior.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - CLI script refactoring with no UI component`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - CLI script refactoring with no UI component`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - CLI script refactoring with no UI flow`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test coverage for CLI script`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - CLI script refactoring with no frontend component`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - non-LLM CLI script change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable, or marked `N/A - unit test execution verifies script behavior`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - CLI script change with no visual output`.

# Evidence Details

## Real LLM-call trajectory

N/A - non-LLM CLI script change.

## Backend + frontend logs

```text
bun test v1.3.14 (0d9b296a)

scripts/generate-view-heroes.test.mjs:
✓ generate-view-heroes CLI option parsing > defaults to standard configuration [0.35ms]
✓ generate-view-heroes CLI option parsing > parses --help and -h flags [0.05ms]
✓ generate-view-heroes CLI option parsing > parses --dry-run and --check flags [0.04ms]
✓ generate-view-heroes CLI option parsing > parses --repo-root=<dir> and --repo-root <dir> [0.07ms]
✓ generate-view-heroes CLI option parsing > rejects --repo-root without a value [0.60ms]
✓ generate-view-heroes CLI option parsing > rejects unknown options [0.10ms]
✓ generate-view-heroes app plugin scan and hero detection > scans app plugins and detects hero assets accurately [1.80ms]
✓ generate-view-heroes execution > runCli returns 0 for --help [0.15ms]
✓ generate-view-heroes execution > main returns help result when --help flag is set [0.12ms]
✓ generate-view-heroes execution > main supports --dry-run mode [0.45ms]

 10 pass
 0 fail
Ran 10 tests across 1 file. [1154.00ms]
```

## Screenshots (before / after) + video walkthrough

N/A - CLI script change.

## Audio / voice walkthrough

N/A - non-audio change.

## Known gaps / failures

None.
