### PR TITLE
fix(plugin-web-search): harden getPageInfo scrape and SSRF-guard page fetches

### DIFF
--- a/plugins/plugin-web-search/src/services/webSearchService.test.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.test.ts
@@ -273,26 +273,64 @@ describe("WebSearchService", () => {
         );
     });
 
-    it("extracts page title and description from fetched HTML", async () => {
+    it("extracts page title, description, metadata, images, and links from fetched HTML", async () => {
+        const html = `
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <title>
+                    Example &amp; Demo &#39;Page&#39;
+                </title>
+                <meta content="A &quot;great&quot; description" name="description">
+                <meta property="og:title" content="OG Example">
+                <meta property="og:image" content="/images/og.png">
+            </head>
+            <body>
+                <h1>Hello</h1>
+                <img src="/assets/hero.jpg" alt="Hero">
+                <img src="https://external.test/logo.svg">
+                <img src="data:image/png;base64,12345">
+                <a href="/docs/guide.html">Guide</a>
+                <a href="https://other.test/about">About</a>
+                <a href="#top">Anchor</a>
+                <a href="javascript:void(0)">JS</a>
+            </body>
+            </html>
+        `;
         vi.stubGlobal(
             "fetch",
-            vi.fn(
-                async () =>
-                    new Response(
-                        '<html><head><title>Example</title><meta name="description" content="Desc"></head></html>'
-                    )
-            )
+            vi.fn(async () => new Response(html))
         );
         const service = await WebSearchService.start(runtime({ TAVILY_API_KEY: "tvly-test" }));
 
-        await expect(service.getPageInfo("https://example.test/page")).resolves.toMatchObject({
-            title: "Example",
-            description: "Desc",
-            content: expect.stringContaining("<title>Example</title>"),
-            metadata: {},
-            images: [],
-            links: [],
+        const pageInfo = await service.getPageInfo("https://example.test/page");
+        expect(pageInfo.title).toBe("Example & Demo 'Page'");
+        expect(pageInfo.description).toBe('A "great" description');
+        expect(pageInfo.metadata).toEqual({
+            description: 'A "great" description',
+            "og:title": "OG Example",
+            "og:image": "/images/og.png",
         });
+        expect(pageInfo.images).toEqual([
+            "https://example.test/assets/hero.jpg",
+            "https://external.test/logo.svg",
+        ]);
+        expect(pageInfo.links).toEqual([
+            "https://example.test/docs/guide.html",
+            "https://other.test/about",
+        ]);
+    });
+
+    it("falls back to og:description when standard description meta tag is absent", async () => {
+        const html = `<html><head><title>Test</title><meta property="og:description" content="Fallback Og Desc"></head></html>`;
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => new Response(html))
+        );
+        const service = await WebSearchService.start(runtime({ TAVILY_API_KEY: "tvly-test" }));
+
+        const pageInfo = await service.getPageInfo("https://example.test/og");
+        expect(pageInfo.description).toBe("Fallback Og Desc");
     });
 
     it("fails page info requests on non-ok HTTP responses", async () => {

--- a/plugins/plugin-web-search/src/services/webSearchService.test.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.test.ts
@@ -1,8 +1,14 @@
-import type { IAgentRuntime } from "@elizaos/core";
+/**
+ * Deterministic unit suite for `WebSearchService`: Tavily option mapping,
+ * graceful degradation without a key, HTML page-info extraction, and
+ * SSRF-closed page fetches via the real shared guard with an injected
+ * transport (never stub the guard away).
+ */
+import { type IAgentRuntime, SsrfBlockedError } from "@elizaos/core";
 import fc from "fast-check";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SearchOptions } from "../types";
-import { WebSearchService } from "./webSearchService";
+import { setPageInfoHttpTransportForTests, WebSearchService } from "./webSearchService";
 
 const searchMock = vi.hoisted(() => vi.fn());
 const tavilyMock = vi.hoisted(() => vi.fn(() => ({ search: searchMock })));
@@ -23,6 +29,7 @@ describe("WebSearchService", () => {
         vi.unstubAllGlobals();
         searchMock.mockReset();
         tavilyMock.mockClear();
+        setPageInfoHttpTransportForTests(undefined);
     });
 
     it("starts inert without TAVILY_API_KEY and trims configured keys", async () => {
@@ -297,10 +304,9 @@ describe("WebSearchService", () => {
             </body>
             </html>
         `;
-        vi.stubGlobal(
-            "fetch",
-            vi.fn(async () => new Response(html))
-        );
+        const fetchImpl = vi.fn(async () => new Response(html));
+        // Inject transport so the real SSRF policy still runs against public hosts.
+        setPageInfoHttpTransportForTests({ fetchImpl });
         const service = await WebSearchService.start(runtime({ TAVILY_API_KEY: "tvly-test" }));
 
         const pageInfo = await service.getPageInfo("https://example.test/page");
@@ -319,14 +325,14 @@ describe("WebSearchService", () => {
             "https://example.test/docs/guide.html",
             "https://other.test/about",
         ]);
+        expect(fetchImpl).toHaveBeenCalledOnce();
     });
 
     it("falls back to og:description when standard description meta tag is absent", async () => {
         const html = `<html><head><title>Test</title><meta property="og:description" content="Fallback Og Desc"></head></html>`;
-        vi.stubGlobal(
-            "fetch",
-            vi.fn(async () => new Response(html))
-        );
+        setPageInfoHttpTransportForTests({
+            fetchImpl: vi.fn(async () => new Response(html)),
+        });
         const service = await WebSearchService.start(runtime({ TAVILY_API_KEY: "tvly-test" }));
 
         const pageInfo = await service.getPageInfo("https://example.test/og");
@@ -334,10 +340,11 @@ describe("WebSearchService", () => {
     });
 
     it("fails page info requests on non-ok HTTP responses", async () => {
-        vi.stubGlobal(
-            "fetch",
-            vi.fn(async () => new Response("missing", { status: 404, statusText: "Not Found" }))
-        );
+        setPageInfoHttpTransportForTests({
+            fetchImpl: vi.fn(
+                async () => new Response("missing", { status: 404, statusText: "Not Found" })
+            ),
+        });
         const service = await WebSearchService.start(runtime({ TAVILY_API_KEY: "tvly-test" }));
 
         await expect(service.getPageInfo("https://example.test/missing")).rejects.toThrow(
@@ -346,8 +353,8 @@ describe("WebSearchService", () => {
     });
 
     it("rejects malformed and non-http page info URLs before fetch", async () => {
-        const fetchMock = vi.fn();
-        vi.stubGlobal("fetch", fetchMock);
+        const fetchImpl = vi.fn();
+        setPageInfoHttpTransportForTests({ fetchImpl });
         const service = await WebSearchService.start(runtime({ TAVILY_API_KEY: "tvly-test" }));
 
         await expect(service.getPageInfo("not a url")).rejects.toThrow("Invalid page info URL");
@@ -357,6 +364,25 @@ describe("WebSearchService", () => {
         await expect(service.getPageInfo("file:///etc/passwd")).rejects.toThrow(
             "Page info URL must use http or https"
         );
-        expect(fetchMock).not.toHaveBeenCalled();
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it("fails closed on private, loopback, and link-local page info URLs", async () => {
+        const fetchImpl = vi.fn(async () => new Response("<title>should not load</title>"));
+        setPageInfoHttpTransportForTests({ fetchImpl });
+        const service = await WebSearchService.start(runtime({ TAVILY_API_KEY: "tvly-test" }));
+
+        await expect(service.getPageInfo("http://127.0.0.1/secret")).rejects.toBeInstanceOf(
+            SsrfBlockedError
+        );
+        await expect(
+            service.getPageInfo("http://169.254.169.254/latest/meta-data/")
+        ).rejects.toBeInstanceOf(SsrfBlockedError);
+        await expect(service.getPageInfo("http://localhost/admin")).rejects.toBeInstanceOf(
+            SsrfBlockedError
+        );
+        await expect(service.getPageInfo("http://[::1]/")).rejects.toBeInstanceOf(SsrfBlockedError);
+        // Policy must reject before the injected transport is invoked.
+        expect(fetchImpl).not.toHaveBeenCalled();
     });
 });

--- a/plugins/plugin-web-search/src/services/webSearchService.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.ts
@@ -6,7 +6,9 @@
  * Tavily's responses to core's shared shape. Degrades gracefully: without
  * `TAVILY_API_KEY` it boots inert and throws a descriptive error on first use
  * rather than crashing boot. `getPageInfo` is a raw fetch + regex scrape (not
- * Tavily-backed); videos reuse web search since Tavily has no video endpoint.
+ * Tavily-backed) that populates title, description, meta tags, images, and
+ * links from untrusted HTML; videos reuse web search since Tavily has no
+ * video endpoint.
  */
 
 import { type IAgentRuntime, IWebSearchService, logger, ServiceType } from "@elizaos/core";
@@ -224,6 +226,19 @@ function extractMetaTags(content: string): {
     return { description, metadata };
 }
 
+function resolveHttpUrl(raw: string, baseUrl: URL): string | null {
+    try {
+        const resolved = new URL(raw, baseUrl);
+        if (resolved.protocol !== "http:" && resolved.protocol !== "https:") {
+            return null;
+        }
+        return resolved.toString();
+    } catch {
+        // error-policy:J3 untrusted HTML may contain unparseable URL candidates
+        return null;
+    }
+}
+
 function extractImages(content: string, baseUrl: URL): string[] {
     const images: string[] = [];
     const seen = new Set<string>();
@@ -235,18 +250,11 @@ function extractImages(content: string, baseUrl: URL): string[] {
             match = imgRegex.exec(content);
             continue;
         }
-        try {
-            const resolved = new URL(rawSrc, baseUrl).toString();
-            if (
-                (resolved.startsWith("http://") || resolved.startsWith("https://")) &&
-                !seen.has(resolved)
-            ) {
-                seen.add(resolved);
-                images.push(resolved);
-                if (images.length >= 20) break;
-            }
-        } catch {
-            // Ignore malformed image URLs
+        const resolved = resolveHttpUrl(rawSrc, baseUrl);
+        if (resolved && !seen.has(resolved)) {
+            seen.add(resolved);
+            images.push(resolved);
+            if (images.length >= 20) break;
         }
         match = imgRegex.exec(content);
     }
@@ -269,18 +277,11 @@ function extractLinks(content: string, baseUrl: URL): string[] {
             match = anchorRegex.exec(content);
             continue;
         }
-        try {
-            const resolved = new URL(rawHref, baseUrl).toString();
-            if (
-                (resolved.startsWith("http://") || resolved.startsWith("https://")) &&
-                !seen.has(resolved)
-            ) {
-                seen.add(resolved);
-                links.push(resolved);
-                if (links.length >= 50) break;
-            }
-        } catch {
-            // Ignore malformed hrefs
+        const resolved = resolveHttpUrl(rawHref, baseUrl);
+        if (resolved && !seen.has(resolved)) {
+            seen.add(resolved);
+            links.push(resolved);
+            if (links.length >= 50) break;
         }
         match = anchorRegex.exec(content);
     }
@@ -410,6 +411,7 @@ export class WebSearchService extends IWebSearchService {
         try {
             parsedUrl = new URL(url);
         } catch {
+            // error-policy:J3 invalid caller URL is an explicit input failure
             throw new Error("Invalid page info URL");
         }
         if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {

--- a/plugins/plugin-web-search/src/services/webSearchService.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.ts
@@ -5,13 +5,20 @@
  * news / images / videos / suggestions / trending / page-info), normalizing
  * Tavily's responses to core's shared shape. Degrades gracefully: without
  * `TAVILY_API_KEY` it boots inert and throws a descriptive error on first use
- * rather than crashing boot. `getPageInfo` is a raw fetch + regex scrape (not
- * Tavily-backed) that populates title, description, meta tags, images, and
- * links from untrusted HTML; videos reuse web search since Tavily has no
- * video endpoint.
+ * rather than crashing boot. `getPageInfo` scrapes title, description, meta
+ * tags, images, and links from untrusted HTML; the page bytes are always
+ * fetched through `fetchWithSsrfGuard` so private / loopback / link-local
+ * targets fail closed and redirect hops are revalidated. Videos reuse web
+ * search since Tavily has no video endpoint.
  */
 
-import { type IAgentRuntime, IWebSearchService, logger, ServiceType } from "@elizaos/core";
+import {
+    fetchWithSsrfGuard,
+    type IAgentRuntime,
+    IWebSearchService,
+    logger,
+    ServiceType,
+} from "@elizaos/core";
 import { tavily } from "@tavily/core";
 
 import type {
@@ -23,6 +30,32 @@ import type {
 } from "../types";
 
 export type TavilyClient = ReturnType<typeof tavily>;
+
+/** Bound how long a remote page-info endpoint may hang the action. */
+const PAGE_INFO_HTTP_TIMEOUT_MS = 15_000;
+/** Cap redirect hops so a hostile chain cannot spin the guard forever. */
+const PAGE_INFO_HTTP_MAX_REDIRECTS = 5;
+
+/**
+ * Deterministic-test seam for the SSRF-guarded page-info transport.
+ * Production leaves this unset so the guard uses Node-pinned defaults.
+ */
+export type PageInfoHttpTransport = Pick<
+    Parameters<typeof fetchWithSsrfGuard>[0],
+    "fetchImpl" | "lookupFn" | "pinnedFetchImpl"
+>;
+
+let pageInfoHttpTransportOverride: PageInfoHttpTransport | undefined;
+
+/**
+ * Override the SSRF-guarded HTTP transport used by {@link WebSearchService.getPageInfo}.
+ * Intended for unit tests only; production must leave this unset.
+ */
+export function setPageInfoHttpTransportForTests(
+    transport: PageInfoHttpTransport | undefined
+): void {
+    pageInfoHttpTransportOverride = transport;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -418,22 +451,49 @@ export class WebSearchService extends IWebSearchService {
             throw new Error("Page info URL must use http or https");
         }
 
-        const response = await fetch(parsedUrl.toString());
-        if (!response.ok) {
-            throw new Error(`Failed to fetch page info: ${response.status} ${response.statusText}`);
+        // Caller-supplied page URLs are untrusted; never use raw fetch with
+        // automatic redirect following. The shared guard blocks private /
+        // loopback / link-local targets and revalidates every redirect hop.
+        const guarded = await fetchWithSsrfGuard({
+            url: parsedUrl.toString(),
+            timeoutMs: PAGE_INFO_HTTP_TIMEOUT_MS,
+            maxRedirects: PAGE_INFO_HTTP_MAX_REDIRECTS,
+            init: {
+                method: "GET",
+                redirect: "manual",
+            },
+            ...pageInfoHttpTransportOverride,
+        });
+        try {
+            if (!guarded.response.ok) {
+                throw new Error(
+                    `Failed to fetch page info: ${guarded.response.status} ${guarded.response.statusText}`
+                );
+            }
+            const content = await guarded.response.text();
+            // Prefer the post-redirect URL for relative image/link resolution.
+            let baseUrl = parsedUrl;
+            try {
+                baseUrl = new URL(guarded.finalUrl || parsedUrl.toString());
+            } catch {
+                // error-policy:J3 finalUrl is transport-reported; keep the
+                // pre-validated request URL if it is not a valid absolute URL.
+                baseUrl = parsedUrl;
+            }
+            const title = extractTitle(content, url);
+            const { description, metadata } = extractMetaTags(content);
+            const images = extractImages(content, baseUrl);
+            const links = extractLinks(content, baseUrl);
+            return {
+                title,
+                description,
+                content,
+                metadata,
+                images,
+                links,
+            };
+        } finally {
+            await guarded.release();
         }
-        const content = await response.text();
-        const title = extractTitle(content, url);
-        const { description, metadata } = extractMetaTags(content);
-        const images = extractImages(content, parsedUrl);
-        const links = extractLinks(content, parsedUrl);
-        return {
-            title,
-            description,
-            content,
-            metadata,
-            images,
-            links,
-        };
     }
 }

--- a/plugins/plugin-web-search/src/services/webSearchService.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.ts
@@ -167,6 +167,126 @@ function freshnessToDays(freshness: NewsSearchOptions["freshness"]): number {
     }
 }
 
+function decodeHtmlEntities(text: string): string {
+    return text
+        .replace(/&amp;/g, "&")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&apos;/g, "'")
+        .replace(/&#(\d+);/g, (_, code) => {
+            const num = Number(code);
+            return Number.isFinite(num) ? String.fromCharCode(num) : _;
+        })
+        .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => {
+            const num = parseInt(hex, 16);
+            return Number.isFinite(num) ? String.fromCharCode(num) : _;
+        });
+}
+
+function extractTitle(content: string, fallbackUrl: string): string {
+    const match = content.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+    if (!match?.[1]) return fallbackUrl;
+    const cleanText = match[1].replace(/<[^>]+>/g, "").trim();
+    return cleanText ? decodeHtmlEntities(cleanText) : fallbackUrl;
+}
+
+function extractMetaTags(content: string): {
+    description: string;
+    metadata: Record<string, string>;
+} {
+    const metadata: Record<string, string> = {};
+    let description = "";
+
+    const metaRegex = /<meta\s+([^>]+)>/gi;
+    let match = metaRegex.exec(content);
+    while (match !== null) {
+        const attrString = match[1];
+        const keyMatch = attrString.match(/(?:name|property)=["']([^"']+)["']/i);
+        const contentMatch = attrString.match(/content=["']([^"']*)["']/i);
+        if (keyMatch && contentMatch) {
+            const key = keyMatch[1].trim();
+            const val = decodeHtmlEntities(contentMatch[1].trim());
+            metadata[key] = val;
+            const lowerKey = key.toLowerCase();
+            if (
+                !description &&
+                (lowerKey === "description" ||
+                    lowerKey === "og:description" ||
+                    lowerKey === "twitter:description")
+            ) {
+                description = val;
+            }
+        }
+        match = metaRegex.exec(content);
+    }
+    return { description, metadata };
+}
+
+function extractImages(content: string, baseUrl: URL): string[] {
+    const images: string[] = [];
+    const seen = new Set<string>();
+    const imgRegex = /<img\s+[^>]*src=["']([^"']+)["']/gi;
+    let match = imgRegex.exec(content);
+    while (match !== null) {
+        const rawSrc = match[1].trim();
+        if (!rawSrc || rawSrc.startsWith("data:")) {
+            match = imgRegex.exec(content);
+            continue;
+        }
+        try {
+            const resolved = new URL(rawSrc, baseUrl).toString();
+            if (
+                (resolved.startsWith("http://") || resolved.startsWith("https://")) &&
+                !seen.has(resolved)
+            ) {
+                seen.add(resolved);
+                images.push(resolved);
+                if (images.length >= 20) break;
+            }
+        } catch {
+            // Ignore malformed image URLs
+        }
+        match = imgRegex.exec(content);
+    }
+    return images;
+}
+
+function extractLinks(content: string, baseUrl: URL): string[] {
+    const links: string[] = [];
+    const seen = new Set<string>();
+    const anchorRegex = /<a\s+[^>]*href=["']([^"']+)["']/gi;
+    let match = anchorRegex.exec(content);
+    while (match !== null) {
+        const rawHref = match[1].trim();
+        if (
+            !rawHref ||
+            rawHref.startsWith("#") ||
+            rawHref.startsWith("javascript:") ||
+            rawHref.startsWith("mailto:")
+        ) {
+            match = anchorRegex.exec(content);
+            continue;
+        }
+        try {
+            const resolved = new URL(rawHref, baseUrl).toString();
+            if (
+                (resolved.startsWith("http://") || resolved.startsWith("https://")) &&
+                !seen.has(resolved)
+            ) {
+                seen.add(resolved);
+                links.push(resolved);
+                if (links.length >= 50) break;
+            }
+        } catch {
+            // Ignore malformed hrefs
+        }
+        match = anchorRegex.exec(content);
+    }
+    return links;
+}
+
 export class WebSearchService extends IWebSearchService {
     static override serviceType = ServiceType.WEB_SEARCH;
     override capabilityDescription = "Web search and content discovery capabilities" as const;
@@ -301,16 +421,17 @@ export class WebSearchService extends IWebSearchService {
             throw new Error(`Failed to fetch page info: ${response.status} ${response.statusText}`);
         }
         const content = await response.text();
-        const title = content.match(/<title[^>]*>(.*?)<\/title>/i)?.[1] ?? url;
-        const description =
-            content.match(/<meta\s+name=["']description["']\s+content=["']([^"']+)/i)?.[1] ?? "";
+        const title = extractTitle(content, url);
+        const { description, metadata } = extractMetaTags(content);
+        const images = extractImages(content, parsedUrl);
+        const links = extractLinks(content, parsedUrl);
         return {
             title,
             description,
             content,
-            metadata: {},
-            images: [],
-            links: [],
+            metadata,
+            images,
+            links,
         };
     }
 }


### PR DESCRIPTION
# Relates to

Closes #18677
Closes #18690

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused verification was run on the touched surfaces after sync (see Testing).
      Full `bun run verify` was **not** re-run this cycle; scoped plugin unit suite is the
      proof for this pure page-info scrape + SSRF transport change.
- [x] A reviewer can confirm the change from the unit transcript and matrices
      below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `origin/develop`; zero conflicts.
- [x] Focused suite green. Full `bun run verify` not claimed this cycle
      (plugin-web-search page-info parser + SSRF transport + unit tests).

# Risks

**Low–medium.** Changes how `WebSearchService.getPageInfo` fetches and scrapes
caller-supplied page URLs:

- Page bytes now go through `fetchWithSsrfGuard` (private / loopback / link-local
  blocked; redirect hops revalidated; 15s timeout; max 5 redirects).
- Title, description, meta tags, images, and links are populated from the
  response body instead of empty placeholders / partial title-only scraping.
- Relative image/link URLs resolve against the final post-redirect URL; only
  `http`/`https` survive. `data:`, fragments, `javascript:`, and `mailto:` are skipped.
- Malformed embedded URL candidates are skipped (do not fail the whole call).
- Tavily-backed `search` / news / images / videos paths are unchanged.
- Callers that previously hit private IPs via page-info now receive
  `SsrfBlockedError` instead of a successful scrape (intentional fail-closed).

# Background

## What does this PR do?

1. **#18677** — `getPageInfo` no longer returns empty `metadata`, `images`, and
   `links` when the fetched HTML contains them, and no longer drops multiline
   titles or leaves HTML entities undecoded.
2. **#18690** — page-info HTTP(S) fetches route through the shared core SSRF
   guard instead of raw `fetch`, so agent-supplied URLs cannot reach loopback,
   link-local, or private network targets.

## What kind of change is this?

Bug fix (non-breaking for public URLs; fail-closed for SSRF targets that should
never have been reachable).

# Documentation changes needed?

My changes do not require a change to the project documentation. The service
module header documents the page-info scrape + SSRF contract.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-web-search/src/services/webSearchService.ts` — parsers +
   SSRF-guarded `getPageInfo`
2. `plugins/plugin-web-search/src/services/webSearchService.test.ts` — extraction
   matrix and SSRF fail-closed cases

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-web-search test
bun run --cwd plugins/plugin-web-search typecheck
```

Result (exact head `20ccf39e58` / `20ccf39e5876ba7869eacdb3e14424ae66b8e95d`):

```text
 Test Files  3 passed | 1 skipped (4)
      Tests  15 passed | 1 skipped (16)
   Duration  9.97s
```

`typecheck`: clean. Biome clean on the two touched files.

Deterministic matrices:

```text
getPageInfo(HTML with title/entities/meta/img/a)
  title        => decoded multiline title
  description  => name=description (or og/twitter fallback)
  metadata     => { description, og:title, og:image, ... }
  images       => absolute http(s) only; data: skipped; relative resolved
  links        => absolute http(s) only; #/javascript:/mailto: skipped

getPageInfo("not a url" | "file://..." | "data:...")
  => rejects before transport

getPageInfo(...) when transport returns 404
  => rejects with status text

getPageInfo("http://127.0.0.1/...")
getPageInfo("http://169.254.169.254/...")
getPageInfo("http://localhost/...")
getPageInfo("http://[::1]/")
  => SsrfBlockedError; injected fetchImpl never called
```

# Evidence Gate

<!-- evidence-head:20ccf39e5876ba7869eacdb3e14424ae66b8e95d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; pure plugin HTML scrape path with SSRF-guarded transport and injected test fetch.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; pure plugin HTML scrape path with SSRF-guarded transport and injected test fetch.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow; proof is the vitest transcript and matrices above.
<!-- evidence-row:backend-logs -->
- [x] N/A - no HTTP server path under test; transport is injected in unit tests while the real SSRF policy still runs.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior involved.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused Vitest output (15 passed / 1 skipped) and the extraction + SSRF matrices above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text to OCR.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model changes.

## Backend + frontend logs

N/A - unit path only; focused vitest + matrices under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI. Live network scrape against an external page is out of scope for this
unit-only repair (injected transport proves structure + SSRF policy).

## Audio / voice walkthrough

N/A - no voice/TTS/STT surface.

## Known gaps / failures

- Full root `bun run verify` not run this cycle; change is limited to
  `plugin-web-search` page-info scraping/SSRF transport and its unit tests.
- Live network `getPageInfo` against real public sites not exercised (would not
  improve the deterministic HTML + SSRF matrix).
- DNS-rebinding coverage is provided by the shared core guard defaults in
  production; unit tests inject `fetchImpl` so literal-host SSRF policy still
  runs without the Node-pinned transport.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-rama0x1]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZV2Q62EST54VJV6T9MPGF22","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T13:31:20.014Z","completed_at":"2026-08-12T13:34:31.606Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"BbtP-ZJRWPB4UzF3ncD_NZsAieKj4ChaRtgf3RJ6T2hZTP5bTo8UtKwytBkDLfQKlhf4xexGQtyPYhW8bIwMBA"}} -->
