### PR TITLE
fix(ui): keep staging dedicated restore off production ingress

### DIFF
--- a/packages/ui/src/api/client-cloud-agent-base.test.ts
+++ b/packages/ui/src/api/client-cloud-agent-base.test.ts
@@ -171,10 +171,8 @@ describe("cloud-agent-base helpers", () => {
   it("resolveCloudEnvironmentBase prefers page/staging-persisted over prod boot default", () => {
     expect(
       resolveCloudEnvironmentBase({
-        pageHostname:
-          "27bdefac-03d1-4cde-baec-1d018190b298.staging.elizacloud.ai",
-        apiBase:
-          "https://27bdefac-03d1-4cde-baec-1d018190b298.staging.elizacloud.ai",
+        pageHostname: "agent-123.staging.elizacloud.ai",
+        apiBase: "https://agent-123.staging.elizacloud.ai",
         bootCloudApiBase: "https://elizacloud.ai",
       }),
     ).toBe("https://staging.elizacloud.ai");
@@ -182,8 +180,7 @@ describe("cloud-agent-base helpers", () => {
     expect(
       resolveCloudEnvironmentBase({
         pageHostname: "localhost",
-        apiBase:
-          "https://27bdefac-03d1-4cde-baec-1d018190b298.staging.elizacloud.ai",
+        apiBase: "https://agent-123.staging.elizacloud.ai",
         bootCloudApiBase: "https://elizacloud.ai",
       }),
     ).toBe("https://staging.elizacloud.ai");

--- a/packages/ui/src/api/client-cloud-agent-base.test.ts
+++ b/packages/ui/src/api/client-cloud-agent-base.test.ts
@@ -16,6 +16,7 @@ import {
   directCloudSharedAgentIdFromBase,
   isCloudAgentsCollectionBase,
   isElizaCloudControlPlaneAgentlessBase,
+  resolveCloudEnvironmentBase,
 } from "../utils/cloud-agent-base";
 import { resolveCloudAgentApiBase } from "./client-cloud";
 
@@ -165,6 +166,35 @@ describe("cloud-agent-base helpers", () => {
         "https://agent-123.staging.elizacloud.ai",
       );
     }
+  });
+
+  it("resolveCloudEnvironmentBase prefers page/staging-persisted over prod boot default", () => {
+    expect(
+      resolveCloudEnvironmentBase({
+        pageHostname:
+          "27bdefac-03d1-4cde-baec-1d018190b298.staging.elizacloud.ai",
+        apiBase:
+          "https://27bdefac-03d1-4cde-baec-1d018190b298.staging.elizacloud.ai",
+        bootCloudApiBase: "https://elizacloud.ai",
+      }),
+    ).toBe("https://staging.elizacloud.ai");
+
+    expect(
+      resolveCloudEnvironmentBase({
+        pageHostname: "localhost",
+        apiBase:
+          "https://27bdefac-03d1-4cde-baec-1d018190b298.staging.elizacloud.ai",
+        bootCloudApiBase: "https://elizacloud.ai",
+      }),
+    ).toBe("https://staging.elizacloud.ai");
+
+    expect(
+      resolveCloudEnvironmentBase({
+        pageHostname: "localhost",
+        apiBase: "https://agent-123.elizacloud.ai",
+        bootCloudApiBase: "https://staging.elizacloud.ai",
+      }),
+    ).toBe("https://staging.elizacloud.ai");
   });
 
   it("dedicatedCloudAgentIdFromBase extracts production and staging ids", () => {

--- a/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
@@ -83,6 +83,7 @@ function makeDeps(): RestoringSessionDeps {
 describe("cloud restore routes the client without waiting on the Steward refresh", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   const realFetch = globalThis.fetch;
+  const realLocation = window.location;
   const pendingRequests: Array<{
     url: string;
     resolve: (r: Response) => void;
@@ -111,6 +112,10 @@ describe("cloud restore routes the client without waiting on the Steward refresh
 
   afterEach(() => {
     globalThis.fetch = realFetch;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: realLocation,
+    });
     setBootConfig(DEFAULT_BOOT_CONFIG);
     localStorage.clear();
     vi.restoreAllMocks();
@@ -295,6 +300,60 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     expect(clientRef.setBaseUrl).toHaveBeenCalledWith(
       `https://${STAGING_AGENT_ID}.staging.elizacloud.ai`,
     );
+    expect(clientRef.setToken).toHaveBeenCalledWith("paired-token");
+  });
+
+  it("keeps staging dedicated ingress when the page is staging but boot defaults to prod", async () => {
+    // Regression: agent-subdomain bundles ship cloudApiBase=https://elizacloud.ai.
+    // Restore must not rewrite *.staging.elizacloud.ai onto production.
+    setBootConfig({
+      ...DEFAULT_BOOT_CONFIG,
+      cloudApiBase: "https://elizacloud.ai",
+    });
+    const stagingOrigin = `https://${STAGING_AGENT_ID}.staging.elizacloud.ai`;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: new URL(`${stagingOrigin}/`),
+    });
+    const restored: PersistedActiveServer = {
+      id: `cloud:${STAGING_AGENT_ID}`,
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase: stagingOrigin,
+      accessToken: "paired-token",
+    };
+    const clientRef = { setBaseUrl: vi.fn(), setToken: vi.fn() };
+
+    await applyRestoredConnection({
+      restoredActiveServer: restored,
+      clientRef,
+    });
+
+    expect(clientRef.setBaseUrl).toHaveBeenCalledWith(stagingOrigin);
+    expect(clientRef.setToken).toHaveBeenCalledWith("paired-token");
+  });
+
+  it("does not demote a persisted staging dedicated base under the prod boot default", async () => {
+    setBootConfig({
+      ...DEFAULT_BOOT_CONFIG,
+      cloudApiBase: "https://elizacloud.ai",
+    });
+    const stagingOrigin = `https://${STAGING_AGENT_ID}.staging.elizacloud.ai`;
+    const restored: PersistedActiveServer = {
+      id: `cloud:${STAGING_AGENT_ID}`,
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase: stagingOrigin,
+      accessToken: "paired-token",
+    };
+    const clientRef = { setBaseUrl: vi.fn(), setToken: vi.fn() };
+
+    await applyRestoredConnection({
+      restoredActiveServer: restored,
+      clientRef,
+    });
+
+    expect(clientRef.setBaseUrl).toHaveBeenCalledWith(stagingOrigin);
     expect(clientRef.setToken).toHaveBeenCalledWith("paired-token");
   });
 });

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -57,6 +57,7 @@ import {
   dedicatedCloudAgentIdFromBase,
   isDedicatedCloudAgentBase,
   isElizaCloudControlPlaneAgentlessBase,
+  resolveCloudEnvironmentBase,
 } from "../utils/cloud-agent-base";
 import { getElizaApiBase, getElizaApiToken } from "../utils/eliza-globals";
 import {
@@ -129,8 +130,15 @@ async function reconcileLegacyDedicatedCloudApiBase(
   if (!stewardToken || !isDedicatedCloudAgentBase(active.apiBase)) return null;
   const agentId = recoverCloudAgentId(active);
   if (!agentId) return null;
+  const pageHostname =
+    typeof window !== "undefined" ? window.location.hostname : "";
   const cloudApiBase = resolveDirectCloudAuthApiBase(
-    getBootConfig().cloudApiBase || RESTORE_DEFAULT_DIRECT_CLOUD_BASE_URL,
+    resolveCloudEnvironmentBase({
+      pageHostname,
+      apiBase: active.apiBase,
+      bootCloudApiBase: getBootConfig().cloudApiBase,
+      fallback: RESTORE_DEFAULT_DIRECT_CLOUD_BASE_URL,
+    }),
   );
   try {
     const response = await fetch(
@@ -164,6 +172,12 @@ async function reconcileLegacyDedicatedCloudApiBase(
 /**
  * Repair a restored managed-cloud target using the current environment and,
  * for legacy dedicated-looking records, the server-authoritative runtime tier.
+ *
+ * Environment priority for dedicated ingress rebuild:
+ * live Cloud page host → already-staging persisted base → boot config → prod
+ * default. Agent-subdomain UI bundles ship the production boot default, so
+ * trusting boot alone rewrote staging dedicated hosts onto production and
+ * CORS-wedged `/api/*` probes during restore.
  */
 function backfillCloudApiBase(
   active: PersistedActiveServer,
@@ -171,14 +185,27 @@ function backfillCloudApiBase(
   if (active.kind !== "cloud") return active;
   const agentId = recoverCloudAgentId(active);
   if (!agentId) return active;
-  const cloudApiBase =
-    getBootConfig().cloudApiBase ||
-    active.apiBase ||
-    RESTORE_DEFAULT_DIRECT_CLOUD_BASE_URL;
-  const dedicatedApiBase = buildDedicatedCloudAgentApiBase(
-    agentId,
-    cloudApiBase,
-  );
+  const pageHostname =
+    typeof window !== "undefined" ? window.location.hostname : "";
+  const cloudApiBase = resolveCloudEnvironmentBase({
+    pageHostname,
+    apiBase: active.apiBase,
+    bootCloudApiBase: getBootConfig().cloudApiBase,
+    fallback: RESTORE_DEFAULT_DIRECT_CLOUD_BASE_URL,
+  });
+  // When the user is already on this agent's dedicated ingress, keep that
+  // origin — do not rebuild through a mismatched boot-config environment.
+  const pageOrigin =
+    typeof window !== "undefined"
+      ? `${window.location.protocol}//${window.location.host}`
+      : "";
+  const pageAgentId = pageOrigin
+    ? dedicatedCloudAgentIdFromBase(pageOrigin)
+    : null;
+  const dedicatedApiBase =
+    pageAgentId && pageAgentId.toLowerCase() === agentId.toLowerCase()
+      ? pageOrigin
+      : buildDedicatedCloudAgentApiBase(agentId, cloudApiBase);
   if (!dedicatedApiBase) return active;
   const sharedApiBase = buildCloudSharedAgentApiBase(
     resolveDirectCloudAuthApiBase(cloudApiBase),

--- a/packages/ui/src/utils/cloud-agent-base.ts
+++ b/packages/ui/src/utils/cloud-agent-base.ts
@@ -96,11 +96,58 @@ export const ELIZA_CLOUD_CONTROL_PLANE_HOSTS = new Set([
   ...STAGING_CONSOLE_HOSTS,
 ]);
 
-function isStagingCloudHostname(hostname: string): boolean {
+export function isStagingCloudHostname(hostname: string): boolean {
   const host = hostname.toLowerCase();
   return (
     STAGING_CONSOLE_HOSTS.has(host) || host.endsWith(".staging.elizacloud.ai")
   );
+}
+
+const PROD_CLOUD_ENVIRONMENT_BASE = "https://elizacloud.ai";
+const STAGING_CLOUD_ENVIRONMENT_BASE = "https://staging.elizacloud.ai";
+
+/**
+ * Choose the Cloud environment origin used when rebuilding a dedicated-agent
+ * ingress. Prefer the live page host and an already-staging persisted base
+ * over boot config: agent-subdomain bundles ship with the production default
+ * `cloudApiBase`, so trusting boot alone rewrote
+ * `*.staging.elizacloud.ai` → `*.elizacloud.ai` and CORS-wedged boot (#16163
+ * follow-up).
+ */
+export function resolveCloudEnvironmentBase(options: {
+  pageHostname?: string | null;
+  apiBase?: string | null;
+  bootCloudApiBase?: string | null;
+  fallback?: string;
+}): string {
+  const pageHost = options.pageHostname?.trim().toLowerCase() ?? "";
+  if (pageHost && isStagingCloudHostname(pageHost)) {
+    return STAGING_CLOUD_ENVIRONMENT_BASE;
+  }
+  if (
+    pageHost?.endsWith(".elizacloud.ai") &&
+    !ELIZA_CLOUD_CONTROL_PLANE_HOSTS.has(pageHost)
+  ) {
+    return PROD_CLOUD_ENVIRONMENT_BASE;
+  }
+
+  const activeUrl = options.apiBase
+    ? normalizeHttpUrl(options.apiBase.trim())
+    : null;
+  if (activeUrl && isStagingCloudHostname(activeUrl.hostname)) {
+    return STAGING_CLOUD_ENVIRONMENT_BASE;
+  }
+
+  const boot = options.bootCloudApiBase?.trim() ?? "";
+  const bootUrl = boot ? normalizeHttpUrl(boot) : null;
+  if (bootUrl && isStagingCloudHostname(bootUrl.hostname)) {
+    return STAGING_CLOUD_ENVIRONMENT_BASE;
+  }
+  if (bootUrl) {
+    return stripTrailingSlash(bootUrl.toString());
+  }
+
+  return options.fallback?.trim() || PROD_CLOUD_ENVIRONMENT_BASE;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes staging dedicated agent boot hang where restore rewrote `apiBase` from `*.staging.elizacloud.ai` to production `*.elizacloud.ai`, causing CORS / `agent_not_found` while the splash stayed on Booting up.
- Prefer live Cloud page host + already-staging persisted bases over the production boot-config default when rebuilding dedicated ingress (`resolveCloudEnvironmentBase`).
- When the page is already this agent's dedicated origin, keep that origin instead of reconstructing through boot config.
- Closes #18721. Regression introduced by #16163 / `b9547abf5c`.

## Test plan
- [x] `bunx vitest run src/api/client-cloud-agent-base.test.ts src/state/startup-phase-restore.concurrency.test.ts --coverage.enabled=false` (30/30)
- [ ] Open `https://<id>.staging.elizacloud.ai/` for a running staging agent and confirm Network calls stay on `*.staging.elizacloud.ai`
- [ ] Confirm console no longer shows CORS to `*.elizacloud.ai` during `polling-backend`
- [ ] Staging app with boot `cloudApiBase=staging` still repairs legacy production dedicated bases to staging


Made with [Cursor](https://cursor.com)