### PR TITLE
perf(cloud): prewarm shared-runtime turn caches at agent create (kills the 13-27s first-message warming wall)

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-create-prewarm.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-create-prewarm.test.ts
@@ -1,0 +1,315 @@
+/**
+ * POST /api/v1/eliza/agents — provision-time shared-runtime cache prewarm.
+ *
+ * A fresh shared agent's first turn is served cache-only, so every cache it
+ * consults (admission snapshot, pricing, character, conversation Durable
+ * Object) is cold at create time and the first send eats a 13-27s retryable
+ * 503 warming wall (measured on staging, QA-MATRIX-2026-08-11 §2/§3). The
+ * create route must schedule `prewarmSharedAgentTurnCaches` under the Worker
+ * execution context so those caches are warm before a human can type.
+ *
+ * Contract under test (fails on develop, passes with the fix):
+ *   - a fresh SHARED create registers the prewarm with executionCtx.waitUntil,
+ *     passing the created agent row + the conversation DO namespace;
+ *   - the response is returned without awaiting the prewarm (off the response
+ *     path);
+ *   - idempotent reuse and dedicated creates do NOT schedule it;
+ *   - a missing execution context (non-Worker runtime) degrades to no prewarm
+ *     instead of failing the create.
+ *
+ * Mocks only the module boundaries the handler imports — the route logic is
+ * real (same approach as eliza-agents-create-idempotency.test.ts).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+
+const createAgent = mock();
+const updateAgentEnvironment = mock(async () => undefined);
+const listAgents = mock(async () => []);
+
+const enqueueAgentProvision = mock(async () => ({
+  id: "job-1",
+  status: "pending",
+  estimated_completion_at: new Date("2026-08-12T00:01:30.000Z"),
+}));
+const triggerImmediate = mock(async () => undefined);
+
+const checkAgentCreditGate = mock(
+  async (): Promise<{ allowed: boolean; balance: number; error?: string }> => ({
+    allowed: true,
+    balance: 100,
+  }),
+);
+const checkProvisioningWorkerHealth = mock(
+  async (): Promise<{ ok: boolean; status?: number; code?: string }> => ({
+    ok: true,
+  }),
+);
+const prepareManagedElizaEnvironment = mock(async () => ({
+  changed: false,
+  environmentVars: {},
+}));
+
+const prewarmSharedAgentTurnCaches = mock(async () => undefined);
+
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: {
+    claimWarmContainer: mock(async () => null),
+    listByOrganization: mock(async () => []),
+    delete: mock(async () => undefined),
+  },
+}));
+
+mock.module("@/db/repositories/characters", () => ({
+  userCharactersRepository: {
+    findByIdInOrganizationForWrite: mock(async () => undefined),
+    findByIdsInOrganization: mock(async () => []),
+  },
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+class AgentQuotaExceededError extends Error {
+  readonly count: number;
+  readonly max: number;
+  constructor(count: number, max: number) {
+    super(`Agent quota exceeded (${count}/${max}).`);
+    this.name = "AgentQuotaExceededError";
+    this.count = count;
+    this.max = max;
+  }
+}
+
+class AgentImageNotAllowedError extends Error {
+  readonly image: string;
+  readonly reason: "not_allowlisted" | "not_digest_pinned";
+  constructor(image: string, reason: "not_allowlisted" | "not_digest_pinned") {
+    super(`Docker image '${image}' is not allowed.`);
+    this.name = "AgentImageNotAllowedError";
+    this.image = image;
+    this.reason = reason;
+  }
+}
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: {
+    createAgent,
+    updateAgentEnvironment,
+    listAgents,
+  },
+  AgentImageNotAllowedError,
+  AgentQuotaExceededError,
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: { enqueueAgentProvision, triggerImmediate },
+}));
+
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate,
+}));
+
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth,
+  provisioningWorkerFailureBody: (h: { code?: string }) => ({
+    success: false,
+    code: h.code ?? "worker_unavailable",
+  }),
+}));
+
+mock.module("@/lib/services/eliza-managed-launch", () => ({
+  prepareManagedElizaEnvironment,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+mock.module("@/lib/services/shared-runtime/prewarm-shared-agent", () => ({
+  prewarmSharedAgentTurnCaches,
+}));
+
+const { default: agentsRoute } = await import("../v1/eliza/agents/route");
+
+const app = new Hono();
+app.route("/api/v1/eliza/agents", agentsRoute);
+
+const NAMESPACE = {
+  getByName: () => ({ fetch: async () => new Response(null) }),
+};
+
+function sharedAgent() {
+  return {
+    id: "8e1f5f66-3f5a-45c9-9d64-2f8f8a1c2b3d",
+    agent_name: "fresh-shared",
+    organization_id: "org-1",
+    user_id: "user-1",
+    status: "running",
+    execution_tier: "shared",
+    created_at: new Date("2026-08-12T00:00:00.000Z"),
+    agent_config: {},
+    character_id: null,
+  };
+}
+
+interface RegisteredWaits {
+  promises: Promise<unknown>[];
+}
+
+function workerExecutionCtx(registered: RegisteredWaits) {
+  return {
+    waitUntil: (promise: Promise<unknown>) => {
+      registered.promises.push(promise);
+    },
+    passThroughOnException: () => undefined,
+  };
+}
+
+async function postCreate(
+  body: unknown,
+  options: { executionCtx?: unknown; env?: Record<string, unknown> } = {},
+) {
+  return app.fetch(
+    new Request("https://api.example.test/api/v1/eliza/agents", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    options.env ?? {},
+    // Hono surfaces this as c.executionCtx.
+    options.executionCtx as never,
+  );
+}
+
+describe("POST /api/v1/eliza/agents — shared create schedules the turn-cache prewarm", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    createAgent.mockReset();
+    enqueueAgentProvision.mockClear();
+    checkAgentCreditGate.mockClear();
+    checkProvisioningWorkerHealth.mockClear();
+    checkProvisioningWorkerHealth.mockResolvedValue({ ok: true });
+    prepareManagedElizaEnvironment.mockClear();
+    prewarmSharedAgentTurnCaches.mockClear();
+  });
+
+  test("fresh shared create registers the prewarm under executionCtx.waitUntil with the agent + DO namespace", async () => {
+    const agent = sharedAgent();
+    createAgent.mockResolvedValue({ agent, idempotent: false });
+    const registered: RegisteredWaits = { promises: [] };
+
+    const res = await postCreate(
+      { agentName: "fresh-shared" },
+      {
+        executionCtx: workerExecutionCtx(registered),
+        env: { SHARED_RUNTIME_CONVERSATIONS: NAMESPACE },
+      },
+    );
+
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { created: boolean; source: string };
+    expect(json.created).toBe(true);
+    expect(json.source).toBe("shared_runtime");
+
+    // The prewarm import + call is registered with the Worker lifetime.
+    expect(registered.promises.length).toBeGreaterThan(0);
+    await Promise.all(registered.promises);
+    expect(prewarmSharedAgentTurnCaches).toHaveBeenCalledTimes(1);
+    const [prewarmedAgent, prewarmOptions] = prewarmSharedAgentTurnCaches.mock
+      .calls[0] as unknown as [{ id: string }, { namespace?: unknown }];
+    expect(prewarmedAgent.id).toBe(agent.id);
+    expect(prewarmOptions.namespace).toBe(NAMESPACE);
+  });
+
+  test("response does not await the prewarm (off the response path)", async () => {
+    const agent = sharedAgent();
+    createAgent.mockResolvedValue({ agent, idempotent: false });
+    let resolvePrewarm: () => void = () => undefined;
+    prewarmSharedAgentTurnCaches.mockImplementationOnce(
+      () =>
+        new Promise<undefined>((resolve) => {
+          resolvePrewarm = () => resolve(undefined);
+        }),
+    );
+    const registered: RegisteredWaits = { promises: [] };
+
+    // If the route awaited the prewarm, this fetch would hang forever.
+    const res = await postCreate(
+      { agentName: "fresh-shared" },
+      {
+        executionCtx: workerExecutionCtx(registered),
+        env: { SHARED_RUNTIME_CONVERSATIONS: NAMESPACE },
+      },
+    );
+    expect(res.status).toBe(201);
+    // The prewarm call happens after the route's dynamic import resolves
+    // (strictly after the response above); wait for it before releasing.
+    while (prewarmSharedAgentTurnCaches.mock.calls.length === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    resolvePrewarm();
+    await Promise.all(registered.promises);
+  });
+
+  test("idempotent reuse does NOT schedule a prewarm (the agent already served turns)", async () => {
+    const agent = sharedAgent();
+    createAgent.mockResolvedValue({ agent, idempotent: true });
+    const registered: RegisteredWaits = { promises: [] };
+
+    const res = await postCreate(
+      { agentName: "fresh-shared" },
+      {
+        executionCtx: workerExecutionCtx(registered),
+        env: { SHARED_RUNTIME_CONVERSATIONS: NAMESPACE },
+      },
+    );
+
+    expect(res.status).toBe(200);
+    await Promise.all(registered.promises);
+    expect(prewarmSharedAgentTurnCaches).not.toHaveBeenCalled();
+  });
+
+  test("dedicated create does NOT schedule the shared prewarm", async () => {
+    const agent = {
+      ...sharedAgent(),
+      execution_tier: "dedicated-always",
+      status: "pending",
+    };
+    createAgent.mockResolvedValue({ agent, idempotent: false });
+    const registered: RegisteredWaits = { promises: [] };
+
+    const res = await postCreate(
+      { agentName: "fresh-dedicated", alwaysOn: true },
+      {
+        executionCtx: workerExecutionCtx(registered),
+        env: { SHARED_RUNTIME_CONVERSATIONS: NAMESPACE },
+      },
+    );
+
+    expect(res.status).toBe(202);
+    await Promise.all(registered.promises);
+    expect(prewarmSharedAgentTurnCaches).not.toHaveBeenCalled();
+  });
+
+  test("missing execution context (non-Worker runtime) degrades to no prewarm, create still succeeds", async () => {
+    const agent = sharedAgent();
+    createAgent.mockResolvedValue({ agent, idempotent: false });
+
+    const res = await postCreate({ agentName: "fresh-shared" });
+
+    expect(res.status).toBe(201);
+    expect(prewarmSharedAgentTurnCaches).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -486,6 +486,34 @@ app.post("/", async (c) => {
     });
 
     if (executionTier === "shared") {
+      // Provision-time cache prewarm: hydrate every cache the cache-only first
+      // turn consults (admission snapshot, pricing, character, conversation
+      // Durable Object) NOW, off the response path, so the user's first message
+      // doesn't bounce off the 13-27s retryable-503 warming wall
+      // (CHAT-CORE-LATENCY §6 item 1). Best-effort: a failed prewarm only means
+      // the turn path's existing warming 503s remain the fallback.
+      let createExecutionCtx:
+        | { waitUntil(promise: Promise<unknown>): void }
+        | undefined;
+      try {
+        const candidate = c.executionCtx;
+        if (candidate && typeof candidate.waitUntil === "function") {
+          createExecutionCtx = candidate;
+        }
+      } catch {
+        // Hono throws outside Workers (tests, node runtimes); skip the prewarm.
+        createExecutionCtx = undefined;
+      }
+      if (createExecutionCtx) {
+        createExecutionCtx.waitUntil(
+          import("@/lib/services/shared-runtime/prewarm-shared-agent").then(
+            ({ prewarmSharedAgentTurnCaches }) =>
+              prewarmSharedAgentTurnCaches(agent, {
+                namespace: c.env?.SHARED_RUNTIME_CONVERSATIONS,
+              }),
+          ),
+        );
+      }
       return c.json(
         {
           success: true,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Verifies provision-time prewarm uses the production character projection and
+ * warms the exact model/provider pricing pair consumed by cache-only admission.
+ * External cache, character, and Durable Object boundaries are deterministic mocks.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
+import type { UserCharacter } from "../../../db/repositories/characters";
+
+const calls: string[] = [];
+const calculateCost = mock(
+  async (model: string, provider: string, inputTokens: number, outputTokens: number) => {
+    calls.push(`pricing:${provider}:${model}`);
+    return { inputCost: inputTokens, outputCost: outputTokens, totalCost: 2 };
+  },
+);
+const getById = mock(async (_id: string): Promise<UserCharacter | undefined> => undefined);
+const warmInferenceAdmissionSnapshot = mock(async () => {
+  calls.push("admission");
+});
+
+mock.module("../../pricing", () => ({
+  calculateCost,
+  getProviderFromModel: (model: string) => model.split("/", 1)[0] || "openai",
+  normalizeModelName: (model: string) => model.split("/").at(-1) ?? model,
+}));
+mock.module("../characters/characters", () => ({ charactersService: { getById } }));
+mock.module("../inference-admission-snapshot", () => ({ warmInferenceAdmissionSnapshot }));
+mock.module("./conversation-coordinator", () => ({
+  coordinateSharedHistory: async () => [],
+}));
+mock.module("./run-shared-agent-turn", () => ({
+  resolveSharedAgentTurnModel: (preferred?: string) => preferred?.trim() || null,
+}));
+
+const { prewarmSharedAgentTurnCaches } = await import("./prewarm-shared-agent");
+
+function agent(config: Record<string, unknown>, characterId: string | null = null): AgentSandbox {
+  return {
+    id: "agent-1",
+    organization_id: "org-1",
+    user_id: "user-1",
+    agent_name: "Agent",
+    agent_config: config,
+    character_id: characterId,
+  } as AgentSandbox;
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  calculateCost.mockClear();
+  getById.mockClear();
+  getById.mockImplementation(async () => undefined);
+  warmInferenceAdmissionSnapshot.mockClear();
+});
+
+describe("prewarmSharedAgentTurnCaches model pricing", () => {
+  test("warms the nested agent_config.character.model pricing pair", async () => {
+    await prewarmSharedAgentTurnCaches(
+      agent({
+        model: "openai/gpt-top-level",
+        character: { model: "anthropic/claude-nested" },
+      }),
+    );
+
+    expect(calculateCost).toHaveBeenCalledWith("claude-nested", "anthropic", 1, 1, "bitrouter");
+  });
+
+  test("hydrates a linked character before warming its settings.model pricing pair", async () => {
+    getById.mockImplementation(async () => {
+      calls.push("character");
+      return {
+        id: "character-1",
+        organization_id: "org-1",
+        name: "Linked",
+        settings: { model: "cerebras/gpt-oss-120b" },
+      } as UserCharacter;
+    });
+
+    await prewarmSharedAgentTurnCaches(
+      agent(
+        {
+          model: "openai/gpt-top-level",
+          character: { model: "anthropic/claude-nested" },
+        },
+        "character-1",
+      ),
+    );
+
+    expect(getById).toHaveBeenCalledWith("character-1");
+    expect(calculateCost).toHaveBeenCalledWith("gpt-oss-120b", "cerebras", 1, 1, "bitrouter");
+    expect(calls.indexOf("character")).toBeLessThan(calls.indexOf("pricing:cerebras:gpt-oss-120b"));
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
@@ -1,0 +1,120 @@
+/**
+ * Provision-time cache prewarm for shared-runtime agents (CHAT-CORE-LATENCY §6
+ * item 1: move hydration from "first paying request" to "agent create").
+ *
+ * A fresh shared agent's FIRST turn is served entirely from caches
+ * (fail-closed, cache-only by design): conversation history (Durable Object),
+ * the combined inference-admission snapshot (org balance + rate tier), model
+ * pricing rates, and the linked character projection. None of those entries
+ * exist for a brand-new agent/org, so the first send bounces off 2-4 retryable
+ * 503s ("Conversation cache is warming. Retry shortly.", "Billing
+ * authorization is warming. Retry shortly.") before the first 200 — measured
+ * 13-27s of client-visible first-message wall on staging across 14/14 fresh
+ * agents (QA-MATRIX-2026-08-11 §2/§3, FIRSTFIVE-CLOSE-2026-08-12). Clients
+ * that do not retry the retryable 503 surface a broken first message at the
+ * exact worst moment of the funnel.
+ *
+ * This runs the SAME authoritative hydration the 503 path already schedules
+ * under waitUntil — just at create time, seconds before a human can type. By
+ * the first message every gate the turn consults is warm.
+ *
+ * Best-effort by design: legs are independent and a failure only means the
+ * first turn falls back to today's retryable-503 warming behavior — this can
+ * only remove latency, never change an authorization or billing outcome.
+ * Callers must keep it off the response path (Worker executionCtx.waitUntil).
+ */
+
+import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
+import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
+import { calculateCost, getProviderFromModel } from "../../pricing";
+import { logger } from "../../utils/logger";
+import { warmInferenceAdmissionSnapshot } from "../inference-admission-snapshot";
+import { coordinateSharedHistory } from "./conversation-coordinator";
+import { resolveSharedAgentTurnModel } from "./run-shared-agent-turn";
+
+export interface PrewarmSharedAgentOptions {
+  /**
+   * The conversation Durable Object namespace. Optional so non-Worker callers
+   * (tests, legacy runtimes) can still warm the KV-backed projections; without
+   * it only the conversation-object leg is skipped.
+   */
+  namespace?: RuntimeDurableObjectNamespace;
+}
+
+function configuredModel(agent: AgentSandbox): string | undefined {
+  const config = agent.agent_config;
+  if (!config || typeof config !== "object") return undefined;
+  const model = (config as Record<string, unknown>).model;
+  return typeof model === "string" && model.trim() ? model.trim() : undefined;
+}
+
+/**
+ * Hydrate every cache the cache-only shared first turn consults. Resolves when
+ * all legs have settled; never rejects (failed legs are logged and the turn
+ * path's retryable warming 503s remain the fallback).
+ */
+export async function prewarmSharedAgentTurnCaches(
+  agent: AgentSandbox,
+  options: PrewarmSharedAgentOptions = {},
+): Promise<void> {
+  const legs: Array<{ leg: string; run: Promise<unknown> }> = [];
+
+  // 1. Combined admission snapshot: org balance + rate-limit tier. The
+  //    projection behind "Billing authorization is warming", "Inference
+  //    admission cache is warming", and the rate-limit warming 503s.
+  legs.push({
+    leg: "admission-snapshot",
+    run: warmInferenceAdmissionSnapshot(agent.organization_id),
+  });
+
+  // 2. Pricing rates for the model the first turn will bill. The authoritative
+  //    (non-cache-only) read populates the durable pricing cache that the
+  //    cache-only admission path consults ("AI pricing cache is warming").
+  const model = resolveSharedAgentTurnModel(configuredModel(agent));
+  if (model) {
+    legs.push({
+      leg: "pricing",
+      run: calculateCost(model, getProviderFromModel(model), 1, 1, "bitrouter"),
+    });
+  }
+
+  // 3. Linked character projection ("Character cache is warming"). getById
+  //    writes the same `character:data:<id>` entry the cache-only turn reads.
+  if (agent.character_id) {
+    const characterId = agent.character_id;
+    legs.push({
+      leg: "character",
+      run: import("../characters/characters").then(({ charactersService }) =>
+        charactersService.getById(characterId),
+      ),
+    });
+  }
+
+  // 4. Conversation Durable Object hydration ("Conversation cache is
+  //    warming"). The first history read on a cold object starts its
+  //    authoritative Postgres hydration under the object's own waitUntil and
+  //    reports warming; swallowing that expected rejection leaves the object
+  //    hydrated for the real first turn. Launch model: one canonical
+  //    conversation per shared agent (roomId === agentId), the same room the
+  //    REST turn dispatch addresses.
+  if (options.namespace) {
+    legs.push({
+      leg: "conversation-object",
+      run: coordinateSharedHistory(agent.id, agent.id, { namespace: options.namespace }).catch(
+        () => undefined,
+      ),
+    });
+  }
+
+  const results = await Promise.allSettled(legs.map(({ run }) => run));
+  results.forEach((result, index) => {
+    if (result.status === "rejected") {
+      logger.warn("[shared-runtime prewarm] leg failed; first turn falls back to warming 503s", {
+        agentId: agent.id,
+        organizationId: agent.organization_id,
+        leg: legs[index].leg,
+        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+      });
+    }
+  });
+}

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
@@ -26,11 +26,12 @@
 
 import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
 import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
