### PR TITLE
fix(ui): guard formatTime and unify the date/time fallback contract

### DIFF
--- a/packages/app/test/ui-smoke/agent-detail-invalid-date-capture.spec.ts
+++ b/packages/app/test/ui-smoke/agent-detail-invalid-date-capture.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Targeted before/after capture for the AgentDetailPage invalid-timestamp
+ * fallback fix (#18812) — reuses the same auth/API-stub infrastructure as
+ * the general cloud-surfaces audit, but overrides the agent-detail response
+ * with a malformed createdAt/lastHeartbeatAt to demonstrate the actual
+ * defect and its fix, rather than the healthy/valid-data path the general
+ * audit fixture exercises.
+ */
+import { expect, test } from "@playwright/test";
+import {
+  installCloudApiStubs,
+  seedStewardToken,
+} from "./helpers/cloud-audit-fixtures";
+
+test.use({ video: "on" });
+
+test("agent detail page renders explicit fallbacks for a malformed agent timestamp", async ({
+  page,
+}) => {
+  await seedStewardToken(page);
+  await installCloudApiStubs(page);
+  await page.route("**/api/v1/eliza/agents/agent-smoke-1", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: {
+          id: "agent-smoke-1",
+          agentName: "Smoke Agent",
+          agent_name: "Smoke Agent",
+          status: "running",
+          executionTier: "standard",
+          databaseStatus: "ready",
+          webUiUrl: null,
+          bridgeUrl: null,
+          errorMessage: null,
+          createdAt: "not-a-date",
+          created_at: "not-a-date",
+          updatedAt: "not-a-date",
+          lastHeartbeatAt: "not-a-date",
+          lastActiveAt: "not-a-date",
+        },
+      }),
+    });
+  });
+
+  await page.goto("/dashboard/agents/agent-smoke-1", {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForSelector("text=Smoke Agent", { timeout: 15_000 });
+  await page.waitForTimeout(500);
+
+  const bodyText = await page.textContent("body");
+  expect(bodyText).not.toContain("Invalid Date");
+
+  await page.screenshot({
+    path: "test-results/agent-detail-invalid-date-capture.png",
+    fullPage: true,
+  });
+
+  await page.mouse.wheel(0, 300);
+  await page.waitForTimeout(600);
+  await page.mouse.wheel(0, -300);
+  await page.waitForTimeout(600);
+});

--- a/packages/ui/src/cloud/instances/AgentDetailPage.test.tsx
+++ b/packages/ui/src/cloud/instances/AgentDetailPage.test.tsx
@@ -1,13 +1,117 @@
-/** Verifies agent detail date formatting rejects malformed API timestamps. */
-import { describe, expect, it, vi } from "vitest";
-import { formatDate, formatRelativeShort } from "./AgentDetailPage";
+/** Verifies agent detail rendering rejects malformed API timestamps. */
+// @vitest-environment jsdom
+
+import type { AgentDetailDto } from "@elizaos/cloud-shared/lib/types/cloud-api";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../shell/CloudI18nProvider", () => ({
+  useCloudT:
+    () => (_key: string, options?: { defaultValue?: string; n?: number }) =>
+      (options?.defaultValue ?? _key).replace("{{n}}", String(options?.n)),
+}));
+
+vi.mock("../lib/use-session-auth", () => ({
+  useSessionAuth: () => ({
+    ready: true,
+    authenticated: true,
+    user: { id: "u1", email: "a@b.test" },
+  }),
+}));
+
+vi.mock("../lib/use-document-title", () => ({
+  useDocumentTitle: vi.fn(),
+}));
+
+const agentState: {
+  data: AgentDetailDto;
+  isLoading: boolean;
+  error: Error | null;
+} = {
+  data: {} as AgentDetailDto,
+  isLoading: false,
+  error: null,
+};
+
+vi.mock("./lib/data/eliza-agents", () => ({
+  useAgent: () => agentState,
+}));
+
+vi.mock("./components/agent-actions", () => ({
+  ElizaAgentActions: () => null,
+}));
+vi.mock("./components/docker-logs-viewer", () => ({
+  DockerLogsViewer: () => null,
+}));
+vi.mock("./components/eliza-agent-backups-panel", () => ({
+  ElizaAgentBackupsPanel: () => null,
+}));
+vi.mock("./components/eliza-agent-logs-viewer", () => ({
+  ElizaAgentLogsViewer: () => null,
+}));
+vi.mock("./components/eliza-agent-tabs", () => ({
+  ElizaAgentTabs: () => null,
+}));
+vi.mock("./components/eliza-connect-button", () => ({
+  ElizaConnectButton: () => null,
+}));
+
+import { PageHeaderProvider } from "../../cloud-ui/components/layout";
+import AgentDetailPage, {
+  formatDate,
+  formatRelativeShort,
+} from "./AgentDetailPage";
 
 const t = vi.fn(
   (_key: string, options?: { defaultValue?: string }) =>
     options?.defaultValue ?? _key,
 ) as never;
 
+const baseAgent: AgentDetailDto = {
+  id: "test-agent-1",
+  agentName: "Timestamp Test Agent",
+  status: "running",
+  databaseStatus: "ready",
+  lastBackupAt: null,
+  lastHeartbeatAt: "2026-08-12T11:30:00.000Z",
+  errorMessage: null,
+  createdAt: "2026-08-11T09:15:00.000Z",
+  updatedAt: "2026-08-12T11:30:00.000Z",
+  token_address: null,
+  token_chain: null,
+  token_name: null,
+  token_ticker: null,
+  dockerImage: null,
+  executionTier: "shared",
+  webUiUrl: null,
+  bridgeUrl: null,
+  errorCount: 0,
+  walletAddress: null,
+  walletProvider: null,
+  walletStatus: "none",
+  adminDetails: null,
+};
+
+function renderPage(agent: AgentDetailDto) {
+  agentState.data = agent;
+  return render(
+    <MemoryRouter initialEntries={["/dashboard/agents/test-agent-1"]}>
+      <PageHeaderProvider>
+        <Routes>
+          <Route path="/dashboard/agents/:id" element={<AgentDetailPage />} />
+        </Routes>
+      </PageHeaderProvider>
+    </MemoryRouter>,
+  );
+}
+
 describe("AgentDetailPage date formatting", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
   it("renders an unavailable fallback for malformed non-null dates", async () => {
     expect(formatDate("not-a-date")).toBe("—");
     expect(formatRelativeShort("not-a-date", t)).toBe("Never");
@@ -17,5 +121,55 @@ describe("AgentDetailPage date formatting", () => {
     expect(formatDate(null)).toBe("—");
     expect(formatRelativeShort(null, t)).toBe("Never");
     expect(formatRelativeShort(new Date().toISOString(), t)).toBe("Just now");
+  });
+
+  it("renders intentional fallbacks for malformed non-null timestamps", () => {
+    const { container } = renderPage({
+      ...baseAgent,
+      createdAt: "not-a-date",
+      lastHeartbeatAt: "not-a-date",
+    });
+
+    expect(container.textContent).not.toContain("Invalid Date");
+    expect(screen.getAllByText("—")).toHaveLength(2);
+    expect(screen.getByText("Never")).toBeTruthy();
+  });
+
+  it("renders intentional fallbacks outside the ECMAScript TimeClip range", () => {
+    const outsideTimeClipRange = "+275760-09-13T00:00:00.001Z";
+    expect(Number.isNaN(new Date(outsideTimeClipRange).getTime())).toBe(true);
+
+    const { container } = renderPage({
+      ...baseAgent,
+      createdAt: outsideTimeClipRange,
+      lastHeartbeatAt: outsideTimeClipRange,
+    });
+
+    expect(container.textContent).not.toContain("Invalid Date");
+    expect(screen.getAllByText("—")).toHaveLength(2);
+    expect(screen.getByText("Never")).toBeTruthy();
+  });
+
+  it("preserves ordinary rendered date, time, and relative-time values", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-12T12:00:00.000Z"));
+    const createdAt = "2026-08-11T09:15:00.000Z";
+    const lastHeartbeatAt = "2026-08-12T11:30:00.000Z";
+
+    renderPage({ ...baseAgent, createdAt, lastHeartbeatAt });
+
+    expect(screen.getByText(formatDate(createdAt))).toBeTruthy();
+    expect(
+      screen.getByText(
+        new Date(createdAt).toLocaleTimeString(undefined, {
+          hour: "2-digit",
+          minute: "2-digit",
+        }),
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("30m ago")).toBeTruthy();
+    expect(screen.getByText(formatDate(lastHeartbeatAt))).toBeTruthy();
+    expect(screen.queryByText("—")).toBeNull();
+    expect(screen.queryByText("Never")).toBeNull();
   });
 });

--- a/packages/ui/src/cloud/instances/AgentDetailPage.test.tsx
+++ b/packages/ui/src/cloud/instances/AgentDetailPage.test.tsx
@@ -131,7 +131,7 @@ describe("AgentDetailPage date formatting", () => {
     });
 
     expect(container.textContent).not.toContain("Invalid Date");
-    expect(screen.getAllByText("—")).toHaveLength(2);
+    expect(screen.getAllByText("—")).toHaveLength(3);
     expect(screen.getByText("Never")).toBeTruthy();
   });
 
@@ -146,7 +146,7 @@ describe("AgentDetailPage date formatting", () => {
     });
 
     expect(container.textContent).not.toContain("Invalid Date");
-    expect(screen.getAllByText("—")).toHaveLength(2);
+    expect(screen.getAllByText("—")).toHaveLength(3);
     expect(screen.getByText("Never")).toBeTruthy();
   });
 

--- a/packages/ui/src/cloud/instances/AgentDetailPage.tsx
+++ b/packages/ui/src/cloud/instances/AgentDetailPage.tsx
@@ -47,7 +47,9 @@ export function formatDate(date: string | null): string {
 
 function formatTime(date: string | null): string {
   if (!date) return "";
-  return new Date(date).toLocaleTimeString(undefined, {
+  const timestamp = new Date(date).getTime();
+  if (!Number.isFinite(timestamp)) return "";
+  return new Date(timestamp).toLocaleTimeString(undefined, {
     hour: "2-digit",
     minute: "2-digit",
   });

--- a/packages/ui/src/cloud/instances/AgentDetailPage.tsx
+++ b/packages/ui/src/cloud/instances/AgentDetailPage.tsx
@@ -46,9 +46,9 @@ export function formatDate(date: string | null): string {
 }
 
 function formatTime(date: string | null): string {
-  if (!date) return "";
+  if (!date) return "—";
   const timestamp = new Date(date).getTime();
-  if (!Number.isFinite(timestamp)) return "";
+  if (!Number.isFinite(timestamp)) return "—";
   return new Date(timestamp).toLocaleTimeString(undefined, {
     hour: "2-digit",
     minute: "2-digit",


### PR DESCRIPTION
# Relates to

Closes #18812. Re-opened as a new PR from `#18828` (`fix/agent-detail-invalid-time`), which the maintainer (`lalalune`) closed as incomplete — GitHub did not allow reopening the original closed PR (`reopenPullRequest` API call failed), so this is a fresh PR from the same branch with the requested work now done, rather than a duplicate.

Follow-up to merged #18727 and #18786. Reviewing #18786, the maintainer found a third instance of the same bug class in this file — `formatTime` had no guard at all — and opened #18812. Closing #18828, the maintainer additionally flagged that the fallback contract itself needed fixing (a blank string reads as a rendering glitch next to a visible `"—"` date, not a deliberate unavailable state) and that the evidence gate (real screenshots/video/OCR/app-audit) was still outstanding. Both are addressed below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun run verify` was run; it fails on an unrelated, pre-existing issue (see Known gaps). The scoped equivalent for everything this change touches passes clean (see Testing).
- [x] A reviewer can confirm the change works without reading the code, from the real screenshots/video and focused regression tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` fails at `@elizaos/plugin-workflow#lint:check` — confirmed pre-existing and unrelated by reproducing the identical failure against unmodified `origin/develop` content for that package, independent of this branch. The scoped equivalent (`typecheck`+`lint:check` for `@elizaos/ui` and its full dependency graph, the actual substance of `verify`'s turbo step) passes 58/58 clean — see Testing.

# Risks

Low-medium. Two local formatting helpers, one behavior change beyond pure bug-fixing: `formatTime`'s fallback changed from `""` to `"—"` for **both** the null and invalid cases, at the maintainer's explicit request, to give the date/time pair one shared, visible "unavailable" contract instead of a blank line next to a dash. This is a deliberate, disclosed UX change, not an oversight — verified with a full old-vs-new input sweep (below); every valid/edge-but-valid input renders unchanged, only the fallback string itself moved from invisible to visible.

# Background

## What does this PR do?

1. `formatTime` now guards on `Number.isFinite(timestamp)` and returns `"—"` (matching `formatDate`'s existing fallback) for both `null` and malformed/out-of-range input, instead of returning `""` for null and literally `"Invalid Date"` for malformed input.
2. Adds a real component-level render regression for `AgentDetailPage` itself (not just the exported helper functions), per the maintainer's explicit ask in #18812 — following the existing page-level test convention in `DashboardHomePage.test.tsx` (mocked `useSessionAuth`, `MemoryRouter`/`Routes`/`PageHeaderProvider`). Mocks `useAgent` and the page's heavier sub-components to isolate the date/time-formatting behavior in the page's own top-level JSX, then asserts:
   - malformed `createdAt`/`lastHeartbeatAt` → no `"Invalid Date"` text anywhere in the rendered container, three `"—"` fallbacks present;
   - a value outside the ECMAScript `Date` TimeClip range → same;
   - ordinary valid timestamps → the real formatted date/time/relative-time strings render unchanged (control case).
3. Adds a real, targeted Playwright capture (`packages/app/test/ui-smoke/agent-detail-invalid-date-capture.spec.ts`) that renders the actual `AgentDetailPage` through the production renderer build against a malformed-timestamp API fixture and asserts no `"Invalid Date"` text renders — this is what produced the before/after screenshots and video below.

## What kind of change is this?

Bug fix (non-breaking), with one disclosed fallback-string UX change.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

1. `packages/ui/src/cloud/instances/AgentDetailPage.tsx` (`formatTime`)
2. `packages/ui/src/cloud/instances/AgentDetailPage.test.tsx`
3. `packages/app/test/ui-smoke/agent-detail-invalid-date-capture.spec.ts` (new — the real production-render capture used for the evidence below)

## Detailed testing steps

```text
bun run --cwd packages/ui test -- src/cloud/instances/AgentDetailPage.test.tsx
Test Files  1 passed (1)
     Tests  5 passed (5)

bunx @biomejs/biome check packages/ui/src/cloud/instances/AgentDetailPage.tsx packages/ui/src/cloud/instances/AgentDetailPage.test.tsx
Checked 2 files. No fixes applied.

tsc --noEmit -p tsconfig.json
exit 0
```

Scoped verify (the actual typecheck+lint:check turbo step `bun run verify` runs, scoped to this change's full dependency graph, since full-repo `verify` hits an unrelated pre-existing failure — see Known gaps):

```text
node packages/scripts/run-turbo.mjs run typecheck lint:check --filter=@elizaos/ui --concurrency=8
Tasks: 58 successful, 58 total
```

Real production-render capture, against the actual built `packages/app` renderer (`VITE_PLAYWRIGHT_TEST_AUTH=true bun run build:web`), driven by a real malformed-timestamp API fixture — not a unit test:

```text
VITE_PLAYWRIGHT_TEST_AUTH=true node scripts/run-ui-playwright.mjs \
  --config playwright.ui-smoke.config.ts --project=chromium \
  test/ui-smoke/agent-detail-invalid-date-capture.spec.ts
1 passed (against the fixed build)
1 failed on "not.toContain('Invalid Date')" (against the pre-fix build, confirming the bug is real)
```

General cloud-surface health audit (`VITE_PLAYWRIGHT_TEST_AUTH=true bun run --cwd packages/app audit:cloud`) — walks every registered cloud route at desktop+mobile: `dashboard-agents-detail desktop` and `dashboard-agents-detail mobile` both passed. 90/93 total passed; the 2 unrelated failures (`coverage matches the registered cloud routes` — a stale route-registry listing for `dashboard/apps`, `dashboard/mcps`, etc. that have nothing to do with this page; `auth-bridge mobile` — a redirect-timing test) were independently confirmed pre-existing and unrelated.

Independent old-vs-new behavior sweep for `formatTime` (manual, beyond the automated suite):

```text
formatTime(null)                              old=""              new="—"  <- fallback now visible (disclosed UX change)
formatTime("not-a-date")                      old="Invalid Date"  new="—"  <- fixed
formatTime("2024-01-15T10:30:00.000Z")        old="11:30 AM"      new="11:30 AM"
formatTime("2024")                            old="01:00 AM"      new="01:00 AM"
formatTime("0")                               old="12:00 AM"      new="12:00 AM"
formatTime("9999-99-99")                      old="Invalid Date"  new="—"  <- fixed
formatTime("+275760-09-13T00:00:00.001Z")     old="Invalid Date"  new="—"  <- fixed
```

# Evidence Gate

<!-- evidence-head:309ae1f3 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshot (pre-fix build, real malformed-timestamp fixture, literal "Invalid Date" visible under "Created"): ![before](https://github.com/Svector-anu/eliza/releases/download/pr-evidence/18812-before.png)
<!-- evidence-row:after-screenshots -->
- [x] After screenshot (this fix, same fixture): ![after](https://github.com/Svector-anu/eliza/releases/download/pr-evidence/18812-after.png)
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video (fixed build, malformed-timestamp fixture, scroll interaction): https://github.com/Svector-anu/eliza/releases/download/pr-evidence/18812-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic frontend formatting logic, no backend behavior change.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no request or state-transition behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: component-level render regression (5 tests), real production-render Playwright capture (proves the bug on pre-fix build, proves the fix on post-fix build), and the manual old-vs-new sweep above.
<!-- evidence-row:ocr-review -->
- [x] OCR review (`node scripts/evidence-review/generate.mjs --ocr=on`, tesseract.js engine): the before screenshot's OCR text includes extra characters in the exact "Created" field position that the after screenshot's OCR text does not (`"...Never ~$720/mo voll Dote"` vs. `"...Never ~$720/mo"`) — an imperfect but genuine machine transcription of "Invalid Date" against small, low-contrast text; not hand-edited or fabricated.

Evidence release note: `pr-evidence.mjs attach` uploads to `elizaOS/eliza`'s own `pr-evidence` release, which requires push access this fork account does not have (`gh release upload` returned `404`). Uploaded instead to a `pr-evidence` release on this fork (`Svector-anu/eliza`), which GitHub renders inline identically since image/video embeds work from any public URL.

# Known gaps / failures

- Full root `bun run verify` fails at `@elizaos/plugin-workflow#lint:check` (a pre-existing Biome formatting nit in that plugin's test file, confirmed identical against unmodified `origin/develop` content, unrelated to this change). The scoped equivalent for this change's actual dependency graph passes 58/58 — see Testing.
- The cloud-surface audit's `coverage matches the registered cloud routes` and `auth-bridge mobile` cases failed; both confirmed pre-existing/unrelated (stale route-registry entries for unrelated pages; an auth-redirect timing test) — not caused by or related to this change.
- OCR transcription of the before screenshot's "Invalid Date" text is imperfect (`"voll Dote"`) due to small/low-contrast rendering — reported honestly rather than cleaned up, per this repo's evidence-integrity standard.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
