### PR TITLE
fix(video): validate format metadata fields

### DIFF
--- a/plugins/plugin-video/src/services/video.test.ts
+++ b/plugins/plugin-video/src/services/video.test.ts
@@ -1,3 +1,5 @@
+/** Exercises VideoService metadata and parsing boundaries with deterministic binary doubles. */
+
 import type { ElizaError, IAgentRuntime, Media } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { BinaryResolver } from "./binaries";
@@ -111,6 +113,76 @@ describe("VideoService deterministic behavior", () => {
     ).rejects.toMatchObject({
       code: "VIDEO_METADATA_INVALID",
     } satisfies Partial<ElizaError>);
+  });
+
+  it("rejects malformed fields before they enter the public format DTO", async () => {
+    const malformedFields: Array<[string, unknown]> = [
+      ["format_id", 123],
+      ["url", {}],
+      ["ext", false],
+      ["quality", {}],
+      ["quality", Number.POSITIVE_INFINITY],
+      ["filesize", "huge"],
+      ["filesize", -1],
+      ["vcodec", 123],
+      ["acodec", false],
+      ["resolution", []],
+      ["fps", Number.POSITIVE_INFINITY],
+      ["fps", -1],
+      ["tbr", Number.NaN],
+      ["tbr", -1],
+    ];
+
+    for (const [field, value] of malformedFields) {
+      const { service } = createServiceWithYtDlp([
+        { formats: [{ [field]: value }] },
+      ]);
+
+      await expect(
+        service.getVideoInfo("https://youtu.be/malformed-field"),
+      ).rejects.toMatchObject({
+        code: "VIDEO_METADATA_FORMAT_FIELD_INVALID",
+        context: { index: 0, field },
+      } satisfies Partial<ElizaError>);
+    }
+  });
+
+  it("normalizes legitimate missing format fields without leaking null", async () => {
+    const { service } = createServiceWithYtDlp([
+      {
+        formats: [
+          {
+            format_id: "720p",
+            url: "https://example.com/video",
+            ext: "mp4",
+            quality: 7,
+            filesize: null,
+            vcodec: null,
+            acodec: "aac",
+            resolution: "1280x720",
+            fps: 30,
+            tbr: 2500,
+          },
+        ],
+      },
+    ]);
+
+    await expect(
+      service.getAvailableFormats("https://youtu.be/valid-format"),
+    ).resolves.toEqual([
+      {
+        formatId: "720p",
+        url: "https://example.com/video",
+        extension: "mp4",
+        quality: "7",
+        fileSize: undefined,
+        videoCodec: undefined,
+        audioCodec: "aac",
+        resolution: "1280x720",
+        fps: 30,
+        bitrate: 2500,
+      },
+    ]);
   });
 
   it("preserves the original yt-dlp failure", async () => {

--- a/plugins/plugin-video/src/services/video.ts
+++ b/plugins/plugin-video/src/services/video.ts
@@ -36,23 +36,10 @@ interface YtDlpJson {
   thumbnail?: string;
   view_count?: number;
   upload_date?: string;
-  formats?: YtDlpFormatRow[];
+  formats?: unknown;
   categories?: string[];
   subtitles?: Record<string, YtDlpSubtitleTrack[]>;
   automatic_captions?: Record<string, YtDlpSubtitleTrack[]>;
-}
-
-interface YtDlpFormatRow {
-  format_id?: string;
-  url?: string;
-  ext?: string;
-  quality?: string | number;
-  filesize?: number;
-  vcodec?: string;
-  acodec?: string;
-  resolution?: string;
-  fps?: number;
-  tbr?: number;
 }
 
 interface CaptionSegment {
@@ -83,21 +70,67 @@ function parseYtDlpUploadDate(value: string | undefined): Date | undefined {
   return Number.isNaN(parsed.getTime()) ? undefined : parsed;
 }
 
-function toVideoFormat(format: YtDlpFormatRow): VideoFormat {
+function invalidFormatField(
+  index: number,
+  field: string,
+  value: unknown,
+): never {
+  throw new ElizaError("yt-dlp returned an invalid format field.", {
+    code: "VIDEO_METADATA_FORMAT_FIELD_INVALID",
+    context: { index, field, receivedType: typeof value },
+    severity: "ephemeral",
+  });
+}
+
+function optionalFormatString(
+  format: Record<string, unknown>,
+  field: string,
+  index: number,
+): string | undefined {
+  const value = format[field];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") invalidFormatField(index, field, value);
+  return value;
+}
+
+function optionalFormatNumber(
+  format: Record<string, unknown>,
+  field: string,
+  index: number,
+): number | undefined {
+  const value = format[field];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    invalidFormatField(index, field, value);
+  }
+  return value;
+}
+
+function formatQuality(format: Record<string, unknown>, index: number): string {
+  const value = format.quality;
+  if (value === undefined || value === null || value === "") return "unknown";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return String(value);
+  }
+  return invalidFormatField(index, "quality", value);
+}
+
+function toVideoFormat(
+  format: Record<string, unknown>,
+  index: number,
+): VideoFormat {
   return {
-    formatId: format.format_id ?? "",
-    url: format.url ?? "",
-    extension: format.ext ?? "",
-    quality:
-      format.quality !== undefined && format.quality !== ""
-        ? String(format.quality)
-        : "unknown",
-    fileSize: format.filesize,
-    videoCodec: format.vcodec,
-    audioCodec: format.acodec,
-    resolution: format.resolution,
-    fps: format.fps,
-    bitrate: format.tbr,
+    formatId: optionalFormatString(format, "format_id", index) ?? "",
+    url: optionalFormatString(format, "url", index) ?? "",
+    extension: optionalFormatString(format, "ext", index) ?? "",
+    quality: formatQuality(format, index),
+    fileSize: optionalFormatNumber(format, "filesize", index),
+    videoCodec: optionalFormatString(format, "vcodec", index),
+    audioCodec: optionalFormatString(format, "acodec", index),
+    resolution: optionalFormatString(format, "resolution", index),
+    fps: optionalFormatNumber(format, "fps", index),
+    bitrate: optionalFormatNumber(format, "tbr", index),
   };
 }
 
@@ -123,7 +156,7 @@ function parseYtDlpFormats(value: unknown): VideoFormat[] {
         severity: "ephemeral",
       });
     }
