### PR TITLE
fix(agent): clear settled documents loader timeout

### DIFF
--- a/packages/agent/src/api/documents-service-loader.test.ts
+++ b/packages/agent/src/api/documents-service-loader.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Verifies the documents-service loader's bounded startup wait, including a
+ * real Bun subprocess that catches referenced timers left after fast startup.
+ */
+import { spawnSync } from "node:child_process";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type DocumentsServiceLike,
+  getDocumentsService,
+} from "./documents-service-loader.ts";
+
+const service = {} as DocumentsServiceLike;
+
+function makeRuntime(options: {
+  load: () => Promise<unknown>;
+  registerAfterLoad?: boolean;
+}): IAgentRuntime {
+  let registered = false;
+  return {
+    getService: vi.fn(() => (registered ? service : null)),
+    getServiceLoadPromise: vi.fn(async () => {
+      await options.load();
+      registered = options.registerAfterLoad === true;
+    }),
+  } as unknown as IAgentRuntime;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+});
+
+describe("getDocumentsService", () => {
+  it("clears the losing timeout after the service registers", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "60000");
+    const runtime = makeRuntime({
+      load: async () => undefined,
+      registerAfterLoad: true,
+    });
+
+    await expect(getDocumentsService(runtime)).resolves.toEqual({ service });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears the timeout when loading settles without registration", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "60000");
+    const runtime = makeRuntime({ load: async () => undefined });
+
+    await expect(getDocumentsService(runtime)).resolves.toEqual({
+      service: null,
+      reason: "not_registered",
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears the timeout after a rejected service load", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "60000");
+    const runtime = makeRuntime({
+      load: async () => {
+        throw new Error("documents plugin failed to start");
+      },
+    });
+
+    await expect(getDocumentsService(runtime)).resolves.toEqual({
+      service: null,
+      reason: "timeout",
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("keeps a never-settling load bounded by the configured timeout", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "25");
+    const runtime = makeRuntime({
+      load: () => new Promise<never>(() => undefined),
+    });
+
+    const loading = getDocumentsService(runtime);
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(loading).resolves.toEqual({
+      service: null,
+      reason: "timeout",
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe("documents-service loader process lifecycle", () => {
+  function runLoader(caseName: "fast" | "timeout") {
+    const moduleUrl = new URL("./documents-service-loader.ts", import.meta.url)
+      .href;
+    const script = `
+      const { getDocumentsService } = await import(${JSON.stringify(moduleUrl)});
+      const mode = process.env.DOCUMENTS_LOADER_CASE;
+      let registered = false;
+      const service = {};
+      const runtime = {
+        getService: () => registered ? service : null,
+        getServiceLoadPromise: () => mode === "fast"
+          ? Promise.resolve().then(() => { registered = true; })
+          : new Promise(() => {}),
+      };
+      const result = await getDocumentsService(runtime);
+      console.log(JSON.stringify({ hasService: result.service === service, reason: result.reason ?? null }));
+    `;
+    const startedAt = performance.now();
+    const result = spawnSync(
+      "bun",
+      ["--conditions=eliza-source", "--eval", script],
+      {
+        cwd: new URL("../../..", import.meta.url),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          DOCUMENTS_LOADER_CASE: caseName,
+          DOCUMENTS_SERVICE_TIMEOUT_MS: caseName === "fast" ? "60000" : "25",
+        },
+        timeout: 5_000,
+      },
+    );
+    return { durationMs: performance.now() - startedAt, result };
+  }
+
+  it("exits promptly after fast loading instead of waiting 60 seconds", () => {
+    const { durationMs, result } = runLoader("fast");
+
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({
+      hasService: true,
+      reason: null,
+    });
+    expect(durationMs).toBeLessThan(5_000);
+  });
+
+  it("retains the referenced timer long enough to settle a hung load", () => {
+    const { durationMs, result } = runLoader("timeout");
+
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({
+      hasService: false,
+      reason: "timeout",
+    });
+    expect(durationMs).toBeGreaterThanOrEqual(20);
+  });
+});

--- a/packages/agent/src/api/documents-service-loader.ts
+++ b/packages/agent/src/api/documents-service-loader.ts
@@ -141,20 +141,24 @@ export async function getDocumentsService(
   let service = runtime.getService<Service & DocumentsServiceLike>("documents");
   if (service) return { service };
 
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
     const servicePromise = runtime.getServiceLoadPromise("documents");
     const timeoutMs = getDocumentsServiceTimeoutMs();
-    const timeout = new Promise<never>((_resolve, reject) => {
-      setTimeout(
+    const timeoutPromise = new Promise<never>((_resolve, reject) => {
+      timeout = setTimeout(
         () => reject(new Error("documents service timeout")),
         timeoutMs,
       );
     });
-    await Promise.race([servicePromise, timeout]);
+    await Promise.race([servicePromise, timeoutPromise]);
     service = runtime.getService<Service & DocumentsServiceLike>("documents");
     if (service) return { service };
     return { service: null, reason: "not_registered" };
   } catch {
+    // error-policy:J1 Translate load timeout/rejection into the typed loader result.
     return { service: null, reason: "timeout" };
+  } finally {
+    if (timeout) clearTimeout(timeout);
   }
 }


### PR DESCRIPTION
# Relates to

Fixes #18726

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were attempted after sync; the exact unrelated dependency-tree blockers are recorded below.
- [x] A reviewer can confirm the lifecycle change from the measured base/head subprocess evidence below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop` `4e955327a47c792fade4459c9d281a1a9b5dfb9c`; zero conflicts, ahead 1 / behind 0.
- [x] `bun run verify` was run after final sync; its unrelated local dependency-tree stop is documented under **Known gaps / failures**.

# Risks

Low. The change only clears the loader's losing timeout after `Promise.race` settles. The timeout remains referenced while a documents-service load is genuinely unresolved, so the existing bounded `timeout` result remains intact.

# Background

## What does this PR do?

- captures the documents-service loader timeout handle and clears it in `finally` on success, unregistered resolution, rejection, or timeout settlement;
- preserves the typed `timeout` behavior for a never-settling load;
- adds four fake-timer contract tests and two real Bun subprocess lifecycle regressions.

Before this change, a fast documents-service startup returned its service result but left the losing 10–60 second timer referenced, keeping short-lived agent, CLI, and test processes alive.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This corrects an internal loader lifecycle invariant and adds executable coverage; no user-facing API or configuration contract changes.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/documents-service-loader.test.ts`, especially the two real subprocess cases, then the `try/finally` around the race in `documents-service-loader.ts`.

## Detailed testing steps

Final exact head: `cb3d23ef8688d340acff0c5f2e43846648772205`  
Toolchain: Node `v24.15.0`, Bun `1.3.14`

- `bunx vitest run --config packages/agent/vitest.config.ts src/api/documents-service-loader.test.ts --coverage.enabled=false` — **PASS**, 1 file / 6 tests.
- `bun run --cwd packages/agent lint:check` — **PASS**, 875 files.
- `bun run --cwd packages/agent typecheck` — **PASS**.
- `bun run --cwd packages/agent build` — **PASS**.
- `bun run --cwd packages/agent test` — **PASS**, 392/392 isolated files.
- `git diff --check HEAD^..HEAD` — **PASS**.
- Real boundary harness, same runtime and loader API:

| Case | Configured loader deadline | Observed outcome |
|---|---:|---|
| Base fast service (`4e955327`) | 60,000 ms | service result printed, then parent killed it at 1,508 ms (`SIGKILL`, `ETIMEDOUT`) |
| Fixed fast service (`cb3d23ef`) | 60,000 ms | exit 0 in 19 ms with the service result |
| Fixed hung service (`cb3d23ef`) | 25 ms | exit 0 in 42 ms with `{ reason: "timeout" }` |

# Evidence Gate

<!-- evidence-head:cb3d23ef8688d340acff0c5f2e43846648772205 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only timer lifecycle helper; no rendered UI surface changes.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only timer lifecycle helper; no rendered UI surface changes.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no interactive UI flow; the process lifecycle is captured by real subprocess outcomes.`
<!-- evidence-row:backend-logs -->
- [x] Backend subprocess transcript from the real loader path:

  <details><summary>Exact measured JSONL records</summary>

  ```jsonl
  {"case":"base-fast-service","durationMs":1508,"status":null,"signal":"SIGKILL","errorCode":"ETIMEDOUT","serviceResult":{"hasService":true,"reason":null}}
  {"case":"fixed-fast-service","durationMs":19,"status":0,"signal":null,"errorCode":null,"serviceResult":{"hasService":true,"reason":null}}
  {"case":"fixed-hung-service","durationMs":42,"status":0,"signal":null,"errorCode":null,"serviceResult":{"hasService":false,"reason":"timeout"}}
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend request, state, or rendered surface changes.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no action, provider, prompt, model, or inference path changes.`
<!-- evidence-row:domain-artifacts -->
- [x] [Measured base-versus-head loader outcome matrix](https://github.com/user-attachments/assets/99ee9917-7270-466c-8614-809e6727d5f7) (1120×630 PNG; SHA-256 `0beaf221047d42c4304448f1d4d045cf612d8662c5f100f1e14c1da75b9d9d43`).
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered product surface; the evidence matrix was visually inspected for legibility and exact measured values.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no provider/model/action/prompt path changed.`

## Backend + frontend logs

The structured backend subprocess records are inline in the evidence row above. They show the base process already produced a successful service result yet remained alive until forced termination; the fixed process exits promptly, while the genuine timeout path still returns its typed result.

Frontend logs are `N/A` because no frontend code, request, or state surface is involved.

## Screenshots (before / after) + video walkthrough

`N/A - backend-only loader lifecycle correction with no UI flow.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or audio path changes.`

## Known gaps / failures

- `bun install --frozen-lockfile` could not refresh this checkout because the repository currently requests unresolved `pepr@^1.1.7`; exact package tests ran against the existing workspace dependency tree.
- Final `bun run verify` passed the agent and UI lint stages, then stopped at unchanged `@elizaos/cloud-api:typecheck` because that available local dependency tree lacks its declared `jose` package. The PR changes only the two `packages/agent/src/api/documents-service-loader*` files. An earlier UI-format report on an unchanged file was not reproducible under the exact forced UI task.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 207112800 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [marcoworms-documents-loader-timer]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZVDXWFFJM1B8A12GM10H0PQ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T16:47:13.903Z","completed_at":"2026-08-12T17:45:55.454Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":7243694,"output_tokens":640260,"cache_creation_tokens":0,"cache_read_tokens":199228846,"total_tokens":207112800,"cost_micro_usd":"102248332","session_count":37},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAWOuFq4QKFpEzUxdS-xUTGOp-_XL5j-TbR18ldYqv818","device_key_id":"27a2bd6f25b7dfbdcd447074ad6ad4d4eff92654605004b081bd547e02c21550","device_signature":"WDTVAi99HZNab2-H9HMamlfp1VeXVCE24s8tnMaV6zeunByeTCOjPX4y1aijOUrYNTiw1Kvczcq-GtWCQAtkAQ"}} -->
