### PR TITLE
fix(evidence): reject conflicting AI-QA reviewer modes

### DIFF
--- a/packages/app/test/audit/ai-qa-reviewer-args.test.ts
+++ b/packages/app/test/audit/ai-qa-reviewer-args.test.ts
@@ -4,13 +4,16 @@
  */
 
 import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { parseReviewerArgs } from "../../../../scripts/ai-qa/reviewer-args.mjs";
 
 const reviewerScripts = [
   {
     label: "screenshot reviewer",
+    supportsVerdictMd: false,
     path: resolve(
       import.meta.dirname,
       "../../../../scripts/ai-qa/review-screenshots.mjs",
@@ -18,6 +21,7 @@ const reviewerScripts = [
   },
   {
     label: "walkthrough reviewer",
+    supportsVerdictMd: true,
     path: resolve(
       import.meta.dirname,
       "../../../../scripts/ai-qa/review-walkthrough.mjs",
@@ -31,6 +35,11 @@ const {
   OPENAI_API_KEY: _openAiKey,
   ...keylessEnvironment
 } = process.env;
+const temporaryRoot = mkdtempSync(resolve(tmpdir(), "ai-qa-reviewer-args-"));
+
+afterAll(() => {
+  rmSync(temporaryRoot, { recursive: true, force: true });
+});
 
 describe("AI-QA reviewer arguments", () => {
   it("preserves defaults and supported screenshot options", () => {
@@ -47,14 +56,14 @@ describe("AI-QA reviewer arguments", () => {
         "--concurrency",
         "8",
         "--strict",
-        "--update-debt",
       ]),
     ).toEqual({
       runDir: "reports/example",
       concurrency: 8,
       strict: true,
-      updateDebt: true,
+      updateDebt: false,
     });
+    expect(parseReviewerArgs(["--update-debt"]).updateDebt).toBe(true);
   });
 
   it("supports the walkthrough-only verdict destination", () => {
@@ -72,6 +81,14 @@ describe("AI-QA reviewer arguments", () => {
     [["--strcit"], "unknown argument: --strcit"],
     [["positional"], "unknown argument: positional"],
     [["--strict", "--strict"], "--strict may be specified only once"],
+    [
+      ["--strict", "--update-debt"],
+      "--strict and --update-debt cannot be combined",
+    ],
+    [
+      ["--update-debt", "--strict"],
+      "--strict and --update-debt cannot be combined",
+    ],
     [
       ["--concurrency", "2", "--concurrency", "3"],
       "--concurrency may be specified only once",
@@ -114,6 +131,34 @@ describe("AI-QA reviewer arguments", () => {
       expect(result.stderr).toContain("unknown argument: --strcit");
       expect(result.stdout).not.toContain("skipping");
       expect(result.stdout).not.toContain("PASSED");
+    },
+  );
+
+  it.each(
+    reviewerScripts.flatMap((reviewer) => [
+      { ...reviewer, flags: ["--strict", "--update-debt"] },
+      { ...reviewer, flags: ["--update-debt", "--strict"] },
+    ]),
+  )(
+    "rejects conflicting flags before work at the real $label boundary: $flags",
+    ({ label, path, flags, supportsVerdictMd }) => {
+      const caseName = `${label.replaceAll(" ", "-")}-${flags[0].slice(2)}`;
+      const runDir = resolve(temporaryRoot, caseName, "run");
+      const verdictMd = resolve(temporaryRoot, caseName, "verdict.md");
+      const args = [path, ...flags, "--run-dir", runDir];
+      if (supportsVerdictMd) args.push("--verdict-md", verdictMd);
+      const result = spawnSync(process.execPath, args, {
+        encoding: "utf8",
+        env: keylessEnvironment,
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "--strict and --update-debt cannot be combined",
+      );
+      expect(result.stdout).not.toContain("skipping");
+      expect(existsSync(runDir)).toBe(false);
+      expect(existsSync(verdictMd)).toBe(false);
     },
   );
 

--- a/scripts/ai-qa/review-screenshots.mjs
+++ b/scripts/ai-qa/review-screenshots.mjs
@@ -19,7 +19,7 @@
  *
  * Usage:
  *   node scripts/ai-qa/review-screenshots.mjs [--run-dir reports/ai-qa/<id>]
- *     [--concurrency 4] [--strict] [--update-debt]
+ *     [--concurrency 4] [--strict | --update-debt]
  */
 
 import { existsSync } from "node:fs";

--- a/scripts/ai-qa/review-walkthrough.mjs
+++ b/scripts/ai-qa/review-walkthrough.mjs
@@ -17,7 +17,7 @@
  *
  * Usage:
  *   node scripts/ai-qa/review-walkthrough.mjs [--run-dir reports/walkthrough/<id>]
- *     [--concurrency 4] [--strict] [--update-debt]
+ *     [--concurrency 4] [--strict | --update-debt]
  *     [--verdict-md packages/app/test/ui-smoke/walkthrough/WALKTHROUGH_VERDICTS.md]
  */
 

--- a/scripts/ai-qa/reviewer-args.mjs
+++ b/scripts/ai-qa/reviewer-args.mjs
@@ -64,5 +64,9 @@ export function parseReviewerArgs(argv, { defaultVerdictMd } = {}) {
     throw new Error(`unknown argument: ${argument}`);
   }
 
+  if (options.strict && options.updateDebt) {
+    throw new Error("--strict and --update-debt cannot be combined");
+  }
+
   return options;
 }


### PR DESCRIPTION
# Relates to

Closes #18850.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm fail-before-work behavior from the real-entrypoint matrix below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@fa0573bacfe0810c1ee1c0ffb9ecb6951f33834f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@fa0573bacfe0810c1ee1c0ffb9ecb6951f33834f`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 tasks and all repository audits passed.

# Risks

Low. This rejects a previously ambiguous combination of two operational modes. Each mode remains valid by itself, and all parser defaults and entrypoint-specific options are unchanged.

# Background

## What does this PR do?

Defines one fail-fast contract for the shared AI-QA reviewer arguments: `--strict` and `--update-debt` are mutually exclusive.

Strict mode enforces the current debt baseline, while update-debt mode mutates that baseline. Combining them made the screenshot reviewer silently return before strict gating while the walkthrough reviewer continued and failed. Rejecting the contradictory request before credential checks, model calls, or artifact writes removes that silent bypass without inventing precedence.

Both reviewer usage headers now expose the modes as alternatives. Real subprocess tests cover both flag orders at both entrypoints and assert the requested output paths remain absent.

## What kind of change is this?

Bug fix (fail-fast evidence tooling contract).

# Documentation changes needed?

No external documentation change is needed. Both maintained CLI usage headers now show `--strict | --update-debt`.

# Testing

## Where should a reviewer start?

- `scripts/ai-qa/reviewer-args.mjs`
- `packages/app/test/audit/ai-qa-reviewer-args.test.ts`
- `scripts/ai-qa/review-screenshots.mjs`
- `scripts/ai-qa/review-walkthrough.mjs`

## Detailed testing steps

```text
bun test packages/app/test/audit/ai-qa-reviewer-args.test.ts
30 pass, 0 fail, 65 assertions; shared parser has 100% function and line coverage

bun run --cwd packages/app typecheck
pass

bun run --cwd packages/app lint
289 files checked; no fixes required

bun run --cwd packages/app test
752 script tests passed, 1 skipped; 84 Vitest files and 660 tests passed

bun run verify
350 successful, 350 total; all repository audits passed
```

# Evidence Gate

<!-- evidence-head:dbdbd7fe32059515b96886e1e771fdc1ad68683e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this changes terminal-only evidence tooling, not rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no view, style, layout, or visual asset changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the affected flow rejects contradictory flags before review work.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service is started or changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the corrected path fails before credentials or any model call.
<!-- evidence-row:domain-artifacts -->
- [x] Real subprocess matrix proves identical fail-fast behavior and absence of requested artifacts.

```text
review-screenshots strict-first exit=1 artifacts=not-created stderr=[vision-review] fatal Error: --strict and --update-debt cannot be combined
review-screenshots debt-first exit=1 artifacts=not-created stderr=[vision-review] fatal Error: --strict and --update-debt cannot be combined
review-walkthrough strict-first exit=1 artifacts=not-created stderr=[walkthrough-vision] fatal Error: --strict and --update-debt cannot be combined
review-walkthrough debt-first exit=1 artifacts=not-created stderr=[walkthrough-vision] fatal Error: --strict and --update-debt cannot be combined
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered UI changes.

# Evidence Details

## Real LLM-call trajectory

N/A - rejecting the invalid combination before a model call is the behavior under test.

## Backend + frontend logs

N/A - no backend/frontend surface changes. The subprocess transcript above is the affected boundary.

## Screenshots (before / after) + video walkthrough

N/A - no rendered files or UI flows are changed.

## Audio / voice walkthrough

N/A - no audio or voice behavior changes.

## Known gaps / failures

The package-mandated `bun run --cwd packages/app audit:app` completed 214/215 tests with zero broken captures, then failed the unchanged global minimalism ratchet for four existing rows: `builtin-browser` mobile portrait and landscape (60.76 > 45), `builtin-plugins` mobile portrait (88.10 > 79.75), and `builtin-trajectories` mobile landscape (51.65 > 45). This branch changes none of those views or their baselines. All 30 focused tests, app typecheck/lint/test lanes, and the authoritative root `bun run verify` gate pass on the synchronized head.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@fa0573bacfe0810c1ee1c0ffb9ecb6951f33834f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@fa0573bacfe0810c1ee1c0ffb9ecb6951f33834f:packages/skills/skills/contribute-to-eliza"} -->
