### PR TITLE
chore(cloud): open the gated staging QA session exchange for one identity

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -401,6 +401,22 @@ __filename = '"/worker.js"'
 
 [env.staging.vars]
 NODE_ENV = "production"
+# Staging-only QA session exchange (#18223). Committed vars, not secrets: these
+# are allow-list identifiers, and the exchange serves nothing unless a caller's
+# API key, organization AND user all appear below — so the list has to survive a
+# redeploy that wipes secrets rather than silently reopening or disappearing.
+#
+# Why it exists: the messaging onboarding path (POST /api/v1/agents/:id/message
+# and the eliza-app onboarding chat) refuses a wallet API key by design — one
+# wants a service key, the other a Steward session. Neither is reachable from a
+# test harness, so the shared-to-dedicated journey has never been exercised end
+# to end. This exchange is the gated way in, scoped to a single QA identity.
+#
+# ENABLED is the kill switch; unset (or "false") closes the door outright.
+STAGING_SESSION_EXCHANGE_ENABLED = "true"
+STAGING_SESSION_EXCHANGE_ALLOWED_API_KEY_IDS = "651350d4-5287-4d0d-aebf-e31991f94dc4"
+STAGING_SESSION_EXCHANGE_ALLOWED_ORGANIZATION_IDS = "08561e32-37f1-4b27-8c6d-492ef4b3379c"
+STAGING_SESSION_EXCHANGE_ALLOWED_USER_IDS = "1b2b7f49-db5b-4892-b5d3-7b93828b4a02"
 # Apps (Product 2): wire the real deploy trigger so POST /api/v1/apps/:id/deploy
 # enqueues an APP_DEPLOY job the provisioning-worker daemon runs (instead of the
 # legacy status-only stub). Staging only — the apps data plane (tenant DB +


### PR DESCRIPTION
# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was loaded for this change`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop`. One file, four lines of config.

# Risks

**Staging only, one identity, kill switch present.** Production is untouched — verified by walking every `[env.*]` block: the four assignments live in `[env.staging.vars]` and nowhere else.

The exchange serves nothing unless a caller's API key, organization **and** user all appear in the lists. `STAGING_SESSION_EXCHANGE_ENABLED` closes it outright.

Committed as vars rather than set as secrets on purpose: these are allow-list identifiers, not credentials, and the list must survive a redeploy that wipes secrets rather than silently reopening or vanishing.

# Background

## What does this PR do?

Turns on the gated QA session exchange that #18223 shipped and nobody switched on.

The reason it matters: **the messaging onboarding path has never been exercised end to end**, and not for lack of trying. Both doors refuse a wallet API key by design:

| Route | Requires | Result with an API key |
|---|---|---|
| `POST /api/v1/agents/:id/message` | a service key (S2S) | `Invalid or missing service key` |
| `POST /api/eliza-app/onboarding/chat` | a Steward session | `Invalid Authorization header` |

So every "onboarding test" to date has gone through the provisioning API — a different path from the one a real user takes, and a different path from the one that broke for a real user (#18463: the six-minute spinner). The shared-to-dedicated journey by messages, without a break, has simply never been provable.

This is the gated way in, scoped to a single QA identity on staging.

## What kind of change is this?

Chore — staging configuration.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/wrangler.toml`, `[env.staging.vars]`. Confirm the four keys are inside that block and that no `[env.production*]` block gained them.

## Detailed testing steps

Config-only; the behaviour it unlocks is the point, and it is verified after deploy by driving the messaging onboarding path with the exchanged session. The gate logic itself is already covered by `packages/cloud/api/__tests__/staging-session-exchange.test.ts` from #18223.

# Evidence Gate

<!-- evidence-head:62a2e7f95c735d7c8a11fca2e6ad9289e452ac76 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this diff is four configuration keys in a Worker environment block; no rendered surface exists before or after.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this diff is four configuration keys in a Worker environment block; no rendered surface exists before or after.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing flow in an allow-list; what it unlocks is a test capability, not a product surface.
<!-- evidence-row:backend-logs -->
- [x] The two refusals that motivate this change, captured live against staging with a wallet API key:

```
POST /api/v1/eliza/agents/<id>/message
  {"success":false,"error":"Not found","code":"resource_not_found"}
POST /api/v1/agents/<id>/message
  {"success":false,"error":"Invalid or missing service key","code":"authentication_required"}
POST /api/eliza-app/onboarding/chat
  {"success":false,"error":"Invalid Authorization header","code":"validation_error"}
agent under test: status=running, bridge=http://100.64.2.20:2138
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer code is touched; this is a Worker environment block.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behaviour is touched by this change.
<!-- evidence-row:domain-artifacts -->
- [x] Scope check — every assignment and the block it lands in:

```
416: STAGING_SESSION_EXCHANGE_ENABLED                   [env.staging.vars]
417: STAGING_SESSION_EXCHANGE_ALLOWED_API_KEY_IDS       [env.staging.vars]
418: STAGING_SESSION_EXCHANGE_ALLOWED_ORGANIZATION_IDS  [env.staging.vars]
419: STAGING_SESSION_EXCHANGE_ALLOWED_USER_IDS          [env.staging.vars]
production blocks containing STAGING_SESSION_EXCHANGE: none
```

Related: #18223 (shipped the exchange), #18463 (the spinner this finally makes testable).

[stan-cloud]
