### PR TITLE
fix(ci): regreen develop client, server, and smoke lanes broken by stale test ports

### DIFF
--- a/packages/app/test/ui-smoke/automations.spec.ts
+++ b/packages/app/test/ui-smoke/automations.spec.ts
@@ -603,14 +603,24 @@ async function installAutomationsApi(
         updatedAt: NOW_ISO,
       };
       conversations.set(conversation.id, conversation);
-      const draftId =
-        typeof body.metadata?.draftId === "string"
-          ? body.metadata.draftId
-          : `draft-${conversations.size}`;
-      automations = [
-        ...automations,
-        draftWorkflowItem(draftId, conversation.id),
-      ];
+      // Only a workflow-draft conversation materializes an automation row.
+      // The chat shell also POSTs /api/conversations (greeting bootstrap when
+      // hydration finds zero conversations); on the real backend that plain
+      // chat conversation never surfaces in /api/automations, so the mock
+      // must not fabricate a draft for it.
+      const isWorkflowDraft =
+        body.metadata?.scope === "automation-workflow-draft" ||
+        typeof body.metadata?.draftId === "string";
+      if (isWorkflowDraft) {
+        const draftId =
+          typeof body.metadata?.draftId === "string"
+            ? body.metadata.draftId
+            : `draft-${conversations.size}`;
+        automations = [
+          ...automations,
+          draftWorkflowItem(draftId, conversation.id),
+        ];
+      }
       await fulfillJson(route, { conversation });
       return;
     }

