### PR TITLE
fix(cloud): reject noncanonical mock stack ports

### DIFF
--- a/scripts/cloud/__tests__/mock-stack-up.test.mjs
+++ b/scripts/cloud/__tests__/mock-stack-up.test.mjs
@@ -77,6 +77,21 @@ describe("mock-stack-up orchestrator", () => {
   });
 
   test.each([
+    ["--port-frontend", "03000"],
+    ["--port-api", "01"],
+    ["--port-cp", "00080"],
+    ["--port-hetzner", "065535"],
+  ])("%s rejects a non-canonical override %s", async (flag, value) => {
+    const r = await redirectedRun([flag, value, "--help"]);
+    expect(r.code).toBe(1);
+    const combined = r.stdout + r.stderr;
+    expect(combined).toContain(
+      `${flag} requires a decimal port between 1 and 65535`,
+    );
+    expect(combined).not.toContain("Eliza cloud mock stack — ready");
+  });
+
+  test.each([
     ["non-numeric", ["not-a-port"]],
     ["empty", [""]],
     ["trailing junk", ["23456junk"]],

--- a/scripts/cloud/mock-stack-up.mjs
+++ b/scripts/cloud/mock-stack-up.mjs
@@ -58,7 +58,12 @@ function parsePortOverride(flag, value) {
     return { error: `${flag} requires a decimal port between 1 and 65535` };
   }
   const port = Number(value);
-  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+  if (
+    !Number.isSafeInteger(port) ||
+    port < 1 ||
+    port > 65_535 ||
+    String(port) !== value
+  ) {
     return { error: `${flag} requires a decimal port between 1 and 65535` };
   }
   return { port };


### PR DESCRIPTION
# Relates to

Closes #18566.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] Real-process tests prove rejection before the heavy mock stack boots.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@c267370f268318db7d3683552f8e5750da76ddc0`; zero conflicts.
- [x] `bun run verify` passes: 350/350 Turbo tasks and all repository audits.

# Risks

Low. Explicit leading-zero port operands that previously normalized silently now fail at the CLI boundary. Canonical ports `1..65535` and the existing automatic-port behavior when no override is supplied remain unchanged.

# Background

## What does this PR do?

The shared mock-stack port parser accepted digit-only strings such as `01` and `00080`, then normalized them with `Number`. The issue requires canonical decimal TCP ports, so the parser now additionally requires `String(port) === value` after range and safe-integer validation.

Real-process regressions cover every flag: `--port-frontend`, `--port-api`, `--port-cp`, and `--port-hetzner`.

## What kind of change is this?

Bug fix completing the reviewed canonical-input residual after #18567.

# Documentation changes needed?

No. The CLI already promises decimal TCP ports; this enforces that contract.

# Testing

## Where should a reviewer start?

```bash
bun test scripts/cloud/__tests__/mock-stack-up.test.mjs
```

## Detailed testing results

- Mock-stack real-process suite: 23/23 passed, 69 assertions.
- All four port flags reject leading-zero operands before the ready banner.
- Existing canonical boundaries `1` and `65535` pass.
- Existing skip-everything boot reaches its handled shutdown path.
- Targeted Biome: no errors or edits; one unrelated pre-existing log-stream assignment warning.
- Root verify: 350/350 Turbo tasks plus all audits passed.

# Evidence Gate

<!-- evidence-head:22203fcc31815c1a2665e866e83e787ccc6302ad -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CLI parser only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CLI parser only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - rejected inputs exit before any cloud service starts; the applicable real-process transcript is included below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - rejected configuration creates no service or persistent artifact by design.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Real CLI transcript

```text
--port-frontend 03000: rejected before boot
--port-api 01: rejected before boot
--port-cp 00080: rejected before boot
--port-hetzner 065535: rejected before boot
23 pass, 0 fail, 69 assertions
bun run verify: 350 successful, 350 total; all repository audits passed
```

## Known gaps / failures

Screenshots, video, frontend/backend logs, live-model trajectories, and domain artifacts are inapplicable because this is an offline CLI validation boundary. No test or verification failure remains.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza"} -->
