### PR TITLE
fix(cloud): describe MiniMax M3 as an agentic flagship

### DIFF
--- a/packages/cloud/shared/src/lib/models/catalog.test.ts
+++ b/packages/cloud/shared/src/lib/models/catalog.test.ts
@@ -8,6 +8,7 @@ import {
   CEREBRAS_DEFAULT_TEXT_SMALL_MODEL,
   FALLBACK_TEXT_SELECTOR_MODELS,
   STATIC_TEXT_CATALOG_MODELS,
+  toSelectorModel,
 } from "./catalog";
 
 /**
@@ -69,22 +70,41 @@ describe("#8426 text catalog recommendation invariants", () => {
 });
 
 describe("MiniMax static catalog", () => {
-  test("describes flagship M3 without matching the provider name as a mini model", () => {
+  test("generates the complete flagship M3 selector entry", () => {
     const modelId = "minimax/minimax-m3";
     const catalogModel = STATIC_TEXT_CATALOG_MODELS.find((model) => model.id === modelId);
     const selectorModel = FALLBACK_TEXT_SELECTOR_MODELS.find((model) => model.modelId === modelId);
 
-    expect(catalogModel?.description).toBe("General-purpose language model");
-    expect(selectorModel?.description).toBe("General-purpose language model");
-    expect(selectorModel?.description).not.toBe("Faster, lower-cost option");
+    expect(catalogModel?.description).toBe("Flagship long-context agentic coding model");
+    expect(selectorModel).toEqual({
+      id: modelId,
+      modelId,
+      provider: "minimax",
+      name: "Minimax M3",
+      description: "Flagship long-context agentic coding model",
+    });
+  });
+
+  test("does not derive a mini tier from the provider prefix", () => {
+    const selectorModel = toSelectorModel({
+      id: "minimax/agent-base",
+      object: "model",
+      created: 0,
+      owned_by: "minimax",
+    });
+
+    expect(selectorModel.description).toBe("General-purpose language model");
   });
 
   test("keeps the mini heuristic for model names that explicitly use it", () => {
-    const selectorModel = FALLBACK_TEXT_SELECTOR_MODELS.find(
-      (model) => model.modelId === "openai/gpt-5-mini",
-    );
+    const selectorModel = toSelectorModel({
+      id: "minimax/agent-mini",
+      object: "model",
+      created: 0,
+      owned_by: "minimax",
+    });
 
-    expect(selectorModel?.description).toBe("Faster, lower-cost option");
+    expect(selectorModel.description).toBe("Faster, lower-cost option");
   });
 });
 
@@ -104,7 +124,7 @@ describe("OpenAI o-series selector metadata", () => {
 
   test("does not apply OpenAI o-series precedence to MiniMax or true mini models", () => {
     const expectedDescriptions = new Map([
-      ["minimax/minimax-m3", "General-purpose language model"],
+      ["minimax/minimax-m3", "Flagship long-context agentic coding model"],
       ["openai/gpt-5-mini", "Faster, lower-cost option"],
     ]);
 

--- a/packages/cloud/shared/src/lib/models/catalog.ts
+++ b/packages/cloud/shared/src/lib/models/catalog.ts
@@ -399,9 +399,13 @@ function buildSelectorName(modelId: string): string {
 }
 
 function buildSelectorDescription(modelId: string): string {
-  const [provider = "", rawName = modelId] = modelId.toLowerCase().split("/", 2);
+  const normalizedModelId = modelId.toLowerCase();
+  const [provider = "", rawName = normalizedModelId] = normalizedModelId.split("/", 2);
   const id = rawName.startsWith(`${provider}-`) ? rawName.slice(provider.length + 1) : rawName;
 
+  if (normalizedModelId === "minimax/minimax-m3") {
+    return "Flagship long-context agentic coding model";
+  }
   if (id.includes("codex")) return "Coding-focused model";
   if (id.includes("deep-research")) return "Research-focused reasoning model";
   if (id.includes("thinking")) return "Extended reasoning model";


### PR DESCRIPTION
# Relates to

Fixes #18808.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the generated selector contract from the exact-head tests and linked evidence artifact below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex-desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on `origin/develop@fa0573bacfe0810c1ee1c0ffb9ecb6951f33834f`; zero conflicts and 0 commits behind at verification time.
- [x] `bun run verify` passes post-sync: 350/350 workspace tasks and every trailing repository audit passed.

# Risks

Low. This changes one explicit generated description and its deterministic tests. The stable request ID, routing, pricing, model capabilities, provider calls, and generic selector heuristics remain unchanged.

# Background

## What does this PR do?

- Gives `minimax/minimax-m3` the explicit selector description `Flagship long-context agentic coding model`.
- Preserves the stable request ID rather than using the dated upstream canonical slug.
- Locks the complete generated selector entry in a regression test.
- Proves that the `minimax` provider prefix does not trigger the generic `mini` tier while a model basename containing `mini` still does.

## What kind of change is this?

Bug fix (non-breaking metadata correction).

# Documentation changes needed?

No. The selector entry is the user-facing catalog metadata; no external configuration or API contract changed.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/models/catalog.ts` and the `MiniMax static catalog` matrix in `catalog.test.ts`.

## Detailed testing steps

- `bun test packages/cloud/shared/src/lib/models/catalog.test.ts` — PASS, 12/12 tests and 26 assertions.
- `bun run --cwd packages/cloud/shared test` — PASS, all 162 isolated package batches completed with no failed batch.
- `bun run --cwd packages/cloud/shared lint:check` — PASS, 1,857 files checked.
- `bun run --cwd packages/cloud/shared typecheck` — PASS.
- `bun install --frozen-lockfile --ignore-scripts` — PASS, no dependency or lockfile changes.
- `bun run verify` — PASS, 350/350 workspace tasks and every repository audit.
- `git diff --check` — PASS.

# Evidence Gate

<!-- evidence-head:66f06e96a87f49f8d8ebfa7e029cc4715ec5cb2b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI source or current rendered selector surface changed; this is generated backend catalog metadata.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI source or current rendered selector surface changed; the exact generated object is attached as a domain artifact.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic catalog generation has no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - pure in-process catalog construction performs no backend request, persistence, or structured logging.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, or rendered component changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model invocation, routing, prompt, provider, or generated output behavior changed; only selector presentation metadata changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Live-upstream and exact-head selector evidence](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18808-selector-evidence.json) records OpenRouter's current M3 metadata, the local generated selector object, both heuristic controls, and four passing assertions.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or screenshot applies.

# Evidence Details

## Domain artifact

The linked JSON was generated from the production-equivalent pre-rebase head; current head `66f06e96a87f49f8d8ebfa7e029cc4715ec5cb2b` preserves the M3 selector object and revalidates it in the 12/12 integrated catalog suite. It pairs the live OpenRouter catalog record (`minimax/minimax-m3`, 1,048,576-token context, long-horizon agentic/coding description) with the exact local selector output and verifies:

```text
stableRequestId: true
flagshipDescription: true
providerPrefixDoesNotTriggerMini: true
basenameMiniStillTriggers: true
```

Artifact SHA-256: `22b1a04c4b2b0104a39c6e097f59f72b96c4404a4ea4854cd2ab89b0a7e58d9b`.

## Real LLM-call trajectory

N/A - this patch does not invoke or route a model. The live upstream catalog was queried only to validate the presentation claim and stable request ID.

## Backend + frontend logs

N/A - the affected code is a pure synchronous catalog builder with no I/O, runtime logger, frontend network request, or state transition.

## Screenshots (before / after) + video walkthrough

N/A - repository search confirms the fallback selector list is currently exported to Cloud configuration/model modules but has no rendered app/UI consumer. The exact before/after contract is therefore represented by the focused production-object test and JSON domain artifact rather than a fabricated screenshot.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT surface changed.

## Known gaps / failures

No test or verification failure remains. Screenshots, video, runtime logs, and a live-LLM trajectory are inapplicable for this pure generated metadata path; the live provider catalog and exact local generated object are attached instead.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-issue-triage]