### PR TITLE
fix(shared): handle raw array query results and non-string inputs in sql-compat

### DIFF
--- a/packages/shared/src/utils/sql-compat.test.ts
+++ b/packages/shared/src/utils/sql-compat.test.ts
@@ -1,0 +1,192 @@
+import type { AgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ensureRuntimeSqlCompatibility,
+  executeRawSql,
+  quoteIdent,
+  sanitizeIdentifier,
+  sqlLiteral,
+} from "./sql-compat.ts";
+
+describe("quoteIdent", () => {
+  it("quotes valid SQL identifiers", () => {
+    expect(quoteIdent("users")).toBe('"users"');
+    expect(quoteIdent("table_name")).toBe('"table_name"');
+  });
+
+  it("escapes internal double quotes", () => {
+    expect(quoteIdent('user"name')).toBe('"user""name"');
+    expect(quoteIdent('a"b"c')).toBe('"a""b""c"');
+  });
+
+  it("handles non-string values gracefully", () => {
+    expect(quoteIdent(null as unknown as string)).toBe('""');
+    expect(quoteIdent(undefined as unknown as string)).toBe('""');
+  });
+});
+
+describe("sanitizeIdentifier", () => {
+  it("returns sanitized identifier for alphanumeric strings", () => {
+    expect(sanitizeIdentifier("users")).toBe("users");
+    expect(sanitizeIdentifier("  my_table_123  ")).toBe("my_table_123");
+  });
+
+  it("strips special characters and SQL injection attempts", () => {
+    expect(sanitizeIdentifier("users; DROP TABLE users;--")).toBe(
+      "usersDROPTABLEusers",
+    );
+    expect(sanitizeIdentifier("table-name!@#")).toBe("tablename");
+  });
+
+  it("returns null for non-string, empty, or overly long inputs", () => {
+    expect(sanitizeIdentifier(null)).toBeNull();
+    expect(sanitizeIdentifier(undefined)).toBeNull();
+    expect(sanitizeIdentifier("   ")).toBeNull();
+    expect(sanitizeIdentifier("!!!")).toBeNull();
+    expect(sanitizeIdentifier("a".repeat(129))).toBeNull();
+  });
+});
+
+describe("sqlLiteral", () => {
+  it("wraps string values in single quotes", () => {
+    expect(sqlLiteral("public")).toBe("'public'");
+    expect(sqlLiteral("hello world")).toBe("'hello world'");
+  });
+
+  it("escapes internal single quotes", () => {
+    expect(sqlLiteral("O'Connor")).toBe("'O''Connor'");
+    expect(sqlLiteral("a'b'c")).toBe("'a''b''c'");
+  });
+
+  it("handles non-string values gracefully", () => {
+    expect(sqlLiteral(null as unknown as string)).toBe("''");
+    expect(sqlLiteral(undefined as unknown as string)).toBe("''");
+  });
+});
+
+describe("executeRawSql", () => {
+  it("throws error when db execute is missing", async () => {
+    const runtime = { adapter: {} } as unknown as AgentRuntime;
+    await expect(executeRawSql(runtime, "SELECT 1")).rejects.toThrow(
+      "Database adapter not available",
+    );
+  });
+
+  it("executes raw SQL and parses standard object response", async () => {
+    const mockExecute = vi.fn().mockResolvedValue({
+      rows: [{ id: 1, name: "test" }],
+      fields: [{ name: "id" }, { name: "name" }],
+    });
+    const runtime = {
+      adapter: { db: { execute: mockExecute } },
+    } as unknown as AgentRuntime;
+
+    const result = await executeRawSql(runtime, "SELECT * FROM test");
+    expect(result.rows).toEqual([{ id: 1, name: "test" }]);
+    expect(result.columns).toEqual(["id", "name"]);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("executes raw SQL and parses direct array response from driver", async () => {
+    const mockExecute = vi
+      .fn()
+      .mockResolvedValue([
+        { column_name: "agent_id" },
+        { column_name: "room_state" },
+      ]);
+    const runtime = {
+      adapter: { db: { execute: mockExecute } },
+    } as unknown as AgentRuntime;
+
+    const result = await executeRawSql(runtime, "SELECT column_name FROM info");
+    expect(result.rows).toEqual([
+      { column_name: "agent_id" },
+      { column_name: "room_state" },
+    ]);
+    expect(result.columns).toEqual(["column_name"]);
+  });
+});
+
+describe("ensureRuntimeSqlCompatibility", () => {
+  it("returns silently when runtime or database adapter is missing", async () => {
+    await expect(ensureRuntimeSqlCompatibility(null)).resolves.toBeUndefined();
+    await expect(
+      ensureRuntimeSqlCompatibility(undefined),
+    ).resolves.toBeUndefined();
+    await expect(
+      ensureRuntimeSqlCompatibility({} as AgentRuntime),
+    ).resolves.toBeUndefined();
+  });
+
+  it("succeeds when all required columns are present in information_schema", async () => {
+    const mockExecute = vi.fn().mockImplementation((query) => {
+      const sqlString = JSON.stringify(query);
+
+      if (sqlString.includes("participants")) {
+        return Promise.resolve({
+          rows: [{ column_name: "agent_id" }, { column_name: "room_state" }],
+        });
+      }
+      if (sqlString.includes("trajectories")) {
+        return Promise.resolve({
+          rows: [
+            { column_name: "step_count" },
+            { column_name: "llm_call_count" },
+            { column_name: "total_prompt_tokens" },
+            { column_name: "total_completion_tokens" },
+            { column_name: "total_reward" },
+            { column_name: "scenario_id" },
+            { column_name: "batch_id" },
+          ],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const runtime = {
+      adapter: { db: { execute: mockExecute } },
+    } as unknown as AgentRuntime;
+
+    await expect(
+      ensureRuntimeSqlCompatibility(runtime),
+    ).resolves.toBeUndefined();
+    // Subsequent calls return immediately due to WeakSet caching
+    await expect(
+      ensureRuntimeSqlCompatibility(runtime),
+    ).resolves.toBeUndefined();
+  });
+
+  it("falls back to PRAGMA table_info and throws error if required column is missing", async () => {
+    const mockExecute = vi.fn().mockResolvedValue({ rows: [] });
+    const runtime = {
+      adapter: { db: { execute: mockExecute } },
+    } as unknown as AgentRuntime;
+
+    await expect(ensureRuntimeSqlCompatibility(runtime)).rejects.toThrow(
+      "[sql-compat] Missing required column",
+    );
+  });
+
+  it("deduplicates concurrent compatibility checks on the same runtime", async () => {
+    let resolveExecute: (val: unknown) => void = () => {};
+    const pendingPromise = new Promise((res) => {
+      resolveExecute = res;
+    });
+
+    const mockExecute = vi.fn().mockImplementation(() => pendingPromise);
+    const runtime = {
+      adapter: { db: { execute: mockExecute } },
+    } as unknown as AgentRuntime;
+
+    const p1 = ensureRuntimeSqlCompatibility(runtime);
+    const p2 = ensureRuntimeSqlCompatibility(runtime);
+
+    resolveExecute({
+      rows: [{ column_name: "agent_id" }, { column_name: "room_state" }],
+    });
+
+    await expect(Promise.all([p1, p2])).rejects.toThrow(
+      "[sql-compat] Missing required column",
+    );
+  });
+});

--- a/packages/shared/src/utils/sql-compat.ts
+++ b/packages/shared/src/utils/sql-compat.ts
@@ -9,6 +9,7 @@ const repairedRuntimes = new WeakSet<AgentRuntime>();
 const repairPromises = new WeakMap<AgentRuntime, Promise<void>>();
 
 export function quoteIdent(name: string): string {
+  if (typeof name !== "string") return '""';
   return `"${name.replace(/"/g, '""')}"`;
 }
 
@@ -24,6 +25,7 @@ export function sanitizeIdentifier(
 }
 
 export function sqlLiteral(value: string): string {
+  if (typeof value !== "string") return "''";
   return `'${value.replace(/'/g, "''")}'`;
 }
 
@@ -36,10 +38,13 @@ export async function executeRawSql(
 }> {
   const db = runtime.adapter.db as
     | {
-        execute: (query: { queryChunks: unknown[] }) => Promise<{
-          rows: Record<string, unknown>[];
-          fields?: Array<{ name: string }>;
-        }>;
+        execute: (query: { queryChunks: unknown[] }) => Promise<
+          | {
+              rows: Record<string, unknown>[];
+              fields?: Array<{ name: string }>;
+            }
+          | Record<string, unknown>[]
+        >;
       }
     | undefined;
 
@@ -49,9 +54,17 @@ export async function executeRawSql(
 
   const { sql } = await import("drizzle-orm");
   const result = await db.execute(sql.raw(sqlText));
-  const rows = Array.isArray(result.rows) ? result.rows : [];
-  const columns = Array.isArray(result.fields)
-    ? result.fields.map((field) => field.name)
+  const rows = Array.isArray(result)
+    ? (result as Record<string, unknown>[])
+    : Array.isArray((result as { rows?: Record<string, unknown>[] })?.rows)
+      ? (result as { rows: Record<string, unknown>[] }).rows
+      : [];
+  const columns = Array.isArray(
+    (result as { fields?: Array<{ name: string }> })?.fields,
+  )
+    ? (result as { fields: Array<{ name: string }> }).fields.map(
+        (field) => field.name,
+      )
     : Object.keys(rows[0] ?? {});
 
   return { rows, columns };


### PR DESCRIPTION
# Relates to

N/A - Non-duplicate maintenance fix identified during codebase audit.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun test packages/shared/src/utils/sql-compat.test.ts` ran cleanly with 100% function coverage.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Google / Antigravity / Gemini 3.6 Flash (High)`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI (agy)`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

Client / agent tooling: Antigravity CLI (agy)
Attribution status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused test suite `packages/shared/src/utils/sql-compat.test.ts` passes post-sync.

# Risks

Low. Refines SQL raw query result array parsing in `packages/shared/src/utils/sql-compat.ts` so driver implementations returning direct row arrays (e.g. SQLite/PGlite custom drivers) are parsed correctly instead of evaluating to empty rows, and adds defensive type checks for non-string identifier/literal inputs.

# Background

## What does this PR do?

1. Updates `executeRawSql` in `packages/shared/src/utils/sql-compat.ts` to recognize database adapters returning direct `Record<string, unknown>[]` arrays from `db.execute()`, avoiding false missing-column schema errors.
2. Defends `quoteIdent` and `sqlLiteral` against non-string inputs.
3. Adds comprehensive unit test coverage in `packages/shared/src/utils/sql-compat.test.ts`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue) / Improvements

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/shared/src/utils/sql-compat.ts`
- `packages/shared/src/utils/sql-compat.test.ts`

## Detailed testing steps

Run the unit test suite:
```bash
bun test packages/shared/src/utils/sql-compat.test.ts
```

# Evidence Gate

<!-- evidence-head:7346633929fd6d9ca83b29e87e877704f36e6feb -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Backend/utility change with no rendered visual surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - Backend/utility change with no rendered visual surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Backend/utility change with no rendered visual surface.
<!-- evidence-row:backend-logs -->
- [x] Unit test execution output pasted in Evidence Details below.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - Backend/utility change with no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - Non-LLM SQL utility change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - Pure code fix and unit tests.
<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered visual surface.

# Evidence Details

## Backend + frontend logs

```
$ bun test packages/shared/src/utils/sql-compat.test.ts
bun test v1.3.14 (0d9b296a)

packages/shared/src/utils/sql-compat.test.ts:
✓ quoteIdent > quotes valid SQL identifiers [0.21ms]
✓ quoteIdent > escapes internal double quotes [0.05ms]
✓ quoteIdent > handles non-string values gracefully [0.04ms]
✓ sanitizeIdentifier > returns sanitized identifier for alphanumeric strings [0.13ms]
✓ sanitizeIdentifier > strips special characters and SQL injection attempts [0.05ms]
✓ sanitizeIdentifier > returns null for non-string, empty, or overly long inputs [0.14ms]
✓ sqlLiteral > wraps string values in single quotes [0.12ms]
✓ sqlLiteral > escapes internal single quotes [0.04ms]
✓ sqlLiteral > handles non-string values gracefully [0.03ms]
✓ executeRawSql > throws error when db execute is missing [0.44ms]
✓ executeRawSql > executes raw SQL and parses standard object response [26.19ms]
✓ executeRawSql > executes raw SQL and parses direct array response from driver [0.29ms]
✓ ensureRuntimeSqlCompatibility > returns silently when runtime or database adapter is missing [0.37ms]
✓ ensureRuntimeSqlCompatibility > succeeds when all required columns are present in information_schema [1.91ms]
✓ ensureRuntimeSqlCompatibility > falls back to PRAGMA table_info and throws error if required column is missing [0.37ms]
✓ ensureRuntimeSqlCompatibility > deduplicates concurrent compatibility checks on the same runtime [0.86ms]
-----------------------------------------|---------|---------|-------------------
File                                     | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------|---------|---------|-------------------
All files                                |  100.00 |   96.21 |
 packages/shared/src/utils/sql-compat.ts |  100.00 |   96.21 | 107,116-119
-----------------------------------------|---------|---------|-------------------

 16 pass
 0 fail
 34 expect() calls
Ran 16 tests across 1 file. [127.00ms]
```

## Known gaps / failures

None.