-    return toVideoFormat(format as YtDlpFormatRow);
+    return toVideoFormat(format as Record<string, unknown>, index);
   });
 }
 
@@ -371,7 +404,7 @@ export class VideoService extends IVideoService {
       return [];
     }
 
-    return parseYtDlpFormats((result as YtDlpJson).formats);
+    return parseYtDlpFormats((result as Record<string, unknown>).formats);
   }
 
   private ensureDataDirectoryExists() {


### PR DESCRIPTION
Relates to #18730. Follow-up to #18815.

## What changed

#18815 correctly rejects malformed yt-dlp format containers, but it was merged before the reviewed field-level boundary was repaired. An object entry could still contain values such as `format_id: 123`, `url: {}`, `filesize: "huge"`, or `fps: Infinity`, and those values escaped into the public `VideoFormat` DTO through an unchecked cast.

This follow-up validates every consumed field before constructing the DTO:

- string metadata must be a string when present;
- numeric metadata must be finite and nonnegative when present;
- numeric quality values receive the same finite/nonnegative validation before string conversion;
- missing or `null` optional extractor metadata remains explicitly unavailable;
- malformed fields throw `ElizaError` with code `VIDEO_METADATA_FORMAT_FIELD_INVALID` plus the entry index and field name;
- the deterministic test module now has the repository-required prose header.

The shared parser remains the single boundary used by `getVideoInfo()` and `getAvailableFormats()`; no second validation path or degraded-success fallback was added.

## Verification

Exact head: `9e0884c87c5b42bb97e34a5485b4d34c9e82b051`, rebased onto `develop` `a7b91ee0894d1e8dd961174d9606f420db21e543`.

- `bun run --cwd plugins/plugin-video test`: passed, 31 tests / 4 intentional integration skips.
- `bun run --cwd plugins/plugin-video typecheck`: passed.
- `bun run --cwd plugins/plugin-video build`: passed.
- `bun run --cwd plugins/plugin-video lint:check`: passed with seven pre-existing informational private-method suggestions and no errors.
- `git diff --check origin/develop...HEAD`: passed.
- `bun run verify`: repository preflight and touched-package checks passed, then the aggregate gate stopped on an unrelated formatting error already present byte-for-byte on `origin/develop` in `plugins/plugin-workflow/__tests__/unit/execution-diagnostics.test.ts`. This branch does not modify that package or file.

The adversarial regression covers every consumed format field, including wrong primitive/container types, `NaN`, infinity, and negative numeric values. A positive regression proves legitimate `null` optional metadata is normalized to `undefined` rather than leaking into the DTO.

## Evidence Gate

<!-- evidence-head:9e0884c87c5b42bb97e34a5485b4d34c9e82b051 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - parser/service boundary only; no rendered UI source changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - parser/service boundary only; no rendered UI source changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changed; deterministic service tests exercise the boundary.
<!-- evidence-row:backend-logs -->
- [x] N/A - this is a local plugin service boundary; exact error codes and contexts are asserted directly.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, action, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent artifact is produced; public DTO output and typed failures are asserted by the package suite.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Anthropic / claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a7b91ee0894d1e8dd961174d9606f420db21e543:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `user-authorized fallback attribution`

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@a7b91ee0894d1e8dd961174d9606f420db21e543:packages/skills/skills/contribute-to-eliza
Attribution status: user-authorized fallback attribution
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"codex-desktop","skill_revision":"elizaOS/eliza@a7b91ee0894d1e8dd961174d9606f420db21e543:packages/skills/skills/contribute-to-eliza"} -->