### PR TITLE
fix(core): reject orphaned prompt context config

### DIFF
--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -359,9 +359,7 @@ export { sanitizeOutboundText } from "./services/message/outbound-sanitize";
 export * from "./services/notification";
 export * from "./services/optimized-prompt";
 export {
-	applyOptimizedProviderSelection,
 	type OptimizedPromptRuntimeLike,
-	resolveOptimizedContextConfigForRuntime,
 	resolveOptimizedPromptForRuntime,
 } from "./services/optimized-prompt-resolver";
 export * from "./services/pairing";

--- a/packages/core/src/services/optimized-prompt-resolver.test.ts
+++ b/packages/core/src/services/optimized-prompt-resolver.test.ts
@@ -21,8 +21,6 @@ import {
 	parseDisabledTasksEnv,
 } from "./optimized-prompt";
 import {
-	applyOptimizedProviderSelection,
-	resolveOptimizedContextConfig,
 	resolveOptimizedPrompt,
 	resolveOptimizedPromptForRuntime,
 } from "./optimized-prompt-resolver";
@@ -269,70 +267,5 @@ describe("resolveOptimizedPromptForRuntime — per-task wiring", () => {
 	test("runtime without getService → baseline", () => {
 		const out = resolveOptimizedPromptForRuntime({}, "response", BASELINE);
 		expect(out).toBe(BASELINE);
-	});
-});
-
-describe("optimized context config", () => {
-	test("resolves contextConfig from the optimized artifact", () => {
-		const service = new OptimizedPromptService();
-		service.setDisabledTasksFromEnv(undefined);
-		const direct = service as unknown as {
-			cache: Partial<
-				Record<
-					OptimizedPromptTask,
-					{ artifact: OptimizedPromptArtifact; loadedAt: number }
-				>
-			>;
-		};
-		direct.cache.action_planner = {
-			artifact: {
-				...makeArtifact("action_planner", "OPT_ACTION_PLANNER"),
-				contextConfig: {
-					providerSet: ["RECENT_MESSAGES", "ACTIONS", "FACTS"],
-					providerOrder: ["FACTS", "RECENT_MESSAGES"],
-					renderTemplates: {
-						RECENT_MESSAGES: "{{role}}: {{text}}",
-					},
-					budgetVector: {
-						RECENT_MESSAGES: 1200,
-					},
-				},
-			},
-			loadedAt: Date.now(),
-		};
-
-		expect(resolveOptimizedContextConfig(service, "action_planner")).toEqual({
-			providerSet: ["RECENT_MESSAGES", "ACTIONS", "FACTS"],
-			providerOrder: ["FACTS", "RECENT_MESSAGES"],
-			renderTemplates: {
-				RECENT_MESSAGES: "{{role}}: {{text}}",
-			},
-			budgetVector: {
-				RECENT_MESSAGES: 1200,
-			},
-		});
-	});
-
-	test("applies provider set and order without inventing providers", () => {
-		const selected = applyOptimizedProviderSelection(
-			["ACTIONS", "RECENT_MESSAGES", "FACTS", "PLATFORM"],
-			{
-				providerSet: ["RECENT_MESSAGES", "FACTS", "MISSING"],
-				providerOrder: ["MISSING", "FACTS", "RECENT_MESSAGES"],
-			},
-		);
-
-		expect(selected).toEqual(["FACTS", "RECENT_MESSAGES"]);
-	});
-
-	test("preserves eligible providers not named in providerOrder", () => {
-		const selected = applyOptimizedProviderSelection(
-			["ACTIONS", "RECENT_MESSAGES", "FACTS"],
-			{
-				providerOrder: ["FACTS"],
-			},
-		);
-
-		expect(selected).toEqual(["FACTS", "ACTIONS", "RECENT_MESSAGES"]);
 	});
 });

