### PR TITLE
fix(scripts): filter trajectory list matches before limit

### DIFF
--- a/packages/scripts/__tests__/trajectory-list.test.ts
+++ b/packages/scripts/__tests__/trajectory-list.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Exercises trajectory list filtering and limiting through the real CLI.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "../lib/spawn-sync-captured.mjs";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const TRAJECTORY_CLI = path.resolve(SCRIPT_DIR, "../trajectory.ts");
+const RUNTIME_BIN = process.execPath;
+const BASE_TIME_MS = Date.parse("2026-01-01T00:00:00.000Z");
+
+interface FixtureOptions {
+  id: string;
+  agent: string;
+  mtimeMs: number;
+  startedAt?: number;
+}
+
+function writeTrajectory(directory: string, options: FixtureOptions): string {
+  const filePath = path.join(directory, `${options.id}.json`);
+  writeFileSync(
+    filePath,
+    JSON.stringify({
+      trajectoryId: options.id,
+      agentId: options.agent,
+      rootMessage: { id: `message-${options.id}`, text: "fixture" },
+      startedAt: options.startedAt ?? options.mtimeMs,
+      status: "finished",
+      stages: [],
+      metrics: {
+        totalLatencyMs: 1,
+        totalCostUsd: 0,
+        toolCallsExecuted: 0,
+        finalDecision: "FINISH",
+      },
+    }),
+  );
+  utimesSync(filePath, options.mtimeMs / 1000, options.mtimeMs / 1000);
+  return filePath;
+}
+
+function writeMalformedTrajectory(
+  directory: string,
+  id: string,
+  mtimeMs: number,
+): string {
+  const filePath = path.join(directory, `${id}.json`);
+  writeFileSync(filePath, "{not valid json");
+  utimesSync(filePath, mtimeMs / 1000, mtimeMs / 1000);
+  return filePath;
+}
+
+function runList(directory: string, args: string[] = []) {
+  return spawnSync(RUNTIME_BIN, [TRAJECTORY_CLI, "list", ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ELIZA_TRAJECTORY_DIR: directory,
+      NO_COLOR: "1",
+    },
+    timeout: 30_000,
+  });
+}
+
+function withFixture(run: (directory: string) => void): void {
+  const directory = mkdtempSync(path.join(tmpdir(), "trajectory-list-"));
+  try {
+    run(directory);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+describe("trajectory list", () => {
+  test("finds an older match behind twenty newer trajectories from another agent", () =>
+    withFixture((directory) => {
+      writeTrajectory(directory, {
+        id: "target-old",
+        agent: "target-agent",
+        mtimeMs: BASE_TIME_MS,
+      });
+      for (let index = 1; index <= 20; index++) {
+        writeTrajectory(directory, {
+          id: `other-${index}`,
+          agent: "other-agent",
+          mtimeMs: BASE_TIME_MS + index * 1_000,
+        });
+      }
+
+      const result = runList(directory, [
+        "--agent",
+        "target-agent",
+        "--limit",
+        "20",
+      ]);
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toContain("target-old");
+      expect(result.stdout).not.toContain(
+        "No trajectories matched the filter.",
+      );
+    }));
+
+  test("limit one returns only the newest matching trajectory", () =>
+    withFixture((directory) => {
+      writeTrajectory(directory, {
+        id: "match-old",
+        agent: "target-agent",
+        mtimeMs: BASE_TIME_MS,
+      });
+      writeTrajectory(directory, {
+        id: "match-new",
+        agent: "target-agent",
+        mtimeMs: BASE_TIME_MS + 2_000,
+      });
+
+      const result = runList(directory, [
+        "--agent",
+        "target-agent",
+        "--limit",
+        "1",
+      ]);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("match-new");
+      expect(result.stdout).not.toContain("match-old");
+    }));
+
+  test("malformed and since-filtered files do not consume the result limit", () =>
+    withFixture((directory) => {
+      writeTrajectory(directory, {
+        id: "match-old",
+        agent: "target-agent",
+        mtimeMs: BASE_TIME_MS,
+        startedAt: BASE_TIME_MS + 5_000,
+      });
+      writeTrajectory(directory, {
+        id: "match-new",
+        agent: "target-agent",
+        mtimeMs: BASE_TIME_MS + 1_000,
+        startedAt: BASE_TIME_MS + 6_000,
+      });
+      writeTrajectory(directory, {
+        id: "before-cutoff",
+        agent: "target-agent",
+        mtimeMs: BASE_TIME_MS + 2_000,
+        startedAt: BASE_TIME_MS - 1_000,
+      });
+      const malformedPath = writeMalformedTrajectory(
+        directory,
+        "malformed",
+        BASE_TIME_MS + 3_000,
+      );
+
+      const result = runList(directory, [
+        "--since",
+        new Date(BASE_TIME_MS).toISOString(),
+        "--limit",
+        "2",
+      ]);
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain(`skip ${malformedPath}:`);
+      expect(result.stdout).toContain("match-new");
+      expect(result.stdout).toContain("match-old");
+      expect(result.stdout).not.toContain("before-cutoff");
+    }));
+
+  test("preserves the no-match message", () =>
+    withFixture((directory) => {
+      writeTrajectory(directory, {
+        id: "other-agent-only",
+        agent: "other-agent",
+        mtimeMs: BASE_TIME_MS,
+      });
+
+      const result = runList(directory, ["--agent", "target-agent"]);
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout.trim()).toBe("No trajectories matched the filter.");
+    }));
+});

--- a/packages/scripts/trajectory.ts
+++ b/packages/scripts/trajectory.ts
@@ -320,6 +320,8 @@ async function cmdList(opts: ListOptions): Promise<void> {
     return;
   }
 
+  const limit = opts.limit ?? 20;
+
   const rows: Array<{
     id: string;
     started: string;
@@ -331,7 +333,9 @@ async function cmdList(opts: ListOptions): Promise<void> {
     agent: string;
   }> = [];
 
-  for (const file of files.slice(0, opts.limit ?? 20)) {
+  for (const file of files) {
+    if (rows.length >= limit) break;
+
     try {
       const raw = await fs.readFile(file.filePath, "utf8");
       const traj = JSON.parse(raw) as RecordedTrajectory;


### PR DESCRIPTION
# Relates to

Closes #18770

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` with zero conflicts and zero commits behind.
- [ ] `bun run verify` was attempted with pinned Bun 1.3.14 and Node 24.15.0; it is blocked before Turbo by the current base Biome consistency drift described below. All scoped and adjacent gates pass.
- [x] A reviewer can confirm the behavior from the real-process regression and transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on `origin/develop@b9dec8f6054b9d563be68fbb8421bb95b18cd977`; zero commits behind at push time.
- [x] Exact contribution head: `b98952bf40d616756277c5c2a9aa56cb4d804f40`.

# Risks

Low. The change only affects the read-only trajectory inspection CLI. It preserves newest-first ordering, the default limit of 20, table output, malformed-file warnings, and no-match output. It changes the limit from a cap on files examined to the documented/user-visible cap on matching rows returned.

# Background

## What does this PR do?

`trajectory list` previously sliced the globally newest files to `--limit` before parsing and applying `--agent` or `--since`. Twenty newer trajectories from other agents could therefore hide an older valid match and produce `No trajectories matched the filter.`

This PR scans the existing newest-first file list, applies parsing and filters, appends only matching rows, and stops when the requested number of matching rows is reached. A real subprocess suite controls file mtimes and proves hidden matches, newest-match limiting, malformed/nonmatching scan behavior, and unchanged no-match output.

## What kind of change is this?

Bug fix (non-breaking CLI correctness fix).

# Documentation changes needed?

No. The existing help already describes `--limit` as a list result limit; this patch makes runtime behavior match that contract.

# Testing

## Where should a reviewer start?

Start at `cmdList` in `packages/scripts/trajectory.ts`, then run `packages/scripts/__tests__/trajectory-list.test.ts`.

## Detailed testing steps

Pinned toolchain: Bun 1.3.14 and Node 24.15.0.

```bash
bun test packages/scripts/__tests__/trajectory-list.test.ts \
  packages/scripts/__tests__/trajectory-validate.test.ts \
  packages/scripts/__tests__/script-test-inventory.test.ts
# 34 pass, 0 fail, 558 assertions

./node_modules/.bin/biome check \
  packages/scripts/trajectory.ts \
  packages/scripts/__tests__/trajectory-list.test.ts
# checked 2 files, no errors; two pre-existing undeclared-env warnings

git diff --check origin/develop...HEAD
# pass

RUN_TURBO_CONCURRENCY=4 bun run verify
# blocked before Turbo by current-base check:biome-version drift:
# canonical expected 2.5.7, while package overrides, biome schemas,
# bun.lock, and plugin locks still resolve 2.5.6
```

The focused real CLI suite alone passes 4/4 with 15 assertions.

# Evidence Gate

<!-- evidence-head:b98952bf40d616756277c5c2a9aa56cb4d804f40 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - read-only terminal output only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - read-only terminal output only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the entire behavior is deterministically captured by the real CLI subprocess test.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service, request, database, or network path changed; this is a read-only local CLI.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend, request, or browser path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, model, action, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Controlled trajectory JSON fixtures and emitted CLI rows:
<details><summary>Domain assertions</summary>

```text
20 newer nonmatching records do not hide target-old at --limit 20.
--limit 1 emits match-new and excludes match-old.
malformed and --since-filtered files do not consume the two-row limit.
an all-nonmatching directory preserves No trajectories matched the filter.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or image surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changed.

## Backend + frontend logs

Before the fix, on current develop with 20 newer `other-agent` files and one older `target-agent` file:

```text
trajectory list --agent target-agent --limit 20
No trajectories matched the filter.

trajectory list --agent target-agent --limit 21
target-old ... target-agent
```

After the fix, the real subprocess regression with the same ordering passes and returns `target-old` at limit 20. The combined scoped suite reports:

```text
34 pass
0 fail
558 assertions
```

No frontend path exists for this change.

## Screenshots (before / after) + video walkthrough

N/A - terminal-only, deterministic CLI output with no UI surface.

## Audio / voice walkthrough

N/A - no audio path changed.

## Known gaps / failures

- Root `bun run verify` cannot reach project typecheck/lint on this base because `check:biome-version` expects 2.5.7 while the repository package/config/lock sources still declare 2.5.6. This PR does not touch dependency or Biome configuration files. The two changed files pass the repository-resolved Biome 2.5.6 binary.
- Existing `--limit` numeric parsing semantics are outside #18770; this PR only corrects filter-before-limit ordering.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 12491993 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [trajectory-list-filter-limit]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZVVAS3PR6K8G5PJJFF4TJYE","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T20:41:27.926Z","completed_at":"2026-08-12T20:48:49.462Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":330619,"output_tokens":30302,"cache_creation_tokens":0,"cache_read_tokens":12131072,"total_tokens":12491993,"cost_micro_usd":"8627691","session_count":5},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"59NCOq-ShnGGg11Ph0aBvfbHs2paoY92gGmt-XMXcm9C74FxHfdW0kkIpD5ffIYjxQlwinW_uwrgJ43g87WeAw"}} -->
