### PR TITLE
fix(core): validate optimized prompt artifacts before persistence

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,6 +9,23 @@
 
 ### Changed
 
+- **Optimized-prompt artifact compatibility decision:** The retired
+  `OptimizedPromptContextConfig` channel and its provider-selection helpers
+  (`resolveOptimizedContextConfigForRuntime` and
+  `applyOptimizedProviderSelection`) remain removed; no deprecated shims are
+  restored because their training consumer was removed and the settings were
+  inert at runtime. The removed context-config portions of the
+  `./services/optimized-prompt-resolver` source surface are likewise no longer
+  supported. Migrate callers by removing those imports and omit `contextConfig`
+  from generated artifacts; remaining prompt resolution uses
+  `OptimizedPromptService` and `resolveOptimizedPromptForRuntime`. Artifacts
+  carrying `contextConfig`, even when the own-property value is `undefined`,
+  are rejected at parse and write boundaries.
+  - **Why:** A retired field cannot be allowed to cross the signed persistence
+    boundary or appear to control provider selection. An explicit migration
+    note makes the intentional source break reviewable instead of preserving
+    an inert compatibility API.
+
 - **Documentation:** Removed `docs/OUTGOING_CONTENT_HOOKS.md` and `docs/PIPELINE_MODEL_STREAMING_AND_DPE.md` in favor of [docs/PIPELINE_HOOKS.md](./docs/PIPELINE_HOOKS.md).
   - **Why:** One hooks guide is easier to discover and update than parallel granular files.
 

--- a/packages/core/src/services/optimized-prompt.test.ts
+++ b/packages/core/src/services/optimized-prompt.test.ts
@@ -184,6 +184,15 @@ describe("OptimizedPromptService — symlink-based versioning", () => {
 		expect(parsed).toBeNull();
 	});
 
