### PR TITLE
fix(local-inference): resolve runtime media for vision

### DIFF
--- a/packages/core/src/media/index.ts
+++ b/packages/core/src/media/index.ts
@@ -11,6 +11,7 @@ export {
 	fetchRemoteMedia,
 	MediaFetchError,
 	type MediaFetchErrorCode,
+	readResponseWithLimit,
 } from "./fetch.js";
 export {
 	type CachedImageDescription,

--- a/plugins/plugin-local-inference/__tests__/provider.test.ts
+++ b/plugins/plugin-local-inference/__tests__/provider.test.ts
@@ -4,7 +4,7 @@
  * handlers behave when no backend service is present. Uses a mock runtime.
  */
 import { ModelType } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	createLocalInferenceModelHandlers,
 	isLocalInferenceUnavailableError,
@@ -12,13 +12,21 @@ import {
 	LocalInferenceUnavailableError,
 } from "../src/provider.ts";
 
-function runtimeWithService(service: Record<string, unknown>) {
+function runtimeWithService(
+	service: Record<string, unknown>,
+	fetchImpl?: typeof fetch,
+) {
 	return {
+		...(fetchImpl ? { fetch: fetchImpl } : {}),
 		getService: vi.fn((name: string) =>
 			name === "localInferenceLoader" ? service : null,
 		),
 	};
 }
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
 
 describe("local inference provider", () => {
 	it("delegates text generation to the runtime local inference service", async () => {
@@ -165,6 +173,41 @@ describe("local inference provider", () => {
 		});
 		expect(describeImage).toHaveBeenCalledWith({
 			imageUrl: "data:image/png;base64,AAAA",
+			prompt: "describe it",
+		});
+	});
+
+	it("inlines a canonical local media-store image before legacy backend dispatch", async () => {
+		vi.stubEnv("SERVER_PORT", "4317");
+		const describeImage = vi.fn(async () => ({
+			title: "A stored image",
+			description: "The runtime-owned attachment.",
+		}));
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response(Uint8Array.from([1, 2, 3]), {
+					headers: { "content-type": "image/png" },
+				}),
+		) as unknown as typeof fetch;
+		const runtime = runtimeWithService({ describeImage }, fetchImpl);
+		const handlers = createLocalInferenceModelHandlers();
+		const imageUrl = `/api/media/${"a".repeat(64)}.png`;
+
+		await expect(
+			handlers[ModelType.IMAGE_DESCRIPTION]?.(runtime as never, {
+				imageUrl,
+				prompt: "describe it",
+			} as never),
+		).resolves.toEqual({
+			title: "A stored image",
+			description: "The runtime-owned attachment.",
+		});
+		expect(fetchImpl).toHaveBeenCalledWith(
+			`http://localhost:4317${imageUrl}`,
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
+		expect(describeImage).toHaveBeenCalledWith({
+			imageUrl: "data:image/png;base64,AQID",
 			prompt: "describe it",
 		});
 	});

--- a/plugins/plugin-local-inference/src/provider.ts
+++ b/plugins/plugin-local-inference/src/provider.ts
@@ -52,6 +52,8 @@ import { transcriptsRoutes } from "./routes/transcripts-routes.js";
 import { voiceProfilePluginRoutes } from "./routes/voice-profile-plugin-routes.js";
 import { handleVoiceEntityBound } from "./runtime/voice-entity-binding.js";
 import { augmentVisionRequest } from "./services/vision/augmenter.js";
+import { prepareVisionImageInput } from "./services/vision/image-input.js";
+import type { VisionImageInput } from "./services/vision/types.js";
 import { extractRequestedVoiceId } from "./services/voice/requested-voice.js";
 
 export const LOCAL_INFERENCE_PROVIDER_ID = "eliza-local-inference";
@@ -796,7 +798,7 @@ function tryGetImageGenArbiter(
 }
 
 function paramsToVisionRequest(params: ImageDescriptionParams | string): {
-	image: { kind: "dataUrl"; dataUrl: string } | { kind: "url"; url: string };
+	image: VisionImageInput;
 	prompt?: string;
 	signal?: AbortSignal;
 	onTextChunk?: (chunk: string) => void | Promise<void>;
@@ -845,6 +847,19 @@ function paramsToVisionRequest(params: ImageDescriptionParams | string): {
 	};
 }
 
+function paramsWithPreparedVisionImage(
+	params: ImageDescriptionParams | string,
+	image: VisionImageInput,
+): ImageDescriptionParams | string {
+	if (image.kind !== "bytes") {
+		return params;
+	}
+	const dataUrl = `data:${image.mimeType ?? "application/octet-stream"};base64,${Buffer.from(image.bytes).toString("base64")}`;
+	return typeof params === "string"
+		? dataUrl
+		: { ...params, imageUrl: dataUrl };
+}
+
 /**
  * Runtime setting marker that plugin-vision's `hasEliza1VisionHandler`
  * polls. Setting this to `"1"` makes VisionService prefer the eliza-1
@@ -878,6 +893,10 @@ function createImageDescriptionHandler() {
 		params: ImageDescriptionParams | string,
 	): Promise<ImageDescriptionResult> => {
 		const service = requireService(runtime, ModelType.IMAGE_DESCRIPTION);
+		const request = paramsToVisionRequest(params);
+		request.image = await prepareVisionImageInput(runtime, request.image, {
+			signal: request.signal,
+		});
 		const arbiter = tryGetArbiter(service);
 		if (arbiter?.requestVisionDescribe) {
 			// WS2 path. The arbiter owns the model handle and the projector
@@ -891,7 +910,6 @@ function createImageDescriptionHandler() {
 				typeof modelKeyCandidate === "string" && modelKeyCandidate
 					? modelKeyCandidate
 					: "gemma-vl";
-			const request = paramsToVisionRequest(params);
 			await augmentVisionRequest(request);
 			const result = await arbiter.requestVisionDescribe<
 				typeof request,
@@ -899,11 +917,16 @@ function createImageDescriptionHandler() {
 			>({ modelKey, payload: request });
 			return normalizeImageDescription(result);
 		}
+		const preparedParams = paramsWithPreparedVisionImage(params, request.image);
 		if (typeof service.describeImage === "function") {
-			return normalizeImageDescription(await service.describeImage(params));
+			return normalizeImageDescription(
+				await service.describeImage(preparedParams),
+			);
 		}
 		if (typeof service.imageDescription === "function") {
-			return normalizeImageDescription(await service.imageDescription(params));
+			return normalizeImageDescription(
+				await service.imageDescription(preparedParams),
+			);
 		}
 		throw unavailable(
 			ModelType.IMAGE_DESCRIPTION,

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -76,6 +76,12 @@ import {
 	elizaHarnessSchemaFromSkeleton,
 } from "../services/structured-output";
 import type { AgentModelSlot } from "../services/types";
+import {
+	prepareVisionImageInput,
+	VISION_IMAGE_FETCH_TIMEOUT_MS,
+	VISION_IMAGE_MAX_BYTES,
+} from "../services/vision/image-input";
+import type { VisionImageInput } from "../services/vision/types";
 import { decodeMonoPcm16Wav, type TranscriptionAudio } from "../services/voice";
 import { extractRequestedKokoroVoiceId } from "../services/voice/requested-voice.js";
 import { DEFAULT_MODELS_DIR } from "./embedding-manager-support";
@@ -1013,7 +1019,7 @@ function makeTranscriptionHandler(): TranscriptionHandler {
 }
 
 function paramsToVisionRequest(params: ImageDescriptionParams | string): {
-	image: { kind: "dataUrl"; dataUrl: string } | { kind: "url"; url: string };
+	image: VisionImageInput;
 	prompt?: string;
 	signal?: AbortSignal;
 	onTextChunk?: (chunk: string) => void | Promise<void>;
@@ -1135,6 +1141,9 @@ function makeImageDescriptionHandler(): ImageDescriptionHandler {
 				? modelKeyCandidate
 				: "gemma-vl";
 		const request = paramsToVisionRequest(params);
+		request.image = await prepareVisionImageInput(runtime, request.image, {
+			signal: request.signal,
+		});
 		const result = await arbiter.requestVisionDescribe<
 			typeof request,
 			ImageDescriptionResult | string
@@ -1177,20 +1186,19 @@ export function float32ToBase64LE(pcm: Float32Array): string {
 	return buf.toString("base64");
 }
 
-/** Cap remote vision image downloads so a malicious URL cannot force unbounded memory. */
-const IMAGE_DESCRIPTION_MAX_BYTES = 20 * 1024 * 1024;
-/** Bound remote image fetch time for IMAGE_DESCRIPTION URL inputs. */
-const IMAGE_DESCRIPTION_FETCH_TIMEOUT_MS = 15_000;
-
 /** Resolve a vision request to base64 image bytes for the bionic host. */
-export async function imageRequestToBase64(image: {
-	kind: "dataUrl" | "url";
-	dataUrl?: string;
-	url?: string;
-}): Promise<string> {
+export async function imageRequestToBase64(
+	image: VisionImageInput,
+): Promise<string> {
 	if (image.kind === "dataUrl" && image.dataUrl) {
 		const comma = image.dataUrl.indexOf(",");
 		return comma >= 0 ? image.dataUrl.slice(comma + 1) : image.dataUrl;
+	}
+	if (image.kind === "base64") {
+		return image.base64;
+	}
+	if (image.kind === "bytes") {
+		return Buffer.from(image.bytes).toString("base64");
 	}
 	if (image.kind === "url") {
 		const url = typeof image.url === "string" ? image.url.trim() : "";
@@ -1204,8 +1212,8 @@ export async function imageRequestToBase64(image: {
 			// guard; bare `fetch` would let vision describe internal hosts.
 			const media = await fetchRemoteMedia({
 				url,
-				maxBytes: IMAGE_DESCRIPTION_MAX_BYTES,
-				timeoutMs: IMAGE_DESCRIPTION_FETCH_TIMEOUT_MS,
+				maxBytes: VISION_IMAGE_MAX_BYTES,
+				timeoutMs: VISION_IMAGE_FETCH_TIMEOUT_MS,
 				maxRedirects: 5,
 			});
 			return media.buffer.toString("base64");
@@ -1254,6 +1262,9 @@ function makeBionicImageDescriptionHandler(): ImageDescriptionHandler {
 			);
 		}
 		const request = paramsToVisionRequest(params);
+		request.image = await prepareVisionImageInput(runtime, request.image, {
+			signal: request.signal,
+		});
 		const description = await loader.describeImage({
 			imageBase64: await imageRequestToBase64(request.image),
 			prompt: request.prompt,

--- a/plugins/plugin-local-inference/src/services/vision/capacitor-llama.ts
+++ b/plugins/plugin-local-inference/src/services/vision/capacitor-llama.ts
@@ -35,6 +35,10 @@
 import { existsSync, promises as fs } from "node:fs";
 import { fetchRemoteMedia } from "@elizaos/core";
 import { resolveImageBytes } from "./hash";
+import {
+	VISION_IMAGE_FETCH_TIMEOUT_MS,
+	VISION_IMAGE_MAX_BYTES,
+} from "./image-input.js";
 import type {
 	VisionDescribeBackend,
 	VisionDescribeBackendOptions,
@@ -237,8 +241,8 @@ async function imageInputToDataUrl(
 			// shared SSRF media guard rather than bare `fetch`.
 			const media = await fetchRemoteMedia({
 				url,
-				maxBytes: 20 * 1024 * 1024,
-				timeoutMs: 15_000,
+				maxBytes: VISION_IMAGE_MAX_BYTES,
+				timeoutMs: VISION_IMAGE_FETCH_TIMEOUT_MS,
 				maxRedirects: 5,
 			});
 			const mimeType = input.mimeType ?? media.contentType ?? "image/png";

--- a/plugins/plugin-local-inference/src/services/vision/image-input.test.ts
+++ b/plugins/plugin-local-inference/src/services/vision/image-input.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests the runtime-owned media resolver with a mocked local transport and no
+ * backend substitution. Remote URLs remain untouched for the real SSRF layer.
+ */
+
+import { getLocalServerUrl, type IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+	prepareVisionImageInput,
+	VISION_IMAGE_MAX_BYTES,
+} from "./image-input.js";
+
+const HASH = "a".repeat(64);
+const MEDIA_PATH = `/api/media/${HASH}.png`;
+
+function runtimeWithFetch(fetchImpl: typeof fetch): IAgentRuntime {
+	return { fetch: fetchImpl } as unknown as IAgentRuntime;
+}
+
+describe("prepareVisionImageInput", () => {
+	it("loads a canonical relative media-store handle through runtime.fetch", async () => {
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response(Uint8Array.from([1, 2, 3]), {
+					headers: { "content-type": "image/png" },
+				}),
+		) as unknown as typeof fetch;
+
+		await expect(
+			prepareVisionImageInput(runtimeWithFetch(fetchImpl), {
+				kind: "url",
+				url: MEDIA_PATH,
+			}),
+		).resolves.toEqual({
+			kind: "bytes",
+			bytes: Uint8Array.from([1, 2, 3]),
+			mimeType: "image/png",
+		});
+		expect(fetchImpl).toHaveBeenCalledWith(
+			getLocalServerUrl(MEDIA_PATH),
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
+	});
+
+	it("loads the same canonical handle when it uses the exact local origin", async () => {
+		const fetchImpl = vi.fn(
+			async () => new Response(Uint8Array.from([9])),
+		) as unknown as typeof fetch;
+
+		await expect(
+			prepareVisionImageInput(runtimeWithFetch(fetchImpl), {
+				kind: "url",
+				url: getLocalServerUrl(MEDIA_PATH),
+			}),
+		).resolves.toMatchObject({
+			kind: "bytes",
+			bytes: Uint8Array.from([9]),
+		});
+	});
+
+	it("leaves public and private remote URLs for the SSRF-guarded backend", async () => {
+		const fetchImpl = vi.fn() as unknown as typeof fetch;
+		const runtime = runtimeWithFetch(fetchImpl);
+		for (const url of [
+			"https://example.test/image.png",
+			"http://127.0.0.1/private.png",
+			"/tmp/local-image.png",
+		]) {
+			await expect(
+				prepareVisionImageInput(runtime, { kind: "url", url }),
+			).resolves.toEqual({ kind: "url", url });
+		}
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		"/api/media/not-a-content-hash.png",
+		`${MEDIA_PATH}?download=1`,
+		`${MEDIA_PATH}/../secret`,
+	])("rejects malformed local media-store path %s", async (url) => {
+		const fetchImpl = vi.fn() as unknown as typeof fetch;
+		await expect(
+			prepareVisionImageInput(runtimeWithFetch(fetchImpl), {
+				kind: "url",
+				url,
+			}),
+		).rejects.toThrow("local media URL is not canonical");
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+
+	it("rejects an oversized local response before reading its body", async () => {
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response(Uint8Array.from([1]), {
+					headers: {
+						"content-length": String(VISION_IMAGE_MAX_BYTES + 1),
+					},
+				}),
+		) as unknown as typeof fetch;
+
+		await expect(
+			prepareVisionImageInput(runtimeWithFetch(fetchImpl), {
+				kind: "url",
+				url: MEDIA_PATH,
+			}),
+		).rejects.toThrow(`exceeds ${VISION_IMAGE_MAX_BYTES} bytes`);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/vision/image-input.ts
+++ b/plugins/plugin-local-inference/src/services/vision/image-input.ts
@@ -1,0 +1,126 @@
+/**
+ * Resolves canonical runtime-owned media URLs before vision backend dispatch.
+ * Local content-addressed handles use the runtime fetch; every other URL stays
+ * remote so the backend's shared SSRF guard remains authoritative.
+ */
+
+import {
+	getLocalServerUrl,
+	type IAgentRuntime,
+	MediaFetchError,
+	readResponseWithLimit,
+} from "@elizaos/core";
+import type { VisionImageInput } from "./types.js";
+
+export const VISION_IMAGE_MAX_BYTES = 20 * 1024 * 1024;
+export const VISION_IMAGE_FETCH_TIMEOUT_MS = 15_000;
+
+const LOCAL_MEDIA_STORE_PATH = /^\/api\/media\/[a-f0-9]{64}\.[a-z0-9]{1,8}$/;
+
+function trustedLocalMediaUrl(rawUrl: string): URL | null {
+	const url = rawUrl.trim();
+	if (url.startsWith("/")) {
+		if (!url.startsWith("/api/media/")) {
+			return null;
+		}
+		if (!LOCAL_MEDIA_STORE_PATH.test(url)) {
+			throw new MediaFetchError(
+				"fetch_failed",
+				"IMAGE_DESCRIPTION local media URL is not canonical",
+			);
+		}
+		return new URL(getLocalServerUrl(url));
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return null;
+	}
+
+	const localOrigin = new URL(getLocalServerUrl("/")).origin;
+	if (parsed.origin !== localOrigin) {
+		return null;
+	}
+	if (
+		parsed.username ||
+		parsed.password ||
+		parsed.search ||
+		parsed.hash ||
+		!LOCAL_MEDIA_STORE_PATH.test(parsed.pathname)
+	) {
+		throw new MediaFetchError(
+			"fetch_failed",
+			"IMAGE_DESCRIPTION local media URL is not canonical",
+		);
+	}
+	return parsed;
+}
+
+/**
+ * Convert a trusted local media-store URL to bounded bytes. Remote inputs are
+ * deliberately returned unchanged for the backend's SSRF-guarded resolver.
+ */
+export async function prepareVisionImageInput(
+	runtime: IAgentRuntime,
+	input: VisionImageInput,
+	options: { signal?: AbortSignal } = {},
+): Promise<VisionImageInput> {
+	if (input.kind !== "url") {
+		return input;
+	}
+	const localUrl = trustedLocalMediaUrl(input.url);
+	if (!localUrl) {
+		return input;
+	}
+
+	const runtimeFetch = runtime.fetch ?? globalThis.fetch;
+	const timeoutSignal = AbortSignal.timeout(VISION_IMAGE_FETCH_TIMEOUT_MS);
+	const signal = options.signal
+		? AbortSignal.any([options.signal, timeoutSignal])
+		: timeoutSignal;
+	try {
+		const response = await runtimeFetch(localUrl.href, { signal });
+		if (!response.ok) {
+			throw new MediaFetchError(
+				"http_error",
+				`IMAGE_DESCRIPTION local media fetch failed (HTTP ${response.status})`,
+			);
+		}
+		const contentLength = response.headers.get("content-length");
+		if (
+			contentLength !== null &&
+			Number.isFinite(Number(contentLength)) &&
+			Number(contentLength) > VISION_IMAGE_MAX_BYTES
+		) {
+			throw new MediaFetchError(
+				"max_bytes",
+				`IMAGE_DESCRIPTION image exceeds ${VISION_IMAGE_MAX_BYTES} bytes`,
+			);
+		}
+		const buffer = await readResponseWithLimit(
+			response,
+			VISION_IMAGE_MAX_BYTES,
+		);
+		return {
+			kind: "bytes",
+			bytes: new Uint8Array(buffer),
+			mimeType:
+				input.mimeType ??
+				response.headers.get("content-type") ??
+				"application/octet-stream",
+		};
+	} catch (error) {
+		// error-policy:J2 Preserve the typed media failure while adding a stable
+		// local vision-fetch boundary for transport and stream errors.
+		if (error instanceof Error && error.name === "MediaFetchError") {
+			throw error;
+		}
+		throw new MediaFetchError(
+			"fetch_failed",
+			"IMAGE_DESCRIPTION local media fetch failed",
+			error,
+		);
+	}
+}


### PR DESCRIPTION
# Relates to

Fixes #18760

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated `develop` blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code from the tests and exact-process evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8a2070e78423ccb9d602df4478e498f740facc86:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop@8a2070e78423ccb9d602df4478e498f740facc86`; zero conflicts.
- [x] `bun run verify` was run post-sync. It stops at the unrelated Biome version-consistency failure already tracked by #18756 and still tracked by #18756; closed PR #18761 did not land; all gates before that point and all changed-surface checks pass.

# Risks

Low. Only the canonical content-addressed media shape `/api/media/<64 lowercase hex>.<short alphanumeric extension>` may use the trusted runtime fetch. An absolute URL must also match the runtime server origin exactly and carry no credentials, query, or fragment. Every other HTTP(S) URL remains on the DNS-pinned SSRF guard. The local response retains the same 20 MiB streaming limit and 15-second abort bound as remote vision input.

# Background

## What does this PR do?

- Resolves runtime-owned media-store handles at the IMAGE_DESCRIPTION model-handler boundary, where `IAgentRuntime.fetch` is available.
- Converts trusted local responses to bounded bytes before arbiter, bionic-host, Capacitor, or legacy backend dispatch.
- Leaves public and private remote URLs untouched for the existing shared SSRF-guarded resolver; no policy exception or loopback allowlist is added.
- Rejects malformed media-store paths rather than treating them as filesystem paths or remote URLs.
- Exposes core's existing `readResponseWithLimit` through the media barrel so local and remote branches share the same streamed cancellation implementation.
- Centralizes the vision byte/time limits so backend paths cannot drift.

## What kind of change is this?

Bug fix; non-breaking for canonical media handles and remote URLs.

# Documentation changes needed?

No. This restores the documented single media-store and SSRF invariants without changing a public workflow or configuration surface.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-local-inference/src/services/vision/image-input.ts`
2. `plugins/plugin-local-inference/src/provider.ts`
3. `plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts`
4. `plugins/plugin-local-inference/src/services/vision/image-input.test.ts`

## Detailed testing steps

- `bun install` — PASS with pinned Bun 1.3.14; 6,400 packages installed and the 971 MiB artifact bundle checksum/extraction completed.
- `bun run --cwd plugins/plugin-local-inference typecheck` — PASS.
- `bun run --cwd plugins/plugin-local-inference lint:check` — PASS, 497 files.
- `bun run --cwd plugins/plugin-local-inference test` — PASS, 267 files; 2,724 passed and 18 intentionally skipped; 3/3 CI-script tests passed.
- `bun run --cwd plugins/plugin-local-inference build` — PASS.
- `bun run --cwd packages/core build:node` — PASS.
- `bun run --cwd packages/core build` — PASS for Node, browser, edge, testing, and declarations.
- Focused vision/core run — PASS, 6 files and 73 assertions.
- `git diff --check` — PASS.
- `bun run verify` — ran post-rebase; stopped at current-base Biome 2.5.7/2.5.6 inconsistency (#18756 / #18761), before any diff-related failure.

# Evidence Gate

<!-- evidence-head:a0df28763e2dcd518558e7f27137b126ad82cc8b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only media resolution; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only media resolution; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or rendered user flow changed.
<!-- evidence-row:backend-logs -->
- [x] <details><summary>Exact-process local HTTP and SSRF output</summary>

  ```text
  local media: kind=bytes byteLength=4 hex=01020304 mimeType=image/png
  private remote: blocked=true reason=SsrfBlockedError: Blocked: private/internal IP address
  process exit: 0 (both outcomes asserted before output)
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request surface, or state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this change resolves bytes before backend dispatch; prompts, model selection, inference, and model output semantics are unchanged.
<!-- evidence-row:domain-artifacts -->
- [x] <details><summary>Resolved media artifact</summary>

  ```json
  {"kind":"bytes","byteLength":4,"hex":"01020304","mimeType":"image/png"}
  {"source":"real local HTTP response","path":"canonical /api/media/<sha256>.png"}
  {"asserted":true,"processExit":0}
  ```
  </details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered UI changed.

# Evidence Details

## Backend + domain proof

A fresh Bun process started a real local HTTP server, set `SERVER_PORT` before importing core, fetched a canonical runtime media URL through `prepareVisionImageInput`, then exercised the real `fetchRemoteMedia` policy through `imageRequestToBase64` against a private loopback URL. The command asserted both outcomes before printing:

```json
{
  "localMedia": {
    "kind": "bytes",
    "byteLength": 4,
    "hex": "01020304",
    "mimeType": "image/png"
  },
  "privateRemote": {
    "blocked": true,
    "error": "[local-inference] IMAGE_DESCRIPTION failed to fetch http://127.0.0.1/private.png: Failed to fetch media from http://127.0.0.1/private.png: SsrfBlockedError: Blocked: private/internal IP address"
  }
}
```

This proves the formerly broken own-store path returns the exact served bytes while the security boundary still rejects private remote input.

## Screenshots and walkthrough

N/A - the diff contains no UI, CSS, SVG, or rendered asset change. Test-output screenshots would not provide behavioral evidence beyond the exact machine-readable output above.

## Known gaps / failures

- Root `bun run verify` is currently blocked on `develop` by the Biome 2.5.7 manifest versus 2.5.6 override/schema/lock inconsistency tracked in #18756. Closed PR #18761 did not land, so #18756 remains the base-wide blocker. This PR does not mix the unrelated dependency-policy change into the media fix.
- No real-LLM trajectory is attached because the changed branch ends before inference and does not alter model inputs after byte resolution, prompts, provider choice, or output interpretation. The real local HTTP and real SSRF transport paths are exercised directly instead.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@8a2070e78423ccb9d602df4478e498f740facc86:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex/18760-local-media-vision]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@8a2070e78423ccb9d602df4478e498f740facc86:packages/skills/skills/contribute-to-eliza"} -->




