### PR TITLE
fix(agent): point bug reports at current repository

### DIFF
--- a/packages/agent/src/api/bug-report-routes.ts
+++ b/packages/agent/src/api/bug-report-routes.ts
@@ -11,7 +11,7 @@ import os from "node:os";
 import { logger, type RouteRequestContext } from "@elizaos/core";
 import { PostBugReportRequestSchema } from "@elizaos/shared";
 
-export const DEFAULT_BUG_REPORT_REPO = "eliza-ai/eliza";
+export const DEFAULT_BUG_REPORT_REPO = "elizaOS/eliza";
 export const BUG_REPORT_REPO_ENV_KEY = "ELIZA_BUG_REPORT_REPO";
 const BUG_REPORT_REPO_FALLBACK_ENV_KEY = "BUG_REPORT_REPO";
 

--- a/packages/agent/test/api/bug-report-routes.test.ts
+++ b/packages/agent/test/api/bug-report-routes.test.ts
@@ -1,0 +1,210 @@
+/** Exercises bug-report routing with deterministic environment and fetch fixtures. */
+import type http from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BUG_REPORT_REPO_ENV_KEY,
+  DEFAULT_BUG_REPORT_REPO,
+  handleBugReportRoutes,
+  resetBugReportRateLimit,
+  resolveBugReportRepo,
+} from "../../src/api/bug-report-routes.ts";
+
+type BugReportRouteContext = Parameters<typeof handleBugReportRoutes>[0];
+
+const validBugReport = {
+  description: "The agent fails to start",
+  stepsToReproduce: "Run the agent",
+};
+
+function createContext(
+  body: Record<string, unknown> = validBugReport,
+  ip = "127.0.0.1",
+): BugReportRouteContext & {
+  responseBody?: unknown;
+  responseStatus?: number;
+} {
+  const req = {
+    socket: { remoteAddress: ip },
+  } as unknown as http.IncomingMessage;
+  const res = {} as http.ServerResponse;
+  const ctx = {
+    req,
+    res,
+    method: "POST",
+    pathname: "/api/bug-report",
+    readJsonBody: vi.fn(async () => body),
+    json: vi.fn(
+      (_res: http.ServerResponse, responseBody: unknown, status = 200) => {
+        ctx.responseBody = responseBody;
+        ctx.responseStatus = status;
+      },
+    ),
+    error: vi.fn((_res: http.ServerResponse, message: string, status = 500) => {
+      ctx.responseBody = { error: message };
+      ctx.responseStatus = status;
+    }),
+  } as BugReportRouteContext & {
+    responseBody?: unknown;
+    responseStatus?: number;
+  };
+  return ctx;
+}
+
+describe.sequential("bug report repository routing", () => {
+  beforeEach(() => {
+    resetBugReportRateLimit();
+    vi.stubEnv(BUG_REPORT_REPO_ENV_KEY, "");
+    vi.stubEnv("BUG_REPORT_REPO", "");
+    vi.stubEnv("GITHUB_TOKEN", "");
+    vi.stubEnv("ELIZA_BUG_REPORT_API_URL", "");
+    vi.stubEnv("ELIZA_BUG_REPORT_API_TOKEN", "");
+  });
+
+  afterEach(() => {
+    resetBugReportRateLimit();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("uses the canonical elizaOS repository when no override is configured", () => {
+    expect(DEFAULT_BUG_REPORT_REPO).toBe("elizaOS/eliza");
+    expect(resolveBugReportRepo({})).toBe("elizaOS/eliza");
+  });
+
+  it.each([
+    [BUG_REPORT_REPO_ENV_KEY, "owner/primary", "owner/primary"],
+    ["BUG_REPORT_REPO", "owner/legacy", "owner/legacy"],
+  ])("uses a valid %s override", async (key, value, expectedRepo) => {
+    vi.stubEnv(key, value);
+    const ctx = createContext();
+
+    expect(await handleBugReportRoutes(ctx)).toBe(true);
+    expect(ctx.responseBody).toEqual({
+      fallback: `https://github.com/${expectedRepo}/issues/new?template=bug_report.yml`,
+    });
+  });
+
+  it("gives a valid primary override precedence over the legacy override", () => {
+    expect(
+      resolveBugReportRepo({
+        [BUG_REPORT_REPO_ENV_KEY]: "owner/primary",
+        BUG_REPORT_REPO: "owner/legacy",
+      }),
+    ).toBe("owner/primary");
+  });
+
+  it.each([
+    ["blank", "   "],
+    ["missing owner", "/repo"],
+    ["missing repository", "owner/"],
+    ["extra path segment", "owner/repo/issues"],
+  ])("falls back for a %s primary override", (_name, value) => {
+    expect(
+      resolveBugReportRepo({
+        [BUG_REPORT_REPO_ENV_KEY]: value,
+        BUG_REPORT_REPO: "also invalid",
+      }),
+    ).toBe(DEFAULT_BUG_REPORT_REPO);
+  });
+
+  it("returns the canonical no-token fallback URL without making a request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const ctx = createContext();
+
+    expect(await handleBugReportRoutes(ctx)).toBe(true);
+    expect(ctx.responseBody).toEqual({
+      fallback:
+        "https://github.com/elizaOS/eliza/issues/new?template=bug_report.yml",
+    });
+    expect(ctx.responseStatus).toBe(200);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts sanitized reports to the canonical GitHub API URL when a token exists", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "test-token-not-a-credential");
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            html_url: "https://github.com/elizaOS/eliza/issues/123",
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const ctx = createContext({
+      description: "<b>Broken</b>\nagent",
+      stepsToReproduce: "Run <script>unsafe</script> once",
+      logs: `credential ghp_${"a".repeat(20)}`,
+    });
+
+    expect(await handleBugReportRoutes(ctx)).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.github.com/repos/elizaOS/eliza/issues");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer test-token-not-a-credential",
+      Accept: "application/vnd.github.v3+json",
+      "Content-Type": "application/json",
+    });
+    const payload = JSON.parse(String(init.body));
+    expect(payload.title).toBe("[Bug] Broken agent");
+    expect(payload.body).toContain("Run unsafe once");
+    expect(payload.body).toContain("credential [redacted-token]");
+    expect(payload.labels).toEqual(["bug", "triage", "user-reported"]);
+    expect(ctx.responseBody).toEqual({
+      url: "https://github.com/elizaOS/eliza/issues/123",
+    });
+  });
+
+  it("keeps remote intake precedence over token-backed GitHub submission", async () => {
+    vi.stubEnv(
+      "ELIZA_BUG_REPORT_API_URL",
+      "https://intake.example.test/reports",
+    );
+    vi.stubEnv("ELIZA_BUG_REPORT_API_TOKEN", "remote-test-token");
+    vi.stubEnv("GITHUB_TOKEN", "github-test-token");
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            accepted: true,
+            id: "report-1",
+            url: "https://intake.example.test/reports/report-1",
+          }),
+          { status: 202, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const ctx = createContext();
+
+    expect(await handleBugReportRoutes(ctx)).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://intake.example.test/reports");
+    expect(ctx.responseBody).toEqual({
+      accepted: true,
+      id: "report-1",
+      url: "https://intake.example.test/reports/report-1",
+      destination: "remote",
+    });
+  });
+
+  it("preserves the per-client submission rate limit", async () => {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const ctx = createContext(validBugReport, "192.0.2.1");
+      expect(await handleBugReportRoutes(ctx)).toBe(true);
+      expect(ctx.responseStatus).toBe(200);
+    }
+
+    const limited = createContext(validBugReport, "192.0.2.1");
+    expect(await handleBugReportRoutes(limited)).toBe(true);
+    expect(limited.responseStatus).toBe(429);
+    expect(limited.responseBody).toEqual({
+      error: "Too many bug reports. Try again later.",
+    });
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #18785.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the unrelated
      current-`develop` Biome version blocker is recorded below.
- [x] A reviewer can confirm the changed route contract from the focused
      handler-level regression transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `8a2070e78423ccb9d602df4478e498f740facc86`; zero conflicts.
- [x] `bun run verify` was run post-sync; the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. This changes only the built-in default GitHub repository used by the
Agent bug-report route. Explicit valid repository overrides, remote intake,
redaction, labels, and rate limiting are unchanged and covered by regression
tests.

# Background

## What does this PR do?

Updates the built-in bug-report destination from the retired
`eliza-ai/eliza` repository to the current `elizaOS/eliza` repository. Adds
handler-level tests for the unauthenticated fallback, token-backed GitHub API
destination, override precedence and validation, sanitization, remote-intake
precedence, and rate limiting.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is needed; the fix corrects an internal default to
match the repository's current canonical owner/name.

# Testing

## Where should a reviewer start?

Run the focused Agent route test below. It invokes the real Hono handler and
records the outbound fetch URL without creating a junk GitHub issue.

## Detailed testing steps

```bash
./node_modules/.bin/vitest run \
  --config packages/agent/vitest.config.ts \
  packages/agent/test/api/bug-report-routes.test.ts \
  --reporter=dot
```

Expected: `1 passed` test file and `12 passed` tests.

# Evidence Gate

<!-- evidence-head:aec48361dc12921e0c5af0ba4ba425c9a8dba6c6 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - this backend route change has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - this backend route change has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - the destination contract is fully deterministic and has no visual flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - creating a live junk GitHub issue would mutate upstream state; the real handler path and exact outbound URL are proven by the focused fetch-recorder test below.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: N/A - no frontend code, request state, or visual behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt, model, provider, action, or agent decision behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - this route-default correction creates no database, memory, wallet, audio, or generated-file artifact.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface or user-visible text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-facing behavior changed.

## Backend + frontend logs

Focused handler-level proof on Node 24.15.0 and Bun 1.3.14:

```text
RUN  v4.1.5 packages/agent
............
Test Files  1 passed (1)
Tests       12 passed (12)
```

The token-backed regression asserts the exact outbound endpoint:

```text
https://api.github.com/repos/elizaOS/eliza/issues
```

The no-token regression asserts the fallback report contains:

```text
https://github.com/elizaOS/eliza/issues/new
```

GitHub control probes returned `404` for `eliza-ai/eliza` and `200` for
`elizaOS/eliza` before implementation.

## Screenshots (before / after) + video walkthrough

N/A - backend-only route destination change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

- `bun run verify` stops on current `develop` at
  `check-biome-version-consistency.mjs`: the checker expects Biome `2.5.7`,
  while repository manifests, schemas, and lockfiles resolve `2.5.6`. The
  failure occurs before the changed package and is unrelated to this two-file
  diff.
- `bun run --cwd packages/agent typecheck` is also blocked by missing
  pre-existing optional workspace packages and generated declarations
  (`@elizaos/plugin-capacitor-bridge`, `@elizaos/plugin-wallet`,
  `@elizaos/cloud-routing`, and others). No diagnostic names either changed
  file.
- A live GitHub issue submission was intentionally not performed. The focused
  test invokes the real handler with a fetch recorder, proving the exact URL,
  request shape, and surrounding behavior without creating upstream junk.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 36195076 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [symbiex-more-contributions]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZVXWPJA4RBXTD7X76FB4JNW","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T21:26:12.298Z","completed_at":"2026-08-12T21:45:18.833Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":664076,"output_tokens":73976,"cache_creation_tokens":0,"cache_read_tokens":35457024,"total_tokens":36195076,"cost_micro_usd":"23268172","session_count":5},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"qxHcUyBusRovyMJgnEVAG7PVlBcwwuVAestcJbL0s24-uylFPVkLiywqow2eee5cT1ZYiL-wkZ7OL4pE70vhDg"}} -->

