### PR TITLE
fix(core): preserve MessageRefStore write recency

### DIFF
--- a/packages/core/src/features/messaging/triage/__tests__/message-ref-store.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/message-ref-store.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Deterministic boundary coverage for MessageRefStore write-recency eviction.
+ * The real in-memory store is exercised at its production message and draft
+ * capacities without replacing the system under test.
+ */
+
+import { describe, expect, it } from "vitest";
+import { MessageRefStore } from "../message-ref-store.ts";
+import type { DraftRecord, MessageRef } from "../types.ts";
+
+const MESSAGE_CAPACITY = 5000;
+const DRAFT_CAPACITY = 2000;
+
+function message(
+	index: number,
+	overrides: Partial<MessageRef> = {},
+): MessageRef {
+	return {
+		id: `message-${index}`,
+		source: "gmail",
+		externalId: `external-${index}`,
+		from: { identifier: `sender-${index}@example.com` },
+		to: [],
+		snippet: `message ${index}`,
+		receivedAtMs: index,
+		hasAttachments: false,
+		isRead: false,
+		...overrides,
+	};
+}
+
+function draft(
+	index: number,
+	overrides: Partial<DraftRecord> = {},
+): DraftRecord {
+	return {
+		draftId: `draft-${index}`,
+		source: "gmail",
+		to: [{ identifier: `recipient-${index}@example.com` }],
+		body: `draft body ${index}`,
+		preview: `draft preview ${index}`,
+		createdAtMs: index,
+		sent: false,
+		...overrides,
+	};
+}
+
+function fillMessages(store: MessageRefStore): void {
+	store.saveMessages(
+		Array.from({ length: MESSAGE_CAPACITY }, (_, index) => message(index)),
+	);
+}
+
+function fillMessagesAfter(store: MessageRefStore, firstIndex: number): void {
+	store.saveMessages(
+		Array.from({ length: MESSAGE_CAPACITY - firstIndex }, (_, offset) =>
+			message(firstIndex + offset),
+		),
+	);
+}
+
+function fillDrafts(store: MessageRefStore): void {
+	for (let index = 0; index < DRAFT_CAPACITY; index += 1) {
+		store.saveDraft(draft(index));
+	}
+}
+
+describe("MessageRefStore write-recency eviction", () => {
+	it("keeps a singly refreshed message and evicts the oldest untouched message", () => {
+		const store = new MessageRefStore();
+		fillMessages(store);
+
+		store.saveMessage(message(0, { snippet: "fresh message zero" }));
+		store.saveMessage(message(MESSAGE_CAPACITY));
+
+		expect(store.getMessage("message-0")?.snippet).toBe("fresh message zero");
+		expect(store.getMessage("message-1")).toBeNull();
+		expect(store.getMessage(`message-${MESSAGE_CAPACITY}`)).not.toBeNull();
+		expect(store.listMessages()).toHaveLength(MESSAGE_CAPACITY);
+	});
+
+	it("uses complete batch order and the last duplicate value for recency", () => {
+		const store = new MessageRefStore();
+		fillMessages(store);
+
+		store.saveMessages([
+			message(0, { snippet: "first refresh" }),
+			message(MESSAGE_CAPACITY),
+			message(0, { snippet: "last refresh" }),
+		]);
+
+		const listed = store.listMessages();
+		expect(store.getMessage("message-0")?.snippet).toBe("last refresh");
+		expect(store.getMessage("message-1")).toBeNull();
+		expect(listed).toHaveLength(MESSAGE_CAPACITY);
+		expect(listed.slice(-2).map((ref) => ref.id)).toEqual([
+			`message-${MESSAGE_CAPACITY}`,
+			"message-0",
+		]);
+	});
+
+	it.each([
+		{
+			name: "addTag",
+			seed: message(0, { tags: ["existing"] }),
+			mutate: (store: MessageRefStore) => store.addTag("message-0", "urgent"),
+			expectedTags: ["existing", "urgent"],
+		},
+		{
+			name: "removeTag",
+			seed: message(0, { tags: ["remove", "keep"] }),
+			mutate: (store: MessageRefStore) =>
+				store.removeTag("message-0", "remove"),
+			expectedTags: ["keep"],
+		},
+	])(
+		"refreshes message recency after $name writes",
+		({ seed, mutate, expectedTags }) => {
+			const store = new MessageRefStore();
+			store.saveMessage(seed);
+			fillMessagesAfter(store, 1);
+
+			expect(mutate(store)?.tags).toEqual(expectedTags);
+			store.saveMessage(message(MESSAGE_CAPACITY));
+
+			expect(store.getMessage("message-0")?.tags).toEqual(expectedTags);
+			expect(store.getMessage("message-1")).toBeNull();
+		},
+	);
+
+	it("does not refresh message or draft recency on reads or an empty-tag removal", () => {
+		const store = new MessageRefStore();
+		fillMessages(store);
+		fillDrafts(store);
+
+		expect(store.getMessage("message-0")).not.toBeNull();
+		expect(store.findByExternalId("gmail", "external-0")).not.toBeNull();
+		expect(store.listMessages()).toHaveLength(MESSAGE_CAPACITY);
+		expect(store.removeTag("message-0", "absent")).not.toBeNull();
+		expect(store.getDraft("draft-0")).not.toBeNull();
+
+		store.saveMessage(message(MESSAGE_CAPACITY));
+		store.saveDraft(draft(DRAFT_CAPACITY));
+
+		expect(store.getMessage("message-0")).toBeNull();
+		expect(store.getDraft("draft-0")).toBeNull();
+	});
+
+	it("keeps an overwritten draft and evicts the oldest untouched draft", () => {
+		const store = new MessageRefStore();
+		fillDrafts(store);
+
+		store.saveDraft(draft(0, { body: "fresh draft body" }));
+		store.saveDraft(draft(DRAFT_CAPACITY));
+
+		expect(store.getDraft("draft-0")?.body).toBe("fresh draft body");
+		expect(store.getDraft("draft-1")).toBeNull();
+		expect(store.getDraft(`draft-${DRAFT_CAPACITY}`)).not.toBeNull();
+	});
+
+	it("keeps a sent draft and its provider result across overflow", () => {
+		const store = new MessageRefStore();
+		fillDrafts(store);
+
+		expect(store.markDraftSent("draft-0", "provider-message-0")).toMatchObject({
+			sent: true,
+			sentExternalId: "provider-message-0",
+		});
+		store.saveDraft(draft(DRAFT_CAPACITY));
+
+		expect(store.getDraft("draft-0")).toMatchObject({
+			sent: true,
+			sentExternalId: "provider-message-0",
+		});
+		expect(store.getDraft("draft-1")).toBeNull();
+	});
+
+	it("keeps a scheduled draft and its durable commit across overflow", () => {
+		const store = new MessageRefStore();
+		fillDrafts(store);
+		const scheduleCommit = {
+			kind: "durable" as const,
+			id: "task-0",
+			committedAt: "2026-08-12T21:00:00.000Z",
+			idempotencyKey: "schedule-draft-0",
+			replayed: false,
+		};
+
+		expect(
+			store.markDraftScheduled(
+				"draft-0",
+				1_786_569_000_000,
+				"schedule-0",
+				scheduleCommit,
+			),
+		).toMatchObject({
+			scheduledForMs: 1_786_569_000_000,
+			scheduledId: "schedule-0",
+			scheduleCommit,
+		});
+		store.saveDraft(draft(DRAFT_CAPACITY));
+
+		expect(store.getDraft("draft-0")).toMatchObject({
+			scheduledForMs: 1_786_569_000_000,
+			scheduledId: "schedule-0",
+			scheduleCommit,
+		});
+		expect(store.getDraft("draft-1")).toBeNull();
+	});
+});

