### PR TITLE
test(app): make seed port precedence test hermetic

### DIFF
--- a/packages/scripts/__tests__/seed-message-corpus.test.mjs
+++ b/packages/scripts/__tests__/seed-message-corpus.test.mjs
@@ -148,15 +148,15 @@ describe("seed-message-corpus CLI boundary", () => {
     }
   });
 
-  test("valid CLI port overrides invalid env before any seed request", () => {
-    const result = runCli(["--api-port=44444"], {
+  test("valid CLI port overrides invalid env without entering network work", () => {
+    const result = runCli(["--api-port=44444", "--messages=not-an-integer"], {
       ELIZA_API_PORT: "notaport",
     });
     const combined = `${result.stdout}${result.stderr}`;
-    expect(combined).toContain(
-      "Seeding backdated message corpus via http://127.0.0.1:44444",
-    );
+    expect(result.status).not.toBe(0);
+    expect(combined).toContain("--messages must be an integer");
     expect(combined).not.toContain("ELIZA_API_PORT must be");
+    expect(combined).not.toContain("Seeding backdated message corpus");
   });
 
   test("--help bypasses an invalid environment port", () => {


### PR DESCRIPTION
# Relates to

Fixes #18849.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the no-network precedence path from the exact-head subprocess test and linked transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex-desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@fa0573bacfe0810c1ee1c0ffb9ecb6951f33834f`; zero conflicts and 0 commits behind at final verification.
- [x] `bun run verify` passes post-sync: 350/350 workspace tasks and every repository audit passed.

# Risks

Low. This changes one test invocation and its assertions. Production parsing, seeding, ports, request construction, and CLI behavior are untouched.

# Background

## What does this PR do?

- Keeps the valid `--api-port=44444` versus invalid `ELIZA_API_PORT` precedence proof.
- Adds a later invalid `--messages` operand so the real CLI subprocess must fail during parsing before network work begins.
- Asserts the later diagnostic is emitted, the invalid environment diagnostic is absent, and the seeding banner immediately preceding `fetch` is never reached.
- Removes the previous passing path that could POST `{}` to a developer service on fixed localhost port 44444.

## What kind of change is this?

Test safety fix (non-breaking).

# Documentation changes needed?

No. Production CLI behavior and public documentation are unchanged.

# Testing

## Where should a reviewer start?

The `valid CLI port overrides invalid env without entering network work` case in `packages/scripts/__tests__/seed-message-corpus.test.mjs`.

## Detailed testing steps

- `bun test packages/scripts/__tests__/seed-message-corpus.test.mjs` — PASS, 13/13 tests and 78 assertions.
- `bun run audit:scripts` — PASS, no orphan/no-op/broken scripts.
- `bun install --frozen-lockfile --ignore-scripts` — PASS, no dependency or lockfile changes.
- `bun run verify` — PASS, 350/350 workspace tasks and every repository audit.
- `git diff --check` — PASS.

# Evidence Gate

<!-- evidence-head:ed955f60573812192975b2bb84679146c865e253 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only subprocess safety change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only subprocess safety change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic offline test boundary has no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - production backend and request execution are intentionally never entered by this hermetic parser-boundary test.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, or code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Hermetic precedence proof](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18849-hermetic-transcript.json) records the argv, environment conflict, required later parser diagnostic, forbidden network-boundary banner, focused result, and root verification.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Backend + domain evidence

Exact-head probe:

```text
argv: --api-port=44444 --messages=not-an-integer
ELIZA_API_PORT: notaport
exit: nonzero
required: --messages must be an integer
forbidden: ELIZA_API_PORT must be
forbidden: Seeding backdated message corpus
focused suite: 13 pass, 0 fail, 78 assertions
root verify: 350/350 workspace tasks, all audits pass
```

`seed-message-corpus.mjs` prints `Seeding backdated message corpus ...` immediately before its first `postJson`/`fetch`. Requiring the later parser diagnostic while forbidding that banner means any entry into network work fails the regression.

Artifact SHA-256: `fac33f41765bfef77b9604aab3e9d5ad0daca155e8559b0923c7ccadbd0bcce9`.

## Real LLM-call trajectory

N/A - no model path changed.

## Screenshots (before / after) + video walkthrough

N/A - only a Node/Bun subprocess test changed; no rendered application surface exists to capture.

## Audio / voice walkthrough

N/A - no audio or voice surface changed.

## Known gaps / failures

No test or verification failure remains. Visual, frontend, runtime-integration, and LLM artifacts are inapplicable because the repaired test is specifically required to stop before any network or application runtime work.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-issue-triage]
