### PR TITLE
fix(video): normalize all automatic caption line breaks

### DIFF
--- a/plugins/plugin-video/src/services/video.test.ts
+++ b/plugins/plugin-video/src/services/video.test.ts
@@ -73,4 +73,43 @@ describe("VideoService deterministic behavior", () => {
     const keys = vi.mocked(runtime.setCache).mock.calls.map(([key]) => key);
     expect(new Set(keys).size).toBe(2);
   });
+
+  it("normalizes every automatic-caption line break", async () => {
+    const { service } = createServiceWithYtDlp([
+      {
+        title: "Captioned video",
+        channel: "channel",
+        description: "description",
+        automatic_captions: {
+          en: [{ url: "https://captions.example/video.json" }],
+        },
+      },
+    ]);
+    const runtime = createRuntime();
+    const captionResponse = new Response(
+      JSON.stringify({
+        events: [
+          { segs: [{ utf8: "first\nsecond\r\n" }] },
+          { segs: [{ utf8: "third\nfourth" }] },
+        ],
+      }),
+    );
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(captionResponse);
+
+    try {
+      const result = await service.processVideo(
+        "https://youtu.be/captioned-video",
+        runtime,
+      );
+
+      expect(result.text).toBe("first second third fourth");
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://captions.example/video.json",
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });

--- a/plugins/plugin-video/src/services/video.ts
+++ b/plugins/plugin-video/src/services/video.ts
@@ -556,7 +556,7 @@ export class VideoService extends IVideoService {
           )
           .map((event) => event.segs.map((seg) => seg.utf8 ?? "").join(""))
           .join("")
-          .replace("\n", " ");
+          .replace(/\r?\n/g, " ");
       } else {
         elizaLogger.log(
           "Unexpected caption format:",


### PR DESCRIPTION
# Relates to

Self-found bug; no numbered issue exists.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      focused regression test recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. This changes only whitespace normalization in automatic-caption transcript text.

# Background

## What does this PR do?

Automatic-caption parsing used `.replace("\n", " ")` (`plugins/plugin-video/src/services/video.ts:559`), which replaces only the *first* LF in the joined caption text and never touches CR. Captions with multiple line breaks — the common case — leaked every subsequent `\n` and any `\r\n` straight into the transcript text.

The parser now replaces every LF/CRLF break with a space via `.replace(/\r?\n/g, " ")`.

Traced live call path (not just a name match — verified end to end):
- `plugins/plugin-video/src/index.ts:7` registers this exact `VideoService` as the plugin's video service.
- `plugins/plugin-discord/messages.ts:3150` calls `videoService.processVideo(url, this.runtime)` for video URLs found in inbound Discord messages.
- `plugins/plugin-discord/attachments.ts:693` calls `videoService.processVideo(attachment.url, this.runtime)` for inbound video attachments.
- The defect itself is at `plugins/plugin-video/src/services/video.ts:559`, inside `parseCaption`.

## What kind of change is this?

Bug fix (non-breaking).

## Why are we doing this? Any context or related work?

A transcript with embedded raw newlines instead of normalized spacing degrades any downstream consumer (chat context, search, summarization) that expects a single-line transcript string.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-video/src/services/video.ts:559` (`parseCaption`)
2. `plugins/plugin-video/src/services/video.test.ts` (new test)

## Detailed testing steps

```text
bun run --cwd packages/core build

bun run --cwd plugins/plugin-video test -- src/services/video.test.ts
Test Files  1 passed (1)
     Tests  3 passed (3)

bun run --cwd plugins/plugin-video test
Test Files  2 passed | 1 skipped (3)
     Tests  22 passed | 4 skipped (26)

bunx @biomejs/biome check plugins/plugin-video/src/services/video.ts plugins/plugin-video/src/services/video.test.ts
Checked 2 files. No fixes applied.
```

All of the above independently re-run and confirmed after rebase, not just taken from the implementation run.

The new test drives the real public `processVideo` path with a caption fixture containing mixed `\n` and `\r\n` segments and asserts the fully normalized transcript (`"first second third fourth"`).

# Evidence Gate

<!-- evidence-head:c8a0af623fb1a5d693ffcedb69faa47dc5b8bf6a -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - pure transcript-parsing logic, no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic unit coverage directly exercises the service path via the public API.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused regression test output above confirms the normalized transcript through the real `processVideo` path.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface changed.

# Known gaps / failures

- Full root `bun run verify` was not run; the focused plugin-video test suite (22 passed, 4 pre-existing integration-gated skips), typecheck, and Biome all passed on the changed files.
- `@elizaos/core` required a local build (`bun run --cwd packages/core build`) before plugin-video's tests could resolve it — a workspace-build prerequisite, not a defect in this change.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [hunt-and-implement-1]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZVHG3Q4C6P7Q2V6BBGKHT1R","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T17:49:36.868Z","completed_at":"2026-08-12T17:52:32.797Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAVq8Ggvxg2RCIBwXtE9az5b_tYKj9qVj_3nvqPhhTcAA","device_key_id":"e60c0d298778b55b0d73aec8f38dfc80913a79223c40de61bea259417fe35ec3","device_signature":"iRf8EQZxQw-aBvczYp_1vHTH0qrrnHTAcKvokcBTlybtaipWoAYW2y_10CuOQwOHmhF7fJrFBHXYYZcmRYYTDA"}} -->
