### PR TITLE
fix(google-genai): route IMAGE_DESCRIPTION image fetches through SSRF media guard (#18699)

### DIFF
--- a/plugins/plugin-google-genai/models/image.ts
+++ b/plugins/plugin-google-genai/models/image.ts
@@ -14,7 +14,7 @@ import type {
   ImageDescriptionParams,
   RecordLlmCallDetails,
 } from "@elizaos/core";
-import { logger, recordLlmCall } from "@elizaos/core";
+import { fetchRemoteMedia, logger, recordLlmCall } from "@elizaos/core";
 import type { ImageDescriptionResponse } from "../types";
 import {
   createGoogleGenAI,
@@ -49,15 +49,12 @@ export async function handleImageDescription(
   }
 
   try {
-    const imageResponse = await fetch(imageUrl);
-    if (!imageResponse.ok) {
-      throw new Error(`Failed to fetch image: ${imageResponse.statusText}`);
-    }
-
-    const imageData = await imageResponse.arrayBuffer();
-    const base64Image = Buffer.from(imageData).toString("base64");
-    const contentType =
-      imageResponse.headers.get("content-type") || "image/jpeg";
+    const { buffer: imageBuffer, contentType } = await fetchRemoteMedia({
+      url: imageUrl,
+      maxBytes: 10_000_000, // 10 MB image cap
+      timeoutMs: 30_000,
+    });
+    const base64Image = Buffer.from(imageBuffer).toString("base64");
 
     const details: RecordLlmCallDetails = {
       model: modelName,

--- a/plugins/plugin-google-genai/models/image.ts
+++ b/plugins/plugin-google-genai/models/image.ts
@@ -14,7 +14,7 @@ import type {
   ImageDescriptionParams,
   RecordLlmCallDetails,
 } from "@elizaos/core";
-import { fetchRemoteMedia, logger, recordLlmCall } from "@elizaos/core";
+import { logger, recordLlmCall } from "@elizaos/core";
 import type { ImageDescriptionResponse } from "../types";
 import {
   createGoogleGenAI,
@@ -49,6 +49,14 @@ export async function handleImageDescription(
   }
 
   try {
+    // fetchRemoteMedia uses the SSRF guard (DNS-based host validation) which is
+    // a Node-only API. Use dynamic import so the plugin's browser bundle does
+    // not statically pull it in (#18699).
+    const core = await import("@elizaos/core");
+    const { fetchRemoteMedia } = core;
+    if (!fetchRemoteMedia) {
+      throw new Error("fetchRemoteMedia is not available in this runtime.");
+    }
     const { buffer: imageBuffer, contentType } = await fetchRemoteMedia({
       url: imageUrl,
       maxBytes: 10_000_000, // 10 MB image cap


### PR DESCRIPTION
## Summary

`handleImageDescription` in `plugins/plugin-google-genai/models/image.ts` downloaded caller-supplied image URLs with raw `fetch()` — no host/protocol policy beyond the runtime default. Agent or tool-supplied URLs could target loopback (127.0.0.1), link-local (169.254.169.254 cloud metadata), and private network addresses, then base64-inline the response into the Gemini request.

## Fix

Routes image fetches through `@elizaos/core` `fetchRemoteMedia` which enforces:
- Private/loopback/link-local host blocking (SSRF guard)
- Redirect hop revalidation
- 10MB body size cap
- 30s timeout

## RP Investigation findings

- Vulnerable call was at `models/image.ts:53` — raw `fetch(imageUrl)`
- Core provides `fetchRemoteMedia` at `packages/core/src/media/fetch.ts` which internally routes to `fetchWithSsrfGuard`
- No existing unit tests for `handleImageDescription` — coverage gap noted

---

AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Lane: hermes-t3rpz