### PR TITLE
fix(app-core): reject malformed device host env overrides

### DIFF
--- a/packages/app-core/scripts/fixtures/process-tree-listener.mjs
+++ b/packages/app-core/scripts/fixtures/process-tree-listener.mjs
@@ -1,0 +1,12 @@
+/** Opens a TCP listener so process-tree teardown tests can detect orphaned descendants. */
+import { createServer } from "node:net";
+
+const port = Number(process.env.PROCESS_TREE_LISTENER_PORT);
+if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+  throw new Error("PROCESS_TREE_LISTENER_PORT must be a valid TCP port");
+}
+
+const server = createServer();
+server.listen(port, "127.0.0.1", () => {
+  console.log(`[process-tree-listener] ready pid=${process.pid} port=${port}`);
+});

--- a/packages/app-core/scripts/serve-real-local-agent-env.test.ts
+++ b/packages/app-core/scripts/serve-real-local-agent-env.test.ts
@@ -1,8 +1,10 @@
 /** Covers device E2E host env parsing before runtime or server startup. */
 import { spawn } from "node:child_process";
+import { createServer } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { signalSpawnedProcessTree } from "./lib/kill-process-tree.mjs";
 import {
   resolveNonNegativeIntegerEnv,
   resolvePort,
@@ -12,8 +14,24 @@ import {
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPT = path.join(SCRIPT_DIR, "serve-real-local-agent.ts");
 const RUN_NODE_TSX = path.join(SCRIPT_DIR, "run-node-tsx.mjs");
+const PROCESS_TREE_LISTENER = path.join(
+  SCRIPT_DIR,
+  "fixtures/process-tree-listener.mjs",
+);
 
-function runRealHost(env: NodeJS.ProcessEnv): Promise<{
+function runWrappedScript({
+  detached = process.platform !== "win32",
+  env,
+  script = SCRIPT,
+  timeoutMs = 30_000,
+  timeoutSignal = process.platform === "win32" ? "SIGKILL" : "SIGTERM",
+}: {
+  detached?: boolean;
+  env: NodeJS.ProcessEnv;
+  script?: string;
+  timeoutMs?: number;
+  timeoutSignal?: NodeJS.Signals;
+}): Promise<{
   status: number | null;
   signal: NodeJS.Signals | null;
   stdout: string;
@@ -21,8 +39,7 @@ function runRealHost(env: NodeJS.ProcessEnv): Promise<{
   timedOut: boolean;
 }> {
   return new Promise((resolve, reject) => {
-    const detached = process.platform !== "win32";
-    const child = spawn(process.execPath, [RUN_NODE_TSX, SCRIPT], {
+    const child = spawn(process.execPath, [RUN_NODE_TSX, script], {
       cwd: path.resolve(SCRIPT_DIR, "../../.."),
       detached,
       env,
@@ -39,18 +56,66 @@ function runRealHost(env: NodeJS.ProcessEnv): Promise<{
     });
     const timer = setTimeout(() => {
       timedOut = true;
-      if (detached && child.pid) {
-        process.kill(-child.pid, "SIGTERM");
-      } else {
-        child.kill("SIGTERM");
-      }
-    }, 30_000);
-    child.on("error", reject);
-    child.on("exit", (status, signal) => {
+      signalSpawnedProcessTree(child, timeoutSignal);
+    }, timeoutMs);
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on("close", (status, signal) => {
       clearTimeout(timer);
       resolve({ status, signal, stdout, stderr, timedOut });
     });
   });
+}
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("free-port probe did not return a TCP address"));
+        return;
+      }
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(address.port);
+      });
+    });
+  });
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function canListen(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.unref();
+    server.once("error", () => resolve(false));
+    server.listen(port, "127.0.0.1", () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+async function waitForTreeRelease(pid: number, port: number): Promise<boolean> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid) && (await canListen(port))) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return !isPidAlive(pid) && (await canListen(port));
 }
 
 describe("serve-real-local-agent env parsing", () => {
@@ -101,10 +166,12 @@ describe("serve-real-local-agent env parsing", () => {
   );
 
   it("fails the real host process before runtime creation", async () => {
-    const result = await runRealHost({
-      ...process.env,
-      ELIZA_NODE_PATH: process.execPath,
-      ELIZA_API_PORT: "31337junk",
+    const result = await runWrappedScript({
+      env: {
+        ...process.env,
+        ELIZA_NODE_PATH: process.execPath,
+        ELIZA_API_PORT: "31337junk",
+      },
     });
 
     expect(result.timedOut).toBe(false);
@@ -113,5 +180,35 @@ describe("serve-real-local-agent env parsing", () => {
       "Invalid ELIZA_API_PORT/ELIZA_PORT: 31337junk",
     );
     expect(result.stdout).not.toContain("real API up");
+  });
+
+  it("terminates the wrapper descendant and releases its listener port", async () => {
+    const port = await getFreePort();
+    const result = await runWrappedScript({
+      detached: false,
+      env: {
+        ...process.env,
+        ELIZA_NODE_PATH: process.execPath,
+        PROCESS_TREE_LISTENER_PORT: String(port),
+      },
+      script: PROCESS_TREE_LISTENER,
+      timeoutMs: 2_000,
+      // Windows ChildProcess.kill terminates the wrapper without delivering a
+      // catchable POSIX signal. SIGKILL reproduces that lifecycle on Unix.
+      timeoutSignal: "SIGKILL",
+    });
+    const match = result.stdout.match(
+      /\[process-tree-listener\] ready pid=(\d+) port=(\d+)/,
+    );
+    expect(match).not.toBeNull();
+    const descendantPid = Number(match?.[1]);
+
+    try {
+      expect(result.timedOut).toBe(true);
+      expect(Number(match?.[2])).toBe(port);
+      expect(await waitForTreeRelease(descendantPid, port)).toBe(true);
+    } finally {
+      if (isPidAlive(descendantPid)) process.kill(descendantPid, "SIGKILL");
+    }
   });
 });

--- a/packages/app-core/scripts/serve-real-local-agent-env.test.ts
+++ b/packages/app-core/scripts/serve-real-local-agent-env.test.ts
@@ -1,0 +1,117 @@
+/** Covers device E2E host env parsing before runtime or server startup. */
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  resolveNonNegativeIntegerEnv,
+  resolvePort,
+  resolvePositiveIntegerEnv,
+} from "./serve-real-local-agent";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(SCRIPT_DIR, "serve-real-local-agent.ts");
+const RUN_NODE_TSX = path.join(SCRIPT_DIR, "run-node-tsx.mjs");
+
+function runRealHost(env: NodeJS.ProcessEnv): Promise<{
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}> {
+  return new Promise((resolve, reject) => {
+    const detached = process.platform !== "win32";
+    const child = spawn(process.execPath, [RUN_NODE_TSX, SCRIPT], {
+      cwd: path.resolve(SCRIPT_DIR, "../../.."),
+      detached,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      if (detached && child.pid) {
+        process.kill(-child.pid, "SIGTERM");
+      } else {
+        child.kill("SIGTERM");
+      }
+    }, 30_000);
+    child.on("error", reject);
+    child.on("exit", (status, signal) => {
+      clearTimeout(timer);
+      resolve({ status, signal, stdout, stderr, timedOut });
+    });
+  });
+}
+
+describe("serve-real-local-agent env parsing", () => {
+  it("preserves defaults and valid explicit values", () => {
+    expect(resolvePort({})).toBe(31337);
+    expect(resolvePort({ ELIZA_PORT: "2142" })).toBe(2142);
+    expect(resolvePort({ ELIZA_API_PORT: "31338", ELIZA_PORT: "2142" })).toBe(
+      31338,
+    );
+    expect(resolveNonNegativeIntegerEnv("INTERVAL", "9", {})).toBe(9);
+    expect(
+      resolveNonNegativeIntegerEnv("INTERVAL", "9", { INTERVAL: "0" }),
+    ).toBe(0);
+    expect(resolvePositiveIntegerEnv("CHUNK", "4", { CHUNK: "08" })).toBe(8);
+  });
+
+  it.each([
+    "31337junk",
+    "31337.5",
+    "+31337",
+    "-1",
+    " ",
+    "0",
+    "65536",
+    "9007199254740992",
+  ])("rejects malformed API port %s", (value) => {
+    expect(() => resolvePort({ ELIZA_API_PORT: value })).toThrow(
+      `Invalid ELIZA_API_PORT/ELIZA_PORT: ${value}`,
+    );
+  });
+
+  it.each(["1junk", "1.5", "+1", "-1", " ", "9007199254740992"])(
+    "rejects malformed non-negative integer %s",
+    (value) => {
+      expect(() =>
+        resolveNonNegativeIntegerEnv("INTERVAL", "0", { INTERVAL: value }),
+      ).toThrow(`INTERVAL must be a non-negative integer: ${value}`);
+    },
+  );
+
+  it.each(["1junk", "1.5", "+1", "-1", " ", "0", "9007199254740992"])(
+    "rejects malformed positive integer %s",
+    (value) => {
+      expect(() =>
+        resolvePositiveIntegerEnv("CHUNK", "4", { CHUNK: value }),
+      ).toThrow();
+    },
+  );
+
+  it("fails the real host process before runtime creation", async () => {
+    const result = await runRealHost({
+      ...process.env,
+      ELIZA_NODE_PATH: process.execPath,
+      ELIZA_API_PORT: "31337junk",
+    });
+
+    expect(result.timedOut).toBe(false);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "Invalid ELIZA_API_PORT/ELIZA_PORT: 31337junk",
+    );
+    expect(result.stdout).not.toContain("real API up");
+  });
+});

--- a/packages/app-core/scripts/serve-real-local-agent.ts
+++ b/packages/app-core/scripts/serve-real-local-agent.ts
@@ -8,9 +8,11 @@
  */
 
 import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { ModelType, type Route } from "@elizaos/core";
-import { backgroundUploadImageRoute } from "../../agent/src/api/background-routes.ts";
 import { createDeterministicModelPlugin } from "@elizaos/core/testing";
+import { backgroundUploadImageRoute } from "../../agent/src/api/background-routes.ts";
 import { startApiServer } from "../src/api/server.ts";
 import { useIsolatedConfigEnv } from "../test/helpers/isolated-config.ts";
 import { createRealTestRuntime } from "../test/helpers/real-runtime.ts";
@@ -145,26 +147,40 @@ async function installGeneratedRegistryFixture(): Promise<() => void> {
   };
 }
 
-function resolvePort(): number {
-  const raw = process.env.ELIZA_API_PORT ?? process.env.ELIZA_PORT ?? "31337";
-  const port = Number.parseInt(raw, 10);
-  if (!Number.isFinite(port) || port <= 0) {
+export function resolvePort(env = process.env): number {
+  const raw = env.ELIZA_API_PORT ?? env.ELIZA_PORT ?? "31337";
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`Invalid ELIZA_API_PORT/ELIZA_PORT: ${raw}`);
+  }
+  const port = Number(raw);
+  if (!Number.isSafeInteger(port) || port <= 0 || port > 65535) {
     throw new Error(`Invalid ELIZA_API_PORT/ELIZA_PORT: ${raw}`);
   }
   return port;
 }
 
-function resolveNonNegativeIntegerEnv(name: string, fallback: string): number {
-  const raw = process.env[name] ?? fallback;
-  const value = Number.parseInt(raw, 10);
+export function resolveNonNegativeIntegerEnv(
+  name: string,
+  fallback: string,
+  env = process.env,
+): number {
+  const raw = env[name] ?? fallback;
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`${name} must be a non-negative integer: ${raw}`);
+  }
+  const value = Number(raw);
   if (!Number.isSafeInteger(value) || value < 0) {
     throw new Error(`${name} must be a non-negative integer: ${raw}`);
   }
   return value;
 }
 
