### PR TITLE
fix(voice): bound placeholder preset dimensions

### DIFF
--- a/packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs
+++ b/packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs
@@ -35,8 +35,9 @@
  *   --concurrency N  Parallel TTS dispatches when synthesizing phrases. Default 2.
  *
  * `--dim` and `--concurrency` accept only complete positive safe-integer
- * decimals. Suffixes, fractions, signs, zero, and missing/flag-shaped values
- * fail at the CLI boundary before any output path is created.
+ * decimals; `--dim` is additionally capped by the v1 format's uint32 section
+ * layout. Suffixes, fractions, signs, zero, out-of-range dimensions, and
+ * missing/flag-shaped values fail before any output path is created.
  *
  * Run with `bun` (it resolves the `.ts` imports):
  *   bun packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs --placeholder
@@ -46,18 +47,31 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 const PLACEHOLDER_DEFAULT_DIM = 256;
+const UINT32_MAX = 0xffff_ffff;
+const VOICE_PRESET_V1_HEADER_BYTES = 24;
+
+// v1 stores the embedding byte length and the following phrase-section offset
+// as uint32. The embedding must leave that offset representable.
+export const MAX_PLACEHOLDER_DIM = Math.floor(
+  (UINT32_MAX - VOICE_PRESET_V1_HEADER_BYTES) / Float32Array.BYTES_PER_ELEMENT,
+);
 
 /**
- * Accept only complete positive safe-integer decimals (1..MAX_SAFE_INTEGER).
+ * Accept only complete positive safe-integer decimals up to `maximum`.
  * Rejects suffixes (`1junk`), fractions, signs, zero, leading zeros, whitespace,
  * empty values, and non-decimal forms so the CLI never silently truncates or
  * falls back to a different dimension/concurrency than the operator requested.
  *
  * @param {unknown} value
  * @param {string} flag
+ * @param {number} [maximum]
  * @returns {number}
  */