+	it("rejects contextConfig even when the own-property value is undefined", () => {
+		const parsed = parseOptimizedPromptArtifact({
+			...makeArtifact(1),
+			contextConfig: undefined,
+		} as unknown);
+
+		expect(parsed).toBeNull();
+	});
+
 	it("rejects invalid public artifacts before signing, persistence, or caching", async () => {
 		const invalidArtifacts = [
 			{
@@ -209,15 +218,35 @@ describe("OptimizedPromptService — symlink-based versioning", () => {
 		expect(service.getPrompt("action_planner")).toBeNull();
 	});
 
-	it("preserves valid artifacts across set, get, and refresh", async () => {
+	it("rejects an artifact task mismatch with typed expected/actual context", async () => {
+		const artifact = makeArtifact(1);
+		await expect(service.setPrompt("response", artifact)).rejects.toMatchObject(
+			{
+				name: "ElizaError",
+				code: "OPTIMIZED_PROMPT_ARTIFACT_TASK_MISMATCH",
+				context: {
+					expectedTask: "response",
+					actualTask: "action_planner",
+				},
+			},
+		);
+		expect(existsSync(join(storeRoot, "response"))).toBe(false);
+		expect(service.getPrompt("response")).toBeNull();
+	});
+
+	it("preserves valid artifacts across set, get, and a fresh-service reload", async () => {
 		const artifact = makeArtifact(1);
 		const path = await service.setPrompt("action_planner", artifact);
 
 		expect(path).toBe(join(storeRoot, "action_planner", "v1.json"));
 		expect(service.getPrompt("action_planner")?.prompt).toBe(artifact.prompt);
 
-		await service.refresh();
-		expect(service.getPrompt("action_planner")?.prompt).toBe(artifact.prompt);
+		const restartedService = createService();
+		restartedService.setStoreRoot(storeRoot);
+		await restartedService.refresh();
+		expect(restartedService.getPrompt("action_planner")?.prompt).toBe(
+			artifact.prompt,
+		);
 	});
 
 	it("retains the most recent OPTIMIZED_PROMPT_RETAIN_VERSIONS artifacts", async () => {

--- a/packages/core/src/services/optimized-prompt.test.ts
+++ b/packages/core/src/services/optimized-prompt.test.ts
@@ -184,6 +184,42 @@ describe("OptimizedPromptService — symlink-based versioning", () => {
 		expect(parsed).toBeNull();
 	});
 
+	it("rejects invalid public artifacts before signing, persistence, or caching", async () => {
+		const invalidArtifacts = [
+			{
+				...makeArtifact(1),
+				contextConfig: { providerSet: ["RECENT_MESSAGES"] },
+			},
+			{
+				...makeArtifact(1),
+				unsupportedExtra: "must not cross the artifact boundary",
+			},
+		] as OptimizedPromptArtifact[];
+
+		for (const invalidArtifact of invalidArtifacts) {
+			await expect(
+				service.setPrompt("action_planner", invalidArtifact),
+			).rejects.toMatchObject({
+				name: "ElizaError",
+				code: "OPTIMIZED_PROMPT_ARTIFACT_INVALID",
+			});
+		}
+
+		expect(existsSync(join(storeRoot, "action_planner"))).toBe(false);
+		expect(service.getPrompt("action_planner")).toBeNull();
+	});
+
+	it("preserves valid artifacts across set, get, and refresh", async () => {
+		const artifact = makeArtifact(1);
+		const path = await service.setPrompt("action_planner", artifact);
+
+		expect(path).toBe(join(storeRoot, "action_planner", "v1.json"));
+		expect(service.getPrompt("action_planner")?.prompt).toBe(artifact.prompt);
+
+		await service.refresh();
+		expect(service.getPrompt("action_planner")?.prompt).toBe(artifact.prompt);
+	});
+
 	it("retains the most recent OPTIMIZED_PROMPT_RETAIN_VERSIONS artifacts", async () => {
 		const totalWrites = OPTIMIZED_PROMPT_RETAIN_VERSIONS + 2;
 		for (let i = 1; i <= totalWrites; i += 1) {

--- a/packages/core/src/services/optimized-prompt.ts
+++ b/packages/core/src/services/optimized-prompt.ts
@@ -392,12 +392,7 @@ export function parseOptimizedPromptArtifact(
 	// retired with its training consumer; accepting it (or any future extra)
 	// here would let an unconsumed producer field cross the signing boundary.
 	for (const key of Object.keys(raw)) {
-		// Preserve compatibility with producers that materialize an optional
-		// retired field as `undefined`; it is omitted from the canonical output.
-		if (
-			!OPTIMIZED_PROMPT_ARTIFACT_KEYS.has(key) &&
-			!(key === "contextConfig" && raw.contextConfig === undefined)
-		) {
+		if (!OPTIMIZED_PROMPT_ARTIFACT_KEYS.has(key)) {
 			return null;
 		}
 	}
@@ -417,10 +412,6 @@ export function parseOptimizedPromptArtifact(
 	}
 	if (typeof raw.generatedAt !== "string") return null;
 	if (!Array.isArray(raw.lineage)) return null;
-	// The training plugin that consumed contextConfig was removed in #17695.
-	// Reject the orphaned channel instead of loading an artifact whose provider
-	// selection, ordering, templates, and budgets cannot affect the runtime.
-	if (raw.contextConfig !== undefined) return null;
 	const lineage: OptimizedPromptLineageEntry[] = [];
 	for (const entry of raw.lineage) {
 		if (!isStringRecord(entry)) continue;
@@ -702,8 +693,15 @@ export class OptimizedPromptService extends Service {
 			);
 		}
 		if (validatedArtifact.task !== task) {
-			throw new Error(
-				`[OptimizedPromptService] artifact.task=${validatedArtifact.task} does not match target task=${task}`,
+			throw new ElizaError(
+				"Optimized prompt artifact task does not match the target task",
+				{
+					code: "OPTIMIZED_PROMPT_ARTIFACT_TASK_MISMATCH",
+					context: {
+						expectedTask: task,
+						actualTask: validatedArtifact.task,
+					},
+				},
 			);
 		}
 		const dir = join(this.storeRoot, task);

--- a/packages/core/src/services/optimized-prompt.ts
+++ b/packages/core/src/services/optimized-prompt.ts
@@ -364,6 +364,22 @@ function isTask(value: unknown): value is OptimizedPromptTask {
 	);
 }
 
+const OPTIMIZED_PROMPT_ARTIFACT_KEYS = new Set([
+	"task",
+	"optimizer",
+	"baseline",
+	"prompt",
+	"score",
+	"baselineScore",
+	"datasetId",
+	"datasetSize",
+	"generatedAt",
+	"fewShotExamples",
+	"lineage",
+	"frontier",
+	"promotionDecision",
+]);
+
 /**
  * Strict parser. We reject artifacts that are missing required fields so a
  * corrupt file cannot silently shadow the baseline prompt with garbage.
@@ -372,6 +388,12 @@ export function parseOptimizedPromptArtifact(
 	raw: unknown,
 ): OptimizedPromptArtifact | null {
 	if (!isStringRecord(raw)) return null;
+	// Keep the persisted contract closed. In particular, contextConfig was
+	// retired with its training consumer; accepting it (or any future extra)
+	// here would let an unconsumed producer field cross the signing boundary.
+	for (const key of Object.keys(raw)) {
+		if (!OPTIMIZED_PROMPT_ARTIFACT_KEYS.has(key)) return null;
+	}
 	if (!isTask(raw.task)) return null;
 	if (!isOptimizerName(raw.optimizer)) return null;
 	if (typeof raw.baseline !== "string" || typeof raw.prompt !== "string") {
@@ -662,13 +684,25 @@ export class OptimizedPromptService extends Service {
 		task: OptimizedPromptTask,
 		artifact: OptimizedPromptArtifact,
 	): Promise<string> {
-		if (artifact.task !== task) {
+		const validatedArtifact = parseOptimizedPromptArtifact(artifact);
+		if (!validatedArtifact) {
+			throw new ElizaError(
+				"Optimized prompt artifact failed strict validation",
+				{
+					code: "OPTIMIZED_PROMPT_ARTIFACT_INVALID",
+					context: { task },
+				},
+			);
+		}
+		if (validatedArtifact.task !== task) {
 			throw new Error(
-				`[OptimizedPromptService] artifact.task=${artifact.task} does not match target task=${task}`,
+				`[OptimizedPromptService] artifact.task=${validatedArtifact.task} does not match target task=${task}`,
 			);
 		}
 		const dir = join(this.storeRoot, task);
-		return runExclusive(dir, () => this.writeArtifact(task, dir, artifact));
+		return runExclusive(dir, () =>
+			this.writeArtifact(task, dir, validatedArtifact),
+		);
 	}
 
 	private async writeArtifact(

--- a/packages/core/src/services/optimized-prompt.ts
+++ b/packages/core/src/services/optimized-prompt.ts
@@ -392,7 +392,14 @@ export function parseOptimizedPromptArtifact(
 	// retired with its training consumer; accepting it (or any future extra)
 	// here would let an unconsumed producer field cross the signing boundary.
 	for (const key of Object.keys(raw)) {
-		if (!OPTIMIZED_PROMPT_ARTIFACT_KEYS.has(key)) return null;
+		// Preserve compatibility with producers that materialize an optional
+		// retired field as `undefined`; it is omitted from the canonical output.
+		if (
+			!OPTIMIZED_PROMPT_ARTIFACT_KEYS.has(key) &&
+			!(key === "contextConfig" && raw.contextConfig === undefined)
+		) {
+			return null;
+		}
 	}
 	if (!isTask(raw.task)) return null;
 	if (!isOptimizerName(raw.optimizer)) return null;


### PR DESCRIPTION
# Relates to

Closes #18817

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Targets `develop` and is based on current `origin/develop`.
- [x] Adds focused persistence/cache regressions and passes diff checks.
- [ ] Full repository verification remains for hosted CI.

# Contribution provenance

<!-- contribution-attribution:v1 -->
- AI assistance: `yes`
- Model(s) used: `openai/gpt-5.6-sol`
- Agent tooling: `codex`
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
- Provenance status: `self-reported`

# What changed

`parseOptimizedPromptArtifact` already rejected the retired `contextConfig` channel, but public `setPrompt()` only checked `artifact.task` before signing, persisting, and caching the raw object. Invalid artifacts could therefore appear live until restart, when refresh discarded them. The service now validates and canonicalizes artifacts before any write/cache side effect, rejects unsupported top-level keys with an actionable `ElizaError`, and preserves valid set/get/refresh behavior.

# Testing

- Focused optimized-prompt regression coverage added for rejected `contextConfig`, unsupported extras, side-effect-free failure, and valid refresh compatibility.
- Biome: passed.
- `git diff --check`: passed.
- Local focused test execution is blocked by the dependency-free worktree's missing `adze` package; no install was performed.

# Evidence Gate

<!-- evidence-head:dfa4f85197844951f96a9a41c0b8605cc3427a32 -->
<!-- evidence-row:before-screenshots -->
- [ ] N/A - deterministic persistence service with no UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - deterministic persistence service with no UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing visual flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - focused tests use temporary local storage, not a deployed backend.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model or prompt generation behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - local signed artifact files are directly asserted by regression tests.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text changed.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 47872301 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [symbiex-batch20]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZWBHQCKKGB7V7QN1D25X1JP","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T01:24:52.756Z","completed_at":"2026-08-13T01:36:59.629Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339f76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":1457442,"output_tokens":90507,"cache_creation_tokens":0,"cache_read_tokens":46324352,"total_tokens":47872301,"cost_micro_usd":"30428830","session_count":12},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"w4mZuT1zUAwf4JZEJAbo5Z2DCuo10-FqYPVFoOJLb6CI77Q-EGnIjFM_XEssTPvUNnbauIb-mR905YWHuHwaDA"}} -->
