### PR TITLE
fix(cloud): add Discord Owner ID field to gateway connector form

### DIFF
--- a/packages/cloud/shared/src/db/schemas/discord-connections.ts
+++ b/packages/cloud/shared/src/db/schemas/discord-connections.ts
@@ -25,6 +25,8 @@ export const DiscordConnectionMetadataSchema = z
     disabledChannels: z.array(z.string()).optional(),
     responseMode: z.enum(["always", "mention", "keyword"]).optional(),
     keywords: z.array(z.string()).optional(),
+    /** Discord user snowflake treated as the bot owner. */
+    ownerDiscordUserId: z.string().regex(/^\d{15,20}$/).optional(),
   })
   .refine(
     (data) => {

--- a/packages/ui/src/cloud/connectors/discord-gateway-connection.tsx
+++ b/packages/ui/src/cloud/connectors/discord-gateway-connection.tsx
@@ -86,7 +86,10 @@ async function fetchRuntimeCharacters(
 interface DiscordConnectionPatch {
   characterId: string | null;
   isActive: boolean;
-  metadata: { responseMode: "always" | "mention" | "keyword" };
+  metadata: {
+    responseMode: "always" | "mention" | "keyword";
+    ownerDiscordUserId?: string;
+  };
   botToken?: string;
 }
 
@@ -106,6 +109,7 @@ interface DiscordGatewayConnection {
     keywords?: string[];
     enabledChannels?: string[];
     disabledChannels?: string[];
+    ownerDiscordUserId?: string;
   } | null;
   connectedAt: string | null;
   lastHeartbeat: string | null;
@@ -188,6 +192,7 @@ export function DiscordGatewayConnection() {
   const [responseMode, setResponseMode] = useState<
     "always" | "mention" | "keyword"
   >("always");
+  const [ownerDiscordUserId, setOwnerDiscordUserId] = useState("");
 
   // Edit state for existing connections
   const [editState, setEditState] = useState<
@@ -196,6 +201,7 @@ export function DiscordGatewayConnection() {
       {
         characterId: string;
         responseMode: "always" | "mention" | "keyword";
+        ownerDiscordUserId: string;
         botToken: string;
         isActive: boolean;
       }
@@ -333,7 +339,12 @@ export function DiscordGatewayConnection() {
             applicationId: applicationId.trim(),
             botToken: botToken.trim(),
             characterId,
-            metadata: { responseMode },
+            metadata: {
+              responseMode,
+              ...(ownerDiscordUserId.trim()
+                ? { ownerDiscordUserId: ownerDiscordUserId.trim() }
+                : {}),
+            },
           },
         },
       );
@@ -349,6 +360,7 @@ export function DiscordGatewayConnection() {
         setBotToken("");
         setCharacterId("");
         setResponseMode("always");
+        setOwnerDiscordUserId("");
         setShowForm(false);
         void fetchConnections();
       } else {
@@ -399,6 +411,9 @@ export function DiscordGatewayConnection() {
         isActive: edit.isActive,
         metadata: {
           responseMode: edit.responseMode,
+          ...(edit.ownerDiscordUserId.trim()
+            ? { ownerDiscordUserId: edit.ownerDiscordUserId.trim() }
+            : {}),
         },
       };
 
@@ -484,6 +499,7 @@ export function DiscordGatewayConnection() {
         [conn.id]: {
           characterId: conn.characterId || "",
           responseMode: conn.metadata?.responseMode || "always",
+          ownerDiscordUserId: conn.metadata?.ownerDiscordUserId || "",
           botToken: "",
           isActive: conn.isActive,
         },
@@ -748,6 +764,30 @@ export function DiscordGatewayConnection() {
                                     </SelectItem>
                                   </SelectContent>
                                 </Select>
+                              </div>
+
+                              <div className="space-y-2">
+                                <Label>
+                                  {t("cloud.discord.ownerDiscordUserId", {
+                                    defaultValue: "Discord Owner ID",
+                                  })}
+                                </Label>
+                                <Input
+                                  placeholder={t(
+                                    "cloud.discord.ownerDiscordUserIdPlaceholder",
+                                    {
+                                      defaultValue: "Your Discord user snowflake",
+                                    },
+                                  )}
+                                  value={edit.ownerDiscordUserId}
+                                  onChange={(e) =>
+                                    updateEditState(
+                                      conn.id,
+                                      "ownerDiscordUserId",
+                                      e.target.value,
+                                    )
+                                  }
+                                />
                               </div>
                             </div>
 
@@ -1245,6 +1285,22 @@ export function DiscordGatewayConnection() {
               })}
             </p>
           </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="ownerDiscordUserId">
+            {t("cloud.discord.ownerDiscordUserId", {
+              defaultValue: "Discord Owner ID",
+            })}
+          </Label>
+          <Input
+            id="ownerDiscordUserId"
+            placeholder={t("cloud.discord.ownerDiscordUserIdPlaceholder", {
+              defaultValue: "Your Discord user snowflake",
+            })}
+            value={ownerDiscordUserId}
+            onChange={(e) => setOwnerDiscordUserId(e.target.value)}
+          />
         </div>
 
         <Button


### PR DESCRIPTION
## Summary
- Adds a **Discord Owner ID** input to the Cloud Discord Gateway Bot create/edit form
- Persists the optional owner snowflake on connection metadata (`ownerDiscordUserId`)
- Closes the UI gap where only Application ID + Bot Token were configurable

Fixes #18691

## Test plan
- [ ] Open Cloud → Discord Gateway Bot connector
- [ ] Create a connection and confirm Discord Owner ID field is present
- [ ] Save with a valid Discord user snowflake; reload and confirm the value persists on edit
- [ ] Leave Owner ID empty; connection create/update still succeeds
- [ ] Invalid non-snowflake values are rejected by the API metadata schema


Made with [Cursor](https://cursor.com)