### PR TITLE
fix(core): reject blank embedding dimension aliases

### DIFF
--- a/packages/core/src/features/documents/config-numeric-validation.test.ts
+++ b/packages/core/src/features/documents/config-numeric-validation.test.ts
@@ -149,4 +149,32 @@ describe("validateModelConfig numeric boundary", () => {
 			/Model configuration validation failed: BATCH_DELAY_MS:/,
 		);
 	});
+
+	it.each([
+		["LOCAL_EMBEDDING_DIMENSIONS", "local", ""],
+		["LOCAL_EMBEDDING_DIMENSIONS", "local", "   "],
+		["OPENAI_EMBEDDING_DIMENSIONS", "openai", ""],
+		["OPENAI_EMBEDDING_DIMENSIONS", "openai", "   "],
+	] as const)("rejects a blank %s alias", (setting, provider, value) => {
+		vi.stubEnv("EMBEDDING_PROVIDER", provider);
+		vi.stubEnv(setting, value);
+
+		expect(() => validateModelConfig()).toThrow(
+			/Model configuration validation failed: EMBEDDING_DIMENSION:/,
+		);
+	});
+
+	it("preserves the real configuration-boundary defaults", () => {
+		vi.stubEnv("EMBEDDING_PROVIDER", "local");
+
+		expect(validateModelConfig()).toMatchObject({
+			MAX_INPUT_TOKENS: 4000,
+			MAX_OUTPUT_TOKENS: 4096,
+			EMBEDDING_DIMENSION: 384,
+			MAX_CONCURRENT_REQUESTS: 100,
+			REQUESTS_PER_MINUTE: 500,
+			TOKENS_PER_MINUTE: 1_000_000,
+			BATCH_DELAY_MS: 100,
+		});
+	});
 });

--- a/packages/core/src/features/documents/config.ts
+++ b/packages/core/src/features/documents/config.ts
@@ -65,10 +65,16 @@ export function validateModelConfig(runtime?: IAgentRuntime): ModelConfig {
 		);
 		const embeddingProvider = getSetting("EMBEDDING_PROVIDER");
 		const localEmbeddingModel = getSetting("LOCAL_EMBEDDING_MODEL");
-		const localEmbeddingDimensions = getSetting("LOCAL_EMBEDDING_DIMENSIONS");
+		const localEmbeddingDimensions = getNumericSetting(
+			"LOCAL_EMBEDDING_DIMENSIONS",
+		);
+		const openaiEmbeddingDimensions = getNumericSetting(
+			"OPENAI_EMBEDDING_DIMENSIONS",
+		);
 		const inferredLocalEmbeddings =
 			!embeddingProvider &&
-			Boolean(localEmbeddingModel || localEmbeddingDimensions);
+			(localEmbeddingModel !== undefined ||
+				localEmbeddingDimensions !== undefined);
 		const resolvedEmbeddingProvider =
 			embeddingProvider || (inferredLocalEmbeddings ? "local" : undefined);
 		const assumePluginOpenAI = !resolvedEmbeddingProvider;
@@ -83,10 +89,10 @@ export function validateModelConfig(runtime?: IAgentRuntime): ModelConfig {
 				: "text-embedding-3-small");
 		const embeddingDimension =
 			getNumericSetting("EMBEDDING_DIMENSION") ??
-			((resolvedEmbeddingProvider === "local"
+			(resolvedEmbeddingProvider === "local"
 				? localEmbeddingDimensions
-				: getSetting("OPENAI_EMBEDDING_DIMENSIONS")) ||
-				(resolvedEmbeddingProvider === "local" ? "384" : "1536"));
+				: openaiEmbeddingDimensions) ??
+			(resolvedEmbeddingProvider === "local" ? "384" : "1536");
 
 		const rawOpenaiApiKey = getSetting("OPENAI_API_KEY");
 		const rawOpenaiBaseURL = getSetting("OPENAI_BASE_URL");


### PR DESCRIPTION
# Relates to

Closes #18793.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `c267370f268318db7d3683552f8e5750da76ddc0`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 Turbo tasks and all repository audits.

# Risks

Low. The change is limited to document configuration parsing. Deployments that explicitly set a blank legacy embedding-dimension alias will now fail validation instead of silently receiving a default; that fail-fast behavior is the intended correction.

# Background

## What does this PR do?

- Preserves raw `LOCAL_EMBEDDING_DIMENSIONS` and `OPENAI_EMBEDDING_DIMENSIONS` values until schema validation.
- Uses nullish fallback so empty and whitespace-only aliases fail instead of silently selecting `384` or `1536`.
- Adds caller-boundary regressions for both aliases and for the real document configuration defaults.

## What kind of change is this?

Bug fix, completing the residual validation gap left after #18796.

# Documentation changes needed?

No. This restores the documented strict numeric-setting contract and changes no public API.

# Testing

## Where should a reviewer start?

Run the focused configuration test and inspect the four alias cases plus the real-default regression:

```bash
bunx vitest run packages/core/src/features/documents/config-numeric-validation.test.ts
```

## Detailed testing results

- Focused numeric validation: 20/20 passed.
- Full core suite: 514 files passed; 5,767 tests passed; 1 intentional skip.
- Core typecheck passed.
- Multi-target core build passed for Node, browser, edge, testing module, and declarations.
- Root `bun run verify` passed 350/350 Turbo tasks and all repository audits.

# Evidence Gate

<!-- evidence-head:7a06059a6c75dc391f84cf24d0020bb3fa5515cf -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - configuration parsing only; no UI surface exists before this change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - configuration parsing only; no rendered output changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or visual user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - the code path is a deterministic synchronous configuration boundary, proven directly by the focused caller tests before any backend ingestion starts.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, or state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider call, action, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - invalid configuration now throws before documents, memories, database rows, or other domain artifacts can be created.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or text changed.

# Evidence Details

## Known gaps / failures

Screenshots, video, UI logs, live-model trajectories, and domain artifacts are inapplicable because this is a deterministic pre-ingestion configuration parser change. No test, build, typecheck, lint, or repository verification failure remains.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza"} -->
