### PR TITLE
fix(agent): fail closed on non-finite trigger interval humanize

### DIFF
--- a/packages/agent/src/actions/trigger.ts
+++ b/packages/agent/src/actions/trigger.ts
@@ -306,7 +306,10 @@ function describeSchedule(
   nowMs = Date.now(),
 ): string {
   if (t.triggerType === "interval") {
-    return describeIntervalMs(t.intervalMs ?? DEFAULT_INTERVAL_MS);
+    return (
+      describeIntervalMs(t.intervalMs ?? DEFAULT_INTERVAL_MS) ??
+      "on a custom schedule"
+    );
   }
   if (t.triggerType === "once") {
     const friendly = t.scheduledAtIso

--- a/packages/agent/src/triggers/humanize.test.ts
+++ b/packages/agent/src/triggers/humanize.test.ts
@@ -136,4 +136,12 @@ describe("describeIntervalMs", () => {
     expect(describeIntervalMs(1500)).toBe("every 2 seconds");
     expect(describeIntervalMs(10)).toBe("every second");
   });
+
+  it("fails closed on non-finite and non-positive intervals", () => {
+    expect(describeIntervalMs(Number.NaN)).toBeNull();
+    expect(describeIntervalMs(Number.POSITIVE_INFINITY)).toBeNull();
+    expect(describeIntervalMs(Number.NEGATIVE_INFINITY)).toBeNull();
+    expect(describeIntervalMs(0)).toBeNull();
+    expect(describeIntervalMs(-1000)).toBeNull();
+  });
 });

--- a/packages/agent/src/triggers/humanize.ts
+++ b/packages/agent/src/triggers/humanize.ts
@@ -203,8 +203,14 @@ export function describeOnceAt(
  * Describe a repeat interval ("every 12 hours", "every 90 minutes"). Picks
  * the largest unit that divides evenly; sub-second remainders round to
  * seconds so raw millisecond counts never surface.
+ *
+ * Non-finite and non-positive values return `null` so chat copy never shows
+ * `NaN`/`Infinity` (or a fabricated "every second") for corrupt trigger state.
  */
-export function describeIntervalMs(intervalMs: number): string {
+export function describeIntervalMs(intervalMs: number): string | null {
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    return null;
+  }
   const every = (n: number, unit: string) =>
     n === 1 ? `every ${unit}` : `every ${n} ${unit}s`;
   if (intervalMs >= DAY_MS && intervalMs % DAY_MS === 0) {


### PR DESCRIPTION
# Relates to

Closes #18697

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused verification was run on the touched surfaces after sync (see Testing).
      Full `bun run verify` was **not** run this cycle; scoped humanize unit suite is
      the proof for this pure presentation helper change.
- [x] A reviewer can confirm the change from the unit transcript and matrix
      below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `origin/develop`; zero conflicts.
- [x] Focused suite green. Full `bun run verify` not claimed this cycle
      (trigger schedule humanizer + unit tests + null degrade in trigger action).

# Risks

**Low.** Changes only how `describeIntervalMs` handles non-finite / non-positive
`intervalMs` and how `describeSchedule` degrades when the helper returns null:

- `NaN` / `±Infinity` previously produced labels like `"every NaN seconds"` /
  `"every Infinity seconds"` in trigger chat acknowledgements.
- `0` / negative previously became `"every second"` via `Math.max(1, …)`.
- Those inputs now return `null`; chat text degrades to `"on a custom schedule"`
  (same neutral path as unrecognized cron shapes).
- Finite positive intervals keep the existing unit phrasing unchanged.

# Background

## What does this PR do?

`describeIntervalMs` never validated `intervalMs` before unit flooring and
rounding. Non-finite values produced user-visible `NaN`/`Infinity` strings, and
non-positive values were silently clamped into `"every second"`.

The fix requires a finite positive interval before unit selection, returns
`null` for invalid input (matching `describeOnceAt` / `describeCronSchedule`),
and lets `describeSchedule` degrade to a neutral phrase.

## What kind of change is this?

Bug fix (presentation / fail-closed; no public API consumers beyond the
TRIGGER action schedule phrasing path).

# Documentation changes needed?

My changes do not require a change to the project documentation. The function
JSDoc documents the fail-closed contract.

# Testing

## Where should a reviewer start?

1. `packages/agent/src/triggers/humanize.ts` — `describeIntervalMs`
2. `packages/agent/src/triggers/humanize.test.ts` — non-finite / non-positive matrix
3. `packages/agent/src/actions/trigger.ts` — `describeSchedule` null degrade

## Detailed testing steps

```bash
bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/triggers/humanize.test.ts
bunx biome check packages/agent/src/triggers/humanize.ts packages/agent/src/triggers/humanize.test.ts packages/agent/src/actions/trigger.ts
```

Result (exact head `ff03723dc387213f69255eec854ce390e31c7cab`):

```text
 Test Files  1 passed (1)
      Tests  12 passed (12)
   Duration  313ms
```

Biome: clean on the three touched files.

Deterministic matrix:

```text
describeIntervalMs(NaN | ±Infinity | 0 | -1000) => null
describeIntervalMs(60_000)                      => "every minute"
describeIntervalMs(12 * 60 * 60 * 1000)          => "every 12 hours"
describeIntervalMs(1500)                        => "every 2 seconds"
```

# Evidence Gate

<!-- evidence-head:ff03723dc387213f69255eec854ce390e31c7cab -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; pure string helper used in TRIGGER chat acknowledgements.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; pure string helper used in TRIGGER chat acknowledgements.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow; proof is the vitest transcript and matrix above.
<!-- evidence-row:backend-logs -->
- [x] N/A - no HTTP server path under test; pure function unit tests.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent planning/model behavior changed beyond schedule-label formatting of trigger acknowledgements.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused Vitest output (12 passed) and the non-finite/finite matrix above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text to OCR.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model changes beyond optional schedule-label string formatting.

## Backend + frontend logs

N/A - unit path only; focused vitest + matrix under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI. Trigger acknowledgement labels are plain strings verified by unit tests.

## Audio / voice walkthrough

N/A - no voice/TTS/STT surface.

## Known gaps / failures

- Full root `bun run verify` not run this cycle; change is limited to one
  trigger humanizer helper, its unit tests, and a single null-degrade in the
  TRIGGER action schedule phrasing path.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-rama0x1]
<!-- elizaos-contribution-attribution:v2 {\"provider\":\"xai\",\"model\":\"grok-4.5\",\"client\":\"grok\",\"skill_revision\":\"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza\",\"run\":{\"schema_version\":\"1\",\"run_id\":\"run_01KZV3KVC2ZDAETB61JGTV3HP4\",\"project\":\"eliza\",\"repository\":\"elizaOS/eliza\",\"started_at\":\"2026-08-12T13:46:59.330Z\",\"completed_at\":\"2026-08-12T13:51:47.554Z\",\"skill_sha256\":\"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6\",\"usage\":{\"source\":\"ccusage-session-v20\",\"confidence\":\"unavailable\",\"input_tokens\":0,\"output_tokens\":0,\"cache_creation_tokens\":0,\"cache_read_tokens\":0,\"total_tokens\":0,\"cost_micro_usd\":\"0\",\"session_count\":0},\"trajectory_sha256\":null,\"signature_algorithm\":\"ed25519\",\"device_public_key\":\"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI\",\"device_key_id\":\"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea\",\"device_signature\":\"nLDr6Dob0o9f_m5h3bb4OlAILAvW9Jm6SeOjRJ-wA_DKqODI6aB_xMBp5E5725tr_qXCwFmpegp5UI3VI-EgAA\"}} -->