### PR TITLE
fix(app-core): resolve CDN retry policy from env supplied to main

### DIFF
--- a/packages/app-core/scripts/validate-cdn-assets.mjs
+++ b/packages/app-core/scripts/validate-cdn-assets.mjs
@@ -27,7 +27,7 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function getValidationRetryPolicy({ env = process.env } = {}) {
+export function getValidationRetryPolicy({ env = process.env } = {}) {
   const explicitAttempts = Number.parseInt(
     env.ELIZA_CDN_VALIDATE_ATTEMPTS ?? "",
     10,
@@ -234,6 +234,10 @@ export function resolveValidationGitRef({
 }
 
 export async function main({ cwd = repoRoot, env = process.env } = {}) {
+  // Resolve the retry policy from the supplied env up front, before any
+  // manifest read or network probe, so programmatic callers get the policy
+  // they injected rather than whatever happens to be in process.env.
+  const retryPolicy = getValidationRetryPolicy({ env });
   const releaseTag = resolveElizaReleaseTag({ env });
   const gitSha = resolveCurrentGitSha({ cwd, env });
   const explicitValidationRef = env.ELIZA_CDN_VALIDATION_REF?.trim();
@@ -279,7 +283,6 @@ export async function main({ cwd = repoRoot, env = process.env } = {}) {
     }
   }
 
-  const retryPolicy = getValidationRetryPolicy();
   const appAssetRoot = env.ELIZA_CDN_APP_ASSET_ROOT || "packages/app/public";
   const homepageAssetRoot =
     env.ELIZA_CDN_HOMEPAGE_ASSET_ROOT || "packages/homepage/public";

--- a/packages/app-core/scripts/validate-cdn-assets.test.mjs
+++ b/packages/app-core/scripts/validate-cdn-assets.test.mjs
@@ -1,0 +1,143 @@
+/**
+ * Verifies CDN validation retry-policy resolution against injected
+ * environments: `getValidationRetryPolicy` defaults and overrides, and that
+ * `main({ env })` builds its retry policy from the supplied env rather than
+ * `process.env`. Deterministic and offline — network is stubbed via
+ * `globalThis.fetch` over a real temporary manifest fixture (#18634).
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeStaticAssetManifest } from "./lib/static-asset-manifest.mjs";
+import { getValidationRetryPolicy, main } from "./validate-cdn-assets.mjs";
+
+const POLICY_ENV_KEYS = [
+  "ELIZA_CDN_VALIDATE_ATTEMPTS",
+  "ELIZA_CDN_VALIDATE_DELAY_MS",
+  "ELIZA_CDN_VALIDATE_CONCURRENCY",
+  "CI",
+];
+const savedProcessEnv = new Map(
+  POLICY_ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+const temporaryDirectories = [];
+
+afterEach(() => {
+  for (const [key, value] of savedProcessEnv) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  for (const dir of temporaryDirectories.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("getValidationRetryPolicy", () => {
+  it("uses local defaults when overrides are unset or empty", () => {
+    expect(getValidationRetryPolicy({ env: {} })).toEqual({
+      attempts: 1,
+      delayMs: 0,
+      concurrency: 2,
+    });
+    expect(
+      getValidationRetryPolicy({
+        env: {
+          ELIZA_CDN_VALIDATE_ATTEMPTS: "",
+          ELIZA_CDN_VALIDATE_DELAY_MS: "",
+          ELIZA_CDN_VALIDATE_CONCURRENCY: "",
+        },
+      }),
+    ).toEqual({ attempts: 1, delayMs: 0, concurrency: 2 });
+  });
+
+  it("uses CI defaults when the injected env sets CI=true", () => {
+    expect(getValidationRetryPolicy({ env: { CI: "true" } })).toEqual({
+      attempts: 3,
+      delayMs: 5000,
+      concurrency: 4,
+    });
+  });
+
+  it("honors explicit overrides from the injected env", () => {
+    expect(
+      getValidationRetryPolicy({
+        env: {
+          ELIZA_CDN_VALIDATE_ATTEMPTS: "5",
+          ELIZA_CDN_VALIDATE_DELAY_MS: "0",
+          ELIZA_CDN_VALIDATE_CONCURRENCY: "7",
+        },
+      }),
+    ).toEqual({ attempts: 5, delayMs: 0, concurrency: 7 });
+  });
+
+  it("ignores process.env when an env is injected", () => {
+    process.env.ELIZA_CDN_VALIDATE_ATTEMPTS = "9";
+    process.env.CI = "true";
+    expect(getValidationRetryPolicy({ env: {} })).toEqual({
+      attempts: 1,
+      delayMs: 0,
+      concurrency: 2,
+    });
+    expect(getValidationRetryPolicy().attempts).toBe(9);
+  });
+});
+
+describe("main({ env }) retry-policy plumbing", () => {
+  function createManifestFixture() {
+    const root = mkdtempSync(path.join(os.tmpdir(), "eliza-cdn-validate-"));
+    temporaryDirectories.push(root);
+    const appPublic = path.join(root, "packages/app/public");
+    mkdirSync(appPublic, { recursive: true });
+    writeFileSync(path.join(appPublic, "asset.txt"), "fixture");
+    writeStaticAssetManifest(root);
+    return root;
+  }
+
+  it("probes assets with the injected policy, not process.env", async () => {
+    const root = createManifestFixture();
+    // The plumbing bug this guards against: main() building its policy from
+    // process.env. Give process.env a 1-attempt policy and the injected env a
+    // 3-attempt policy — the observed probe count tells us which one won.
+    process.env.ELIZA_CDN_VALIDATE_ATTEMPTS = "1";
+    delete process.env.CI;
+
+    let assetProbes = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url) => {
+        if (String(url).endsWith("/package.json")) {
+          return { ok: true, status: 200 };
+        }
+        assetProbes += 1;
+        return { ok: false, status: 503 };
+      }),
+    );
+    const exitError = new Error("process.exit(1)");
+    vi.spyOn(process, "exit").mockImplementation(() => {
+      throw exitError;
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      main({
+        cwd: root,
+        env: {
+          ELIZA_RELEASE_TAG: "v0.0.0-test",
+          ELIZA_CDN_VALIDATE_ATTEMPTS: "3",
+          ELIZA_CDN_VALIDATE_DELAY_MS: "0",
+          ELIZA_CDN_VALIDATE_CONCURRENCY: "1",
+        },
+      }),
+    ).rejects.toBe(exitError);
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(assetProbes).toBe(3);
+  });
+});


### PR DESCRIPTION
# fix(app-core): resolve CDN retry policy from env supplied to main

Fixes #18634.

## Scope A only — env plumbing, no behavior rewrite

`main({ env })` built its retry policy from an argument-less `getValidationRetryPolicy()` call, so a programmatic caller's injected environment was silently ignored in favor of `process.env`. This PR resolves the policy from the supplied env — `main({ env })` → `getValidationRetryPolicy({ env })` — up front, **before any manifest read or network probe**, and exports the helper for direct testing.

Deliberately **not** touched: the parseInt fallback semantics. lalalune closed #18637 noting the existing parseInt handling is deliberately fail-safe; this PR keeps that behavior exactly as-is and only fixes which env object the policy is read from.

## Changes

- `packages/app-core/scripts/validate-cdn-assets.mjs` — hoist `getValidationRetryPolicy({ env })` to the top of `main()`, using the caller-supplied env; export the helper. (+7/−2 in this file)
- `packages/app-core/scripts/validate-cdn-assets.test.mjs` — offline unit coverage for the policy resolver plus a real-`main` fixture proving the injected policy drives the probe count. (+143)

Head: `c5b79656`.

## Evidence

Focused vitest, fully offline (mocked fetch, temp-dir fixture manifest; no network, no UI surface):

```
cd packages/app-core && node ../scripts/run-vitest.mjs run --config vitest.config.ts scripts/validate-cdn-assets.test.mjs

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

The real-`main` fixture test fails against the pre-fix code (injected `ELIZA_CDN_VALIDATE_ATTEMPTS` was ignored, probe count came from `process.env`) and passes with this change.

---

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [claude-18634]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZWB6BGK3GZ7FMVTQW24E97S","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T01:18:40.147Z","completed_at":"2026-08-13T01:38:40.932Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA1wup-TpOQbidV6XOR-nWj5-01vmuc1Uuv5emKqsM8iA","device_key_id":"dbd0806ed31cfab14a18eeb4990c66497a5ce64fdb0d37d3c878b8f5e6227484","device_signature":"r67sF-zNLQNOFftyo-sPUc5rQ--NQfzj7ysuFFLwhsl5NktOyKIyO_k3wpz4QVPj7_6x56UTWtaWpckrq8j8DQ"}} -->
