### PR TITLE
fix(discord): prioritize cached DMs in startup scan

### DIFF
--- a/plugins/plugin-discord/__tests__/startup-reaction-reconcile.test.ts
+++ b/plugins/plugin-discord/__tests__/startup-reaction-reconcile.test.ts
@@ -4,8 +4,9 @@
  * messages, terminal/others' reactions are untouched, every dimension of the
  * scan is hard-capped, failures are counted and logged, never thrown, and the
  * scan never eats a marker belonging to the CURRENT process (post-scan-start
- * messages and registry-active turns are excluded). Uses plain-object
- * discord.js fakes, matching service-shutdown-drain.test.ts.
+ * messages and registry-active turns are excluded). Cached DMs are prioritized
+ * inside the shared channel cap. Uses plain-object discord.js fakes, matching
+ * service-shutdown-drain.test.ts.
  */
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -282,6 +283,22 @@ describe("reconcileStrandedStatusReactions", () => {
 
 		expect(summary.channelsScanned).toBe(1);
 		expect(dmReaction.users.remove).toHaveBeenCalledWith(BOT_ID);
+	});
+
+	it("scans cached DMs before guild channels consume the shared cap", async () => {
+		const guildFirst = makeChannel([makeMessage()]);
+		const guildSecond = makeChannel([makeMessage()]);
+		const dm = makeChannel([makeMessage()]);
+
+		const summary = await scan(
+			makeClient([guildFirst, guildSecond], { dmChannels: [dm] }),
+			{ maxChannels: 2 },
+		);
+
+		expect(summary.channelsScanned).toBe(2);
+		expect(dm.messages.fetch).toHaveBeenCalledTimes(1);
+		expect(guildFirst.messages.fetch).toHaveBeenCalledTimes(1);
+		expect(guildSecond.messages.fetch).not.toHaveBeenCalled();
 	});
 
 	it("skips entirely and warns when the client has no user id", async () => {

--- a/plugins/plugin-discord/startup-reaction-reconcile.ts
+++ b/plugins/plugin-discord/startup-reaction-reconcile.ts
@@ -17,6 +17,12 @@
  * this runs detached from the ready path, where a rejection would be treated
  * as a terminal login failure.
  *
+ * Discord's bot API cannot enumerate existing DM channels. The DM leg can
+ * therefore scan only channels already present in `client.channels.cache`;
+ * after a cold restart that cache may be empty until a DM gateway event arrives.
+ * Cached DMs are scanned before guild channels so the shared channel cap cannot
+ * starve the DM coverage that is available on warm reconnects.
+ *
  * The scan must never eat a marker the CURRENT process just placed: message
  * listeners bind before login resolves, so a turn can start (and stamp ⏳/🤔)
  * before this scan runs. Two guards enforce that: messages created at or
@@ -30,7 +36,7 @@ import { IN_PROGRESS_STATUS_EMOJIS } from "./status-reactions";
 /** Setting/env name; set to "0" or "false" to disable the scan entirely. */
 export const STARTUP_REACTION_SCAN_SETTING = "DISCORD_STARTUP_REACTION_SCAN";
 
-/** Hard cap on channels inspected across all guilds plus cached DMs. */
+/** Hard cap on channels inspected across cached DMs plus all guilds. */
 export const STARTUP_SCAN_MAX_CHANNELS = 50;
 
 /** Recent messages fetched per channel (one fetch per channel). */
@@ -91,7 +97,7 @@ function channelLabel(channel: { id?: string }): string {
 	return typeof channel?.id === "string" ? channel.id : "unknown-channel";
 }
 
-/** Collect scannable channels: guild text channels the bot can read, then cached DMs. */
+/** Collect scannable channels: cached DMs first, then readable guild text channels. */
 function collectChannels(client: Client, cap: number): TextBasedChannel[] {
 	const channels: TextBasedChannel[] = [];
 	const seen = new Set<string>();
@@ -109,16 +115,16 @@ function collectChannels(client: Client, cap: number): TextBasedChannel[] {
 		seen.add(candidate.id);
 		channels.push(candidate);
 	};
+	for (const channel of client.channels.cache.values()) {
+		const dm = channel as { isDMBased?: () => boolean };
+		if (typeof dm.isDMBased === "function" && dm.isDMBased()) push(channel);
+		if (channels.length >= cap) return channels;
+	}
 	for (const guild of client.guilds.cache.values()) {
 		for (const channel of guild.channels.cache.values()) {
 			push(channel);
 			if (channels.length >= cap) return channels;
 		}
-	}
-	for (const channel of client.channels.cache.values()) {
-		const dm = channel as { isDMBased?: () => boolean };
-		if (typeof dm.isDMBased === "function" && dm.isDMBased()) push(channel);
-		if (channels.length >= cap) break;
 	}
 	return channels;
 }


### PR DESCRIPTION
# Relates to

Closes #18746 by implementing the issue's bounded option 3: document the Discord API cold-cache limitation and prioritize available cached DMs before guild channels consume the shared scan cap.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Rebased onto current `origin/develop` with zero conflicts.
- [x] Focused and full Discord package validation passes at the exact head.
- [x] Root verification was run; its only blocker is the repository Biome baseline tracked and fixed by #18772.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b9dec8f6054b9d563be68fbb8421bb95b18cd977:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `97fe1ca832829f35b0b40307acefdc83505442f1`; zero conflicts.
- [x] `bun install` completed with no tracked changes.

# Risks

Low. The scan retains the same channel cap, per-channel message cap, time budget, filtering, and guild behavior. Only channel priority changes: cached DMs consume the shared cap before guild channels. Discord still cannot enumerate uncached DM channels after a cold restart; the source contract now states that limitation explicitly.

# Background

## What does this PR do?

- Documents that Discord's bot API cannot enumerate existing DMs and a cold client's DM cache may be empty.
- Scans cached DM channels before guild text channels.
- Adds deterministic coverage proving a cached DM cannot be starved when guild channels exceed the shared cap.

## What kind of change is this?

Discord connector correctness fix and honest capability documentation.

# Documentation changes needed?

The limitation is documented at the scan definition, where maintainers and callers see the invariant. No user configuration changes.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-discord/startup-reaction-reconcile.ts` channel collection order and contract header.
2. `plugins/plugin-discord/__tests__/startup-reaction-reconcile.test.ts` cap-starvation regression.

## Detailed testing steps

```bash
bun install
bun test plugins/plugin-discord/__tests__/startup-reaction-reconcile.test.ts
bun run --cwd plugins/plugin-discord typecheck
bun run --cwd plugins/plugin-discord test
bun run --cwd plugins/plugin-discord build
bunx @biomejs/biome check plugins/plugin-discord/startup-reaction-reconcile.ts plugins/plugin-discord/__tests__/startup-reaction-reconcile.test.ts
bun run verify
```

Exact-head results:

```text
Focused startup reconciliation: 13 passed, 0 failed; touched source 100% function/line coverage.
Discord package: 74 files passed; 595 tests passed.
Discord typecheck: passed.
Discord build: passed.
Scoped Biome: 2 files checked; no fixes needed.
Root verify: stopped at check:biome-version on the existing repository 2.5.6/2.5.7 split fixed by #18772.
```

# Evidence Gate

<!-- evidence-head:1ed92c47dfa97ca896a55fe4bdcfd9d8ed402dcb -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - connector startup ordering has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - connector startup ordering has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend process changes; deterministic unit and package test transcripts are recorded in Testing.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact is produced; the deterministic retained/evicted channel-order proof is recorded in Testing.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic connector startup bookkeeping only.

## Backend + frontend logs

The deterministic Discord.js fake exercises the real reconciliation function and verifies `messages.fetch` ordering. A live cold-start DM enumeration proof is impossible by Discord API contract; this PR deliberately implements the issue's accepted honest-labeling option.

## Screenshots (before / after) + video walkthrough

N/A - no UI source changes.

## Audio / voice walkthrough

N/A - no audio surface.

## Known gaps / failures

- Discord cannot enumerate uncached DM channels after cold start; this PR documents rather than fabricates that capability, as allowed by #18746 option 3.
- Root verification is currently blocked before package execution by the repository-wide Biome consistency gap fixed in #18772. All affected-package gates pass on this exact head.

AI provider/model: openai / gpt-5
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@b9dec8f6054b9d563be68fbb8421bb95b18cd977:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex Desktop","skill_revision":"elizaOS/eliza@b9dec8f6054b9d563be68fbb8421bb95b18cd977:packages/skills/skills/contribute-to-eliza"} -->
