### PR TITLE
fix(ui): publish typed Steward storage transitions

### DIFF
--- a/packages/shared/src/steward-session-client/index.test.ts
+++ b/packages/shared/src/steward-session-client/index.test.ts
@@ -1,5 +1,16 @@
+/** Tests the shared Steward browser-session contract with deterministic DOM state. */
+// @vitest-environment jsdom
+
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { hasStewardAuthedCookie, stewardAuthedCookieName } from "./index";
+import {
+  clearStoredStewardToken,
+  hasStewardAuthedCookie,
+  STEWARD_SESSION_CHANGE_EVENT,
+  STEWARD_TOKEN_KEY,
+  type StewardSessionChangeDetail,
+  stewardAuthedCookieName,
+  writeStoredStewardToken,
+} from "./index";
 
 function stubDocumentCookie(cookie: string): void {
   vi.stubGlobal("document", { cookie });
@@ -26,5 +37,37 @@ describe("steward session marker cookie", () => {
 
     stubDocumentCookie("steward-authed-staging=1; steward-authed=1");
     expect(hasStewardAuthedCookie("staging")).toBe(true);
+  });
+});
+
+describe("Steward session storage transitions", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("publishes ordered typed transitions after canonical writes and clears", () => {
+    const transitions: StewardSessionChangeDetail[] = [];
+    const listener = (event: Event) => {
+      transitions.push(
+        (event as CustomEvent<StewardSessionChangeDetail>).detail,
+      );
+    };
+    window.addEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
+
+    try {
+      writeStoredStewardToken("steward-token");
+      expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe("steward-token");
+      clearStoredStewardToken();
+      expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    } finally {
+      window.removeEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
+    }
+
+    expect(transitions).toHaveLength(2);
+    expect(transitions[0]?.state).toBe("present");
+    expect(transitions[1]?.state).toBe("cleared");
+    expect(transitions[1]?.sessionEpoch).toBeGreaterThan(
+      transitions[0]?.sessionEpoch ?? 0,
+    );
   });
 });

--- a/packages/shared/src/steward-session-client/index.ts
+++ b/packages/shared/src/steward-session-client/index.ts
@@ -19,6 +19,29 @@
 /** localStorage key for the Steward access token (JWT). */
 export const STEWARD_TOKEN_KEY = "steward_session_token";
 
+/** Typed browser event emitted after a canonical Steward token mutation. */
+export const STEWARD_SESSION_CHANGE_EVENT = "steward-session-change";
+
+export interface StewardSessionChangeDetail {
+  state: "present" | "cleared";
+  sessionEpoch: number;
+}
+
+let sessionEpoch = 0;
+
+/** Publish a credential-domain-specific transition without exposing the token. */
+export function dispatchStewardSessionChange(
+  state: StewardSessionChangeDetail["state"],
+): void {
+  if (typeof window === "undefined") return;
+  sessionEpoch += 1;
+  window.dispatchEvent(
+    new CustomEvent<StewardSessionChangeDetail>(STEWARD_SESSION_CHANGE_EVENT, {
+      detail: { state, sessionEpoch },
+    }),
+  );
+}
+
 /**
  * localStorage key for the Steward refresh token.
  *
@@ -165,7 +188,9 @@ export function writeStoredStewardToken(token: string): void {
   } catch {
     // localStorage may be disabled (private mode, quota, sandboxed iframe);
     // callers that need durability should detect this themselves.
+    return;
   }
+  dispatchStewardSessionChange("present");
 }
 
 export function clearStoredStewardToken(): void {
@@ -175,7 +200,9 @@ export function clearStoredStewardToken(): void {
     window.localStorage.removeItem(STEWARD_REFRESH_TOKEN_KEY);
   } catch {
     // ignore
+    return;
   }
+  dispatchStewardSessionChange("cleared");
 }
 
 /**

--- a/packages/ui/src/api/client-cloud-trusted-shell-boundary.test.ts
+++ b/packages/ui/src/api/client-cloud-trusted-shell-boundary.test.ts
@@ -4,7 +4,11 @@
  */
 // @vitest-environment jsdom
 
