### PR TITLE
fix(ci): dependabot bun lockfile updates + drop biome override pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
-  # JS/TS workspace (root). Bun monorepo — pulls all workspace package.json files.
-  - package-ecosystem: "npm"
+  # JS/TS workspace (root). Bun monorepo — use bun ecosystem so dependabot
+  # commits bun.lock with package.json bumps (npm ecosystem was leaving
+  # frozen-lockfile CI red). See elizaOS/eliza#18756.
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/package.json
+++ b/package.json
@@ -308,7 +308,6 @@
     "@elizaos/app-core": "workspace:*",
     "@elizaos/agent": "workspace:*",
     "@elizaos/plugin-solana": "2.0.0-alpha.3",
-    "@biomejs/biome": "2.5.6",
     "playwright": "1.61.1",
     "playwright-core": "1.61.1",
     "@playwright/test": "1.61.1",


### PR DESCRIPTION
# Relates to

Closes #18756

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `grok-build`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribute-to-eliza measured run on this client; session model is not an approved skill model`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Full monorepo `bun run verify` was not re-run for this config-only two-file
      change; focused validation is documented under Testing and Known gaps.

# Risks

Low. Changes Dependabot package-ecosystem for the root workspace from `npm` to
`bun`, and removes a root `overrides` pin on `@biomejs/biome` that made version
bumps no-ops. No application runtime code, no UI, no API surface. Risk is limited
to future Dependabot PR shape (lockfile inclusion) and biome resolution following
the direct `devDependency` pin.

# Background

## What does this PR do?

Fixes the two CI/dependabot issues tracked in #18756:

1. **Dependabot left `bun.lock` stale** because the root stream used
   `package-ecosystem: npm` on a Bun monorepo. Switch it to **`bun`** so package
   bumps ship with lockfile updates and `bun install --frozen-lockfile` stays green.
2. **Root `overrides` pinned `@biomejs/biome` to 2.5.6**, so biome version bumps
   were no-ops. Remove that override; the direct `devDependency` remains the
   intended pin.

Diff is only:

- `.github/dependabot.yml` — `package-ecosystem: "bun"` for the root workspace
- root `package.json` — drop `@biomejs/biome` from `overrides`

## What kind of change is this?

Bug fixes / CI config (non-breaking; no application behavior change)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. `.github/dependabot.yml` root update stream (`package-ecosystem: bun`)
2. root `package.json` `overrides` (confirm `@biomejs/biome` pin removed; direct
   `devDependencies["@biomejs/biome"]` still present)

## Detailed testing steps

- `git diff origin/develop...HEAD --stat` → only the two files above
- `grep -n 'package-ecosystem' .github/dependabot.yml` → root stream is `bun`
- `node -e "const p=require('./package.json'); if (p.overrides['@biomejs/biome']) process.exit(1)"` → exit 0
- After merge: next Dependabot bump PRs should include `bun.lock` when packages change

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:047a412c84d787d3691365ecb7a6d98c190329b5 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - config-only change to dependabot.yml and package.json overrides; no rendered UI source surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - config-only change to dependabot.yml and package.json overrides; no rendered UI source surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow; Dependabot ecosystem and override pin only
<!-- evidence-row:backend-logs -->
- [x] N/A - no application backend path; CI and package metadata configuration only
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend source change; console and network logs do not apply
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action provider prompt or model runtime behavior in this diff
<!-- evidence-row:domain-artifacts -->
- [x] N/A - reviewed artifact is the two-file source diff; no runtime domain state created
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface for OCR text review on this config change

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model runtime path in this PR.

## Backend + frontend logs

N/A - config-only; no request path.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no interactive flow.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

- Full monorepo `bun run verify` not re-run after the final rebase: this PR is
  config-only (Dependabot ecosystem + override pin). Focused checks:
  two-file diffstat, dependabot.yml ecosystem string, and absence of biome
  override. Live Dependabot acceptance of `package-ecosystem: bun` is validated
  by GitHub after merge on the next scheduled update, not by this PR's CI alone.
- Security Advisory Gate may remain pending/queued on the PR (external to this
  config diff).
