### PR TITLE
fix(discord): expose owner, DM policy, and allowlist on agent config surfaces

### DIFF
--- a/packages/agent/src/api/server-helpers-plugin.discord-params.test.ts
+++ b/packages/agent/src/api/server-helpers-plugin.discord-params.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for the Discord plugin chat-config form parameters emitted by
+ * resolvePluginConfigReply. Ensures owner user IDs, DM policy, and allowlist
+ * fields appear alongside bot token / application ID. Deterministic.
+ */
+import { describe, expect, it } from "vitest";
+import { resolvePluginConfigReply } from "./server-helpers-plugin.ts";
+
+type FormSpec = {
+  version: number;
+  root: string;
+  elements: Record<string, { type: string; props?: Record<string, unknown> }>;
+  state: Record<string, string>;
+};
+
+function parseForm(reply: string): FormSpec {
+  const match = reply.match(/```json-render\n([\s\S]*?)\n```/);
+  if (!match?.[1]) {
+    throw new Error(
+      `expected json-render form fence, got: ${reply.slice(0, 200)}`,
+    );
+  }
+  return JSON.parse(match[1]) as FormSpec;
+}
+
+describe("resolvePluginConfigReply discord ownership fields", () => {
+  it("includes owner, DM policy, and allowlist inputs on configure discord", async () => {
+    const reply = await resolvePluginConfigReply("configure discord", {
+      config: {},
+      runtime: null,
+    } as never);
+    expect(typeof reply).toBe("string");
+    if (typeof reply !== "string") {
+      throw new Error("expected configure discord to return a form string");
+    }
+    const form = parseForm(reply);
+
+    expect(form.state.pluginId).toBe("discord");
+    expect(form.state["config.DISCORD_API_TOKEN"]).toBe("");
+    expect(form.state["config.DISCORD_APPLICATION_ID"]).toBe("");
+    expect(form.state["config.ELIZA_DISCORD_OWNER_USER_IDS_JSON"]).toBe("");
+    expect(form.state["config.DISCORD_DM_POLICY"]).toBe("");
+    expect(form.state["config.DISCORD_ALLOW_FROM"]).toBe("");
+
+    const labels = Object.values(form.elements)
+      .filter((el) => el.type === "Input")
+      .map((el) => String(el.props?.label ?? ""));
+
+    expect(labels).toEqual(
+      expect.arrayContaining([
+        "Bot Token",
+        "Application ID (optional, auto-resolved when omitted)",
+        'Owner Discord user IDs (JSON array, e.g. ["123456789012345678"])',
+        "DM policy (open | allowlist | pairing | disabled)",
+        "DM allowlist (comma-separated Discord user IDs)",
+      ]),
+    );
+  });
+
+  it("returns null for prompts that are not plugin config intents", async () => {
+    const reply = await resolvePluginConfigReply("what is the weather", {
+      config: {},
+      runtime: null,
+    } as never);
+    expect(reply).toBeNull();
+  });
+});

--- a/packages/agent/src/api/server-helpers-plugin.ts
+++ b/packages/agent/src/api/server-helpers-plugin.ts
@@ -32,6 +32,21 @@ const PLUGIN_PARAMS: Record<
       label: "Application ID (optional, auto-resolved when omitted)",
       secret: false,
     },