-export function parsePositiveSafeInteger(value, flag) {
+export function parsePositiveSafeInteger(
+  value,
+  flag,
+  maximum = Number.MAX_SAFE_INTEGER,
+) {
   if (value === undefined || value === null) {
     throw new Error(`${flag} requires a positive safe integer value`);
   }
@@ -68,9 +82,9 @@ export function parsePositiveSafeInteger(value, flag) {
     );
   }
   const n = Number.parseInt(raw, 10);
-  if (!Number.isSafeInteger(n) || n < 1 || String(n) !== raw) {
+  if (!Number.isSafeInteger(n) || n < 1 || n > maximum || String(n) !== raw) {
     throw new Error(
-      `${flag} must be a positive safe integer (received ${JSON.stringify(raw)})`,
+      `${flag} must be a positive safe integer no greater than ${maximum} (received ${JSON.stringify(raw)})`,
     );
   }
   return n;
@@ -129,7 +143,11 @@ export function parseArgs(argv) {
       case "--dim": {
         const taken = takeFlagValue(argv, i, "--dim");
         i = taken.nextIndex;
-        args.dim = parsePositiveSafeInteger(taken.value, "--dim");
+        args.dim = parsePositiveSafeInteger(
+          taken.value,
+          "--dim",
+          MAX_PLACEHOLDER_DIM,
+        );
         break;
       }
       case "--concurrency": {
@@ -160,7 +178,7 @@ function printUsageAndExit(code) {
       "  build-default-voice-preset.mjs --embedding PATH [--bundle ROOT] [--no-phrases]",
       "                                 [--out PATH] [--concurrency N]",
       "",
-      "  --dim N           Placeholder embedding dimension (positive safe integer, default 256).",
+      `  --dim N           Placeholder embedding dimension (1..${MAX_PLACEHOLDER_DIM}, default 256).`,
       "  --concurrency N   Parallel TTS phrase synthesis workers (positive safe integer, default 2).",
       "",
     ].join("\n"),

--- a/plugins/plugin-local-inference/src/services/voice/voice-preset-generator.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-preset-generator.test.ts
@@ -24,6 +24,7 @@ const SCRIPT = path.join(
 	"voice-preset",
 	"build-default-voice-preset.mjs",
 );
+const MAX_PLACEHOLDER_DIM = 1_073_741_817;
 
 function runGenerator(args: string[]): string {
 	return execFileSync("bun", [SCRIPT, ...args], {
@@ -136,6 +137,40 @@ describe("build-default-voice-preset.mjs", () => {
 	});
 
 	describe("fail-closed --dim / --concurrency (issue #18613)", () => {
+		it("accepts the largest format-representable --dim without allocating it", () => {
+			const out = path.join(dir, "max.bin");
+			const result = runGeneratorExpectFailure([
+				"--placeholder",
+				"--dim",
+				String(MAX_PLACEHOLDER_DIM),
+				"--out",
+				out,
+				"--probe-after-dim",
+			]);
+
+			expect(result.status).toBe(1);
+			expect(result.stderr).toMatch(/Unknown argument: --probe-after-dim/);
+			expect(result.stderr).not.toMatch(/--dim must/);
+			expect(existsSync(out)).toBe(false);
+		});
+
+		it("rejects the first unrepresentable --dim before allocation or output", () => {
+			const out = path.join(dir, "too-large.bin");
+			const result = runGeneratorExpectFailure([
+				"--placeholder",
+				"--dim",
+				String(MAX_PLACEHOLDER_DIM + 1),
+				"--out",
+				out,
+			]);
+
+			expect(result.status).toBe(1);
+			expect(result.stderr).toMatch(
+				new RegExp(`--dim.*no greater than ${MAX_PLACEHOLDER_DIM}`),
+			);
+			expect(existsSync(out)).toBe(false);
+		});
+
 		const malformedCases: Array<{
 			name: string;
 			/** Full argv after SCRIPT; must include --out pointing at a nested path. */


### PR DESCRIPTION
# Relates to

Closes #18613.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the boundary behavior from the subprocess evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@c267370f268318db7d3683552f8e5750da76ddc0`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 tasks and every repository audit passed.

# Risks

Low. This narrows only explicit placeholder `--dim` values that the v1 voice-preset layout cannot represent. Existing defaults and valid dimensions are unchanged.

# Background

## What does this PR do?

Bounds placeholder embedding dimensions using the actual v1 binary layout: a 24-byte header, Float32 embedding bytes, and a uint32 phrase-section offset. `--dim 1073741817` is the largest representable value; `1073741818` now fails during argument parsing instead of reaching `new Float32Array(...)` or wrapping a serialized offset.

The regression tests exercise max and max+1 in real Bun subprocesses. The max probe intentionally supplies a later unknown flag, proving dimension parsing succeeded while stopping before the enormous allocation. Both paths prove no output was created.

## What kind of change is this?

Bug fix (non-breaking, fail-closed CLI boundary validation).

# Documentation changes needed?

No project-documentation change is needed. The CLI header and `--help` text now state the bounded dimension contract.

# Testing

## Where should a reviewer start?

- `packages/app-core/scripts/voice-preset/build-default-voice-preset.mjs`
- `plugins/plugin-local-inference/src/services/voice/voice-preset-generator.test.ts`

## Detailed testing steps

```text
bun test plugins/plugin-local-inference/src/services/voice/voice-preset-generator.test.ts
21 pass, 0 fail, 107 assertions

bun run --cwd packages/app-core typecheck
pass

bun run --cwd plugins/plugin-local-inference typecheck
pass

bun run --cwd packages/app-core lint:check
339 files checked, pass

bun run --cwd plugins/plugin-local-inference lint:check
497 files checked, pass

bun run verify
350 successful, 350 total; all repository audits passed
```

# Evidence Gate

<!-- evidence-head:6510546b57896f0b151fa2a94e593d7845896265 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this is a command-line parser with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this is a command-line parser with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - rejection occurs before allocation or any interactive flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server or backend service is started by this CLI boundary.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model execution changes.
<!-- evidence-row:domain-artifacts -->
- [x] Real CLI subprocess transcripts and output-nonexistence checks are included below.

```text
--dim 1073741817 -> Unknown argument: --probe-after-dim; max_status=1; max_output_exists=no
--dim 1073741818 -> --dim must be a positive safe integer no greater than 1073741817
max_plus_one_status=1; max_plus_one_output_exists=no; rejection occurred before allocation and output creation
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or UI surface changes.

# Evidence Details

## Domain artifact: exact CLI boundary transcript

```text
$ ... --placeholder --dim 1073741817 --out /tmp/...-max.bin --probe-after-dim
[voice-preset] Error: Unknown argument: --probe-after-dim
max_status=1 max_output_exists=no

$ ... --placeholder --dim 1073741818 --out /tmp/...-too-large.bin
[voice-preset] Error: --dim must be a positive safe integer no greater than 1073741817 (received "1073741818")
max_plus_one_status=1 max_plus_one_output_exists=no
```

The first result proves the maximum passed `--dim` validation and reached the subsequent sentinel without allocating. The second proves max+1 failed at the parser. Neither command created output.

## Real LLM-call trajectory

N/A - deterministic CLI argument parsing only; no LLM is invoked.

## Backend + frontend logs

N/A - the command fails before importing the voice runtime and does not start backend/frontend services.

## Screenshots (before / after) + video walkthrough

N/A - the changed path has no rendered UI.

## Audio / voice walkthrough

N/A - despite owning a voice-preset file, this change exercises only numeric parsing before model/audio/runtime execution.

## Known gaps / failures

None. Hardware, model weights, audio capture, screenshots, and live services are inapplicable because the affected behavior completes before allocation and before the voice runtime import.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza"} -->
