### PR TITLE
fix(core): preserve raw active dimension aliases

### DIFF
--- a/packages/core/src/features/documents/config-numeric-validation.test.ts
+++ b/packages/core/src/features/documents/config-numeric-validation.test.ts
@@ -161,32 +161,47 @@ describe("validateModelConfig numeric boundary", () => {
 	});
 
 	it.each([
-		["LOCAL_EMBEDDING_DIMENSIONS", "local", "", 384],
-		["LOCAL_EMBEDDING_DIMENSIONS", "local", "   ", 384],
-		["OPENAI_EMBEDDING_DIMENSIONS", "openai", "", 1536],
-		["OPENAI_EMBEDDING_DIMENSIONS", "openai", "   ", 1536],
-	] as const)(
-		"treats a blank %s alias as unset and uses the provider default",
-		(setting, provider, value, expected) => {
-			vi.stubEnv("EMBEDDING_PROVIDER", provider);
-			vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
-			vi.stubEnv(setting, value);
+		["LOCAL_EMBEDDING_DIMENSIONS", "local", ""],
+		["LOCAL_EMBEDDING_DIMENSIONS", "local", "   "],
+		["OPENAI_EMBEDDING_DIMENSIONS", "openai", ""],
+		["OPENAI_EMBEDDING_DIMENSIONS", "openai", "   "],
+	] as const)("rejects a blank active %s alias", (setting, provider, value) => {
+		vi.stubEnv("EMBEDDING_PROVIDER", provider);
+		vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
+		vi.stubEnv(setting, value);
 
-			expect(validateModelConfig()).toMatchObject({
-				EMBEDDING_PROVIDER: provider,
-				EMBEDDING_DIMENSION: expected,
-			});
-		},
-	);
+		expect(() => validateModelConfig()).toThrow(
+			/Model configuration validation failed: EMBEDDING_DIMENSION:/,
+		);
+	});
 
-	it("treats a blank OpenAI alias as unset when OpenAI is inferred", () => {
+	it("rejects a blank OpenAI alias when OpenAI is inferred", () => {
 		vi.stubEnv("EMBEDDING_PROVIDER", undefined);
 		vi.stubEnv("OPENAI_EMBEDDING_DIMENSIONS", "");
 
-		expect(validateModelConfig()).toMatchObject({
-			EMBEDDING_DIMENSION: 1536,
-		});
+		expect(() => validateModelConfig()).toThrow(
+			/Model configuration validation failed: EMBEDDING_DIMENSION:/,
+		);
 	});
+
+	it.each([
+		["LOCAL_EMBEDDING_DIMENSIONS", "local", "768"],
+		["OPENAI_EMBEDDING_DIMENSIONS", "openai", "3072"],
+	] as const)(
+		"does not let a valid environment %s hide an active blank runtime value",
+		(setting, provider, environmentValue) => {
+			vi.stubEnv(setting, environmentValue);
+			vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
+			const runtime = runtimeWithSettings({
+				EMBEDDING_PROVIDER: provider,
+				[setting]: "   ",
+			});
+
+			expect(() => validateModelConfig(runtime)).toThrow(
+				/Model configuration validation failed: EMBEDDING_DIMENSION:/,
+			);
+		},
+	);
 
 	it("ignores inactive local and OpenAI aliases for Google embeddings", () => {
 		vi.stubEnv("EMBEDDING_PROVIDER", "google");

--- a/packages/core/src/features/documents/config.ts
+++ b/packages/core/src/features/documents/config.ts
@@ -65,17 +65,12 @@ export function validateModelConfig(runtime?: IAgentRuntime): ModelConfig {
 		);
 		const embeddingProvider = getSetting("EMBEDDING_PROVIDER");
 		const localEmbeddingModel = getSetting("LOCAL_EMBEDDING_MODEL");
-		// Alias dimension reads follow the same blank-is-unset convention as
-		// normalizeEnvValue: a blank/whitespace-only alias falls through to the
-		// provider default instead of reaching the numeric schema.
-		const getDimensionAlias = (key: string) => {
-			const raw = getNumericSetting(key);
-			return typeof raw === "string" ? normalizeEnvValue(raw) : raw;
-		};
-		const localEmbeddingDimensions = getDimensionAlias(
+		// Keep numeric aliases raw so explicit blanks reach schema validation;
+		// provider scoping below prevents an inactive alias from leaking across.
+		const localEmbeddingDimensions = getNumericSetting(
 			"LOCAL_EMBEDDING_DIMENSIONS",
 		);
-		const openaiEmbeddingDimensions = getDimensionAlias(
+		const openaiEmbeddingDimensions = getNumericSetting(
 			"OPENAI_EMBEDDING_DIMENSIONS",
 		);
 		const inferredLocalEmbeddings =


### PR DESCRIPTION
# Relates to

Closes #18793. Corrects the active-alias regression merged by #18842.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` pass on the exact head.
- [x] The real configuration boundary is covered by focused caller tests.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - maintainer PR-review repair`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on `origin/develop@da13515bf850d94aec8881d9a97de70bcb2c4961`; zero conflicts and one scoped commit ahead.
- [x] Exact-head `bun run verify` passes: 350/350 tasks and all repository audits.

# Risks

Low and bounded to document configuration parsing. Active blank legacy dimension aliases now fail during schema validation instead of silently receiving a provider default. Inactive aliases remain isolated from the selected provider, and omitted aliases still receive the existing defaults.

# Background

## What does this PR do?

- Preserves raw values for active `LOCAL_EMBEDDING_DIMENSIONS` and `OPENAI_EMBEDDING_DIMENSIONS` aliases so explicit empty and whitespace-only numeric settings reach schema validation.
- Keeps provider-scoped alias resolution, so inactive aliases cannot leak into Google or another embedding provider.
- Adds runtime-over-environment regressions proving a valid deployment alias cannot hide a blank active per-agent value.

#18793 explicitly requires whitespace-only document numeric settings to fail at the shared configuration boundary. #18842 initially implemented that contract, then its final commit reversed it to blank-as-unset immediately before merge.

## What kind of change is this?

Bug fix restoring the accepted strict numeric-setting contract.

# Documentation changes needed?

No. This restores the issue's documented validation behavior and changes no public API.

# Testing

## Where should a reviewer start?

`packages/core/src/features/documents/config-numeric-validation.test.ts` and the provider-scoped alias resolution in `config.ts`.

## Detailed testing results

- `bunx vitest run packages/core/src/features/documents/config-numeric-validation.test.ts` — 25/25 pass.
- `bun run --cwd packages/core typecheck` — pass.
- `bun run --cwd packages/core build` — all Node/browser/edge targets and declarations pass.
- `bun run --cwd packages/core test` — 514 files passed; 5,772 tests passed; 1 intentional skip.
- `bun run verify` — 350/350 tasks and all repository audits pass.
- Verified with Node 24.15.0 and Bun 1.3.14.

# Evidence Gate

<!-- evidence-head:f0347dda68951978a78a8ac2d8c425c52ee89d52 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - synchronous configuration validation has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no view, style, layout, or visual asset changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - invalid input fails before ingestion or interactive runtime work.
<!-- evidence-row:backend-logs -->
- [x] N/A - the deterministic parser boundary runs before backend ingestion starts.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider call, action, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Focused caller tests prove active blanks fail, inactive aliases remain isolated, and omitted/default values remain intact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Known gaps / failures

No focused, package, build, or repository verification failure remains. Visual, frontend, live-model, and persistent-domain evidence is inapplicable because the change is a deterministic pre-ingestion configuration boundary.