### PR TITLE
fix(openai): route TRANSCRIPTION audio URL fetches through SSRF media guard

### DIFF
--- a/plugins/plugin-openai/__tests__/transcription-ssrf.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/transcription-ssrf.shape.test.ts
@@ -17,26 +17,37 @@ const mocks = vi.hoisted(() => ({
   realFetchRemoteMedia: null as null | ((...args: unknown[]) => Promise<unknown>),
 }));
 
-vi.mock("@elizaos/core", async (importActual) => {
-  const actual = await importActual<typeof import("@elizaos/core")>();
-  mocks.realFetchRemoteMedia = actual.fetchRemoteMedia as (...args: unknown[]) => Promise<unknown>;
-  return {
-    ...actual,
-    logger: {
-      debug: vi.fn(),
-      error: vi.fn(),
-      log: vi.fn(),
-      warn: vi.fn(),
-    },
-    recordLlmCall: mocks.recordLlmCall,
-    fetchRemoteMedia: (...args: unknown[]) => {
-      if (mocks.useRealFetchRemoteMedia && mocks.realFetchRemoteMedia) {
-        return mocks.realFetchRemoteMedia(...args);
-      }
-      return mocks.fetchRemoteMedia(...args);
-    },
-  };
-});
+// The handler imports logger/recordLlmCall from `@elizaos/core` but loads
+// `fetchRemoteMedia` lazily from `@elizaos/core/node` so the browser bundle
+// never pulls it in. Under Node both specifiers resolve to the same module
+// file, so both mocks must expose the same full mocked surface.
+const coreMockFactory = vi.hoisted(
+  () => async (importActual: () => Promise<Record<string, unknown>>) => {
+    const actual = await importActual();
+    mocks.realFetchRemoteMedia = actual.fetchRemoteMedia as (
+      ...args: unknown[]
+    ) => Promise<unknown>;
+    return {
+      ...actual,
+      logger: {
+        debug: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn(),
+        warn: vi.fn(),
+      },
+      recordLlmCall: mocks.recordLlmCall,
+      fetchRemoteMedia: (...args: unknown[]) => {
+        if (mocks.useRealFetchRemoteMedia && mocks.realFetchRemoteMedia) {
+          return mocks.realFetchRemoteMedia(...args);
+        }
+        return mocks.fetchRemoteMedia(...args);
+      },
+    };
+  }
+);
+
+vi.mock("@elizaos/core", coreMockFactory);
+vi.mock("@elizaos/core/node", coreMockFactory);
 
 vi.mock("../utils/config", () => ({
   getAuthHeader: mocks.getAuthHeader,

--- a/plugins/plugin-openai/__tests__/transcription-ssrf.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/transcription-ssrf.shape.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for TRANSCRIPTION audio-URL loading: SSRF fail-closed private
+ * hosts via real `fetchRemoteMedia`, plus the happy path that posts guarded
+ * bytes to the provider. Config and `recordLlmCall` are mocked; no live model
+ * or public network is required for the blocked-URL cases.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  recordLlmCall: vi.fn(),
+  fetchRemoteMedia: vi.fn(),
+  getAuthHeader: vi.fn(() => ({ Authorization: "Bearer test-key" })),
+  getBaseURL: vi.fn(() => "https://api.openai.com/v1"),
+  getTranscriptionModel: vi.fn(() => "gpt-4o-mini-transcribe"),
+  useRealFetchRemoteMedia: false,
+  realFetchRemoteMedia: null as null | ((...args: unknown[]) => Promise<unknown>),
+}));
+
+vi.mock("@elizaos/core", async (importActual) => {
+  const actual = await importActual<typeof import("@elizaos/core")>();
+  mocks.realFetchRemoteMedia = actual.fetchRemoteMedia as (...args: unknown[]) => Promise<unknown>;
+  return {
+    ...actual,
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    },
+    recordLlmCall: mocks.recordLlmCall,
+    fetchRemoteMedia: (...args: unknown[]) => {
+      if (mocks.useRealFetchRemoteMedia && mocks.realFetchRemoteMedia) {
+        return mocks.realFetchRemoteMedia(...args);
+      }
+      return mocks.fetchRemoteMedia(...args);
+    },
+  };
+});
+
+vi.mock("../utils/config", () => ({
+  getAuthHeader: mocks.getAuthHeader,
+  getBaseURL: mocks.getBaseURL,
+  getTranscriptionModel: mocks.getTranscriptionModel,
+  getTTSInstructions: vi.fn(() => undefined),
+  getTTSModel: vi.fn(() => "gpt-4o-mini-tts"),
+  getTTSVoice: vi.fn(() => "nova"),
+}));
+
+import { handleTranscription } from "../models/audio";
+
+function createRuntime(): IAgentRuntime {
+  return {
+    getSetting: vi.fn(() => null),
+  } as unknown as IAgentRuntime;
+}
+
+describe("OpenAI transcription SSRF policy (real fetchRemoteMedia)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useRealFetchRemoteMedia = true;
+    mocks.recordLlmCall.mockImplementation(async (_runtime, _details, fn) => fn());
+  });
+
+  afterEach(() => {
+    mocks.useRealFetchRemoteMedia = false;
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    "http://127.0.0.1/secret.wav",
+    "http://[::1]/secret.wav",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://localhost/internal.wav",
+    "http://10.0.0.5/intranet.wav",
+    "http://192.168.1.1/router.wav",
+  ])("fails closed for blocked audio URL %s without calling the provider", async (url) => {
+    const fetchMock = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    await expect(handleTranscription(createRuntime(), url)).rejects.toThrow(
+      /Failed to fetch media|not allowed|blocked|private|loopback|link-local|Invalid URL|SSRF/i
+    );
+    expect(mocks.recordLlmCall).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty URL strings before any fetch", async () => {
+    mocks.useRealFetchRemoteMedia = false;
+    const fetchMock = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    await expect(handleTranscription(createRuntime(), "   ")).rejects.toThrow(
+      "TRANSCRIPTION requires a valid audio URL"
+    );
+    expect(mocks.recordLlmCall).not.toHaveBeenCalled();
+    expect(mocks.fetchRemoteMedia).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("OpenAI transcription audio URL happy path (mocked remote media)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useRealFetchRemoteMedia = false;
+    mocks.recordLlmCall.mockImplementation(async (_runtime, _details, fn) => fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads audio through fetchRemoteMedia bounds then posts to the provider", async () => {
+    const audioBytes = Buffer.from([
+      0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74,
+      0x20, 0x10, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x44, 0xac, 0x00, 0x00, 0x88, 0x58,
+      0x01, 0x00, 0x02, 0x00, 0x10, 0x00, 0x64, 0x61, 0x74, 0x61, 0x00, 0x00, 0x00, 0x00,
+    ]);
+    mocks.fetchRemoteMedia.mockResolvedValue({
+      buffer: audioBytes,
+      contentType: "audio/wav",
+      fileName: "sample.wav",
+    });
+
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ text: "hello world" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    const text = await handleTranscription(createRuntime(), "https://cdn.example.com/sample.wav");
+
+    expect(text).toBe("hello world");
+    expect(mocks.fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://cdn.example.com/sample.wav",
+        maxBytes: 25 * 1024 * 1024,
+        timeoutMs: 30_000,
+        maxRedirects: 5,
+      })
+    );
+    expect(mocks.recordLlmCall).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [providerUrl, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(providerUrl).toBe("https://api.openai.com/v1/audio/transcriptions");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(FormData);
+  });
+
+  it("loads CoreTranscriptionParams.audioUrl through the same SSRF media guard", async () => {
+    mocks.fetchRemoteMedia.mockResolvedValue({
+      buffer: Buffer.from([1, 2, 3, 4]),
+      contentType: "audio/webm",
+      fileName: "clip.webm",
+    });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ text: "from params" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    const text = await handleTranscription(createRuntime(), {
+      audioUrl: "https://cdn.example.com/clip.webm",
+      prompt: "focus on speech",
+    });
+
+    expect(text).toBe("from params");
+    expect(mocks.fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://cdn.example.com/clip.webm",
+        maxBytes: 25 * 1024 * 1024,
+      })
+    );
+  });
+});