--- a/packages/core/src/features/messaging/triage/message-ref-store.ts
+++ b/packages/core/src/features/messaging/triage/message-ref-store.ts
@@ -10,10 +10,16 @@ import type { DraftRecord, MessageRef, MessageSource } from "./types.ts";
 
 // Process-local stores grow one entry per message/draft ever seen by triage.
 // Without a bound, a long-running agent that triages many messages leaks memory.
-// Cap with FIFO eviction (Map insertion order) — oldest refs drop once over the
-// cap; active turns reference recently-saved messages, which stay resident.
+// Cap by last-write order (Map insertion order refreshed on writes) — oldest
+// refs drop once over the cap while recently-saved active entries stay resident.
 const MAX_MESSAGES = 5000;
 const MAX_DRAFTS = 2000;
+
+function setMostRecent<K, V>(map: Map<K, V>, key: K, value: V): void {
+	// Map.set preserves an existing key's insertion slot, so delete it first.
+	map.delete(key);
+	map.set(key, value);
+}
 
 function capMap<K, V>(map: Map<K, V>, max: number): void {
 	while (map.size > max) {
@@ -28,12 +34,12 @@ export class MessageRefStore {
 	private drafts = new Map<string, DraftRecord>();
 
 	saveMessage(ref: MessageRef): void {
-		this.messages.set(ref.id, ref);
+		setMostRecent(this.messages, ref.id, ref);
 		capMap(this.messages, MAX_MESSAGES);
 	}
 
 	saveMessages(refs: readonly MessageRef[]): void {
-		for (const r of refs) this.messages.set(r.id, r);
+		for (const r of refs) setMostRecent(this.messages, r.id, r);
 		capMap(this.messages, MAX_MESSAGES);
 	}
 
@@ -57,7 +63,7 @@ export class MessageRefStore {
 		const tags = existing.tags ? [...existing.tags] : [];
 		if (!tags.includes(tag)) tags.push(tag);
 		const next: MessageRef = { ...existing, tags };
-		this.messages.set(messageId, next);
+		setMostRecent(this.messages, messageId, next);
 		return next;
 	}
 
@@ -67,12 +73,12 @@ export class MessageRefStore {
 		if (!existing.tags || existing.tags.length === 0) return existing;
 		const tags = existing.tags.filter((t) => t !== tag);
 		const next: MessageRef = { ...existing, tags };
-		this.messages.set(messageId, next);
+		setMostRecent(this.messages, messageId, next);
 		return next;
 	}
 
 	saveDraft(record: DraftRecord): void {
-		this.drafts.set(record.draftId, record);
+		setMostRecent(this.drafts, record.draftId, record);
 		capMap(this.drafts, MAX_DRAFTS);
 	}
 
@@ -88,7 +94,7 @@ export class MessageRefStore {
 			sent: true,
 			sentExternalId: externalId,
 		};
-		this.drafts.set(draftId, next);
+		setMostRecent(this.drafts, draftId, next);
 		return next;
 	}
 
@@ -106,7 +112,7 @@ export class MessageRefStore {
 			scheduledId,
 			scheduleCommit,
 		};
-		this.drafts.set(draftId, next);
+		setMostRecent(this.drafts, draftId, next);
 		return next;
 	}
 


### PR DESCRIPTION
# Relates to

Fixes #18783.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto exact `origin/develop@1b67bf39d618082df6d3413f57afd1d6a760cf5a` with zero conflicts.
- [x] `bun install` and the final verification matrix were run after sync.
- [x] The exact committed base/head behavior is visible in the attached evidence.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact latest `origin/develop@1b67bf39d618082df6d3413f57afd1d6a760cf5a`; zero conflicts and `ahead 1 / behind 0` at the final gate.
- [x] `bun run verify` was rerun after the repository-wide Biome migration landed; final result recorded below.

# Risks

Low. This changes only process-local bounded `Map` write ordering. Reads remain non-refreshing, message/draft caps remain 5,000/2,000, and batch eviction still runs once after the complete batch.

# Background

## What does this PR do?

`Map.set(existingKey, value)` preserves the key's original insertion position. That let a just-resaved message, tag mutation, draft overwrite, or draft status update remain the oldest entry and be evicted by the next insert. This PR adds one delete-then-set helper and routes every successful message/draft write through it, making eviction follow last-write order while leaving reads unchanged.

The focused regression exercises the real production capacities and covers single and ordered-batch message writes, last-duplicate semantics, isolated tag additions/removals, non-refreshing reads/early no-op, draft overwrites, and sent/scheduled transitions.

## What kind of change is this?

Bug fix (non-breaking cache-correctness change).

# Documentation changes needed?

No user-facing documentation change is needed. The source comment now states the actual last-write eviction policy.

# Testing

## Where should a reviewer start?

- `packages/core/src/features/messaging/triage/message-ref-store.ts`
- `packages/core/src/features/messaging/triage/__tests__/message-ref-store.test.ts`

## Detailed testing steps

Pinned toolchain: Node `v24.15.0`, Bun `1.3.14`.

- `bun install --frozen-lockfile --ignore-scripts` — PASS (6,380 packages)
- focused Vitest — PASS, 1 file / 8 tests
- `bun run --cwd packages/core lint:check` — PASS (only one existing warning and one existing info in unchanged files)
- `bun run --cwd packages/core typecheck` — PASS
- `bun run --cwd packages/core build:node` — PASS
- `bun run --cwd packages/core build` — PASS for Node/browser/edge/testing outputs and declarations
- `bun run --cwd packages/core test` — 512 files / 5,738 tests PASS and 4 skipped; the only sandbox-blocked integration then passed 1 file / 3 tests when loopback binding was permitted
- `bun run check:agents-claude` — PASS, 154 paired guides
- `bun run verify` — PASS, including Turbo 350/350 tasks and all repository audits
- exact committed base/head evidence harness — base reproduced 7 regressions; head PASS 8/8
- `git diff-tree --check HEAD^ HEAD` — PASS

# Evidence Gate

<!-- evidence-head:e3307d8d52ffe0e73a050a5b38b5d657d407637c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only in-memory cache ordering change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only in-memory cache ordering change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic process-local cache behavior has no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] Exact committed source was exercised at the 5,000-message and 2,000-draft production boundaries; representative native JSONL records are included below.
<details>
<summary>Exact committed base/head records</summary>

