### PR TITLE
fix(agent): omit NaN days ago from pending-permissions denied ages

### DIFF
--- a/packages/agent/src/providers/pending-permissions-provider.test.ts
+++ b/packages/agent/src/providers/pending-permissions-provider.test.ts
@@ -1,7 +1,8 @@
 /**
  * Unit coverage for the pending-permissions provider and its formatters:
  * formatPendingPermissionLine (denied / not-determined / restricted states with
- * relative timing and last-blocked-feature attribution),
+ * relative timing and last-blocked-feature attribution, including non-finite
+ * denied-age fail-closed lines from #18705),
  * buildPendingPermissionsContext (the PENDING PERMISSIONS section, empty when
  * nothing is pending), and pendingPermissionsProvider itself (silent when the
  * permissions registry is absent or empty, populated otherwise, registered at
@@ -94,6 +95,89 @@ describe("formatPendingPermissionLine", () => {
         NOW,
       ),
     ).toBe("- health: restricted (entitlement_required)");
+  });
+
+  it("omits relative age when lastBlockedFeature.at is non-finite (#18705)", () => {
+    const deniedWithAt = (at: number): PermissionState => ({
+      id: "reminders",
+      status: "denied",
+      lastChecked: NOW,
+      canRequest: false,
+      platform: "darwin",
+      lastBlockedFeature: {
+        app: "lifeops",
+        action: "reminders.create",
+        at,
+      },
+    });
+
+    for (const at of [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+    ]) {
+      const line = formatPendingPermissionLine(deniedWithAt(at), NOW);
+      expect(line).toBe("- reminders: denied (lifeops.reminders.create)");
+      expect(line).not.toMatch(/NaN/i);
+    }
+  });
+
+  it("omits relative age when the clock argument is non-finite (#18705)", () => {
+    const line = formatPendingPermissionLine(
+      {
+        id: "reminders",
+        status: "denied",
+        lastChecked: NOW,
+        canRequest: false,
+        platform: "darwin",
+        lastBlockedFeature: {
+          app: "lifeops",
+          action: "reminders.create",
+          at: NOW - 60_000,
+        },
+      },
+      Number.NaN,
+    );
+    expect(line).toBe("- reminders: denied (lifeops.reminders.create)");
+    expect(line).not.toMatch(/NaN/i);
+  });
+
+  it("keeps finite minute and hour buckets for denied age", () => {
+    expect(
+      formatPendingPermissionLine(
+        {
+          id: "camera",
+          status: "denied",
+          lastChecked: NOW,
+          canRequest: false,
+          platform: "darwin",
+          lastBlockedFeature: {
+            app: "native",
+            action: "camera.open",
+            at: NOW - 5 * 60_000,
+          },
+        },
+        NOW,
+      ),
+    ).toBe("- camera: denied 5 minutes ago (native.camera.open)");
+
+    expect(
+      formatPendingPermissionLine(
+        {
+          id: "microphone",
+          status: "denied",
+          lastChecked: NOW,
+          canRequest: false,
+          platform: "darwin",
+          lastBlockedFeature: {
+            app: "native",
+            action: "mic.open",
+            at: NOW - 3 * 60 * 60_000,
+          },
+        },
+        NOW,
+      ),
+    ).toBe("- microphone: denied 3 hours ago (native.mic.open)");
   });
 });
 

--- a/packages/agent/src/providers/pending-permissions-provider.ts
+++ b/packages/agent/src/providers/pending-permissions-provider.ts
@@ -7,7 +7,8 @@
  *
  * Surfaces only when `registry.pending()` is non-empty so we never bloat the
  * prompt for the steady state. Each line names the permission, current status,
- * and the most recent feature that was blocked.
+ * and the most recent feature that was blocked. Denied-age labels fail closed
+ * on non-finite timestamps so provider text never shows "NaN days ago".
  */
 
 import type {
@@ -53,7 +54,12 @@ const RELATIVE_TIME_MIN = 60_000;
 const RELATIVE_TIME_HOUR = 60 * RELATIVE_TIME_MIN;
 const RELATIVE_TIME_DAY = 24 * RELATIVE_TIME_HOUR;
 
+/**
+ * Coarse English age for a denied-feature stamp. Non-finite `now` or `then`
+ * return empty so callers can omit the age clause rather than emit "NaN days ago".
+ */
 function formatRelativeTime(now: number, then: number): string {
+  if (!Number.isFinite(now) || !Number.isFinite(then)) return "";
   const delta = Math.max(0, now - then);
   if (delta < RELATIVE_TIME_MIN) return "just now";
   if (delta < RELATIVE_TIME_HOUR) {
@@ -76,7 +82,12 @@ export function formatPendingPermissionLine(
   const block = state.lastBlockedFeature;
   if (state.status === "denied" && block) {
     const when = formatRelativeTime(now, block.at);
-    return `- ${id}: denied ${when} (${block.app}.${block.action})`;
+    const feature = `${block.app}.${block.action}`;
+    // Omit the age clause when the stamp is non-finite; still name the feature.
+    if (when) {
+      return `- ${id}: denied ${when} (${feature})`;
+    }
+    return `- ${id}: denied (${feature})`;
   }
   if (state.status === "denied") {
     return `- ${id}: denied`;


### PR DESCRIPTION
# Relates to

Closes #18705

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused verification was run on the touched surfaces after sync (see Testing).
      Full `bun run verify` was **not** re-run this cycle; scoped provider unit suite is the
      proof for this pure presentation helper change.
- [x] A reviewer can confirm the change from the unit transcript and denied-line
      matrices below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `origin/develop`; zero conflicts.
- [x] Focused suite green. Full `bun run verify` not claimed this cycle
      (agent pending-permissions provider formatter + unit tests only).

# Risks

**Low.** Changes only denied-line age formatting when `lastBlockedFeature.at` or
the clock argument is non-finite:

- Finite healthy ages keep the same English buckets (`just now` / `N minute(s) ago` / `N hour(s) ago` / `N day(s) ago`).
- Non-finite stamps omit the age clause but still name the blocked feature
  (`- id: denied (app.action)`), so the planner still sees what was blocked.
- Permission registry storage, probing, and non-denied statuses are unchanged.

# Background

## What does this PR do?

Fixes #18705: the pending-permissions provider no longer emits `NaN days ago`
into planner context when a denied feature stamp (or the clock) is non-finite.

- `formatRelativeTime` requires finite `now` and `then`; otherwise returns `""`
- `formatPendingPermissionLine` omits the age clause when the age string is empty
- Unit coverage for non-finite `at`, non-finite clock, and finite minute/hour buckets

## What kind of change is this?

Bug fix (fail-closed denied-age labels in the pending-permissions provider).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior is
internal to a provider formatter; issue #18705 is the contract record.

# Testing

## Where should a reviewer start?

1. `packages/agent/src/providers/pending-permissions-provider.ts` —
   `formatRelativeTime` / `formatPendingPermissionLine`
2. `packages/agent/src/providers/pending-permissions-provider.test.ts` —
   non-finite matrix + finite bucket cases

## Detailed testing steps

```bash
cd packages/agent && bun test src/providers/pending-permissions-provider.test.ts
```

Result:

```text
 12 pass
 0 fail
 21 expect() calls
Ran 12 tests across 1 file. [1229.00ms]
```

Denied-line matrix:

```text
finite at = now - 2d
  => "- reminders: denied 2 days ago (lifeops.reminders.create)"

finite at = now - 5m
  => "- camera: denied 5 minutes ago (native.camera.open)"

finite at = now - 3h
  => "- microphone: denied 3 hours ago (native.mic.open)"

at = NaN | +Infinity | -Infinity
  => "- reminders: denied (lifeops.reminders.create)"  (no NaN substring)

now = NaN, finite at
  => "- reminders: denied (lifeops.reminders.create)"  (no NaN substring)
```

Biome: `bunx biome check --write` clean on both touched files after format write.

# Evidence Gate

<!-- evidence-head:ee238b127cb2a43b52e69b110b0dfeada2384790 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; pure provider text formatting for planner context.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; pure provider text formatting for planner context.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow; failure mode is a polluted provider string containing `NaN`.
<!-- evidence-row:backend-logs -->
- [x] N/A - no HTTP/server path exercised; proof is the vitest/bun test transcript and denied-line matrix above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network surface in the unit path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt template, or model behavior change; only a pure string formatter used by a provider.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact is the denied-line string matrix under Testing (finite buckets + non-finite omit-age cases).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text to OCR.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model changes beyond a pure age string helper.

## Backend + frontend logs

N/A - unit path only; focused bun test + matrix pasted under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT surface.

## Known gaps / failures

- Full root `bun run verify` not run this cycle; change is limited to
  `pending-permissions-provider.ts` age formatting and its unit tests.
- Package `bun run test` batch runner was not used for the full agent suite
  (it fans out ~391 isolated files); focused `bun test` on the single file is
  the proof for this PR.
- Related but separate: conversation `formatRelativeTimestamp` non-finite
  handling is tracked by #18693 / PR #18694 and is intentionally out of scope.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-rama0x1]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZV4W7Z8S09HGDR1DH2J0FVX","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T14:09:02.952Z","completed_at":"2026-08-12T14:21:34.255Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"2m4Uho9QvBOwiJqcb_iEQS0AZLPlkI96nsEGT4z2Yai5rtOdOIvcD2Cjiz5-0GQBj-PyoxjY01l7GQr0lC2CBA"}} -->