### PR TITLE
fix(cloud): bound the retryable provisioning class so a failed provision settles

### DIFF
--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
@@ -14,7 +14,10 @@
 
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 
-import { jobsRepository, StaleJobExecutionError } from "../../db/repositories/jobs";
+import {
+  jobsRepository,
+  StaleJobExecutionError,
+} from "../../db/repositories/jobs";
 import type { Job } from "../../db/schemas/jobs";
 import { elizaSandboxService } from "./eliza-sandbox";
 import { JOB_TYPES, type ProvisioningJobType } from "./provisioning-job-types";
@@ -92,15 +95,26 @@ function harness(job: Job) {
     },
     "assertNoConflictingLifecycleExecution",
   ).mockResolvedValue(undefined);
-  const ordinaryClaimSpy = spyOn(jobsRepository, "claimPendingJobs").mockImplementation(
-    async (f: { type: string }) => (f.type === job.type ? [job] : []),
+  const ordinaryClaimSpy = spyOn(
+    jobsRepository,
+    "claimPendingJobs",
+  ).mockImplementation(async (f: { type: string }) =>
+    f.type === job.type ? [job] : [],
   );
-  const leaseSpy = spyOn(jobsRepository, "assertExecutionLease").mockResolvedValue(undefined);
-  const renewLeaseSpy = spyOn(jobsRepository, "renewExecutionLease").mockResolvedValue("lost");
+  const leaseSpy = spyOn(
+    jobsRepository,
+    "assertExecutionLease",
+  ).mockResolvedValue(undefined);
+  const renewLeaseSpy = spyOn(
+    jobsRepository,
+    "renewExecutionLease",
+  ).mockResolvedValue("lost");
   const sharedClaimSpy = spyOn(
     jobsRepository,
     "claimPendingJobsWithinSharedRunningLimit",
-  ).mockImplementation(async (f: { type: string }) => (f.type === job.type ? [job] : []));
+  ).mockImplementation(async (f: { type: string }) =>
+    f.type === job.type ? [job] : [],
+  );
   const claimSpy = {
     mockRestore() {
       conflictSpy.mockRestore();
@@ -110,12 +124,25 @@ function harness(job: Job) {
       renewLeaseSpy.mockRestore();
     },
   };
-  const recoverSpy = spyOn(jobsRepository, "recoverStaleJobs").mockResolvedValue(EMPTY_RECOVERY);
-  const updateStatusSpy = spyOn(jobsRepository, "settleExecution").mockResolvedValue(undefined);
-  const updateSpy = spyOn(jobsRepository, "updateForExecution").mockImplementation(
-    async (claimedJob, updates) => ({ ...claimedJob, ...updates }),
-  );
-  const incrementSpy = spyOn(jobsRepository, "incrementAttempt").mockResolvedValue(undefined);
+  const recoverSpy = spyOn(
+    jobsRepository,
+    "recoverStaleJobs",
+  ).mockResolvedValue(EMPTY_RECOVERY);
+  const updateStatusSpy = spyOn(
+    jobsRepository,
+    "settleExecution",
+  ).mockResolvedValue(undefined);
+  const updateSpy = spyOn(
+    jobsRepository,
+    "updateForExecution",
+  ).mockImplementation(async (claimedJob, updates) => ({
+    ...claimedJob,
+    ...updates,
+  }));
+  const incrementSpy = spyOn(
+    jobsRepository,
+    "incrementAttempt",
+  ).mockResolvedValue(undefined);
   const retryLaterSpy = spyOn(
     jobsRepository,
     "retryLaterWithoutIncrementingAttempts",
@@ -134,8 +161,13 @@ function harness(job: Job) {
 }
 
 const serviceSpies: Array<{ mockRestore: () => void }> = [];
-function stub<M extends keyof typeof elizaSandboxService>(method: M, value: unknown) {
-  const spy = spyOn(elizaSandboxService, method).mockResolvedValue(value as never);
+function stub<M extends keyof typeof elizaSandboxService>(
+  method: M,
+  value: unknown,
+) {
+  const spy = spyOn(elizaSandboxService, method).mockResolvedValue(
+    value as never,
+  );
   serviceSpies.push(spy);
   return spy;
 }
@@ -173,7 +205,12 @@ const AGENT_ARMS: Array<{
     method: "provision",
     success: {
       success: true,
-      sandboxRecord: { id: AGENT, organization_id: ORG, user_id: USER, status: "running" },
+      sandboxRecord: {
+        id: AGENT,
+        organization_id: ORG,
+        user_id: USER,
+        status: "running",
+      },
       bridgeUrl: "http://10.0.0.5:8080",
       healthUrl: "http://10.0.0.5:8081",
     },
@@ -204,7 +241,11 @@ const AGENT_ARMS: Array<{
     type: JOB_TYPES.AGENT_SLEEP,
     data: {},
     method: "executeSleep",
-    success: { success: true, containerRemoved: true, backupId: "backup-sleep" },
+    success: {
+      success: true,
+      containerRemoved: true,
+      backupId: "backup-sleep",
+    },
   },
   {
     name: "wake",
@@ -234,7 +275,11 @@ const AGENT_ARMS: Array<{
   {
     name: "upgrade",
     type: JOB_TYPES.AGENT_UPGRADE,
-    data: { dockerImage: "eliza/agent", fromDigest: "sha256:old", toDigest: "sha256:new" },
+    data: {
+      dockerImage: "eliza/agent",
+      fromDigest: "sha256:old",
+      toDigest: "sha256:new",
+    },
     method: "executeUpgrade",
     success: {
       success: true,
@@ -288,7 +333,12 @@ const AGENT_ARMS: Array<{
     type: JOB_TYPES.AGENT_LOGS,
     data: { tail: 100 },
     method: "executeLogs",
-    success: { success: true, status: "ok", logs: "line-1\nline-2", message: "collected" },
+    success: {
+      success: true,
+      status: "ok",
+      logs: "line-1\nline-2",
+      message: "collected",
+    },
   },
   {
     name: "snapshot",
@@ -422,38 +472,42 @@ describe("executeJob dispatch — success path per job type marks the job comple
     const first = harness(makeJob(arm.type, arm.data));
     let pendingAudit: Record<string, unknown> | undefined;
     let pendingSnapshot: Job | undefined;
-    const findByIdSpy = spyOn(jobsRepository, "findByIdForWrite").mockImplementation(async () => {
+    const findByIdSpy = spyOn(
+      jobsRepository,
+      "findByIdForWrite",
+    ).mockImplementation(async () => {
       return pendingSnapshot;
     });
-    const canarySpy = spyOn(elizaSandboxService, "executeAdminCanaryUpgrade").mockImplementation(
-      async (params) => {
-        const tx = {
-          update: () => ({
-            set: (updates: Record<string, unknown>) => {
-              pendingAudit = updates.result as Record<string, unknown>;
-              pendingSnapshot = { ...first.job, ...updates } as Job;
-              return {
-                where: () => ({
-                  returning: async () => [pendingSnapshot],
-                }),
-              };
-            },
-          }),
-        };
-        await params.onCutoverInTx(tx as never, {
-          oldNodeId: "node-a",
-          oldContainerName: "c-old",
-          newNodeId: "node-b",
-          newContainerName: "c-new",
-          newDigest: params.targetDigest,
-        });
-        return {
-          ...arm.success,
-          cleanupPending: true,
-          error: "old node unreachable",
-        } as never;
-      },
-    );
+    const canarySpy = spyOn(
+      elizaSandboxService,
+      "executeAdminCanaryUpgrade",
+    ).mockImplementation(async (params) => {
+      const tx = {
+        update: () => ({
+          set: (updates: Record<string, unknown>) => {
+            pendingAudit = updates.result as Record<string, unknown>;
+            pendingSnapshot = { ...first.job, ...updates } as Job;
+            return {
+              where: () => ({
+                returning: async () => [pendingSnapshot],
+              }),
+            };
+          },
+        }),
+      };
+      await params.onCutoverInTx(tx as never, {
+        oldNodeId: "node-a",
+        oldContainerName: "c-old",
+        newNodeId: "node-b",
+        newContainerName: "c-new",
+        newDigest: params.targetDigest,
+      });
+      return {
+        ...arm.success,
+        cleanupPending: true,
+        error: "old node unreachable",
+      } as never;
+    });
     serviceSpies.push(canarySpy);
     try {
       const pending = await run(arm.type);
@@ -474,7 +528,8 @@ describe("executeJob dispatch — success path per job type marks the job comple
       findByIdSpy.mockRestore();
     }
 
-    if (!pendingAudit) throw new Error("pending cutover audit was not captured");
+    if (!pendingAudit)
+      throw new Error("pending cutover audit was not captured");
     if (typeof pendingAudit.cutoverAt !== "string") {
       throw new Error("pending cutover audit has no cutover timestamp");
     }
@@ -491,22 +546,24 @@ describe("executeJob dispatch — success path per job type marks the job comple
     const convergeSpy = spyOn(
       elizaSandboxService,
       "convergeReplacementCleanupFence",
-    ).mockImplementation(async (_agentId, _organizationId, _expectation, onConvergedInTx) => {
-      await onConvergedInTx?.({
-        update: () => ({
-          set: (updates: Record<string, unknown>) => {
-            if ("result" in updates) {
-              cleanupCompletion = updates.result as Record<string, unknown>;
-            }
-            return {
-              where: () => ({
-                returning: async () => [{ id: retry.job.id }],
-              }),
-            };
-          },
-        }),
-      } as never);
-    });
+    ).mockImplementation(
+      async (_agentId, _organizationId, _expectation, onConvergedInTx) => {
+        await onConvergedInTx?.({
+          update: () => ({
+            set: (updates: Record<string, unknown>) => {
+              if ("result" in updates) {
+                cleanupCompletion = updates.result as Record<string, unknown>;
+              }
+              return {
+                where: () => ({
+                  returning: async () => [{ id: retry.job.id }],
+                }),
+              };
+            },
+          }),
+        } as never);
+      },
+    );
     serviceSpies.push(convergeSpy);
     try {
       const converged = await run(arm.type);
@@ -536,7 +593,9 @@ describe("executeJob dispatch — success path per job type marks the job comple
   });
 
   test("message: bridge reply is stored on the job result and completes", async () => {
-    const ctx = harness(makeJob(JOB_TYPES.AGENT_MESSAGE, { text: "hello", nonce: "n-1" }));
+    const ctx = harness(
+      makeJob(JOB_TYPES.AGENT_MESSAGE, { text: "hello", nonce: "n-1" }),
+    );
     const bridgeSpy = spyOn(elizaSandboxService, "bridge").mockResolvedValue({
       jsonrpc: "2.0",
       id: null,
@@ -587,7 +646,9 @@ describe("executeJob dispatch — failure path per job type retries (increments 
   }
 
   test("message: bridge error is stored on the job result and the job fails", async () => {
-    const ctx = harness(makeJob(JOB_TYPES.AGENT_MESSAGE, { text: "hello", nonce: "n-1" }));
+    const ctx = harness(
+      makeJob(JOB_TYPES.AGENT_MESSAGE, { text: "hello", nonce: "n-1" }),
+    );
     const bridgeSpy = spyOn(elizaSandboxService, "bridge").mockResolvedValue({
       jsonrpc: "2.0",
       id: null,
@@ -618,7 +679,9 @@ describe("executeJob dispatch — failure path per job type retries (increments 
 
 describe("executeJob dispatch — type-specific disposition rules", () => {
   test("agent_delete preserves billing authorization through worker execution", async () => {
-    const ctx = harness(makeJob(JOB_TYPES.AGENT_DELETE, { authorization: "billing_request" }));
+    const ctx = harness(
+      makeJob(JOB_TYPES.AGENT_DELETE, { authorization: "billing_request" }),
+    );
     const executeDeletionSpy = stub("executeDeletion", {
       success: true,
       containerStopped: true,
@@ -628,7 +691,11 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
     try {
       const res = await run(JOB_TYPES.AGENT_DELETE);
       expect(res).toMatchObject({ succeeded: 1, failed: 0, retried: 0 });
-      expect(executeDeletionSpy).toHaveBeenCalledWith(AGENT, ORG, "billing_request");
+      expect(executeDeletionSpy).toHaveBeenCalledWith(
+        AGENT,
+        ORG,
+        "billing_request",
+      );
     } finally {
       ctx.claimSpy.mockRestore();
       ctx.recoverSpy.mockRestore();
@@ -671,14 +738,21 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
       success: false,
       retryable: true,
       error: "readiness probe transport_unresolved",
-      sandboxRecord: { id: AGENT, organization_id: ORG, user_id: USER, status: "provisioning" },
+      sandboxRecord: {
+        id: AGENT,
+        organization_id: ORG,
+        user_id: USER,
+        status: "provisioning",
+      },
     });
     try {
       const res = await run(JOB_TYPES.AGENT_PROVISION);
       expect(res.retried).toBe(1);
       expect(res.failed).toBe(0);
       expect(ctx.retryLaterSpy).toHaveBeenCalledTimes(1);
-      expect(ctx.retryLaterSpy.mock.calls[0]?.[1]).toBe("readiness probe transport_unresolved");
+      expect(ctx.retryLaterSpy.mock.calls[0]?.[1]).toBe(
+        "readiness probe transport_unresolved",
+      );
       expect(ctx.incrementSpy).not.toHaveBeenCalled();
     } finally {
       ctx.claimSpy.mockRestore();
@@ -697,7 +771,8 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
       retryable: true,
       containerStopped: false,
       containerStarted: false,
-      error: "Refusing to stop without a current backup: Snapshot capture temporarily unavailable",
+      error:
+        "Refusing to stop without a current backup: Snapshot capture temporarily unavailable",
     });
     try {
       const res = await run(JOB_TYPES.AGENT_RESTART);
@@ -724,13 +799,25 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
       success: false,
       retryable: true,
       error: "readiness probe transport_unresolved",
-      sandboxRecord: { id: AGENT, organization_id: ORG, user_id: USER, status: "provisioning" },
+      sandboxRecord: {
+        id: AGENT,
+        organization_id: ORG,
+        user_id: USER,
+        status: "provisioning",
+      },
     });
     try {
       const res = await run(JOB_TYPES.AGENT_PROVISION);
       expect(res).toMatchObject({ claimed: 1, retried: 0, failed: 0 });
+      // Not the claim-time row: the requeue budget is persisted first, and the
+      // row that write returns is the fresh snapshot the fence compares against.
+      // Handing the stale claim row here is what made every requeue lose its
+      // claim and wedge the job `in_progress` until the stale-job sweep.
       expect(ctx.retryLaterSpy).toHaveBeenCalledWith(
-        ctx.job,
+        expect.objectContaining({
+          id: ctx.job.id,
+          data: expect.objectContaining({ transportRequeues: 1 }),
+        }),
         "readiness probe transport_unresolved",
         expect.any(Number),
         expect.any(String),
@@ -752,7 +839,8 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
       success: false,
       containerStopped: true,
       containerStarted: true,
-      error: "Warm-claim credential recovery failed: source-key revocation unavailable",
+      error:
+        "Warm-claim credential recovery failed: source-key revocation unavailable",
     });
     try {
       const res = await run(JOB_TYPES.AGENT_RESTART);
@@ -772,9 +860,14 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
   });
 
   test("auto snapshot of a stopped agent → completed-as-skipped, no retry", async () => {
-    const ctx = harness(makeJob(JOB_TYPES.AGENT_SNAPSHOT, { snapshotType: "auto" }));
+    const ctx = harness(
+      makeJob(JOB_TYPES.AGENT_SNAPSHOT, { snapshotType: "auto" }),
+    );
     const disarmGate = armSnapshotGateFor(JOB_TYPES.AGENT_SNAPSHOT);
-    stub("executeSnapshot", { success: false, error: "Sandbox is not running" });
+    stub("executeSnapshot", {
+      success: false,
+      error: "Sandbox is not running",
+    });
     try {
       const res = await run(JOB_TYPES.AGENT_SNAPSHOT);
       expect(res.succeeded).toBe(1);
@@ -796,7 +889,9 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
   });
 
   test("agent_snapshot transient capture failure → requeued without burning an attempt", async () => {
-    const ctx = harness(makeJob(JOB_TYPES.AGENT_SNAPSHOT, { snapshotType: "auto" }));
+    const ctx = harness(
+      makeJob(JOB_TYPES.AGENT_SNAPSHOT, { snapshotType: "auto" }),
+    );
     const disarmGate = armSnapshotGateFor(JOB_TYPES.AGENT_SNAPSHOT);
     stub("executeSnapshot", {
       success: false,
@@ -823,7 +918,9 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
   });
 
   test("agent_wake integrity-gate refusal → fails and preserves the sleeping row (no writeback)", async () => {
-    const ctx = harness(makeJob(JOB_TYPES.AGENT_WAKE, { restoreBackupId: "b1" }));
+    const ctx = harness(
+      makeJob(JOB_TYPES.AGENT_WAKE, { restoreBackupId: "b1" }),
+    );
     stub("executeWake", {
       success: false,
       error: "restore integrity check failed",
@@ -851,7 +948,11 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
 
   test("permanent-failure writeback is built for provision (dependent row flip) but not for suspend", async () => {
     const provCtx = harness(makeJob(JOB_TYPES.AGENT_PROVISION));
-    stub("provision", { success: false, error: "down", sandboxRecord: { status: "error" } });
+    stub("provision", {
+      success: false,
+      error: "down",
+      sandboxRecord: { status: "error" },
+    });
     try {
       await run(JOB_TYPES.AGENT_PROVISION);
       // AGENT_PROVISION supplies an onFailedInTx callback (arg 4) so the sandbox
@@ -892,7 +993,11 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
     );
     // rolledBack:false → executeAgentUpgrade throws UpgradeFailedError({rolledBack:false}),
     // and buildPermanentFailureWriteback returns the terminal `status:error` branch.
-    stub("executeUpgrade", { success: false, error: "agent not serving", rolledBack: false });
+    stub("executeUpgrade", {
+      success: false,
+      error: "agent not serving",
+      rolledBack: false,
+    });
     try {
       const res = await run(JOB_TYPES.AGENT_UPGRADE);
       expect(res.failed).toBe(1);
@@ -931,9 +1036,17 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
 
   test("agent_provision transport receives the job payload's own agentId/orgId — the contract the single-flight enqueue writes (#15943)", async () => {
     const ctx = harness(makeJob(JOB_TYPES.AGENT_PROVISION));
-    const provisionSpy = spyOn(elizaSandboxService, "provision").mockResolvedValue({
+    const provisionSpy = spyOn(
+      elizaSandboxService,
+      "provision",
+    ).mockResolvedValue({
       success: true,
-      sandboxRecord: { id: AGENT, organization_id: ORG, user_id: USER, status: "running" },
+      sandboxRecord: {
+        id: AGENT,
+        organization_id: ORG,
+        user_id: USER,
+        status: "running",
+      },
     } as never);
     serviceSpies.push(provisionSpy);
     try {
@@ -958,9 +1071,14 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
 
   test("organization-id mismatch between payload and column fails before any transport call", async () => {
     const ctx = harness(
-      makeJob(JOB_TYPES.AGENT_SUSPEND, { organizationId: "99999999-9999-4999-8999-999999999999" }),
+      makeJob(JOB_TYPES.AGENT_SUSPEND, {
+        organizationId: "99999999-9999-4999-8999-999999999999",
+      }),
     );
-    const svcSpy = spyOn(elizaSandboxService, "executeSuspend").mockResolvedValue({
+    const svcSpy = spyOn(
+      elizaSandboxService,
+      "executeSuspend",
+    ).mockResolvedValue({
       success: true,
     } as never);
     try {
@@ -984,7 +1102,10 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
     const job = makeJob(JOB_TYPES.AGENT_SUSPEND);
     const ctx = harness(job);
     ctx.leaseSpy.mockRejectedValueOnce(new StaleJobExecutionError(job.id));
-    const suspendSpy = spyOn(elizaSandboxService, "executeSuspend").mockResolvedValue({
+    const suspendSpy = spyOn(
+      elizaSandboxService,
+      "executeSuspend",
+    ).mockResolvedValue({
       success: true,
       containerStopped: true,
     });
@@ -1028,7 +1149,11 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
 
   test("transient attempt settlement failure retries in-process without startup recovery", async () => {
     const ctx = harness(makeJob(JOB_TYPES.AGENT_SUSPEND));
-    stub("executeSuspend", { success: false, containerStopped: false, error: "provider failed" });
+    stub("executeSuspend", {
+      success: false,
+      containerStopped: false,
+      error: "provider failed",
+    });
     ctx.incrementSpy
       .mockRejectedValueOnce(new Error("temporary database disconnect"))
       .mockResolvedValue(undefined);

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -910,6 +910,29 @@ export const PER_JOB_TIMEOUT_MS = parsePositiveIntEnv(
  *  operators enable the lane. */
 const SNAPSHOT_GATE_RETRY_DELAY_MS = 10 * 60 * 1000;
 const PROVISION_TRANSPORT_RETRY_DELAY_MS = 2 * 60 * 1000;
+
+/**
+ * Requeues a retryable transport failure may take WITHOUT consuming an attempt.
+ *
+ * Without a bound, a provision that keeps failing never reaches
+ * `max_attempts`, so the permanent-failure writeback never runs and the agent
+ * row sits at `provisioning` with a null error indefinitely — the spinner in
+ * #18463. The stuck-provisioning sweep cannot rescue it either: that gate
+ * excludes any agent still owning a pending job, which the requeue guarantees.
+ *
+ * Same shape as the deletion path's re-enqueue budget in this file: a counter,
+ * not a clock, so a slow node cannot buy itself extra passes.
+ */
+const MAX_TRANSPORT_REQUEUES = 5;
+
+/** Where the budget rides on the job row. `data` survives a requeue intact. */
+const TRANSPORT_REQUEUE_KEY = "transportRequeues";
+
+/** Requeues already spent by this job. Absent or malformed counts as none. */
+function readTransportRequeues(job: Job): number {
+  const raw = (job.data as Record<string, unknown> | null)?.[TRANSPORT_REQUEUE_KEY];
+  return typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 0;
+}
 const WARM_CLAIM_RECOVERY_ORPHAN_GRACE_MS = 2 * 60 * 1000;
 const EXECUTION_LEASE_MS = 60_000;
 const EXECUTION_LEASE_HEARTBEAT_MS = 15_000;
@@ -1119,7 +1142,13 @@ export class ProvisioningRecoveryDegradedError extends ElizaError {
 }
 
 function emptyRecoverySummary(): ProvisioningRecoverySummary {
-  return { scanned: 0, retried: 0, permanentlyFailed: 0, unchanged: 0, failures: [] };
+  return {
+    scanned: 0,
+    retried: 0,
+    permanentlyFailed: 0,
+    unchanged: 0,
+    failures: [],
+  };
 }
 
 function addRecoveryResult(
@@ -3133,29 +3162,61 @@ export class ProvisioningJobService {
     ) {
       const retrySnapshot =
         err instanceof RetryableReplacementCleanupError ? err.retrySnapshot : job;
-      const requeued = await this.retryOwnedWrite(job, "retry-later", () =>
-        jobsRepository.retryLaterWithoutIncrementingAttempts(
-          retrySnapshot,
-          errorMsg,
-          PROVISION_TRANSPORT_RETRY_DELAY_MS,
-          this.executionOwnerId,
-        ),
-      );
-      if (requeued) {
-        if (result) result.retried++;
-        logger.warn("[provisioning-jobs] Requeued retryable provision transport failure", {
-          jobId: job.id,
-          delayMs: PROVISION_TRANSPORT_RETRY_DELAY_MS,
-          error: errorMsg,
+      const requeues = readTransportRequeues(retrySnapshot);
+      if (requeues < MAX_TRANSPORT_REQUEUES) {
+        // One owned write does two jobs. It persists the budget on the row that
+        // survives the requeue, AND the row it returns is the fresh snapshot the
+        // fence in retryLaterWithoutIncrementingAttempts compares against. The
+        // claim-time snapshot never matches, because the three call sites all
+        // stamp `result`/`updated_at` on their way here — so without this the
+        // requeue is refused and the job wedges `in_progress` until the stale-job
+        // sweep collects it ~16 minutes later.
+        const counted = await this.updateClaimedExecution(retrySnapshot, {
+          data: {
+            ...(retrySnapshot.data as Record<string, unknown> | null),
+            [TRANSPORT_REQUEUE_KEY]: requeues + 1,
+          },
         });
-      } else {
-        logger.info("[provisioning-jobs] Retryable failure lost its exact job-state claim", {
-          jobId: job.id,
-          error: errorMsg,
-        });
+        const requeued = await this.retryOwnedWrite(job, "retry-later", () =>
+          jobsRepository.retryLaterWithoutIncrementingAttempts(
+            counted ?? retrySnapshot,
+            errorMsg,
+            PROVISION_TRANSPORT_RETRY_DELAY_MS,
+            this.executionOwnerId,
+          ),
+        );
+        if (requeued) {
+          if (result) result.retried++;
+          logger.warn("[provisioning-jobs] Requeued retryable provision transport failure", {
+            jobId: job.id,
+            delayMs: PROVISION_TRANSPORT_RETRY_DELAY_MS,
+            requeues: requeues + 1,
+            maxRequeues: MAX_TRANSPORT_REQUEUES,
+            error: errorMsg,
+          });
+        } else {
+          logger.info("[provisioning-jobs] Retryable failure lost its exact job-state claim", {
+            jobId: job.id,
+            error: errorMsg,
+          });
+        }
+        return;
       }
-      return;
+      // Budget spent. Fall through to the terminal writeback below rather than
+      // requeuing again: a provision that has failed this many times is not a
+      // transient blip, and leaving it pending forever is what strands the agent
+      // row at `provisioning` with a null error while the UI spins on it.
+      logger.warn("[provisioning-jobs] Retryable failure exhausted its requeue budget", {
+        jobId: job.id,
+        requeues,
+        maxRequeues: MAX_TRANSPORT_REQUEUES,
+        error: errorMsg,
+      });
     }
+
+    const requeueBudgetExhausted =
+      err instanceof RetryableProvisionTransportError ||
+      err instanceof RetryableReplacementCleanupError;
 
     if (result) result.failed++;
 
@@ -3178,7 +3239,11 @@ export class ProvisioningJobService {
       jobsRepository.incrementAttempt(
         job.id,
         errorMsg,
-        job.max_attempts,
+        // The requeue budget already supplied this job's retries — five passes
+        // two minutes apart. Settling on this pass rather than restarting the
+        // 30s/2min/8min attempt ladder is the point: the caller has been told
+        // "provisioning" for ten minutes already.
+        requeueBudgetExhausted ? 1 : job.max_attempts,
         onFailedInTx,
         job.execution_generation ?? undefined,
         this.executionOwnerId,
@@ -3391,7 +3456,11 @@ export class ProvisioningJobService {
             .update(apps)
             .set({ deployment_status: "failed", updated_at: new Date() })
             .where(and(eq(apps.id, appId), eq(apps.organization_id, failedJob.organization_id)))
-            .returning({ id: apps.id, api_key_id: apps.api_key_id, slug: apps.slug });
+            .returning({
+              id: apps.id,
+              api_key_id: apps.api_key_id,
+              slug: apps.slug,
+            });
           if (failedApp) {
             await enqueueAppCacheInvalidation(tx, failedJob, failedApp);
             logger.warn(
@@ -3438,7 +3507,11 @@ export class ProvisioningJobService {
             .update(apps)
             .set({ deployment_status: "failed", updated_at: new Date() })
             .where(and(eq(apps.id, appId), eq(apps.organization_id, row.organizationId)))
-            .returning({ id: apps.id, api_key_id: apps.api_key_id, slug: apps.slug });
+            .returning({
+              id: apps.id,
+              api_key_id: apps.api_key_id,
+              slug: apps.slug,
+            });
           if (failedApp) {
             await enqueueAppCacheInvalidation(tx, failedJob, failedApp);
             logger.warn(
@@ -3765,7 +3838,11 @@ export class ProvisioningJobService {
   ): Promise<boolean> {
     if (result.success || result.error !== "Agent not found") return false;
     await this.settleClaimedExecution(job, "completed", {
-      result: { cloudAgentId: agentId, skipped: true, reason: "Agent not found" },
+      result: {
+        cloudAgentId: agentId,
+        skipped: true,
+        reason: "Agent not found",
+      },
       completed_at: new Date(),
     });
     logger.info("[provisioning-jobs] Job completed as no-op — agent no longer exists", {
@@ -5098,7 +5175,12 @@ export class ProvisioningJobService {
     minAgeMs?: number;
     maxAgents?: number;
     concurrency?: number;
-  }): Promise<{ total: number; recovered: number; unresolved: number; failed: number }> {
+  }): Promise<{
+    total: number;
+    recovered: number;
+    unresolved: number;
+    failed: number;
+  }> {
     const minAgeMs = params?.minAgeMs ?? 5 * 60 * 1000; // 5m grace beyond normal boot
     const maxAgents = params?.maxAgents ?? 50;
     const concurrency = params?.concurrency ?? 5;
@@ -5319,7 +5401,9 @@ export class ProvisioningJobService {
       const isWaifuTarget =
         waifuTarget != null && isWaifuWebhookTargetUrl(safeWebhookUrl, waifuTarget);
 
-      const headers: Record<string, string> = { "Content-Type": "application/json" };
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
       let rawBody: string;
 
       if (isWaifuTarget && waifuTarget) {


### PR DESCRIPTION
# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was loaded for this change`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop`. Typecheck and biome clean; 45/45 on the dispatch suite.

# Risks

**A transient blip still retries.** The first five passes keep the existing behaviour exactly: requeue after two minutes, `attempts` untouched. Only the sixth settles.

Success paths and non-retryable failures are untouched — the only change below the branch is one conditional argument to `incrementAttempt`.

# Background

## What does this PR do?

Two defects on the same path, and the second is the one I had wrong for most of this investigation.

**1. The requeue was refused, not perpetual.** All three call sites run `updateClaimedExecution` immediately before raising, which stamps `result`/`updated_at` on the row. The snapshot handed to `retryLaterWithoutIncrementingAttempts` was the *claim-time* job, so the fence compared a stale row against a fresher one and **never matched**. The requeue was dropped and the job wedged `in_progress` for ~16 minutes until the stale-job sweep collected it. Same visible symptom as an infinite loop — agent stuck at `provisioning`, UI spinning — opposite mechanism.

**2. Nothing bounded the class.** Even with the fence repaired, `retryLaterWithoutIncrementingAttempts` never increments `attempts`, so `max_attempts = 3` is unreachable and `buildPermanentFailureWriteback` never runs. The backstop cannot rescue it either: `markStuckProvisioningWithoutActiveJobAsError` is gated behind `hasNoProvisioningOwnerJob()`, whose NOT EXISTS excludes any agent still owning a pending job.

The fix is one owned write doing both jobs: it persists a requeue budget on the row that survives the requeue, **and** the row it returns is the fresh snapshot the fence can match. Budget spent, the branch falls through to the existing terminal writeback with `maxAttempts = 1`, so the agent row gets `status='error'` and a real `error_message` instead of silence.

**No migration.** The budget rides in `job.data`, which survives a requeue intact, and the data guards on this path are structural — unknown keys are tolerated.

The counter shape is copied from the deletion path's re-enqueue budget in the same file rather than inventing a second mechanism.

## What kind of change is this?

Bug fix — provisioning job lifecycle. Addresses the mechanism behind #18463.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The retryable branch in `handleExecutionFailure`, and `MAX_TRANSPORT_REQUEUES` beside `PROVISION_TRANSPORT_RETRY_DELAY_MS`.

## Detailed testing steps

`bun test packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts` — 45/45.

Mutation-proved for the fence repair. Handing the claim-time snapshot back to the fence:

```
(fail) executeJob dispatch > retryable transport lost to another worker is not reported as requeued
 44 pass, 1 fail
```

**Honest gap, stated rather than papered over:** the second mutant does **not** bite. Raising `MAX_TRANSPORT_REQUEUES` to 1000 leaves the suite green, because the existing dispatch tests only exercise the *first* requeue — nothing covers budget exhaustion. So the bound is implemented and reasoned, but **not yet proven by a test**. The missing case is a job claimed with `data.transportRequeues = 5` asserting `failed: 1`, `retried: 0` and a non-null `error_message`, which wants the pglite harness rather than the spy harness. I would rather land this with the gap named than claim a proof I do not have.

# Evidence Gate

<!-- evidence-head:802690a3798488aab897aaccaa7dac8c0f233767 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this is a job-lifecycle branch in the provisioning worker; no rendered surface exists before or after.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this is a job-lifecycle branch in the provisioning worker; no rendered surface exists before or after.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the observable behaviour is a job row settling to failed instead of wedging; there is no user-facing flow in this diff.
<!-- evidence-row:backend-logs -->
- [x] Test transcript, including the mutation that bites and the one that does not:

```
bun test provisioning-jobs-execute-dispatch.test.ts        45 pass, 0 fail
mutant: fence gets the claim snapshot again                44 pass, 1 fail  <- bites
mutant: MAX_TRANSPORT_REQUEUES = 1000                      45 pass, 0 fail  <- does NOT bite
typecheck (packages/cloud/shared)                          clean
biome                                                      clean
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer code is touched; this is a server-side worker path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behaviour is touched by this change.
<!-- evidence-row:domain-artifacts -->
- [x] The state machine, before and after:

```
before   transport failure -> stale snapshot -> fence refuses -> job wedged in_progress
                                                             -> ~16 min -> stale-job sweep
                              attempts never increments -> max_attempts unreachable
                              agent row: provisioning, error_message NULL, forever

after    failure 1..5       -> budget persisted -> fence matches -> requeue +2 min
         failure 6          -> budget spent     -> terminal writeback, maxAttempts=1
                              agent row: status=error, error_message set
```

Related: #18463 (the spinner), #18491 (removed the dominant cause of these failures).

[stan-cloud]
