### PR TITLE
fix(workflow): distinguish invalid date from missing in duration (fixes #18755)

### DIFF
--- a/packages/ui/src/utils/workflow-executions.test.ts
+++ b/packages/ui/src/utils/workflow-executions.test.ts
@@ -118,6 +118,16 @@ describe("workflow execution helpers", () => {
     ).toBe("3 min");
   });
 
+  it("distinguishes missing from invalid dates", () => {
+    expect(formatWorkflowExecutionDuration(undefined)).toBe("Unknown");
+    expect(
+      formatWorkflowExecutionDuration("not-a-date", "2026-06-23T00:00:00Z"),
+    ).toBe("Invalid date");
+    expect(
+      formatWorkflowExecutionDuration("2026-06-23T00:00:00.000Z", "bad"),
+    ).toBe("Invalid date");
+  });
+
   it("builds copyable diagnostics for chat-assisted troubleshooting", () => {
     const diagnostics = buildWorkflowExecutionDiagnostics(SUCCESS_EXECUTION);
 

--- a/packages/ui/src/utils/workflow-executions.ts
+++ b/packages/ui/src/utils/workflow-executions.ts
@@ -120,7 +120,8 @@ export function formatWorkflowExecutionDuration(
   if (!startedAt) return "Unknown";
   const startMs = Date.parse(startedAt);
   const stopMs = stoppedAt ? Date.parse(stoppedAt) : Date.now();
-  if (!Number.isFinite(startMs) || !Number.isFinite(stopMs)) return "Unknown";
+  if (!Number.isFinite(startMs) || !Number.isFinite(stopMs))
+    return "Invalid date";
   const durationMs = Math.max(0, stopMs - startMs);
   if (durationMs < 1000) return `${durationMs} ms`;
   if (durationMs < 60_000) return `${(durationMs / 1000).toFixed(1)} s`;

--- a/plugins/plugin-workflow/__tests__/unit/execution-diagnostics.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/execution-diagnostics.test.ts
@@ -17,7 +17,7 @@ const exec = (over: Partial<WorkflowExecution>): WorkflowExecution =>
   ({ status: 'success', data: { resultData: {} }, ...over }) as unknown as WorkflowExecution;
 
 describe('formatWorkflowExecutionDuration', () => {
-  it('picks ms/s/min units, Unknown on missing/invalid', () => {
+  it('picks ms/s/min units, Unknown on missing and Invalid date on invalid', () => {
     expect(formatWorkflowExecutionDuration(undefined)).toBe('Unknown');
     expect(
       formatWorkflowExecutionDuration('2026-06-23T00:00:00.000Z', '2026-06-23T00:00:00.500Z')
@@ -31,6 +31,7 @@ describe('formatWorkflowExecutionDuration', () => {
     expect(formatWorkflowExecutionDuration('not-a-date', '2026-06-23T00:00:00Z')).toBe(
       'Invalid date'
     );
+    expect(formatWorkflowExecutionDuration('2026-06-23T00:00:00.000Z', 'bad')).toBe('Invalid date');
   });
 });
 

--- a/plugins/plugin-workflow/__tests__/unit/execution-diagnostics.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/execution-diagnostics.test.ts
@@ -28,7 +28,9 @@ describe('formatWorkflowExecutionDuration', () => {
     expect(
       formatWorkflowExecutionDuration('2026-06-23T00:00:00.000Z', '2026-06-23T00:02:00.000Z')
     ).toBe('2 min');
-    expect(formatWorkflowExecutionDuration('not-a-date', '2026-06-23T00:00:00Z')).toBe('Unknown');
+    expect(formatWorkflowExecutionDuration('not-a-date', '2026-06-23T00:00:00Z')).toBe(
+      'Invalid date'
+    );
   });
 });
 

--- a/plugins/plugin-workflow/src/utils/execution-diagnostics.ts
+++ b/plugins/plugin-workflow/src/utils/execution-diagnostics.ts
@@ -113,7 +113,7 @@ export function formatWorkflowExecutionDuration(
   if (!startedAt) return 'Unknown';
   const startMs = Date.parse(startedAt);
   const stopMs = stoppedAt ? Date.parse(stoppedAt) : Date.now();
-  if (!Number.isFinite(startMs) || !Number.isFinite(stopMs)) return 'Unknown';
+  if (!Number.isFinite(startMs) || !Number.isFinite(stopMs)) return 'Invalid date';
   const durationMs = Math.max(0, stopMs - startMs);
   if (durationMs < 1000) return `${durationMs} ms`;
   if (durationMs < 60_000) return `${(durationMs / 1000).toFixed(1)} s`;


### PR DESCRIPTION
# Relates to

Closes #18755

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Workflow UI only. Distinguishes `Invalid date` from `Unknown` (missing) in `formatWorkflowExecutionDuration`; no API or persistence change. Both duplicates (`packages/ui` and `plugins/plugin-workflow`) patched in sync. UI regression + second matrix case added per Uuriko review.

# Background

## What does this PR do?

Fixes #18755: `formatWorkflowExecutionDuration` in `packages/ui/src/utils/workflow-executions.ts:123` and `plugins/plugin-workflow/src/utils/execution-diagnostics.ts:116` returned opaque `"Unknown"` for both missing `startedAt` and malformed ISO (`Date.parse -> NaN`). This conflated "no data yet" with "invalid persisted ISO" and hid backend/localStorage regressions.

This PR keeps `if (!startedAt) return "Unknown"` and changes `if (!Number.isFinite(startMs) || !Number.isFinite(stopMs)) return "Invalid date"` in both files, plus updates tests per Uuriko: UI package regression `distinguishes missing from invalid dates` (both `not-a-date` and `valid+bad`) and plugin title fix.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/utils/workflow-executions.ts` (`formatWorkflowExecutionDuration`), `plugins/plugin-workflow/src/utils/execution-diagnostics.ts`, and both test files.

## Detailed testing steps

- `grep -n "Invalid date" packages/ui/src/utils/workflow-executions.ts plugins/plugin-workflow/src/utils/execution-diagnostics.ts` — both show `return "Invalid date"` on non-finite branch, `Unknown` only on missing.
- `bun test plugins/plugin-workflow/__tests__/unit/execution-diagnostics.test.ts` — 3 pass (title + both invalid cases).
- `bun test packages/ui/src/utils/workflow-executions.test.ts` — 5 pass (includes new `distinguishes missing from invalid dates`).
- `bun x biome check --write` — no errors.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:43bd370dcf4cf1364f00f5b401c1b8c7cbcf5026 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - duration label change is one-line text "Unknown" -> "Invalid date"; verified via unit test not screenshot` .
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - visual change is one-line label, code diff + tests are proof` .
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - workflow execution diagnostics are unit-tested pure functions; no interactive flow to record` .
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - pure client formatting, no backend path` .
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - pure formatting, logs are test output` .
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/action/provider/prompt/model behavior is involved` .
<!-- evidence-row:domain-artifacts -->
- [x] `Invalid date` branch in both `workflow-executions.ts` + `execution-diagnostics.ts` + updated tests (ui + plugin)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - label is typed string, no OCR target` .


AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [workflow-invalid-date]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZSRYPAGBE0DEJAAQJT1VEQZ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T01:21:25.841Z","completed_at":"2026-08-12T01:25:31.709Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAPnQT8iCj4u7N5v1KHxwCtZECLRZKO4Px_PB9j-U6psk","device_key_id":"bcb90204018cc1697d7a8bcda9a8ac16d85133b1d86994eb804401d68920475b","device_signature":"YQt7oRExvX3_Tl8mpcs54lwGMxVVkV0WDvnCVmBvmRbUl_Gqpi1FVqJdHAljbXPR0eLkYZ7ABD2zXvyIsv_kAg"}} -->
