### PR TITLE
fix(inbox): route List-Unsubscribe HTTP fetches through shared SSRF guard

### DIFF
--- a/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
+++ b/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
@@ -19,7 +19,7 @@
  */
 
 import crypto from "node:crypto";
-import type { IAgentRuntime } from "@elizaos/core";
+import { fetchWithSsrfGuard, type IAgentRuntime } from "@elizaos/core";
 import {
   fail,
   type LifeOpsGmailMessageSummary,
@@ -139,6 +139,7 @@ function parseMailtoUnsubscribe(value: string): {
 async function performHttpUnsubscribe(args: {
   url: string;
   oneClick: boolean;
+  fetchImpl?: typeof fetch;
 }): Promise<{
   ok: boolean;
   status: number;
@@ -149,20 +150,28 @@ async function performHttpUnsubscribe(args: {
   if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
     fail(400, "Unsubscribe URL must be http or https.");
   }
-  const response = await fetch(parsed.toString(), {
-    method: args.oneClick ? "POST" : "GET",
-    headers: args.oneClick
-      ? { "Content-Type": "application/x-www-form-urlencoded" }
-      : undefined,
-    body: args.oneClick ? "List-Unsubscribe=One-Click" : undefined,
-    redirect: "follow",
+  const guarded = await fetchWithSsrfGuard({
+    url: parsed.toString(),
+    fetchImpl: args.fetchImpl,
+    init: {
+      method: args.oneClick ? "POST" : "GET",
+      headers: args.oneClick
+        ? { "Content-Type": "application/x-www-form-urlencoded" }
+        : undefined,
+      body: args.oneClick ? "List-Unsubscribe=One-Click" : undefined,
+    },
   });
-  return {
-    ok: response.ok,
-    status: response.status,
-    finalUrl: response.url || parsed.toString(),
-    method: args.oneClick ? "http_one_click" : "http_get",
-  };
+  try {
+    const { response, finalUrl } = guarded;
+    return {
+      ok: response.ok,
+      status: response.status,
+      finalUrl: response.url || finalUrl || parsed.toString(),
+      method: args.oneClick ? "http_one_click" : "http_get",
+    };
+  } finally {
+    await guarded.release?.();
+  }
 }
 
 function headersOf(
@@ -178,11 +187,14 @@ export interface InboxUnsubscribeServiceDeps {
   gmail?: InboxGmailGateway;
   /** Override the persistence repository (tests inject a fake or PGlite-backed one). */
   repository?: InboxUnsubscribeRepository;
+  /** Optional custom fetch implementation (passed to fetchWithSsrfGuard). */
+  fetchImpl?: typeof fetch;
 }
 
 export class InboxUnsubscribeService {
   private readonly gmail: InboxGmailGateway;
   private readonly repository: InboxUnsubscribeRepository;
+  private readonly fetchImpl?: typeof fetch;
 
   constructor(
     private readonly runtime: IAgentRuntime,
@@ -192,6 +204,7 @@ export class InboxUnsubscribeService {
       deps.gmail ?? createInboxGmailGateway(runtime, runtime.agentId);
     this.repository =
       deps.repository ?? new InboxUnsubscribeRepository(runtime);
+    this.fetchImpl = deps.fetchImpl;
   }
 
   private get agentId(): string {
@@ -351,6 +364,7 @@ export class InboxUnsubscribeService {
         const http = await performHttpUnsubscribe({
           url: sender.unsubscribeHttpUrl,
           oneClick: sender.unsubscribeMethod === "http_one_click",
+          fetchImpl: this.fetchImpl ?? (globalThis.fetch as typeof fetch),
         });
         method = http.method;
         httpStatusCode = http.status;

--- a/plugins/plugin-inbox/test/unsubscribe-service.test.ts
+++ b/plugins/plugin-inbox/test/unsubscribe-service.test.ts
@@ -280,6 +280,65 @@ describe("InboxUnsubscribeService", () => {
       expect(records[0]?.metadata.connectorAccountId).toBe("acct-1");
     });
 
+    it("blocks private/loopback targets via SSRF guard", async () => {
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m1",
+            fromEmail: "attacker@malicious.com",
+            listUnsubscribe: "<http://127.0.0.1/unsub>",
+            listUnsubscribePost: "List-Unsubscribe=One-Click",
+          }),
+        ],
+      });
+      const { service, records } = makeService(gateway);
+
+      const { record } = await service.unsubscribeEmailSender({
+        senderEmail: "attacker@malicious.com",
+        userAuthorization: true,
+      });
+
+      expect(record.status).toBe("failed");
+      expect(record.errorMessage).toMatch(
+        /SSRF|blocked|private|loopback|localhost/i,
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(records).toHaveLength(1);
+    });
+
+    it("blocks redirect to private host via SSRF guard", async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 302,
+        headers: new Headers({
+          location: "http://169.254.169.254/latest/meta-data",
+        }),
+        url: "https://public-redirector.com/unsub",
+      } as unknown as Response);
+
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m1",
+            fromEmail: "attacker@malicious.com",
+            listUnsubscribe: "<https://public-redirector.com/unsub>",
+          }),
+        ],
+      });
+      const { service, records } = makeService(gateway);
+
+      const { record } = await service.unsubscribeEmailSender({
+        senderEmail: "attacker@malicious.com",
+        userAuthorization: true,
+      });
+
+      expect(record.status).toBe("failed");
+      expect(record.errorMessage).toMatch(
+        /SSRF|blocked|private|loopback|link-local/i,
+      );
+      expect(records).toHaveLength(1);
+    });
+
     it("sends a mailto unsubscribe through the Gmail gateway", async () => {
       const sendMailto = vi.fn(async () => undefined);
       const gateway = makeGateway({


### PR DESCRIPTION
# Relates to

Closes #18687

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun run --cwd plugins/plugin-inbox test`, `typecheck`, and `lint:check` were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Antigravity / Gemini 3.6 Flash (High)`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused `plugin-inbox` test suite, `typecheck`, and `lint:check` pass post-sync.

# Risks

**Low.** Changes only how `InboxUnsubscribeService.performHttpUnsubscribe` fetches `List-Unsubscribe` URLs in `@elizaos/plugin-inbox`:
- `performHttpUnsubscribe` now uses core's `fetchWithSsrfGuard` instead of raw un-guarded `fetch`.
- Private, loopback, link-local, or blocked IP/host targets fail closed immediately before making network requests.
- Redirect hops are re-validated by `fetchWithSsrfGuard` (preventing redirect-based SSRF into private networks).
- Mailto unsubscribe and non-HTTP paths are completely unaffected.

# Background

## What does this PR do?

Fixes #18687: Routes `List-Unsubscribe` HTTP requests through `fetchWithSsrfGuard` from `@elizaos/core` to prevent SSRF vulnerability when processing attacker-influenced email headers or redirect chains landing on private/internal hosts.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-inbox/src/inbox/unsubscribe-service.ts` — `performHttpUnsubscribe` using `fetchWithSsrfGuard`.
2. `plugins/plugin-inbox/test/unsubscribe-service.test.ts` — SSRF guard test cases for private targets and redirect hops.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-inbox test
bun run --cwd plugins/plugin-inbox typecheck
bun run --cwd plugins/plugin-inbox lint:check
```

Results:
- `test`: 6 test files passed, 71 tests passed (11/11 in `unsubscribe-service.test.ts`).
- `typecheck`: clean (0 errors).
- `lint:check`: clean (60 files checked).

# Evidence Gate

<!-- evidence-head:b86d0193553c84ec5568bcf417d9ceed7bac6e96 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - pure backend plugin service change; no UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - pure backend plugin service change; no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changed; pure backend plugin fetch guard.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server log surface; verified via vitest suite.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, action, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused Vitest suite output (71/71 pass across 6 files in `plugin-inbox`).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model changes.

## Backend + frontend logs

N/A - pure backend plugin service; unit test proof under Testing.

## Screenshots (before / after) + video walkthrough

N/A - pure backend plugin service with no UI surface.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT surface.

## Known gaps / failures

- Full repository `bun run verify` was **not** run this cycle; change is strictly isolated to `plugins/plugin-inbox` email unsubscribe SSRF guarding and unit tests.
- Focused package tests (`bun run --cwd plugins/plugin-inbox test`), typecheck, and Biome linting all passed cleanly.

AI provider/model: Antigravity / Gemini 3.6 Flash (High)
Client / agent tooling: Antigravity
Provenance status: self-reported
— [rama0x1-unattended]
