### PR TITLE
fix(app): preserve startup trace CLI entry semantics

### DIFF
--- a/packages/app/scripts/capture-startup-trace.mjs
+++ b/packages/app/scripts/capture-startup-trace.mjs
@@ -30,7 +30,7 @@
  * model key or a running agent, so it is safe to run in CI behind a dev server.
  */
 
-import { writeFileSync } from "node:fs";
+import { realpathSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
@@ -56,7 +56,7 @@ export function parsePositiveInt(raw, flag, opts = {}) {
       `${flag} requires a positive decimal integer from 1 to ${max}`,
     );
   }
-  if (!/^[1-9]\d*$/.test(raw)) {
+  if (!/^\d+$/.test(raw)) {
     throw new Error(
       `${flag} must be a positive decimal integer from 1 to ${max}, got "${raw}"`,
     );
@@ -253,11 +253,20 @@ async function main(argv = process.argv) {
   process.exit(anyOk ? 0 : 1);
 }
 
-const isMain =
-  process.argv[1] &&
-  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+function isDirectRun(entryPath) {
+  if (!entryPath) return false;
+  try {
+    return (
+      realpathSync(path.resolve(entryPath)) ===
+      realpathSync(fileURLToPath(import.meta.url))
+    );
+  } catch {
+    // error-policy:J3 an unresolved argv entry is not this module's CLI path
+    return false;
+  }
+}
 
-if (isMain) {
+if (isDirectRun(process.argv[1])) {
   // error-policy:J1 CLI boundary — invalid flags and capture failures exit
   // non-zero with a legible message instead of an unhandled rejection.
   main().catch((err) => {

--- a/packages/app/scripts/capture-startup-trace.test.ts
+++ b/packages/app/scripts/capture-startup-trace.test.ts
@@ -4,6 +4,8 @@
  * Chromium launches, so subprocess cases never need a renderer or browser.
  */
 import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -21,7 +23,9 @@ const SCRIPT_PATH = path.join(import.meta.dirname, "capture-startup-trace.mjs");
 describe("parsePositiveInt", () => {
   it("accepts positive decimal integers", () => {
     expect(parsePositiveInt("1", "--runs")).toBe(1);
+    expect(parsePositiveInt("01", "--runs")).toBe(1);
     expect(parsePositiveInt("42", "--runs")).toBe(42);
+    expect(parsePositiveInt("00042", "--runs")).toBe(42);
     expect(parsePositiveInt("60000", "--timeout")).toBe(60_000);
   });
 
@@ -81,6 +85,19 @@ describe("parseArgs --runs / --timeout", () => {
     expect(args.url).toBe("http://127.0.0.1:2138");
   });
 
+  it("preserves complete positive decimal overrides with leading zeros", () => {
+    const args = parseArgs([
+      "node",
+      "capture-startup-trace.mjs",
+      "--runs",
+      "02",
+      "--timeout",
+      "005000",
+    ]);
+    expect(args.runs).toBe(2);
+    expect(args.timeout).toBe(5000);
+  });
+
   it("fails closed when --runs is missing or malformed", () => {
     expect(() =>
       parseArgs(["node", "capture-startup-trace.mjs", "--runs"]),
@@ -130,6 +147,7 @@ describe("CLI --runs / --timeout fail-closed", () => {
   function runCli(extraArgs: string[]) {
     return spawnSync(process.execPath, [SCRIPT_PATH, ...extraArgs], {
       encoding: "utf8",
+      timeout: 15_000,
     });
   }
 
@@ -154,6 +172,38 @@ describe("CLI --runs / --timeout fail-closed", () => {
       expect(result.stdout, args.join(" ")).not.toMatch(
         /Capturing startup trace:/,
       );
+    }
+  }, 30_000);
+
+  it("enters capture through a symlink with zero-padded valid values", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "startup-trace-link-"));
+    const linkedScript = path.join(directory, "capture-trace.mjs");
+    const out = path.join(directory, "trace.json");
+    try {
+      symlinkSync(SCRIPT_PATH, linkedScript);
+      const result = spawnSync(
+        process.execPath,
+        [
+          linkedScript,
+          "--runs",
+          "01",
+          "--timeout",
+          "000001",
+          "--url",
+          "http://127.0.0.1:1",
+          "--out",
+          out,
+        ],
+        { encoding: "utf8", timeout: 15_000 },
+      );
+
+      expect(result.status).not.toBe(0);
+      expect(result.stdout).toMatch(/Capturing startup trace:/);
+      expect(result.stdout).toMatch(/runs=1/);
+      expect(result.stderr).not.toMatch(/--runs|--timeout/);
+      expect(existsSync(out)).toBe(false);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
# Relates to

Closes #18609.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the executable behavior from the symlink transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@c267370f268318db7d3683552f8e5750da76ddc0`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 tasks and all repository audits passed.

# Risks

Low. Numeric inputs remain full-string decimal, safe-integer, positive, and timer-bounded. Entrypoint identity now resolves symlinks instead of silently skipping valid CLI invocations.

# Background

## What does this PR do?

Restores the issue’s “complete positive decimal” contract (`01` and `005000` are valid decimal spellings) while retaining strict rejection of suffixes, signs, fractions, zero, missing values, and timer overflow.

It also makes direct-entry detection realpath-aware. Invoking the script through a symlink now runs capture and reports its actual success/failure instead of exiting 0 without stdout, stderr, or an artifact.

The aggregate subprocess regression now explicitly bounds each child at 15 seconds and allows 30 seconds for all 11 cold-import probes. This does not retry or mask failures: a stuck child is killed and fails the assertions, while slower cold CI imports no longer get mistaken for missing parser stderr.

## What kind of change is this?

Bug fix (non-breaking CLI compatibility and entrypoint correction).

# Documentation changes needed?

No. The existing CLI contract already says positive decimal integers; the implementation is brought back into agreement.

# Testing

## Where should a reviewer start?

- `packages/app/scripts/capture-startup-trace.mjs`
- `packages/app/scripts/capture-startup-trace.test.ts`

## Detailed testing steps

```text
bun test packages/app/scripts/capture-startup-trace.test.ts
20 pass, 0 fail, 72 assertions

bun run --cwd packages/app typecheck
pass

bun run --cwd packages/app lint
289 files checked, no fixes required

bun run verify
350 successful, 350 total; all repository audits passed
```

The app visual audit was run in this same current-develop triage batch against the identical rendered tree (both heads differ from `c267370...` only under `packages/app/scripts`). It captured 215 cases; 214 passed and the global ratchet reported four unrelated current-tree minimalism findings listed below. No rendered source changes in this PR.

# Evidence Gate

<!-- evidence-head:d630afbd9075b44105d6406beb710fbb3ea2ab98 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - only a Node capture CLI and its test change; no rendered UI file changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - only a Node capture CLI and its test change; no rendered UI file changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a terminal-only argument and executable-entry path.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend server changes; the real CLI transcript is below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console, network, request, or state behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Real symlinked executable transcript proves padded values enter capture and no false artifact is emitted.

```text
$ node /tmp/.../capture-trace.mjs --runs 01 --timeout 000001 --url http://127.0.0.1:1 --out /tmp/.../trace.json
Capturing startup trace: url=http://127.0.0.1:1 runs=1 waitFor=startup-shell:first-paint|startup-shell:mounted
[startup-trace] page.goto: Timeout 1ms exceeded.
exit_status=1 artifact_exists=no
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered UI changes.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic CLI parsing and entrypoint identity only.

## Backend + frontend logs

N/A - no backend/frontend application behavior changes. The subprocess transcript above exercises the affected runtime boundary.

## Screenshots (before / after) + video walkthrough

N/A - the diff contains only `packages/app/scripts/*.mjs` and its focused test.

## Audio / voice walkthrough

N/A - no audio or voice surface changes.

## Known gaps / failures

The global app aesthetic audit’s existing findings were:

```text
builtin-browser mobile-portrait: border/divider density 60.76 > 45.00
builtin-browser mobile-landscape: border/divider density 60.76 > 45.00
builtin-plugins mobile-portrait: 88.10 > baselined 75.95 + 5% tolerance
builtin-trajectories mobile-landscape: border/divider density 51.65 > 45.00
```

This PR changes no app source, styling, view, baseline, or screenshot. Updating unrelated views or refreshing their baseline would conceal a separate problem and is intentionally out of scope. Root `bun run verify`, app typecheck/lint, and all 20 affected tests pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza"} -->