-import { calculateCost, getProviderFromModel } from "../../pricing";
+import { calculateCost, getProviderFromModel, normalizeModelName } from "../../pricing";
 import { logger } from "../../utils/logger";
 import { warmInferenceAdmissionSnapshot } from "../inference-admission-snapshot";
 import { coordinateSharedHistory } from "./conversation-coordinator";
 import { resolveSharedAgentTurnModel } from "./run-shared-agent-turn";
+import { projectSharedAgentCharacter } from "./shared-agent-character";
 
 export interface PrewarmSharedAgentOptions {
   /**
@@ -39,13 +40,6 @@ export interface PrewarmSharedAgentOptions {
    * it only the conversation-object leg is skipped.
    */
   namespace?: RuntimeDurableObjectNamespace;
-}
-
-function configuredModel(agent: AgentSandbox): string | undefined {
-  const config = agent.agent_config;
-  if (!config || typeof config !== "object") return undefined;
-  const model = (config as Record<string, unknown>).model;
-  return typeof model === "string" && model.trim() ? model.trim() : undefined;
 }
 
 /**
@@ -67,30 +61,32 @@ export async function prewarmSharedAgentTurnCaches(
     run: warmInferenceAdmissionSnapshot(agent.organization_id),
   });
 
-  // 2. Pricing rates for the model the first turn will bill. The authoritative
-  //    (non-cache-only) read populates the durable pricing cache that the
-  //    cache-only admission path consults ("AI pricing cache is warming").
-  const model = resolveSharedAgentTurnModel(configuredModel(agent));
-  if (model) {
-    legs.push({
-      leg: "pricing",
-      run: calculateCost(model, getProviderFromModel(model), 1, 1, "bitrouter"),
-    });
-  }
+  // 2. Hydrate the linked character before resolving pricing. The live turn's
+  //    canonical projection gives linked settings.model precedence over the
+  //    nested and top-level agent config, so pricing cannot be selected safely
+  //    until this authoritative read completes. getById also writes the exact
+  //    `character:data:<id>` entry the cache-only turn reads.
+  const pricingAndCharacter = (async () => {
+    const linked = agent.character_id
+      ? await import("../characters/characters").then(({ charactersService }) =>
+          charactersService.getById(agent.character_id!),
+        )
+      : undefined;
+    const character = projectSharedAgentCharacter(agent, linked);
+    const model = resolveSharedAgentTurnModel(character.model);
+    if (model) {
+      await calculateCost(
+        normalizeModelName(model),
+        getProviderFromModel(model),
+        1,
+        1,
+        "bitrouter",
+      );
+    }
+  })();
+  legs.push({ leg: "character-and-pricing", run: pricingAndCharacter });
 
-  // 3. Linked character projection ("Character cache is warming"). getById
-  //    writes the same `character:data:<id>` entry the cache-only turn reads.
-  if (agent.character_id) {
-    const characterId = agent.character_id;
-    legs.push({
-      leg: "character",
-      run: import("../characters/characters").then(({ charactersService }) =>
-        charactersService.getById(characterId),
-      ),
-    });
-  }
-
-  // 4. Conversation Durable Object hydration ("Conversation cache is
+  // 3. Conversation Durable Object hydration ("Conversation cache is
   //    warming"). The first history read on a cold object starts its
   //    authoritative Postgres hydration under the object's own waitUntil and
   //    reports warming; swallowing that expected rejection leaves the object

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-agent-character.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-agent-character.ts
@@ -1,0 +1,64 @@
+/**
+ * Canonical character projection for shared-runtime inference and provisioning.
+ * Keeping model precedence here ensures cache prewarm targets the same pricing
+ * key that the first turn later consumes.
+ */
+
+import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
+import type { UserCharacter } from "../../../db/repositories/characters";
+import type { SharedAgentCharacter } from "./run-shared-agent-turn";
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function stringList(value: unknown): string[] {
+  if (typeof value === "string" && value.trim()) return [value.trim()];
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+/** Build the shared-turn character with linked, nested, then top-level precedence. */
+export function projectSharedAgentCharacter(
+  agent: AgentSandbox,
+  linked?: UserCharacter | null,
+): SharedAgentCharacter {
+  if (linked && linked.organization_id !== agent.organization_id) {
+    throw new Error("[shared-runtime] linked character organization mismatch");
+  }
+  const config = record(agent.agent_config) ?? {};
+  const configuredCharacter = record(config.character) ?? config;
+  const settings = record(linked?.settings);
+  const name =
+    stringValue(linked?.name) ??
+    stringValue(configuredCharacter.name) ??
+    stringValue(config.name) ??
+    agent.agent_name ??
+    "Eliza agent";
+  const system =
+    stringValue(linked?.system) ??
+    stringValue(configuredCharacter.system) ??
+    stringValue(config.system) ??
+    stringValue(configuredCharacter.prompt) ??
+    stringValue(config.prompt) ??
+    `You are ${name}, a helpful assistant.`;
+  const bio = [
+    ...stringList(linked?.bio),
+    ...stringList(configuredCharacter.bio),
+    ...stringList(config.bio),
+  ];
+  const model =
+    stringValue(settings?.model) ??
+    stringValue(configuredCharacter.model) ??
+    stringValue(config.model);
+  return {
+    name,
+    system,
+    ...(bio.length ? { bio } : {}),
+    ...(model ? { model } : {}),
+  };
+}

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -54,6 +54,7 @@ import {
   type SharedAgentTurnUsage,
   type SharedTurnMessage,
 } from "./run-shared-agent-turn";
+import { projectSharedAgentCharacter } from "./shared-agent-character";
 import { navIntentActionResult } from "./shared-nav-intent";
 import { SharedRuntimeCacheWarmingError } from "./shared-runtime-errors";
 import { MAX_HISTORY_MESSAGES } from "./shared-runtime-history-policy";
@@ -86,12 +87,6 @@ export { SharedRuntimeCacheWarmingError } from "./shared-runtime-errors";
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function stringList(value: unknown): string[] {
-  if (typeof value === "string" && value.trim()) return [value.trim()];
-  if (!Array.isArray(value)) return [];
-  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
 }
 
 function record(value: unknown): Record<string, unknown> | undefined {
@@ -186,8 +181,6 @@ async function characterFor(
     executionCtx?: BridgeExecutionContext;
   },
 ): Promise<SharedAgentCharacter> {
-  const config = record(agent.agent_config) ?? {};
-  const configuredCharacter = record(config.character) ?? config;
   let linked: UserCharacter | null | undefined;
   if (agent.character_id) {
     if (options.cacheOnly) {
@@ -243,38 +236,7 @@ async function characterFor(
     options.executionCtx.waitUntil(hydration);
     throw new SharedRuntimeCacheWarmingError("Character cache is warming. Retry shortly.");
   }
-  if (linked && linked.organization_id !== agent.organization_id) {
-    throw new Error("[shared-runtime] linked character organization mismatch");
-  }
-  const settings = record(linked?.settings);
-  const name =
-    stringValue(linked?.name) ??
-    stringValue(configuredCharacter.name) ??
-    stringValue(config.name) ??
-    agent.agent_name ??
-    "Eliza agent";
-  const system =
-    stringValue(linked?.system) ??
-    stringValue(configuredCharacter.system) ??
-    stringValue(config.system) ??
-    stringValue(configuredCharacter.prompt) ??
-    stringValue(config.prompt) ??
-    `You are ${name}, a helpful assistant.`;
-  const bio = [
-    ...stringList(linked?.bio),
-    ...stringList(configuredCharacter.bio),
-    ...stringList(config.bio),
-  ];
-  const model =
-    stringValue(settings?.model) ??
-    stringValue(configuredCharacter.model) ??
-    stringValue(config.model);
-  return {
-    name,
-    system,
-    ...(bio.length ? { bio } : {}),
-    ...(model ? { model } : {}),
-  };
+  return projectSharedAgentCharacter(agent, linked);
 }
 
 function billingPrompt(


### PR DESCRIPTION
# Relates to

CHAT-CORE-LATENCY §6 item 1 (server-side prewarm at provision); complements #18426 (client-side retry/idempotency contract — different layer, no scope overlap: that PR makes retries correct, this PR makes them unnecessary on the funnel's first message).

# Risks

Low. The prewarm is best-effort and strictly off the response path (`executionCtx.waitUntil`): every leg failure logs and falls back to today's retryable-503 warming behavior, so it can only remove latency — never change an authorization, billing, or rate-limit outcome. Idempotent reuse and dedicated creates are untouched; non-Worker runtimes (no executionCtx) skip it entirely.

# Background

## What does this PR do?

A fresh shared agent's FIRST message is served cache-only by design (conversation Durable Object history, combined inference-admission snapshot, model pricing rates, linked character projection). For a brand-new agent/org all of those are cold, so the first send bounces off 2-4 retryable 503s ("Conversation cache is warming…", "Billing authorization is warming…") before the first 200.

**Measured on staging (api-staging.elizacloud.ai):** 13-27s claim-to-first-turn wall on 14/14 fresh agents (QA-MATRIX 2026-08-11 journey + N=10 burst: p50 22.7s, p95 37.8s — warming retries were the dominant term, not provisioning). Re-measured 2026-08-12 with an immediate-retry client: attempts at 1.2s and 3.7s both 503 (`shared_runtime_cache_warming`), first 200 at 5.3s.

This PR moves the hydration the 503 path already schedules under `waitUntil` from "first paying request" to "agent create": `POST /api/v1/eliza/agents` now registers `prewarmSharedAgentTurnCaches` (new module) with the Worker execution context for fresh shared creates. Legs: `warmInferenceAdmissionSnapshot` (org balance + rate tier), `calculateCost` for the resolved turn model (populates the durable pricing cache), `charactersService.getById` (character projection), and a conversation-object history read that triggers the DO's own authoritative hydration. By the time a human types their first message, every gate the turn consults is warm.

## What kind of change is this?

Improvements (performance of the first-five-minutes funnel; kills a whole class of first-message failures for clients that don't retry retryable 503s).

# Documentation changes needed?

None — behavior documented in the new module's header comment.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts` (the four legs + why each maps to a warming 503), then the route wiring in `packages/cloud/api/v1/eliza/agents/route.ts`.

## Detailed testing steps

Bidirectional proof (route-level suite, real route logic, boundary mocks only — same approach as `eliza-agents-create-idempotency.test.ts`):

- **develop without the fix:** `bun test __tests__/eliza-agents-create-prewarm.test.ts` → 3/5 fail (no prewarm scheduled).
- **with the fix:** 5/5 pass — fresh shared create registers the prewarm under `waitUntil` with the created agent + DO namespace; response returns without awaiting it; idempotent reuse does NOT schedule it; dedicated create does NOT schedule it; missing executionCtx degrades to no prewarm.
- Neighbor suite `eliza-agents-create-idempotency.test.ts` stays green (10/10).
- `tsc --noEmit` clean for both `packages/cloud/api` and `packages/cloud/shared`; Biome clean.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Contributor model: `anthropic-proxy/claude-fable-5`
<!-- attribution-row:client -->
- Contributor tooling: `moltbot builder lane (FIRSTFIVE-CLOSE-r1)`
<!-- attribution-row:status -->
- Provenance status: `contributor self-reported`

<!-- evidence-head:523bc1c03f8d5bd796a3927cae7f3726dcefdbb1 -->

<!-- evidence-row:backend-logs -->
- [x] [18762-pr18762-backend-test-log.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18762-pr18762-backend-test-log.txt)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only cache prewarm; no UI pixels change

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only cache prewarm; no UI pixels change

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only asynchronous provisioning path covered by route and service tests

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser behavior changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, planner, or model-output behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no generated domain artifact; verification is captured in backend logs

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshot or visual artifact to review

