### PR TITLE
fix(core): regenerate empty embedding vectors

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -10924,7 +10924,7 @@ ${section_end}`;
 		);
 	}
 	async addEmbeddingToMemory(memory: Memory): Promise<Memory> {
-		if (memory.embedding) {
+		if (Array.isArray(memory.embedding) && memory.embedding.length > 0) {
 			return memory;
 		}
 		const memoryText = memory.content.text;
@@ -10980,7 +10980,11 @@ ${section_end}`;
 		priority?: "high" | "normal" | "low",
 	): Promise<void> {
 		priority = priority || "normal";
-		if (!memory || memory.embedding || !memory.content.text) {
+		if (
+			!memory ||
+			(Array.isArray(memory.embedding) && memory.embedding.length > 0) ||
+			!memory.content.text
+		) {
 			return;
 		}
 		if (this.embeddingGenerationDisabledReason !== null) {

--- a/packages/core/src/runtime/__tests__/embedding-dimension.test.ts
+++ b/packages/core/src/runtime/__tests__/embedding-dimension.test.ts
@@ -77,6 +77,46 @@ describe("AgentRuntime.ensureEmbeddingDimension provider failover", () => {
 		expect(ensureDim).toHaveBeenCalledWith(384);
 	});
 
+	it("regenerates empty vectors while preserving non-empty idempotency", async () => {
+		const runtime = makeRuntime();
+		const embedHandler = vi.fn(async () => [0.25, 0.5]);
+		runtime.registerModel(ModelType.TEXT_EMBEDDING, embedHandler, "direct", 0);
+
+		const empty = makeMemory("empty vector");
+		empty.embedding = [];
+		await expect(runtime.addEmbeddingToMemory(empty)).resolves.toBe(empty);
+		expect(empty.embedding).toEqual([0.25, 0.5]);
+
+		const existing = makeMemory("existing vector");
+		existing.embedding = [9];
+		await expect(runtime.addEmbeddingToMemory(existing)).resolves.toBe(
+			existing,
+		);
+		expect(existing.embedding).toEqual([9]);
+		expect(embedHandler).toHaveBeenCalledTimes(1);
+	});
+
+	it("queues empty vectors while skipping non-empty vectors", async () => {
+		const runtime = makeRuntime();
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING,
+			async () => [0.25],
+			"direct",
+			0,
+		);
+		const emitEvent = vi.spyOn(runtime, "emitEvent");
+
+		const empty = makeMemory("queue empty vector");
+		empty.embedding = [];
+		await runtime.queueEmbeddingGeneration(empty);
+		expect(emitEvent).toHaveBeenCalledTimes(1);
+
+		const existing = makeMemory("queue existing vector");
+		existing.embedding = [9];
+		await runtime.queueEmbeddingGeneration(existing);
+		expect(emitEvent).toHaveBeenCalledTimes(1);
+	});
+
 	it("fails over past a broken provider on a non-rate-limit probe error and pins the working provider", async () => {
 		const runtime = makeRuntime();
 		const brokenHandler = vi.fn(async () => {

--- a/packages/core/src/services/embedding.test.ts
+++ b/packages/core/src/services/embedding.test.ts
@@ -124,9 +124,68 @@ describe("EmbeddingGenerationService drain config", () => {
 		expect(service.getQueueSize()).toBe(0);
 		expect(updateMemory).not.toHaveBeenCalled();
 	});
+
+	test("queues empty vectors but skips memories with a non-empty vector", async () => {
+		const runtime = makeRuntime({ batch: false });
+		const service = (await EmbeddingGenerationService.start(
+			runtime,
+		)) as EmbeddingGenerationService;
+		const emptyVector = makeItem("id-empty-vector", "needs embedding");
+		// biome-ignore lint/suspicious/noExplicitAny: exercise malformed persisted vector state
+		(emptyVector.memory as any).embedding = [];
+		const existingVector = makeItem("id-existing-vector", "already embedded");
+		// biome-ignore lint/suspicious/noExplicitAny: exercise valid persisted vector idempotency
+		(existingVector.memory as any).embedding = [9];
+
+		// biome-ignore lint/suspicious/noExplicitAny: exercise the private event handler directly
+		await (service as any).handleEmbeddingRequest({
+			memory: emptyVector.memory,
+			priority: "normal",
+		});
+		// biome-ignore lint/suspicious/noExplicitAny: exercise the private event handler directly
+		await (service as any).handleEmbeddingRequest({
+			memory: existingVector.memory,
+			priority: "normal",
+		});
+
+		expect(service.getQueueSize()).toBe(1);
+		process.env.ELIZA_FAST_SHUTDOWN = "1";
+		await service.stop();
+	});
 });
 
 describe("EmbeddingGenerationService processBatch", () => {
+	test("single-item generation retries an empty vector but preserves idempotency", async () => {
+		const written: { id: string; embedding: number[] }[] = [];
+		const embedHandler = vi.fn(async () => [0.2, 0.4]);
+		const runtime = makeRuntime({
+			batch: false,
+			embedHandler,
+			updateMemory: async ({ id, embedding }) => {
+				written.push({ id, embedding });
+			},
+		});
+		const service = (await EmbeddingGenerationService.start(
+			runtime,
+		)) as EmbeddingGenerationService;
+
+		const empty = makeItem("id-empty-vector", "needs embedding");
+		// biome-ignore lint/suspicious/noExplicitAny: exercise malformed persisted vector state
+		(empty.memory as any).embedding = [];
+		// biome-ignore lint/suspicious/noExplicitAny: exercise the private per-item processor directly
+		await (service as any).generateEmbedding(empty);
+
+		const existing = makeItem("id-existing-vector", "already embedded");
+		// biome-ignore lint/suspicious/noExplicitAny: exercise valid persisted vector idempotency
+		(existing.memory as any).embedding = [9];
+		// biome-ignore lint/suspicious/noExplicitAny: exercise the private per-item processor directly
+		await (service as any).generateEmbedding(existing);
+
+		expect(embedHandler).toHaveBeenCalledTimes(1);
+		expect(written).toEqual([{ id: "id-empty-vector", embedding: [0.2, 0.4] }]);
+		await service.stop();
+	});
+
 	test("batches multiple items into ONE TEXT_EMBEDDING_BATCH call and writes back per id", async () => {
 		let batchCalls = 0;
 		let lastTexts: string[] = [];
@@ -237,7 +296,7 @@ describe("EmbeddingGenerationService processBatch", () => {
 		await service.stop();
 	});
 
-	test("skips empty / already-embedded items but still embeds the rest in one call", async () => {
+	test("skips missing-text / already-embedded items but still embeds empty vectors", async () => {
 		let batchCalls = 0;
 		let lastTexts: string[] = [];
 		const written: string[] = [];
@@ -263,20 +322,24 @@ describe("EmbeddingGenerationService processBatch", () => {
 		const alreadyEmbedded = makeItem("id-skip", "ignored");
 		// biome-ignore lint/suspicious/noExplicitAny: set a pre-existing vector
 		(alreadyEmbedded.memory as any).embedding = [9];
+		const emptyVector = makeItem("id-empty-vector", "needs embedding");
+		// biome-ignore lint/suspicious/noExplicitAny: exercise malformed persisted vector state
+		(emptyVector.memory as any).embedding = [];
 		const items = [
 			makeItem("id-real", "real text"),
 			makeItem("id-empty", undefined),
 			alreadyEmbedded,
+			emptyVector,
 		];
 		const outcomes = await processBatch(items);
 
 		expect(batchCalls).toBe(1);
-		expect(lastTexts).toEqual(["real text"]);
-		// All three outcomes succeed (two skipped, one embedded); only the real
-		// one is written back.
-		expect(outcomes).toHaveLength(3);
+		expect(lastTexts).toEqual(["real text", "needs embedding"]);
+		// All four outcomes succeed (two skipped, two embedded); only the real
+		// and empty-vector items are written back.
+		expect(outcomes).toHaveLength(4);
 		expect(outcomes.every((o) => o.success)).toBe(true);
-		expect(written).toEqual(["id-real"]);
+		expect(written).toEqual(["id-real", "id-empty-vector"]);
 
 		await service.stop();
 	});

--- a/packages/core/src/services/embedding.ts
+++ b/packages/core/src/services/embedding.ts
@@ -167,7 +167,7 @@ export class EmbeddingGenerationService extends Service {
 
 		const { memory, priority = "normal", runId } = payload;
 
-		if (memory.embedding) {
+		if (Array.isArray(memory.embedding) && memory.embedding.length > 0) {
 			this.runtime.logger.debug(
 				{
 					src: "plugin:basic-capabilities:service:embedding",
@@ -218,7 +218,7 @@ export class EmbeddingGenerationService extends Service {
 		}
 
 		// Idempotency: skip a memory that already carries a vector.
-		if (memory.embedding) {
+		if (Array.isArray(memory.embedding) && memory.embedding.length > 0) {
 			return;
 		}
 
@@ -334,7 +334,11 @@ export class EmbeddingGenerationService extends Service {
 			const text = item.memory.content.text;
 			// Same trim rule as the per-item path — backends reject
 			// whitespace-only text as terminally invalid.
-			if (!text?.trim() || item.memory.embedding) {
+			if (
+				!text?.trim() ||
+				(Array.isArray(item.memory.embedding) &&
+					item.memory.embedding.length > 0)
+			) {
 				skipped.push(item);
 			} else {
 				toEmbed.push({ item, text });


### PR DESCRIPTION
# Relates to

Closes #18874

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install --frozen-lockfile` and full `bun run verify` were not run because dependencies are managed through an existing ignored worktree symlink and the full verify path is outside this focused core regression.
- [x] A reviewer can confirm the change works from the focused test evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@361cd3e588f8c073994ad0be1cdfa6a52b4711e5`; zero conflicts and zero commits behind.
- [x] Post-rebase exact-head proof at `ee4cb15a6d44efb150f84883cee7b0b2c492beea`: 2 focused test files / 27 tests passed; Biome and `git diff --check` passed.

# What changed

`embedding: []` is truthy, so the runtime and `EmbeddingGenerationService` previously treated an empty vector as a completed embedding. This patch makes every relevant idempotency gate require a non-empty array:

- `AgentRuntime.addEmbeddingToMemory` regenerates empty vectors.
- `AgentRuntime.queueEmbeddingGeneration` queues empty vectors while still skipping valid vectors.
- Service request handling, single-item generation, and batch partitioning do the same.

Valid non-empty vectors remain idempotent; missing text and disabled-generation behavior are unchanged.

# Testing

Focused command:

```text
bun run --cwd packages/core test -- src/runtime/__tests__/embedding-dimension.test.ts src/services/embedding.test.ts
```

Result: 2 test files passed, 27 tests passed.

Additional checks:

- Biome 2.5.6: 4 changed files checked, no fixes.
- `git diff --check`: passed.
- Core typecheck was attempted and is blocked by an existing dependency declaration gap (`fast-redact` has no declaration file in the reused dependency tree); no source or lockfile change resulted.

# Evidence Gate

<!-- evidence-head:ee4cb15a6d44efb150f84883cee7b0b2c492beea -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - this is deterministic core embedding orchestration with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - this is deterministic core embedding orchestration with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing visual flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - focused tests use an in-memory runtime and mocked embedding handlers; no backend deployment is involved.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend or network path changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - this changes embedding completion guards, not model prompting or agent behavior.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no external domain artifact is produced; test assertions cover memory write-back and queue behavior.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text changed.

# Known gaps

The repository-wide `bun run verify` and a clean dependency install remain for hosted CI/maintainer execution. The focused core regression and formatting checks are green; the only local typecheck blocker is the pre-existing `fast-redact` declaration resolution in the reused dependency tree.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 43642252 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [symbiex-cycle3]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZWAJ4ZPSNWXAEEDEQEJ4NV5","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T01:07:38.102Z","completed_at":"2026-08-13T01:19:39.294Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":1187978,"output_tokens":79746,"cache_creation_tokens":0,"cache_read_tokens":42374528,"total_tokens":43642252,"cost_micro_usd":"29519534","session_count":7},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"WvIZHyLQ5NBEhowaEA9i0ehNAQAyndUi1cFTN9LmgSG5FOF4d_DWr4wIJjq2IZHDny5_0GtuSOY5h3OMVgL1DQ"}} -->
