### PR TITLE
fix(scripts): add CLI parameter validation, output options, and unit tests for testing-coverage-matrix

### DIFF
--- a/scripts/testing-coverage-matrix.mjs
+++ b/scripts/testing-coverage-matrix.mjs
@@ -14,27 +14,29 @@
  * Usage:
  *   node scripts/testing-coverage-matrix.mjs
  *   node scripts/testing-coverage-matrix.mjs --check
+ *   node scripts/testing-coverage-matrix.mjs --output <path>
+ *   node scripts/testing-coverage-matrix.mjs --help
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
 );
-const OUTPUT = path.join(REPO_ROOT, "docs", "TESTING_COVERAGE_MATRIX.md");
+const DEFAULT_OUTPUT = path.join(REPO_ROOT, "docs", "TESTING_COVERAGE_MATRIX.md");
 
 const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/;
 // it.skip / test.skip / describe.skip / xit / xdescribe / .todo / .skipIf(...)
 const SKIP_RE =
   /\b(?:it|test|describe)\.(?:skip|todo)\b|\bx(?:it|describe)\s*\(|\.skipIf\s*\(|\btest\.skip\b/g;
 
-function gitFiles() {
+export function gitFiles(rootDir = REPO_ROOT) {
   return execFileSync("git", ["ls-files"], {
-    cwd: REPO_ROOT,
+    cwd: rootDir,
     encoding: "utf8",
     maxBuffer: 256 * 1024 * 1024,
   })
@@ -42,16 +44,53 @@ function gitFiles() {
     .filter(Boolean);
 }
 
-function readJson(rel) {
-  try {
-    return JSON.parse(readFileSync(path.join(REPO_ROOT, rel), "utf8"));
-  } catch {
-    return null;
+export function parseArgs(argv = process.argv.slice(2)) {
+  const args = { check: false, output: "", help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--check") {
+      args.check = true;
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else if (arg === "--output") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw new Error("Option '--output' requires a non-empty file path argument.");
+      }
+      args.output = argv[++i];
+    } else if (arg.startsWith("--output=")) {
+      const val = arg.slice("--output=".length);
+      if (!val) {
+        throw new Error("Option '--output' requires a non-empty file path argument.");
+      }
+      args.output = val;
+    } else {
+      throw new Error(`Unknown option or argument: ${arg}`);
+    }
   }
+  return args;
 }
 
-function main() {
-  const files = gitFiles();
+export function generateMatrixData(options = {}) {
+  const rootDir = options.rootDir ?? REPO_ROOT;
+  const files = options.files ?? gitFiles(rootDir);
+  const readJsonFn =
+    options.readJsonFn ??
+    ((rel) => {
+      try {
+        return JSON.parse(readFileSync(path.join(rootDir, rel), "utf8"));
+      } catch {
+        return null;
+      }
+    });
+  const readFileTextFn =
+    options.readFileTextFn ??
+    ((file) => {
+      try {
+        return readFileSync(path.join(rootDir, file), "utf8");
+      } catch {
+        return null;
+      }
+    });
 
   // Every directory that owns a package.json (excluding the repo root) is a
   // package node. Tracked files never include node_modules, so this is clean.
@@ -74,7 +113,7 @@ function main() {
     return null;
   }
 
-  const rootPkg = readJson("package.json");
+  const rootPkg = readJsonFn("package.json");
   const workspaceNegations = (rootPkg?.workspaces ?? [])
     .filter((w) => typeof w === "string" && w.startsWith("!"))
     .map((w) => w.slice(1));
@@ -90,10 +129,12 @@ function main() {
 
   // Per-package package.json metadata.
   for (const dir of packageDirs) {
-    const pkg = readJson(`${dir}/package.json`);
+    const pkg = readJsonFn(`${dir}/package.json`);
     const entry = stats.get(dir);
-    entry.name = pkg?.name ?? "(unnamed)";
-    entry.hasTestScript = Boolean(pkg?.scripts?.test);
+    if (entry) {
+      entry.name = pkg?.name ?? "(unnamed)";
+      entry.hasTestScript = Boolean(pkg?.scripts?.test);
+    }
   }
 
   // Assign test files to their owning package and count skips.
@@ -102,13 +143,12 @@ function main() {
     const owner = ownerPackage(file);
     if (!owner) continue;
     const entry = stats.get(owner);
+    if (!entry) continue;
     entry.testFiles += 1;
-    try {
-      const body = readFileSync(path.join(REPO_ROOT, file), "utf8");
+    const body = readFileTextFn(file);
+    if (body) {
       const matches = body.match(SKIP_RE);
       if (matches) entry.skips += matches.length;
-    } catch {
-      // Unreadable tracked file (symlink/binary) — skip silently.
     }
   }
 
@@ -178,24 +218,58 @@ function main() {
   lines.push("");
 
   const content = `${lines.join("\n")}`;
-
-  if (process.argv.includes("--check")) {
-    const current = existsSync(OUTPUT) ? readFileSync(OUTPUT, "utf8") : "";
-    if (current !== content) {
-      console.error(
-        "docs/TESTING_COVERAGE_MATRIX.md is stale. Run `node scripts/testing-coverage-matrix.mjs`.",
-      );
-      process.exit(1);
-    }
-    console.log("TESTING_COVERAGE_MATRIX.md is up to date.");
-    return;
-  }
-
-  writeFileSync(OUTPUT, content);
-  console.log(
-    `Wrote ${path.relative(REPO_ROOT, OUTPUT)}: ${rows.length} packages, ` +
-      `${totals.testFiles} test files, ${totals.skips} skips.`,
-  );
+  return { content, totals, rows };
 }
 
-main();
+export function runCli(argv = process.argv.slice(2), io = {}) {
+  const stdout = io.stdout ?? process.stdout;
+  const stderr = io.stderr ?? process.stderr;
+
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    stderr.write(`[testing-coverage-matrix] Error: ${err.message}\n`);
+    stderr.write("Usage: node scripts/testing-coverage-matrix.mjs [--check] [--output <path>] [--help]\n");
+    return 2;
+  }
+
+  if (args.help) {
+    stdout.write(
+      "Usage: node scripts/testing-coverage-matrix.mjs [options]\n\n" +
+        "Options:\n" +
+        "  --check          Verify that the matrix file is up to date instead of writing it\n" +
+        "  --output <path>  Specify alternative destination path for the matrix file\n" +
+        "  --help, -h       Show this help message\n",
+    );
+    return 0;
+  }
+
+  const outputPath = args.output ? path.resolve(args.output) : DEFAULT_OUTPUT;
+  const { content, totals, rows } = generateMatrixData();
+
+  if (args.check) {
+    const current = existsSync(outputPath) ? readFileSync(outputPath, "utf8") : "";
+    if (current !== content) {
+      stderr.write(
+        `${path.relative(REPO_ROOT, outputPath)} is stale. Run \`node scripts/testing-coverage-matrix.mjs\`.\n`,
+      );
+      return 1;
+    }
+    stdout.write(`${path.relative(REPO_ROOT, outputPath)} is up to date.\n`);
+    return 0;
+  }
+
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, content);
+  stdout.write(
+    `Wrote ${path.relative(REPO_ROOT, outputPath)}: ${rows.length} packages, ` +
+      `${totals.testFiles} test files, ${totals.skips} skips.\n`,
+  );
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  process.exitCode = runCli();
+}
+

--- a/scripts/testing-coverage-matrix.test.mjs
+++ b/scripts/testing-coverage-matrix.test.mjs
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for testing-coverage-matrix.mjs CLI parameter validation,
+ * matrix generation, and execution modes.
+ */
+
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import {
+  generateMatrixData,
+  parseArgs,
+  runCli,
+} from "./testing-coverage-matrix.mjs";
+
+describe("testing coverage matrix script", () => {
+  describe("parseArgs", () => {
+    it("parses empty arguments to defaults", () => {
+      const parsed = parseArgs([]);
+      assert.deepEqual(parsed, { check: false, output: "", help: false });
+    });
+
+    it("parses valid flags correctly", () => {
+      assert.equal(parseArgs(["--check"]).check, true);
+      assert.equal(parseArgs(["--help"]).help, true);
+      assert.equal(parseArgs(["-h"]).help, true);
+      assert.equal(parseArgs(["--output", "custom.md"]).output, "custom.md");
+      assert.equal(parseArgs(["--output=custom.md"]).output, "custom.md");
+    });
+
+    it("rejects unknown options", () => {
+      assert.throws(
+        () => parseArgs(["--invalid-option"]),
+        /Unknown option or argument: --invalid-option/,
+      );
+    });
+
+    it("rejects --output without a value", () => {
+      assert.throws(
+        () => parseArgs(["--output"]),
+        /Option '--output' requires a non-empty file path argument./,
+      );
+      assert.throws(
+        () => parseArgs(["--output", "--check"]),
+        /Option '--output' requires a non-empty file path argument./,
+      );
+      assert.throws(
+        () => parseArgs(["--output="]),
+        /Option '--output' requires a non-empty file path argument./,
+      );
+    });
+  });
+
+  describe("generateMatrixData", () => {
+    it("builds correct matrix summary and table from mocked repo structure", () => {
+      const mockFiles = [
+        "package.json",
+        "packages/pkg-a/package.json",
+        "packages/pkg-a/src/index.test.ts",
+        "packages/pkg-b/package.json",
+      ];
+
+      const mockJson = {
+        "package.json": { name: "root", workspaces: ["packages/*"] },
+        "packages/pkg-a/package.json": {
+          name: "@elizaos/pkg-a",
+          scripts: { test: "vitest" },
+        },
+        "packages/pkg-b/package.json": {
+          name: "@elizaos/pkg-b",
+          scripts: {},
+        },
+      };
+
+      const mockTexts = {
+        "packages/pkg-a/src/index.test.ts": `
+          describe.skip("suite", () => {
+            it("test 1", () => {});
+            it.skip("test 2", () => {});
+            test.skip("test 3", () => {});
+            xit("test 4", () => {});
+          });
+        `,
+      };
+
+      const result = generateMatrixData({
+        files: mockFiles,
+        readJsonFn: (rel) => mockJson[rel] ?? null,
+        readFileTextFn: (file) => mockTexts[file] ?? null,
+      });
+
+      assert.equal(result.totals.withTests, 1);
+      assert.equal(result.totals.inCi, 1);
+      assert.equal(result.totals.testFiles, 1);
+      assert.equal(result.totals.skips, 4);
+      assert.equal(result.totals.zeroTestWithScript, 0);
+
+      assert.ok(result.content.includes("# Testing coverage matrix"));
+      assert.ok(result.content.includes("| @elizaos/pkg-a | `packages/pkg-a` | 1 | 4 | yes | yes |"));
+    });
+
+    it("respects workspace negations in root package.json", () => {
+      const mockFiles = [
+        "package.json",
+        "packages/pkg-a/package.json",
+        "packages/ignored/package.json",
+      ];
+
+      const mockJson = {
+        "package.json": { name: "root", workspaces: ["packages/*", "!packages/ignored"] },
+        "packages/pkg-a/package.json": {
+          name: "@elizaos/pkg-a",
+          scripts: { test: "vitest" },
+        },
+        "packages/ignored/package.json": {
+          name: "@elizaos/ignored",
+          scripts: { test: "vitest" },
+        },
+      };
+
+      const result = generateMatrixData({
+        files: mockFiles,
+        readJsonFn: (rel) => mockJson[rel] ?? null,
+        readFileTextFn: () => null,
+      });
+
+      assert.equal(result.totals.inCi, 1);
+      assert.ok(result.content.includes("| @elizaos/ignored | `packages/ignored` | 0 | 0 | yes | no |"));
+    });
+  });
+
+  describe("runCli", () => {
+    it("returns exit code 0 and prints help when --help is passed", () => {
+      let stdout = "";
+      let stderr = "";
+      const code = runCli(["--help"], {
+        stdout: { write: (msg) => (stdout += msg) },
+        stderr: { write: (msg) => (stderr += msg) },
+      });
+
+      assert.equal(code, 0);
+      assert.ok(stdout.includes("Usage: node scripts/testing-coverage-matrix.mjs"));
+      assert.equal(stderr, "");
+    });
+
+    it("returns exit code 2 and prints error on invalid options", () => {
+      let stdout = "";
+      let stderr = "";
+      const code = runCli(["--bogus"], {
+        stdout: { write: (msg) => (stdout += msg) },
+        stderr: { write: (msg) => (stderr += msg) },
+      });
+
+      assert.equal(code, 2);
+      assert.ok(stderr.includes("[testing-coverage-matrix] Error: Unknown option or argument: --bogus"));
+      assert.equal(stdout, "");
+    });
+
+    it("writes matrix output file and creates nested directory if needed", () => {
+      const tmpDir = mkdtempSync(path.join(tmpdir(), "matrix-test-"));
+      const outFile = path.join(tmpDir, "nested", "matrix.md");
+
+      let stdout = "";
+      let stderr = "";
+      try {
+        const code = runCli(["--output", outFile], {
+          stdout: { write: (msg) => (stdout += msg) },
+          stderr: { write: (msg) => (stderr += msg) },
+        });
+
+        assert.equal(code, 0);
+        assert.ok(existsSync(outFile));
+        const content = readFileSync(outFile, "utf8");
+        assert.ok(content.includes("# Testing coverage matrix"));
+        assert.ok(stdout.includes("Wrote "));
+      } finally {
+        rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("validates --check mode when file is stale vs up to date", () => {
+      const tmpDir = mkdtempSync(path.join(tmpdir(), "matrix-check-"));
+      const outFile = path.join(tmpDir, "matrix.md");
+
+      let stdout = "";
+      let stderr = "";
+      try {
+        // Run once to create current matrix
+        runCli(["--output", outFile], {
+          stdout: { write: () => {} },
+          stderr: { write: () => {} },
+        });
+
+        // Check against matching file -> pass (code 0)
+        stdout = "";
+        stderr = "";
+        let code = runCli(["--check", "--output", outFile], {
+          stdout: { write: (msg) => (stdout += msg) },
+          stderr: { write: (msg) => (stderr += msg) },
+        });
+        assert.equal(code, 0);
+        assert.ok(stdout.includes("is up to date."));
+
+        // Modify file to make it stale -> fail (code 1)
+        writeFileSync(outFile, "# Stale Content\n");
+        stdout = "";
+        stderr = "";
+        code = runCli(["--check", "--output", outFile], {
+          stdout: { write: (msg) => (stdout += msg) },
+          stderr: { write: (msg) => (stderr += msg) },
+        });
+        assert.equal(code, 1);
+        assert.ok(stderr.includes("is stale. Run `node scripts/testing-coverage-matrix.mjs`."));
+      } finally {
+        rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Google/Antigravity-Gemini-3.6-Flash-High`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low - Non-breaking maintenance fix to a developer script (`scripts/testing-coverage-matrix.mjs`) and addition of unit tests (`scripts/testing-coverage-matrix.test.mjs`).

# Background

## What does this PR do?

Adds strict CLI parameter validation, an `--output <path>` option, `--help` output, automatic parent directory creation (`mkdirSync`), and modular exports to `scripts/testing-coverage-matrix.mjs`.
Also introduces a comprehensive test suite in `scripts/testing-coverage-matrix.test.mjs` using `node:test`.

## What kind of change is this?

Bug fixes / Improvements / Tests

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `scripts/testing-coverage-matrix.mjs`
- `scripts/testing-coverage-matrix.test.mjs`

## Detailed testing steps

1. Run the new test suite:
   ```bash
   node --test scripts/testing-coverage-matrix.test.mjs
   ```
2. Test CLI flags:
   ```bash
   node scripts/testing-coverage-matrix.mjs --help
   node scripts/testing-coverage-matrix.mjs --check
   ```
3. Test invalid option rejection:
   ```bash
   node scripts/testing-coverage-matrix.mjs --invalid-flag
   ```

# Evidence Gate

<!-- evidence-head:611f6bfb5ccfcec8bbe4a51272b02918e4a13672 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - No UI surface; developer script change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - No UI surface; developer script change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - No UI flow; developer script change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - CLI test output attached below`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - No frontend interaction`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - Non-agent script edit`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable, or marked `N/A - CLI test output attached below`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - No UI surface`.

# Evidence Details

## CLI Test Execution Logs

```
▶ testing coverage matrix script
  ▶ parseArgs
    ✔ parses empty arguments to defaults (1.364816ms)
    ✔ parses valid flags correctly (0.265468ms)
    ✔ rejects unknown options (0.528778ms)
    ✔ rejects --output without a value (0.350862ms)
  ✔ parseArgs (3.315929ms)
  ▶ generateMatrixData
    ✔ builds correct matrix summary and table from mocked repo structure (1.234313ms)
    ✔ respects workspace negations in root package.json (8.350794ms)
  ✔ generateMatrixData (9.902188ms)
  ▶ runCli
    ✔ returns exit code 0 and prints help when --help is passed (0.467908ms)
    ✔ returns exit code 2 and prints error on invalid options (0.195126ms)
    ✔ writes matrix output file and creates nested directory if needed (255.24234ms)
    ✔ validates --check mode when file is stale vs up to date (712.766074ms)
  ✔ runCli (969.061326ms)
✔ testing coverage matrix script (983.065422ms)
ℹ tests 10
ℹ suites 4
ℹ pass 10
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
```

## Known gaps / failures

None.