### PR TITLE
feat(cloud): add MiniMax M3 to model catalog

### DIFF
--- a/packages/cloud/shared/src/lib/models/catalog.test.ts
+++ b/packages/cloud/shared/src/lib/models/catalog.test.ts
@@ -67,3 +67,12 @@ describe("#8426 text catalog recommendation invariants", () => {
     expect(top?.id).not.toBe(BITROUTER_NITRO_TEXT_MODEL);
   });
 });
+
+describe("MiniMax static catalog", () => {
+  test("includes MiniMax M3 in the catalog and selector", () => {
+    const modelId = "minimax/minimax-m3";
+
+    expect(STATIC_TEXT_CATALOG_MODELS.some((model) => model.id === modelId)).toBe(true);
+    expect(FALLBACK_TEXT_SELECTOR_MODELS.some((model) => model.modelId === modelId)).toBe(true);
+  });
+});

--- a/packages/cloud/shared/src/lib/models/catalog.ts
+++ b/packages/cloud/shared/src/lib/models/catalog.ts
@@ -257,6 +257,7 @@ const MISTRAL_TEXT_MODEL_IDS = [
   "mistralai/ministral-8b",
 ] as const;
 const MINIMAX_TEXT_MODEL_IDS = [
+  "minimax/minimax-m3",
   "minimax/minimax-m2.7",
   "minimax/minimax-m2.5",
   "minimax/minimax-m2.1-lightning",


### PR DESCRIPTION
Reason: Add MiniMax M3 to the static cloud model catalog so it is available in the fallback selector.

Changes:
- Add `minimax/minimax-m3` to the static MiniMax text model ID list.
- Add a focused regression test covering the static catalog and fallback selector.

Checks:
- `bun test packages/cloud/shared/src/lib/models/catalog.test.ts` (6 passed)
- `bunx @biomejs/biome@2.5.7 check packages/cloud/shared/src/lib/models/catalog.ts packages/cloud/shared/src/lib/models/catalog.test.ts`
