### PR TITLE
fix(ci): root-cause and regreen the 08-12 develop red wave (stale test/audit ports + apt-lock infra)

### DIFF
--- a/.github/scripts/install-apt-packages.sh
+++ b/.github/scripts/install-apt-packages.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Install apt packages a CI lane needs, tolerating the package contention that
+# persistent runners create.
+#
+# Sibling of install-playwright-browsers.sh for plain apt packages (ffmpeg for
+# recording lanes). On the shared self-hosted hosts another job's apt-get or
+# unattended-upgrades regularly holds /var/lib/apt/lists/lock, which
+# `apt-get update` fails on with exit 100 even when DPkg::Lock::Timeout is
+# configured — that timeout does not cover the lists lock. The lock holder is
+# always transient, so retry the update+install with backoff instead.
+#
+# A package install that still fails is a hard error: a lane that proceeds
+# without its package fails later with a far less obvious message.
+set -euo pipefail
+
+readonly APT_LOCK_TIMEOUT_SECONDS=600
+readonly INSTALL_ATTEMPTS=5
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <package> [package...]" >&2
+  exit 2
+fi
+
+if ! command -v sudo >/dev/null 2>&1 || ! sudo -n true 2>/dev/null; then
+  echo "::error::passwordless sudo unavailable; cannot install apt packages: $*"
+  exit 1
+fi
+
+# Mirrors the drop-in written by .github/actions/setup-bun-workspace so lanes
+# that call this script without that composite get the same protection.
+if ! printf 'DPkg::Lock::Timeout "%s";\n' "$APT_LOCK_TIMEOUT_SECONDS" \
+  | sudo -n tee /etc/apt/apt.conf.d/99-eliza-ci-dpkg-lock-timeout >/dev/null 2>&1; then
+  echo "::warning::could not configure the apt dpkg lock timeout; relying on retries alone"
+fi
+
+attempt=1
+while true; do
+  if sudo apt-get update \
+    && sudo apt-get install -y -o DPkg::Lock::Timeout="$APT_LOCK_TIMEOUT_SECONDS" "$@"; then
+    exit 0
+  fi
+  if [ "$attempt" -ge "$INSTALL_ATTEMPTS" ]; then
+    echo "::error::apt package install failed after ${INSTALL_ATTEMPTS} attempts: $*"
+    exit 1
+  fi
+  backoff=$((attempt * 30))
+  echo "::warning::apt package install attempt ${attempt}/${INSTALL_ATTEMPTS} failed; retrying in ${backoff}s"
+  sleep "$backoff"
+  attempt=$((attempt + 1))
+done

--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -187,7 +187,7 @@ jobs:
         run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Install ffmpeg (recording stitch)
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+        run: .github/scripts/install-apt-packages.sh ffmpeg
 
       - name: Generate shared i18n assets
         run: bun run --cwd packages/shared build:i18n

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -795,7 +795,7 @@ jobs:
         run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Install ffmpeg (recording stitch)
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+        run: .github/scripts/install-apt-packages.sh ffmpeg
 
       # Drives the REAL in-chat onboarding (greeting → runtime CHOICE →
       # provider → one POST /api/first-run) and all 8 tutorial frames, then

--- a/packages/agent/scripts/audit-capability-router-plugin-surface.ts
+++ b/packages/agent/scripts/audit-capability-router-plugin-surface.ts
@@ -67,6 +67,11 @@ const localOnly = new Set([
   // Connector source names/aliases registered into the in-process runtime source
   // map; connector plugins run direct, so this is not a remote-mirrored surface.
   "connectorSources",
+  // Connector-policy default read in-process by core's passive-connector
+  // resolver and the agent host's plugin-collector loading policy (#18531);
+  // connector plugins run direct, so the capability never crosses the remote
+  // manifest.
+  "passiveConnectorsByDefault",
   "mode",
   "remote",
 ]);

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -295,6 +295,18 @@ vi.mock("./hooks/useAuthStatus", () => ({
   // export both seams. Auth phase is static in these tests, so the re-arm
   // subscription never fires — returning a no-op unsubscribe is faithful.
   isAuthenticatedNow: () => authStatusMock.phase === "authenticated",
+  // notification-store also keys its inbox authority off the full snapshot
+  // (computeAuthorityKey in initNotifications, #18495), so the mock exposes the
+  // same static phase in AuthStatusState shape.
+  getAuthStatusSnapshot: () =>
+    authStatusMock.phase === "authenticated"
+      ? {
+          phase: "authenticated",
+          identity: { id: "test-user" },
+          session: { id: "test-session" },
+          access: {},
+        }
+      : { phase: "unauthenticated" },
   subscribeAuthStatus: () => vi.fn(),
 }));
 