--- a/plugins/plugin-openai/models/audio.ts
+++ b/plugins/plugin-openai/models/audio.ts
@@ -3,6 +3,11 @@
  * endpoint (sniffing the container via `detectAudioMimeType` to pick an upload
  * filename), and `handleTextToSpeech` synthesizes speech via the TTS endpoint.
  * Both accept the core param shapes as well as raw Blob/File/Buffer input.
+ *
+ * Caller-supplied audio URLs load only through `fetchRemoteMedia` so agents and
+ * tools cannot aim transcription at loopback, link-local, or private hosts.
+ * Provider endpoint calls (OpenAI-compatible base URL) stay on the configured
+ * API path and are not remote-media fetches.
  */
 import type {
   TextToSpeechParams as CoreTextToSpeechParams,
@@ -10,7 +15,7 @@ import type {
   IAgentRuntime,
   RecordLlmCallDetails,
 } from "@elizaos/core";
-import { logger, recordLlmCall } from "@elizaos/core";
+import { fetchRemoteMedia, logger, recordLlmCall } from "@elizaos/core";
 import type {
   TextToSpeechParams as LocalTextToSpeechParams,
   TranscriptionParams as LocalTranscriptionParams,
@@ -27,6 +32,11 @@ import {
   getTTSModel,
   getTTSVoice,
 } from "../utils/config";
+
+/** OpenAI Whisper/upload limit is 25 MB; keep the same hard cap server-side. */
+const TRANSCRIPTION_AUDIO_MAX_BYTES = 25 * 1024 * 1024;
+const TRANSCRIPTION_AUDIO_FETCH_TIMEOUT_MS = 30_000;
+const TRANSCRIPTION_AUDIO_MAX_REDIRECTS = 5;
 
 type AudioInput = Blob | File | Buffer;
 type TranscriptionInput = AudioInput | LocalTranscriptionParams | CoreTranscriptionParams | string;
@@ -60,12 +70,21 @@ function isCoreTranscriptionParams(value: unknown): value is CoreTranscriptionPa
 }
 
 async function fetchAudioFromUrl(url: string): Promise<Blob> {
-  // @trajectory-allow Fetches caller-provided audio bytes; no model inference happens here.
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch audio from URL: ${response.status}`);
+  if (!url || url.trim().length === 0) {
+    throw new Error("TRANSCRIPTION requires a valid audio URL");
   }
-  return response.blob();
+  // Untrusted agent/tool audio URLs must not hit private or metadata hosts.
+  // @trajectory-allow Fetches caller-provided audio bytes; no model inference happens here.
+  const media = await fetchRemoteMedia({
+    url,
+    maxBytes: TRANSCRIPTION_AUDIO_MAX_BYTES,
+    timeoutMs: TRANSCRIPTION_AUDIO_FETCH_TIMEOUT_MS,
+    maxRedirects: TRANSCRIPTION_AUDIO_MAX_REDIRECTS,
+  });
+  const mimeType = media.contentType?.startsWith("audio/")
+    ? media.contentType
+    : detectAudioMimeType(media.buffer);
+  return new Blob([new Uint8Array(media.buffer)], { type: mimeType });
 }
 export async function handleTranscription(
   runtime: IAgentRuntime,

--- a/plugins/plugin-openai/models/audio.ts
+++ b/plugins/plugin-openai/models/audio.ts
@@ -15,7 +15,7 @@ import type {
   IAgentRuntime,
   RecordLlmCallDetails,
 } from "@elizaos/core";
-import { fetchRemoteMedia, logger, recordLlmCall } from "@elizaos/core";
+import { logger, recordLlmCall } from "@elizaos/core";
 import type {
   TextToSpeechParams as LocalTextToSpeechParams,
   TranscriptionParams as LocalTranscriptionParams,
@@ -74,7 +74,10 @@ async function fetchAudioFromUrl(url: string): Promise<Blob> {
     throw new Error("TRANSCRIPTION requires a valid audio URL");
   }
   // Untrusted agent/tool audio URLs must not hit private or metadata hosts.
+  // `fetchRemoteMedia` is Node-only, and the browser entry re-exports this
+  // module, so it must load lazily from the node entry rather than statically.
   // @trajectory-allow Fetches caller-provided audio bytes; no model inference happens here.
+  const { fetchRemoteMedia } = await import("@elizaos/core/node");
   const media = await fetchRemoteMedia({
     url,
     maxBytes: TRANSCRIPTION_AUDIO_MAX_BYTES,


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Fixes https://github.com/elizaOS/eliza/issues/18702

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `grok`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** Changes only the remote-audio fetch helper used by OpenAI-compatible
`TRANSCRIPTION` when the caller supplies a URL. Local Blob/File/Buffer inputs
are unchanged. Fail-closed SSRF rejection may surface as a typed fetch error
instead of a silent private-network probe — intentional and desirable.

# Background

## What does this PR do?

`handleTranscription` accepted a caller-supplied audio URL (string or
`CoreTranscriptionParams.audioUrl`) and loaded bytes with raw `fetch`. That
skipped the repository SSRF media policy and allowed loopback, link-local,
metadata, and private network targets.

This PR routes those loads through `@elizaos/core` `fetchRemoteMedia` with a
25 MB cap (OpenAI upload limit), 30s timeout, and 5 redirects, rejects empty
URLs, and adds unit coverage for blocked hosts and the happy-path provider POST.

## What kind of change is this?

Bug fix (non-breaking security hardening of an existing model handler path).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior is
an internal fail-closed fix on an existing handler; package README/CLAUDE.md
already describe TRANSCRIPTION without documenting raw-fetch side channels.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-openai/models/audio.ts` — `fetchAudioFromUrl`
2. `plugins/plugin-openai/__tests__/transcription-ssrf.shape.test.ts`

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-openai test transcription-ssrf
bun run --cwd plugins/plugin-openai typecheck
bun run --cwd plugins/plugin-openai lint:check
```

Expected: 9/9 tests pass; typecheck and lint clean.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:407efc7495a8a03508bf6414860a239a26c7917a -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface; server-side model handler only`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface; server-side model handler only`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing UI flow; deterministic unit contract only`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: focused Vitest output below (real SSRF fail-closed path + happy path)
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network: `N/A - no frontend or browser surface in this change`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - provider calls mocked; change is pre-provider media SSRF policy, not model behavior`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB, memory, schedule, wallet, or generated domain state`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

`N/A - provider layer mocked; SSRF policy rejects private hosts before any OpenAI-compatible transcription request.`

## Backend + frontend logs

Frontend: `N/A - server-side only`.

<details>
<summary>Focused unit tests (real output, commit c7b4fe49bb)</summary>

```text
$ bun run --cwd plugins/plugin-openai test transcription-ssrf
$ vitest run --config ./vitest.config.ts transcription-ssrf

 RUN  v4.1.5 /home/dak/src/eliza/plugins/plugin-openai

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  16:05:24
   Duration  7.90s (transform 6.32s, setup 0ms, import 7.75s, tests 19ms, environment 0ms)

$ bun run --cwd plugins/plugin-openai typecheck
$ tsc --noEmit -p tsconfig.json
(exit 0)

$ bun run --cwd plugins/plugin-openai lint:check
$ bunx @biomejs/biome check .
Checked 50 files in 122ms. No fixes applied.
(exit 0)
```

</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI`

### After

`N/A - no UI`

### Walkthrough video

`N/A - no UI flow`

## Audio / voice walkthrough

`N/A - STT handler security boundary only; no live transcription or TTS round-trip is required to prove SSRF fail-closed host rejection, which is covered by unit tests using the real fetchRemoteMedia policy.`

## Known gaps / failures

- Full root `bun run verify` was **not** run this cycle (scoped package tests + typecheck + lint only). Unrelated monorepo lanes were not exercised.
- CI Security Advisory / first-time workflow approval gates may still require maintainer action on the fork PR; that is process, not a code defect in this diff.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [rama0x1-docs-gate]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZV4E3XGFSC1SH7JGSEYJG4Q","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T14:01:20.048Z","completed_at":"2026-08-12T14:05:24.564Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"FXqDgxJYosfmB758eSnCe5odgbzMQcgTpLklKL6NakfPx5iECsUzPcaAMA7e4y0U2m_lLFS7TEhnaeeH2J9kAQ"}} -->
