### PR TITLE
fix(evidence): reject flag-shaped reviewer values

### DIFF
--- a/packages/app/test/audit/ai-qa-reviewer-args.test.ts
+++ b/packages/app/test/audit/ai-qa-reviewer-args.test.ts
@@ -78,10 +78,19 @@ describe("AI-QA reviewer arguments", () => {
     ],
     [["--run-dir"], "--run-dir requires a value"],
     [["--run-dir", "--strict"], "--run-dir requires a value"],
+    [["--run-dir", "-strict"], "--run-dir requires a value"],
     [["--concurrency"], "--concurrency requires a value"],
     [["--concurrency", "--strict"], "--concurrency requires a value"],
   ])("rejects ambiguous arguments %j", (argv, message) => {
     expect(() => parseReviewerArgs(argv)).toThrow(message);
+  });
+
+  it("rejects flag-shaped walkthrough verdict values", () => {
+    expect(() =>
+      parseReviewerArgs(["--verdict-md", "-strict"], {
+        defaultVerdictMd: "default.md",
+      }),
+    ).toThrow("--verdict-md requires a value");
   });
 
   it.each(["0", "-1", "1.5", "NaN", "Infinity", "9007199254740992"])(
@@ -103,6 +112,25 @@ describe("AI-QA reviewer arguments", () => {
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("unknown argument: --strcit");
+      expect(result.stdout).not.toContain("skipping");
+      expect(result.stdout).not.toContain("PASSED");
+    },
+  );
+
+  it.each(reviewerScripts)(
+    "rejects a flag-shaped value at the real $label boundary",
+    ({ path }) => {
+      const result = spawnSync(
+        process.execPath,
+        [path, "--run-dir", "-strict"],
+        {
+          encoding: "utf8",
+          env: keylessEnvironment,
+        },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("--run-dir requires a value");
       expect(result.stdout).not.toContain("skipping");
       expect(result.stdout).not.toContain("PASSED");
     },

--- a/scripts/ai-qa/reviewer-args.mjs
+++ b/scripts/ai-qa/reviewer-args.mjs
@@ -12,7 +12,9 @@ function requireUnique(seen, argument) {
 
 function takeValue(argv, index, argument) {
   const value = argv[index + 1];
-  if (!value || value.startsWith("--")) {
+  const isNegativeConcurrency =
+    argument === "--concurrency" && /^-\d/u.test(value ?? "");
+  if (!value || (value.startsWith("-") && !isNegativeConcurrency)) {
     throw new Error(`${argument} requires a value`);
   }
   return value;


### PR DESCRIPTION
# Relates to

Closes #18557.

- [x] Rebased onto current `develop`; `bun install` and `bun run verify` pass.
- [x] Both real AI-QA reviewer entrypoints reject the malformed value before credential, filesystem, or model work.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@c267370f268318db7d3683552f8e5750da76ddc0`; zero conflicts.
- [x] Root verify passed 350/350 Turbo tasks and all audits.

# Risks

Low. Value-taking reviewer flags now reject single-dash flag-shaped operands. Negative concurrency retains its existing numeric validation and diagnostic; ordinary paths remain valid.

# Background

## What does this PR do?

The shared reviewer parser rejected only `--...` operands as missing values. A typo such as `--run-dir -strict` or `--verdict-md -strict` was therefore accepted as a path, bypassing strict-mode intent. The boundary now rejects the full option-shaped class while deliberately preserving negative numeric concurrency for the existing positive-integer diagnostic.

## What kind of change is this?

Bug fix completing the reviewed residual after #18558.

# Documentation changes needed?

No. This enforces the existing fail-closed CLI contract.

# Testing

## Where should a reviewer start?

```bash
bunx vitest run packages/app/test/audit/ai-qa-reviewer-args.test.ts
```

- 24/24 tests passed, including real screenshot and walkthrough reviewer subprocesses.
- App typecheck passed.
- Targeted Biome passed with no diagnostics.
- Root verify passed 350/350 tasks and all audits.

# Evidence Gate

<!-- evidence-head:62fa2a10c347a63115756e1460be5343194afc34 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - evidence CLI parser only; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - evidence CLI parser only; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend request path; real subprocess proof is included below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, console, or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - malformed input is rejected before any model call.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - rejection occurs before evidence or filesystem artifacts are created.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

```text
screenshot reviewer --run-dir -strict: exit 1, --run-dir requires a value
walkthrough reviewer --run-dir -strict: exit 1, --run-dir requires a value
focused suite: 24 pass, 0 fail
bun run verify: 350 successful, 350 total; all audits passed
```

## Known gaps / failures

Visual/live evidence is inapplicable because this change is the offline parser that guards those tools before work begins. No test or verification failure remains.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza"} -->
