### PR TITLE
fix(app): preserve padded login timing overrides

### DIFF
--- a/packages/app/scripts/measure-anonymous-login-transfer.mjs
+++ b/packages/app/scripts/measure-anonymous-login-transfer.mjs
@@ -92,13 +92,6 @@ export function parseDecimalInt(raw, flag, opts = {}) {
       `${flag} must be a decimal integer from ${min} to ${max}, got "${raw}"`,
     );
   }
-  // Leading zeros like "08" are rejected so the canonical decimal form is
-  // unambiguous (matches other CLI gates in packages/app scripts).
-  if (raw.length > 1 && raw.startsWith("0")) {
-    throw new Error(
-      `${flag} must be a decimal integer from ${min} to ${max}, got "${raw}"`,
-    );
-  }
   const value = Number(raw);
   if (!Number.isSafeInteger(value) || value < min || value > max) {
     throw new Error(

--- a/packages/app/scripts/measure-anonymous-login-transfer.test.ts
+++ b/packages/app/scripts/measure-anonymous-login-transfer.test.ts
@@ -28,6 +28,8 @@ describe("parseDecimalInt", () => {
   it("accepts non-negative decimal integers through an explicit max", () => {
     expect(parseDecimalInt("0", "--settle-ms", { min: 0 })).toBe(0);
     expect(parseDecimalInt("1", "--timeout", { min: 1 })).toBe(1);
+    expect(parseDecimalInt("08", "--settle-ms")).toBe(8);
+    expect(parseDecimalInt("090000", "--timeout", { min: 1 })).toBe(90_000);
     expect(parseDecimalInt("6000", "--settle-ms")).toBe(6000);
     expect(
       parseDecimalInt(String(MAX_TIMER_DELAY_MS), "--timeout", {
@@ -47,7 +49,6 @@ describe("parseDecimalInt", () => {
     "1e3",
     "+2",
     " 3",
-    "08",
     "NaN",
     "Infinity",
     "--url",
@@ -92,6 +93,19 @@ describe("parseArgs --settle-ms / --timeout", () => {
     expect(args.settleMs).toBe(0);
     expect(args.timeout).toBe(5000);
     expect(args.url).toBe("http://127.0.0.1:4173/login");
+  });
+
+  it("preserves complete decimal overrides with leading zeros", () => {
+    const args = parseArgs([
+      "node",
+      "measure-anonymous-login-transfer.mjs",
+      "--settle-ms",
+      "08",
+      "--timeout",
+      "090000",
+    ]);
+    expect(args.settleMs).toBe(8);
+    expect(args.timeout).toBe(90_000);
   });
 
   it("fails closed when --settle-ms is missing or malformed", () => {
@@ -240,9 +254,9 @@ describe("measure-anonymous-login-transfer CLI", () => {
         [
           linkedScript,
           "--settle-ms",
-          "0",
+          "08",
           "--timeout",
-          "1",
+          "000001",
           "--url",
           "http://127.0.0.1:9/login",
         ],
@@ -250,6 +264,7 @@ describe("measure-anonymous-login-transfer CLI", () => {
       );
       expect(valid.status).not.toBe(0);
       expect(valid.stdout).toMatch(/Measuring cold \/login/);
+      expect(valid.stdout).toMatch(/settleMs=8/);
       expect(valid.stderr).not.toMatch(/--settle-ms|--timeout/);
     } finally {
       rmSync(directory, { recursive: true, force: true });


### PR DESCRIPTION
# Relates to

Closes #18611.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the executable behavior from the CLI transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@c267370f268318db7d3683552f8e5750da76ddc0`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 tasks and all repository audits passed.

# Risks

Low. The parser still requires an all-decimal string, a safe integer, and the existing per-flag timer range. This only restores the pre-fix interpretation of zero-padded decimal overrides.

# Background

## What does this PR do?

Restores valid complete-decimal compatibility for the login-transfer measurement CLI: `--settle-ms 08` resolves to 8 and `--timeout 090000` resolves to 90000. Malformed strings, signs, fractions, zero timeout, and values above the timer ceiling still fail closed.

The real-process regression uses the repaired symlink entrypoint, so it simultaneously proves zero-padded values enter measurement and symlink invocation remains functional.

## What kind of change is this?

Bug fix (non-breaking CLI compatibility correction).

# Documentation changes needed?

No. The existing help contract already says “complete decimal integers,” which includes zero-padded decimal spellings.

# Testing

## Where should a reviewer start?

- `packages/app/scripts/measure-anonymous-login-transfer.mjs`
- `packages/app/scripts/measure-anonymous-login-transfer.test.ts`

## Detailed testing steps

```text
bun test packages/app/scripts/measure-anonymous-login-transfer.test.ts
24 pass, 0 fail, 54 assertions

bun run --cwd packages/app typecheck
pass

bun run --cwd packages/app lint
289 files checked, no fixes required

bun run verify
350 successful, 350 total; all repository audits passed
```

`bun run --cwd packages/app audit:app` was also run because the touched script is package-owned. It captured 215 cases: 214 passed and the final global ratchet failed on four unrelated existing views. Exact details are in **Known gaps / failures**. No rendered file is changed by this PR.

# Evidence Gate

<!-- evidence-head:d3e1087f8cd3ace523256e2f90560909aba163f2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - only a Node measurement CLI parser and its test change; no rendered UI file changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - only a Node measurement CLI parser and its test change; no rendered UI file changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a terminal-only argument compatibility path.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend server behavior changes; the real CLI transcript is below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console, network, request, or state behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Real executable transcript proves padded values reach measurement with the expected numeric value.

```text
$ node packages/app/scripts/measure-anonymous-login-transfer.mjs --settle-ms 08 --timeout 000001 --url http://127.0.0.1:9/login
Measuring cold /login: url=http://127.0.0.1:9/login settleMs=8 sw=blocked cache=empty head=d3e1087f8cd3ace523256e2f90560909aba163f2
[login-transfer] page.goto: Timeout 1ms exceeded.
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered UI changes.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic numeric parsing only.

## Backend + frontend logs

N/A - no backend/frontend application surface changes. The subprocess transcript above is the affected runtime boundary.

## Screenshots (before / after) + video walkthrough

N/A - the diff contains only `packages/app/scripts/*.mjs` and its focused test.

## Audio / voice walkthrough

N/A - no audio or voice surface changes.

## Known gaps / failures

`bun run --cwd packages/app audit:app` completed 214/215 captures, then the global minimalism ratchet reported four unrelated current-tree findings:

```text
builtin-browser mobile-portrait: border/divider density 60.76 > 45.00
builtin-browser mobile-landscape: border/divider density 60.76 > 45.00
builtin-plugins mobile-portrait: 88.10 > baselined 75.95 + 5% tolerance
builtin-trajectories mobile-landscape: border/divider density 51.65 > 45.00
```

This PR changes no app source, styling, view, baseline, or screenshot. Updating those unrelated views or refreshing their baseline would hide a separate problem and is intentionally out of scope. Root `bun run verify`, app typecheck/lint, and all 24 affected tests pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza"} -->