### PR TITLE
fix(agent): reject malformed capability router timeout overrides (#18723)

### DIFF
--- a/packages/agent/src/services/remote-capability-router.test.ts
+++ b/packages/agent/src/services/remote-capability-router.test.ts
@@ -49,6 +49,34 @@ describe("remote capability router", () => {
     });
   });
 
+  it.each([
+    ["trailing junk", "1000junk"],
+    ["non-integer", "1.5"],
+    ["zero", "0"],
+  ])(
+    "falls back to the 60s default timeout for %s override",
+    (_label, value) => {
+      const config = resolveRemoteCapabilityRouterConfig(
+        makeRuntime({
+          ELIZA_CAPABILITY_ROUTER_URL: "https://capability.example/",
+          ELIZA_CAPABILITY_ROUTER_TIMEOUT_MS: value,
+        }),
+      );
+
+      expect(config.requestTimeoutMs).toBe(60_000);
+    },
+  );
+
+  it("uses the 60s default timeout when no override is set", () => {
+    const config = resolveRemoteCapabilityRouterConfig(
+      makeRuntime({
+        ELIZA_CAPABILITY_ROUTER_URL: "https://capability.example/",
+      }),
+    );
+
+    expect(config.requestTimeoutMs).toBe(60_000);
+  });
+
   it("resolves multiple canonical remote endpoint URLs", () => {
     const config = resolveRemoteCapabilityRouterConfig(
       makeRuntime({

--- a/packages/agent/src/services/remote-capability-router.ts
+++ b/packages/agent/src/services/remote-capability-router.ts
@@ -58,6 +58,7 @@ import {
   type TerminalCapability,
   type TerminalRunParams,
 } from "@elizaos/core";
+import { parsePositiveInteger } from "@elizaos/shared";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 
@@ -1066,17 +1067,6 @@ function parseBoolean(value: string | undefined): boolean | undefined {
   if (["1", "true", "yes", "on"].includes(normalized)) return true;
   if (["0", "false", "no", "off"].includes(normalized)) return false;
   return undefined;
-}
-
-function parsePositiveInteger(value: string | undefined): number | undefined {
-  if (!value) return undefined;
-  // Strict validation: reject non-digit-only, non-safe-integer, and
-  // non-positive values. Uses the same logic as @elizaos/shared but without
-  // the fallback parameter (we want undefined for invalid, not a default).
-  const trimmed = value.trim();
-  if (!/^\d+$/.test(trimmed)) return undefined;
-  const parsed = Number.parseInt(trimmed, 10);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 function parseEnvironment(

--- a/packages/agent/src/services/remote-capability-router.ts
+++ b/packages/agent/src/services/remote-capability-router.ts
@@ -1070,8 +1070,13 @@ function parseBoolean(value: string | undefined): boolean | undefined {
 
 function parsePositiveInteger(value: string | undefined): number | undefined {
   if (!value) return undefined;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  // Strict validation: reject non-digit-only, non-safe-integer, and
+  // non-positive values. Uses the same logic as @elizaos/shared but without
+  // the fallback parameter (we want undefined for invalid, not a default).
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 function parseEnvironment(


### PR DESCRIPTION
## Summary

`ELIZA_CAPABILITY_ROUTER_TIMEOUT_MS` used `Number.parseInt` which silently accepts malformed values like `1.5`, `1234ms`, and integers above JavaScript's safe integer range.

## Fix

Replaced the local `parsePositiveInteger` with strict digit-only validation (`/^\d+$/`) and `Number.isSafeInteger` check, matching the pattern from `@elizaos/shared`'s `parsePositiveInteger`. Invalid or absent values keep the existing 60s default.

## RP Investigation

- Vulnerable code: `packages/agent/src/services/remote-capability-router.ts:1071-1075`
- Issue: `Number.parseInt("1000junk")` returns `1000` — silently accepts garbage suffixes
- Shared parser at `packages/shared/src/utils/number-parsing.ts:31-52` uses `/^\d+$/` + `isSafeInteger`

---

AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Lane: hermes-t3rpz