### PR TITLE
fix(plugin-slack): parse DM permalinks, validate timestamp length, and support non-HTTP link schemes

### DIFF
--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -64,6 +64,12 @@ describe("links", () => {
     expect(formatSlackLink("https://x.com")).toBe("<https://x.com>");
     expect(formatSlackLink("https://x.com", "X")).toBe("<https://x.com|X>");
     expect(extractUrlFromSlackLink("<https://x.com|X>")).toBe("https://x.com");
+    expect(extractUrlFromSlackLink("<slack://channel?id=C123|Channel>")).toBe(
+      "slack://channel?id=C123",
+    );
+    expect(extractUrlFromSlackLink("<mailto:alice@example.com>")).toBe(
+      "mailto:alice@example.com",
+    );
     expect(extractUrlFromSlackLink("nope")).toBeNull();
   });
 });
@@ -80,6 +86,9 @@ describe("stripSlackFormatting", () => {
     expect(stripSlackFormatting("see <https://a.com> ok")).toBe(
       "see https://a.com ok",
     );
+    expect(stripSlackFormatting("open <slack://channel?id=C1> ok")).toBe(
+      "open slack://channel?id=C1 ok",
+    );
   });
 
   it("strips every link, not just the first", () => {
@@ -89,6 +98,9 @@ describe("stripSlackFormatting", () => {
     expect(stripSlackFormatting("<https://a.com> and <https://b.com>")).toBe(
       "https://a.com and https://b.com",
     );
+    expect(
+      stripSlackFormatting("<mailto:alice@ex.com|Email> and <tel:+1234567>"),
+    ).toBe("Email and tel:+1234567");
   });
 });
 
@@ -139,5 +151,35 @@ describe("permalink build/parse round-trip", () => {
       messageTs: "1234567890.123456",
     });
     expect(parseSlackMessagePermalink("https://acme.example.com/x")).toBeNull();