-function resolvePositiveIntegerEnv(name: string, fallback: string): number {
-  const value = resolveNonNegativeIntegerEnv(name, fallback);
+export function resolvePositiveIntegerEnv(
+  name: string,
+  fallback: string,
+  env = process.env,
+): number {
+  const value = resolveNonNegativeIntegerEnv(name, fallback, env);
   if (value === 0) {
     throw new Error(`${name} must be greater than zero`);
   }
@@ -267,9 +283,14 @@ async function main(): Promise<void> {
   await new Promise<never>(() => {});
 }
 
-main().catch((error) => {
-  console.error(
-    `[device-e2e-host-agent] FAILED: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`,
-  );
-  process.exit(1);
-});
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main().catch((error) => {
+    console.error(
+      `[device-e2e-host-agent] FAILED: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`,
+    );
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
# Relates to

Closes #18652

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`; synchronized without conflicts onto `origin/develop@131a765c3cfac15495f76eaa5f9b3c3b0e80ae63`.
- [x] Frozen install completed without lockfile changes.
- [x] Focused regression (24/24), app-core typecheck/build, touched-file formatting, and diff checks pass on the final head.
- [x] Workspace build passed 124/124 tasks and the view-bundle guard passed 19/19.
- [x] Broad package/root failures were reproduced byte-for-byte on pristine `origin/develop` and are documented below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Final head `a2413a8a2cfbc97499e735fa1d76b2bc28978300` is based directly on `origin/develop@131a765c3cfac15495f76eaa5f9b3c3b0e80ae63`.
- [x] `git diff --check origin/develop...HEAD` passes and the worktree is clean.
- [x] The only changed paths are the app-core host parser, its focused test, and one listener-only test fixture.

# Risks

Low. Valid environment values and defaults are unchanged. Invalid values fail before runtime creation. If the real-host regression ever times out, cleanup now targets only the spawned wrapper's PID-rooted process tree; Windows uses forced `taskkill /PID <pid> /T /F`, and the harness waits for `close` so inherited pipes and listener descendants are gone before the test resolves.

# Background

## What does this PR do?

- Validates the device E2E host API port as a complete decimal safe integer in `1..65535`.
- Validates deterministic stream interval/chunk env values as complete non-negative/positive safe integers.
- Makes the pure resolvers importable and guards `main()` behind direct execution for deterministic tests.
- Adds 24 focused assertions, including a real-process invalid-input proof.
- Makes timeout cleanup cross-platform and descendant-safe, with a real `run-node-tsx` wrapper plus TCP-listener grandchild regression proving both process exit and port release.

## What kind of change is this?

Bug fix (non-breaking for valid device E2E host configuration) plus regression-harness hardening.

# Documentation changes needed?

No. The supported variables and defaults do not change; invalid values now fail closed.

# Testing

## Where should a reviewer start?

1. `packages/app-core/scripts/serve-real-local-agent.ts` — strict parser boundary and direct-entry guard.
2. `packages/app-core/scripts/serve-real-local-agent-env.test.ts` — parser cases, real subprocess rejection, PID-rooted teardown, and port-release assertion.
3. `packages/app-core/scripts/fixtures/process-tree-listener.mjs` — minimal real descendant used by the teardown regression.

## Detailed testing steps

Environment: Bun 1.3.14 and Node 24.15.0.

```bash
ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile

bun run --cwd packages/app-core test scripts/serve-real-local-agent-env.test.ts
# 1 file passed; 24 tests passed

bun run --cwd packages/app-core typecheck
bun run --cwd packages/app-core build
# both exit 0

bun run build
# 124/124 tasks successful; view-bundle guard 19/19

bun run --cwd packages/app-core test
# 1757 passed; 17 skipped; 1 baseline i18n-contract failure

bun run verify
# reaches the 141-package typecheck/lint matrix, then stops on a baseline cloud-shared formatter error
```

Parser RED: suffix, fraction, signed, out-of-range, and unsafe values were accepted; the real subprocess entered host boot for `ELIZA_API_PORT=31337junk`.

Process-tree RED: forcing the Windows-style uncatchable wrapper lifecycle left the listener grandchild alive and its TCP port occupied. After the fix, the same real wrapper/grandchild test passes and the port can be rebound.

Baseline reproductions on detached pristine `origin/develop@131a765c3c`:

- `check-i18n` reports the same missing `cloud.discord.ownerDiscordUserId` and `cloud.discord.ownerDiscordUserIdPlaceholder` source-locale keys.
- Biome reports the same formatter error in `packages/cloud/shared/src/db/schemas/discord-connections.ts`.
- This branch does not modify either baseline-failing path.

Independent read-only review of `131a765c3c..a2413a8a2c` found no Critical, Important, or Minor issues and assessed the change ready.

# Evidence Gate

<!-- evidence-head:a2413a8a2cfbc97499e735fa1d76b2bc28978300 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - terminal-only pre-start environment parsing; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - terminal-only pre-start environment parsing; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive user flow; the real subprocess transcript covers the changed behavior.
<!-- evidence-row:backend-logs -->
- [ ] N/A - invalid input exits before runtime creation or API server startup.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend or browser behavior.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain state; focused subprocess tests prove descendant exit and TCP port release.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior.

## Backend + frontend logs

N/A - invalid input exits before runtime/server startup; the teardown regression owns only local subprocesses and a loopback test listener.

## Screenshots (before / after) + video walkthrough

N/A - terminal-only environment parsing and process lifecycle behavior.

## Audio / voice walkthrough

N/A - deterministic stream configuration parsing only; no TTS/STT/audio path executes.

## Known gaps / failures

- Full app-core results are 1,757 passed / 17 skipped / 1 failed. The sole i18n failure reproduces on detached pristine `origin/develop@131a765c3c` with the same two missing Discord keys.
- Root `bun run verify` is not green: it stops on a cloud-shared formatter error that reproduces on detached pristine `origin/develop@131a765c3c`.
- The regression reproduces Windows' uncatchable wrapper lifecycle on Unix and statically exercises the repository's Windows `taskkill /T /F` branch; a Windows CI run remains the platform-native confirmation.
- Device execution is not applicable because both the parsing boundary and cleanup regression run before device/runtime startup.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 79384350 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [rndrntwrk-codex-fix-device-host-env]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTZ70TXKMVMXMW0HAMKCEQQ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T12:30:04.637Z","completed_at":"2026-08-12T13:17:06.495Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":4220929,"output_tokens":321565,"cache_creation_tokens":0,"cache_read_tokens":74841856,"total_tokens":79384350,"cost_micro_usd":"232989923","session_count":9},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAca_bmgW70vt_4YdSWBk9O4OcExXrUczaWSsxNRnwtrw","device_key_id":"fb0b00036edfe4c6ff8630ecd4b1182ddf807c431da450ca4064fa05dec7ebe1","device_signature":"KH6UP1Vfibe65BXHgavQLme08eB8NqMb0E8u2syMdrMJCJ6qz9uaFm4Mj2eQc06wZjQP7CuLxoZwG_36AA9sCg"}} -->


