### PR TITLE
fix(scripts): enforce exact autoheal decimal overrides

### DIFF
--- a/packages/scripts/__tests__/ci-autoheal-context.test.mjs
+++ b/packages/scripts/__tests__/ci-autoheal-context.test.mjs
@@ -4,6 +4,15 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "../lib/spawn-sync-captured.mjs";
+
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "ci-autoheal-context.mjs",
+);
 
 const autoheal = await import(
   new URL("../ci-autoheal-context.mjs", import.meta.url).href
@@ -34,17 +43,15 @@ describe("parsePositiveSafeInteger", () => {
   test("accepts complete positive safe-integer decimals", () => {
     expect(parsePositiveSafeInteger("1", "X")).toBe(1);
     expect(parsePositiveSafeInteger("3", "X")).toBe(3);
+    expect(parsePositiveSafeInteger("0003", "X")).toBe(3);
     expect(parsePositiveSafeInteger(42, "X")).toBe(42);
   });
 
-  test("accepts surrounding whitespace after trim", () => {
-    expect(parsePositiveSafeInteger(" 4 ", "X")).toBe(4);
-  });
-
-  test("rejects malformed, signed, fractional, zero, and non-finite values", () => {
+  test("rejects malformed, padded, signed, fractional, zero, and non-finite values", () => {
     for (const value of [
       "abc",
       "3junk",
+      " 4 ",
       "1.5",
       "+2",
       "-1",
@@ -63,7 +70,7 @@ describe("parsePositiveSafeInteger", () => {
 });
 
 describe("resolveAutohealPolicy", () => {
-  test("keeps historical defaults when overrides are unset or blank", () => {
+  test("keeps historical defaults when overrides are unset or empty", () => {
     expect(resolveAutohealPolicy({})).toEqual({
       maxAttempts: DEFAULT_MAX_ATTEMPTS,
       logBudget: DEFAULT_LOG_BUDGET,
@@ -71,7 +78,7 @@ describe("resolveAutohealPolicy", () => {
     expect(
       resolveAutohealPolicy({
         AUTOHEAL_MAX_ATTEMPTS: "",
-        AUTOHEAL_LOG_BUDGET: "   ",
+        AUTOHEAL_LOG_BUDGET: "",
       }),
     ).toEqual({
       maxAttempts: DEFAULT_MAX_ATTEMPTS,
@@ -82,8 +89,8 @@ describe("resolveAutohealPolicy", () => {
   test("accepts valid explicit overrides", () => {
     expect(
       resolveAutohealPolicy({
-        AUTOHEAL_MAX_ATTEMPTS: "5",
-        AUTOHEAL_LOG_BUDGET: "50000",
+        AUTOHEAL_MAX_ATTEMPTS: "0005",
+        AUTOHEAL_LOG_BUDGET: "00050000",
       }),
     ).toEqual({ maxAttempts: 5, logBudget: 50000 });
   });
@@ -113,6 +120,34 @@ describe("resolveAutohealPolicy", () => {
     expect(() => resolveAutohealPolicy({ AUTOHEAL_LOG_BUDGET: "0" })).toThrow(
       /AUTOHEAL_LOG_BUDGET/,
     );
+  });
+
+  test("rejects whitespace-padded overrides for both policy knobs", () => {
+    expect(() =>
+      resolveAutohealPolicy({ AUTOHEAL_MAX_ATTEMPTS: " 4 " }),
+    ).toThrow(/AUTOHEAL_MAX_ATTEMPTS/);
+    expect(() =>
+      resolveAutohealPolicy({ AUTOHEAL_LOG_BUDGET: " 50000 " }),
+    ).toThrow(/AUTOHEAL_LOG_BUDGET/);
+    expect(() =>
+      resolveAutohealPolicy({ AUTOHEAL_MAX_ATTEMPTS: "   " }),
+    ).toThrow(/AUTOHEAL_MAX_ATTEMPTS/);
+  });
+
+  test("real CLI rejects padded overrides before required GitHub configuration", () => {
+    for (const [name, value] of [
+      ["AUTOHEAL_MAX_ATTEMPTS", " 4 "],
+      ["AUTOHEAL_LOG_BUDGET", " 50000 "],
+    ]) {
+      const result = spawnSync(process.execPath, [SCRIPT], {
+        encoding: "utf8",
+        env: { [name]: value },
+        timeout: 5_000,
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(name);
+      expect(result.stderr).not.toContain("GITHUB_REPOSITORY");
+    }
   });
 });
 

--- a/packages/scripts/ci-autoheal-context.mjs
+++ b/packages/scripts/ci-autoheal-context.mjs
@@ -56,14 +56,14 @@ export function parsePositiveSafeInteger(value, label) {
     }
     return value;
   }
-  const raw = String(value ?? "").trim();
+  const raw = String(value ?? "");
   if (!/^\d+$/.test(raw)) {
     throw new Error(
       `${label} must be a positive safe-integer decimal (received ${received})`,
     );
   }
   const parsed = Number.parseInt(raw, 10);
-  if (!Number.isSafeInteger(parsed) || parsed < 1 || String(parsed) !== raw) {
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
     throw new Error(
       `${label} must be a positive safe-integer decimal (received ${received})`,
     );
@@ -72,9 +72,10 @@ export function parsePositiveSafeInteger(value, label) {
 }
 
 /**
- * Resolve auto-heal attempt ceiling and log budget from env. Unset, empty, and
- * whitespace-only values keep historical defaults. Explicit overrides fail
- * closed so a typo cannot disable the attempt ceiling or empty log excerpts.
+ * Resolve auto-heal attempt ceiling and log budget from env. Unset and empty
+ * values keep historical defaults. Explicit overrides fail closed so a typo,
+ * including surrounding whitespace, cannot disable the attempt ceiling or
+ * empty log excerpts.
  *
  * @param {NodeJS.ProcessEnv | Record<string, string | undefined>} [env]
  * @returns {{ maxAttempts: number, logBudget: number }}
@@ -84,12 +85,12 @@ export function resolveAutohealPolicy(env = process.env) {
   const logBudgetRaw = env.AUTOHEAL_LOG_BUDGET;
 
   const maxAttempts =
-    maxAttemptsRaw == null || String(maxAttemptsRaw).trim() === ""
+    maxAttemptsRaw == null || maxAttemptsRaw === ""
       ? DEFAULT_MAX_ATTEMPTS
       : parsePositiveSafeInteger(maxAttemptsRaw, "AUTOHEAL_MAX_ATTEMPTS");
 
   const logBudget =
-    logBudgetRaw == null || String(logBudgetRaw).trim() === ""
+    logBudgetRaw == null || logBudgetRaw === ""
       ? DEFAULT_LOG_BUDGET
       : parsePositiveSafeInteger(logBudgetRaw, "AUTOHEAL_LOG_BUDGET");
 


### PR DESCRIPTION
# Relates to

Closes #18656. This completes the boundary cases left after merged PR #18657.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated baseline failure is recorded below.
- [x] A reviewer can confirm the change from the exact-head terminal evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2a14d09c63b65a1e4a815aa66f8e5b21eeb58b53:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `2a14d09c63b65a1e4a815aa66f8e5b21eeb58b53`; zero conflicts.
- [x] Focused gates pass. Root verification reaches the pre-existing Biome version-consistency failure from #18756, documented below.

# Risks

Low. This changes only parsing of two CI auto-heal operator environment variables. Unset and exactly empty values retain defaults. Valid positive safe-integer decimal overrides retain their numeric behavior, including leading-zero forms. Non-empty whitespace-padded values now fail before GitHub configuration or API work.

# Background

## What does this PR do?

The merged #18657 implementation trimmed input before validation, so `" 4 "` was accepted despite #18656 explicitly requiring whitespace-padded overrides to throw. It also required `String(parsed) === raw`, which rejected leading-zero complete decimal strings that the old `Number(...)` path accepted.

This follow-up validates the original string, removes the canonical-string restriction, and adds resolver plus real-process CLI regressions for both policy knobs.

## What kind of change is this?

Bug fix completing the existing fail-closed policy contract.

# Documentation changes needed?

No external documentation change is needed. The maintained module JSDoc now states the exact unset/empty and whitespace behavior.

# Testing

## Where should a reviewer start?

1. `packages/scripts/ci-autoheal-context.mjs` — `parsePositiveSafeInteger` and `resolveAutohealPolicy`.
2. `packages/scripts/__tests__/ci-autoheal-context.test.mjs` — leading-zero acceptance, padded rejection, and real CLI ordering.

## Detailed testing steps

```bash
bun install
bun test packages/scripts/__tests__/ci-autoheal-context.test.mjs
bunx @biomejs/biome check packages/scripts/ci-autoheal-context.mjs packages/scripts/__tests__/ci-autoheal-context.test.mjs
bun run test:scripts
bun run verify
```

Exact-head focused result:

```text
17 pass
0 fail
52 expect() calls
Ran 17 tests across 1 file.
Checked 2 files. No fixes applied.
```

The real CLI regressions spawn the entrypoint with each padded variable and assert a nonzero exit naming that variable before any `GITHUB_REPOSITORY` failure can occur.

# Evidence Gate

<!-- evidence-head:0bdbfaed82c63bf8bd910ca1461e38fe622d2049 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - offline CI tooling has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - offline CI tooling has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow; the real CLI process transcript is the behavioral proof.
<!-- evidence-row:backend-logs -->
- [x] N/A - the path exits during local policy parsing before any server or GitHub API call.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path is involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, scheduled-item, wallet, media, or generated domain artifact is produced by this parser.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text exists.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic offline CI policy parsing only.

## Backend + frontend logs

N/A - the affected boundary intentionally runs before network/backend initialization; the spawned CLI assertions prove that ordering.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no audio, voice, TTS, or STT surface.

## Known gaps / failures

- `bun install`: passed on the rebased head.
- Focused test: 17 passed, 0 failed.
- Focused Biome: 2 files checked, no fixes.
- `bun run test:scripts`: the changed suite passed inside the aggregate, but the lane failed on the repository baseline `packages/scripts/__tests__/biome-version-consistency.test.ts`: root `package.json` still overrides Biome 2.5.6 while the trusted consistency script expects 2.5.7.
- `bun run verify`: fails at the same pre-existing `check:biome-version` gate before package build/typecheck/lint. The failure lists the root override, governed schemas/templates, and locks still at 2.5.6. This branch touches only the two auto-heal files. The complete #18756 repair is independently available at `d8a8d94611a998fd4ba5d55ff701c0a98574923e` on `origin/fix/dependabot-bun-lock-completion` and is not mixed into this PR.
- Screenshots/video/OCR are N/A because there is no rendered surface.

AI provider/model: openai / gpt-5
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2a14d09c63b65a1e4a815aa66f8e5b21eeb58b53:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2a14d09c63b65a1e4a815aa66f8e5b21eeb58b53:packages/skills/skills/contribute-to-eliza"} -->
