### PR TITLE
test(skills): add unit tests for curated active, proposed, and promoteSkill resolvers

### DIFF
--- a/packages/skills/test/resolver.test.ts
+++ b/packages/skills/test/resolver.test.ts
@@ -8,7 +8,13 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it } from "node:test";
-import { clearSkillsDirCache, getSkillsDir } from "../src/resolver.js";
+import {
+  clearSkillsDirCache,
+  getCuratedActiveDir,
+  getProposedSkillsDir,
+  getSkillsDir,
+  promoteSkill,
+} from "../src/resolver.js";
 
 function makeSkillDir(prefix: string): string {
   const dir = join(tmpdir(), `${prefix}-${Date.now()}`);
@@ -90,5 +96,107 @@ describe("clearSkillsDirCache", () => {
     assert.notStrictEqual(overriddenDir, defaultDir);
 
     rmSync(tempDir, { recursive: true, force: true });
+  });
+});
+
+describe("getCuratedActiveDir and getProposedSkillsDir", () => {
+  const originalStateDir = process.env.ELIZA_STATE_DIR;
+
+  afterEach(() => {
+    if (originalStateDir !== undefined) {
+      process.env.ELIZA_STATE_DIR = originalStateDir;
+    } else {
+      delete process.env.ELIZA_STATE_DIR;
+    }
+  });
+
+  it("resolves curated active and proposed directories relative to state dir", () => {
+    const tempDir = join(tmpdir(), `test-curated-dirs-${Date.now()}`);
+    process.env.ELIZA_STATE_DIR = tempDir;
+
+    const activeDir = getCuratedActiveDir();
+    const proposedDir = getProposedSkillsDir();
+
+    assert.strictEqual(activeDir, join(tempDir, "skills", "curated", "active"));
+    assert.strictEqual(
+      proposedDir,
+      join(tempDir, "skills", "curated", "proposed"),
+    );
+  });
+});
+
+describe("promoteSkill", () => {
+  const originalStateDir = process.env.ELIZA_STATE_DIR;
+  let tempStateDir: string;
+
+  beforeEach(() => {
+    tempStateDir = join(tmpdir(), `test-skills-promote-${Date.now()}`);
+    process.env.ELIZA_STATE_DIR = tempStateDir;
+  });
+
+  afterEach(() => {
+    if (tempStateDir && existsSync(tempStateDir)) {
+      rmSync(tempStateDir, { recursive: true, force: true });
+    }
+    if (originalStateDir !== undefined) {
+      process.env.ELIZA_STATE_DIR = originalStateDir;
+    } else {
+      delete process.env.ELIZA_STATE_DIR;
+    }
+  });
+
+  it("rejects invalid skill names", () => {
+    assert.throws(
+      () => promoteSkill("Invalid_Name"),
+      /Invalid skill name "Invalid_Name"/,
+    );
+    assert.throws(() => promoteSkill("skill!"), /Invalid skill name "skill!"/);
+    assert.throws(
+      () => promoteSkill("CamelCaseSkill"),
+      /Invalid skill name "CamelCaseSkill"/,
+    );
+  });
+
+  it("throws when proposed skill directory does not exist", () => {
+    assert.throws(
+      () => promoteSkill("nonexistent-skill"),
+      /Proposed skill "nonexistent-skill" not found/,
+    );
+  });
+
+  it("atomically promotes a proposed skill to active", () => {
+    const skillName = "test-skill-promo";
+    const proposedDir = join(getProposedSkillsDir(), skillName);
+    mkdirSync(proposedDir, { recursive: true });
+    writeFileSync(
+      join(proposedDir, "SKILL.md"),
+      "---\nname: test-skill-promo\ndescription: A test skill\n---\n# Test",
+    );
+
+    assert.strictEqual(existsSync(proposedDir), true);
+
+    const activeDir = promoteSkill(skillName);
+
+    assert.strictEqual(existsSync(proposedDir), false);
+    assert.strictEqual(existsSync(activeDir), true);
+    assert.strictEqual(activeDir, join(getCuratedActiveDir(), skillName));
+    assert.strictEqual(existsSync(join(activeDir, "SKILL.md")), true);
+  });
+
+  it("throws when active skill already exists", () => {
+    const skillName = "duplicate-skill";
+    const proposedDir = join(getProposedSkillsDir(), skillName);
+    const activeDir = join(getCuratedActiveDir(), skillName);
+
+    mkdirSync(proposedDir, { recursive: true });
+    mkdirSync(activeDir, { recursive: true });
+
+    writeFileSync(join(proposedDir, "SKILL.md"), "proposed");
+    writeFileSync(join(activeDir, "SKILL.md"), "active");
+
+    assert.throws(
+      () => promoteSkill(skillName),
+      /Active skill "duplicate-skill" already exists/,
+    );
   });
 });

--- a/packages/skills/test/resolver.test.ts
+++ b/packages/skills/test/resolver.test.ts
@@ -7,7 +7,7 @@ import assert from "node:assert";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 import {
   clearSkillsDirCache,
   getCuratedActiveDir,


### PR DESCRIPTION
# Relates to

N/A - Unit test coverage expansion for `@elizaos/skills` resolver module.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun test packages/skills` ran cleanly post-sync.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Google/Gemini 3.6 Flash (High)`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun test packages/skills` passes post-sync.

# Risks

Low risk. Only adds unit tests in `packages/skills/test/resolver.test.ts`. No production source code altered.

# Background

## What does this PR do?

Adds unit test coverage to `packages/skills/test/resolver.test.ts` for previously untested export functions in `packages/skills/src/resolver.ts`:
- `getCuratedActiveDir`
- `getProposedSkillsDir`
- `promoteSkill` (including valid promotion, invalid skill name validation, missing proposed directory error handling, and duplicate active skill collision checks).

## What kind of change is this?

Improvements / Test Coverage.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/skills/test/resolver.test.ts`.

## Detailed testing steps

Run:
```bash
bun test packages/skills/test/resolver.test.ts
```

Output:
```
12 pass
0 fail
Ran 12 tests across 1 file.
```

And full package test suite:
```bash
bun test packages/skills
```
Output:
```
88 pass
0 fail
Ran 88 tests across 5 files.
```

# Evidence Gate

<!-- evidence-head:f18b92dc41773f5481ef9b474594d4e8a74f2c9e -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - non-UI unit test addition for @elizaos/skills resolver
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - non-UI unit test addition for @elizaos/skills resolver
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough: N/A - non-UI unit test addition for @elizaos/skills resolver
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend service changes, unit tests pass via bun test
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: N/A - non-UI package tests
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, prompt, provider, or model changes
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no persistent domain artifacts mutated
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output: N/A - non-UI changes

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM or prompt changes.

## Backend + frontend logs

```
$ bun test packages/skills/test/resolver.test.ts
12 pass
0 fail
Ran 12 tests across 1 file. [991.00ms]
```

## Screenshots (before / after) + video walkthrough

N/A - non-UI unit test addition for @elizaos/skills resolver.

## Audio / voice walkthrough

N/A - non-voice change.

## Known gaps / failures

None.

<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.6-flash-high","client":"antigravity","skill_revision":"N/A"} -->

