### PR TITLE
fix(security): enforce spawn injection primitives on config.env writes

### DIFF
--- a/packages/agent/src/api/config-env.test.ts
+++ b/packages/agent/src/api/config-env.test.ts
@@ -1,0 +1,122 @@
+/**
+ * `config.env` is the designated escape hatch for sensitive process-env-only
+ * material, so its write gate has to separate two things that look alike:
+ * spawn injection primitives, which must never be persisted, and agent step-up
+ * secrets, which are exactly what this file exists to hold.
+ */
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { persistConfigEnv } from "./config-env.ts";
+
+let stateDir: string;
+let envSnapshot: NodeJS.ProcessEnv;
+
+beforeEach(async () => {
+  stateDir = await mkdtemp(path.join(tmpdir(), "eliza-config-env-"));
+  // persistConfigEnv mirrors every successful write into process.env, so the
+  // accepted-key cases below would otherwise leak keys such as
+  // ELIZA_CAPABILITY_ROUTER_ENABLED into the rest of the worker.
+  envSnapshot = { ...process.env };
+});
+
+afterEach(async () => {
+  await rm(stateDir, { recursive: true, force: true });
+  for (const key of Object.keys(process.env)) {
+    if (!(key in envSnapshot)) delete process.env[key];
+  }
+  Object.assign(process.env, envSnapshot);
+});
+
+describe("persistConfigEnv rejects spawn injection primitives", () => {
+  it.each([
+    // exact keys from the core spawn denylist
+    "GCONV_PATH",
+    "BASH_ENV",
+    "PYTHONPATH",
+    "GIT_SSH_COMMAND",
+    // prefix families, which the previous exact-only list could not express
+    "NPM_CONFIG_REGISTRY",
+    "DOCKER_HOST",
+    "GIT_CONFIG_KEY_0",
+    "BASH_FUNC_EXPLOIT",
+  ])("rejects %s", async (key) => {
+    await expect(persistConfigEnv(key, "x", { stateDir })).rejects.toThrow(
+      /hijack vector/,
+    );
+  });
+
+  it("still rejects the keys this file blocked before, including the two absent from core", async () => {
+    for (const key of [
+      "NODE_OPTIONS",
+      "LD_PRELOAD",
+      "PATH",
+      "DYLD_FALLBACK_FRAMEWORK_PATH",
+      "DYLD_FALLBACK_LIBRARY_PATH",
+    ]) {
+      await expect(persistConfigEnv(key, "x", { stateDir })).rejects.toThrow(
+        /hijack vector/,
+      );
+    }
+  });
+
+  it("rejects malformed keys before consulting either denylist", async () => {
+    await expect(
+      persistConfigEnv("lower_case", "x", { stateDir }),
+    ).rejects.toThrow(/invalid key/);
+  });
+});
+
+describe("persistConfigEnv still writes what config.env exists to hold", () => {
+  it.each([
+    // agent step-up secrets: on BLOCKED_ENV_KEYS for API writes, but this file
+    // is their designated home — cloud-wallet.ts persists the first one here.
+    "ELIZA_CLOUD_CLIENT_ADDRESS_KEY",
+    "ELIZA_CLOUD_EVM_ADDRESS",
+    "ELIZA_CLOUD_SOLANA_ADDRESS",
+    "WALLET_SOURCE_EVM",
+    "WALLET_SOURCE_SOLANA",
+    "ENABLE_CLOUD_WALLET",
+    "ELIZA_CAPABILITY_ROUTER_ENABLED",
+    "ELIZA_CAPABILITY_ROUTER_URLS",
+    "ELIZA_CAPABILITY_ROUTER_TRUST_POLICY",
+  ])("writes %s", async (key) => {
+    await persistConfigEnv(key, "value", { stateDir });
+    const contents = await readFile(path.join(stateDir, "config.env"), "utf8");
+    expect(contents).toContain(`${key}=value`);
+  });
+
+  it.each([
+    // vault-bootstrap scans config.env for keys matching _TOKEN / _API_KEY /
+    // _PRIVATE_KEY and rewrites each as a vault reference *through this
+    // function*. All of these are on the agent's BLOCKED_ENV_KEYS, so gating
+    // on that predicate instead of core's would reject the migration this
+    // bootstrap exists to perform.
+    "ELIZA_API_TOKEN",
+    "EVM_PRIVATE_KEY",
+    "SOLANA_PRIVATE_KEY",
+    "GITHUB_TOKEN",
+    "STEWARD_API_KEY",
+  ])("writes %s so vault-bootstrap can migrate it", async (key) => {
+    await persistConfigEnv(key, "secret", { stateDir });
+    const contents = await readFile(path.join(stateDir, "config.env"), "utf8");
+    expect(contents).toContain(`${key}=secret`);
+  });
+
+  it("allows keys that only look like a blocked family", async () => {
+    for (const key of [
+      "UVICORN_HOST",
+      "DOCKERFILE_PATH",
+      "GIT_CONFIGURATION",
+    ]) {
+      await persistConfigEnv(key, "ok", { stateDir });
+    }
+    const contents = await readFile(path.join(stateDir, "config.env"), "utf8");
+    expect(contents).toContain("UVICORN_HOST=ok");
+    expect(contents).toContain("DOCKERFILE_PATH=ok");
+    expect(contents).toContain("GIT_CONFIGURATION=ok");
+  });
+});

