### PR TITLE
fix(cloud): reject blank domain searches before registrar lookup

### DIFF
--- a/packages/cloud/api/__tests__/domains-search-validation.test.ts
+++ b/packages/cloud/api/__tests__/domains-search-validation.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireUserOrApiKeyWithOrg = mock();
+const searchDomains = mock();
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/cloudflare-registrar", () => ({
+  cloudflareRegistrarService: { searchDomains },
+}));
+
+const { default: searchRoute } = await import("../v1/domains/search/route");
+
+const app = new Hono();
+app.route("/api/v1/domains/search", searchRoute);
+
+function search(body: string): Response | Promise<Response> {
+  return app.request("/api/v1/domains/search", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+}
+
+describe("POST /api/v1/domains/search validation", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockReset();
+    requireUserOrApiKeyWithOrg.mockResolvedValue({ organization_id: "org-1" });
+    searchDomains.mockReset();
+    searchDomains.mockResolvedValue([]);
+  });
+
+  for (const [name, query] of [
+    ["spaces", "   "],
+    ["tabs", "\t\t"],
+    ["newlines", "\n\r\n"],
+    ["mixed whitespace", " \t\r\n "],
+  ] as const) {
+    test(`rejects ${name} without calling the registrar`, async () => {
+      const response = await search(JSON.stringify({ query }));
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({ success: false });
+      expect(searchDomains).not.toHaveBeenCalled();
+    });
+  }
+
+  test("forwards a padded valid query after trimming", async () => {
+    const response = await search(
+      JSON.stringify({ query: "  example  ", limit: 7 }),
+    );
+
+    expect(response.status).toBe(200);
+    const body: unknown = await response.json();
+    expect(body).toEqual({
+      success: true,
+      query: "example",
+      candidates: [],
+    });
+    expect(searchDomains).toHaveBeenCalledTimes(1);
+    expect(searchDomains).toHaveBeenCalledWith("example", 7);
+  });
+
+  test("preserves malformed JSON failure handling without calling the registrar", async () => {
+    const response = await search("{");
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({ success: false });
+    expect(searchDomains).not.toHaveBeenCalled();
+  });
+
+  test("preserves registrar failure handling", async () => {
+    searchDomains.mockRejectedValueOnce(new Error("registrar unavailable"));
+
+    const response = await search(JSON.stringify({ query: "example" }));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({ success: false });
+    expect(searchDomains).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/api/v1/domains/search/route.ts
+++ b/packages/cloud/api/v1/domains/search/route.ts
@@ -18,11 +18,7 @@ import { computeDomainPrice } from "@/lib/services/domain-pricing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const SearchSchema = z.object({
-  query: z
-    .string()
-    .min(1)
-    .max(100)
-    .transform((s) => s.trim()),
+  query: z.string().trim().min(1).max(100),
   limit: z.number().int().min(1).max(20).optional(),
 });
 


### PR DESCRIPTION
# Relates to

Closes #18775

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` with zero conflicts and zero commits behind.
- [ ] `bun run verify` was attempted with pinned Bun 1.3.14 and Node 24.15.0; it is blocked before Turbo by the current base Biome consistency drift. Cloud API typecheck was also attempted but the reused dependency layout is not a valid package-typecheck environment, as detailed below.
- [x] A reviewer can confirm the API behavior from the focused real Hono route transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on `origin/develop@b9dec8f6054b9d563be68fbb8421bb95b18cd977`; zero commits behind at push time.
- [x] Exact contribution head: `5b12ec79a14770f8cc81cf4d9c5c47c2f45e4f88`.

# Risks

Low. This changes only request-boundary normalization for one read-only domain search route. Valid queries retain the same trimmed value, limit handling, registrar call, priced response mapping, authentication, and failure translation. Whitespace-only input now stops at HTTP 400 instead of reaching the registrar as an empty query.

# Background

## What does this PR do?

The route previously applied Zod `.min(1).max(100)` before trimming. Strings containing only spaces, tabs, or newlines passed validation, became `""`, and reached `cloudflareRegistrarService.searchDomains("")`. The development registrar could then return malformed `.com` and `.io` candidates, while production constructed a request with an empty search parameter.

This PR uses `z.string().trim().min(1).max(100)` and adds real Hono route coverage that mocks only authentication and the registrar boundary.

## What kind of change is this?

Bug fix (non-breaking API input validation).

# Documentation changes needed?

No. Blank input was never a valid domain-search query; this enforces the existing 1..100 character contract after normalization.

# Testing

## Where should a reviewer start?

Start with `SearchSchema` in `packages/cloud/api/v1/domains/search/route.ts`, then run `packages/cloud/api/__tests__/domains-search-validation.test.ts`.

## Detailed testing steps

Pinned toolchain: Bun 1.3.14 and Node 24.15.0.

```bash
bun test packages/cloud/api/__tests__/domains-search-validation.test.ts
# 7 pass, 0 fail, 22 assertions

