### PR TITLE
fix(agent): omit unavailable conversation ages

### DIFF
--- a/packages/agent/src/providers/automation-terminal-bridge.ts
+++ b/packages/agent/src/providers/automation-terminal-bridge.ts
@@ -20,7 +20,7 @@ import {
 } from "../api/conversation-metadata.ts";
 import { hasAdminAccess } from "../security/access.ts";
 import {
-  formatRelativeTimestamp,
+  formatRelativeTimestampPrefix,
   formatSpeakerLabel,
 } from "../shared/conversation-format.ts";
 
@@ -81,9 +81,9 @@ export const automationTerminalBridgeProvider: Provider = {
       const lines = ["Linked terminal conversation:"];
       for (const mem of visibleMessages) {
         const speaker = formatSpeakerLabel(runtime, mem);
-        const ts = formatRelativeTimestamp(mem.createdAt);
+        const age = formatRelativeTimestampPrefix(mem.createdAt);
         const text = (mem.content.text ?? "").slice(0, 300);
-        lines.push(`(${ts}) ${speaker}: ${text}`);
+        lines.push(`${age}${speaker}: ${text}`);
       }
 
       return {

--- a/packages/agent/src/providers/page-scoped-context.ts
+++ b/packages/agent/src/providers/page-scoped-context.ts
@@ -24,7 +24,7 @@ import {
 } from "../api/conversation-metadata.ts";
 import type { ConversationScope } from "../api/server-types.ts";
 import {
-  formatRelativeTimestamp,
+  formatRelativeTimestampPrefix,
   formatSpeakerLabel,
 } from "../shared/conversation-format.ts";
 import { renderLiveStateForScope } from "./page-scoped-live-state.ts";
@@ -69,7 +69,7 @@ const PAGE_SCOPE_BRIEF: Record<string, string> = {
 interface SourceTailEntry {
   speaker: string;
   text: string;
-  ageLabel: string;
+  agePrefix: string;
   role: "user" | "assistant" | "unknown";
 }
 
@@ -140,7 +140,7 @@ async function fetchSourceTail(
   return pruned.map((mem) => ({
     speaker: formatSpeakerLabel(runtime, mem),
     text: (mem.content.text ?? "").slice(0, 280),
-    ageLabel: formatRelativeTimestamp(mem.createdAt),
+    agePrefix: formatRelativeTimestampPrefix(mem.createdAt),
     role: inferRole(mem, runtime.agentId),
   }));
 }
@@ -148,7 +148,7 @@ async function fetchSourceTail(
 function formatSourceTail(entries: SourceTailEntry[]): string {
   const lines: string[] = ["Recent main-chat tail:"];
   for (const entry of entries) {
-    lines.push(`(${entry.ageLabel}) ${entry.speaker}: ${entry.text}`);
+    lines.push(`${entry.agePrefix}${entry.speaker}: ${entry.text}`);
   }
   return lines.join("\n");
 }

--- a/packages/agent/src/providers/recent-conversations.test.ts
+++ b/packages/agent/src/providers/recent-conversations.test.ts
@@ -24,6 +24,33 @@ function message(): Memory {
 }
 
 describe("recentConversationsProvider fast-fail (#12265)", () => {
+  it("omits empty age labels and their parentheses from provider output", async () => {
+    const runtime = {
+      agentId: "00000000-0000-0000-0000-0000000000f0" as UUID,
+      character: { name: "Test Agent" },
+      getRoom: vi.fn(async () => ({
+        id: ROOM_ID,
+        source: "discord",
+        name: "general",
+      })),
+      getRoomsForParticipant: vi.fn(async () => [ROOM_ID]),
+      getMemoriesByRoomIds: vi.fn(async () => [
+        { ...message(), createdAt: Number.POSITIVE_INFINITY },
+      ]),
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+
+    const result = await recentConversationsProvider.get(
+      runtime,
+      message(),
+      EMPTY_STATE,
+    );
+
+    expect(result.text).toContain("[discord] general user: hello there");
+    expect(result.text).not.toContain("()");
+    expect(result.text).not.toContain("NaN");
+  });
+
   it("reports a recall failure and degrades to empty context, not fabricated history", async () => {
     const reportError = vi.fn();
     const runtime = {

--- a/packages/agent/src/providers/recent-conversations.ts
+++ b/packages/agent/src/providers/recent-conversations.ts
@@ -21,7 +21,7 @@ import {
   isPageScopedConversationMetadata,
 } from "../api/conversation-metadata.ts";
 import {
-  formatRelativeTimestamp,
+  formatRelativeTimestampPrefix,
   formatSpeakerLabel,
   roomSourceTag,
 } from "../shared/conversation-format.ts";
@@ -118,10 +118,10 @@ export const recentConversationsProvider: Provider = {
       for (const mem of sorted) {
         const room = roomCache.get(mem.roomId) ?? null;
         const tag = roomSourceTag(room);
-        const ts = formatRelativeTimestamp(mem.createdAt);
+        const age = formatRelativeTimestampPrefix(mem.createdAt);
         const speaker = formatSpeakerLabel(runtime, mem);
         const text = (mem.content.text ?? "").slice(0, 200);
-        lines.push(`${tag} (${ts}) ${speaker}: ${text}`);
+        lines.push(`${tag} ${age}${speaker}: ${text}`);
       }
 
       return {

--- a/packages/agent/src/providers/relevant-conversations.ts
+++ b/packages/agent/src/providers/relevant-conversations.ts
@@ -40,7 +40,7 @@ import {
 } from "../api/conversation-metadata.ts";
 import { HASH_MEMORY_SOURCE, rankByKeyword } from "../api/memory-routes.ts";
 import {
-  formatRelativeTimestamp,
+  formatRelativeTimestampPrefix,
   formatSpeakerLabel,
   roomSourceTag,
 } from "../shared/conversation-format.ts";
@@ -283,7 +283,7 @@ export const relevantConversationsProvider: Provider = {
       for (const mem of filtered) {
         const room = roomCache.get(mem.roomId) ?? null;
         const tag = roomSourceTag(room);
-        const ts = formatRelativeTimestamp(mem.createdAt);
+        const age = formatRelativeTimestampPrefix(mem.createdAt);
         const speaker = formatSpeakerLabel(runtime, mem);
         const source = (mem.content as { source?: string } | undefined)?.source;
         const snippetLength =
@@ -291,7 +291,7 @@ export const relevantConversationsProvider: Provider = {
             ? HASH_MEMORY_SNIPPET_LENGTH
             : RELEVANT_SNIPPET_LENGTH;
         const msgText = truncateWellFormed(memoryText(mem), snippetLength);
-        lines.push(`${tag} (${ts}) ${speaker}: ${msgText}`);
+        lines.push(`${tag} ${age}${speaker}: ${msgText}`);
       }
 
       return {

--- a/packages/agent/src/shared/conversation-format.test.ts
+++ b/packages/agent/src/shared/conversation-format.test.ts
@@ -4,10 +4,11 @@
  * non-finite and out-of-range createdAt values, plus the healthy finite buckets.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   formatRelativeTimestamp,
+  formatRelativeTimestampPrefix,
   roomSourceTag,
 } from "./conversation-format.ts";
 
@@ -45,6 +46,21 @@ describe("formatRelativeTimestamp", () => {
 
   it("treats near-future timestamps as just now (clock skew)", () => {
     expect(formatRelativeTimestamp(Date.now() + 15_000)).toBe("just now");
+  });
+});
+
+describe("formatRelativeTimestampPrefix", () => {
+  it("omits both the label and parentheses for unavailable timestamps", () => {
+    expect(formatRelativeTimestampPrefix()).toBe("");
+    expect(formatRelativeTimestampPrefix(Number.POSITIVE_INFINITY)).toBe("");
+    expect(formatRelativeTimestampPrefix(Number.MAX_VALUE)).toBe("");
+  });
+
+  it("renders healthy labels as a parenthesized line prefix", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    expect(formatRelativeTimestampPrefix(1_700_000_000_000 - 120_000)).toBe(
+      "(2m ago) ",
+    );
   });
 });
 

--- a/packages/agent/src/shared/conversation-format.ts
+++ b/packages/agent/src/shared/conversation-format.ts
@@ -99,3 +99,9 @@ export function formatRelativeTimestamp(createdAt?: number): string {
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
 }
+
+/** Render a relative timestamp as an optional parenthesized line prefix. */
+export function formatRelativeTimestampPrefix(createdAt?: number): string {
+  const label = formatRelativeTimestamp(createdAt);
+  return label ? `(${label}) ` : "";
+}


### PR DESCRIPTION
# Relates to

Fixes #18693.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Frozen install and root verification passed on the patch-identical pre-sync head; exact focused gates passed after the final rebase.
- [x] Exact provider output and all affected consumers are covered below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex-desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@af61fd3ea68e2b244c53f2ecc99f52774ca5adda`; 0 commits behind at final verification.
- [x] Patch-identical pre-sync `bun run verify`: 350/350 workspace tasks and all audits passed; post-sync focused 26/26, Biome, and diff-check passed.

# Risks

Low. Valid relative-time text is unchanged. Only empty age labels stop emitting empty parentheses.

# Background

## What does this PR do?

- Adds one shared optional relative-age prefix formatter.
- Uses it in recent conversations, relevant conversations, the automation terminal bridge, and page-scoped source tails.
- Omits the entire `(<age>) ` fragment when a timestamp is missing, non-finite, or outside the Date range.
- Preserves valid output such as `(2m ago) `.
- Adds a real provider-output regression proving invalid input contains neither `()` nor `NaN`.

## What kind of change is this?

Provider/prompt presentation bug fix (non-breaking).

# Documentation changes needed?

No. No public API or configuration changes.

# Testing

- Affected helper/provider suites: PASS, 4 files and 26/26 tests.
- `bun run --cwd packages/agent test`: PASS, 397/397 isolated files.
- Agent typecheck and lint: PASS.
- Frozen install: PASS, no changes.
- Patch-identical pre-sync root verify: PASS, 350/350 tasks and all audits; post-sync focused 26/26, Biome, and diff-check PASS.
- `git diff --check`: PASS.

# Evidence Gate

<!-- evidence-head:f78a03c50ed8256c5de2c2f3cf037a85c114f32d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - provider prompt text has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - provider prompt text has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic provider tests cover the complete changed presentation flow.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head provider-output transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18693-provider-output-f78a03c5.json) records invalid and valid output plus complete verification.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model call, prompt instruction, action, or decision logic changed; this removes malformed optional metadata before prompt assembly.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - provider output is captured as backend evidence above; no persistent domain artifact changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

Exact invalid provider output:

```text
[discord] general user: hello there
```

Forbidden tokens: `()`, `NaN`. Healthy two-minute output remains `(2m ago) `.

Artifact SHA-256: `a4ed9421be42d9c81ef3a6f2486ebd32d07262578bcc71312daae70893496b75`.

## Screenshots / walkthrough

N/A - these providers supply internal model context, not rendered application UI.

## Known gaps / failures

None. Visual, frontend, persistent-domain, and live-LLM artifacts are inapplicable to this deterministic provider formatting fix.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-issue-triage]

