### PR TITLE
feat(wallet): add non-broadcasting Solana transaction simulation mode (#16613)

### DIFF
--- a/plugins/plugin-wallet/src/chains/registry.ts
+++ b/plugins/plugin-wallet/src/chains/registry.ts
@@ -39,6 +39,7 @@ import type {
   WalletRouterContext,
   WalletRouterExecution,
   WalletRouterParams,
+  WalletSimulationMetadata,
 } from "../types/wallet-router.js";
 import type { SolanaSigner } from "../wallet/backend.js";
 import { buildSendTxParams } from "./evm/actions/helpers";
@@ -403,6 +404,38 @@ function getSolanaConnection(runtime: IAgentRuntime): Connection {
   return new Connection(rpcUrl);
 }
 
+/**
+ * Run a non-broadcasting RPC simulation against an unsigned versioned
+ * transaction. `replaceRecentBlockhash: true` lets the RPC supply a fresh
+ * blockhash so an unsigned Jupiter/PumpPortal-built transaction simulates
+ * correctly without a local signer.
+ */
+async function simulateVersionedTransaction(
+  connection: Connection,
+  transaction: VersionedTransaction,
+  extraMetadata?: Record<string, unknown>,
+): Promise<WalletSimulationMetadata> {
+  const simulation = await connection.simulateTransaction(transaction, {
+    sigVerify: false,
+    replaceRecentBlockhash: true,
+  });
+  const unitsConsumed =
+    typeof simulation.value.unitsConsumed === "bigint"
+      ? Number(simulation.value.unitsConsumed)
+      : simulation.value.unitsConsumed ?? undefined;
+  return {
+    ok: simulation.value.err === null,
+    logs: simulation.value.logs ?? [],
+    err: simulation.value.err
+      ? typeof simulation.value.err === "string"
+        ? simulation.value.err
+        : JSON.stringify(simulation.value.err)
+      : null,
+    unitsConsumed,
+    ...extraMetadata,
+  };
+}
+
 type BrowserAutomationService = {
   execute: (
     command: Record<string, unknown>,
@@ -514,6 +547,27 @@ async function resolvePumpFunSigner(context: WalletRouterContext): Promise<{
       return copy;
     },
   };
+}
+
+/**
+ * Resolve the agent's Solana public key without requiring a private key.
+ * Used by simulate mode, which never signs.
+ */
+async function resolveSolanaPublicKey(
+  context: WalletRouterContext,
+): Promise<PublicKey> {
+  if (context.walletBackend) {
+    const signer = context.walletBackend.getSolanaSignerOrNull?.();
+    if (signer) {
+      return signer.publicKey;
+    }
+  }
+  const { publicKey, keypair } = await getWalletKey(context.runtime, false);
+  const resolved = publicKey ?? keypair?.publicKey;
+  if (!resolved) {
+    throw new Error("Solana public key is not available.");
+  }
+  return resolved;
 }
 
 async function executePumpFunBuy(
@@ -800,6 +854,32 @@ async function executeSolanaSwap(
   const transaction = VersionedTransaction.deserialize(
     Buffer.from(swapData.swapTransaction, "base64"),
   );
+
+  if (params.mode === "simulate") {
+    // Build the real transaction, then simulate without signing or sending.
+    const simulation = await simulateVersionedTransaction(
+      connection,
+      transaction,
+      {
+        quote: quoteData,
+        from: walletPublicKey.toBase58(),
+      },
+    );
+    return {
+      status: "simulated",
+      chain: "solana",
+      chainId: "solana-mainnet",
+      subaction: "swap",
+      dryRun: false,
+      mode: "simulate",
+      from: walletPublicKey.toBase58(),
+      amount: params.amount,
+      fromToken: inputMint,
+      toToken: outputMint,
+      simulation,
+    };
+  }
+
   const { keypair } = await getWalletKey(context.runtime, true);
   if (!keypair) {
     throw new Error("Solana keypair is not available.");

--- a/plugins/plugin-wallet/src/chains/wallet-action.ts
+++ b/plugins/plugin-wallet/src/chains/wallet-action.ts
@@ -45,6 +45,7 @@ import type {
   WalletRouterSubaction,
 } from "../types/wallet-router.js";
 import {
+  WALLET_ROUTER_MODES,
   isWalletRouterSubaction,
   parseWalletRouterParams,
 } from "../types/wallet-router.js";
@@ -324,6 +325,15 @@ function resultText(result: WalletRouterResult): string {
     return formatFailure(result);
   }
   const execution = result.result;
+  if (execution.status === "simulated") {
+    const sim = execution.simulation;
+    const okText = sim?.ok ? "succeeded" : "would revert";
+    const units =
+      sim?.unitsConsumed !== undefined
+        ? `, ${sim.unitsConsumed} compute units`
+        : "";
+    return `Simulated ${execution.subaction} on ${result.handler.chain}: ${okText}${units}.`;
+  }
   if (execution.status === "prepared") {
     const dryRunText = execution.dryRun ? "Dry run prepared" : "Prepared";
     return `${dryRunText} ${execution.subaction} on ${result.handler.chain}.`;
@@ -451,9 +461,16 @@ async function runWalletRouter(
     return walletFinancialGateActionResult(confirmationGate);
   }
 
+  // simulate mode must reach the handler unchanged (it builds + simulates
+  // without signing), so only escalate the legacy default/prepare to execute
+  // when the action was confirmed.
+  const gateRequiresConfirmation = requiresWalletFinancialConfirmation(params);
   const executionParams: WalletRouterParams = {
     ...params,
-    mode: requiresWalletFinancialConfirmation(params) ? "execute" : params.mode,
+    mode:
+      gateRequiresConfirmation && params.mode !== "simulate"
+        ? "execute"
+        : params.mode,
   };
 
   const routed = await service.routeWalletAction(executionParams);
@@ -486,6 +503,7 @@ async function runWalletRouter(
       ? {
           walletActionSucceeded: routed.result.status === "submitted",
           walletActionPrepared: routed.result.status === "prepared",
+          walletActionSimulated: routed.result.status === "simulated",
           walletChain: routed.handler.chain,
           walletSubaction: routed.result
             .subaction satisfies WalletRouterSubaction,
@@ -596,14 +614,14 @@ export const walletRouterAction: Action = {
     {
       name: "mode",
       description:
-        "Prepare without submitting, or request execution. On-chain submission still requires the user to reply yes on a follow-up turn (LLM cannot authorize via mode or confirmed flags).",
+        "prepare without submitting, execute (after user confirmation), or simulate (build the real transaction and run a non-broadcasting RPC simulation that needs only a public key — never signs or sends).",
       required: false,
       schema: {
         type: "string",
-        enum: ["prepare", "execute"],
+        enum: [...WALLET_ROUTER_MODES],
         default: "prepare",
       },
-      examples: ["prepare", "execute"],
+      examples: ["prepare", "execute", "simulate"],
     },
     {
       name: "dryRun",

--- a/plugins/plugin-wallet/src/security/wallet-financial-confirmation.ts
+++ b/plugins/plugin-wallet/src/security/wallet-financial-confirmation.ts
@@ -74,9 +74,14 @@ export function walletFinancialRangeKey(
 }
 
 export function requiresWalletFinancialConfirmation(
-  params: Pick<WalletFinancialWriteParams, "subaction" | "dryRun">,
+  params: Pick<WalletFinancialWriteParams, "subaction" | "dryRun" | "mode">,
 ): boolean {
   if (params.dryRun) {
+    return false;
+  }
+  // simulate mode never signs or broadcasts, so it cannot move funds and
+  // must not require user confirmation the way a real submit does.
+  if (params.mode === "simulate") {
     return false;
   }
   return ON_CHAIN_SUBACTIONS.has(params.subaction);

--- a/plugins/plugin-wallet/src/services/wallet-backend-service.ts
+++ b/plugins/plugin-wallet/src/services/wallet-backend-service.ts
@@ -151,6 +151,27 @@ export class WalletBackendService extends Service {
       return required;
     }
 
+    if (params.mode === "simulate") {
+      // Simulate mode builds the real transaction (live quote/build) and runs
+      // a non-broadcasting RPC simulation against an unsigned transaction,
+      // so it must reach the handler. It never signs or sends and is
+      // therefore exempt from the financial-confirmation gate upstream.
+      try {
+        const result = await handler.execute(params, this.createContext());
+        return {
+          ok: true,
+          handler: this.toMetadata(handler),
+          result,
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error: "EXECUTION_FAILED",
+          detail: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }
+
     if (params.dryRun || params.mode === "prepare") {
       if (
         params.dryRun &&

--- a/plugins/plugin-wallet/src/types/wallet-router.ts
+++ b/plugins/plugin-wallet/src/types/wallet-router.ts
@@ -26,7 +26,7 @@ export const WALLET_ROUTER_SUBACTIONS = [
 
 export type WalletRouterSubaction = (typeof WALLET_ROUTER_SUBACTIONS)[number];
 
-export const WALLET_ROUTER_MODES = ["prepare", "execute"] as const;
+export const WALLET_ROUTER_MODES = ["prepare", "execute", "simulate"] as const;
 
 export type WalletRouterMode = (typeof WALLET_ROUTER_MODES)[number];
 
@@ -93,8 +93,21 @@ export interface WalletRouterContext {
   readonly tokenDataService: ITokenDataService | null;
 }
 
+export interface WalletSimulationMetadata {
+  /** True when the simulated transaction would succeed on-chain. */
+  readonly ok: boolean;
+  /** Simulation logs, when available. */
+  readonly logs: readonly string[];
+  /** Transaction-level error when the simulation would revert. */
+  readonly err?: string | null;
+  /** Compute units consumed by the simulated transaction. */
+  readonly unitsConsumed?: number;
+  /** Additional quote/route details surfaced from the builder. */
+  readonly [key: string]: unknown;
+}
+
 export interface WalletRouterExecution {
-  readonly status: "prepared" | "submitted";
+  readonly status: "prepared" | "simulated" | "submitted";
   readonly chain: string;
   readonly chainId: string;
   readonly subaction: WalletRouterSubaction;
@@ -107,6 +120,7 @@ export interface WalletRouterExecution {
   readonly amount?: string;
   readonly fromToken?: string;
   readonly toToken?: string;
+  readonly simulation?: WalletSimulationMetadata;
   readonly metadata?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
Builds a real Jupiter transaction then calls connection.simulateTransaction() on the unsigned transaction. Returns compute units, logs, and errors. No private key required.

---
AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Lane: hermes-t3rpz