### PR TITLE
fix(notes): set jsdom vitest environment on view tests and add boundary validation tests

### DIFF
--- a/plugins/plugin-notes/src/__tests__/validation.test.ts
+++ b/plugins/plugin-notes/src/__tests__/validation.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for untrusted Notes boundary validators in validation.ts.
+ */
+
+import { describe, expect, it } from "vitest";
+import { NOTES_SCHEMA_VERSION } from "../types.js";
+import {
+  isRecord,
+  parseCreateNoteInput,
+  parseEntityId,
+  parseNoteContent,
+  parseNotesDocument,
+  parseStickyColor,
+  parseUpdateNoteInput,
+} from "../validation.js";
+
+describe("Notes boundary validation", () => {
+  describe("isRecord", () => {
+    it("identifies plain objects and rejects primitives or arrays", () => {
+      expect(isRecord({ key: "val" })).toBe(true);
+      expect(isRecord({})).toBe(true);
+      expect(isRecord(null)).toBe(false);
+      expect(isRecord([])).toBe(false);
+      expect(isRecord("string")).toBe(false);
+      expect(isRecord(123)).toBe(false);
+      expect(isRecord(undefined)).toBe(false);
+    });
+  });
+
+  describe("parseNoteContent", () => {
+    it("splits single-line content into title and empty body", () => {
+      const result = parseNoteContent("Simple Note Title");
+      expect(result).toEqual({
+        title: "Simple Note Title",
+        body: "",
+      });
+    });
+
+    it("splits multi-line content into first line title and remaining body", () => {
+      const result = parseNoteContent(
+        "Header Line\nFirst paragraph\nSecond paragraph",
+      );
+      expect(result).toEqual({
+        title: "Header Line",
+        body: "First paragraph\nSecond paragraph",
+      });
+    });
+
+    it("handles leading and trailing whitespace on lines cleanly", () => {
+      const result = parseNoteContent("   Padded Title   \n   Padded Body   ");
+      expect(result).toEqual({
+        title: "Padded Title",
+        body: "Padded Body",
+      });
+    });
+
+    it("rejects non-string or empty content", () => {
+      expect(() => parseNoteContent(123)).toThrow();
+      expect(() => parseNoteContent("   ")).toThrow();
+    });
+  });
+
+  describe("parseEntityId", () => {
+    it("accepts valid lowercase alphanumeric IDs", () => {
+      expect(parseEntityId("note-123")).toBe("note-123");
+      expect(parseEntityId("abc")).toBe("abc");
+    });
+
+    it("rejects invalid IDs (uppercase, symbols, starting with number)", () => {
+      expect(() => parseEntityId("123note")).toThrow();
+      expect(() => parseEntityId("Note-123")).toThrow();
+      expect(() => parseEntityId("ab")).toThrow();
+      expect(() => parseEntityId("note_123")).toThrow();
+    });
+  });
+
+  describe("parseStickyColor", () => {
+    it("accepts valid sticky colors", () => {
+      expect(parseStickyColor("yellow")).toBe("yellow");
+      expect(parseStickyColor("green")).toBe("green");
+      expect(parseStickyColor("rose")).toBe("rose");
+      expect(parseStickyColor("slate")).toBe("slate");
+    });
+
+    it("rejects unknown colors", () => {
+      expect(() => parseStickyColor("blue")).toThrow();
+      expect(() => parseStickyColor(123)).toThrow();
+    });
+  });
+
+  describe("parseCreateNoteInput", () => {
+    it("validates and defaults sticky color to yellow", () => {
+      const note = parseCreateNoteInput({ title: "Test Note" });
+      expect(note).toEqual({
+        title: "Test Note",
+        body: "",
+        color: "yellow",
+      });
+    });
+
+    it("accepts custom body and valid color", () => {
+      const note = parseCreateNoteInput({
+        title: "Task Note",
+        body: "Details here",
+        color: "rose",
+      });
+      expect(note).toEqual({
+        title: "Task Note",
+        body: "Details here",
+        color: "rose",
+      });
+    });
+
+    it("rejects extra unknown keys in create input", () => {
+      expect(() =>
+        parseCreateNoteInput({ title: "Test", unknownKey: true }),
+      ).toThrow();
+    });
+  });
+
+  describe("parseUpdateNoteInput", () => {
+    it("accepts valid partial patch", () => {
+      const patch = parseUpdateNoteInput({ title: "Updated Title" });
+      expect(patch).toEqual({ title: "Updated Title" });
+    });
+
+    it("rejects empty patch", () => {
+      expect(() => parseUpdateNoteInput({})).toThrow();
+    });
+  });
+
+  describe("parseNotesDocument", () => {
+    it("validates complete notes document structure", () => {
+      const validDoc = {
+        schemaVersion: NOTES_SCHEMA_VERSION,
+        revision: 1,
+        persistedAt: "2026-08-12T12:00:00.000Z",
+        notes: [
+          {
+            id: "note-001",
+            title: "First Note",
+            body: "Content",
+            color: "green",
+            createdAt: "2026-08-12T12:00:00.000Z",
+            updatedAt: "2026-08-12T12:00:00.000Z",
+          },
+        ],
+      };
+      const parsed = parseNotesDocument(validDoc);
+      expect(parsed).toEqual(validDoc);
+    });
+
+    it("rejects duplicate note IDs in document", () => {
+      const docWithDuplicates = {
+        schemaVersion: NOTES_SCHEMA_VERSION,
+        revision: 1,
+        persistedAt: "2026-08-12T12:00:00.000Z",
+        notes: [
+          {
+            id: "note-001",
+            title: "First Note",
+            body: "",
+            color: "yellow",
+            createdAt: "2026-08-12T12:00:00.000Z",
+            updatedAt: "2026-08-12T12:00:00.000Z",
+          },
+          {
+            id: "note-001",
+            title: "Duplicate Note",
+            body: "",
+            color: "slate",
+            createdAt: "2026-08-12T12:00:00.000Z",
+            updatedAt: "2026-08-12T12:00:00.000Z",
+          },
+        ],
+      };
+      expect(() => parseNotesDocument(docWithDuplicates)).toThrow();
+    });
+  });
+});

