### PR TITLE
fix(core): serialize connector-account facade operations to prevent handoff race (#18110)

### DIFF
--- a/packages/core/src/connectors/account-manager.test.ts
+++ b/packages/core/src/connectors/account-manager.test.ts
@@ -459,6 +459,35 @@ describe("fallback-to-durable state handoff", () => {
 		await expect(restarted.listAccounts("google")).resolves.toHaveLength(1);
 	});
 
+	it("lands an in-flight upsert on the durable backend when the adapter attaches mid-call", async () => {
+		// The #18110 interleaving: a facade write starts while only the fallback
+		// exists, and the adapter attaches in the same synchronous frame. The
+		// serialized facade must resolve the backend at execution time — not at
+		// call time — so the write lands durably instead of stranding in the
+		// boot-time fallback.
+		const runtime = makeRuntime();
+		const manager = getConnectorAccountManager(runtime);
+		const storage = manager.getStorage();
+
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+
+		const pendingUpsert = storage.upsertAccount(BOOT_ACCOUNT);
+		(runtime as unknown as { adapter?: InMemoryDatabaseAdapter }).adapter =
+			adapter;
+		await pendingUpsert;
+
+		// The account must be visible on the durable backend itself...
+		const record = await adapter.getConnectorAccount({
+			provider: "google",
+			accountKey: "user@example.com",
+		});
+		expect(record).not.toBeNull();
+		expect(record?.status).toBe("connected");
+		// ...and through the manager, without a stranded fallback copy.
+		await expect(manager.listAccounts("google")).resolves.toHaveLength(1);
+	});
+
 	it("completes an OAuth flow whose provider attaches the adapter mid-startOAuth", async () => {
 		// createOAuthFlow lands in the fallback; the adapter attaches while
 		// startOAuth is awaited; updateOAuthFlow/completeOAuth then resolve the

--- a/packages/core/src/connectors/account-manager.ts
+++ b/packages/core/src/connectors/account-manager.ts
@@ -1193,6 +1193,14 @@ export class ConnectorAccountManager extends Service {
 	private fallbackStorage?: InMemoryConnectorAccountStorage;
 	private storageFacade?: ConnectorAccountStorage;
 	private migration: Promise<void> = Promise.resolve();
+	/**
+	 * Serializes the full backend-selection + operation-invocation sequence so
+	 * that concurrent facade calls cannot interleave across the fallback→durable
+	 * transition (#18110). Without this, a write queued on the fallback backend
+	 * can land after a concurrent read has already selected the durable backend,
+	 * stranding the write in a soon-to-be-cleared fallback.
+	 */
+	private operationQueue: Promise<unknown> = Promise.resolve();
 	private warnedFallback = false;
 
 	constructor(runtime?: IAgentRuntime, storage?: ConnectorAccountStorage) {
@@ -1327,31 +1335,51 @@ export class ConnectorAccountManager extends Service {
 	}
 
 	private createStorageFacade(): ConnectorAccountStorage {
-		const resolve = () => this.backendForOperation();
+		/**
+		 * Run a storage operation through the serialized operation queue so that
+		 * backend resolution + invocation are atomic (#18110). Each operation
+		 * resolves its backend and executes the call within the same queue
+		 * boundary — no concurrent operation can interleave between selection
+		 * and invocation.
+		 */
+		const runSerialized = <T>(
+			fn: (backend: ConnectorAccountStorage) => Promise<T>,
+		): Promise<T> => {
+			const result = this.operationQueue.then(() =>
+				this.backendForOperation().then(fn),
+			);
+			this.operationQueue = result.then(
+				() => undefined,
+				() => undefined,
+			);
+			return result;
+		};
+
 		return {
 			listAccounts: async (provider) =>
-				(await resolve()).listAccounts(provider),
+				runSerialized((b) => b.listAccounts(provider)),
 			getAccount: async (provider, accountId) =>
-				(await resolve()).getAccount(provider, accountId),
+				runSerialized((b) => b.getAccount(provider, accountId)),
 			upsertAccount: async (account) =>
-				(await resolve()).upsertAccount(account),
+				runSerialized((b) => b.upsertAccount(account)),
 			deleteAccount: async (provider, accountId) =>
-				(await resolve()).deleteAccount(provider, accountId),
-			createOAuthFlow: async (flow) => (await resolve()).createOAuthFlow(flow),
+				runSerialized((b) => b.deleteAccount(provider, accountId)),
+			createOAuthFlow: async (flow) =>
+				runSerialized((b) => b.createOAuthFlow(flow)),
 			getOAuthFlow: async (provider, flowIdOrState) =>
-				(await resolve()).getOAuthFlow(provider, flowIdOrState),
+				runSerialized((b) => b.getOAuthFlow(provider, flowIdOrState)),
 			updateOAuthFlow: async (provider, flowIdOrState, patch) =>
-				(await resolve()).updateOAuthFlow(provider, flowIdOrState, patch),
+				runSerialized((b) => b.updateOAuthFlow(provider, flowIdOrState, patch)),
 			consumeOAuthFlow: async (provider, state, consumedBy) =>
-				(await resolve()).consumeOAuthFlow(provider, state, consumedBy),
+				runSerialized((b) => b.consumeOAuthFlow(provider, state, consumedBy)),
 			deleteOAuthFlow: async (provider, flowIdOrState) =>
-				(await resolve()).deleteOAuthFlow(provider, flowIdOrState),
-			findOwnerBinding: async (lookup) => {
-				const backend = await resolve();
-				return typeof backend.findOwnerBinding === "function"
-					? backend.findOwnerBinding(lookup)
-					: null;
-			},
+				runSerialized((b) => b.deleteOAuthFlow(provider, flowIdOrState)),
+			findOwnerBinding: async (lookup) =>
+				runSerialized(async (b) =>
+					typeof b.findOwnerBinding === "function"
+						? b.findOwnerBinding(lookup)
+						: null,
+				),
 		};
 	}
 


### PR DESCRIPTION
## Summary

PR #18095 serialized **migration attempts** but not the full **backend selection → operation invocation** sequence. The facade methods used `(await resolve()).operation()` — the `await` is a microtask boundary where a concurrent adapter attach can interleave.

### The race

1. `facade.upsertAccount(account)` selects the fallback backend and yields
2. An adapter attaches synchronously
3. `facade.listAccounts(provider)` selects the durable backend (fallback is still empty, no migration)
4. The queued write lands on the fallback; the queued read returns zero from durable
5. Process exit loses the stranded write

### Fix

Wrap the entire resolve+invoke sequence in a serialized `operationQueue`. Each operation resolves its backend AND executes the call within the same queue boundary — no concurrent operation can interleave between selection and invocation.

## RP Investigation

Investigated via RP explore session. Confirmed:
- Race is at `packages/core/src/connectors/account-manager.ts:1329-1356` (facade wrappers)
- `backendForOperation()` serializes migration but not invocation
- The fix must serialize the full `resolve() → operation` sequence

---

AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Lane: hermes-t3rpz
