### PR TITLE
fix(bluebubbles): reject partially numeric pagination values

### DIFF
--- a/plugins/plugin-bluebubbles/__tests__/data-routes.test.ts
+++ b/plugins/plugin-bluebubbles/__tests__/data-routes.test.ts
@@ -93,6 +93,42 @@ describe("blueBubblesDataRoutes", () => {
 		});
 	});
 
+	it("ignores malformed pagination values instead of partially parsing them", async () => {
+		const client = {
+			listChats: vi.fn(async () => []),
+		};
+		const service = { getClient: vi.fn(() => client) };
+		const res = makeResponse();
+
+		await route("/api/bluebubbles/chats", "GET").handler(
+			{
+				url: "/api/bluebubbles/chats?limit=10oops&offset=4oops",
+			} as RouteRequest,
+			res,
+			makeRuntime(service),
+		);
+
+		expect(client.listChats).toHaveBeenCalledWith(100, 0);
+	});
+
+	it("ignores malformed pagination values for message listing", async () => {
+		const client = {
+			getMessages: vi.fn(async () => []),
+		};
+		const service = { getClient: vi.fn(() => client) };
+		const res = makeResponse();
+
+		await route("/api/bluebubbles/messages", "GET").handler(
+			{
+				url: "/api/bluebubbles/messages?chatGuid=chat-1&limit=20oops&offset=3oops",
+			} as RouteRequest,
+			res,
+			makeRuntime(service),
+		);
+
+		expect(client.getMessages).toHaveBeenCalledWith("chat-1", 50, 0);
+	});
+
 	it("rejects webhooks without the configured shared secret", async () => {
 		const service = {
 			handleWebhook: vi.fn(async () => undefined),

--- a/plugins/plugin-bluebubbles/src/data-routes.ts
+++ b/plugins/plugin-bluebubbles/src/data-routes.ts
@@ -25,6 +25,12 @@ import { isBlueBubblesWebhookAuthorized } from "./webhook-auth.js";
 const BLUEBUBBLES_SERVICE_NAME = "bluebubbles";
 const DEFAULT_WEBHOOK_PATH = "/webhooks/bluebubbles";
 
+function parsePaginationValue(raw: string | null, fallback: number): number {
+	if (raw === null || !/^-?\d+$/.test(raw.trim())) return fallback;
+	const parsed = Number(raw);
+	return Number.isSafeInteger(parsed) ? parsed : fallback;
+}
+
 type BlueBubblesWebhookPayload = {
 	type: string;
 	data: Record<string, unknown>;
@@ -86,15 +92,12 @@ async function handleChats(
 	}
 	const url = new URL(req.url ?? "/api/bluebubbles/chats", "http://localhost");
 	const limit = Math.min(
-		Math.max(
-			1,
-			Number.parseInt(url.searchParams.get("limit") ?? "100", 10) || 100,
-		),
+		Math.max(1, parsePaginationValue(url.searchParams.get("limit"), 100)),
 		500,
 	);
 	const offset = Math.max(
 		0,
-		Number.parseInt(url.searchParams.get("offset") ?? "0", 10) || 0,
+		parsePaginationValue(url.searchParams.get("offset"), 0),
 	);
 	try {
 		const chats = await client.listChats(limit, offset);
@@ -155,15 +158,12 @@ async function handleMessages(
 		return;
 	}
 	const limit = Math.min(
-		Math.max(
-			1,
-			Number.parseInt(url.searchParams.get("limit") ?? "50", 10) || 50,
-		),
+		Math.max(1, parsePaginationValue(url.searchParams.get("limit"), 50)),
 		500,
 	);
 	const offset = Math.max(
 		0,
-		Number.parseInt(url.searchParams.get("offset") ?? "0", 10) || 0,
+		parsePaginationValue(url.searchParams.get("offset"), 0),
 	);
 	try {
 		const messages = await client.getMessages(chatGuid, limit, offset);


### PR DESCRIPTION
# Relates to

Self-found bug; no numbered issue exists.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      focused regression tests recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change is limited to integer parsing for two read-only pagination query parameters on GET routes. Existing defaults and bounds are preserved.

# Background

## What does this PR do?

BlueBubbles chat and message list routes parsed pagination parameters with `Number.parseInt(value, 10) || fallback`. `Number.parseInt` accepts a numeric prefix, so a malformed value like `limit=10oops` parsed to `10` (a truthy number), never triggering the `|| fallback`.

`parsePaginationValue` now requires the entire trimmed value to match `/^-?\d+$/` and to be a safe integer before accepting it; anything else falls back to the existing route default.

Traced live paths (import chain verified end to end, not just a function-name match):
- `plugins/plugin-bluebubbles/src/data-routes.ts:94` — `handleChats`, serving `GET /api/bluebubbles/chats`.
- `plugins/plugin-bluebubbles/src/data-routes.ts:160` — `handleMessages`, serving `GET /api/bluebubbles/messages`.
- `plugins/plugin-bluebubbles/src/index.ts:15` imports `blueBubblesDataRoutes` from this exact file.
- `plugins/plugin-bluebubbles/src/index.ts:76` spreads `blueBubblesDataRoutes` into the plugin's live `routes` array.

## What kind of change is this?

Bug fix (non-breaking).

## Why are we doing this? Any context or related work?

A malformed pagination query param should fall back to the documented default, not silently misinterpret a numeric prefix as the intended value.

# Documentation changes needed?

No. Defaults and bounds are unchanged; only invalid-input handling changed.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-bluebubbles/src/data-routes.ts` (`parsePaginationValue`, `handleChats`, `handleMessages`)
2. `plugins/plugin-bluebubbles/__tests__/data-routes.test.ts`

## Detailed testing steps

```text
bun run --cwd plugins/plugin-bluebubbles test -- __tests__/data-routes.test.ts
Test Files  1 passed (1)
     Tests  6 passed (6)

bun run --cwd plugins/plugin-bluebubbles test
Test Files  6 passed (6)
     Tests  37 passed (37)

bunx @biomejs/biome check plugins/plugin-bluebubbles/src/data-routes.ts plugins/plugin-bluebubbles/__tests__/data-routes.test.ts
Checked 2 files. No fixes applied.
```

All independently re-run and confirmed after rebase.

# Evidence Gate

<!-- evidence-head:b45df7a78d8ba5ae2a0cf1af5c1d4f48ef3f6920 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - read-only backend query-parsing change.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - focused route tests directly exercise both registered handlers.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no persistent domain artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface changed.

# Known gaps / failures

Full root `bun run verify` was not run; the full owning-plugin test suite (37/37), package typecheck (implicit via vitest/tsc plugin config), and scoped Biome check all passed on the changed files.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [hunt-and-implement-2]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZVP8WP93YA2HESQGRTPJP52","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T19:13:03.178Z","completed_at":"2026-08-12T19:14:43.889Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAVq8Ggvxg2RCIBwXtE9az5b_tYKj9qVj_3nvqPhhTcAA","device_key_id":"e60c0d298778b55b0d73aec8f38dfc80913a79223c40de61bea259417fe35ec3","device_signature":"W1Q-5WZHE_MOkPXq0QrHyP1i-KHWey_yXVpZrrBecVZ-A9RpMl6Z6ly68fuDWVIqQsm6S01o3Xj8E1FlL1G1Cw"}} -->
