### PR TITLE
fix(ui): enforce handoff opt-in on resume

### DIFF
--- a/packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts
+++ b/packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts
@@ -60,6 +60,9 @@ const mocks = vi.hoisted(() => ({
     },
   })),
   silentlyRepointToDedicated: vi.fn(),
+  getBootConfig: vi.fn((): { autoUpgradeSharedToDedicated?: boolean } => ({
+    autoUpgradeSharedToDedicated: true,
+  })),
 }));
 
 vi.mock("../../api", () => ({
@@ -75,6 +78,10 @@ vi.mock("../../api/client-cloud", () => ({
   getCloudAuthToken: mocks.getCloudAuthToken,
   isDirectCloudSharedAgentBase: mocks.isDirectCloudSharedAgentBase,
   resolveDirectCloudAuthApiBase: mocks.resolveDirectCloudAuthApiBase,
+}));
+
+vi.mock("../../config/boot-config-store", () => ({
+  getBootConfig: mocks.getBootConfig,
 }));
 
 // resume-pending-handoff imports loadPersistedActiveServer directly from the
@@ -171,6 +178,9 @@ describe("resumePendingCloudHandoff", () => {
         message: "ok",
       },
     });
+    mocks.getBootConfig.mockReturnValue({
+      autoUpgradeSharedToDedicated: true,
+    });
     window.localStorage.clear();
     __resetResumeForTests();
   });
@@ -213,6 +223,40 @@ describe("resumePendingCloudHandoff", () => {
       cloudApiBase: "https://elizacloud.ai",
       authToken: "cloud-token",
     });
+  });
+
+  it("retires a legacy marker without probing or mutating when automatic upgrade is off", async () => {
+    savePendingCloudHandoff(pending());
+    mocks.loadPersistedActiveServer.mockReturnValue(activeSharedServer());
+    mocks.getBootConfig.mockReturnValue({
+      autoUpgradeSharedToDedicated: false,
+    });
+
+    expect(resumePendingCloudHandoff()).toBe(false);
+    await settle();
+
+    expect(loadPendingCloudHandoff()).toBeNull();
+    expect(mocks.getCloudCompatAgent).not.toHaveBeenCalled();
+    expect(mocks.startCloudAgentHandoff).not.toHaveBeenCalled();
+    expect(mocks.createCloudCompatAgent).not.toHaveBeenCalled();
+    expect(mocks.deleteSharedBridgeAgent).not.toHaveBeenCalled();
+  });
+
+  it("does not inspect or recreate a gone legacy target when automatic upgrade is off", async () => {
+    savePendingCloudHandoff(pending());
+    mocks.loadPersistedActiveServer.mockReturnValue(activeSharedServer());
+    mocks.getBootConfig.mockReturnValue({});
+    mocks.getCloudCompatAgent.mockResolvedValue({
+      success: false,
+      data: { id: "dedicated-1", status: "deleted" },
+    });
+
+    expect(resumePendingCloudHandoff()).toBe(false);
+    await settle();
+
+    expect(loadPendingCloudHandoff()).toBeNull();
+    expect(mocks.getCloudCompatAgent).not.toHaveBeenCalled();
+    expect(mocks.createCloudCompatAgent).not.toHaveBeenCalled();
   });
 
   it("native resume also keeps the live app on the dedicated runtime after switch", async () => {
@@ -427,6 +471,43 @@ describe("resumePendingCloudHandoff", () => {
       sharedApiBase: SHARED_BASE,
       cloudApiBase: "https://elizacloud.ai",
     });
+  });
+
+  it("revalidates opt-in at Retry and performs zero create after policy turns off", async () => {
+    const uniqueShared = "shared-retry-policy-off";
+    savePendingCloudHandoff(
+      pending({
+        sharedAgentId: uniqueShared,
+        dedicatedAgentId: "dedicated-retry-policy-off-dead",
+      }),
+    );
+    mocks.loadPersistedActiveServer.mockReturnValue({
+      kind: "cloud",
+      id: `cloud:${uniqueShared}`,
+      apiBase: SHARED_BASE,
+      accessToken: "cloud-token",
+    });
+    mocks.getCloudCompatAgent.mockResolvedValue({
+      success: false,
+      data: { id: "dedicated-retry-policy-off-dead", status: "deleted" },
+    });
+
+    expect(resumePendingCloudHandoff()).toBe(true);
+    await settle();
+    mocks.getBootConfig.mockReturnValue({
+      autoUpgradeSharedToDedicated: false,
+    });
+
+    window.dispatchEvent(
+      new CustomEvent("eliza:cloud-handoff-retry", {
+        detail: { agentId: uniqueShared },
+      }),
+    );
+    await settle();
+
+    expect(mocks.createCloudCompatAgent).not.toHaveBeenCalled();
+    expect(mocks.startCloudAgentHandoff).not.toHaveBeenCalled();
+    expect(loadPendingCloudHandoff()).toBeNull();
   });
 });
 

--- a/packages/ui/src/cloud/handoff/resume-pending-handoff.ts
+++ b/packages/ui/src/cloud/handoff/resume-pending-handoff.ts
@@ -7,6 +7,7 @@ import {
   getCloudAuthToken,
   isDirectCloudSharedAgentBase,
 } from "../../api/client-cloud";
