### PR TITLE
fix(cloud): handle invalid sandbox status timestamps

### DIFF
--- a/packages/cloud/shared/src/lib/constants/sandbox-status.test.ts
+++ b/packages/cloud/shared/src/lib/constants/sandbox-status.test.ts
@@ -1,0 +1,30 @@
+/** Exercises sandbox status date formatting with valid, absent, and invalid timestamps. */
+
+import { describe, expect, test } from "vitest";
+import { formatRelative, formatRelativeShort } from "./sandbox-status";
+
+describe("sandbox status date formatters", () => {
+  test("preserve null fallbacks", () => {
+    expect(formatRelative(null)).toBe("Never");
+    expect(formatRelativeShort(null)).toBe("—");
+  });
+
+  test("format valid recent dates", () => {
+    const recent = new Date();
+
+    expect(formatRelative(recent)).toBe("Just now");
+    expect(formatRelativeShort(recent)).toBe("Just now");
+  });
+
+  test("use null fallbacks for invalid date strings", () => {
+    expect(formatRelative("not-a-date")).toBe("Never");
+    expect(formatRelativeShort("not-a-date")).toBe("—");
+  });
+
+  test("use null fallbacks for invalid Date objects", () => {
+    const invalid = new Date(Number.NaN);
+
+    expect(formatRelative(invalid)).toBe("Never");
+    expect(formatRelativeShort(invalid)).toBe("—");
+  });
+});

