### PR TITLE
fix(shared): correct token rollover boundary

### DIFF
--- a/packages/shared/src/utils/trajectory-format.test.ts
+++ b/packages/shared/src/utils/trajectory-format.test.ts
@@ -92,12 +92,12 @@ describe("formatTrajectoryTokenCount", () => {
   it("formats thousands with one decimal", () => {
     expect(formatTrajectoryTokenCount(1_000, EMPTY)).toBe("1.0k");
     expect(formatTrajectoryTokenCount(12_345, EMPTY)).toBe("12.3k");
-    expect(formatTrajectoryTokenCount(999_499, EMPTY)).toBe("999.5k");
+    expect(formatTrajectoryTokenCount(999_500, EMPTY)).toBe("999.5k");
+    expect(formatTrajectoryTokenCount(999_949, EMPTY)).toBe("999.9k");
   });
 
   it("promotes to M when rounding crosses the 1000k boundary", () => {
-    // 999.5k rounds to 1000.0k — must promote, "1000.0k" is impossible
-    expect(formatTrajectoryTokenCount(999_500, EMPTY)).toBe("1.0M");
+    // 999.95k rounds to 1000.0k — must promote, "1000.0k" is impossible
     expect(formatTrajectoryTokenCount(999_950, EMPTY)).toBe("1.0M");
   });
 

--- a/packages/shared/src/utils/trajectory-format.ts
+++ b/packages/shared/src/utils/trajectory-format.ts
@@ -36,7 +36,7 @@ export function formatTrajectoryDuration(ms: number | null): string {
 /**
  * Formats a token count as a human-readable string, promoting to "k" at 1,000
  * and "M" at 1,000,000, including when rounding crosses the boundary
- * (e.g. 999,500 rounds to "1.0M", 1,000,000 -> "1.0M").
+ * (e.g. 999,950 rounds to "1.0M", 1,000,000 -> "1.0M").
  */
 export function formatTrajectoryTokenCount(
   count: number | undefined,
@@ -56,10 +56,9 @@ export function formatTrajectoryTokenCount(
   if (count < 1000) return String(count);
   const thousands = count / 1000;
   if (thousands < 1000) {
-    // Round in raw thousands so 999.5k (0.9995M) promotes to "1.0M" instead
-    // of rendering the impossible "1000.0k".
-    if (Math.round(thousands) >= 1000) return "1.0M";
-    return `${thousands.toFixed(1)}k`;
+    const roundedThousands = Math.round(thousands * 10) / 10;
+    if (roundedThousands >= 1000) return "1.0M";
+    return `${roundedThousands.toFixed(1)}k`;
   }
   return `${(count / 1_000_000).toFixed(1)}M`;
 }


### PR DESCRIPTION
# Relates to

Fixes the residual rounding regression in #18527 after #18532 merged.

## Definition of Done

- [x] Targets current `develop` with zero conflicts.
- [x] Uses the repository-pinned Bun 1.3.14 toolchain.
- [x] Focused tests, package typecheck/lint, core build, and root `bun run verify` pass on this exact head.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@f6c52a5593bacbc59842476ac213c595bbc26d88:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Low. This changes one pure display formatter and its boundary tests. Counts below the actual one-decimal rollover retain the `k` unit; counts at or above the rollover retain the merged `M` behavior.

# Background

## What does this PR do?

Merged #18532 checks `Math.round(thousands) >= 1000`, which promotes `999,500` tokens to `1.0M` even though the formatter's one-decimal representation is `999.5k`. The first value whose one-decimal thousands representation reaches the impossible `1000.0k` label is `999,950`.

This follow-up rounds at the formatter's actual one-decimal precision, keeps `999,949` as `999.9k`, and promotes `999,950` to `1.0M`. It preserves #18532's useful minute-to-hour rollover and invalid-input handling.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No external documentation change is needed; the exported formatter JSDoc now states the exact boundary.

# Testing

## Where should a reviewer start?

- `packages/shared/src/utils/trajectory-format.ts`
- `packages/shared/src/utils/trajectory-format.test.ts`

## Detailed testing steps

```text
bun run --cwd packages/shared test -- src/utils/trajectory-format.test.ts
Test Files  1 passed (1)
Tests       19 passed (19)

bun run --cwd packages/shared typecheck
PASS

bun run --cwd packages/shared lint:check
Checked 380 files. No fixes applied.

bun run build:core
Tasks: 56 successful, 56 total

bun run verify
Tasks: 350 successful, 350 total
[anti-larp] clean
```

# Evidence Gate

<!-- evidence-head:2511dd3104e84d351a898d4fb700535a5c170b0e -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - pure shared string formatter; exact before output is 999,500 -> 1.0M.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - pure shared string formatter; exact after outputs are 999,949 -> 999.9k and 999,950 -> 1.0M.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no interactive flow or layout changes.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no backend boundary changes.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - deterministic shared-library formatting has no console, network, or request boundary.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model, prompt, action, provider, or agent behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - pure formatter; exact focused test transcript is included in Testing.`
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - no visual layout or captured UI surface changes.`

AI provider/model: anthropic / anthropic/claude-opus-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@f6c52a5593bacbc59842476ac213c595bbc26d88:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-pr-review]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"anthropic/claude-opus-5","client":"Codex","skill_revision":"elizaOS/eliza@f6c52a5593bacbc59842476ac213c595bbc26d88:packages/skills/skills/contribute-to-eliza"} -->
