### PR TITLE
fix(homepage): route primary CTA into elizacloud login funnel + default auth to app.elizacloud.ai

### DIFF
--- a/packages/homepage/src/lib/api/client.ts
+++ b/packages/homepage/src/lib/api/client.ts
@@ -2,11 +2,15 @@
  * Browser fetch helpers for calling the Eliza Cloud API from the static
  * homepage.
  */
-// Apex, not `www.`: the www host 308-redirects to the apex, and CORS
-// preflights never follow redirects — with the www default every
-// /api/eliza-app/* POST from the homepage died before reaching the API
-// (the get-started Telegram phone step and Discord callback failures).
-const ELIZACLOUD_DEFAULT_URL = "https://elizacloud.ai";
+// Canonical API host is `app.elizacloud.ai`. Both `www.elizacloud.ai`
+// AND the apex `elizacloud.ai` 308-redirect (apex serves the marketing
+// console, not the API), and browser fetch never replays a cross-origin
+// POST + Authorization across a 308, so any build without an explicit
+// VITE_ELIZACLOUD_API_URL override sent every /api/eliza-app/* auth call
+// into a redirect and "wasn't using elizacloud auth" (dead get-started
+// Telegram phone step + Discord callback). Prod overrides this via env;
+// this default keeps local/preview/fork builds pointed at the real API.
+const ELIZACLOUD_DEFAULT_URL = "https://app.elizacloud.ai";
 
 function getBaseUrl(): string {
   return (

--- a/packages/homepage/src/pages/landing.tsx
+++ b/packages/homepage/src/pages/landing.tsx
@@ -51,7 +51,6 @@ const ShaderBackground = lazy(
 );
 const VideoCall = lazy(() => import("@/components/VideoCall"));
 
-import { buildElizaSmsHref } from "@/lib/contact";
 import {
   COMPOSER_VIEWPORT_LIFT_PX,
   hiddenChromeDomProps,
@@ -856,7 +855,20 @@ export default function Leaderboard() {
               <ElizaLogo className="h-8 md:h-10 lg:h-12 w-auto" />
             </button>
             <nav className="flex items-center gap-4">
-              <BlobButton href={buildElizaSmsHref("Hi Eliza")} show={showUI}>
+              {/* Primary CTA steers into the elizacloud login/link funnel
+                  (/get-started), not an sms: deep link that dead-ends on
+                  desktop and never touches elizacloud auth. Canon:
+                  ONBOARD-LOGIN-DIRECT-2026-08-11: "connect should take us to
+                  the elizacloud login flow, link the user, authenticate."
+                  href kept as a graceful fallback for no-JS / new-tab. */}
+              <BlobButton
+                href="/get-started"
+                onClick={(e) => {
+                  e.preventDefault();
+                  navigate("/get-started");
+                }}
+                show={showUI}
+              >
                 <AnimatedLetters
                   text={t("homepage_eliza.leaderboard.getStarted", {
                     defaultValue: "Get Started",


### PR DESCRIPTION
## What

Two surgical fixes to the eliza.app onboarding funnel. Both were making the flow "not use elizacloud auth."

### 1. Primary nav CTA now enters the elizacloud login funnel (was a dead SMS link)
The nav **"Get Started"** button was `href = sms:+1808…` (`buildElizaSmsHref`). On desktop that dead-ends (opens a "send SMS?" prompt or nothing) and it never touches elizacloud auth. Per canon (ONBOARD-LOGIN-DIRECT-2026-08-11: *"connect should take us to the elizacloud login flow, link the user, authenticate"*), the primary CTA now `navigate("/get-started")` — the same funnel the hero "Try Now" already uses. `href="/get-started"` is kept as a no-JS / open-in-new-tab fallback.

### 2. Default auth base URL points at the real API host
`lib/api/client.ts` defaulted to `https://elizacloud.ai`, which **308-redirects** to the marketing console (not the API). Browser `fetch` does not replay a cross-origin `POST` + `Authorization` across a 308, so any build **without** an explicit `VITE_ELIZACLOUD_API_URL` override (local dev, CF **preview** deploys, forks, a missing CI env) sent every `/api/eliza-app/*` auth call into a redirect and silently failed auth. The default is now the canonical API host `https://app.elizacloud.ai`. Prod's build-time env override is unchanged, so prod behavior is identical; this only fixes the non-prod/preview/fork default.

Host probe evidence (`/api/eliza-app/user/me`): `elizacloud.ai` / `www.elizacloud.ai` → **308**; `app.elizacloud.ai` / `api.elizacloud.ai` → **401** (alive).

## Scope / not touched
Nav logo, intro animation, phone animations: untouched. Discord OAuth, Telegram/WhatsApp/Solana pickers, get-started layout: already correct, left alone.

## Verification
- `bun run typecheck` ✅ · `bun run build` ✅
- Default (no-env) build now bakes `app.elizacloud.ai` as the auth base (verified in `dist`).
- Homepage onboarding + contact tests green (17 pass): `tests/get-started-continuation-render`, `tests/onboarding-continuation`, `tests/contact`.
- **CF Pages PREVIEW:** https://3674fbea.eliza-app-home.pages.dev (alias https://sol-elizaapp-flow-20260812.eliza-app-home.pages.dev) — verified: nav "Get Started" routes to `/get-started` (zero `sms:` refs in the deployed landing chunk), auth base baked as `app.elizacloud.ai`.

## QA (for a human)
1. Open the preview → click nav **Get Started** (top-right) → lands on `/get-started` platform picker (not an SMS app).
2. Also click hero **Try Now** → same `/get-started`.
3. Pick **Discord** → real `discord.com/oauth2/authorize?...redirect_uri=.../get-started` (elizacloud OAuth).
4. Complete OAuth → returns to `/get-started`, `POST /api/eliza-app/auth/discord` (Network tab, host `app.elizacloud.ai`, not a 308).
5. DevTools → confirm no request hits `www.elizacloud.ai` / apex `elizacloud.ai` for `/api/eliza-app/*`.

Receipt: `~/.moltbot/projects/eliza-fleet/ELIZAAPP-FLOW-AUDIT-2026-08-12.md`
