### PR TITLE
fix(dev-platform): adopt the bounded shutdown drain in the desktop dev host

### DIFF
--- a/packages/app-core/scripts/dev-platform.mjs
+++ b/packages/app-core/scripts/dev-platform.mjs
@@ -728,7 +728,7 @@ function pushChild(name, cmd, args, cwd, extraEnv = {}) {
       });
     }
   });
-  childNames.set(child, "electrobun");
+  childNames.set(child, name);
   children.push(child);
   return child;
 }

--- a/packages/app-core/scripts/dev-platform.mjs
+++ b/packages/app-core/scripts/dev-platform.mjs
@@ -84,6 +84,10 @@ import { extendNodePathEnv } from "./lib/node-path-env.mjs";
 import { formatOrchestratorDesktopDevBanner } from "./lib/orchestrator-desktop-dev-banner.mjs";
 import { appIdentityEnv } from "./lib/read-app-identity.mjs";
 import { resolveRendererBuildAction } from "./lib/renderer-build-action.mjs";
+import {
+  drainSpawnedChildren,
+  resolveShutdownDrainWindowMs,
+} from "./lib/shutdown-drain.mjs";
 import { viteRendererBuildNeeded } from "./lib/vite-renderer-dist-stale.mjs";
 
 // Linux WebKitGTK: the dmabuf renderer can emit a benign but noisy
@@ -638,6 +642,11 @@ async function warmApiRoutes(port) {
 }
 
 const children = [];
+// Human names for shutdown logging; keyed weakly so tracking stays an array.
+const childNames = new WeakMap();
+// Same bounded window as dev-ui.mjs (#18435): covers the longest bounded
+// child-side teardown (Discord 10 s drain + 2 s reconcile) with margin.
+const SHUTDOWN_DRAIN_WINDOW_MS = resolveShutdownDrainWindowMs(process.env);
 
 /** First Ctrl-C starts graceful shutdown; second exits immediately (pipes keep the process alive until then). */
 let shuttingDown = false;
@@ -719,6 +728,7 @@ function pushChild(name, cmd, args, cwd, extraEnv = {}) {
       });
     }
   });
+  childNames.set(child, "electrobun");
   children.push(child);
   return child;
 }
