### PR TITLE
fix(scripts): preserve Turbo argv boundary

### DIFF
--- a/packages/scripts/__tests__/run-turbo-concurrency.test.ts
+++ b/packages/scripts/__tests__/run-turbo-concurrency.test.ts
@@ -91,6 +91,47 @@ describe("run-turbo concurrency override", () => {
     expect(argv).not.toContain("--concurrency=8");
   });
 
+  test("preserves task pass-through concurrency arguments byte-for-byte", async () => {
+    const { argvFile, fakeTurbo } = await fixture();
+    const passThrough = ["--", "--concurrency=9", "task-value"];
+
+    const result = invoke(fakeTurbo, "5", ["run", "lint", ...passThrough]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const argv = JSON.parse(await readFile(argvFile, "utf8"));
+    const separatorIndex = argv.indexOf("--");
+    expect(argv.slice(separatorIndex)).toEqual(passThrough);
+    expect(
+      argv
+        .slice(0, separatorIndex)
+        .filter((arg) => arg.startsWith("--concurrency")),
+    ).toEqual(["--concurrency=5"]);
+  });
+
+  test("canonicalizes mixed Turbo-owned concurrency duplicates", async () => {
+    const { argvFile, fakeTurbo } = await fixture();
+
+    const result = invoke(fakeTurbo, "5", [
+      "run",
+      "lint",
+      "--concurrency",
+      "8",
+      "--filter=x",
+      "--concurrency=9",
+      "--concurrency",
+      "3",
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const argv = JSON.parse(await readFile(argvFile, "utf8"));
+    expect(argv.filter((arg) => arg.startsWith("--concurrency"))).toEqual([
+      "--concurrency=5",
+    ]);
+    expect(argv).toContain("--filter=x");
+    expect(argv).not.toContain("8");
+    expect(argv).not.toContain("3");
+  });
+
   test.each([
     " ",
     " 4 ",

--- a/packages/scripts/run-turbo.mjs
+++ b/packages/scripts/run-turbo.mjs
@@ -159,7 +159,7 @@ const turboPackageBin =
     .map((nm) => path.join(nm, "turbo/bin/turbo"))
     .find((candidate) => fs.existsSync(candidate)) ??
   path.join(repoRoot, "node_modules/turbo/bin/turbo");
-const turboArgs = rawTurboArgs;
+let turboArgs = rawTurboArgs;
 
 if (!turboArgs.some((arg) => arg === "--ui" || arg.startsWith("--ui="))) {
   turboArgs.unshift("--ui=stream");
@@ -180,19 +180,37 @@ if (
 // tsc processes on a full-workspace cone — the VM itself is OOM-killed and the
 // job exits 143 (#15140) — so CI lanes set this to 4 without forking the
 // `verify`/`typecheck` script definitions.
-if (concurrencyOverride !== null) {
-  const idx = turboArgs.findIndex(
-    (arg) => arg === "--concurrency" || arg.startsWith("--concurrency="),
-  );
-  const override = `--concurrency=${concurrencyOverride}`;
-  if (idx === -1) {
-    if (runIndex !== -1) turboArgs.splice(runIndex + 1, 0, override);
-    else turboArgs.push(override);
-  } else if (turboArgs[idx] === "--concurrency") {
-    turboArgs.splice(idx, 2, override);
-  } else {
-    turboArgs.splice(idx, 1, override);
+function applyConcurrencyOverride(args, concurrency) {
+  const separatorIndex = args.indexOf("--");
+  const turboOwnArgs =
+    separatorIndex === -1 ? args : args.slice(0, separatorIndex);
+  const passThroughArgs =
+    separatorIndex === -1 ? [] : args.slice(separatorIndex);
+  const normalizedTurboOwnArgs = [];
+
+  for (let index = 0; index < turboOwnArgs.length; index += 1) {
+    const arg = turboOwnArgs[index];
+    if (arg.startsWith("--concurrency=")) continue;
+    if (arg === "--concurrency") {
+      if (index + 1 < turboOwnArgs.length) index += 1;
+      continue;
+    }
+    normalizedTurboOwnArgs.push(arg);
   }
+
+  const override = `--concurrency=${concurrency}`;
+  const normalizedRunIndex = normalizedTurboOwnArgs.indexOf("run");
+  if (normalizedRunIndex !== -1) {
+    normalizedTurboOwnArgs.splice(normalizedRunIndex + 1, 0, override);
+  } else {
+    normalizedTurboOwnArgs.push(override);
+  }
+
+  return [...normalizedTurboOwnArgs, ...passThroughArgs];
+}
+
+if (concurrencyOverride !== null) {
+  turboArgs = applyConcurrencyOverride(turboArgs, concurrencyOverride);
 }
 
 // Test seam: RUN_TURBO_BIN points at a Node script that stands in for the


### PR DESCRIPTION
# Relates to

Follow-up to merged PR #18816 and issue #18661.

## What changed

The merged environment override searched and rewrote the complete Turbo argv. That could mutate task pass-through arguments after a bare `--`, and it replaced only the first Turbo-owned concurrency flag, leaving duplicate flags with ambiguous precedence.

This repair splits argv at the first bare separator, canonicalizes only the Turbo-owned prefix, removes every split and equals-form concurrency flag (including split values), inserts exactly one validated environment override, and appends the pass-through suffix byte-for-byte. Real subprocess regressions cover both adversarial shapes.

## Verification

- `bun test packages/scripts/__tests__/run-turbo-concurrency.test.ts packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts packages/scripts/__tests__/run-turbo-windows-init-crash-retry.test.ts` — 43 passed
- `node packages/scripts/run-turbo.self-test.mjs` — passed
- `bun run audit:scripts` — passed
- `bun run audit:focused-tests` — 7,968 files scanned, clean
- `git diff --check origin/develop...HEAD` — passed
- `bun install` — dependency resolution and lockfile save passed; repository artifact sync was still downloading the 971 MiB development bundle at publication time
- `bun run verify` — running against exact head at publication time; no failure observed before publication

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `github:yeet@0.1.8-2841cf9749ae`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:ff743be55d13dc06f5685a7fa2b289c4173ae0cb -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - repository CLI wrapper only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - repository CLI wrapper only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server request path; the applicable subprocess evidence is included below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime or network path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, provider, planner, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Real subprocess argv artifacts:

  <details><summary>Focused matrix</summary>

  ```text
  bun test v1.3.14
  43 pass, 0 fail, 116 expect() calls
  Pass-through suffix ["--","--concurrency=9","task-value"] remained byte-identical; mixed Turbo-owned split/equals duplicates produced only --concurrency=5.
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: Codex desktop
Contribution skill revision: github:yeet@0.1.8-2841cf9749ae
Attribution status: self-reported
— [codex-pr-sweep-repair]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Codex desktop","skill_revision":"github:yeet@0.1.8-2841cf9749ae"} -->