--- a/packages/core/src/services/optimized-prompt-resolver.ts
+++ b/packages/core/src/services/optimized-prompt-resolver.ts
@@ -19,7 +19,6 @@
 
 import {
 	OPTIMIZED_PROMPT_SERVICE,
-	type OptimizedPromptContextConfig,
 	type OptimizedPromptFewShotExample,
 	type OptimizedPromptService,
 	type OptimizedPromptTask,
@@ -65,60 +64,6 @@ export function resolveOptimizedPrompt(
 		return optimized.prompt;
 	}
 	return injectDemonstrations(optimized.prompt, optimized.fewShotExamples);
-}
-
-export function resolveOptimizedContextConfig(
-	service: OptimizedPromptService | null | undefined,
-	task: OptimizedPromptTask,
-): OptimizedPromptContextConfig | null {
-	if (!service) return null;
-	const optimized = service.getPrompt(task);
-	return optimized?.contextConfig ?? null;
-}
-
-export function resolveOptimizedContextConfigForRuntime(
-	runtime: OptimizedPromptRuntimeLike,
-	task: OptimizedPromptTask,
-): OptimizedPromptContextConfig | null {
-	const service =
-		(runtime.getService?.(OPTIMIZED_PROMPT_SERVICE) as
-			| OptimizedPromptService
-			| null
-			| undefined) ?? null;
-	return resolveOptimizedContextConfig(service, task);
-}
-
-/**
- * Apply a learned provider selection/order genome to the provider names the
- * runtime already deemed eligible. This is deliberately pure: runtime hook
- * registration can call it without giving artifacts authority to invent
- * providers that are not registered for the current turn.
- */
-export function applyOptimizedProviderSelection(
-	current: readonly string[],
-	contextConfig: OptimizedPromptContextConfig | null | undefined,
-): string[] {
-	if (!contextConfig) return [...current];
-	const allowed =
-		contextConfig.providerSet && contextConfig.providerSet.length > 0
-			? new Set(contextConfig.providerSet)
-			: null;
-	const deduped = new Set<string>();
-	for (const name of current) {
-		if (typeof name !== "string" || name.length === 0) continue;
-		if (allowed && !allowed.has(name)) continue;
-		deduped.add(name);
-	}
-	const ordered: string[] = [];
-	// providerOrder is optional config: absent means "keep natural order",
-	// which is the empty ordered-prefix — not a masked failure.
-	const configuredOrder = contextConfig.providerOrder;
-	if (configuredOrder) {
-		for (const name of configuredOrder) {
-			if (deduped.delete(name)) ordered.push(name);
-		}
-	}
-	return [...ordered, ...deduped];
 }
 
 /**

--- a/packages/core/src/services/optimized-prompt.test.ts
+++ b/packages/core/src/services/optimized-prompt.test.ts
@@ -164,7 +164,7 @@ describe("OptimizedPromptService — symlink-based versioning", () => {
 		});
 	});
 
-	it("strict parser preserves a valid contextConfig channel", () => {
+	it("rejects the orphaned contextConfig channel", () => {
 		const parsed = parseOptimizedPromptArtifact({
 			...makeArtifact(1),
 			contextConfig: {
@@ -181,16 +181,7 @@ describe("OptimizedPromptService — symlink-based versioning", () => {
 			},
 		});
 
-		expect(parsed?.contextConfig).toEqual({
-			providerSet: ["RECENT_MESSAGES", "FACTS"],
-			providerOrder: ["FACTS", "RECENT_MESSAGES"],
-			renderTemplates: {
-				RECENT_MESSAGES: "{{role}}: {{text}}",
-			},
-			budgetVector: {
-				RECENT_MESSAGES: 1200,
-			},
-		});
+		expect(parsed).toBeNull();
 	});
 
 	it("retains the most recent OPTIMIZED_PROMPT_RETAIN_VERSIONS artifacts", async () => {

--- a/packages/core/src/services/optimized-prompt.ts
+++ b/packages/core/src/services/optimized-prompt.ts
@@ -182,13 +182,6 @@ export interface OptimizedPromptFrontierEntry {
 	feedback?: string;
 }
 
-export interface OptimizedPromptContextConfig {
-	providerSet?: readonly string[];
-	providerOrder?: readonly string[];
-	renderTemplates?: Readonly<Record<string, string>>;
-	budgetVector?: Readonly<Record<string, number>>;
-}
-
 /**
  * Snapshot of the noise-gate promotion decision that accepted this artifact,
  * including the two write-site provenance fields (`incumbentSource` /
@@ -225,13 +218,11 @@ export interface OptimizedPromptArtifact {
 	lineage: OptimizedPromptLineageEntry[];
 	frontier?: OptimizedPromptFrontierEntry[];
 	promotionDecision?: PromotionDecisionSummary;
-	contextConfig?: OptimizedPromptContextConfig;
 }
 
 export interface OptimizedPromptResolved {
 	prompt: string;
 	fewShotExamples?: OptimizedPromptFewShotExample[];
-	contextConfig?: OptimizedPromptContextConfig;
 	optimizerSource: OptimizerName;
 }
 
@@ -397,6 +388,10 @@ export function parseOptimizedPromptArtifact(
 	}
 	if (typeof raw.generatedAt !== "string") return null;
 	if (!Array.isArray(raw.lineage)) return null;
+	// The training plugin that consumed contextConfig was removed in #17695.
+	// Reject the orphaned channel instead of loading an artifact whose provider
+	// selection, ordering, templates, and budgets cannot affect the runtime.
+	if (raw.contextConfig !== undefined) return null;
 	const lineage: OptimizedPromptLineageEntry[] = [];
 	for (const entry of raw.lineage) {
 		if (!isStringRecord(entry)) continue;
@@ -437,7 +432,6 @@ export function parseOptimizedPromptArtifact(
 		fewShotExamples: fewShot,
 		frontier,
 		promotionDecision: coercePromotionDecision(raw.promotionDecision),
-		contextConfig: coerceContextConfig(raw.contextConfig),
 	};
 }
 
@@ -497,59 +491,6 @@ function coercePromotionDecision(
 	};
 	return Object.values(summary).some((entry) => entry !== undefined)
 		? summary
-		: undefined;
-}
-
-function coerceStringArray(value: unknown): string[] | undefined {
-	if (!Array.isArray(value)) return undefined;
-	const out = value.filter(
-		(entry): entry is string =>
-			typeof entry === "string" && entry.trim().length > 0,
-	);
-	return out.length > 0 ? out : undefined;
-}
-
-function coerceStringRecord(
-	value: unknown,
-): Readonly<Record<string, string>> | undefined {
-	if (!isStringRecord(value)) return undefined;
-	const out: Record<string, string> = {};
-	for (const [key, entry] of Object.entries(value)) {
-		if (typeof entry === "string" && entry.trim().length > 0) {
-			out[key] = entry;
-		}
-	}
-	return Object.keys(out).length > 0 ? out : undefined;
-}
-
-function coerceNumberRecord(
-	value: unknown,
-): Readonly<Record<string, number>> | undefined {
-	if (!isStringRecord(value)) return undefined;
-	const out: Record<string, number> = {};
-	for (const [key, entry] of Object.entries(value)) {
-		if (typeof entry === "number" && Number.isFinite(entry) && entry >= 0) {
-			out[key] = entry;
-		}
-	}
-	return Object.keys(out).length > 0 ? out : undefined;
-}
-
-function coerceContextConfig(
-	value: unknown,
-): OptimizedPromptContextConfig | undefined {
-	if (!isStringRecord(value)) return undefined;
-	const config: OptimizedPromptContextConfig = {
-		providerSet: coerceStringArray(value.providerSet),
-		providerOrder: coerceStringArray(value.providerOrder),
-		renderTemplates: coerceStringRecord(value.renderTemplates),
-		budgetVector: coerceNumberRecord(value.budgetVector),
-	};
-	return config.providerSet ||
-		config.providerOrder ||
-		config.renderTemplates ||
-		config.budgetVector
-		? config
 		: undefined;
 }
 
@@ -679,7 +620,6 @@ export class OptimizedPromptService extends Service {
 		return {
 			prompt: entry.artifact.prompt,
 			fewShotExamples: entry.artifact.fewShotExamples,
-			contextConfig: entry.artifact.contextConfig,
 			optimizerSource: entry.artifact.optimizer,
 		};
 	}


### PR DESCRIPTION
# Relates to

Closes #14875

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@f6c52a5593bacbc59842476ac213c595bbc26d88:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Summary

The training plugin and its runtime hook were removed in #17695, but core still accepted and exposed its contextConfig artifact channel. Provider selection, provider ordering, render templates, and budget vectors therefore loaded successfully while doing nothing.

This change makes the artifact boundary fail closed when contextConfig is present and removes the orphaned type, resolver, ordering helper, and root exports. Ordinary optimized instruction and few-shot artifacts are unchanged. No timeout, catch, retry, fallback, or fabricated ordering behavior is added.

# Testing

```text
$ bun run --cwd packages/core test -- src/services/optimized-prompt.test.ts src/services/optimized-prompt-resolver.test.ts
Test Files  2 passed (2)
Tests       124 passed (124)

$ bun run --cwd packages/core typecheck
exit 0
$ bun x biome check <five changed core files>
Checked 5 files. No fixes applied.
$ bun run --cwd packages/core build
Node, browser, edge, testing, and declarations passed.
$ bun install
Checked 3451 installs across 3746 packages (no changes).
$ bun run verify
Tasks: 350 successful, 350 total; all repository audits passed.
$ git diff --check
exit 0
```

# Evidence Gate

<!-- evidence-head:973fa5375bfee635a1e22dde1422026e025426ff -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core artifact parser and exports only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - core artifact parser and exports only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic artifact parsing with no interactive flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no running backend path changed; the exact parser test transcript is embedded above.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend source or runtime changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model invocation or prompt content changes; this removes an unconsumed artifact metadata channel.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the domain result is the explicit null parse result asserted by the exact-head deterministic regression.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text.

# Risks

Deliberately breaking only for callers that still emit or import the removed training-only contextConfig contract. Repository-wide search found no remaining consumer, and rejecting the full artifact prevents operators from believing inert settings are active.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@f6c52a5593bacbc59842476ac213c595bbc26d88:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@f6c52a5593bacbc59842476ac213c595bbc26d88:packages/skills/skills/contribute-to-eliza"} -->