+    {
+      key: "ELIZA_DISCORD_OWNER_USER_IDS_JSON",
+      label: 'Owner Discord user IDs (JSON array, e.g. ["123456789012345678"])',
+      secret: false,
+    },
+    {
+      key: "DISCORD_DM_POLICY",
+      label: "DM policy (open | allowlist | pairing | disabled)",
+      secret: false,
+    },
+    {
+      key: "DISCORD_ALLOW_FROM",
+      label: "DM allowlist (comma-separated Discord user IDs)",
+      secret: false,
+    },
   ],
   twitter: [
     { key: "TWITTER_USERNAME", label: "Username", secret: false },

--- a/packages/agent/src/config/env-vars.discord-ownership.test.ts
+++ b/packages/agent/src/config/env-vars.discord-ownership.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for Discord ownership and DM-policy projection in
+ * collectConnectorEnvVars. Covers the ELIZA_DISCORD_OWNER_USER_IDS_JSON JSON
+ * array contract (must not comma-join) and DISCORD_DM_POLICY /
+ * DISCORD_ALLOW_FROM mapping. Deterministic pure-function harness.
+ */
+import { describe, expect, it } from "vitest";
+import { CONNECTOR_ENV_MAP, collectConnectorEnvVars } from "./env-vars.ts";
+import type { ElizaConfig } from "./types.ts";
+
+describe("CONNECTOR_ENV_MAP.discord ownership and DM fields", () => {
+  it("maps dmPolicy, allowFrom, and ownerUserIdsJson to the plugin env keys", () => {
+    expect(CONNECTOR_ENV_MAP.discord.dmPolicy).toBe("DISCORD_DM_POLICY");
+    expect(CONNECTOR_ENV_MAP.discord.allowFrom).toBe("DISCORD_ALLOW_FROM");
+    expect(CONNECTOR_ENV_MAP.discord.ownerUserIdsJson).toBe(
+      "ELIZA_DISCORD_OWNER_USER_IDS_JSON",
+    );
+  });
+});
+
+describe("collectConnectorEnvVars discord ownership and DM policy", () => {
+  it("projects dmPolicy and allowFrom string fields", () => {
+    const cfg = {
+      connectors: {
+        discord: {
+          token: "bot-token",
+          dmPolicy: "allowlist",
+          allowFrom: "111111111111111111, 222222222222222222",
+        },
+      },
+    } as ElizaConfig;
+
+    const env = collectConnectorEnvVars(cfg);
+    expect(env.DISCORD_API_TOKEN).toBe("bot-token");
+    expect(env.DISCORD_DM_POLICY).toBe("allowlist");
+    expect(env.DISCORD_ALLOW_FROM).toBe(
+      "111111111111111111, 222222222222222222",
+    );
+  });
+
+  it("comma-joins allowFrom arrays (plugin env is comma-separated)", () => {
+    const cfg = {
+      connectors: {
+        discord: {
+          token: "bot-token",
+          allowFrom: ["111111111111111111", "222222222222222222"],
+        },
+      },
+    } as ElizaConfig;
+
+    const env = collectConnectorEnvVars(cfg);
+    expect(env.DISCORD_ALLOW_FROM).toBe(
+      "111111111111111111,222222222222222222",
+    );
+  });
+
+  it("JSON-stringifies ownerUserIds arrays for ELIZA_DISCORD_OWNER_USER_IDS_JSON", () => {
+    const cfg = {
+      connectors: {
+        discord: {
+          token: "bot-token",
+          ownerUserIds: ["111111111111111111", "222222222222222222"],
+        },
+      },
+    } as ElizaConfig;
+
+    const env = collectConnectorEnvVars(cfg);
+    expect(env.ELIZA_DISCORD_OWNER_USER_IDS_JSON).toBe(
+      JSON.stringify(["111111111111111111", "222222222222222222"]),
+    );
+    // Must not be the comma-joined form parseDiscordOwnerUserIds rejects.
+    expect(env.ELIZA_DISCORD_OWNER_USER_IDS_JSON).not.toBe(
+      "111111111111111111,222222222222222222",
+    );
+  });
+
+  it("passes through ownerUserIdsJson strings unchanged", () => {
+    const raw = '["111111111111111111"]';
+    const cfg = {
+      connectors: {
+        discord: {
+          token: "bot-token",
+          ownerUserIdsJson: raw,
+        },
+      },
+    } as ElizaConfig;
+
+    const env = collectConnectorEnvVars(cfg);
+    expect(env.ELIZA_DISCORD_OWNER_USER_IDS_JSON).toBe(raw);
+  });
+
+  it("omits empty ownership and policy fields", () => {
+    const cfg = {
+      connectors: {
+        discord: {
+          token: "bot-token",
+          dmPolicy: "  ",
+          allowFrom: [],
+          ownerUserIds: [],
+          ownerUserIdsJson: "",
+        },
+      },
+    } as ElizaConfig;
+
+    const env = collectConnectorEnvVars(cfg);
+    expect(env.DISCORD_API_TOKEN).toBe("bot-token");
+    expect(env.DISCORD_DM_POLICY).toBeUndefined();
+    expect(env.DISCORD_ALLOW_FROM).toBeUndefined();
+    expect(env.ELIZA_DISCORD_OWNER_USER_IDS_JSON).toBeUndefined();
+  });
+});

--- a/packages/agent/src/config/env-vars.ts
+++ b/packages/agent/src/config/env-vars.ts
@@ -37,6 +37,12 @@ export const CONNECTOR_ENV_MAP: Readonly<
     token: "DISCORD_API_TOKEN",
     botToken: "DISCORD_API_TOKEN",
     applicationId: "DISCORD_APPLICATION_ID",
+    dmPolicy: "DISCORD_DM_POLICY",
+    allowFrom: "DISCORD_ALLOW_FROM",
+    // String form of ELIZA_DISCORD_OWNER_USER_IDS_JSON (JSON array text).
+    // Array `ownerUserIds` is handled specially below — must JSON.stringify,
+    // not comma-join, for parseDiscordOwnerUserIds.
+    ownerUserIdsJson: "ELIZA_DISCORD_OWNER_USER_IDS_JSON",
     syncProfile: "DISCORD_SYNC_PROFILE",
     profileName: "DISCORD_PROFILE_NAME",
     profileAvatar: "DISCORD_PROFILE_AVATAR",
@@ -172,7 +178,8 @@ export function collectConnectorEnvVars(
     const configObj = connectorConfig as Record<string, unknown>;
 
     // Mirror Discord token aliases so older plugins and settings surfaces
-    // agree on a single configured state.
+    // agree on a single configured state. Owner snowflakes must stay JSON
+    // (not comma-joined) for ELIZA_DISCORD_OWNER_USER_IDS_JSON.
     if (connectorName === "discord") {
       const tokenValue =
         (typeof configObj.token === "string" && configObj.token.trim()) ||
@@ -182,15 +189,34 @@ export function collectConnectorEnvVars(
         entries.DISCORD_API_TOKEN = tokenValue;
         entries.DISCORD_BOT_TOKEN = tokenValue;
       }
+
+      const ownerUserIds = configObj.ownerUserIds;
+      if (Array.isArray(ownerUserIds)) {
+        const snowflakes = ownerUserIds
+          .map((entry) => {
+            if (typeof entry === "string") return entry.trim();
+            if (typeof entry === "number" && Number.isFinite(entry)) {
+              return String(entry);
+            }
+            return "";
+          })
+          .filter((entry) => entry.length > 0);
+        if (snowflakes.length > 0) {
+          entries.ELIZA_DISCORD_OWNER_USER_IDS_JSON =
+            JSON.stringify(snowflakes);
+        }
+      }
     }
 
     for (const [configField, envKey] of Object.entries(envMap)) {
       // Discord token/botToken are handled above with token-first precedence; the
       // env map maps both fields to DISCORD_API_TOKEN, so applying them here would
-      // let botToken overwrite token.
+      // let botToken overwrite token. ownerUserIds is handled above as JSON.
       if (
         connectorName === "discord" &&
-        (configField === "token" || configField === "botToken")
+        (configField === "token" ||
+          configField === "botToken" ||
+          configField === "ownerUserIds")
       ) {
         continue;
       }

--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -44,6 +44,7 @@
       "source": "bundled",
       "tags": [
         "agent-skills",
+        "clawhub",
         "otto",
         "skills",
         "agents",
@@ -65,6 +66,14 @@
           "sensitive": false,
           "label": "Auto Load",
           "help": "Automatically load installed skills on startup",
+          "advanced": false
+        },
+        "SKILLS_REGISTRY": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "label": "Registry",
+          "help": "Skill registry URL (default: https://clawhub.ai)",
           "advanced": false
         },
         "BUNDLED_SKILLS_DIRS": {
@@ -1400,6 +1409,30 @@
           "sensitive": false,
           "label": "Listen Channel Ids",
           "help": "Comma-separated list of Discord channel IDs where the bot will only listen (not respond).",
+          "advanced": false
+        },
+        "ELIZA_DISCORD_OWNER_USER_IDS_JSON": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "label": "Owner User IDs (JSON)",
+          "help": "JSON array of Discord user snowflakes that alias to the canonical Eliza owner entity (e.g. [\"123456789012345678\"]). Use when ownership cannot be inferred from the Discord application team.",
+          "advanced": false
+        },
+        "DISCORD_DM_POLICY": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "label": "DM Policy",
+          "help": "Direct-message access policy: open, allowlist, pairing (default), or disabled.",
+          "advanced": false
+        },
+        "DISCORD_ALLOW_FROM": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "label": "DM Allow From",
+          "help": "Comma-separated Discord user snowflakes allowed to DM the bot under the allowlist policy (also seeds the pairing allowlist).",
           "advanced": false
         }
       },