```jsonl
{"record_type":"run","repository":"elizaOS/eliza","base":"1b67bf39d618082df6d3413f57afd1d6a760cf5a","head":"e3307d8d52ffe0e73a050a5b38b5d657d407637c","node":"v24.15.0","capacities":{"messages":5000,"drafts":2000},"exact_committed_source":true,"network":false,"secrets":false,"model":false,"connector":false,"database":false}
{"record_type":"case","revision_role":"base","scenario":"save_message_refresh","contract_pass":false,"observation":{"refreshed_value":null,"oldest_untouched_evicted":false,"new_entry_retained":true,"size":5000}}
{"record_type":"case","revision_role":"head","scenario":"save_message_refresh","contract_pass":true,"observation":{"refreshed_value":"fresh message zero","oldest_untouched_evicted":true,"new_entry_retained":true,"size":5000}}
{"record_type":"summary","base":{"contract_passed":1,"contract_total":8,"regressions_reproduced":7},"head":{"contract_passed":8,"contract_total":8},"verdict":"BASE_REPRODUCED_HEAD_PASS"}
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, network, or rendered state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no provider, model, prompt, action-routing, or agent-response behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head deterministic 5,000-message / 2,000-draft outcome matrix (PNG SHA-256 `69e2d33acd70b346c4b082fa387edd9ad6c7ae824240c756f2e4b6e7030ad52a`; JSONL SHA-256 `9b6fac51437a89dc99f7a7b12feafc575dc989905dec6f502cf90db838b0929e`):
<img width="1800" height="900" alt="MessageRefStore exact-head write-recency matrix" src="https://github.com/user-attachments/assets/b2b161e6-d99f-422e-b44b-40be09ea86ab" />
The exact committed outcomes are also preserved inline:
<details>
<summary>Domain outcome matrix</summary>

```jsonl
{"record_type":"domain-matrix","base":"1b67bf39d618082df6d3413f57afd1d6a760cf5a","head":"e3307d8d52ffe0e73a050a5b38b5d657d407637c","production_capacities":{"messages":5000,"drafts":2000},"exact_committed_source":true}
{"revision_role":"base","contract_passed":1,"contract_total":8,"regressions_reproduced":7,"verdict":"REPRODUCED"}
{"revision_role":"head","contract_passed":8,"contract_total":8,"scenarios":["saveMessage","saveMessages-last-duplicate","addTag","removeTag","read-no-refresh","saveDraft","markDraftSent","markDraftScheduled"],"verdict":"PASS"}
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - the matrix is a generated test artifact, not a rendered product UI surface; it was manually inspected at 1800x900 for visible, unclipped labels and results.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model path changed.

