### PR TITLE
test(build): harden stale lock validation coverage

### DIFF
--- a/packages/scripts/__tests__/with-package-build-lock.test.ts
+++ b/packages/scripts/__tests__/with-package-build-lock.test.ts
@@ -27,7 +27,7 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, "../../..");
 const WRAPPER = path.resolve(SCRIPT_DIR, "../with-package-build-lock.mjs");
 const LOCK_ROOT = path.join(REPO_ROOT, ".turbo", "build-locks");
-const NODE_BIN = process.execPath;
+const NODE_BIN = "node";
 const cleanupPaths = new Set<string>();
 
 function uniquePackageKey(label: string): string {
@@ -50,16 +50,19 @@ function lockPathFor(packageKey: string): string {
 function runWrapper(
   packageKey: string,
   command: string[],
-  staleMs = "1000",
+  staleMs: string | null = "1000",
   timeout = 15_000,
 ) {
+  const env = { ...process.env };
+  if (staleMs === null) {
+    delete env.ELIZA_PACKAGE_BUILD_LOCK_STALE_MS;
+  } else {
+    env.ELIZA_PACKAGE_BUILD_LOCK_STALE_MS = staleMs;
+  }
   return spawnSync(NODE_BIN, [WRAPPER, packageKey, "--", ...command], {
     cwd: REPO_ROOT,
     encoding: "utf8",
-    env: {
-      ...process.env,
-      ELIZA_PACKAGE_BUILD_LOCK_STALE_MS: staleMs,
-    },
+    env,
     timeout,
   });
 }
@@ -108,6 +111,7 @@ async function waitForPath(target: string, timeoutMs = 5_000): Promise<void> {
 afterEach(() => {
   for (const target of cleanupPaths) {
     rmSync(target, { recursive: true, force: true });
+    if (!existsSync(path.dirname(target))) continue;
     for (const candidate of new Bun.Glob(`${path.basename(target)}.*`).scanSync(
       {
         cwd: path.dirname(target),
@@ -123,12 +127,19 @@ afterEach(() => {
 describe("with-package-build-lock", () => {
   test("rejects malformed stale thresholds before acquiring a lock", () => {
     for (const value of [
+      "",
+      " ",
+      "\t",
       "0",
       "-1",
       "+1",
       "1.5",
+      "1e3",
       "1junk",
       " 1",
+      "1 ",
+      "NaN",
+      "Infinity",
       "9007199254740992",
     ]) {
       const packageKey = uniquePackageKey("invalid-threshold");
@@ -139,6 +150,22 @@ describe("with-package-build-lock", () => {
         "ELIZA_PACKAGE_BUILD_LOCK_STALE_MS must be a positive decimal safe integer",
       );
       expect(result.stderr).not.toContain("at parseStaleAfterMs");
+      expect(existsSync(lockPath)).toBe(false);
+    }
+  });
+
+  test("accepts the unset default and complete positive safe integers", () => {
+    for (const value of [null, "1", "1800000", "9007199254740991"] as const) {
+      const packageKey = uniquePackageKey("valid-threshold");
+      const lockPath = lockPathFor(packageKey);
+      const result = runWrapper(
+        packageKey,
+        [NODE_BIN, "-e", "process.stdout.write('acquired')"],
+        value,
+      );
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("acquired");
+      expect(result.stderr).toBe("");
       expect(existsSync(lockPath)).toBe(false);
     }
   });


### PR DESCRIPTION
# Relates to

Closes #18643

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated base blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code from the exact CLI/test evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex-desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8a2070e78423ccb9d602df4478e498f740facc86:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [x] Focused tests and Biome pass post-sync; root verification reaches only the unrelated Biome-version mismatch documented below.

# Risks

Low. The product script is unchanged. The test harness now invokes the declared Node runtime, handles an absent generated lock directory, and expands boundary coverage. A regression here can affect only this focused test file.

# Background

## What does this PR do?

PR #18579 already fixed #18643's unsafe `parseInt` behavior on `develop`, including strict raw-string validation and cleanup-safe signal handlers. Its new regression suite, however, failed from a clean checkout: the malformed-value path correctly avoided creating `.turbo/build-locks`, then teardown tried to glob that missing directory and threw `ENOENT`.

This PR makes that suite hermetic, runs the wrapper through pinned Node rather than Bun's `process.execPath`, and proves the complete input contract. Empty, whitespace, zero, signed, fractional, exponent, suffixed, non-finite, and unsafe values fail before lock acquisition; unset and positive safe-integer decimal values succeed.

The explicitly empty override remains a fail-fast configuration error. Treating an explicitly present empty value as an implicit default would hide deployment drift and contradict the repository's configuration-boundary policy.

## What kind of change is this?

Bug fix to deterministic test infrastructure and expanded regression coverage for the already-merged runtime fix.

# Documentation changes needed?

No documentation change is needed; this repairs and strengthens the executable contract test.

# Testing

## Where should a reviewer start?

`packages/scripts/__tests__/with-package-build-lock.test.ts`, especially the environment construction, teardown guard, and the first two validation tests.

## Detailed testing steps

```bash
node --version
rmdir .turbo/build-locks
bun test packages/scripts/__tests__/with-package-build-lock.test.ts
bunx biome check packages/scripts/__tests__/with-package-build-lock.test.ts
git diff --check
```

# Evidence Gate

<!-- evidence-head:e55a83e7f0b9442e6561e6181e39dace493dcf9e -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only terminal tooling; no rendered UI exists.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface: N/A - test-only terminal tooling; no rendered UI exists.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached: N/A - deterministic offline test harness with no interactive flow.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end: N/A - no backend service is involved; the real Node CLI subprocess output is included in the domain-artifact row.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change: N/A - no frontend or network path is involved.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes: N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable: exact clean-checkout failure and fixed pinned-Node regression transcripts:

  <details><summary>Before: clean checkout teardown failure</summary>

  ```text
  $ bun test packages/scripts/__tests__/with-package-build-lock.test.ts
  error: ENOENT: no such file or directory, open '.../.turbo/build-locks\0'
  at packages/scripts/__tests__/with-package-build-lock.test.ts:111:72
  (fail) with-package-build-lock > rejects malformed stale thresholds before acquiring a lock
  6 pass
  1 fail
  ```

  </details>

  <details><summary>After: absent lock root, real Node 24.15.0, full focused suite</summary>

  ```text
  $ node --version
  v24.15.0
  $ rmdir .turbo/build-locks
  $ bun test packages/scripts/__tests__/with-package-build-lock.test.ts
  (pass) rejects malformed stale thresholds before acquiring a lock
  (pass) accepts the unset default and complete positive safe integers
  (pass) rejects workspace-root and escaping package keys without touching other locks
  (pass) keeps a live owner exclusive after the stale-age threshold
  (pass) serializes simultaneous takeovers of one dead-owner lock
  (pass) waits for the age bound before reclaiming incomplete metadata
  (pass) releases the lock after a command-start failure
  (pass) an old owner cleanup preserves a replacement lock
  8 pass
  0 fail
  99 expect() calls
  $ bunx biome check packages/scripts/__tests__/with-package-build-lock.test.ts
  Checked 1 file. No fixes applied.
  $ git diff --check
  # exit 0
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no runtime model call or agent behavior changes.

## Backend + frontend logs

N/A - offline build-script test harness only. Exact real-process output is embedded in the applicable evidence row.

## Screenshots (before / after) + video walkthrough

N/A - no UI or interactive surface.

## Audio / voice walkthrough

N/A - no voice, audio, transcript, TTS, or STT surface.

## Known gaps / failures

- `bun run verify` stops at `check:biome-version` because current `develop` expects Biome 2.5.7 while its overrides, schemas, and lockfiles remain at 2.5.6. This is the existing base-wide #18756 and remains tracked by #18756; closed PR #18761 did not land. This test-only PR does not touch dependencies or Biome configuration.
- Screenshots, video, backend/frontend logs, OCR, audio, and LLM trajectories are N/A because this is deterministic offline Node CLI test infrastructure.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@8a2070e78423ccb9d602df4478e498f740facc86:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-build-lock-stale-ms]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@8a2070e78423ccb9d602df4478e498f740facc86:packages/skills/skills/contribute-to-eliza"} -->



