### PR TITLE
fix(skills): surface malformed frontmatter YAML

### DIFF
--- a/packages/skills/src/frontmatter.ts
+++ b/packages/skills/src/frontmatter.ts
@@ -4,6 +4,7 @@
  * it, and writes it back. Provenance records whether a skill is human-authored,
  * agent-generated, or agent-refined (see types.ts).
  */
+import { ElizaError } from "@elizaos/core";
 import { parse, stringify } from "yaml";
 import type {
   SkillFrontmatter,
@@ -16,6 +17,9 @@ export interface ParsedFrontmatter<T extends Record<string, unknown>> {
   frontmatter: T;
   body: string;
 }
+
+/** Stable error code raised when a SKILL.md frontmatter block is invalid YAML. */
+export const INVALID_SKILL_FRONTMATTER_YAML = "INVALID_SKILL_FRONTMATTER_YAML";
 
 function normalizeNewlines(value: string): string {
   return value.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
@@ -81,13 +85,19 @@ export function parseFrontmatter<
   if (!yamlString) {
     return { frontmatter: {} as T, body };
   }
+  let parsed: unknown;
   try {
-    const parsed = parse(yamlString);
-    if (isRecord(parsed)) {
-      return { frontmatter: parsed as T, body };
-    }
-  } catch {
-    // error-policy:J3 untrusted YAML frontmatter parse fails closed to empty record
+    parsed = parse(yamlString);
+  } catch (cause: unknown) {
+    // error-policy:J2 preserve the YAML parser failure behind a stable domain code
+    throw new ElizaError("Skill frontmatter contains invalid YAML", {
+      code: INVALID_SKILL_FRONTMATTER_YAML,
+      context: { parser: "yaml" },
+      cause,
+    });
+  }
+  if (isRecord(parsed)) {
+    return { frontmatter: parsed as T, body };
   }
   return { frontmatter: {} as T, body };
 }

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -30,6 +30,7 @@ export {
   formatSkillsList,
 } from "./formatter.js";
 export {
+  INVALID_SKILL_FRONTMATTER_YAML,
   type ParsedFrontmatter,
   parseFrontmatter,
   resolveSkillInvocationPolicy,

--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -14,8 +14,9 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
-import { resolveStateDir } from "@elizaos/core";
+import { isElizaError, resolveStateDir } from "@elizaos/core";
 import {
+  INVALID_SKILL_FRONTMATTER_YAML,
   parseFrontmatter,
   resolveSkillInvocationPolicy,
   resolveSkillMetadata,
@@ -100,7 +101,21 @@ function loadSkillFromFile(
     return { skill: null, diagnostics };
   }
 
-  const { frontmatter } = parseFrontmatter<SkillFrontmatter>(rawContent);
+  let frontmatter: SkillFrontmatter;
+  try {
+    ({ frontmatter } = parseFrontmatter<SkillFrontmatter>(rawContent));
+  } catch (error: unknown) {
+    // error-policy:J1 skill discovery translates its known parser failure into a warning diagnostic
+    if (!isElizaError(error) || error.code !== INVALID_SKILL_FRONTMATTER_YAML) {
+      throw error;
+    }
+    diagnostics.push({
+      type: "warning",
+      message: error.message,
+      path: filePath,
+    });
+    return { skill: null, diagnostics };
+  }
   const skillDir = dirname(filePath);
   const parentDirName = basename(skillDir);
 

--- a/packages/skills/test/frontmatter.test.ts
+++ b/packages/skills/test/frontmatter.test.ts
@@ -4,8 +4,10 @@
  * non-plain collection roots, CRLF, and metadata/policy extraction.
  */
 import assert from "node:assert";
+import { ElizaError } from "@elizaos/core";
 import { describe, it } from "node:test";
 import {
+  INVALID_SKILL_FRONTMATTER_YAML,
   parseFrontmatter,
   resolveSkillInvocationPolicy,
   resolveSkillMetadata,
@@ -91,14 +93,21 @@ Body`;
     assert.strictEqual(result.frontmatter["user-invocable"], false);
   });
 
-  it("handles malformed YAML syntax without throwing", () => {
+  it("throws a typed error for malformed YAML and preserves the parser cause", () => {
     const content = `---
 invalid: : : yaml syntax error
 ---
 Body content`;
-    const result = parseFrontmatter(content);
-    assert.deepStrictEqual(result.frontmatter, {});
-    assert.strictEqual(result.body, "Body content");
+    assert.throws(
+      () => parseFrontmatter(content),
+      (error: unknown) => {
+        assert.ok(error instanceof ElizaError);
+        assert.strictEqual(error.code, INVALID_SKILL_FRONTMATTER_YAML);
+        assert.strictEqual(error.message, "Skill frontmatter contains invalid YAML");
+        assert.ok(error.cause instanceof Error);
+        return true;
+      },
+    );
   });
 
   it("returns empty frontmatter for non-object YAML frontmatter blocks", () => {
@@ -178,6 +187,15 @@ name: test
 ---`;
     const body = stripFrontmatter(content);
     assert.strictEqual(body, "");
+  });
+
+  it("does not hide malformed YAML while stripping frontmatter", () => {
+    assert.throws(
+      () => stripFrontmatter("---\ninvalid: : : yaml syntax error\n---\nBody"),
+      (error: unknown) =>
+        error instanceof ElizaError &&
+        error.code === INVALID_SKILL_FRONTMATTER_YAML,
+    );
   });
 });
 

