### PR TITLE
test(app): bound startup trace CLI cases

### DIFF
--- a/packages/app/scripts/capture-startup-trace.test.ts
+++ b/packages/app/scripts/capture-startup-trace.test.ts
@@ -127,33 +127,64 @@ describe("parseArgs --runs / --timeout", () => {
 });
 
 describe("CLI --runs / --timeout fail-closed", () => {
+  const invalidCliCases: Array<[string, string[], RegExp]> = [
+    ["--runs junk", ["--runs", "junk"], /^\[startup-trace\] --runs must/m],
+    ["--runs 10junk", ["--runs", "10junk"], /^\[startup-trace\] --runs must/m],
+    ["--runs 0", ["--runs", "0"], /^\[startup-trace\] --runs must/m],
+    ["--runs -3", ["--runs", "-3"], /^\[startup-trace\] --runs must/m],
+    ["missing --runs value", ["--runs"], /^\[startup-trace\] --runs requires/m],
+    [
+      "--runs followed by another option",
+      ["--runs", "--url", "http://127.0.0.1:1"],
+      /^\[startup-trace\] --runs requires/m,
+    ],
+    [
+      "--timeout junk",
+      ["--timeout", "junk"],
+      /^\[startup-trace\] --timeout must/m,
+    ],
+    [
+      "--timeout 10junk",
+      ["--timeout", "10junk"],
+      /^\[startup-trace\] --timeout must/m,
+    ],
+    ["--timeout 0", ["--timeout", "0"], /^\[startup-trace\] --timeout must/m],
+    [
+      "missing --timeout value",
+      ["--timeout"],
+      /^\[startup-trace\] --timeout requires/m,
+    ],
+    [
+      "overflowing --timeout",
+      ["--timeout", String(MAX_TIMER_DELAY_MS + 1)],
+      /^\[startup-trace\] --timeout must/m,
+    ],
+  ];
+
   function runCli(extraArgs: string[]) {
     return spawnSync(process.execPath, [SCRIPT_PATH, ...extraArgs], {
       encoding: "utf8",
+      killSignal: "SIGKILL",
+      maxBuffer: 256 * 1024,
+      timeout: 3_000,
     });
   }
 
-  it("rejects malformed and missing values before launching a capture", () => {
-    for (const args of [
-      ["--runs", "junk"],
-      ["--runs", "10junk"],
-      ["--runs", "0"],
-      ["--runs", "-3"],
-      ["--runs"],
-      ["--runs", "--url", "http://127.0.0.1:1"],
-      ["--timeout", "junk"],
-      ["--timeout", "10junk"],
-      ["--timeout", "0"],
-      ["--timeout"],
-      ["--timeout", String(MAX_TIMER_DELAY_MS + 1)],
-    ]) {
+  it.each(invalidCliCases)(
+    "rejects %s before launching a capture",
+    (_label, args, expectedDiagnostic) => {
       const result = runCli(args);
+      expect(result.error, args.join(" ")).toBeUndefined();
+      expect(result.signal, args.join(" ")).toBeNull();
       expect(result.status, args.join(" ")).not.toBe(0);
-      expect(result.stderr, args.join(" ")).toMatch(/startup-trace/i);
+      // Anchor on the CLI boundary prefix and the exact flag. A bootstrap or
+      // import failure can mention capture-startup-trace.mjs without ever
+      // reaching parseArgs, and must not satisfy this regression.
+      expect(result.stderr, args.join(" ")).toMatch(expectedDiagnostic);
       // Must not reach the capture banner that prints after successful parse.
       expect(result.stdout, args.join(" ")).not.toMatch(
         /Capturing startup trace:/,
       );
-    }
-  });
+    },
+  );
 });


### PR DESCRIPTION
# Closes #18868

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run; exact-head post-rebase validation is recorded below.
- [x] A reviewer can confirm the changed boundary from the real-process transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@9da0daa68b91dcefe274783e33cf9f5320aea0b1`; zero conflicts.
- [x] Full repository verification passed, followed by repeated exact-head focused checks after the final rebase.

# Risks

Low. This changes one test harness only. Production startup tracing, argument parsing, browser launch, and capture behavior are unchanged. Each real subprocess now has an explicit three-second deadline, forced termination signal, bounded output buffer, and assertions that it exited normally rather than being killed.

# Background

## What does this PR do?

Splits one sequential eleven-case real-process loop into independent parameterized tests. Each malformed-input case now owns Bun's ordinary per-test timeout while the spawned child is explicitly bounded. This preserves the important assertion that invalid `--runs` and `--timeout` values fail before capture work, without hiding a hung child behind a larger global test timeout.

## What kind of change is this?

Test reliability fix; no production behavior change.

# Documentation changes needed?

N/A - no product, command, or public contract changes.

# Testing

## Where should a reviewer start?

Run:

```bash
bun test packages/app/scripts/capture-startup-trace.test.ts
```

## Detailed testing steps

- Repeated the normal focused command three times: each run passed 28/28 under Bun's default per-test timeout in about six seconds total.
- Each of the eleven real subprocesses completed normally in roughly 0.4-0.8 seconds, returned a nonzero status, had no spawn error or signal, emitted its expected argument diagnostic, and never printed the capture banner.
- `bunx biome check packages/app/scripts/capture-startup-trace.test.ts` passed.
- `bun run audit:scripts` passed.
- `git diff --check origin/develop...HEAD` passed.
- Full `bun run verify` passed all 350/350 Turbo tasks and subsequent repository audits before the final unrelated-core rebase; the exact-head focused and repository-script checks were rerun after that rebase.

# Evidence Gate

<!-- evidence-head:bb9b7f71d934318ba5d3c70d1d8637198c6b04b2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-harness-only change with no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-harness-only change with no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow or UI changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime path changes; the real subprocess transcript is the affected boundary.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no durable product artifact is produced; the inline real-process transcript is the affected test evidence.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered UI changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changes.

## Backend + frontend logs

N/A - this is a deterministic script-test boundary. Exact real-process transcript:

```text
 packages/app/scripts/capture-startup-trace.mjs --runs junk
[startup-trace] --runs must be a positive decimal integer from 1 to 9007199254740991, got "junk"
exit: 1; stdout: empty
```

The test anchors this exact CLI prefix and flag diagnostic; an import/bootstrap failure mentioning the script filename cannot satisfy it.

## Screenshots (before / after) + video walkthrough

N/A - no rendered files or product flows changed.

## Audio / voice walkthrough

N/A - no audio or voice behavior changed.

## Known gaps / failures

The isolated app typecheck in a symlinked disposable checkout cannot resolve existing optional workspace database dependencies such as `drizzle-orm` and `pg`; it reports no diagnostic in the changed test file. The full repository verification's owning-workspace typecheck passed before the final rebase, and the final rebase only updates the base while preserving this patch unchanged.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"N/A"} -->



