### PR TITLE
fix(scripts): preserve seed port argument precedence

### DIFF
--- a/packages/scripts/__tests__/seed-message-corpus.test.mjs
+++ b/packages/scripts/__tests__/seed-message-corpus.test.mjs
@@ -39,7 +39,6 @@ describe("parseTcpPort", () => {
     expect(parseTcpPort(String(DEFAULT_API_PORT), "--api-port")).toBe(
       DEFAULT_API_PORT,
     );
-    expect(parseTcpPort(" 31337 ", "ELIZA_API_PORT")).toBe(31337);
   });
 
   test("rejects zero, out-of-range, partial, signed, and non-decimal forms", () => {
@@ -50,6 +49,8 @@ describe("parseTcpPort", () => {
       "-1",
       "1.5",
       "31337junk",
+      "31337=garbage",
+      " 31337 ",
       "0x10",
       "1e2",
       "031337",
@@ -90,7 +91,7 @@ describe("resolveApiPortFromEnv", () => {
 describe("parseArgs port wiring", () => {
   test("CLI --api-port overrides env and default", () => {
     const options = parseArgs(["--api-port=44444"], {
-      ELIZA_API_PORT: "40000",
+      ELIZA_API_PORT: "notaport",
     });
     expect(options.apiPort).toBe(44444);
   });
@@ -115,7 +116,16 @@ describe("seed-message-corpus CLI boundary", () => {
   });
 
   test("rejects invalid --api-port before any seed request", () => {
-    for (const value of ["0", "99999", "65536", "31337junk", "-1", "1.5"]) {
+    for (const value of [
+      "0",
+      "99999",
+      "65536",
+      "31337junk",
+      "31337=garbage",
+      " 31337 ",
+      "-1",
+      "1.5",
+    ]) {
       const result = runCli([`--api-port=${value}`]);
       expect(result.status).not.toBe(0);
       const combined = `${result.stdout}${result.stderr}`;
@@ -127,7 +137,7 @@ describe("seed-message-corpus CLI boundary", () => {
   });
 
   test("rejects invalid ELIZA_API_PORT before any seed request", () => {
-    for (const value of ["0", "notaport", "31337junk", "99999"]) {
+    for (const value of ["0", "notaport", "31337junk", " 31337 ", "99999"]) {
       const result = runCli([], { ELIZA_API_PORT: value });
       expect(result.status).not.toBe(0);
       const combined = `${result.stdout}${result.stderr}`;
@@ -136,5 +146,23 @@ describe("seed-message-corpus CLI boundary", () => {
       );
       expect(combined).not.toContain("Seeding backdated message corpus");
     }
+  });
+
+  test("valid CLI port overrides invalid env before any seed request", () => {
+    const result = runCli(["--api-port=44444"], {
+      ELIZA_API_PORT: "notaport",
+    });
+    const combined = `${result.stdout}${result.stderr}`;
+    expect(combined).toContain(
+      "Seeding backdated message corpus via http://127.0.0.1:44444",
+    );
+    expect(combined).not.toContain("ELIZA_API_PORT must be");
+  });
+
+  test("--help bypasses an invalid environment port", () => {
+    const result = runCli(["--help"], { ELIZA_API_PORT: "notaport" });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Usage:");
+    expect(result.stderr).toBe("");
   });
 });

--- a/packages/scripts/seed-message-corpus.mjs
+++ b/packages/scripts/seed-message-corpus.mjs
@@ -36,20 +36,22 @@ const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
  * @param {NodeJS.ProcessEnv} [env]
  */
 export function parseArgs(argv, env = process.env) {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    printHelp();
+    process.exit(0);
+  }
   const options = {
-    apiPort: resolveApiPortFromEnv(env),
+    apiPort: undefined,
     host: env.ELIZA_API_HOST || "127.0.0.1",
     body: {},
   };
   for (const arg of argv) {
-    if (arg === "--help" || arg === "-h") {
-      printHelp();
-      process.exit(0);
-    }
-    const [key, value] = arg.split("=", 2);
-    if (value === undefined) {
+    const separatorIndex = arg.indexOf("=");
+    if (separatorIndex === -1) {
       throw new Error(`Expected --key=value, got ${arg}`);
     }
+    const key = arg.slice(0, separatorIndex);
+    const value = arg.slice(separatorIndex + 1);
     switch (key) {
       case "--api-port":
         options.apiPort = parseTcpPort(value, "--api-port");
@@ -76,6 +78,7 @@ export function parseArgs(argv, env = process.env) {
         throw new Error(`Unknown flag ${key}`);
     }
   }
+  options.apiPort ??= resolveApiPortFromEnv(env);
   return options;
 }
 
@@ -101,7 +104,7 @@ export function resolveApiPortFromEnv(env = process.env) {
  * @param {string} label
  */
 export function parseTcpPort(value, label) {
-  const raw = String(value ?? "").trim();
+  const raw = String(value ?? "");
   if (!/^\d+$/.test(raw)) {
     throw new Error(
       `${label} must be a TCP port integer from 1 to 65535 (received ${JSON.stringify(String(value ?? ""))})`,


### PR DESCRIPTION
# Relates to

Closes #18596. This completes the reviewed boundary cases left after merged PR #18597.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated baseline failure is recorded below.
- [x] The exact-head terminal evidence demonstrates the behavior without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2a14d09c63b65a1e4a815aa66f8e5b21eeb58b53:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `2a14d09c63b65a1e4a815aa66f8e5b21eeb58b53`; zero conflicts.
- [x] Focused gates pass. Root verification reaches the pre-existing Biome consistency failure from #18756, documented below.

# Risks

Low. The change is isolated to local CLI parsing. Valid ports, the default port, and the corpus seeding/search path remain unchanged. Help now wins before environment validation, an explicit CLI port wins over the environment, and malformed byte representations fail before the seeding banner or fetch path.

# Background

## What does this PR do?

Merged PR #18597 introduced the intended TCP-port validator but left three reviewed regressions:

1. It resolved `ELIZA_API_PORT` before scanning argv, so invalid env blocked a valid CLI override and `--help`.
2. `split("=", 2)` discarded additional separators, accepting `--api-port=44444=garbage` as `44444`.
3. `.trim()` silently accepted whitespace-padded non-canonical values.

This follow-up defers env resolution until no CLI port was supplied, handles help before option resolution, preserves everything after the first separator for validation, and validates the original untrimmed port string.

## What kind of change is this?

Bug fix completing the existing fail-closed CLI contract.

# Documentation changes needed?

No documentation change is needed; the existing module header already states the canonical TCP-port contract.

# Testing

## Where should a reviewer start?

1. `packages/scripts/seed-message-corpus.mjs` — `parseArgs` and `parseTcpPort`.
2. `packages/scripts/__tests__/seed-message-corpus.test.mjs` — parser and spawned-entrypoint regressions.

## Detailed testing steps

```bash
bun install
bun test packages/scripts/__tests__/seed-message-corpus.test.mjs
bunx @biomejs/biome check packages/scripts/seed-message-corpus.mjs packages/scripts/__tests__/seed-message-corpus.test.mjs
bun run verify
```

Exact-head focused transcript:

```text
13 pass
0 fail
76 expect() calls
Ran 13 tests across 1 file.
Checked 2 files. No fixes applied.
```

The spawned CLI coverage proves padded, extra-separator, out-of-range, and malformed ports exit before `Seeding backdated message corpus`; a valid CLI port overrides an invalid env value; and `--help` with invalid env exits zero with usage.

# Evidence Gate

<!-- evidence-head:11bd9dcafa5e8a7d542c1616d76777e7316de9e6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - local CLI validation has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - local CLI validation has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow; real spawned-process assertions provide the behavioral proof.
<!-- evidence-row:backend-logs -->
- [x] N/A - invalid inputs exit before any backend/network request.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface or browser request is involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - invalid-input tests intentionally stop before corpus/domain artifacts are created.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text exists.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic local command validation only.

## Backend + frontend logs

N/A - the tested failures precede backend/network initialization. The CLI suite asserts that the seeding banner never appears for rejected values.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no audio or voice surface.

## Known gaps / failures

- `bun install`: passed with no dependency changes.
- Focused test: 13 passed, 0 failed.
- Focused Biome: 2 files checked, no fixes.
- `bun run verify`: fails at the pre-existing `check:biome-version` gate before package build/typecheck/lint. Current `develop` expects Biome 2.5.7 while root overrides, governed schemas/templates, and locks remain at 2.5.6. This branch touches only the two seed-script files. The complete #18756 repair remains independently available at `d8a8d94611a998fd4ba5d55ff701c0a98574923e` on `origin/fix/dependabot-bun-lock-completion` and is not mixed into this PR.
- Screenshots/video/OCR are N/A because there is no rendered surface.

AI provider/model: openai / gpt-5
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2a14d09c63b65a1e4a815aa66f8e5b21eeb58b53:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2a14d09c63b65a1e4a815aa66f8e5b21eeb58b53:packages/skills/skills/contribute-to-eliza"} -->
