### PR TITLE
fix(cloud): report shared prewarm history failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.test.ts
@@ -4,9 +4,12 @@
  * External cache, character, and Durable Object boundaries are deterministic mocks.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
 import type { UserCharacter } from "../../../db/repositories/characters";
+import * as realLoggerNs from "../../utils/logger";
+
+const realLogger = { ...realLoggerNs };
 
 const calls: string[] = [];
 const calculateCost = mock(
@@ -19,6 +22,8 @@ const getById = mock(async (_id: string): Promise<UserCharacter | undefined> => 
 const warmInferenceAdmissionSnapshot = mock(async () => {
   calls.push("admission");
 });
+const coordinateSharedHistory = mock(async () => [] as unknown[]);
+const loggerWarn = mock(() => {});
 
 mock.module("../../pricing", () => ({
   calculateCost,
@@ -28,13 +33,20 @@ mock.module("../../pricing", () => ({
 mock.module("../characters/characters", () => ({ charactersService: { getById } }));
 mock.module("../inference-admission-snapshot", () => ({ warmInferenceAdmissionSnapshot }));
 mock.module("./conversation-coordinator", () => ({
-  coordinateSharedHistory: async () => [],
+  coordinateSharedHistory,
+}));
+mock.module("../../utils/logger", () => ({
+  logger: { debug: mock(), error: mock(), info: mock(), warn: loggerWarn },
 }));
 mock.module("./run-shared-agent-turn", () => ({
   resolveSharedAgentTurnModel: (preferred?: string) => preferred?.trim() || null,
 }));
 
 const { prewarmSharedAgentTurnCaches } = await import("./prewarm-shared-agent");
+
+afterAll(() => {
+  mock.module("../../utils/logger", () => realLogger);
+});
 
 function agent(config: Record<string, unknown>, characterId: string | null = null): AgentSandbox {
   return {
@@ -53,6 +65,9 @@ beforeEach(() => {
   getById.mockClear();
   getById.mockImplementation(async () => undefined);
   warmInferenceAdmissionSnapshot.mockClear();
+  coordinateSharedHistory.mockClear();
+  coordinateSharedHistory.mockImplementation(async () => []);
+  loggerWarn.mockClear();
 });
 
 describe("prewarmSharedAgentTurnCaches model pricing", () => {
@@ -91,5 +106,24 @@ describe("prewarmSharedAgentTurnCaches model pricing", () => {
     expect(getById).toHaveBeenCalledWith("character-1");
     expect(calculateCost).toHaveBeenCalledWith("gpt-oss-120b", "cerebras", 1, 1, "bitrouter");
     expect(calls.indexOf("character")).toBeLessThan(calls.indexOf("pricing:cerebras:gpt-oss-120b"));
+  });
+
+  test("logs a conversation hydration rejection observed by allSettled", async () => {
+    const error = new Error("conversation cache is warming");
+    coordinateSharedHistory.mockRejectedValue(error);
+
+    await expect(
+      prewarmSharedAgentTurnCaches(agent({}), { namespace: {} as never }),
+    ).resolves.toBeUndefined();
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "[shared-runtime prewarm] leg failed; first turn falls back to warming 503s",
+      expect.objectContaining({
+        agentId: "agent-1",
+        organizationId: "org-1",
+        leg: "conversation-object",
+        error: error.message,
+      }),
+    );
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
@@ -89,16 +89,15 @@ export async function prewarmSharedAgentTurnCaches(
   // 3. Conversation Durable Object hydration ("Conversation cache is
   //    warming"). The first history read on a cold object starts its
   //    authoritative Postgres hydration under the object's own waitUntil and
-  //    reports warming; swallowing that expected rejection leaves the object
-  //    hydrated for the real first turn. Launch model: one canonical
+  //    reports warming; Promise.allSettled observes and logs that rejection
+  //    while leaving the object hydrated for the real first turn. Launch model:
+  //    one canonical
   //    conversation per shared agent (roomId === agentId), the same room the
   //    REST turn dispatch addresses.
   if (options.namespace) {
     legs.push({
       leg: "conversation-object",
-      run: coordinateSharedHistory(agent.id, agent.id, { namespace: options.namespace }).catch(
-        () => undefined,
-      ),
+      run: coordinateSharedHistory(agent.id, agent.id, { namespace: options.namespace }),
     });
   }
 


### PR DESCRIPTION
# Relates to

Follow-up to merged PR #18762.

## What changed

The shared-agent prewarm wrapped `coordinateSharedHistory(...)` with `.catch(() => undefined)`. That converted the conversation Durable Object's warming rejection into a fulfilled promise, so the surrounding `Promise.allSettled` observer could never log the failed leg.

This repair removes that inner catch. The existing `allSettled` boundary still keeps provisioning best-effort and non-throwing, while now emitting the same structured warning used for every other failed prewarm leg. A regression proves the conversation rejection is observed, includes the agent, organization, leg, and error context, and does not reject the prewarm call.

## Verification

- `bun test packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.test.ts` — 3 passed
- `bunx --no-install @biomejs/biome check packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.test.ts` — passed
- `bun run --cwd packages/cloud/shared typecheck` — passed
- `bun run --cwd packages/cloud/shared lint:check` — 1,857 files checked, passed
- `git diff --check origin/develop...HEAD` — passed
- `bun run verify` — passed before the final develop sync; after rebasing onto `origin/develop@00d6bb2e45bcf5e61bfa21e5726f233f7fd6ffc8`, blocked only by an unrelated existing formatter failure in `plugins/plugin-workflow/__tests__/unit/execution-diagnostics.test.ts`

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - repository contribution guidance and the GitHub publication skill were read directly`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:aefe49068667a988bfedddaaf18842f6ed888c3b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only error observability; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only error observability; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] Deterministic boundary regression:

  <details><summary>Backend boundary output</summary>

  ```text
  bun test v1.3.14
  3 pass, 0 fail, 6 expect() calls
  Conversation hydration rejection reached the allSettled warning boundary and the best-effort prewarm call resolved.
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, provider call, planner, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Focused warning-observability regression:

  <details><summary>Focused test output</summary>

  ```text
  bun test v1.3.14
  3 pass, 0 fail, 6 expect() calls
  Verified conversation-object rejection is logged with agentId, organizationId, leg, and error while prewarm resolves.
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - repository contribution guidance and the GitHub publication skill were read directly
Attribution status: self-reported
— [codex-pr-sweep-repair]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Codex desktop","skill_revision":"N/A - repository contribution guidance and the GitHub publication skill were read directly"} -->
