### PR TITLE
fix(google-genai): route IMAGE_DESCRIPTION image fetches through SSRF media guard

### DIFF
--- a/plugins/plugin-google-genai/__tests__/image-description.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/image-description.shape.test.ts
@@ -25,6 +25,11 @@ vi.mock("@elizaos/core", () => ({
     warn: vi.fn(),
   },
   recordLlmCall: mocks.recordLlmCall,
+}));
+
+// The handler loads `fetchRemoteMedia` lazily from the node entry so the
+// browser bundle never pulls it in; mock that entry, not `@elizaos/core`.
+vi.mock("@elizaos/core/node", () => ({
   fetchRemoteMedia: mocks.fetchRemoteMedia,
 }));
 

--- a/plugins/plugin-google-genai/__tests__/image-description.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/image-description.shape.test.ts
@@ -2,9 +2,9 @@
  * Unit tests for `handleImageDescription`: the JSON and prose parse paths plus
  * the failure paths that must surface as typed errors instead of a fabricated
  * `{ title, description }` result — uninitialized client, image fetch failure,
- * provider (`generateContent`) rejection, and an empty model completion. The
- * config, tokenization, `recordLlmCall`, and global `fetch` layers are mocked;
- * no live model or network call is made.
+ * SSRF-blocked private hosts, provider (`generateContent`) rejection, and an
+ * empty model completion. Config, tokenization, `recordLlmCall`, and
+ * `fetchRemoteMedia` are mocked; no live model or network call is made.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   generateContent: vi.fn(),
   countTokens: vi.fn(),
   recordLlmCall: vi.fn(),
