### PR TITLE
fix(cloud): validate runtime lifecycle timeout

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/runtime/lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/runtime/lifecycle.test.ts
@@ -1,0 +1,139 @@
+/** Verifies hosted runtime stop/close deadlines use strict, timer-safe overrides. */
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { elizaLogger } from "@elizaos/core";
+import { runWithLifecycleTimeout } from "./lifecycle";
+
+const originalTimeout = process.env.RUNTIME_LIFECYCLE_TIMEOUT_MS;
+const nativeSetTimeout = globalThis.setTimeout;
+const nativeClearTimeout = globalThis.clearTimeout;
+
+afterEach(() => {
+  globalThis.setTimeout = nativeSetTimeout;
+  globalThis.clearTimeout = nativeClearTimeout;
+  if (originalTimeout === undefined) {
+    delete process.env.RUNTIME_LIFECYCLE_TIMEOUT_MS;
+  } else {
+    process.env.RUNTIME_LIFECYCLE_TIMEOUT_MS = originalTimeout;
+  }
+});
+
+function captureScheduledDelay(value: string | undefined): {
+  delay: number;
+  cleared: boolean;
+  fire: () => void;
+} {
+  if (value === undefined) {
+    delete process.env.RUNTIME_LIFECYCLE_TIMEOUT_MS;
+  } else {
+    process.env.RUNTIME_LIFECYCLE_TIMEOUT_MS = value;
+  }
+
+  let scheduledDelay: number | undefined;
+  let scheduledCallback: (() => void) | undefined;
+  let cleared = false;
+  const handle = { unref: () => {} } as unknown as ReturnType<typeof setTimeout>;
+  globalThis.setTimeout = ((callback: (...args: unknown[]) => void, delay?: number) => {
+    scheduledDelay = delay;
+    scheduledCallback = () => callback();
+    return handle;
+  }) as typeof setTimeout;
+  globalThis.clearTimeout = ((timer: ReturnType<typeof setTimeout>) => {
+    if (timer === handle) cleared = true;
+  }) as typeof clearTimeout;
+
+  return {
+    get delay() {
+      if (scheduledDelay === undefined) throw new Error("timeout was not scheduled");
+      return scheduledDelay;
+    },
+    get cleared() {
+      return cleared;
+    },
+    fire() {
+      if (!scheduledCallback) throw new Error("timeout was not scheduled");
+      scheduledCallback();
+    },
+  };
+}
+
+describe("runWithLifecycleTimeout", () => {
+  test.each([
+    ["1", 1],
+    [" 25 ", 25],
+    ["10000", 10_000],
+    ["2147483647", 2_147_483_647],
+  ])("uses timer-safe positive integer override %s", async (value, expected) => {
+    const observation = captureScheduledDelay(value);
+    await runWithLifecycleTimeout(Promise.resolve(), "Stop", "RuntimeCache", "agent-1");
+
+    expect(observation.delay).toBe(expected);
+    expect(observation.cleared).toBe(true);
+  });
+
+  test.each([
+    ["unset", undefined],
+    ["empty", ""],
+    ["whitespace", "   "],
+    ["zero", "0"],
+    ["negative", "-1"],
+    ["signed", "+1"],
+    ["fractional", "1.5"],
+    ["scientific", "1e3"],
+    ["suffix", "25ms"],
+    ["NaN", "NaN"],
+    ["Infinity", "Infinity"],
+    ["timer overflow", "2147483648"],
+    ["unsafe integer", "9007199254740992"],
+  ])("uses the default for invalid override: %s", async (_label, value) => {
+    const observation = captureScheduledDelay(value);
+    await runWithLifecycleTimeout(Promise.resolve(), "Close", "DbAdapterPool", "agent-2");
+
+    expect(observation.delay).toBe(10_000);
+    expect(observation.cleared).toBe(true);
+  });
+
+  test("bounds a never-settling operation and logs the exact configured deadline", async () => {
+    process.env.RUNTIME_LIFECYCLE_TIMEOUT_MS = "10";
+    const warning = spyOn(elizaLogger, "warn").mockImplementation(() => {});
+
+    try {
+      await runWithLifecycleTimeout(
+        new Promise<void>(() => {}),
+        "Stop",
+        "RuntimeCache",
+        "agent-timeout",
+      );
+
+      expect(warning).toHaveBeenCalledWith(
+        "[RuntimeCache] Stop timed out after 10ms for agent-timeout",
+      );
+    } finally {
+      warning.mockRestore();
+    }
+  });
+
+  test.each(["5ms", "2147483648"])(
+    "does not fire at the permissively parsed prefix for invalid override %s",
+    async (value) => {
+      process.env.RUNTIME_LIFECYCLE_TIMEOUT_MS = value;
+      let resolveOperation: (() => void) | undefined;
+      let lifecycleSettled = false;
+      const operation = new Promise<void>((resolve) => {
+        resolveOperation = resolve;
+      });
+      const lifecycle = runWithLifecycleTimeout(
+        operation,
+        "Close",
+        "DbAdapterPool",
+        "agent-real-timer",
+      ).then(() => {
+        lifecycleSettled = true;
+      });
+
+      await new Promise<void>((resolve) => nativeSetTimeout(resolve, 50));
+      expect(lifecycleSettled).toBe(false);
+      resolveOperation?.();
+      await lifecycle;
+    },
+  );
+});

