### PR TITLE
fix(core): keep no-op tag calls eviction-neutral

### DIFF
--- a/packages/core/src/features/messaging/triage/__tests__/message-ref-store.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/message-ref-store.test.ts
@@ -146,6 +146,28 @@ describe("MessageRefStore write-recency eviction", () => {
 		expect(store.getDraft("draft-0")).toBeNull();
 	});
 
+	it.each([
+		{
+			name: "adding an existing tag",
+			mutate: (store: MessageRefStore) => store.addTag("message-0", "keep"),
+		},
+		{
+			name: "removing an absent tag from a nonempty tag list",
+			mutate: (store: MessageRefStore) =>
+				store.removeTag("message-0", "absent"),
+		},
+	])("does not refresh recency when $name", ({ mutate }) => {
+		const store = new MessageRefStore();
+		store.saveMessage(message(0, { tags: ["keep"] }));
+		fillMessagesAfter(store, 1);
+
+		expect(mutate(store)?.tags).toEqual(["keep"]);
+		store.saveMessage(message(MESSAGE_CAPACITY));
+
+		expect(store.getMessage("message-0")).toBeNull();
+		expect(store.getMessage("message-1")).not.toBeNull();
+	});
+
 	it("keeps an overwritten draft and evicts the oldest untouched draft", () => {
 		const store = new MessageRefStore();
 		fillDrafts(store);

--- a/packages/core/src/features/messaging/triage/message-ref-store.ts
+++ b/packages/core/src/features/messaging/triage/message-ref-store.ts
@@ -60,8 +60,9 @@ export class MessageRefStore {
 	addTag(messageId: string, tag: string): MessageRef | null {
 		const existing = this.messages.get(messageId);
 		if (!existing) return null;
+		if (existing.tags?.includes(tag)) return existing;
 		const tags = existing.tags ? [...existing.tags] : [];
-		if (!tags.includes(tag)) tags.push(tag);
+		tags.push(tag);
 		const next: MessageRef = { ...existing, tags };
 		setMostRecent(this.messages, messageId, next);
 		return next;
@@ -72,6 +73,7 @@ export class MessageRefStore {
 		if (!existing) return null;
 		if (!existing.tags || existing.tags.length === 0) return existing;
 		const tags = existing.tags.filter((t) => t !== tag);
+		if (tags.length === existing.tags.length) return existing;
 		const next: MessageRef = { ...existing, tags };
 		setMostRecent(this.messages, messageId, next);
 		return next;


### PR DESCRIPTION
# Relates to

Fixes #18783.

This is the narrow follow-up requested after #18787: it addresses the exact pre-merge review finding that an idempotent tag call still refreshed cache eviction order.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change from the exact-head boundary evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@08189736afd975dd98c5b03b2d658072410b959d`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 Turbo tasks and every repository audit passed.

# Risks

Low. The change only short-circuits two semantic no-ops in the process-local `MessageRefStore`. Real tag mutations retain their established write-recency behavior, cache capacities stay 5,000/2,000, and callers do not depend on receiving a cloned object for a no-op.

# Background

## What does this PR do?

- Returns the existing message before `setMostRecent` when `addTag` receives a tag already present.
- Returns the existing message when `removeTag` filters no tag from a nonempty tag list.
- Adds real 5,000-message capacity regressions proving both no-ops leave the oldest entry eligible for eviction while preserving its stored tags.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is needed. This restores the already documented last-write eviction contract rather than adding a new public behavior.

# Testing

## Where should a reviewer start?

`packages/core/src/features/messaging/triage/__tests__/message-ref-store.test.ts`, in the table-driven no-op boundary regression, then the two early returns in `message-ref-store.ts`.

## Detailed testing steps

- `bunx vitest run --config vitest.config.ts src/features/messaging/triage/__tests__/message-ref-store.test.ts --coverage.enabled=false` from `packages/core`: **10/10 passed**.
- `bun run --cwd packages/core test`: **514 files, 5,764 tests passed, 1 skipped**.
- `bun run --cwd packages/core lint:check`: passed (only unrelated existing diagnostics).
- `bun run --cwd packages/core typecheck`: passed.
- `bun run --cwd packages/core build:node`: passed.
- `bun run --cwd packages/core build`: passed for Node/browser/edge/testing bundles and declarations.
- `bun run verify`: passed; Turbo **350/350**, followed by all repository audits.
- `git diff --check origin/develop...HEAD`: passed.

# Evidence Gate

<!-- evidence-head:e31c24f232bef81b4e42d189b51876cbf182eee2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this is a process-local TypeScript cache-policy change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this is a process-local TypeScript cache-policy change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no interactive or rendered user flow; the behavior is a deterministic eviction boundary.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server, connector, request, or structured backend logging path changed; the production store is exercised directly at its real capacity.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, network, console, or state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent selection, action, provider, prompt, model, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact committed-source, real-capacity base/head matrix (1800x1100; SHA-256 `99797bbd7d9b937fea590cfac9bab499ef145de64953dfa0a6f2bc79b721d66f`): ![Issue 18783 no-op tag recency matrix](https://github.com/user-attachments/assets/5d6ecfa4-6ef8-4d4d-bf89-e60ada9a1010)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered product UI or user-facing visual text changed; the attached matrix was visually inspected at original resolution for evidence readability.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic in-memory cache logic only; no provider-to-model-to-action path is changed or needed to exercise the production boundary.

## Backend + frontend logs

N/A - there is no backend request or frontend surface. The focused production-store transcript is summarized here for reviewer reproducibility:

```text
HEAD e31c24f232bef81b4e42d189b51876cbf182eee2
Test Files  1 passed (1)
Tests       10 passed (10)
Duration    141ms
```

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changed.

## Known gaps / failures

- UI, frontend, video, OCR, live backend, and live-LLM evidence are intentionally N/A because this patch changes only deterministic process-local `Map` eviction behavior.
- The evidence harness imported the exact committed base and head production store and used the real 5,000-message capacity. Base reproduced both incorrect retentions; head passed both contracts. The PNG was deterministically rerendered byte-identically and visually inspected with no clipping.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [leaderboard-acceptance-monitor-r21]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZW90RTFJ7Y9Z2NTSFR0419R","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T00:40:40.015Z","completed_at":"2026-08-13T01:02:53.149Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAWOuFq4QKFpEzUxdS-xUTGOp-_XL5j-TbR18ldYqv818","device_key_id":"27a2bd6f25b7dfbdcd447074ad6ad4d4eff92654605004b081bd547e02c21550","device_signature":"IlLG5XlMCnwDMdRTI6g9Uqh-Wtc3wxlxvunnmFiBv0KTDrUJblyzylTSDcisIfqVmVcrax1A7_czUGuMfdIvBg"}} -->
