### PR TITLE
fix(agent): validate capability router timeout

### DIFF
--- a/packages/agent/src/services/remote-capability-router.test.ts
+++ b/packages/agent/src/services/remote-capability-router.test.ts
@@ -49,6 +49,25 @@ describe("remote capability router", () => {
     });
   });
 
+  it.each([
+    ["absent", undefined],
+    ["zero", "0"],
+    ["negative", "-1"],
+    ["decimal", "1.5"],
+    ["suffix garbage", "1234ms"],
+    ["unsafe integer", "9007199254740992"],
+  ])("uses the default timeout for %s input", (_description, value) => {
+    const config = resolveRemoteCapabilityRouterConfig(
+      makeRuntime(
+        value === undefined
+          ? {}
+          : { ELIZA_CAPABILITY_ROUTER_TIMEOUT_MS: value },
+      ),
+    );
+
+    expect(config.requestTimeoutMs).toBe(60_000);
+  });
+
   it("resolves multiple canonical remote endpoint URLs", () => {
     const config = resolveRemoteCapabilityRouterConfig(
       makeRuntime({

--- a/packages/agent/src/services/remote-capability-router.ts
+++ b/packages/agent/src/services/remote-capability-router.ts
@@ -58,6 +58,7 @@ import {
   type TerminalCapability,
   type TerminalRunParams,
 } from "@elizaos/core";
+import { parsePositiveInteger } from "@elizaos/shared";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 
@@ -1066,12 +1067,6 @@ function parseBoolean(value: string | undefined): boolean | undefined {
   if (["1", "true", "yes", "on"].includes(normalized)) return true;
   if (["0", "false", "no", "off"].includes(normalized)) return false;
   return undefined;
-}
-
-function parsePositiveInteger(value: string | undefined): number | undefined {
-  if (!value) return undefined;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 function parseEnvironment(


### PR DESCRIPTION
# Relates to

Closes #18723.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Based on current `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run; the unrelated base-repository blocker is exact below.
- [x] Exact-head focused and package-wide evidence is included.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b9dec8f6054b9d563be68fbb8421bb95b18cd977:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on `b9dec8f6054b9d563be68fbb8421bb95b18cd977`; zero conflicts.
- [x] Re-fetched `origin/develop` immediately before publication; the base SHA was unchanged.

# Risks

Low-risk configuration validation fix. It changes only malformed timeout override handling and preserves the public router config shape, valid positive integer behavior, and the existing 60-second default. No protocol, endpoint routing, UI, model, device, persistence, or live service behavior changes.

# Background

## What does this PR do?

- Replaces the capability router's local permissive `Number.parseInt` helper with the canonical strict `parsePositiveInteger` utility from `@elizaos/shared`.
- Rejects zero, negative, decimal, suffix-garbage, and unsafe-integer timeout overrides.
- Preserves valid positive safe integers and the 60-second default for absent or invalid values.
- Adds table-driven regression coverage for every required invalid class.

## What kind of change is this?

Agent configuration bug fix.

# Documentation changes needed?

No user documentation change is needed; the accepted variable and default are unchanged.

# Testing

## Where should a reviewer start?

1. `packages/agent/src/services/remote-capability-router.ts`
2. `packages/agent/src/services/remote-capability-router.test.ts`

## Detailed testing steps

```bash
bun install
bun test packages/agent/src/services/remote-capability-router.test.ts
bun run --cwd packages/agent test
bun run --cwd packages/agent typecheck
bun run --cwd packages/agent lint:check
bun run verify
```

Exact-head results:

```text
Focused remote-capability suite: 24 passed, 0 failed.
Agent package suite: 395/395 test files passed.
Agent typecheck: passed.
Agent lint: 878 files checked, no fixes applied.
bun install: 3,461 installs checked across 3,767 packages, no changes.
git diff --check: passed.
Root verify stopped at the pre-existing incomplete Biome 2.5.7 migration described below.
```

# Evidence Gate

<!-- evidence-head:467cbd81546b0564b9886c75013ece0fa557e46f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - agent environment parsing has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - agent environment parsing has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - this deterministic config resolver does not boot or call a live backend; the real package test transcript is included above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, scheduled-item, wallet, media, or other persisted artifact is produced by configuration parsing.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic environment-variable parsing only.

## Backend + frontend logs

N/A - no live runtime or frontend surface. The resolver is exercised directly by the focused and complete agent test lanes.

## Screenshots (before / after) + video walkthrough

N/A - no UI source or rendered state changes.

## Audio / voice walkthrough

N/A - no audio surface.

## Known gaps / failures

- The exact-head focused suite, complete 395-file agent suite, typecheck, lint, install, and diff integrity checks pass.
- Root `bun run verify` stops at `check:biome-version` because current `develop` declares expected Biome 2.5.7 while its override, manifests, schemas, and lockfiles remain at 2.5.6. PR #18772 is the complete fix for that unrelated repository-wide base blocker. This branch touches neither Biome configuration nor lockfiles.
- Screenshots, video, and OCR are N/A because there is no rendered surface.

AI provider/model: openai / gpt-5
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@b9dec8f6054b9d563be68fbb8421bb95b18cd977:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex Desktop","skill_revision":"elizaOS/eliza@b9dec8f6054b9d563be68fbb8421bb95b18cd977:packages/skills/skills/contribute-to-eliza"} -->
