### PR TITLE
fix(skills): safely handle malformed and non-object YAML in frontmatter parsing

### DIFF
--- a/packages/skills/src/frontmatter.ts
+++ b/packages/skills/src/frontmatter.ts
@@ -21,8 +21,17 @@ function normalizeNewlines(value: string): string {
   return value.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
+/**
+ * True only for plain string-keyed records (Object.prototype or null-prototype).
+ * yaml.parse can return Set/Map/collection instances for !!set / !!omap roots;
+ * those must not be typed or returned as Record<string, unknown>.
+ */
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
 }
 
 function frontmatterValue(
@@ -78,7 +87,7 @@ export function parseFrontmatter<
       return { frontmatter: parsed as T, body };
     }
   } catch {
-    // Malformed YAML frontmatter block falls back safely to empty object
+    // error-policy:J3 untrusted YAML frontmatter parse fails closed to empty record
   }
   return { frontmatter: {} as T, body };
 }

--- a/packages/skills/src/frontmatter.ts
+++ b/packages/skills/src/frontmatter.ts
@@ -72,8 +72,15 @@ export function parseFrontmatter<
   if (!yamlString) {
     return { frontmatter: {} as T, body };
   }
-  const parsed = parse(yamlString);
-  return { frontmatter: (parsed ?? {}) as T, body };
+  try {
+    const parsed = parse(yamlString);
+    if (isRecord(parsed)) {
+      return { frontmatter: parsed as T, body };
+    }
+  } catch {
+    // Malformed YAML frontmatter block falls back safely to empty object
+  }
+  return { frontmatter: {} as T, body };
 }
 
 export function stripFrontmatter(content: string): string {

--- a/packages/skills/test/frontmatter.test.ts
+++ b/packages/skills/test/frontmatter.test.ts
@@ -1,6 +1,7 @@
 /**
- * Tests for parseFrontmatter: valid YAML blocks, absent/empty frontmatter, CRLF
- * line endings, and a missing closing delimiter. Deterministic string parsing.
+ * Deterministic unit coverage for parseFrontmatter and skill frontmatter
+ * resolvers: valid blocks, absent/empty/malformed YAML, non-object and
+ * non-plain collection roots, CRLF, and metadata/policy extraction.
  */
 import assert from "node:assert";
 import { describe, it } from "node:test";
@@ -117,6 +118,42 @@ Body content`;
     const arrayResult = parseFrontmatter(arrayContent);
     assert.deepStrictEqual(arrayResult.frontmatter, {});
     assert.strictEqual(arrayResult.body, "Body content");
+  });
+
+  it("returns empty frontmatter for YAML Set and Map collection roots", () => {
+    const setContent = `---
+!!set
+? alpha
+? beta
+---
+Body content`;
+    const setResult = parseFrontmatter(setContent);
+    assert.deepStrictEqual(setResult.frontmatter, {});
+    assert.strictEqual(setResult.body, "Body content");
+    assert.ok(!(setResult.frontmatter instanceof Set));
+
+    const omapContent = `---
+!!omap
+- alpha: 1
+- beta: 2
+---
+Body content`;
+    const omapResult = parseFrontmatter(omapContent);
+    assert.deepStrictEqual(omapResult.frontmatter, {});
+    assert.strictEqual(omapResult.body, "Body content");
+    assert.ok(!(omapResult.frontmatter instanceof Map));
+  });
+
+  it("accepts plain and null-prototype-equivalent mapping roots", () => {
+    const content = `---
+name: plain-skill
+description: mapping root
+---
+Body`;
+    const result = parseFrontmatter<SkillFrontmatter>(content);
+    assert.strictEqual(result.frontmatter.name, "plain-skill");
+    assert.strictEqual(result.frontmatter.description, "mapping root");
+    assert.strictEqual(result.body, "Body");
   });
 });
 

--- a/packages/skills/test/frontmatter.test.ts
+++ b/packages/skills/test/frontmatter.test.ts
@@ -89,6 +89,35 @@ Body`;
     assert.strictEqual(result.frontmatter["disable-model-invocation"], true);
     assert.strictEqual(result.frontmatter["user-invocable"], false);
   });
