### PR TITLE
fix(discord): resolve root with eliza-source condition

### DIFF
--- a/plugins/plugin-discord/__tests__/package-exports.test.ts
+++ b/plugins/plugin-discord/__tests__/package-exports.test.ts
@@ -1,0 +1,72 @@
+/** Verifies Discord package resolution in real Bun child processes under development and default conditions. */
+
+import { spawnSync } from "node:child_process";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const packageRoot = fileURLToPath(new URL("../", import.meta.url));
+let fixtureRoot: string;
+let installedPackageRoot: string;
+
+beforeAll(() => {
+	fixtureRoot = mkdtempSync(path.join(tmpdir(), "discord-package-exports-"));
+	installedPackageRoot = path.join(
+		fixtureRoot,
+		"node_modules/@elizaos/plugin-discord",
+	);
+	mkdirSync(path.join(installedPackageRoot, "dist"), { recursive: true });
+	writeFileSync(
+		path.join(installedPackageRoot, "package.json"),
+		readFileSync(path.join(packageRoot, "package.json")),
+	);
+	writeFileSync(path.join(installedPackageRoot, "index.ts"), "export {};\n");
+	writeFileSync(
+		path.join(installedPackageRoot, "dist/index.js"),
+		"export {};\n",
+	);
+});
+
+afterAll(() => {
+	rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+function resolvePackageRoot(conditions: string[] = []): string {
+	const result = spawnSync(
+		"bun",
+		[
+			...conditions.map((condition) => `--conditions=${condition}`),
+			"--eval",
+			"process.stdout.write(import.meta.resolve('@elizaos/plugin-discord'));",
+		],
+		{ cwd: fixtureRoot, encoding: "utf8", timeout: 30_000 },
+	);
+
+	expect(result.status, result.stderr).toBe(0);
+	return fileURLToPath(result.stdout.trim());
+}
+
+describe("@elizaos/plugin-discord package exports", () => {
+	it("resolves source for the development condition", () => {
+		expect(path.normalize(resolvePackageRoot(["eliza-source"]))).toBe(
+			path.normalize(realpathSync(path.join(installedPackageRoot, "index.ts"))),
+		);
+	});
+
+	it("keeps default package resolution on the distributable entry", () => {
+		expect(path.normalize(resolvePackageRoot())).toBe(
+			path.normalize(
+				realpathSync(path.join(installedPackageRoot, "dist/index.js")),
+			),
+		);
+	});
+});

--- a/plugins/plugin-discord/package.json
+++ b/plugins/plugin-discord/package.json
@@ -15,6 +15,11 @@
 		"./package.json": "./package.json",
 		".": {
 			"types": "./dist/index.d.ts",
+			"eliza-source": {
+				"types": "./index.ts",
+				"import": "./index.ts",
+				"default": "./index.ts"
+			},
 			"import": "./dist/index.js",
 			"default": "./dist/index.js"
 		},


### PR DESCRIPTION
# Relates to

Relates to #18737. Supersedes stale, maintainer-closed draft #18744.

This PR intentionally lands only the Discord root export-condition slice. It does not close or alter the issue author's separately claimed complementary generic stale-`dist` warning work.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop@c267370f268318db7d3683552f8e5750da76ddc0` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` pass after the final sync.
- [x] A reviewer can confirm the changed resolution behavior from the deterministic real Bun child-process test and exact-head transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based exactly on current `origin/develop@c267370f268318db7d3683552f8e5750da76ddc0`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. Only the explicit `eliza-source` development condition changes. Ordinary package resolution remains on `dist/index.js`, with a real-process regression assertion preserving that packaged/default path.

# Background

## What does this PR do?

Adds the missing root `eliza-source` export for `@elizaos/plugin-discord`, pointing development resolution at `index.ts`. A focused test installs a minimal package fixture and asks real Bun child processes to resolve the package under both source-conditioned and default execution.

## What kind of change is this?

Bug fix (non-breaking development-resolution correction).

## Why are we doing this?

The dev stack starts Bun with `--conditions=eliza-source`, while Discord's root export still selected stale `dist/index.js`. Subpath exports and peer packages already follow the source-condition contract. Maintainer review of #18744 found the two-file repair valid and minimal, then requested this current-base reland.

# Documentation changes needed?

No external documentation change is needed. The manifest now conforms to the repository's existing source-conditioned development convention.

# Testing

## Where should a reviewer start?

Start with `plugins/plugin-discord/__tests__/package-exports.test.ts`, then inspect the five-line root export condition in `plugins/plugin-discord/package.json`.

## Detailed testing steps

Pinned toolchain: Bun 1.3.14 and Node 24.15.0.

- `bun install --frozen-lockfile --ignore-scripts` — PASS; lockfile unchanged.
- `bun test plugins/plugin-discord/__tests__/package-exports.test.ts` — PASS, 2/2 tests and 4 assertions.
- `bun run --cwd plugins/plugin-discord typecheck` — PASS.
- `bun run --cwd plugins/plugin-discord lint:check` — PASS, 151 files checked with no fixes.
- `bun run --cwd plugins/plugin-discord build` — PASS.
- `bun run verify` — PASS, including all repository audits.
- `git diff --check` — PASS.

# Evidence Gate

<!-- evidence-head:7bbaaf9650efe0c744b2a70de124895569814e06 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - package export metadata has no rendered UI surface before the change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - package export metadata has no rendered UI surface after the change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic module resolution has no interactive visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service starts; the applicable exact-head real-process resolver transcript is included below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, console, network, or state transition changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - package resolution creates no persistent domain artifact; the two resolved targets are asserted directly by the focused test.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or visual text changes.

# Evidence Details

## Real Bun resolver transcript

```text
HEAD 7bbaaf9650efe0c744b2a70de124895569814e06
BASE c267370f268318db7d3683552f8e5750da76ddc0
COMMAND bun test plugins/plugin-discord/__tests__/package-exports.test.ts
PASS resolves source for the development condition -> index.ts
PASS keeps default package resolution on the distributable entry -> dist/index.js
2 pass
0 fail
4 expect() calls
```

## Real LLM-call trajectory

N/A - this is deterministic package-resolution metadata and does not change model or agent behavior.

## Backend + frontend logs

N/A - the tested boundary is local module resolution before any backend or frontend process starts.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface or interactive flow changes.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changes.

## Known gaps / failures

The fresh isolated checkout's first Discord typecheck ran before generated/internal dependency declarations existed and reported only missing workspace artifacts. After the repository build generated those declared artifacts, the exact-head Discord typecheck and root verification both passed. Root lint replayed existing non-failing warnings outside the changed package; the Discord lint is clean. No remaining failure is attributable to this PR.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [issue-18737-source-resolution-reland]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZW69CKFB49Y6T77AK0Z0H01","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T23:52:56.687Z","completed_at":"2026-08-13T00:02:16.795Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAhF2ageyJvlDoe_JCeJ8dre---IaulxsqhaiFj11CQp8","device_key_id":"46ffa292f1c2f8b4f4ab4e8a1844b1ada18e416b6c0917274238cff9af1448e9","device_signature":"1qzHrjb0EKcnDjvpD5DRa2S--JPKvhrc-Cf95cZgDkpn7Z3oCYszbikAGy4NVNM4Sz8yE2Ccbm2lSkkd5uE3Bg"}} -->