+import { getBootConfig } from "../../config/boot-config-store";
 import {
   CLOUD_HANDOFF_RETRY_EVENT,
   type CloudHandoffRetryDetail,
@@ -101,6 +102,15 @@ export function resumePendingCloudHandoff(): boolean {
 
   const pending = loadPendingCloudHandoff();
   if (!pending) return false;
+
+  if (getBootConfig().autoUpgradeSharedToDedicated !== true) {
+    // A marker can outlive the host policy that authorized it. Retire only the
+    // local resume instruction: the dedicated resource may already exist and
+    // must not be deleted implicitly, but default-off startup must perform no
+    // probe, handoff, or fresh billable mutation (#18204).
+    clearPendingCloudHandoff();
+    return false;
+  }
 
   const active = loadPersistedActiveServer();
   if (active?.kind !== "cloud" || !active.apiBase) {
@@ -239,6 +249,11 @@ async function runFreshDedicatedHandoff(
   pending: PendingCloudHandoff,
   authToken: string,
 ): Promise<void> {
+  // Consent is live configuration, not authority captured when the listener
+  // was armed. Revalidate immediately before the billable create so a host
+  // policy change cannot be bypassed by a stale Retry event (#18204).
+  if (getBootConfig().autoUpgradeSharedToDedicated !== true) return;
+
   try {
     const created = await client.createCloudCompatAgent({
       agentName: "Eliza",


### PR DESCRIPTION
# Relates to

Fixes #18204.

- [x] This PR targets `develop` and is based on current `origin/develop@8a2070e78423ccb9d602df4478e498f740facc86` with zero conflicts.
- [x] `bun install` was already current; `bun run verify` was run and its exact unrelated current-develop blocker is recorded below.
- [x] A reviewer can confirm the billing boundary from the attached deterministic evidence.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8a2070e78423ccb9d602df4478e498f740facc86:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop@8a2070e78423ccb9d602df4478e498f740facc86`; zero conflicts and path-disjoint intervening changes.
- [x] `bun run verify` stops before branch code at the existing repository-wide Biome 2.5.6/2.5.7 mismatch; merged PR #18769 resolved that base repair.

# Risks

Low. The change only retires a local pending marker when automatic shared-to-dedicated upgrade is not explicitly enabled. It never deletes the already-created dedicated resource. Opted-in hosts retain the existing resume and Retry behavior.

# Background

## What does this PR do?

Makes `resumePendingCloudHandoff()` the authoritative opt-in boundary for legacy and startup resume paths. When `autoUpgradeSharedToDedicated !== true`, it clears only the local pending instruction and performs zero target probe, handoff, bridge deletion, or dedicated create. The dead-target Retry path rechecks current policy immediately before `forceCreate`.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is needed; this enforces the boot-config contract already documented in code and #18204.

# Testing

## Where should a reviewer start?

`packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts`

## Detailed testing steps

- Run `bun run --cwd packages/ui test --run src/cloud/handoff/resume-pending-handoff.test.ts`.
- Verify all 16 tests pass, including default-off live/gone markers, opt-in same-target resume, exactly-once session behavior, and policy revocation before Retry.
- Run `bun run --cwd packages/ui typecheck`, `bun run --cwd packages/ui lint`, and `bun run --cwd packages/ui build`.

# Evidence Gate

<!-- evidence-head:a3288a37ab3caecd3f78ee6007312d58f6e4858c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered component, style, SVG, or visible layout changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered component, style, SVG, or visible layout changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pre-network state-machine billing decision with no rendered interaction
<!-- evidence-row:backend-logs -->
- [ ] N/A - default-off acceptance requires that no backend request is emitted
<!-- evidence-row:frontend-logs -->
- [x] [18781-a3288a3-frontend-vitest.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18781-a3288a3-frontend-vitest.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, model, prompt, provider, or action behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [18781-a3288a3-domain-artifacts.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18781-a3288a3-domain-artifacts.json)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

# Evidence Details

## Real LLM-call trajectory

N/A - no model call is involved.

## Backend + frontend logs

The deterministic jsdom contract observes every mutation collaborator directly. Default-off tests assert zero control-plane probe, handoff, create, shared-bridge delete, and marker retention.

## Screenshots (before / after) + video walkthrough

N/A - only `.ts` state-machine code and its test changed; no rendered UI file changed.

## Audio / voice walkthrough

N/A - no audio behavior changed.

## Known gaps / failures

- Full UI suite: 945 files / 9,893 non-skipped tests passed; one unrelated existing `src/backgrounds/AppBackground.test.tsx` case fails on a React Suspense `act()` console warning and reproduces in isolation. This branch does not touch backgrounds or React rendering.
- Root `bun run verify`: stops at `check:biome-version` because current develop expects 2.5.7 while manifests, schemas, and lockfiles remain 2.5.6. merged PR #18769 resolved that base repair.
- Hosted checks remain authoritative after push.

— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@8a2070e78423ccb9d602df4478e498f740facc86:packages/skills/skills/contribute-to-eliza"} -->