--- a/packages/cloud/shared/src/lib/eliza/runtime/lifecycle.ts
+++ b/packages/cloud/shared/src/lib/eliza/runtime/lifecycle.ts
@@ -1,11 +1,14 @@
 // Wires hosted Eliza agent lifecycle behavior for cloud runtime services.
 import { type AgentRuntime, elizaLogger } from "@elizaos/core";
+import { parsePositiveInteger } from "@elizaos/shared/utils/number-parsing";
 
 const DEFAULT_RUNTIME_LIFECYCLE_TIMEOUT_MS = 10_000;
+// Node coerces larger setTimeout delays to 1 ms and emits an overflow warning.
+const MAX_NODE_TIMEOUT_MS = 2_147_483_647;
 
 function getRuntimeLifecycleTimeoutMs(): number {
-  const configured = Number.parseInt(process.env.RUNTIME_LIFECYCLE_TIMEOUT_MS ?? "", 10);
-  return Number.isFinite(configured) && configured > 0
+  const configured = parsePositiveInteger(process.env.RUNTIME_LIFECYCLE_TIMEOUT_MS);
+  return configured !== undefined && configured <= MAX_NODE_TIMEOUT_MS
     ? configured
     : DEFAULT_RUNTIME_LIFECYCLE_TIMEOUT_MS;
 }


### PR DESCRIPTION
# Relates to

Fixes #18748

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after the final sync.
- [x] A reviewer can confirm the behavior without reading the implementation from
      the exact-head base/head scheduler transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@ebcf7fff1bc672b72f11ffed2d0b6c36c1318478`; zero conflicts.
- [x] `bun run verify` passes post-sync on Node 24.15.0 / Bun 1.3.14.

# Risks

Low. This tightens one operational environment-variable parser. Existing valid
integer values remain unchanged; malformed, unsafe, and Node timer-overflow
values retain the existing 10,000 ms fallback. No schema, persistence, network,
authentication, provider, or UI surface changes.

# Background

## What does this PR do?

It replaces permissive `parseInt` handling for
`RUNTIME_LIFECYCLE_TIMEOUT_MS` with the shared strict positive-integer parser
and rejects values above Node's 2,147,483,647 ms timer ceiling. This prevents
inputs such as `25ms`, `1e3`, and `2147483648` from scheduling 25 ms, 1 ms, or
an overflow-coerced 1 ms lifecycle deadline.

The regression suite exercises the production scheduler, exact boundaries,
timer cleanup, a real never-settling timeout, and real-timer cases proving
malformed prefixes and overflow values do not fire early.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project-documentation change is needed. The source comment records the Node
timer ceiling, and #18748 documents the override policy and operational impact.

# Testing

## Where should a reviewer start?

- `packages/cloud/shared/src/lib/eliza/runtime/lifecycle.ts`
- `packages/cloud/shared/src/lib/eliza/runtime/lifecycle.test.ts`

## Detailed testing steps

Final-synced verification used Node 24.15.0 and Bun 1.3.14:

- `bun install --frozen-lockfile` — passed; lockfile unchanged.
- linked-workspace build — 56/56 passed.
- focused lifecycle suite — 20 passed, 0 failed.
- shared number-parser suite — 6 passed, 0 failed.
- `bun run --cwd packages/cloud/shared lint:check` — passed (1,849 files).
- `bun run --cwd packages/cloud/shared typecheck` — passed.
- full `packages/cloud/shared` test matrix — 162/162 batches passed.
- `bun run verify` — passed.
- exact-file Biome and `git diff HEAD^..HEAD --check` — passed.

# Evidence Gate

<!-- evidence-head:6005570f51baa3d217f3e8a96f8d6db9c7928eea -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend-only cloud runtime timeout parsing; no rendered UI surface changed.`

<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend-only cloud runtime timeout parsing; no rendered UI surface changed.`

<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no interactive or rendered user flow changed.`

<!-- evidence-row:backend-logs -->
- [x] Exact committed base/head scheduler output and native Node 24 overflow behavior are pasted below.

<details>
<summary>Exact-head backend scheduler transcript (JSONL)</summary>

