### PR TITLE
fix(discord): resolve source in dev

### DIFF
--- a/plugins/plugin-discord/__tests__/package-exports.test.ts
+++ b/plugins/plugin-discord/__tests__/package-exports.test.ts
@@ -1,0 +1,72 @@
+/** Verifies Discord package resolution in real Bun child processes under development and default conditions. */
+
+import { spawnSync } from "node:child_process";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const packageRoot = fileURLToPath(new URL("../", import.meta.url));
+let fixtureRoot: string;
+let installedPackageRoot: string;
+
+beforeAll(() => {
+	fixtureRoot = mkdtempSync(path.join(tmpdir(), "discord-package-exports-"));
+	installedPackageRoot = path.join(
+		fixtureRoot,
+		"node_modules/@elizaos/plugin-discord",
+	);
+	mkdirSync(path.join(installedPackageRoot, "dist"), { recursive: true });
+	writeFileSync(
+		path.join(installedPackageRoot, "package.json"),
+		readFileSync(path.join(packageRoot, "package.json")),
+	);
+	writeFileSync(path.join(installedPackageRoot, "index.ts"), "export {};\n");
+	writeFileSync(
+		path.join(installedPackageRoot, "dist/index.js"),
+		"export {};\n",
+	);
+});
+
+afterAll(() => {
+	rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+function resolvePackageRoot(conditions: string[] = []): string {
+	const result = spawnSync(
+		"bun",
+		[
+			...conditions.map((condition) => `--conditions=${condition}`),
+			"--eval",
+			"process.stdout.write(import.meta.resolve('@elizaos/plugin-discord'));",
+		],
+		{ cwd: fixtureRoot, encoding: "utf8", timeout: 30_000 },
+	);
+
+	expect(result.status, result.stderr).toBe(0);
+	return fileURLToPath(result.stdout.trim());
+}
+
+describe("@elizaos/plugin-discord package exports", () => {
+	it("resolves source for the development condition", () => {
+		expect(path.normalize(resolvePackageRoot(["eliza-source"]))).toBe(
+			path.normalize(realpathSync(path.join(installedPackageRoot, "index.ts"))),
+		);
+	});
+
+	it("keeps default package resolution on the distributable entry", () => {
+		expect(path.normalize(resolvePackageRoot())).toBe(
+			path.normalize(
+				realpathSync(path.join(installedPackageRoot, "dist/index.js")),
+			),
+		);
+	});
+});

--- a/plugins/plugin-discord/package.json
+++ b/plugins/plugin-discord/package.json
@@ -15,6 +15,11 @@
 		"./package.json": "./package.json",
 		".": {
 			"types": "./dist/index.d.ts",
+			"eliza-source": {
+				"types": "./index.ts",
+				"import": "./index.ts",
+				"default": "./index.ts"
+			},
 			"import": "./dist/index.js",
 			"default": "./dist/index.js"
 		},


### PR DESCRIPTION
# Relates to

Closes #18737.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto `develop@4e955327a47c792fade4459c9d281a1a9b5dfb9c`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. Only the explicit `eliza-source` development condition changes. Ordinary
package resolution still targets `dist/index.js`, with a regression assertion
covering that production/package behavior.

# Background

## What does this PR do?

Adds the missing root `eliza-source` export for `@elizaos/plugin-discord` and
real Bun child-process coverage for both source-conditioned and default
resolution.

## What kind of change is this?

Bug fix (non-breaking development resolution fix).

## Why are we doing this?

The dev stack starts Bun with `--conditions=eliza-source`, but the Discord
package root ignored that condition and silently loaded a stale `dist/index.js`.
Its subpath exports and peer connector packages already follow the intended
source-condition contract.

# Documentation changes needed?

No documentation change is needed. This makes the Discord manifest conform to
the existing documented dev-stack and package-export convention.

# Testing

## Where should a reviewer start?

Start with `plugins/plugin-discord/__tests__/package-exports.test.ts`, then the
five-line root export condition in `plugins/plugin-discord/package.json`.

## Detailed testing steps

Pinned toolchain: Bun 1.3.14 and Node 24.15.0.

Before the fix, the new regression produced one failure: source-conditioned
resolution returned `dist/index.js`; the default-resolution assertion passed.

After the fix, on the final synchronized head:

```text
Focused resolver suite: 1 file passed, 2/2 tests passed
Discord package typecheck: PASS
Discord package lint: 151 files checked, no fixes
Discord package build: PASS
Root bun run verify: PASS (exit 0)
git diff --check: PASS
```

# Evidence Gate

<!-- evidence-head:bb63baf89941d78ff440c6f83560f94528fe7545 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - package export metadata has no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - package export metadata has no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive user flow changes
<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic local module resolution has no server request or logging path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request, console, network, or state transition changes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - package resolution produces no persistent database, file, media, or external domain artifact
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changes

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

N/A - this is a deterministic package-resolution contract with no backend,
frontend, network, database, or external-service path.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no UI surface changes.

### After

N/A - no UI surface changes.

### Walkthrough video

N/A - no interactive flow changes.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changes.

## Known gaps / failures

- The package's default parallel Vitest command left a worker alive without a
  final report. A serial verbose rerun progressed through the suite and isolated
  unrelated 60-second timeouts in existing `local-routes-e2e.test.ts` setup
  status cases. This PR does not change routes, setup state, or those tests.
- The changed contract is covered by its own real Bun child-process test, while
  package typecheck/lint/build and the full root verification all pass.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [issue-18737-source-resolution]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZVHK6J46VFY8N4390VE8GMR","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T17:51:18.084Z","completed_at":"2026-08-12T18:26:29.823Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAhF2ageyJvlDoe_JCeJ8dre---IaulxsqhaiFj11CQp8","device_key_id":"46ffa292f1c2f8b4f4ab4e8a1844b1ada18e416b6c0917274238cff9af1448e9","device_signature":"w6mS1mvO8PSmG4YOLLScPnitUrpsLj5ByxTcXwu4CaBqrH5nk7Vw6CTR0RdnfJCaUzaS73gkSKE3eOCVQ-kyBQ"}} -->

