### PR TITLE
fix(cloud): return iMessage onboarding to conversation

### DIFF
--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -202,7 +202,13 @@ const CLOUD_AUDIT_CASES: CloudAuditCase[] = [
   // get-started/ — a continuation token is required to exercise the real
   // messaging handoff page instead of its missing-token redirect.
   {
-    slug: "get-started",
+    slug: "get-started-confirm",
+    path: "/get-started?onboardingSession=audit-continuation-token",
+    route: "get-started",
+    auth: AUTH,
+  },
+  {
+    slug: "get-started-success",
     path: "/get-started?onboardingSession=audit-continuation-token",
     route: "get-started",
     auth: AUTH,
@@ -622,6 +628,35 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
           await seedStewardToken(page);
         }
         await installCloudApiStubs(page);
+        if (auditCase.slug.startsWith("get-started-")) {
+          await page.route(
+            "**/api/eliza-app/onboarding/chat**",
+            async (route) => {
+              const request = route.request();
+              if (request.method() === "GET") {
+                await route.fulfill({
+                  status: 200,
+                  contentType: "application/json",
+                  body: JSON.stringify({
+                    success: true,
+                    data: {
+                      platform: "blooio",
+                      platformUserId: "+14155550123",
+                      platformDisplayName: "+14155550123",
+                      returnUrl: "sms:+18087881821",
+                    },
+                  }),
+                });
+                return;
+              }
+              await route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify({ success: true, data: {} }),
+              });
+            },
+          );
+        }
         if (auditCase.slug === "join") {
           await page.route("**/api/cloud/compat/agents**", async (route) => {
             await route.fulfill({
@@ -641,6 +676,15 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
           });
         }
         await page.goto(auditCase.path, { waitUntil: "domcontentloaded" });
+
+        if (auditCase.slug === "get-started-success") {
+          await page
+            .getByRole("button", { name: "Connect this iMessage account" })
+            .click();
+          await expect(
+            page.getByRole("button", { name: "Back to iMessage" }),
+          ).toBeVisible();
+        }
 
         // Routes with expectedFinalPath always redirect on localhost (the
         // harness hostname is 127.0.0.1). Assert the final URL matches the

--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -682,8 +682,8 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
             .getByRole("button", { name: "Connect this iMessage account" })
             .click();
           await expect(
-            page.getByRole("button", { name: "Back to iMessage" }),
-          ).toBeVisible();
+            page.getByRole("link", { name: "Back to iMessage" }),
+          ).toHaveAttribute("href", "sms:+18087881821");
         }
 
         // Routes with expectedFinalPath always redirect on localhost (the

--- a/packages/cloud/api/__tests__/eliza-app-onboarding-chat-platform-caller.test.ts
+++ b/packages/cloud/api/__tests__/eliza-app-onboarding-chat-platform-caller.test.ts
@@ -321,6 +321,32 @@ describe("onboarding chat — trusted platform gateway caller", () => {
     expect(resolveIdentity).toHaveBeenLastCalledWith("+15551234568", "phone");
   });
 
