### PR TITLE
fix(scripts): reject invalid RUN_TURBO_CONCURRENCY overrides

### DIFF
--- a/packages/scripts/__tests__/run-turbo-concurrency-env.test.ts
+++ b/packages/scripts/__tests__/run-turbo-concurrency-env.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Offline unit tests for RUN_TURBO_CONCURRENCY fail-closed resolution and argv
+ * injection. Pure helpers plus a real subprocess seam (RUN_TURBO_BIN) so the
+ * runner rejects typos before Turbo starts and still injects valid caps.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  applyTurboConcurrency,
+  parsePositiveSafeInteger,
+  resolveTurboConcurrency,
+} from "../lib/run-turbo-concurrency.mjs";
+import { spawnSync } from "../lib/spawn-sync-captured.mjs";
+
+const repoRoot = resolve(import.meta.dir, "../../..");
+const runTurbo = join(repoRoot, "packages/scripts/run-turbo.mjs");
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+}, 30_000);
+
+describe("parsePositiveSafeInteger", () => {
+  test("accepts complete positive safe-integer decimals", () => {
+    expect(parsePositiveSafeInteger("1", "X")).toBe(1);
+    expect(parsePositiveSafeInteger("4", "X")).toBe(4);
+    expect(parsePositiveSafeInteger(42, "X")).toBe(42);
+  });
+
+  test("accepts surrounding whitespace after trim", () => {
+    expect(parsePositiveSafeInteger(" 4 ", "X")).toBe(4);
+  });
+
+  test("rejects malformed, signed, fractional, zero, and non-finite values", () => {
+    for (const value of [
+      "abc",
+      "3junk",
+      "1.5",
+      "+2",
+      "-1",
+      "0",
+      "",
+      " ",
+      "08",
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      1.5,
+      0,
+      -3,
+    ]) {
+      expect(() => parsePositiveSafeInteger(value, "LABEL")).toThrow(/LABEL/);
+    }
+  });
+});
+
+describe("resolveTurboConcurrency", () => {
+  test("returns null when override is unset, empty, or whitespace-only", () => {
+    expect(resolveTurboConcurrency({})).toBeNull();
+    expect(resolveTurboConcurrency({ RUN_TURBO_CONCURRENCY: "" })).toBeNull();
+    expect(
+      resolveTurboConcurrency({ RUN_TURBO_CONCURRENCY: "   " }),
+    ).toBeNull();
+  });
+
+  test("accepts valid positive integers", () => {
+    expect(resolveTurboConcurrency({ RUN_TURBO_CONCURRENCY: "4" })).toBe(4);
+    expect(resolveTurboConcurrency({ RUN_TURBO_CONCURRENCY: " 8 " })).toBe(8);
+  });
+
+  test("rejects explicit malformed overrides", () => {
+    for (const value of ["abc", "0", "-1", "1.5", "4x", "+2"]) {
+      expect(() =>
+        resolveTurboConcurrency({ RUN_TURBO_CONCURRENCY: value }),
+      ).toThrow(/RUN_TURBO_CONCURRENCY/);
+    }
+  });
+});
+
+describe("applyTurboConcurrency", () => {
+  test("leaves args unchanged when concurrency is null", () => {
+    const args = ["run", "lint", "--filter=x"];
+    expect(applyTurboConcurrency(args, null)).toEqual(args);
+  });
+
+  test("inserts after run when no concurrency flag is present", () => {
+    expect(applyTurboConcurrency(["run", "lint"], 4)).toEqual([
+      "run",
+      "--concurrency=4",
+      "lint",
+    ]);
+  });
+
+  test("appends when there is no run command word", () => {
+    expect(applyTurboConcurrency(["lint"], 2)).toEqual([
+      "lint",
+      "--concurrency=2",
+    ]);
+  });
+
+  test("replaces existing --concurrency= form", () => {
+    expect(
+      applyTurboConcurrency(["run", "--concurrency=8", "lint"], 4),
+    ).toEqual(["run", "--concurrency=4", "lint"]);
+  });
+
+  test("replaces existing --concurrency value form", () => {
+    expect(
+      applyTurboConcurrency(["run", "--concurrency", "8", "lint"], 4),
+    ).toEqual(["run", "--concurrency=4", "lint"]);
+  });
+});
+
+describe("run-turbo.mjs RUN_TURBO_CONCURRENCY integration", () => {
+  async function fixtureFakeTurbo() {
+    const dir = await mkdtemp(join(tmpdir(), "run-turbo-concurrency-"));
+    tempDirs.push(dir);
+    const argvFile = join(dir, "argv.json");
+    const fakeTurbo = join(dir, "fake-turbo.mjs");
+    await writeFile(
+      fakeTurbo,
+      [
+        'import { writeFileSync } from "node:fs";',
+        `writeFileSync(${JSON.stringify(argvFile)}, JSON.stringify(process.argv.slice(2)));`,
+        "process.exit(0);",
+      ].join("\n"),
+    );
+    return { fakeTurbo, argvFile };
+  }
+
+  function invoke(
+    fakeTurbo: string,
+    env: Record<string, string | undefined> = {},
+  ) {
+    const child = spawnSync("node", [runTurbo, "run", "lint"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        RUN_TURBO_BIN: fakeTurbo,
+        RUN_TURBO_NO_INIT_CRASH_RETRY: "1",
+        ...env,
+      },
+      timeout: 30_000,
+    });
+    return {
+      exitCode: child.status,
+      stdout: child.stdout ?? "",
+      stderr: child.stderr ?? "",
+    };
+  }
+
+  test("injects a valid env concurrency cap into Turbo argv", async () => {
+    const { fakeTurbo, argvFile } = await fixtureFakeTurbo();
+    const result = invoke(fakeTurbo, { RUN_TURBO_CONCURRENCY: "4" });
+    expect(result.exitCode).toBe(0);
+    const argv = JSON.parse(await readFile(argvFile, "utf8")) as string[];
+    expect(argv).toContain("--concurrency=4");
+  });
+
+  test("replaces a CLI concurrency flag when the env cap is set", async () => {
+    const { fakeTurbo, argvFile } = await fixtureFakeTurbo();
+    const child = spawnSync(
+      "node",
+      [runTurbo, "run", "--concurrency=8", "lint"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          RUN_TURBO_BIN: fakeTurbo,
+          RUN_TURBO_NO_INIT_CRASH_RETRY: "1",
+          RUN_TURBO_CONCURRENCY: "4",
+        },
+        timeout: 30_000,
+      },
+    );
+    expect(child.status).toBe(0);
+    const argv = JSON.parse(await readFile(argvFile, "utf8")) as string[];
+    expect(argv).toContain("--concurrency=4");
+    expect(argv).not.toContain("--concurrency=8");
+  });
+
+  test("rejects malformed RUN_TURBO_CONCURRENCY before Turbo starts", async () => {
+    const { fakeTurbo, argvFile } = await fixtureFakeTurbo();
+    for (const value of ["abc", "0", "-1", "1.5", "4x"]) {
+      const result = invoke(fakeTurbo, { RUN_TURBO_CONCURRENCY: value });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/RUN_TURBO_CONCURRENCY/);
+      expect(result.stderr).toMatch(/\[run-turbo\]/);
+    }
+    // Fake turbo must never have been invoked.
+    await expect(readFile(argvFile, "utf8")).rejects.toThrow();
+  });
+
+  test("omits env concurrency injection when the override is blank", async () => {
+    const { fakeTurbo, argvFile } = await fixtureFakeTurbo();
+    const result = invoke(fakeTurbo, { RUN_TURBO_CONCURRENCY: "" });
+    expect(result.exitCode).toBe(0);
+    const argv = JSON.parse(await readFile(argvFile, "utf8")) as string[];
+    expect(argv.some((arg) => arg.startsWith("--concurrency"))).toBe(false);
+  });
+});