./node_modules/.bin/biome check \
  packages/cloud/api/v1/domains/search/route.ts \
  packages/cloud/api/__tests__/domains-search-validation.test.ts
# checked 2 files, no fixes or errors

git diff --check origin/develop...HEAD
# pass

bun run --cwd packages/cloud/api typecheck
# attempted with reused dependency links; inconclusive due broad dependency-layout
# diagnostics (duplicated Hono types and missing workspace package links).
# After the owned response-body typing was corrected, the rerun reports no
# diagnostic for domains-search-validation.test.ts.

RUN_TURBO_CONCURRENCY=4 bun run verify
# blocked before Turbo by current-base check:biome-version drift:
# canonical expected 2.5.7, while package overrides, biome schemas,
# bun.lock, and plugin locks still resolve 2.5.6
```

# Evidence Gate

<!-- evidence-head:5b12ec79a14770f8cc81cf4d9c5c47c2f45e4f88 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - API validation only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - API validation only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the request/response contract is fully captured by the real route test.
<!-- evidence-row:backend-logs -->
- [x] Focused real Hono route transcript:
<details><summary>Domain search route evidence</summary>

```text
spaces, tabs, newlines, mixed whitespace => HTTP 400; registrar calls: 0
padded "  example  ", limit 7 => HTTP 200; registrar call: searchDomains("example", 7)
malformed JSON => HTTP 500; registrar calls: 0
registrar rejection => HTTP 500 through the existing failure boundary
focused suite => 7 pass, 0 fail, 22 assertions
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend, browser, or client path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, model, action, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Real response and collaborator-call assertions:
<details><summary>Response contract</summary>

```text
blank spaces/tabs/newlines/mixed => status 400, success false, registrar calls 0
padded valid input => status 200, query example, candidates []
valid collaborator call => searchDomains("example", 7), exactly once
malformed JSON => status 500, registrar calls 0
registrar rejection => status 500 through the existing failure boundary
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no image or rendered visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changed.

## Backend + frontend logs

The focused route suite drives the real Hono route and asserts HTTP status, response JSON, and registrar call count/arguments. It passes 7/7 with 22 assertions. No frontend path exists for this change.

## Screenshots (before / after) + video walkthrough

N/A - API-only change with no rendered surface.

## Audio / voice walkthrough

N/A - no audio path changed.

## Known gaps / failures

- Root `bun run verify` cannot reach project typecheck/lint on this base because `check:biome-version` expects 2.5.7 while repository package/config/lock sources still declare 2.5.6. This PR does not touch those files.
- A fresh package install was deliberately not performed. Cloud API typecheck under read-only reused dependency links produced 2,892 broad dependency-layout diagnostics (notably duplicated Hono identities and missing workspace packages), so it is not claimed as a valid typecheck result. The new test has no remaining owned diagnostic in that run; focused runtime and Biome gates are green.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 21888377 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [domain-search-blank-query]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZVW1GFWJEWFK597CM9ADBA9","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T20:53:52.764Z","completed_at":"2026-08-12T21:00:55.399Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":400818,"output_tokens":40007,"cache_creation_tokens":0,"cache_read_tokens":21447552,"total_tokens":21888377,"cost_micro_usd":"13928076","session_count":4},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"_7zn7eVyYKnprJ8E1ohtmQvt3-OPRa12DI5n2f-elSqnfxlEmfru3lOktlUMv-6c6th_JDnfzu_gyc0ZGsM8DQ"}} -->
