### PR TITLE
fix(cloud): validate agent-server capacity at boot

### DIFF
--- a/packages/cloud/services/agent-server/AGENTS.md
+++ b/packages/cloud/services/agent-server/AGENTS.md
@@ -54,6 +54,10 @@ Required at boot (process exits 1 if any is missing):
 `SERVER_NAME`, `REDIS_URL`, `DATABASE_URL`, `CAPACITY`, `TIER`,
 `AGENT_SERVER_SHARED_SECRET`.
 
+`CAPACITY` must be a canonical decimal integer from `1` through `200`; the
+server validates it once before connecting to Redis and uses that numeric value
+for status and admission until the process exits.
+
 - `DATABASE_URL` is mapped to `POSTGRES_URL` for `@elizaos/plugin-sql` if the
   latter is unset.
 - `AGENT_SERVER_SHARED_SECRET` is the internal service-to-service token; callers

--- a/packages/cloud/services/agent-server/CLAUDE.md
+++ b/packages/cloud/services/agent-server/CLAUDE.md
@@ -54,6 +54,10 @@ Required at boot (process exits 1 if any is missing):
 `SERVER_NAME`, `REDIS_URL`, `DATABASE_URL`, `CAPACITY`, `TIER`,
 `AGENT_SERVER_SHARED_SECRET`.
 
+`CAPACITY` must be a canonical decimal integer from `1` through `200`; the
+server validates it once before connecting to Redis and uses that numeric value
+for status and admission until the process exits.
+
 - `DATABASE_URL` is mapped to `POSTGRES_URL` for `@elizaos/plugin-sql` if the
   latter is unset.
 - `AGENT_SERVER_SHARED_SECRET` is the internal service-to-service token; callers

--- a/packages/cloud/services/agent-server/__tests__/unit/capacity.test.ts
+++ b/packages/cloud/services/agent-server/__tests__/unit/capacity.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Exercises the agent-server capacity boundary through the real manager API
+ * and a subprocess boot while keeping runtime initialization out of the unit
+ * harness.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { AgentManager } from "../../src/agent-manager";
+
+const originalCapacity = process.env.CAPACITY;
+
+afterEach(() => {
+  if (originalCapacity === undefined) {
+    delete process.env.CAPACITY;
+  } else {
+    process.env.CAPACITY = originalCapacity;
+  }
+});
+
+function reserveAgent(manager: AgentManager, agentId: string): void {
+  (
+    manager as unknown as {
+      agents: Map<string, unknown>;
+    }
+  ).agents.set(agentId, {
+    agentId,
+    characterRef: "test:character",
+    state: "stopped",
+  });
+}
+
+describe("AgentManager capacity", () => {
+  test("reports and enforces the parsed capacity after the environment changes", async () => {
+    const manager = new AgentManager(1);
+    reserveAgent(manager, "reserved-agent");
+    process.env.CAPACITY = "200";
+
+    expect(manager.getStatus()).toMatchObject({
+      capacity: 1,
+      agentCount: 1,
+    });
+    await expect(
+      manager.startAgent("overflow-agent", "test:character"),
+    ).rejects.toThrow("At capacity");
+  });
+
+  test("rejects malformed capacity before opening Redis or listening", async () => {
+    let child: ReturnType<typeof Bun.spawn> | undefined;
+    let deadline: ReturnType<typeof setTimeout> | undefined;
+    let timedOut = false;
+
+    try {
+      child = Bun.spawn(
+        [process.execPath, "--conditions=eliza-source", "run", "src/index.ts"],
+        {
+          cwd: fileURLToPath(new URL("../..", import.meta.url)),
+          env: {
+            SERVER_NAME: "capacity-test",
+            REDIS_URL: "redis://127.0.0.1:1",
+            DATABASE_URL: "postgres://unused:unused@127.0.0.1:1/unused",
+            CAPACITY: "1e2",
+            TIER: "test",
+            AGENT_SERVER_SHARED_SECRET: "test-secret",
+            MOCK_REDIS: "1",
+            PORT: "0",
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      deadline = setTimeout(() => {
+        timedOut = true;
+        child?.kill();
+      }, 5_000);
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ]);
+      const output = `${stdout}${stderr}`;
+
+      expect(timedOut).toBe(false);
+      expect(exitCode).toBe(1);
+      expect(output).toContain(
+        "CAPACITY must be a canonical decimal integer from 1 to 200",
+      );
+      expect(output).not.toContain("[redis] using in-memory mock");
+      expect(output).not.toContain("Agent-server listening");
+    } finally {
+      if (deadline) clearTimeout(deadline);
+      if (child?.exitCode === null) {
+        child.kill();
+        await child.exited;
+      }
+    }
+  });
+});

--- a/packages/cloud/services/agent-server/__tests__/unit/config.test.ts
+++ b/packages/cloud/services/agent-server/__tests__/unit/config.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   ensureServerName,
   getAdvertisedServerUrl,
+  getAgentCapacity,
   getAutoStartAgentConfig,
   normalizeServerName,
 } from "../../src/config";