+  fetchRemoteMedia: vi.fn(),
 }));
 
 vi.mock("@elizaos/core", () => ({
@@ -24,6 +25,7 @@ vi.mock("@elizaos/core", () => ({
     warn: vi.fn(),
   },
   recordLlmCall: mocks.recordLlmCall,
+  fetchRemoteMedia: mocks.fetchRemoteMedia,
 }));
 
 vi.mock("../utils/config", () => ({
@@ -44,15 +46,12 @@ function createRuntime(): IAgentRuntime {
   } as unknown as IAgentRuntime;
 }
 
-function mockFetchOk() {
-  const fetchMock = vi.fn(async () => ({
-    ok: true,
-    statusText: "OK",
-    headers: { get: () => "image/png" },
-    arrayBuffer: async () => new ArrayBuffer(8),
-  }));
-  vi.stubGlobal("fetch", fetchMock);
-  return fetchMock;
+function mockMediaOk(contentType = "image/png") {
+  mocks.fetchRemoteMedia.mockResolvedValue({
+    buffer: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]),
+    contentType,
+    fileName: "cat.png",
+  });
 }
 
 describe("Google GenAI image description", () => {
@@ -73,7 +72,7 @@ describe("Google GenAI image description", () => {
   });
 
   it("returns the model's JSON title/description on success", async () => {
-    mockFetchOk();
+    mockMediaOk();
     mocks.generateContent.mockResolvedValue({
       text: JSON.stringify({
         title: "A cat",
@@ -90,10 +89,19 @@ describe("Google GenAI image description", () => {
       title: "A cat",
       description: "A ginger cat on a sofa.",
     });
+    expect(mocks.fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://example.com/cat.png",
+        maxBytes: 20 * 1024 * 1024,
+        timeoutMs: 15_000,
+        maxRedirects: 5,
+      }),
+    );
+    expect(mocks.generateContent).toHaveBeenCalledTimes(1);
   });
 
   it("parses a title/description out of prose when the model returns non-JSON", async () => {
-    mockFetchOk();
+    mockMediaOk();
     mocks.generateContent.mockResolvedValue({
       text: "Title: Sunset\nA warm orange sunset over the ocean.",
     });
@@ -108,38 +116,70 @@ describe("Google GenAI image description", () => {
   });
 
   it("throws when the client is not initialized instead of fabricating a result", async () => {
-    mockFetchOk();
+    mockMediaOk();
     mocks.createGoogleGenAI.mockReturnValue(null);
 
     await expect(
       handleImageDescription(createRuntime(), "https://example.com/x.png"),
     ).rejects.toThrow("Google Generative AI client not initialized");
 
+    expect(mocks.fetchRemoteMedia).not.toHaveBeenCalled();
     expect(mocks.generateContent).not.toHaveBeenCalled();
   });
 
-  it("throws when the image fetch fails instead of fabricating a result", async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: false,
-      statusText: "Not Found",
-      headers: { get: () => null },
-      arrayBuffer: async () => new ArrayBuffer(0),
-    }));
-    vi.stubGlobal("fetch", fetchMock);
+  it("throws when the image URL is empty instead of fetching", async () => {
+    await expect(
+      handleImageDescription(createRuntime(), { imageUrl: "" }),
+    ).rejects.toThrow("IMAGE_DESCRIPTION requires a valid image URL");
+
+    expect(mocks.fetchRemoteMedia).not.toHaveBeenCalled();
+    expect(mocks.generateContent).not.toHaveBeenCalled();
+  });
+
+  it("throws when the guarded image fetch fails instead of fabricating a result", async () => {
+    mocks.fetchRemoteMedia.mockRejectedValue(
+      new Error(
+        "Failed to fetch media from https://example.com/missing.png: HTTP 404 Not Found",
+      ),
+    );
 
     const result = handleImageDescription(
       createRuntime(),
       "https://example.com/missing.png",
     );
 
-    await expect(result).rejects.toThrow("Failed to fetch image: Not Found");
+    await expect(result).rejects.toThrow(/Failed to fetch media/);
     // Must not swallow into a { title: "Failed to analyze image", ... } object.
     await expect(result).rejects.not.toHaveProperty("title");
     expect(mocks.generateContent).not.toHaveBeenCalled();
   });
 
+  it("fails closed on loopback and private image URLs without calling the model", async () => {
+    const blocked = [
+      "http://127.0.0.1/secret.png",
+      "http://169.254.169.254/latest/meta-data/",
+      "http://localhost/internal.png",
+      "http://10.0.0.5/intranet.png",
+    ];
+
+    for (const url of blocked) {
+      mocks.fetchRemoteMedia.mockRejectedValueOnce(
+        new Error(`Failed to fetch media from ${url}: blocked by SSRF policy`),
+      );
+      mocks.generateContent.mockClear();
+
+      await expect(
+        handleImageDescription(createRuntime(), url),
+      ).rejects.toThrow(/Failed to fetch media|SSRF|blocked/i);
+      expect(mocks.fetchRemoteMedia).toHaveBeenCalledWith(
+        expect.objectContaining({ url }),
+      );
+      expect(mocks.generateContent).not.toHaveBeenCalled();
+    }
+  });
+
   it("propagates a provider rejection instead of fabricating a result", async () => {
-    mockFetchOk();
+    mockMediaOk();
     mocks.generateContent.mockRejectedValue(
       new Error("429 rate limit exceeded"),
     );
@@ -156,7 +196,7 @@ describe("Google GenAI image description", () => {
   });
 
   it("throws on an empty model completion instead of returning an empty description", async () => {
-    mockFetchOk();
+    mockMediaOk();
     mocks.generateContent.mockResolvedValue({ text: "   " });
 
     await expect(

--- a/plugins/plugin-google-genai/__tests__/image-description.ssrf.test.ts
+++ b/plugins/plugin-google-genai/__tests__/image-description.ssrf.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Integration-backed unit tests for IMAGE_DESCRIPTION SSRF fail-closed: real
+ * `@elizaos/core` `fetchRemoteMedia` policy against literal private/loopback
+ * hosts, with only the Gemini client and LLM call layers mocked. Proves the
+ * handler never reaches the model for blocked image URLs.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createGoogleGenAI: vi.fn(),
+  generateContent: vi.fn(),
+  countTokens: vi.fn(),
+  recordLlmCall: vi.fn(),
+}));
+
+vi.mock("@elizaos/core", async (importActual) => {
+  const actual = await importActual<typeof import("@elizaos/core")>();
+  return {
+    ...actual,
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    },
+    recordLlmCall: mocks.recordLlmCall,
+  };
+});
+
+vi.mock("../utils/config", () => ({
+  createGoogleGenAI: mocks.createGoogleGenAI,
+  getImageModel: vi.fn(() => "gemini-2.0-flash"),
+  getSafetySettings: vi.fn(() => []),
+}));
+
+vi.mock("../utils/tokenization", () => ({
+  countTokens: mocks.countTokens,
+}));
+
+import { handleImageDescription } from "../models/image";
+
+function createRuntime(): IAgentRuntime {
+  return {
+    getSetting: vi.fn(() => null),
+  } as unknown as IAgentRuntime;
+}
+
+describe("Google GenAI image description SSRF policy (real fetchRemoteMedia)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.countTokens.mockResolvedValue(5);
+    mocks.recordLlmCall.mockImplementation(async (_runtime, _details, fn) =>
+      fn(),
+    );
+    mocks.createGoogleGenAI.mockReturnValue({
+      models: { generateContent: mocks.generateContent },
+    });
+    mocks.generateContent.mockResolvedValue({
+      text: JSON.stringify({ title: "x", description: "y" }),
+    });
+  });
+
+  it.each([
+    "http://127.0.0.1/secret.png",
+    "http://[::1]/secret.png",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://localhost/internal.png",
+    "http://10.0.0.5/intranet.png",
+    "http://192.168.1.1/router.png",
+  ])(
+    "fails closed for blocked image URL %s without calling the model",
+    async (url) => {
+      await expect(
+        handleImageDescription(createRuntime(), url),
+      ).rejects.toThrow(
+        /Failed to fetch media|not allowed|blocked|private|loopback|link-local|Invalid URL|SSRF/i,
+      );
+      expect(mocks.generateContent).not.toHaveBeenCalled();
+      expect(mocks.recordLlmCall).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/plugins/plugin-google-genai/models/image.ts
+++ b/plugins/plugin-google-genai/models/image.ts
@@ -4,9 +4,11 @@
  * model's JSON output and falls back to regex title extraction from prose. The
  * call is wrapped in `recordLlmCall` for trajectory capture.
  *
- * Provider failures (image fetch error, bad key, model-not-found, rate-limit,
- * timeout, safety block, empty completion) surface as typed errors so the caller
- * and model see a real failure — they are never fabricated into a
+ * Image bytes are loaded only through `fetchRemoteMedia` so caller-supplied URLs
+ * cannot reach loopback, link-local, or private network targets (SSRF). Provider
+ * failures (image fetch error, bad key, model-not-found, rate-limit, timeout,
+ * safety block, empty completion) surface as typed errors so the caller and
+ * model see a real failure — they are never fabricated into a
  * `{ title, description }` result the runtime would read as a real description.
  */
 import type {
@@ -14,7 +16,7 @@ import type {
   ImageDescriptionParams,
   RecordLlmCallDetails,
 } from "@elizaos/core";
-import { logger, recordLlmCall } from "@elizaos/core";
+import { fetchRemoteMedia, logger, recordLlmCall } from "@elizaos/core";
 import type { ImageDescriptionResponse } from "../types";
 import {
   createGoogleGenAI,
@@ -22,6 +24,11 @@ import {
   getSafetySettings,
 } from "../utils/config";
 import { countTokens } from "../utils/tokenization";
+
+/** Cap inline image payloads so a hostile host cannot force unbounded memory. */
+const IMAGE_DESCRIPTION_MAX_BYTES = 20 * 1024 * 1024;
+const IMAGE_DESCRIPTION_FETCH_TIMEOUT_MS = 15_000;
+const IMAGE_DESCRIPTION_MAX_REDIRECTS = 5;
 
 export async function handleImageDescription(
   runtime: IAgentRuntime,
@@ -48,16 +55,20 @@ export async function handleImageDescription(
       "Please analyze this image and provide a title and detailed description.";
   }
 
-  try {
-    const imageResponse = await fetch(imageUrl);
-    if (!imageResponse.ok) {
-      throw new Error(`Failed to fetch image: ${imageResponse.statusText}`);
-    }
+  if (!imageUrl || imageUrl.trim().length === 0) {
+    throw new Error("IMAGE_DESCRIPTION requires a valid image URL");
+  }
 
-    const imageData = await imageResponse.arrayBuffer();
-    const base64Image = Buffer.from(imageData).toString("base64");
-    const contentType =
-      imageResponse.headers.get("content-type") || "image/jpeg";
+  try {
+    // Untrusted agent/tool image URLs must not hit private or metadata hosts.
+    const media = await fetchRemoteMedia({
+      url: imageUrl,
+      maxBytes: IMAGE_DESCRIPTION_MAX_BYTES,
+      timeoutMs: IMAGE_DESCRIPTION_FETCH_TIMEOUT_MS,
+      maxRedirects: IMAGE_DESCRIPTION_MAX_REDIRECTS,
+    });
+    const base64Image = media.buffer.toString("base64");
+    const contentType = media.contentType || "image/jpeg";
 
     const details: RecordLlmCallDetails = {
       model: modelName,

--- a/plugins/plugin-google-genai/models/image.ts
+++ b/plugins/plugin-google-genai/models/image.ts
@@ -16,7 +16,7 @@ import type {
   ImageDescriptionParams,
   RecordLlmCallDetails,
 } from "@elizaos/core";
-import { fetchRemoteMedia, logger, recordLlmCall } from "@elizaos/core";
+import { logger, recordLlmCall } from "@elizaos/core";
 import type { ImageDescriptionResponse } from "../types";
 import {
   createGoogleGenAI,
@@ -61,6 +61,9 @@ export async function handleImageDescription(
 
   try {
     // Untrusted agent/tool image URLs must not hit private or metadata hosts.
+    // `fetchRemoteMedia` is Node-only, and the browser entry re-exports this
+    // module, so it must load lazily from the node entry rather than statically.
+    const { fetchRemoteMedia } = await import("@elizaos/core/node");
     const media = await fetchRemoteMedia({
       url: imageUrl,
       maxBytes: IMAGE_DESCRIPTION_MAX_BYTES,


### PR DESCRIPTION
# Relates to

Closes #18699

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused verification was run on the touched surfaces after sync (see Testing).
      Full `bun run verify` was **not** run this cycle; scoped google-genai image
      description unit suites are the proof for this pure media-fetch change.
- [x] A reviewer can confirm the change from the unit transcript and SSRF matrix
      below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `origin/develop`; zero conflicts.
- [x] Focused suite green. Full `bun run verify` not claimed this cycle
      (plugin-google-genai IMAGE_DESCRIPTION media fetch + unit tests only).

# Risks

**Low–medium.** Changes how `handleImageDescription` downloads caller-supplied
image URLs before Gemini inline encoding:

- Bytes now go through `@elizaos/core` `fetchRemoteMedia` (SSRF guard: private /
  loopback / link-local blocked; redirect hops revalidated; 15s timeout; max 5
  redirects; 20 MiB body cap).
- Empty image URLs fail closed before any transport.
- Successful public-URL path still base64-inlines the image and preserves existing
  JSON/prose parse behaviour.
- Fetch / oversized-payload failures still throw; they do not fabricate a
  `{ title, description }` object.

# Background

## What does this PR do?

`handleImageDescription` previously used raw `fetch(imageUrl)`. Agent or tool
supplied URLs could target loopback, private networks, or link-local metadata
endpoints, then inline the response into the Gemini request.

The fix routes downloads through `fetchRemoteMedia`, sets explicit timeout /
redirect / byte bounds, validates empty URLs, and adds unit coverage for success,
HTTP failure, empty URL, and real-policy SSRF fail-closed against private hosts.

## What kind of change is this?

Bug fix (security / fail-closed server-side image fetch for IMAGE_DESCRIPTION).

# Documentation changes needed?

My changes do not require a change to the project documentation. The file header
documents the SSRF media-guard contract.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-google-genai/models/image.ts` — `fetchRemoteMedia` call site
2. `plugins/plugin-google-genai/__tests__/image-description.shape.test.ts` — mocked
   media helper + contract matrix
3. `plugins/plugin-google-genai/__tests__/image-description.ssrf.test.ts` — real
   `fetchRemoteMedia` policy against private/loopback URLs

## Detailed testing steps

```bash
cd plugins/plugin-google-genai
bunx vitest run __tests__/image-description.shape.test.ts __tests__/image-description.ssrf.test.ts
bunx biome check models/image.ts __tests__/image-description.shape.test.ts __tests__/image-description.ssrf.test.ts
```

Result (exact head `59dba531e980a54365beb7c4d4b6edf1881a0604`):

```text
 Test Files  2 passed (2)
      Tests  14 passed (14)
   Duration  8.00s

Checked 3 files in 16ms. No fixes applied.
```

Deterministic matrix:

```text
https://example.com/cat.png          → fetchRemoteMedia + model path (JSON title/description)
empty imageUrl                       → throw before fetchRemoteMedia
HTTP/media fetch failure             → throw; generateContent not called
http://127.0.0.1/...                 → real SSRF policy reject; model not called
http://169.254.169.254/...           → real SSRF policy reject; model not called
http://localhost/...                 → real SSRF policy reject; model not called
http://10.0.0.5/...                  → real SSRF policy reject; model not called
http://192.168.1.1/...               → real SSRF policy reject; model not called
```

# Evidence Gate

<!-- evidence-head:59dba531e980a54365beb7c4d4b6edf1881a0604 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; server-side model-handler media fetch only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; server-side model-handler media fetch only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow; fail-closed behaviour proven by unit matrix.
<!-- evidence-row:backend-logs -->
- [x] N/A - pure unit proof with mocked Gemini client; no agent process logs.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - transport/SSRF fail-closed change only; model selection and prompt text unchanged; success path still mocked for deterministic parse tests.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, wallet, schedule, or generated media artifact; unit transcript is the domain proof.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - this PR only changes how image bytes are fetched before the existing Gemini
call. Model prompt/response parse paths are covered by deterministic unit tests
with a mocked `generateContent`.

## Backend + frontend logs

N/A - unit suites only; see Testing transcript above.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

- Full `bun run verify` was not run this cycle (scoped plugin unit + Biome only).
- Live network fetch of a public image through Gemini was not exercised; success
  path remains covered by the existing mocked JSON/prose unit tests after the
  media helper swap.
- Project-token receipt footer omitted: contribute-to-eliza receipt script only
  accepts `codex` / `claude-code` clients; this cycle ran under operator-approved
  Grok Build (`xai/grok-4.5`) and must not forge those client identities.