--- a/packages/ui/src/hooks/useAccounts.test.tsx
+++ b/packages/ui/src/hooks/useAccounts.test.tsx
@@ -29,7 +29,7 @@ vi.mock("../api", () => ({ client }));
 vi.mock("@elizaos/logger", () => ({
   logger: { warn: loggerWarn },
 }));
-vi.mock("../state", () => ({
+vi.mock("../state/app-store", () => ({
   useAppSelector: (
     selector: (state: {
       t: (key: string, vars?: Record<string, unknown>) => string;

--- a/plugins/plugin-discord/__tests__/connector-loop.real.test.ts
+++ b/plugins/plugin-discord/__tests__/connector-loop.real.test.ts
@@ -275,6 +275,11 @@ async function driveDiscordTurn(options: {
 			ownerDiscordUserIds,
 			accountPool: { get: () => null, getDefault: () => null },
 			turnDrainRegistry: createTurnDrainRegistry(),
+			// The shutdown cordon field is a constructor-initialized class field;
+			// `Object.create` skips the constructor, and `admitInboundMessage`
+			// treats anything other than exactly `null` as a closed ingress, so
+			// the harness must open it explicitly.
+			ingressClosedReason: null,
 		},
 	);
 


### PR DESCRIPTION
# Relates to

Develop red wave after the 2026-08-12 merge window (last green Tests run on `f9fcb92291e`, first red `e11f20c5ef4`: Tests run 31569493060, Scenario run 31569493059, CI run 31569493049).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync (both exit 0).
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. Three of five changes are test/audit-harness-only (no product code); the CI change only hardens an apt step that already existed; no public surface changes.

# Background

## What does this PR do?

Root-causes and regreens the five deterministic red signatures on the develop tip `e11f20c5ef4` after ~57 PRs merged in the 08-12 window. Each signature was bisected to its causal commit; every one turned out to be a stale test/audit port behind a deliberate product change (or pure CI infra), so no merged PR is reverted:

| Failing signature (job) | Causal commit | Root cause | Fix |
| --- | --- | --- | --- |
| `packages/ui src/hooks/useAccounts.test.tsx` — 2 reds in CI, 4 locally (Client Tests / Zero-Key unit+UI) | `940f0d66114` (#18314) | Account components moved `useAppSelector` imports from `../../state` to `../../state/app-store`; the test still mocked `../state`, so rendering `AccountCard` evaluated the real store barrel and the hook harness hung/misreported | Point the test mock at `../state/app-store` (stale-test port; product change is deliberate) |
| `packages/ui src/App.navigate-view-wiring.test.tsx` — "No getAuthStatusSnapshot export…" (Zero-Key unit + UI coverage) | `120fbf84228` (#18495) | notification-store's authority keying now calls `getAuthStatusSnapshot()` during App mount; the test's `./hooks/useAuthStatus` mock predates the new export | Export a faithful `getAuthStatusSnapshot` from the mock (stale-test port) |
| `plugins/plugin-discord __tests__/connector-loop.real.test.ts` — 5 reds, zero outbound replies (Zero-Key harness E2E) | `2f177f10521` (shutdown ingress cordon) | The cordon added a constructor-initialized field `ingressClosedReason: string \| null = null`; the harness builds the service via `Object.create(DiscordService.prototype)` (skipping the constructor), so the field was `undefined`, `admitInboundMessage`'s `=== null` open-check failed, and every inbound turn was silently dropped | Harness now supplies `ingressClosedReason: null` alongside the other constructor-owned state it already provides (stale-test port; the cordon itself is correct) |
| Server Tests — `test:remote-capabilities:surface-audit` exit 1 | `7dc6c263dee` (#18531) | New typed capability `Plugin.passiveConnectorsByDefault` was never classified in the capability-router surface audit | Classify it `localOnly` with rationale: connector policy is resolved in-process (core resolver + agent plugin-collector); it never crosses the remote manifest |
| Scenario `Zero-Key full-walkthrough (mock lane)` — apt exit 100 | infra (not covered by #18545) | The `sudo apt-get update && sudo apt-get install -y ffmpeg` step bypassed the #18545 hardening; `DPkg::Lock::Timeout` does not cover `/var/lib/apt/lists/lock`, so a concurrent job's apt-get killed the lane | New `.github/scripts/install-apt-packages.sh` (retry/backoff mirror of `install-playwright-browsers.sh`), wired into `scenario-pr.yml` and `app-live-e2e.yml` |

Signatures investigated and attributed but intentionally NOT patched here:

- **Plugin Tests (4/4) — plugin-agent-orchestrator cluster** (acp-git-commit-race, auto-goal-verify, credential-proxy-env, model-gateway-lease, sub-agent-router): all timeouts of 5s subprocess-spawning tests plus one cross-test leakage (`lease-2` seen where `lease-1` expected, i.e. the prior timed-out test's state). All 5 files pass locally at the tip (179/179), and the same job did NOT fail on the second Tests run of the same sha (31584038093). Environmental flake under shard load, not a code regression.
- **Zero-Key app browser lanes** (settings-mobile cloud sections, onboarding-to-home, automations): NOT the apt-race class — the hardened playwright installer ran and succeeded in those jobs. The failing subsets vary run-to-run (e.g. `cloud-account/organization/plugin-grants/monetization` on the tip run vs `mcps/cloud-plugin-grants/cloud-api-keys` on `131a765c3cf`), each failing section sits at the full 30s visibility timeout, and each passes locally in ~6s. This is a load-dependent race in the deferred private cloud-surface registration chain (`dd5fdd97c0c`…`8494af711ed`), which needs its own scoped issue; onboarding-to-home was already addressed separately by #18724.

## What kind of change is this?

Bug fixes (test/audit ports and CI hardening; non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Each fix was verified red-then-green at the same checkout:

```bash
# 1. useAccounts (red: 4 failed before the mock repoint, green after)
bun run --cwd packages/ui exec vitest run src/hooks/useAccounts.test.tsx

# 2. navigate-view wiring (red: getAuthStatusSnapshot missing, green after)
bun run --cwd packages/ui exec vitest run src/App.navigate-view-wiring.test.tsx

# 3. discord connector loop (red: 5 failed / zero outbound replies, green after)
ELIZA_LIVE_TEST=0 SCENARIO_USE_DETERMINISTIC_MODEL=1 TEST_LANE=pr \
  bun run --cwd plugins/plugin-discord test:real-runtime

# 4. surface audit (red: passiveConnectorsByDefault unclassified, green after)
bun run test:remote-capabilities:surface-audit

# 5. apt hardening
bash -n .github/scripts/install-apt-packages.sh && shellcheck .github/scripts/install-apt-packages.sh
```

## Detailed testing steps

None: Automated tests are acceptable (all five signatures are CI-lane assertions; local red→green transcripts below).

# Evidence Gate

<!-- evidence-head:6d439bfb44d86e7350054cb346fb74d6f93bfeb1 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI change; all fixes are test-harness, audit-script, and CI-workflow code. The red CI runs (31569493060 / 31569493059 / 31569493049) are the "before" state.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI change (see above); the green PR checks on this head are the "after" state.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow changed; CI-lane regreen only.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: red→green test transcripts inline below (Evidence Details).
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend behavior change; the jsdom test transcripts below cover the touched UI test surfaces.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior change; the discord connector fix is deterministic-model harness state, exercised by the deterministic connector-loop suite below.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: red→green command output for all five signatures inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface changed.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model-path change; the discord connector loop runs the deterministic model provider by design.`

## Backend + frontend logs

<details>
<summary>1. useAccounts.test.tsx — red at tip, green after mock repoint</summary>

Red (tip `e11f20c5ef4`, unmodified):

```
 × reconciles a failed probe so the card immediately exposes reauthentication 1016ms
 × drops a rejected poll invalidated by a newer mutation instead of setting a stale error 1011ms
 × reports reconciliation failure while preserving the primary probe rejection 59ms
 × surfaces a rejected strategy save before rethrowing it 1008ms
 Test Files  1 failed (1)
      Tests  4 failed | 3 passed (7)
```

Bisect: green with `packages/ui` at `71ce7b96431`, red at `940f0d66114` (#18314) — the commit that moved account components to `../../state/app-store`.

Green (this branch, post-rebase):

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

</details>

<details>
<summary>2. App.navigate-view-wiring.test.tsx — red at tip, green after mock export</summary>

Red (tip):

```
FAIL  src/App.navigate-view-wiring.test.tsx > App navigate-view event wiring > keeps an unauthenticated shared Cloud app inside first-run onboarding
Error: [vitest] No "getAuthStatusSnapshot" export is defined on the "./hooks/useAuthStatus" mock.
 ❯ initNotifications src/state/notifications/notification-store.ts:701:5
 Test Files  1 failed (1)
      Tests  1 failed | 20 passed (21)
```

Green (this branch, post-rebase):

```
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

</details>

<details>
<summary>3. plugin-discord connector-loop — red at tip, green after cordon-state fix</summary>

Red (tip):

```
FAIL __tests__/connector-loop.real.test.ts > … > waits for ready-time owner hydration … — expected [] to have a length of 1 but got +0
FAIL … co-mention … — an explicit co-mention still delivers a reply: expected 0 to be greater than 0
FAIL … deterministic model provider to a delivered reply — expected 0 to be greater than 0
FAIL … drifted tool-call reply to the Discord wire seam … — expected 0 to be greater than 0
FAIL … drifted tool-call reply to the DM seam … — expected 0 to be greater than 0
 Test Files  1 failed | 1 passed (2)
      Tests  5 failed | 12 passed (17)
```

Bisect over the five window commits touching `plugins/plugin-discord`: green at `df2d28962fd`, red from `2f177f10521` (shutdown ingress cordon) onward. Mechanism: `Object.create(DiscordService.prototype)` skips the constructor, leaving `ingressClosedReason` `undefined`; `admitInboundMessage` only treats exactly `null` as open, so every inbound turn was dropped before `runMessageTurn`.

Green (this branch, post-rebase):

```
 Test Files  2 passed (2)
      Tests  17 passed (17)
```

</details>

<details>
<summary>4. remote-capabilities surface audit — red at tip, green after classification</summary>

Red (tip):

```
[capability-router-surface-audit] failed
- Plugin.passiveConnectorsByDefault is not classified for capability-router remote plugins.
error: script "test:remote-capabilities:surface-audit" exited with code 1
```

Green (this branch): exit 0 with the full surface report.

</details>

<details>
<summary>5. ffmpeg apt-lock failure (CI infra) — from the failing full-walkthrough job log</summary>

```
##[group]Run sudo apt-get update && sudo apt-get install -y ffmpeg
E: Could not get lock /var/lib/apt/lists/lock. It is held by process 1823059 (apt-get)
E: Unable to lock directory /var/lib/apt/lists/
##[error]Process completed with exit code 100.
```

The same job's playwright install (routed through the #18545 hardened script) succeeded moments earlier — proof the merged installer was in use and the remaining exposure was this raw step. `shellcheck` and `bash -n` pass on the new script.

</details>

Gates on this branch after rebase onto latest `origin/develop`: `bun run verify` exit 0; `packages/ui`, `packages/agent`, `plugins/plugin-discord` typecheck clean; Biome clean on all touched files.

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no rendered UI change; failing CI runs linked above are the before state.`

### After

`N/A - no rendered UI change; green checks on this PR head are the after state.`

### Walkthrough video

`N/A - no user-facing flow changed.`

## Audio / voice walkthrough

`N/A - no voice surface touched.`

## Known gaps / failures

- The plugin-agent-orchestrator Plugin Tests (4/4) cluster is shard-load flake (timeouts + cross-test mock leakage); it passed on the rerun of the same sha and passes locally 179/179. No change shipped for it.
- The Zero-Key app browser section-visibility flake (deferred private cloud-surface registration under CI load) is real but load-dependent and out of scope for this regreen; it needs its own scoped issue against the `dd5fdd97c0c`…`8494af711ed` registration-split chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
