### PR TITLE
fix(workflow): distinguish invalid duration dates from missing start

### DIFF
--- a/packages/ui/src/utils/workflow-executions.test.ts
+++ b/packages/ui/src/utils/workflow-executions.test.ts
@@ -118,6 +118,16 @@ describe("workflow execution helpers", () => {
     ).toBe("3 min");
   });
 
+  it("distinguishes missing start from invalid ISO dates", () => {
+    expect(formatWorkflowExecutionDuration(undefined)).toBe("Unknown");
+    expect(
+      formatWorkflowExecutionDuration("not-a-date", "2026-06-23T00:00:00Z"),
+    ).toBe("Invalid date");
+    expect(
+      formatWorkflowExecutionDuration("2026-06-23T00:00:00Z", "not-a-date"),
+    ).toBe("Invalid date");
+  });
+
   it("builds copyable diagnostics for chat-assisted troubleshooting", () => {
     const diagnostics = buildWorkflowExecutionDiagnostics(SUCCESS_EXECUTION);
 

--- a/packages/ui/src/utils/workflow-executions.ts
+++ b/packages/ui/src/utils/workflow-executions.ts
@@ -120,7 +120,8 @@ export function formatWorkflowExecutionDuration(
   if (!startedAt) return "Unknown";
   const startMs = Date.parse(startedAt);
   const stopMs = stoppedAt ? Date.parse(stoppedAt) : Date.now();
-  if (!Number.isFinite(startMs) || !Number.isFinite(stopMs)) return "Unknown";
+  if (!Number.isFinite(startMs) || !Number.isFinite(stopMs))
+    return "Invalid date";
   const durationMs = Math.max(0, stopMs - startMs);
   if (durationMs < 1000) return `${durationMs} ms`;
   if (durationMs < 60_000) return `${(durationMs / 1000).toFixed(1)} s`;

--- a/plugins/plugin-workflow/__tests__/unit/execution-diagnostics.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/execution-diagnostics.test.ts
@@ -17,7 +17,7 @@ const exec = (over: Partial<WorkflowExecution>): WorkflowExecution =>
   ({ status: 'success', data: { resultData: {} }, ...over }) as unknown as WorkflowExecution;
 
 describe('formatWorkflowExecutionDuration', () => {
-  it('picks ms/s/min units, Unknown on missing/invalid', () => {
+  it('picks ms/s/min units; Unknown when missing, Invalid date when unparseable', () => {
     expect(formatWorkflowExecutionDuration(undefined)).toBe('Unknown');
     expect(
       formatWorkflowExecutionDuration('2026-06-23T00:00:00.000Z', '2026-06-23T00:00:00.500Z')
@@ -28,7 +28,12 @@ describe('formatWorkflowExecutionDuration', () => {
     expect(
       formatWorkflowExecutionDuration('2026-06-23T00:00:00.000Z', '2026-06-23T00:02:00.000Z')
     ).toBe('2 min');
-    expect(formatWorkflowExecutionDuration('not-a-date', '2026-06-23T00:00:00Z')).toBe('Unknown');
+    expect(formatWorkflowExecutionDuration('not-a-date', '2026-06-23T00:00:00Z')).toBe(
+      'Invalid date'
+    );
+    expect(
+      formatWorkflowExecutionDuration('2026-06-23T00:00:00Z', 'not-a-date')
+    ).toBe('Invalid date');
   });
 });
 

--- a/plugins/plugin-workflow/src/utils/execution-diagnostics.ts
+++ b/plugins/plugin-workflow/src/utils/execution-diagnostics.ts
@@ -113,7 +113,7 @@ export function formatWorkflowExecutionDuration(
   if (!startedAt) return 'Unknown';
   const startMs = Date.parse(startedAt);
   const stopMs = stoppedAt ? Date.parse(stoppedAt) : Date.now();
-  if (!Number.isFinite(startMs) || !Number.isFinite(stopMs)) return 'Unknown';
+  if (!Number.isFinite(startMs) || !Number.isFinite(stopMs)) return 'Invalid date';
   const durationMs = Math.max(0, stopMs - startMs);
   if (durationMs < 1000) return `${durationMs} ms`;
   if (durationMs < 60_000) return `${(durationMs / 1000).toFixed(1)} s`;


### PR DESCRIPTION
# Relates to

Closes #18755

Also completes the dual-copy + UI regression coverage left open by #18758 (same label split; that PR does not update `packages/ui` tests).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused package tests were run after sync; full monorepo `bun run verify`
      is recorded under Known gaps as not required for this pure-function change.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `grok-build`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribute-to-eliza measured run on this client; session model is not an approved skill model`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `upstream/develop`; zero conflicts.
- [x] Focused tests pass post-sync (logs below); full `bun run verify` not re-run for this pure util change.

# Risks

Low. Label-only change in pure duration formatters (UI + plugin-workflow duplicates). No API, persistence, or planner behavior. Callers that string-matched `"Unknown"` for bad ISO would now see `"Invalid date"` — that is the intended observability fix.

# Background

## What does this PR do?

`formatWorkflowExecutionDuration` treated missing `startedAt` and non-finite `Date.parse` results as the same `"Unknown"` string. That hid stale localStorage / backend ISO regressions behind the same badge as "not started yet".

- Missing / falsy `startedAt` → still `"Unknown"`
- Non-finite start or stop → `"Invalid date"`
- Same change in `packages/ui` and `plugins/plugin-workflow` so the copies cannot drift
- Unit coverage for missing start, invalid start, and invalid stop on **both** suites (UI was previously untested for this branch)

## What kind of change is this?

Bug fixes (non-breaking observability fix for duration labels)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. `packages/ui/src/utils/workflow-executions.ts` (`formatWorkflowExecutionDuration`)
2. `plugins/plugin-workflow/src/utils/execution-diagnostics.ts` (duplicate)
3. Unit tests in both packages

## Detailed testing steps

```bash
bun test packages/ui/src/utils/workflow-executions.test.ts
# 5 pass
bun test plugins/plugin-workflow/__tests__/unit/execution-diagnostics.test.ts
# 3 pass
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:219ef3718d36770dda4b31df3c61e9d7e1ee81e8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - pure duration label string change; no rendered UI layout surface to capture
<!-- evidence-row:after-screenshots -->
- [x] N/A - pure duration label string change; behavior proven by unit tests not pixels
<!-- evidence-row:walkthrough-video -->
- [x] N/A - pure functions with unit coverage; no interactive user flow to record
<!-- evidence-row:backend-logs -->
- [x] N/A - no application backend path; client-side duration formatting only
<!-- evidence-row:frontend-logs -->
- [x] N/A - pure formatting; proof is unit test output not console network logs
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action provider prompt or model runtime behavior in this diff
<!-- evidence-row:domain-artifacts -->
- [x] N/A - reviewed artifact is the dual-copy source diff plus unit test expectations
<!-- evidence-row:ocr-review -->
- [x] N/A - typed string labels only; no OCR visual surface for this change

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model runtime path.

## Backend + frontend logs

<details>
<summary>Focused unit test output</summary>

```
bun test packages/ui/src/utils/workflow-executions.test.ts
5 pass, 0 fail

bun test plugins/plugin-workflow/__tests__/unit/execution-diagnostics.test.ts
3 pass, 0 fail
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - pure functions.

## Known gaps / failures

- Full monorepo `bun run verify` not run; scoped pure-function change with package unit tests green.
- Related open PR #18758 implements the same label split without UI suite coverage; this PR is the complete dual-copy + UI regression version. Prefer merge of one coherent change; close the other as superseded if both remain open.