### PR TITLE
fix(pdf): validate unpdf boundary data

### DIFF
--- a/plugins/plugin-pdf/__tests__/pdf-service.integration.test.ts
+++ b/plugins/plugin-pdf/__tests__/pdf-service.integration.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Exercises PdfService metadata and text extraction through the real unpdf parser.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { PdfService } from "../services/pdf";
+
+function buildPdfWithHostileMetadata(text: string): Buffer {
+	const objects = [
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+		`<< /Length ${text.length + 25} >>\nstream\nBT /F1 12 Tf 72 720 Td (${text}) Tj ET\nendstream`,
+		"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+		"<< /Title 123 /Author (Ada) /CreationDate 0 /ModDate false >>",
+	];
+
+	let body = "%PDF-1.4\n";
+	const offsets = [0];
+	for (let index = 0; index < objects.length; index += 1) {
+		offsets.push(Buffer.byteLength(body));
+		body += `${index + 1} 0 obj\n${objects[index]}\nendobj\n`;
+	}
+
+	const xrefStart = Buffer.byteLength(body);
+	body += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+	for (const offset of offsets.slice(1)) {
+		body += `${String(offset).padStart(10, "0")} 00000 n \n`;
+	}
+	body += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R /Info 6 0 R >>\n`;
+	body += `startxref\n${xrefStart}\n%%EOF\n`;
+	return Buffer.from(body);
+}
+
+describe("PdfService real unpdf boundary", () => {
+	it("extracts text while omitting numeric and boolean metadata dates", async () => {
+		const service = new PdfService({} as IAgentRuntime);
+		const info = await service.getDocumentInfo(
+			buildPdfWithHostileMetadata("real parser boundary")
+		);
+
+		expect(info.text).toBe("real parser boundary");
+		expect(info.metadata.author).toBe("Ada");
+		expect(info.metadata.title).toBeUndefined();
+		expect(info.metadata.creationDate).toBeUndefined();
+		expect(info.metadata.modificationDate).toBeUndefined();
+	});
+});

--- a/plugins/plugin-pdf/__tests__/pdf-service.test.ts
+++ b/plugins/plugin-pdf/__tests__/pdf-service.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests PdfService parsing and validation with deterministic unpdf boundary mocks.
+ */
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime } from "@elizaos/core";
 import { MAX_PDF_BUFFER_BYTES, PdfService } from "../services/pdf";
@@ -9,14 +13,14 @@ vi.mock("unpdf", () => ({
 }));
 
 interface MockPageInput {
-	items: unknown[];
+	items: unknown;
 	width?: number;
 	height?: number;
 }
 
 function makePdf(
 	pages: MockPageInput[],
-	info: Record<string, string | undefined> = {}
+	info: Record<string, unknown> | null | undefined = {}
 ) {
 	return {
 		numPages: pages.length,
@@ -59,7 +63,9 @@ describe("PdfService", () => {
 		await expect(service().convertPdfToText(validPdfBuffer())).resolves.toBe(
 			"Hello world\nSecond page"
 		);
-		expect(getDocumentProxyMock).toHaveBeenCalledWith(expect.any(Uint8Array));
+		const parserInput = getDocumentProxyMock.mock.calls[0]?.[0];
+		expect(parserInput).toBeInstanceOf(Uint8Array);
+		expect(Buffer.isBuffer(parserInput)).toBe(false);
 	});
 
 	it("honors start/end page bounds and returns page count for ranged extraction", async () => {
@@ -277,5 +283,69 @@ describe("PdfService", () => {
 		const info = await service().getDocumentInfo(validPdfBuffer());
 		expect(info.metadata.creationDate).toBeUndefined();
 		expect(info.metadata.title).toBeUndefined();
+	});
+
+	it("omits non-string metadata dates instead of coercing fabricated epochs", async () => {
+		getDocumentProxyMock.mockResolvedValue(
+			makePdf([{ items: [{ str: "hello" }] }], {
+				CreationDate: 0,
+				ModDate: false,
+				Title: 123,
+				Author: { name: "Ada" },
+			})
+		);
+
+		const info = await service().getDocumentInfo(validPdfBuffer());
+		expect(info.metadata).toEqual({
+			title: undefined,
+			author: undefined,
+			subject: undefined,
+			keywords: undefined,
+			creator: undefined,
+			producer: undefined,
+			creationDate: undefined,
+			modificationDate: undefined,
+		});
+	});
+
+	it("accepts finite Date metadata objects and omits invalid Date objects", async () => {
+		const creationDate = new Date("2024-03-04T05:06:07.000Z");
+		getDocumentProxyMock.mockResolvedValue(
+			makePdf([{ items: [{ str: "hello" }] }], {
+				CreationDate: creationDate,
+				ModDate: new Date(Number.NaN),
+			})
+		);
+
+		const info = await service().getDocumentInfo(validPdfBuffer());
+		expect(info.metadata.creationDate).toBe(creationDate);
+		expect(info.metadata.modificationDate).toBeUndefined();
+	});
+
+	it.each([null, undefined, {}, "not-an-array", 42])(
+		"fails explicitly when unpdf returns non-array text items: %j",
+		async (items) => {
+			getDocumentProxyMock.mockResolvedValue(makePdf([{ items }]));
+			await expect(service().convertPdfToText(validPdfBuffer())).rejects.toThrow(
+				"PDF text content items must be an array"
+			);
+
+			getDocumentProxyMock.mockResolvedValue(makePdf([{ items }]));
+			await expect(
+				service().convertPdfToTextWithOptions(validPdfBuffer())
+			).resolves.toEqual({
+				success: false,
+				error: "PDF text content items must be an array",
+			});
+
+			getDocumentProxyMock.mockResolvedValue(makePdf([{ items }]));
+			await expect(service().getDocumentInfo(validPdfBuffer())).rejects.toThrow(
+				"PDF text content items must be an array"
+			);
+		}
+	);
+
+	it("fails cleanup on malformed caller input instead of returning uncleaned content", () => {
+		expect(() => service().cleanUpContent(null as never)).toThrow();
 	});
 });

--- a/plugins/plugin-pdf/services/pdf.ts
+++ b/plugins/plugin-pdf/services/pdf.ts
@@ -1,5 +1,10 @@
+/**
+ * Implements local PDF input validation, text extraction, metadata parsing,
+ * and content cleanup for the runtime PDF service.
+ */
+
 import type { IAgentRuntime } from "@elizaos/core";
-import { logger, Service, ServiceType } from "@elizaos/core";
+import { Service, ServiceType } from "@elizaos/core";
 import { getDocumentProxy } from "unpdf";
 
 import type {
@@ -26,7 +31,11 @@ function isTextItem(item: unknown): item is PdfTextItem {
   );
 }
 
-function collectTextStrings(items: readonly unknown[]): string[] {
+function collectTextStrings(items: unknown): string[] {
+  if (!Array.isArray(items)) {
+    throw new TypeError("PDF text content items must be an array");
+  }
+
   const textItems: string[] = [];
   for (const item of items) {
     if (isTextItem(item)) {
@@ -70,7 +79,7 @@ function validatePdfInput(input: unknown): Uint8Array {
     throw new TypeError("PDF input is not a supported PDF document");
   }
 
-  return input;
+  return new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
 }
 
 function validatePageOption(value: unknown, name: string): number | undefined {
@@ -104,10 +113,13 @@ function normalizeExtractionOptions(
   };
 }
 
-function parseMetadataDate(value: string | Date | undefined | null): Date | undefined {
-  if (value === undefined || value === null) return undefined;
+function parseMetadataDate(value: unknown): Date | undefined {
+  if (typeof value !== "string" && !(value instanceof Date)) {
+    return undefined;
+  }
+
   const date = value instanceof Date ? value : new Date(value);
-  return Number.isNaN(date.getTime()) ? undefined : date;
+  return Number.isFinite(date.getTime()) ? date : undefined;
 }
 
 export class PdfService extends Service {
@@ -129,29 +141,21 @@ export class PdfService extends Service {
   async stop(): Promise<void> {}
 
   async convertPdfToText(pdfBuffer: Buffer | Uint8Array): Promise<string> {
-    try {
-      const uint8Array = validatePdfInput(pdfBuffer);
-      const pdf = await getDocumentProxy(uint8Array);
-      const numPages = pdf.numPages;
+    const uint8Array = validatePdfInput(pdfBuffer);
+    const pdf = await getDocumentProxy(uint8Array);
+    const numPages = pdf.numPages;
 
-      const textPages: string[] = [];
+    const textPages: string[] = [];
 
-      for (let pageNum = 1; pageNum <= numPages; pageNum++) {
-        const page = await pdf.getPage(pageNum);
-        const textContent = await page.getTextContent();
-        const pageText = collectTextStrings(textContent.items).join(" ");
-        textPages.push(pageText);
-      }
-
-      const rawText = textPages.join("\n");
-      return this.cleanUpContent(rawText);
-    } catch (error) {
-      const bufferSize = pdfBuffer instanceof Uint8Array ? pdfBuffer.length : "unknown";
-      logger.error(
-        `PdfService: Failed to convert PDF to text - error: ${error}, bufferSize: ${bufferSize}`
-      );
-      throw error;
+    for (let pageNum = 1; pageNum <= numPages; pageNum++) {
+      const page = await pdf.getPage(pageNum);
+      const textContent = await page.getTextContent();
+      const pageText = collectTextStrings(textContent.items).join(" ");
+      textPages.push(pageText);
     }
+
+    const rawText = textPages.join("\n");
+    return this.cleanUpContent(rawText);
   }
 
   async convertPdfToTextWithOptions(
@@ -188,6 +192,7 @@ export class PdfService extends Service {
         pageCount: numPages,
       };
     } catch (error) {
+      // error-policy:J1 PdfConversionResult is this public method's structured failure boundary.
       return {
         success: false,
         error: error instanceof Error ? error.message : String(error),
@@ -201,7 +206,10 @@ export class PdfService extends Service {
     const numPages = pdf.numPages;
 
     const metadataResult = await pdf.getMetadata();
-    const info = (metadataResult.info ?? {}) as Record<string, string | Date | undefined | null>;
+    const info =
+      typeof metadataResult.info === "object" && metadataResult.info !== null
+        ? (metadataResult.info as Record<string, unknown>)
+        : {};
 
     const metadata: PdfMetadata = {
       title: typeof info.Title === "string" ? info.Title : undefined,
@@ -243,33 +251,24 @@ export class PdfService extends Service {
   }
 
   cleanUpContent(content: string): string {
-    try {
-      const filtered = content
-        .split("")
-        .filter((char) => {
-          const charCode = char.charCodeAt(0);
-          return !(
-            charCode === 0 ||
-            (charCode >= 1 && charCode <= 8) ||
-            (charCode >= 11 && charCode <= 12) ||
-            (charCode >= 14 && charCode <= 31) ||
-            charCode === 127
-          );
-        })
-        .join("");
+    const filtered = content
+      .split("")
+      .filter((char) => {
+        const charCode = char.charCodeAt(0);
+        return !(
+          charCode === 0 ||
+          (charCode >= 1 && charCode <= 8) ||
+          (charCode >= 11 && charCode <= 12) ||
+          (charCode >= 14 && charCode <= 31) ||
+          charCode === 127
+        );
+      })
+      .join("");
 
-      const cleaned = filtered
-        .replace(/[^\S\r\n]+/g, " ")
-        .replace(/[ \t]+(\r?\n)/g, "$1")
-        .trim();
-
-      return cleaned;
-    } catch (error) {
-      logger.error(
-        `PdfService: Failed to clean up content - error: ${error}, contentLength: ${content.length}`
-      );
-      return content;
-    }
+    return filtered
+      .replace(/[^\S\r\n]+/g, " ")
+      .replace(/[ \t]+(\r?\n)/g, "$1")
+      .trim();
   }
 }
 


### PR DESCRIPTION
# Relates to

Closes #18728.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can reproduce the real unpdf boundary and adversarial-shape matrix below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@fa0573bacfe0810c1ee1c0ffb9ecb6951f33834f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@fa0573bacfe0810c1ee1c0ffb9ecb6951f33834f`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 tasks with 0 cache hits, followed by all repository audits.

# Risks

Low. Metadata fields are optional, so unsupported runtime types now remain unavailable instead of being coerced. Malformed text-content collection shapes now fail explicitly. Valid string/Date metadata and array text extraction retain their existing behavior.

# Background

## What does this PR do?

Repairs the public `PdfService` boundary in four related ways:

- Converts validated `Buffer` inputs into a plain `Uint8Array` view before calling unpdf. The real parser rejects Node `Buffer` instances even though the service publicly accepts them.
- Treats metadata as untrusted runtime data and admits dates only from strings or finite `Date` objects. Numbers, booleans, invalid dates, and non-string descriptive fields no longer become fabricated metadata.
- Requires `textContent.items` to be an array. Malformed parser output throws through the direct APIs or becomes the options API's documented structured failure result; it is never disguised as empty text.
- Removes catch-and-return cleanup behavior that could surface unsanitized content after an internal failure. Cleanup now succeeds or fails visibly.

A new integration test constructs a valid PDF in memory and sends it through the real unpdf parser. It proves actual Buffer input, text extraction, valid author metadata, and hostile numeric/boolean metadata behavior together.

## What kind of change is this?

Bug fix (fail-fast untrusted parser boundary).

# Documentation changes needed?

No external documentation change is needed. The existing README already promises Buffer support and structured metadata; this PR makes the implementation honor that contract.

# Testing

## Where should a reviewer start?

- `plugins/plugin-pdf/services/pdf.ts`
- `plugins/plugin-pdf/__tests__/pdf-service.integration.test.ts`
- `plugins/plugin-pdf/__tests__/pdf-service.test.ts`

## Detailed testing steps

```text
bun run --cwd plugins/plugin-pdf lint:check
8 files checked; no fixes required

bun run --cwd plugins/plugin-pdf typecheck
pass

bun run --cwd plugins/plugin-pdf test -- --reporter=verbose
2 files passed; 28 tests passed, including the real unpdf boundary

bun run --cwd plugins/plugin-pdf build
Node, browser, and TypeScript declaration builds passed

bun run verify
350 successful, 350 total, 0 cached; all repository audits passed
```

# Evidence Gate

<!-- evidence-head:ef22ac8947caf87becabd6caed5524ebb9285b61 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this is a local service/parser boundary with no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no view, style, layout, or visual asset changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - behavior is exercised through deterministic PDF service calls.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend process or transport route is changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no action, provider, prompt, planner, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Real unpdf parse plus adversarial API matrix prove the corrected boundary.

```text
real unpdf input: Node Buffer normalized to plain Uint8Array; extracted text="real parser boundary" and author="Ada"
real hostile Info dictionary: Title=123, CreationDate=0, ModDate=false; all three resulting fields were undefined rather than coerced
direct convert/getDocumentInfo APIs: null, undefined, object, string, and numeric text items each rejected with "PDF text content items must be an array"
options conversion API: the same five malformed collection shapes returned success=false with the exact explicit boundary error
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered UI changes.

# Evidence Details

## Real LLM-call trajectory

N/A - this changes only local deterministic PDF parsing.

## Backend + frontend logs

N/A - no backend/frontend surface changes. The real parser transcript above is the affected boundary.

## Screenshots (before / after) + video walkthrough

N/A - no rendered files or UI flows are changed.

## Audio / voice walkthrough

N/A - no audio or voice behavior changes.

## Known gaps / failures

None. The real parser integration, adversarial unit matrix, package lint/typecheck/test/build lanes, installation, diff checks, and full uncached root verification pass on the synchronized head.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@fa0573bacfe0810c1ee1c0ffb9ecb6951f33834f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@fa0573bacfe0810c1ee1c0ffb9ecb6951f33834f:packages/skills/skills/contribute-to-eliza"} -->
