### PR TITLE
fix(agent): fail closed on non-finite relative timestamps

### DIFF
--- a/packages/agent/src/shared/conversation-format.test.ts
+++ b/packages/agent/src/shared/conversation-format.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for conversation presentation helpers used by recent/relevant
+ * conversation providers. Covers relative-timestamp fail-closed behavior for
+ * non-finite and out-of-range createdAt values, plus the healthy finite buckets.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  formatRelativeTimestamp,
+  roomSourceTag,
+} from "./conversation-format.ts";
+
+describe("formatRelativeTimestamp", () => {
+  it("returns empty for missing, zero, and non-finite timestamps", () => {
+    expect(formatRelativeTimestamp(undefined)).toBe("");
+    expect(formatRelativeTimestamp(0)).toBe("");
+    expect(formatRelativeTimestamp(Number.NaN)).toBe("");
+    expect(formatRelativeTimestamp(Number.POSITIVE_INFINITY)).toBe("");
+    expect(formatRelativeTimestamp(Number.NEGATIVE_INFINITY)).toBe("");
+    // Outside the Date range: getTime() is NaN even though the number is finite.
+    expect(formatRelativeTimestamp(Number.MAX_VALUE)).toBe("");
+  });
+
+  it("does not emit NaN-based garbage labels", () => {
+    for (const value of [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      Number.MAX_VALUE,
+    ]) {
+      const label = formatRelativeTimestamp(value);
+      expect(label).not.toMatch(/NaN/i);
+      expect(label).toBe("");
+    }
+  });
+
+  it("formats finite recent past timestamps into coarse buckets", () => {
+    const now = Date.now();
+    expect(formatRelativeTimestamp(now - 5_000)).toBe("just now");
+    expect(formatRelativeTimestamp(now - 2 * 60_000)).toBe("2m ago");
+    expect(formatRelativeTimestamp(now - 3 * 3_600_000)).toBe("3h ago");
+    expect(formatRelativeTimestamp(now - 4 * 86_400_000)).toBe("4d ago");
+  });
+
+  it("treats near-future timestamps as just now (clock skew)", () => {
+    expect(formatRelativeTimestamp(Date.now() + 15_000)).toBe("just now");
+  });
+});
+
+describe("roomSourceTag", () => {
+  it("renders source and name, with fallbacks for missing room", () => {
+    expect(roomSourceTag(null)).toBe("[unknown]");
+    expect(
+      roomSourceTag({
+        id: "11111111-1111-1111-1111-111111111111",
+        source: "discord",
+        name: "general",
+        type: "GROUP",
+      } as never),
+    ).toBe("[discord] general");
+  });
+});

--- a/packages/agent/src/shared/conversation-format.ts
+++ b/packages/agent/src/shared/conversation-format.ts
@@ -4,7 +4,8 @@
  * character name for the agent, otherwise a display/username pair pulled from
  * message metadata (source-specific keys first). roomSourceTag renders a
  * "[source] name" room tag, and formatRelativeTimestamp renders a createdAt as a
- * coarse "just now / Nm / Nh / Nd ago" string.
+ * coarse "just now / Nm / Nh / Nd ago" string. Non-finite timestamps fail closed
+ * to an empty label rather than leaking "NaNd ago" into provider context.
  */
 import type { IAgentRuntime, Memory, Room } from "@elizaos/core";
 import { asNonEmptyString, asRecord } from "@elizaos/shared";
