### PR TITLE
fix(cloud): avoid provider-name selector heuristics

### DIFF
--- a/packages/cloud/shared/src/lib/models/catalog.test.ts
+++ b/packages/cloud/shared/src/lib/models/catalog.test.ts
@@ -69,10 +69,21 @@ describe("#8426 text catalog recommendation invariants", () => {
 });
 
 describe("MiniMax static catalog", () => {
-  test("includes MiniMax M3 in the catalog and selector", () => {
+  test("describes flagship M3 without matching the provider name as a mini model", () => {
     const modelId = "minimax/minimax-m3";
+    const catalogModel = STATIC_TEXT_CATALOG_MODELS.find((model) => model.id === modelId);
+    const selectorModel = FALLBACK_TEXT_SELECTOR_MODELS.find((model) => model.modelId === modelId);
 
-    expect(STATIC_TEXT_CATALOG_MODELS.some((model) => model.id === modelId)).toBe(true);
-    expect(FALLBACK_TEXT_SELECTOR_MODELS.some((model) => model.modelId === modelId)).toBe(true);
+    expect(catalogModel?.description).toBe("General-purpose language model");
+    expect(selectorModel?.description).toBe("General-purpose language model");
+    expect(selectorModel?.description).not.toBe("Faster, lower-cost option");
+  });
+
+  test("keeps the mini heuristic for model names that explicitly use it", () => {
+    const selectorModel = FALLBACK_TEXT_SELECTOR_MODELS.find(
+      (model) => model.modelId === "openai/gpt-5-mini",
+    );
+
+    expect(selectorModel?.description).toBe("Faster, lower-cost option");
   });
 });

--- a/packages/cloud/shared/src/lib/models/catalog.ts
+++ b/packages/cloud/shared/src/lib/models/catalog.ts
@@ -399,7 +399,8 @@ function buildSelectorName(modelId: string): string {
 }
 
 function buildSelectorDescription(modelId: string): string {
-  const id = modelId.toLowerCase();
+  const [provider = "", rawName = modelId] = modelId.toLowerCase().split("/", 2);
+  const id = rawName.startsWith(`${provider}-`) ? rawName.slice(provider.length + 1) : rawName;
 
   if (id.includes("codex")) return "Coding-focused model";
   if (id.includes("deep-research")) return "Research-focused reasoning model";


### PR DESCRIPTION
# Relates to

Follow-up to merged PR #18773, which added `minimax/minimax-m3` to the static model catalog.

## What changed

The fallback selector description heuristic previously searched the complete provider-qualified model ID. Because `minimax/minimax-m3` contains `mini` in the provider name, flagship M3 was incorrectly presented as a faster, lower-cost mini model.

This repair evaluates the model basename and removes a duplicated provider prefix before applying name heuristics. M3 now receives the neutral general-purpose description, while real mini variants such as `openai/gpt-5-mini` retain the lower-cost description.

## Verification

- `bun test packages/cloud/shared/src/lib/models/catalog.test.ts` — 7 passed
- `bunx --no-install @biomejs/biome check packages/cloud/shared/src/lib/models/catalog.ts packages/cloud/shared/src/lib/models/catalog.test.ts` — passed
- `bun run --cwd packages/cloud/shared typecheck` — passed
- `bun run --cwd packages/cloud/shared lint:check` — 1,857 files checked, passed
- `bun run verify` — passed after rebasing onto current `origin/develop`
- `git diff --check` — passed

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - repository contribution guidance was read directly; no contribution skill was loaded`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:5942dd7cf7d29ff71fba77df495ce531d0d7751f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - model catalog metadata has no rendered UI implementation in this change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - model catalog metadata has no rendered UI implementation in this change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic selector metadata has no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - this is a pure catalog-description function; the focused regression asserts the produced catalog and selector DTOs.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime, request, console, or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model execution, prompt, provider call, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic selector DTO regression:

  <details><summary>Focused artifact output</summary>

  ```text
  bun test v1.3.14
  7 pass, 0 fail, 16 expect() calls
  Verified minimax/minimax-m3 => General-purpose language model; openai/gpt-5-mini => Faster, lower-cost option
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - repository contribution guidance was read directly; no contribution skill was loaded
Attribution status: self-reported
— [codex-pr-sweep-repair]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Codex desktop","skill_revision":"N/A - repository contribution guidance was read directly; no contribution skill was loaded"} -->
