### PR TITLE
fix(video): reject malformed format metadata

### DIFF
--- a/plugins/plugin-video/src/services/video.test.ts
+++ b/plugins/plugin-video/src/services/video.test.ts
@@ -1,4 +1,4 @@
-import type { IAgentRuntime, Media } from "@elizaos/core";
+import type { ElizaError, IAgentRuntime, Media } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { BinaryResolver } from "./binaries";
 import { VideoService } from "./video";
@@ -88,6 +88,40 @@ describe("VideoService deterministic behavior", () => {
     expect(info.formats).toEqual([]);
   });
 
+  it("rejects malformed yt-dlp format collections with a typed error", async () => {
+    const { service } = createServiceWithYtDlp([
+      { title: "Malformed metadata", formats: { format_id: "not-an-array" } },
+      { formats: [null] },
+      "not-json-metadata",
+    ]);
+
+    await expect(
+      service.getVideoInfo("https://youtu.be/malformed"),
+    ).rejects.toMatchObject({
+      code: "VIDEO_METADATA_FORMATS_INVALID",
+    } satisfies Partial<ElizaError>);
+    await expect(
+      service.getAvailableFormats("https://youtu.be/malformed"),
+    ).rejects.toMatchObject({
+      code: "VIDEO_METADATA_FORMAT_ENTRY_INVALID",
+      context: { index: 0 },
+    } satisfies Partial<ElizaError>);
+    await expect(
+      service.getAvailableFormats("https://youtu.be/malformed"),
+    ).rejects.toMatchObject({
+      code: "VIDEO_METADATA_INVALID",
+    } satisfies Partial<ElizaError>);
+  });
+
+  it("preserves the original yt-dlp failure", async () => {
+    const upstreamFailure = new Error("yt-dlp unavailable");
+    const { service } = createServiceWithYtDlp([upstreamFailure]);
+
+    await expect(
+      service.getAvailableFormats("https://youtu.be/upstream-failure"),
+    ).rejects.toBe(upstreamFailure);
+  });
+
   it("parses SRT subtitles with CRLF line endings cleanly", () => {
     const { service } = createServiceWithYtDlp([]);
     const srtContent = [
@@ -133,5 +167,11 @@ describe("VideoService deterministic behavior", () => {
     expect(service["parseCaption"](JSON.stringify({ events: "invalid" }))).toBe(
       "Error: Unable to parse captions",
     );
+  });
+
+  it("returns false for non-string video URL input", () => {
+    const { service } = createServiceWithYtDlp([]);
+    expect(service.isVideoUrl(null as unknown as string)).toBe(false);
+    expect(service.isVideoUrl({} as unknown as string)).toBe(false);
   });
 });

--- a/plugins/plugin-video/src/services/video.ts
+++ b/plugins/plugin-video/src/services/video.ts
@@ -1,9 +1,12 @@
 /// <reference path="../types/fluent-ffmpeg.d.ts" />
 
+/** Provides validated video metadata, download, conversion, and transcription services. */
+
 import fs from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
+  ElizaError,
   elizaLogger,
   type IAgentRuntime,
   type ITranscriptionService,
@@ -80,6 +83,50 @@ function parseYtDlpUploadDate(value: string | undefined): Date | undefined {
   return Number.isNaN(parsed.getTime()) ? undefined : parsed;
 }
 
+function toVideoFormat(format: YtDlpFormatRow): VideoFormat {
+  return {
+    formatId: format.format_id ?? "",
+    url: format.url ?? "",
+    extension: format.ext ?? "",
+    quality:
+      format.quality !== undefined && format.quality !== ""
+        ? String(format.quality)
+        : "unknown",
+    fileSize: format.filesize,
+    videoCodec: format.vcodec,
+    audioCodec: format.acodec,
+    resolution: format.resolution,
+    fps: format.fps,
+    bitrate: format.tbr,
+  };
+}
+
+function parseYtDlpFormats(value: unknown): VideoFormat[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new ElizaError("yt-dlp returned a non-array formats field.", {
+      code: "VIDEO_METADATA_FORMATS_INVALID",
+      context: { receivedType: typeof value },
+      severity: "ephemeral",
+    });
+  }
+
+  return value.map((format, index) => {
+    if (
+      typeof format !== "object" ||
+      format === null ||
+      Array.isArray(format)
+    ) {
+      throw new ElizaError("yt-dlp returned an invalid format entry.", {
+        code: "VIDEO_METADATA_FORMAT_ENTRY_INVALID",
+        context: { index, receivedType: typeof format },
+        severity: "ephemeral",
+      });
+    }
+    return toVideoFormat(format as YtDlpFormatRow);
+  });
+}
+
 export class VideoService extends IVideoService {
   public readonly capabilityDescription =
     "Video download, processing, and conversion capabilities";
@@ -129,23 +176,7 @@ export class VideoService extends IVideoService {
   // Required abstract methods from IVideoService
   async getVideoInfo(url: string): Promise<VideoInfo> {
     const videoInfo = await this.fetchVideoInfo(url);
-    const formats: VideoFormat[] = (videoInfo.formats ?? []).map(
-      (f: YtDlpFormatRow) => ({
-        formatId: f.format_id ?? "",
-        url: f.url ?? "",
-        extension: f.ext ?? "",
-        quality:
-          f.quality !== undefined && f.quality !== ""
-            ? String(f.quality)
-            : "unknown",
-        fileSize: f.filesize,
-        videoCodec: f.vcodec,
-        audioCodec: f.acodec,
-        resolution: f.resolution,
-        fps: f.fps,
-        bitrate: f.tbr,
-      }),
-    );
+    const formats = parseYtDlpFormats(videoInfo.formats);
     return {
       title: videoInfo.title,
       duration: videoInfo.duration,
@@ -315,47 +346,32 @@ export class VideoService extends IVideoService {
   }
 
   async getAvailableFormats(url: string): Promise<VideoFormat[]> {
-    try {
-      const result = await this.binaries.runYtDlp(url, {
-        dumpJson: true,
-        verbose: true,
-        callHome: false,
-        noCheckCertificates: true,
-        preferFreeFormats: true,
-        youtubeSkipDashManifest: true,
-        skipDownload: true,
+    const result = await this.binaries.runYtDlp(url, {
+      dumpJson: true,
+      verbose: true,
+      callHome: false,
+      noCheckCertificates: true,
+      preferFreeFormats: true,
+      youtubeSkipDashManifest: true,
+      skipDownload: true,
+    });
+
+    if (
+      typeof result !== "object" ||
+      result === null ||
+      Array.isArray(result)
+    ) {
+      throw new ElizaError("yt-dlp returned invalid metadata.", {
+        code: "VIDEO_METADATA_INVALID",
+        context: { receivedType: typeof result },
+        severity: "ephemeral",
       });
-
-      if (
-        typeof result === "object" &&
-        result !== null &&
-        "formats" in result
-      ) {
-        const parsed = result as YtDlpJson;
-        if (Array.isArray(parsed.formats) && parsed.formats.length) {
-          return parsed.formats.map((format: YtDlpFormatRow) => ({
-            formatId: format.format_id ?? "",
-            url: format.url ?? "",
-            extension: format.ext ?? "",
-            quality:
-              format.quality !== undefined && format.quality !== ""
-                ? String(format.quality)
-                : "unknown",
-            fileSize: format.filesize,
-            videoCodec: format.vcodec,
-            audioCodec: format.acodec,
-            resolution: format.resolution,
-            fps: format.fps,
-            bitrate: format.tbr,
-          }));
-        }
-      }
-
-      return [];
-    } catch (error) {
-      elizaLogger.log("Error getting available formats:", loggableError(error));
-      throw new Error("Failed to get available formats");
     }
+    if (!("formats" in result)) {
+      return [];
+    }
+
+    return parseYtDlpFormats((result as YtDlpJson).formats);
   }
 
   private ensureDataDirectoryExists() {
@@ -375,6 +391,7 @@ export class VideoService extends IVideoService {
         hostname.endsWith(".vimeo.com")
       );
     } catch {
+      // error-policy:J3 Invalid URL input is the negative result of this predicate.
       return false;
     }
   }


### PR DESCRIPTION
Relates to #18730.

## What changed

PR #18731 fixed the CRLF, caption-newline, and invalid-date cases, but its final reviewed revision left the issue's untrusted `formats` boundary partially open:

- `getVideoInfo` still called `.map` on any non-null `formats` value, producing an opaque runtime error for malformed non-array metadata;
- `getAvailableFormats` silently returned an empty array for malformed metadata and caught every upstream failure, replacing the real cause with `Failed to get available formats`.

This follow-up validates yt-dlp format metadata once for both callers. Missing/null `formats` remains the explicit unavailable state. Malformed collections and entries now throw typed `ElizaError` failures with stable codes and context, while genuine yt-dlp failures propagate unchanged. It also retains the predicate-only URL parser boundary with a documented J3 invalid-input result.

No timeout, retry, catch-and-continue data path, degraded-success fallback, or fabricated empty format list was added.

## Verification

Exact head: `02d38b4d5f85370a869502e8362ad17686b8a3ec`, rebased onto `develop` `2304ed16450cea1355936c2c61650e5b33a1d66c`.

- `bun install`: passed, no lockfile changes.
- `bun run --cwd plugins/plugin-video test`: 2 files passed, 1 integration file intentionally skipped; 29 passed / 4 skipped.
- `bun run --cwd plugins/plugin-video typecheck`: passed.
- `bun run --cwd plugins/plugin-video build`: passed, Node bundle and declarations generated.
- `bun run --cwd plugins/plugin-video lint:check`: passed (seven pre-existing informational private-method suggestions, zero errors/warnings).
- `bun run verify`: 350/350 Turbo tasks passed; all trailing build-model, dependency, secret, fleet-routing, script, view-inventory, and focused-test audits passed.
- `git diff --check origin/develop...HEAD`: passed.

The focused regressions prove malformed collection, malformed entry, malformed top-level metadata, preservation of the original upstream error object, and non-string URL rejection.

## Evidence Gate

<!-- evidence-head:02d38b4d5f85370a869502e8362ad17686b8a3ec -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - parser/service boundary only; no rendered UI source changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - parser/service boundary only; no rendered UI source changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changed; deterministic service tests exercise the exact boundary.
<!-- evidence-row:backend-logs -->
- [x] N/A - local plugin service with no server transport; exact-head package tests exercise the real parser and propagated error objects.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, action, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact is produced; typed `ElizaError` codes/context and preserved upstream errors are asserted directly by the 29-test package suite.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI / gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2304ed16450cea1355936c2c61650e5b33a1d66c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@2304ed16450cea1355936c2c61650e5b33a1d66c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@2304ed16450cea1355936c2c61650e5b33a1d66c:packages/skills/skills/contribute-to-eliza"} -->