### PR TITLE
fix(app): bound walkthrough duration after conversion

### DIFF
--- a/packages/app/scripts/walkthrough-device-matrix.mjs
+++ b/packages/app/scripts/walkthrough-device-matrix.mjs
@@ -31,9 +31,9 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, realpathSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
 import { resolveDeviceId } from "./ios-device-lib.mjs";
 import {
@@ -47,6 +47,8 @@ const APP_DIR = resolve(dirname(SCRIPT_PATH), "..");
 const REPO_ROOT = resolve(APP_DIR, "../..");
 /** Largest delay Node accepts without clamping (2^31-1). */
 export const MAX_NODE_TIMER_MS = 2_147_483_647;
+/** Largest whole-second duration whose millisecond conversion fits a Node timer. */
+export const MAX_DURATION_SECONDS = Math.floor(MAX_NODE_TIMER_MS / 1_000);
 export const DEFAULT_DURATION_SECONDS = 30;
 
 /**
@@ -117,12 +119,12 @@ export function parseArgs(argv, env = process.env) {
       const value = argv[++i];
       if (value === undefined || value.startsWith("--")) {
         throw new Error(
-          `--duration requires an integer from 1 to ${MAX_NODE_TIMER_MS}`,
+          `--duration requires an integer from 1 to ${MAX_DURATION_SECONDS}`,
         );
       }
       a.duration = parsePositiveInteger(value, "--duration", {
         min: 1,
-        max: MAX_NODE_TIMER_MS,
+        max: MAX_DURATION_SECONDS,
       });
     } else if (arg === "--require") {
       const value = argv[++i];
@@ -658,7 +660,17 @@ async function main() {
   process.exit(computeExitCode(matrix, args.require));
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+function isDirectRun(entryPath) {
+  if (!entryPath) return false;
+  try {
+    return realpathSync(resolve(entryPath)) === realpathSync(SCRIPT_PATH);
+  } catch {
+    // error-policy:J3 an unresolved argv entry is not this module's CLI path
+    return false;
+  }
+}
+
+if (isDirectRun(process.argv[1])) {
   main().catch((error) => {
     console.error(`[walkthrough] device matrix failed: ${error.message}`);
     process.exit(1);

--- a/packages/app/scripts/walkthrough-device-matrix.test.mjs
+++ b/packages/app/scripts/walkthrough-device-matrix.test.mjs
@@ -4,6 +4,9 @@
 // (#13573). No device is touched — matrices are fabricated in-process.
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 import {
@@ -14,6 +17,7 @@ import {
   erroredLanes,
   iosDeviceConnectionState,
   isLaneRequired,
+  MAX_DURATION_SECONDS,
   MAX_NODE_TIMER_MS,
   parseArgs,
   parsePositiveInteger,
@@ -104,7 +108,7 @@ describe("walkthrough device matrix required lanes", () => {
       "10junk",
       "NaN",
       "Infinity",
-      String(MAX_NODE_TIMER_MS + 1),
+      String(MAX_DURATION_SECONDS + 1),
     ]) {
       assert.throws(() => parseArgs(["--duration", bad], {}), /--duration/);
     }
@@ -143,6 +147,81 @@ describe("real CLI rejection for --duration", () => {
     assert.match(result.stderr, /--duration/);
     assert.doesNotMatch(result.stdout, /=== walkthrough device matrix ===/);
     assert.doesNotMatch(result.stdout + result.stderr, /reports\/walkthrough/);
+  });
+
+  it("accepts the timer-safe maximum and rejects the next second", () => {
+    assert.equal(
+      parseArgs(["--duration", String(MAX_DURATION_SECONDS)], {}).duration,
+      MAX_DURATION_SECONDS,
+    );
+    assert.throws(
+      () => parseArgs(["--duration", String(MAX_DURATION_SECONDS + 1)], {}),
+      new RegExp(`--duration.*1 to ${MAX_DURATION_SECONDS}`),
+    );
+  });
+
+  it("enforces max and max+1 through the direct executable", () => {
+    const accepted = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        "--duration",
+        String(MAX_DURATION_SECONDS),
+        "--definitely-invalid",
+      ],
+      { encoding: "utf8", env: { PATH: process.env.PATH ?? "" } },
+    );
+    assert.equal(accepted.status, 1);
+    assert.match(accepted.stderr, /Unknown argument: --definitely-invalid/);
+    assert.doesNotMatch(accepted.stderr, /--duration must be/);
+
+    const rejected = spawnSync(
+      process.execPath,
+      [scriptPath, "--duration", String(MAX_DURATION_SECONDS + 1)],
+      { encoding: "utf8", env: { PATH: process.env.PATH ?? "" } },
+    );
+    assert.equal(rejected.status, 1);
+    assert.match(rejected.stderr, /--duration/);
+    assert.doesNotMatch(rejected.stdout, /=== walkthrough device matrix ===/);
+  });
+
+  it("enforces max and max+1 through a symlinked executable", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "walkthrough-duration-"));
+    const symlinkPath = join(tempDir, "walkthrough-device-matrix.mjs");
+    try {
+      symlinkSync(scriptPath, symlinkPath);
+      const accepted = spawnSync(
+        process.execPath,
+        [
+          symlinkPath,
+          "--duration",
+          String(MAX_DURATION_SECONDS),
+          "--definitely-invalid",
+        ],
+        {
+          encoding: "utf8",
+          env: { PATH: process.env.PATH ?? "" },
+        },
+      );
+      assert.equal(accepted.status, 1);
+      assert.match(accepted.stderr, /Unknown argument: --definitely-invalid/);
+      assert.doesNotMatch(accepted.stderr, /--duration must be/);
+
+      const rejected = spawnSync(
+        process.execPath,
+        [symlinkPath, "--duration", String(MAX_DURATION_SECONDS + 1)],
+        {
+          encoding: "utf8",
+          env: { PATH: process.env.PATH ?? "" },
+        },
+      );
+
+      assert.equal(rejected.status, 1);
+      assert.match(rejected.stderr, /--duration/);
+      assert.doesNotMatch(rejected.stdout, /=== walkthrough device matrix ===/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
# Relates to

Closes #18617.

- [x] Rebased onto current `develop`; `bun install` and `bun run verify` pass.
- [x] Direct and symlinked executable boundaries prove the timer-safe maximum and max+1 behavior.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@c267370f268318db7d3683552f8e5750da76ddc0`; zero conflicts.
- [x] Root verify passed 350/350 Turbo tasks and all audits.

# Risks

Low. The accepted duration ceiling changes from an incorrectly interpreted millisecond value to the largest whole-second value whose later millisecond conversion is safe. Existing practical durations and the default remain unchanged.

# Background

## What does this PR do?

`--duration` is measured in seconds, but the parser compared it directly with Node's millisecond timer ceiling. `2147484` seconds therefore passed, became `2147484000ms`, and Node clamped the timer to 1 ms.

The parser now caps seconds at `floor(2147483647 / 1000) = 2147483`. The executable guard is also realpath-aware so symlinked invocations execute validation instead of silently exiting zero.

## What kind of change is this?

Bug fix completing the reviewed timer-conversion and symlink residual after #18621.

# Documentation changes needed?

No. The CLI usage remains seconds; invalid overflow now fails before device work.

# Testing

## Where should a reviewer start?

```bash
bun test packages/app/scripts/walkthrough-device-matrix.test.mjs
```

- 32/32 tests passed.
- Direct executable: `2147483` passes parsing; `2147484` fails with `--duration` diagnostic.
- Symlinked executable: identical max/max+1 behavior.
- No device or report path runs for rejected input.
- App typecheck and targeted Biome passed.
- Root verify passed 350/350 tasks and all audits.

# Evidence Gate

<!-- evidence-head:c526a8ade091d1f1b11687ca16dd1f84b53a8370 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - non-rendered CLI validation only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - non-rendered CLI validation only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - invalid duration is rejected before any walkthrough capture begins.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend request path; real executable transcripts are summarized below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend launches for rejected input.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - rejected input creates no walkthrough report or capture artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

```text
direct executable 2147483: duration accepted; following sentinel flag rejected
direct executable 2147484: duration rejected before matrix/report work
symlink executable 2147483 / 2147484: same results
focused suite: 32 pass, 0 fail
bun run verify: 350 successful, 350 total; all audits passed
```

## Known gaps / failures

Device screenshots and walkthrough media are inapplicable because this change deliberately fails before device capture. No test or verification failure remains.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza"} -->