--- a/packages/skills/test/loader.test.ts
+++ b/packages/skills/test/loader.test.ts
@@ -149,6 +149,38 @@ name: no-desc
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("reports malformed YAML instead of a fabricated metadata error", () => {
+    const tempDir = createTempDir("skill-loader-malformed-yaml");
+    try {
+      const filePath = join(tempDir, "malformed.md");
+      writeFileSync(
+        filePath,
+        `---
+invalid: : : yaml syntax error
+---
+# Malformed`,
+      );
+
+      const result = loadSkillsFromDir({ dir: tempDir, source: "test" });
+
+      assert.deepStrictEqual(result.skills, []);
+      assert.deepStrictEqual(result.diagnostics, [
+        {
+          type: "warning",
+          message: "Skill frontmatter contains invalid YAML",
+          path: filePath,
+        },
+      ]);
+      assert.ok(
+        !result.diagnostics.some((diagnostic) =>
+          diagnostic.message.includes("description is required"),
+        ),
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("loadSkills and loadSkillEntries", () => {


### PR DESCRIPTION
# Relates to

Closes #18709.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can reproduce the malformed-YAML parser and loader boundary below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e1ed5a0bec2f7e2ef5cedd718dedf61f3bf584a9:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@e1ed5a0bec2f7e2ef5cedd718dedf61f3bf584a9`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 tasks with 0 cache hits, followed by all repository audits.

# Risks

Low and intentional. Direct `parseFrontmatter` and `stripFrontmatter` callers now receive a typed failure for malformed YAML instead of a fabricated empty mapping. Skill discovery remains a structured boundary: it rejects the invalid skill and emits one accurate warning. Syntactically valid scalar, array, Set, Map, empty, absent, and plain mapping roots retain their existing behavior.

# Background

## What does this PR do?

Malformed YAML was caught and returned as `{}`. The loader then reported `description is required`, making broken syntax indistinguishable from a valid empty mapping.

This change:

- Throws `ElizaError` with stable code `INVALID_SKILL_FRONTMATTER_YAML` from the parser and preserves the YAML parser exception as `cause`.
- Exports the stable code for public callers that need to classify the failure.
- Translates only that known code at the skill-discovery boundary into `Skill frontmatter contains invalid YAML`, rejects the skill, and lets unrelated failures propagate.
- Keeps plain-object admission and existing non-record-root behavior unchanged.

## What kind of change is this?

Bug fix (fail-fast untrusted YAML boundary).

# Documentation changes needed?

No external documentation change is needed. The package loader already promises diagnostics for skills that fail to parse; this makes that diagnostic truthful.

# Testing

## Where should a reviewer start?

- `packages/skills/src/frontmatter.ts`
- `packages/skills/src/loader.ts`
- `packages/skills/test/frontmatter.test.ts`
- `packages/skills/test/loader.test.ts`

## Detailed testing steps

```text
bun run --cwd packages/skills lint:check
6 source files checked; no fixes required

bun run --cwd packages/skills typecheck
pass

bun run --cwd packages/skills test
6 files; 101 tests passed

bun run --cwd packages/skills build
pass

bun run verify
350 successful, 350 total, 0 cached; all repository audits passed
```

# Evidence Gate

<!-- evidence-head:f6a32c2c7ed99409e76a4d6ab45e68106688ab19 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this is a local parser/loader boundary with no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no view, style, layout, or visual asset changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - behavior is exercised through deterministic parser and filesystem loader calls.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend process or transport route is changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no action, provider, prompt, planner, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Typed parser failure and real temporary-file loader regression prove the corrected boundary.

```text
parseFrontmatter(malformed YAML): throws ElizaError code=INVALID_SKILL_FRONTMATTER_YAML; cause is the real YAML parser Error
stripFrontmatter(malformed YAML): propagates the same typed failure instead of hiding it
loadSkillsFromDir(temp directory containing malformed.md): skills=[]; diagnostics=["Skill frontmatter contains invalid YAML"]
misleading downstream diagnostic "description is required": absent
plain/scalar/array/Set/Map/empty/absent cases: existing regressions remain green
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered UI changes.

# Evidence Details

## Real LLM-call trajectory

N/A - this changes only deterministic local YAML parsing.

## Backend + frontend logs

N/A - no backend/frontend surface changes. The parser and loader transcript above is the affected boundary.

## Screenshots (before / after) + video walkthrough

N/A - no rendered files or UI flows are changed.

## Audio / voice walkthrough

N/A - no audio or voice behavior changes.

## Known gaps / failures

None. Parser and real filesystem-loader regressions, package lint/typecheck/test/build lanes, installation, diff checks, and full uncached root verification pass on the synchronized head.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@e1ed5a0bec2f7e2ef5cedd718dedf61f3bf584a9:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@e1ed5a0bec2f7e2ef5cedd718dedf61f3bf584a9:packages/skills/skills/contribute-to-eliza"} -->