### PR TITLE
fix(commands): strip leading @ from botMention in normalizeCommandBody

### DIFF
--- a/plugins/plugin-commands/__tests__/parser.test.ts
+++ b/plugins/plugin-commands/__tests__/parser.test.ts
@@ -34,6 +34,11 @@ describe("normalizeCommandBody", () => {
 		expect(normalizeCommandBody("@Bot  /status", "bot")).toBe("/status");
 	});
 
+	it("strips a leading bot mention when botMention parameter includes a leading @", () => {
+		expect(normalizeCommandBody("@Bot  /status", "@bot")).toBe("/status");
+		expect(normalizeCommandBody("@eliza /help", "@eliza")).toBe("/help");
+	});
+
 	it("rewrites a colon command separator to a space", () => {
 		expect(normalizeCommandBody("/think: high")).toBe("/think high");
 		expect(normalizeCommandBody("!mode:fast")).toBe("!mode fast");
@@ -188,5 +193,10 @@ describe("parseCommand", () => {
 	it("uses the first alias as the canonical form", () => {
 		const help = define({ key: "help", textAliases: ["/help", "/h", "/?"] });
 		expect(parseCommand("/h", help)?.canonical).toBe("/help");
+	});
+
+	it("safely handles command definitions with missing textAliases", () => {
+		const bare = define({ key: "bare", textAliases: undefined as unknown as string[] });
+		expect(parseCommand("/bare", bare)).toBeNull();
 	});
 });

--- a/plugins/plugin-commands/src/parser.ts
+++ b/plugins/plugin-commands/src/parser.ts
@@ -73,7 +73,7 @@ export function parseCommand(
 
 	// Find the matching alias
 	let matchedAlias: string | null = null;
-	for (const alias of definition.textAliases) {
+	for (const alias of definition.textAliases ?? []) {
 		const normalized = alias.toLowerCase();
 		if (trimmed.toLowerCase() === normalized) {
 			matchedAlias = alias;
@@ -106,7 +106,7 @@ export function parseCommand(
 
 	const parsed: ParsedCommand = {
 		key: definition.key,
-		canonical: definition.textAliases[0] ?? `/${definition.key}`,
+		canonical: definition.textAliases?.[0] ?? `/${definition.key}`,
 		args,
 	};
 	if (rawArgs) {
@@ -206,8 +206,16 @@ export function normalizeCommandBody(
 
 	// Remove textual bot mention prefix (e.g., "@bot /status" -> "/status")
 	if (botMention) {
-		const mentionPattern = new RegExp(`^@${escapeRegExp(botMention)}\\s*`, "i");
-		normalized = normalized.replace(mentionPattern, "");
+		const cleanMention = botMention.startsWith("@")
+			? botMention.slice(1)
+			: botMention;
+		if (cleanMention) {
+			const mentionPattern = new RegExp(
+				`^@${escapeRegExp(cleanMention)}\\s*`,
+				"i",
+			);
+			normalized = normalized.replace(mentionPattern, "");
+		}
 	}
 
 	// Handle colon in command (e.g., "/command: args" -> "/command args")


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Google/Gemini 3.6 Flash (High)`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low risk. Changes are confined to argument normalization and fallback handling in `plugins/plugin-commands/src/parser.ts`.

# Background

## What does this PR do?

1. Strips leading `@` from `botMention` parameter in `normalizeCommandBody` so passed mentions like `"@MyBot"` resolve identically to `"MyBot"` when removing textual mentions from incoming command text (`@MyBot /help` -> `/help`).
2. Adds defensive optional chaining (`definition.textAliases ?? []`) when matching command aliases in `parseCommand`.
3. Adds unit test coverage in `plugins/plugin-commands/__tests__/parser.test.ts`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-commands/src/parser.ts`: inspect `normalizeCommandBody` and `parseCommand`.
- `plugins/plugin-commands/__tests__/parser.test.ts`: review unit test additions.

## Detailed testing steps

Run focused unit tests and typechecking:
```bash
bun run --cwd plugins/plugin-commands test
bun run --cwd plugins/plugin-commands typecheck
```

# Evidence Gate

<!-- evidence-head:b1abad0a3ebfd6a4ce1897a535dcfff4e2919185 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - non-UI backend parser change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - non-UI backend parser change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - non-UI backend parser change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - non-UI backend parser unit tests pass clean`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - non-UI backend parser change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - non-LLM command parser change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - non-UI backend parser change`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - non-UI backend parser change`.

# Evidence Details

## Backend + frontend logs

Test suite output for `@elizaos/plugin-commands`:
```
 RUN  v4.1.5 /home/dak/src/eliza-agy/plugins/plugin-commands

 Test Files  10 passed (10)
      Tests  145 passed (145)
   Start at  19:08:05
   Duration  16.47s (transform 29.49s, setup 0ms, import 45.93s, tests 287ms, environment 2ms)
```

## Known gaps / failures

None.
