### PR TITLE
fix(ui): hide desktop Discord/iMessage connector modes on managed Cloud

### DIFF
--- a/packages/ui/src/components/connectors/ConnectorModeSelector.helpers.ts
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.helpers.ts
@@ -1,8 +1,9 @@
 /**
  * Pure helpers backing `ConnectorModeSelector`: resolves a connector's ordered
  * setup modes from the connector-mode registry, appends the plugin-managed mode
- * from the connector-account catalog when applicable, filters cloud-only modes
- * by Eliza Cloud connectivity, and maps a selected mode to its setup plugin id.
+ * from the connector-account catalog when applicable, filters modes by cloud
+ * connectivity and managed-container availability, and maps a selected mode to
+ * its setup plugin id.
  */
 
 import {
@@ -57,7 +58,8 @@ function withPluginManagedMode(
 /**
  * Returns available modes for a connector, rendered generically from the modes
  * the connector plugin declared in the connector-mode registry. Cloud-only
- * modes are filtered out when Eliza Cloud is not connected. When a global
+ * modes are filtered out when Eliza Cloud is not connected, and co-located
+ * desktop modes can opt out of managed Cloud containers. When a global
  * `channelMode` lens is given, declared modes classified into the *other* lens
  * are filtered out too, and plugin-managed injection follows the same
  * `connectorSupportsChannelMode` policy used by the index/detail surfaces.
@@ -66,13 +68,16 @@ export function getConnectorModes(
   connectorId: string,
   options?: {
     elizaCloudConnected?: boolean;
+    cloudProvisioned?: boolean;
     channelMode?: ConnectorChannelMode;
   },
 ): ConnectorMode[] {
   const cloud = options?.elizaCloudConnected ?? false;
+  const managedCloud = options?.cloudProvisioned ?? false;
   const lens = options?.channelMode;
   const modes: ConnectorMode[] = getDeclaredConnectorModes(connectorId)
     .filter((mode) => cloud || !mode.cloudOnly)
+    .filter((mode) => !managedCloud || !mode.hideOnManagedCloud)
     .filter(
       (mode) =>
         lens === undefined ||

--- a/packages/ui/src/components/connectors/ConnectorModeSelector.hooks.ts
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.hooks.ts
@@ -1,7 +1,7 @@
 /**
  * React state hook for `ConnectorModeSelector`: tracks the selected connector
  * mode, seeds it from the connector's default, and re-defaults when the
- * available mode list changes (e.g. Eliza Cloud connects/disconnects).
+ * available mode list changes (e.g. cloud connectivity or hosting changes).
  */
 
 import { useEffect, useState } from "react";
@@ -22,6 +22,7 @@ export function useConnectorMode(
   connectorId: string,
   options?: {
     elizaCloudConnected?: boolean;
+    cloudProvisioned?: boolean;
     channelMode?: ConnectorChannelMode;
   },
 ) {

--- a/packages/ui/src/components/connectors/ConnectorModeSelector.tsx
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.tsx
@@ -17,18 +17,22 @@ export function ConnectorModeSelector({
   selectedMode,
   onModeChange,
   elizaCloudConnected,
+  cloudProvisioned,
   channelMode,
 }: {
   connectorId: string;
   selectedMode: string;
   onModeChange: (modeId: string) => void;
   elizaCloudConnected?: boolean;
+  /** Whether the agent host is a managed Eliza Cloud container. */
+  cloudProvisioned?: boolean;
   /** Global channel-mode lens; filters out modes classified into the other lens. */
   channelMode?: ConnectorChannelMode;
 }) {
   const t = useAppSelector((s) => s.t);
   const modes = getConnectorModes(connectorId, {
     elizaCloudConnected,
+    cloudProvisioned,
     channelMode,
   });
 

--- a/packages/ui/src/components/connectors/connector-mode-registry.test.ts
+++ b/packages/ui/src/components/connectors/connector-mode-registry.test.ts
@@ -94,6 +94,96 @@ describe("connector mode registry seam", () => {
     expect(modeToSetupPluginId("discord", "bot")).toBe("discord");
   });
 
+  it("hides only co-located desktop modes in managed Cloud containers", () => {
+    expect(
+      getConnectorModes("discord", {
+        elizaCloudConnected: true,
+        cloudProvisioned: true,
+      }).map((mode) => mode.id),
+    ).toEqual(["managed", "bot"]);
+    expect(
+      getConnectorModes("imessage", {
+        elizaCloudConnected: true,
+        cloudProvisioned: true,
+      }).map((mode) => mode.id),
+    ).toEqual(["blooio", "cloud-bluebubbles", "bluebubbles"]);
+
+    expect(
+      getConnectorModes("telegram", {
+        elizaCloudConnected: true,
+        cloudProvisioned: true,
+      }).map((mode) => mode.id),
+    ).toContain("account");
+    expect(
+      getConnectorModes("signal", { cloudProvisioned: true }).map(
+        (mode) => mode.id,
+      ),
+    ).toContain("qr");
+    expect(
+      getConnectorModes("whatsapp", { cloudProvisioned: true }).map(
+        (mode) => mode.id,
+      ),
+    ).toContain("qr");
+    expect(
+      getConnectorModes("bluebubbles", { cloudProvisioned: true }).map(
+        (mode) => mode.id,
+      ),
+    ).toContain("local");
+  });
+
+  it("keeps co-located desktop modes outside managed Cloud containers", () => {
+    expect(
+      getConnectorModes("discord", {
+        elizaCloudConnected: true,
+        cloudProvisioned: false,
+      }).map((mode) => mode.id),
+    ).toContain("local");
+    expect(
+      getConnectorModes("imessage", {
+        elizaCloudConnected: true,
+        cloudProvisioned: false,
+      }).map((mode) => mode.id),
+    ).toContain("direct");
+  });
+
+  it("applies Cloud connectivity and managed-container filtering independently", () => {
+    registerConnectorModes("cloud-filter-seam", [
+      {
+        id: "cloud",
+        label: "Cloud",
+        description: "Requires an Eliza Cloud connection.",
+        setupPluginId: "cloud-filter-seam",
+        cloudOnly: true,
+      },
+      {
+        id: "desktop",
+        label: "Desktop",
+        description: "Requires a co-located desktop.",
+        setupPluginId: "cloud-filter-seam",
+        hideOnManagedCloud: true,
+      },
+      {
+        id: "always",
+        label: "Always",
+        description: "Available in every hosting configuration.",
+        setupPluginId: "cloud-filter-seam",
+      },
+    ]);
+
+    expect(
+      getConnectorModes("cloud-filter-seam", {
+        elizaCloudConnected: false,
+        cloudProvisioned: false,
+      }).map((mode) => mode.id),
+    ).toEqual(["desktop", "always"]);
+    expect(
+      getConnectorModes("cloud-filter-seam", {
+        elizaCloudConnected: true,
+        cloudProvisioned: true,
+      }).map((mode) => mode.id),
+    ).toEqual(["cloud", "always"]);
+  });
+
   it("offers BlueBubbles phone registration only when Eliza Cloud is connected", () => {
     const offline = getConnectorModes("bluebubbles", {
       elizaCloudConnected: false,

--- a/packages/ui/src/components/connectors/connector-mode-registry.ts
+++ b/packages/ui/src/components/connectors/connector-mode-registry.ts
@@ -54,6 +54,8 @@ export interface ConnectorModeDeclaration {
   setupPluginId: string;
   /** Mode is only offered when Eliza Cloud is connected. */
   cloudOnly?: boolean;
+  /** Mode is unavailable inside a managed Eliza Cloud agent container. */
+  hideOnManagedCloud?: boolean;
   /**
    * Which global channel-mode lens this setup mode belongs to: `"delegate"`
    * when the agent acts through the owner's own account on the platform, or
@@ -322,6 +324,7 @@ registerConnectorModes("discord", [
     managementMode: "local-setup",
     setupPluginId: "discordlocal",
     channelMode: "delegate",
+    hideOnManagedCloud: true,
   },
   {
     id: "bot",
@@ -523,6 +526,7 @@ registerConnectorModes("imessage", [
     managementMode: "local-setup",
     setupPluginId: "imessage",
     channelMode: "delegate",
+    hideOnManagedCloud: true,
     defaultPriority: 2,
   },
   {

--- a/packages/ui/src/components/pages/plugin-view-connectors.tsx
+++ b/packages/ui/src/components/pages/plugin-view-connectors.tsx
@@ -409,14 +409,23 @@ function ConnectorPluginCard({
   testResults,
   togglingPlugins,
 }: ConnectorPluginCardProps) {
-  const { elizaCloudConnected, setActionNotice, setState, setTab } =
-    useAppSelectorShallow((s) => ({
-      elizaCloudConnected: s.elizaCloudConnected,
-      setActionNotice: s.setActionNotice,
-      setState: s.setState,
-      setTab: s.setTab,
-    }));
-  const connectorMode = useConnectorMode(plugin.id, { elizaCloudConnected });
+  const {
+    cloudProvisioned,
+    elizaCloudConnected,
+    setActionNotice,
+    setState,
+    setTab,
+  } = useAppSelectorShallow((s) => ({
+    cloudProvisioned: s.firstRunCloudProvisionedContainer,
+    elizaCloudConnected: s.elizaCloudConnected,
+    setActionNotice: s.setActionNotice,
+    setState: s.setState,
+    setTab: s.setTab,
+  }));
+  const connectorMode = useConnectorMode(plugin.id, {
+    cloudProvisioned,
+    elizaCloudConnected,
+  });
   const [managedDiscordBusy, setManagedDiscordBusy] = useState(false);
   // Keyed by role so the "agent" and "your account" buttons can each show
   // their own loading state — clicking one no longer disables the other.
@@ -988,6 +997,7 @@ function ConnectorPluginCard({
             selectedMode={connectorMode.selectedMode}
             onModeChange={connectorMode.setSelectedMode}
             elizaCloudConnected={elizaCloudConnected}
+            cloudProvisioned={cloudProvisioned}
           />
         )}
 

--- a/packages/ui/src/components/settings/ConnectorsSection.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.tsx
@@ -268,6 +268,9 @@ function ConnectorListRow({
 function ConnectorConfigurationSurface({ plugin }: { plugin: PluginInfo }) {
   const t = useAppSelector((s) => s.t);
   const elizaCloudConnected = useAppSelector((s) => s.elizaCloudConnected);
+  const cloudProvisioned = useAppSelector(
+    (s) => s.firstRunCloudProvisionedContainer,
+  );
   const handlePluginConfigSave = useAppSelector(
     (s) => s.handlePluginConfigSave,
   );
@@ -281,6 +284,7 @@ function ConnectorConfigurationSurface({ plugin }: { plugin: PluginInfo }) {
   const channelMode = useConnectorChannelMode();
   const connectorMode = useConnectorMode(plugin.id, {
     elizaCloudConnected,
+    cloudProvisioned,
     channelMode,
   });
   const setupPluginId = connectorMode.setupPluginId;
@@ -377,6 +381,7 @@ function ConnectorConfigurationSurface({ plugin }: { plugin: PluginInfo }) {
             selectedMode={connectorMode.selectedMode}
             onModeChange={connectorMode.setSelectedMode}
             elizaCloudConnected={elizaCloudConnected}
+            cloudProvisioned={cloudProvisioned}
             channelMode={channelMode}
           />
         </div>


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

No existing issue specifically tracked this UX gap; scoped from Connectors mode review for managed Cloud agents (`cloudProvisioned`).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `cursor/grok-4.5`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `cursor`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill receipt for this Cursor session`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** UI-only filtering of two already-unusable setup modes on managed Cloud containers. Local desktop and non-provisioned agents keep the modes. Bot/cloud gateway modes are unchanged. Mis-wiring the signal to hostname/`elizaCloudConnected` was avoided; uses `cloudProvisioned` / `firstRunCloudProvisionedContainer`.

# Background

## What does this PR do?

Hides co-located desktop/Mac Connectors modes when the agent reports `cloudProvisioned`:

- Discord `local` (Desktop App / IPC)
- iMessage `direct` (chat.db + Full Disk Access)

Adds a declarative `hideOnManagedCloud` flag on connector mode declarations and filters it beside the existing `cloudOnly` gate.

## What kind of change is this?

Bug fixes / UX improvement (non-breaking): stop offering setup paths that cannot work inside managed Eliza Cloud agent containers.

## Why are we doing this? Any context or related work?

Managed Cloud agents have no local Discord desktop or Mac Messages DB. Showing those modes creates dead-end Connectors UX. Conservative hide set only — Telegram personal, Signal QR, WhatsApp QR, and remote BlueBubbles stay available.

# Documentation changes needed?

No.

# Testing instructions

1. On a **local desktop** agent (`cloudProvisioned=false`): Settings → Connectors → Discord still shows Desktop App; iMessage still shows Direct (chat.db).
2. On a **managed Cloud** agent (`GET /api/status` → `cloud.cloudProvisioned: true`): Discord Desktop App and iMessage Direct are absent; Discord Bot / Managed and iMessage Blooio / BlueBubbles / Cloud BlueBubbles remain.
3. With Cloud account disconnected: `cloudOnly` modes still hide independently of the managed-container filter.

# Test plan

- [x] Focused unit tests for registry + filtering
- [ ] Manual smoke on local agent Connectors (Discord + iMessage)
- [ ] Manual smoke on managed Cloud agent Connectors (modes hidden)

# Evidence

| Row | Status |
|---|---|
| Focused tests | Pass — `bun test packages/ui/src/components/connectors/connector-mode-registry.test.ts` → **18 pass / 0 fail** |
| Screenshots / recording | N/A — no visual redesign; mode list filtering only |
| Backend logs | N/A — UI filter only; uses existing `/api/status` `cloudProvisioned` |
| Live-model trajectory | N/A — no agent behavior change |
| `bun run verify` | Not re-run on this branch; focused connector tests pass. Pre-existing package typecheck noise reported around unrelated `getAuthStatusSnapshot` fixture if full UI typecheck is required. |

# Known gaps / failures

- Full root `bun run verify` not completed in this session.
- Conservative scope: only Discord Desktop + iMessage Direct; other local-session modes left visible by design.


Made with [Cursor](https://cursor.com)