### PR TITLE
fix(ui): fail closed on invalid log-viewer timestamps

### DIFF
--- a/packages/ui/src/cloud-ui/components/log-viewer-format.ts
+++ b/packages/ui/src/cloud-ui/components/log-viewer-format.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure timestamp formatting for the cloud log viewer.
+ * Kept in a .ts module so unit tests can import it without loading the React
+ * component graph.
+ */
+
+export type LogViewerTimestamp = string | number | Date | null | undefined;
+
+/**
+ * Locale time label for structured log rows / refresh stamps.
+ * Fail closed on empty or non-finite Date values so bad API timestamps
+ * render blank instead of the browser's "Invalid Date" string.
+ */
+export function formatTimestamp(value: LogViewerTimestamp): string {
+  if (value == null || value === "") return "";
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(parsed.getTime())) return "";
+  return parsed.toLocaleTimeString();
+}

--- a/packages/ui/src/cloud-ui/components/log-viewer.test.ts
+++ b/packages/ui/src/cloud-ui/components/log-viewer.test.ts
@@ -1,0 +1,28 @@
+/** Verifies log-viewer timestamp formatting rejects malformed values. */
+import { describe, expect, it, vi } from "vitest";
+import { formatTimestamp } from "./log-viewer-format";
+
+describe("formatTimestamp", () => {
+  it("returns empty for missing and non-finite timestamps", () => {
+    expect(formatTimestamp(undefined)).toBe("");
+    expect(formatTimestamp(null)).toBe("");
+    expect(formatTimestamp("")).toBe("");
+    expect(formatTimestamp("not-a-date")).toBe("");
+    expect(formatTimestamp(Number.NaN)).toBe("");
+    expect(formatTimestamp(new Date(Number.NaN))).toBe("");
+  });
+
+  it("formats finite timestamps with toLocaleTimeString", () => {
+    const spy = vi
+      .spyOn(Date.prototype, "toLocaleTimeString")
+      .mockReturnValue("12:34:56 PM");
+    try {
+      expect(formatTimestamp("2026-01-15T12:34:56.000Z")).toBe("12:34:56 PM");
+      expect(formatTimestamp(1_768_478_400_000)).toBe("12:34:56 PM");
+      expect(formatTimestamp(new Date(1_768_478_400_000))).toBe("12:34:56 PM");
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/ui/src/cloud-ui/components/log-viewer.tsx
+++ b/packages/ui/src/cloud-ui/components/log-viewer.tsx
@@ -26,6 +26,7 @@ import {
 import { Skeleton } from "../../components/ui/skeleton";
 import { cn } from "../lib/utils";
 import { BrandButton, BrandCard } from "./brand";
+import { formatTimestamp } from "./log-viewer-format";
 
 type BadgeVariant = React.ComponentProps<typeof Badge>["variant"];
 
@@ -117,11 +118,6 @@ export interface LogViewerProps {
   entryLevelBorderColor?: (level: string) => string;
   onCopyEntry?: (entry: LogViewerStructuredEntry) => void;
   className?: string;
-}
-
-function formatTimestamp(value: LogViewerStructuredEntry["timestamp"]): string {
-  if (!value) return "";
-  return new Date(value).toLocaleTimeString();
 }
 
 function getDefaultLineClassName(line: string): string {
@@ -261,7 +257,7 @@ export function LogViewer({
             {subtitle && <p className="text-sm text-white/60">{subtitle}</p>}
             {fetchedAt && (
               <p className="mt-1 text-xs text-white/60">
-                Refreshed at {new Date(fetchedAt).toLocaleTimeString()}
+                Refreshed at {formatTimestamp(fetchedAt)}
               </p>
             )}
           </div>


### PR DESCRIPTION
# Relates to

Same Invalid Date bug class as #18727 / #18786, in an independent cloud-ui surface (`LogViewer`). No numbered issue; found while scanning unguarded `toLocaleTimeString` call sites outside the AgentDetailPage files already claimed by #18786.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `upstream/develop` with zero conflicts.
- [x] Focused unit tests were run after sync; details in Testing below.
- [x] A reviewer can confirm the change works without reading the code, from the unit coverage below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4`
<!-- attribution-row:client -->
- Agent tooling: `grok-bot`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribute-to-eliza measured run on this client; session model is not an approved skill model`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `upstream/develop`; zero conflicts.
- [x] Focused tests pass post-sync (`bun test packages/ui/src/cloud-ui/components/log-viewer.test.ts` → 2/2); biome check clean on touched files.

# Risks

Low. Pure display helper for the cloud log viewer. Empty / invalid timestamps already rendered blank via the falsy short-circuit; non-finite values now match that blank fallback instead of `Invalid Date`. Valid timestamps keep `toLocaleTimeString` behavior.

# Background

## What does this PR do?

`formatTimestamp` in `packages/ui/src/cloud-ui/components/log-viewer.tsx` only guarded falsy values before `toLocaleTimeString`. Malformed API strings / `Invalid Date` objects still rendered the browser's `"Invalid Date"` in structured log rows. The refresh stamp used the same unguarded pattern inline.

- Extract the helper to `log-viewer-format.ts` (pure `.ts` so tests do not load the React component graph)
- Return `\"\"` for null/empty **and** non-finite `Date` values
- Reuse the helper for the `fetchedAt` stamp
- Add unit coverage for missing, invalid, and valid inputs

## What kind of change is this?

Bug fix (non-breaking UI label hardening).

# Documentation changes needed?

None.

# Testing

## Where should a reviewer start?

1. `packages/ui/src/cloud-ui/components/log-viewer-format.ts`
2. `packages/ui/src/cloud-ui/components/log-viewer.test.ts`
3. Call-site wiring in `log-viewer.tsx` (import + `fetchedAt` / entry timestamp)

## Detailed testing steps

```bash
bun test packages/ui/src/cloud-ui/components/log-viewer.test.ts
# 2 pass, 0 fail
bun x @biomejs/biome check \
  packages/ui/src/cloud-ui/components/log-viewer.tsx \
  packages/ui/src/cloud-ui/components/log-viewer-format.ts \
  packages/ui/src/cloud-ui/components/log-viewer.test.ts
# clean
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:d93166e01dccc0b2393a3af60e6bb49d1b314299 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - pure timestamp label helper; no layout/UI chrome change`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - pure timestamp label helper; behavior proven by unit tests`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - pure function with unit coverage; no interactive flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - client-side formatting only; no backend path`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - pure formatting; proof is unit test output`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - reviewed artifact is the helper diff plus unit expectations`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - typed string labels only; no OCR surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no model-facing change.`

## Backend + frontend logs

<details>
<summary>Focused unit test output</summary>

```
bun test packages/ui/src/cloud-ui/components/log-viewer.test.ts
2 pass, 0 fail
```

</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - pure functions.`

### After

`N/A - pure functions.`

### Walkthrough video

`N/A - pure functions.`

## Known gaps / failures

- Did not boot the live cloud agent-logs page; the defect and fix are deterministic from the pure helper (same class as #18727/#18786).
- Full monorepo `bun run verify` not re-run for this focused pure-util change.