-import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import {
+  STEWARD_SESSION_CHANGE_EVENT,
+  STEWARD_TOKEN_KEY,
+  type StewardSessionChangeDetail,
+} from "@elizaos/shared/steward-session-client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const platform = vi.hoisted(() => ({
@@ -201,7 +205,14 @@ describe("dedicated Cloud account boundary on trusted app shells", () => {
       localStorage.setItem(STEWARD_TOKEN_KEY, "  rejected-token  ");
       const fetchSpy = mockTrustedShellResponse({ error: "unauthorized" }, 401);
       const syncListener = vi.fn();
+      const sessionTransitions: StewardSessionChangeDetail[] = [];
+      const sessionListener = (event: Event) => {
+        sessionTransitions.push(
+          (event as CustomEvent<StewardSessionChangeDetail>).detail,
+        );
+      };
       window.addEventListener("steward-token-sync", syncListener);
+      window.addEventListener(STEWARD_SESSION_CHANGE_EVENT, sessionListener);
       const client = new ElizaClient(DEDICATED_STAGING_BASE, "rejected-token");
 
       await expect(client.getCloudStatus()).resolves.toMatchObject({
@@ -210,6 +221,8 @@ describe("dedicated Cloud account boundary on trusted app shells", () => {
       });
       expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
       expect(syncListener).toHaveBeenCalledTimes(1);
+      expect(sessionTransitions).toHaveLength(1);
+      expect(sessionTransitions[0]?.state).toBe("cleared");
 
       await expect(client.getCloudCompatAgents()).resolves.toMatchObject({
         success: false,
@@ -222,6 +235,7 @@ describe("dedicated Cloud account boundary on trusted app shells", () => {
         expect(fetchSpy).toHaveBeenCalledTimes(1);
       }
       window.removeEventListener("steward-token-sync", syncListener);
+      window.removeEventListener(STEWARD_SESSION_CHANGE_EVENT, sessionListener);
     },
   );
 

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.ts
@@ -258,7 +258,6 @@ async function clearRejectedCookieSession(): Promise<void> {
     );
   }
   clearStoredStewardToken();
-  dispatchStewardSessionChange("cleared");
 }
 
 /**

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -235,6 +235,7 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
               writeStoredStewardToken(body.token);
               lastSyncedToken.current = body.token;
               wasAuthenticated.current = true;
+              dispatchStewardSessionChange("present");
             }
             try {
               window.dispatchEvent(new CustomEvent("steward-token-sync"));

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -235,7 +235,6 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
               writeStoredStewardToken(body.token);
               lastSyncedToken.current = body.token;
               wasAuthenticated.current = true;
-              dispatchStewardSessionChange("present");
             }
             try {
               window.dispatchEvent(new CustomEvent("steward-token-sync"));

--- a/packages/ui/src/cloud/shell/StewardProviderShared.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.ts
@@ -9,7 +9,6 @@ import {
   STEWARD_TOKEN_KEY,
 } from "@elizaos/shared/steward-session-client";
 import { createContext } from "react";
-import { dispatchStewardSessionChange } from "../../events/steward-session-event";
 import { scrubPersistedAgentProfileTokens } from "../../state/agent-profiles";
 import { scrubPersistedActiveServerToken } from "../../state/persistence";
 import { decodeJwtPayload } from "../lib/jwt";
@@ -177,7 +176,6 @@ export function clearStaleStewardSession(): void {
   scrubPersistedActiveServerToken();
   scrubPersistedAgentProfileTokens();
   clearServerStewardSessionCookies();
-  dispatchStewardSessionChange("cleared");
   try {
     window.dispatchEvent(new CustomEvent("steward-token-sync"));
   } catch {

--- a/packages/ui/src/events/steward-session-event.ts
+++ b/packages/ui/src/events/steward-session-event.ts
@@ -1,22 +1,7 @@
-/** Publishes typed Steward session transitions without exposing credentials. */
+/** Re-exports the canonical typed Steward session transition contract. */
 
-export const STEWARD_SESSION_CHANGE_EVENT = "steward-session-change";
-
-export interface StewardSessionChangeDetail {
-  state: "present" | "cleared";
-  sessionEpoch: number;
-}
-
-let sessionEpoch = 0;
-
-export function dispatchStewardSessionChange(
-  state: StewardSessionChangeDetail["state"],
-): void {
-  if (typeof window === "undefined") return;
-  sessionEpoch += 1;
-  window.dispatchEvent(
-    new CustomEvent<StewardSessionChangeDetail>(STEWARD_SESSION_CHANGE_EVENT, {
-      detail: { state, sessionEpoch },
-    }),
-  );
-}
+export {
+  dispatchStewardSessionChange,
+  STEWARD_SESSION_CHANGE_EVENT,
+  type StewardSessionChangeDetail,
+} from "@elizaos/shared/steward-session-client";

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -7,6 +7,10 @@
  * with the API client and bridges mocked — deterministic, no real server.
  */
 import type { AgentNotification } from "@elizaos/core";
+import {
+  clearStoredStewardToken,
+  writeStoredStewardToken,
+} from "@elizaos/shared/steward-session-client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "../../api/client-types-core";
 import {
@@ -1219,6 +1223,30 @@ describe("notification-store — authority isolation (#18391)", () => {
         expect(__getStateForTests().notifications).toHaveLength(1),
       );
       expect(__getStateForTests().notifications[0]?.id).toBe("b-row");
+    });
+
+    it("clears immediately when a canonical rejected-token path removes the Steward credential", async () => {
+      __setAuthStatusForTests(authenticated("user-a", "session-a"));
+      writeStoredStewardToken("rejected-steward-token");
+      const notifA = makeNotification({ id: "a-row", title: "A's row" });
+      listNotifications.mockResolvedValueOnce({
+        notifications: [notifA],
+        unreadCount: 1,
+      });
+      initNotifications();
+      await vi.waitFor(() =>
+        expect(__getStateForTests().notifications).toHaveLength(1),
+      );
+      rotateConnection.mockClear();
+
+      // client-cloud's dedicated-agent 401 path calls this canonical clear
+      // while the unrelated Eliza API bearer remains present.
+      expect(hasToken()).toBe(true);
+      clearStoredStewardToken();
+
+      expect(__getStateForTests().notifications).toHaveLength(0);
+      expect(__getStateForTests().hydrationStatus).toBe("idle");
+      expect(rotateConnection).toHaveBeenCalledTimes(1);
     });
 
     it("drops a stale WS event delivered during the credential-invalidated window", async () => {


### PR DESCRIPTION
# Relates to

Fixes #18747 (remaining merged-review finding from #18752).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package verification was run after sync; the exact unrelated root blocker is recorded below.
- [x] A reviewer can confirm the change from the deterministic contract evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8a2070e78423ccb9d602df4478e498f740facc86:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop@8a2070e78423ccb9d602df4478e498f740facc86`; zero conflicts.
- [x] `bun run verify` was attempted post-sync; its unrelated current-develop Biome 2.5.6/2.5.7 mismatch is documented below (#18756; closed PR #18761 did not land).

# Risks

Low. This moves the existing typed browser event to the canonical shared token-mutation boundary. Every successful canonical write now emits `present`; every successful canonical clear emits `cleared`. Failed storage mutations emit no success transition. Existing legacy sync events remain for older consumers.

# Background

## What does this PR do?

The merged #18752 notification store correctly stopped inferring Steward logout from the unrelated Eliza API bearer, but several token mutation paths still emitted only the ambiguous legacy `steward-token-sync` event. In particular, a dedicated Cloud control-plane 401 could clear the stored Steward token without synchronously invalidating the outgoing notification authority.

This PR:

- owns the typed event contract beside `writeStoredStewardToken` / `clearStoredStewardToken`;
- emits typed, monotonic transitions only after successful storage mutations;
- keeps the UI event module as a compatibility re-export;
- removes now-duplicate typed dispatches from migrated UI callers;
- proves the actual control-plane 401 path emits exactly one `cleared` transition on native, Electrobun, and localhost;
- proves that canonical clearing synchronously empties the inbox and rotates the socket even while the separate agent bearer remains present.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No user-facing documentation change. The public storage helper contract and tests document the new invariant.

# Testing

## Where should a reviewer start?

- `packages/shared/src/steward-session-client/index.ts`
- `packages/ui/src/api/client-cloud-trusted-shell-boundary.test.ts`
- `packages/ui/src/state/notifications/notification-store.test.ts`

## Detailed testing steps

- `bun run --cwd packages/shared test` — 123 files, 1,408 tests passed.
- `bun run --cwd packages/ui test -- --silent=passed-only --reporter=dot` — 946 files, 9,885 passed / 7 skipped.
- `bun run --cwd packages/shared typecheck` — passed.
- `bun run --cwd packages/ui typecheck` — passed.
- `bun run --cwd packages/ui lint:check` — passed with 8 pre-existing cookie warnings.
- Touched-file Biome check — 8 files passed.
- `bun run --cwd packages/shared build` — passed.
- `bun run --cwd packages/ui build` — passed; 46 runtime exports verified.
- `git diff --check` — passed.

# Evidence Gate

<!-- evidence-head:54c2d1b8facd1fb45fedd22f98f9e9739a3e00ee -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered component, stylesheet, SVG, or visual behavior changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered component, stylesheet, SVG, or visual behavior changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic storage, browser-event, and notification-store race with no rendered flow
<!-- evidence-row:backend-logs -->
- [ ] N/A - client-side storage and notification state only
<!-- evidence-row:frontend-logs -->
- [x] [18777-54c2d1b-frontend-vitest.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18777-54c2d1b-frontend-vitest.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, or agent behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [18777-54c2d1b-domain-artifacts.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18777-54c2d1b-domain-artifacts.json)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior.

## Backend + frontend logs

Frontend deterministic evidence:

- real dedicated-agent Cloud 401 clears the current token and emits one typed `cleared` transition on all three trusted-shell cases;
- a refreshed token from a newer request remains preserved;
- canonical clear empties the inbox synchronously, leaves hydration idle until identity is known, and rotates the same-base socket once;
- the Eliza API bearer remains present, proving the credential domains are not conflated.

## Screenshots (before / after) + video walkthrough

N/A - no JSX/CSS/SVG or rendered UI behavior changed.

## Known gaps / failures

- Root `bun run verify` stops at the repository-wide current-develop Biome consistency mismatch: policy expects 2.5.7 while manifests, schemas, and lockfiles remain on 2.5.6. This is tracked by #18756; closed PR #18761 did not land and is unrelated to this diff.
- Shared `lint:check` encounters the known former formatter mismatch in `trajectory-format.test.ts`, resolved by merged PR #18769; all eight touched files pass Biome.
- Screenshots/video/OCR are N/A because this changes no rendered surface.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@8a2070e78423ccb9d602df4478e498f740facc86:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@8a2070e78423ccb9d602df4478e498f740facc86:packages/skills/skills/contribute-to-eliza"} -->




