### PR TITLE
fix(agent): reject bug-report dot path repositories

### DIFF
--- a/packages/agent/src/api/bug-report-routes.ts
+++ b/packages/agent/src/api/bug-report-routes.ts
@@ -19,6 +19,10 @@ function sanitizeRepoName(value: string | undefined): string | null {
   const trimmed = value?.trim();
   if (!trimmed) return null;
   if (!/^[\w.-]+\/[\w.-]+$/.test(trimmed)) return null;
+  const [owner, repo] = trimmed.split("/");
+  if (owner === "." || owner === ".." || repo === "." || repo === "..") {
+    return null;
+  }
   return trimmed;
 }
 

--- a/packages/agent/test/api/bug-report-routes.test.ts
+++ b/packages/agent/test/api/bug-report-routes.test.ts
@@ -99,6 +99,11 @@ describe.sequential("bug report repository routing", () => {
     ["missing owner", "/repo"],
     ["missing repository", "owner/"],
     ["extra path segment", "owner/repo/issues"],
+    ["dot owner", "./repo"],
+    ["parent owner", "../repo"],
+    ["dot repository", "owner/."],
+    ["parent repository", "owner/.."],
+    ["dot path", "../.."],
   ])("falls back for a %s primary override", (_name, value) => {
     expect(
       resolveBugReportRepo({
@@ -119,6 +124,20 @@ describe.sequential("bug report repository routing", () => {
         "https://github.com/elizaOS/eliza/issues/new?template=bug_report.yml",
     });
     expect(ctx.responseStatus).toBe(200);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the canonical no-token URL for a dot-path override", async () => {
+    vi.stubEnv(BUG_REPORT_REPO_ENV_KEY, "../..");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const ctx = createContext();
+
+    expect(await handleBugReportRoutes(ctx)).toBe(true);
+    expect(ctx.responseBody).toEqual({
+      fallback:
+        "https://github.com/elizaOS/eliza/issues/new?template=bug_report.yml",
+    });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -158,6 +177,27 @@ describe.sequential("bug report repository routing", () => {
     expect(ctx.responseBody).toEqual({
       url: "https://github.com/elizaOS/eliza/issues/123",
     });
+  });
+
+  it("posts to the canonical GitHub API for a dot-path override", async () => {
+    vi.stubEnv(BUG_REPORT_REPO_ENV_KEY, "../..");
+    vi.stubEnv("GITHUB_TOKEN", "test-token-not-a-credential");
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            html_url: "https://github.com/elizaOS/eliza/issues/123",
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const ctx = createContext();
+
+    expect(await handleBugReportRoutes(ctx)).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.github.com/repos/elizaOS/eliza/issues");
   });
 
   it("keeps remote intake precedence over token-backed GitHub submission", async () => {


### PR DESCRIPTION
# Relates to

Fixes #18785.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` were run after sync.
- [x] A reviewer can verify both malformed-override route modes from the exact-head tests and linked structured transcript.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex-desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@fa0573bacfe0810c1ee1c0ffb9ecb6951f33834f`; zero conflicts and 0 commits behind at final verification.
- [x] `bun run verify` passes post-sync: 350/350 workspace tasks and every repository audit passed.

# Risks

Low. This tightens only repository-name validation for the two otherwise-valid path segments `.` and `..`. Ordinary owner/repository overrides, precedence, sanitization, rate limiting, and remote intake are unchanged.

# Background

## What does this PR do?

- Rejects `.` and `..` as either GitHub repository path segment.
- Falls back to `elizaOS/eliza` for malformed overrides such as `../..`.
- Exercises both no-token fallback URL generation and token-backed GitHub API routing at the real handler boundary.
- Adds an adversarial resolver matrix for dot and parent segments in owner and repository positions.

## What kind of change is this?

Backend input-validation bug fix (non-breaking).

# Documentation changes needed?

No. Valid configuration and public API behavior are unchanged.

# Testing

## Where should a reviewer start?

`packages/agent/test/api/bug-report-routes.test.ts`, especially the two `dot-path override` route cases.

## Detailed testing steps

- `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/test/api/bug-report-routes.test.ts` — PASS, 19/19.
- `bun run --cwd packages/agent test` — PASS, 397 isolated batches.
- `bun run --cwd packages/agent typecheck` — PASS.
- `bun run --cwd packages/agent lint:check` — PASS.
- `bun install --frozen-lockfile --ignore-scripts` — PASS, no changes.
- `bun run verify` — PASS, 350/350 workspace tasks and all repository audits.
- `git diff --check` — PASS.

# Evidence Gate

<!-- evidence-head:737b9f1659e72af987140df8953c476c071ab320 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend repository-destination validation has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend repository-destination validation has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic HTTP handler tests cover the complete changed flow without an interactive surface.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head route-boundary transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18785-route-boundary.json) records the malformed override, request mode, canonical destination, status, fetch count, adversarial matrix, and verification results.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, or code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, provider, prompt, action, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the affected artifacts are backend destination URLs and are captured in the structured route transcript above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Backend evidence

The exact-head route test invokes `POST /api/bug-report` with `ELIZA_BUG_REPORT_REPO=../..` in both modes:

```text
fallback: status 200, fetch calls 0
destination: https://github.com/elizaOS/eliza/issues/new?template=bug_report.yml

token-backed: recorded fetch calls 1
destination: https://api.github.com/repos/elizaOS/eliza/issues
```

Artifact SHA-256: `17736e2dce166e032b73d6a8db884ae8f1f2b7dc87059d3defd5fa12f013ab8d`.

## Real LLM-call trajectory

N/A - no model path changed.

## Screenshots (before / after) + video walkthrough

N/A - this change affects only backend destination validation and its deterministic handler tests.

## Known gaps / failures

No test or verification failure remains. Visual, frontend, persistent-domain, and LLM evidence are inapplicable to this backend repository-name validator.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-issue-triage]
