### PR TITLE
fix(local-inference): route IMAGE_DESCRIPTION image fetches through SSRF media guard

### DIFF
--- a/plugins/plugin-local-inference/src/runtime/bionic-wire-encoding.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/bionic-wire-encoding.test.ts
@@ -8,13 +8,43 @@
  * byte-order or prefix-stripping bug here corrupts every ASR/vision frame
  * silently (the host just gets garbage), so this pins the exact wire format.
  *
+ * URL-kind images load through the shared `fetchRemoteMedia` SSRF guard so a
+ * caller-supplied private or loopback host cannot be reached from vision.
+ *
  * `ensure-local-inference-handler` has heavy import side-effects (the service
  * layer), so — like its sibling `ensure-local-inference-handler.test.ts` — the
  * service modules are stubbed before the import so the two encoders can be
  * exercised in isolation.
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mediaMocks = vi.hoisted(() => ({
+	fetchRemoteMedia: vi.fn(),
+	useRealFetchRemoteMedia: false,
+	realFetchRemoteMedia: null as
+		| null
+		| ((...args: unknown[]) => Promise<unknown>),
+}));
+
+vi.mock("@elizaos/core", async (importActual) => {
+	const actual = await importActual<typeof import("@elizaos/core")>();
+	mediaMocks.realFetchRemoteMedia = actual.fetchRemoteMedia as (
+		...args: unknown[]
+	) => Promise<unknown>;
+	return {
+		...actual,
+		fetchRemoteMedia: (...args: unknown[]) => {
+			if (
+				mediaMocks.useRealFetchRemoteMedia &&
+				mediaMocks.realFetchRemoteMedia
+			) {
+				return mediaMocks.realFetchRemoteMedia(...args);
+			}
+			return mediaMocks.fetchRemoteMedia(...args);
+		},
+	};
+});
 
 vi.mock("../services/active-model", () => ({
 	resolveLocalInferenceLoadArgs: vi.fn(async (t) => t),
@@ -65,10 +95,10 @@ import {
 	imageRequestToBase64,
 } from "./ensure-local-inference-handler";
 
-const originalFetch = globalThis.fetch;
 afterEach(() => {
-	globalThis.fetch = originalFetch;
+	mediaMocks.useRealFetchRemoteMedia = false;
 	vi.restoreAllMocks();
+	vi.clearAllMocks();
 });
 
 describe("float32ToBase64LE", () => {
@@ -107,6 +137,7 @@ describe("imageRequestToBase64", () => {
 				dataUrl: `data:image/png;base64,${payload}`,
 			}),
 		).resolves.toBe(payload);
+		expect(mediaMocks.fetchRemoteMedia).not.toHaveBeenCalled();
 	});
 
 	it("returns a comma-less dataUrl verbatim", async () => {
@@ -115,28 +146,45 @@ describe("imageRequestToBase64", () => {
 		).resolves.toBe("rawbase64nocomma");
 	});
 
-	it("fetches a url and base64-encodes the response bytes", async () => {
-		const bytes = new Uint8Array([1, 2, 3, 4]);
-		globalThis.fetch = vi.fn(
-			async () => new Response(bytes, { status: 200 }),
-		) as unknown as typeof fetch;
+	it("loads a url through fetchRemoteMedia bounds then base64-encodes the bytes", async () => {
+		const bytes = Buffer.from([1, 2, 3, 4]);
+		mediaMocks.fetchRemoteMedia.mockResolvedValue({
+			buffer: bytes,
+			contentType: "image/png",
+			fileName: "i.png",
+		});
 
 		await expect(
 			imageRequestToBase64({ kind: "url", url: "https://example.test/i.png" }),
-		).resolves.toBe(Buffer.from(bytes).toString("base64"));
+		).resolves.toBe(bytes.toString("base64"));
+		expect(mediaMocks.fetchRemoteMedia).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: "https://example.test/i.png",
+				maxBytes: 20 * 1024 * 1024,
+				timeoutMs: 15_000,
+				maxRedirects: 5,
+			}),
+		);
 	});
 
-	it("throws when the url fetch is not ok", async () => {
-		globalThis.fetch = vi.fn(
-			async () => new Response("nope", { status: 404 }),
-		) as unknown as typeof fetch;
+	it("throws when the image URL is empty or whitespace instead of fetching", async () => {
+		await expect(
+			imageRequestToBase64({ kind: "url", url: "   " }),
+		).rejects.toThrow("IMAGE_DESCRIPTION requires a valid image URL");
+		expect(mediaMocks.fetchRemoteMedia).not.toHaveBeenCalled();
+	});
+
+	it("throws when the guarded image fetch fails", async () => {
+		mediaMocks.fetchRemoteMedia.mockRejectedValue(
+			new Error("Failed to fetch media from https://example.test/missing: 404"),
+		);
 
 		await expect(
 			imageRequestToBase64({
 				kind: "url",
 				url: "https://example.test/missing",
 			}),
-		).rejects.toThrow(/404/);
+		).rejects.toThrow(/failed to fetch.*missing/i);
 	});
 
 	it("throws when neither a dataUrl nor a url is resolvable", async () => {
@@ -144,4 +192,32 @@ describe("imageRequestToBase64", () => {
 			/could not resolve image bytes/,
 		);
 	});
+});
+
+describe("imageRequestToBase64 SSRF policy (real fetchRemoteMedia)", () => {
+	beforeEach(() => {
+		mediaMocks.useRealFetchRemoteMedia = true;
+	});
+
+	it.each([
+		"http://127.0.0.1/secret.png",
+		"http://[::1]/secret.png",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://localhost/internal.png",
+		"http://10.0.0.5/intranet.png",
+		"http://192.168.1.1/router.png",
+	])(
+		"fails closed for blocked image URL %s without calling global fetch",
+		async (url) => {
+			const fetchMock = vi.fn();
+			vi.spyOn(globalThis, "fetch").mockImplementation(
+				fetchMock as typeof fetch,
+			);
+
+			await expect(imageRequestToBase64({ kind: "url", url })).rejects.toThrow(
+				/Failed to fetch media|not allowed|blocked|private|loopback|link-local|Invalid URL|SSRF/i,
+			);
+			expect(fetchMock).not.toHaveBeenCalled();
+		},
+	);
 });

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -24,6 +24,7 @@
 import {
 	type AgentRuntime,
 	applyBackgroundInferenceBudget,
+	fetchRemoteMedia,
 	type GenerateTextParams,
 	getInferencePriorityGate,
 	type IAgentRuntime,
@@ -1176,6 +1177,11 @@ export function float32ToBase64LE(pcm: Float32Array): string {
 	return buf.toString("base64");
 }
 
+/** Cap remote vision image downloads so a malicious URL cannot force unbounded memory. */
+const IMAGE_DESCRIPTION_MAX_BYTES = 20 * 1024 * 1024;
+/** Bound remote image fetch time for IMAGE_DESCRIPTION URL inputs. */
+const IMAGE_DESCRIPTION_FETCH_TIMEOUT_MS = 15_000;
+
 /** Resolve a vision request to base64 image bytes for the bionic host. */
 export async function imageRequestToBase64(image: {
 	kind: "dataUrl" | "url";
@@ -1186,14 +1192,32 @@ export async function imageRequestToBase64(image: {
 		const comma = image.dataUrl.indexOf(",");
 		return comma >= 0 ? image.dataUrl.slice(comma + 1) : image.dataUrl;
 	}
-	if (image.kind === "url" && image.url) {
-		const resp = await fetch(image.url);
-		if (!resp.ok) {
+	if (image.kind === "url") {
+		const url = typeof image.url === "string" ? image.url.trim() : "";
+		if (!url) {
 			throw new Error(
-				`[local-inference] IMAGE_DESCRIPTION failed to fetch ${image.url}: ${resp.status}`,
+				"[local-inference] IMAGE_DESCRIPTION requires a valid image URL",
 			);
 		}
-		return Buffer.from(await resp.arrayBuffer()).toString("base64");
+		try {
+			// Caller-supplied image URLs must go through the shared SSRF media
+			// guard; bare `fetch` would let vision describe internal hosts.
+			const media = await fetchRemoteMedia({
+				url,
+				maxBytes: IMAGE_DESCRIPTION_MAX_BYTES,
+				timeoutMs: IMAGE_DESCRIPTION_FETCH_TIMEOUT_MS,
+				maxRedirects: 5,
+			});
+			return media.buffer.toString("base64");
+		} catch (err) {
+			// error-policy:J2 context-adding rethrow — preserve guarded-fetch cause
+			throw new Error(
+				`[local-inference] IMAGE_DESCRIPTION failed to fetch ${url}: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+				{ cause: err },
+			);
+		}
 	}
 	throw new Error(
 		"[local-inference] IMAGE_DESCRIPTION could not resolve image bytes",

--- a/plugins/plugin-local-inference/src/services/vision/capacitor-llama.ts
+++ b/plugins/plugin-local-inference/src/services/vision/capacitor-llama.ts
@@ -33,6 +33,7 @@
  */
 
 import { existsSync, promises as fs } from "node:fs";
+import { fetchRemoteMedia } from "@elizaos/core";
 import { resolveImageBytes } from "./hash";
 import type {
 	VisionDescribeBackend,
@@ -232,16 +233,16 @@ async function imageInputToDataUrl(
 				const mimeType = input.mimeType ?? guessMimeFromPath(filePath);
 				return `data:${mimeType};base64,${bytes.toString("base64")}`;
 			}
-			const res = await fetch(url);
-			if (!res.ok) {
-				throw new Error(
-					`[vision/capacitor-llama] failed to fetch image: ${res.status} ${res.statusText}`,
-				);
-			}
-			const buf = new Uint8Array(await res.arrayBuffer());
-			const mimeType =
-				input.mimeType ?? res.headers.get("content-type") ?? "image/png";
-			return `data:${mimeType};base64,${Buffer.from(buf).toString("base64")}`;
+			// Remote http(s) URLs are caller-controlled — route through the
+			// shared SSRF media guard rather than bare `fetch`.
+			const media = await fetchRemoteMedia({
+				url,
+				maxBytes: 20 * 1024 * 1024,
+				timeoutMs: 15_000,
+				maxRedirects: 5,
+			});
+			const mimeType = input.mimeType ?? media.contentType ?? "image/png";
+			return `data:${mimeType};base64,${media.buffer.toString("base64")}`;
 		}
 	}
 }


### PR DESCRIPTION
# Relates to

Closes #18714

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused verification was run on the touched surfaces after sync (see Testing).
      Full `bun run verify` was **not** run this cycle; scoped local-inference unit
      suite + typecheck is the proof for this media-fetch boundary change.
- [x] A reviewer can confirm the change from the unit transcript and matrices
      below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `origin/develop`; zero conflicts.
- [x] Focused suite green. Full `bun run verify` not claimed this cycle
      (local-inference IMAGE_DESCRIPTION remote media path + unit tests only).

# Risks

**Low–medium (security hardening).** Changes only how remote vision image URLs
are loaded for local IMAGE_DESCRIPTION:

- Private/loopback/link-local hosts that previously succeeded with bare `fetch`
  now fail closed through shared `fetchRemoteMedia` (intended).
- Remote downloads are capped at 20 MiB and 15s with max 5 redirects, matching
  the Google GenAI / OpenAI media pattern.
- On-device `file://` and absolute filesystem paths in capacitor-llama are
  unchanged (local asset path, not remote SSRF).
- dataUrl inputs for the bionic host path are unchanged.

# Background

## What does this PR do?

Routes caller-supplied remote image URLs for local IMAGE_DESCRIPTION through
`@elizaos/core` `fetchRemoteMedia` in:

1. `imageRequestToBase64` (bionic-host vision wire path)
2. `imageInputToDataUrl` remote http(s) branch (capacitor-llama vision backend)

Adds unit coverage for happy-path bounds, empty URL rejection, fetch failure,
and real private-host SSRF fail-closed without calling global `fetch`.

## What kind of change is this?

Bug fix (non-breaking security hardening of an existing media fetch path).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior aligns
with the existing shared media SSRF contract documented for core media fetch.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts`
   — `imageRequestToBase64` uses `fetchRemoteMedia`.
2. `plugins/plugin-local-inference/src/services/vision/capacitor-llama.ts`
   — remote URL branch only.
3. `plugins/plugin-local-inference/src/runtime/bionic-wire-encoding.test.ts`
   — focused unit proof including real SSRF policy cases.

## Detailed testing steps

```bash
cd plugins/plugin-local-inference
NODE_OPTIONS='--experimental-sqlite' bunx vitest run src/runtime/bionic-wire-encoding.test.ts
bun run typecheck
```

### Focused vitest (this head)

```text
 Test Files  1 passed (1)
      Tests  15 passed (15)
   Duration  8.58s
```

### Package typecheck

```text
$ tsc --noEmit -p tsconfig.json
(exit 0)
```

### Full package suite note

A prior full `vitest run` in the package reported **266 files / 2717 tests passed**
(2 skipped) after the production change, before the final format-only test edit
pass. The focused 15-test file is the authoritative evidence for this PR head.

# Evidence Gate

<!-- evidence-head:fe3070dd12846a66c08e9036eb6730e4bc34bce5 -->

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - non-UI media-fetch security boundary; no rendered surface changes
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - non-UI media-fetch security boundary; no rendered surface changes
<!-- evidence-row:mobile-screenshots -->
- Mobile screenshots: N/A - no mobile UI or layout change
<!-- evidence-row:video-walkthrough -->
- Video walkthrough (MP4): N/A - pure server-side fetch guard; no interactive UI path
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - unit-level SSRF policy rejects private hosts before network I/O; no live agent log stream required
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend change
<!-- evidence-row:llm-trajectories -->
- Real-LLM trajectories: N/A - no model, prompt, planner, or action behavior change; only image byte loading
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no durable domain state, DB rows, scheduled items, or on-chain effects

# Known gaps / failures

- Full `bun run verify` not run this cycle (scoped package typecheck + focused
  vitest only). No unrelated blocker observed on the touched surface.

# Checklist

- [x] I have tested these changes locally
- [x] Relevant unit tests pass for the touched path
- [x] No secrets committed

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [unattended-rama0x1]
<!-- elizaos-contribution-attribution:v2 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZV7478G2NYREMPRQ6TVE3TC","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T14:48:21.520Z","completed_at":"2026-08-12T14:53:36.655Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAfSOzl0u299Ah_P-BVQB5nBFok5AlnLQ2MuW5tCLxjYI","device_key_id":"a72da1818d857298846853771e072ebfa715eca432a3532cafacd99c42b513ea","device_signature":"li_pnK56nmBngR7n84UzuV20P3k6kAOgZ0m8xnhF-VpLgVBYy19o2xklF_SHrdOvHIs-ujL8tl7SwXV-ZNDiBQ"}} -->