### PR TITLE
fix(skills): handle dangling symlinks and read errors safely during skill discovery

### DIFF
--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -91,6 +91,7 @@ function loadSkillFromFile(
   try {
     rawContent = readFileSync(filePath, "utf-8");
   } catch (err: unknown) {
+    // error-policy:J3 unreadable skill file on untrusted filesystem becomes a warning diagnostic, never a fake skill
     diagnostics.push({
       type: "warning",
       message: `Failed to read skill file: ${err instanceof Error ? err.message : String(err)}`,
@@ -151,6 +152,7 @@ function loadSkillsFromDirInternal(
   try {
     entries = readdirSync(dir, { withFileTypes: true });
   } catch (err: unknown) {
+    // error-policy:J3 unreadable skills directory on untrusted filesystem becomes a warning diagnostic with no skills
     diagnostics.push({
       type: "warning",
       message: `Failed to read directory "${dir}": ${err instanceof Error ? err.message : String(err)}`,
@@ -178,6 +180,7 @@ function loadSkillsFromDirInternal(
         isDirectory = stats.isDirectory();
         isFile = stats.isFile();
       } catch (err: unknown) {
+        // error-policy:J3 dangling or inaccessible symlink becomes a warning diagnostic and the entry is skipped
         diagnostics.push({
           type: "warning",
           message: `Dangling or inaccessible symlink "${entry.name}": ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -87,7 +87,18 @@ function loadSkillFromFile(
 ): { skill: Skill | null; diagnostics: SkillDiagnostic[] } {
   const diagnostics: SkillDiagnostic[] = [];
 
-  const rawContent = readFileSync(filePath, "utf-8");
+  let rawContent: string;
+  try {
+    rawContent = readFileSync(filePath, "utf-8");
+  } catch (err: unknown) {
+    diagnostics.push({
+      type: "warning",
+      message: `Failed to read skill file: ${err instanceof Error ? err.message : String(err)}`,
+      path: filePath,
+    });
+    return { skill: null, diagnostics };
+  }
+
   const { frontmatter } = parseFrontmatter<SkillFrontmatter>(rawContent);
   const skillDir = dirname(filePath);
   const parentDirName = basename(skillDir);
@@ -136,7 +147,17 @@ function loadSkillsFromDirInternal(
     return { skills, diagnostics };
   }
 
-  const entries = readdirSync(dir, { withFileTypes: true });
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch (err: unknown) {
+    diagnostics.push({
+      type: "warning",
+      message: `Failed to read directory "${dir}": ${err instanceof Error ? err.message : String(err)}`,
+      path: dir,
+    });
+    return { skills, diagnostics };
+  }
 
   for (const entry of entries) {
     if (entry.name.startsWith(".")) {
@@ -152,9 +173,19 @@ function loadSkillsFromDirInternal(
     let isDirectory = entry.isDirectory();
     let isFile = entry.isFile();
     if (entry.isSymbolicLink()) {
-      const stats = statSync(fullPath);
-      isDirectory = stats.isDirectory();
-      isFile = stats.isFile();
+      try {
+        const stats = statSync(fullPath);
+        isDirectory = stats.isDirectory();
+        isFile = stats.isFile();
+      } catch (err: unknown) {
+        diagnostics.push({
+          type: "warning",
+          message: `Dangling or inaccessible symlink "${entry.name}": ${err instanceof Error ? err.message : String(err)}`,
+          path: fullPath,
+        });
+        isDirectory = false;
+        isFile = false;
+      }
     }
 
     if (isDirectory) {

--- a/packages/skills/src/resolver.ts
+++ b/packages/skills/src/resolver.ts
@@ -27,6 +27,7 @@ function looksLikeSkillsDir(dir: string): boolean {
   try {
     entries = readdirSync(dir, { withFileTypes: true });
   } catch {
+    // error-policy:J3 unreadable candidate directory on untrusted filesystem is explicitly not a skills dir
     return false;
   }
 
@@ -43,6 +44,7 @@ function looksLikeSkillsDir(dir: string): boolean {
         isFile = stats.isFile();
         isDirectory = stats.isDirectory();
       } catch {
+        // error-policy:J3 dangling or inaccessible symlink is treated as neither file nor directory
         isFile = false;
         isDirectory = false;
       }

--- a/packages/skills/src/resolver.ts
+++ b/packages/skills/src/resolver.ts
@@ -23,16 +23,34 @@ function looksLikeSkillsDir(dir: string): boolean {
     return false;
   }
 
-  const entries = readdirSync(dir, { withFileTypes: true });
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+
   for (const entry of entries) {
     if (entry.name.startsWith(".")) {
       continue;
     }
     const fullPath = join(dir, entry.name);
-    if (entry.isFile() && entry.name.endsWith(".md")) {
+    let isFile = entry.isFile();
+    let isDirectory = entry.isDirectory();
+    if (entry.isSymbolicLink()) {
+      try {
+        const stats = statSync(fullPath);
+        isFile = stats.isFile();
+        isDirectory = stats.isDirectory();
+      } catch {
+        isFile = false;
+        isDirectory = false;
+      }
+    }
+    if (isFile && entry.name.endsWith(".md")) {
       return true;
     }
-    if (entry.isDirectory()) {
+    if (isDirectory) {
       if (existsSync(join(fullPath, "SKILL.md"))) {
         return true;
       }

--- a/packages/skills/test/loader.test.ts
+++ b/packages/skills/test/loader.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for loadSkills, loadSkillsFromDir, and loadSkillEntries in packages/skills/src/loader.ts.
+ * Tests loading valid skills, warning diagnostics for invalid metadata, and safe handling of
+ * dangling symlinks and read errors.
+ */
+import assert from "node:assert";
+import {
+  mkdirSync,
+  rmdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import {
+  loadSkillEntries,
+  loadSkills,
+  loadSkillsFromDir,
+} from "../src/loader.js";
+
+function createTempDir(prefix: string): string {
+  const dir = join(
+    tmpdir(),
+    `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("loadSkillsFromDir", () => {
+  it("returns empty result for non-existent directory", () => {
+    const result = loadSkillsFromDir({
+      dir: "/non/existent/path/for/skills/test",
+      source: "test",
+    });
+    assert.deepStrictEqual(result.skills, []);
+    assert.deepStrictEqual(result.diagnostics, []);
+  });
+
+  it("loads valid skills from direct markdown files and SKILL.md subdirectories", () => {
+    const tempDir = createTempDir("skill-loader-valid");
+    try {
+      // 1. Direct markdown file in root
+      writeFileSync(
+        join(tempDir, "root-skill.md"),
+        `---
+name: root-skill
+description: Root markdown skill description
+---
+# Root Skill`,
+      );
+
+      // 2. Subdirectory with SKILL.md
+      const subDir = join(tempDir, "sub-skill");
+      mkdirSync(subDir, { recursive: true });
+      writeFileSync(
+        join(subDir, "SKILL.md"),
+        `---
+name: sub-skill
+description: Subdirectory skill description
+---
+# Sub Skill`,
+      );
+
+      const result = loadSkillsFromDir({ dir: tempDir, source: "test" });
+      assert.strictEqual(result.skills.length, 2);
+
+      const rootSkill = result.skills.find((s) => s.name === "root-skill");
+      assert.ok(rootSkill);
+      assert.strictEqual(
+        rootSkill.description,
+        "Root markdown skill description",
+      );
+
+      const subSkill = result.skills.find((s) => s.name === "sub-skill");
+      assert.ok(subSkill);
+      assert.strictEqual(
+        subSkill.description,
+        "Subdirectory skill description",
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("safely ignores dangling symlinks and emits warning diagnostic", () => {
+    const tempDir = createTempDir("skill-loader-symlink");
+    try {
+      // Create a valid skill file
+      writeFileSync(
+        join(tempDir, "valid-skill.md"),
+        `---
+name: valid-skill
+description: Valid skill description
+---
+# Valid Skill`,
+      );
+
+      // Create a dangling symlink pointing to a missing target
+      const brokenTarget = join(tempDir, "non-existent-target.md");
+      const brokenSymlink = join(tempDir, "dangling-link.md");
+      try {
+        symlinkSync(brokenTarget, brokenSymlink);
+      } catch {
+        // Fallback if symlink creation is unsupported on OS
+      }
+
+      const result = loadSkillsFromDir({ dir: tempDir, source: "test" });
+      const validSkill = result.skills.find((s) => s.name === "valid-skill");
+      assert.ok(validSkill);
+
+      // Verify that the dangling symlink produced a diagnostic without crashing
+      const symlinkDiag = result.diagnostics.find(
+        (d) => d.message.includes("Dangling or inaccessible symlink") || d.message.includes("dangling"),
+      );
+      // On OS supporting symlinks, symlinkDiag will be recorded
+      assert.ok(result.skills.length >= 1);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits warning diagnostics for missing or invalid metadata", () => {
+    const tempDir = createTempDir("skill-loader-invalid");
+    try {
+      // Missing description
+      writeFileSync(
+        join(tempDir, "no-desc.md"),
+        `---
+name: no-desc
+---
+# No Desc`,
+      );
+
+      const result = loadSkillsFromDir({ dir: tempDir, source: "test" });
+      assert.strictEqual(result.skills.length, 0);
+
+      const descDiag = result.diagnostics.find((d) =>
+        d.message.includes("description is required"),
+      );
+      assert.ok(descDiag);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("loadSkills and loadSkillEntries", () => {
+  it("detects name collisions across skill sources", () => {
+    const tempDir1 = createTempDir("skill-source-1");
+    const tempDir2 = createTempDir("skill-source-2");
+
+    try {
+      writeFileSync(
+        join(tempDir1, "dup-skill.md"),
+        `---
+name: dup-skill
+description: First skill
+---
+# First`,
+      );
+
+      writeFileSync(
+        join(tempDir2, "dup-skill.md"),
+        `---
+name: dup-skill
+description: Second skill
+---
+# Second`,
+      );
+
+      const result = loadSkills({
+        includeDefaults: false,
+        skillPaths: [tempDir1, tempDir2],
+      });
+
+      assert.strictEqual(result.skills.length, 1);
+      const collision = result.diagnostics.find((d) => d.type === "collision");
+      assert.ok(collision);
+      assert.strictEqual(collision.collision?.name, "dup-skill");
+    } finally {
+      rmSync(tempDir1, { recursive: true, force: true });
+      rmSync(tempDir2, { recursive: true, force: true });
+    }
+  });
+
+  it("loadSkillEntries parses full metadata and invocation policy", () => {
+    const tempDir = createTempDir("skill-entries");
+    try {
+      writeFileSync(
+        join(tempDir, "policy-skill.md"),
+        `---
+name: policy-skill
+description: Policy skill
+primary-env: node
+disable-model-invocation: true
+---
+# Content`,
+      );
+
+      const entries = loadSkillEntries({
+        includeDefaults: false,
+        skillPaths: [tempDir],
+      });
+
+      assert.strictEqual(entries.length, 1);
+      const entry = entries[0];
+      assert.strictEqual(entry.skill.name, "policy-skill");
+      assert.strictEqual(entry.metadata.primaryEnv, "node");
+      assert.strictEqual(entry.invocation.disableModelInvocation, true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/skills/test/loader.test.ts
+++ b/packages/skills/test/loader.test.ts
@@ -101,10 +101,12 @@ description: Valid skill description
       // Create a dangling symlink pointing to a missing target
       const brokenTarget = join(tempDir, "non-existent-target.md");
       const brokenSymlink = join(tempDir, "dangling-link.md");
+      let symlinksSupported = true;
       try {
         symlinkSync(brokenTarget, brokenSymlink);
       } catch {
-        // Fallback if symlink creation is unsupported on OS
+        // error-policy:J3 symlink creation unsupported on this OS; skip the diagnostic assertion below
+        symlinksSupported = false;
       }
 
       const result = loadSkillsFromDir({ dir: tempDir, source: "test" });
@@ -112,10 +114,12 @@ description: Valid skill description
       assert.ok(validSkill);
 
       // Verify that the dangling symlink produced a diagnostic without crashing
-      const symlinkDiag = result.diagnostics.find(
-        (d) => d.message.includes("Dangling or inaccessible symlink") || d.message.includes("dangling"),
-      );
-      // On OS supporting symlinks, symlinkDiag will be recorded
+      if (symlinksSupported) {
+        const symlinkDiag = result.diagnostics.find((d) =>
+          d.message.includes("Dangling or inaccessible symlink"),
+        );
+        assert.ok(symlinkDiag);
+      }
       assert.ok(result.skills.length >= 1);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Antigravity / Gemini 3.6 Flash (High)`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run test packages/skills` passes post-sync.

# Risks

Low risk. Only affects skill directory discovery and parsing error boundaries in `@elizaos/skills`.

# Background

## What does this PR do?

1. Wraps `statSync` in `try / catch` during symbolic link scanning in `loadSkillsFromDirInternal` and `looksLikeSkillsDir` so dangling symlinks (links to missing targets) are safely skipped and log warning diagnostics rather than throwing unhandled `ENOENT` exceptions during agent initialization.
2. Wraps file reading in `loadSkillFromFile` and directory scanning in `loadSkillsFromDirInternal` in `try / catch` to safely emit warning diagnostics for unreadable files/directories.
3. Adds comprehensive unit test suite in `packages/skills/test/loader.test.ts` to verify skill loading, dangling symlink safety, invalid metadata warning diagnostics, and collision handling.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/skills/src/loader.ts`: Check `loadSkillFromFile` and `loadSkillsFromDirInternal` error boundaries and symlink safety.
- `packages/skills/src/resolver.ts`: Check `looksLikeSkillsDir` error handling.
- `packages/skills/test/loader.test.ts`: Review unit tests for loader resilience and dangling symlinks.

## Detailed testing steps

Run unit tests in `@elizaos/skills`:
```bash
bun test packages/skills
```

Output:
```
89 pass
0 fail
Ran 89 tests across 6 files.
```

Typecheck:
```bash
bun --cwd packages/skills typecheck
```

# Evidence Gate

<!-- evidence-head:1cd12a127f37c6b3fdb65bb7d011e8327cfcc36a -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend skill loading fix with no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend skill loading fix with no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend skill loading fix with no UI surface`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - non-runtime package unit test coverage`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend UI changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no LLM or prompt changes`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - unit test evidence attached`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no UI surface`.

# Evidence Details

## Backend + frontend logs

Test execution output from `bun test packages/skills`:

```
bun test packages/skills

 packages/skills/test/frontmatter.test.ts
 packages/skills/test/formatter.test.ts
 packages/skills/test/loader.test.ts
 packages/skills/test/provenance.test.ts
 packages/skills/test/resolver.test.ts
 packages/skills/test/contribute-to-eliza.test.ts

 89 pass
 0 fail
Ran 89 tests across 6 files.
```

## Known gaps / failures

None. All 89 tests in `@elizaos/skills` pass cleanly and TypeScript compilation succeeds with zero errors.
