### PR TITLE
fix(discord): expose DM policy controls

### DIFF
--- a/packages/cloud/shared/src/db/schemas/discord-connections.test.ts
+++ b/packages/cloud/shared/src/db/schemas/discord-connections.test.ts
@@ -1,0 +1,25 @@
+/** Verifies the validated metadata persisted for Discord Gateway connections. */
+
+import { describe, expect, test } from "bun:test";
+import { DiscordConnectionMetadataSchema } from "./discord-connections";
+
+describe("DiscordConnectionMetadataSchema ownership controls", () => {
+  test("preserves owner user IDs, DM policy, and the DM allowlist", () => {
+    const metadata = {
+      responseMode: "mention" as const,
+      ownerDiscordUserId: "123456789012345678",
+      dmPolicy: "allowlist" as const,
+      allowFrom: ["234567890123456789"],
+    };
+
+    expect(DiscordConnectionMetadataSchema.parse(metadata)).toEqual(metadata);
+  });
+
+  test("rejects unsupported DM policies", () => {
+    const result = DiscordConnectionMetadataSchema.safeParse({
+      dmPolicy: "friends-only",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/db/schemas/discord-connections.ts
+++ b/packages/cloud/shared/src/db/schemas/discord-connections.ts
@@ -26,7 +26,12 @@ export const DiscordConnectionMetadataSchema = z
     responseMode: z.enum(["always", "mention", "keyword"]).optional(),
     keywords: z.array(z.string()).optional(),
     /** Discord user snowflake treated as the bot owner. */
-    ownerDiscordUserId: z.string().regex(/^\d{15,20}$/).optional(),
+    ownerDiscordUserId: z
+      .string()
+      .regex(/^\d{15,20}$/)
+      .optional(),
+    dmPolicy: z.enum(["pairing", "allowlist", "open", "disabled"]).optional(),
+    allowFrom: z.array(z.string().trim().min(1)).optional(),
   })
   .refine(
     (data) => {
@@ -128,6 +133,12 @@ export const discordConnections = pgTable(
      *
      * @property {string[]} keywords - Trigger words for "keyword" responseMode.
      *   Case-insensitive substring matching. Required when responseMode is "keyword".
+     *
+     * @property {"pairing" | "allowlist" | "open" | "disabled"} dmPolicy -
+     *   Direct-message access policy.
+     *
+     * @property {string[]} allowFrom - Discord user IDs allowed to send DMs
+     *   under the allowlist or pairing policy.
      *
      * @example
      * // Bot responds only when mentioned in #general channel

--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -1338,6 +1338,49 @@
           "help": "Discord application ID for the bot (auto-resolved from bot token if omitted)",
           "advanced": false
         },
+        "ELIZA_DISCORD_OWNER_USER_IDS_JSON": {
+          "type": "json",
+          "required": false,
+          "sensitive": false,
+          "label": "Owner Discord user IDs",
+          "help": "JSON array of Discord user IDs that intentionally alias to the canonical Eliza owner entity.",
+          "advanced": false
+        },
+        "DISCORD_DM_POLICY": {
+          "type": "select",
+          "required": false,
+          "sensitive": false,
+          "default": "pairing",
+          "label": "DM policy",
+          "help": "Choose who may send direct messages to this agent.",
+          "advanced": false,
+          "options": [
+            {
+              "value": "pairing",
+              "label": "Pairing"
+            },
+            {
+              "value": "allowlist",
+              "label": "Allowlist"
+            },
+            {
+              "value": "open",
+              "label": "Open"
+            },
+            {
+              "value": "disabled",
+              "label": "Disabled"
+            }
+          ]
+        },
+        "DISCORD_ALLOW_FROM": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "label": "DM allowlist",
+          "help": "Comma-separated Discord user IDs allowed under the allowlist or pairing policy.",
+          "advanced": false
+        },
         "CHANNEL_IDS": {
           "type": "string",
           "required": false,

--- a/packages/ui/src/cloud/connectors/discord-gateway-connection.test.tsx
+++ b/packages/ui/src/cloud/connectors/discord-gateway-connection.test.tsx
@@ -1,0 +1,221 @@
+/** Verifies the Discord Gateway ownership controls and persisted payload. */
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DiscordGatewayConnection } from "./discord-gateway-connection";
+
+const apiMocks = vi.hoisted(() => ({
+  api: vi.fn(),
+  apiFetch: vi.fn(),
+  connections: [] as Array<Record<string, unknown>>,
+  translate: (
+    key: string,
+    options?: { defaultValue?: string; [name: string]: unknown },
+  ) => {
+    let value = options?.defaultValue ?? key;
+    for (const [name, replacement] of Object.entries(options ?? {})) {
+      value = value.replace(`{{${name}}}`, String(replacement));
+    }
+    return value;
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("../lib/api-client", () => ({
+  ApiError: class ApiError extends Error {
+    constructor(
+      public readonly status: number,
+      public readonly code: string,
+      message: string,
+      public readonly body?: unknown,
+    ) {
+      super(message);
+    }
+  },
+  api: apiMocks.api,
+  apiFetch: apiMocks.apiFetch,
+}));
+
+vi.mock("../shell/CloudI18nProvider", () => ({
+  useCloudT: () => apiMocks.translate,
+}));
+
+vi.mock("../../cloud-ui/components/connection-card", () => ({
+  ConnectionCard: ({
+    setupContent,
+    connectedContent,
+    status,
+  }: {
+    setupContent?: React.ReactNode;
+    connectedContent?: React.ReactNode;
+    status?: string;
+  }) => <div>{status === "connected" ? connectedContent : setupContent}</div>,
+  ConnectionCallout: () => null,
+  ConnectionDisconnectAction: () => null,
+  ConnectionInstructions: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+beforeEach(() => {
+  apiMocks.connections = [];
+  apiMocks.api.mockImplementation(
+    async (path: string, init?: { method?: string; json?: unknown }) => {
+      if (path === "/api/v1/discord/connections" && init?.method === "POST") {
+        return { success: true };
+      }
+      if (path === "/api/v1/discord/connections") {
+        return { connections: apiMocks.connections };
+      }
+      if (
+        path === "/api/v1/discord/connections/connection-1" &&
+        init?.method === "PATCH"
+      ) {
+        return { success: true };
+      }
+      if (path === "/api/v1/dashboard") {
+        return {
+          agents: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              name: "Revenue Agent",
+            },
+          ],
+        };
+      }
+      if (path === "/api/agents") {
+        return { agents: [] };
+      }
+      throw new Error(`Unexpected API path: ${path}`);
+    },
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("DiscordGatewayConnection ownership controls", () => {
+  it("renders the owner and DM policy fields", async () => {
+    render(<DiscordGatewayConnection />);
+
+    expect(await screen.findByLabelText("Discord Owner ID")).toBeTruthy();
+    expect(screen.getByLabelText("DM policy")).toBeTruthy();
+    expect(screen.getByLabelText("DM allowlist")).toBeTruthy();
+  });
+
+  it("persists normalized ownership metadata when creating a connection", async () => {
+    render(<DiscordGatewayConnection />);
+
+    fireEvent.change(await screen.findByLabelText("Application ID"), {
+      target: { value: "123456789012345678" },
+    });
+    fireEvent.change(screen.getByLabelText("Bot Token"), {
+      target: { value: "not-a-real-token" },
+    });
+    fireEvent.change(screen.getByLabelText("Discord Owner ID"), {
+      target: { value: "234567890123456789" },
+    });
+    fireEvent.change(screen.getByLabelText("DM allowlist"), {
+      target: { value: "456789012345678901" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Connect Discord Bot" }),
+    );
+
+    await waitFor(() =>
+      expect(apiMocks.api).toHaveBeenCalledWith(
+        "/api/v1/discord/connections",
+        expect.objectContaining({
+          method: "POST",
+          json: {
+            applicationId: "123456789012345678",
+            botToken: "not-a-real-token",
+            characterId: "11111111-1111-4111-8111-111111111111",
+            metadata: {
+              responseMode: "always",
+              ownerDiscordUserId: "234567890123456789",
+              dmPolicy: "pairing",
+              allowFrom: ["456789012345678901"],
+            },
+          },
+        }),
+      ),
+    );
+  });
+
+  it("loads and updates ownership metadata for an existing connection", async () => {
+    apiMocks.connections = [
+      {
+        id: "connection-1",
+        applicationId: "123456789012345678",
+        botUserId: "123456789012345679",
+        characterId: "11111111-1111-4111-8111-111111111111",
+        status: "connected",
+        errorMessage: null,
+        guildCount: 1,
+        eventsReceived: 2,
+        eventsRouted: 2,
+        isActive: true,
+        metadata: {
+          responseMode: "mention",
+          ownerDiscordUserId: "234567890123456789",
+          dmPolicy: "allowlist",
+          allowFrom: ["345678901234567890"],
+          enabledChannels: ["567890123456789012"],
+        },
+        connectedAt: null,
+        lastHeartbeat: null,
+        createdAt: "2026-08-12T00:00:00.000Z",
+      },
+    ];
+
+    render(<DiscordGatewayConnection />);
+    fireEvent.click(await screen.findByText("App: 123456789012345678"));
+
+    const ownerInput = await screen.findByLabelText("Discord Owner ID");
+    expect((ownerInput as HTMLInputElement).value).toBe("234567890123456789");
+    expect(screen.getByLabelText("DM policy").textContent).toContain(
+      "Allowlist",
+    );
+    expect(
+      (screen.getByLabelText("DM allowlist") as HTMLInputElement).value,
+    ).toBe("345678901234567890");
+
+    fireEvent.change(ownerInput, {
+      target: { value: "456789012345678901" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() =>
+      expect(apiMocks.api).toHaveBeenCalledWith(
+        "/api/v1/discord/connections/connection-1",
+        expect.objectContaining({
+          method: "PATCH",
+          json: {
+            characterId: "11111111-1111-4111-8111-111111111111",
+            isActive: true,
+            metadata: {
+              responseMode: "mention",
+              ownerDiscordUserId: "456789012345678901",
+              dmPolicy: "allowlist",
+              allowFrom: ["345678901234567890"],
+              enabledChannels: ["567890123456789012"],
+            },
+          },
+        }),
+      ),
+    );
+  });
+});

--- a/packages/ui/src/cloud/connectors/discord-gateway-connection.tsx
+++ b/packages/ui/src/cloud/connectors/discord-gateway-connection.tsx
@@ -86,11 +86,21 @@ async function fetchRuntimeCharacters(
 interface DiscordConnectionPatch {
   characterId: string | null;
   isActive: boolean;
-  metadata: {
-    responseMode: "always" | "mention" | "keyword";
-    ownerDiscordUserId?: string;
-  };
+  metadata: DiscordConnectionMetadata;
   botToken?: string;
+}
+
+type DiscordResponseMode = "always" | "mention" | "keyword";
+type DiscordDmPolicy = "pairing" | "allowlist" | "open" | "disabled";
+
+interface DiscordConnectionMetadata {
+  responseMode?: DiscordResponseMode;
+  ownerDiscordUserId?: string;
+  dmPolicy?: DiscordDmPolicy;
+  allowFrom?: string[];
+  keywords?: string[];
+  enabledChannels?: string[];
+  disabledChannels?: string[];
 }
 
 interface DiscordGatewayConnection {
@@ -104,13 +114,7 @@ interface DiscordGatewayConnection {
   eventsReceived: number;
   eventsRouted: number;
   isActive: boolean;
-  metadata: {
-    responseMode?: "always" | "mention" | "keyword";
-    keywords?: string[];
-    enabledChannels?: string[];
-    disabledChannels?: string[];
-    ownerDiscordUserId?: string;
-  } | null;
+  metadata: DiscordConnectionMetadata | null;
   connectedAt: string | null;
   lastHeartbeat: string | null;
   createdAt: string;
@@ -126,6 +130,41 @@ function apiErrorMessage(error: unknown, fallback: string): string {
     return error.message || fallback;
   }
   return fallback;
+}
+
+function parseDiscordUserIds(value: string): string[] {
+  return [
+    ...new Set(
+      value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+function buildConnectionMetadata({
+  responseMode,
+  ownerDiscordUserId,
+  dmPolicy,
+  allowFrom,
+}: {
+  responseMode: DiscordResponseMode;
+  ownerDiscordUserId: string;
+  dmPolicy: DiscordDmPolicy;
+  allowFrom: string;
+}): DiscordConnectionMetadata {
+  const normalizedAllowFrom = parseDiscordUserIds(allowFrom);
+  return {
+    responseMode,
+    dmPolicy,
+    ...(ownerDiscordUserId.trim()
+      ? { ownerDiscordUserId: ownerDiscordUserId.trim() }
+      : {}),
+    ...(normalizedAllowFrom.length > 0
+      ? { allowFrom: normalizedAllowFrom }
+      : {}),
+  };
 }
 
 function getStatusBadge(status: DiscordGatewayConnection["status"], t: TFn) {
@@ -193,6 +232,8 @@ export function DiscordGatewayConnection() {
     "always" | "mention" | "keyword"
   >("always");
   const [ownerDiscordUserId, setOwnerDiscordUserId] = useState("");
+  const [dmPolicy, setDmPolicy] = useState<DiscordDmPolicy>("pairing");
+  const [allowFrom, setAllowFrom] = useState("");
 
   // Edit state for existing connections
   const [editState, setEditState] = useState<
@@ -202,6 +243,9 @@ export function DiscordGatewayConnection() {
         characterId: string;
         responseMode: "always" | "mention" | "keyword";
         ownerDiscordUserId: string;
+        dmPolicy: DiscordDmPolicy;
+        allowFrom: string;
+        baseMetadata: DiscordConnectionMetadata;
         botToken: string;
         isActive: boolean;
       }
@@ -339,12 +383,12 @@ export function DiscordGatewayConnection() {
             applicationId: applicationId.trim(),
             botToken: botToken.trim(),
             characterId,
-            metadata: {
+            metadata: buildConnectionMetadata({
               responseMode,
-              ...(ownerDiscordUserId.trim()
-                ? { ownerDiscordUserId: ownerDiscordUserId.trim() }
-                : {}),
-            },
+              ownerDiscordUserId,
+              dmPolicy,
+              allowFrom,
+            }),
           },
         },
       );
@@ -361,6 +405,8 @@ export function DiscordGatewayConnection() {
         setCharacterId("");
         setResponseMode("always");
         setOwnerDiscordUserId("");
+        setDmPolicy("pairing");
+        setAllowFrom("");
         setShowForm(false);
         void fetchConnections();
       } else {
@@ -410,10 +456,21 @@ export function DiscordGatewayConnection() {
         characterId: edit.characterId || null,
         isActive: edit.isActive,
         metadata: {
-          responseMode: edit.responseMode,
-          ...(edit.ownerDiscordUserId.trim()
-            ? { ownerDiscordUserId: edit.ownerDiscordUserId.trim() }
+          ...(edit.baseMetadata.keywords
+            ? { keywords: edit.baseMetadata.keywords }
             : {}),
+          ...(edit.baseMetadata.enabledChannels
+            ? { enabledChannels: edit.baseMetadata.enabledChannels }
+            : {}),
+          ...(edit.baseMetadata.disabledChannels
+            ? { disabledChannels: edit.baseMetadata.disabledChannels }
+            : {}),
+          ...buildConnectionMetadata({
+            responseMode: edit.responseMode,
+            ownerDiscordUserId: edit.ownerDiscordUserId,
+            dmPolicy: edit.dmPolicy,
+            allowFrom: edit.allowFrom,
+          }),
         },
       };
 
@@ -500,6 +557,9 @@ export function DiscordGatewayConnection() {
           characterId: conn.characterId || "",
           responseMode: conn.metadata?.responseMode || "always",
           ownerDiscordUserId: conn.metadata?.ownerDiscordUserId || "",
+          dmPolicy: conn.metadata?.dmPolicy || "pairing",
+          allowFrom: conn.metadata?.allowFrom?.join(", ") || "",
+          baseMetadata: conn.metadata || {},
           botToken: "",
           isActive: conn.isActive,
         },
@@ -767,16 +827,20 @@ export function DiscordGatewayConnection() {
                               </div>
 
                               <div className="space-y-2">
-                                <Label>
+                                <Label
+                                  htmlFor={`ownerDiscordUserId-${conn.id}`}
+                                >
                                   {t("cloud.discord.ownerDiscordUserId", {
                                     defaultValue: "Discord Owner ID",
                                   })}
                                 </Label>
                                 <Input
+                                  id={`ownerDiscordUserId-${conn.id}`}
                                   placeholder={t(
                                     "cloud.discord.ownerDiscordUserIdPlaceholder",
                                     {
-                                      defaultValue: "Your Discord user snowflake",
+                                      defaultValue:
+                                        "Your Discord user snowflake",
                                     },
                                   )}
                                   value={edit.ownerDiscordUserId}
@@ -789,6 +853,72 @@ export function DiscordGatewayConnection() {
                                   }
                                 />
                               </div>
+                            </div>
+
+                            {/* Direct-message access */}
+                            <div className="space-y-2">
+                              <Label htmlFor={`dmPolicy-${conn.id}`}>
+                                {t("cloud.discord.dmPolicy", {
+                                  defaultValue: "DM policy",
+                                })}
+                              </Label>
+                              <Select
+                                value={edit.dmPolicy}
+                                onValueChange={(value) =>
+                                  updateEditState(conn.id, "dmPolicy", value)
+                                }
+                              >
+                                <SelectTrigger id={`dmPolicy-${conn.id}`}>
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="pairing">
+                                    {t("cloud.discord.dmPolicyPairing", {
+                                      defaultValue: "Pairing",
+                                    })}
+                                  </SelectItem>
+                                  <SelectItem value="allowlist">
+                                    {t("cloud.discord.dmPolicyAllowlist", {
+                                      defaultValue: "Allowlist",
+                                    })}
+                                  </SelectItem>
+                                  <SelectItem value="open">
+                                    {t("cloud.discord.dmPolicyOpen", {
+                                      defaultValue: "Open",
+                                    })}
+                                  </SelectItem>
+                                  <SelectItem value="disabled">
+                                    {t("cloud.discord.dmPolicyDisabled", {
+                                      defaultValue: "Disabled",
+                                    })}
+                                  </SelectItem>
+                                </SelectContent>
+                              </Select>
+                            </div>
+                            <div className="space-y-2">
+                              <Label htmlFor={`allowFrom-${conn.id}`}>
+                                {t("cloud.discord.dmAllowlist", {
+                                  defaultValue: "DM allowlist",
+                                })}
+                              </Label>
+                              <Input
+                                id={`allowFrom-${conn.id}`}
+                                placeholder="234567890123456789"
+                                value={edit.allowFrom}
+                                onChange={(event) =>
+                                  updateEditState(
+                                    conn.id,
+                                    "allowFrom",
+                                    event.target.value,
+                                  )
+                                }
+                              />
+                              <p className="text-xs text-muted-foreground">
+                                {t("cloud.discord.dmAllowlistHint", {
+                                  defaultValue:
+                                    "Comma-separated sender IDs allowed by pairing or allowlist policy.",
+                                })}
+                              </p>
                             </div>
 
                             {/* Bot Token Update */}
@@ -1301,6 +1431,60 @@ export function DiscordGatewayConnection() {
             value={ownerDiscordUserId}
             onChange={(e) => setOwnerDiscordUserId(e.target.value)}
           />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="dmPolicy">
+            {t("cloud.discord.dmPolicy", { defaultValue: "DM policy" })}
+          </Label>
+          <Select
+            value={dmPolicy}
+            onValueChange={(value) => setDmPolicy(value as DiscordDmPolicy)}
+          >
+            <SelectTrigger id="dmPolicy">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="pairing">
+                {t("cloud.discord.dmPolicyPairing", {
+                  defaultValue: "Pairing",
+                })}
+              </SelectItem>
+              <SelectItem value="allowlist">
+                {t("cloud.discord.dmPolicyAllowlist", {
+                  defaultValue: "Allowlist",
+                })}
+              </SelectItem>
+              <SelectItem value="open">
+                {t("cloud.discord.dmPolicyOpen", { defaultValue: "Open" })}
+              </SelectItem>
+              <SelectItem value="disabled">
+                {t("cloud.discord.dmPolicyDisabled", {
+                  defaultValue: "Disabled",
+                })}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="allowFrom">
+            {t("cloud.discord.dmAllowlist", {
+              defaultValue: "DM allowlist",
+            })}
+          </Label>
+          <Input
+            id="allowFrom"
+            placeholder="234567890123456789"
+            value={allowFrom}
+            onChange={(event) => setAllowFrom(event.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">
+            {t("cloud.discord.dmAllowlistHint", {
+              defaultValue:
+                "Comma-separated sender IDs allowed by pairing or allowlist policy.",
+            })}
+          </p>
         </div>
 
         <Button

--- a/plugins/plugin-discord/README.md
+++ b/plugins/plugin-discord/README.md
@@ -78,6 +78,12 @@ DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES=true
 # If true, only respond when explicitly @mentioned (default: true)
 DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS=true
 
+# Direct-message access controls (Optional)
+# pairing (default), allowlist, open, or disabled.
+DISCORD_DM_POLICY=pairing
+# Comma-separated Discord user IDs allowed by allowlist/pairing.
+DISCORD_ALLOW_FROM=123456789012345678
+
 # Generation Timeout (Optional)
 # Wall-clock budget for generating a single reply before the bot gives up and
 # posts "I timed out while generating that reply." On timeout the underlying
@@ -101,6 +107,12 @@ DISCORD_TEST_CHANNEL_ID=123456789012345678
 # they stay auditable as separate connector-admin identities.
 ELIZA_DISCORD_OWNER_USER_IDS_JSON='["123456789012345678"]'
 ```
+
+The agent's Discord plugin configuration form exposes **Owner Discord user
+IDs**, **DM policy**, and **DM allowlist** under its access settings. The Eliza
+Cloud **Discord Gateway Bot** create/edit form exposes **Discord Owner ID** plus
+the same DM controls and persists them with the connection metadata, so they do
+not need to be entered as raw environment variables.
 
 Settings can also be configured in your character file under `settings.discord`:
 

--- a/plugins/plugin-discord/__tests__/configuration-metadata.test.ts
+++ b/plugins/plugin-discord/__tests__/configuration-metadata.test.ts
@@ -1,0 +1,73 @@
+/** Verifies the Discord connector configuration fields exposed to agent UIs. */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const pluginRoot = resolve(import.meta.dirname, "..");
+const packageManifest = JSON.parse(
+	readFileSync(resolve(pluginRoot, "package.json"), "utf8"),
+) as {
+	agentConfig?: {
+		pluginParameters?: Record<string, Record<string, unknown>>;
+		configUiHints?: Record<string, Record<string, unknown>>;
+	};
+};
+const registryEntry = JSON.parse(
+	readFileSync(resolve(pluginRoot, "registry-entry.json"), "utf8"),
+) as { config?: Record<string, Record<string, unknown>> };
+
+const ownershipKeys = [
+	"ELIZA_DISCORD_OWNER_USER_IDS_JSON",
+	"DISCORD_DM_POLICY",
+	"DISCORD_ALLOW_FROM",
+] as const;
+
+describe("Discord ownership configuration metadata", () => {
+	it("exposes owner and DM controls to the agent plugin form", () => {
+		const parameters = packageManifest.agentConfig?.pluginParameters ?? {};
+		const hints = packageManifest.agentConfig?.configUiHints ?? {};
+
+		for (const key of ownershipKeys) {
+			expect(parameters[key]).toMatchObject({
+				type: "string",
+				required: false,
+				sensitive: false,
+			});
+			expect(hints[key]).toMatchObject({ group: "access" });
+		}
+		expect(parameters.DISCORD_DM_POLICY?.options).toEqual([
+			"pairing",
+			"allowlist",
+			"open",
+			"disabled",
+		]);
+		expect(hints.ELIZA_DISCORD_OWNER_USER_IDS_JSON?.type).toBe("json");
+	});
+
+	it("keeps the registry configuration surface in sync", () => {
+		const config = registryEntry.config ?? {};
+
+		expect(config.ELIZA_DISCORD_OWNER_USER_IDS_JSON).toMatchObject({
+			type: "json",
+			required: false,
+			sensitive: false,
+		});
+		expect(config.DISCORD_DM_POLICY).toMatchObject({
+			type: "select",
+			required: false,
+			sensitive: false,
+		});
+		expect(config.DISCORD_DM_POLICY?.options).toEqual([
+			{ value: "pairing", label: "Pairing" },
+			{ value: "allowlist", label: "Allowlist" },
+			{ value: "open", label: "Open" },
+			{ value: "disabled", label: "Disabled" },
+		]);
+		expect(config.DISCORD_ALLOW_FROM).toMatchObject({
+			type: "string",
+			required: false,
+			sensitive: false,
+		});
+	});
+});

--- a/plugins/plugin-discord/package.json
+++ b/plugins/plugin-discord/package.json
@@ -121,6 +121,31 @@
 				"required": true,
 				"sensitive": false
 			},
+			"ELIZA_DISCORD_OWNER_USER_IDS_JSON": {
+				"type": "string",
+				"description": "JSON array of Discord user IDs that intentionally alias to the canonical Eliza owner entity.",
+				"required": false,
+				"sensitive": false
+			},
+			"DISCORD_DM_POLICY": {
+				"type": "string",
+				"description": "Direct-message access policy: pairing, allowlist, open, or disabled.",
+				"required": false,
+				"sensitive": false,
+				"default": "pairing",
+				"options": [
+					"pairing",
+					"allowlist",
+					"open",
+					"disabled"
+				]
+			},
+			"DISCORD_ALLOW_FROM": {
+				"type": "string",
+				"description": "Comma-separated Discord user IDs allowed to send direct messages under the allowlist or pairing policy.",
+				"required": false,
+				"sensitive": false
+			},
 			"CHANNEL_IDS": {
 				"type": "string",
 				"description": "Comma-separated list of Discord channel IDs that will be parsed into an array if provided.",
@@ -180,6 +205,25 @@
 				"label": "Application ID",
 				"order": 2,
 				"group": "connection"
+			},
+			"ELIZA_DISCORD_OWNER_USER_IDS_JSON": {
+				"label": "Owner Discord user IDs",
+				"order": 17,
+				"group": "access",
+				"type": "json",
+				"requires": "DISCORD_API_TOKEN"
+			},
+			"DISCORD_DM_POLICY": {
+				"label": "DM policy",
+				"order": 18,
+				"group": "access",
+				"requires": "DISCORD_API_TOKEN"
+			},
+			"DISCORD_ALLOW_FROM": {
+				"label": "DM allowlist",
+				"order": 19,
+				"group": "access",
+				"requires": "DISCORD_API_TOKEN"
 			},
 			"CHANNEL_IDS": {
 				"label": "Respond in channels",

--- a/plugins/plugin-discord/registry-entry.json
+++ b/plugins/plugin-discord/registry-entry.json
@@ -23,6 +23,37 @@
 			"help": "Discord application ID for the bot (auto-resolved from bot token if omitted)",
 			"advanced": false
 		},
+		"ELIZA_DISCORD_OWNER_USER_IDS_JSON": {
+			"type": "json",
+			"required": false,
+			"sensitive": false,
+			"label": "Owner Discord user IDs",
+			"help": "JSON array of Discord user IDs that intentionally alias to the canonical Eliza owner entity.",
+			"advanced": false
+		},
+		"DISCORD_DM_POLICY": {
+			"type": "select",
+			"required": false,
+			"sensitive": false,
+			"default": "pairing",
+			"label": "DM policy",
+			"help": "Choose who may send direct messages to this agent.",
+			"advanced": false,
+			"options": [
+				{ "value": "pairing", "label": "Pairing" },
+				{ "value": "allowlist", "label": "Allowlist" },
+				{ "value": "open", "label": "Open" },
+				{ "value": "disabled", "label": "Disabled" }
+			]
+		},
+		"DISCORD_ALLOW_FROM": {
+			"type": "string",
+			"required": false,
+			"sensitive": false,
+			"label": "DM allowlist",
+			"help": "Comma-separated Discord user IDs allowed under the allowlist or pairing policy.",
+			"advanced": false
+		},
 		"CHANNEL_IDS": {
 			"type": "string",
 			"required": false,


### PR DESCRIPTION
## Summary

- exposes Discord owner, DM policy, and sender allowlist controls in first-party agent configuration metadata
- validates and persists the same controls in Eliza Cloud connection metadata
- adds create/edit connector UI coverage, normalization tests, registry metadata, and documentation
- preserves the singular Owner ID field that landed independently in #18700 while narrowing this PR to the remaining DM controls

Closes #18691

## Verification

- Discord plugin: 75 files / 596 tests passed
- plugin-discord typecheck: passed
- Cloud shared schema tests: 2 passed; typecheck passed
- UI connector tests: 3 passed
- registry tests: 36 passed; typecheck passed
- targeted Biome checks and `git diff --check`: passed
- full `bun run verify`: 348/350 tasks passed; the only failure is the existing duplicate `getAuthStatusSnapshot` in `packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts`, byte-identical to `origin/develop` (`523504e8cc9d357408a9ee84fa969f26d8965bc4`)
- `generate:first-party:check`: baseline generated registry is stale for unrelated `agent-skills` data; the Discord source and generated entry compare equal

## Evidence

Attachments are being uploaded to this draft before it is marked ready for review.

## Boundaries

- no live Discord credentials, provider calls, deployment, or database migration
- Cloud values persist connector metadata; gateway runtime enforcement changes are outside this ticket

<!-- evidence-head:3bd47848d567f7d364859570a7870886fd9a9310 -->

<img width="1280" height="988" alt="after-desktop-filled" src="https://github.com/user-attachments/assets/950fa6cc-bda9-4a91-acd2-6d1dd5479d3e" />
<img width="1440" height="1000" alt="before-desktop" src="https://github.com/user-attachments/assets/113ac467-aca3-40b9-bcd0-91e7674745ee" />
<img width="390" height="1051" alt="before-mobile" src="https://github.com/user-attachments/assets/5119f8a9-0852-4b57-84ea-d0a353469046" />
[backend.log](https://github.com/user-attachments/files/30987786/backend.log)
[frontend-network.log](https://github.com/user-attachments/files/30987787/frontend-network.log)
<img width="390" height="1251" alt="after-mobile" src="https://github.com/user-attachments/assets/c268ca10-8a66-4390-ab8d-0d4e9dab3c7c" />
<img width="1440" height="1000" alt="after-desktop" src="https://github.com/user-attachments/assets/dd32a173-eb5b-44ab-a789-ecec9ade4d39" />

https://github.com/user-attachments/assets/82228916-9a5b-4498-bfea-0a7496c86fd2

[domain-artifacts.txt](https://github.com/user-attachments/files/30987789/domain-artifacts.txt)
[after-desktop-ocr.txt](https://github.com/user-attachments/files/30987790/after-desktop-ocr.txt)
[before-desktop-ocr.txt](https://github.com/user-attachments/files/30987792/before-desktop-ocr.txt)


AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 104201660 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [rndrntwrk-codex-fix-discord-owner-dm-controls]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZV3H5TGWSRKQRHAABJ16DAV","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T13:45:31.729Z","completed_at":"2026-08-12T14:27:45.415Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":3871854,"output_tokens":369486,"cache_creation_tokens":0,"cache_read_tokens":99960320,"total_tokens":104201660,"cost_micro_usd":"80424010","session_count":11},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAca_bmgW70vt_4YdSWBk9O4OcExXrUczaWSsxNRnwtrw","device_key_id":"fb0b00036edfe4c6ff8630ecd4b1182ddf807c431da450ca4064fa05dec7ebe1","device_signature":"Tw1rLirNjM-07F-vgU_CnVhKLtBEuVOne1HNDLWQ4y-YIrimfekYPafvTSDlcWOEBJNCTo0qP9x5MCyDyjk4Ag"}} -->
