### PR TITLE
fix(scripts): apply RUN_TURBO_CONCURRENCY only before bare --

### DIFF
--- a/packages/scripts/__tests__/run-turbo-concurrency.test.ts
+++ b/packages/scripts/__tests__/run-turbo-concurrency.test.ts
@@ -127,4 +127,50 @@ describe("run-turbo concurrency override", () => {
       expect.arrayContaining(["lint", "--concurrency=6"]),
     );
   });
+
+  test("does not rewrite task pass-through concurrency after bare --", async () => {
+    const { argvFile, fakeTurbo } = await fixture();
+
+    const result = invoke(fakeTurbo, "4", [
+      "run",
+      "lint",
+      "--",
+      "--concurrency",
+      "8",
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const argv = JSON.parse(await readFile(argvFile, "utf8"));
+    const sep = argv.indexOf("--");
+    expect(sep).toBeGreaterThan(-1);
+    const owned = argv.slice(0, sep);
+    const pass = argv.slice(sep);
+    expect(owned.filter((a: string) => a.startsWith("--concurrency")).length).toBe(
+      1,
+    );
+    expect(owned).toContain("--concurrency=4");
+    expect(pass).toEqual(["--", "--concurrency", "8"]);
+  });
+
+  test("removes every pre-separator concurrency occurrence before injecting one override", async () => {
+    const { argvFile, fakeTurbo } = await fixture();
+
+    const result = invoke(fakeTurbo, "4", [
+      "run",
+      "lint",
+      "--concurrency",
+      "8",
+      "--concurrency=9",
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const argv = JSON.parse(await readFile(argvFile, "utf8"));
+    const concurrencyFlags = argv.filter(
+      (a: string) => a === "--concurrency" || a.startsWith("--concurrency="),
+    );
+    expect(concurrencyFlags).toEqual(["--concurrency=4"]);
+    expect(argv).not.toContain("8");
+    expect(argv).not.toContain("9");
+    expect(argv).not.toContain("--concurrency=9");
+  });
 });

--- a/packages/scripts/run-turbo.mjs
+++ b/packages/scripts/run-turbo.mjs
@@ -180,19 +180,31 @@ if (
 // tsc processes on a full-workspace cone — the VM itself is OOM-killed and the
 // job exits 143 (#15140) — so CI lanes set this to 4 without forking the
 // `verify`/`typecheck` script definitions.
+//
+// Only the argv prefix before a bare `--` is Turbo-owned. Task pass-through
+// after `--` must not be rewritten (e.g. `run lint -- --concurrency 8`).
+// Strip every pre-separator concurrency occurrence and insert exactly one
+// env override so mixed duplicates cannot reach Turbo.
 if (concurrencyOverride !== null) {
-  const idx = turboArgs.findIndex(
-    (arg) => arg === "--concurrency" || arg.startsWith("--concurrency="),
-  );
-  const override = `--concurrency=${concurrencyOverride}`;
-  if (idx === -1) {
-    if (runIndex !== -1) turboArgs.splice(runIndex + 1, 0, override);
-    else turboArgs.push(override);
-  } else if (turboArgs[idx] === "--concurrency") {
-    turboArgs.splice(idx, 2, override);
-  } else {
-    turboArgs.splice(idx, 1, override);
+  const sep = turboArgs.indexOf("--");
+  const owned = sep === -1 ? turboArgs.slice() : turboArgs.slice(0, sep);
+  const passThrough = sep === -1 ? [] : turboArgs.slice(sep);
+  const stripped = [];
+  for (let i = 0; i < owned.length; i++) {
+    const arg = owned[i];
+    if (arg === "--concurrency") {
+      i += 1; // skip value token
+      continue;
+    }
+    if (arg.startsWith("--concurrency=")) continue;
+    stripped.push(arg);
   }
+  const override = `--concurrency=${concurrencyOverride}`;
+  const ownedRunIndex = stripped.indexOf("run");
+  if (ownedRunIndex !== -1) stripped.splice(ownedRunIndex + 1, 0, override);
+  else stripped.push(override);
+  turboArgs.length = 0;
+  turboArgs.push(...stripped, ...passThrough);
 }
 
 // Test seam: RUN_TURBO_BIN points at a Node script that stands in for the


### PR DESCRIPTION
# Relates to

Residual of #18661 after #18816 (post-merge audit): env override must not rewrite task pass-through after bare `--`, and must collapse all pre-separator concurrency flags to a single override.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `grok-build`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - session model is not an approved contribute-to-eliza measured model`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `upstream/develop`
- [x] `bun test packages/scripts/__tests__/run-turbo-concurrency.test.ts` — **20 pass**

# Risks

Low. Only changes how `RUN_TURBO_CONCURRENCY` rewrites argv. Unset/empty env behavior unchanged. Valid overrides still inject/replace Turbo-owned concurrency. Task args after bare `--` are preserved byte-for-byte.

# Background

## What does this PR do?

1. Split argv at bare `--`.
2. Strip every `--concurrency` / `--concurrency=` token from the Turbo-owned prefix.
3. Insert exactly one `--concurrency=<env>` override.
4. Concatenate the pass-through suffix unchanged.
5. Subprocess regressions for pass-through preservation and multi-flag collapse.

## What kind of change is this?

Bug fixes (CLI boundary correctness)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

```bash
bun test packages/scripts/__tests__/run-turbo-concurrency.test.ts
# 20 pass
```

# Evidence Gate

<!-- evidence-head:08673ace8a7e27d0ab3c05756c52b507c22897ca -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CLI argv rewrite only; no UI
<!-- evidence-row:after-screenshots -->
- [x] N/A - CLI argv rewrite only; no UI
<!-- evidence-row:walkthrough-video -->
- [x] N/A - offline subprocess tests with fake Turbo seam
<!-- evidence-row:backend-logs -->
- [x] N/A - no application backend
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model runtime
<!-- evidence-row:domain-artifacts -->
- [x] N/A - source + subprocess tests
<!-- evidence-row:ocr-review -->
- [x] N/A - no OCR surface