### PR TITLE
fix(app): preserve login measurement symlink entry

### DIFF
--- a/packages/app/scripts/measure-anonymous-login-transfer.mjs
+++ b/packages/app/scripts/measure-anonymous-login-transfer.mjs
@@ -29,7 +29,13 @@
  */
 
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { createServer } from "node:http";
 import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -436,11 +442,20 @@ async function main(argv = process.argv) {
   process.exit(0);
 }
 
-const isMain =
-  process.argv[1] &&
-  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+function isDirectRun(entryPath) {
+  if (!entryPath) return false;
+  try {
+    return (
+      realpathSync(resolve(entryPath)) ===
+      realpathSync(fileURLToPath(import.meta.url))
+    );
+  } catch {
+    // error-policy:J3 an unresolved argv entry is not this module's CLI path
+    return false;
+  }
+}
 
-if (isMain) {
+if (isDirectRun(process.argv[1])) {
   // error-policy:J1 CLI boundary — invalid flags and measure failures exit
   // non-zero with a legible message instead of an unhandled rejection.
   main().catch((err) => {

--- a/packages/app/scripts/measure-anonymous-login-transfer.test.ts
+++ b/packages/app/scripts/measure-anonymous-login-transfer.test.ts
@@ -5,6 +5,8 @@
  * browser.
  */
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -217,5 +219,40 @@ describe("measure-anonymous-login-transfer CLI", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toMatch(/--settle-ms/);
     expect(result.stdout).toMatch(/--timeout/);
+  });
+
+  it("enters the CLI through a symlink for invalid and valid arguments", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "login-transfer-link-"));
+    const linkedScript = path.join(directory, "measure-login.mjs");
+    try {
+      symlinkSync(SCRIPT_PATH, linkedScript);
+
+      const invalid = spawnSync(
+        process.execPath,
+        [linkedScript, "--settle-ms", "abc"],
+        { encoding: "utf8", timeout: 15_000 },
+      );
+      expect(invalid.status).toBe(1);
+      expect(invalid.stderr).toMatch(/--settle-ms/);
+
+      const valid = spawnSync(
+        process.execPath,
+        [
+          linkedScript,
+          "--settle-ms",
+          "0",
+          "--timeout",
+          "1",
+          "--url",
+          "http://127.0.0.1:9/login",
+        ],
+        { encoding: "utf8", timeout: 15_000 },
+      );
+      expect(valid.status).not.toBe(0);
+      expect(valid.stdout).toMatch(/Measuring cold \/login/);
+      expect(valid.stderr).not.toMatch(/--settle-ms|--timeout/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
# Relates to

Closes #18611. Completes the symlink-entry regression left after merged PR #18614.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Rebases cleanly onto current `origin/develop`.
- [x] `bun install`, focused tests, app typecheck/lint, app audit, and root verify were invoked; unrelated failures are exact below.
- [x] Exact-head real-process evidence proves both symlink paths.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b9dec8f6054b9d563be68fbb8421bb95b18cd977:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `b9dec8f6054b9d563be68fbb8421bb95b18cd977`; zero conflicts.
- [x] Focused/package gates pass; unrelated root and visual-audit baselines are documented below.

# Risks

Low. Only direct-entry detection and its test change. Normal real-path execution and measurement semantics are unchanged. Unresolvable argv entry paths fail closed as non-entry imports.

# Background

## What does this PR do?

Node resolves an ESM module symlink before assigning `import.meta.url`, while #18614 compared it with lexical `process.argv[1]`. Running the measurement through a symlink therefore exited zero without validating or measuring. This uses resolved real paths for both sides and adds a spawned symlink regression for invalid rejection and valid measurement-path entry.

## What kind of change is this?

Bug fix completing the CLI boundary contract.

# Documentation changes needed?

No external documentation change is needed.

# Testing

## Where should a reviewer start?

1. `packages/app/scripts/measure-anonymous-login-transfer.mjs` — direct-entry predicate.
2. `packages/app/scripts/measure-anonymous-login-transfer.test.ts` — real symlink subprocess test.

## Detailed testing steps

```bash
bun test packages/app/scripts/measure-anonymous-login-transfer.test.ts
bun run --cwd packages/app typecheck
bun run --cwd packages/app lint
bun run --cwd packages/app audit:app
bun run verify
```

Exact-head focused result:

```text
24 pass
0 fail
50 expect() calls
Ran 24 tests across 1 file.
App typecheck passed.
App lint checked 289 files; no fixes applied.
```

The symlink case proves invalid input exits 1 naming the flag and a valid `--settle-ms 0 --timeout 1` invocation reaches `Measuring cold /login` rather than silently returning.

# Evidence Gate

<!-- evidence-head:d89d2f6e7e9e65649f0e279736131e96a7766b4f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - measurement CLI entry detection does not alter rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - measurement CLI entry detection does not alter rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive product flow; spawned CLI evidence proves the path.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend behavior changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/state behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model path changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifact is produced by entry detection.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic CLI tooling only.

## Backend + frontend logs

N/A - the changed contract precedes Chromium navigation and application requests.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI diff.

## Audio / voice walkthrough

N/A - no audio surface.

## Known gaps / failures

- `bun install`: passed with no changes.
- Focused test: 24 passed, 0 failed; package typecheck/lint passed.
- `bun run --cwd packages/app audit:app`: executed the full 215-test capture matrix; 214 passed and the final aggregate failed on four unrelated existing minimalism ratchet findings (`builtin-browser` mobile portrait/landscape, `builtin-plugins` mobile portrait, `builtin-trajectories` mobile landscape). This two-file CLI diff changes no renderer code or visual output.
- `bun run verify`: stops at the pre-existing #18756 Biome 2.5.7 consistency mismatch. The independent completion remains at `d8a8d94611a998fd4ba5d55ff701c0a98574923e` on `origin/fix/dependabot-bun-lock-completion`.
- Screenshots/video/OCR are N/A because the diff has no rendered surface; the mandatory audit was nevertheless executed as above.

AI provider/model: openai / gpt-5
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@b9dec8f6054b9d563be68fbb8421bb95b18cd977:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex Desktop","skill_revision":"elizaOS/eliza@b9dec8f6054b9d563be68fbb8421bb95b18cd977:packages/skills/skills/contribute-to-eliza"} -->
