### PR TITLE
fix(ui): render fallback for invalid agent heartbeat/created dates

### DIFF
--- a/packages/ui/src/cloud/instances/AgentDetailPage.test.tsx
+++ b/packages/ui/src/cloud/instances/AgentDetailPage.test.tsx
@@ -1,0 +1,21 @@
+/** Verifies agent detail date formatting rejects malformed API timestamps. */
+import { describe, expect, it, vi } from "vitest";
+import { formatDate, formatRelativeShort } from "./AgentDetailPage";
+
+const t = vi.fn(
+  (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? _key,
+) as never;
+
+describe("AgentDetailPage date formatting", () => {
+  it("renders an unavailable fallback for malformed non-null dates", async () => {
+    expect(formatDate("not-a-date")).toBe("—");
+    expect(formatRelativeShort("not-a-date", t)).toBe("Never");
+  });
+
+  it("preserves valid and null date behavior", () => {
+    expect(formatDate(null)).toBe("—");
+    expect(formatRelativeShort(null, t)).toBe("Never");
+    expect(formatRelativeShort(new Date().toISOString(), t)).toBe("Just now");
+  });
+});

--- a/packages/ui/src/cloud/instances/AgentDetailPage.tsx
+++ b/packages/ui/src/cloud/instances/AgentDetailPage.tsx
@@ -34,9 +34,11 @@ import { useAgent } from "./lib/data/eliza-agents";
 import { useT } from "./lib/i18n";
 import { statusBadgeColor, statusDotColor } from "./lib/sandbox-status";
 
-function formatDate(date: string | null): string {
+export function formatDate(date: string | null): string {
   if (!date) return "—";
-  return new Date(date).toLocaleDateString(undefined, {
+  const timestamp = new Date(date).getTime();
+  if (!Number.isFinite(timestamp)) return "—";
+  return new Date(timestamp).toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
     year: "numeric",
@@ -51,13 +53,16 @@ function formatTime(date: string | null): string {
   });
 }
 
-function formatRelativeShort(
+export function formatRelativeShort(
   date: string | null,
   t: ReturnType<typeof useT>,
 ): string {
   if (!date) return t("cloud.agents.detail.never", { defaultValue: "Never" });
   const d = new Date(date);
-  const diffMs = Date.now() - d.getTime();
+  const timestamp = d.getTime();
+  if (!Number.isFinite(timestamp))
+    return t("cloud.agents.detail.never", { defaultValue: "Never" });
+  const diffMs = Date.now() - timestamp;
   const diffMin = Math.floor(diffMs / 60_000);
   if (diffMin < 1)
     return t("cloud.agents.detail.justNow", { defaultValue: "Just now" });


### PR DESCRIPTION
# Relates to

Closes #18812.

Originally flagged in review on the now-merged `#18727` (startrack3r, `packages/ui/src/cloud/instances/AgentDetailPage.tsx:58-60`) as a second, independent copy of the same bug class fixed there. The maintainer (`lalalune`) reviewed this PR, found a third instance (`formatTime`, no guard at all) in the same file, and opened #18812 as the scoped tracking issue with explicit acceptance criteria — including a real `AgentDetailPage` component render regression, not just unit tests on the exported helpers. That fix is in progress as a follow-up commit on this branch.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      focused regression tests recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Two local formatting helpers only. Both fallbacks already existed for the `null` case; this extends the same fallback to a malformed-but-non-null case. Verified against a wider sweep of inputs (empty string, "0", year-only, epoch, valid ISO, out-of-range calendar date) beyond the two invalid cases the fix targets — every input except the two invalid ones produces byte-identical output to before.

# Background

## What does this PR do?

`AgentDetailPage.tsx`'s local `formatDate` and `formatRelativeShort` both guard the `null` case but not an invalid-but-non-null date string. `new Date(date).getTime()` is `NaN` for a malformed value; every numeric comparison in `formatRelativeShort` is then false, and both functions fall through to `toLocaleDateString()`, which renders the literal string `"Invalid Date"`.

Both now check `Number.isFinite(timestamp)` and return the function's existing fallback when it isn't:
- `formatDate`: `"—"`
- `formatRelativeShort`: `"Never"`

Traced live path:
- Source contract: `packages/ui/src/api/client-cloud.ts:108` — `lastHeartbeatAt` is a real `string | null` cloud API response field, not an internally-trusted value.
- Page registration: `packages/ui/src/cloud/instances/index.ts:37-41`.
- Render sites: `AgentDetailPage.tsx:259` (created date), `:272` (relative heartbeat), `:276` (absolute heartbeat).

There is no downstream sanitization between the API response and these renders.

## What kind of change is this?

Bug fix (non-breaking).

## Why are we doing this?

A malformed timestamp from the cloud API should render the page's existing deliberate unavailable state, not the literal string `"Invalid Date"`.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

1. `packages/ui/src/cloud/instances/AgentDetailPage.tsx` (`formatDate`, `formatRelativeShort`)
2. `packages/ui/src/cloud/instances/AgentDetailPage.test.tsx`

## Detailed testing steps

```text
bun run --cwd packages/ui test -- src/cloud/instances/AgentDetailPage.test.tsx
Test Files  1 passed (1)
     Tests  2 passed (2)

bunx @biomejs/biome check packages/ui/src/cloud/instances/AgentDetailPage.tsx packages/ui/src/cloud/instances/AgentDetailPage.test.tsx
Checked 2 files. No fixes applied.
```

All independently re-run and confirmed after rebase, not just taken from the implementation run.

Independent old-vs-new behavior sweep (not part of the automated suite, run manually to confirm no unintended edge-case regression, per lesson learned from a prior self-found PR that silently changed behavior for inputs outside its target pattern):

```text
formatDate("")                                old="—"              new="—"
formatDate("not-a-date")                      old="Invalid Date"   new="—"        <- fixed
formatDate("2024-01-15T00:00:00.000Z")        old="Jan 15, 2024"   new="Jan 15, 2024"
formatDate("2024")                            old="Jan 1, 2024"    new="Jan 1, 2024"
formatDate("0")                               old="Jan 1, 2000"    new="Jan 1, 2000"
formatDate("9999-99-99")                      old="Invalid Date"   new="—"        <- fixed
```
Only the two invalid-date cases change; every valid or edge-but-valid input is unchanged.

# Evidence Gate

<!-- evidence-head:18f62861ccf741a7758ee2ec809a311f05f7977b -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - pure formatting-helper logic change; no layout/styling changed.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - pure formatting-helper logic change; no layout/styling changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic frontend formatting logic, no backend behavior change.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no request or state-transition behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused regression tests plus an independent manual old-vs-new behavior sweep, both confirmed above.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface changed.

# Known gaps / failures

Full root `bun run verify` was not run; the focused UI test, package typecheck, and scoped Biome check all passed on the changed files.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [hunt-and-implement-3]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZVXE1ZWJZQ7JAKTJ9FNMAS9","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T21:18:12.476Z","completed_at":"2026-08-12T21:22:30.496Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAVq8Ggvxg2RCIBwXtE9az5b_tYKj9qVj_3nvqPhhTcAA","device_key_id":"e60c0d298778b55b0d73aec8f38dfc80913a79223c40de61bea259417fe35ec3","device_signature":"52I_O-YNqSzcv9sW53dZ5BYXOjLcYaN-U1ZkYyukhYKr9wGIq9H8bSTYPfi_CGqoktf5nJVBI8p6sqWCQ-JoAg"}} -->