--- a/plugins/plugin-notes/src/validation.ts
+++ b/plugins/plugin-notes/src/validation.ts
@@ -111,8 +111,9 @@ export function parseNoteContent(
     maxLength: MAX_NOTE_CONTENT_LENGTH,
   });
   const [firstLine = "", ...remainingLines] = content.split(/\r?\n/);
-  const title = firstLine.slice(0, MAX_TITLE_LENGTH).trim();
-  const overflow = firstLine.slice(MAX_TITLE_LENGTH).trim();
+  const trimmedFirstLine = firstLine.trim();
+  const title = trimmedFirstLine.slice(0, MAX_TITLE_LENGTH).trim();
+  const overflow = trimmedFirstLine.slice(MAX_TITLE_LENGTH).trim();
   const body = [overflow, ...remainingLines].join("\n").trim();
   return {
     title: parseRequiredTitle(title, `${field}.firstLine`),

--- a/plugins/plugin-notes/src/views/NotesViews.test.tsx
+++ b/plugins/plugin-notes/src/views/NotesViews.test.tsx
@@ -1,6 +1,8 @@
 /**
  * Verifies that Notes is a read-only projection of authoritative capability
  * state across loading, empty, populated, and error conditions.
+ *
+ * @vitest-environment jsdom
  */
 
 import { cleanup, render, screen } from "@testing-library/react";

--- a/plugins/plugin-notes/src/views/useNotesState.test.tsx
+++ b/plugins/plugin-notes/src/views/useNotesState.test.tsx
@@ -1,6 +1,8 @@
 /**
  * Exercises the browser synchronization hook against controlled transport
  * promises, including lifecycle refreshes that can overlap after a reconnect.
+ *
+ * @vitest-environment jsdom
  */
 
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";


### PR DESCRIPTION
## Summary

`plugins/plugin-notes/src/views/NotesViews.test.tsx` and `plugins/plugin-notes/src/views/useNotesState.test.tsx` use `@testing-library/react` and access DOM globals (`window`, `document`), but were missing the `// @vitest-environment jsdom` directive comment. Running Vitest on `plugins/plugin-notes` previously failed 12 tests with `ReferenceError: document is not defined`.

This PR:
1. Adds `@vitest-environment jsdom` to both `NotesViews.test.tsx` and `useNotesState.test.tsx`, resolving the test runner failures.
2. Trims leading whitespace before title and overflow slicing in `parseNoteContent` in `plugins/plugin-notes/src/validation.ts`.
3. Adds comprehensive unit test coverage in `plugins/plugin-notes/src/__tests__/validation.test.ts` for all boundary validators (`parseNoteContent`, `parseEntityId`, `parseStickyColor`, `parseCreateNoteInput`, `parseUpdateNoteInput`, `parseNotesDocument`).

## PR Checklist

- [x] Code follows the repository style guidelines and passes Biome formatting
- [x] Focused tests pass locally with real output attached
- [x] No breaking API changes

## Evidence Table

| Evidence Type | Included | Details |
| --- | --- | --- |
| Screenshots or recording | N/A | Non-UI test environment configuration and backend validation fix |
| Logs | Yes | `node packages/scripts/run-vitest.mjs run plugins/plugin-notes` passes 7/7 files (62/62 tests) |
| Real-LLM trajectories | N/A | No LLM provider or prompt changes |
| Domain artifacts | N/A | No persistent schema or storage changes |
| CI or local commands | Yes | `node packages/scripts/run-vitest.mjs run plugins/plugin-notes` and `npx biome check` |

### Test Output

```
 RUN  v4.1.5 /home/dak/src/eliza-agy

 Test Files  7 passed (7)
      Tests  62 passed (62)
   Start at  15:07:33
   Duration  12.93s
```

## Contribution Provenance

- AI assistance: yes
- AI provider/model: Antigravity / Gemini 3.6 Flash (High)
- Client / agent tooling: Antigravity CLI
- Attribution status: self-reported
— [rama0x1]
<!-- eliza-computer-attribution:v1 {"provider":"antigravity","model":"Gemini 3.6 Flash (High)","client":"Antigravity CLI"} -->