+
+  it("handles malformed YAML syntax without throwing", () => {
+    const content = `---
+invalid: : : yaml syntax error
+---
+Body content`;
+    const result = parseFrontmatter(content);
+    assert.deepStrictEqual(result.frontmatter, {});
+    assert.strictEqual(result.body, "Body content");
+  });
+
+  it("returns empty frontmatter for non-object YAML frontmatter blocks", () => {
+    const scalarContent = `---
+"just a string scalar"
+---
+Body content`;
+    const scalarResult = parseFrontmatter(scalarContent);
+    assert.deepStrictEqual(scalarResult.frontmatter, {});
+    assert.strictEqual(scalarResult.body, "Body content");
+
+    const arrayContent = `---
+- item1
+- item2
+---
+Body content`;
+    const arrayResult = parseFrontmatter(arrayContent);
+    assert.deepStrictEqual(arrayResult.frontmatter, {});
+    assert.strictEqual(arrayResult.body, "Body content");
+  });
 });
 
 describe("stripFrontmatter", () => {


### PR DESCRIPTION
# Relates to

Closes #18709

Addresses review feedback on this PR (plain-object predicate for YAML collection roots; `error-policy:J3` on the parse catch).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused verification was run on the touched surfaces after sync (see Testing).
      Full `bun run verify` was **not** re-run this cycle; scoped package suite is the
      proof for this pure frontmatter parser change.
- [x] A reviewer can confirm the change from the unit transcript and matrix below
      without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop` (`8618e2d669`); zero conflicts.
- [x] Focused suite green after review-addressing commit. Full `bun run verify`
      not claimed this cycle (two-file parser/unit-test change in `@elizaos/skills`).

# Risks

**Low.** Changes only how untrusted YAML frontmatter roots are accepted:

- Valid plain mapping roots (normal SKILL.md frontmatter) still parse as records.
- Scalar, array, `!!set` (`Set`), and `!!omap` (`Map`) roots fail closed to `{}`
  while preserving the markdown body.
- Malformed YAML still fails closed without throwing.
- Callers that previously received a `Set`/`Map` typed as `Record` now get `{}`
  (the intended contract).

# Background

## What does this PR do?

Hardens `parseFrontmatter` in `@elizaos/skills` so only plain string-keyed
records become frontmatter:

1. **Plain-object predicate** — accept only `Object.prototype` or null-prototype
   objects. Reject `Set`, `Map`, arrays, scalars, and other host objects.
2. **Malformed YAML** — catch remains fail-closed to empty record with
   `// error-policy:J3`.
3. **Regression tests** — scalar, array, `!!set`, `!!omap`, and plain mapping roots.

## What kind of change is this?

Bug fix (fail-closed untrusted YAML frontmatter typing / collection roots).

# Documentation changes needed?

My changes do not require a change to the project documentation. The file header
and tests document the plain-record contract.

# Testing

## Where should a reviewer start?

1. `packages/skills/src/frontmatter.ts` — `isRecord` + `parseFrontmatter`
2. `packages/skills/test/frontmatter.test.ts` — collection-root and fail-closed cases

## Detailed testing steps

```bash
bun run --cwd packages/skills test ./test/frontmatter.test.ts
```

Result (post-sync head `c0a59b76e3`):

```text
 87 pass
 0 fail
Ran 87 tests across 6 files. [1462.00ms]
```

Also:

```bash
bunx @biomejs/biome check packages/skills/src/frontmatter.ts packages/skills/test/frontmatter.test.ts
bun run --cwd packages/skills typecheck
bun run --cwd packages/skills lint:check
```

All clean.

Deterministic matrix:

```text
plain mapping root          => frontmatter fields preserved
scalar YAML root            => frontmatter {}
array YAML root             => frontmatter {}
!!set root (Set instance)   => frontmatter {}  (not Set)
!!omap root (Map instance)  => frontmatter {}  (not Map)
malformed YAML syntax       => frontmatter {}  (no throw)
body always preserved when a closed --- block is present
```

# Evidence Gate

<!-- evidence-head:c0a59b76e3ff381a559b27a7c912a32c17b61844 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; pure YAML frontmatter parser in `@elizaos/skills`.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; pure YAML frontmatter parser.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow; failure mode is empty frontmatter record vs thrown parse / Set-Map leak.
<!-- evidence-row:backend-logs -->
- [x] N/A - no HTTP/server path; proof is the package unit transcript and matrix above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior involved.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused package suite **87/87 pass** and the deterministic parse matrix above (plain vs Set/Map/scalar/array roots).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text to OCR.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model changes.

## Backend + frontend logs

N/A - unit path only; package vitest/bun test transcript under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT surface.

## Known gaps / failures

- Full root `bun run verify` not run this cycle; change is limited to
  `packages/skills/src/frontmatter.ts` and its unit tests.
- Live skill-load through the agent host is not re-exercised; unit path covers the
  public `parseFrontmatter` contract used by loaders.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-worker]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZV5R9AP8F851N00YAGVC8J3","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T14:24:21.846Z","completed_at":"2026-08-12T14:26:59.973Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"moDP-kgtloxg9uyuXwnthnxoW8_3n5AkeZjQ1BvKqfYEDANd0ARqltpTL9TcUSvuMTR7o3AHTPKP64MsiN_sDQ"}} -->