--- a/packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts
+++ b/packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts
@@ -206,6 +206,14 @@ describe("filtered build generated outputs", () => {
     tempDirs.push(dir);
 
     const copiedRunTurbo = join(dir, "packages/scripts/run-turbo.mjs");
+    const concurrencyHelper = join(
+      repoRoot,
+      "packages/scripts/lib/run-turbo-concurrency.mjs",
+    );
+    const copiedConcurrencyHelper = join(
+      dir,
+      "packages/scripts/lib/run-turbo-concurrency.mjs",
+    );
     const copiedGenerator = join(
       dir,
       "packages/shared/scripts/generate-keywords.mjs",
@@ -219,9 +227,10 @@ describe("filtered build generated outputs", () => {
       "packages/core/src/i18n/generated/validation-keyword-data.ts",
     ];
 
-    await mkdir(join(dir, "packages/scripts"), { recursive: true });
+    await mkdir(join(dir, "packages/scripts/lib"), { recursive: true });
     await mkdir(join(dir, "packages/shared/scripts"), { recursive: true });
     await copyFile(runTurbo, copiedRunTurbo);
+    await copyFile(concurrencyHelper, copiedConcurrencyHelper);
     await copyFile(keywordGenerator, copiedGenerator);
     await cp(keywordSources, copiedKeywords, { recursive: true });
     await writeFile(

--- a/packages/scripts/lib/run-turbo-concurrency.mjs
+++ b/packages/scripts/lib/run-turbo-concurrency.mjs
@@ -1,0 +1,89 @@
+/**
+ * Fail-closed RUN_TURBO_CONCURRENCY resolution for the shared Turbo runner.
+ * Pure helpers so unit tests can exercise accept/reject paths without spawning
+ * Turbo or materializing generated-source prerequisites.
+ */
+
+/**
+ * Parses a complete positive safe-integer decimal string. Partial suffixes,
+ * signs, fractions, whitespace-only, zero, and non-finite values throw so a
+ * typo in RUN_TURBO_CONCURRENCY cannot disable or corrupt the CI fan-out cap
+ * that prevents hosted-runner OOM kills (#15140).
+ *
+ * @param {string | number | undefined | null} value
+ * @param {string} label
+ * @returns {number}
+ */
+export function parsePositiveSafeInteger(value, label) {
+  const received =
+    typeof value === "number"
+      ? JSON.stringify(value)
+      : JSON.stringify(String(value ?? ""));
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 1) {
+      throw new Error(
+        `${label} must be a positive safe-integer decimal (received ${received})`,
+      );
+    }
+    return value;
+  }
+  const raw = String(value ?? "").trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `${label} must be a positive safe-integer decimal (received ${received})`,
+    );
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || String(parsed) !== raw) {
+    throw new Error(
+      `${label} must be a positive safe-integer decimal (received ${received})`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Resolve the RUN_TURBO_CONCURRENCY override. Unset, empty, and whitespace-only
+ * values mean "do not inject". Explicit overrides fail closed so a typo cannot
+ * forward garbage to Turbo or silently drop the OOM-protection cap.
+ *
+ * @param {NodeJS.ProcessEnv | Record<string, string | undefined>} [env]
+ * @returns {number | null}
+ */
+export function resolveTurboConcurrency(env = process.env) {
+  const raw = env.RUN_TURBO_CONCURRENCY;
+  if (raw == null || String(raw).trim() === "") {
+    return null;
+  }
+  return parsePositiveSafeInteger(raw, "RUN_TURBO_CONCURRENCY");
+}
+
+/**
+ * Inject or replace `--concurrency=<n>` on a Turbo argv copy. When
+ * `concurrency` is null the args are returned unchanged. When set, an existing
+ * CLI concurrency flag is replaced so the env cap wins for CI.
+ *
+ * @param {string[]} turboArgs
+ * @param {number | null} concurrency
+ * @returns {string[]}
+ */
+export function applyTurboConcurrency(turboArgs, concurrency) {
+  if (concurrency == null) {
+    return turboArgs;
+  }
+  const args = [...turboArgs];
+  const runIndex = args.indexOf("run");
+  const idx = args.findIndex(
+    (arg) => arg === "--concurrency" || arg.startsWith("--concurrency="),
+  );
+  const override = `--concurrency=${concurrency}`;
+  if (idx === -1) {
+    if (runIndex !== -1) args.splice(runIndex + 1, 0, override);
+    else args.push(override);
+  } else if (args[idx] === "--concurrency") {
+    args.splice(idx, 2, override);
+  } else {
+    args.splice(idx, 1, override);
+  }
+  return args;
+}

--- a/packages/scripts/run-turbo.mjs
+++ b/packages/scripts/run-turbo.mjs
@@ -10,6 +10,10 @@ import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  applyTurboConcurrency,
+  resolveTurboConcurrency,
+} from "./lib/run-turbo-concurrency.mjs";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -155,20 +159,19 @@ if (
 // runners (4 vCPU / 16 GB) die at the package-script default of 8 concurrent
 // tsc processes on a full-workspace cone — the VM itself is OOM-killed and the
 // job exits 143 (#15140) — so CI lanes set this to 4 without forking the
-// `verify`/`typecheck` script definitions.
-if (process.env.RUN_TURBO_CONCURRENCY) {
-  const idx = turboArgs.findIndex(
-    (arg) => arg === "--concurrency" || arg.startsWith("--concurrency="),
-  );
-  const override = `--concurrency=${process.env.RUN_TURBO_CONCURRENCY}`;
-  if (idx === -1) {
-    if (runIndex !== -1) turboArgs.splice(runIndex + 1, 0, override);
-    else turboArgs.push(override);
-  } else if (turboArgs[idx] === "--concurrency") {
-    turboArgs.splice(idx, 2, override);
-  } else {
-    turboArgs.splice(idx, 1, override);
-  }
+// `verify`/`typecheck` script definitions. Fail closed on typos before Turbo
+// starts so a malformed override cannot disable or corrupt that cap.
+let resolvedConcurrency;
+try {
+  resolvedConcurrency = resolveTurboConcurrency(process.env);
+} catch (error) {
+  console.error(`[run-turbo] ${error.message}`);
+  process.exit(1);
+}
+if (resolvedConcurrency != null) {
+  const withConcurrency = applyTurboConcurrency(turboArgs, resolvedConcurrency);
+  turboArgs.length = 0;
+  turboArgs.push(...withConcurrency);
 }
 
 // Test seam: RUN_TURBO_BIN points at a Node script that stands in for the


### PR DESCRIPTION
# Relates to

Closes #18661

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `grok`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** Scoped to `RUN_TURBO_CONCURRENCY` parsing in the shared Turbo runner.
- Valid CI values such as `4` continue to inject `--concurrency=4`.
- Unset/blank env still means no env-driven concurrency injection.
- Explicit malformed overrides now fail closed before Turbo starts (previously forwarded raw).
- Pure helpers live in `packages/scripts/lib/run-turbo-concurrency.mjs`; fixture copy updated for the filtered-build contract test.

# Background

## What does this PR do?

`packages/scripts/run-turbo.mjs` used to inject:

```text
--concurrency=${process.env.RUN_TURBO_CONCURRENCY}
```

with no validation. Typos (`abc`), zero, negatives, fractions, and partial suffixes could disable or corrupt the CI fan-out cap that prevents hosted-runner OOM kills (#15140 context).

This PR:

1. Parses `RUN_TURBO_CONCURRENCY` as a complete positive safe-integer decimal.
2. Unset / empty / whitespace-only → no injection (historical default).
3. Explicit invalid override → `[run-turbo]` error and exit `1` before Turbo starts.
4. Valid override still injects/replaces `--concurrency=<n>` (env cap wins over CLI).
5. Adds offline pure unit tests plus `RUN_TURBO_BIN` subprocess proof.

## What kind of change is this?

Bug fix (non-breaking for valid operators; fail-closed for previously silent typos).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior is enforced in the runner with a clear error message.

# Testing

## Where should a reviewer start?

1. `packages/scripts/lib/run-turbo-concurrency.mjs` — pure parse/resolve/apply
2. `packages/scripts/run-turbo.mjs` — fail-closed call site
3. `packages/scripts/__tests__/run-turbo-concurrency-env.test.ts` — accept/reject + argv injection

## Detailed testing steps

```bash
# New + regression run-turbo suite
bun test \
  packages/scripts/__tests__/run-turbo-concurrency-env.test.ts \
  packages/scripts/__tests__/run-turbo-windows-init-crash-retry.test.ts \
  packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts

node packages/scripts/run-turbo.self-test.mjs

# Manual fail-closed
RUN_TURBO_CONCURRENCY=abc node packages/scripts/run-turbo.mjs run lint
# → exit 1, stderr: [run-turbo] RUN_TURBO_CONCURRENCY must be a positive safe-integer decimal ...

RUN_TURBO_CONCURRENCY=0 node packages/scripts/run-turbo.mjs run lint
# → exit 1
```

**Results on this branch (head `1a325ef365130b75afe2ba27a8a5bf5849ed153f`):**

- `bun test` across the three files above: **38 pass, 0 fail**
- `run-turbo.self-test.mjs`: **passed**
- Manual invalid env: exit `1` with labeled error; fake-turbo argv never written
- Manual valid `RUN_TURBO_CONCURRENCY=4` via `RUN_TURBO_BIN`: argv contains `"--concurrency=4"`

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:1a325ef365130b75afe2ba27a8a5bf5849ed153f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - scripts-only change; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - scripts-only change; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - scripts-only change; no user-facing flow
<!-- evidence-row:backend-logs -->
- [x] N/A - no server/runtime path; this is the CLI Turbo runner. Fail-closed stderr and successful argv injection via the `RUN_TURBO_BIN` seam are shown by the offline subprocess tests in the **Testing** section above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend/network path
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB/memory/wallet/on-chain/audio artifacts; pure CLI/env validation
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

<details>
<summary>Fail-closed invalid overrides</summary>

```text
$ RUN_TURBO_CONCURRENCY=abc node packages/scripts/run-turbo.mjs run lint
[run-turbo] RUN_TURBO_CONCURRENCY must be a positive safe-integer decimal (received "abc")
exit:1

$ RUN_TURBO_CONCURRENCY=0 node packages/scripts/run-turbo.mjs run lint
[run-turbo] RUN_TURBO_CONCURRENCY must be a positive safe-integer decimal (received "0")
exit:1
```

</details>

<details>
<summary>Valid override injects --concurrency=4 (RUN_TURBO_BIN fake)</summary>

```text
$ RUN_TURBO_CONCURRENCY=4 RUN_TURBO_BIN=<fake> RUN_TURBO_NO_INIT_CRASH_RETRY=1 \
    node packages/scripts/run-turbo.mjs run lint
exit:0
argv: ["--ui=stream","run","--concurrency=4","--log-order=stream","lint"]
```

</details>

<details>
<summary>Focused test suite</summary>

```text
bun test packages/scripts/__tests__/run-turbo-concurrency-env.test.ts \
  packages/scripts/__tests__/run-turbo-windows-init-crash-retry.test.ts \
  packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts
# 38 pass, 0 fail

node packages/scripts/run-turbo.self-test.mjs
# run-turbo self-test passed
```

</details>

Frontend: N/A - no frontend.

## Screenshots (before / after) + video walkthrough

N/A - scripts-only; no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A - scripts-only; no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

- Full `bun run verify` was **not** run this cycle (scoped scripts change; focused run-turbo suite + self-test were green). Reviewer can expand if desired.
- Unrelated local dirty file `plugins/plugin-mcp/src/service.ts` was left unstaged and is not part of this PR.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [rama0x1-unattended]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTZK9XXXBCXQDDYMJQWMTKJ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T12:36:47.165Z","completed_at":"2026-08-12T12:42:31.359Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"fYZiT07dYa-hDdLp-9D8jqTCF8rYSQWOmsaG7R0QYG-T2xhjchkjl3YrygnnJ50tJGxGtVz4DDTuAJrEJYGkCw"}} -->
