### PR TITLE
fix(google-workspace): re-auth reuses granted capabilities for omitted scopes

### DIFF
--- a/plugins/plugin-google-workspace/src/connector-account-provider.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.ts
@@ -11,6 +11,11 @@
  * capabilities (gmail.read+send+manage, calendar.read+write, drive.read+write,
  * meet.create+read) are requested; granted capabilities are recorded on the
  * returned account so downstream consumers know which surfaces are usable.
+ *
+ * Re-auth (`accountId` set, scopes omitted) reuses that account's stored
+ * `grantedCapabilities` so a reconnect never expands privilege beyond the
+ * prior grant. New-account starts without scopes keep the all-capability
+ * default until a caller supplies an explicit subset.
  */
 
 import { createHash, randomBytes } from "node:crypto";
@@ -165,6 +170,66 @@ function normalizeRequestedCapabilities(scopes: readonly string[] | undefined): 
     );
   }
   return [...requested];
+}
+
+/**
+ * Reads recognized capability IDs from account metadata. Unknown entries are
+ * dropped rather than expanded so a re-auth cannot invent new privileges.
+ */
+function grantedCapabilitiesFromMetadata(metadata: unknown): GoogleCapability[] {
+  if (!isRecord(metadata)) return [];
+  const raw = metadata.grantedCapabilities;
+  if (!Array.isArray(raw)) return [];
+  const capabilities: GoogleCapability[] = [];
+  for (const value of raw) {
+    if (typeof value === "string" && isGoogleCapability(value)) {
+      capabilities.push(value);
+    }
+  }
+  return capabilities;
+}
+
+/**
+ * Resolves the capability list for startOAuth. Explicit `scopes` always win.
+ * When scopes are omitted and `accountId` names an existing account, re-auth
+ * reuses that account's stored grant (least privilege). Missing accounts and
+ * empty grants fail closed.
+ */
+async function resolveStartOAuthCapabilities(
+  request: ConnectorOAuthStartRequest,
+  manager: ConnectorAccountManager
+): Promise<GoogleCapability[]> {
+  const hasExplicitScopes = Array.isArray(request.scopes) && request.scopes.length > 0;
+  if (hasExplicitScopes) {
+    return normalizeRequestedCapabilities(request.scopes);
+  }
+
+  const accountId = nonEmptyString(request.accountId);
+  if (!accountId) {
+    return normalizeRequestedCapabilities(request.scopes);
+  }
+
+  const account = await manager.getAccount(GOOGLE_SERVICE_NAME, accountId);
+  if (!account) {
+    throw new ElizaError(`Google OAuth re-auth could not find account ${accountId}.`, {
+      code: "GOOGLE_OAUTH_ACCOUNT_NOT_FOUND",
+      context: { accountId, provider: GOOGLE_SERVICE_NAME },
+      severity: "fatal",
+    });
+  }
+
+  const granted = grantedCapabilitiesFromMetadata(account.metadata);
+  if (granted.length === 0) {
+    throw new ElizaError(
+      "Google OAuth re-auth requires the account's granted capabilities; none are recorded.",
+      {
+        code: "GOOGLE_OAUTH_CAPABILITY_REQUIRED",
+        context: { accountId, provider: GOOGLE_SERVICE_NAME },
+        severity: "fatal",
+      }
+    );
+  }
+  return granted;
 }
 
 function normalizeGrantedCapabilities(scopes: readonly string[]): {
@@ -412,11 +477,11 @@ export function createGoogleConnectorAccountProvider(
 
     startOAuth: async (
       request: ConnectorOAuthStartRequest,
-      _manager: ConnectorAccountManager
+      manager: ConnectorAccountManager
     ): Promise<ConnectorOAuthStartResult> => {
       const config = readClientConfig(runtime);
       const redirectUri = request.redirectUri ?? config.redirectUri;
-      const capabilities = normalizeRequestedCapabilities(request.scopes);
+      const capabilities = await resolveStartOAuthCapabilities(request, manager);
       const oauthScopes = scopesForGoogleCapabilities(capabilities);
       const codeVerifier = createCodeVerifier();
       const codeChallenge = createCodeChallenge(codeVerifier);

--- a/plugins/plugin-google-workspace/src/index.test.ts
+++ b/plugins/plugin-google-workspace/src/index.test.ts
@@ -199,6 +199,211 @@ describe("google plugin", () => {
     });
   });
 
+  it("re-auth with accountId and omitted scopes reuses the account's granted capabilities", async () => {
+    const runtime = {
+      getSetting: (key: string) =>
+        ({
+          GOOGLE_CLIENT_ID: "google-client",
+          GOOGLE_CLIENT_SECRET: "google-secret",
+          GOOGLE_REDIRECT_URI: "http://localhost/oauth/google/callback",
+        })[key],
+      getService: () => null,
+    } as never;
+    const provider = createGoogleConnectorAccountProvider(runtime);
+    const manager = {
+      getAccount: vi.fn(async () => ({
+        id: "acct_google_reauth",
+        provider: "google",
+        role: "OWNER",
+        purpose: ["calendar"],
+        accessGate: "open",
+        status: "connected",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        metadata: {
+          grantedCapabilities: ["calendar.read", "gmail.read"],
+        },
+      })),
+    };
+
+    const result = await provider.startOAuth?.(
+      {
+        provider: "google",
+        accountId: "acct_google_reauth",
+        flow: {
+          id: "flow-reauth-granted",
+          provider: "google",
+          state: "state-reauth-granted",
+          status: "pending",
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      },
+      manager as never
+    );
+
+    expect(manager.getAccount).toHaveBeenCalledWith("google", "acct_google_reauth");
+    const url = new URL(result?.authUrl ?? "");
+    const requestedScopes = new Set(
+      (url.searchParams.get("scope") ?? "").split(" ").filter(Boolean)
+    );
+    expect(requestedScopes).toEqual(
+      new Set([
+        GOOGLE_OAUTH_SCOPES.profile.openid,
+        GOOGLE_OAUTH_SCOPES.profile.email,
+        GOOGLE_OAUTH_SCOPES.profile.profile,
+        GOOGLE_OAUTH_SCOPES.calendar.read,
+        GOOGLE_OAUTH_SCOPES.gmail.read,
+      ])
+    );
+    expect(requestedScopes).not.toContain(GOOGLE_OAUTH_SCOPES.calendar.write);
+    expect(requestedScopes).not.toContain(GOOGLE_OAUTH_SCOPES.gmail.send);
+    expect(requestedScopes).not.toContain(GOOGLE_OAUTH_SCOPES.drive.read);
+    expect(result?.metadata).toMatchObject({
+      requestedCapabilities: ["calendar.read", "gmail.read"],
+    });
+  });
+
+  it("re-auth fails closed when the account is missing", async () => {
+    const runtime = {
+      getSetting: (key: string) =>
+        ({
+          GOOGLE_CLIENT_ID: "google-client",
+          GOOGLE_CLIENT_SECRET: "google-secret",
+          GOOGLE_REDIRECT_URI: "http://localhost/oauth/google/callback",
+        })[key],
+      getService: () => null,
+    } as never;
+    const provider = createGoogleConnectorAccountProvider(runtime);
+    const manager = {
+      getAccount: vi.fn(async () => null),
+    };
+
+    await expect(
+      provider.startOAuth?.(
+        {
+          provider: "google",
+          accountId: "acct_missing",
+          flow: {
+            id: "flow-reauth-missing",
+            provider: "google",
+            state: "state-reauth-missing",
+            status: "pending",
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        },
+        manager as never
+      )
+    ).rejects.toThrow("could not find account acct_missing");
+  });
+
+  it("re-auth fails closed when the account has no recorded granted capabilities", async () => {
+    const runtime = {
+      getSetting: (key: string) =>
+        ({
+          GOOGLE_CLIENT_ID: "google-client",
+          GOOGLE_CLIENT_SECRET: "google-secret",
+          GOOGLE_REDIRECT_URI: "http://localhost/oauth/google/callback",
+        })[key],
+      getService: () => null,
+    } as never;
+    const provider = createGoogleConnectorAccountProvider(runtime);
+    const manager = {
+      getAccount: vi.fn(async () => ({
+        id: "acct_empty_grant",
+        provider: "google",
+        role: "OWNER",
+        purpose: ["messaging"],
+        accessGate: "open",
+        status: "connected",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        metadata: {},
+      })),
+    };
+
+    await expect(
+      provider.startOAuth?.(
+        {
+          provider: "google",
+          accountId: "acct_empty_grant",
+          flow: {
+            id: "flow-reauth-empty",
+            provider: "google",
+            state: "state-reauth-empty",
+            status: "pending",
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        },
+        manager as never
+      )
+    ).rejects.toThrow("none are recorded");
+  });
+
+  it("explicit scopes still override re-auth account grants", async () => {
+    const runtime = {
+      getSetting: (key: string) =>
+        ({
+          GOOGLE_CLIENT_ID: "google-client",
+          GOOGLE_CLIENT_SECRET: "google-secret",
+          GOOGLE_REDIRECT_URI: "http://localhost/oauth/google/callback",
+        })[key],
+      getService: () => null,
+    } as never;
+    const provider = createGoogleConnectorAccountProvider(runtime);
+    const manager = {
+      getAccount: vi.fn(async () => ({
+        id: "acct_override",
+        provider: "google",
+        role: "OWNER",
+        purpose: ["messaging"],
+        accessGate: "open",
+        status: "connected",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        metadata: {
+          grantedCapabilities: ["gmail.read", "gmail.send"],
+        },
+      })),
+    };
+
+    const result = await provider.startOAuth?.(
+      {
+        provider: "google",
+        accountId: "acct_override",
+        scopes: ["calendar.read"],
+        flow: {
+          id: "flow-reauth-override",
+          provider: "google",
+          state: "state-reauth-override",
+          status: "pending",
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      },
+      manager as never
+    );
+
+    expect(manager.getAccount).not.toHaveBeenCalled();
+    const url = new URL(result?.authUrl ?? "");
+    const requestedScopes = new Set(
+      (url.searchParams.get("scope") ?? "").split(" ").filter(Boolean)
+    );
+    expect(requestedScopes).toEqual(
+      new Set([
+        GOOGLE_OAUTH_SCOPES.profile.openid,
+        GOOGLE_OAUTH_SCOPES.profile.email,
+        GOOGLE_OAUTH_SCOPES.profile.profile,
+        GOOGLE_OAUTH_SCOPES.calendar.read,
+      ])
+    );
+    expect(result?.metadata).toMatchObject({
+      requestedCapabilities: ["calendar.read"],
+    });
+  });
+
   it("keeps account auth resolution explicit", async () => {
     const service = new GoogleWorkspaceService();
     const metadata = service.getOAuthProviderMetadata();


### PR DESCRIPTION
# Relates to

Closes #18543

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused verification was run on the touched surfaces after sync (see Testing).
      Full `bun run verify` was **not** re-run this cycle; scoped suite is the
      proof for this pure OAuth capability-resolution change.
- [x] A reviewer can confirm the change from the unit transcript and re-auth
      matrix below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `origin/develop`; zero conflicts.
- [x] Focused suite green. Full `bun run verify` not claimed this cycle
      (plugin-local OAuth resolver + unit tests; see Known gaps).

# Risks

**Low.** Changes only how Google `startOAuth` chooses requested capabilities
when scopes are omitted. Explicit-scope starts and happy-path OAuth complete
paths are unchanged. Re-auth without scopes now reuses the prior grant instead
of expanding to the full capability set (least privilege). Missing accounts and
empty grants fail closed with typed errors.

# Background

## What does this PR do?

Fixes #18543: when `startOAuth` is called with `accountId` and omitted/empty
scopes (the `reconnectAccount` shape: `startOAuth({ accountId })`), the
provider now loads the account and requests only its recorded
`metadata.grantedCapabilities` instead of expanding to every Google capability.

- Missing account → `GOOGLE_OAUTH_ACCOUNT_NOT_FOUND`
- Empty/missing grant list → `GOOGLE_OAUTH_CAPABILITY_REQUIRED`
- Explicit scopes still override any stored grant
- New-account starts without `accountId` keep the existing all-capability default

## What kind of change is this?

Bug fix (least-privilege re-auth for Google Workspace OAuth reconnect).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior is
internal to the connector account provider; issue #18543 is the contract record.
File header documents the re-auth rule.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-google-workspace/src/connector-account-provider.ts` —
   `resolveStartOAuthCapabilities` / `grantedCapabilitiesFromMetadata`
2. `plugins/plugin-google-workspace/src/index.test.ts` — re-auth, missing
   account, empty grant, and explicit-scope override cases

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-google-workspace test src/index.test.ts
```

Result:

```text
 Test Files  1 passed (1)
      Tests  28 passed (28)
   Duration  8.10s
```

Re-auth matrix (unit path against the shipped provider):

```text
accountId + omitted scopes + granted [calendar.read,gmail.read]
  => auth URL scopes = identity + calendar.read + gmail.read only
  => no calendar.write / gmail.send / drive.read

accountId + missing account
  => throws "could not find account …"

accountId + metadata without grantedCapabilities
  => throws "none are recorded"

accountId + explicit scopes ["calendar.read"]
  => uses calendar.read only; manager.getAccount not called
```

Biome: `bunx biome check --write` clean on both touched files after format write.

Plugin `typecheck` reports pre-existing workspace-resolution errors for
`@elizaos/core` when run in isolation (unrelated; present on develop paths
outside this change). Focused vitest is the proof for this PR.

# Evidence Gate

<!-- evidence-head:07cbbc24e682912f6c5ddfd5becf9cccce81e3c3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; pure OAuth capability resolution in the Google connector provider.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; pure OAuth capability resolution in the Google connector provider.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow in this PR; failure mode is a typed OAuth start error and scope list on the auth URL.
<!-- evidence-row:backend-logs -->
- [x] N/A - no HTTP/server path exercised; proof is the vitest transcript and re-auth matrix above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network surface in the unit path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior involved.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB rows, memories, tasks, wallet, or generated media; domain artifact is the auth-URL scope set asserted by the tests.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text to OCR.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model changes.

## Backend + frontend logs

N/A - unit path only; focused vitest + matrix pasted under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT surface.

## Known gaps / failures

- Full root `bun run verify` not run this cycle; change is limited to
  `connector-account-provider.ts` capability resolution and its unit tests.
- Live Google OAuth browser flow not exercised (requires GOOGLE_CLIENT_*
  secrets and an interactive consent screen). Unit tests construct the
  authorization URL and assert the scope set equals the stored grant.
- Compatible with upcoming fail-closed new-account scope requirements (#18522):
  re-auth with `accountId` supplies scopes from the stored grant before empty
  lists are rejected.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-rama0x1]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZV0JSPC5NNWYR0EMFWVC022","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T12:53:59.116Z","completed_at":"2026-08-12T12:55:29.506Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"hNZ-S7DMXkIw_fShjt1IG5kOUgq8a5EM6DTnxg08SAQKej5OTHU9_eaIOXhOnugJNLbgxisDiuqQcR-naaicBg"}} -->
