### PR TITLE
fix(ui): fail closed when WalletConnect project id is missing or placeholder

### DIFF
--- a/packages/ui/src/cloud/billing/wallet/steward-wallet-providers.tsx
+++ b/packages/ui/src/cloud/billing/wallet/steward-wallet-providers.tsx
@@ -17,6 +17,11 @@
  * `Could not resolve "<pkg>" imported by "@wagmi/connectors"` at click time
  * (#15600 — MetaMask). package.json therefore declares `@metamask/connect-evm`
  * even though no source file imports it (guarded by wallet-connector-deps.test.ts).
+ *
+ * WalletConnect project id (#18459): when the public project id is missing or
+ * still a placeholder, this module never substitutes `YOUR_WC_PROJECT_ID`.
+ * Injected-wallet connectors still mount so browser extensions work; QR /
+ * deep-link WalletConnect stays unavailable rather than false-green.
  */
 
 import { BRAND_COLORS } from "@elizaos/shared/brand";
@@ -34,11 +39,56 @@ import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
 import { SolflareWalletAdapter } from "@solana/wallet-adapter-solflare";
 import type { ReactNode } from "react";
 import { useMemo } from "react";
-import { type Config, http, WagmiProvider } from "wagmi";
+import { type Config, createConfig, http, WagmiProvider } from "wagmi";
 import { base, bsc } from "wagmi/chains";
+import { injected } from "wagmi/connectors";
+import { readWalletConnectProjectIdFromEnv } from "./wallet-connect-project-id";
 
 const DEFAULT_SOLANA_RPC_URL = "https://api.mainnet-beta.solana.com";
-const FALLBACK_WALLETCONNECT_PROJECT_ID = "YOUR_WC_PROJECT_ID";
+
+function buildEvmTransports(alchemyKey: string | undefined) {
+  return {
+    [base.id]: alchemyKey
+      ? http(`https://base-mainnet.g.alchemy.com/v2/${alchemyKey}`)
+      : http("https://base-rpc.publicnode.com"),
+    [bsc.id]: http("https://bsc-dataseed.binance.org"),
+  } as const;
+}
+
+/**
+ * Build the EVM wagmi config. When a real WalletConnect project id is present,
+ * RainbowKit's full connector set (including WalletConnect QR) is used. When
+ * it is not, only the injected connector is registered so extension wallets
+ * keep working without a false-green WalletConnect configuration.
+ */
+export function buildStewardEvmConfig(options: {
+  appUrl: string;
+  walletConnectProjectId: string | null;
+  alchemyKey: string | undefined;
+}): Config {
+  const transports = buildEvmTransports(options.alchemyKey);
+
+  if (options.walletConnectProjectId) {
+    return getDefaultConfig({
+      appName: "Eliza Cloud",
+      appDescription:
+        "Sign in to chat with your Eliza Cloud agent and manage your account",
+      appUrl: options.appUrl,
+      projectId: options.walletConnectProjectId,
+      chains: [base, bsc],
+      transports,
+      ssr: false,
+    });
+  }
+
+  return createConfig({
+    chains: [base, bsc],
+    connectors: [injected({ shimDisconnect: true })],
+    transports,
+    ssr: false,
+    multiInjectedProviderDiscovery: true,
+  });
+}
 
 export function StewardWalletProviders({ children }: { children: ReactNode }) {
   const appUrl =
@@ -46,9 +96,7 @@ export function StewardWalletProviders({ children }: { children: ReactNode }) {
     (typeof window !== "undefined"
       ? window.location.origin
       : "http://localhost:3000");
-  const walletConnectProjectId =
-    process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID?.trim() ||
-    FALLBACK_WALLETCONNECT_PROJECT_ID;
+  const walletConnectProjectId = readWalletConnectProjectIdFromEnv();
   const alchemyKey = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY?.trim();
   const heliusKey = process.env.NEXT_PUBLIC_HELIUS_API_KEY?.trim();
   const solanaEndpoint =
@@ -59,20 +107,10 @@ export function StewardWalletProviders({ children }: { children: ReactNode }) {
 
   const evmConfig = useMemo<Config>(
     () =>
-      getDefaultConfig({
-        appName: "Eliza Cloud",
-        appDescription:
-          "Sign in to chat with your Eliza Cloud agent and manage your account",
+      buildStewardEvmConfig({
         appUrl,
-        projectId: walletConnectProjectId,
-        chains: [base, bsc],
-        transports: {
-          [base.id]: alchemyKey
-            ? http(`https://base-mainnet.g.alchemy.com/v2/${alchemyKey}`)
-            : http("https://base-rpc.publicnode.com"),
-          [bsc.id]: http("https://bsc-dataseed.binance.org"),
-        },
-        ssr: false,
+        walletConnectProjectId,
+        alchemyKey: alchemyKey || undefined,
       }),
     [alchemyKey, appUrl, walletConnectProjectId],
   );

--- a/packages/ui/src/cloud/billing/wallet/wallet-connect-project-id.test.ts
+++ b/packages/ui/src/cloud/billing/wallet/wallet-connect-project-id.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for WalletConnect project-id fail-closed resolution.
+ *
+ * Deterministic pure-function coverage for #18459: blank, placeholder, and
+ * short sentinel values must never be treated as a configured project id.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  isConfiguredWalletConnectProjectId,
+  resolveWalletConnectProjectId,
+  WALLETCONNECT_PROJECT_ID_PLACEHOLDER,
+} from "./wallet-connect-project-id";
+
+describe("isConfiguredWalletConnectProjectId", () => {
+  it("accepts a realistic public project id", () => {
+    expect(
+      isConfiguredWalletConnectProjectId("a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"),
+    ).toBe(true);
+    expect(isConfiguredWalletConnectProjectId("  abcd1234  ")).toBe(true);
+  });
+
+  it("rejects missing, blank, and nullish values", () => {
+    expect(isConfiguredWalletConnectProjectId(undefined)).toBe(false);
+    expect(isConfiguredWalletConnectProjectId(null)).toBe(false);
+    expect(isConfiguredWalletConnectProjectId("")).toBe(false);
+    expect(isConfiguredWalletConnectProjectId("   ")).toBe(false);
+  });
+
+  it("rejects the documented YOUR_WC_PROJECT_ID placeholder", () => {
+    expect(
+      isConfiguredWalletConnectProjectId(WALLETCONNECT_PROJECT_ID_PLACEHOLDER),
+    ).toBe(false);
+    expect(isConfiguredWalletConnectProjectId("your_wc_project_id")).toBe(
+      false,
+    );
+    expect(isConfiguredWalletConnectProjectId("Your_WC_Project_Id")).toBe(
+      false,
+    );
+  });
+
+  it("rejects generic placeholder / replace-me sentinels", () => {
+    expect(isConfiguredWalletConnectProjectId("replace_with_real_id")).toBe(
+      false,
+    );
+    expect(isConfiguredWalletConnectProjectId("replace-me")).toBe(false);
+    expect(isConfiguredWalletConnectProjectId("placeholder")).toBe(false);
+    expect(isConfiguredWalletConnectProjectId("changeme")).toBe(false);
+    expect(isConfiguredWalletConnectProjectId("todo")).toBe(false);
+  });
+
+  it("rejects values shorter than eight characters", () => {
+    expect(isConfiguredWalletConnectProjectId("abc")).toBe(false);
+    expect(isConfiguredWalletConnectProjectId("1234567")).toBe(false);
+  });
+});
+
+describe("resolveWalletConnectProjectId", () => {
+  it("returns the first configured candidate", () => {
+    expect(
+      resolveWalletConnectProjectId(
+        undefined,
+        "",
+        WALLETCONNECT_PROJECT_ID_PLACEHOLDER,
+        "  real-project-id-001  ",
+        "second-valid-id",
+      ),
+    ).toBe("real-project-id-001");
+  });
+
+  it("returns null when every candidate is unusable", () => {
+    expect(
+      resolveWalletConnectProjectId(
+        undefined,
+        null,
+        "",
+        "   ",
+        WALLETCONNECT_PROJECT_ID_PLACEHOLDER,
+        "todo",
+        "short",
+      ),
+    ).toBeNull();
+  });
+
+  it("never invents a fallback when called with no arguments", () => {
+    expect(resolveWalletConnectProjectId()).toBeNull();
+  });
+});
+
+describe("buildStewardEvmConfig fail-closed paths", () => {
+  it("registers only the injected connector when project id is null", async () => {
+    const { buildStewardEvmConfig } = await import(
+      "./steward-wallet-providers"
+    );
+    const config = buildStewardEvmConfig({
+      appUrl: "https://elizacloud.ai",
+      walletConnectProjectId: null,
+      alchemyKey: undefined,
+    });
+    const connectors = config.connectors ?? [];
+    // Injected-only: browser extensions still work; WalletConnect QR is not
+    // mounted without a real project id (#18459).
+    expect(connectors.map((c) => c.id)).toEqual(["injected"]);
+    expect(connectors.map((c) => c.type)).toEqual(["injected"]);
+  });
+
+  it("uses RainbowKit getDefaultConfig (multi-connector) when a real project id is provided", async () => {
+    const { buildStewardEvmConfig } = await import(
+      "./steward-wallet-providers"
+    );
+    const withProjectId = buildStewardEvmConfig({
+      appUrl: "https://elizacloud.ai",
+      walletConnectProjectId: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+      alchemyKey: undefined,
+    });
+    const withoutProjectId = buildStewardEvmConfig({
+      appUrl: "https://elizacloud.ai",
+      walletConnectProjectId: null,
+      alchemyKey: undefined,
+    });
+    const withConnectors = withProjectId.connectors ?? [];
+    const withoutConnectors = withoutProjectId.connectors ?? [];
+    // Full RainbowKit stack is larger than the injected-only fail-closed path.
+    // Connector ids differ across Node/jsdom vs browser (mocks vs WC), so assert
+    // the structural difference rather than a specific WalletConnect id string.
+    expect(withConnectors.length).toBeGreaterThan(withoutConnectors.length);
+    expect(withConnectors.map((c) => c.id)).not.toEqual(["injected"]);
+  });
+});

--- a/packages/ui/src/cloud/billing/wallet/wallet-connect-project-id.ts
+++ b/packages/ui/src/cloud/billing/wallet/wallet-connect-project-id.ts
@@ -1,0 +1,80 @@
+/**
+ * Resolves a WalletConnect Cloud project id for the packaged wallet stack.
+ *
+ * The public project id is not a secret, but a placeholder or blank value
+ * silently breaks QR/deep-link WalletConnect while injected wallets can still
+ * appear healthy. Callers must fail closed: never substitute
+ * `YOUR_WC_PROJECT_ID` or any other non-configured sentinel (#18459).
+ */
+
+/** Documented placeholder still present in older templates and docs samples. */
+export const WALLETCONNECT_PROJECT_ID_PLACEHOLDER = "YOUR_WC_PROJECT_ID";
+
+/**
+ * Whether a raw env candidate is a usable WalletConnect project id.
+ *
+ * Rejects empty/whitespace, the documented placeholder, and generic
+ * replace-me / placeholder tokens. Real Reown/WalletConnect ids are
+ * non-empty alphanumeric (with optional hyphen/underscore) strings that are
+ * not those sentinels.
+ */
+export function isConfiguredWalletConnectProjectId(
+  value: string | undefined | null,
+): value is string {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return false;
+
+  const normalized = trimmed.toLowerCase();
+  if (
+    normalized === WALLETCONNECT_PROJECT_ID_PLACEHOLDER.toLowerCase() ||
+    normalized.includes("your_wc_") ||
+    normalized.includes("your-wc-") ||
+    normalized.includes("replace_with") ||
+    normalized.includes("replace-me") ||
+    normalized.includes("placeholder") ||
+    normalized === "changeme" ||
+    normalized === "todo"
+  ) {
+    return false;
+  }
+
+  // WalletConnect/Reown project ids are opaque public tokens; require a
+  // minimum length so a single character or "0" cannot pass as configured.
+  if (trimmed.length < 8) return false;
+
+  return true;
+}
+
+/**
+ * Pick the first configured WalletConnect project id from candidate env values.
+ * Returns `null` when none is usable — callers must not invent a fallback.
+ */
+export function resolveWalletConnectProjectId(
+  ...candidates: ReadonlyArray<string | undefined | null>
+): string | null {
+  for (const candidate of candidates) {
+    if (isConfiguredWalletConnectProjectId(candidate)) {
+      return candidate.trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * Read WalletConnect project id from the Vite / process env surfaces used by
+ * the cloud shell. Vite only inlines literal `import.meta.env.*` property
+ * accesses; keep those explicit so production bundles can substitute values.
+ */
+export function readWalletConnectProjectIdFromEnv(): string | null {
+  return resolveWalletConnectProjectId(
+    import.meta.env?.VITE_WALLETCONNECT_PROJECT_ID,
+    import.meta.env?.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID,
+    typeof process !== "undefined"
+      ? process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID
+      : undefined,
+    typeof process !== "undefined"
+      ? process.env.VITE_WALLETCONNECT_PROJECT_ID
+      : undefined,
+  );
+}


### PR DESCRIPTION
# Relates to

Closes #18459

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused verification was run on the touched surfaces after sync (see Testing).
      Full `bun run verify` was **not** re-run this cycle; scoped unit suite is the
      proof for this pure WalletConnect project-id resolution change.
- [x] A reviewer can confirm the change from the unit transcript and connector
      matrix below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `origin/develop`; zero conflicts.
- [x] Focused suite green. Full `bun run verify` not claimed this cycle
      (UI package WalletConnect config + unit tests; see Known gaps).

# Risks

**Low–medium.** Changes how the EVM wallet provider tree is built when
`NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` / `VITE_WALLETCONNECT_PROJECT_ID` is
missing or still the `YOUR_WC_PROJECT_ID` placeholder:

- **With a real project id:** RainbowKit `getDefaultConfig` path is unchanged
  (full connector set including WalletConnect QR).
- **Without a real project id:** only the `injected` connector mounts. Browser
  extension wallets still work; QR/deep-link WalletConnect is unavailable
  instead of false-green against a placeholder id.
- Solana wallet adapters are unchanged.
- Production still needs a real public project id injected at build time for
  full WalletConnect UX; this PR stops the silent placeholder path.

# Background

## What does this PR do?

Fixes #18459: the wallet provider tree no longer falls back to the literal
placeholder `YOUR_WC_PROJECT_ID` when the public WalletConnect project id is
missing or unconfigured.

- Pure resolver rejects empty, placeholder, replace-me, and short sentinel values
- Valid id → existing RainbowKit `getDefaultConfig` (WalletConnect enabled)
- Invalid/missing id → `createConfig` with injected-only connectors (fail closed
  for WalletConnect, inject path preserved)
- Env read covers `VITE_*` and `NEXT_PUBLIC_*` surfaces used by the cloud shell

## What kind of change is this?

Bug fix (fail-closed WalletConnect configuration for Steward login / billing).

# Documentation changes needed?

My changes do not require a change to the project documentation. The cloud
`.env.example` already documents `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID`; the
module header records the fail-closed contract.

# Testing

## Where should a reviewer start?

1. `packages/ui/src/cloud/billing/wallet/wallet-connect-project-id.ts` — pure
   fail-closed resolution
2. `packages/ui/src/cloud/billing/wallet/steward-wallet-providers.tsx` —
   `buildStewardEvmConfig` branches
3. `packages/ui/src/cloud/billing/wallet/wallet-connect-project-id.test.ts` —
   acceptance matrix

## Detailed testing steps

```bash
bun run --cwd packages/ui test src/cloud/billing/wallet/wallet-connect-project-id.test.ts
```

Result:

```text
 Test Files  1 passed (1)
      Tests  10 passed (10)
   Duration  1.49s
```

Deterministic matrix:

```text
resolveWalletConnectProjectId()
  undefined / "" / "YOUR_WC_PROJECT_ID" / "todo" / "short"  => null
  "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"                     => that id

buildStewardEvmConfig({ walletConnectProjectId: null })
  connectors => ["injected"] only

buildStewardEvmConfig({ walletConnectProjectId: "<real>" })
  connectors.length > injected-only path (RainbowKit default stack)
```

Biome: clean on the three touched files after format write.

Package `typecheck` reports pre-existing workspace errors
(`@elizaos/cloud-routing` missing; e2e auth-stub redeclare) unrelated to this
change; present on develop-isolated UI typecheck outside this diff.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface change; pure provider config / connector
  selection. Failure mode is connector set composition, not pixels.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface change; pure provider config / connector
  selection.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow implemented in this PR; QR/deep-link
  WalletConnect with a real project id is out of scope for this unit-only
  fail-closed repair (requires a real Reown project id and a disposable wallet).
<!-- evidence-row:backend-logs -->
- [x] N/A - no HTTP/server path; proof is the vitest transcript and connector
  matrix above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend network surface in the unit path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior involved.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused Vitest output (10/10 pass) and the connector
  matrix above; domain artifact is the connector set for missing vs real project id.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text to OCR.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model changes.

## Backend + frontend logs

N/A - unit path only; focused vitest + matrix pasted under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI. Live QR/deep-link proof with a real WalletConnect project id is
explicitly deferred (needs secrets + disposable wallet; not available in this
cycle). The unit path proves the false-green placeholder path is removed.

## Audio / voice walkthrough

N/A - no voice/TTS/STT surface.

## Known gaps / failures

- Full root `bun run verify` not run this cycle; change is limited to UI wallet
  provider config and its unit tests.
- Live WalletConnect QR / SIWE browser flow not exercised (requires a real
  `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` and an interactive wallet). Unit tests
  assert injected-only vs multi-connector structural difference.
- Production build-time gate that *fails the package build* when the id is
  missing is not added here; runtime fail-closed removes the placeholder path.
  A separate follow-up can enforce injection at packaging time if maintainers want
  a hard build error for staging/prod images.
- Packages/ui typecheck still reports unrelated workspace errors on this
  worktree (see Testing).

AI provider/model: xai / grok-4.5
Client / agent tooling: Grok Build
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [unattended-rama0x1]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"Grok Build","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->