### PR TITLE
fix(inbox): route List-Unsubscribe HTTP fetches through shared SSRF guard

### DIFF
--- a/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
+++ b/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
@@ -16,10 +16,15 @@
  * Authorization: `unsubscribeEmailSender` requires `userAuthorization === true`.
  * The two-phase confirmation gate (`requireConfirmation`) lives in the PA route
  * layer that owns the HTTP surface; this service trusts the pre-confirmed flag.
+ *
+ * HTTP List-Unsubscribe targets come from untrusted email headers, so
+ * `performHttpUnsubscribe` always goes through `fetchWithSsrfGuard` (private /
+ * loopback / link-local blocked; redirects revalidated per hop). Tests inject a
+ * deterministic transport via {@link InboxUnsubscribeServiceDeps.httpTransport}.
  */
 
 import crypto from "node:crypto";
-import type { IAgentRuntime } from "@elizaos/core";
+import { fetchWithSsrfGuard, type IAgentRuntime } from "@elizaos/core";
 import {
   fail,
   type LifeOpsGmailMessageSummary,
@@ -44,6 +49,16 @@ import { InboxUnsubscribeRepository } from "./unsubscribe-repository.ts";
 
 const DEFAULT_SCAN_MAX_MESSAGES = 200;
 const MAX_SENDERS_RETURNED = 200;
+/** Bound how long a remote List-Unsubscribe endpoint may hang the action. */
+const UNSUBSCRIBE_HTTP_TIMEOUT_MS = 15_000;
+/** Cap redirect hops so a hostile chain cannot spin the guard forever. */
+const UNSUBSCRIBE_HTTP_MAX_REDIRECTS = 5;
+
+/** Deterministic-test seam for the SSRF-guarded unsubscribe transport. */
+export type UnsubscribeHttpTransport = Pick<
+  Parameters<typeof fetchWithSsrfGuard>[0],
+  "fetchImpl" | "lookupFn" | "pinnedFetchImpl"
+>;
 
 function headerValue(
   headers: Record<string, unknown> | undefined,
@@ -139,30 +154,51 @@ function parseMailtoUnsubscribe(value: string): {
 async function performHttpUnsubscribe(args: {
   url: string;
   oneClick: boolean;
+  transport?: UnsubscribeHttpTransport;
 }): Promise<{
   ok: boolean;
   status: number;
   finalUrl: string;
   method: Extract<EmailUnsubscribeMethod, "http_one_click" | "http_get">;
 }> {
-  const parsed = new URL(args.url);
+  let parsed: URL;
+  try {
+    parsed = new URL(args.url);
+  } catch {
+    // error-policy:J3 List-Unsubscribe URL text is untrusted header input.
+    fail(400, "Unsubscribe URL is not a valid absolute URL.");
+  }
   if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
     fail(400, "Unsubscribe URL must be http or https.");
   }
-  const response = await fetch(parsed.toString(), {
-    method: args.oneClick ? "POST" : "GET",
-    headers: args.oneClick
-      ? { "Content-Type": "application/x-www-form-urlencoded" }
-      : undefined,
-    body: args.oneClick ? "List-Unsubscribe=One-Click" : undefined,
-    redirect: "follow",
+
+  // Headers are attacker-influenced; never use raw fetch with automatic
+  // redirect following. The shared guard blocks private/loopback targets and
+  // revalidates every redirect hop before connecting.
+  const guarded = await fetchWithSsrfGuard({
+    url: parsed.toString(),
+    timeoutMs: UNSUBSCRIBE_HTTP_TIMEOUT_MS,
+    maxRedirects: UNSUBSCRIBE_HTTP_MAX_REDIRECTS,
+    init: {
+      method: args.oneClick ? "POST" : "GET",
+      headers: args.oneClick
+        ? { "Content-Type": "application/x-www-form-urlencoded" }
+        : undefined,
+      body: args.oneClick ? "List-Unsubscribe=One-Click" : undefined,
+      redirect: "manual",
+    },
+    ...args.transport,
   });
-  return {
-    ok: response.ok,
-    status: response.status,
-    finalUrl: response.url || parsed.toString(),
-    method: args.oneClick ? "http_one_click" : "http_get",
-  };
+  try {
+    return {
+      ok: guarded.response.ok,
+      status: guarded.response.status,
+      finalUrl: guarded.finalUrl || parsed.toString(),
+      method: args.oneClick ? "http_one_click" : "http_get",
+    };
+  } finally {
+    await guarded.release();
+  }
 }
 
 function headersOf(
@@ -178,11 +214,18 @@ export interface InboxUnsubscribeServiceDeps {
   gmail?: InboxGmailGateway;
   /** Override the persistence repository (tests inject a fake or PGlite-backed one). */
   repository?: InboxUnsubscribeRepository;
+  /**
+   * Override the SSRF-guarded HTTP transport used for List-Unsubscribe fetches.
+   * Production leaves this unset so the guard uses Node-pinned defaults; unit
+   * tests inject a deterministic `fetchImpl` so the real policy still runs.
+   */
+  httpTransport?: UnsubscribeHttpTransport;
 }
 
 export class InboxUnsubscribeService {
   private readonly gmail: InboxGmailGateway;
   private readonly repository: InboxUnsubscribeRepository;
+  private readonly httpTransport: UnsubscribeHttpTransport | undefined;
 
   constructor(
     private readonly runtime: IAgentRuntime,
@@ -192,6 +235,7 @@ export class InboxUnsubscribeService {
       deps.gmail ?? createInboxGmailGateway(runtime, runtime.agentId);
     this.repository =
       deps.repository ?? new InboxUnsubscribeRepository(runtime);
+    this.httpTransport = deps.httpTransport;
   }
 
   private get agentId(): string {
@@ -351,6 +395,7 @@ export class InboxUnsubscribeService {
         const http = await performHttpUnsubscribe({
           url: sender.unsubscribeHttpUrl,
           oneClick: sender.unsubscribeMethod === "http_one_click",
+          transport: this.httpTransport,
         });
         method = http.method;
         httpStatusCode = http.status;

--- a/plugins/plugin-inbox/test/unsubscribe-service.test.ts
+++ b/plugins/plugin-inbox/test/unsubscribe-service.test.ts
@@ -6,11 +6,15 @@
  * runtime service or connector-account manager is needed) and a fake in-memory
  * repository, then assert: List-Unsubscribe header parsing → sender scan, the
  * two-phase authorization gate, the HTTP one-click / mailto branches, the Gmail
- * manage capability gate for block/trash, and that the outcome is persisted.
+ * manage capability gate for block/trash, SSRF-closed HTTP unsubscribe against
+ * private/metadata targets, and that the outcome is persisted.
+ *
+ * HTTP paths inject a deterministic `fetchImpl` into the real shared SSRF guard
+ * so policy still runs; tests never stub the guard away.
  */
 
 import type { IAgentRuntime, UUID } from "@elizaos/core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   EmailUnsubscribeRecord,
   EmailUnsubscribeRequest,
@@ -151,23 +155,25 @@ function makeGateway(
   };
 }
 
-function makeService(gmail: InboxGmailGateway) {
+function makeService(
+  gmail: InboxGmailGateway,
+  options: { httpTransport?: { fetchImpl: typeof fetch } } = {},
+) {
   const { repository, records } = fakeRepository();
   const service = new InboxUnsubscribeService(makeRuntime(), {
     gmail,
     repository,
+    // Always inject the test wire so the Node-pinned production transport is
+    // not used; the real SSRF policy still runs on the injected fetchImpl.
+    httpTransport: options.httpTransport ?? { fetchImpl: fetchSpy },
   });
   return { service, records };
 }
 
-describe("InboxUnsubscribeService", () => {
-  const fetchSpy = vi.fn();
+const fetchSpy = vi.fn();
 
+describe("InboxUnsubscribeService", () => {
   beforeEach(() => {
-    vi.stubGlobal("fetch", fetchSpy);
-  });
-  afterEach(() => {
-    vi.unstubAllGlobals();
     fetchSpy.mockReset();
   });
 
@@ -246,11 +252,15 @@ describe("InboxUnsubscribeService", () => {
 
   describe("unsubscribeEmailSender execution", () => {
     it("performs an HTTP one-click POST and records success", async () => {
-      fetchSpy.mockResolvedValue({
-        ok: true,
-        status: 200,
-        url: "https://brand.com/unsub/done",
-      } as Response);
+      fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        expect(url).toBe("https://brand.com/unsub");
+        return new Response(null, {
+          status: 200,
+          // Guard reports finalUrl from the request URL; response.url is not
+          // always populated by the Response constructor.
+        });
+      });
       const gateway = makeGateway({
         messages: [
           gmailMessage({
@@ -275,7 +285,7 @@ describe("InboxUnsubscribeService", () => {
       expect(record.method).toBe("http_one_click");
       expect(record.status).toBe("succeeded");
       expect(record.httpStatusCode).toBe(200);
-      expect(record.httpFinalUrl).toBe("https://brand.com/unsub/done");
+      expect(record.httpFinalUrl).toBe("https://brand.com/unsub");
       expect(records).toHaveLength(1);
       expect(records[0]?.metadata.connectorAccountId).toBe("acct-1");
     });
@@ -322,11 +332,9 @@ describe("InboxUnsubscribeService", () => {
       });
       const { service, records } = makeService(gateway);
 
-      fetchSpy.mockResolvedValue({
-        ok: true,
-        status: 200,
-        url: "https://brand.com/unsub",
-      } as Response);
+      fetchSpy.mockImplementation(
+        async () => new Response(null, { status: 200 }),
+      );
 
       const { record } = await service.unsubscribeEmailSender({
         senderEmail: "news@brand.com",
@@ -359,11 +367,9 @@ describe("InboxUnsubscribeService", () => {
       });
       const { service } = makeService(gateway);
 
-      fetchSpy.mockResolvedValue({
-        ok: true,
-        status: 202,
-        url: "https://brand.com/unsub",
-      } as Response);
+      fetchSpy.mockImplementation(
+        async () => new Response(null, { status: 202 }),
+      );
 
       const { record } = await service.unsubscribeEmailSender({
         senderEmail: "news@brand.com",
@@ -393,6 +399,60 @@ describe("InboxUnsubscribeService", () => {
 
       expect(record.status).toBe("blocked_no_mechanism");
       expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("fails closed on a literal metadata List-Unsubscribe URL without calling fetch", async () => {
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m1",
+            fromEmail: "evil@attacker.test",
+            listUnsubscribe: "<http://169.254.169.254/latest/meta-data/>",
+            listUnsubscribePost: "List-Unsubscribe=One-Click",
+          }),
+        ],
+      });
+      const { service, records } = makeService(gateway);
+
+      const { record } = await service.unsubscribeEmailSender({
+        senderEmail: "evil@attacker.test",
+        userAuthorization: true,
+      });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(record.status).toBe("failed");
+      expect(record.errorMessage).toMatch(/private|internal|blocked/i);
+      expect(records).toHaveLength(1);
+    });
+
+    it("fails closed when a public unsubscribe URL redirects to a loopback target", async () => {
+      fetchSpy.mockImplementation(async () => {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "http://127.0.0.1/secret" },
+        });
+      });
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m1",
+            fromEmail: "news@brand.com",
+            listUnsubscribe: "<https://brand.com/unsub>",
+            listUnsubscribePost: "List-Unsubscribe=One-Click",
+          }),
+        ],
+      });
+      const { service, records } = makeService(gateway);
+
+      const { record } = await service.unsubscribeEmailSender({
+        senderEmail: "news@brand.com",
+        userAuthorization: true,
+      });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(record.status).toBe("failed");
+      expect(record.errorMessage).toMatch(/blocked/i);
+      expect(records).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
# Relates to

Closes #18687

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused verification was run on the touched surfaces after sync (see Testing).
      Full `bun run verify` was **not** re-run this cycle; scoped unsubscribe unit
      suite is the proof for this SSRF transport change.
- [x] A reviewer can confirm the change from the unit transcript and matrix below
      without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `origin/develop`; zero conflicts.
- [x] Focused suite green. Full `bun run verify` not claimed this cycle
      (plugin-inbox unsubscribe HTTP path only; see Known gaps).

# Risks

**Low–medium (security hardening).** Changes only how HTTP List-Unsubscribe
targets are fetched:

- **With a public http(s) endpoint:** one-click POST / GET still run through the
  shared SSRF guard; status and final URL are recorded as before.
- **With a private / loopback / link-local / blocked hostname target:** the
  guard fails closed before transport; the attempt is recorded as `failed` with
  the SSRF error message (no silent success).
- **With a public URL that redirects to a private target:** redirect hops are
  revalidated; the attempt fails closed after the first hop.
- Mailto unsubscribe and the two-phase authorization gate are unchanged.
- Production uses Node-pinned SSRF defaults; unit tests inject a deterministic
  `fetchImpl` so the real policy still runs.

# Background

## What does this PR do?

Fixes #18687: `InboxUnsubscribeService.performHttpUnsubscribe` no longer uses
raw `fetch(..., { redirect: \"follow\" })` on attacker-influenced email header
URLs.

- Route List-Unsubscribe HTTP through `fetchWithSsrfGuard` from `@elizaos/core`
- Manual redirect mode with a bounded hop count; timeout 15s
- Injectable `httpTransport` seam for deterministic unit tests
- Unit coverage for success, metadata IP block, and redirect-to-loopback block

## What kind of change is this?

Bug fix / security hardening (fail-closed untrusted URL fetch).

# Documentation changes needed?

My changes do not require a change to the project documentation. The service
module header documents the SSRF contract.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-inbox/src/inbox/unsubscribe-service.ts` — `performHttpUnsubscribe`
2. `plugins/plugin-inbox/test/unsubscribe-service.test.ts` — acceptance matrix

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-inbox test test/unsubscribe-service.test.ts
bunx @biomejs/biome check plugins/plugin-inbox/src/inbox/unsubscribe-service.ts plugins/plugin-inbox/test/unsubscribe-service.test.ts
```

Result (exact head `3d5a7fedd5a9`):

```text
 Test Files  1 passed (1)
      Tests  11 passed (11)
   Duration  11.56s
```

Biome: clean on the two touched files.

Deterministic matrix:

```text
List-Unsubscribe https://brand.com/unsub (one-click)
  => POST via SSRF guard; status succeeded; transport called once

List-Unsubscribe http://169.254.169.254/...
  => failed closed before transport; error matches /private|internal|blocked/i

List-Unsubscribe https://brand.com/unsub → 302 Location: http://127.0.0.1/secret
  => failed after first hop; error matches /blocked/i; transport called once

mailto:unsub@shop.com
  => Gmail gateway only; HTTP transport not called

userAuthorization missing
  => 409 gate unchanged
```

Package-wide `bun run --cwd plugins/plugin-inbox test` also ran: 135 unit tests
passed; 4 real-runtime/live suites fail to resolve `@elizaos/vault` entry on this
worktree (pre-existing environment issue, unrelated to this diff).

# Evidence Gate

<!-- evidence-head:3d5a7fedd5a96aa4d302f72a749cd93ea3b04590 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; pure service HTTP transport path with injected fetch.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; pure service HTTP transport path with injected fetch.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow; proof is the vitest transcript and SSRF matrix.
<!-- evidence-row:backend-logs -->
- [x] N/A - no HTTP server path under test; List-Unsubscribe fetch is stubbed via injected transport under the real guard.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior involved.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused Vitest output (11/11 pass) and the SSRF matrix above; domain artifact is the recorded unsubscribe status for blocked vs allowed targets.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text to OCR.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model changes.

## Backend + frontend logs

N/A - unit path only; focused vitest + matrix under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI. Live network unsubscribe against a real ESP endpoint is out of scope
for this unit-only SSRF transport repair (injected transport proves policy).

## Audio / voice walkthrough

N/A - no voice/TTS/STT surface.

## Known gaps / failures

- Full root `bun run verify` not run this cycle; change is limited to
  `plugin-inbox` unsubscribe HTTP transport and its unit tests.
- Live network List-Unsubscribe against a real ESP is not exercised (requires
  Gmail credentials and outbound network; unit matrix covers policy).
- Package-wide real-runtime/live suites fail on this worktree with missing
  `@elizaos/vault` package entry resolution; pre-existing and unrelated to this
  diff (135 non-integration unit tests still passed).

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-rama0x1]
<!-- elizaos-contribution-attribution:v2 {\"provider\":\"xai\",\"model\":\"grok-4.5\",\"client\":\"grok\",\"skill_revision\":\"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza\",\"run\":{\"schema_version\":\"1\",\"run_id\":\"run_01KZV266JDW8KGAFFG1794PFR8\",\"project\":\"eliza\",\"repository\":\"elizaOS/eliza\",\"started_at\":\"2026-08-12T13:22:03.469Z\",\"completed_at\":\"2026-08-12T13:26:49.187Z\",\"skill_sha256\":\"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6\",\"usage\":{\"source\":\"ccusage-session-v20\",\"confidence\":\"unavailable\",\"input_tokens\":0,\"output_tokens\":0,\"cache_creation_tokens\":0,\"cache_read_tokens\":0,\"total_tokens\":0,\"cost_micro_usd\":\"0\",\"session_count\":0},\"trajectory_sha256\":null,\"signature_algorithm\":\"ed25519\",\"device_public_key\":\"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI\",\"device_key_id\":\"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea\",\"device_signature\":\"wmzyH5DERRWGFQsNBRU59x6fZbwkRDIDvMOI55BqShf3T4p8G46PpxEBdoiKBDErl2L7dkjVS3c2tjmu8qsqDw\"}} -->