### PR TITLE
fix(cloud): authorize the running-agent delete enqueue in the ownership test

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
@@ -693,6 +693,9 @@ describe("enqueueAgentDeleteOnce initializes ownership from the pre-delete state
         agentId,
         organizationId: orgId,
         userId,
+        // #18573's admission guard refuses an unqualified delete of a running
+        // dedicated agent; this first enqueue models an authorized user request.
+        authorization: "user_request",
       });
       expect(await ownership(agentId)).toBe(true);
 


### PR DESCRIPTION
## Problem

Merged #18573 added an admission guard refusing unqualified deletes of running dedicated agents on the enqueue path. `deletion-allocation-ownership.test.ts`'s first `enqueueAgentDeleteOnce` seeds exactly that state, so develop's cloud `unit-tests` lane is red on one test: `a placed, running agent starts its deletion owning one slot; a re-enqueue keeps that answer` (409 `Agent is running; suspend it before deletion`). #18616 already fixed the proven-absence twin; this is the last residual from #18573.

## Fix

One call: pass `authorization: "user_request"` in the first enqueue (modeling an authorized user request). The recovery-sweep re-enqueue in the same test deliberately stays unqualified — by then the row is `deletion_pending`, so the guard doesn't apply, pinning that a sweep can continue an admitted deletion.

## Verification

At tip a70014e524a: baseline 25/26 (exactly this test red); with the fix 26/26, 67 assertions (PGlite schema guard green — the suite runs for real).

## Evidence

<!-- evidence-head:155e53ff1229a5f290c42c6e8a7c7d6781c6e423 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change.
<!-- evidence-row:backend-logs -->
- [x] Red-then-green at tip a70014e524a:

```
baseline: 25 pass / 1 fail — (fail) enqueueAgentDeleteOnce initializes ownership ... re-enqueue keeps that answer (409 Agent is running; suspend it before deletion)
with fix: 26 pass / 0 fail, 67 expect() calls
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM invoked.
<!-- evidence-row:domain-artifacts -->
- [x] The one-call diff plus the in-test comment documenting #18573's guard semantics.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)