### PR TITLE
fix(scripts): validate Turbo concurrency override

### DIFF
--- a/packages/scripts/__tests__/run-turbo-concurrency.test.ts
+++ b/packages/scripts/__tests__/run-turbo-concurrency.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Exercises the run-turbo concurrency override through real subprocesses and
+ * a fake Turbo binary so invalid environment input cannot reach the task graph.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "../lib/spawn-sync-captured.mjs";
+
+const repoRoot = resolve(import.meta.dir, "../../..");
+const runTurbo = join(repoRoot, "packages/scripts/run-turbo.mjs");
+const tempDirs: string[] = [];
+
+async function fixture() {
+  const dir = await mkdtemp(join(tmpdir(), "run-turbo-concurrency-"));
+  tempDirs.push(dir);
+  const argvFile = join(dir, "argv.json");
+  const fakeTurbo = join(dir, "fake-turbo.mjs");
+  await writeFile(
+    fakeTurbo,
+    `import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(argvFile)}, JSON.stringify(process.argv.slice(2)));\n`,
+  );
+  return { argvFile, fakeTurbo };
+}
+
+function invoke(
+  fakeTurbo: string,
+  concurrency: string | undefined,
+  args = ["run", "lint", "--concurrency", "8"],
+) {
+  const env = { ...process.env, RUN_TURBO_BIN: fakeTurbo };
+  if (concurrency === undefined) {
+    delete env.RUN_TURBO_CONCURRENCY;
+  } else {
+    env.RUN_TURBO_CONCURRENCY = concurrency;
+  }
+
+  return spawnSync("node", [runTurbo, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env,
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("run-turbo concurrency override", () => {
+  test.each([undefined, ""])(
+    "preserves CLI concurrency when the environment value is %s",
+    async (concurrency) => {
+      const { argvFile, fakeTurbo } = await fixture();
+
+      const result = invoke(fakeTurbo, concurrency);
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(await readFile(argvFile, "utf8"))).toEqual(
+        expect.arrayContaining(["--concurrency", "8"]),
+      );
+    },
+  );
+
+  test.each(["1", "4", String(Number.MAX_SAFE_INTEGER)])(
+    "injects a valid positive safe integer (%s)",
+    async (concurrency) => {
+      const { argvFile, fakeTurbo } = await fixture();
+
+      const result = invoke(fakeTurbo, concurrency);
+
+      expect(result.status, result.stderr).toBe(0);
+      const argv = JSON.parse(await readFile(argvFile, "utf8"));
+      expect(argv).toContain(`--concurrency=${concurrency}`);
+      expect(argv).not.toContain("--concurrency");
+      expect(argv).not.toContain("8");
+    },
+  );
+
+  test("replaces an equals-form CLI concurrency flag", async () => {
+    const { argvFile, fakeTurbo } = await fixture();
+
+    const result = invoke(fakeTurbo, "5", ["run", "lint", "--concurrency=8"]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const argv = JSON.parse(await readFile(argvFile, "utf8"));
+    expect(argv).toContain("--concurrency=5");
+    expect(argv).not.toContain("--concurrency=8");
+  });
+
+  test.each([
+    " ",
+    " 4 ",
+    "0",
+    "-1",
+    "+3",
+    "1.5",
+    "1e2",
+    "3junk",
+    "NaN",
+    "Infinity",
+    String(Number.MAX_SAFE_INTEGER + 1),
+  ])("rejects %j before Turbo starts", async (concurrency) => {
+    const { argvFile, fakeTurbo } = await fixture();
+
+    const result = invoke(fakeTurbo, concurrency);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "[run-turbo] RUN_TURBO_CONCURRENCY must be a positive safe-integer decimal",
+    );
+    await expect(readFile(argvFile, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  test("injects the override for a bare Turbo invocation", async () => {
+    const { argvFile, fakeTurbo } = await fixture();
+
+    const result = invoke(fakeTurbo, "6", ["lint"]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(await readFile(argvFile, "utf8"))).toEqual(
+      expect.arrayContaining(["lint", "--concurrency=6"]),
+    );
+  });
+});

--- a/packages/scripts/run-turbo.mjs
+++ b/packages/scripts/run-turbo.mjs
@@ -63,6 +63,30 @@ if (process.env.RUN_TURBO_LOCKFILE_CHECK_ONLY === "1") {
 }
 
 const rawTurboArgs = process.argv.slice(2);
+
+function readConcurrencyOverride() {
+  const raw = process.env.RUN_TURBO_CONCURRENCY;
+  if (raw === undefined || raw === "") return null;
+
+  const parsed = Number(raw);
+  if (!/^\d+$/u.test(raw) || !Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(
+      `RUN_TURBO_CONCURRENCY must be a positive safe-integer decimal; received ${JSON.stringify(raw)}`,
+    );
+  }
+
+  return raw;
+}
+
+let concurrencyOverride;
+try {
+  concurrencyOverride = readConcurrencyOverride();
+} catch (error) {
+  // error-policy:J1 This CLI boundary translates invalid environment input into a clear non-zero exit.
+  console.error(`[run-turbo] ${error.message}`);
+  process.exit(1);
+}
+
 // Turbo accepts tasks as `turbo run <task>` or bare `turbo <task>`, with flags
 // anywhere in between (`run --filter=x typecheck`), and forwards everything
 // after a bare `--` to the tasks themselves. Collect every non-flag argument
@@ -156,11 +180,11 @@ if (
 // tsc processes on a full-workspace cone — the VM itself is OOM-killed and the
 // job exits 143 (#15140) — so CI lanes set this to 4 without forking the
 // `verify`/`typecheck` script definitions.
-if (process.env.RUN_TURBO_CONCURRENCY) {
+if (concurrencyOverride !== null) {
   const idx = turboArgs.findIndex(
     (arg) => arg === "--concurrency" || arg.startsWith("--concurrency="),
   );
-  const override = `--concurrency=${process.env.RUN_TURBO_CONCURRENCY}`;
+  const override = `--concurrency=${concurrencyOverride}`;
   if (idx === -1) {
     if (runIndex !== -1) turboArgs.splice(runIndex + 1, 0, override);
     else turboArgs.push(override);


### PR DESCRIPTION
# Relates to

Fixes #18661.

Definition of Done: full standard in [`CONTRIBUTING.md`](../blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto exact `origin/develop@a5928254c0dc44fe40f828c30eb325b01af4411b` with zero conflicts.
- [x] `bun install` and `bun run verify` passed after the final sync.
- [x] A reviewer can confirm the behavior from the real subprocess matrix below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a5928254c0dc44fe40f828c30eb325b01af4411b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact latest `origin/develop@a5928254c0dc44fe40f828c30eb325b01af4411b`; zero conflicts and `ahead 1 / behind 0`.
- [x] `bun run verify` passes at exact head `509368acfc038e6b79b15263ca4fb505a8509fab`.

# Risks

Low. This changes only the repository Turbo wrapper's environment boundary. Unset and empty values preserve existing behavior; explicit valid values retain the existing replacement semantics. Invalid explicit values now fail before Turbo starts.

# Background

## What does this PR do?

It validates `RUN_TURBO_CONCURRENCY` as a complete positive safe-integer decimal before any generated-source prerequisite or Turbo process can start. It rejects whitespace, zero, negatives, signs, fractions, exponent notation, suffixes, non-finite text, and values above `Number.MAX_SAFE_INTEGER` with a clear `[run-turbo]` error.

The subprocess suite uses the existing `RUN_TURBO_BIN` seam to prove:

- unset and empty values preserve a CLI `--concurrency 8`;
- valid values replace both split and equals-form CLI flags;
- bare invocations receive the valid override;
- every invalid value exits 1 and never creates the fake Turbo argv artifact.

## What kind of change is this?

Bug fix in repository build/CI tooling.

# Documentation changes needed?

N/A - the environment contract and failure text are encoded at the owning wrapper boundary and covered by offline subprocess tests.

# Testing

## Where should a reviewer start?

Run the concurrency subprocess test and inspect the fake-Turbo artifact/non-artifact assertions.

## Detailed testing steps

- `bun test packages/scripts/__tests__/run-turbo-concurrency.test.ts packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts packages/scripts/__tests__/run-turbo-windows-init-crash-retry.test.ts` — PASS, 41/41.
- `node packages/scripts/run-turbo.self-test.mjs` — PASS.
- `bun run audit:scripts` — PASS.
- `bun run audit:focused-tests` — PASS.
- `bun install` after final rebase — PASS, no changes.
- `bun run verify` after final rebase — PASS, 350/350 Turbo tasks plus every repository audit.
- `git diff --check` — PASS.

# Evidence Gate

<!-- evidence-head:509368acfc038e6b79b15263ca4fb505a8509fab -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - repository CLI wrapper only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - repository CLI wrapper only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing visual interaction.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server/backend request path; the applicable CLI subprocess transcript is included below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact; fake-Turbo argv creation and deliberate non-creation are asserted by the 18-case focused subprocess suite below.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real subprocess transcript

```text
bun test v1.3.14
packages/scripts/__tests__/run-turbo-concurrency.test.ts
18 pass
0 fail
54 expect() calls

combined run-turbo wrapper regression matrix:
41 pass
0 fail
108 expect() calls

bun run verify:
Tasks: 350 successful, 350 total
audit-build-typecheck: consistent
audit-turbo-build-deps: no phantom edges or cycles
audit-tee-secret-leak: PASS
audit-scripts: OK
audit-view-bundle-inventory: 19 targets, 0 exclusions
anti-larp: 0 focused, 0 orphaned skips
```

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior.

## Backend + frontend logs

The relevant execution boundary is the CLI subprocess. Invalid values are verified to emit `[run-turbo] RUN_TURBO_CONCURRENCY must be a positive safe-integer decimal`, exit 1, and leave the fake Turbo argv artifact absent.

## Screenshots (before / after) + video walkthrough

N/A - no UI or visual output.

## Audio / voice walkthrough

N/A - no audio path.

## Known gaps / failures

None. No deployment is required.

AI provider/model: openai / gpt-5
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@a5928254c0dc44fe40f828c30eb325b01af4411b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-run-turbo-concurrency-18661]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex Desktop","skill_revision":"elizaOS/eliza@a5928254c0dc44fe40f828c30eb325b01af4411b:packages/skills/skills/contribute-to-eliza"} -->