@@ -77,12 +78,19 @@ export function roomSourceTag(room: Room | null): string {
 
 /**
  * Format a createdAt timestamp as a human-readable relative string.
+ *
+ * Missing, zero, and non-finite inputs (NaN / ±Infinity / out-of-range Date
+ * values) return an empty string so provider context never shows garbage like
+ * "NaNd ago". Finite past timestamps keep the existing coarse buckets.
  */
 export function formatRelativeTimestamp(createdAt?: number): string {
-  if (!createdAt) return "";
-  const date = new Date(createdAt);
-  const now = Date.now();
-  const diffMs = now - date.getTime();
+  if (createdAt == null || createdAt === 0) return "";
+  // Construct Date first and require a finite getTime(). That rejects NaN /
+  // ±Infinity and finite values outside the Date range, which still pass
+  // Number.isFinite but yield NaN from getTime() and "NaNd ago" from floor.
+  const time = new Date(createdAt).getTime();
+  if (!Number.isFinite(time)) return "";
+  const diffMs = Date.now() - time;
   if (diffMs < 60_000) return "just now";
   const minutes = Math.floor(diffMs / 60_000);
   if (minutes < 60) return `${minutes}m ago`;


### PR DESCRIPTION
# Relates to

Closes #18693

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused verification was run on the touched surfaces after sync (see Testing).
      Full `bun run verify` was **not** run this cycle; scoped agent unit suite is the
      proof for this pure presentation helper change.
- [x] A reviewer can confirm the change from the unit transcript and matrices
      below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `origin/develop`; zero conflicts.
- [x] Focused suite green. Full `bun run verify` not claimed this cycle
      (agent conversation presentation helper + unit tests only).

# Risks

**Low.** Changes only the fail-closed behavior of `formatRelativeTimestamp` when
`createdAt` is non-finite or outside the Date range:

- `NaN` / `±Infinity` / `Number.MAX_VALUE` previously produced labels containing
  `NaN` (for example `"NaNd ago"`) in provider prompt context.
- Those inputs now return `""` (same as missing/zero), so memory age is simply
  omitted rather than polluted.
- Finite healthy past timestamps keep the existing coarse buckets unchanged.
- Call sites (recent/relevant conversations, page-scoped context) already treat
  empty age labels as optional decoration.

# Background

## What does this PR do?

`formatRelativeTimestamp` only falsy-checked `createdAt`, then floored
`Date.now() - new Date(createdAt).getTime()`. For `Infinity` and out-of-range
values, `getTime()` is `NaN`, so the day branch rendered `"NaNd ago"` into
conversation provider text.

The fix requires a finite `Date.getTime()` before any unit flooring, matching
the fail-closed pattern already used in core/UI relative-time formatters.

## What kind of change is this?

Bug fix (presentation / fail-closed; no API shape change).

# Documentation changes needed?

My changes do not require a change to the project documentation. The module
header and function JSDoc document the fail-closed contract.

# Testing

## Where should a reviewer start?

1. `packages/agent/src/shared/conversation-format.ts` — `formatRelativeTimestamp`
2. `packages/agent/src/shared/conversation-format.test.ts` — non-finite matrix + finite buckets

## Detailed testing steps

```bash
bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/shared/conversation-format.test.ts
bunx biome check packages/agent/src/shared/conversation-format.ts packages/agent/src/shared/conversation-format.test.ts
```

Result (exact head `fbf78cdcd1` / `fbf78cdcd1f0632779a3f09e6dc83c70e86e5ec3`):

```text
 Test Files  1 passed (1)
      Tests  5 passed (5)
   Duration  8.38s
```

Biome: clean on the two touched files.

Deterministic matrix:

```text
formatRelativeTimestamp(undefined | 0 | NaN | ±Infinity | MAX_VALUE)
  => ""

formatRelativeTimestamp(now - 5s)   => "just now"
formatRelativeTimestamp(now - 2m)   => "2m ago"
formatRelativeTimestamp(now - 3h)   => "3h ago"
formatRelativeTimestamp(now - 4d)   => "4d ago"
formatRelativeTimestamp(now + 15s)  => "just now"  (clock skew)
```

# Evidence Gate

<!-- evidence-head:fbf78cdcd1f0632779a3f09e6dc83c70e86e5ec3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; pure string helper used in agent provider prompt text.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; pure string helper used in agent provider prompt text.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow; proof is the vitest transcript and matrix above.
<!-- evidence-row:backend-logs -->
- [x] N/A - no HTTP server path under test; pure function unit tests.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior logic changed beyond age-label formatting of provider context.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused Vitest output (5 passed) and the non-finite/finite matrix above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text to OCR.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model changes beyond optional age-label string formatting.

## Backend + frontend logs

N/A - unit path only; focused vitest + matrix under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI. Provider context labels are plain strings verified by unit tests.

## Audio / voice walkthrough

N/A - no voice/TTS/STT surface.

## Known gaps / failures

- Full root `bun run verify` not run this cycle; change is limited to one agent
  presentation helper and its unit tests.
- Package-wide `bun run --cwd packages/agent typecheck` reports pre-existing
  unresolved optional-plugin/type-shim errors unrelated to this change; the
  touched pure TypeScript files typecheck via the vitest transform path.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-rama0x1]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZV31V2BKRVQJQYBWNNEYA06","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T13:37:09.195Z","completed_at":"2026-08-12T13:45:37.779Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"vVBenvMT8kyJAXSDizaW7mFdJjZjDaVdHdTaTVePiy39isGg3EO9iMK7t3l-p0ALE0uxcgMsvULQIY0aA5fEBA"}} -->