--- a/packages/cloud/shared/src/lib/constants/sandbox-status.ts
+++ b/packages/cloud/shared/src/lib/constants/sandbox-status.ts
@@ -30,6 +30,7 @@ export function statusBadgeColor(status: string): string {
 export function formatRelative(date: Date | string | null): string {
   if (!date) return "Never";
   const d = new Date(date);
+  if (!Number.isFinite(d.getTime())) return "Never";
   const diffMs = Date.now() - d.getTime();
   const diffMin = Math.floor(diffMs / 60_000);
   if (diffMin < 1) return "Just now";
@@ -45,6 +46,7 @@ export function formatRelative(date: Date | string | null): string {
 export function formatRelativeShort(date: Date | string | null): string {
   if (!date) return "—";
   const d = new Date(date);
+  if (!Number.isFinite(d.getTime())) return "—";
   const diffMs = Date.now() - d.getTime();
   const diffMin = Math.floor(diffMs / 60_000);
   if (diffMin < 1) return "Just now";

--- a/packages/ui/src/cloud/instances/lib/sandbox-status.test.ts
+++ b/packages/ui/src/cloud/instances/lib/sandbox-status.test.ts
@@ -1,0 +1,21 @@
+/** Verifies formatRelative falls back gracefully on invalid/non-finite dates. */
+import { describe, expect, it } from "vitest";
+import { formatRelative } from "./sandbox-status";
+
+describe("formatRelative", () => {
+  it("returns Never for null", () => {
+    expect(formatRelative(null)).toBe("Never");
+  });
+
+  it("formats a valid recent date", () => {
+    expect(formatRelative(new Date())).toBe("Just now");
+  });
+
+  it("returns Never for an unparseable date string", () => {
+    expect(formatRelative("not-a-date")).toBe("Never");
+  });
+
+  it("returns Never for an already-invalid Date object", () => {
+    expect(formatRelative(new Date(Number.NaN))).toBe("Never");
+  });
+});

--- a/packages/ui/src/cloud/instances/lib/sandbox-status.ts
+++ b/packages/ui/src/cloud/instances/lib/sandbox-status.ts
@@ -49,6 +49,7 @@ export function statusBadgeColor(status: string): string {
 export function formatRelative(date: Date | string | null): string {
   if (!date) return "Never";
   const d = new Date(date);
+  if (!Number.isFinite(d.getTime())) return "Never";
   const diffMs = Date.now() - d.getTime();
   const diffMin = Math.floor(diffMs / 60_000);
   if (diffMin < 1) return "Just now";


### PR DESCRIPTION
# Relates to

No existing issue specifically tracks this defect. This is a self-found bug identified by inspecting the cloud sandbox status formatter and its live agents-table consumers.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      focused regression tests recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. This changes only invalid-input behavior in two pure date-formatting helpers. Valid timestamps and existing null fallbacks retain their current behavior.

# Background

## What does this PR do?

`formatRelative` and `formatRelativeShort` accepted `Date | string | null` but only handled the null case explicitly.

For a malformed timestamp or already-invalid `Date`, `getTime()` returned `NaN`. Every relative-time comparison then evaluated false, causing both functions to fall through to `toLocaleDateString()` and return the literal string `"Invalid Date"`.

This PR checks that the parsed timestamp is finite and returns each function's existing null fallback when it is not:

- `formatRelative`: `"Never"`
- `formatRelativeShort`: `"—"`

The live call site is `packages/ui/src/cloud/instances/components/eliza-agents-table.tsx`, which passes raw `created_at` and `last_heartbeat_at` cloud API fields to `formatRelative` in both the table and expanded detail view.

This was found independently from the issue tracker. Related prior art for the same general non-finite relative-time bug class includes #18548 and #18694; neither changes this cloud helper.

## What kind of change is this?

Bug fix (non-breaking change which fixes invalid timestamp rendering).

## Why are we doing this? Any context or related work?

Malformed or edge-case timestamps from the sandbox API should render a deliberate unavailable value rather than exposing `"Invalid Date"` in a production table cell.

# Documentation changes needed?

No. This restores graceful behavior within an existing formatting contract and does not change a public API.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/lib/constants/sandbox-status.ts`
2. `packages/cloud/shared/src/lib/constants/sandbox-status.test.ts`
3. `packages/ui/src/cloud/instances/components/eliza-agents-table.tsx` for the live consumer

## Detailed testing steps

```text
bun run --cwd packages/cloud/shared test -- src/lib/constants/sandbox-status.test.ts

4 pass
0 fail
8 expect() calls
Ran 4 tests across 1 file.
```

Additional checks:

```text
bunx @biomejs/biome check \
  packages/cloud/shared/src/lib/constants/sandbox-status.ts \
  packages/cloud/shared/src/lib/constants/sandbox-status.test.ts

Checked 2 files. No fixes applied.
```

```text
bun run --cwd packages/cloud/shared typecheck

Passed.
```

```text
git diff --check -- \
  packages/cloud/shared/src/lib/constants/sandbox-status.ts \
  packages/cloud/shared/src/lib/constants/sandbox-status.test.ts

Passed with no output.
```

Regression coverage includes:

- existing null behavior for both functions
- valid recent dates for both functions
- invalid/unparseable strings for both functions
- an already-invalid `Date` object for both functions

# Evidence Gate

<!-- evidence-head:343922cdda20c83018f17ce060d101e9bf907429 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - pure formatting-helper logic change; no rendered component source or visual layout changed.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - pure formatting-helper logic change; no rendered component source or visual layout changed.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - no interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - this is a deterministic pure helper with no backend request or service path.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no request behavior or frontend state transition changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused regression suite passed with 4 tests and 8 assertions, covering null, valid, invalid-string, and invalid-Date inputs.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface was modified.

# Evidence Details

## Real LLM-call trajectory

N/A - no model or agent behavior changed.

## Backend + frontend logs

N/A - the changed surface is a pure deterministic formatter. The focused test output above exercises the complete changed behavior.

## Screenshots (before / after) + video walkthrough

N/A - no rendered component, styling, layout, or interactive flow changed.

## Audio / voice walkthrough

N/A - not an audio or voice change.

## Known gaps / failures

- Git metadata writes were unavailable in the Codex implementation sandbox: branch creation failed with `Unable to create '.git/index.lock': Operation not permitted`. Branch creation, commit, rebase, and push were completed outside that sandbox, using the exact file contents Codex produced and verified.
- Full root `bun run verify` was not run. The focused package tests, package typecheck, scoped Biome check, and diff whitespace check passed.
- `bun run --cwd packages/cloud/shared test:vitest -- src/lib/constants/sandbox-status.test.ts` was rejected before collection because this package's Vitest configuration includes only three explicitly named suites. The package's primary Bun test runner successfully ran the exact new file with 4 passing tests, independently re-verified after rebase.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [implement-sandbox-status-invalid-date]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZVDJVT7S4K89WNG2FJCAT1E","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T16:41:12.775Z","completed_at":"2026-08-12T16:44:15.708Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAVq8Ggvxg2RCIBwXtE9az5b_tYKj9qVj_3nvqPhhTcAA","device_key_id":"e60c0d298778b55b0d73aec8f38dfc80913a79223c40de61bea259417fe35ec3","device_signature":"9UEESjFFdvGHaHIv8iskLWx6DG07j_m5o-yee-5UknTOTyaIIQ3OC-TlXTnmyodNukZohtwgb3j-1acmEoXQBg"}} -->