## Backend + frontend logs

See the backend-logs row above. Frontend logs are N/A because no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered or interactive UI surface changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT path changed.

## Known gaps / failures

The prior repository-wide Biome-version blocker was resolved by merged #18772 before this rebase. The first sandboxed attempts exposed two permission-only constraints: Wrangler could not write its normal user-preference log directory, and the unchanged pinned-fetch integration could not bind `127.0.0.1`. Bounded normal-permission reruns passed the integration 3/3 and complete root verification. The full core aggregate passed 5,738 tests with four skips on an earlier equivalent implementation head; its only sandbox-blocked loopback suite then passed 3/3 with normal permissions. After the final non-overlapping base sync, the exact head passed the focused regression, core lint/typecheck, guide parity, root verification (Turbo 350/350 plus every audit), and diff checks. No live model, connector, database, or secrets were required for this deterministic process-local cache boundary.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [message-ref-write-recency]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZVX7CRBK1W97F6R7HMD0TAT","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T21:14:34.123Z","completed_at":"2026-08-12T21:34:52.606Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAWOuFq4QKFpEzUxdS-xUTGOp-_XL5j-TbR18ldYqv818","device_key_id":"27a2bd6f25b7dfbdcd447074ad6ad4d4eff92654605004b081bd547e02c21550","device_signature":"FGnZBHfsKFBPvJgNvTi6nrLxCxQGjlG4_otz8PZBzppmbeOeopuXAcCJZiObo-ARJvpZ3Ih-H6fI5cFXXOoqDA"}} -->
