### PR TITLE
fix(app): reject padded Playwright port overrides

### DIFF
--- a/packages/app/scripts/lib/playwright-port.mjs
+++ b/packages/app/scripts/lib/playwright-port.mjs
@@ -22,7 +22,7 @@ export const MAX_TCP_PORT = 65535;
  * @returns {number}
  */
 export function parsePlaywrightPort(value, label) {
-  const raw = String(value ?? "").trim();
+  const raw = String(value ?? "");
   if (!/^\d+$/.test(raw)) {
     throw new Error(
       `${label} must be a TCP port integer from ${MIN_TCP_PORT} to ${MAX_TCP_PORT} (received ${JSON.stringify(String(value ?? ""))})`,
@@ -53,7 +53,7 @@ export function parsePlaywrightPort(value, label) {
  */
 export function resolvePlaywrightPortEnv(env, envName, defaultPort) {
   const raw = env?.[envName];
-  if (raw === undefined || raw === null || String(raw).trim() === "") {
+  if (raw === undefined || raw === null || raw === "") {
     return defaultPort;
   }
   return parsePlaywrightPort(raw, envName);

--- a/packages/app/scripts/lib/playwright-port.test.mjs
+++ b/packages/app/scripts/lib/playwright-port.test.mjs
@@ -4,6 +4,8 @@
  * invalid override that must abort before webServer or baseURL wiring.
  */
 import { describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
 import {
   MAX_TCP_PORT,
   MIN_TCP_PORT,
@@ -21,10 +23,6 @@ describe("parsePlaywrightPort", () => {
     expect(parsePlaywrightPort("31337", "ELIZA_UI_SMOKE_API_PORT")).toBe(31337);
   });
 
-  it("trims surrounding whitespace from operator env interpolation", () => {
-    expect(parsePlaywrightPort("  2138\n", "PORT")).toBe(2138);
-  });
-
   it("rejects partial parses, fractions, signed values, and non-digits", () => {
     for (const bad of [
       "2138junk",
@@ -35,6 +33,8 @@ describe("parsePlaywrightPort", () => {
       "0x84a",
       "2e3",
       "1_000",
+      " 2138 ",
+      "\t31337\n",
     ]) {
       expect(() => parsePlaywrightPort(bad, "PORT")).toThrow(
         /must be a TCP port integer from 1 to 65535/,
@@ -60,20 +60,13 @@ describe("parsePlaywrightPort", () => {
 describe("resolvePlaywrightPortEnv", () => {
   const DEFAULT = 2138;
 
-  it("keeps the documented default when the env var is unset or empty", () => {
+  it("keeps the documented default only when the env var is unset or empty", () => {
     expect(resolvePlaywrightPortEnv({}, "ELIZA_UI_SMOKE_PORT", DEFAULT)).toBe(
       DEFAULT,
     );
     expect(
       resolvePlaywrightPortEnv(
         { ELIZA_UI_SMOKE_PORT: "" },
-        "ELIZA_UI_SMOKE_PORT",
-        DEFAULT,
-      ),
-    ).toBe(DEFAULT);
-    expect(
-      resolvePlaywrightPortEnv(
-        { ELIZA_UI_SMOKE_PORT: "   " },
         "ELIZA_UI_SMOKE_PORT",
         DEFAULT,
       ),
@@ -91,6 +84,13 @@ describe("resolvePlaywrightPortEnv", () => {
   });
 
   it("fails closed on an explicit invalid override instead of falling back", () => {
+    expect(() =>
+      resolvePlaywrightPortEnv(
+        { ELIZA_UI_SMOKE_PORT: "   " },
+        "ELIZA_UI_SMOKE_PORT",
+        DEFAULT,
+      ),
+    ).toThrow(/ELIZA_UI_SMOKE_PORT/);
     expect(() =>
       resolvePlaywrightPortEnv(
         { ELIZA_UI_SMOKE_API_PORT: "31337junk" },
@@ -118,4 +118,56 @@ describe("resolvePlaywrightPortEnv", () => {
     expect(MIN_TCP_PORT).toBe(1);
     expect(MAX_TCP_PORT).toBe(65535);
   });
+});
+
+describe("Playwright lane boundaries", () => {
+  const appDir = path.resolve(import.meta.dir, "../..");
+
+  it.each([
+    ["playwright.ui-smoke.config.ts", "ELIZA_UI_SMOKE_PORT"],
+    ["playwright.android-browser.config.ts", "ELIZA_UI_SMOKE_API_PORT"],
+    ["playwright.hmr.config.ts", "ELIZA_HMR_UI_PORT"],
+    ["playwright.dev-smoke.config.ts", "ELIZA_DEV_SMOKE_API_PORT"],
+  ])("rejects a padded %s override through %s", (config, envName) => {
+    const result = spawnSync(
+      process.execPath,
+      ["-e", `await import(${JSON.stringify(path.join(appDir, config))})`],
+      {
+        cwd: appDir,
+        encoding: "utf8",
+        env: { ...process.env, [envName]: " 2138 " },
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      `${envName} must be a TCP port integer from 1 to 65535`,
+    );
+  });
+
+  it.each(["ELIZA_UI_SMOKE_API_PORT", "ELIZA_UI_SMOKE_PORT"])(
+    "rejects whitespace-only %s before the Playwright runner launches",
+    (envName) => {
+      const result = spawnSync(
+        process.execPath,
+        [
+          path.join(appDir, "scripts/run-ui-playwright.mjs"),
+          "--config",
+          "playwright.ui-smoke.config.ts",
+          "--list",
+        ],
+        {
+          cwd: appDir,
+          encoding: "utf8",
+          env: { ...process.env, [envName]: "   " },
+        },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        `${envName} must be a TCP port integer from 1 to 65535`,
+      );
+      expect(result.stdout).not.toContain("Listing tests:");
+    },
+  );
 });


### PR DESCRIPTION
# Relates to

Closes #18618.

- [x] Rebased onto current `develop`; `bun install` and `bun run verify` pass.
- [x] All four real Playwright configs and the UI-smoke runner are exercised before launch.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@c267370f268318db7d3683552f8e5750da76ddc0`; zero conflicts.
- [x] Root verify passed 350/350 Turbo tasks and all audits.

# Risks

Low. Only exact empty strings and absent environment values retain defaults. Explicit whitespace-only or padded values now fail at configuration load instead of being trimmed into a valid port or disguised as absent.

# Background

## What does this PR do?

The shared Playwright port helper called `trim()` before both absence detection and canonical parsing. That accepted `" 2138 "` and treated `"   "` as an omitted setting, contradicting the issue's explicit canonical-decimal boundary.

This change preserves raw explicit values. Tests import all four real configs with padded overrides and invoke the real UI-smoke runner with whitespace-only pre-set ports, proving failure before Playwright launches.

## What kind of change is this?

Bug fix completing the reviewed residual after #18619.

# Documentation changes needed?

No. This enforces the existing canonical TCP-port contract.

# Testing

## Where should a reviewer start?

```bash
bun test packages/app/scripts/lib/playwright-port.test.mjs
```

- 14/14 tests passed, 45 assertions, 100% helper coverage.
- Real config probes cover ui-smoke, android-browser, HMR, and dev-smoke.
- Real runner probes cover both UI-smoke port variables before launch.
- App typecheck and targeted Biome passed.
- Root verify passed 350/350 tasks and all audits.

# Evidence Gate

<!-- evidence-head:e469259e87a1bef9c5b0a795533007714e9d5049 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Playwright configuration/CLI validation only; no rendered application surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Playwright configuration/CLI validation only; no rendered application surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - invalid settings fail before an interactive browser flow begins.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend request path; real config/runner subprocess evidence is included below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - invalid settings fail before browser console or network activity.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact is created by configuration validation.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

```text
four Playwright config imports with padded explicit ports: exit 1 with env-specific diagnostic
UI-smoke runner with whitespace-only API/UI port: exit 1 before test listing
focused suite: 14 pass, 0 fail, 45 assertions
bun run verify: 350 successful, 350 total; all audits passed
```

## Known gaps / failures

Screenshots and live browser artifacts are inapplicable because the changed behavior occurs before Playwright or any rendered UI starts. No test or verification failure remains.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza"} -->