```jsonl
{"record":"metadata","schema":"eliza-runtime-lifecycle-timeout/v1","baseSha":"ebcf7fff1bc672b72f11ffed2d0b6c36c1318478","headSha":"6005570f51baa3d217f3e8a96f8d6db9c7928eea","node":"v24.15.0","bun":"1.3.14","execution":"exact committed lifecycle blobs with real workspace imports; timer handle instrumented for requested delay/unref/clear; native Node record proves effective overflow"}
{"record":"production-scheduler","variant":"base","sourceSha":"ebcf7fff1bc672b72f11ffed2d0b6c36c1318478","cases":[{"input":"<unset>","scheduledDelay":10000,"unrefCalled":true,"cleared":true},{"input":"25","scheduledDelay":25,"unrefCalled":true,"cleared":true},{"input":" 25 ","scheduledDelay":25,"unrefCalled":true,"cleared":true},{"input":"25ms","scheduledDelay":25,"unrefCalled":true,"cleared":true},{"input":"1e3","scheduledDelay":1,"unrefCalled":true,"cleared":true},{"input":"+1","scheduledDelay":1,"unrefCalled":true,"cleared":true},{"input":"1.5","scheduledDelay":1,"unrefCalled":true,"cleared":true},{"input":"2147483647","scheduledDelay":2147483647,"unrefCalled":true,"cleared":true},{"input":"2147483648","scheduledDelay":2147483648,"unrefCalled":true,"cleared":true},{"input":"9007199254740992","scheduledDelay":9007199254740992,"unrefCalled":true,"cleared":true}]}
{"record":"production-scheduler","variant":"head","sourceSha":"6005570f51baa3d217f3e8a96f8d6db9c7928eea","cases":[{"input":"<unset>","scheduledDelay":10000,"unrefCalled":true,"cleared":true},{"input":"25","scheduledDelay":25,"unrefCalled":true,"cleared":true},{"input":" 25 ","scheduledDelay":25,"unrefCalled":true,"cleared":true},{"input":"25ms","scheduledDelay":10000,"unrefCalled":true,"cleared":true},{"input":"1e3","scheduledDelay":10000,"unrefCalled":true,"cleared":true},{"input":"+1","scheduledDelay":10000,"unrefCalled":true,"cleared":true},{"input":"1.5","scheduledDelay":10000,"unrefCalled":true,"cleared":true},{"input":"2147483647","scheduledDelay":2147483647,"unrefCalled":true,"cleared":true},{"input":"2147483648","scheduledDelay":10000,"unrefCalled":true,"cleared":true},{"input":"9007199254740992","scheduledDelay":10000,"unrefCalled":true,"cleared":true}]}
{"record":"node-overflow-boundary","node":"v24.15.0","requested":2147483648,"effective":1,"warnings":[{"name":"TimeoutOverflowWarning","message":"2147483648 does not fit into a 32-bit signed integer. Timeout duration was set to 1.","code":null}]}
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request, network, or rendered state path changed.`

<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model behavior changed.`

<!-- evidence-row:domain-artifacts -->
- [x] Exact-head base/head lifecycle-timeout matrix:
      ![Base/head runtime lifecycle timeout matrix](https://github.com/user-attachments/assets/f8730fe3-37bf-4206-8a23-b90256880670)
      (source PNG SHA-256: `99277ed483076e2d452ec6d8b3fa102a74100efcf9ea39c4ab168bf96b4e7eee`).

<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered product UI surface changed.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt, or model behavior changed.`

## Backend + frontend logs

The backend transcript above executes the exact committed base and head source
blobs with real workspace imports, instruments only the Node timer handle, and
separately records Node 24's native overflow boundary. Transcript SHA-256:
`d86dd7da071f28499e7abc9041c0d98c4b231c4ed92da9842b1066e666888ada`.

Frontend: `N/A - no frontend surface changed.`

## Screenshots (before / after) + video walkthrough

`N/A - backend-only timer lifecycle change with no rendered or interactive UI.`

## Known gaps / failures

- No deployment was performed; the changed integration boundary is Node's
  timer scheduler, exercised directly on pinned Node 24.15.0.
- The first sandboxed full-suite attempt could not bind localhost (`EPERM`).
  The exact unsandboxed rerun completed all 162/162 cloud-shared batches, and
  the final root `bun run verify` passed.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 62219814 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [marcoworms-runtime-lifecycle-timeout]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZVP0PBJSRPYE8HKSBB95DZT","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T19:08:34.546Z","completed_at":"2026-08-12T19:30:43.086Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":1723751,"output_tokens":107221,"cache_creation_tokens":0,"cache_read_tokens":60388842,"total_tokens":62219814,"cost_micro_usd":"4170367","session_count":12},"trajectory_sha256":"d86dd7da071f28499e7abc9041c0d98c4b231c4ed92da9842b1066e666888ada","signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAWOuFq4QKFpEzUxdS-xUTGOp-_XL5j-TbR18ldYqv818","device_key_id":"27a2bd6f25b7dfbdcd447074ad6ad4d4eff92654605004b081bd547e02c21550","device_signature":"66FY_ZBQBb3qAowy8CdzlccAvRco5h7JjF8aCP6TC5kL1M2gpy0TXC-K_KoDrbWwF-OPh8e-cNyQEFfYhG1gBw"}} -->
