### PR TITLE
fix(cloud): remove public payment agent attribution

### DIFF
--- a/packages/cloud/api/v1/payment-requests/route.test.ts
+++ b/packages/cloud/api/v1/payment-requests/route.test.ts
@@ -1,8 +1,6 @@
 /**
- * Exercises payment-request agent ownership at the authenticated API boundary.
- * Bun test with mocked auth, sandbox, and payment-request service modules; the
- * real Hono route under test must reject foreign/missing agents with 404
- * before any provider intent is created.
+ * Exercises the payment-request creation boundary with mocked authentication
+ * and payment services, proving public callers cannot attach agent identity.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
@@ -11,17 +9,11 @@ const requireUserOrApiKeyWithOrg = mock(async () => ({
   id: "user-a",
   organization_id: "org-a",
 }));
-const getAgentForWrite = mock(
-  async (): Promise<{ id: string; organization_id: string } | undefined> => ({
-    id: "agent-a",
-    organization_id: "org-a",
-  }),
-);
 const createPaymentRequest = mock(async (input: Record<string, unknown>) => ({
   paymentRequest: {
     id: "payment-request-a",
     organizationId: input.organizationId,
-    agentId: input.agentId,
+    agentId: null,
   },
   hostedUrl: "https://pay.example/request-a",
 }));
@@ -29,10 +21,6 @@ const listPaymentRequests = mock(async () => []);
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
-}));
-
-mock.module("@/lib/services/eliza-sandbox", () => ({
-  elizaSandboxService: { getAgentForWrite },
 }));
 
 mock.module("@/lib/services/payment-requests-default", () => ({
@@ -59,7 +47,7 @@ const { default: paymentRequestsRoute } = await import("./route");
 const app = new Hono();
 app.route("/api/v1/payment-requests", paymentRequestsRoute);
 
-function createRequest(agentId: string): Request {
+function createRequest(body: Record<string, unknown> = {}): Request {
   return new Request("https://api.example.test/api/v1/payment-requests", {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -67,21 +55,16 @@ function createRequest(agentId: string): Request {
       provider: "oxapay",
       amountCents: 100,
       paymentContext: "any_payer",
-      agentId,
+      ...body,
     }),
   });
 }
 
-describe("POST /api/v1/payment-requests agent ownership", () => {
+describe("POST /api/v1/payment-requests agent identity", () => {
   beforeEach(() => {
     requireUserOrApiKeyWithOrg.mockReset();
     requireUserOrApiKeyWithOrg.mockResolvedValue({
       id: "user-a",
-      organization_id: "org-a",
-    });
-    getAgentForWrite.mockReset();
-    getAgentForWrite.mockResolvedValue({
-      id: "agent-a",
       organization_id: "org-a",
     });
     createPaymentRequest.mockReset();
@@ -89,38 +72,32 @@ describe("POST /api/v1/payment-requests agent ownership", () => {
       paymentRequest: {
         id: "payment-request-a",
         organizationId: "org-a",
-        agentId: "agent-a",
+        agentId: null,
       },
       hostedUrl: "https://pay.example/request-a",
     });
   });
 
-  test("allows an agent owned by the caller's organization", async () => {
-    const response = await app.fetch(createRequest("agent-a"));
+  test("creates a payment request when agent identity is omitted", async () => {
+    const response = await app.fetch(createRequest());
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({ success: true });
-    expect(getAgentForWrite).toHaveBeenCalledWith("agent-a", "org-a");
     expect(createPaymentRequest).toHaveBeenCalledWith(
-      expect.objectContaining({ organizationId: "org-a", agentId: "agent-a" }),
+      expect.not.objectContaining({ agentId: expect.anything() }),
     );
   });
 
-  test.each(["foreign-agent", "missing-agent"])(
-    "rejects a %s before creating a payment request",
-    async (agentId) => {
-      getAgentForWrite.mockResolvedValueOnce(undefined);
+  test("rejects agent identity before creating a provider intent", async () => {
+    const response = await app.fetch(
+      createRequest({ agentId: "00000000-0000-4000-8000-000000000001" }),
+    );
 
-      const response = await app.fetch(createRequest(agentId));
-
-      expect(response.status).toBe(404);
-      await expect(response.json()).resolves.toMatchObject({
-        success: false,
-        error: "Agent not found",
-        code: "resource_not_found",
-      });
-      expect(getAgentForWrite).toHaveBeenCalledWith(agentId, "org-a");
-      expect(createPaymentRequest).not.toHaveBeenCalled();
-    },
-  );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: "Invalid request",
+    });
+    expect(createPaymentRequest).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cloud/api/v1/payment-requests/route.ts
+++ b/packages/cloud/api/v1/payment-requests/route.ts
@@ -13,13 +13,12 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
-import { failureResponse, NotFoundError } from "@/lib/api/cloud-worker-errors";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
-import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { getPaymentRequestsService } from "@/lib/services/payment-requests-default";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -52,7 +51,9 @@ const CreatePaymentRequestSchema = z.object({
   callbackUrl: z.string().url().optional(),
   callbackSecret: z.string().min(8).max(256).optional(),
   payerIdentityId: z.string().min(1).max(256).optional(),
-  agentId: z.string().min(1).max(256).optional(),
+  // Agent attribution is an internal payment-service concern. The public
+  // creation route has no consumer for it and must not accept an unowned ID.
+  agentId: z.never().optional(),
   successUrl: z.string().url().optional(),
   cancelUrl: z.string().url().optional(),
   success_url: z.string().url().optional(),
@@ -109,16 +110,6 @@ app.post("/", async (c) => {
       );
     }
 
-    if (parsed.data.agentId) {
-      const agent = await elizaSandboxService.getAgentForWrite(
-        parsed.data.agentId,
-        user.organization_id,
-      );
-      if (!agent) {
-        throw NotFoundError("Agent not found");
-      }
-    }
-
     const { successUrl, cancelUrl, metadata } = paymentMetadata(parsed.data);
     if (parsed.data.provider === "stripe" && (!successUrl || !cancelUrl)) {
       return c.json(
@@ -143,7 +134,6 @@ app.post("/", async (c) => {
       callbackSecret: parsed.data.callbackSecret,
       payerIdentityId: parsed.data.payerIdentityId,
       payerUserId: user.id,
-      agentId: parsed.data.agentId,
       metadata,
     });
 


### PR DESCRIPTION
## Summary

- Removes `agentId` from the public payment-request creation contract.
- Rejects callers that attempt to attach agent identity before any payment provider intent is created.
- Keeps payment-request creation unchanged when agent identity is omitted.

## Why

#18553 attempted to authorize the optional field through `agent_sandboxes.id`, but `payment_requests.agent_id` is the canonical agent/character identifier. Those identities are distinct for normal sandboxes. Repository-wide consumer inspection found no live public POST caller that supplies `agentId`; the core `PaymentRequestsClient` contract does not expose it. Removing the unused public input is therefore the smallest fail-closed correction and avoids a second ownership lookup or TOCTOU boundary.

Follow-up to #18553.

## Validation

Exact head: `04dcfb4ca2ec283a1aa157e3c6e50cbef5f9f5e6`.

- `bun test packages/cloud/api/v1/payment-requests/route.test.ts` — 2 passed, 6 assertions.
- `bun run --cwd packages/cloud/api test` — all 243 isolated files passed.
- `bun run --cwd packages/cloud/api typecheck` — passed, including production Worker dry-run (17.35 MB upload bundle).
- `bun run --cwd packages/cloud/api lint:check` — passed (1,023 files).
- `bun run verify` — passed on the exact pushed head.
- `git diff origin/develop...HEAD --check` — passed.

## Evidence Gate

<!-- evidence-head:04dcfb4ca2ec283a1aa157e3c6e50cbef5f9f5e6 -->

- [x] Before full-page screenshots: N/A - API-only authorization contract; no rendered UI changes.
- [x] After full-page screenshots: N/A - API-only authorization contract; no rendered UI changes.
- [x] Walkthrough video: N/A - no interactive UI flow changed.
- [x] Backend logs: focused route test proves supplied agent identity returns 400 and the payment service is never called; full Cloud API lane passes.
- [x] Frontend logs: N/A - no frontend code or request flow changed.
- [x] Real-LLM trajectory: N/A - no model, prompt, planner, or agent behavior changed.
- [x] Domain artifacts: exact HTTP response and zero provider-service invocation are asserted; full package and root gates pass.
- [x] OCR review: N/A - no visual surface changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
- AI assistance: `yes`
- Model(s) used: `anthropic/claude-opus-5`
- Agent tooling: `Codex`
- Skill path: `elizaOS/eliza@2304ed16450cea1355936c2c61650e5b33a1d66c:packages/skills/skills/contribute-to-eliza`
- Provenance status: `self-reported`

AI provider/model: anthropic / anthropic/claude-opus-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@2304ed16450cea1355936c2c61650e5b33a1d66c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-prs-65-96]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"anthropic/claude-opus-5","client":"Codex","skill_revision":"elizaOS/eliza@2304ed16450cea1355936c2c61650e5b33a1d66c:packages/skills/skills/contribute-to-eliza"} -->
