### PR TITLE
fix(app-core): reject invalid voice-duet numeric CLI overrides

### DIFF
--- a/packages/app-core/scripts/voice-duet-cli.test.ts
+++ b/packages/app-core/scripts/voice-duet-cli.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Focused CLI-boundary tests for voice-duet numeric option validation.
+ * Invalid numeric flags must fail before model load / duet startup.
+ */
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parseArgs, parsePositiveInteger } from "./voice-duet.mjs";
+
+const SCRIPT_PATH = fileURLToPath(new URL("./voice-duet.mjs", import.meta.url));
+
+describe("voice-duet parseArgs numeric validation", () => {
+  it("keeps endless turns and default ringMs when omitted", () => {
+    const args = parseArgs([]);
+    expect(args.turns).toBe(Number.POSITIVE_INFINITY);
+    expect(args.ringMs).toBe(200);
+    expect(args.parallel).toBeNull();
+  });
+
+  it("parses valid numeric overrides", () => {
+    expect(
+      parseArgs([
+        "--turns",
+        "2",
+        "--ring-ms",
+        "200",
+        "--parallel",
+        "2",
+        "--prewarm-lead-ms",
+        "0",
+      ]),
+    ).toMatchObject({
+      turns: 2,
+      ringMs: 200,
+      parallel: 2,
+      prewarmLeadMs: 0,
+    });
+  });
+
+  it.each(["", "0", "-3", "1.5", "10junk", "NaN", "Infinity", "+1"])(
+    "rejects invalid --turns %p",
+    (value) => {
+      expect(() => parseArgs(["--turns", value])).toThrow(/--turns/);
+    },
+  );
+
+  it("rejects missing --ring-ms without consuming the next flag", () => {
+    expect(() => parseArgs(["--ring-ms", "--two-process"])).toThrow(
+      /--ring-ms requires a value/,
+    );
+  });
+
+  it("rejects malformed optional int knobs instead of null", () => {
+    expect(() => parseArgs(["--parallel", "junk"])).toThrow(/--parallel/);
+    expect(() => parseArgs(["--draft-max", "0"])).toThrow(/--draft-max/);
+  });
+
+  it("parsePositiveInteger accepts complete positives", () => {
+    expect(parsePositiveInteger("1", "--turns")).toBe(1);
+    expect(parsePositiveInteger("200", "--ring-ms")).toBe(200);
+  });
+});
+
+describe("voice-duet real CLI rejection", () => {
+  it("exits non-zero with a named flag before loading the voice stack", () => {
+    // voice-duet is a Bun harness (`import.meta.main`); run via bun.
+    const result = spawnSync("bun", [SCRIPT_PATH, "--turns", "junk"], {
+      encoding: "utf8",
+      env: { PATH: process.env.PATH ?? "" },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/--turns/);
+    // Must not start prereq/model load chatter for a pure parse failure.
+    expect(result.stdout + result.stderr).not.toMatch(
+      /Loading|prereq|llama-server|OmniVoice/i,
+    );
+  });
+});

--- a/packages/app-core/scripts/voice-duet.mjs
+++ b/packages/app-core/scripts/voice-duet.mjs
@@ -59,6 +59,37 @@ const __filename = fileURLToPath(import.meta.url);
 // CLI
 // ---------------------------------------------------------------------------
 
+function requireFlagValue(argv, i, flag) {
+  const value = argv[i + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+/**
+ * Accept only a complete positive decimal integer string (>= 1).
+ * Rejects missing, fractional, signed, partial, zero, and non-finite values.
+ */
+function parsePositiveInteger(raw, flag) {
+  if (raw === undefined || raw === null) {
+    throw new Error(`${flag} requires a positive integer >= 1`);
+  }
+  const value = String(raw);
+  if (!/^[1-9]\d*$/.test(value)) {
+    throw new Error(
+      `${flag} must be a positive integer >= 1 (received ${JSON.stringify(value)})`,
+    );
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(
+      `${flag} must be a positive integer >= 1 (received ${JSON.stringify(value)})`,
+    );
+  }
+  return parsed;
+}
+
 function parseArgs(argv) {
   const out = {
     model: "eliza-1-2b",
@@ -87,42 +118,96 @@ function parseArgs(argv) {
   };
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
-    if (a === "--model") out.model = argv[++i] ?? out.model;
-    else if (a === "--turns") {
-      const n = Number(argv[++i]);
-      out.turns = Number.isFinite(n) && n > 0 ? Math.floor(n) : Infinity;
-    } else if (a === "--character-a") out.characterA = argv[++i] ?? null;
-    else if (a === "--character-b") out.characterB = argv[++i] ?? null;
-    else if (a === "--seed-text") out.seedText = argv[++i] ?? out.seedText;
-    else if (a === "--report") out.report = argv[++i] ?? null;
-    else if (a === "--ring-ms") {
-      const n = Number(argv[++i]);
-      if (Number.isFinite(n) && n > 0) out.ringMs = Math.floor(n);
+    if (a === "--model") {
+      out.model = requireFlagValue(argv, i, "--model");
+      i += 1;
+    } else if (a === "--turns") {
+      out.turns = parsePositiveInteger(
+        requireFlagValue(argv, i, "--turns"),
+        "--turns",
+      );
+      i += 1;
+    } else if (a === "--character-a") {
+      out.characterA = requireFlagValue(argv, i, "--character-a");
+      i += 1;
+    } else if (a === "--character-b") {
+      out.characterB = requireFlagValue(argv, i, "--character-b");
+      i += 1;
+    } else if (a === "--seed-text") {
+      out.seedText = requireFlagValue(argv, i, "--seed-text");
+      i += 1;
+    } else if (a === "--report") {
+      out.report = requireFlagValue(argv, i, "--report");
+      i += 1;
+    } else if (a === "--ring-ms") {
+      out.ringMs = parsePositiveInteger(
+        requireFlagValue(argv, i, "--ring-ms"),
+        "--ring-ms",
+      );
+      i += 1;
     } else if (a === "--two-process") out.twoProcess = true;
     else if (a === "--list-active") out.listActive = true;
     else if (a === "--platform-report" || a === "--list-active-platforms")
       out.platformReport = true;
-    else if (a === "--parallel") out.parallel = intArg(argv[++i]);
-    else if (a === "--draft-max") out.draftMax = intArg(argv[++i]);
-    else if (a === "--draft-min") out.draftMin = intArg(argv[++i]);
-    else if (a === "--ctx-size-draft") out.ctxSizeDraft = intArg(argv[++i]);
-    else if (a === "--prewarm-lead-ms") out.prewarmLeadMs = intArg(argv[++i]);
-    else if (a === "--chunk-words") out.chunkWords = intArg(argv[++i]);
-    else if (a === "--kv-cache-type") out.kvCacheType = argv[++i] ?? null;
-    else if (a === "--backend") out.backend = argv[++i] ?? null;
-    else if (a === "--as-peer-b") out.asPeerB = true;
+    else if (a === "--parallel") {
+      out.parallel = parsePositiveInteger(
+        requireFlagValue(argv, i, "--parallel"),
+        "--parallel",
+      );
+      i += 1;
+    } else if (a === "--draft-max") {
+      out.draftMax = parsePositiveInteger(
+        requireFlagValue(argv, i, "--draft-max"),
+        "--draft-max",
+      );
+      i += 1;
+    } else if (a === "--draft-min") {
+      out.draftMin = parsePositiveInteger(
+        requireFlagValue(argv, i, "--draft-min"),
+        "--draft-min",
+      );
+      i += 1;
+    } else if (a === "--ctx-size-draft") {
+      out.ctxSizeDraft = parsePositiveInteger(
+        requireFlagValue(argv, i, "--ctx-size-draft"),
+        "--ctx-size-draft",
+      );
+      i += 1;
+    } else if (a === "--prewarm-lead-ms") {
+      // allow 0 for prewarm lead (issue: positive for other knobs; prewarm 0 is valid)
+      const raw = requireFlagValue(argv, i, "--prewarm-lead-ms");
+      if (!/^(0|[1-9]\d*)$/.test(String(raw))) {
+        throw new Error(
+          `--prewarm-lead-ms must be an integer >= 0 (received ${JSON.stringify(String(raw))})`,
+        );
+      }
+      const n = Number(raw);
+      if (!Number.isSafeInteger(n) || n < 0) {
+        throw new Error(
+          `--prewarm-lead-ms must be an integer >= 0 (received ${JSON.stringify(String(raw))})`,
+        );
+      }
+      out.prewarmLeadMs = n;
+      i += 1;
+    } else if (a === "--chunk-words") {
+      out.chunkWords = parsePositiveInteger(
+        requireFlagValue(argv, i, "--chunk-words"),
+        "--chunk-words",
+      );
+      i += 1;
+    } else if (a === "--kv-cache-type") {
+      out.kvCacheType = requireFlagValue(argv, i, "--kv-cache-type");
+      i += 1;
+    } else if (a === "--backend") {
+      out.backend = requireFlagValue(argv, i, "--backend");
+      i += 1;
+    } else if (a === "--as-peer-b") out.asPeerB = true;
     else if (a === "--help" || a === "-h") out.help = true;
     else {
-      console.error(`[voice-duet] unknown argument: ${a}`);
-      out.help = true;
+      throw new Error(`unknown argument: ${a}`);
     }
   }
   return out;
-}
-
-function intArg(s) {
-  const n = Number(s);
-  return Number.isFinite(n) ? Math.floor(n) : null;
 }
 
 const USAGE = `Usage: bun run --cwd packages/app-core voice:duet [-- <options>]
@@ -1341,7 +1426,15 @@ async function runAsPeerB(args) {
 // ---------------------------------------------------------------------------
 
 if (import.meta.main) {
-  const parsed = parseArgs(process.argv.slice(2));
+  let parsed;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(
+      `[voice-duet] ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
   if (parsed.asPeerB) {
     runAsPeerB(parsed).catch((err) => {
       process.stderr.write(
@@ -1371,4 +1464,5 @@ export {
   extractEmotionFromTranscript,
   loadCharacter,
   parseArgs,
+  parsePositiveInteger,
 };


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18692

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused package checks were run after sync; full monorepo `bun run verify`
      is not claimed below.
- [x] A reviewer can confirm the change from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused package checks pass post-sync; full `bun run verify` is not claimed.

# Risks

Low. CLI-boundary validation only for `voice-duet.mjs`. Invalid numeric flags
now fail closed before model load. Omitting `--turns` still means endless;
default `ringMs=200` is preserved. No duet audio/model semantics changes for
valid input.

# Background

## What does this PR do?

Hardens `packages/app-core/scripts/voice-duet.mjs` numeric CLI parsing:

- `--turns` when provided: complete positive integer `>= 1` (omit → endless)
- `--ring-ms` when provided: complete positive integer `>= 1` (omit → 200)
- Optional int knobs (`--parallel`, `--draft-max`, etc.): fail closed on garbage
- `--prewarm-lead-ms` allows `0`
- Missing value-taking flags no longer silently steal the next token
- Real CLI rejection path under Bun before voice stack load

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. `packages/app-core/scripts/voice-duet.mjs` — `parseArgs` / `parsePositiveInteger`
2. `packages/app-core/scripts/voice-duet-cli.test.ts`

## Detailed testing steps

```bash
export PATH="$HOME/.bun/bin:$PATH"
bun run --cwd packages/app-core test -- scripts/voice-duet-cli.test.ts
bun packages/app-core/scripts/voice-duet.mjs --turns junk
bunx biome check packages/app-core/scripts/voice-duet.mjs packages/app-core/scripts/voice-duet-cli.test.ts
```

Observed:

- **14 pass / 0 fail** focused tests
- CLI: exit 1, stderr names `--turns`, no model/prereq load
- Biome clean on touched files

# Evidence Gate

<!-- evidence-head:6483e7f8134a6d6c8a64eb2c7ef23467a01a3b33 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface; CLI option validation only`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface; CLI option validation only`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI flow; terminal CLI validation only`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - invalid path never reaches the voice stack`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend path`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/model path`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked
      `N/A - terminal test output is the domain artifact`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model path.

## Backend + frontend logs

N/A - local CLI validation only.

```text
bun run --cwd packages/app-core test -- scripts/voice-duet-cli.test.ts
Test Files  1 passed (1)
     Tests  14 passed (14)

bun packages/app-core/scripts/voice-duet.mjs --turns junk
# [voice-duet] --turns must be a positive integer >= 1 (received "junk")
# exit 1
```

## Screenshots (before / after) + video walkthrough

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI flow.

## Audio / voice walkthrough

N/A - CLI validation only; does not change the voice loop for valid flags.

## Known gaps / failures

- Full monorepo `bun run verify` not re-run for this scripts-only change;
  focused suite + Biome on the touched surface pass. No GPU/model required for
  the acceptance criteria.


AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [hermes-agent-cortex]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTQ84PMF046HN97RVYM4YFE","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T10:10:52.757Z","completed_at":"2026-08-12T11:02:52.207Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEABCQ_La8E3A-mhoOGQAU1JDjb5V6pW0qzF_zrcALUa7w","device_key_id":"2ca15083498fec081db8f2a4bbc2afcd06af5a23f516c26e16441b7fa6261099","device_signature":"QmJwPNun2wLeyRBhA9-fCuW8cHWtL0YzbTFewPEdhvLIAw3pPMWhhd7q2bFhw9khOjlBXa6f-hpciVgayiSeCw"}} -->
