### PR TITLE
fix(ui): remove duplicate auth fixture export

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts
@@ -63,15 +63,6 @@ export function useAuthStatus(): {
  * authenticated snapshot (never the `loading` phase the real probe races), so
  * priming is inherently a no-op.
  */
-/**
- * Non-hook full snapshot read used by the notification store (#18391).
- * The fixture is a fixed authenticated snapshot, so return that constant;
- * the export must exist here or the aliased e2e bundle fails to resolve it.
- */
-export function getAuthStatusSnapshot(): typeof AUTHENTICATED_STATE {
-  return AUTHENTICATED_STATE;
-}
-
 export function primeAuthStatusProbe(): void {}
 
 /**


### PR DESCRIPTION
# Relates to

- Post-merge regression report on #18641:
  https://github.com/elizaOS/eliza/pull/18641#issuecomment-5267315891
- Same-file coordination: #18650 carries the required export addition from
  stale base `e11f20c5ef45a66fb5b8411cb6c8bab5e7208b88`. This PR repairs current
  `develop`; #18650 should drop or resolve its redundant addition when rebasing.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact
      unrelated root-gate failure is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from
      the compiler and existing E2E evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on latest `origin/develop` at
      `8618e2d669535b34edf6ed1a881d14b96aece3ec`; zero conflicts.
- [x] Focused UI typecheck and home-screen E2E pass. Root `bun run verify`
      reaches the workspace graph, then stops on the unrelated existing Biome
      failure documented below.

# Risks

**Low.** The diff only removes one of two byte-equivalent exported function
declarations. One `getAuthStatusSnapshot` export remains with its documentation,
and the full home-screen E2E confirms the aliased fixture contract still works.

# Background

## What does this PR do?

Deletes the redundant `getAuthStatusSnapshot` comment/function block from the
home-screen E2E auth stub. Current `develop` acquired two declarations through
concurrent stale-base contributions, which makes `@elizaos/ui` typecheck fail
with `TS2323` and `TS2393`.

The earlier duplicate was removed because that restores the existing
`primeAuthStatusProbe` and `getAuthStatusSnapshot` JSDoc blocks to their
intended adjacent exports. Runtime behavior is unchanged.

## What kind of change is this?

Bug fix: restores the current integration branch's TypeScript verification.

# Documentation changes needed?

No documentation change is required. The remaining fixture exports retain
their existing inline contract documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts`

## Detailed testing steps

Pinned toolchain: Bun 1.3.14 and Node 24.15.0.

Before the deletion:

```text
home-screen-fixture.auth-stub.ts(71,17): TS2323 / TS2393
home-screen-fixture.auth-stub.ts(82,17): TS2323 / TS2393
```

After the deletion:

```bash
bun run --cwd packages/ui typecheck
# exit 0

bun run --cwd packages/ui test:home-screen-e2e
# HOME-SCREEN E2E PASSED
# complete mobile + desktop flow; no page errors

git diff --check
# exit 0
```

No new test was added: the package typecheck is the direct failure-sensitive
regression gate, and the existing home-screen E2E exercises the retained
fixture export through the real aliased bundle.

# Evidence Gate

<!-- evidence-head:638de2a754222b1c07cbdf4988854de99fcb7902 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI behavior changes; this is a duplicate TypeScript
      declaration in a test-only fixture module.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI behavior changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow changes; the existing full home-screen E2E is the
      applicable integration proof.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend or HTTP path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/state transition changes; the E2E completed
      with zero page errors.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain records or generated product artifacts; exact pre-fix
      compiler diagnostics and post-fix typecheck/E2E results are recorded in
      **Testing**.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changes.

## Backend + frontend logs

N/A - no backend request or frontend state-transition behavior changes. The
applicable compiler and E2E transcript is summarized in **Testing**.

## Screenshots (before / after) + video walkthrough

N/A - the changed file is a test-only TypeScript auth stub, not a rendered
surface. The full existing home-screen E2E passed without page errors.

## Audio / voice walkthrough

N/A - no voice, audio, transcript, TTS, or STT surface.

## Known gaps / failures

- `bun run verify` reached the workspace typecheck/lint graph, then failed on
  an unrelated current-`develop` Biome formatting error in
  `packages/cloud/shared/src/db/schemas/discord-connections.ts` at the
  `ownerDiscordUserId` schema field. This PR does not touch that file.
- The first home-screen E2E attempt compiled its bundle, then Chromium was
  denied macOS Mach rendezvous access by the command sandbox. The same pinned
  command was rerun with browser-launch permission and passed completely.
- The E2E fixture is intentionally ignored by the repository's Biome config;
  direct Biome check/format commands therefore process zero files. The source
  is deletion-only and `git diff --check` passes.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [codex-auth-stub-regression]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZV6GCGKQ4QBCG2RKKG80Z3Y","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T14:37:31.540Z","completed_at":"2026-08-12T14:49:06.782Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAhF2ageyJvlDoe_JCeJ8dre---IaulxsqhaiFj11CQp8","device_key_id":"46ffa292f1c2f8b4f4ab4e8a1844b1ada18e416b6c0917274238cff9af1448e9","device_signature":"KinhO5a6djqFz78c9hiiKScAm2MoupNsPHQXhVhxXz981r8jgdarvEBsGoi93DNfumbPTnNGl48RkLHRtgsMBQ"}} -->
