### PR TITLE
feat(cloud): carry an agent's state across nodes when it is relocated

### DIFF
--- a/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
@@ -366,7 +366,17 @@ export const WARM_POOL_USER_ID = "00000000-0000-4000-8000-000000077002";
 
 export type AgentSandboxPoolStatus = "unclaimed";
 
-export type AgentBackupSnapshotType = "auto" | "manual" | "pre-shutdown" | "pre-upgrade";
+/**
+ * `pre-move` is deliberately distinct from `pre-upgrade`: a rollback restores
+ * the latest `pre-upgrade` point, so a relocation writing under that label
+ * would silently become the state a later rollback replays.
+ */
+export type AgentBackupSnapshotType =
+  | "auto"
+  | "manual"
+  | "pre-shutdown"
+  | "pre-upgrade"
+  | "pre-move";
 
 /**
  * Outcome of the last restorability verification pass over a backup row

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -9135,3 +9135,160 @@ describe("snapshot hydration budgets (#16639)", () => {
     ).toThrow("file budget");
   });
 });
+
+describe("ElizaSandboxService.transferStateForRelocation", () => {
+  // A blue/green replacement moves the CONTAINER, not the state: agent volumes
+  // are host bind-mounts, so the pglite directory does not follow a container
+  // to another machine. The caller retires the source placement on the strength
+  // of this answer, so the contract is that `transferred: true` is reported
+  // only after a completed push — anything else is a move that did not happen.
+  const SOURCE_SNAPSHOT = {
+    memories: [{ id: "m1" }],
+    config: { agentName: "probe" },
+    workspaceFiles: {},
+    manifest: { version: 1, tables: ["memories"] },
+  };
+
+  function bridgeStub(opts: { snapshotStatus?: number; restoreStatus?: number; body?: unknown }) {
+    const calls: string[] = [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = fetchUrl(input);
+      calls.push(url);
+      if (url.endsWith("/api/snapshot")) {
+        const status = opts.snapshotStatus ?? 200;
+        if (status !== 200) return new Response("nope", { status });
+        return Response.json(opts.body ?? SOURCE_SNAPSHOT);
+      }
+      if (url.endsWith("/api/restore")) {
+        const status = opts.restoreStatus ?? 200;
+        if (status !== 200) return new Response("refused", { status });
+        return Response.json({ ok: true });
+      }
+      return Response.json({ ok: true });
+    });
+    return calls;
+  }
+
+  async function runTransfer(sandbox: AgentSandbox) {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    return (
+      new ElizaSandboxService() as unknown as {
+        transferStateForRelocation: (o: {
+          agentId: string;
+          orgId: string;
+          targetBridgeUrl: string;
+          authRec: Pick<AgentSandbox, "id" | "environment_vars">;
+        }) => Promise<{ transferred: boolean; reason?: string; detail?: string }>;
+      }
+    ).transferStateForRelocation({
+      agentId: sandbox.id,
+      orgId: sandbox.organization_id,
+      targetBridgeUrl: "https://blue.example",
+      authRec: sandbox,
+    });
+  }
+
+  test("an image with no snapshot endpoint is unrelocatable, and nothing is pushed", async () => {
+    const sandbox = customSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
+      sandbox as never,
+    );
+    const calls = bridgeStub({ snapshotStatus: 404 });
+    try {
+      const outcome = await runTransfer(sandbox);
+      expect(outcome.transferred).toBe(false);
+      expect(outcome.reason).toBe("capture-unsupported");
+      // The decisive assertion: the replacement was never given a state, so a
+      // caller that retired the source here would destroy the only copy.
+      expect(calls.some((u) => u.endsWith("/api/restore"))).toBe(false);
+    } finally {
+      findSpy.mockRestore();
+    }
+  });
+
+  test("a capture without a full manifest is refused before anything is pushed", async () => {
+    const sandbox = customSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
+      sandbox as never,
+    );
+    // Same shape minus the manifest: a partial capture would survive as silent
+    // data loss once the source container is destroyed.
+    const calls = bridgeStub({ body: { ...SOURCE_SNAPSHOT, manifest: undefined } });
+    try {
+      const outcome = await runTransfer(sandbox);
+      expect(outcome.transferred).toBe(false);
+      expect(outcome.reason).toBe("capture-failed");
+      expect(outcome.detail).toContain("manifest");
+      expect(calls.some((u) => u.endsWith("/api/restore"))).toBe(false);
+    } finally {
+      findSpy.mockRestore();
+    }
+  });
+
+  test("a refused restore is never reported as transferred", async () => {
+    const sandbox = customSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
+      sandbox as never,
+    );
+    const backupSpy = spyOn(agentSandboxesRepository, "createBackup").mockResolvedValue({
+      id: "backup-1",
+      size_bytes: 4096,
+    } as never);
+    const stateSpy = spyOn(
+      agentSandboxesRepository,
+      "getReconstructedBackupState",
+    ).mockResolvedValue(SOURCE_SNAPSHOT as never);
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(null as never);
+    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(
+      undefined as never,
+    );
+    // No parent chain: forces a full backup, which is the shape a relocation
+    // must carry anyway.
+    const latestSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
+      undefined as never,
+    );
+    bridgeStub({ restoreStatus: 500 });
+    try {
+      const outcome = await runTransfer(sandbox);
+      expect(outcome.transferred).toBe(false);
+      expect(outcome.reason).toBe("push-failed");
+    } finally {
+      for (const s of [findSpy, backupSpy, stateSpy, updateSpy, pruneSpy, latestSpy])
+        s.mockRestore();
+    }
+  });
+
+  test("reports transferred only after the restore actually completed", async () => {
+    const sandbox = customSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
+      sandbox as never,
+    );
+    const backupSpy = spyOn(agentSandboxesRepository, "createBackup").mockResolvedValue({
+      id: "backup-1",
+      size_bytes: 4096,
+    } as never);
+    const stateSpy = spyOn(
+      agentSandboxesRepository,
+      "getReconstructedBackupState",
+    ).mockResolvedValue(SOURCE_SNAPSHOT as never);
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(null as never);
+    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(
+      undefined as never,
+    );
+    // No parent chain: forces a full backup, which is the shape a relocation
+    // must carry anyway.
+    const latestSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
+      undefined as never,
+    );
+    const calls = bridgeStub({});
+    try {
+      const outcome = await runTransfer(sandbox);
+      expect(outcome.transferred).toBe(true);
+      expect(calls.some((u) => u.endsWith("/api/snapshot"))).toBe(true);
+      expect(calls.some((u) => u.endsWith("/api/restore"))).toBe(true);
+    } finally {
+      for (const s of [findSpy, backupSpy, stateSpy, updateSpy, pruneSpy, latestSpy])
+        s.mockRestore();
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -484,6 +484,22 @@ export interface SnapshotResult {
 }
 
 /**
+ * Outcome of carrying an agent's state onto a replacement container.
+ *
+ * `capture-unsupported` is not a failure to retry: the running image has no
+ * snapshot endpoint, so the agent cannot be relocated at all and must be left
+ * where it is. Every other reason describes a move that did not happen and can
+ * be attempted again.
+ */
+export type StateTransferOutcome =
+  | { transferred: true; snapshotId: string; sizeBytes: number }
+  | {
+      transferred: false;
+      reason: "capture-unsupported" | "capture-failed" | "reconstruct-failed" | "push-failed";
+      detail: string;
+    };
+
+/**
  * Sentinel error for "the running agent image does not serve POST /api/snapshot".
  * The deployed elizaOS (V2) agent image binds its API to ELIZA_PORT/PORT and
  * does not expose the bridge `/api/snapshot` route — only the cloud-agent
@@ -6417,6 +6433,82 @@ export class ElizaSandboxService {
       bytes: backup.size_bytes,
     });
     return { success: true, backup };
+  }
+
+  /**
+   * Carry an agent's durable state from the container it runs on today onto a
+   * replacement container on another node.
+   *
+   * This exists because a blue/green replacement moves the CONTAINER, not the
+   * state. Agent volumes are host bind-mounts (`/data/agents/<id>` mounted at
+   * `/root/.eliza`), so the pglite data directory does not follow a container
+   * to a new machine, and the `pre-upgrade` snapshot the upgrade path takes is
+   * only a rollback point — it is never pushed into the new container. A
+   * relocation built on the upgrade sequence alone would therefore start the
+   * agent on an empty database and destroy the old one on cutover.
+   *
+   * The only cross-node transport is the application-level snapshot/restore
+   * rail, which is node-agnostic by construction. This method is that rail,
+   * with the ordering that makes it safe:
+   *
+   *   1. capture from the OLD container while it is still live and serving;
+   *   2. reconstruct, so a backup that cannot be replayed is caught here;
+   *   3. push onto the new container.
+   *
+   * It never reports success without a completed push, so the caller may only
+   * retire the old placement once this resolves `transferred: true`. An image
+   * that cannot snapshot is reported as `capture-unsupported` rather than as a
+   * failure: such an agent is not relocatable, and the caller must leave it
+   * where it is instead of moving it without its data.
+   */
+  async transferStateForRelocation(opts: {
+    agentId: string;
+    orgId: string;
+    targetBridgeUrl: string;
+    /** Carries the agent's API token so the restore is not rejected (#15261). */
+    authRec: Pick<AgentSandbox, "id" | "environment_vars">;
+  }): Promise<StateTransferOutcome> {
+    const captured = await this.snapshot(opts.agentId, opts.orgId, "pre-move");
+    if (!captured.success || !captured.backup) {
+      const detail = captured.error ?? "unknown snapshot failure";
+      return {
+        transferred: false,
+        reason: detail === SNAPSHOT_ENDPOINT_UNSUPPORTED ? "capture-unsupported" : "capture-failed",
+        detail,
+      };
+    }
+
+    const restoreState = await agentSandboxesRepository.getReconstructedBackupState(
+      captured.backup.id,
+    );
+    if (!restoreState) {
+      return {
+        transferred: false,
+        reason: "reconstruct-failed",
+        detail: `pre-move backup ${captured.backup.id} could not be reconstructed`,
+      };
+    }
+
+    try {
+      await this.pushState(opts.targetBridgeUrl, restoreState, {
+        trusted: true,
+        authRec: opts.authRec,
+      });
+    } catch (error) {
+      // error-policy:J2 the caller decides what to do with a half-moved agent,
+      // and it can only decide correctly if the reason survives.
+      return {
+        transferred: false,
+        reason: "push-failed",
+        detail: error instanceof Error ? error.message : String(error),
+      };
+    }
+
+    return {
+      transferred: true,
+      snapshotId: captured.backup.id,
+      sizeBytes: captured.backup.size_bytes ?? 0,
+    };
   }
 
   /**

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -6411,10 +6411,15 @@ export class ElizaSandboxService {
       throw error;
     }
 
-    if (type === "pre-upgrade" && !stateData.manifest) {
+    // Both labels gate a destructive follow-up — a rollback replays the
+    // `pre-upgrade` point, and a relocation destroys the source container once
+    // the `pre-move` capture is restored elsewhere. A partial capture would
+    // survive either as silent data loss, so neither is accepted without a
+    // full-agent manifest.
+    if ((type === "pre-upgrade" || type === "pre-move") && !stateData.manifest) {
       return {
         success: false,
-        error: "Pre-upgrade snapshot did not include a full-agent manifest",
+        error: `${type} snapshot did not include a full-agent manifest`,
       };
     }
 


### PR DESCRIPTION
# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was loaded for this change`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop`; zero conflicts. Independent of #18616 and #18639.
- [x] `packages/cloud/shared` typecheck clean, biome clean, 192/192 on the full `eliza-sandbox` suite.

# Risks

**Nothing calls this yet.** It is the primitive a relocation job will need; adding it changes no existing path.

The one behaviour change is a widened guard: `pre-move` captures now require a full-agent manifest, exactly as `pre-upgrade` already did. No caller depended on the old message text (grepped).

# Background

## What does this PR do?

A blue/green replacement moves the **container**, not the state. Agent volumes are host bind-mounts (`/data/agents/<id>` at `/root/.eliza`), so the pglite data directory does not follow a container to another machine. And the `pre-upgrade` snapshot the upgrade path takes is only a **rollback point** — it is never pushed into the new container; the restore leg lives in the *downgrade* path.

So a relocation built on the upgrade sequence alone would start the agent on an empty database and then destroy the old one at cutover. That is silent, total data loss for every moved agent, and it is the trap this PR exists to close before any move code is written.

`transferStateForRelocation` is the missing leg, with the ordering that makes it safe:

1. capture from the **old** container while it is still live and serving;
2. reconstruct, so a backup that cannot be replayed is caught before anything is destroyed;
3. push onto the new container.

It never reports success without a completed push, so a caller may only retire the old placement once it resolves `transferred: true`.

Two deliberate distinctions:

- **`pre-move` is its own snapshot type.** A rollback restores the latest `pre-upgrade` point, so writing a relocation under that label would silently become the state a later rollback replays.
- **`capture-unsupported` is not a failure.** An image with no snapshot endpoint means the agent is *unrelocatable* and must be left where it is — not retried.

## What kind of change is this?

Feature — control-plane groundwork for node evacuation (#18485).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`transferStateForRelocation` in `eliza-sandbox.ts`, then its four tests in `eliza-sandbox.test.ts`.

## Detailed testing steps

`bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts -t transferStateForRelocation` — 4 tests driving the real service through the existing harness (repository spied, bridge transport stubbed).

Mutation-proved. Making a failed push report success:

```
(fail) transferStateForRelocation > a refused restore is never reported as transferred
        Expected: false
        Received: true
```

Reverted against the git object; 192/192 on the full file after.

The two capture-failure tests additionally assert that **no restore call was made at all** — a caller that retired the source at that point would destroy the only copy.

# Evidence Gate

<!-- evidence-head:0613f4cbfa6524b79865c3797442bf28d809a1e7 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this is a service primitive with no caller and no rendered surface, before or after.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this is a service primitive with no caller and no rendered surface, before or after.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing flow in a state-transfer method that nothing yet invokes.
<!-- evidence-row:backend-logs -->
- [x] Test transcript, which is the behavioural evidence for a primitive with no runtime caller yet:

```
bun test eliza-sandbox.test.ts -t transferStateForRelocation     4 pass, 0 fail
  an image with no snapshot endpoint is unrelocatable, and nothing is pushed
  a capture without a full manifest is refused before anything is pushed
  a refused restore is never reported as transferred
  reports transferred only after the restore actually completed
bun test eliza-sandbox.test.ts                                 192 pass, 0 fail
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer code is touched; this is a server-only service method.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behaviour is touched by this change.
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is the ordering, since the whole value is which step precedes which:

```
capture from OLD (live)  ->  reconstruct  ->  push onto NEW  ->  caller may retire OLD
        |                        |                  |
  unsupported ->            unreplayable ->     refused ->    transferred:false, OLD kept
```

Related: #18491 and #18639 (node sizing), #18616 (`placement_state`), #18485 (fleet placement).

[stan-cloud]
