### PR TITLE
fix(cloud): return iMessage onboarding to conversation

### DIFF
--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -202,7 +202,13 @@ const CLOUD_AUDIT_CASES: CloudAuditCase[] = [
   // get-started/ — a continuation token is required to exercise the real
   // messaging handoff page instead of its missing-token redirect.
   {
-    slug: "get-started",
+    slug: "get-started-confirm",
+    path: "/get-started?onboardingSession=audit-continuation-token",
+    route: "get-started",
+    auth: AUTH,
+  },
+  {
+    slug: "get-started-success",
     path: "/get-started?onboardingSession=audit-continuation-token",
     route: "get-started",
     auth: AUTH,
@@ -622,6 +628,35 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
           await seedStewardToken(page);
         }
         await installCloudApiStubs(page);
+        if (auditCase.slug.startsWith("get-started-")) {
+          await page.route(
+            "**/api/eliza-app/onboarding/chat**",
+            async (route) => {
+              const request = route.request();
+              if (request.method() === "GET") {
+                await route.fulfill({
+                  status: 200,
+                  contentType: "application/json",
+                  body: JSON.stringify({
+                    success: true,
+                    data: {
+                      platform: "blooio",
+                      platformUserId: "+14155550123",
+                      platformDisplayName: "+14155550123",
+                      returnUrl: "sms:+18087881821",
+                    },
+                  }),
+                });
+                return;
+              }
+              await route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify({ success: true, data: {} }),
+              });
+            },
+          );
+        }
         if (auditCase.slug === "join") {
           await page.route("**/api/cloud/compat/agents**", async (route) => {
             await route.fulfill({
@@ -641,6 +676,15 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
           });
         }
         await page.goto(auditCase.path, { waitUntil: "domcontentloaded" });
+
+        if (auditCase.slug === "get-started-success") {
+          await page
+            .getByRole("button", { name: "Connect this iMessage account" })
+            .click();
+          await expect(
+            page.getByRole("button", { name: "Back to iMessage" }),
+          ).toBeVisible();
+        }
 
         // Routes with expectedFinalPath always redirect on localhost (the
         // harness hostname is 127.0.0.1). Assert the final URL matches the

--- a/packages/cloud/api/__tests__/eliza-app-onboarding-chat-platform-caller.test.ts
+++ b/packages/cloud/api/__tests__/eliza-app-onboarding-chat-platform-caller.test.ts
@@ -321,6 +321,32 @@ describe("onboarding chat — trusted platform gateway caller", () => {
     expect(resolveIdentity).toHaveBeenLastCalledWith("+15551234568", "phone");
   });
 
+  test("preserves a trusted iMessage reply address for the browser return link", async () => {
+    resolveIdentity.mockResolvedValue(null);
+    const gatewayData = await dataOf(
+      await post({
+        sessionId: "platform:blooio:+15551234568",
+        message: "My name is Ada",
+        platform: "blooio",
+        platformUserId: "+15551234568",
+        platformDisplayName: "Ada",
+        platformReplyAddress: "+18087881821",
+      }),
+    );
+    const continuation = continuationFromReply(gatewayData.reply);
+
+    getCurrentUser.mockResolvedValue(activeStewardUser());
+    const preview = await get(continuation, STEWARD_JWT);
+
+    expect(preview.status).toBe(200);
+    expect(await dataOf(preview)).toEqual({
+      platform: "blooio",
+      platformUserId: "+15551234568",
+      platformDisplayName: "Ada",
+      returnUrl: "sms:+18087881821",
+    });
+  });
+
   test("falls back to anonymous onboarding when the platform identity is unknown", async () => {
     resolveIdentity.mockResolvedValue(null);
 
@@ -553,6 +579,7 @@ describe("onboarding chat — trusted platform gateway caller", () => {
       platform: "discord",
       platformUserId: "1234567890",
       platformDisplayName: "attested-discord-user",
+      returnUrl: null,
     });
     expect(linkDiscordToUser).not.toHaveBeenCalled();
     expect(ensureElizaAppProvisioning).not.toHaveBeenCalled();

--- a/packages/cloud/api/eliza-app/onboarding/chat/route.ts
+++ b/packages/cloud/api/eliza-app/onboarding/chat/route.ts
@@ -59,6 +59,7 @@ const chatSchema = z.object({
   platform: platformSchema.optional(),
   platformUserId: z.string().trim().max(256).optional(),
   platformDisplayName: z.string().trim().max(120).optional(),
+  platformReplyAddress: z.string().trim().max(256).optional(),
   statusOnly: z.boolean().optional(),
   confirmPlatformLink: z.boolean().optional(),
 });
@@ -232,6 +233,9 @@ app.post("/", async (c) => {
       platform: parsed.data.platform as OnboardingPlatform | undefined,
       platformUserId: parsed.data.platformUserId,
       platformDisplayName: parsed.data.platformDisplayName,
+      platformReplyAddress: caller.trustedPlatformIdentity
+        ? parsed.data.platformReplyAddress
+        : undefined,
       authenticatedUser: caller.authenticatedUser,
       trustedPlatformIdentity: caller.trustedPlatformIdentity,
       idempotencyKey: idempotencyKey || undefined,
@@ -293,7 +297,7 @@ app.post("/", async (c) => {
         new ApiError(
           409,
           "session_not_ready",
-          "Confirm the Discord account before connecting it",
+          "Confirm the messaging account before connecting it",
         ),
       );
     }
@@ -306,7 +310,7 @@ app.post("/", async (c) => {
         new ApiError(
           409,
           "identity_conflict",
-          "This Discord account is already linked to another account",
+          "This messaging account is already linked to another account",
         ),
       );
     }

--- a/packages/cloud/e2e/tests/bluebubbles-gateway.spec.ts
+++ b/packages/cloud/e2e/tests/bluebubbles-gateway.spec.ts
@@ -358,7 +358,8 @@ test.describe("registered BlueBubbles gateway", () => {
           },
           body: JSON.stringify({
             sessionId: continuationToken,
-            platform: "blooio",
+            platform: "web",
+            confirmPlatformLink: true,
           }),
         },
       );

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -207,6 +207,7 @@ describe("gateway webhook handler e2e routing", () => {
       platform: "twilio",
       platformUserId: "+15551234567",
       platformDisplayName: "Ada",
+      platformReplyAddress: "+15550000000",
     });
   });
 

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -404,6 +404,12 @@ async function sendOnboardingReply(
         platform: adapter.platform,
         platformUserId: event.senderId,
         platformDisplayName: event.senderName,
+        platformReplyAddress:
+          adapter.platform === "blooio"
+            ? config.fromNumber
+            : adapter.platform === "twilio"
+              ? config.phoneNumber
+              : undefined,
       }),
       signal: AbortSignal.timeout(30_000),
     });

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
@@ -436,6 +436,7 @@ describe("AgentGatewayRouterService phone routing", () => {
         message: "hello",
         platform: "blooio",
         platformUserId: "+1 (555) 555-0100",
+        platformReplyAddress: "+14159611510",
         sessionId: "platform:blooio:+1 (555) 555-0100",
         trustedPlatformIdentity: true,
         idempotencyKey: "blooio:msg-1",
@@ -500,6 +501,7 @@ describe("AgentGatewayRouterService phone routing", () => {
     });
     expect(runOnboardingChat).toHaveBeenCalledWith(
       expect.objectContaining({
+        platformReplyAddress: "+14159611510",
         trustedPlatformIdentity: true,
         idempotencyKey: "blooio:msg-1",
       }),
@@ -536,6 +538,7 @@ describe("AgentGatewayRouterService phone routing", () => {
     });
     expect(runOnboardingChat).toHaveBeenCalledWith(
       expect.objectContaining({
+        platformReplyAddress: "+14159611510",
         authenticatedUser: {
           userId: "known-user",
           organizationId: "known-org",
@@ -621,6 +624,7 @@ describe("AgentGatewayRouterService phone routing", () => {
     });
     expect(runOnboardingChat).toHaveBeenCalledWith(
       expect.objectContaining({
+        platformReplyAddress: "+14159611510",
         authenticatedUser: {
           userId: "known-user",
           organizationId: "known-org",

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
@@ -843,6 +843,7 @@ export class AgentGatewayRouterService {
         message: args.body,
         platform: args.provider,
         platformUserId: args.from,
+        platformReplyAddress: args.to,
         sessionId: `platform:${args.provider}:${args.from}`,
         trustedPlatformIdentity: true,
         idempotencyKey: args.providerMessageId
@@ -866,6 +867,7 @@ export class AgentGatewayRouterService {
           message: args.body,
           platform: args.provider,
           platformUserId: args.from,
+          platformReplyAddress: args.to,
           sessionId: `platform:${args.provider}:${args.from}`,
           trustedPlatformIdentity: true,
           idempotencyKey: args.providerMessageId
@@ -893,6 +895,7 @@ export class AgentGatewayRouterService {
           message: args.body,
           platform: args.provider,
           platformUserId: args.from,
+          platformReplyAddress: args.to,
           sessionId: `platform:${args.provider}:${args.from}`,
           trustedPlatformIdentity: true,
           authenticatedUser: {
@@ -999,6 +1002,7 @@ export class AgentGatewayRouterService {
         message: args.body,
         platform: args.provider,
         platformUserId: args.from,
+        platformReplyAddress: args.to,
         sessionId: `platform:${args.provider}:${args.from}`,
         trustedPlatformIdentity: true,
         authenticatedUser: {

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -80,9 +80,8 @@ mock.module("./user-service", () => ({
   },
 }));
 
-const { runOnboardingChat, validateTelegramOnboardingContinuation } = await import(
-  `./onboarding-chat.ts?test=onboarding-chat-${Date.now()}`
-);
+const { inspectOnboardingContinuation, runOnboardingChat, validateTelegramOnboardingContinuation } =
+  await import(`./onboarding-chat.ts?test=onboarding-chat-${Date.now()}`);
 const { peekLocalGreetingQueue, clearLocalGreetingQueue } = await import(
   "./onboarding-proactive-greeting"
 );
@@ -996,6 +995,7 @@ describe("runOnboardingChat", () => {
         platform: "blooio",
         platformUserId: "+14155550123",
         sessionId: continuationToken(result),
+        confirmPlatformLink: true,
         authenticatedUser: {
           userId: "user-1",
           organizationId: "org-1",
@@ -1043,6 +1043,7 @@ describe("runOnboardingChat", () => {
         userId: "phone-user",
         organizationId: "phone-org",
       },
+      confirmPlatformLink: true,
     });
 
     expect(ensureElizaAppProvisioning).toHaveBeenCalledWith({
@@ -1083,6 +1084,7 @@ describe("runOnboardingChat", () => {
       message,
       platform: "blooio",
       platformUserId: PHONE,
+      platformReplyAddress: "+18087881821",
       sessionId: PLATFORM_SESSION,
       trustedPlatformIdentity: true,
     });
@@ -1219,6 +1221,7 @@ describe("runOnboardingChat", () => {
           userId: "victim-user",
           organizationId: "victim-org",
         },
+        confirmPlatformLink: true,
       });
       expect(victimBound.session.id).toBe(PLATFORM_SESSION);
       expect(victimBound.session.userId).toBe("victim-user");
@@ -1242,7 +1245,7 @@ describe("runOnboardingChat", () => {
       expect(linkPhoneToUser).not.toHaveBeenCalledWith("attacker-user", PHONE);
     });
 
-    test("an opaque web continuation cannot mutate the platform identity and still links the phone", async () => {
+    test("previews and explicitly confirms a trusted iMessage continuation", async () => {
       ensureElizaAppProvisioning.mockResolvedValue({
         status: "provisioning",
         agentId: "agent-1",
@@ -1251,15 +1254,42 @@ describe("runOnboardingChat", () => {
       });
 
       const gatewayTurn = await runTrustedPhoneTurn("My name is Sam");
+      const token = continuationToken(gatewayTurn);
+      const preview = await inspectOnboardingContinuation(token, {
+        userId: "user-1",
+        organizationId: "org-1",
+      });
+      expect(preview).toEqual({
+        platform: "blooio",
+        platformUserId: PHONE,
+        platformDisplayName: PHONE,
+        returnUrl: "sms:+18087881821",
+      });
       const continued = await runOnboardingChat({
-        sessionId: continuationToken(gatewayTurn),
+        sessionId: token,
         platform: "web",
         authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+        confirmPlatformLink: true,
       });
 
       expect(continued.session.platform).toBe("blooio");
       expect(continued.session.platformUserId).toBe(PHONE);
       expect(linkPhoneToUser).toHaveBeenCalledWith("user-1", PHONE);
+    });
+
+    test("requires explicit confirmation before linking a trusted iMessage identity", async () => {
+      const gatewayTurn = await runTrustedPhoneTurn("My name is Sam");
+      await expect(
+        runOnboardingChat({
+          sessionId: continuationToken(gatewayTurn),
+          platform: "web",
+          authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+        }),
+      ).rejects.toMatchObject({
+        code: "ONBOARDING_PLATFORM_LINK_CONFIRMATION_REQUIRED",
+      });
+      expect(linkPhoneToUser).not.toHaveBeenCalled();
+      expect(ensureElizaAppProvisioning).not.toHaveBeenCalled();
     });
   });
 
@@ -1757,6 +1787,7 @@ describe("runOnboardingChat", () => {
         const second = await runOnboardingChat({
           platform: "blooio",
           sessionId: browserContinuation,
+          confirmPlatformLink: true,
           authenticatedUser: { userId: "user-1", organizationId: "org-1" },
         });
         expect(second.handoffComplete).toBe(true);
@@ -1766,6 +1797,7 @@ describe("runOnboardingChat", () => {
         const third = await runOnboardingChat({
           platform: "blooio",
           sessionId: browserContinuation,
+          confirmPlatformLink: true,
           authenticatedUser: { userId: "user-1", organizationId: "org-1" },
         });
         expect(third.handoffComplete).toBe(true);
@@ -2015,6 +2047,7 @@ describe("runOnboardingChat", () => {
       await runOnboardingChat({
         sessionId: continuationToken(named),
         platform: "web",
+        confirmPlatformLink: true,
         authenticatedUser: { userId: "user-1", organizationId: "org-1" },
       });
       expect(peekLocalGreetingQueue()).toHaveLength(0);
@@ -2145,6 +2178,7 @@ describe("runOnboardingChat", () => {
           await runOnboardingChat({
             platform: "blooio",
             sessionId: continuationToken(named),
+            confirmPlatformLink: true,
             authenticatedUser: { userId: "user-1", organizationId: "org-1" },
             statusOnly: true,
           });
@@ -2177,6 +2211,7 @@ describe("runOnboardingChat", () => {
         await runOnboardingChat({
           platform: "blooio",
           sessionId: continuationToken(named),
+          confirmPlatformLink: true,
           authenticatedUser: { userId: "user-1", organizationId: "org-1" },
           statusOnly: true,
         });

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -16,6 +16,7 @@ import {
   hasCloudBindingsContext,
 } from "../../runtime/cloud-bindings";
 import { logger } from "../../utils/logger";
+import { normalizePhoneNumber } from "../../utils/phone-normalization";
 import { launchManagedElizaAgent } from "../eliza-managed-launch";
 import {
   enqueueDiscordProactiveGreeting,
@@ -54,6 +55,12 @@ export interface OnboardingSession {
   platformUserId?: string;
   platformDisplayName?: string;
   /**
+   * Trusted transport address that opens the originating conversation after
+   * browser authentication. Phone gateways set this to their receiving number;
+   * browser callers cannot set it through the public route.
+   */
+  platformReplyAddress?: string;
+  /**
    * True once a trusted transport (internal gateway auth) has attested the
    * platform identity on this session. Only trusted platform identities may
    * be linked to a cloud account after login.
@@ -74,6 +81,7 @@ export interface OnboardingChatInput {
   platform?: OnboardingPlatform;
   platformUserId?: string;
   platformDisplayName?: string;
+  platformReplyAddress?: string;
   authenticatedUser?: {
     userId: string;
     organizationId: string;
@@ -96,9 +104,10 @@ export interface OnboardingChatInput {
 }
 
 export interface OnboardingContinuationPreview {
-  platform: "discord" | "telegram";
+  platform: "discord" | "telegram" | "blooio" | "twilio";
   platformUserId: string;
   platformDisplayName: string;
+  returnUrl: string | null;
 }
 
 export interface OnboardingChatCta {
@@ -334,15 +343,28 @@ async function loadOnboardingSessionForValidation(
  * authenticated browser continuation: possession of the opaque continuation
  * token (delivered only inside the platform DM) plus an explicit in-browser
  * confirmation is the ownership proof — the model #18161 shipped for Discord,
- * now shared by Telegram. Phone-shaped platforms are excluded: their identity
- * IS the phone number and links through the dedicated phone path.
+ * now shared by Telegram and phone gateways. Phone-shaped platforms still use
+ * the dedicated phone linker after confirmation.
  */
-type BrowserLinkablePlatform = "discord" | "telegram";
+type BrowserLinkablePlatform = "discord" | "telegram" | "blooio" | "twilio";
 
 function isBrowserLinkablePlatform(
   platform: OnboardingPlatform | undefined,
 ): platform is BrowserLinkablePlatform {
-  return platform === "discord" || platform === "telegram";
+  return (
+    platform === "discord" ||
+    platform === "telegram" ||
+    platform === "blooio" ||
+    platform === "twilio"
+  );
+}
+
+function buildMessagingReturnUrl(session: OnboardingSession): string | null {
+  if (session.platform !== "blooio" && session.platform !== "twilio") {
+    return null;
+  }
+  const replyAddress = normalizePhoneNumber(session.platformReplyAddress ?? "");
+  return replyAddress ? `sms:${replyAddress}` : null;
 }
 
 function trustedBrowserContinuationError(session: OnboardingSession | null): ElizaError {
@@ -357,7 +379,7 @@ function isBrowserLinkableContinuationForAccount(
   session: OnboardingSession | null,
   authenticatedAccount: { userId: string; organizationId: string },
 ): session is OnboardingSession & {
-  platform: "discord" | "telegram";
+  platform: BrowserLinkablePlatform;
   platformUserId: string;
 } {
   const hasUserBinding = session?.userId !== undefined;
@@ -389,6 +411,7 @@ export async function inspectOnboardingContinuation(
     platform: session.platform,
     platformUserId: session.platformUserId,
     platformDisplayName: session.platformDisplayName?.trim() || session.platformUserId,
+    returnUrl: buildMessagingReturnUrl(session),
   };
 }
 
@@ -720,8 +743,17 @@ function isPhoneLikePlatformIdentity(args: {
   );
 }
 
-function platformLinkLabel(platform: "discord" | "telegram"): string {
-  return platform === "discord" ? "Discord" : "Telegram";
+function platformLinkLabel(platform: BrowserLinkablePlatform): string {
+  switch (platform) {
+    case "discord":
+      return "Discord";
+    case "telegram":
+      return "Telegram";
+    case "blooio":
+      return "iMessage";
+    case "twilio":
+      return "SMS";
+  }
 }
 
 async function maybeLinkAuthenticatedPlatformIdentity(
@@ -738,11 +770,11 @@ async function maybeLinkAuthenticatedPlatformIdentity(
     return session;
   }
 
-  // Discord / Telegram: a PRIOR gateway turn attested "this session belongs
-  // to platform user X"; the user then authenticated (e.g. Steward email
-  // login) via the opaque continuation credential. Bind the platform identity
-  // so the gateway router resolves their DMs to the provisioned agent instead
-  // of onboarding forever. Skipped on gateway turns themselves
+  // Browser-linkable platforms: a PRIOR gateway turn attested "this session
+  // belongs to platform user X"; the user then authenticated (e.g. Steward
+  // email login) via the opaque continuation credential. Bind the platform
+  // identity so the gateway router resolves their messages to the provisioned
+  // agent instead of onboarding forever. Skipped on gateway turns themselves
   // (input.trustedPlatformIdentity): there the authenticated account was
   // RESOLVED FROM the user_identities projection, so the link already exists
   // and re-linking would just add a DB round trip to every DM turn. Also
@@ -780,10 +812,15 @@ async function maybeLinkAuthenticatedPlatformIdentity(
             discordId: session.platformUserId,
             username: displayName,
           })
-        : await elizaAppUserService.linkTelegramToUser(input.authenticatedUser.userId, {
-            id: session.platformUserId,
-            username: displayName,
-          });
+        : platform === "telegram"
+          ? await elizaAppUserService.linkTelegramToUser(input.authenticatedUser.userId, {
+              id: session.platformUserId,
+              username: displayName,
+            })
+          : await elizaAppUserService.linkPhoneToUser(
+              input.authenticatedUser.userId,
+              session.platformUserId,
+            );
     if (!link.success) {
       throw new ElizaError(
         link.error || `${platformLinkLabel(platform)} identity could not be linked`,
@@ -1203,6 +1240,8 @@ function newSession(id: string, input: OnboardingChatInput): OnboardingSession {
     platform: input.platform,
     platformUserId: input.platformUserId,
     platformDisplayName: input.platformDisplayName,
+    platformReplyAddress:
+      input.trustedPlatformIdentity === true ? input.platformReplyAddress : undefined,
     history: [],
   };
 }
@@ -1274,6 +1313,9 @@ export async function runOnboardingChatWithStore(
     platform: session.platform ?? input.platform,
     platformUserId: session.platformUserId ?? input.platformUserId,
     platformDisplayName: input.platformDisplayName ?? session.platformDisplayName,
+    platformReplyAddress:
+      session.platformReplyAddress ??
+      (input.trustedPlatformIdentity === true ? input.platformReplyAddress : undefined),
     updatedAt: nowIso(),
   };
 

--- a/packages/homepage/package.json
+++ b/packages/homepage/package.json
@@ -13,7 +13,7 @@
     "clean": "node ../scripts/rm-path-recursive.mjs dist",
     "check:release-data": "node ../app-core/scripts/check-homepage-release-data.mjs",
     "check:snapshot-inventory": "bun scripts/check-snapshot-inventory.ts",
-    "test": "bun test tests/smoke.node.test.mjs tests/screenshot-stability.node.test.mjs tests/e2e-port.node.test.mjs tests/channel-build-config.node.test.mjs tests/contact.test.ts tests/snapshot-inventory.test.ts tests/auth-return.test.ts tests/wallet-linking.test.ts tests/release-availability.test.ts edge/apple-app-site-association.test.ts tests/landing-a11y-helpers.test.ts tests/provisioning-poll-body.test.ts tests/provisioning-poll-hook.test.ts tests/onboarding-continuation.test.ts tests/get-started-continuation-render.test.tsx",
+    "test": "bun test tests/smoke.node.test.mjs tests/screenshot-stability.node.test.mjs tests/e2e-port.node.test.mjs tests/channel-build-config.node.test.mjs tests/contact.test.ts tests/snapshot-inventory.test.ts tests/auth-return.test.ts tests/wallet-linking.test.ts tests/release-availability.test.ts edge/apple-app-site-association.test.ts tests/landing-a11y-helpers.test.ts tests/provisioning-poll-body.test.ts tests/provisioning-poll-hook.test.ts tests/onboarding-continuation.test.ts tests/get-started-continuation-render.test.tsx tests/legacy-onboarding-redirect.test.ts",
     "test:aasa-edge": "bun run typecheck:aasa-edge && bun test edge/apple-app-site-association.test.ts",
     "typecheck:aasa-edge": "bunx --package typescript@6.0.3 tsc --noEmit -p edge/tsconfig.json",
     "deploy:aasa-edge": "bunx wrangler@4.100.0 deploy --config wrangler-aasa.toml --strict",

--- a/packages/homepage/src/App.tsx
+++ b/packages/homepage/src/App.tsx
@@ -4,8 +4,9 @@
  */
 import { BRAND_COLORS } from "@elizaos/shared/brand";
 import { Loader2 } from "lucide-react";
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { getLegacyOnboardingRedirect } from "@/lib/legacy-onboarding-redirect";
 
 const MarketingPage = lazy(() => import("@/pages/marketing"));
 const LandingPage = lazy(() => import("@/pages/landing"));
@@ -31,6 +32,21 @@ function RouteFallback() {
   );
 }
 
+function GetStartedRoute() {
+  const redirectUrl =
+    typeof window === "undefined"
+      ? null
+      : getLegacyOnboardingRedirect(window.location);
+
+  useEffect(() => {
+    if (redirectUrl) {
+      window.location.replace(redirectUrl);
+    }
+  }, [redirectUrl]);
+
+  return redirectUrl ? <RouteFallback /> : <GetStartedPage />;
+}
+
 export function App() {
   return (
     <BrowserRouter>
@@ -42,7 +58,7 @@ export function App() {
           <Route element={<AuthedShell />}>
             <Route path="/login" element={<LoginPage />} />
             <Route path="/connected" element={<ConnectedPage />} />
-            <Route path="/get-started" element={<GetStartedPage />} />
+            <Route path="/get-started" element={<GetStartedRoute />} />
             <Route path="/profile/edit" element={<ProfileEditPage />} />
           </Route>
           <Route path="*" element={<NotFoundPage />} />

--- a/packages/homepage/src/lib/legacy-onboarding-redirect.ts
+++ b/packages/homepage/src/lib/legacy-onboarding-redirect.ts
@@ -1,0 +1,24 @@
+/**
+ * Redirects continuation links previously issued on eliza.app into the
+ * authenticated Cloud app while leaving organic homepage onboarding intact.
+ */
+
+const LEGACY_HOMEPAGE_HOSTS = new Set(["eliza.app", "www.eliza.app"]);
+const CLOUD_APP_ORIGIN = "https://app.elizacloud.ai";
+
+export function getLegacyOnboardingRedirect(location: {
+  hostname: string;
+  pathname: string;
+  search: string;
+  hash: string;
+}): string | null {
+  if (
+    !LEGACY_HOMEPAGE_HOSTS.has(location.hostname.toLowerCase()) ||
+    location.pathname !== "/get-started" ||
+    !new URLSearchParams(location.search).has("onboardingSession")
+  ) {
+    return null;
+  }
+
+  return `${CLOUD_APP_ORIGIN}${location.pathname}${location.search}${location.hash}`;
+}

--- a/packages/homepage/tests/legacy-onboarding-redirect.test.ts
+++ b/packages/homepage/tests/legacy-onboarding-redirect.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Covers the compatibility redirect for continuation URLs already sent with
+ * the retired eliza.app onboarding host.
+ */
+import { describe, expect, test } from "bun:test";
+import { getLegacyOnboardingRedirect } from "../src/lib/legacy-onboarding-redirect";
+
+describe("legacy onboarding redirect", () => {
+  test("preserves an existing eliza.app continuation URL", () => {
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "eliza.app",
+        pathname: "/get-started",
+        search: "?onboardingSession=session-123&source=imessage",
+        hash: "#continue",
+      }),
+    ).toBe(
+      "https://app.elizacloud.ai/get-started?onboardingSession=session-123&source=imessage#continue",
+    );
+  });
+
+  test("supports the legacy www host", () => {
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "www.eliza.app",
+        pathname: "/get-started",
+        search: "?onboardingSession=session-123",
+        hash: "",
+      }),
+    ).toBe(
+      "https://app.elizacloud.ai/get-started?onboardingSession=session-123",
+    );
+  });
+
+  test("leaves organic homepage onboarding and non-production hosts alone", () => {
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "eliza.app",
+        pathname: "/get-started",
+        search: "?method=imessage",
+        hash: "",
+      }),
+    ).toBeNull();
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "localhost",
+        pathname: "/get-started",
+        search: "?onboardingSession=session-123",
+        hash: "",
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/ui/src/cloud/join/GetStartedPage.test.tsx
+++ b/packages/ui/src/cloud/join/GetStartedPage.test.tsx
@@ -37,6 +37,7 @@ vi.mock("./lib/onboarding-continuation", async (importOriginal) => {
       platform: "discord" as const,
       platformUserId: "1234567890",
       platformDisplayName: "attested-discord-user",
+      returnUrl: null,
     })),
     completePendingOnboardingContinuation: vi.fn(async () => {
       actual.clearPendingOnboardingSession();
@@ -52,6 +53,7 @@ beforeEach(() => {
     platform: "discord",
     platformUserId: "1234567890",
     platformDisplayName: "attested-discord-user",
+    returnUrl: null,
   });
   vi.mocked(completePendingOnboardingContinuation).mockReset();
   vi.mocked(completePendingOnboardingContinuation).mockImplementation(
@@ -127,6 +129,7 @@ describe("GetStartedPage", () => {
       platform: "telegram",
       platformUserId: "123456789",
       platformDisplayName: "attested-telegram-user",
+      returnUrl: null,
     });
     const entry = `/get-started?onboardingSession=${TOKEN}`;
     window.history.replaceState(null, "", entry);
@@ -146,5 +149,33 @@ describe("GetStartedPage", () => {
       screen.getByRole("button", { name: /Connect this Telegram account/ }),
     );
     expect(await screen.findByText("You're connected")).toBeTruthy();
+  });
+
+  it("offers a deep link back to the originating iMessage conversation", async () => {
+    vi.mocked(previewPendingOnboardingContinuation).mockResolvedValue({
+      platform: "blooio",
+      platformUserId: "+14155550123",
+      platformDisplayName: "Shaw",
+      returnUrl: "sms:+18087881821",
+    });
+    const entry = `/get-started?onboardingSession=${TOKEN}`;
+    window.history.replaceState(null, "", entry);
+
+    render(
+      <MemoryRouter initialEntries={[entry]}>
+        <Routes>
+          <Route path="/get-started" element={<GetStartedPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Shaw")).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: /Connect this iMessage account/ }),
+    );
+    expect(await screen.findByText("You're connected")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Back to iMessage" }),
+    ).toBeTruthy();
   });
 });

--- a/packages/ui/src/cloud/join/GetStartedPage.tsx
+++ b/packages/ui/src/cloud/join/GetStartedPage.tsx
@@ -23,6 +23,7 @@ import { Button } from "../../components/ui/button";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import {
   completePendingOnboardingContinuation,
+  type MessagingContinuationPreview,
   peekPendingOnboardingSession,
   previewPendingOnboardingContinuation,
   sanitizeOnboardingSessionToken,
@@ -31,6 +32,21 @@ import {
 import { useJoinSessionAuth } from "./lib/use-join-session";
 
 type GetStartedPhase = "checking" | "confirm" | "linking" | "done" | "error";
+
+function messagingPlatformLabel(
+  platform: MessagingContinuationPreview["platform"],
+): string {
+  switch (platform) {
+    case "discord":
+      return "Discord";
+    case "telegram":
+      return "Telegram";
+    case "blooio":
+      return "iMessage";
+    case "twilio":
+      return "SMS";
+  }
+}
 
 function describeContinuationError(err: unknown): string {
   if (err instanceof Error && err.message.trim()) return err.message;
@@ -43,11 +59,8 @@ export default function GetStartedPage(): React.JSX.Element {
   const [searchParams] = useSearchParams();
   const [phase, setPhase] = useState<GetStartedPhase>("checking");
   const [error, setError] = useState<string | null>(null);
-  const [platformIdentity, setPlatformIdentity] = useState<{
-    platform: "discord" | "telegram";
-    platformUserId: string;
-    platformDisplayName: string;
-  } | null>(null);
+  const [platformIdentity, setPlatformIdentity] =
+    useState<MessagingContinuationPreview | null>(null);
   // StrictMode double-mount guard: the redemption POST must run once.
   const startedRef = useRef(false);
 
@@ -142,10 +155,7 @@ export default function GetStartedPage(): React.JSX.Element {
         {phase === "confirm" && platformIdentity ? (
           <div className="flex flex-col items-center gap-4">
             <h1 className="font-poppins text-lg font-semibold text-white">
-              Connect your{" "}
-              {platformIdentity.platform === "telegram"
-                ? "Telegram"
-                : "Discord"}{" "}
+              Connect your {messagingPlatformLabel(platformIdentity.platform)}{" "}
               account?
             </h1>
             <p className="text-sm text-white/70">
@@ -154,7 +164,9 @@ export default function GetStartedPage(): React.JSX.Element {
               <span className="block text-xs text-white/50">
                 {platformIdentity.platform === "telegram"
                   ? "Telegram ID"
-                  : "Discord ID"}{" "}
+                  : platformIdentity.platform === "discord"
+                    ? "Discord ID"
+                    : "Phone"}{" "}
                 {platformIdentity.platformUserId}
               </span>
             </p>
@@ -166,10 +178,7 @@ export default function GetStartedPage(): React.JSX.Element {
               }}
               className="bg-txt px-6 py-2.5 font-semibold text-bg"
             >
-              Connect this{" "}
-              {platformIdentity.platform === "telegram"
-                ? "Telegram"
-                : "Discord"}{" "}
+              Connect this {messagingPlatformLabel(platformIdentity.platform)}{" "}
               account
             </Button>
           </div>
@@ -186,6 +195,17 @@ export default function GetStartedPage(): React.JSX.Element {
                   "Head back to your chat — your agent will pick up right where you left off. Setup finishes in the background.",
               })}
             </p>
+            {platformIdentity?.returnUrl ? (
+              <Button
+                type="button"
+                onClick={() =>
+                  window.location.assign(platformIdentity.returnUrl ?? "/join")
+                }
+                className="bg-txt px-6 py-2.5 font-semibold text-bg transition-colors hover:bg-txt/90"
+              >
+                Back to {messagingPlatformLabel(platformIdentity.platform)}
+              </Button>
+            ) : null}
             <Button
               variant="ghost"
               type="button"

--- a/packages/ui/src/cloud/join/lib/onboarding-continuation.test.ts
+++ b/packages/ui/src/cloud/join/lib/onboarding-continuation.test.ts
@@ -83,6 +83,7 @@ describe("previewPendingOnboardingContinuation", () => {
         platform: "discord",
         platformUserId: "1234567890",
         platformDisplayName: "attested-user",
+        returnUrl: null,
       },
     });
     const preview = await previewPendingOnboardingContinuation(TOKEN, {
@@ -93,6 +94,24 @@ describe("previewPendingOnboardingContinuation", () => {
       `/api/eliza-app/onboarding/chat?sessionId=${encodeURIComponent(TOKEN)}`,
     );
     expect(preview.platformDisplayName).toBe("attested-user");
+  });
+
+  it("carries a trusted iMessage return deep link", async () => {
+    const preview = await previewPendingOnboardingContinuation(TOKEN, {
+      get: vi.fn().mockResolvedValue({
+        data: {
+          platform: "blooio",
+          platformUserId: "+14155550123",
+          platformDisplayName: "Shaw",
+          returnUrl: "sms:+18087881821",
+        },
+      }),
+      post: vi.fn(),
+    });
+    expect(preview).toMatchObject({
+      platform: "blooio",
+      returnUrl: "sms:+18087881821",
+    });
   });
 });
 

--- a/packages/ui/src/cloud/join/lib/onboarding-continuation.ts
+++ b/packages/ui/src/cloud/join/lib/onboarding-continuation.ts
@@ -138,9 +138,10 @@ const defaultTransport: OnboardingContinuationTransport = {
 };
 
 export interface MessagingContinuationPreview {
-  platform: "discord" | "telegram";
+  platform: "discord" | "telegram" | "blooio" | "twilio";
   platformUserId: string;
   platformDisplayName: string;
+  returnUrl: string | null;
 }
 
 export async function previewPendingOnboardingContinuation(


### PR DESCRIPTION
# Relates to

Relates to #17870.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync. The exact unrelated verify blocker is recorded below.
- [x] A reviewer can confirm the changed flow from the focused tests and local visual audit; attachment collection remains before this draft is marked ready.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` is blocked by an unrelated Biome formatting failure already present on `develop`; see Known gaps / failures.

# Risks

Medium. This changes authentication continuation, phone identity linking, and gateway reply-address propagation. The implementation only accepts a reply address from trusted internal gateway callers, requires explicit account-link confirmation, and constructs the return deep link from the gateway's configured receiving number rather than user input.

# Background

## What does this PR do?

- Redirects legacy `eliza.app/get-started?onboardingSession=...` links to the authenticated Cloud app while preserving the complete query and hash.
- Carries the trusted Blooio/Twilio receiving number through the gateway into onboarding state.
- Previews and explicitly confirms iMessage/SMS identity linking after sign-in.
- Links the attested phone identity to the signed-in account and returns `sms:<receiving-number>` for the success CTA.
- Renders `Back to iMessage` / `Back to SMS` after successful provisioning while keeping in-app chat as the alternative.
- Extends API, router, gateway, full-stack, UI, and visual-audit coverage for the flow.

## What kind of change is this?

Bug fix (non-breaking).

## Root cause

Older onboarding replies pointed at the public homepage, the phone gateway did not persist its trusted receiving address, and the browser continuation only supported Discord/Telegram. After authentication there was therefore no trusted phone identity handoff and no deep link back to the originating Messages conversation.

# Documentation changes needed?

No user-facing documentation change is required. The behavior is covered by code contracts and tests.

# Testing

## Where should a reviewer start?

- `packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts`
- `packages/ui/src/cloud/join/GetStartedPage.tsx`
- `packages/homepage/src/lib/legacy-onboarding-redirect.ts`

## Detailed testing steps

1. Send `Hey Eliza, what can you do?` over the configured Blooio iMessage number and provide a name.
2. Open the returned onboarding link while signed out.
3. Complete Steward/Google login and confirm the displayed iMessage identity.
4. Verify provisioning completes and `Back to iMessage` opens the configured Eliza receiving-number conversation.

Automated validation:

- `bun install` — passed after rebase.
- `bun run build:core` — 56/56 tasks passed.
- Focused UI Vitest — 2 files, 16 tests passed.
- Focused onboarding/API/router/gateway Bun suite — exited 0.
- Homepage redirect + continuation render tests — exited 0.
- Homepage typecheck and lint — passed.
- Focused app cloud visual audit — 4/4 desktop/mobile confirmation and success captures passed.
- `bun run verify` — reaches an unrelated upstream `plugin-workflow` formatting failure documented below.

# Evidence Gate

<!-- evidence-head:ba7a482f7c3328e24654e31b9be938587916d8bc -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18836-evidence-before-production.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18836-evidence-after-audit.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18836-walkthrough-get-started.mp4
<!-- evidence-row:backend-logs -->
- [x] [18836-backend-test-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18836-backend-test-logs.txt)
<!-- evidence-row:frontend-logs -->
- [x] [18836-frontend-test-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18836-frontend-test-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the changed onboarding path is deterministic and performs no LLM call.
<!-- evidence-row:domain-artifacts -->
- [x] [18836-domain-artifacts-e2e.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18836-domain-artifacts-e2e.txt)
<!-- evidence-row:ocr-review -->
- [x] [18836-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18836-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - the changed onboarding path is deterministic and performs no LLM call.

## Backend + frontend logs

Pending deployment. The production test confirmed that OAuth returns to `/get-started`, while the currently deployed gateway still emits the legacy `eliza.app` URL and reuses the expired continuation token.

## Screenshots (before / after) + video walkthrough

Pending attachment before this draft is marked ready. Local visual audit covered desktop and mobile confirmation and success states.

## Known gaps / failures

- Current production is not yet running this branch, so the final live iMessage return cannot pass until the homepage and gateway are deployed.
- Post-rebase `bun run verify` is blocked outside this PR's diff by Biome formatting in `plugins/plugin-workflow/__tests__/unit/execution-diagnostics.test.ts`. Running that package's `lint:check` reproduces the same formatter-only failure on current `origin/develop`.
- The complete homepage aggregate test command has an existing cross-file ordering race in `get-started-continuation-render.test.tsx`; that file passes in isolation, and the new redirect test passes.

# Deploy Notes

Deploy both the homepage Pages project and the gateway-webhook service after merge. The gateway service requires its documented manual Railway deployment; merging alone does not update the live iMessage path.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-desktop]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->