@@ -910,6 +920,7 @@ async function launch() {
     onSpawn: (child) => {
       if (child.stdout) prefixStream("api", child.stdout);
       if (child.stderr) prefixStream("api", child.stderr);
+      childNames.set(child, "api");
       children.push(child);
       child.on("exit", (code, signal) => {
         const reason = signal ? `signal ${signal}` : `exit ${code}`;
@@ -1144,11 +1155,15 @@ async function launch() {
 }
 
 /**
- * SIGTERM still-running children, wait for `exit` (or force SIGKILL), then `process.exit`.
+ * SIGTERM still-running children, await their exits up to the bounded drain
+ * window, SIGKILL only stragglers, then `process.exit`.
  *
- * Skips PIDs that already exited so we do not signal stale trees after app Quit.
- * `checkAllExited` + short timeout **why:** piped stdio keeps the event loop alive until
- * every child is gone; exiting early avoids staring at a hung terminal after children die.
+ * Skips PIDs that already exited so we do not signal stale trees after app
+ * Quit. Exit follows child exit directly **why:** piped stdio keeps the event
+ * loop alive until every child is gone; exiting as soon as they are reaped
+ * avoids staring at a hung terminal, while the window keeps a child mid
+ * graceful teardown (e.g. the Discord drain, #17749) from being SIGKILLed the
+ * way the old fixed 1.5 s fuse did (#16318).
  */
 function shutdownDesktopDev({
   exitCode = 0,
@@ -1159,39 +1174,24 @@ function shutdownDesktopDev({
 
   console.log(message);
 
-  let exitScheduled = false;
-  const finish = () => {
-    if (exitScheduled) return;
-    exitScheduled = true;
+  // Bounded drain instead of a fixed 1.5 s SIGKILL fuse (#16318, matching the
+  // dev-ui supervisor fixed in #18435): children that exit promptly release
+  // the supervisor as soon as they are reaped, only a straggler that outlives
+  // the window is escalated (loudly, per child), and a bounded kill grace
+  // keeps exit from racing the escalation. Already-exited children are
+  // skipped inside the drain, preserving the no-stale-tree-signal behavior.
+  void drainSpawnedChildren({
+    children: children.map((child, index) => ({
+      name: childNames.get(child) ?? `child-${index + 1}`,
+      child,
+    })),
+    drainWindowMs: SHUTDOWN_DRAIN_WINDOW_MS,
+    signalTree: signalSpawnedProcessTree,
+    log: (line) => console.log(line),
+    warn: (line) => console.error(line),
+  }).then(() => {
     process.exit(exitCode);
-  };
-
-  const checkAllExited = () => {
-    const anyRunning = children.some(
-      (c) => c.exitCode === null && c.signalCode === null,
-    );
-    if (!anyRunning) {
-      finish();
-    }
-  };
-
-  for (const child of children) {
-    child.once("exit", checkAllExited);
-    child.once("error", checkAllExited);
-    if (child.exitCode === null && child.signalCode === null) {
-      signalSpawnedProcessTree(child, "SIGTERM");
-    }
-  }
-  checkAllExited();
-
-  setTimeout(() => {
-    for (const child of children) {
-      if (child.exitCode === null && child.signalCode === null) {
-        signalSpawnedProcessTree(child, "SIGKILL");
-      }
-    }
-    finish();
-  }, 1500).unref();
+  });
 }
 
 function cleanup() {

--- a/packages/app-core/scripts/lib/shutdown-drain.test.mjs
+++ b/packages/app-core/scripts/lib/shutdown-drain.test.mjs
@@ -305,8 +305,14 @@ describe("dev-platform supervisor wiring", () => {
     expect(devPlatformSource).not.toContain("}, 1500).unref();");
   });
 
-  it("names both tracked children for loud escalation logs", () => {
-    expect(devPlatformSource).toContain('childNames.set(child, "electrobun");');
+  it("names tracked children for loud escalation logs", () => {
+    // pushChild is generic (called with "vite" and "electrobun"): the stored
+    // name must be the caller's argument, never a hard-coded literal, or a
+    // Vite straggler is misreported as Electrobun (#18708 review, @w1kke).
+    expect(devPlatformSource).toContain("childNames.set(child, name);");
+    expect(devPlatformSource).not.toContain(
+      'childNames.set(child, "electrobun");',
+    );
     expect(devPlatformSource).toContain('childNames.set(child, "api");');
   });
 });

--- a/packages/app-core/scripts/lib/shutdown-drain.test.mjs
+++ b/packages/app-core/scripts/lib/shutdown-drain.test.mjs
@@ -284,3 +284,29 @@ describe("dev-ui supervisor wiring", () => {
     );
   });
 });
+
+describe("dev-platform supervisor wiring", () => {
+  const devPlatformSource = readFileSync(
+    path.join(libDir, "..", "dev-platform.mjs"),
+    "utf8",
+  );
+
+  it("routes shutdownDesktopDev through the bounded drain", () => {
+    expect(devPlatformSource).toContain("void drainSpawnedChildren({");
+    expect(devPlatformSource).toContain(
+      "drainWindowMs: SHUTDOWN_DRAIN_WINDOW_MS,",
+    );
+    expect(devPlatformSource).toContain(
+      "signalTree: signalSpawnedProcessTree,",
+    );
+  });
+
+  it("no longer SIGKILLs surviving children on a fixed fuse", () => {
+    expect(devPlatformSource).not.toContain("}, 1500).unref();");
+  });
+
+  it("names both tracked children for loud escalation logs", () => {
+    expect(devPlatformSource).toContain('childNames.set(child, "electrobun");');
+    expect(devPlatformSource).toContain('childNames.set(child, "api");');
+  });
+});


### PR DESCRIPTION
# Relates to

Slice of #16318 (packaged-runtime supervisor only), per [the claim comment](https://github.com/elizaOS/eliza/issues/16318#issuecomment-5268073095). This PR must NOT close the issue: the runtime-level ingress cordon (claimed by hermesagent270) and the live Discord restart drain evidence remain open there. Companion to #18435 (dev-ui supervisor) and #18470/#18549 (startup reconciliation).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and focused verification were run after sync; details in Testing below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from and rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passes post-sync (drain + no-install suites 22/22, biome, `node --check`, `audit:scripts`, `git diff --check`).

# Risks

Low. Dev-host script only. `shutdownDesktopDev` keeps its exact external contract (same call sites, same force-exit second-signal path in `cleanup()`); the only behavior change is that a child mid graceful teardown gets the bounded window (default 15 s, `ELIZA_DEV_SHUTDOWN_DRAIN_MS` override, timer-safe range enforced by the merged resolver) instead of a 1.5 s SIGKILL, and escalation is now named and logged instead of silent. Prompt exits still release the supervisor immediately, as before.

# Background

## What does this PR do?

`shutdownDesktopDev` in `packages/app-core/scripts/dev-platform.mjs` already awaited child exits, but its escalation was a fixed 1500 ms SIGKILL fuse over every surviving child tree: silent (no straggler named), no kill grace before `process.exit`, and shorter than the teardown children are entitled to perform (Discord: `DISCORD_SHUTDOWN_DRAIN_TIMEOUT_MS = 10_000` plus `DISCORD_REACTION_RECONCILE_TIMEOUT_MS = 2_000`, #17749). This is the same defect class #18435 fixed in the dev-ui supervisor, on the desktop host instead.

The fix routes `shutdownDesktopDev` through the `drainSpawnedChildren` module that merged in #18435, including its timer-safe env-resolved window and the bd8b5ac hardening (never-spawned children excluded). Tracked children are named via a WeakMap (the generic `pushChild` caller name: `vite`/`electrobun`, plus `api` at the supervisor spawn site) so escalation logs say which child overran. Already-exited children are skipped inside the drain, preserving the existing no-stale-tree-signal behavior after app Quit.

## What kind of change is this?

Bug fix (non-breaking; dev tooling only).

# Documentation changes needed?

None; the shutdown contract is documented at the definition site.

# Testing

## Where should a reviewer start?

1. The `shutdownDesktopDev` diff in `packages/app-core/scripts/dev-platform.mjs` (one function body plus two one-line name registrations and the import).
2. `packages/app-core/scripts/lib/shutdown-drain.test.mjs`: the new `dev-platform supervisor wiring` suite, alongside the module's existing 13 deterministic/real-process tests (which are the behavior evidence for the drain itself, unchanged here).

Commands run at this head:

```bash
node scripts/run-vitest.mjs run --config vitest.config.ts scripts/lib/shutdown-drain.test.mjs scripts/dev-platform-no-install.test.mjs   # 22/22
bun x biome check packages/app-core/scripts/dev-platform.mjs packages/app-core/scripts/lib/shutdown-drain.test.mjs                       # clean
node --check packages/app-core/scripts/dev-platform.mjs
bun run audit:scripts
git diff --check
```

## Detailed testing steps

`bun run dev:desktop`, quit or SIGTERM the host: children that exit promptly release the supervisor immediately; with `ELIZA_DEV_SHUTDOWN_DRAIN_MS=200`, a slow child is escalated with a named log line instead of silently SIGKILLed.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:9fd3a11abb818fc80cd9acf1e2bf51fb307f626d -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - dev supervisor script change; no UI surface renders`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - dev supervisor script change; no UI surface renders`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - terminal-only supervisor behavior`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the drain module's real-process behavior (prompt release on SIGTERM-honoring children; named SIGKILL escalation of a SIGTERM-ignoring child) is proven by its own real-process test suite, unchanged here, and by the live supervisor logs attached to merged #18435 which exercised the identical module and log lines under `bun run dev`. This diff changes only which host calls the module. `N/A - no new backend log surface beyond the #18435 evidence; the electrobun desktop host cannot boot in the headless Linux environment this was validated in`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend involvement`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no domain outputs; deterministic tests and the referenced #18435 logs carry the behavior evidence`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no model-facing change.`

## Backend + frontend logs

See the backend-logs row: the identical module and log lines were live-proven on #18435; this PR only adopts them in the desktop host, whose electrobun runtime needs a display the validation sandbox does not have. Frontend: `N/A`.

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface.`

### After

`N/A - no UI surface.`

### Walkthrough video

`N/A - terminal-only supervisor behavior.`

## Audio / voice walkthrough

`N/A - no voice surface.`

## Known gaps / failures

- No live desktop-host run: electrobun requires a display; the headless validation environment cannot boot it. The drain behavior itself is covered by the module's deterministic and real-process tests and the #18435 live logs; what is untested live here is only this host's wiring, which the source-shape suite pins.
- The compute receipt below reports zero project-attributed tokens with `unavailable` confidence: the isolated build environment has no local Claude Code usage data for ccusage to read. Signed zero rather than fabricated usage, per the skill contract.
- The ingress cordon (claimed by hermesagent270) and live Discord restart drain evidence remain open on #16318.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [claude-code-wbaxterh]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZV5HH0271K1VXETZGA47AHP","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T14:20:40.322Z","completed_at":"2026-08-12T14:22:15.995Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ6-B_keoGBnP1vX0AEdBc1-mwYlyxZ0hgzt21ESQWaQ","device_key_id":"972ca87555be4523e052622617f964f99285337b7f81650e8da644fb2ac176b6","device_signature":"RnuH4mCZRdZxdQj5pDoWWX0glyLRUrUm1kUA8lEiAA1ihHlgRYOJc_HgNSH9hwHDFDp9vCWx_FdtuXyjV8UdAg"}} -->
