### PR TITLE
test(shared): stabilize trajectory formatter checks

### DIFF
--- a/packages/shared/src/utils/trajectory-format.test.ts
+++ b/packages/shared/src/utils/trajectory-format.test.ts
@@ -74,9 +74,9 @@ describe("formatTrajectoryTokenCount", () => {
 
   it("fails closed on non-finite or negative values", () => {
     expect(formatTrajectoryTokenCount(Number.NaN, EMPTY)).toBe("—");
-    expect(
-      formatTrajectoryTokenCount(Number.POSITIVE_INFINITY, EMPTY),
-    ).toBe("—");
+    expect(formatTrajectoryTokenCount(Number.POSITIVE_INFINITY, EMPTY)).toBe(
+      "—",
+    );
     expect(formatTrajectoryTokenCount(-1, EMPTY)).toBe("—");
     // emptyLabel is honored, not hardcoded to "—"
     expect(formatTrajectoryTokenCount(Number.NaN, { emptyLabel: "n/a" })).toBe(
@@ -125,7 +125,13 @@ describe("formatTrajectoryTimestamp", () => {
   it("formats non-today dates with a short month and day", () => {
     const date = new Date(Date.now() - 3 * 86_400_000);
     const out = formatTrajectoryTimestamp(date.toISOString(), "smart");
-    expect(out).toMatch(/[A-Za-z]{3} \d{1,2}, \d{1,2}:\d{2}/);
+    const expected = new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(date);
+    expect(out).toBe(expected);
   });
 
   it("formats detailed mode with seconds", () => {


### PR DESCRIPTION
# Relates to

Follow-up to #18742. This also unblocks the `lint` check currently failing on unrelated PRs such as #18764.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated base blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code from the exact test and lint evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex-desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@97fe1ca832829f35b0b40307acefdc83505442f1:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [x] Shared-package and repository-wide lint pass post-sync; root verification reaches only the unrelated Biome-version mismatch documented below.

# Risks

Low. This changes only assertions in one test file. The locale-derived expected value mirrors the production formatter's documented `Intl` options without altering runtime behavior.

# Background

## What does this PR do?

- Applies the repository's pinned Biome formatting to the non-finite token-count assertion merged in #18742, fixing the current `develop` lint failure.
- Replaces a locale-specific regex for non-today timestamps with the exact host-locale `Intl.DateTimeFormat` contract used by production. The old test failed under Bun on valid output such as `Aug 9 at 08:36 PM`.

## What kind of change is this?

Test reliability and CI repair; no product behavior changes.

# Documentation changes needed?

No documentation change is needed.

# Testing

## Where should a reviewer start?

`packages/shared/src/utils/trajectory-format.test.ts`.

## Detailed testing steps

```bash
bun test packages/shared/src/utils/trajectory-format.test.ts
bun run --cwd packages/shared lint:check
bun run --cwd packages/shared test
bun run --cwd packages/shared typecheck
NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run lint:check --concurrency=8
git diff --check
```

# Evidence Gate

<!-- evidence-head:0ba28133395c8e73c7c10b89e7ccb0fd6679c208 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only assertion changes; no rendered UI behavior changed.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface: N/A - test-only assertion changes; no rendered UI behavior changed.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached: N/A - no interactive product flow changed.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end: N/A - no backend service path changed; CI and test-runner transcripts are in the domain-artifact row.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change: N/A - no frontend request or state path changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable: hosted failure and exact post-fix test/lint results:

  <details><summary>Before: hosted lint and direct locale failures</summary>

  ```text
  @elizaos/shared:lint:check: src/utils/trajectory-format.test.ts format
  Formatter would have printed the following content
  Found 1 error.
  @elizaos/shared#lint:check exited (1)

  $ bun test packages/shared/src/utils/trajectory-format.test.ts
  Expected: /[A-Za-z]{3} \\d{1,2}, \\d{1,2}:\\d{2}/
  Received: "Aug 9 at 08:36 PM"
  18 pass
  1 fail
  ```

  </details>

  <details><summary>After: focused, package, and repository-wide proof</summary>

  ```text
  $ bun test packages/shared/src/utils/trajectory-format.test.ts
  19 pass
  0 fail
  46 expect() calls

  $ bun run --cwd packages/shared test
  Test Files  123 passed (123)
  Tests       1407 passed (1407)

  $ bun run --cwd packages/shared lint:check
  Checked 380 files. No fixes applied.

  $ bun run --cwd packages/shared typecheck
  # exit 0

  $ node packages/scripts/run-turbo.mjs run lint:check --concurrency=8
  Tasks: 132 successful, 132 total
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes: N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - test assertions only.

## Backend + frontend logs

N/A - no runtime service or frontend path changed. The hosted CI failure and corrected test-runner output are embedded above.

## Screenshots (before / after) + video walkthrough

N/A - no UI behavior changed.

## Audio / voice walkthrough

N/A - no audio or voice surface changed.

## Known gaps / failures

- `bun run verify` stops at `check:biome-version` because current `develop` expects Biome 2.5.7 while its overrides, schemas, and lockfiles remain at 2.5.6. This remains tracked by #18756; closed PR #18761 did not land. The complete repository-wide lint lane passes with this PR.
- Visual, network, model, and media evidence is N/A because the diff contains test assertions only.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@97fe1ca832829f35b0b40307acefdc83505442f1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-trajectory-test-stability]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@97fe1ca832829f35b0b40307acefdc83505442f1:packages/skills/skills/contribute-to-eliza"} -->