--- a/packages/agent/src/api/config-env.ts
+++ b/packages/agent/src/api/config-env.ts
@@ -29,6 +29,8 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 
+import { isBlockedSpawnEnvKey } from "@elizaos/core";
+
 import { resolveStateDir } from "../config/paths.ts";
 
 const CONFIG_ENV_FILENAME = "config.env";
@@ -42,6 +44,24 @@ const KEY_PATTERN = /^[A-Z][A-Z0-9_]*$/;
  * escape hatch for sensitive process-env-only material. These are
  * shell/runtime hijack vectors — they must never be set from the
  * application layer, regardless of provenance.
+ *
+ * `validateKey` checks this set *in addition to* `isBlockedSpawnEnvKey`,
+ * which carries the core spawn denylist and its prefix families. Two
+ * deliberate choices there:
+ *
+ * 1. It is a union, not a replacement. This list is not a subset of core's:
+ *    `DYLD_FALLBACK_FRAMEWORK_PATH` and `DYLD_FALLBACK_LIBRARY_PATH` are
+ *    blocked here and absent from core, so deferring entirely to the shared
+ *    predicate would silently unblock them.
+ * 2. It uses core's spawn predicate rather than the agent's
+ *    `isBlockedEnvKey`. The agent set is the spawn set plus thirteen agent
+ *    step-up secrets, and those secrets are exactly what `vault-bootstrap`
+ *    migrates *through this function* — it scans `config.env` for keys
+ *    matching `_TOKEN` / `_API_KEY` / `_PRIVATE_KEY` and rewrites each as a
+ *    vault reference. Ten of the thirteen match that heuristic
+ *    (`ELIZA_API_TOKEN`, `EVM_PRIVATE_KEY`, `GITHUB_TOKEN`, ...), so using the
+ *    agent predicate here would reject the very migration the vault bootstrap
+ *    exists to perform. Only injection primitives belong on this gate.
  */
 const BLOCKED_CONFIG_ENV_KEYS: ReadonlySet<string> = new Set([
   "NODE_OPTIONS",
@@ -127,7 +147,7 @@ function validateKey(key: string): void {
       `persistConfigEnv: invalid key "${key}" — must match /^[A-Z][A-Z0-9_]*$/`,
     );
   }
-  if (BLOCKED_CONFIG_ENV_KEYS.has(key)) {
+  if (BLOCKED_CONFIG_ENV_KEYS.has(key) || isBlockedSpawnEnvKey(key)) {
     throw new Error(
       `persistConfigEnv: key "${key}" is a shell/runtime hijack vector and cannot be written`,
     );


### PR DESCRIPTION
# Relates to

Follows up on @Dlordkendex's review of #18439, which flagged that `packages/agent/src/api/config-env.ts` maintains its own exact-only denylist and is not routed through the shared predicate. I said there I would do it in its own PR rather than widen one under review; this is that PR.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` (`f2a915f4`) with zero conflicts.
- [x] `bun install` and `bun run verify` were both run after sync. **`verify` does not complete locally, on a blocker unrelated to this change:** `@elizaos/cloud-api#typecheck` fails with `Cannot find module 'jose'`. `jose` is declared at `packages/cloud/api/package.json:41` but is absent from the local `node_modules`, so this is an install artifact in my environment rather than a repo defect, and it reproduces identically on unmodified `develop`. **135 of 137 turbo stages pass**, including every `audit:*` script, `check:agents-claude`, `check:biome-version`, `check:worker-bundle`, `fix-deps:check` and `ensure-plugin-test-conventions:check`. Per-package typecheck, Biome and focused suites for the changed files are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `f2a915f4`; zero conflicts, zero commits behind at time of writing.
- [x] Focused suites pass post-sync; see **Testing** below.

# Risks

Medium-low, and the risk is over-blocking rather than under-blocking. `validateKey` now rejects more keys, and `persistConfigEnv` throws rather than dropping silently, so a caller that previously succeeded on one of these keys now gets an error.

Two checks were run rather than assumed:

- **Every caller of *this* function still writes.** Worth being precise about which callers those are: the repository contains three files named `config-env.ts`, and **two of them are write gates** — this one and `plugins/plugin-elizacloud/src/lib/config-env.ts`, which carries a byte-identical 21-key `BLOCKED_CONFIG_ENV_KEYS` and its own `persistConfigEnv`. (`plugins/plugin-agent-orchestrator/src/services/config-env.ts` is a read-only helper: no `persistConfigEnv`, no `validateKey`, no denylist.) Enumerating by function name matches both writers; enumerating by import resolves to three real callers of this one:
  - `packages/agent/src/runtime/first-time-setup.ts:28` — four literal keys.
  - `packages/agent/src/api/server.ts:393`, which wires this function into the route context at `:2361`, reaching `remote-capability-routes.ts` — three literal keys.
  - `packages/app-core/src/services/vault-bootstrap.ts:23` — the only caller that does not pass a literal.

  All nine literal keys are asserted to still write, in the tests below. `plugin-elizacloud`'s wallet and cloud routes call *their own* copy and are unaffected by this PR.
- **`vault-bootstrap.ts:209` is the caller that matters.** It iterates keys already present in the on-disk `config.env`, so an existing install whose `config.env` contains a now-blocked injection primitive will throw there. That call sits inside a per-key `try`/`catch` (`vault-bootstrap.ts:207-219`) recording `failed.push(key)`, so the loop continues rather than aborting. Worth being precise about the resulting state: `vault.set()` runs at `:208` *before* `persistConfigEnv` at `:209`, so a throw leaves the secret written to the vault while the plaintext remains in `config.env`, with the key logged as failed. That is a partial migration, not a clean skip. It applies only to keys that are injection primitives *and* match the sensitivity heuristic — an intersection that is empty for every key the heuristic actually targets (`_TOKEN`, `_API_KEY`, `_PRIVATE_KEY`), since none of those is a spawn primitive. This is the one behaviour change existing installs can observe.

# Background

## What does this PR do?

`persistConfigEnv` validated against `BLOCKED_CONFIG_ENV_KEYS`, a 21-key exact-match set local to this file. Exact matching cannot express a namespace, so none of the prefix families reached this gate at all, and several exact primitives the core denylist carries were simply absent:

```
GCONV_PATH           passed        BASH_ENV             passed
PYTHONPATH           passed        GIT_SSH_COMMAND      passed
NPM_CONFIG_REGISTRY  passed        DOCKER_HOST          passed
GIT_CONFIG_KEY_0     passed        BASH_FUNC_EXPLOIT    passed
```

`validateKey` now also consults core's `isBlockedSpawnEnvKey`. Two decisions in that sentence are deliberate and worth stating, because the obvious implementation of the review comment is wrong in both directions:

**1. Union, not replacement.** `BLOCKED_CONFIG_ENV_KEYS` is *not* a subset of core's set — `DYLD_FALLBACK_FRAMEWORK_PATH` and `DYLD_FALLBACK_LIBRARY_PATH` are blocked here and absent from core. Deferring entirely to the shared predicate would have silently unblocked two dyld search-path variables in a PR whose purpose is to tighten this gate. Both are pinned by a test.

**2. Core's spawn predicate, not the agent's `isBlockedEnvKey`.** The agent set is core's spawn set plus thirteen agent step-up secrets. Those secrets are precisely what `vault-bootstrap` migrates *through this function*: it scans `config.env` for keys matching `_TOKEN` / `_API_KEY` / `_PRIVATE_KEY` (`vault-bootstrap.ts:84-88`) and rewrites each as a vault reference via `persistConfigEnv`. Ten of the thirteen match that heuristic:

```
ELIZA_API_TOKEN            EVM_PRIVATE_KEY        STEWARD_API_KEY
ELIZA_WALLET_EXPORT_TOKEN  SOLANA_PRIVATE_KEY     STEWARD_AGENT_TOKEN
ELIZA_TERMINAL_RUN_TOKEN   OPINION_PRIVATE_KEY    OPINION_API_KEY
GITHUB_TOKEN
```

Gating on the agent predicate would therefore reject the exact migration the vault bootstrap exists to perform. This is checkable rather than asserted — swap `isBlockedSpawnEnvKey` for `isBlockedEnvKey` in `validateKey` and six of the tests added here fail:

```
× writes ELIZA_API_TOKEN so vault-bootstrap can migrate it
× writes EVM_PRIVATE_KEY so vault-bootstrap can migrate it
× writes SOLANA_PRIVATE_KEY so vault-bootstrap can migrate it
× writes GITHUB_TOKEN so vault-bootstrap can migrate it
× writes STEWARD_API_KEY so vault-bootstrap can migrate it
× writes ELIZA_CLOUD_CLIENT_ADDRESS_KEY
      Tests  6 failed | 19 passed (25)
```

@Dlordkendex — this is a partial disagreement with the review comment as literally worded. The prefix families and the missing exact primitives are exactly the gap you identified and they are closed here; only the predicate differs, for the reason above. Happy to be told otherwise.

The import is `@elizaos/core` at module scope, matching what `packages/agent/src/config/blocked-env-keys.ts` already does. `packages/core` declares no dependency on `@elizaos/agent`, so the edge is one-way and no import cycle is introduced.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/config-env.ts` — the single changed condition in `validateKey` and the comment recording the two decisions above. Then `config-env.test.ts`, which is new.

## Detailed testing steps

The defect is demonstrated by reverting the source change and re-running the same new tests, not by asserting the fix against itself.

```
new config-env tests                            1 file,  25 passed (25)
same tests, config-env.ts reverted to develop   1 file,  8 failed | 17 passed (25)
same tests, gate swapped to isBlockedEnvKey      1 file,  6 failed | 19 passed (25)

packages/agent/src/api/   (this branch)   4 failed | 1121 passed | 34 skipped (1159)
packages/agent/src/api/   (develop)       4 failed | 1096 passed | 34 skipped (1134)
   -> same 4 pre-existing failures; 1121 - 1096 = 25, exactly the new tests

plugins/plugin-wallet     (this branch)  22 failed | 237 passed (259)
plugins/plugin-wallet     (develop)      22 failed | 237 passed (259)
   -> identical; the wallet callers are unaffected
```

`tsc --noEmit -p packages/agent/tsconfig.json` reports 21 error lines both with and without this change — all pre-existing unresolved-workspace-dependency errors under `src/api/__tests__/`, none in `config-env.ts`. Biome clean on both changed files.

# Known gaps / failures

- **This changes behaviour for existing installs.** A `config.env` that already contains a now-blocked key (say `DOCKER_HOST`, written before this gate existed) will throw on the next write to that key. `vault-bootstrap.ts:209` catches per key and records the failure, so migration degrades rather than aborts, but the key is not silently accepted either. That is the intended posture; flagging it because it is observable.
- **`persistConfigEnv` throws where the sibling gates `continue`.** @isfinne noted on #18439 that the config/API gates drop blocked keys silently and return success. This gate does the opposite — it has always thrown — so the two surfaces remain inconsistent with each other. Aligning them is a separate change and I have not made it here.
- **The test suite restores `process.env`.** `persistConfigEnv` mirrors every accepted write into `process.env` (`config-env.ts:320`), so the accepted-key cases would otherwise leak `ELIZA_CAPABILITY_ROUTER_ENABLED` and eight others into the worker. The suite snapshots and restores around each test; a probe test asserting no key survives is included in the transcript. The agent package uses the `forks` pool, so this could not cross files today — the restore is there so it stays true if the pool changes.
- **`vault-bootstrap.ts:209` is the only caller that does not pass a literal.** It re-persists keys already on disk, so it is the only path where a key of unknown provenance reaches `validateKey`. That is also why it is the only caller whose behaviour can change on an existing install.
- **The same write gate exists twice and this PR hardens one copy.** `plugins/plugin-elizacloud/src/lib/config-env.ts` defines its own `persistConfigEnv`, `KEY_PATTERN` and a byte-identical 21-key `BLOCKED_CONFIG_ENV_KEYS`, so it has exactly the gap fixed here. It is *not* reachable with an attacker-chosen key today — all five of its call sites (`cloud-wallet.ts:140`, `cloud-routes-autonomous.ts:669/677/684/687`) pass string literals — so this is a latent inconsistency rather than a live hole. Aligning it is a separate PR; flagging it so nobody reads this one as closing the class repository-wide.
- **The read path applies `config.env` to `process.env` without consulting any denylist.** `config.ts:237` calls `readConfigEnvSync`, which applies no denylist, and `config.ts:251` hands the result to `applyConfigEnvToProcessEnv`, which skips only unresolved vault sentinels before `process.env[key] = value`. Demonstrated rather than inferred — a hand-written `config.env` parses as:

  ```
  input:  lower_case=1 /  SPACED=2 / LD_PRELOAD=/tmp/evil.so / 9BAD=3 / GOOD_KEY=ok
  parsed: { GOOD_KEY: "ok", LD_PRELOAD: "/tmp/evil.so", SPACED: "2" }
  ```

  `KEY_PATTERN` correctly drops `lower_case` and `9BAD`, but `LD_PRELOAD` passes. So this PR hardens what may be *written* through this function; it does not constrain what an already-present file applies at load. Reaching that needs either a writer passing a non-literal key (none today, per the caller audit) or filesystem write to the state dir, so it is not an exploitable chain as things stand — but the property "only safe keys reach `process.env` from `config.env`" is **not** established by this change and should not be inferred from it.
- **The read and write sides normalise keys differently.** `parseConfigEnv:116` trims the key before testing `KEY_PATTERN`, so a hand-edited ` SPACED=2` is read as `SPACED`; `validateKey` does not trim, so `persistConfigEnv(" SPACED", …)` throws as malformed. A key that can never be written through the gate can therefore exist in the file and be read. This does not widen the surface — an untrimmed `LD_PRELOAD=…` line already parses — but the asymmetry is worth knowing about.
- **Value-driven line injection is not possible**, which was checked rather than assumed: `encodeValue` quotes and escapes `\n` / `\r`, so `persistConfigEnv("SAFE_KEY", "x\nLD_PRELOAD=/tmp/evil.so")` writes a single quoted line and parses back to `["SAFE_KEY"]` alone. The key gate cannot be bypassed through the value.
- **No exploit is claimed for the newly blocked keys on this path.** What is demonstrated is that they previously passed a gate whose stated purpose is to refuse shell/runtime hijack vectors. Whether any of them is reachable with attacker-controlled input through a current caller is a separate question — the caller audit above says no, today.
- **`bun run verify` does not complete locally** on an unmet `jose` dependency in `@elizaos/cloud-api`, unrelated to this change and reproducing on unmodified `develop`. Detailed in the Definition of Done above.

# Evidence

<!-- evidence-head:94047428f95f6381fbe644dc7ad44d3780aa2513 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; this changes one condition in a config-file write gate.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; behaviour is asserted by the new unit tests.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the observable behaviour is accept-or-throw on a key; the revert-and-fail run is the demonstration.
<!-- evidence-row:backend-logs -->
- [x] Full verification transcript inline below: the new tests, the same tests with the source reverted, both suites compared against develop, the typecheck parity, Biome, and the caller-key audit.

<details><summary>Verification at <code>9404742</code> (vitest 4.1.5)</summary>

```
$ vitest run packages/agent/src/api/config-env.test.ts
 Test Files  1 passed (1)
      Tests  25 passed (25)

$ # config-env.ts reverted to unmodified develop, same tests
 Test Files  1 failed (1)
      Tests  8 failed | 17 passed (25)

$ # gate swapped to the agent predicate (isBlockedEnvKey), same tests
      Tests  6 failed | 19 passed (25)   <- why this PR uses core's predicate

$ # process.env leak check: config-env suite + a probe asserting no keys survive
      Tests  19 passed (19)

$ vitest run packages/agent/src/api/          # this branch
      Tests  4 failed | 1121 passed | 34 skipped (1159)
$ vitest run packages/agent/src/api/          # unmodified develop
      Tests  4 failed | 1096 passed | 34 skipped (1134)

$ vitest run plugins/plugin-wallet            # this branch
      Tests  22 failed | 237 passed (259)
$ vitest run plugins/plugin-wallet            # unmodified develop
      Tests  22 failed | 237 passed (259)

$ tsc --noEmit -p packages/agent/tsconfig.json
  this branch: 21 error lines    develop: 21 error lines
  errors mentioning config-env:  0

$ biome check packages/agent/src/api/config-env{,.test}.ts
Checked 2 files. No fixes applied.

--- caller-key audit against isBlockedSpawnEnvKey ---
ELIZA_CLOUD_CLIENT_ADDRESS_KEY     ok
ELIZA_CLOUD_EVM_ADDRESS            ok
ELIZA_CLOUD_SOLANA_ADDRESS         ok
WALLET_SOURCE_EVM                  ok
WALLET_SOURCE_SOLANA               ok
ENABLE_CLOUD_WALLET                ok
ELIZA_CAPABILITY_ROUTER_ENABLED    ok
ELIZA_CAPABILITY_ROUTER_URLS       ok
ELIZA_CAPABILITY_ROUTER_TRUST_POLICY  ok
  -> all 9 literal caller keys still write

--- primitives now caught at this gate ---
GCONV_PATH BASH_ENV PYTHONPATH NPM_CONFIG_REGISTRY
DOCKER_HOST GIT_CONFIG_KEY_0 BASH_FUNC_x  -> all BLOCKED
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface is touched.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, action, or model behaviour changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, scheduled-task, or generated-file output changed.

---

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
