### PR TITLE
fix(ui): guard agent detail time labels against Invalid Date

### DIFF
--- a/packages/ui/src/cloud/instances/AgentDetailPage.test.tsx
+++ b/packages/ui/src/cloud/instances/AgentDetailPage.test.tsx
@@ -1,21 +1,39 @@
-/** Verifies agent detail date formatting rejects malformed API timestamps. */
+/** Pure date helpers — no React tree / core keyword graph required. */
 import { describe, expect, it, vi } from "vitest";
-import { formatDate, formatRelativeShort } from "./AgentDetailPage";
+import {
+  formatDate,
+  formatRelativeShort,
+  formatTime,
+} from "./agent-detail-dates";
 
 const t = vi.fn(
   (_key: string, options?: { defaultValue?: string }) =>
     options?.defaultValue ?? _key,
 ) as never;
 
+/** Beyond ECMAScript TimeClip (±8.64e15 ms) — getTime is non-finite. */
+const OUTSIDE_TIMECLIP = "275760-09-13T00:00:00.000Z";
+
 describe("AgentDetailPage date formatting", () => {
-  it("renders an unavailable fallback for malformed non-null dates", async () => {
+  it("renders an unavailable fallback for malformed non-null dates", () => {
     expect(formatDate("not-a-date")).toBe("—");
     expect(formatRelativeShort("not-a-date", t)).toBe("Never");
+    expect(formatTime("not-a-date")).toBe("");
+  });
+
+  it("returns empty time for out-of-range timestamps instead of Invalid Date", () => {
+    expect(formatTime(OUTSIDE_TIMECLIP)).toBe("");
+    expect(formatDate(OUTSIDE_TIMECLIP)).toBe("—");
+    expect(formatTime("not-a-date")).not.toMatch(/Invalid Date/i);
   });
 
   it("preserves valid and null date behavior", () => {
     expect(formatDate(null)).toBe("—");
+    expect(formatTime(null)).toBe("");
     expect(formatRelativeShort(null, t)).toBe("Never");
     expect(formatRelativeShort(new Date().toISOString(), t)).toBe("Just now");
+    const valid = "2024-05-31T15:30:00.000Z";
+    expect(formatTime(valid).length).toBeGreaterThan(0);
+    expect(formatTime(valid)).not.toMatch(/Invalid Date/i);
   });
 });

--- a/packages/ui/src/cloud/instances/AgentDetailPage.tsx
+++ b/packages/ui/src/cloud/instances/AgentDetailPage.tsx
@@ -33,52 +33,13 @@ import { ElizaConnectButton } from "./components/eliza-connect-button";
 import { useAgent } from "./lib/data/eliza-agents";
 import { useT } from "./lib/i18n";
 import { statusBadgeColor, statusDotColor } from "./lib/sandbox-status";
+import {
+  formatDate,
+  formatRelativeShort,
+  formatTime,
+} from "./agent-detail-dates";
 
-export function formatDate(date: string | null): string {
-  if (!date) return "—";
-  const timestamp = new Date(date).getTime();
-  if (!Number.isFinite(timestamp)) return "—";
-  return new Date(timestamp).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-}
-
-function formatTime(date: string | null): string {
-  if (!date) return "";
-  return new Date(date).toLocaleTimeString(undefined, {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
-export function formatRelativeShort(
-  date: string | null,
-  t: ReturnType<typeof useT>,
-): string {
-  if (!date) return t("cloud.agents.detail.never", { defaultValue: "Never" });
-  const d = new Date(date);
-  const timestamp = d.getTime();
-  if (!Number.isFinite(timestamp))
-    return t("cloud.agents.detail.never", { defaultValue: "Never" });
-  const diffMs = Date.now() - timestamp;
-  const diffMin = Math.floor(diffMs / 60_000);
-  if (diffMin < 1)
-    return t("cloud.agents.detail.justNow", { defaultValue: "Just now" });
-  if (diffMin < 60)
-    return t("cloud.agents.detail.minutesAgo", {
-      defaultValue: "{{n}}m ago",
-      n: diffMin,
-    });
-  const diffH = Math.floor(diffMin / 60);
-  if (diffH < 24)
-    return t("cloud.agents.detail.hoursAgo", {
-      defaultValue: "{{n}}h ago",
-      n: diffH,
-    });
-  return formatDate(date);
-}
+export { formatDate, formatRelativeShort, formatTime };
 
 export default function AgentDetailPage() {
   const t = useT();

--- a/packages/ui/src/cloud/instances/agent-detail-dates.ts
+++ b/packages/ui/src/cloud/instances/agent-detail-dates.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure date/time formatters for AgentDetailPage (no React / runtime imports).
+ */
+
+export function formatDate(date: string | null): string {
+  if (!date) return "—";
+  const timestamp = new Date(date).getTime();
+  if (!Number.isFinite(timestamp)) return "—";
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function formatTime(date: string | null): string {
+  if (!date) return "";
+  const timestamp = new Date(date).getTime();
+  // Same finite TimeClip policy as formatDate — never surface native "Invalid Date".
+  if (!Number.isFinite(timestamp)) return "";
+  return new Date(timestamp).toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function formatRelativeShort(
+  date: string | null,
+  t: (key: string, options?: { defaultValue?: string; n?: number }) => string,
+): string {
+  if (!date) return t("cloud.agents.detail.never", { defaultValue: "Never" });
+  const d = new Date(date);
+  const timestamp = d.getTime();
+  if (!Number.isFinite(timestamp))
+    return t("cloud.agents.detail.never", { defaultValue: "Never" });
+  const diffMs = Date.now() - timestamp;
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1)
+    return t("cloud.agents.detail.justNow", { defaultValue: "Just now" });
+  if (diffMin < 60)
+    return t("cloud.agents.detail.minutesAgo", {
+      defaultValue: "{{n}}m ago",
+      n: diffMin,
+    });
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24)
+    return t("cloud.agents.detail.hoursAgo", {
+      defaultValue: "{{n}}h ago",
+      n: diffH,
+    });
+  return formatDate(date);
+}


### PR DESCRIPTION
# Relates to

Closes #18812 (follow-up to #18727 / #18786 — `formatTime` still unguarded on the rendered detail pair).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `grok-build`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - session model is not an approved contribute-to-eliza measured model`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `upstream/develop`
- [x] Pure unit tests: 3 pass (`AgentDetailPage.test.tsx` via `agent-detail-dates`)

# Risks

Low. Empty-string fallback for invalid times matches the previous null path. Valid timestamps unchanged.

# Background

## What does this PR do?

1. Apply finite `getTime` guard to `formatTime`.
2. Extract pure formatters to `agent-detail-dates.ts` so tests do not load the full UI/core graph.
3. Unit coverage for malformed, out-of-TimeClip, null, and valid inputs — never `Invalid Date`.

## What kind of change is this?

Bug fixes (UI label correctness)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

```bash
cd packages/ui
node ../../node_modules/vitest/vitest.mjs run --config vitest.config.ts src/cloud/instances/AgentDetailPage.test.tsx
# 3 pass
```

Note: full `packages/app audit:app` desktop captures were not run in this agent environment (no app packaging). Pure formatter contract for the issue is covered by unit tests.

# Evidence Gate

<!-- evidence-head:d7d01ec78b229430148919008fd921a7cc4e44dc -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - pure label formatters; issue is string-level Invalid Date, proven by unit tests
<!-- evidence-row:after-screenshots -->
- [x] N/A - pure label formatters; unit tests assert no Invalid Date string
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow required for pure formatters
<!-- evidence-row:backend-logs -->
- [x] N/A - client formatting only
<!-- evidence-row:frontend-logs -->
- [x] N/A - pure functions; no network path
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model runtime
<!-- evidence-row:domain-artifacts -->
- [x] N/A - source + unit expectations
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshots
