### PR TITLE
fix(scripts): validate turbo cache byte caps

### DIFF
--- a/packages/scripts/__tests__/prune-turbo-cache.test.mjs
+++ b/packages/scripts/__tests__/prune-turbo-cache.test.mjs
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { spawnSync } from "../lib/spawn-sync-captured.mjs";
 import {
   DEFAULT_MAX_GB,
   maxBytesFromGb,
@@ -15,7 +16,6 @@ import {
   pruneTurboCache,
   resolveCacheDir,
 } from "../prune-turbo-cache.mjs";
-import { spawnSync } from "../lib/spawn-sync-captured.mjs";
 
 const SCRIPT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -64,6 +64,21 @@ describe("parseMaxGb", () => {
   });
 });
 
+describe("maxBytesFromGb", () => {
+  test("rounds valid fractional gigabytes to a positive safe byte cap", () => {
+    expect(maxBytesFromGb(1.5)).toBe(1_610_612_736);
+    expect(maxBytesFromGb(1e-9)).toBe(1);
+  });
+
+  test("rejects underflow, overflow, and unsafe byte conversions", () => {
+    for (const value of [1e-20, 8_388_608, 1e300]) {
+      expect(() => maxBytesFromGb(value)).toThrow(
+        /--max-gb.*positive safe-integer byte cap/,
+      );
+    }
+  });
+});
+
 describe("parseArgs", () => {
   test("defaults to 20 GB when --max-gb is omitted", () => {
     const options = parseArgs(["--dry-run"]);
@@ -87,9 +102,12 @@ describe("parseArgs", () => {
       "--max-gb=abc",
       "--max-gb=NaN",
       "--max-gb=Infinity",
+      "--max-gb=1e-20",
+      "--max-gb=8388608",
+      "--max-gb=1e300",
     ]) {
       expect(() => parseArgs([arg])).toThrow(
-        /must be a positive finite number of gigabytes/,
+        /must (?:be a positive finite number of gigabytes|convert to a positive safe-integer byte cap)/,
       );
     }
   });
@@ -97,9 +115,9 @@ describe("parseArgs", () => {
 
 describe("resolveCacheDir", () => {
   test("prefers TURBO_CACHE_DIR over the default relative path", () => {
-    expect(resolveCacheDir({ TURBO_CACHE_DIR: "/tmp/custom-turbo" }, "/repo")).toBe(
-      path.resolve("/tmp/custom-turbo"),
-    );
+    expect(
+      resolveCacheDir({ TURBO_CACHE_DIR: "/tmp/custom-turbo" }, "/repo"),
+    ).toBe(path.resolve("/tmp/custom-turbo"));
     expect(resolveCacheDir({}, "/repo")).toBe(
       path.resolve("/repo", ".turbo/cache"),
     );
@@ -185,11 +203,14 @@ describe("prune-turbo-cache CLI", () => {
         "--max-gb=abc",
         "--max-gb=NaN",
         "--max-gb=Infinity",
+        "--max-gb=1e-20",
+        "--max-gb=8388608",
+        "--max-gb=1e300",
       ]) {
         const result = runCli([arg], { TURBO_CACHE_DIR: cacheDir });
         expect(result.status).toBe(2);
         expect(result.stderr).toMatch(
-          /must be a positive finite number of gigabytes/,
+          /must (?:be a positive finite number of gigabytes|convert to a positive safe-integer byte cap)/,
         );
         expect(fs.existsSync(keep)).toBe(true);
       }

--- a/packages/scripts/prune-turbo-cache.mjs
+++ b/packages/scripts/prune-turbo-cache.mjs
@@ -12,9 +12,9 @@
  *      (each entry = `<hash>.tar.zst` + `<hash>-meta.json` + `<hash>-manifest.json`)
  *      until the cache is under the cap.
  *
- * `--max-gb` must be a positive finite number of gigabytes when provided.
- * Invalid overrides fail closed before any eviction so a typo cannot either
- * skip pruning (NaN cap) or wipe the cache (zero/negative cap).
+ * `--max-gb` must be a positive finite number that rounds to a positive,
+ * safely representable whole-byte cap. Invalid overrides fail closed before
+ * eviction so a typo cannot skip pruning or wipe the cache.
  *
  * Usage:
  *   node packages/scripts/prune-turbo-cache.mjs [--max-gb=20] [--dry-run]
@@ -51,12 +51,20 @@ export function parseMaxGb(value, label = "--max-gb") {
 }
 
 /**
- * Convert a gigabyte cap to a whole-byte budget.
+ * Convert a gigabyte cap to a nearest-whole-byte budget. A positive GB value
+ * is not usable when it rounds below one byte or exceeds safe integer range.
  * @param {number} maxGb
+ * @param {string} [label]
  * @returns {number}
  */
-export function maxBytesFromGb(maxGb) {
-  return Math.round(maxGb * BYTES_PER_GB);
+export function maxBytesFromGb(maxGb, label = "--max-gb") {
+  const maxBytes = Math.round(maxGb * BYTES_PER_GB);
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+    throw new Error(
+      `${label} must convert to a positive safe-integer byte cap (received ${JSON.stringify(maxGb)})`,
+    );
+  }
+  return maxBytes;
 }
 
 /**
@@ -196,9 +204,7 @@ function main(argv = process.argv.slice(2), env = process.env) {
   });
 
   if (result.missing) {
-    console.log(
-      `[prune-turbo-cache] No cache at ${cacheDir}; nothing to do.`,
-    );
+    console.log(`[prune-turbo-cache] No cache at ${cacheDir}; nothing to do.`);
     return;
   }
 


### PR DESCRIPTION
# Relates to

Closes #18602.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm rejection and non-eviction from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@c267370f268318db7d3683552f8e5750da76ddc0`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 tasks and all repository audits passed.

# Risks

Low. The existing nearest-whole-byte policy is retained. This only rejects explicit caps whose converted byte value is zero, infinite, or outside JavaScript’s safe-integer range.

# Background

## What does this PR do?

Moves validation to the actual eviction unit. A positive finite gigabyte number is accepted only when multiplying by `1024 ** 3` and rounding produces a positive safe-integer byte cap.

This closes three fail-open paths:

- `1e-20` no longer rounds to a zero-byte wipe policy.
- `8388608` no longer produces unsafe integer `9007199254740992`.
- `1e300` no longer multiplies to `Infinity`.

Valid fractional caps remain supported and are deliberately rounded to the nearest whole byte; values that round to at least one safe byte remain valid.

## What kind of change is this?

Bug fix (fail-closed CLI conversion boundary).

# Documentation changes needed?

No external documentation change is needed. The script header and conversion JSDoc now state the exact byte-cap contract.

# Testing

## Where should a reviewer start?

- `packages/scripts/prune-turbo-cache.mjs`
- `packages/scripts/__tests__/prune-turbo-cache.test.mjs`

## Detailed testing steps

```text
bun test packages/scripts/__tests__/prune-turbo-cache.test.mjs
13 pass, 0 fail, 72 assertions

bunx biome check packages/scripts/prune-turbo-cache.mjs packages/scripts/__tests__/prune-turbo-cache.test.mjs
2 files checked, pass

bun run verify
350 successful, 350 total; all repository audits passed
```

The real CLI test creates an isolated cache with `keep.tar.zst`, runs every invalid override, and asserts exit 2 plus `existsSync(keep) === true` after each command.

# Evidence Gate

<!-- evidence-head:098c7f9b49f71e282711df167a8e1459a8ef7535 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this is a non-rendered repository maintenance CLI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this is a non-rendered repository maintenance CLI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the affected flow is terminal validation before filesystem mutation.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service is started or changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Real CLI transcript and isolated-cache sentinel assertions prove rejection occurs before eviction.

```text
[prune-turbo-cache] --max-gb must convert to a positive safe-integer byte cap (received 1e-20); exit=2
[prune-turbo-cache] --max-gb must convert to a positive safe-integer byte cap (received 8388608); exit=2
[prune-turbo-cache] --max-gb must convert to a positive safe-integer byte cap (received 1e+300); exit=2
isolated cache run: keep.tar.zst remained present after every rejected command, proving no eviction ran
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered UI changes.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic numeric conversion and filesystem boundary only.

## Backend + frontend logs

N/A - no backend/frontend surface changes. The CLI transcript above is the affected boundary.

## Screenshots (before / after) + video walkthrough

N/A - no rendered files or UI flows are changed.

## Audio / voice walkthrough

N/A - no audio or voice behavior changes.

## Known gaps / failures

None. Focused parser, conversion, isolated-cache CLI tests, formatting, installation, and full root verification pass on the synchronized head.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@c267370f268318db7d3683552f8e5750da76ddc0:packages/skills/skills/contribute-to-eliza"} -->
