### PR TITLE
fix(plugins): bridge Settings credentials into runtime.getSetting

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -99,6 +99,7 @@ export * from "./api/index.ts";
 export { setOwnerContact } from "./api/owner-contact-helpers.ts";
 export {
   findPrimaryEnvKey,
+  isBlockedEnvKey,
   readBundledPluginPackageMetadata,
 } from "./api/plugin-discovery-helpers.ts";
 export * from "./api/plugin-runtime-apply.ts";

--- a/packages/core/src/__tests__/runtime-settings.test.ts
+++ b/packages/core/src/__tests__/runtime-settings.test.ts
@@ -81,6 +81,32 @@ describe("AgentRuntime.getSetting", () => {
 		expect(runtime.getSetting("ROUTE_POLICY")).toBe('{"default":"owner"}');
 	});
 
+	it("clears secrets and settings when setSetting receives null", () => {
+		const runtime = new AgentRuntime({
+			character: {
+				name: "set-setting-clear-test",
+				secrets: {
+					DISCORD_API_TOKEN: "old-token",
+				},
+				settings: {
+					DISCORD_APPLICATION_ID: "old-app",
+				},
+			} as Character,
+			settings: {
+				DISCORD_API_TOKEN: "constructor-token",
+				DISCORD_APPLICATION_ID: "constructor-app",
+			},
+		});
+
+		expect(runtime.getSetting("DISCORD_API_TOKEN")).toBe("old-token");
+		runtime.setSetting("DISCORD_API_TOKEN", null, true);
+		expect(runtime.getSetting("DISCORD_API_TOKEN")).toBeNull();
+
+		expect(runtime.getSetting("DISCORD_APPLICATION_ID")).toBe("old-app");
+		runtime.setSetting("DISCORD_APPLICATION_ID", null, false);
+		expect(runtime.getSetting("DISCORD_APPLICATION_ID")).toBeNull();
+	});
+
 	it("uses fresh constructor settings over DB-persisted agent settings on restart", async () => {
 		const adapter = new InMemoryDatabaseAdapter();
 		const characterName = "runtime-settings-restart-test";

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -3478,6 +3478,11 @@ export class AgentRuntime implements IAgentRuntime {
 			if (value !== null && value !== undefined) {
 				// Secrets are stored as strings
 				this.character.secrets[key] = String(value);
+			} else {
+				// null clears — callers use setSetting(key, null) to revoke a
+				// previously bridged credential (cloud disconnect, connector
+				// admin wipe, plugin Settings blanking an optional param).
+				delete this.character.secrets[key];
 			}
 		} else {
 			if (!this.character.settings) {
@@ -3485,7 +3490,16 @@ export class AgentRuntime implements IAgentRuntime {
 			}
 			if (value !== null && value !== undefined) {
 				this.character.settings[key] = value;
+			} else {
+				delete this.character.settings[key];
 			}
+		}
+		// Keep the constructor settings map aligned so getRuntimeSettingValue
+		// cannot resurrect a cleared key after character.secrets/settings drop it.
+		if (value !== null && value !== undefined) {
+			this.settings[key] = value;
+		} else {
+			delete this.settings[key];
 		}
 	}
 

--- a/plugins/plugin-registry/src/api/app-plugins-routes.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.ts
@@ -48,6 +48,7 @@ import {
   type RegistryEntry,
 } from "@elizaos/registry/first-party";
 import { asRecord, CONNECTOR_PLUGINS } from "@elizaos/shared";
+import { bridgePluginParamsToRuntime } from "./bridge-plugin-settings.ts";
 import { VaultMissError } from "@elizaos/vault";
 
 const require = createRequire(import.meta.url);
@@ -1666,6 +1667,25 @@ export async function handlePluginsCompatRoutes(
     const result = persistCompatPluginMutation(pluginId, body, plugin);
     if (result.status === 200) {
       const nextConfig = loadElizaConfig();
+      // Bridge process.env / just-saved config into runtime.getSetting before
+      // hot reload — catalog isSet reads env, connectors read getSetting (#18713).
+      if (body.config && typeof body.config === "object" && !Array.isArray(body.config)) {
+        const bridgedValues: Record<string, string | undefined> = {};
+        for (const [key, value] of Object.entries(
+          body.config as Record<string, unknown>,
+        )) {
+          if (typeof value === "string") {
+            bridgedValues[key] = value.trim() ? value : undefined;
+          }
+        }
+        bridgePluginParamsToRuntime(
+          state.current,
+          plugin.parameters ?? [],
+          bridgedValues,
+        );
+      } else if (body.enabled === true) {
+        bridgePluginParamsToRuntime(state.current, plugin.parameters ?? []);
+      }
       const runtimeApply = await applyCompatRuntimeMutation({
         state,
         pluginId,

--- a/plugins/plugin-registry/src/api/app-plugins-routes.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.ts
@@ -15,6 +15,7 @@ import {
   discoverPluginsFromManifest,
   findPrimaryEnvKey,
   isAdvancedCapabilityPluginId,
+  isBlockedEnvKey,
   isVaultRef,
   loadElizaConfig,
   type PluginRuntimeApplyResult,
@@ -48,7 +49,11 @@ import {
   type RegistryEntry,
 } from "@elizaos/registry/first-party";
 import { asRecord, CONNECTOR_PLUGINS } from "@elizaos/shared";
-import { bridgePluginParamsToRuntime } from "./bridge-plugin-settings.ts";
+import {
+  bridgePluginParamsToRuntime,
+  clearPluginParamValues,
+  collectAgentScopedPluginParamValues,
+} from "./bridge-plugin-settings.ts";
 import { VaultMissError } from "@elizaos/vault";
 
 const require = createRequire(import.meta.url);
@@ -1667,24 +1672,51 @@ export async function handlePluginsCompatRoutes(
     const result = persistCompatPluginMutation(pluginId, body, plugin);
     if (result.status === 200) {
       const nextConfig = loadElizaConfig();
-      // Bridge process.env / just-saved config into runtime.getSetting before
-      // hot reload — catalog isSet reads env, connectors read getSetting (#18713).
-      if (body.config && typeof body.config === "object" && !Array.isArray(body.config)) {
+      // Fold agent-scoped config into runtime.getSetting before hot reload —
+      // catalog isSet reads env, connectors read getSetting (#18713).
+      if (
+        body.config &&
+        typeof body.config === "object" &&
+        !Array.isArray(body.config)
+      ) {
         const bridgedValues: Record<string, string | undefined> = {};
         for (const [key, value] of Object.entries(
           body.config as Record<string, unknown>,
         )) {
-          if (typeof value === "string") {
-            bridgedValues[key] = value.trim() ? value : undefined;
-          }
+          if (typeof value !== "string") continue;
+          if (isBlockedEnvKey(key)) continue;
+          bridgedValues[key] = value.trim() ? value : undefined;
         }
         bridgePluginParamsToRuntime(
           state.current,
           plugin.parameters ?? [],
           bridgedValues,
+          { isBlockedKey: isBlockedEnvKey },
         );
-      } else if (body.enabled === true) {
-        bridgePluginParamsToRuntime(state.current, plugin.parameters ?? []);
+      } else if (typeof body.enabled === "boolean") {
+        if (body.enabled) {
+          const entry = asRecord(nextConfig.plugins?.entries?.[pluginId]);
+          const agentScoped = collectAgentScopedPluginParamValues(
+            plugin.parameters ?? [],
+            {
+              entryConfig: asRecord(entry?.config),
+              configEnv: asRecord(nextConfig.env),
+            },
+          );
+          bridgePluginParamsToRuntime(
+            state.current,
+            plugin.parameters ?? [],
+            agentScoped,
+            { isBlockedKey: isBlockedEnvKey },
+          );
+        } else {
+          bridgePluginParamsToRuntime(
+            state.current,
+            plugin.parameters ?? [],
+            clearPluginParamValues(plugin.parameters ?? []),
+            { isBlockedKey: isBlockedEnvKey },
+          );
+        }
       }
       const runtimeApply = await applyCompatRuntimeMutation({
         state,

--- a/plugins/plugin-registry/src/api/bridge-plugin-settings.test.ts
+++ b/plugins/plugin-registry/src/api/bridge-plugin-settings.test.ts
@@ -1,10 +1,39 @@
 /**
- * Unit coverage for bridging plugin Settings values into runtime.setSetting
+ * Unit coverage for folding plugin Settings values into runtime.setSetting
  * so connector plugins can observe credentials via getSetting without a full
  * process restart. Deterministic mocks only — no live Discord/Telegram.
  */
 import { describe, expect, it, vi } from "vitest";
-import { bridgePluginParamsToRuntime } from "./bridge-plugin-settings.ts";
+import {
+  bridgePluginParamsToRuntime,
+  clearPluginParamValues,
+  collectAgentScopedPluginParamValues,
+} from "./bridge-plugin-settings.ts";
+
+describe("collectAgentScopedPluginParamValues", () => {
+  it("prefers entry.config over config.env and skips blanks", () => {
+    expect(
+      collectAgentScopedPluginParamValues(
+        [
+          { key: "DISCORD_API_TOKEN", sensitive: true },
+          { key: "DISCORD_APPLICATION_ID", sensitive: false },
+          { key: "MISSING", sensitive: false },
+        ],
+        {
+          entryConfig: { DISCORD_API_TOKEN: " from-entry " },
+          configEnv: {
+            DISCORD_API_TOKEN: "from-env",
+            DISCORD_APPLICATION_ID: "app-id",
+            MISSING: "   ",
+          },
+        },
+      ),
+    ).toEqual({
+      DISCORD_API_TOKEN: "from-entry",
+      DISCORD_APPLICATION_ID: "app-id",
+    });
+  });
+});
 
 describe("bridgePluginParamsToRuntime", () => {
   it("writes trimmed values through setSetting with sensitive flag", () => {
@@ -35,34 +64,45 @@ describe("bridgePluginParamsToRuntime", () => {
     );
   });
 
-  it("hydrates from process.env when values map is omitted", () => {
-    const previous = process.env.DISCORD_API_TOKEN;
-    process.env.DISCORD_API_TOKEN = "from-env";
-    try {
-      const setSetting = vi.fn();
-      bridgePluginParamsToRuntime(
-        { setSetting },
-        [{ key: "DISCORD_API_TOKEN", sensitive: true }],
-      );
-      expect(setSetting).toHaveBeenCalledWith(
-        "DISCORD_API_TOKEN",
-        "from-env",
-        true,
-      );
-    } finally {
-      if (previous === undefined) {
-        delete process.env.DISCORD_API_TOKEN;
-      } else {
-        process.env.DISCORD_API_TOKEN = previous;
-      }
-    }
+  it("skips non-empty writes for blocked keys but still clears them", () => {
+    const setSetting = vi.fn();
+    const isBlockedKey = (key: string) => key === "ELIZA_API_TOKEN";
+    bridgePluginParamsToRuntime(
+      { setSetting },
+      [
+        { key: "ELIZA_API_TOKEN", sensitive: true },
+        { key: "DISCORD_API_TOKEN", sensitive: true },
+      ],
+      {
+        ELIZA_API_TOKEN: "host-token",
+        DISCORD_API_TOKEN: "bot-token",
+      },
+      { isBlockedKey },
+    );
+    expect(setSetting).toHaveBeenCalledTimes(1);
+    expect(setSetting).toHaveBeenCalledWith(
+      "DISCORD_API_TOKEN",
+      "bot-token",
+      true,
+    );
+
+    setSetting.mockClear();
+    bridgePluginParamsToRuntime(
+      { setSetting },
+      [{ key: "ELIZA_API_TOKEN", sensitive: true }],
+      clearPluginParamValues([{ key: "ELIZA_API_TOKEN", sensitive: true }]),
+      { isBlockedKey },
+    );
+    expect(setSetting).toHaveBeenCalledWith("ELIZA_API_TOKEN", null, true);
   });
 
   it("is a no-op without a runtime setSetting", () => {
     expect(() =>
-      bridgePluginParamsToRuntime(null, [
-        { key: "DISCORD_API_TOKEN", sensitive: true },
-      ], { DISCORD_API_TOKEN: "x" }),
+      bridgePluginParamsToRuntime(
+        null,
+        [{ key: "DISCORD_API_TOKEN", sensitive: true }],
+        { DISCORD_API_TOKEN: "x" },
+      ),
     ).not.toThrow();
   });
 });

--- a/plugins/plugin-registry/src/api/bridge-plugin-settings.test.ts
+++ b/plugins/plugin-registry/src/api/bridge-plugin-settings.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit coverage for bridging plugin Settings values into runtime.setSetting
+ * so connector plugins can observe credentials via getSetting without a full
+ * process restart. Deterministic mocks only — no live Discord/Telegram.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { bridgePluginParamsToRuntime } from "./bridge-plugin-settings.ts";
+
+describe("bridgePluginParamsToRuntime", () => {
+  it("writes trimmed values through setSetting with sensitive flag", () => {
+    const setSetting = vi.fn();
+    bridgePluginParamsToRuntime(
+      { setSetting },
+      [{ key: "DISCORD_API_TOKEN", sensitive: true }],
+      { DISCORD_API_TOKEN: "  abc123  " },
+    );
+    expect(setSetting).toHaveBeenCalledWith(
+      "DISCORD_API_TOKEN",
+      "abc123",
+      true,
+    );
+  });
+
+  it("clears blank submitted values with null", () => {
+    const setSetting = vi.fn();
+    bridgePluginParamsToRuntime(
+      { setSetting },
+      [{ key: "DISCORD_APPLICATION_ID", sensitive: false }],
+      { DISCORD_APPLICATION_ID: "   " },
+    );
+    expect(setSetting).toHaveBeenCalledWith(
+      "DISCORD_APPLICATION_ID",
+      null,
+      false,
+    );
+  });
+
+  it("hydrates from process.env when values map is omitted", () => {
+    const previous = process.env.DISCORD_API_TOKEN;
+    process.env.DISCORD_API_TOKEN = "from-env";
+    try {
+      const setSetting = vi.fn();
+      bridgePluginParamsToRuntime(
+        { setSetting },
+        [{ key: "DISCORD_API_TOKEN", sensitive: true }],
+      );
+      expect(setSetting).toHaveBeenCalledWith(
+        "DISCORD_API_TOKEN",
+        "from-env",
+        true,
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.DISCORD_API_TOKEN;
+      } else {
+        process.env.DISCORD_API_TOKEN = previous;
+      }
+    }
+  });
+
+  it("is a no-op without a runtime setSetting", () => {
+    expect(() =>
+      bridgePluginParamsToRuntime(null, [
+        { key: "DISCORD_API_TOKEN", sensitive: true },
+      ], { DISCORD_API_TOKEN: "x" }),
+    ).not.toThrow();
+  });
+});

--- a/plugins/plugin-registry/src/api/bridge-plugin-settings.ts
+++ b/plugins/plugin-registry/src/api/bridge-plugin-settings.ts
@@ -1,5 +1,5 @@
 /**
- * Bridges plugin Settings mutations into the live runtime's getSetting surface.
+ * Folds plugin Settings mutations into the live runtime's getSetting surface.
  *
  * Plugin catalog `isSet` reads `process.env`, but connector plugins (Discord,
  * Telegram, …) resolve credentials via `runtime.getSetting()`, which never
@@ -7,6 +7,10 @@
  * UI look configured while hot-loaded plugins still saw an empty token.
  * Callers must invoke this before applyPluginRuntimeMutation / plugin reload
  * so init() and service constructors observe the same values the catalog does.
+ *
+ * Sources must be agent-scoped (PUT body, entry.config, config.env). Do not
+ * hydrate from bare process.env — that can copy host secrets across agents in
+ * a shared process (#18713).
  */
 import type { AgentRuntime } from "@elizaos/core";
 
@@ -17,35 +21,88 @@ export type BridgedPluginParam = {
 
 type RuntimeSettingWriter = Pick<AgentRuntime, "setSetting">;
 
+export type FoldPluginParamsOptions = {
+  /**
+   * Reject host/step-up keys (ELIZA_API_TOKEN, DATABASE_URL, …). Required on
+   * write paths; clearing a key with null/blank still runs so disable can
+   * revoke previously folded credentials.
+   */
+  isBlockedKey?: (key: string) => boolean;
+};
+
+/**
+ * Collect declared plugin params from agent-owned config only (entry.config
+ * wins over config.env). Missing keys are omitted — callers should not clear
+ * on enable just because a param was never saved.
+ */
+export function collectAgentScopedPluginParamValues(
+  parameters: readonly BridgedPluginParam[],
+  sources: {
+    entryConfig?: Record<string, unknown> | null;
+    configEnv?: Record<string, unknown> | null;
+  },
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const param of parameters) {
+    const fromEntry = sources.entryConfig?.[param.key];
+    const fromEnv = sources.configEnv?.[param.key];
+    const raw =
+      typeof fromEntry === "string" && fromEntry.trim()
+        ? fromEntry.trim()
+        : typeof fromEnv === "string" && fromEnv.trim()
+          ? fromEnv.trim()
+          : undefined;
+    if (raw !== undefined) {
+      values[param.key] = raw;
+    }
+  }
+  return values;
+}
+
+/**
+ * Build a clear-map for every declared param (disable / revoke path).
+ */
+export function clearPluginParamValues(
+  parameters: readonly BridgedPluginParam[],
+): Record<string, string | undefined> {
+  const values: Record<string, string | undefined> = {};
+  for (const param of parameters) {
+    values[param.key] = undefined;
+  }
+  return values;
+}
+
 /**
  * Writes (or clears) plugin parameter values onto `runtime.setSetting`.
  *
- * When `values` is provided, only those keys are updated — blank/missing
- * values clear the setting. When omitted, every parameter is hydrated from
- * `process.env` (used on enable so a previously saved token becomes visible
- * to getSetting before the plugin reloads).
+ * Only keys present in `values` are touched. Blank/undefined clears.
+ * Non-empty writes of blocked keys are skipped.
  */
 export function bridgePluginParamsToRuntime(
   runtime: RuntimeSettingWriter | null | undefined,
   parameters: readonly BridgedPluginParam[],
-  values?: Readonly<Record<string, string | undefined>>,
+  values: Readonly<Record<string, string | undefined>>,
+  options: FoldPluginParamsOptions = {},
 ): void {
   if (!runtime || typeof runtime.setSetting !== "function") {
     return;
   }
 
+  const { isBlockedKey } = options;
+
   for (const param of parameters) {
-    if (values && !Object.hasOwn(values, param.key)) {
+    if (!Object.hasOwn(values, param.key)) {
       continue;
     }
-    const raw = values ? values[param.key] : process.env[param.key];
+    const raw = values[param.key];
     const secret = Boolean(param.sensitive);
     if (typeof raw === "string" && raw.trim()) {
+      if (isBlockedKey?.(param.key)) {
+        continue;
+      }
       runtime.setSetting(param.key, raw.trim(), secret);
       continue;
     }
-    if (values) {
-      runtime.setSetting(param.key, null, secret);
-    }
+    runtime.setSetting(param.key, null, secret);
   }
 }

--- a/plugins/plugin-registry/src/api/bridge-plugin-settings.ts
+++ b/plugins/plugin-registry/src/api/bridge-plugin-settings.ts
@@ -1,0 +1,51 @@
+/**
+ * Bridges plugin Settings mutations into the live runtime's getSetting surface.
+ *
+ * Plugin catalog `isSet` reads `process.env`, but connector plugins (Discord,
+ * Telegram, …) resolve credentials via `runtime.getSetting()`, which never
+ * falls through to process.env. Writing only process.env / config.env made the
+ * UI look configured while hot-loaded plugins still saw an empty token.
+ * Callers must invoke this before applyPluginRuntimeMutation / plugin reload
+ * so init() and service constructors observe the same values the catalog does.
+ */
+import type { AgentRuntime } from "@elizaos/core";
+
+export type BridgedPluginParam = {
+  key: string;
+  sensitive?: boolean;
+};
+
+type RuntimeSettingWriter = Pick<AgentRuntime, "setSetting">;
+
+/**
+ * Writes (or clears) plugin parameter values onto `runtime.setSetting`.
+ *
+ * When `values` is provided, only those keys are updated — blank/missing
+ * values clear the setting. When omitted, every parameter is hydrated from
+ * `process.env` (used on enable so a previously saved token becomes visible
+ * to getSetting before the plugin reloads).
+ */
+export function bridgePluginParamsToRuntime(
+  runtime: RuntimeSettingWriter | null | undefined,
+  parameters: readonly BridgedPluginParam[],
+  values?: Readonly<Record<string, string | undefined>>,
+): void {
+  if (!runtime || typeof runtime.setSetting !== "function") {
+    return;
+  }
+
+  for (const param of parameters) {
+    if (values && !Object.hasOwn(values, param.key)) {
+      continue;
+    }
+    const raw = values ? values[param.key] : process.env[param.key];
+    const secret = Boolean(param.sensitive);
+    if (typeof raw === "string" && raw.trim()) {
+      runtime.setSetting(param.key, raw.trim(), secret);
+      continue;
+    }
+    if (values) {
+      runtime.setSetting(param.key, null, secret);
+    }
+  }
+}

--- a/plugins/plugin-registry/src/api/plugin-routes.test.ts
+++ b/plugins/plugin-registry/src/api/plugin-routes.test.ts
@@ -199,7 +199,9 @@ describe("handlePluginRoutes config persistence", () => {
       },
     };
     const setSetting = vi.fn();
-    process.env.DISCORD_API_TOKEN = "keep-me";
+    // Poison process.env with a different value — enable must fold from
+    // agent-scoped config, not host env.
+    process.env.DISCORD_API_TOKEN = "host-poison";
     const ctx = makeContext({ enabled: true }, config);
     ctx.state.runtime = { setSetting } as never;
 
@@ -214,6 +216,31 @@ describe("handlePluginRoutes config persistence", () => {
       "keep-me",
       true,
     );
+  });
+
+  it("clears folded credentials when disabling a plugin", async () => {
+    const config = {
+      env: { DISCORD_API_TOKEN: "keep-me" },
+      plugins: {
+        entries: {
+          discord: {
+            enabled: true,
+            config: { DISCORD_API_TOKEN: "keep-me" },
+          },
+        },
+      },
+    };
+    const setSetting = vi.fn();
+    const ctx = makeContext({ enabled: false }, config);
+    ctx.state.runtime = { setSetting } as never;
+
+    await handlePluginRoutes(ctx);
+
+    expect(config.plugins.entries.discord).toEqual({
+      enabled: false,
+      config: { DISCORD_API_TOKEN: "keep-me" },
+    });
+    expect(setSetting).toHaveBeenCalledWith("DISCORD_API_TOKEN", null, true);
   });
 
   it("removes blank optional config values from persisted and process env", async () => {

--- a/plugins/plugin-registry/src/api/plugin-routes.test.ts
+++ b/plugins/plugin-registry/src/api/plugin-routes.test.ts
@@ -152,10 +152,12 @@ describe("handlePluginRoutes config persistence", () => {
 
   it("persists submitted config to env and plugins.entries", async () => {
     const config = { env: {}, plugins: { entries: {} } };
+    const setSetting = vi.fn();
     const ctx = makeContext(
       { config: { DISCORD_API_TOKEN: "abc123" } },
       config,
     );
+    ctx.state.runtime = { setSetting } as never;
 
     const handled = await handlePluginRoutes(ctx);
 
@@ -173,10 +175,44 @@ describe("handlePluginRoutes config persistence", () => {
       },
     });
     expect(process.env.DISCORD_API_TOKEN).toBe("abc123");
+    expect(setSetting).toHaveBeenCalledWith(
+      "DISCORD_API_TOKEN",
+      "abc123",
+      true,
+    );
     expect(mocks.saveElizaConfig).toHaveBeenCalledWith(config);
     expect(ctx.json).toHaveBeenCalledWith(
       ctx.res,
       expect.objectContaining({ ok: true }),
+    );
+  });
+
+  it("preserves entry config when enabling a plugin", async () => {
+    const config = {
+      env: { DISCORD_API_TOKEN: "keep-me" },
+      plugins: {
+        entries: {
+          discord: {
+            config: { DISCORD_API_TOKEN: "keep-me" },
+          },
+        },
+      },
+    };
+    const setSetting = vi.fn();
+    process.env.DISCORD_API_TOKEN = "keep-me";
+    const ctx = makeContext({ enabled: true }, config);
+    ctx.state.runtime = { setSetting } as never;
+
+    await handlePluginRoutes(ctx);
+
+    expect(config.plugins.entries.discord).toEqual({
+      config: { DISCORD_API_TOKEN: "keep-me" },
+      enabled: true,
+    });
+    expect(setSetting).toHaveBeenCalledWith(
+      "DISCORD_API_TOKEN",
+      "keep-me",
+      true,
     );
   });
 
@@ -193,7 +229,9 @@ describe("handlePluginRoutes config persistence", () => {
         },
       },
     };
+    const setSetting = vi.fn();
     const ctx = makeContext({ config: { DISCORD_API_TOKEN: " " } }, config);
+    ctx.state.runtime = { setSetting } as never;
 
     await handlePluginRoutes(ctx);
 
@@ -209,6 +247,7 @@ describe("handlePluginRoutes config persistence", () => {
       },
     });
     expect(process.env.DISCORD_API_TOKEN).toBeUndefined();
+    expect(setSetting).toHaveBeenCalledWith("DISCORD_API_TOKEN", null, true);
   });
 
   it.each(["../../evil", "@scope/../evil", "plugin name", "", "   "])(

--- a/plugins/plugin-registry/src/api/plugin-routes.ts
+++ b/plugins/plugin-registry/src/api/plugin-routes.ts
@@ -30,7 +30,11 @@ import {
 import type { AgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import type { PluginParamDef, ReadJsonBodyOptions } from "@elizaos/shared";
-import { bridgePluginParamsToRuntime } from "./bridge-plugin-settings.ts";
+import {
+  bridgePluginParamsToRuntime,
+  clearPluginParamValues,
+  collectAgentScopedPluginParamValues,
+} from "./bridge-plugin-settings.ts";
 import {
   asRecord,
   isElizaSettingsDebugEnabled,
@@ -905,12 +909,13 @@ export async function handlePluginRoutes(
         pluginEntry.config = nextPluginConfig;
         entries[pluginId] = pluginEntry;
         // Catalog isSet reads process.env; Discord/Telegram init read
-        // runtime.getSetting(). Bridge before the hot reload so the live
-        // runtime secrets match what the UI just saved (#18713).
+        // runtime.getSetting(). Fold agent-scoped values before hot reload
+        // so live secrets match what the UI just saved (#18713).
         bridgePluginParamsToRuntime(
           state.runtime,
           plugin.parameters,
           bridgedValues,
+          { isBlockedKey: isBlockedEnvKey },
         );
       }
       plugin.configured = true;
@@ -987,13 +992,32 @@ export async function handlePluginRoutes(
           if (!allow.includes(pluginId) && !allow.includes(packageName)) {
             allow.push(pluginId);
           }
-          // Token may already be in process.env from an earlier save that
-          // never reached getSetting (pre-fix UI path). Hydrate secrets
-          // before the plugin graph reload so Discord init sees the token.
-          bridgePluginParamsToRuntime(state.runtime, plugin.parameters);
+          // Fold previously saved agent-scoped credentials into getSetting
+          // before the plugin graph reload (never bare process.env).
+          const agentScoped = collectAgentScopedPluginParamValues(
+            plugin.parameters,
+            {
+              entryConfig: asRecord(entries[pluginId]?.config),
+              configEnv: asRecord(state.config.env),
+            },
+          );
+          bridgePluginParamsToRuntime(
+            state.runtime,
+            plugin.parameters,
+            agentScoped,
+            { isBlockedKey: isBlockedEnvKey },
+          );
         } else {
           state.config.plugins.allow = allow.filter(
             (p: string) => p !== pluginId && p !== packageName,
+          );
+          // Revoke folded credentials so getSetting cannot keep serving a
+          // token after the plugin is disabled (#18713).
+          bridgePluginParamsToRuntime(
+            state.runtime,
+            plugin.parameters,
+            clearPluginParamValues(plugin.parameters),
+            { isBlockedKey: isBlockedEnvKey },
           );
         }
 

--- a/plugins/plugin-registry/src/api/plugin-routes.ts
+++ b/plugins/plugin-registry/src/api/plugin-routes.ts
@@ -30,6 +30,7 @@ import {
 import type { AgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import type { PluginParamDef, ReadJsonBodyOptions } from "@elizaos/shared";
+import { bridgePluginParamsToRuntime } from "./bridge-plugin-settings.ts";
 import {
   asRecord,
   isElizaSettingsDebugEnabled,
@@ -879,6 +880,7 @@ export async function handlePluginRoutes(
         : {};
       let touchedPluginConfig = false;
 
+      const bridgedValues: Record<string, string | undefined> = {};
       for (const [key, value] of Object.entries(body.config)) {
         if (
           allowedParamKeys.has(key) &&
@@ -890,16 +892,26 @@ export async function handlePluginRoutes(
             process.env[key] = value;
             (state.config.env as Record<string, unknown>)[key] = value;
             nextPluginConfig[key] = value;
+            bridgedValues[key] = value;
           } else if (!allowedParamsByKey.get(key)?.required) {
             delete process.env[key];
             delete (state.config.env as Record<string, unknown>)[key];
             delete nextPluginConfig[key];
+            bridgedValues[key] = undefined;
           }
         }
       }
       if (touchedPluginConfig) {
         pluginEntry.config = nextPluginConfig;
         entries[pluginId] = pluginEntry;
+        // Catalog isSet reads process.env; Discord/Telegram init read
+        // runtime.getSetting(). Bridge before the hot reload so the live
+        // runtime secrets match what the UI just saved (#18713).
+        bridgePluginParamsToRuntime(
+          state.runtime,
+          plugin.parameters,
+          bridgedValues,
+        );
       }
       plugin.configured = true;
 
@@ -960,7 +972,12 @@ export async function handlePluginRoutes(
 
         const entries = (state.config.plugins as Record<string, unknown>)
           .entries as Record<string, Record<string, unknown>>;
-        entries[pluginId] = { enabled: body.enabled };
+        // Preserve any previously saved entry.config — replacing the whole
+        // object with `{ enabled }` wiped Discord tokens on enable (#18713).
+        entries[pluginId] = {
+          ...(entries[pluginId] ?? {}),
+          enabled: body.enabled,
+        };
 
         // Keep plugins.allow aligned with entries[pluginId].enabled so the
         // enable-state drift check in buildCoreToggleDiagnostics() stays clean.
@@ -970,6 +987,10 @@ export async function handlePluginRoutes(
           if (!allow.includes(pluginId) && !allow.includes(packageName)) {
             allow.push(pluginId);
           }
+          // Token may already be in process.env from an earlier save that
+          // never reached getSetting (pre-fix UI path). Hydrate secrets
+          // before the plugin graph reload so Discord init sees the token.
+          bridgePluginParamsToRuntime(state.runtime, plugin.parameters);
         } else {
           state.config.plugins.allow = allow.filter(
             (p: string) => p !== pluginId && p !== packageName,


### PR DESCRIPTION
# Relates to

Closes #18713

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `cursor/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `cursor`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Medium.** Live plugin Settings saves now call `runtime.setSetting` before hot reload. Incorrect bridging could expose or clear credentials incorrectly; covered by unit tests for write/clear/enable-preserve paths. No public API shape change.

# Background

## What does this PR do?

Fixes the Discord (and shared connector) Settings false-green: UI/`process.env` showed the token as set while `runtime.getSetting("DISCORD_API_TOKEN")` stayed empty after hot enable/config, so the gateway never connected.

- Bridge plugin param writes into `runtime.setSetting()` before `applyPluginRuntimeMutation` (agent + compat routes)
- Preserve `plugins.entries.<id>.config` when enabling (stop wiping tokens)
- Make `setSetting(key, null)` actually clear secrets/settings and the constructor settings map
- Regression tests for bridge, enable-preserve, blank-clear, and null-clear

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-registry/src/api/bridge-plugin-settings.ts`
2. Enable-path preserve + bridge in `plugin-routes.ts`
3. Compat PUT bridge in `app-plugins-routes.ts`
4. `setSetting` null-clear in `packages/core/src/runtime.ts`

## Detailed testing steps


 RUN  v4.1.5 /Users/studio/Documents/GitHub/eliza/plugins/plugin-registry


 Test Files  2 passed (2)
      Tests  13 passed (13)
   Start at  20:28:20
   Duration  162ms (transform 102ms, setup 0ms, import 125ms, tests 11ms, environment 0ms)


 RUN  v4.1.5 /Users/studio/Documents/GitHub/eliza/packages/core


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  20:28:21
   Duration  2.58s (transform 1.83s, setup 0ms, import 2.49s, tests 24ms, environment 0ms)

Generating keyword code from JSON...

  Loaded action-search.generated.keywords.json: 114 entries
  Loaded context-search.keywords.json: 38 entries
  Loaded shared.keywords.json: 73 entries
  Loaded typescript.keywords.json: 16 entries
  Loaded validate.keywords.json: 2 entries

Total: 241 entries, 6 locales

  TypeScript (shared): /Users/studio/Documents/GitHub/eliza/packages/shared/src/i18n/generated/validation-keyword-data.ts
  JavaScript (shared): /Users/studio/Documents/GitHub/eliza/packages/shared/src/i18n/generated/validation-keyword-data.js
  TypeScript (core):   /Users/studio/Documents/GitHub/eliza/packages/core/src/i18n/generated/validation-keyword-data.ts

Done!

Manual (staging/local agent):

1. Enable Discord without a token → expect warn (unchanged).
2. Save `DISCORD_API_TOKEN` while enabled → expect no \"token not provided\" after reload; gateway attempts login.
3. Save token first, then enable → entry.config preserved; getSetting sees token on enable reload.

# Evidence Gate

<!-- evidence-head:25793d895f5aa35159d4181ab585196299122df6 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI/render surface changed; backend Settings PUT + getSetting bridge only`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI/render surface changed; backend Settings PUT + getSetting bridge only`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI/render surface changed; backend Settings PUT + getSetting bridge only`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit tests cover setSetting bridge/clear/enable-preserve; staging RCA for #18713 documented the pre-fix failure path`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend code changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no model/prompt/action path changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - config/runtime settings bridge only; no domain artifact producer changed`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no model/prompt/action path changed`

## Backend + frontend logs

Focused test run (pass):

```
plugins/plugin-registry: Test Files 2 passed (2) / Tests 13 passed
packages/core runtime-settings: Test Files 1 passed (1) / Tests 7 passed
```

Staging pre-fix failure (from #18713 RCA): Discord enabled → `Discord bot token not provided` while catalog `isSet=true` and `/api/health` `connectors: {}`.

## Screenshots (before / after) + video walkthrough

`N/A - no UI/render surface changed`

## Audio / voice walkthrough

`N/A - not a voice change`

## Known gaps / failures

- Full root `bun run verify` not run in this session (focused package tests + typecheck only). Reviewer/CI should run verify before merge.
- Live staging restart validation for sayo agent left as follow-up after deploy.

Made with [Cursor](https://cursor.com)