### PR TITLE
fix(agent): cap capability router request timeout

### DIFF
--- a/packages/agent/src/services/remote-capability-router.test.ts
+++ b/packages/agent/src/services/remote-capability-router.test.ts
@@ -28,6 +28,7 @@ const originalFetch = globalThis.fetch;
 describe("remote capability router", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
   });
 
   it("resolves canonical env names", () => {
@@ -67,6 +68,55 @@ describe("remote capability router", () => {
 
     expect(config.requestTimeoutMs).toBe(60_000);
   });
+
+  it.each([
+    ["runtime timer maximum", "2147483647", 2_147_483_647],
+    ["above runtime timer maximum", "2147483648", 60_000],
+  ])("resolves %s timeout", (_description, value, expected) => {
+    const config = resolveRemoteCapabilityRouterConfig(
+      makeRuntime({ ELIZA_CAPABILITY_ROUTER_TIMEOUT_MS: value }),
+    );
+
+    expect(config.requestTimeoutMs).toBe(expected);
+  });
+
+  it.each([
+    ["runtime timer maximum", 2_147_483_647, 2_147_483_647],
+    ["above runtime timer maximum", 2_147_483_648, 60_000],
+  ])(
+    "uses %s at the request timer boundary",
+    async (_description, value, expected) => {
+      globalThis.fetch = vi.fn(async () =>
+        jsonResponse({
+          environment: "server",
+          available: true,
+          capabilities: {
+            fs: true,
+            pty: true,
+            git: true,
+            model: true,
+            plugin: true,
+          },
+        }),
+      ) as unknown as typeof fetch;
+      const setTimeoutSpy = vi
+        .spyOn(globalThis, "setTimeout")
+        .mockImplementation((() => 1) as unknown as typeof setTimeout);
+      const service = new RemoteCapabilityRouterService(makeRuntime(), {
+        enabled: true,
+        baseUrl: "https://capability.example",
+        environment: "server",
+        requestTimeoutMs: value,
+      });
+
+      await service.availability();
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        expected,
+      );
+    },
+  );
 
   it("resolves multiple canonical remote endpoint URLs", () => {
     const config = resolveRemoteCapabilityRouterConfig(

--- a/packages/agent/src/services/remote-capability-router.ts
+++ b/packages/agent/src/services/remote-capability-router.ts
@@ -61,6 +61,7 @@ import {
 import { parsePositiveInteger } from "@elizaos/shared";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+const MAX_REQUEST_TIMEOUT_MS = 2_147_483_647;
 
 export type RemoteCapabilityEndpointConfig = {
   id: string;
@@ -94,6 +95,7 @@ export class RemoteCapabilityRouterService
 
   private readonly broker: RuntimeBrokerCapabilityRouter;
   private readonly endpoints: RemoteCapabilityEndpointConfig[];
+  private readonly routerConfig: RemoteCapabilityRouterConfig;
   private readonly moduleEndpointById = new Map<
     string,
     RemoteCapabilityEndpointConfig
@@ -101,7 +103,7 @@ export class RemoteCapabilityRouterService
 
   constructor(
     runtime?: IAgentRuntime,
-    private readonly routerConfig: RemoteCapabilityRouterConfig = runtime
+    routerConfig: RemoteCapabilityRouterConfig = runtime
       ? resolveRemoteCapabilityRouterConfig(runtime)
       : (undefined as never),
   ) {
@@ -112,6 +114,12 @@ export class RemoteCapabilityRouterService
       });
     }
     super(runtime);
+    this.routerConfig = {
+      ...routerConfig,
+      requestTimeoutMs: normalizeRequestTimeoutMs(
+        routerConfig.requestTimeoutMs,
+      ),
+    };
     this.environment = routerConfig.environment;
     this.broker = new RuntimeBrokerCapabilityRouter({
       environment: routerConfig.environment,
@@ -377,6 +385,9 @@ export function resolveRemoteCapabilityRouterConfig(
     parseBoolean(get("ELIZA_CAPABILITY_ROUTER_ENABLED")) ??
     parseBoolean(get("ELIZA_REMOTE_CAPABILITY_ENABLED")) ??
     (Boolean(baseUrl) || endpoints.length > 0);
+  const requestTimeoutMs = parsePositiveInteger(
+    get("ELIZA_CAPABILITY_ROUTER_TIMEOUT_MS"),
+  );
   return {
     enabled,
     baseUrl: baseUrl ? stripTrailingSlash(baseUrl) : undefined,
@@ -386,10 +397,17 @@ export function resolveRemoteCapabilityRouterConfig(
     ...(endpoints.length === 0 ? {} : { endpoints }),
     environment:
       parseEnvironment(get("ELIZA_CAPABILITY_ROUTER_ENVIRONMENT")) ?? "server",
-    requestTimeoutMs:
-      parsePositiveInteger(get("ELIZA_CAPABILITY_ROUTER_TIMEOUT_MS")) ??
-      DEFAULT_REQUEST_TIMEOUT_MS,
+    requestTimeoutMs: normalizeRequestTimeoutMs(requestTimeoutMs),
   };
+}
+
+function normalizeRequestTimeoutMs(value: number | undefined): number {
+  return value !== undefined &&
+    Number.isSafeInteger(value) &&
+    value > 0 &&
+    value <= MAX_REQUEST_TIMEOUT_MS
+    ? value
+    : DEFAULT_REQUEST_TIMEOUT_MS;
 }
 
 export type RemoteCapabilityServer = {


### PR DESCRIPTION
# Relates to

Closes #18723.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change from the focused router-boundary test evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`, `openai/gpt-5.6-luna`
<!-- attribution-row:client -->
- Agent tooling: `Pi`, `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on latest `origin/develop` `c267370f268318db7d3683552f8e5750da76ddc0`; zero conflicts.
- [x] `bun run verify` passes after install and sync.

# Risks

Low. The change only normalizes the remote capability router request timeout before any constructor path can pass it to the runtime timer. Valid timeouts through `2_147_483_647` are unchanged; larger or otherwise invalid numeric values use the existing 60-second fallback.

# Background

## What does this PR do?

- Enforces the Bun/Node `setTimeout` ceiling of `2_147_483_647` ms in `RemoteCapabilityRouterService`.
- Applies the same limit to environment config resolution.
- Keeps the public router config shape and 60-second fallback unchanged.
- Adds exact max/max+1 tests at both the config resolver and real `availability()` timer boundary.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No. The environment variable, public config shape, and documented default do not change.

# Testing

## Where should a reviewer start?

1. `packages/agent/src/services/remote-capability-router.ts`
2. `packages/agent/src/services/remote-capability-router.test.ts`

## Detailed testing steps

```bash
bun install --frozen-lockfile --minimum-release-age=0
bunx vitest run packages/agent/src/services/remote-capability-router.test.ts --coverage.enabled=false
bun run --cwd packages/agent test
bun run --cwd packages/agent typecheck
bunx @biomejs/biome check packages/agent/src/services/remote-capability-router.ts packages/agent/src/services/remote-capability-router.test.ts
bun run verify
```

Exact-head results:

```text
Focused router suite: 28 passed, 0 failed.
Agent package lane: 397/397 test files passed.
Agent typecheck: passed.
Biome: 2 changed files checked, no fixes needed.
Frozen install: 112 packages installed; no manifest or lockfile change.
Root verify: 350/350 tasks passed; all following audits passed.
git diff --check: passed.
```

# Evidence Gate

<!-- evidence-head:d9c65abf2ddef1256d6bc8f0490ee571a06279a4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - request timeout normalization has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - request timeout normalization has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic timer-boundary coverage calls RemoteCapabilityRouterService.availability() and inspects the exact setTimeout delay; no live backend is required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, or agent decision behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - timeout normalization creates no persisted domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic numeric validation and timer setup only.

## Backend + frontend logs

N/A - no live backend or frontend is required. The focused test calls `RemoteCapabilityRouterService.availability()` and verifies the exact delay passed to `setTimeout` for max and max+1 values.

## Screenshots (before / after) + video walkthrough

N/A - no UI source or rendered surface changes.

## Audio / voice walkthrough

N/A - no audio surface.

## Known gaps / failures

- Initial install attempts inherited the contributor machine's untracked `~/.bunfig.toml` seven-day release-age policy and rejected current locked dependencies. The successful required install used `--frozen-lockfile --minimum-release-age=0`, changed no repository config, manifest, or lockfile, and was followed by all focused, package, and root checks above.
- Screenshots, video, OCR, live backend logs, domain artifacts, and LLM trajectories are N/A because this is a deterministic server-side timeout normalization change with no rendered, persisted, or model-driven surface.


AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [pi-gpt-5-6-sol]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZW5X7NSVTYRYNKAM33GCTHM","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T23:46:18.426Z","completed_at":"2026-08-13T00:13:42.678Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAxa1JY4P2PV9nCLf2LboHBoyxB3rMeHhq-cgfBBLbaes","device_key_id":"86353a99076b4a43820c828ffca47429f5faaa82f28636b0d58364b4f5269279","device_signature":"l3-aA31JlEHnT8WPa2GF0FsVbUCFUofNmQvbMZBnmhXaMGhg3bagC5xdRv_iRbn1HnnDzdw8K32PjIG7xwJuAg"}} -->