--- a/packages/shared/src/utils/trajectory-format.test.ts
+++ b/packages/shared/src/utils/trajectory-format.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import {
   formatTrajectoryDuration,
   formatTrajectoryTimestamp,

--- a/packages/ui/src/App.screen-background-fuzz.test.tsx
+++ b/packages/ui/src/App.screen-background-fuzz.test.tsx
@@ -178,6 +178,15 @@ vi.mock("./hooks/useAuthStatus", () => ({
   // probe from the mounted App's notifications-boot effect; the mock must
   // provide them or the probe throws mid-effect. Authenticated => probe on.
   isAuthenticatedNow: () => true,
+  // notification-store also keys its inbox authority off the full snapshot
+  // (computeAuthorityKey in initNotifications, #18495), so the mock exposes a
+  // static authenticated AuthStatusState alongside the boolean seam.
+  getAuthStatusSnapshot: () => ({
+    phase: "authenticated",
+    identity: { id: "test-user" },
+    session: { id: "test-session" },
+    access: {},
+  }),
   subscribeAuthStatus: () => vi.fn(),
 }));
 vi.mock("./hooks/useActivityEvents", () => ({

--- a/packages/ui/src/App.surface-manifest-wallpaper.test.tsx
+++ b/packages/ui/src/App.surface-manifest-wallpaper.test.tsx
@@ -152,6 +152,15 @@ vi.mock("./hooks/useAuthStatus", () => ({
   // probe from the mounted App's notifications-boot effect; the mock must
   // provide them or the probe throws mid-effect. Authenticated => probe on.
   isAuthenticatedNow: () => true,
+  // notification-store also keys its inbox authority off the full snapshot
+  // (computeAuthorityKey in initNotifications, #18495), so the mock exposes a
+  // static authenticated AuthStatusState alongside the boolean seam.
+  getAuthStatusSnapshot: () => ({
+    phase: "authenticated",
+    identity: { id: "test-user" },
+    session: { id: "test-session" },
+    access: {},
+  }),
   subscribeAuthStatus: () => vi.fn(),
 }));
 vi.mock("./hooks/useActivityEvents", () => ({

--- a/packages/ui/src/App.surface-mutation-fuzz.test.tsx
+++ b/packages/ui/src/App.surface-mutation-fuzz.test.tsx
@@ -174,6 +174,15 @@ vi.mock("./hooks/useAuthStatus", () => ({
   // probe from the mounted App's notifications-boot effect; the mock must
   // provide them or the probe throws mid-effect. Authenticated => probe on.
   isAuthenticatedNow: () => true,
+  // notification-store also keys its inbox authority off the full snapshot
+  // (computeAuthorityKey in initNotifications, #18495), so the mock exposes a
+  // static authenticated AuthStatusState alongside the boolean seam.
+  getAuthStatusSnapshot: () => ({
+    phase: "authenticated",
+    identity: { id: "test-user" },
+    session: { id: "test-session" },
+    access: {},
+  }),
   subscribeAuthStatus: () => vi.fn(),
 }));
 vi.mock("./hooks/useActivityEvents", () => ({


### PR DESCRIPTION
## Summary

Develop's own CI is red and every open PR inherits the failures through develop merges. The 08-12 bun-zip stale-port infra breakage and the first stale-mock wave were already fixed by #18739 and #18741, but the first post-fix run on develop tip (`4e955327a47`, run [31626813070](https://github.com/elizaOS/eliza/actions/runs/31626813070)) exposed three remaining deterministic reds. Each is a stale test port behind a deliberate product change — production behavior is untouched:

- **Tests (client)**: `packages/ui` `App.screen-background-fuzz.test.tsx`, `App.surface-manifest-wallpaper.test.tsx`, and `App.surface-mutation-fuzz.test.tsx` mock `./hooks/useAuthStatus` without `getAuthStatusSnapshot`, which #18495's notification-store authority keying reads during App mount (`initNotifications` → `computeAuthorityKey`). This PR exports the same static authenticated snapshot #18741 already added to `App.navigate-view-wiring.test.tsx`'s mock.
- **Tests (server)**: `packages/shared/src/utils/trajectory-format.test.ts` (added by #18532) imports from `bun:test`, but the shared lane runs vitest (`run-vitest.mjs`), so the whole suite fails collection with `Cannot find package 'bun:test'`. Import from `vitest` like every other shared test.
- **Smoke (2)**: `packages/app` ui-smoke `automations.spec.ts`'s `POST /api/conversations` mock appended a workflow-draft automation row for **every** conversation create. The chat shell's zero-conversation hydration deliberately POSTs a greeting bootstrap conversation (`{"includeGreeting":true,"lang":"en"}` — verified in the Playwright trace), which the mock turned into a phantom "Draft" row, breaking the empty-state assertions and the `Prompts` tab count (`Prompts2` vs `1`). On the real backend a chat conversation never surfaces in `/api/automations`; the mock now materializes a draft row only for creates carrying workflow-draft metadata (`metadata.scope === "automation-workflow-draft"` or a `draftId`).

Not changed, judged on the merits:

- **Quality / Android release AAB / Tests lanes on run 31625311542** all died in `setup-bun-workspace` with `ECONNREFUSED 127.0.0.1:43025` — a stale cached localhost download-URL introduced by `ec042c36927` and already root-caused and fixed on develop by #18739 (`16effcebdcd` caches only `bun.zip` and writes the URL outside the cached path). Verified fixed: Quality (Extended) on develop tip completed green ([31626813162](https://github.com/elizaOS/eliza/actions/runs/31626813162)).
- **`useAccounts.test.tsx` (8 tests)** — already fixed on develop by #18741 (mock pointed at the moved `../state/app-store` barrel); passes at tip locally (7/7).
- **Smoke (4)** `settings-mobile-load` `cloud-account`/`cloud-billing` — both pass locally at tip (6.3s/6.2s); the CI failures show 37s "section root never became visible" timeouts, consistent with runner contention, not a deterministic red. If they stay red on this PR's gates I'll follow up in-scope.

## Evidence

| Lane | Root cause | Fix | Evidence |
| --- | --- | --- | --- |
| Tests (client) | `useAuthStatus` mocks missing `getAuthStatusSnapshot` (read since #18495) in 3 App test files | Test-pin: export the snapshot seam, mirroring #18741's established treatment | <details><summary>vitest: 3 files, 20/20 pass at evidence-head</summary><pre>$ bunx vitest run src/App.screen-background-fuzz.test.tsx src/App.surface-manifest-wallpaper.test.tsx src/App.surface-mutation-fuzz.test.tsx&#10; Test Files  3 passed (3)&#10;      Tests  20 passed (20)&#10;   Duration  26.80s</pre>Before the fix the same run failed with:<pre>Error: [vitest] No "getAuthStatusSnapshot" export is defined on the "./hooks/useAuthStatus" mock.&#10; ❯ initNotifications src/state/notifications/notification-store.ts:701:5</pre></details> |
| Tests (server) | `trajectory-format.test.ts` imports `bun:test` in the vitest shared lane (from #18532) | Test-pin: import from `vitest`; assertions and production code unchanged | <details><summary>vitest: suite collects and passes 15/15</summary><pre>$ bunx vitest run src/utils/trajectory-format.test.ts&#10;      Tests  15 passed (15)&#10;   Duration  387ms</pre>Before:<pre>Error: Cannot find package 'bun:test' imported from packages/shared/src/utils/trajectory-format.test.ts</pre></details> |
| Smoke (2) | automations mock fabricates a draft automation from the chat greeting-bootstrap `POST /api/conversations` | Harness-contract fix: append a draft row only for workflow-draft-scoped creates | <details><summary>Playwright: full automations spec 4/4 pass</summary><pre>$ node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/automations.spec.ts&#10;  ✓ automations overview empty state encourages creating tasks and workflows (5.5s)&#10;  ✓ automations empty state remains reachable beside chat in short landscape (5.3s)&#10;  ✓ automations can list tasks, create a task, and inspect workflow JSON (6.2s)&#10;  ✓ automations renders an event trigger and creates a new event automation (5.7s)&#10;  4 passed (32.7s)</pre>Trace proof of the phantom row's origin (empty-state test, pre-fix):<pre>POST /api/conversations {"includeGreeting":true,"lang":"en"}&#10;page snapshot: button "Prompts": Prompts 1 / listitem: button "Open Draft": Draft Inactive Apr 23, 1:00 PM</pre></details> |
| Quality / Android AAB / Smoke lanes (run 31625311542) | Stale cached Bun localhost URL (`ECONNREFUSED 127.0.0.1:43025`) from `ec042c36927` | N/A — already fixed on develop by #18739; verified green at tip (Quality Extended run 31626813162) | <details><summary>failed-job log signature</summary><pre>bun zip url http://127.0.0.1:45949/bun.zip&#10;with: bun-download-url: http://127.0.0.1:43025/bun.zip&#10;##[error]Error: connect ECONNREFUSED 127.0.0.1:43025</pre></details> |

- evidence-head: 0f922e21e4d5985638103e31789aa607ad105dc5
- Biome: `Checked 5 files. No fixes applied.` — clean.
- Typecheck: `packages/shared` and `packages/ui` clean; `packages/app` fails identically at clean develop tip on this host (`mobile-bridges.ts` needs the native capacitor bridge build) — pre-existing local-env, untouched by this test-only change.

## Contribution attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

Root-cause analysis, fixes, and evidence: Claude Fable 5 (session driven by shaw), building directly on the develop-side infra fixes in #18739 (Sayo) and the stale-port test fixes in #18741.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:75a3b248f5465407991c5e6e370f7eaca4114f99 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18749-before-phantom-draft.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18749-after-empty-state.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18749-automations-empty-state-pass.mp4

<!-- evidence-row:backend-logs -->
- [x] Pasted transcript (packages/shared vitest lane at evidence-head; pre-fix the suite failed collection with `Cannot find package 'bun:test'`):

  ```
  $ bunx vitest run src/utils/trajectory-format.test.ts
   RUN  v4.1.5 packages/shared
   Test Files  1 passed (1)
        Tests  15 passed (15)
     Duration  371ms
  ```

<!-- evidence-row:frontend-logs -->
- [x] Pasted transcript (packages/ui fixed App suites + useAccounts at evidence-head):

  ```
  $ bunx vitest run src/App.screen-background-fuzz.test.tsx src/App.surface-manifest-wallpaper.test.tsx src/App.surface-mutation-fuzz.test.tsx src/hooks/useAccounts.test.tsx
   Test Files  4 passed (4)
        Tests  27 passed (27)
  Pre-fix failure: Error: [vitest] No "getAuthStatusSnapshot" export is defined on the "./hooks/useAuthStatus" module override
   -> initNotifications src/state/notifications/notification-store.ts:701
  ```

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic test-harness repair; no model path is exercised by these lanes

<!-- evidence-row:domain-artifacts -->
- [x] Pasted transcript (packages/app ui-smoke automations spec at evidence-head; pre-fix 3 of these failed on a phantom "Draft" row fabricated from the chat greeting-bootstrap POST /api/conversations with includeGreeting=true):

  ```
  $ node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/automations.spec.ts
    ok automations overview empty state encourages creating tasks and workflows (5.8s)
    ok automations empty state remains reachable beside chat in short landscape (5.7s)
    ok automations can list tasks, create a task, and inspect workflow JSON (6.1s)
    ok automations renders an event trigger and creates a new event automation (5.8s)
    4 passed
  ```