@@ -42,6 +43,32 @@ describe("ensureServerName", () => {
 
     expect(ensureServerName(env)).toBe("8baf830a-2dc3-465d-b7ed-725fae3eaa56");
     expect(env.SERVER_NAME).toBe("8baf830a-2dc3-465d-b7ed-725fae3eaa56");
+  });
+});
+
+describe("getAgentCapacity", () => {
+  test.each(["1", "16", "200"])("accepts canonical capacity %s", (value) => {
+    expect(getAgentCapacity({ CAPACITY: value })).toBe(Number(value));
+  });
+
+  test.each([
+    undefined,
+    "",
+    "0",
+    "201",
+    "01",
+    "+1",
+    "-1",
+    "1.0",
+    "1e2",
+    " 1",
+    "1 ",
+    "Infinity",
+    "NaN",
+    "١",
+    "9007199254740993",
+  ])("rejects non-canonical or out-of-range capacity %p", (value) => {
+    expect(() => getAgentCapacity({ CAPACITY: value })).toThrow(/CAPACITY/);
   });
 });
 

--- a/packages/cloud/services/agent-server/__tests__/unit/handle-message.test.ts
+++ b/packages/cloud/services/agent-server/__tests__/unit/handle-message.test.ts
@@ -56,7 +56,7 @@ const OK_RESULT = {
 
 describe("AgentManager.handleMessage fail-closed message pipeline", () => {
   test("throws a structural error when the runtime has no message service", async () => {
-    const manager = new AgentManager();
+    const manager = new AgentManager(1);
     withRunningAgent(manager, "agent-1", makeRuntime({ messageService: null }));
 
     await expect(
@@ -65,7 +65,7 @@ describe("AgentManager.handleMessage fail-closed message pipeline", () => {
   });
 
   test("does not fabricate a reply string when message service is missing", async () => {
-    const manager = new AgentManager();
+    const manager = new AgentManager(1);
     withRunningAgent(manager, "agent-1", makeRuntime({ messageService: null }));
 
     let thrown: unknown;
@@ -80,7 +80,7 @@ describe("AgentManager.handleMessage fail-closed message pipeline", () => {
   });
 
   test("returns accumulated response text from the message pipeline", async () => {
-    const manager = new AgentManager();
+    const manager = new AgentManager(1);
     const handleMessage = mock(
       async (_rt: IAgentRuntime, _mem: Memory, callback?: HandlerCallback) => {
         await callback?.({ text: "hello " });
@@ -99,7 +99,7 @@ describe("AgentManager.handleMessage fail-closed message pipeline", () => {
   });
 
   test("passes canonical connector provenance to the runtime message pipeline", async () => {
-    const manager = new AgentManager();
+    const manager = new AgentManager(1);
     let received: Memory | undefined;
     const handleMessage = mock(
       async (_rt: IAgentRuntime, mem: Memory, callback?: HandlerCallback) => {
@@ -149,7 +149,7 @@ describe("AgentManager.handleMessage fail-closed message pipeline", () => {
   });
 
   test("returns empty string (not a fabricated literal) on a deliberate no-response", async () => {
-    const manager = new AgentManager();
+    const manager = new AgentManager(1);
     const handleMessage = mock(
       async () =>
         ({
@@ -172,7 +172,7 @@ describe("AgentManager.handleMessage fail-closed message pipeline", () => {
   });
 
   test("still surfaces getRuntime not-found as its own error (unchanged)", async () => {
-    const manager = new AgentManager();
+    const manager = new AgentManager(1);
     await expect(
       manager.handleMessage("missing", "user-1", "hi"),
     ).rejects.toThrow("Agent not found");

--- a/packages/cloud/services/agent-server/src/agent-manager.ts
+++ b/packages/cloud/services/agent-server/src/agent-manager.ts
@@ -189,6 +189,8 @@ export class AgentManager {
   private inFlight = 0;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
+  constructor(private readonly capacity: number) {}
+
   /** Returns the internal K8s service URL for this pod. */
   private getServerUrl(): string {
     return getAdvertisedServerUrl();
@@ -273,7 +275,7 @@ export class AgentManager {
     return {
       serverName: process.env.SERVER_NAME,
       tier: process.env.TIER,
-      capacity: Number(process.env.CAPACITY),
+      capacity: this.capacity,
       agentCount: this.agents.size,
       inFlight: this.inFlight,
       draining: this._draining,
@@ -304,7 +306,7 @@ export class AgentManager {
    * @throws {Error} "Agent already exists" if the agent is already loaded
    */
   async startAgent(agentId: string, characterRef: string) {
-    if (this.agents.size >= Number(process.env.CAPACITY)) {
+    if (this.agents.size >= this.capacity) {
       throw new Error("At capacity");
     }
     if (this.agents.has(agentId)) {

--- a/packages/cloud/services/agent-server/src/config.ts
+++ b/packages/cloud/services/agent-server/src/config.ts
@@ -6,6 +6,8 @@ export interface AutoStartAgentConfig {
   characterRef: string;
 }
 
+const MAX_AGENT_CAPACITY = 200;
+
 export function normalizeServerName(
   value: string | undefined,
 ): string | undefined {
@@ -45,6 +47,28 @@ export function getRequiredEnv(name: string, env: Env = process.env): string {
     throw new Error(`Missing required env var: ${name}`);
   }
   return value;
+}
+
+/** Returns the validated per-pod agent limit from the process environment. */
+export function getAgentCapacity(env: Env = process.env): number {
+  const value = env.CAPACITY;
+  if (value === undefined || value.length === 0) {
+    throw new Error("Missing required env var: CAPACITY");
+  }
+  if (!/^[1-9][0-9]*$/.test(value)) {
+    throw new Error(
+      `CAPACITY must be a canonical decimal integer from 1 to ${MAX_AGENT_CAPACITY}`,
+    );
+  }
+
+  const capacity = Number(value);
+  if (!Number.isSafeInteger(capacity) || capacity > MAX_AGENT_CAPACITY) {
+    throw new Error(
+      `CAPACITY must be a canonical decimal integer from 1 to ${MAX_AGENT_CAPACITY}`,
+    );
+  }
+
+  return capacity;
 }
 
 export function getAutoStartAgentConfig(

--- a/packages/cloud/services/agent-server/src/index.ts
+++ b/packages/cloud/services/agent-server/src/index.ts
@@ -3,6 +3,7 @@ import { Elysia } from "elysia";
 import { AgentManager } from "./agent-manager";
 import {
   ensureServerName,
+  getAgentCapacity,
   getAutoStartAgentConfig,
   getRequiredEnv,
 } from "./config";
@@ -21,7 +22,6 @@ const required = [
   "SERVER_NAME",
   "REDIS_URL",
   "DATABASE_URL",
-  "CAPACITY",
   "TIER",
   "AGENT_SERVER_SHARED_SECRET",
 ];
@@ -34,6 +34,14 @@ for (const key of required) {
   }
 }
 
+let capacity: number;
+try {
+  capacity = getAgentCapacity();
+} catch (err) {
+  logger.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}
+
 let autoStartAgent: ReturnType<typeof getAutoStartAgentConfig>;
 try {
   autoStartAgent = getAutoStartAgentConfig();
@@ -44,7 +52,7 @@ try {
 
 const PORT = Number(process.env.PORT ?? 3000);
 const sharedSecret = getRequiredEnv("AGENT_SERVER_SHARED_SECRET");
-const manager = new AgentManager();
+const manager = new AgentManager(capacity);
 
 // Initialize manager before accepting connections
 await manager.initialize();
@@ -65,7 +73,7 @@ logger.info("Agent-server listening", {
   serverName: process.env.SERVER_NAME,
   port: PORT,
   tier: process.env.TIER,
-  capacity: process.env.CAPACITY,
+  capacity,
 });
 
 process.on("SIGTERM", async () => {


### PR DESCRIPTION
# Relates to

Fixes #18763

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on exact current `origin/develop` with zero conflicts.
- [x] The locked install, package verification, dependency build, and root verification gate were run after sync; the exact unrelated root blocker is recorded below.
- [x] A reviewer can confirm the change from the real process-boundary evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact head `ceb068e75b366752dcb6182d1f3d962ab3e11d1f` has parent/current `origin/develop` `b9dec8f6054b9d563be68fbb8421bb95b18cd977`; ahead 1, behind 0.
- [x] `bun run verify` was run post-sync and stopped at the current-base Biome 2.5.7 manifest versus 2.5.6 override/schema/lock inconsistency tracked by #18756 and open PR #18761. All changed-package gates pass.

# Risks

Low. This intentionally makes agent-server fail at boot when `CAPACITY` is blank, malformed, non-canonical, or outside the operator's existing `1..200` contract. A manually configured deployment that previously relied on whitespace, exponent, fractional, signed, or out-of-range syntax must correct that value before it can start. Valid canonical deployments are unchanged.

# Background

## What does this PR do?

- Parses `CAPACITY` once at startup as a canonical ASCII decimal integer from 1 through 200, before Redis initialization or HTTP listen.
- Injects the validated number into `AgentManager`, so status and admission never re-read or re-coerce mutable process state.
- Preserves immediate slot reservation and verifies a full slot rejects another start.
- Documents the configuration contract and adds parser, manager, and real-process regressions.

## What kind of change is this?

Bug fix; no API or persistence-schema change.

# Documentation changes needed?

Included: the paired agent-server `AGENTS.md` / `CLAUDE.md` guides now document the canonical `1..200` boot contract.

# Testing

## Where should a reviewer start?

1. `packages/cloud/services/agent-server/src/config.ts`
2. `packages/cloud/services/agent-server/src/index.ts`
3. `packages/cloud/services/agent-server/src/agent-manager.ts`
4. `packages/cloud/services/agent-server/__tests__/unit/capacity.test.ts`

## Detailed testing steps

Pinned toolchain: Node `v24.15.0`, Bun `1.3.14`.

- `bun install --frozen-lockfile --ignore-scripts` — PASS, 6,400 packages.
- Agent-server dependency-cone build — PASS, 9/9 tasks.
- `bun run --cwd packages/cloud/services/agent-server test` — PASS, 93 tests / 240 assertions.
- `bun run --cwd packages/cloud/services/agent-server lint:check` — PASS, 17 files.
- `bun run --cwd packages/cloud/services/agent-server typecheck` — PASS.
- `bun run check:agents-claude` — PASS, 154 paired guides byte-identical.
- Exact base/head process matrix — PASS, 18/18 cases.
- `git diff --check` — PASS.
- `bun run verify` — INCOMPLETE on the unrelated current-develop Biome version-consistency mismatch described above; it stops before any diff-related failure.

# Evidence Gate

<!-- evidence-head:ceb068e75b366752dcb6182d1f3d962ab3e11d1f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only environment validation and admission state; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only environment validation and admission state; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or rendered user flow changed; the real process boundary is captured below.
<!-- evidence-row:backend-logs -->
- [x] <details><summary>Exact base/head process outcomes</summary>

  ```text
  base b9dec8f6054b | CAPACITY=abc | booted | HTTP 200 | reported capacity=null
  head ceb068e75b36 | 14 malformed/out-of-range values | rejected before listen | 14/14 PASS
  head ceb068e75b36 | CAPACITY=1,8,200 | booted | status reported 1,8,200 | 3/3 PASS
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, network, or state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, provider, prompt, model input, or model output behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] ![Agent-server capacity boot matrix](https://github.com/user-attachments/assets/62e3b8a0-8de6-42ff-a520-07f598c5a8a8)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered product UI surface changed; the attached PNG is a generated backend result matrix, not product UI.

# Evidence Details

## Backend + domain proof

A secret-free harness ran the exact committed base and head through the real `src/index.ts` / Elysia `/status` boundary using the package's explicit `MOCK_REDIS=1` test transport. The base demonstrably boots with `CAPACITY=abc` and serializes its `NaN` status as `null`. The head rejects 14 malformed and out-of-range forms before Redis/listen, while canonical 1, 8, and 200 boot and report their exact numeric capacity. The fixed manager separately proves that mutating `process.env.CAPACITY` cannot change status or bypass a full slot.

Artifact SHA-256: `9d669673e86f5f7b0f02e96ac0efbfe8e2c2a8f0eb65f4314845767b3381c389`.

## Known gaps / failures

- Root `bun run verify` is currently blocked on `develop` by the Biome 2.5.7 direct manifest versus 2.5.6 override/schema/lock inconsistency tracked in #18756; open PR #18761 addresses that repository-wide baseline. This PR does not mix that unrelated dependency-policy repair into the agent-server fix.
- No live cloud deployment was used. The changed boundary is startup parsing, Redis-before-listen ordering, status serialization, and in-process admission. Those paths are exercised by an exact-process loopback harness plus the real manager API; no external credentials or service are required.
- Screenshots, video, frontend logs, OCR, and LLM trajectory are not applicable because no rendered, frontend, connector, action, prompt, provider, or model surface changed.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 47461593 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [agent-server-capacity-validation]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZVSJ5ANWXRFDBPT1V01TFAB","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T20:10:32.661Z","completed_at":"2026-08-12T20:30:08.385Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":1738388,"output_tokens":104166,"cache_creation_tokens":0,"cache_read_tokens":45619039,"total_tokens":47461593,"cost_micro_usd":"5451841","session_count":10},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAWOuFq4QKFpEzUxdS-xUTGOp-_XL5j-TbR18ldYqv818","device_key_id":"27a2bd6f25b7dfbdcd447074ad6ad4d4eff92654605004b081bd547e02c21550","device_signature":"ren-BlsCXQTaZ_1Jaf7zgY7s243_JflKG6qvuwqndfGMeLjC_NgQP0QkxqDLaDzwIGyiLwcFefL-2GyvP9K3Cw"}} -->