+  test("preserves a trusted iMessage reply address for the browser return link", async () => {
+    resolveIdentity.mockResolvedValue(null);
+    const gatewayData = await dataOf(
+      await post({
+        sessionId: "platform:blooio:+15551234568",
+        message: "My name is Ada",
+        platform: "blooio",
+        platformUserId: "+15551234568",
+        platformDisplayName: "Ada",
+        platformReplyAddress: "+18087881821",
+      }),
+    );
+    const continuation = continuationFromReply(gatewayData.reply);
+
+    getCurrentUser.mockResolvedValue(activeStewardUser());
+    const preview = await get(continuation, STEWARD_JWT);
+
+    expect(preview.status).toBe(200);
+    expect(await dataOf(preview)).toEqual({
+      platform: "blooio",
+      platformUserId: "+15551234568",
+      platformDisplayName: "Ada",
+      returnUrl: "sms:+18087881821",
+    });
+  });
+
   test("falls back to anonymous onboarding when the platform identity is unknown", async () => {
     resolveIdentity.mockResolvedValue(null);
 
@@ -553,6 +579,7 @@ describe("onboarding chat — trusted platform gateway caller", () => {
       platform: "discord",
       platformUserId: "1234567890",
       platformDisplayName: "attested-discord-user",
+      returnUrl: null,
     });
     expect(linkDiscordToUser).not.toHaveBeenCalled();
     expect(ensureElizaAppProvisioning).not.toHaveBeenCalled();

--- a/packages/cloud/api/eliza-app/onboarding/chat/route.ts
+++ b/packages/cloud/api/eliza-app/onboarding/chat/route.ts
@@ -59,6 +59,7 @@ const chatSchema = z.object({
   platform: platformSchema.optional(),
   platformUserId: z.string().trim().max(256).optional(),
   platformDisplayName: z.string().trim().max(120).optional(),
+  platformReplyAddress: z.string().trim().max(256).optional(),
   statusOnly: z.boolean().optional(),
   confirmPlatformLink: z.boolean().optional(),
 });
@@ -232,6 +233,9 @@ app.post("/", async (c) => {
       platform: parsed.data.platform as OnboardingPlatform | undefined,
       platformUserId: parsed.data.platformUserId,
       platformDisplayName: parsed.data.platformDisplayName,
+      platformReplyAddress: caller.trustedPlatformIdentity
+        ? parsed.data.platformReplyAddress
+        : undefined,
       authenticatedUser: caller.authenticatedUser,
       trustedPlatformIdentity: caller.trustedPlatformIdentity,
       idempotencyKey: idempotencyKey || undefined,
@@ -293,7 +297,7 @@ app.post("/", async (c) => {
         new ApiError(
           409,
           "session_not_ready",
-          "Confirm the Discord account before connecting it",
+          "Confirm the messaging account before connecting it",
         ),
       );
     }
@@ -306,7 +310,7 @@ app.post("/", async (c) => {
         new ApiError(
           409,
           "identity_conflict",
-          "This Discord account is already linked to another account",
+          "This messaging account is already linked to another account",
         ),
       );
     }

--- a/packages/cloud/e2e/tests/bluebubbles-gateway.spec.ts
+++ b/packages/cloud/e2e/tests/bluebubbles-gateway.spec.ts
@@ -358,7 +358,8 @@ test.describe("registered BlueBubbles gateway", () => {
           },
           body: JSON.stringify({
             sessionId: continuationToken,
-            platform: "blooio",
+            platform: "web",
+            confirmPlatformLink: true,
           }),
         },
       );

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -207,6 +207,7 @@ describe("gateway webhook handler e2e routing", () => {
       platform: "twilio",
       platformUserId: "+15551234567",
       platformDisplayName: "Ada",
+      platformReplyAddress: "+15550000000",
     });
   });
 

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -404,6 +404,12 @@ async function sendOnboardingReply(
         platform: adapter.platform,
         platformUserId: event.senderId,
         platformDisplayName: event.senderName,
+        platformReplyAddress:
+          adapter.platform === "blooio"
+            ? config.fromNumber
+            : adapter.platform === "twilio"
+              ? config.phoneNumber
+              : undefined,
       }),
       signal: AbortSignal.timeout(30_000),
     });

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
@@ -436,6 +436,7 @@ describe("AgentGatewayRouterService phone routing", () => {
         message: "hello",
         platform: "blooio",
         platformUserId: "+1 (555) 555-0100",
+        platformReplyAddress: "+14159611510",
         sessionId: "platform:blooio:+1 (555) 555-0100",
         trustedPlatformIdentity: true,
         idempotencyKey: "blooio:msg-1",
@@ -500,6 +501,7 @@ describe("AgentGatewayRouterService phone routing", () => {
     });
     expect(runOnboardingChat).toHaveBeenCalledWith(
       expect.objectContaining({
+        platformReplyAddress: "+14159611510",
         trustedPlatformIdentity: true,
         idempotencyKey: "blooio:msg-1",
       }),
@@ -536,6 +538,7 @@ describe("AgentGatewayRouterService phone routing", () => {
     });
     expect(runOnboardingChat).toHaveBeenCalledWith(
       expect.objectContaining({
+        platformReplyAddress: "+14159611510",
         authenticatedUser: {
           userId: "known-user",
           organizationId: "known-org",
@@ -621,6 +624,7 @@ describe("AgentGatewayRouterService phone routing", () => {
     });
     expect(runOnboardingChat).toHaveBeenCalledWith(
       expect.objectContaining({
+        platformReplyAddress: "+14159611510",
         authenticatedUser: {
           userId: "known-user",
           organizationId: "known-org",

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
@@ -843,6 +843,7 @@ export class AgentGatewayRouterService {
         message: args.body,
         platform: args.provider,
         platformUserId: args.from,
+        platformReplyAddress: args.to,
         sessionId: `platform:${args.provider}:${args.from}`,
         trustedPlatformIdentity: true,
         idempotencyKey: args.providerMessageId
@@ -866,6 +867,7 @@ export class AgentGatewayRouterService {
           message: args.body,
           platform: args.provider,
           platformUserId: args.from,
+          platformReplyAddress: args.to,
           sessionId: `platform:${args.provider}:${args.from}`,
           trustedPlatformIdentity: true,
           idempotencyKey: args.providerMessageId
@@ -893,6 +895,7 @@ export class AgentGatewayRouterService {
           message: args.body,
           platform: args.provider,
           platformUserId: args.from,
+          platformReplyAddress: args.to,
           sessionId: `platform:${args.provider}:${args.from}`,
           trustedPlatformIdentity: true,
           authenticatedUser: {
@@ -999,6 +1002,7 @@ export class AgentGatewayRouterService {
         message: args.body,
         platform: args.provider,
         platformUserId: args.from,
+        platformReplyAddress: args.to,
         sessionId: `platform:${args.provider}:${args.from}`,
         trustedPlatformIdentity: true,
         authenticatedUser: {

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -80,9 +80,8 @@ mock.module("./user-service", () => ({
   },
 }));
 
-const { runOnboardingChat, validateTelegramOnboardingContinuation } = await import(
-  `./onboarding-chat.ts?test=onboarding-chat-${Date.now()}`
-);
+const { inspectOnboardingContinuation, runOnboardingChat, validateTelegramOnboardingContinuation } =
+  await import(`./onboarding-chat.ts?test=onboarding-chat-${Date.now()}`);
 const { peekLocalGreetingQueue, clearLocalGreetingQueue } = await import(
   "./onboarding-proactive-greeting"
 );
@@ -996,6 +995,7 @@ describe("runOnboardingChat", () => {
         platform: "blooio",
         platformUserId: "+14155550123",
         sessionId: continuationToken(result),
+        confirmPlatformLink: true,
         authenticatedUser: {
           userId: "user-1",
           organizationId: "org-1",
@@ -1043,6 +1043,7 @@ describe("runOnboardingChat", () => {
         userId: "phone-user",
         organizationId: "phone-org",
       },
+      confirmPlatformLink: true,
     });
 
     expect(ensureElizaAppProvisioning).toHaveBeenCalledWith({
@@ -1083,6 +1084,7 @@ describe("runOnboardingChat", () => {
       message,
       platform: "blooio",
       platformUserId: PHONE,
+      platformReplyAddress: "+18087881821",
       sessionId: PLATFORM_SESSION,
       trustedPlatformIdentity: true,
     });
@@ -1219,6 +1221,7 @@ describe("runOnboardingChat", () => {
           userId: "victim-user",
           organizationId: "victim-org",
         },
+        confirmPlatformLink: true,
       });
       expect(victimBound.session.id).toBe(PLATFORM_SESSION);
       expect(victimBound.session.userId).toBe("victim-user");
@@ -1242,7 +1245,7 @@ describe("runOnboardingChat", () => {
       expect(linkPhoneToUser).not.toHaveBeenCalledWith("attacker-user", PHONE);
     });
 
-    test("an opaque web continuation cannot mutate the platform identity and still links the phone", async () => {
+    test("previews and explicitly confirms a trusted iMessage continuation", async () => {
       ensureElizaAppProvisioning.mockResolvedValue({
         status: "provisioning",
         agentId: "agent-1",
@@ -1251,15 +1254,42 @@ describe("runOnboardingChat", () => {
       });
 
       const gatewayTurn = await runTrustedPhoneTurn("My name is Sam");
+      const token = continuationToken(gatewayTurn);
+      const preview = await inspectOnboardingContinuation(token, {
+        userId: "user-1",
+        organizationId: "org-1",
+      });
+      expect(preview).toEqual({
+        platform: "blooio",
+        platformUserId: PHONE,
+        platformDisplayName: PHONE,
+        returnUrl: "sms:+18087881821",
+      });
       const continued = await runOnboardingChat({
-        sessionId: continuationToken(gatewayTurn),
+        sessionId: token,
         platform: "web",
         authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+        confirmPlatformLink: true,
       });
 
       expect(continued.session.platform).toBe("blooio");
       expect(continued.session.platformUserId).toBe(PHONE);
       expect(linkPhoneToUser).toHaveBeenCalledWith("user-1", PHONE);
+    });
+
+    test("requires explicit confirmation before linking a trusted iMessage identity", async () => {
+      const gatewayTurn = await runTrustedPhoneTurn("My name is Sam");
+      await expect(
+        runOnboardingChat({
+          sessionId: continuationToken(gatewayTurn),
+          platform: "web",
+          authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+        }),
+      ).rejects.toMatchObject({
+        code: "ONBOARDING_PLATFORM_LINK_CONFIRMATION_REQUIRED",
+      });
+      expect(linkPhoneToUser).not.toHaveBeenCalled();
+      expect(ensureElizaAppProvisioning).not.toHaveBeenCalled();
     });
   });
 
@@ -1757,6 +1787,7 @@ describe("runOnboardingChat", () => {
         const second = await runOnboardingChat({
           platform: "blooio",
           sessionId: browserContinuation,
+          confirmPlatformLink: true,
           authenticatedUser: { userId: "user-1", organizationId: "org-1" },
         });
         expect(second.handoffComplete).toBe(true);
@@ -1766,6 +1797,7 @@ describe("runOnboardingChat", () => {
         const third = await runOnboardingChat({
           platform: "blooio",
           sessionId: browserContinuation,
+          confirmPlatformLink: true,
           authenticatedUser: { userId: "user-1", organizationId: "org-1" },
         });
         expect(third.handoffComplete).toBe(true);
@@ -2015,6 +2047,7 @@ describe("runOnboardingChat", () => {
       await runOnboardingChat({
         sessionId: continuationToken(named),
         platform: "web",
+        confirmPlatformLink: true,
         authenticatedUser: { userId: "user-1", organizationId: "org-1" },
       });
       expect(peekLocalGreetingQueue()).toHaveLength(0);
@@ -2145,6 +2178,7 @@ describe("runOnboardingChat", () => {
           await runOnboardingChat({
             platform: "blooio",
             sessionId: continuationToken(named),
+            confirmPlatformLink: true,
             authenticatedUser: { userId: "user-1", organizationId: "org-1" },
             statusOnly: true,
           });
@@ -2177,6 +2211,7 @@ describe("runOnboardingChat", () => {
         await runOnboardingChat({
           platform: "blooio",
           sessionId: continuationToken(named),
+          confirmPlatformLink: true,
           authenticatedUser: { userId: "user-1", organizationId: "org-1" },
           statusOnly: true,
         });

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -1277,6 +1277,24 @@ describe("runOnboardingChat", () => {
       expect(linkPhoneToUser).toHaveBeenCalledWith("user-1", PHONE);
     });
 
+    test("returns legacy iMessage sessions through the configured gateway number", async () => {
+      cloudEnv = { ELIZA_APP_BLOOIO_PHONE_NUMBER: "+18087881821" };
+      const gatewayTurn = await runOnboardingChat({
+        message: "My name is Sam",
+        platform: "blooio",
+        platformUserId: PHONE,
+        sessionId: PLATFORM_SESSION,
+        trustedPlatformIdentity: true,
+      });
+
+      await expect(
+        inspectOnboardingContinuation(continuationToken(gatewayTurn), {
+          userId: "user-1",
+          organizationId: "org-1",
+        }),
+      ).resolves.toMatchObject({ returnUrl: "sms:+18087881821" });
+    });
+
     test("requires explicit confirmation before linking a trusted iMessage identity", async () => {
       const gatewayTurn = await runTrustedPhoneTurn("My name is Sam");
       await expect(

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -363,7 +363,17 @@ function buildMessagingReturnUrl(session: OnboardingSession): string | null {
   if (session.platform !== "blooio" && session.platform !== "twilio") {
     return null;
   }
-  const replyAddress = normalizePhoneNumber(session.platformReplyAddress ?? "");
+  const env = getCloudAwareEnv();
+  // Sessions issued before platformReplyAddress shipped still need to return
+  // to Messages after deployment. The configured Eliza gateway number is the
+  // trusted migration fallback; new sessions retain their exact gateway value.
+  const configuredReplyAddress =
+    session.platform === "blooio"
+      ? env.ELIZA_APP_BLOOIO_PHONE_NUMBER || env.BLOOIO_FROM_NUMBER
+      : env.ELIZA_APP_TWILIO_PHONE_NUMBER || env.TWILIO_PHONE_NUMBER;
+  const replyAddress = normalizePhoneNumber(
+    session.platformReplyAddress ?? configuredReplyAddress ?? "",
+  );
   return replyAddress ? `sms:${replyAddress}` : null;
 }
 

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -16,6 +16,7 @@ import {
   hasCloudBindingsContext,
 } from "../../runtime/cloud-bindings";
 import { logger } from "../../utils/logger";
+import { normalizePhoneNumber } from "../../utils/phone-normalization";
 import { launchManagedElizaAgent } from "../eliza-managed-launch";
 import {
   enqueueDiscordProactiveGreeting,
@@ -54,6 +55,12 @@ export interface OnboardingSession {
   platformUserId?: string;
   platformDisplayName?: string;
   /**
+   * Trusted transport address that opens the originating conversation after
+   * browser authentication. Phone gateways set this to their receiving number;
+   * browser callers cannot set it through the public route.
+   */
+  platformReplyAddress?: string;
+  /**
    * True once a trusted transport (internal gateway auth) has attested the
    * platform identity on this session. Only trusted platform identities may
    * be linked to a cloud account after login.
@@ -74,6 +81,7 @@ export interface OnboardingChatInput {
   platform?: OnboardingPlatform;
   platformUserId?: string;
   platformDisplayName?: string;
+  platformReplyAddress?: string;
   authenticatedUser?: {
     userId: string;
     organizationId: string;
@@ -96,9 +104,10 @@ export interface OnboardingChatInput {
 }
 
 export interface OnboardingContinuationPreview {
-  platform: "discord" | "telegram";
+  platform: "discord" | "telegram" | "blooio" | "twilio";
   platformUserId: string;
   platformDisplayName: string;
+  returnUrl: string | null;
 }
 
 export interface OnboardingChatCta {
@@ -334,15 +343,28 @@ async function loadOnboardingSessionForValidation(
  * authenticated browser continuation: possession of the opaque continuation
  * token (delivered only inside the platform DM) plus an explicit in-browser
  * confirmation is the ownership proof — the model #18161 shipped for Discord,
- * now shared by Telegram. Phone-shaped platforms are excluded: their identity
- * IS the phone number and links through the dedicated phone path.
+ * now shared by Telegram and phone gateways. Phone-shaped platforms still use
+ * the dedicated phone linker after confirmation.
  */
-type BrowserLinkablePlatform = "discord" | "telegram";
+type BrowserLinkablePlatform = "discord" | "telegram" | "blooio" | "twilio";
 
 function isBrowserLinkablePlatform(
   platform: OnboardingPlatform | undefined,
 ): platform is BrowserLinkablePlatform {
-  return platform === "discord" || platform === "telegram";
+  return (
+    platform === "discord" ||
+    platform === "telegram" ||
+    platform === "blooio" ||
+    platform === "twilio"
+  );
+}
+
+function buildMessagingReturnUrl(session: OnboardingSession): string | null {
+  if (session.platform !== "blooio" && session.platform !== "twilio") {
+    return null;
+  }
+  const replyAddress = normalizePhoneNumber(session.platformReplyAddress ?? "");
+  return replyAddress ? `sms:${replyAddress}` : null;
 }
 
 function trustedBrowserContinuationError(session: OnboardingSession | null): ElizaError {
@@ -357,7 +379,7 @@ function isBrowserLinkableContinuationForAccount(
   session: OnboardingSession | null,
   authenticatedAccount: { userId: string; organizationId: string },
 ): session is OnboardingSession & {
-  platform: "discord" | "telegram";
+  platform: BrowserLinkablePlatform;
   platformUserId: string;
 } {
   const hasUserBinding = session?.userId !== undefined;
@@ -389,6 +411,7 @@ export async function inspectOnboardingContinuation(
     platform: session.platform,
     platformUserId: session.platformUserId,
     platformDisplayName: session.platformDisplayName?.trim() || session.platformUserId,
+    returnUrl: buildMessagingReturnUrl(session),
   };
 }
 
@@ -720,8 +743,17 @@ function isPhoneLikePlatformIdentity(args: {
   );
 }
 
-function platformLinkLabel(platform: "discord" | "telegram"): string {
-  return platform === "discord" ? "Discord" : "Telegram";
+function platformLinkLabel(platform: BrowserLinkablePlatform): string {
+  switch (platform) {
+    case "discord":
+      return "Discord";
+    case "telegram":
+      return "Telegram";
+    case "blooio":
+      return "iMessage";
+    case "twilio":
+      return "SMS";
+  }
 }
 
 async function maybeLinkAuthenticatedPlatformIdentity(
@@ -738,11 +770,11 @@ async function maybeLinkAuthenticatedPlatformIdentity(
     return session;
   }
 
-  // Discord / Telegram: a PRIOR gateway turn attested "this session belongs
-  // to platform user X"; the user then authenticated (e.g. Steward email
-  // login) via the opaque continuation credential. Bind the platform identity
-  // so the gateway router resolves their DMs to the provisioned agent instead
-  // of onboarding forever. Skipped on gateway turns themselves
+  // Browser-linkable platforms: a PRIOR gateway turn attested "this session
+  // belongs to platform user X"; the user then authenticated (e.g. Steward
+  // email login) via the opaque continuation credential. Bind the platform
+  // identity so the gateway router resolves their messages to the provisioned
+  // agent instead of onboarding forever. Skipped on gateway turns themselves
   // (input.trustedPlatformIdentity): there the authenticated account was
   // RESOLVED FROM the user_identities projection, so the link already exists
   // and re-linking would just add a DB round trip to every DM turn. Also
@@ -780,10 +812,15 @@ async function maybeLinkAuthenticatedPlatformIdentity(
             discordId: session.platformUserId,
             username: displayName,
           })
-        : await elizaAppUserService.linkTelegramToUser(input.authenticatedUser.userId, {
-            id: session.platformUserId,
-            username: displayName,
-          });
+        : platform === "telegram"
+          ? await elizaAppUserService.linkTelegramToUser(input.authenticatedUser.userId, {
+              id: session.platformUserId,
+              username: displayName,
+            })
+          : await elizaAppUserService.linkPhoneToUser(
+              input.authenticatedUser.userId,
+              session.platformUserId,
+            );
     if (!link.success) {
       throw new ElizaError(
         link.error || `${platformLinkLabel(platform)} identity could not be linked`,
@@ -1203,6 +1240,8 @@ function newSession(id: string, input: OnboardingChatInput): OnboardingSession {
     platform: input.platform,
     platformUserId: input.platformUserId,
     platformDisplayName: input.platformDisplayName,
+    platformReplyAddress:
+      input.trustedPlatformIdentity === true ? input.platformReplyAddress : undefined,
     history: [],
   };
 }
@@ -1274,6 +1313,9 @@ export async function runOnboardingChatWithStore(
     platform: session.platform ?? input.platform,
     platformUserId: session.platformUserId ?? input.platformUserId,
     platformDisplayName: input.platformDisplayName ?? session.platformDisplayName,
+    platformReplyAddress:
+      session.platformReplyAddress ??
+      (input.trustedPlatformIdentity === true ? input.platformReplyAddress : undefined),
     updatedAt: nowIso(),
   };
 

--- a/packages/homepage/package.json
+++ b/packages/homepage/package.json
@@ -13,7 +13,7 @@
     "clean": "node ../scripts/rm-path-recursive.mjs dist",
     "check:release-data": "node ../app-core/scripts/check-homepage-release-data.mjs",
     "check:snapshot-inventory": "bun scripts/check-snapshot-inventory.ts",
-    "test": "bun test tests/smoke.node.test.mjs tests/screenshot-stability.node.test.mjs tests/e2e-port.node.test.mjs tests/channel-build-config.node.test.mjs tests/contact.test.ts tests/snapshot-inventory.test.ts tests/auth-return.test.ts tests/wallet-linking.test.ts tests/release-availability.test.ts edge/apple-app-site-association.test.ts tests/landing-a11y-helpers.test.ts tests/provisioning-poll-body.test.ts tests/provisioning-poll-hook.test.ts tests/onboarding-continuation.test.ts tests/get-started-continuation-render.test.tsx",
+    "test": "bun test tests/smoke.node.test.mjs tests/screenshot-stability.node.test.mjs tests/e2e-port.node.test.mjs tests/channel-build-config.node.test.mjs tests/contact.test.ts tests/snapshot-inventory.test.ts tests/auth-return.test.ts tests/wallet-linking.test.ts tests/release-availability.test.ts edge/apple-app-site-association.test.ts tests/landing-a11y-helpers.test.ts tests/provisioning-poll-body.test.ts tests/provisioning-poll-hook.test.ts tests/onboarding-continuation.test.ts tests/get-started-continuation-render.test.tsx tests/legacy-onboarding-redirect.test.ts",
     "test:aasa-edge": "bun run typecheck:aasa-edge && bun test edge/apple-app-site-association.test.ts",
     "typecheck:aasa-edge": "bunx --package typescript@6.0.3 tsc --noEmit -p edge/tsconfig.json",
     "deploy:aasa-edge": "bunx wrangler@4.100.0 deploy --config wrangler-aasa.toml --strict",

--- a/packages/homepage/src/App.tsx
+++ b/packages/homepage/src/App.tsx
@@ -4,8 +4,9 @@
  */
 import { BRAND_COLORS } from "@elizaos/shared/brand";
 import { Loader2 } from "lucide-react";
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { getLegacyOnboardingRedirect } from "@/lib/legacy-onboarding-redirect";
 
 const MarketingPage = lazy(() => import("@/pages/marketing"));
 const LandingPage = lazy(() => import("@/pages/landing"));
@@ -31,6 +32,21 @@ function RouteFallback() {
   );
 }
 
+function GetStartedRoute() {
+  const redirectUrl =
+    typeof window === "undefined"
+      ? null
+      : getLegacyOnboardingRedirect(window.location);
+
+  useEffect(() => {
+    if (redirectUrl) {
+      window.location.replace(redirectUrl);
+    }
+  }, [redirectUrl]);
+
+  return redirectUrl ? <RouteFallback /> : <GetStartedPage />;
+}
+
 export function App() {
   return (
     <BrowserRouter>
@@ -42,7 +58,7 @@ export function App() {
           <Route element={<AuthedShell />}>
             <Route path="/login" element={<LoginPage />} />
             <Route path="/connected" element={<ConnectedPage />} />
-            <Route path="/get-started" element={<GetStartedPage />} />
+            <Route path="/get-started" element={<GetStartedRoute />} />
             <Route path="/profile/edit" element={<ProfileEditPage />} />
           </Route>
           <Route path="*" element={<NotFoundPage />} />

--- a/packages/homepage/src/lib/legacy-onboarding-redirect.ts
+++ b/packages/homepage/src/lib/legacy-onboarding-redirect.ts
@@ -1,0 +1,24 @@
+/**
+ * Redirects continuation links previously issued on eliza.app into the
+ * authenticated Cloud app while leaving organic homepage onboarding intact.
+ */
+
+const LEGACY_HOMEPAGE_HOSTS = new Set(["eliza.app", "www.eliza.app"]);
+const CLOUD_APP_ORIGIN = "https://app.elizacloud.ai";
+
+export function getLegacyOnboardingRedirect(location: {
+  hostname: string;
+  pathname: string;
+  search: string;
+  hash: string;
+}): string | null {
+  if (
+    !LEGACY_HOMEPAGE_HOSTS.has(location.hostname.toLowerCase()) ||
+    location.pathname !== "/get-started" ||
+    !new URLSearchParams(location.search).has("onboardingSession")
+  ) {
+    return null;
+  }
+
+  return `${CLOUD_APP_ORIGIN}${location.pathname}${location.search}${location.hash}`;
+}

--- a/packages/homepage/tests/legacy-onboarding-redirect.test.ts
+++ b/packages/homepage/tests/legacy-onboarding-redirect.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Covers the compatibility redirect for continuation URLs already sent with
+ * the retired eliza.app onboarding host.
+ */
+import { describe, expect, test } from "bun:test";
+import { getLegacyOnboardingRedirect } from "../src/lib/legacy-onboarding-redirect";
+
+describe("legacy onboarding redirect", () => {
+  test("preserves an existing eliza.app continuation URL", () => {
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "eliza.app",
+        pathname: "/get-started",
+        search: "?onboardingSession=session-123&source=imessage",
+        hash: "#continue",
+      }),
+    ).toBe(
+      "https://app.elizacloud.ai/get-started?onboardingSession=session-123&source=imessage#continue",
+    );
+  });
+
+  test("supports the legacy www host", () => {
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "www.eliza.app",
+        pathname: "/get-started",
+        search: "?onboardingSession=session-123",
+        hash: "",
+      }),
+    ).toBe(
+      "https://app.elizacloud.ai/get-started?onboardingSession=session-123",
+    );
+  });
+
+  test("leaves organic homepage onboarding and non-production hosts alone", () => {
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "eliza.app",
+        pathname: "/get-started",
+        search: "?method=imessage",
+        hash: "",
+      }),
+    ).toBeNull();
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "localhost",
+        pathname: "/get-started",
+        search: "?onboardingSession=session-123",
+        hash: "",
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/ui/src/cloud/join/GetStartedPage.test.tsx
+++ b/packages/ui/src/cloud/join/GetStartedPage.test.tsx
@@ -37,6 +37,7 @@ vi.mock("./lib/onboarding-continuation", async (importOriginal) => {
       platform: "discord" as const,
       platformUserId: "1234567890",
       platformDisplayName: "attested-discord-user",
+      returnUrl: null,
     })),
     completePendingOnboardingContinuation: vi.fn(async () => {
       actual.clearPendingOnboardingSession();
@@ -52,6 +53,7 @@ beforeEach(() => {
     platform: "discord",
     platformUserId: "1234567890",
     platformDisplayName: "attested-discord-user",
+    returnUrl: null,
   });
   vi.mocked(completePendingOnboardingContinuation).mockReset();
   vi.mocked(completePendingOnboardingContinuation).mockImplementation(
@@ -127,6 +129,7 @@ describe("GetStartedPage", () => {
       platform: "telegram",
       platformUserId: "123456789",
       platformDisplayName: "attested-telegram-user",
+      returnUrl: null,
     });
     const entry = `/get-started?onboardingSession=${TOKEN}`;
     window.history.replaceState(null, "", entry);
@@ -146,5 +149,33 @@ describe("GetStartedPage", () => {
       screen.getByRole("button", { name: /Connect this Telegram account/ }),
     );
     expect(await screen.findByText("You're connected")).toBeTruthy();
+  });
+
+  it("offers a deep link back to the originating iMessage conversation", async () => {
+    vi.mocked(previewPendingOnboardingContinuation).mockResolvedValue({
+      platform: "blooio",
+      platformUserId: "+14155550123",
+      platformDisplayName: "Shaw",
+      returnUrl: "sms:+18087881821",
+    });
+    const entry = `/get-started?onboardingSession=${TOKEN}`;
+    window.history.replaceState(null, "", entry);
+
+    render(
+      <MemoryRouter initialEntries={[entry]}>
+        <Routes>
+          <Route path="/get-started" element={<GetStartedPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Shaw")).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: /Connect this iMessage account/ }),
+    );
+    expect(await screen.findByText("You're connected")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Back to iMessage" }),
+    ).toBeTruthy();
   });
 });

--- a/packages/ui/src/cloud/join/GetStartedPage.test.tsx
+++ b/packages/ui/src/cloud/join/GetStartedPage.test.tsx
@@ -175,7 +175,9 @@ describe("GetStartedPage", () => {
     );
     expect(await screen.findByText("You're connected")).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: "Back to iMessage" }),
-    ).toBeTruthy();
+      screen
+        .getByRole("link", { name: "Back to iMessage" })
+        .getAttribute("href"),
+    ).toBe("sms:+18087881821");
   });
 });

--- a/packages/ui/src/cloud/join/GetStartedPage.tsx
+++ b/packages/ui/src/cloud/join/GetStartedPage.tsx
@@ -23,6 +23,7 @@ import { Button } from "../../components/ui/button";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import {
   completePendingOnboardingContinuation,
+  type MessagingContinuationPreview,
   peekPendingOnboardingSession,
   previewPendingOnboardingContinuation,
   sanitizeOnboardingSessionToken,
@@ -31,6 +32,21 @@ import {
 import { useJoinSessionAuth } from "./lib/use-join-session";
 
 type GetStartedPhase = "checking" | "confirm" | "linking" | "done" | "error";
+
+function messagingPlatformLabel(
+  platform: MessagingContinuationPreview["platform"],
+): string {
+  switch (platform) {
+    case "discord":
+      return "Discord";
+    case "telegram":
+      return "Telegram";
+    case "blooio":
+      return "iMessage";
+    case "twilio":
+      return "SMS";
+  }
+}
 
 function describeContinuationError(err: unknown): string {
   if (err instanceof Error && err.message.trim()) return err.message;
@@ -43,11 +59,8 @@ export default function GetStartedPage(): React.JSX.Element {
   const [searchParams] = useSearchParams();
   const [phase, setPhase] = useState<GetStartedPhase>("checking");
   const [error, setError] = useState<string | null>(null);
-  const [platformIdentity, setPlatformIdentity] = useState<{
-    platform: "discord" | "telegram";
-    platformUserId: string;
-    platformDisplayName: string;
-  } | null>(null);
+  const [platformIdentity, setPlatformIdentity] =
+    useState<MessagingContinuationPreview | null>(null);
   // StrictMode double-mount guard: the redemption POST must run once.
   const startedRef = useRef(false);
 
@@ -142,10 +155,7 @@ export default function GetStartedPage(): React.JSX.Element {
         {phase === "confirm" && platformIdentity ? (
           <div className="flex flex-col items-center gap-4">
             <h1 className="font-poppins text-lg font-semibold text-white">
-              Connect your{" "}
-              {platformIdentity.platform === "telegram"
-                ? "Telegram"
-                : "Discord"}{" "}
+              Connect your {messagingPlatformLabel(platformIdentity.platform)}{" "}
               account?
             </h1>
             <p className="text-sm text-white/70">
@@ -154,7 +164,9 @@ export default function GetStartedPage(): React.JSX.Element {
               <span className="block text-xs text-white/50">
                 {platformIdentity.platform === "telegram"
                   ? "Telegram ID"
-                  : "Discord ID"}{" "}
+                  : platformIdentity.platform === "discord"
+                    ? "Discord ID"
+                    : "Phone"}{" "}
                 {platformIdentity.platformUserId}
               </span>
             </p>
@@ -166,10 +178,7 @@ export default function GetStartedPage(): React.JSX.Element {
               }}
               className="bg-txt px-6 py-2.5 font-semibold text-bg"
             >
-              Connect this{" "}
-              {platformIdentity.platform === "telegram"
-                ? "Telegram"
-                : "Discord"}{" "}
+              Connect this {messagingPlatformLabel(platformIdentity.platform)}{" "}
               account
             </Button>
           </div>
@@ -186,6 +195,17 @@ export default function GetStartedPage(): React.JSX.Element {
                   "Head back to your chat — your agent will pick up right where you left off. Setup finishes in the background.",
               })}
             </p>
+            {platformIdentity?.returnUrl ? (
+              <Button
+                type="button"
+                onClick={() =>
+                  window.location.assign(platformIdentity.returnUrl ?? "/join")
+                }
+                className="bg-txt px-6 py-2.5 font-semibold text-bg transition-colors hover:bg-txt/90"
+              >
+                Back to {messagingPlatformLabel(platformIdentity.platform)}
+              </Button>
+            ) : null}
             <Button
               variant="ghost"
               type="button"

--- a/packages/ui/src/cloud/join/GetStartedPage.tsx
+++ b/packages/ui/src/cloud/join/GetStartedPage.tsx
@@ -197,13 +197,12 @@ export default function GetStartedPage(): React.JSX.Element {
             </p>
             {platformIdentity?.returnUrl ? (
               <Button
-                type="button"
-                onClick={() =>
-                  window.location.assign(platformIdentity.returnUrl ?? "/join")
-                }
+                asChild
                 className="bg-txt px-6 py-2.5 font-semibold text-bg transition-colors hover:bg-txt/90"
               >
-                Back to {messagingPlatformLabel(platformIdentity.platform)}
+                <a href={platformIdentity.returnUrl}>
+                  Back to {messagingPlatformLabel(platformIdentity.platform)}
+                </a>
               </Button>
             ) : null}
             <Button

--- a/packages/ui/src/cloud/join/lib/onboarding-continuation.test.ts
+++ b/packages/ui/src/cloud/join/lib/onboarding-continuation.test.ts
@@ -83,6 +83,7 @@ describe("previewPendingOnboardingContinuation", () => {
         platform: "discord",
         platformUserId: "1234567890",
         platformDisplayName: "attested-user",
+        returnUrl: null,
       },
     });
     const preview = await previewPendingOnboardingContinuation(TOKEN, {
@@ -93,6 +94,24 @@ describe("previewPendingOnboardingContinuation", () => {
       `/api/eliza-app/onboarding/chat?sessionId=${encodeURIComponent(TOKEN)}`,
     );
     expect(preview.platformDisplayName).toBe("attested-user");
+  });
+
+  it("carries a trusted iMessage return deep link", async () => {
+    const preview = await previewPendingOnboardingContinuation(TOKEN, {
+      get: vi.fn().mockResolvedValue({
+        data: {
+          platform: "blooio",
+          platformUserId: "+14155550123",
+          platformDisplayName: "Shaw",
+          returnUrl: "sms:+18087881821",
+        },
+      }),
+      post: vi.fn(),
+    });
+    expect(preview).toMatchObject({
+      platform: "blooio",
+      returnUrl: "sms:+18087881821",
+    });
   });
 });
 

--- a/packages/ui/src/cloud/join/lib/onboarding-continuation.ts
+++ b/packages/ui/src/cloud/join/lib/onboarding-continuation.ts
@@ -138,9 +138,10 @@ const defaultTransport: OnboardingContinuationTransport = {
 };
 
 export interface MessagingContinuationPreview {
-  platform: "discord" | "telegram";
+  platform: "discord" | "telegram" | "blooio" | "twilio";
   platformUserId: string;
   platformDisplayName: string;
+  returnUrl: string | null;
 }
 
 export async function previewPendingOnboardingContinuation(

--- a/packages/ui/src/cloud/public-pages/lib/login-return-to.test.ts
+++ b/packages/ui/src/cloud/public-pages/lib/login-return-to.test.ts
@@ -8,7 +8,12 @@
  */
 
 import { afterEach, describe, expect, it } from "vitest";
-import { defaultLoginReturnTo, resolveLoginReturnTo } from "./login-return-to";
+import {
+  consumePendingOAuthReturnTo,
+  defaultLoginReturnTo,
+  resolveLoginReturnTo,
+  storePendingOAuthReturnTo,
+} from "./login-return-to";
 
 const realLocation = window.location;
 function setHostname(hostname: string): void {
@@ -24,6 +29,8 @@ function params(returnTo?: string) {
 
 describe("login return-to resolution", () => {
   afterEach(() => {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
     Object.defineProperty(window, "location", {
       configurable: true,
       value: realLocation,
@@ -56,5 +63,22 @@ describe("login return-to resolution", () => {
     setHostname("elizacloud.ai");
     expect(resolveLoginReturnTo(params("//evil.example"))).toBe("/join");
     expect(resolveLoginReturnTo(params("https://evil.example"))).toBe("/join");
+  });
+
+  it("restores /get-started in another same-origin tab after login", () => {
+    storePendingOAuthReturnTo(params("/get-started"));
+
+    // sessionStorage is tab-scoped; localStorage is the hand-through used by
+    // OAuth popups and email magic links opened in a new tab.
+    window.sessionStorage.clear();
+    expect(resolveLoginReturnTo(params(), consumePendingOAuthReturnTo())).toBe(
+      "/get-started",
+    );
+    expect(consumePendingOAuthReturnTo()).toBeNull();
+  });
+
+  it("never persists an external login destination", () => {
+    storePendingOAuthReturnTo(params("https://evil.example/get-started"));
+    expect(consumePendingOAuthReturnTo()).toBeNull();
   });
 });

--- a/packages/ui/src/cloud/public-pages/lib/login-return-to.ts
+++ b/packages/ui/src/cloud/public-pages/lib/login-return-to.ts
@@ -1,8 +1,8 @@
 /**
  * Login `returnTo` resolution for the app-hosted Steward login surface.
  *
- * Sanitizes + persists the post-login destination across the OAuth redirect
- * round-trip (which can't carry it in the OAuth `redirect_uri`).
+ * Sanitizes + persists the post-login destination across OAuth and email-link
+ * round trips, which cannot safely carry it in their callback URLs.
  */
 
 // Every successful login enters through `/join`. On an app host, that flow

--- a/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.test.tsx
@@ -23,6 +23,7 @@ const callbackState = vi.hoisted(() => ({
         email: string,
       ) => Promise<{ token: string; refreshToken?: string }>
     >(),
+  pendingReturnTo: null as string | null,
 }));
 
 // Stub StewardAuthProvider with a marker that ALSO supplies the Steward context
@@ -64,6 +65,14 @@ vi.mock("../../lib/use-page-title", () => ({ usePageTitle: () => {} }));
 vi.mock("../../lib/steward-session", () => ({
   syncStewardSessionCookie: vi.fn(),
 }));
+vi.mock("../../lib/login-return-to", () => ({
+  defaultLoginReturnTo: () => "/join",
+  consumePendingOAuthReturnTo: () => {
+    const value = callbackState.pendingReturnTo;
+    callbackState.pendingReturnTo = null;
+    return value;
+  },
+}));
 vi.mock("../../../../cloud-ui/components/auth/authorize-return", () => ({
   readStoredAppAuthorizeReturnTo: () => null,
   clearStoredAppAuthorizeReturnTo: () => {},
@@ -74,10 +83,13 @@ vi.mock("../../../../cloud-ui/components/brand/brand-button", () => ({
   ),
 }));
 
-import EmailCallbackPage from "./email-callback-page";
+import EmailCallbackPage, {
+  resolveEmailCallbackDestination,
+} from "./email-callback-page";
 
 beforeEach(() => {
   callbackState.verifyEmailCallback.mockReset();
+  callbackState.pendingReturnTo = null;
 });
 
 afterEach(() => {
@@ -188,6 +200,18 @@ describe("EmailCallbackPage", () => {
     await waitFor(() =>
       expect(callbackState.verifyEmailCallback).toHaveBeenCalledTimes(2),
     );
+  });
+
+  it("restores a pending messaging continuation after magic-link verification", async () => {
+    expect(resolveEmailCallbackDestination(null, "/get-started")).toBe(
+      "/get-started",
+    );
+    expect(
+      resolveEmailCallbackDestination(
+        "/app-auth/authorize?id=1",
+        "/get-started",
+      ),
+    ).toBe("/app-auth/authorize?id=1");
   });
 
   it("rejects an incomplete callback and offers a safe keyboard-reachable recovery action", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.tsx
@@ -19,7 +19,10 @@ import {
   LocalStewardAuthContext,
   StewardAuthProvider,
 } from "../../../shell/StewardProvider";
-import { defaultLoginReturnTo } from "../../lib/login-return-to";
+import {
+  consumePendingOAuthReturnTo,
+  defaultLoginReturnTo,
+} from "../../lib/login-return-to";
 import { syncStewardSessionCookie } from "../../lib/steward-session";
 import { usePageTitle } from "../../lib/use-page-title";
 
@@ -29,6 +32,13 @@ type EmailVerificationResult = {
   token: string;
   refreshToken?: string;
 };
+
+export function resolveEmailCallbackDestination(
+  appAuthorizeReturnTo: string | null,
+  pendingLoginReturnTo: string | null,
+): string {
+  return appAuthorizeReturnTo ?? pendingLoginReturnTo ?? defaultLoginReturnTo();
+}
 
 const pendingEmailVerifications = new Map<
   string,
@@ -99,6 +109,7 @@ function EmailCallbackContent() {
   const [searchParams] = useSearchParams();
   const auth = useContext(LocalStewardAuthContext);
   const attemptedRef = useRef(false);
+  const successDestinationRef = useRef<string | null>(null);
   const [status, setStatus] = useState<CallbackStatus>("verifying");
   const [error, setError] = useState<string | null>(null);
 
@@ -125,10 +136,13 @@ function EmailCallbackContent() {
       return;
     }
 
-    const destination = returnTo ?? defaultLoginReturnTo();
-
     let redirectTimer: ReturnType<typeof setTimeout> | null = null;
     const finishSuccess = () => {
+      const destination = resolveEmailCallbackDestination(
+        returnTo,
+        consumePendingOAuthReturnTo(),
+      );
+      successDestinationRef.current = destination;
       clearStoredAppAuthorizeReturnTo();
       setStatus("success");
       redirectTimer = setTimeout(() => {
@@ -219,7 +233,11 @@ function EmailCallbackContent() {
         </p>
         <BrandButton
           className="mt-2"
-          onClick={() => returnTo && window.location.assign(returnTo)}
+          onClick={() =>
+            window.location.assign(
+              successDestinationRef.current ?? defaultLoginReturnTo(),
+            )
+          }
         >
           {t("cloud.emailCallback.continue", {
             defaultValue: "Continue to app authorization",

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -631,7 +631,9 @@ export default function StewardLoginSection() {
     persistStewardToken(token);
     await syncStewardSessionCookie(token, refreshToken);
     toast.success("Signed in!");
-    setRedirectTo(resolveLoginReturnTo(searchParams));
+    setRedirectTo(
+      resolveLoginReturnTo(searchParams, consumePendingOAuthReturnTo()),
+    );
     setStep("success");
   }
 
@@ -743,6 +745,10 @@ export default function StewardLoginSection() {
     setLoading("email");
     setError(null);
     try {
+      // The magic link can open in a new same-origin tab. Persist the pending
+      // destination before asking Steward to send it so the callback can
+      // resume an onboarding continuation instead of falling back to /join.
+      storePendingOAuthReturnTo(searchParams);
       const challenge = await startStewardEmailLogin(
         { baseUrl: stewardApiUrl, tenantId: STEWARD_TENANT_ID },
         email.trim(),


### PR DESCRIPTION
## Summary

Replaces #18836 and relates to #18806.

This restores the complete iMessage onboarding continuation:

- trusted gateway requests persist the Eliza receiving number needed to return to the originating Messages conversation
- onboarding confirms the phone identity before linking it to the signed-in account
- Google OAuth and email magic-link login preserve the onboarding session and return to `/get-started`
- successful onboarding exposes a native `sms:` link labeled **Back to iMessage**, with web chat as an alternative
- legacy `eliza.app/get-started?onboardingSession=...` links redirect to the deployed app host while preserving query parameters and fragments
- Blooio and Twilio preview paths use the same trusted continuation contract

## Verification

- [x] rebased on `origin/develop`
- [x] `bun install`
- [x] `bun run verify` — 350/350 build/typecheck tasks passed; repository audits passed on the rebased change
- [x] focused contract suites — 161 tests passed
- [x] strict onboarding browser audit — 6/6 passed, 0 `broken`, 0 `needs-work`
- [x] desktop and mobile confirmation/success captures reviewed
- [x] legacy pre-field session returns through the configured trusted iMessage number
- [x] exact native return link asserted as `href="sms:+18087881821"`
- [x] OCR review confirms nonblank, legible confirmation and success states
- [x] hosted PR preview exercised — legacy link preserves `onboardingSession` and reaches `/login?returnTo=/get-started`; preview-only email submission cannot complete because the static Pages preview has no matching feature-branch API deployment
- [ ] deployed gateway/API exercised from a fresh real iMessage through login and back into Messages

The full app visual audit passed 214/215 captures with 0 broken views. Its single failure is the existing `develop` minimalism ratchet on unrelated built-in browser/plugins/trajectories mobile captures. The scoped strict audit for every touched onboarding state is green.

The standalone BlueBubbles E2E was attempted twice, but the local stack failed before the onboarding assertions at the pre-existing agent configuration endpoint with HTTP 500 (`internal_error`). This PR does not count that as end-to-end proof.

## Risk and rollout

Risk: medium. The change spans gateway metadata, cloud onboarding/auth continuation, homepage routing, and UI deep-link rendering.

The static homepage/app preview validates routing and UI. Complete live proof additionally requires the matching cloud API and gateway revision; the canonical deployment workflows do not deploy feature-branch API/gateway code. Production has not been changed by this PR.

## Evidence

| Artifact | Evidence |
| --- | --- |
| Before | [Production legacy link ignores the onboarding session](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18836-evidence-before-production.jpg) |
| After | [Reviewed desktop + mobile confirmation/success states](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18886-after-desktop-mobile.jpg) |
| Walkthrough | [Confirmation → success → native return CTA (MP4)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18886-walkthrough.mp4) |
| Browser audit | [Strict scoped audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18886-browser-audit-report.json) |
| Backend | [Focused test output](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18886-backend-tests.log) |
| Frontend | [Browser console/network review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18886-frontend-logs.txt) |
| Domain | [Exact-head contract artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18886-domain-artifacts.json) |
| OCR | [Desktop/mobile legibility review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18886-ocr-review.txt) |

No model trajectory is applicable: this is a deterministic routing, authentication, persistence, and native-link flow.

<!-- evidence-head:fde004a2cb806d97370e988015318c9bd3c61474 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18836-evidence-before-production.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18886-after-desktop-mobile.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18886-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [x] [18886-backend-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18886-backend-tests.log)

<!-- evidence-row:frontend-logs -->
- [x] [18886-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18886-frontend-logs.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic routing, authentication, persistence, and native-link flow; no model inference is executed

<!-- evidence-row:domain-artifacts -->
- [x] [18886-domain-artifacts.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18886-domain-artifacts.json)

<!-- evidence-row:ocr-review -->
- [x] [18886-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18886-ocr-review.txt)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@fde004a2cb806d97370e988015318c9bd3c61474:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@fde004a2cb806d97370e988015318c9bd3c61474:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-imessage-onboarding]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@fde004a2cb806d97370e988015318c9bd3c61474:packages/skills/skills/contribute-to-eliza"} -->
