### PR TITLE
fix(plugin-video): reject calendar-invalid upload dates and caption CR

### DIFF
--- a/plugins/plugin-video/src/services/video-parse.test.ts
+++ b/plugins/plugin-video/src/services/video-parse.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeCaptionNewlines,
+  parseYtDlpUploadDate,
+} from "./video-parse";
+
+describe("parseYtDlpUploadDate", () => {
+  it("parses valid compact YYYYMMDD as UTC midnight", () => {
+    expect(parseYtDlpUploadDate("20240531")?.toISOString()).toBe(
+      "2024-05-31T00:00:00.000Z",
+    );
+  });
+
+  it("accepts leap-day compact dates", () => {
+    expect(parseYtDlpUploadDate("20240229")?.toISOString()).toBe(
+      "2024-02-29T00:00:00.000Z",
+    );
+  });
+
+  it("rejects calendar-invalid compact dates that Date.UTC would overflow", () => {
+    expect(parseYtDlpUploadDate("20240231")).toBeUndefined();
+    expect(parseYtDlpUploadDate("20230229")).toBeUndefined();
+    expect(parseYtDlpUploadDate("20240431")).toBeUndefined();
+    expect(parseYtDlpUploadDate("20249999")).toBeUndefined();
+  });
+
+  it("returns undefined for empty input", () => {
+    expect(parseYtDlpUploadDate(undefined)).toBeUndefined();
+    expect(parseYtDlpUploadDate("")).toBeUndefined();
+  });
+});
+
+describe("normalizeCaptionNewlines", () => {
+  it("replaces LF globally with spaces", () => {
+    expect(normalizeCaptionNewlines("First line\nsecond line\nThird line\n")).toBe(
+      "First line second line Third line ",
+    );
+  });
+
+  it("normalizes CRLF and bare CR without leaking \\r", () => {
+    const out = normalizeCaptionNewlines("first\r\nsecond\rthird\nfourth");
+    expect(out).toBe("first second third fourth");
+    expect(out).not.toContain("\r");
+  });
+});

--- a/plugins/plugin-video/src/services/video-parse.test.ts
+++ b/plugins/plugin-video/src/services/video-parse.test.ts
@@ -1,8 +1,7 @@
+/** Verifies pure video metadata and caption parsers with deterministic boundary cases. */
+
 import { describe, expect, it } from "vitest";