--- a/plugins/plugin-discord/package.json
+++ b/plugins/plugin-discord/package.json
@@ -168,6 +168,24 @@
 				"description": "Comma-separated list of Discord channel IDs where the bot will only listen (not respond).",
 				"required": false,
 				"sensitive": false
+			},
+			"ELIZA_DISCORD_OWNER_USER_IDS_JSON": {
+				"type": "string",
+				"description": "JSON array of Discord user snowflakes that alias to the canonical Eliza owner entity (e.g. [\"123456789012345678\"]). Required for reliable owner recognition when the Discord application team cannot be inferred.",
+				"required": false,
+				"sensitive": false
+			},
+			"DISCORD_DM_POLICY": {
+				"type": "string",
+				"description": "Direct-message access policy: open, allowlist, pairing (default), or disabled.",
+				"required": false,
+				"sensitive": false
+			},
+			"DISCORD_ALLOW_FROM": {
+				"type": "string",
+				"description": "Comma-separated Discord user snowflakes allowed to DM the bot when DISCORD_DM_POLICY is allowlist (also used as the static pairing allowlist seed).",
+				"required": false,
+				"sensitive": false
 			}
 		},
 		"configUiHints": {
@@ -180,6 +198,24 @@
 				"label": "Application ID",
 				"order": 2,
 				"group": "connection"
+			},
+			"ELIZA_DISCORD_OWNER_USER_IDS_JSON": {
+				"label": "Owner user IDs (JSON)",
+				"order": 3,
+				"group": "connection",
+				"requires": "DISCORD_API_TOKEN"
+			},
+			"DISCORD_DM_POLICY": {
+				"label": "DM policy",
+				"order": 4,
+				"group": "connection",
+				"requires": "DISCORD_API_TOKEN"
+			},
+			"DISCORD_ALLOW_FROM": {
+				"label": "DM allowlist",
+				"order": 5,
+				"group": "connection",
+				"requires": "DISCORD_API_TOKEN"
 			},
 			"CHANNEL_IDS": {
 				"label": "Respond in channels",

--- a/plugins/plugin-discord/registry-entry.json
+++ b/plugins/plugin-discord/registry-entry.json
@@ -86,6 +86,30 @@
 			"label": "Listen Channel Ids",
 			"help": "Comma-separated list of Discord channel IDs where the bot will only listen (not respond).",
 			"advanced": false
+		},
+		"ELIZA_DISCORD_OWNER_USER_IDS_JSON": {
+			"type": "string",
+			"required": false,
+			"sensitive": false,
+			"label": "Owner User IDs (JSON)",
+			"help": "JSON array of Discord user snowflakes that alias to the canonical Eliza owner entity (e.g. [\"123456789012345678\"]). Use when ownership cannot be inferred from the Discord application team.",
+			"advanced": false
+		},
+		"DISCORD_DM_POLICY": {
+			"type": "string",
+			"required": false,
+			"sensitive": false,
+			"label": "DM Policy",
+			"help": "Direct-message access policy: open, allowlist, pairing (default), or disabled.",
+			"advanced": false
+		},
+		"DISCORD_ALLOW_FROM": {
+			"type": "string",
+			"required": false,
+			"sensitive": false,
+			"label": "DM Allow From",
+			"help": "Comma-separated Discord user snowflakes allowed to DM the bot under the allowlist policy (also seeds the pairing allowlist).",
+			"advanced": false
 		}
 	},
 	"render": {


### PR DESCRIPTION
# Relates to

Fixes agent-side acceptance criteria for #18691 (Cloud Gateway form already gained Owner ID via #18700; this PR completes the agent plugin form, connector env projection, and chat config widget).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** Additive config surface only: new optional plugin parameters, registry
fields, connector env keys, and chat-form inputs. No runtime Discord gateway
behavior change unless an operator sets the newly exposed fields. Owner array
projection deliberately JSON-stringifies (does not comma-join) so
`parseDiscordOwnerUserIds` accepts the value.

# Background

## What does this PR do?

Operators configuring Discord on the agent (plugins page, connector config, and
\"configure discord\" chat form) could only set Bot Token + Application ID. Owner
recognition and DM gating env vars existed and were documented, but were not
exposed in the UI parameter catalog or projected from `connectors.discord`.

This PR:

1. Adds `ELIZA_DISCORD_OWNER_USER_IDS_JSON`, `DISCORD_DM_POLICY`, and
   `DISCORD_ALLOW_FROM` to plugin `agentConfig.pluginParameters` + UI hints.
2. Mirrors those fields in `registry-entry.json` and regenerates first-party
   `generated.json`.
3. Extends `CONNECTOR_ENV_MAP` / `collectConnectorEnvVars` so connector config
   projects the env keys (owner snowflake arrays become JSON, not CSV).
4. Extends the chat \"configure discord\" form parameter list.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an incomplete config surface)

# Documentation changes needed?

No — plugin README/CLAUDE already document these env vars. This change makes the
UI/catalog match that documentation.

# Testing performed

Focused unit tests (not full `bun run verify`):

```
cd packages/agent && bunx vitest run --config vitest.config.ts --maxWorkers=1 \
  src/config/env-vars.discord-ownership.test.ts \
  src/api/server-helpers-plugin.discord-params.test.ts

 Test Files  2 passed (2)
      Tests  8 passed (8)
   Duration  10.03s
```

Also: `bun run --cwd packages/registry generate:first-party:check` → up to date.

# Evidence

| Evidence | Status |
| --- | --- |
| Screenshots (desktop + mobile, before/after) | N/A - no visual component change; parameters appear via existing plugin form renderer from catalog metadata |
| Video walkthrough (MP4) | N/A - config-surface metadata and pure projection helpers only |
| Backend logs | N/A - no server runtime path exercised beyond unit tests |
| Frontend console / network logs | N/A - no UI code path changed in this PR |
| Real-LLM trajectory | N/A - no agent/model behavior change |
| Domain artifacts (DB rows, scheduled items, etc.) | N/A - no persistence schema change outside optional connector config keys |
| Focused test transcript | See Testing performed above (8/8 green) |

# Known gaps / failures

- Full monorepo `bun run verify` was **not** run this cycle (time/scope); focused
  agent unit tests + registry generate check were run.
- Cloud Gateway Bot DM policy / allow-from fields remain future work (Owner ID
  already landed in #18700). This PR completes the **agent** form and env
  projection path called out in #18691.

# Test plan

- [ ] Open agent Plugins → Discord configure form; confirm Owner user IDs (JSON),
      DM policy, and DM allowlist fields render after Bot Token / Application ID
- [ ] Save `DISCORD_DM_POLICY=open` and a JSON owner id array; restart agent;
      confirm env / settings carry the values and owner recognition works
- [ ] \"configure discord\" chat intent still renders a form including the three
      new fields
- [ ] `bun run --cwd packages/registry generate:first-party:check` stays green

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-rama0x1]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZV62SB4RMV1BBQYQF7DACG3","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T14:30:05.924Z","completed_at":"2026-08-12T14:43:01.883Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"xGiLr7oXUQViT7VaasJ2Suh3r3eMUjETKjEi-Mq_2qlFlLx1qka_ZZCHDCzFrMz3g1K8_0Uqzmpw-wjDwGUxDA"}} -->