### PR TITLE
perf(cloud-api): thin-path /steward/auth/providers past full-app bootstrap (#18049)

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -1,5 +1,5 @@
 /** Verifies Cloud Worker routing and thin-inference dispatch with deterministic fixtures. */
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import cloudApiWorker, {
   getFrontendAliasApiProxyTarget,
@@ -7,9 +7,11 @@ import cloudApiWorker, {
   getHostedFrontendServeRewrite,
   isCanonicalInferencePath,
   isThinInferenceEnabled,
+  isThinStewardPublicPath,
   redirectFrontendHost,
   SharedRuntimeConversation,
 } from "./index";
+import { resetProvidersResponseCacheForTests } from "./steward/embedded";
 
 test("exports the shared-runtime conversation Durable Object", () => {
   expect(typeof SharedRuntimeConversation).toBe("function");
@@ -91,6 +93,158 @@ describe("thin inference entry dispatch", () => {
 
     expect(response.status).toBe(401);
     expect(response.headers.get("x-eliza-inference-path")).toBe("thin");
+  });
+});
+
+describe("thin Steward public path dispatch (#18049)", () => {
+  const executionCtx = {
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as ExecutionContext;
+
+  const stewardEnv = {
+    ENVIRONMENT: "test",
+    NODE_ENV: "test",
+    ELIZA_DEPLOY_COMMIT: "test-commit-18049",
+    STEWARD_API_URL: "https://steward.example.test",
+    STEWARD_TENANT_ID: "elizacloud-staging",
+    GOOGLE_CLIENT_ID: "google-client-id",
+    GOOGLE_CLIENT_SECRET: "google-client-secret",
+  } as unknown as AppEnv["Bindings"];
+
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    resetProvidersResponseCacheForTests();
+  });
+
+  test("matches only login-critical Steward GETs", () => {
+    expect(isThinStewardPublicPath("/steward/auth/providers")).toBe(true);
+    expect(isThinStewardPublicPath("/steward/auth/providers/")).toBe(true);
+    expect(isThinStewardPublicPath("/steward/tenants/config")).toBe(true);
+    expect(isThinStewardPublicPath("/steward/auth/email/send")).toBe(false);
+    expect(isThinStewardPublicPath("/steward/auth/nonce")).toBe(false);
+    expect(isThinStewardPublicPath("/api/v1/oauth/providers")).toBe(false);
+  });
+
+  test("dispatches GET /steward/auth/providers through the thin shell", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      expect(url).toBe("https://steward.example.test/auth/providers");
+      return Response.json({
+        ok: true,
+        data: {
+          passkey: true,
+          email: true,
+          siwe: false,
+          siws: false,
+          google: false,
+          discord: false,
+          github: false,
+          oauth: [],
+        },
+      });
+    }) as typeof fetch;
+
+    try {
+      const response = await cloudApiWorker.fetch(
+        new Request("https://api.elizacloud.ai/steward/auth/providers", {
+          method: "GET",
+          headers: { origin: "https://app.elizacloud.ai" },
+        }),
+        stewardEnv,
+        executionCtx,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("x-eliza-steward-path")).toBe("thin");
+      expect(response.headers.get("server-timing")).toContain("entry_dispatch");
+      expect(response.headers.get("x-eliza-providers-cache")).toBe("miss");
+
+      const body = (await response.json()) as {
+        ok?: boolean;
+        data?: { google?: boolean; passkey?: boolean };
+      };
+      expect(body.ok).toBe(true);
+      expect(body.data?.passkey).toBe(true);
+      // Env OAuth creds patch google even when Steward reports false.
+      expect(body.data?.google).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("serves GET /steward/tenants/config from the thin shell without upstream", async () => {
+    let upstreamCalls = 0;
+    globalThis.fetch = (async () => {
+      upstreamCalls += 1;
+      return new Response("should-not-be-called", { status: 500 });
+    }) as typeof fetch;
+
+    try {
+      const response = await cloudApiWorker.fetch(
+        new Request("https://api.elizacloud.ai/steward/tenants/config", {
+          method: "GET",
+        }),
+        stewardEnv,
+        executionCtx,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("x-eliza-steward-path")).toBe("thin");
+      expect(upstreamCalls).toBe(0);
+      const body = (await response.json()) as {
+        ok?: boolean;
+        data?: { features?: { enableSolana?: boolean } };
+      };
+      expect(body.ok).toBe(true);
+      expect(body.data?.features?.enableSolana).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("reuses isolate providers cache on the second GET", async () => {
+    let upstreamCalls = 0;
+    globalThis.fetch = (async () => {
+      upstreamCalls += 1;
+      return Response.json({
+        ok: true,
+        data: {
+          passkey: true,
+          email: true,
+          google: false,
+          oauth: [],
+        },
+      });
+    }) as typeof fetch;
+
+    try {
+      const first = await cloudApiWorker.fetch(
+        new Request("https://api.elizacloud.ai/steward/auth/providers"),
+        stewardEnv,
+        executionCtx,
+      );
+      const second = await cloudApiWorker.fetch(
+        new Request("https://api.elizacloud.ai/steward/auth/providers"),
+        stewardEnv,
+        executionCtx,
+      );
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(first.headers.get("x-eliza-providers-cache")).toBe("miss");
+      expect(second.headers.get("x-eliza-providers-cache")).toBe("hit");
+      expect(upstreamCalls).toBe(1);
+      expect(second.headers.get("x-eliza-steward-path")).toBe("thin");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -110,12 +110,15 @@ describe("thin Steward public path dispatch (#18049)", () => {
     STEWARD_TENANT_ID: "elizacloud-staging",
     GOOGLE_CLIENT_ID: "google-client-id",
     GOOGLE_CLIENT_SECRET: "google-client-secret",
+    REDIS_RATE_LIMITING: "false",
+    BLOB: {},
   } as unknown as AppEnv["Bindings"];
 
   const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
     resetProvidersResponseCacheForTests();
+    globalThis.fetch = originalFetch;
   });
 
   test("matches only login-critical Steward GETs", () => {
@@ -149,7 +152,7 @@ describe("thin Steward public path dispatch (#18049)", () => {
           oauth: [],
         },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     try {
       const response = await cloudApiWorker.fetch(
@@ -184,7 +187,7 @@ describe("thin Steward public path dispatch (#18049)", () => {
     globalThis.fetch = (async () => {
       upstreamCalls += 1;
       return new Response("should-not-be-called", { status: 500 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     try {
       const response = await cloudApiWorker.fetch(
@@ -222,7 +225,7 @@ describe("thin Steward public path dispatch (#18049)", () => {
           oauth: [],
         },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     try {
       const first = await cloudApiWorker.fetch(

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -17,14 +17,18 @@ import { makeCronHandler } from "@/lib/cron/cloudflare-cron";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { serveBlobHostRequest } from "./blob-host";
 import { serveRegistryHostRequest } from "./registry-host";
+import { isThinStewardPublicPath } from "./steward/public-paths";
 
 export { AnonymousChatGate } from "./anonymous-chat-gate";
 export { InferenceAdmissionGate } from "./inference-admission-gate";
 export { OnboardingSessionCoordinator } from "./onboarding-session-coordinator";
 export { SharedRuntimeConversation } from "./shared-runtime-conversation";
+export { isThinStewardPublicPath } from "./steward/public-paths";
 
 let appPromise: Promise<Hono<AppEnv>> | undefined;
 const inferenceAppPromises = new Map<string, Promise<Hono<AppEnv>>>();
+/** Lazy thin shell for login-critical Steward GETs (#18049). */
+let stewardThinAppPromise: Promise<Hono<AppEnv>> | undefined;
 
 const STAGING_SESSION_UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -159,6 +163,51 @@ type AgentDomainBindings = Pick<
 async function getApp(): Promise<Hono<AppEnv>> {
   appPromise ??= import("./bootstrap-app").then((m) => m.createApp());
   return appPromise;
+}
+
+async function getStewardThinApp(): Promise<Hono<AppEnv>> {
+  stewardThinAppPromise ??= import("./steward/thin-app").then((m) =>
+    m.createStewardThinApp(),
+  );
+  return stewardThinAppPromise;
+}
+
+async function dispatchThinSteward(
+  request: Request,
+  env: AppEnv["Bindings"],
+  ctx: ExecutionContext,
+): Promise<Response | null> {
+  const method = request.method.toUpperCase();
+  if (method !== "GET" && method !== "HEAD" && method !== "OPTIONS") {
+    return null;
+  }
+  const pathname = new URL(request.url).pathname;
+  if (!isThinStewardPublicPath(pathname)) return null;
+
+  const dispatchStartedAt = performance.now();
+  const moduleWasInitialized = stewardThinAppPromise !== undefined;
+  const app = await getStewardThinApp();
+  const moduleInitMs = performance.now() - dispatchStartedAt;
+  const response = await app.fetch(request, env, ctx);
+  const dispatchMs = performance.now() - dispatchStartedAt;
+
+  const headers = new Headers(response.headers);
+  headers.set("X-Eliza-Steward-Path", "thin");
+  headers.append(
+    "Server-Timing",
+    `entry_dispatch;dur=${dispatchMs.toFixed(1)}`,
+  );
+  if (!moduleWasInitialized) {
+    headers.append(
+      "Server-Timing",
+      `steward_module_init;dur=${moduleInitMs.toFixed(1)}`,
+    );
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 async function getInferenceApp(
@@ -499,6 +548,12 @@ export default {
         frontendAliasApiTarget.toString(),
         createFrontendAliasProxyInit(request, url),
       );
+      const stewardThinResponse = await dispatchThinSteward(
+        apiRequest,
+        env,
+        ctx,
+      );
+      if (stewardThinResponse) return stewardThinResponse;
       const inferenceResponse = await dispatchInference(apiRequest, env, ctx);
       if (inferenceResponse) return inferenceResponse;
       return (await getApp()).fetch(apiRequest, env, ctx);
@@ -527,6 +582,10 @@ export default {
     if (url.pathname === "/api/health") {
       return healthResponse(env);
     }
+
+    // Login-critical Steward GETs before full-app bootstrap (#18049).
+    const stewardThinResponse = await dispatchThinSteward(request, env, ctx);
+    if (stewardThinResponse) return stewardThinResponse;
 
     const inferenceResponse = await dispatchInference(request, env, ctx);
     if (inferenceResponse) return inferenceResponse;

--- a/packages/cloud/api/src/steward/embedded.ts
+++ b/packages/cloud/api/src/steward/embedded.ts
@@ -191,23 +191,27 @@ function hasOAuthCreds(
  * upstream leg is still material after the thin entry path removes cold
  * bootstrap.
  *
- * Staleness bound (hard ceiling **60s** from fetch):
+ * Staleness bound (hard ceiling **60s from original fetch**):
  * - Isolate entry expires after PROVIDERS_CACHE_TTL_MS (60s), or sooner when
  *   `ELIZA_DEPLOY_COMMIT` changes (new deploy / key mismatch).
- * - Browser/shared `Cache-Control` is `public, max-age=60` only — **no**
- *   `stale-while-revalidate`, so intermediaries cannot serve a removed provider
- *   past the same 60s bound (#18049 risk callout).
+ * - Browser/shared `Cache-Control` is `public, max-age=<remaining>` only —
+ *   **no** `stale-while-revalidate`. On hits we emit the *remaining* lifetime
+ *   so isolate age + downstream max-age never compose past 60s from fetch
+ *   (a hit at t=59s gets max-age=1, not a fresh max-age=60).
  * - No cross-isolate shared store; each Worker isolate has its own entry.
  */
 export const PROVIDERS_CACHE_TTL_MS = 60_000;
-/** Browser/shared-cache policy; must keep total staleness ≤ PROVIDERS_CACHE_TTL_MS. */
+/** Fresh-miss browser policy (full remaining budget at t=0). */
 export const PROVIDERS_BROWSER_CACHE_CONTROL = "public, max-age=60";
 
 type ProvidersCacheEntry = {
   body: ArrayBuffer;
   status: number;
   contentType: string;
+  /** Absolute epoch ms when the isolate entry becomes unusable. */
   expiresAt: number;
+  /** Absolute epoch ms of the upstream fetch that produced this body. */
+  fetchedAt: number;
   deployCommit: string | null;
 };
 
@@ -217,16 +221,31 @@ function providersCacheKey(env: AppEnv["Bindings"]): string | null {
   return env.ELIZA_DEPLOY_COMMIT?.trim() || null;
 }
 
+/**
+ * Cache-Control for a response whose origin fetch was `ageMs` ago.
+ * Always `public, max-age=<remaining>` with remaining ∈ [0, 60] seconds and
+ * no stale-while-revalidate, so total age from fetch cannot exceed 60s.
+ */
+export function providersCacheControlForAgeMs(ageMs: number): string {
+  const remainingMs = Math.max(0, PROVIDERS_CACHE_TTL_MS - Math.max(0, ageMs));
+  const maxAgeSec = Math.ceil(remainingMs / 1000);
+  return `public, max-age=${maxAgeSec}`;
+}
+
 function readProvidersCache(env: AppEnv["Bindings"]): Response | null {
   const entry = providersResponseCache;
   if (!entry) return null;
-  if (entry.expiresAt <= Date.now()) return null;
+  const now = Date.now();
+  if (entry.expiresAt <= now) return null;
   if (entry.deployCommit !== providersCacheKey(env)) return null;
+  const ageMs = now - entry.fetchedAt;
+  if (ageMs >= PROVIDERS_CACHE_TTL_MS) return null;
   return new Response(entry.body.slice(0), {
     status: entry.status,
     headers: {
       "content-type": entry.contentType,
-      "cache-control": PROVIDERS_BROWSER_CACHE_CONTROL,
+      "cache-control": providersCacheControlForAgeMs(ageMs),
+      age: String(Math.floor(ageMs / 1000)),
       "x-eliza-providers-cache": "hit",
     },
   });
@@ -241,16 +260,19 @@ async function writeProvidersCache(
   if (!contentType.includes("application/json")) return response;
 
   const body = await response.clone().arrayBuffer();
+  const fetchedAt = Date.now();
   providersResponseCache = {
     body,
     status: response.status,
     contentType,
-    expiresAt: Date.now() + PROVIDERS_CACHE_TTL_MS,
+    fetchedAt,
+    expiresAt: fetchedAt + PROVIDERS_CACHE_TTL_MS,
     deployCommit: providersCacheKey(env),
   };
 
   const headers = new Headers(response.headers);
-  headers.set("cache-control", PROVIDERS_BROWSER_CACHE_CONTROL);
+  headers.set("cache-control", providersCacheControlForAgeMs(0));
+  headers.set("age", "0");
   headers.set("x-eliza-providers-cache", "miss");
   return new Response(body.slice(0), {
     status: response.status,
@@ -268,6 +290,16 @@ export function expireProvidersResponseCacheForTests(): void {
   if (providersResponseCache) {
     providersResponseCache.expiresAt = Date.now() - 1;
   }
+}
+
+/**
+ * Test helper — rewind/advance the isolate entry's clocks by `deltaMs`
+ * (positive = age the entry as if that many ms already elapsed).
+ */
+export function ageProvidersResponseCacheForTests(deltaMs: number): void {
+  if (!providersResponseCache) return;
+  providersResponseCache.fetchedAt -= deltaMs;
+  providersResponseCache.expiresAt -= deltaMs;
 }
 
 /**

--- a/packages/cloud/api/src/steward/embedded.ts
+++ b/packages/cloud/api/src/steward/embedded.ts
@@ -1,11 +1,14 @@
 // Boots cloud API src steward embedded Worker infrastructure under Cloudflare runtime constraints.
 import type { MiddlewareHandler } from "hono";
-import { STEWARD_AUTH_UPSTREAM_TIMEOUT_MS } from "@/lib/auth/steward-client";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const REQUEST_TTL_SECONDS = 60;
+// Keep in lockstep with STEWARD_AUTH_UPSTREAM_TIMEOUT_MS in
+// packages/cloud/shared/src/lib/auth/steward-client.ts. Inlined so this module
+// (and the thin login path that loads it) does not pull the JWT/jose graph.
+const STEWARD_AUTH_UPSTREAM_TIMEOUT_MS = 25_000;
 
 function bytesToHex(bytes: Uint8Array): string {
   let out = "";
@@ -181,6 +184,80 @@ function hasOAuthCreds(
 }
 
 /**
+ * Isolate-local cache for GET /auth/providers (#18049).
+ *
+ * The enabled provider set changes at deploy/config time (OAuth env + Steward
+ * config), not per request. A short TTL cuts warm multi-sample p95 when the
+ * upstream leg is still material after the thin entry path removes cold
+ * bootstrap. Staleness window: at most PROVIDERS_CACHE_TTL_MS, or sooner when
+ * `ELIZA_DEPLOY_COMMIT` changes (new deploy). No cross-isolate shared store —
+ * each Worker isolate has its own entry.
+ */
+const PROVIDERS_CACHE_TTL_MS = 60_000;
+const PROVIDERS_BROWSER_CACHE_CONTROL =
+  "public, max-age=30, stale-while-revalidate=120";
+
+type ProvidersCacheEntry = {
+  body: ArrayBuffer;
+  status: number;
+  contentType: string;
+  expiresAt: number;
+  deployCommit: string | null;
+};
+
+let providersResponseCache: ProvidersCacheEntry | null = null;
+
+function providersCacheKey(env: AppEnv["Bindings"]): string | null {
+  return env.ELIZA_DEPLOY_COMMIT?.trim() || null;
+}
+
+function readProvidersCache(env: AppEnv["Bindings"]): Response | null {
+  const entry = providersResponseCache;
+  if (!entry) return null;
+  if (entry.expiresAt <= Date.now()) return null;
+  if (entry.deployCommit !== providersCacheKey(env)) return null;
+  return new Response(entry.body.slice(0), {
+    status: entry.status,
+    headers: {
+      "content-type": entry.contentType,
+      "cache-control": PROVIDERS_BROWSER_CACHE_CONTROL,
+      "x-eliza-providers-cache": "hit",
+    },
+  });
+}
+
+async function writeProvidersCache(
+  response: Response,
+  env: AppEnv["Bindings"],
+): Promise<Response> {
+  if (!response.ok) return response;
+  const contentType = response.headers.get("content-type") || "";
+  if (!contentType.includes("application/json")) return response;
+
+  const body = await response.clone().arrayBuffer();
+  providersResponseCache = {
+    body,
+    status: response.status,
+    contentType,
+    expiresAt: Date.now() + PROVIDERS_CACHE_TTL_MS,
+    deployCommit: providersCacheKey(env),
+  };
+
+  const headers = new Headers(response.headers);
+  headers.set("cache-control", PROVIDERS_BROWSER_CACHE_CONTROL);
+  headers.set("x-eliza-providers-cache", "miss");
+  return new Response(body.slice(0), {
+    status: response.status,
+    headers,
+  });
+}
+
+/** Test helper — clears the isolate providers cache between cases. */
+export function resetProvidersResponseCacheForTests(): void {
+  providersResponseCache = null;
+}
+
+/**
  * The deployed Steward 0.3.9 image's `/auth/providers` returns `false` for
  * google/discord/github even when the OAuth env vars are populated, while the
  * `/auth/oauth/<provider>/authorize` flow still works. Patch the proxied
@@ -226,6 +303,11 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
   const url = new URL(c.req.url);
   if (c.req.method === "GET" && isPublicStewardTenantConfigPath(url.pathname)) {
     return c.json({ ok: true, data: PUBLIC_STEWARD_TENANT_CONFIG });
+  }
+
+  if (c.req.method === "GET" && isAuthProvidersPath(url.pathname)) {
+    const cached = readProvidersCache(c.env);
+    if (cached) return cached;
   }
 
   const upstream = resolveStewardUpstream(c.env, url);
@@ -353,7 +435,8 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
     );
   }
   if (c.req.method === "GET" && isAuthProvidersPath(url.pathname)) {
-    return patchProvidersResponse(response, c.env);
+    const patched = await patchProvidersResponse(response, c.env);
+    return writeProvidersCache(patched, c.env);
   }
   return response;
 };

--- a/packages/cloud/api/src/steward/embedded.ts
+++ b/packages/cloud/api/src/steward/embedded.ts
@@ -189,13 +189,19 @@ function hasOAuthCreds(
  * The enabled provider set changes at deploy/config time (OAuth env + Steward
  * config), not per request. A short TTL cuts warm multi-sample p95 when the
  * upstream leg is still material after the thin entry path removes cold
- * bootstrap. Staleness window: at most PROVIDERS_CACHE_TTL_MS, or sooner when
- * `ELIZA_DEPLOY_COMMIT` changes (new deploy). No cross-isolate shared store —
- * each Worker isolate has its own entry.
+ * bootstrap.
+ *
+ * Staleness bound (hard ceiling **60s** from fetch):
+ * - Isolate entry expires after PROVIDERS_CACHE_TTL_MS (60s), or sooner when
+ *   `ELIZA_DEPLOY_COMMIT` changes (new deploy / key mismatch).
+ * - Browser/shared `Cache-Control` is `public, max-age=60` only — **no**
+ *   `stale-while-revalidate`, so intermediaries cannot serve a removed provider
+ *   past the same 60s bound (#18049 risk callout).
+ * - No cross-isolate shared store; each Worker isolate has its own entry.
  */
-const PROVIDERS_CACHE_TTL_MS = 60_000;
-const PROVIDERS_BROWSER_CACHE_CONTROL =
-  "public, max-age=30, stale-while-revalidate=120";
+export const PROVIDERS_CACHE_TTL_MS = 60_000;
+/** Browser/shared-cache policy; must keep total staleness ≤ PROVIDERS_CACHE_TTL_MS. */
+export const PROVIDERS_BROWSER_CACHE_CONTROL = "public, max-age=60";
 
 type ProvidersCacheEntry = {
   body: ArrayBuffer;
@@ -255,6 +261,13 @@ async function writeProvidersCache(
 /** Test helper — clears the isolate providers cache between cases. */
 export function resetProvidersResponseCacheForTests(): void {
   providersResponseCache = null;
+}
+
+/** Test helper — force the current isolate entry past its expiry. */
+export function expireProvidersResponseCacheForTests(): void {
+  if (providersResponseCache) {
+    providersResponseCache.expiresAt = Date.now() - 1;
+  }
 }
 
 /**

--- a/packages/cloud/api/src/steward/public-paths.ts
+++ b/packages/cloud/api/src/steward/public-paths.ts
@@ -1,0 +1,22 @@
+/**
+ * Path matchers for login-critical Steward reads (#18049).
+ *
+ * Kept dependency-free so the Worker entry can classify requests without
+ * evaluating the embedded Steward proxy or the full Hono bootstrap graph.
+ */
+
+/**
+ * Login-critical Steward reads that must not wait on full-app bootstrap.
+ *
+ * - GET /steward/auth/providers — gates sign-in buttons (#18049)
+ * - GET /steward/tenants/config — pure local JSON (no upstream)
+ *
+ * OPTIONS preflight for these paths is also eligible for the thin shell.
+ */
+export function isThinStewardPublicPath(pathname: string): boolean {
+  const normalized = pathname.replace(/\/+$/, "") || "/";
+  return (
+    normalized === "/steward/auth/providers" ||
+    normalized === "/steward/tenants/config"
+  );
+}

--- a/packages/cloud/api/src/steward/thin-app.test.ts
+++ b/packages/cloud/api/src/steward/thin-app.test.ts
@@ -5,7 +5,9 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import {
-  embeddedStewardHandler,
+  expireProvidersResponseCacheForTests,
+  PROVIDERS_BROWSER_CACHE_CONTROL,
+  PROVIDERS_CACHE_TTL_MS,
   resetProvidersResponseCacheForTests,
 } from "./embedded";
 import { isThinStewardPublicPath } from "./public-paths";
@@ -21,9 +23,37 @@ const stewardEnv = {
   STEWARD_TENANT_ID: "elizacloud-staging",
   GOOGLE_CLIENT_ID: "google-client-id",
   GOOGLE_CLIENT_SECRET: "google-client-secret",
+  REDIS_RATE_LIMITING: "false",
+  BLOB: {},
 } as unknown as AppEnv["Bindings"];
 
 const originalFetch = globalThis.fetch;
+
+function stubFetch(
+  impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
+): void {
+  // Node 24's `typeof fetch` includes `preconnect`; bridge via unknown.
+  globalThis.fetch = impl as unknown as typeof fetch;
+}
+
+function providersUpstreamResponse(
+  overrides: Record<string, unknown> = {},
+): Response {
+  return Response.json({
+    ok: true,
+    data: {
+      passkey: true,
+      email: true,
+      siwe: false,
+      siws: false,
+      google: false,
+      discord: false,
+      github: false,
+      oauth: [],
+      ...overrides,
+    },
+  });
+}
 
 beforeEach(() => {
   resetProvidersResponseCacheForTests();
@@ -41,9 +71,23 @@ describe("isThinStewardPublicPath", () => {
   });
 });
 
+describe("providers cache policy (#18049 staleness)", () => {
+  test("browser Cache-Control total staleness is ≤ isolate TTL (no SWR extension)", () => {
+    expect(PROVIDERS_CACHE_TTL_MS).toBe(60_000);
+    expect(PROVIDERS_BROWSER_CACHE_CONTROL).toBe("public, max-age=60");
+    expect(PROVIDERS_BROWSER_CACHE_CONTROL).not.toContain(
+      "stale-while-revalidate",
+    );
+    const maxAgeMatch = PROVIDERS_BROWSER_CACHE_CONTROL.match(/max-age=(\d+)/i);
+    expect(maxAgeMatch).toBeTruthy();
+    const maxAgeSeconds = Number(maxAgeMatch![1]);
+    expect(maxAgeSeconds * 1000).toBeLessThanOrEqual(PROVIDERS_CACHE_TTL_MS);
+  });
+});
+
 describe("createStewardThinApp", () => {
   test("proxies GET /steward/auth/providers and patches OAuth from env", async () => {
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
+    stubFetch(async (input: RequestInfo | URL) => {
       const url =
         typeof input === "string"
           ? input
@@ -51,20 +95,8 @@ describe("createStewardThinApp", () => {
             ? input.toString()
             : input.url;
       expect(url).toBe(`${UPSTREAM}/auth/providers`);
-      return Response.json({
-        ok: true,
-        data: {
-          passkey: true,
-          email: true,
-          siwe: false,
-          siws: false,
-          google: false,
-          discord: false,
-          github: false,
-          oauth: [],
-        },
-      });
-    }) as typeof fetch;
+      return providersUpstreamResponse();
+    });
 
     const app = createStewardThinApp();
     const response = await app.request(
@@ -78,6 +110,9 @@ describe("createStewardThinApp", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("x-eliza-providers-cache")).toBe("miss");
+    expect(response.headers.get("cache-control")).toBe(
+      PROVIDERS_BROWSER_CACHE_CONTROL,
+    );
     const body = (await response.json()) as {
       ok?: boolean;
       data?: { google?: boolean; passkey?: boolean };
@@ -87,12 +122,12 @@ describe("createStewardThinApp", () => {
     expect(body.data?.google).toBe(true);
   });
 
-  test("serves GET /steward/tenants/config without upstream", async () => {
+  test("serves GET /steward/tenants/config without upstream and defaults no-store", async () => {
     let upstreamCalls = 0;
-    globalThis.fetch = (async () => {
+    stubFetch(async () => {
       upstreamCalls += 1;
       return new Response("nope", { status: 500 });
-    }) as typeof fetch;
+    });
 
     const app = createStewardThinApp();
     const response = await app.request(
@@ -103,6 +138,7 @@ describe("createStewardThinApp", () => {
 
     expect(response.status).toBe(200);
     expect(upstreamCalls).toBe(0);
+    expect(response.headers.get("cache-control")).toBe("no-store");
     const body = (await response.json()) as {
       ok?: boolean;
       data?: { features?: { enableSolana?: boolean } };
@@ -113,18 +149,10 @@ describe("createStewardThinApp", () => {
 
   test("reuses isolate providers cache on the second GET", async () => {
     let upstreamCalls = 0;
-    globalThis.fetch = (async () => {
+    stubFetch(async () => {
       upstreamCalls += 1;
-      return Response.json({
-        ok: true,
-        data: {
-          passkey: true,
-          email: true,
-          google: false,
-          oauth: [],
-        },
-      });
-    }) as typeof fetch;
+      return providersUpstreamResponse();
+    });
 
     const app = createStewardThinApp();
     const first = await app.request(
@@ -142,7 +170,132 @@ describe("createStewardThinApp", () => {
     expect(second.status).toBe(200);
     expect(first.headers.get("x-eliza-providers-cache")).toBe("miss");
     expect(second.headers.get("x-eliza-providers-cache")).toBe("hit");
+    expect(second.headers.get("cache-control")).toBe(
+      PROVIDERS_BROWSER_CACHE_CONTROL,
+    );
     expect(upstreamCalls).toBe(1);
+  });
+
+  test("expires isolate cache after TTL so a removed provider cannot stick", async () => {
+    let upstreamCalls = 0;
+    stubFetch(async () => {
+      upstreamCalls += 1;
+      return providersUpstreamResponse(
+        upstreamCalls === 1 ? { google: true } : { google: false, oauth: [] },
+      );
+    });
+
+    const app = createStewardThinApp();
+    const first = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      stewardEnv,
+    );
+    expect(first.headers.get("x-eliza-providers-cache")).toBe("miss");
+
+    expireProvidersResponseCacheForTests();
+
+    const second = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      stewardEnv,
+    );
+    expect(second.headers.get("x-eliza-providers-cache")).toBe("miss");
+    expect(upstreamCalls).toBe(2);
+  });
+
+  test("invalidates isolate cache when ELIZA_DEPLOY_COMMIT changes", async () => {
+    let upstreamCalls = 0;
+    stubFetch(async () => {
+      upstreamCalls += 1;
+      return providersUpstreamResponse();
+    });
+
+    const app = createStewardThinApp();
+    const envA = {
+      ...stewardEnv,
+      ELIZA_DEPLOY_COMMIT: "commit-a",
+    } as unknown as AppEnv["Bindings"];
+    const envB = {
+      ...stewardEnv,
+      ELIZA_DEPLOY_COMMIT: "commit-b",
+    } as unknown as AppEnv["Bindings"];
+
+    const first = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      envA,
+    );
+    const second = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      envB,
+    );
+
+    expect(first.headers.get("x-eliza-providers-cache")).toBe("miss");
+    expect(second.headers.get("x-eliza-providers-cache")).toBe("miss");
+    expect(upstreamCalls).toBe(2);
+  });
+
+  test("fails closed in production when REDIS_RATE_LIMITING=true without Redis", async () => {
+    let upstreamCalls = 0;
+    stubFetch(async () => {
+      upstreamCalls += 1;
+      return providersUpstreamResponse();
+    });
+
+    const app = createStewardThinApp();
+    const response = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      {
+        ...stewardEnv,
+        ENVIRONMENT: "production",
+        REDIS_RATE_LIMITING: "true",
+        // no REDIS_URL / redis binding → buildRedisClient returns null
+      } as unknown as AppEnv["Bindings"],
+    );
+
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as { code?: string };
+    expect(body.code).toBe("RATE_LIMIT_UNAVAILABLE");
+    expect(upstreamCalls).toBe(0);
+  });
+
+  test("HEAD /steward/auth/providers is accepted by the thin shell", async () => {
+    stubFetch(async () => providersUpstreamResponse());
+
+    const app = createStewardThinApp();
+    const response = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "HEAD" },
+      stewardEnv,
+    );
+
+    // Hono may answer HEAD via GET handler; either 200 or method-shaped success.
+    expect([200, 204].includes(response.status) || response.status < 500).toBe(
+      true,
+    );
+  });
+
+  test("OPTIONS preflight gets first-party CORS for app origin", async () => {
+    const app = createStewardThinApp();
+    const response = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://app.elizacloud.ai",
+          "access-control-request-method": "GET",
+        },
+      },
+      stewardEnv,
+    );
+
+    expect(response.status).toBeLessThan(500);
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      "https://app.elizacloud.ai",
+    );
   });
 });
 
@@ -155,14 +308,12 @@ describe("embeddedStewardHandler providers cache", () => {
       {
         ENVIRONMENT: "test",
         NODE_ENV: "test",
+        REDIS_RATE_LIMITING: "false",
+        BLOB: {},
       } as unknown as AppEnv["Bindings"],
     );
     expect(response.status).toBe(503);
     const body = (await response.json()) as { error?: string };
     expect(body.error).toBe("steward_upstream_not_configured");
-  });
-
-  test("handler is the same middleware used by the thin shell", () => {
-    expect(typeof embeddedStewardHandler).toBe("function");
   });
 });

--- a/packages/cloud/api/src/steward/thin-app.test.ts
+++ b/packages/cloud/api/src/steward/thin-app.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Isolated thin Steward shell tests (#18049). Avoids importing the full Worker
+ * entrypoint so these run without the monolithic bootstrap dependency graph.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import {
+  embeddedStewardHandler,
+  resetProvidersResponseCacheForTests,
+} from "./embedded";
+import { isThinStewardPublicPath } from "./public-paths";
+import { createStewardThinApp } from "./thin-app";
+
+const UPSTREAM = "https://steward.example.test";
+
+const stewardEnv = {
+  ENVIRONMENT: "test",
+  NODE_ENV: "test",
+  ELIZA_DEPLOY_COMMIT: "test-commit-18049-thin",
+  STEWARD_API_URL: UPSTREAM,
+  STEWARD_TENANT_ID: "elizacloud-staging",
+  GOOGLE_CLIENT_ID: "google-client-id",
+  GOOGLE_CLIENT_SECRET: "google-client-secret",
+} as unknown as AppEnv["Bindings"];
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  resetProvidersResponseCacheForTests();
+  globalThis.fetch = originalFetch;
+});
+
+describe("isThinStewardPublicPath", () => {
+  test("matches only login-critical Steward GETs", () => {
+    expect(isThinStewardPublicPath("/steward/auth/providers")).toBe(true);
+    expect(isThinStewardPublicPath("/steward/auth/providers/")).toBe(true);
+    expect(isThinStewardPublicPath("/steward/tenants/config")).toBe(true);
+    expect(isThinStewardPublicPath("/steward/auth/email/send")).toBe(false);
+    expect(isThinStewardPublicPath("/steward/auth/nonce")).toBe(false);
+    expect(isThinStewardPublicPath("/api/v1/oauth/providers")).toBe(false);
+  });
+});
+
+describe("createStewardThinApp", () => {
+  test("proxies GET /steward/auth/providers and patches OAuth from env", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      expect(url).toBe(`${UPSTREAM}/auth/providers`);
+      return Response.json({
+        ok: true,
+        data: {
+          passkey: true,
+          email: true,
+          siwe: false,
+          siws: false,
+          google: false,
+          discord: false,
+          github: false,
+          oauth: [],
+        },
+      });
+    }) as typeof fetch;
+
+    const app = createStewardThinApp();
+    const response = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      {
+        method: "GET",
+        headers: { origin: "https://app.elizacloud.ai" },
+      },
+      stewardEnv,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-eliza-providers-cache")).toBe("miss");
+    const body = (await response.json()) as {
+      ok?: boolean;
+      data?: { google?: boolean; passkey?: boolean };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data?.passkey).toBe(true);
+    expect(body.data?.google).toBe(true);
+  });
+
+  test("serves GET /steward/tenants/config without upstream", async () => {
+    let upstreamCalls = 0;
+    globalThis.fetch = (async () => {
+      upstreamCalls += 1;
+      return new Response("nope", { status: 500 });
+    }) as typeof fetch;
+
+    const app = createStewardThinApp();
+    const response = await app.request(
+      "https://api.elizacloud.ai/steward/tenants/config",
+      { method: "GET" },
+      stewardEnv,
+    );
+
+    expect(response.status).toBe(200);
+    expect(upstreamCalls).toBe(0);
+    const body = (await response.json()) as {
+      ok?: boolean;
+      data?: { features?: { enableSolana?: boolean } };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data?.features?.enableSolana).toBe(true);
+  });
+
+  test("reuses isolate providers cache on the second GET", async () => {
+    let upstreamCalls = 0;
+    globalThis.fetch = (async () => {
+      upstreamCalls += 1;
+      return Response.json({
+        ok: true,
+        data: {
+          passkey: true,
+          email: true,
+          google: false,
+          oauth: [],
+        },
+      });
+    }) as typeof fetch;
+
+    const app = createStewardThinApp();
+    const first = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      stewardEnv,
+    );
+    const second = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      stewardEnv,
+    );
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(first.headers.get("x-eliza-providers-cache")).toBe("miss");
+    expect(second.headers.get("x-eliza-providers-cache")).toBe("hit");
+    expect(upstreamCalls).toBe(1);
+  });
+});
+
+describe("embeddedStewardHandler providers cache", () => {
+  test("returns 503 when upstream is not configured", async () => {
+    const app = createStewardThinApp();
+    const response = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      {
+        ENVIRONMENT: "test",
+        NODE_ENV: "test",
+      } as unknown as AppEnv["Bindings"],
+    );
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as { error?: string };
+    expect(body.error).toBe("steward_upstream_not_configured");
+  });
+
+  test("handler is the same middleware used by the thin shell", () => {
+    expect(typeof embeddedStewardHandler).toBe("function");
+  });
+});

--- a/packages/cloud/api/src/steward/thin-app.test.ts
+++ b/packages/cloud/api/src/steward/thin-app.test.ts
@@ -5,9 +5,11 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import {
+  ageProvidersResponseCacheForTests,
   expireProvidersResponseCacheForTests,
   PROVIDERS_BROWSER_CACHE_CONTROL,
   PROVIDERS_CACHE_TTL_MS,
+  providersCacheControlForAgeMs,
   resetProvidersResponseCacheForTests,
 } from "./embedded";
 import { isThinStewardPublicPath } from "./public-paths";
@@ -78,10 +80,48 @@ describe("providers cache policy (#18049 staleness)", () => {
     expect(PROVIDERS_BROWSER_CACHE_CONTROL).not.toContain(
       "stale-while-revalidate",
     );
-    const maxAgeMatch = PROVIDERS_BROWSER_CACHE_CONTROL.match(/max-age=(\d+)/i);
-    expect(maxAgeMatch).toBeTruthy();
-    const maxAgeSeconds = Number(maxAgeMatch![1]);
-    expect(maxAgeSeconds * 1000).toBeLessThanOrEqual(PROVIDERS_CACHE_TTL_MS);
+    expect(providersCacheControlForAgeMs(0)).toBe("public, max-age=60");
+    expect(providersCacheControlForAgeMs(59_000)).toBe("public, max-age=1");
+    expect(providersCacheControlForAgeMs(60_000)).toBe("public, max-age=0");
+  });
+
+  test("cache hit near TTL emits remaining max-age so total age never exceeds 60s", async () => {
+    let upstreamCalls = 0;
+    stubFetch(async () => {
+      upstreamCalls += 1;
+      return providersUpstreamResponse();
+    });
+
+    const app = createStewardThinApp();
+    const miss = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      stewardEnv,
+    );
+    expect(miss.status).toBe(200);
+    expect(miss.headers.get("x-eliza-providers-cache")).toBe("miss");
+    expect(miss.headers.get("cache-control")).toBe("public, max-age=60");
+    expect(miss.headers.get("age")).toBe("0");
+
+    // Age the isolate entry by 59s (same clock the reader uses via fetchedAt).
+    ageProvidersResponseCacheForTests(59_000);
+
+    const hit = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      stewardEnv,
+    );
+    expect(hit.status).toBe(200);
+    expect(hit.headers.get("x-eliza-providers-cache")).toBe("hit");
+    expect(hit.headers.get("cache-control")).toBe("public, max-age=1");
+    expect(hit.headers.get("age")).toBe("59");
+    // Isolate age (59) + remaining max-age (1) = 60 — never a fresh max-age=60.
+    const maxAge = Number(
+      hit.headers.get("cache-control")?.match(/max-age=(\d+)/i)?.[1],
+    );
+    const age = Number(hit.headers.get("age"));
+    expect(age + maxAge).toBeLessThanOrEqual(60);
+    expect(upstreamCalls).toBe(1);
   });
 });
 

--- a/packages/cloud/api/src/steward/thin-app.ts
+++ b/packages/cloud/api/src/steward/thin-app.ts
@@ -6,22 +6,61 @@
  * spend multi-second module-init on the anonymous `/steward/auth/providers`
  * path that gates the sign-in buttons.
  *
- * This shell mounts only CORS + the embedded Steward handler so those GETs
- * never evaluate `bootstrap-app` / `_router.generated`. Mutating Steward auth
- * still uses the full app (signing, rate limits, observability).
+ * This shell mirrors the dependency-light protections already used by the thin
+ * inference entry (`inference-app.ts`) plus the production Redis fail-closed
+ * rate-limit config guard from `bootstrap-app.ts`, without evaluating
+ * `_router.generated`. Mutating Steward auth still uses the full app.
  */
 
 import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { logger as honoLogger } from "hono/logger";
 import { requestId } from "hono/request-id";
 import { secureHeaders } from "hono/secure-headers";
+import { runWithDbCacheAsync } from "@/db/client";
+import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
+import { hasRedisConfig } from "@/lib/cache/redis-factory";
 import { corsMiddleware } from "@/lib/cors/cloud-api-hono-cors";
+import {
+  getIpKey,
+  getRequestIp,
+  rateLimit,
+  rateLimitConfigVerdict,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { observeCloudRequest } from "@/lib/observability/cloud-backend-observability";
+import { resolveElizaTraceId } from "@/lib/observability/http-telemetry";
+import { httpTelemetryMiddleware } from "@/lib/observability/http-telemetry-hono";
+import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import { runWithRequestContext } from "@/lib/runtime/request-context";
+import { setRuntimeR2Bucket } from "@/lib/storage/r2-runtime-binding";
+import { logger } from "@/lib/utils/logger";
+import { describeUnhandledError } from "@/lib/utils/unhandled-error-detail";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { embeddedStewardHandler } from "./embedded";
 
 export function createStewardThinApp(): Hono<AppEnv> {
   const app = new Hono<AppEnv>({ strict: false });
 
+  app.use("*", async (c, next) => {
+    setRuntimeR2Bucket(c.env.BLOB);
+    await runWithCloudBindingsAsync(
+      c.env as Record<string, unknown>,
+      async () =>
+        runWithRequestContext(
+          {
+            clientIp: getRequestIp(c),
+            idempotencyKey:
+              c.req.header("idempotency-key") ||
+              c.req.header("x-request-id") ||
+              crypto.randomUUID(),
+          },
+          async () => runWithDbCacheAsync(async () => next()),
+        ),
+    );
+  });
+
   app.use("*", requestId());
+  app.use("*", httpTelemetryMiddleware());
   app.use("*", corsMiddleware);
   app.use(
     "*",
@@ -36,8 +75,126 @@ export function createStewardThinApp(): Hono<AppEnv> {
     }),
   );
 
+  // Default JSON to no-store unless the handler set an explicit Cache-Control
+  // (providers sets a ≤60s public policy; tenant config stays no-store).
+  app.use("*", async (c, next) => {
+    await next();
+    if (
+      !c.res.headers.has("Cache-Control") &&
+      c.res.headers.get("Content-Type")?.includes("application/json")
+    ) {
+      c.res.headers.set("Cache-Control", "no-store");
+    }
+  });
+
+  app.use("*", honoLogger());
+  app.use("*", async (c, next) => {
+    c.set("requestId", c.get("requestId") ?? crypto.randomUUID());
+    c.set("user", undefined);
+    await next();
+  });
+  app.use("*", async (c, next) => {
+    const reqId = c.get("requestId") ?? crypto.randomUUID();
+    const traceId = c.get("traceId") ?? resolveElizaTraceId(c.req.raw.headers);
+    c.set("requestId", reqId);
+    c.set("traceId", traceId);
+    return observeCloudRequest(
+      {
+        id: reqId,
+        traceId,
+        method: c.req.method,
+        path: new URL(c.req.url).pathname,
+      },
+      async () => {
+        await next();
+        const user = c.get("user");
+        return {
+          result: undefined,
+          status: c.res.status,
+          userId: user?.id ?? null,
+          organizationId: user?.organization_id ?? null,
+          authMethod: c.get("authMethod") ?? null,
+        };
+      },
+    );
+  });
+
+  // Same production Redis fail-closed contract as bootstrap-app (#9853): never
+  // silently serve login-critical traffic when rate limiting is marked required
+  // but Redis is unreachable.
+  let rateLimitConfigLogged = false;
+  app.use("*", async (c, next) => {
+    const env = c.env as { ENVIRONMENT?: string; REDIS_RATE_LIMITING?: string };
+    const verdict = rateLimitConfigVerdict({
+      environment: env.ENVIRONMENT,
+      redisRateLimiting: env.REDIS_RATE_LIMITING,
+      // Config presence only — avoid constructing a Redis client on every
+      // login-critical request (same fail-closed decision as bootstrap-app).
+      hasRedisClient: hasRedisConfig(c.env),
+    });
+    if (!rateLimitConfigLogged) {
+      rateLimitConfigLogged = true;
+      if (verdict === "fail-closed") {
+        logger.error(
+          "[steward-thin-app] FATAL: REDIS_RATE_LIMITING=true in production but no Redis client is reachable (set the REDIS_URL secret). Failing closed — refusing traffic rather than serving with rate limiting silently disabled.",
+        );
+      } else if (verdict === "warn-disabled") {
+        logger.warn(
+          '[steward-thin-app] Rate limiting is DISABLED in production (REDIS_RATE_LIMITING!="true") — limiters fall open. Cutover (#9853 P1.1): provision Redis, set REDIS_URL, then set REDIS_RATE_LIMITING="true" and redeploy.',
+        );
+      }
+    }
+    if (verdict === "fail-closed") {
+      return c.json(
+        {
+          error: "Rate limiting misconfigured",
+          code: "RATE_LIMIT_UNAVAILABLE",
+        },
+        503,
+      );
+    }
+    await next();
+  });
+
+  // Global IP backstop (600/min) — same ceiling/namespace as bootstrap-app and
+  // inference-app so thin login GETs are not unmetered.
+  app.use(
+    "*",
+    rateLimit(
+      {
+        windowMs: 60_000,
+        maxRequests: 600,
+        keyGenerator: (c) => `global:${getIpKey(c)}`,
+      },
+      { bindingName: "GLOBAL_RATE_LIMITER" },
+    ),
+  );
+
   app.all("/steward", embeddedStewardHandler);
   app.all("/steward/*", embeddedStewardHandler);
+
+  app.notFound((c) =>
+    c.json(
+      { success: false, error: "Not found", code: "resource_not_found" },
+      404,
+    ),
+  );
+  app.onError((err, c) => {
+    if (
+      err instanceof ApiError ||
+      (err instanceof HTTPException && err.status < 500)
+    ) {
+      logger.debug("[StewardThinApp] Request rejected", {
+        status: err.status,
+        message: err.message,
+      });
+      return failureResponse(c, err);
+    }
+    logger.error("[StewardThinApp] Unhandled error", {
+      error: describeUnhandledError(err),
+    });
+    return failureResponse(c, err);
+  });
 
   return app;
 }

--- a/packages/cloud/api/src/steward/thin-app.ts
+++ b/packages/cloud/api/src/steward/thin-app.ts
@@ -1,0 +1,43 @@
+/**
+ * Thin Hono shell for login-critical Steward GETs (#18049).
+ *
+ * The monolithic bootstrap loads ~580 routes and service singletons (e.g.
+ * PayoutAlerts) before the embedded Steward proxy runs. Cold isolates then
+ * spend multi-second module-init on the anonymous `/steward/auth/providers`
+ * path that gates the sign-in buttons.
+ *
+ * This shell mounts only CORS + the embedded Steward handler so those GETs
+ * never evaluate `bootstrap-app` / `_router.generated`. Mutating Steward auth
+ * still uses the full app (signing, rate limits, observability).
+ */
+
+import { Hono } from "hono";
+import { requestId } from "hono/request-id";
+import { secureHeaders } from "hono/secure-headers";
+import { corsMiddleware } from "@/lib/cors/cloud-api-hono-cors";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import { embeddedStewardHandler } from "./embedded";
+
+export function createStewardThinApp(): Hono<AppEnv> {
+  const app = new Hono<AppEnv>({ strict: false });
+
+  app.use("*", requestId());
+  app.use("*", corsMiddleware);
+  app.use(
+    "*",
+    secureHeaders({
+      xContentTypeOptions: "nosniff",
+      strictTransportSecurity: "max-age=63072000; includeSubDomains; preload",
+      xFrameOptions: "DENY",
+      referrerPolicy: "strict-origin-when-cross-origin",
+      crossOriginResourcePolicy: "cross-origin",
+      crossOriginEmbedderPolicy: false,
+      crossOriginOpenerPolicy: false,
+    }),
+  );
+
+  app.all("/steward", embeddedStewardHandler);
+  app.all("/steward/*", embeddedStewardHandler);
+
+  return app;
+}


### PR DESCRIPTION
# Relates to

Fixes #18049

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts at branch time.
- [x] Focused package verification was run after review repairs (see Testing).
      Full root `bun run verify` was **not** re-run this cycle; scoped cloud-api
      unit suite + `tsc --noEmit` are the proof for this Worker thin-path change.
- [x] A reviewer can confirm the change from the pasted transcripts and cache
      matrix without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `elizaOS/develop`; review repairs on top.
- [x] Focused suite green. Full `bun run verify` not claimed this cycle.

# Risks

**Medium.** Login-critical anonymous path:

- Thin dispatch skips full route graph but preserves rate limit, Redis fail-closed,
  CORS/security headers, telemetry, default JSON `no-store`.
- Provider list cached ≤**60s from original fetch** (isolate + downstream
  `max-age` remaining; no SWR). Deploy commit invalidates isolate cache.
- Mutating Steward auth still uses the full app.

# Background

## What does this PR do?

Fixes #18049 cold multi-second `getApp()` bootstrap on
`GET /steward/auth/providers`. Thin entry + remaining-lifetime cache.

## What kind of change is this?

Performance improvement (Worker cold-path for login-critical Steward GETs).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. `packages/cloud/api/src/steward/embedded.ts` — remaining `max-age` + `Age`
2. `packages/cloud/api/src/steward/thin-app.ts` — shell parity
3. `packages/cloud/api/src/index.ts` — thin dispatch
4. `packages/cloud/api/src/steward/thin-app.test.ts` — t≈59s regression

## Detailed testing steps

```bash
# prerequisite in pristine checkout: bun run --cwd packages/core build
cd packages/cloud/api
bun test src/steward/thin-app.test.ts __tests__/steward-embedded-signing.test.ts
bun run tsc --noEmit
```

# Evidence Gate

<!-- evidence-head:8acd7873bada452e8da7c3f69b3b9bfa57e5326e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface change; Worker API path only. Client already
  ships `LoginOptionsSkeleton` (#18256). Failure mode is HTTP latency/headers.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface change; Worker API path only.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow; proof is unit transcript + header matrix.

<!-- evidence-row:backend-logs -->
- [x] Focused unit + typecheck transcript (exact head `8acd7873bada452e8da7c3f69b3b9bfa57e5326e`):

```text
$ bun test src/steward/thin-app.test.ts __tests__/steward-embedded-signing.test.ts
 20 pass
 0 fail
 76 expect() calls
Ran 20 tests across 2 files. [640.00ms]

$ bun run tsc --noEmit
tsc exit=0
```

Cache/marker sample from the t≈59s regression (same suite):

```text
miss: X-Eliza-Providers-Cache=miss  Cache-Control=public, max-age=60  Age=0
hit@59s: X-Eliza-Providers-Cache=hit  Cache-Control=public, max-age=1  Age=59
assert: age + max-age (59+1) <= 60
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code change in this PR.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior involved.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact — providers cache contract + thin markers:

```text
PROVIDERS_CACHE_TTL_MS = 60000
providersCacheControlForAgeMs(0)     => public, max-age=60
providersCacheControlForAgeMs(59000) => public, max-age=1
providersCacheControlForAgeMs(60000) => public, max-age=0
no stale-while-revalidate

Entry dispatch markers (thin path):
  X-Eliza-Steward-Path: thin
  X-Eliza-Providers-Cache: hit|miss
  Cache-Control: public, max-age=<remaining>
  Age: <seconds since fetch>
```

Pre-deploy live baseline (prior unmerged head; no thin markers yet) remains in PR discussion comment. Post-merge deploy sample still required for production p95.

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text to OCR.

# Evidence Details

## Known gaps / failures

- Full root `bun run verify` not run this cycle.
- Package `typecheck` also runs wrangler dry-run; claimed gate is `tsc --noEmit` exit 0.
- Pristine archive needs `packages/core` build before thin-app tests resolve `@elizaos/core`.
- Post-deploy `X-Eliza-Steward-Path: thin` + p95 sample blocked until merge/API deploy.

AI provider/model: xai / grok-4.5
Client / agent tooling: Grok Build
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [raynord22]