### PR TITLE
fix(ui): close notification authority races

### DIFF
--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -325,6 +325,7 @@ describe("ElizaClient websocket connection policy", () => {
       client.connectWs();
       for (let i = 0; i < 15; i++) {
         instances[instances.length - 1].onclose?.();
+        if (i < 14) vi.runOnlyPendingTimers();
       }
       expect(client.getConnectionState().state).toBe("failed");
     } finally {
@@ -533,5 +534,36 @@ describe("ElizaClient websocket connection policy", () => {
 
     expect(instances).toHaveLength(1);
     expect(client.getConnectionState().state).toBe("disconnected");
+  });
+
+  it("drops a queued frame from a socket closed by setBaseUrl", () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient("https://agent-a.example.test", "token");
+    const handler = vi.fn();
+    client.onWsEvent("agent_event", handler);
+    client.connectWs();
+    const staleMessage = instances[0].onmessage;
+
+    client.setBaseUrl("https://agent-b.example.test");
+    staleMessage?.({
+      data: JSON.stringify({ type: "agent_event", payload: "stale" }),
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(instances[0].onmessage).toBeNull();
+  });
+
+  it("rotates an open anonymous socket when an API token is installed", () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient("https://agent.example.test");
+    client.connectWs();
+    instances[0].readyState = 1;
+    instances[0].onopen?.();
+
+    client.setToken("new-token");
+
+    expect(instances).toHaveLength(2);
+    expect(instances[0].onmessage).toBeNull();
+    expect(instances[1].url).toContain("token=new-token");
   });
 });

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -913,7 +913,9 @@ export class ElizaClient {
    * the credential.
    */
   private installToken(token: string | null, notify: boolean): void {
-    this._token = token?.trim() || null;
+    const nextToken = token?.trim() || null;
+    const tokenChanged = nextToken !== this._token;
+    this._token = nextToken;
     // Boot config is the canonical source. fetchWithCsrf and authBase read here.
     const config = getBootConfig();
     setBootConfig({ ...config, apiToken: this._token ?? undefined });
@@ -925,6 +927,7 @@ export class ElizaClient {
     if (notify && typeof window !== "undefined") {
       window.dispatchEvent(new CustomEvent("steward-token-sync"));
     }
+    if (tokenChanged && this.ws) this.rotateConnection();
   }
 
   getBaseUrl(): string {
@@ -1752,9 +1755,11 @@ export class ElizaClient {
     if (token) params.set("token", token);
     url += `?${params.toString()}`;
 
-    this.ws = new WebSocket(url);
+    const socket = new WebSocket(url);
+    this.ws = socket;
 
-    this.ws.onopen = () => {
+    socket.onopen = () => {
+      if (this.ws !== socket) return;
       const token = this.apiToken;
       if (token && this.ws?.readyState === WebSocket.OPEN) {
         this.ws.send(JSON.stringify({ type: "auth", token }));
@@ -1802,7 +1807,8 @@ export class ElizaClient {
       }
     };
 
-    this.ws.onmessage = (event) => {
+    socket.onmessage = (event) => {
+      if (this.ws !== socket) return;
       try {
         const data = JSON.parse(event.data as string) as Record<
           string,
@@ -1815,7 +1821,8 @@ export class ElizaClient {
       }
     };
 
-    this.ws.onclose = () => {
+    socket.onclose = () => {
+      if (this.ws !== socket) return;
       this.ws = null;
       // Track disconnection time if not already set
       if (this.disconnectedAt === null) {
@@ -1847,7 +1854,8 @@ export class ElizaClient {
       this.scheduleReconnect();
     };
 
-    this.ws.onerror = () => {
+    socket.onerror = () => {
+      if (this.ws !== socket) return;
       // close handler will fire
     };
   }
@@ -2116,8 +2124,19 @@ export class ElizaClient {
       this.networkStatusUnsubscribe();
       this.networkStatusUnsubscribe = null;
     }
-    this.ws?.close();
-    this.ws = null;
+    const socket = this.ws;
+    if (socket) {
+      socket.onopen = null;
+      socket.onclose = null;
+      socket.onerror = null;
+      socket.onmessage = null;
+      try {
+        socket.close();
+      } catch {
+        // error-policy:J6 intentional teardown of an already-closing socket.
+      }
+      if (this.ws === socket) this.ws = null;
+    }
     this.wsSendQueue = [];
     this.wsEventBacklog.clear();
     // Reset connection state on intentional disconnect

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.ts
@@ -14,6 +14,7 @@ import {
   type StewardNonceExchangeResponse,
   StewardSessionError,
 } from "@elizaos/shared/steward-session-client";
+import { dispatchStewardSessionChange } from "../../../events/steward-session-event";
 import { ELIZA_CLOUD_DIRECT_API_BY_HOST } from "../../shell/steward-url";
 
 export function resolveStewardAuthEndpoint(
@@ -73,6 +74,7 @@ export async function syncStewardSessionCookie(
   }
 
   if (typeof window !== "undefined") {
+    dispatchStewardSessionChange("present");
     window.dispatchEvent(
       new CustomEvent("steward-token-sync", { detail: { token } }),
     );
@@ -256,6 +258,7 @@ async function clearRejectedCookieSession(): Promise<void> {
     );
   }
   clearStoredStewardToken();
+  dispatchStewardSessionChange("cleared");
 }
 
 /**

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -31,6 +31,7 @@ import {
   useMemo,
   useRef,
 } from "react";
+import { dispatchStewardSessionChange } from "../../events/steward-session-event";
 import { scrubPersistedAgentProfileTokens } from "../../state/agent-profiles";
 import { scrubPersistedActiveServerToken } from "../../state/persistence";
 import { reportRendererDiagnostic } from "../../utils/renderer-diagnostics";
@@ -125,6 +126,7 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
       })
         .then(async (res) => {
           if (res.ok) {
+            dispatchStewardSessionChange("present");
             window.dispatchEvent(
               new CustomEvent("steward-token-sync", {
                 detail: { token, userId: user?.id },
@@ -233,6 +235,7 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
               writeStoredStewardToken(body.token);
               lastSyncedToken.current = body.token;
               wasAuthenticated.current = true;
+              dispatchStewardSessionChange("present");
             }
             try {
               window.dispatchEvent(new CustomEvent("steward-token-sync"));

--- a/packages/ui/src/cloud/shell/StewardProviderShared.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.ts
@@ -9,6 +9,7 @@ import {
   STEWARD_TOKEN_KEY,
 } from "@elizaos/shared/steward-session-client";
 import { createContext } from "react";
+import { dispatchStewardSessionChange } from "../../events/steward-session-event";
 import { scrubPersistedAgentProfileTokens } from "../../state/agent-profiles";
 import { scrubPersistedActiveServerToken } from "../../state/persistence";
 import { decodeJwtPayload } from "../lib/jwt";
@@ -176,6 +177,7 @@ export function clearStaleStewardSession(): void {
   scrubPersistedActiveServerToken();
   scrubPersistedAgentProfileTokens();
   clearServerStewardSessionCookies();
+  dispatchStewardSessionChange("cleared");
   try {
     window.dispatchEvent(new CustomEvent("steward-token-sync"));
   } catch {

--- a/packages/ui/src/events/steward-session-event.ts
+++ b/packages/ui/src/events/steward-session-event.ts
@@ -1,0 +1,22 @@
+/** Publishes typed Steward session transitions without exposing credentials. */
+
+export const STEWARD_SESSION_CHANGE_EVENT = "steward-session-change";
+
+export interface StewardSessionChangeDetail {
+  state: "present" | "cleared";
+  sessionEpoch: number;
+}
+
+let sessionEpoch = 0;
+
+export function dispatchStewardSessionChange(
+  state: StewardSessionChangeDetail["state"],
+): void {
+  if (typeof window === "undefined") return;
+  sessionEpoch += 1;
+  window.dispatchEvent(
+    new CustomEvent<StewardSessionChangeDetail>(STEWARD_SESSION_CHANGE_EVENT, {
+      detail: { state, sessionEpoch },
+    }),
+  );
+}

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -9,6 +9,20 @@
 import type { AgentNotification } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "../../api/client-types-core";
+import {
+  STEWARD_SESSION_CHANGE_EVENT,
+  type StewardSessionChangeDetail,
+} from "../../events/steward-session-event";
+
+let stewardSessionEpoch = 0;
+function publishStewardSession(state: "present" | "cleared"): void {
+  stewardSessionEpoch += 1;
+  window.dispatchEvent(
+    new CustomEvent<StewardSessionChangeDetail>(STEWARD_SESSION_CHANGE_EVENT, {
+      detail: { state, sessionEpoch: stewardSessionEpoch },
+    }),
+  );
+}
 
 const listNotifications = vi.fn();
 const markNotificationReadApi = vi.fn();
@@ -787,15 +801,17 @@ describe("notification-store", () => {
     expect(__getStateForTests().unreadCount).toBe(1);
   });
 
-  it("restores an entire producer batch when one delete rejects", async () => {
+  it("restores only the failed member of a partially successful producer batch", async () => {
     removeNotificationApi
       .mockResolvedValueOnce({ ok: true })
       .mockRejectedValueOnce(new Error("network"));
     __ingestNotificationForTests(makeNotification({ id: "batch-1" }), 1);
     __ingestNotificationForTests(makeNotification({ id: "batch-2" }), 2);
     await removeNotifications(["batch-1", "batch-2"]);
-    expect(__getStateForTests().notifications).toHaveLength(2);
-    expect(__getStateForTests().unreadCount).toBe(2);
+    expect(__getStateForTests().notifications.map((n) => n.id)).toEqual([
+      "batch-2",
+    ]);
+    expect(__getStateForTests().unreadCount).toBe(1);
   });
 
   it("restores the inbox when clear rejects", async () => {
@@ -1158,8 +1174,7 @@ describe("notification-store — authority isolation (#18391)", () => {
     initNotifications();
     await vi.waitFor(() => expect(listNotifications).toHaveBeenCalledTimes(1));
 
-    hasToken.mockReturnValue(false);
-    window.dispatchEvent(new Event("steward-token-sync"));
+    publishStewardSession("cleared");
     expect(rotateConnection).toHaveBeenCalledTimes(1);
   });
 
@@ -1185,8 +1200,7 @@ describe("notification-store — authority isolation (#18391)", () => {
       // updated yet — this is exactly the gap useAuthStatus leaves open.
       // Invalidation deliberately does not fetch (identity is unknown), so
       // no response needs to be queued for it.
-      hasToken.mockReturnValue(false);
-      window.dispatchEvent(new Event("steward-token-sync"));
+      publishStewardSession("cleared");
 
       // Synchronous: no await before this assertion.
       expect(__getStateForTests().notifications).toHaveLength(0);
@@ -1213,8 +1227,7 @@ describe("notification-store — authority isolation (#18391)", () => {
       await vi.waitFor(() => expect(agentEventHandlers()).toHaveLength(1));
       const handlerA = agentEventHandlers()[0];
 
-      hasToken.mockReturnValue(false);
-      window.dispatchEvent(new Event("steward-token-sync"));
+      publishStewardSession("cleared");
 
       handlerA({
         stream: "notification",
@@ -1244,8 +1257,7 @@ describe("notification-store — authority isolation (#18391)", () => {
       );
       rotateConnection.mockClear();
 
-      hasToken.mockReturnValue(true);
-      window.dispatchEvent(new Event("steward-token-sync"));
+      publishStewardSession("present");
       await Promise.resolve();
 
       // No extra clear/refetch/rotation beyond what the base change already did.
@@ -1283,6 +1295,7 @@ describe("notification-store mutations — authority-scoped rollback (#18542)", 
     rotateConnection.mockReset();
     markNotificationReadApi.mockReset();
     invokeDesktopBridgeRequest.mockReset().mockResolvedValue(null);
+    stewardSessionEpoch = 0;
   });
 
   afterEach(() => {
@@ -1346,5 +1359,71 @@ describe("notification-store mutations — authority-scoped rollback (#18542)", 
     await markNotificationRead("a-row");
 
     expect(__getStateForTests().notifications[0]?.readAt).toBeNull();
+  });
+
+  it("does not let an older failed mutation erase a newer confirmed mutation", async () => {
+    __setAuthStatusForTests(authenticated("user-a", "session-a"));
+    const notif = makeNotification({ id: "same-row", readAt: null });
+    listNotifications.mockResolvedValueOnce({
+      notifications: [notif],
+      unreadCount: 1,
+    });
+    initNotifications();
+    await vi.waitFor(() =>
+      expect(__getStateForTests().notifications).toHaveLength(1),
+    );
+
+    let rejectFirst!: (error: unknown) => void;
+    markNotificationReadApi
+      .mockReturnValueOnce(
+        new Promise((_resolve, reject) => {
+          rejectFirst = reject;
+        }),
+      )
+      .mockResolvedValueOnce({ ok: true });
+    const first = markNotificationRead("same-row");
+    await markNotificationRead("same-row");
+    rejectFirst(new Error("late failure"));
+    await first;
+
+    expect(__getStateForTests().notifications[0]?.readAt).not.toBeNull();
+  });
+
+  it("discards a rollback after an A-to-X-to-A authority round trip", async () => {
+    __setAuthStatusForTests(authenticated("user-a", "session-a"));
+    const original = makeNotification({ id: "a-row", readAt: null });
+    listNotifications.mockResolvedValueOnce({
+      notifications: [original],
+      unreadCount: 1,
+    });
+    initNotifications();
+    await vi.waitFor(() =>
+      expect(__getStateForTests().notifications).toHaveLength(1),
+    );
+    let rejectMutation!: (error: unknown) => void;
+    markNotificationReadApi.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectMutation = reject;
+      }),
+    );
+    const mutation = markNotificationRead("a-row");
+
+    listNotifications
+      .mockResolvedValueOnce({ notifications: [], unreadCount: 0 })
+      .mockResolvedValueOnce({
+        notifications: [{ ...original, title: "fresh A" }],
+        unreadCount: 1,
+      });
+    __setAuthStatusForTests(authenticated("user-x", "session-x"));
+    await vi.waitFor(() =>
+      expect(__getStateForTests().notifications).toHaveLength(0),
+    );
+    __setAuthStatusForTests(authenticated("user-a", "session-a"));
+    await vi.waitFor(() =>
+      expect(__getStateForTests().notifications[0]?.title).toBe("fresh A"),
+    );
+    rejectMutation(new Error("late failure"));
+    await mutation;
+    expect(__getStateForTests().notifications[0]?.title).toBe("fresh A");
   });
 });

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -30,6 +30,10 @@ import {
 } from "../../bridge/native-notifications";
 import { APP_RESUME_EVENT } from "../../events";
 import {
+  STEWARD_SESSION_CHANGE_EVENT,
+  type StewardSessionChangeDetail,
+} from "../../events/steward-session-event";
+import {
   type AuthStatusState,
   getAuthStatusSnapshot,
   isAuthenticatedNow,
@@ -99,6 +103,10 @@ let currentAuthorityKey: string | null = null;
 // base switch (already handled by client.onBaseUrlChange's own transport
 // teardown) — see reconcileAuthority (#18542).
 let currentAuthorityBaseUrl: string | null = null;
+let authorityEpoch = 0;
+let lastStewardSessionEpoch = 0;
+let mutationRevision = 0;
+const notificationMutationRevisions = new Map<string, number>();
 // Unsubscribes the currently-bound live WS notification handler; rebound on
 // every authority change so a handler closure from a superseded authority can
 // never reach ingest(), even if a message is somehow still in flight.
@@ -410,6 +418,8 @@ function isAnonAuthorityKey(key: string | null): boolean {
  *  authority. Shared by {@link reconcileAuthority} and {@link
  *  invalidateAuthorityForCredentialChange} (#18542). */
 function clearForAuthorityChange(): void {
+  authorityEpoch += 1;
+  notificationMutationRevisions.clear();
   if (hydrationRetryTimer) {
     clearTimeout(hydrationRetryTimer);
     hydrationRetryTimer = null;
@@ -474,23 +484,16 @@ const INVALIDATED_AUTHORITY_KEY = "credential-invalidated";
 
 /**
  * `useAuthStatus` deliberately keeps the previous authenticated snapshot
- * until the async `/api/auth/me` probe resolves, so a real logout is
- * invisible to {@link reconcileAuthority} for the duration of that
- * round-trip — the inbox and live delivery would keep serving the outgoing
- * authority's data (#18542). `client`'s synchronous `steward-token-sync`
- * event fires immediately on any credential change; when it reflects a
- * cleared token (`!client.hasToken()`), that is logout-shaped and cannot wait
- * for the probe, so invalidate to a sentinel that can never equal a real
- * computed key — clearing rows/unread and unbinding live delivery — without
- * hydrating (identity is unknown until the probe's eventual publish runs the
- * real reconcile). A non-empty token (login, refresh, or an agent handoff's
- * repointBaseUrl token swap) is not logout-shaped: recompute from whatever
- * the auth snapshot currently says, which is a no-op if a same-tick base
- * change already reconciled correctly (e.g. the handoff path) and otherwise
- * catches up once the snapshot is fresh.
+ * until the async `/api/auth/me` probe resolves. The typed Steward session
+ * event distinguishes a real clear from login/refresh without consulting the
+ * unrelated Eliza API bearer. A clear invalidates synchronously; a present
+ * transition reconciles against the latest typed auth snapshot.
  */
-function onCredentialSync(): void {
-  if (client.hasToken()) {
+function onStewardSessionChange(event: Event): void {
+  const detail = (event as CustomEvent<StewardSessionChangeDetail>).detail;
+  if (!detail || detail.sessionEpoch <= lastStewardSessionEpoch) return;
+  lastStewardSessionEpoch = detail.sessionEpoch;
+  if (detail.state === "present") {
     reconcileAuthority(getAuthStatusSnapshot());
     return;
   }
@@ -711,9 +714,15 @@ export function initNotifications(): void {
     client.onBaseUrlChange(() => reconcileAuthority(getAuthStatusSnapshot())),
   );
   if (typeof window !== "undefined") {
-    window.addEventListener("steward-token-sync", onCredentialSync);
+    window.addEventListener(
+      STEWARD_SESSION_CHANGE_EVENT,
+      onStewardSessionChange,
+    );
     notificationCleanups.push(() =>
-      window.removeEventListener("steward-token-sync", onCredentialSync),
+      window.removeEventListener(
+        STEWARD_SESSION_CHANGE_EVENT,
+        onStewardSessionChange,
+      ),
     );
     const retryOnline = () => void retryNotificationHydration();
     window.addEventListener("online", retryOnline);
@@ -770,11 +779,29 @@ export async function seedDevNotificationsIfEmpty(): Promise<void> {
  *  recognize its snapshot is stale (#18542). */
 interface MutationSnapshot {
   authorityKey: string | null;
-  state: NotificationState;
+  authorityEpoch: number;
+  originals: Map<string, AgentNotification>;
+  revisions: Map<string, number>;
 }
 
-function snapshotForMutation(): MutationSnapshot {
-  return { authorityKey: currentAuthorityKey, state };
+function snapshotForMutation(ids: readonly string[]): MutationSnapshot {
+  const originals = new Map(
+    state.notifications
+      .filter((notification) => ids.includes(notification.id))
+      .map((notification) => [notification.id, notification]),
+  );
+  const revisions = new Map<string, number>();
+  for (const id of ids) {
+    mutationRevision += 1;
+    notificationMutationRevisions.set(id, mutationRevision);
+    revisions.set(id, mutationRevision);
+  }
+  return {
+    authorityKey: currentAuthorityKey,
+    authorityEpoch,
+    originals,
+    revisions,
+  };
 }
 
 /**
@@ -793,23 +820,39 @@ function revertMutation(
   snapshot: MutationSnapshot,
   op: string,
   err: unknown,
+  ids: readonly string[] = [...snapshot.originals.keys()],
 ): void {
-  if (snapshot.authorityKey !== currentAuthorityKey) {
+  if (
+    snapshot.authorityKey !== currentAuthorityKey ||
+    snapshot.authorityEpoch !== authorityEpoch
+  ) {
     logger.warn(
       { err },
       `[notification-store] ${op} failed after an authority switch; stale rollback discarded`,
     );
     return;
   }
-  setState({
-    notifications: snapshot.state.notifications,
-    unreadCount: snapshot.state.unreadCount,
-  });
+  const restoreIds = ids.filter(
+    (id) =>
+      snapshot.revisions.get(id) === notificationMutationRevisions.get(id),
+  );
+  if (restoreIds.length > 0) {
+    const restoreSet = new Set(restoreIds);
+    const restored = state.notifications.filter(
+      (notification) => !restoreSet.has(notification.id),
+    );
+    for (const id of restoreIds) {
+      const original = snapshot.originals.get(id);
+      if (original) restored.push(original);
+    }
+    restored.sort((a, b) => b.createdAt - a.createdAt);
+    setState({ notifications: restored, unreadCount: countUnread(restored) });
+  }
   logger.error({ err }, `[notification-store] ${op} failed; reverted`);
 }
 
 export async function markNotificationRead(id: string): Promise<void> {
-  const snapshot = snapshotForMutation();
+  const snapshot = snapshotForMutation([id]);
   const now = Date.now();
   const notifications = state.notifications.map((n) =>
     n.id === id && !n.readAt ? { ...n, readAt: now } : n,
@@ -823,7 +866,7 @@ export async function markNotificationRead(id: string): Promise<void> {
 }
 
 export async function markAllNotificationsRead(): Promise<void> {
-  const snapshot = snapshotForMutation();
+  const snapshot = snapshotForMutation(state.notifications.map((n) => n.id));
   const now = Date.now();
   const notifications = state.notifications.map((n) =>
     n.readAt ? n : { ...n, readAt: now },
@@ -837,7 +880,7 @@ export async function markAllNotificationsRead(): Promise<void> {
 }
 
 export async function removeNotification(id: string): Promise<void> {
-  const snapshot = snapshotForMutation();
+  const snapshot = snapshotForMutation([id]);
   const notifications = state.notifications.filter((n) => n.id !== id);
   setState({ notifications, unreadCount: countUnread(notifications) });
   if (ephemeralNotificationIds.delete(id)) return;
@@ -854,28 +897,32 @@ export async function removeNotifications(
 ): Promise<void> {
   if (ids.length === 0) return;
   const idSet = new Set(ids);
-  const snapshot = snapshotForMutation();
+  const snapshot = snapshotForMutation(ids);
   const notifications = state.notifications.filter((n) => !idSet.has(n.id));
   setState({ notifications, unreadCount: countUnread(notifications) });
   const ephemeralIds = ids.filter((id) => ephemeralNotificationIds.delete(id));
   const ephemeralIdSet = new Set(ephemeralIds);
   const persistedIds = ids.filter((id) => !ephemeralIdSet.has(id));
   if (persistedIds.length === 0) return;
-  try {
-    await Promise.all(persistedIds.map((id) => client.removeNotification(id)));
-  } catch (err) {
-    // Re-adding these ephemeral IDs into a superseded authority's set would
-    // let its stray local-only rows resurface under the new authority — only
-    // restore them when the authority that owned them is still current.
-    if (snapshot.authorityKey === currentAuthorityKey) {
-      for (const id of ephemeralIds) ephemeralNotificationIds.add(id);
-    }
-    revertMutation(snapshot, "removeNotifications", err);
+  const results = await Promise.allSettled(
+    persistedIds.map((id) => client.removeNotification(id)),
+  );
+  const failedIds = persistedIds.filter(
+    (_id, index) => results[index]?.status === "rejected",
+  );
+  if (failedIds.length > 0) {
+    const errors = results
+      .filter(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      )
+      .map((result) => result.reason);
+    revertMutation(snapshot, "removeNotifications", errors, failedIds);
   }
 }
 
 export async function clearNotifications(): Promise<void> {
-  const snapshot = snapshotForMutation();
+  const snapshot = snapshotForMutation(state.notifications.map((n) => n.id));
   const previousEphemeralIds = [...ephemeralNotificationIds];
   setState({ notifications: [], unreadCount: 0 });
   ephemeralNotificationIds.clear();
@@ -914,6 +961,10 @@ export function __resetNotificationStoreForTests(): void {
   hydrationReadinessDeadlineAt = 0;
   currentAuthorityKey = null;
   currentAuthorityBaseUrl = null;
+  authorityEpoch = 0;
+  lastStewardSessionEpoch = 0;
+  mutationRevision = 0;
+  notificationMutationRevisions.clear();
   notificationEventUnsub?.();
   notificationEventUnsub = null;
   liveEventRevision = 0;


### PR DESCRIPTION
## Summary

- replace ambiguous Steward token-sync inference with typed `present` / `cleared` session transitions and monotonic session epochs
- fence WebSocket callbacks to their originating socket, detach handlers before close, and rotate an anonymous open socket when credentials change
- make notification rollback authority-epoch and per-item-revision aware so a late failure cannot erase a newer successful mutation
- settle batch deletes independently and restore only the persisted IDs whose requests failed

Fixes #18747. Follow-up to #18550 and the post-merge review findings documented in the issue.

## Local verification

- `bun test packages/ui/src/state/notifications/notification-store.test.ts packages/ui/src/api/client-base-websocket.test.ts` — 86/86 passed
- `bun run --cwd packages/ui test` — passed
- `bun run --cwd packages/ui typecheck` — passed
- `bun run --cwd packages/ui lint:check` — passed (8 pre-existing `noDocumentCookie` warnings)
- `bun run --cwd packages/ui build` — passed; 46 runtime exports verified
- `bun run verify` — passed; 350/350 workspace tasks, exit 0

## Evidence

| Evidence | Result |
| --- | --- |
| Before screenshots | N/A — state and transport behavior has no rendered UI delta. |
| After screenshots | N/A — state and transport behavior has no rendered UI delta. |
| Walkthrough video | N/A — deterministic non-visual store and WebSocket contracts. |
| Backend logs | N/A — client-side UI state and transport only. |
| Frontend console/network logs | Focused Vitest regressions passed 86/86; full UI test lane passed. |
| Live-model trajectory | N/A — no agent/model behavior changed. |
| Domain artifact | Deterministic notification snapshots and FakeWebSocket assertions cover stale-socket delivery, authenticated reconnect, interleaved mutation failure, partial batch failure, and A→X→A authority changes. |

<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZVM3QS3C8VH4PMRFZ0QR1Q5","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T18:35:17.155Z","completed_at":"2026-08-12T19:23:40.879Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":197700,"output_tokens":16043,"cache_creation_tokens":0,"cache_read_tokens":15822592,"total_tokens":16036335,"cost_micro_usd":"9381086","session_count":1},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEABGe4fV_PPi4aKX7l-LF2u0-A5ZUoJEgkLr-PwrXlgEw","device_key_id":"1ef5dc9a7ed9b85d08d30f10597a4600d5dbd4eff9254abeefd0722c483dc368","device_signature":"wLckEQV0wkripWWR05SDNuvMagFxy3ST4ihgo3Gx2saivOA_OFXo3dJKYgGikul87VBaYZYz3ZB8tcFNKBGlDA"}} -->