-import {
-  normalizeCaptionNewlines,
-  parseYtDlpUploadDate,
-} from "./video-parse";
+import { normalizeCaptionNewlines, parseYtDlpUploadDate } from "./video-parse";
 
 describe("parseYtDlpUploadDate", () => {
   it("parses valid compact YYYYMMDD as UTC midnight", () => {
@@ -32,9 +31,9 @@ describe("parseYtDlpUploadDate", () => {
 
 describe("normalizeCaptionNewlines", () => {
   it("replaces LF globally with spaces", () => {
-    expect(normalizeCaptionNewlines("First line\nsecond line\nThird line\n")).toBe(
-      "First line second line Third line ",
-    );
+    expect(
+      normalizeCaptionNewlines("First line\nsecond line\nThird line\n"),
+    ).toBe("First line second line Third line ");
   });
 
   it("normalizes CRLF and bare CR without leaking \\r", () => {

--- a/plugins/plugin-video/src/services/video-parse.ts
+++ b/plugins/plugin-video/src/services/video-parse.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure subtitle / metadata parsers for VideoService (no runtime imports).
+ */
+
+/** yt-dlp compact `YYYYMMDD` or general date string → UTC midnight Date, or undefined. */
+export function parseYtDlpUploadDate(
+  value: string | undefined,
+): Date | undefined {
+  if (!value) return undefined;
+  const compact = value.match(/^(\d{4})(\d{2})(\d{2})$/);
+  if (compact) {
+    const year = Number(compact[1]);
+    const month = Number(compact[2]);
+    const day = Number(compact[3]);
+    // Date.UTC overflows invalid calendar days (e.g. 20240231 → March 2).
+    // Round-trip Y/M/D so impossible compact dates reject as undefined.
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    if (
+      Number.isNaN(parsed.getTime()) ||
+      parsed.getUTCFullYear() !== year ||
+      parsed.getUTCMonth() !== month - 1 ||
+      parsed.getUTCDate() !== day
+    ) {
+      return undefined;
+    }
+    return parsed;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+/** Collapse CRLF / bare CR / LF into single spaces (no residual `\r`). */
+export function normalizeCaptionNewlines(text: string): string {
+  return text.replace(/\r\n?/g, "\n").replace(/\n/g, " ");
+}

--- a/plugins/plugin-video/src/services/video.test.ts
+++ b/plugins/plugin-video/src/services/video.test.ts
@@ -270,7 +270,7 @@ describe("VideoService deterministic behavior", () => {
     const { service } = createServiceWithYtDlp([]);
     const captionJson = JSON.stringify({
       events: [
-        { segs: [{ utf8: "first\r\nsecond" }, { utf8: "\rthird" }] },
+        { segs: [{ utf8: "first\r\nsecond" }, { utf8: "\rthird\r" }] },
         { segs: [{ utf8: "fourth\rfifth\n" }] },
       ],
     });

--- a/plugins/plugin-video/src/services/video.test.ts
+++ b/plugins/plugin-video/src/services/video.test.ts
@@ -194,6 +194,42 @@ describe("VideoService deterministic behavior", () => {
     ).rejects.toBe(upstreamFailure);
   });
 
+  it("rejects calendar-invalid compact upload_date values that Date would overflow", async () => {
+    const { service, runYtDlp } = createServiceWithYtDlp([
+      {
+        title: "Feb 31",
+        upload_date: "20240231",
+        formats: [],
+      },
+      {
+        title: "Non-leap Feb 29",
+        upload_date: "20230229",
+        formats: [],
+      },
+      {
+        title: "Apr 31",
+        upload_date: "20240431",
+        formats: [],
+      },
+      {
+        title: "Leap Feb 29",
+        upload_date: "20240229",
+        formats: [],
+      },
+    ]);
+
+    const feb31 = await service.getVideoInfo("https://youtu.be/feb31");
+    const nonLeap = await service.getVideoInfo("https://youtu.be/nonleap");
+    const apr31 = await service.getVideoInfo("https://youtu.be/apr31");
+    const leap = await service.getVideoInfo("https://youtu.be/leap");
+
+    expect(feb31.uploadDate).toBeUndefined();
+    expect(nonLeap.uploadDate).toBeUndefined();
+    expect(apr31.uploadDate).toBeUndefined();
+    expect(leap.uploadDate?.toISOString()).toBe("2024-02-29T00:00:00.000Z");
+    expect(runYtDlp).toHaveBeenCalledTimes(4);
+  });
+
   it("parses SRT subtitles with CRLF line endings cleanly", () => {
     const { service } = createServiceWithYtDlp([]);
     const srtContent = [
@@ -228,6 +264,20 @@ describe("VideoService deterministic behavior", () => {
 
     const parsed = service["parseCaption"](captionJson);
     expect(parsed).toBe("First line second line Third line ");
+  });
+
+  it("normalizes CRLF and bare CR inside caption segments without leaking \\r", () => {
+    const { service } = createServiceWithYtDlp([]);
+    const captionJson = JSON.stringify({
+      events: [
+        { segs: [{ utf8: "first\r\nsecond" }, { utf8: "\rthird" }] },
+        { segs: [{ utf8: "fourth\rfifth\n" }] },
+      ],
+    });
+
+    const parsed = service["parseCaption"](captionJson);
+    expect(parsed).toBe("first second third fourth fifth ");
+    expect(parsed).not.toContain("\r");
   });
 
   it("handles invalid or malformed caption JSON gracefully", () => {

--- a/plugins/plugin-video/src/services/video.ts
+++ b/plugins/plugin-video/src/services/video.ts
@@ -22,6 +22,10 @@ import {
 } from "@elizaos/core";
 import ffmpeg from "fluent-ffmpeg";
 import { BinaryResolver } from "./binaries";
+import {
+  normalizeCaptionNewlines,
+  parseYtDlpUploadDate,
+} from "./video-parse";
 
 /** Minimal yt-dlp JSON shape used by this service (fields vary by extractor). */
 interface YtDlpSubtitleTrack {
@@ -56,18 +60,6 @@ interface CaptionJson {
 
 function loggableError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function parseYtDlpUploadDate(value: string | undefined): Date | undefined {
-  if (!value) return undefined;
-  const compact = value.match(/^(\d{4})(\d{2})(\d{2})$/);
-  if (compact) {
-    const [, year, month, day] = compact;
-    const parsed = new Date(`${year}-${month}-${day}T00:00:00.000Z`);
-    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
-  }
-  const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
 }
 
 function invalidFormatField(
@@ -604,7 +596,7 @@ export class VideoService extends IVideoService {
     try {
       const jsonContent = JSON.parse(captionContent) as CaptionJson;
       if (Array.isArray(jsonContent?.events)) {
-        return jsonContent.events
+        const joined = jsonContent.events
           .filter((event): event is { segs: CaptionSegment[] } =>
             Array.isArray(event?.segs),
           )
@@ -613,8 +605,8 @@ export class VideoService extends IVideoService {
               .map((seg) => (typeof seg?.utf8 === "string" ? seg.utf8 : ""))
               .join(""),
           )
-          .join("")
-          .replace(/\n/g, " ");
+          .join("");
+        return normalizeCaptionNewlines(joined);
       } else {
         elizaLogger.log(
           "Unexpected caption format:",

--- a/plugins/plugin-video/src/services/video.ts
+++ b/plugins/plugin-video/src/services/video.ts
@@ -22,10 +22,7 @@ import {
 } from "@elizaos/core";
 import ffmpeg from "fluent-ffmpeg";
 import { BinaryResolver } from "./binaries";
-import {
-  normalizeCaptionNewlines,
-  parseYtDlpUploadDate,
-} from "./video-parse";
+import { normalizeCaptionNewlines, parseYtDlpUploadDate } from "./video-parse";
 
 /** Minimal yt-dlp JSON shape used by this service (fields vary by extractor). */
 interface YtDlpSubtitleTrack {


### PR DESCRIPTION
# Relates to

Partial residual of #18730 after #18731: calendar-invalid compact dates and caption CRLF/CR normalization.

**Not in scope:** format metadata validation, completed by #18815 and #18825 and preserved by this rebased patch.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `grok-build`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - session model is not an approved contribute-to-eliza measured model`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact head `903c0cd0336a080c0ea2a1a16cfeab8b94c3f7ef` is based on `develop@0d3f572c52616d34d7dbc6edc5ee17318531f9f1`.
- [x] Full plugin-video and repository gates pass.

# Risks

Low. Pure date/string helpers only. Valid compact dates and leap days are unchanged. Invalid calendar overflows that previously became shifted dates now return `undefined`. Caption text loses residual `\r` from Windows-style segments.

# Background

## What does this PR do?

1. **`parseYtDlpUploadDate`**: round-trip UTC year/month/day so compact values such as `20240231` and non-leap `20230229` reject instead of overflowing through `Date.UTC`.
2. **`normalizeCaptionNewlines`**: normalize CRLF, bare CR, and LF before spacing so transcripts never contain `\r`.
3. Extract pure helpers to `video-parse.ts` for direct boundary tests while retaining full `VideoService` integration coverage.

## What kind of change is this?

Bug fixes for metadata and caption parsing correctness.

# Testing

- `bun run --cwd plugins/plugin-video test`: PASS, 39 tests / 4 intentional integration skips.
- `bun run --cwd plugins/plugin-video typecheck`: PASS.
- `bun run --cwd plugins/plugin-video build`: PASS.
- `bun run --cwd plugins/plugin-video lint:check`: PASS, no errors.
- `bun run verify`: PASS, 350/350 Turbo tasks and every repository audit.
- `git diff --check origin/develop...HEAD`: PASS.

The exact-head tests cover valid compact dates, leap day, impossible February and April dates, CRLF, bare CR, LF, and the real `VideoService.parseCaption()` integration boundary.

# Evidence Gate

<!-- evidence-head:903c0cd0336a080c0ea2a1a16cfeab8b94c3f7ef -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - pure date/string parsers; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - pure date/string parsers; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - pure functions with deterministic unit and service integration coverage.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server transport path; exact DTO/parser behavior is asserted by plugin tests.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent artifact; Date results and normalized captions are asserted directly.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshots or OCR surface.