+  });
+
+  it("parses user DM channel permalinks and non-fractional 10-digit timestamps", () => {
+    expect(
+      parseSlackMessagePermalink(
+        "https://acme.slack.com/archives/U1234567/p1700000000123456",
+      ),
+    ).toEqual({
+      workspaceDomain: "acme",
+      channelId: "U1234567",
+      messageTs: "1700000000.123456",
+    });
+
+    expect(
+      parseSlackMessagePermalink(
+        "https://acme.slack.com/archives/C0ABCDE/p1700000000",
+      ),
+    ).toEqual({
+      workspaceDomain: "acme",
+      channelId: "C0ABCDE",
+      messageTs: "1700000000",
+    });
+  });
+
+  it("returns null for malformed short timestamps", () => {
+    expect(
+      parseSlackMessagePermalink(
+        "https://acme.slack.com/archives/C0ABCDE/p12345",
+      ),
+    ).toBeNull();
   });
 });

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -344,7 +344,9 @@ export function extractChannelIdFromMention(mention: string): string | null {
  * Extracts URL from a Slack link
  */
 export function extractUrlFromSlackLink(link: string): string | null {
-  const match = link.match(/^<(https?:\/\/[^|>]+)(?:\|[^>]*)?>$/);
+  const match = link.match(
+    /^<((?:https?|slack|mailto|tel):[^|>]+)(?:\|[^>]*)?>$/,
+  );
   return match ? match[1] : null;
 }
 
@@ -448,8 +450,8 @@ export function stripSlackFormatting(text: string): string {
     .replace(/<#[CGD][A-Z0-9]+(?:\|[^>]*)?>/gi, "") // Channel mentions
     .replace(/<!subteam\^[A-Z0-9]+(?:\|[^>]*)?>/gi, "") // User group mentions
     .replace(/<!(?:here|channel|everyone)(?:\|[^>]*)?>/gi, "") // Special mentions
-    .replace(/<(https?:\/\/[^|>]+)\|([^>]*)>/g, "$2") // Links with text → label
-    .replace(/<(https?:\/\/[^>]+)>/g, "$1") // Plain links → URL
+    .replace(/<((?:https?|slack|mailto|tel):[^|>]+)\|([^>]*)>/g, "$2") // Links with text → label
+    .replace(/<((?:https?|slack|mailto|tel):[^>]+)>/g, "$1") // Plain links → URL
     .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
@@ -475,15 +477,21 @@ export function parseSlackMessagePermalink(
   link: string,
 ): { workspaceDomain: string; channelId: string; messageTs: string } | null {
   const match = link.match(
-    /^https?:\/\/([^.]+)\.slack\.com\/archives\/([CGD][A-Z0-9]+)\/p(\d+)/i,
+    /^https?:\/\/([^.]+)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d+)/i,
   );
   if (!match) {
     return null;
   }
 
   const ts = match[3];
-  // Convert p1234567890123456 to 1234567890.123456
-  const messageTs = `${ts.slice(0, 10)}.${ts.slice(10)}`;
+  if (ts.length < 10) {
+    return null;
+  }
+
+  const fractional = ts.slice(10);
+  const messageTs = fractional
+    ? `${ts.slice(0, 10)}.${fractional}`
+    : ts.slice(0, 10);
 
   return {
     workspaceDomain: match[1],


### PR DESCRIPTION
# Relates to

N/A - Non-duplicate maintenance fix identified during codebase audit.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun test plugins/plugin-slack/src/formatting.test.ts` ran cleanly with 100% test pass rate.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Antigravity / Gemini 3.6 Flash (High)`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI (agy)`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

Client / agent tooling: Antigravity CLI (agy)
Attribution status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused test suite `plugins/plugin-slack/src/formatting.test.ts` passes post-sync.

# Risks

Low. Hardens Slack message permalink parsing and link stripping/extraction in `plugins/plugin-slack/src/formatting.ts`. Ensures DM archive URLs (`/archives/U...`), 10-digit timestamps without microsecond fractions, and non-HTTP link schemes (`slack://`, `mailto:`, `tel:`) are handled correctly without generating invalid timestamp strings or failing regex matches.

# Background

## What does this PR do?

1. Updates `parseSlackMessagePermalink` in `plugins/plugin-slack/src/formatting.ts` to support all valid Slack channel and DM user ID formats (`/archives/([A-Z0-9]+)/p...`).
2. Validates timestamp length in `parseSlackMessagePermalink` to return `null` for malformed short timestamps (e.g. `p12345`), and formats non-fractional 10-digit timestamps cleanly without trailing dots.
3. Updates `extractUrlFromSlackLink` and `stripSlackFormatting` to support all valid Slack link schemes (`http://`, `https://`, `slack://`, `mailto:`, `tel:`).
4. Adds unit test coverage in `plugins/plugin-slack/src/formatting.test.ts`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue) / Improvements

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-slack/src/formatting.ts`
- `plugins/plugin-slack/src/formatting.test.ts`

## Detailed testing steps

Run the focused test suite:
```bash
bun test plugins/plugin-slack/src/formatting.test.ts
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Backend/formatting utility change with no rendered visual surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - Backend/formatting utility change with no rendered visual surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Backend/formatting utility change with no rendered visual surface.
<!-- evidence-row:backend-logs -->
- [x] Unit test execution output pasted in Evidence Details below.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - Formatting utility change with no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - Non-LLM formatting utility change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - Pure code fix and unit tests.
<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered visual surface.

# Evidence Details

## Backend + frontend logs

```
$ bun test plugins/plugin-slack/src/formatting.test.ts
bun test v1.3.14 (0d9b296a)

plugins/plugin-slack/src/formatting.test.ts:
✓ escapeSlackMrkdwn > escapes the three Slack control chars, leaves clean text untouched [0.59ms]
✓ markdownToSlackMrkdwn > converts bold/italic/strikethrough to Slack syntax [0.44ms]
✓ mention builders + extractors round-trip > user mention [0.36ms]
✓ mention builders + extractors round-trip > channel mention [0.28ms]
✓ mention builders + extractors round-trip > group + special mentions [0.07ms]
✓ links > formats with optional label and extracts the url back [0.20ms]
✓ stripSlackFormatting > removes mrkdwn markup, mentions, and unescapes entities [0.30ms]
✓ stripSlackFormatting > unwraps plain links to their URL instead of deleting them [0.05ms]
✓ stripSlackFormatting > strips every link, not just the first [0.05ms]
✓ chunkSlackText > never emits a chunk over the limit, even when closing a split code block [0.51ms]
✓ chunkSlackText > does not fence-close a code block that only opens after the break point [0.15ms]
✓ truncateText > appends ellipsis only when over the limit [0.07ms]
✓ permalink build/parse round-trip > encodes and decodes channel + message timestamp [0.22ms]
✓ permalink build/parse round-trip > parses user DM channel permalinks and non-fractional 10-digit timestamps [0.06ms]
✓ permalink build/parse round-trip > returns null for malformed short timestamps [0.04ms]
----------------------------------------|---------|---------|-------------------
File                                    | % Funcs | % Lines | Uncovered Line #s
----------------------------------------|---------|---------|-------------------
All files                               |   71.43 |   78.39 |
 plugins/plugin-slack/src/formatting.ts |   71.43 |   78.39 | 31,51,88,138-147,201,205,231,264-267,315-323,356,363-369,376-385,392-400,407,414
----------------------------------------|---------|---------|-------------------

 15 pass
 0 fail
 41 expect() calls
Ran 15 tests across 1 file. [95.00ms]
```

## Known gaps / failures

None.
