### PR TITLE
fix(app-core): classify noisy and multi-marker Node runtime probes

### DIFF
--- a/packages/app-core/scripts/run-node-runtime.mjs
+++ b/packages/app-core/scripts/run-node-runtime.mjs
@@ -8,8 +8,9 @@ import { spawnSync } from "node:child_process";
 
 const KNOWN_UNSTABLE_BUN_LINUX = /^1\.3\.9(?:$|[-+].*)/;
 const MIN_NODE_MAJOR = 24;
-/** Matches a Node version token emitted by the runtime probe anywhere in stdout. */
-const NODE_PROBE_VERSION_PATTERN = /(?:^|[\s\r\n])node:([0-9][^\s\r\n]*)/g;
+/** Exact per-line probe markers only — never mid-line noise such as `(node:123)`. */
+const EXACT_NODE_PROBE_LINE = /^node:(.+)$/;
+const EXACT_BUN_PROBE_LINE = /^bun$/;
 
 /**
  * Builds the child-process env for the Node runtime probe. Inherits PATH and
@@ -22,19 +23,30 @@ export function buildNodeProbeEnv(parentEnv = process.env) {
   return env;
 }
 
-function extractNodeProbeVersion(text) {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return null;
-  }
-  for (const line of trimmed.split(/\r?\n/)) {
-    const exact = /^node:(.+)$/.exec(line.trim());
-    if (exact) {
-      return exact[1];
+/**
+ * Collect exact `bun` / `node:<version>` markers from probe stdout, one token
+ * per non-empty line. Mid-line chatter (deprecation banners, PID tags) is
+ * ignored so a valid marker cannot be mistaken for noise or vice versa.
+ *
+ * @param {string} text
+ * @returns {{ bun: boolean, nodeVersions: string[] }}
+ */
+export function collectProbeMarkers(text) {
+  let bun = false;
+  const nodeVersions = [];
+  for (const rawLine of String(text ?? "").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (EXACT_BUN_PROBE_LINE.test(line)) {
+      bun = true;
+      continue;
+    }
+    const nodeMatch = EXACT_NODE_PROBE_LINE.exec(line);
+    if (nodeMatch) {
+      nodeVersions.push(nodeMatch[1]);
     }
   }
-  const matches = [...trimmed.matchAll(NODE_PROBE_VERSION_PATTERN)];
-  return matches.at(-1)?.[1] ?? null;
+  return { bun, nodeVersions };
 }
 
 /**
@@ -154,13 +166,27 @@ export function parseNodeMajor(version) {
 
 export function validateNodeProbeOutput(output) {
   const text = output?.trim() ?? "";
-  if (text === "bun") {
+  const { bun, nodeVersions } = collectProbeMarkers(text);
+
+  // Bun detection stays priority: a shimmed Bun that also prints node-looking
+  // chatter must still fail as Bun, not as a missing/ambiguous Node marker.
+  if (bun) {
     return { ok: false, reason: "resolved to Bun, not Node.js" };
   }
-  const version = extractNodeProbeVersion(text);
-  if (!version) {
+
+  if (nodeVersions.length === 0) {
     return { ok: false, reason: "did not report a Node.js runtime" };
   }
+
+  const uniqueVersions = [...new Set(nodeVersions)];
+  if (uniqueVersions.length > 1) {
+    return {
+      ok: false,
+      reason: `reported more than one Node.js runtime (${uniqueVersions.join(", ")})`,
+    };
+  }
+
+  const version = uniqueVersions[0];
   const major = parseNodeMajor(version);
   if (major === null) {
     return { ok: false, reason: `could not parse Node.js version ${version}` };

--- a/packages/app-core/scripts/run-node-runtime.test.mjs
+++ b/packages/app-core/scripts/run-node-runtime.test.mjs
@@ -131,6 +131,48 @@ describe("run-node-runtime node validation", () => {
     ).toEqual({ ok: true, reason: null });
   });
 
+  test("still attributes Bun when a shim greets before the marker", () => {
+    expect(
+      validateNodeProbeOutput("[apm-bootstrap] instrumenting process\nbun"),
+    ).toEqual({
+      ok: false,
+      reason: "resolved to Bun, not Node.js",
+    });
+  });
+
+  test("reports the version reason for old Node under noisy stdout", () => {
+    const result = validateNodeProbeOutput(
+      "[apm-bootstrap] instrumenting process\nnode:22.23.0",
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("Node.js 22.23.0 is too old");
+    expect(result.reason).not.toContain("did not report a Node.js runtime");
+  });
+
+  test("rejects disagreeing multi-node markers as ambiguous", () => {
+    const result = validateNodeProbeOutput("node:24.0.0\nnode:22.0.0");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("more than one Node.js runtime");
+    expect(result.reason).toContain("24.0.0");
+    expect(result.reason).toContain("22.0.0");
+  });
+
+  test("accepts agreeing repeated node markers", () => {
+    expect(validateNodeProbeOutput("node:24.4.0\nnode:24.4.0")).toEqual({
+      ok: true,
+      reason: null,
+    });
+  });
+
+  test("rejects junk-only probe output", () => {
+    expect(
+      validateNodeProbeOutput("[apm-bootstrap] instrumenting process"),
+    ).toEqual({
+      ok: false,
+      reason: "did not report a Node.js runtime",
+    });
+  });
+
   test("strips NODE_OPTIONS from the shared probe env without removing PATH", () => {
     const env = buildNodeProbeEnv({
       PATH: "/usr/bin",


### PR DESCRIPTION
# Relates to

Closes #18500

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused verification was run on the touched surfaces after sync (see Testing).
      Full `bun run verify` was **not** re-run this cycle; scoped suite is the
      proof for this pure classifier change.
- [x] A reviewer can confirm the change from the unit transcript and classifier
      matrix below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop` after push; zero conflicts.
- [x] Focused suite green post-rebase. Full `bun run verify` not claimed this cycle
      (pure script classifier + unit tests; see Known gaps).

# Risks

**Low.** Changes only how probe stdout tokens are classified. Existing happy
paths (clean `node:24+`, banner/trailing noise, NODE_OPTIONS strip) stay
accepted. Fail-closed expands for ambiguous multi-marker output, which is
correcter than silently picking the last token.

# Background

## What does this PR do?

Completes the remaining #18500 acceptance gaps after the partial
`NODE_OPTIONS` strip + basic noise landing already on develop:

1. A shim greeting before an exact `bun` line is still attributed as Bun
   (was mislabeled `did not report a Node.js runtime`).
2. Disagreeing exact multi-`node:` markers fail as ambiguous instead of
   silently taking the last version.
3. Old Node under noisy stdout keeps the true version reason.
4. Agreeing repeated markers and junk-only output keep their existing verdicts.

Marker matching is strict per non-empty line (`bun` or `node:<version>`), so
mid-line PID tags like `(node:123) DeprecationWarning` cannot masquerade as
runtime tokens.

## What kind of change is this?

Bug fix (non-breaking classifier correctness for runtime probe stdout).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior is
internal launcher probe validation; issue #18500 is the contract record.

# Testing

## Where should a reviewer start?

1. `packages/app-core/scripts/run-node-runtime.mjs` — `collectProbeMarkers` +
   `validateNodeProbeOutput`
2. `packages/app-core/scripts/run-node-runtime.test.mjs` — new bun-shim,
   multi-marker, old-noisy, junk cases

## Detailed testing steps

```bash
bun run --cwd packages/app-core test scripts/run-node-runtime.test.mjs
```

Post-rebase result:

```text
 Test Files  1 passed (1)
      Tests  20 passed (20)
   Duration  218ms
```

Classifier matrix (real newlines, importing the shipped module):

```text
clean       => { ok: true, reason: null }
banner      => { ok: true, reason: null }
trailing    => { ok: true, reason: null }
deprecation => { ok: true, reason: null }
bun-shim    => { ok: false, reason: 'resolved to Bun, not Node.js' }
two-marker  => { ok: false, reason: 'reported more than one Node.js runtime (24.0.0, 22.0.0)' }
agree-repeat=> { ok: true, reason: null }
junk        => { ok: false, reason: 'did not report a Node.js runtime' }
old-noisy   => { ok: false, reason: 'Node.js 22.23.0 is too old; Node.js 24+ is required' }
```

`buildNodeProbeEnv` still strips `NODE_OPTIONS` and preserves other env keys.
Live `probeNodeExecutable(process.execPath)` on this host (Node 22.23.2)
returns clean `node:22.23.2` and the true age reason (no false \"did not report\").

Biome: `bunx biome check` clean on both touched files after format write.

# Evidence Gate

<!-- evidence-head:d1cc936fba8bd4805b9e0cd82591717a5c835150 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; pure Node runtime probe classifier in app-core scripts.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; pure Node runtime probe classifier in app-core scripts.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow; failure mode is a CLI/runtime error string only.
<!-- evidence-row:backend-logs -->
- [x] N/A - no HTTP/server path; proof is the vitest transcript and classifier matrix above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior involved.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB rows, memories, tasks, wallet, or generated media; domain artifact is the stdout matrix above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text to OCR.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model changes.

## Backend + frontend logs

N/A - classifier unit path only; focused vitest + matrix pasted under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT surface.

## Known gaps / failures

- Full root `bun run verify` not run this cycle; change is limited to
  `run-node-runtime.mjs` marker classification and its unit tests. Focused
  suite is green after rebase on latest `origin/develop`.
- This worker host has Node 22.23.2 on PATH, so a live end-to-end acceptance of
  Node 24 under real preload noise cannot be demonstrated here; the unit matrix
  covers those stdout shapes directly against the shipped validator.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-rama0x1]
<!-- elizaos-contribution-attribution:v2 {\"provider\":\"xai\",\"model\":\"grok-4.5\",\"client\":\"grok\",\"skill_revision\":\"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza\",\"run\":{\"schema_version\":\"1\",\"run_id\":\"run_01KZV01C8Y2FQ9CT6336Q25ZVT\",\"project\":\"eliza\",\"repository\":\"elizaOS/eliza\",\"started_at\":\"2026-08-12T12:44:28.318Z\",\"completed_at\":\"2026-08-12T12:48:12.033Z\",\"skill_sha256\":\"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6\",\"usage\":{\"source\":\"ccusage-session-v20\",\"confidence\":\"unavailable\",\"input_tokens\":0,\"output_tokens\":0,\"cache_creation_tokens\":0,\"cache_read_tokens\":0,\"total_tokens\":0,\"cost_micro_usd\":\"0\",\"session_count\":0},\"trajectory_sha256\":null,\"signature_algorithm\":\"ed25519\",\"device_public_key\":\"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI\",\"device_key_id\":\"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea\",\"device_signature\":\"uAAU403Ed2SoA1SqXikiT34R71-SkkFO33e4P8NILiFI2Hzbuu3s1g-jldxfb9TfCOmIprOi-G8tJlutZmoyBg\"}} -->