### PR TITLE
fix(whatsapp): make Cloud API webhooks account-scoped and delivery idempotent (#16342)

### DIFF
--- a/plugins/plugin-whatsapp/__tests__/inbound-claim-pglite.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/inbound-claim-pglite.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Proves WhatsApp inbound claim exclusion and fencing against a real runtime
+ * and PGLite adapter. The suite exercises production document unique-insert
+ * and compare-and-swap behavior; no database method is mocked.
+ */
+import {
+	type AgentRuntime,
+	createUniqueUuid,
+	type Memory,
+	type MemoryMetadata,
+	MemoryType,
+	type UUID,
+} from "@elizaos/core";
+import {
+	createTestRuntime,
+	type TestRuntimeResult,
+} from "@elizaos/core/testing";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+	completeClaim,
+	createInboundClaimId,
+	tryClaim,
+} from "../src/inbound-claim";
+
+let testRuntime: TestRuntimeResult;
+let runtime: AgentRuntime;
+
+beforeAll(async () => {
+	testRuntime = await createTestRuntime({ characterName: "WhatsAppClaimTest" });
+	runtime = testRuntime.runtime;
+}, 180_000);
+
+afterAll(async () => {
+	await testRuntime.cleanup();
+});
+
+describe("WhatsApp inbound claims on PGLite", () => {
+	it("elects one winner and preserves a distinct inbound message row", async () => {
+		const externalMessageId = `wamid.race.${crypto.randomUUID()}`;
+		const claimId = createInboundClaimId(runtime, "default", externalMessageId);
+		const inboundMessageId = createUniqueUuid(
+			runtime,
+			`whatsapp:chat:${externalMessageId}`,
+		) as UUID;
+
+		const contenders = await Promise.all([
+			tryClaim(runtime, claimId, "default", externalMessageId),
+			tryClaim(runtime, claimId, "default", externalMessageId),
+		]);
+		expect(contenders.filter((result) => result.won)).toHaveLength(1);
+
+		const winner = contenders.find((result) => result.won)?.state;
+		expect(winner).not.toBeNull();
+		if (!winner) throw new Error("PGLite claim race did not produce an owner");
+		const activeClaim = await runtime.getMemoryById(claimId);
+		if (!activeClaim) throw new Error("PGLite claim race did not persist its document");
+
+		const inboundMessage: Memory = {
+			id: inboundMessageId,
+			entityId: runtime.agentId,
+			agentId: runtime.agentId,
+			roomId: activeClaim.roomId,
+			worldId: activeClaim.worldId,
+			content: { text: "real inbound WhatsApp payload", source: "whatsapp" },
+			metadata: {
+				type: "message",
+				source: "whatsapp",
+				messageIdFull: externalMessageId,
+			} as MemoryMetadata,
+			createdAt: Date.now(),
+		};
+		await runtime.createMemory(inboundMessage, "messages", true);
+		await completeClaim(runtime, claimId, winner);
+
+		const persistedClaim = await runtime.getMemoryById(claimId);
+		const persistedMessage = await runtime.getMemoryById(inboundMessageId);
+		expect(claimId).not.toBe(inboundMessageId);
+		expect(persistedClaim?.metadata).toMatchObject({
+			type: MemoryType.DOCUMENT,
+			documentRevision: 1,
+			whatsappClaim: { stage: "processed", revision: 1 },
+		});
+		expect(persistedMessage?.metadata).toMatchObject({
+			type: "message",
+			source: "whatsapp",
+			messageIdFull: externalMessageId,
+		});
+	});
+
+	it("atomically fences a stale owner and rejects its terminal write", async () => {
+		const externalMessageId = `wamid.stale.${crypto.randomUUID()}`;
+		const claimId = createInboundClaimId(runtime, "default", externalMessageId);
+		const initial = await tryClaim(runtime, claimId, "default", externalMessageId);
+		expect(initial.won).toBe(true);
+		if (!initial.state) throw new Error("Initial PGLite claim has no state");
+
+		const document = await runtime.getMemoryById(claimId);
+		if (!document) throw new Error("Initial PGLite claim document was not stored");
+		const staleState = {
+			...initial.state,
+			updatedAt: Date.now() - 10 * 60 * 1000,
+		};
+		await runtime.updateMemory({
+			id: claimId,
+			metadata: {
+				...document.metadata,
+				whatsappClaim: staleState,
+			} as MemoryMetadata,
+		});
+
+		const successors = await Promise.all([
+			tryClaim(runtime, claimId, "default", externalMessageId),
+			tryClaim(runtime, claimId, "default", externalMessageId),
+		]);
+		expect(successors.filter((result) => result.won)).toHaveLength(1);
+		const successor = successors.find((result) => result.won)?.state;
+		expect(successor?.revision).toBe(1);
+		expect(successor?.generation).not.toBe(initial.state.generation);
+
+		await expect(completeClaim(runtime, claimId, initial.state)).rejects.toMatchObject({
+			code: "WHATSAPP_INBOUND_CLAIM_CONFLICT",
+		});
+	});
+});

--- a/plugins/plugin-whatsapp/__tests__/webhook-account-idempotency.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/webhook-account-idempotency.test.ts
@@ -1,255 +1,583 @@
 /**
- * Verifies WhatsApp Cloud API webhook account routing and inbound delivery
- * idempotency with a deterministic mocked runtime and no network access.
+ * Verifies WhatsApp Cloud API webhook account routing, durable inbound
+ * delivery idempotency with generation fencing and restart convergence, and
+ * account-slice acceptance paths (named-account credential inheritance,
+ * duplicate normalized account ids, account-bound send/status/recovery).
+ *
+ * The harness uses a shared in-memory store backing multiple service
+ * instances to prove multi-host exclusion and restart convergence without
+ * network access. The store implements getMemoryById, createMemory, and
+ * updateMemory with the same semantics as the runtime adapter (ON CONFLICT
+ * DO NOTHING on createMemory with unique=true).
  */
-import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import type { IAgentRuntime, Memory, MemoryMetadata, UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { WhatsAppConnectorService } from "../src/runtime-service";
+import {
+	isStaleProcessing,
+	type InboundClaimState,
+} from "../src/inbound-claim";
+
+// ── Shared in-memory store ────────────────────────────────────────────
+
+interface StoreEntry {
+	memory: Memory;
+	table: string;
+	unique?: boolean;
+}
+
+class SharedMemoryStore {
+	private entries = new Map<string, StoreEntry>();
+
+	async getMemoryById(id: UUID): Promise<Memory | null> {
+		const entry = this.entries.get(String(id));
+		return entry ? { ...entry.memory } : null;
+	}
+
+	async createMemory(
+		memory: Memory,
+		table: string,
+		unique?: boolean,
+	): Promise<UUID> {
+		const id = String(memory.id ?? crypto.randomUUID());
+		if (unique && this.entries.has(id)) {
+			// ON CONFLICT DO NOTHING — the existing row persists.
+			return id as UUID;
+		}
+		this.entries.set(id, { memory: { ...memory, id: id as UUID }, table, unique });
+		return id as UUID;
+	}
+
+	async updateMemory(
+		memory: Partial<Memory> & { id: UUID; metadata?: MemoryMetadata },
+	): Promise<boolean> {
+		const entry = this.entries.get(String(memory.id));
+		if (!entry) return false;
+		entry.memory = { ...entry.memory, ...memory } as Memory;
+		return true;
+	}
+
+	/** Snapshot for assertions. */
+	snapshot(): Map<string, StoreEntry> {
+		return new Map(this.entries);
+	}
+
+	/** Clear for test isolation. */
+	clear(): void {
+		this.entries.clear();
+	}
+
+	getClaimState(id: UUID): InboundClaimState | null {
+		const entry = this.entries.get(String(id));
+		if (!entry) return null;
+		const raw = (entry.memory.metadata as Record<string, unknown>)?.whatsappClaim;
+		return (raw as InboundClaimState) ?? null;
+	}
+}
+
+// ── Harness ───────────────────────────────────────────────────────────
 
 type CloudAccountConfig = {
-  accountId: string;
-  transport: "cloudapi";
-  accessToken: string;
-  phoneNumberId: string;
-  dmPolicy: "open" | "disabled";
+	accountId: string;
+	transport: "cloudapi";
+	accessToken: string;
+	phoneNumberId: string;
+	dmPolicy: "open" | "disabled";
 };
 
-function makeRuntime(settings: Record<string, unknown> = {}) {
-  const getMemoryById = vi.fn(async (): Promise<Memory | null> => null);
-  const createMemory = vi.fn(async () => undefined);
-  const ensureConnection = vi.fn(async () => undefined);
-  const ensureRoomExists = vi.fn(async () => undefined);
-  const handleMessage = vi.fn(async () => undefined);
-  const runtime = {
-    agentId: "agent-1" as UUID,
-    character: { settings },
-    getSetting: vi.fn((key: string) =>
-      key === "WHATSAPP_AUTO_REPLY" ? false : undefined
-    ),
-    getMemoryById,
-    createMemory,
-    ensureConnection,
-    ensureRoomExists,
-    messageService: { handleMessage },
-    logger: {
-      warn: vi.fn(),
-      error: vi.fn(),
-      info: vi.fn(),
-      debug: vi.fn(),
-    },
-  } as never as IAgentRuntime;
+function makeRuntimeWithStore(
+	store: SharedMemoryStore,
+	settings: Record<string, unknown> = {},
+) {
+	const runtime = {
+		agentId: "agent-1" as UUID,
+		character: { settings },
+		getSetting: vi.fn((key: string) =>
+			key === "WHATSAPP_AUTO_REPLY" ? false : undefined,
+		),
+		getMemoryById: vi.fn(async (id: UUID) => store.getMemoryById(id)),
+		createMemory: vi.fn(async (memory: Memory, table: string, unique?: boolean) =>
+			store.createMemory(memory, table, unique),
+		),
+		updateMemory: vi.fn(
+			async (memory: Partial<Memory> & { id: UUID; metadata?: MemoryMetadata }) =>
+				store.updateMemory(memory),
+		),
+		ensureConnection: vi.fn(async () => undefined),
+		ensureRoomExists: vi.fn(async () => undefined),
+		messageService: { handleMessage: vi.fn(async () => undefined) },
+		logger: {
+			warn: vi.fn(),
+			error: vi.fn(),
+			info: vi.fn(),
+			debug: vi.fn(),
+		},
+	} as never as IAgentRuntime;
 
-  return {
-    runtime,
-    getMemoryById,
-    createMemory,
-    ensureConnection,
-    ensureRoomExists,
-    handleMessage,
-  };
+	return runtime;
 }
 
 function cloudAccount(
-  accountId: string,
-  phoneNumberId: string,
-  dmPolicy: "open" | "disabled" = "open"
+	accountId: string,
+	phoneNumberId: string,
+	dmPolicy: "open" | "disabled" = "open",
 ): CloudAccountConfig {
-  return {
-    accountId,
-    transport: "cloudapi",
-    accessToken: `token-${accountId}`,
-    phoneNumberId,
-    dmPolicy,
-  };
+	return {
+		accountId,
+		transport: "cloudapi",
+		accessToken: `token-${accountId}`,
+		phoneNumberId,
+		dmPolicy,
+	};
 }
 
 function configuredService(
-  runtime: IAgentRuntime,
-  configs: CloudAccountConfig[] = [cloudAccount("default", "phone-default")]
+	runtime: IAgentRuntime,
+	configs: CloudAccountConfig[] = [cloudAccount("default", "phone-default")],
 ): WhatsAppConnectorService {
-  const service = new WhatsAppConnectorService(runtime);
-  Object.assign(service, {
-    defaultAccountId: "default",
-    configs: new Map(configs.map((config) => [config.accountId, config])),
-  });
-  return service;
+	const service = new WhatsAppConnectorService(runtime);
+	Object.assign(service, {
+		defaultAccountId: "default",
+		configs: new Map(configs.map((config) => [config.accountId, config])),
+	});
+	return service;
 }
 
 function webhook(phoneNumberId: string | undefined, messageId = "wamid.1") {
-  return {
-    entry: [
-      {
-        changes: [
-          {
-            value: {
-              metadata: {
-                display_phone_number: "+1 415 555 2671",
-                ...(phoneNumberId === undefined ? {} : { phone_number_id: phoneNumberId }),
-              },
-              messages: [
-                {
-                  from: "14155552671",
-                  id: messageId,
-                  timestamp: "1700000000",
-                  type: "text",
-                  text: { body: "hello" },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    ],
-  } as never;
+	return {
+		entry: [
+			{
+				changes: [
+					{
+						value: {
+							metadata: {
+								display_phone_number: "+1 415 555 2671",
+								...(phoneNumberId === undefined
+									? {}
+									: { phone_number_id: phoneNumberId }),
+							},
+							messages: [
+								{
+									from: "14155552671",
+									id: messageId,
+									timestamp: "1700000000",
+									type: "text",
+									text: { body: "hello" },
+								},
+							],
+						},
+					},
+				],
+			},
+		],
+	} as never;
 }
 
 function inflightSize(service: WhatsAppConnectorService): number {
-  return (
-    service as unknown as {
-      inflightInboundMessageIds: Set<string>;
-    }
-  ).inflightInboundMessageIds.size;
+	return (
+		service as unknown as {
+			inflightInboundMessageIds: Set<string>;
+		}
+	).inflightInboundMessageIds.size;
 }
 
+// ── Tests ─────────────────────────────────────────────────────────────
+
 describe("WhatsApp Cloud API webhook account routing", () => {
-  it("routes messages by metadata.phone_number_id", async () => {
-    const { runtime, createMemory } = makeRuntime();
-    const service = configuredService(runtime, [
-      cloudAccount("default", "phone-default"),
-      cloudAccount("work", "phone-work"),
-    ]);
+	it("routes messages by metadata.phone_number_id", async () => {
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store);
+		const service = configuredService(runtime, [
+			cloudAccount("default", "phone-default"),
+			cloudAccount("work", "phone-work"),
+		]);
 
-    await service.handleWebhook(webhook("phone-work"));
+		await service.handleWebhook(webhook("phone-work"));
 
-    expect(createMemory).toHaveBeenCalledTimes(1);
-    const memory = createMemory.mock.calls[0]?.[0] as Memory;
-    expect(memory.metadata).toMatchObject({ accountId: "work" });
-  });
+		// The first createMemory call is the durable claim; the second is
+		// the inbound message. Filter to "messages" table.
+		const messageCalls = (
+			runtime.createMemory as ReturnType<typeof vi.fn>
+		).mock.calls.filter((c) => c[1] === "messages");
+		expect(messageCalls.length).toBe(1);
+		const memory = messageCalls[0]?.[0] as Memory;
+		expect(memory.metadata).toMatchObject({ accountId: "work" });
+	});
 
-  it.each([undefined, "phone-unknown"])(
-    "fails closed for a missing or unknown phone number id: %s",
-    async (phoneNumberId) => {
-      const { runtime, createMemory, ensureConnection, getMemoryById } = makeRuntime();
-      const service = configuredService(runtime, [
-        cloudAccount("default", "phone-default"),
-        cloudAccount("work", "phone-work"),
-      ]);
+	it.each([undefined, "phone-unknown"])(
+		"fails closed for a missing or unknown phone number id: %s",
+		async (phoneNumberId) => {
+			const store = new SharedMemoryStore();
+			const runtime = makeRuntimeWithStore(store);
+			const service = configuredService(runtime, [
+				cloudAccount("default", "phone-default"),
+				cloudAccount("work", "phone-work"),
+			]);
 
-      await service.handleWebhook(webhook(phoneNumberId));
+			await service.handleWebhook(webhook(phoneNumberId));
 
-      expect(getMemoryById).not.toHaveBeenCalled();
-      expect(ensureConnection).not.toHaveBeenCalled();
-      expect(createMemory).not.toHaveBeenCalled();
-    }
-  );
+			// No claim or message should be created — the webhook is dropped
+			// before any side effect.
+			expect(runtime.createMemory).not.toHaveBeenCalled();
+			expect(runtime.ensureConnection).not.toHaveBeenCalled();
+		},
+	);
 
-  it("rejects duplicate Cloud API phone number configuration before connecting", async () => {
-    const { runtime } = makeRuntime({
-      whatsapp: {
-        accounts: {
-          alpha: {
-            accessToken: "token-alpha",
-            phoneNumberId: "phone-shared",
-            dmPolicy: "open",
-          },
-          beta: {
-            accessToken: "token-beta",
-            phoneNumberId: "phone-shared",
-            dmPolicy: "open",
-          },
-        },
-      },
-    });
-    const service = new WhatsAppConnectorService(runtime);
+	it("rejects duplicate Cloud API phone number configuration before connecting", async () => {
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store, {
+			whatsapp: {
+				accounts: {
+					alpha: {
+						accessToken: "token-alpha",
+						phoneNumberId: "phone-shared",
+						dmPolicy: "open",
+					},
+					beta: {
+						accessToken: "token-beta",
+						phoneNumberId: "phone-shared",
+						dmPolicy: "open",
+					},
+				},
+			},
+		});
+		const service = new WhatsAppConnectorService(runtime);
 
-    await expect(service.initialize()).rejects.toThrow(
-      'WhatsApp Cloud API accounts "alpha" and "beta" share the same phone_number_id "phone-shared"'
-    );
-  });
+		await expect(service.initialize()).rejects.toThrow(
+			'WhatsApp Cloud API accounts "alpha" and "beta" share the same phone_number_id "phone-shared"',
+		);
+	});
 });
 
-describe("WhatsApp inbound delivery idempotency", () => {
-  it("collapses concurrent delivery of the same message", async () => {
-    const { runtime, createMemory, getMemoryById } = makeRuntime();
-    const service = configuredService(runtime);
-    let releaseLookup: (() => void) | undefined;
-    const lookupBlocked = new Promise<void>((resolve) => {
-      releaseLookup = resolve;
-    });
-    getMemoryById.mockImplementation(async () => {
-      await lookupBlocked;
-      return null;
-    });
+describe("WhatsApp inbound delivery idempotency — durable staged claims", () => {
+	it("collapses concurrent delivery of the same message within one process", async () => {
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store);
+		const service = configuredService(runtime);
 
-    const first = service.handleWebhook(webhook("phone-default"));
-    await vi.waitFor(() => expect(getMemoryById).toHaveBeenCalledTimes(1));
-    const duplicate = service.handleWebhook(webhook("phone-default"));
+		const first = service.handleWebhook(webhook("phone-default"));
+		// Fire a second delivery immediately while the first is still
+		// in-flight — the in-process Set must collapse it.
+		const duplicate = service.handleWebhook(webhook("phone-default"));
 
-    expect(getMemoryById).toHaveBeenCalledTimes(1);
-    releaseLookup?.();
-    await Promise.all([first, duplicate]);
+		await Promise.all([first, duplicate]);
 
-    expect(createMemory).toHaveBeenCalledTimes(1);
-    expect(inflightSize(service)).toBe(0);
-  });
+		expect(
+			(runtime.createMemory as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(c) => c[1] === "messages",
+			).length,
+		).toBe(1);
+		expect(inflightSize(service)).toBe(0);
+	});
 
-  it("skips durable duplicates and clears the in-flight key after each return", async () => {
-    const { runtime, createMemory, getMemoryById } = makeRuntime();
-    const service = configuredService(runtime);
-    getMemoryById.mockResolvedValue({ id: "existing-memory" as UUID } as Memory);
+	it("skips durable duplicates across service instances (restart convergence)", async () => {
+		const store = new SharedMemoryStore();
 
-    await service.handleWebhook(webhook("phone-default"));
-    await service.handleWebhook(webhook("phone-default"));
+		// First instance processes the message
+		const runtime1 = makeRuntimeWithStore(store);
+		const service1 = configuredService(runtime1);
+		await service1.handleWebhook(webhook("phone-default"));
 
-    expect(getMemoryById).toHaveBeenCalledTimes(2);
-    expect(createMemory).not.toHaveBeenCalled();
-    expect(inflightSize(service)).toBe(0);
-  });
+		expect(
+			(runtime1.createMemory as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(c) => c[1] === "messages",
+			).length,
+		).toBe(1);
 
-  it("propagates storage-check failures and clears the in-flight key for retry", async () => {
-    const { runtime, createMemory, ensureConnection, getMemoryById } = makeRuntime();
-    const service = configuredService(runtime);
-    getMemoryById.mockRejectedValueOnce(new Error("storage unavailable"));
+		// Second instance (restart / second host) receives the same message.
+		// The durable claim persisted by instance 1 must prevent duplicate
+		// side effects.
+		const runtime2 = makeRuntimeWithStore(store);
+		const service2 = configuredService(runtime2);
+		await service2.handleWebhook(webhook("phone-default"));
 
-    await expect(service.handleWebhook(webhook("phone-default"))).rejects.toThrow(
-      "storage unavailable"
-    );
-    expect(ensureConnection).not.toHaveBeenCalled();
-    expect(createMemory).not.toHaveBeenCalled();
-    expect(inflightSize(service)).toBe(0);
+		expect(
+			(runtime2.createMemory as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(c) => c[1] === "messages",
+			).length,
+		).toBe(0);
+		expect(runtime2.ensureConnection).not.toHaveBeenCalled();
+	});
 
-    getMemoryById.mockResolvedValue(null);
-    await service.handleWebhook(webhook("phone-default"));
+	it("marks claim as processed after successful delivery", async () => {
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store);
+		const service = configuredService(runtime);
 
-    expect(createMemory).toHaveBeenCalledTimes(1);
-    expect(inflightSize(service)).toBe(0);
-  });
+		await service.handleWebhook(webhook("phone-default", "wamid.processed"));
 
-  it("clears the in-flight key after policy-denied returns", async () => {
-    const { runtime, createMemory, getMemoryById } = makeRuntime();
-    const service = configuredService(runtime, [
-      cloudAccount("default", "phone-default", "disabled"),
-    ]);
+		// Find the claim memory in the store (not the message memory).
+		const snapshot = store.snapshot();
+		const claims = Array.from(snapshot.values()).filter(
+			(e) =>
+				(e.memory.metadata as Record<string, unknown>)?.whatsappClaim !==
+				undefined,
+		);
+		expect(claims.length).toBe(1);
+		const claimState = (
+			claims[0].memory.metadata as Record<string, unknown>
+		).whatsappClaim as InboundClaimState;
+		expect(claimState.stage).toBe("processed");
+	});
 
-    await service.handleWebhook(webhook("phone-default"));
-    await service.handleWebhook(webhook("phone-default"));
+	it("transitions claim to failed on processing error", async () => {
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store);
+		const service = configuredService(runtime);
 
-    expect(getMemoryById).toHaveBeenCalledTimes(2);
-    expect(createMemory).not.toHaveBeenCalled();
-    expect(inflightSize(service)).toBe(0);
-  });
+		// Make ensureConnection throw
+		(runtime.ensureConnection as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+			new Error("connection failed"),
+		);
 
-  it("clears the in-flight key after processing errors", async () => {
-    const { runtime, createMemory } = makeRuntime();
-    const service = configuredService(runtime);
-    createMemory.mockRejectedValueOnce(new Error("write failed"));
+		await expect(
+			service.handleWebhook(webhook("phone-default", "wamid.failed")),
+		).rejects.toThrow("connection failed");
 
-    await expect(service.handleWebhook(webhook("phone-default"))).rejects.toThrow("write failed");
-    expect(inflightSize(service)).toBe(0);
+		const snapshot = store.snapshot();
+		const claims = Array.from(snapshot.values()).filter(
+			(e) =>
+				(e.memory.metadata as Record<string, unknown>)?.whatsappClaim !==
+				undefined,
+		);
+		expect(claims.length).toBe(1);
+		const claimState = (
+			claims[0].memory.metadata as Record<string, unknown>
+		).whatsappClaim as InboundClaimState;
+		expect(claimState.stage).toBe("failed");
+		expect(claimState.error).toBe("connection failed");
+	});
 
-    await service.handleWebhook(webhook("phone-default"));
+	it("clears the in-flight key after policy-denied returns", async () => {
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store);
+		const service = configuredService(runtime, [
+			cloudAccount("default", "phone-default", "disabled"),
+		]);
 
-    expect(createMemory).toHaveBeenCalledTimes(2);
-    expect(inflightSize(service)).toBe(0);
-  });
+		await service.handleWebhook(webhook("phone-default"));
+		await service.handleWebhook(webhook("phone-default"));
+
+		expect(inflightSize(service)).toBe(0);
+	});
+
+	it("clears the in-flight key after processing errors", async () => {
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store);
+		const service = configuredService(runtime);
+		(runtime.createMemory as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+			new Error("write failed"),
+		);
+
+		await expect(
+			service.handleWebhook(webhook("phone-default")),
+		).rejects.toThrow("write failed");
+		expect(inflightSize(service)).toBe(0);
+	});
+
+	it("reclaims a stale processing claim after the staleness threshold", async () => {
+		const store = new SharedMemoryStore();
+
+		// Simulate a crashed host: insert a processing claim with an old
+		// updatedAt timestamp directly into the store.
+		const staleState: InboundClaimState = {
+			stage: "processing",
+			generation: Date.now() - 10 * 60 * 1000,
+			hostId: "dead-host:9999",
+			accountId: "default",
+			externalMessageId: "wamid.stale",
+			claimedAt: Date.now() - 10 * 60 * 1000,
+			updatedAt: Date.now() - 10 * 60 * 1000,
+		};
+		const claimMemory: Memory = {
+			id: "stale-claim-id" as UUID,
+			entityId: "agent-1" as UUID,
+			agentId: "agent-1" as UUID,
+			roomId: "stale-claim-id" as UUID,
+			content: { text: "" },
+			metadata: { type: "whatsapp_inbound_claim", whatsappClaim: staleState } as unknown as MemoryMetadata,
+			createdAt: Date.now() - 10 * 60 * 1000,
+		};
+		await store.createMemory(claimMemory, "whatsapp_inbound_claims", true);
+
+		// isStaleProcessing should return true for this old claim
+		expect(isStaleProcessing(staleState)).toBe(true);
+
+		// A new service instance should be able to reclaim and process it
+		const runtime = makeRuntimeWithStore(store);
+		const service = configuredService(runtime);
+		await service.handleWebhook(webhook("phone-default", "wamid.stale"));
+
+		// The message should be processed (createMemory called for messages)
+		expect(
+			(runtime.createMemory as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(c) => c[1] === "messages",
+			).length,
+		).toBe(1);
+	});
+
+	it("generates different claim ids for different accounts", async () => {
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store);
+		const service = configuredService(runtime, [
+			cloudAccount("default", "phone-default"),
+			cloudAccount("work", "phone-work"),
+		]);
+
+		await service.handleWebhook(webhook("phone-default", "wamid.shared"));
+		await service.handleWebhook(webhook("phone-work", "wamid.shared"));
+
+		// Same external message id, different accounts → both should be
+		// processed because the deterministic UUID includes the accountId.
+		expect(
+			(runtime.createMemory as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(c) => c[1] === "messages",
+			).length,
+		).toBe(2);
+	});
+});
+
+describe("WhatsApp account-slice acceptance paths", () => {
+	it("named accounts never inherit base/env credentials", async () => {
+		// This test verifies that named accounts with their own credentials
+		// do not fall back to base/env credentials. We verify this through
+		// the resolveWhatsAppAccount function behavior: a named account with
+		// its own accessToken should resolve to that token, not the base
+		// token.
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store, {
+			whatsapp: {
+				accessToken: "base-token",
+				phoneNumberId: "base-phone",
+				dmPolicy: "open",
+				accounts: {
+					named: {
+						accessToken: "named-token",
+						phoneNumberId: "named-phone",
+						dmPolicy: "open",
+					},
+				},
+			},
+		});
+
+		const service = new WhatsAppConnectorService(runtime);
+		await service.initialize();
+
+		const configs = (
+			service as unknown as { configs: Map<string, { accessToken: string; phoneNumberId: string }> }
+		).configs;
+
+		const namedConfig = configs.get("named");
+		expect(namedConfig).toBeDefined();
+		expect(namedConfig?.accessToken).toBe("named-token");
+		expect(namedConfig?.phoneNumberId).toBe("named-phone");
+
+		// Default account should inherit base credentials
+		const defaultConfig = configs.get("default");
+		expect(defaultConfig).toBeDefined();
+		expect(defaultConfig?.accessToken).toBe("base-token");
+		expect(defaultConfig?.phoneNumberId).toBe("base-phone");
+	});
+
+	it("rejects duplicate normalized account ids at startup", async () => {
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store, {
+			whatsapp: {
+				accounts: {
+					Alpha: {
+						accessToken: "token-alpha",
+						phoneNumberId: "phone-alpha",
+						dmPolicy: "open",
+					},
+					alpha: {
+						// "Alpha" normalizes to "alpha" — this is a duplicate
+						accessToken: "token-alpha2",
+						phoneNumberId: "phone-alpha2",
+						dmPolicy: "open",
+					},
+				},
+			},
+		});
+
+		// This should either deduplicate or reject — currently the code uses
+		// a Map so only one survives. Verify no crash and exactly one account.
+		const service = new WhatsAppConnectorService(runtime);
+		await service.initialize();
+
+		const configs = (
+			service as unknown as { configs: Map<string, unknown> }
+		).configs;
+
+		// Both normalize to "alpha", so only one config exists in the Map.
+		expect(configs.has("alpha")).toBe(true);
+		expect(configs.size).toBeLessThanOrEqual(1);
+	});
+
+	it("account-bound webhook delivery resolves the correct account", async () => {
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store);
+		const service = configuredService(runtime, [
+			cloudAccount("default", "phone-default"),
+			cloudAccount("work", "phone-work"),
+		]);
+
+		// Deliver to "work" account
+		await service.handleWebhook(webhook("phone-work", "wamid.work.1"));
+
+		const messageCalls = (
+			runtime.createMemory as ReturnType<typeof vi.fn>
+		).mock.calls.filter((c) => c[1] === "messages");
+		expect(messageCalls.length).toBe(1);
+		const workMemory = messageCalls[0]?.[0] as Memory;
+		expect(workMemory.metadata).toMatchObject({ accountId: "work" });
+
+		// Deliver to "default" account with different message id
+		await service.handleWebhook(webhook("phone-default", "wamid.default.1"));
+
+		const allMessageCalls = (
+			runtime.createMemory as ReturnType<typeof vi.fn>
+		).mock.calls.filter((c) => c[1] === "messages");
+		expect(allMessageCalls.length).toBe(2);
+		const defaultMemory = allMessageCalls[1]?.[0] as Memory;
+		expect(defaultMemory.metadata).toMatchObject({ accountId: "default" });
+	});
+
+	it("recovery from failed claim allows reprocessing", async () => {
+		const store = new SharedMemoryStore();
+
+		// First attempt fails
+		const runtime1 = makeRuntimeWithStore(store);
+		const service1 = configuredService(runtime1);
+		(runtime1.ensureConnection as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+			new Error("transient failure"),
+		);
+
+		await expect(
+			service1.handleWebhook(webhook("phone-default", "wamid.recover")),
+		).rejects.toThrow("transient failure");
+
+		// Verify claim is in failed state
+		const snapshot = store.snapshot();
+		const claims = Array.from(snapshot.values()).filter(
+			(e) =>
+				(e.memory.metadata as Record<string, unknown>)?.whatsappClaim !==
+				undefined,
+		);
+		expect(claims.length).toBe(1);
+		const failedState = (
+			claims[0].memory.metadata as Record<string, unknown>
+		).whatsappClaim as InboundClaimState;
+		expect(failedState.stage).toBe("failed");
+
+		// Second attempt (retry) should succeed — failed claims are reclaimable
+		const runtime2 = makeRuntimeWithStore(store);
+		const service2 = configuredService(runtime2);
+		await service2.handleWebhook(webhook("phone-default", "wamid.recover"));
+
+		expect(
+			(runtime2.createMemory as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(c) => c[1] === "messages",
+			).length,
+		).toBe(1);
+	});
 });

--- a/plugins/plugin-whatsapp/__tests__/webhook-account-idempotency.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/webhook-account-idempotency.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Verifies WhatsApp Cloud API webhook account routing and inbound delivery
+ * idempotency with a deterministic mocked runtime and no network access.
+ */
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { WhatsAppConnectorService } from "../src/runtime-service";
+
+type CloudAccountConfig = {
+  accountId: string;
+  transport: "cloudapi";
+  accessToken: string;
+  phoneNumberId: string;
+  dmPolicy: "open" | "disabled";
+};
+
+function makeRuntime(settings: Record<string, unknown> = {}) {
+  const getMemoryById = vi.fn(async (): Promise<Memory | null> => null);
+  const createMemory = vi.fn(async () => undefined);
+  const ensureConnection = vi.fn(async () => undefined);
+  const ensureRoomExists = vi.fn(async () => undefined);
+  const handleMessage = vi.fn(async () => undefined);
+  const runtime = {
+    agentId: "agent-1" as UUID,
+    character: { settings },
+    getSetting: vi.fn((key: string) =>
+      key === "WHATSAPP_AUTO_REPLY" ? false : undefined
+    ),
+    getMemoryById,
+    createMemory,
+    ensureConnection,
+    ensureRoomExists,
+    messageService: { handleMessage },
+    logger: {
+      warn: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    },
+  } as never as IAgentRuntime;
+
+  return {
+    runtime,
+    getMemoryById,
+    createMemory,
+    ensureConnection,
+    ensureRoomExists,
+    handleMessage,
+  };
+}
+
+function cloudAccount(
+  accountId: string,
+  phoneNumberId: string,
+  dmPolicy: "open" | "disabled" = "open"
+): CloudAccountConfig {
+  return {
+    accountId,
+    transport: "cloudapi",
+    accessToken: `token-${accountId}`,
+    phoneNumberId,
+    dmPolicy,
+  };
+}
+
+function configuredService(
+  runtime: IAgentRuntime,
+  configs: CloudAccountConfig[] = [cloudAccount("default", "phone-default")]
+): WhatsAppConnectorService {
+  const service = new WhatsAppConnectorService(runtime);
+  Object.assign(service, {
+    defaultAccountId: "default",
+    configs: new Map(configs.map((config) => [config.accountId, config])),
+  });
+  return service;
+}
+
+function webhook(phoneNumberId: string | undefined, messageId = "wamid.1") {
+  return {
+    entry: [
+      {
+        changes: [
+          {
+            value: {
+              metadata: {
+                display_phone_number: "+1 415 555 2671",
+                ...(phoneNumberId === undefined ? {} : { phone_number_id: phoneNumberId }),
+              },
+              messages: [
+                {
+                  from: "14155552671",
+                  id: messageId,
+                  timestamp: "1700000000",
+                  type: "text",
+                  text: { body: "hello" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  } as never;
+}
+
+function inflightSize(service: WhatsAppConnectorService): number {
+  return (
+    service as unknown as {
+      inflightInboundMessageIds: Set<string>;
+    }
+  ).inflightInboundMessageIds.size;
+}
+
+describe("WhatsApp Cloud API webhook account routing", () => {
+  it("routes messages by metadata.phone_number_id", async () => {
+    const { runtime, createMemory } = makeRuntime();
+    const service = configuredService(runtime, [
+      cloudAccount("default", "phone-default"),
+      cloudAccount("work", "phone-work"),
+    ]);
+
+    await service.handleWebhook(webhook("phone-work"));
+
+    expect(createMemory).toHaveBeenCalledTimes(1);
+    const memory = createMemory.mock.calls[0]?.[0] as Memory;
+    expect(memory.metadata).toMatchObject({ accountId: "work" });
+  });
+
+  it.each([undefined, "phone-unknown"])(
+    "fails closed for a missing or unknown phone number id: %s",
+    async (phoneNumberId) => {
+      const { runtime, createMemory, ensureConnection, getMemoryById } = makeRuntime();
+      const service = configuredService(runtime, [
+        cloudAccount("default", "phone-default"),
+        cloudAccount("work", "phone-work"),
+      ]);
+
+      await service.handleWebhook(webhook(phoneNumberId));
+
+      expect(getMemoryById).not.toHaveBeenCalled();
+      expect(ensureConnection).not.toHaveBeenCalled();
+      expect(createMemory).not.toHaveBeenCalled();
+    }
+  );
+
+  it("rejects duplicate Cloud API phone number configuration before connecting", async () => {
+    const { runtime } = makeRuntime({
+      whatsapp: {
+        accounts: {
+          alpha: {
+            accessToken: "token-alpha",
+            phoneNumberId: "phone-shared",
+            dmPolicy: "open",
+          },
+          beta: {
+            accessToken: "token-beta",
+            phoneNumberId: "phone-shared",
+            dmPolicy: "open",
+          },
+        },
+      },
+    });
+    const service = new WhatsAppConnectorService(runtime);
+
+    await expect(service.initialize()).rejects.toThrow(
+      'WhatsApp Cloud API accounts "alpha" and "beta" share the same phone_number_id "phone-shared"'
+    );
+  });
+});
+
+describe("WhatsApp inbound delivery idempotency", () => {
+  it("collapses concurrent delivery of the same message", async () => {
+    const { runtime, createMemory, getMemoryById } = makeRuntime();
+    const service = configuredService(runtime);
+    let releaseLookup: (() => void) | undefined;
+    const lookupBlocked = new Promise<void>((resolve) => {
+      releaseLookup = resolve;
+    });
+    getMemoryById.mockImplementation(async () => {
+      await lookupBlocked;
+      return null;
+    });
+
+    const first = service.handleWebhook(webhook("phone-default"));
+    await vi.waitFor(() => expect(getMemoryById).toHaveBeenCalledTimes(1));
+    const duplicate = service.handleWebhook(webhook("phone-default"));
+
+    expect(getMemoryById).toHaveBeenCalledTimes(1);
+    releaseLookup?.();
+    await Promise.all([first, duplicate]);
+
+    expect(createMemory).toHaveBeenCalledTimes(1);
+    expect(inflightSize(service)).toBe(0);
+  });
+
+  it("skips durable duplicates and clears the in-flight key after each return", async () => {
+    const { runtime, createMemory, getMemoryById } = makeRuntime();
+    const service = configuredService(runtime);
+    getMemoryById.mockResolvedValue({ id: "existing-memory" as UUID } as Memory);
+
+    await service.handleWebhook(webhook("phone-default"));
+    await service.handleWebhook(webhook("phone-default"));
+
+    expect(getMemoryById).toHaveBeenCalledTimes(2);
+    expect(createMemory).not.toHaveBeenCalled();
+    expect(inflightSize(service)).toBe(0);
+  });
+
+  it("propagates storage-check failures and clears the in-flight key for retry", async () => {
+    const { runtime, createMemory, ensureConnection, getMemoryById } = makeRuntime();
+    const service = configuredService(runtime);
+    getMemoryById.mockRejectedValueOnce(new Error("storage unavailable"));
+
+    await expect(service.handleWebhook(webhook("phone-default"))).rejects.toThrow(
+      "storage unavailable"
+    );
+    expect(ensureConnection).not.toHaveBeenCalled();
+    expect(createMemory).not.toHaveBeenCalled();
+    expect(inflightSize(service)).toBe(0);
+
+    getMemoryById.mockResolvedValue(null);
+    await service.handleWebhook(webhook("phone-default"));
+
+    expect(createMemory).toHaveBeenCalledTimes(1);
+    expect(inflightSize(service)).toBe(0);
+  });
+
+  it("clears the in-flight key after policy-denied returns", async () => {
+    const { runtime, createMemory, getMemoryById } = makeRuntime();
+    const service = configuredService(runtime, [
+      cloudAccount("default", "phone-default", "disabled"),
+    ]);
+
+    await service.handleWebhook(webhook("phone-default"));
+    await service.handleWebhook(webhook("phone-default"));
+
+    expect(getMemoryById).toHaveBeenCalledTimes(2);
+    expect(createMemory).not.toHaveBeenCalled();
+    expect(inflightSize(service)).toBe(0);
+  });
+
+  it("clears the in-flight key after processing errors", async () => {
+    const { runtime, createMemory } = makeRuntime();
+    const service = configuredService(runtime);
+    createMemory.mockRejectedValueOnce(new Error("write failed"));
+
+    await expect(service.handleWebhook(webhook("phone-default"))).rejects.toThrow("write failed");
+    expect(inflightSize(service)).toBe(0);
+
+    await service.handleWebhook(webhook("phone-default"));
+
+    expect(createMemory).toHaveBeenCalledTimes(2);
+    expect(inflightSize(service)).toBe(0);
+  });
+});

--- a/plugins/plugin-whatsapp/__tests__/webhook-account-idempotency.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/webhook-account-idempotency.test.ts
@@ -1,21 +1,26 @@
 /**
  * Verifies WhatsApp Cloud API webhook account routing, durable inbound
- * delivery idempotency with generation fencing and restart convergence, and
+ * delivery idempotency with CAS fencing and restart convergence, and
  * account-slice acceptance paths (named-account credential inheritance,
  * duplicate normalized account ids, account-bound send/status/recovery).
  *
- * The harness uses a shared in-memory store backing multiple service
- * instances to prove multi-host exclusion and restart convergence without
- * network access. The store implements getMemoryById, createMemory, and
- * updateMemory with the same semantics as the runtime adapter (ON CONFLICT
- * DO NOTHING on createMemory with unique=true).
+ * The deterministic harness models the adapter's unique insert and atomic
+ * document compare-and-swap contract. A separate PGLite suite exercises the
+ * production adapter and schema without mocks.
  */
-import type { IAgentRuntime, Memory, MemoryMetadata, UUID } from "@elizaos/core";
+import {
+	type IAgentRuntime,
+	type Memory,
+	type MemoryMetadata,
+	type UUID,
+} from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { WhatsAppConnectorService } from "../src/runtime-service";
 import {
+	createInboundClaimId,
 	isStaleProcessing,
 	type InboundClaimState,
+	tryClaim,
 } from "../src/inbound-claim";
 
 // ── Shared in-memory store ────────────────────────────────────────────
@@ -55,6 +60,26 @@ class SharedMemoryStore {
 		if (!entry) return false;
 		entry.memory = { ...entry.memory, ...memory } as Memory;
 		return true;
+	}
+
+	async compareAndSwapDocument(params: {
+		documentId: UUID;
+		expected: { revision: number; roomId: UUID; entityId: UUID; scope: string };
+		replacement: Memory;
+	}): Promise<{ status: "updated" | "conflict" | "not_found" }> {
+		const entry = this.entries.get(String(params.documentId));
+		if (!entry) return { status: "not_found" };
+		const metadata = entry.memory.metadata as Record<string, unknown> | undefined;
+		if (
+			metadata?.documentRevision !== params.expected.revision ||
+			metadata.scope !== params.expected.scope ||
+			entry.memory.roomId !== params.expected.roomId ||
+			entry.memory.entityId !== params.expected.entityId
+		) {
+			return { status: "conflict" };
+		}
+		entry.memory = { ...params.replacement };
+		return { status: "updated" };
 	}
 
 	/** Snapshot for assertions. */
@@ -103,7 +128,18 @@ function makeRuntimeWithStore(
 			async (memory: Partial<Memory> & { id: UUID; metadata?: MemoryMetadata }) =>
 				store.updateMemory(memory),
 		),
+		adapter: {
+			documentListQueryCapability: 2,
+			getDocument: vi.fn(async ({ documentId }: { documentId: UUID }) =>
+				store.getMemoryById(documentId),
+			),
+			compareAndSwapDocument: vi.fn(
+				async (params: Parameters<SharedMemoryStore["compareAndSwapDocument"]>[0]) =>
+					store.compareAndSwapDocument(params),
+			),
+		},
 		ensureConnection: vi.fn(async () => undefined),
+		ensureWorldExists: vi.fn(async () => undefined),
 		ensureRoomExists: vi.fn(async () => undefined),
 		messageService: { handleMessage: vi.fn(async () => undefined) },
 		logger: {
@@ -112,6 +148,7 @@ function makeRuntimeWithStore(
 			info: vi.fn(),
 			debug: vi.fn(),
 		},
+		reportError: vi.fn(),
 	} as never as IAgentRuntime;
 
 	return runtime;
@@ -375,36 +412,85 @@ describe("WhatsApp inbound delivery idempotency — durable staged claims", () =
 		expect(inflightSize(service)).toBe(0);
 	});
 
+	it("fails closed when durable idempotency storage is unavailable", async () => {
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store);
+		Object.assign(runtime, { adapter: undefined });
+		const service = configuredService(runtime);
+
+		await expect(service.handleWebhook(webhook("phone-default"))).rejects.toMatchObject({
+			code: "WHATSAPP_IDEMPOTENCY_STORAGE_UNAVAILABLE",
+		});
+		expect(runtime.ensureConnection).not.toHaveBeenCalled();
+		expect(inflightSize(service)).toBe(0);
+	});
+
+	it("propagates terminal claim transition failures", async () => {
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store);
+		const service = configuredService(runtime);
+		(
+			runtime.adapter.compareAndSwapDocument as ReturnType<typeof vi.fn>
+		).mockRejectedValueOnce(new Error("claim transition write failed"));
+
+		await expect(service.handleWebhook(webhook("phone-default"))).rejects.toThrow(
+			"claim transition write failed",
+		);
+		expect(inflightSize(service)).toBe(0);
+	});
+
+	it("reports a failed-state transition without hiding the processing cause", async () => {
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store);
+		const service = configuredService(runtime);
+		(runtime.ensureConnection as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+			new Error("original processing failure"),
+		);
+		(
+			runtime.adapter.compareAndSwapDocument as ReturnType<typeof vi.fn>
+		).mockRejectedValueOnce(new Error("failed-state CAS failure"));
+
+		await expect(service.handleWebhook(webhook("phone-default"))).rejects.toMatchObject({
+			code: "WHATSAPP_INBOUND_CLAIM_TRANSITION_FAILED",
+			cause: expect.objectContaining({ message: "original processing failure" }),
+		});
+		expect(runtime.reportError).toHaveBeenCalledWith(
+			"plugin:whatsapp:inbound-claim",
+			expect.objectContaining({ message: "failed-state CAS failure" }),
+			expect.objectContaining({ externalMessageId: "wamid.1" }),
+		);
+		expect(inflightSize(service)).toBe(0);
+	});
+
 	it("reclaims a stale processing claim after the staleness threshold", async () => {
 		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store);
+		const claimId = createInboundClaimId(runtime, "default", "wamid.stale");
+		const initial = await tryClaim(runtime, claimId, "default", "wamid.stale");
+		if (!initial.state) throw new Error("Initial deterministic claim has no state");
 
-		// Simulate a crashed host: insert a processing claim with an old
-		// updatedAt timestamp directly into the store.
+		// Simulate a crashed host by aging the actual claim document while
+		// retaining its production namespace and revision metadata.
 		const staleState: InboundClaimState = {
-			stage: "processing",
-			generation: Date.now() - 10 * 60 * 1000,
-			hostId: "dead-host:9999",
-			accountId: "default",
-			externalMessageId: "wamid.stale",
+			...initial.state,
 			claimedAt: Date.now() - 10 * 60 * 1000,
 			updatedAt: Date.now() - 10 * 60 * 1000,
 		};
-		const claimMemory: Memory = {
-			id: "stale-claim-id" as UUID,
-			entityId: "agent-1" as UUID,
-			agentId: "agent-1" as UUID,
-			roomId: "stale-claim-id" as UUID,
-			content: { text: "" },
-			metadata: { type: "whatsapp_inbound_claim", whatsappClaim: staleState } as unknown as MemoryMetadata,
-			createdAt: Date.now() - 10 * 60 * 1000,
-		};
-		await store.createMemory(claimMemory, "whatsapp_inbound_claims", true);
+		const claimMemory = await store.getMemoryById(claimId);
+		if (!claimMemory) throw new Error("Initial deterministic claim was not stored");
+		await store.updateMemory({
+			id: claimId,
+			metadata: {
+				...claimMemory.metadata,
+				whatsappClaim: staleState,
+			} as unknown as MemoryMetadata,
+		});
+		(runtime.createMemory as ReturnType<typeof vi.fn>).mockClear();
 
 		// isStaleProcessing should return true for this old claim
 		expect(isStaleProcessing(staleState)).toBe(true);
 
 		// A new service instance should be able to reclaim and process it
-		const runtime = makeRuntimeWithStore(store);
 		const service = configuredService(runtime);
 		await service.handleWebhook(webhook("phone-default", "wamid.stale"));
 
@@ -499,18 +585,30 @@ describe("WhatsApp account-slice acceptance paths", () => {
 			},
 		});
 
-		// This should either deduplicate or reject — currently the code uses
-		// a Map so only one survives. Verify no crash and exactly one account.
+		const service = new WhatsAppConnectorService(runtime);
+		await expect(service.initialize()).rejects.toThrow(
+			'WhatsApp account IDs "Alpha" and "alpha" both normalize to "alpha"',
+		);
+	});
+
+	it("does not inherit base provider identity when a named account omits it", async () => {
+		const store = new SharedMemoryStore();
+		const runtime = makeRuntimeWithStore(store, {
+			whatsapp: {
+				accessToken: "base-token",
+				phoneNumberId: "base-phone",
+				dmPolicy: "open",
+				accounts: { named: { accessToken: "named-token", dmPolicy: "open" } },
+			},
+		});
+
 		const service = new WhatsAppConnectorService(runtime);
 		await service.initialize();
-
 		const configs = (
-			service as unknown as { configs: Map<string, unknown> }
+			service as unknown as { configs: Map<string, { phoneNumberId: string }> }
 		).configs;
-
-		// Both normalize to "alpha", so only one config exists in the Map.
-		expect(configs.has("alpha")).toBe(true);
-		expect(configs.size).toBeLessThanOrEqual(1);
+		expect(configs.has("default")).toBe(true);
+		expect(configs.has("named")).toBe(false);
 	});
 
 	it("account-bound webhook delivery resolves the correct account", async () => {

--- a/plugins/plugin-whatsapp/src/accounts.ts
+++ b/plugins/plugin-whatsapp/src/accounts.ts
@@ -198,6 +198,24 @@ export function listWhatsAppAccountIds(runtime: IAgentRuntime): string[] {
   return result.slice().sort((a, b) => a.localeCompare(b));
 }
 
+/** Rejects aliases that normalize to the same runtime account boundary. */
+export function assertUniqueWhatsAppAccountIds(runtime: IAgentRuntime): void {
+  const accounts = getMultiAccountConfig(runtime).accounts;
+  if (!accounts || typeof accounts !== "object") return;
+
+  const seen = new Map<string, string>();
+  for (const rawId of Object.keys(accounts)) {
+    const normalized = normalizeAccountId(rawId);
+    const previous = seen.get(normalized);
+    if (previous !== undefined) {
+      throw new Error(
+        `WhatsApp account IDs "${previous}" and "${rawId}" both normalize to "${normalized}"; account IDs must be unique after trimming and lowercasing`
+      );
+    }
+    seen.set(normalized, rawId);
+  }
+}
+
 /**
  * Resolves the default account ID to use
  */
@@ -276,7 +294,7 @@ function filterDefined<T extends object>(obj: T): Partial<T> {
   return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined)) as Partial<T>;
 }
 
-function mergeWhatsAppAccountConfig(
+export function resolveWhatsAppAccountConfig(
   runtime: IAgentRuntime,
   accountId: string
 ): WhatsAppAccountRuntimeConfig {
@@ -307,11 +325,23 @@ function mergeWhatsAppAccountConfig(
     groupPolicy: envGroupPolicy as WhatsAppAccountRuntimeConfig["groupPolicy"] | undefined,
   };
 
-  // Merge order: env defaults < base config < account config
-  // Filter undefined values to prevent them from overwriting defined values
+  // Only the default account may inherit transport credentials from env/base.
+  // Named accounts share policy defaults but own every provider identity and
+  // credential, preventing accidental cross-account webhook or send routing.
+  const namedBaseConfig: WhatsAppAccountRuntimeConfig = {
+    enabled: baseConfig.enabled,
+    dmPolicy: baseConfig.dmPolicy,
+    groupPolicy: baseConfig.groupPolicy,
+    mediaMaxMb: baseConfig.mediaMaxMb,
+    textChunkLimit: baseConfig.textChunkLimit,
+  };
+  const inherited =
+    accountId === DEFAULT_ACCOUNT_ID
+      ? { ...filterDefined(envConfig), ...filterDefined(baseConfig) }
+      : filterDefined(namedBaseConfig);
+
   return {
-    ...filterDefined(envConfig),
-    ...filterDefined(baseConfig),
+    ...inherited,
     ...filterDefined(accountConfig),
   };
 }
@@ -327,7 +357,7 @@ export function resolveWhatsAppAccount(
   const multiConfig = getMultiAccountConfig(runtime);
 
   const baseEnabled = multiConfig.enabled !== false;
-  const merged = mergeWhatsAppAccountConfig(runtime, normalizedAccountId);
+  const merged = resolveWhatsAppAccountConfig(runtime, normalizedAccountId);
   const accountEnabled = merged.enabled !== false;
   const enabled = baseEnabled && accountEnabled;
 

--- a/plugins/plugin-whatsapp/src/inbound-claim.ts
+++ b/plugins/plugin-whatsapp/src/inbound-claim.ts
@@ -1,253 +1,343 @@
 /**
- * Durable staged inbound delivery claims for the WhatsApp connector.
+ * Owns durable WhatsApp inbound delivery leases in the runtime document store.
  *
- * Meta redelivers a webhook when it does not see a 200 quickly enough, and a
- * single webhook batch can repeat a message id. The deterministic UUID
- * derived from `(accountId, externalMessageId)` keys a claim row in the
- * runtime's memory store. The claim transitions through a staged lifecycle —
- * `processing → processed / failed` with `abandoned` for crashed hosts — so a
- * second host or a process restart converges instead of duplicating side
- * effects (ensureConnection, room creation, model turn, auto-reply).
- *
- * Generation fencing: each claim carries a monotonic generation counter
- * (wall-clock claimedAt). A stale `processing` claim (host died mid-turn) is
- * fenced to a new generation only after the staleness threshold elapses.
- * Completion and failure transitions check the expected generation before
- * writing, so a zombie host that wakes up after its successor has taken over
- * cannot overwrite the successor's terminal state.
- *
- * Best-effort note: the runtime memory API does not expose conditional
- * (CAS) updates, so the read-then-write in `fenceStaleClaim` and
- * `transitionClaim` has a narrow TOCTOU window. The in-process Set guard in
- * `WhatsAppConnectorService` closes the common concurrent-redelivery path;
- * the durable claim closes restart and multi-host paths. SQL adapters apply
- * `ON CONFLICT DO NOTHING` on `createMemory(unique=true)`, so two hosts
- * racing to insert the same claim id results in exactly one persisted row —
- * the loser reads back the winner's generation and yields.
+ * A deterministic claim document is distinct from the inbound message row. New
+ * claims use the memory store's unique insert; reclaim and terminal transitions
+ * use the adapter's document compare-and-swap contract, whose SQL implementation
+ * locks the row and checks its revision in the same transaction. A random lease
+ * token fences every owner without relying on wall-clock uniqueness.
  */
 
-import { hostname } from "node:os";
-import type { IAgentRuntime, Memory, MemoryMetadata, UUID } from "@elizaos/core";
+import { randomUUID } from "node:crypto";
+import {
+  ChannelType,
+  createUniqueUuid,
+  ElizaError,
+  type IAgentRuntime,
+  type Memory,
+  type MemoryMetadata,
+  MemoryType,
+  type UUID,
+} from "@elizaos/core";
 
-/** Staged lifecycle of a durable inbound claim. */
 export type InboundClaimStage = "processing" | "processed" | "failed" | "abandoned";
 
-/** Metadata persisted alongside the claim memory row. */
 export interface InboundClaimState {
   stage: InboundClaimStage;
-  /** Monotonic ownership epoch — wall-clock ms at claim time. */
-  generation: number;
-  /** `hostname:pid` of the host that owns this generation. */
-  hostId: string;
+  /** Collision-resistant ownership token checked together with revision. */
+  generation: UUID;
+  /** Document CAS revision owned by this generation. */
+  revision: number;
   accountId: string;
   externalMessageId: string;
   claimedAt: number;
   updatedAt: number;
-  /** Present when `stage === "failed"`. */
   error?: string;
 }
 
-/** Memory table used for durable claim rows. */
-export const WHATSAPP_INBOUND_CLAIM_TABLE = "whatsapp_inbound_claims";
-
-/**
- * Elapsed time after which a `processing` claim is considered stale (host
- * crashed or was OOM-killed mid-turn). Meta webhooks are expected to complete
- * within 30 s; 5 min gives generous headroom for model latency.
- */
+export const WHATSAPP_INBOUND_CLAIM_TABLE = "documents";
 const STALE_PROCESSING_MS = 5 * 60 * 1000;
+const CLAIM_SOURCE = "whatsapp-inbound-claim";
+const namespacePromises = new WeakMap<IAgentRuntime, Promise<void>>();
 
-const CLAIM_METADATA_TYPE = "whatsapp_inbound_claim";
-
-function currentHostId(): string {
-  return `${hostname()}:${process.pid}`;
+function claimWorldId(runtime: IAgentRuntime): UUID {
+  return createUniqueUuid(runtime, "whatsapp:inbound-claims:world") as UUID;
 }
 
-/**
- * Extracts the claim state from a memory row's metadata, or `null` if the
- * row is not a claim (e.g. it is the inbound message itself).
- */
+function claimRoomId(runtime: IAgentRuntime): UUID {
+  return createUniqueUuid(runtime, "whatsapp:inbound-claims:room") as UUID;
+}
+
+async function ensureClaimNamespace(runtime: IAgentRuntime): Promise<void> {
+  const existing = namespacePromises.get(runtime);
+  if (existing) return existing;
+
+  const setup = (async () => {
+    const worldId = claimWorldId(runtime);
+    try {
+      await runtime.ensureWorldExists({
+        id: worldId,
+        name: "WhatsApp inbound claims",
+        agentId: runtime.agentId,
+      });
+    } catch (error) {
+      // error-policy:J1 A cross-host duplicate-key race is translated into
+      // success only after the durable adapter confirms the expected world.
+      const [persisted] = await runtime.adapter.getWorldsByIds([worldId]);
+      if (!persisted) throw error;
+    }
+
+    const roomId = claimRoomId(runtime);
+    try {
+      await runtime.ensureRoomExists({
+        id: roomId,
+        name: "WhatsApp inbound claims",
+        source: CLAIM_SOURCE,
+        type: ChannelType.API,
+        channelId: `whatsapp-inbound-claims-${runtime.agentId}`,
+        worldId,
+      });
+    } catch (error) {
+      // error-policy:J1 Apply the same verified duplicate-key translation to
+      // the shared claim room; all other persistence failures still escape.
+      const [persisted] = await runtime.adapter.getRoomsByIds([roomId]);
+      if (!persisted || persisted.worldId !== worldId) throw error;
+    }
+  })();
+  namespacePromises.set(runtime, setup);
+  return setup;
+}
+
+export function createInboundClaimId(
+  runtime: IAgentRuntime,
+  accountId: string,
+  externalMessageId: string
+): UUID {
+  return createUniqueUuid(
+    runtime,
+    `whatsapp:inbound-claim:${accountId}:${externalMessageId}`
+  ) as UUID;
+}
+
 function parseClaim(memory: Memory | null): InboundClaimState | null {
-  if (!memory?.metadata) return null;
-  const raw = (memory.metadata as Record<string, unknown>)?.whatsappClaim;
+  if (memory?.metadata?.type !== MemoryType.DOCUMENT) return null;
+  const raw = (memory.metadata as Record<string, unknown>).whatsappClaim;
   if (!raw || typeof raw !== "object") return null;
-  return raw as InboundClaimState;
+  const state = raw as Partial<InboundClaimState>;
+  if (
+    !["processing", "processed", "failed", "abandoned"].includes(String(state.stage)) ||
+    typeof state.generation !== "string" ||
+    !Number.isSafeInteger(state.revision) ||
+    typeof state.accountId !== "string" ||
+    typeof state.externalMessageId !== "string" ||
+    typeof state.claimedAt !== "number" ||
+    typeof state.updatedAt !== "number"
+  ) {
+    return null;
+  }
+  return state as InboundClaimState;
 }
 
 function buildClaimMetadata(state: InboundClaimState): MemoryMetadata {
   return {
-    type: CLAIM_METADATA_TYPE,
+    type: MemoryType.DOCUMENT,
+    scope: "agent-private",
+    source: CLAIM_SOURCE,
+    timestamp: state.claimedAt,
+    documentRevision: state.revision,
     whatsappClaim: state,
   } as unknown as MemoryMetadata;
 }
 
-function buildClaimMemory(claimId: UUID, state: InboundClaimState, runtime: IAgentRuntime): Memory {
+function buildClaimMemory(
+  claimId: UUID,
+  state: InboundClaimState,
+  runtime: IAgentRuntime,
+  createdAt = state.claimedAt
+): Memory {
   return {
     id: claimId,
     entityId: runtime.agentId,
     agentId: runtime.agentId,
-    roomId: claimId,
-    content: { text: "" },
+    roomId: claimRoomId(runtime),
+    worldId: claimWorldId(runtime),
+    content: { text: "WhatsApp inbound delivery claim" },
     metadata: buildClaimMetadata(state),
-    createdAt: state.claimedAt,
+    createdAt,
+    unique: true,
   };
 }
 
-/**
- * Determines whether a `processing` claim is stale enough to fence.
- */
+function requester(runtime: IAgentRuntime) {
+  return {
+    agentId: runtime.agentId,
+    requesterEntityId: runtime.agentId,
+    requesterRoomIds: [claimRoomId(runtime)],
+    requesterRole: "RUNTIME" as const,
+  };
+}
+
+async function readClaimDocument(runtime: IAgentRuntime, claimId: UUID): Promise<Memory | null> {
+  return runtime.adapter.getDocument({
+    ...requester(runtime),
+    documentId: claimId,
+  });
+}
+
+function assertClaimStorage(runtime: IAgentRuntime): void {
+  const adapter = runtime.adapter;
+  if (
+    adapter?.documentListQueryCapability !== 2 ||
+    typeof adapter.getDocument !== "function" ||
+    typeof adapter.compareAndSwapDocument !== "function" ||
+    typeof runtime.createMemory !== "function"
+  ) {
+    throw new ElizaError("WhatsApp idempotency storage is unavailable", {
+      code: "WHATSAPP_IDEMPOTENCY_STORAGE_UNAVAILABLE",
+      context: { agentId: runtime.agentId },
+    });
+  }
+}
+
 export function isStaleProcessing(state: InboundClaimState, now = Date.now()): boolean {
   return state.stage === "processing" && now - state.updatedAt > STALE_PROCESSING_MS;
 }
 
-/**
- * Result of attempting to acquire a durable claim.
- */
 export interface ClaimResult {
-  /** `true` when this host owns the claim and may proceed with side effects. */
   won: boolean;
-  /** The current persisted state (null if no store was available). */
   state: InboundClaimState | null;
 }
 
-/**
- * Attempts to atomically acquire (or re-acquire after crash) a durable
- * inbound claim. Returns `{ won: true }` when this host should process the
- * message; `{ won: false }` when another host or a prior delivery already
- * completed or is actively processing it.
- *
- * Flow:
- * 1. Read the existing claim (if any).
- * 2. If `processed` — skip (already done).
- * 3. If `processing` and not stale — skip (another host is handling it).
- * 4. If `processing` and stale, or `failed`/`abandoned` — fence/re-claim.
- * 5. If no claim exists — insert a new `processing` claim (ON CONFLICT DO
- *    NOTHING in SQL), then read back to confirm ownership.
- */
+function freshProcessingState(
+  accountId: string,
+  externalMessageId: string,
+  revision: number,
+  now: number
+): InboundClaimState {
+  return {
+    stage: "processing",
+    generation: randomUUID() as UUID,
+    revision,
+    accountId,
+    externalMessageId,
+    claimedAt: now,
+    updatedAt: now,
+  };
+}
+
 export async function tryClaim(
   runtime: IAgentRuntime,
   claimId: UUID,
   accountId: string,
   externalMessageId: string
 ): Promise<ClaimResult> {
-  const hostId = currentHostId();
+  assertClaimStorage(runtime);
+  await ensureClaimNamespace(runtime);
   const now = Date.now();
-  const generation = now;
+  let document = await readClaimDocument(runtime, claimId);
 
-  if (typeof runtime.getMemoryById !== "function") {
-    return { won: true, state: null };
-  }
-
-  const existing = await runtime.getMemoryById(claimId);
-  const existingClaim = parseClaim(existing);
-
-  if (!existingClaim) {
-    // Fresh claim — insert as processing. SQL ON CONFLICT DO NOTHING
-    // means a concurrent inserter's row persists; we detect loss by
-    // reading back and comparing hostId + generation.
-    const state: InboundClaimState = {
-      stage: "processing",
-      generation,
-      hostId,
-      accountId,
-      externalMessageId,
-      claimedAt: now,
-      updatedAt: now,
+  if (!document) {
+    const proposed = freshProcessingState(accountId, externalMessageId, 0, now);
+    await runtime.createMemory(
+      buildClaimMemory(claimId, proposed, runtime),
+      WHATSAPP_INBOUND_CLAIM_TABLE,
+      true
+    );
+    document = await readClaimDocument(runtime, claimId);
+    const persisted = parseClaim(document);
+    if (!persisted) {
+      throw new ElizaError("WhatsApp claim insert produced no readable claim", {
+        code: "WHATSAPP_INBOUND_CLAIM_INVALID",
+        context: { accountId, externalMessageId, claimId },
+      });
+    }
+    return {
+      won: persisted.generation === proposed.generation,
+      state: persisted,
     };
-    if (typeof runtime.createMemory === "function") {
-      await runtime.createMemory(
-        buildClaimMemory(claimId, state, runtime),
-        WHATSAPP_INBOUND_CLAIM_TABLE,
-        true
-      );
-    }
-    const after = await runtime.getMemoryById(claimId);
-    const afterClaim = parseClaim(after);
-    if (afterClaim && afterClaim.hostId === hostId && afterClaim.generation === generation) {
-      return { won: true, state: afterClaim };
-    }
-    return { won: false, state: afterClaim };
   }
 
-  // Existing claim present — check stage
-  if (existingClaim.stage === "processed") {
-    return { won: false, state: existingClaim };
+  const existing = parseClaim(document);
+  if (!existing) {
+    throw new ElizaError("WhatsApp claim row has invalid metadata", {
+      code: "WHATSAPP_INBOUND_CLAIM_INVALID",
+      context: { accountId, externalMessageId, claimId },
+    });
+  }
+  if (existing.stage === "processed") return { won: false, state: existing };
+  if (existing.stage === "processing" && !isStaleProcessing(existing, now)) {
+    return { won: false, state: existing };
   }
 
-  if (existingClaim.stage === "processing" && !isStaleProcessing(existingClaim, now)) {
-    return { won: false, state: existingClaim };
-  }
-
-  // Reclaimable: stale processing, failed, or abandoned.
-  // Fence the stale owner (if any) and take ownership.
-  const newState: InboundClaimState = {
-    ...existingClaim,
-    stage: "processing",
-    generation,
-    hostId,
-    updatedAt: now,
-    error: undefined,
-  };
-  await runtime.updateMemory({
-    id: claimId,
-    metadata: buildClaimMetadata(newState),
+  const replacement = freshProcessingState(
+    accountId,
+    externalMessageId,
+    existing.revision + 1,
+    now
+  );
+  const result = await runtime.adapter.compareAndSwapDocument({
+    ...requester(runtime),
+    documentId: claimId,
+    expected: {
+      scope: "agent-private",
+      roomId: claimRoomId(runtime),
+      entityId: runtime.agentId,
+      revision: existing.revision,
+    },
+    replacement: buildClaimMemory(claimId, replacement, runtime, document.createdAt),
   });
+  if (result.status === "updated") return { won: true, state: replacement };
 
-  return { won: true, state: newState };
+  const current = parseClaim(await readClaimDocument(runtime, claimId));
+  return { won: false, state: current };
 }
 
-/**
- * Transitions a claim to `processed`. Checks the expected generation first;
- * if a successor has fenced this claim, the transition is a no-op (the
- * successor's terminal state must not be overwritten by a zombie).
- */
+async function transitionClaim(
+  runtime: IAgentRuntime,
+  claimId: UUID,
+  expected: InboundClaimState,
+  stage: "processed" | "failed" | "abandoned",
+  error?: string
+): Promise<void> {
+  assertClaimStorage(runtime);
+  const document = await readClaimDocument(runtime, claimId);
+  const current = parseClaim(document);
+  if (
+    !document ||
+    !current ||
+    current.generation !== expected.generation ||
+    current.revision !== expected.revision
+  ) {
+    throw new ElizaError("WhatsApp inbound claim ownership was lost", {
+      code: "WHATSAPP_INBOUND_CLAIM_CONFLICT",
+      context: { claimId, expectedGeneration: expected.generation, stage },
+    });
+  }
+
+  const next: InboundClaimState = {
+    ...expected,
+    stage,
+    revision: expected.revision + 1,
+    updatedAt: Date.now(),
+    ...(error ? { error } : { error: undefined }),
+  };
+  const result = await runtime.adapter.compareAndSwapDocument({
+    ...requester(runtime),
+    documentId: claimId,
+    expected: {
+      scope: "agent-private",
+      roomId: claimRoomId(runtime),
+      entityId: runtime.agentId,
+      revision: expected.revision,
+    },
+    replacement: buildClaimMemory(claimId, next, runtime, document.createdAt),
+  });
+  if (result.status !== "updated") {
+    throw new ElizaError("WhatsApp inbound claim transition lost its CAS", {
+      code: "WHATSAPP_INBOUND_CLAIM_CONFLICT",
+      context: {
+        claimId,
+        expectedGeneration: expected.generation,
+        stage,
+        status: result.status,
+      },
+    });
+  }
+}
+
 export async function completeClaim(
   runtime: IAgentRuntime,
   claimId: UUID,
   expected: InboundClaimState
 ): Promise<void> {
-  if (typeof runtime.getMemoryById !== "function") return;
-  const current = await runtime.getMemoryById(claimId);
-  const currentClaim = parseClaim(current);
-  if (currentClaim && currentClaim.generation !== expected.generation) {
-    // We were fenced — do not overwrite the successor's state.
-    return;
-  }
-  const now = Date.now();
-  await runtime.updateMemory({
-    id: claimId,
-    metadata: buildClaimMetadata({
-      ...expected,
-      stage: "processed",
-      updatedAt: now,
-    }),
-  });
+  await transitionClaim(runtime, claimId, expected, "processed");
 }
 
-/**
- * Transitions a claim to `failed`. Same generation guard as
- * `completeClaim`.
- */
 export async function failClaim(
   runtime: IAgentRuntime,
   claimId: UUID,
   expected: InboundClaimState,
   error: string
 ): Promise<void> {
-  if (typeof runtime.getMemoryById !== "function") return;
-  const current = await runtime.getMemoryById(claimId);
-  const currentClaim = parseClaim(current);
-  if (currentClaim && currentClaim.generation !== expected.generation) {
-    return;
-  }
-  const now = Date.now();
-  await runtime.updateMemory({
-    id: claimId,
-    metadata: buildClaimMetadata({
-      ...expected,
-      stage: "failed",
-      updatedAt: now,
-      error,
-    }),
-  });
+  await transitionClaim(runtime, claimId, expected, "failed", error);
 }

--- a/plugins/plugin-whatsapp/src/inbound-claim.ts
+++ b/plugins/plugin-whatsapp/src/inbound-claim.ts
@@ -1,0 +1,253 @@
+/**
+ * Durable staged inbound delivery claims for the WhatsApp connector.
+ *
+ * Meta redelivers a webhook when it does not see a 200 quickly enough, and a
+ * single webhook batch can repeat a message id. The deterministic UUID
+ * derived from `(accountId, externalMessageId)` keys a claim row in the
+ * runtime's memory store. The claim transitions through a staged lifecycle —
+ * `processing → processed / failed` with `abandoned` for crashed hosts — so a
+ * second host or a process restart converges instead of duplicating side
+ * effects (ensureConnection, room creation, model turn, auto-reply).
+ *
+ * Generation fencing: each claim carries a monotonic generation counter
+ * (wall-clock claimedAt). A stale `processing` claim (host died mid-turn) is
+ * fenced to a new generation only after the staleness threshold elapses.
+ * Completion and failure transitions check the expected generation before
+ * writing, so a zombie host that wakes up after its successor has taken over
+ * cannot overwrite the successor's terminal state.
+ *
+ * Best-effort note: the runtime memory API does not expose conditional
+ * (CAS) updates, so the read-then-write in `fenceStaleClaim` and
+ * `transitionClaim` has a narrow TOCTOU window. The in-process Set guard in
+ * `WhatsAppConnectorService` closes the common concurrent-redelivery path;
+ * the durable claim closes restart and multi-host paths. SQL adapters apply
+ * `ON CONFLICT DO NOTHING` on `createMemory(unique=true)`, so two hosts
+ * racing to insert the same claim id results in exactly one persisted row —
+ * the loser reads back the winner's generation and yields.
+ */
+
+import { hostname } from "node:os";
+import type { IAgentRuntime, Memory, MemoryMetadata, UUID } from "@elizaos/core";
+
+/** Staged lifecycle of a durable inbound claim. */
+export type InboundClaimStage = "processing" | "processed" | "failed" | "abandoned";
+
+/** Metadata persisted alongside the claim memory row. */
+export interface InboundClaimState {
+  stage: InboundClaimStage;
+  /** Monotonic ownership epoch — wall-clock ms at claim time. */
+  generation: number;
+  /** `hostname:pid` of the host that owns this generation. */
+  hostId: string;
+  accountId: string;
+  externalMessageId: string;
+  claimedAt: number;
+  updatedAt: number;
+  /** Present when `stage === "failed"`. */
+  error?: string;
+}
+
+/** Memory table used for durable claim rows. */
+export const WHATSAPP_INBOUND_CLAIM_TABLE = "whatsapp_inbound_claims";
+
+/**
+ * Elapsed time after which a `processing` claim is considered stale (host
+ * crashed or was OOM-killed mid-turn). Meta webhooks are expected to complete
+ * within 30 s; 5 min gives generous headroom for model latency.
+ */
+const STALE_PROCESSING_MS = 5 * 60 * 1000;
+
+const CLAIM_METADATA_TYPE = "whatsapp_inbound_claim";
+
+function currentHostId(): string {
+  return `${hostname()}:${process.pid}`;
+}
+
+/**
+ * Extracts the claim state from a memory row's metadata, or `null` if the
+ * row is not a claim (e.g. it is the inbound message itself).
+ */
+function parseClaim(memory: Memory | null): InboundClaimState | null {
+  if (!memory?.metadata) return null;
+  const raw = (memory.metadata as Record<string, unknown>)?.whatsappClaim;
+  if (!raw || typeof raw !== "object") return null;
+  return raw as InboundClaimState;
+}
+
+function buildClaimMetadata(state: InboundClaimState): MemoryMetadata {
+  return {
+    type: CLAIM_METADATA_TYPE,
+    whatsappClaim: state,
+  } as unknown as MemoryMetadata;
+}
+
+function buildClaimMemory(claimId: UUID, state: InboundClaimState, runtime: IAgentRuntime): Memory {
+  return {
+    id: claimId,
+    entityId: runtime.agentId,
+    agentId: runtime.agentId,
+    roomId: claimId,
+    content: { text: "" },
+    metadata: buildClaimMetadata(state),
+    createdAt: state.claimedAt,
+  };
+}
+
+/**
+ * Determines whether a `processing` claim is stale enough to fence.
+ */
+export function isStaleProcessing(state: InboundClaimState, now = Date.now()): boolean {
+  return state.stage === "processing" && now - state.updatedAt > STALE_PROCESSING_MS;
+}
+
+/**
+ * Result of attempting to acquire a durable claim.
+ */
+export interface ClaimResult {
+  /** `true` when this host owns the claim and may proceed with side effects. */
+  won: boolean;
+  /** The current persisted state (null if no store was available). */
+  state: InboundClaimState | null;
+}
+
+/**
+ * Attempts to atomically acquire (or re-acquire after crash) a durable
+ * inbound claim. Returns `{ won: true }` when this host should process the
+ * message; `{ won: false }` when another host or a prior delivery already
+ * completed or is actively processing it.
+ *
+ * Flow:
+ * 1. Read the existing claim (if any).
+ * 2. If `processed` — skip (already done).
+ * 3. If `processing` and not stale — skip (another host is handling it).
+ * 4. If `processing` and stale, or `failed`/`abandoned` — fence/re-claim.
+ * 5. If no claim exists — insert a new `processing` claim (ON CONFLICT DO
+ *    NOTHING in SQL), then read back to confirm ownership.
+ */
+export async function tryClaim(
+  runtime: IAgentRuntime,
+  claimId: UUID,
+  accountId: string,
+  externalMessageId: string
+): Promise<ClaimResult> {
+  const hostId = currentHostId();
+  const now = Date.now();
+  const generation = now;
+
+  if (typeof runtime.getMemoryById !== "function") {
+    return { won: true, state: null };
+  }
+
+  const existing = await runtime.getMemoryById(claimId);
+  const existingClaim = parseClaim(existing);
+
+  if (!existingClaim) {
+    // Fresh claim — insert as processing. SQL ON CONFLICT DO NOTHING
+    // means a concurrent inserter's row persists; we detect loss by
+    // reading back and comparing hostId + generation.
+    const state: InboundClaimState = {
+      stage: "processing",
+      generation,
+      hostId,
+      accountId,
+      externalMessageId,
+      claimedAt: now,
+      updatedAt: now,
+    };
+    if (typeof runtime.createMemory === "function") {
+      await runtime.createMemory(
+        buildClaimMemory(claimId, state, runtime),
+        WHATSAPP_INBOUND_CLAIM_TABLE,
+        true
+      );
+    }
+    const after = await runtime.getMemoryById(claimId);
+    const afterClaim = parseClaim(after);
+    if (afterClaim && afterClaim.hostId === hostId && afterClaim.generation === generation) {
+      return { won: true, state: afterClaim };
+    }
+    return { won: false, state: afterClaim };
+  }
+
+  // Existing claim present — check stage
+  if (existingClaim.stage === "processed") {
+    return { won: false, state: existingClaim };
+  }
+
+  if (existingClaim.stage === "processing" && !isStaleProcessing(existingClaim, now)) {
+    return { won: false, state: existingClaim };
+  }
+
+  // Reclaimable: stale processing, failed, or abandoned.
+  // Fence the stale owner (if any) and take ownership.
+  const newState: InboundClaimState = {
+    ...existingClaim,
+    stage: "processing",
+    generation,
+    hostId,
+    updatedAt: now,
+    error: undefined,
+  };
+  await runtime.updateMemory({
+    id: claimId,
+    metadata: buildClaimMetadata(newState),
+  });
+
+  return { won: true, state: newState };
+}
+
+/**
+ * Transitions a claim to `processed`. Checks the expected generation first;
+ * if a successor has fenced this claim, the transition is a no-op (the
+ * successor's terminal state must not be overwritten by a zombie).
+ */
+export async function completeClaim(
+  runtime: IAgentRuntime,
+  claimId: UUID,
+  expected: InboundClaimState
+): Promise<void> {
+  if (typeof runtime.getMemoryById !== "function") return;
+  const current = await runtime.getMemoryById(claimId);
+  const currentClaim = parseClaim(current);
+  if (currentClaim && currentClaim.generation !== expected.generation) {
+    // We were fenced — do not overwrite the successor's state.
+    return;
+  }
+  const now = Date.now();
+  await runtime.updateMemory({
+    id: claimId,
+    metadata: buildClaimMetadata({
+      ...expected,
+      stage: "processed",
+      updatedAt: now,
+    }),
+  });
+}
+
+/**
+ * Transitions a claim to `failed`. Same generation guard as
+ * `completeClaim`.
+ */
+export async function failClaim(
+  runtime: IAgentRuntime,
+  claimId: UUID,
+  expected: InboundClaimState,
+  error: string
+): Promise<void> {
+  if (typeof runtime.getMemoryById !== "function") return;
+  const current = await runtime.getMemoryById(claimId);
+  const currentClaim = parseClaim(current);
+  if (currentClaim && currentClaim.generation !== expected.generation) {
+    return;
+  }
+  const now = Date.now();
+  await runtime.updateMemory({
+    id: claimId,
+    metadata: buildClaimMetadata({
+      ...expected,
+      stage: "failed",
+      updatedAt: now,
+      error,
+    }),
+  });
+}

--- a/plugins/plugin-whatsapp/src/runtime-service.ts
+++ b/plugins/plugin-whatsapp/src/runtime-service.ts
@@ -225,11 +225,38 @@ function resolveRuntimeConfigs(runtime: IAgentRuntime): RuntimeServiceConfig[] {
   }
 
   if (configs.length > 0) {
+    assertUniqueCloudApiPhoneNumberIds(configs);
     return configs;
   }
 
   const legacy = resolveRuntimeConfig(runtime);
   return legacy ? [legacy] : [];
+}
+
+/**
+ * Rejects startup when two or more Cloud API accounts share the same
+ * `phoneNumberId`. A duplicate would let an inbound webhook (which is scoped by
+ * `metadata.phone_number_id`) resolve to the wrong account, cross-pollinating
+ * credentials, rooms, and identity. Throws before any client connects.
+ */
+function assertUniqueCloudApiPhoneNumberIds(configs: RuntimeServiceConfig[]): void {
+  const seen = new Map<string, string>();
+  for (const config of configs) {
+    if (config.transport !== "cloudapi") {
+      continue;
+    }
+    const phoneId = config.phoneNumberId.trim();
+    if (!phoneId) {
+      continue;
+    }
+    const existingAccountId = seen.get(phoneId);
+    if (existingAccountId !== undefined && existingAccountId !== config.accountId) {
+      throw new Error(
+        `WhatsApp Cloud API accounts "${existingAccountId}" and "${config.accountId}" share the same phone_number_id "${phoneId}"; each Cloud API account must resolve to one canonical phone number`
+      );
+    }
+    seen.set(phoneId, config.accountId);
+  }
 }
 
 function toTimestampMs(value: number | string | undefined): number {
@@ -595,6 +622,16 @@ export class WhatsAppConnectorService extends Service {
   config: RuntimeServiceConfig | undefined = undefined;
   private knownTargets: Map<string, KnownWhatsAppTarget> = new Map();
 
+  /**
+   * In-process inbound delivery guard. Meta redelivers a webhook when it does
+   * not see a 200 quickly enough, and a single webhook batch can contain the
+   * same message id twice. This set prevents duplicate side effects (replies,
+   * memory writes, connection records) across concurrent redelivery within one
+   * process lifetime; the durable check in `processIncomingMessage` covers
+   * restarts. Bounded: entries are cleared once a turn finishes.
+   */
+  private inflightInboundMessageIds: Set<string> = new Set();
+
   constructor(runtime?: IAgentRuntime) {
     super(runtime);
     if (runtime) {
@@ -936,6 +973,25 @@ export class WhatsAppConnectorService extends Service {
         const phoneNumberId =
           typeof metadata.phone_number_id === "string" ? metadata.phone_number_id : undefined;
         const accountId = this.resolveWebhookAccountId(phoneNumberId);
+
+        // Fail closed: when Cloud API accounts are configured, a webhook whose
+        // phone_number_id does not match any of them is rejected before any
+        // side effect. This prevents cross-account misattribution — an unknown
+        // or cross-account sender must never inherit the default account's
+        // credentials, rooms, or identity. display_phone_number is only trusted
+        // once the webhook has been bound to a known account.
+        if (accountId === null) {
+          this.runtime.logger.warn(
+            {
+              src: "plugin:whatsapp",
+              agentId: this.runtime.agentId,
+              phoneNumberId: phoneNumberId ?? null,
+            },
+            "WhatsApp webhook phone_number_id does not match any configured Cloud API account; dropping webhook to prevent cross-account misattribution"
+          );
+          continue;
+        }
+
         if (typeof metadata.display_phone_number === "string") {
           this.phoneNumbers.set(accountId, metadata.display_phone_number);
           if (accountId === this.defaultAccountId) {
@@ -981,9 +1037,21 @@ export class WhatsAppConnectorService extends Service {
     return null;
   }
 
-  private resolveWebhookAccountId(phoneNumberId?: string | null): string {
+  /**
+   * Resolves a webhook's account from its `metadata.phone_number_id`.
+   *
+   * Fail-closed: when at least one Cloud API account is configured, a webhook
+   * whose phone_number_id matches none of them returns `null` so `handleWebhook`
+   * can drop it before side effects. Only the single-account, env-only, or
+   * Baileys-only deployments (where the webhook carries no scoping id) fall back
+   * to the default account — and only when that default is the sole possibility.
+   */
+  private resolveWebhookAccountId(phoneNumberId?: string | null): string | null {
     const normalizedPhoneNumberId =
-      typeof phoneNumberId === "string" && phoneNumberId.trim() ? phoneNumberId.trim() : undefined;
+      typeof phoneNumberId === "string" && phoneNumberId.trim()
+        ? phoneNumberId.trim()
+        : undefined;
+
     if (normalizedPhoneNumberId) {
       for (const [accountId, config] of this.configs) {
         if (config.transport === "cloudapi" && config.phoneNumberId === normalizedPhoneNumberId) {
@@ -991,7 +1059,21 @@ export class WhatsAppConnectorService extends Service {
         }
       }
     }
-    return this.defaultAccountId;
+
+    // No Cloud API accounts are configured at all (Baileys-only, or the service
+    // is unconfigured). The webhook cannot be account-scoped, so the default is
+    // the only resolution. This path is not reached for real Cloud API traffic.
+    const hasCloudApiAccount = Array.from(this.configs.values()).some(
+      (config) => config.transport === "cloudapi"
+    );
+    if (!hasCloudApiAccount) {
+      return this.defaultAccountId;
+    }
+
+    // Cloud API account(s) are configured but the webhook's phone_number_id did
+    // not match any of them (or was missing). Fail closed rather than inherit
+    // the default account.
+    return null;
   }
 
   private bindClientEvents(client: BaileysClient | WhatsAppClient, accountId: string): void {
@@ -1124,6 +1206,66 @@ export class WhatsAppConnectorService extends Service {
     const isGroup = isWhatsAppGroupJid(params.chatId);
     const normalizedSender = normalizeWhatsAppTarget(params.senderId) ?? params.senderId;
 
+    // Delivery idempotency: Meta redelivers a webhook when it does not see a
+    // 200 quickly, and a single batch can repeat a message id. The inbound
+    // memory id is a deterministic function of (accountId, chatId, external
+    // message id), so a duplicate maps to the same UUID. Guard two layers:
+    //   1. in-process set — collapses concurrent redelivery before any side
+    //      effect fires, and is cleared once the turn completes;
+    //   2. durable getMemoryById — survives restarts and process recycling.
+    // Both checks run before ensureConnection / room / reply side effects, so a
+    // redelivered message creates no duplicate contact, room, model input, or
+    // auto-reply. Policy-denied messages still return early below.
+    const chatKey =
+      accountId === DEFAULT_ACCOUNT_ID ? params.chatId : `${accountId}:${params.chatId}`;
+    const dedupeKey = `${accountId}:${params.externalMessageId}`;
+    if (this.inflightInboundMessageIds.has(dedupeKey)) {
+      this.runtime.logger.debug(
+        {
+          src: "plugin:whatsapp",
+          agentId: this.runtime.agentId,
+          accountId,
+          externalMessageId: params.externalMessageId,
+        },
+        "WhatsApp inbound message is already being processed in-process; skipping duplicate delivery"
+      );
+      return;
+    }
+    this.inflightInboundMessageIds.add(dedupeKey);
+    try {
+      const inboundMemoryId = toMemoryId(this.runtime, chatKey, params.externalMessageId);
+      if (typeof this.runtime.getMemoryById === "function") {
+        const existing = await this.runtime.getMemoryById(inboundMemoryId);
+        if (existing) {
+          this.runtime.logger.debug(
+            {
+              src: "plugin:whatsapp",
+              agentId: this.runtime.agentId,
+              accountId,
+              externalMessageId: params.externalMessageId,
+            },
+            "WhatsApp inbound message already ingested; skipping duplicate delivery"
+          );
+          return;
+        }
+      }
+    } catch (dedupeError) {
+      // A transient storage failure must not drop the message; fall through to
+      // normal processing. The in-process guard still collapses concurrent
+      // redelivery within this process.
+      this.runtime.logger.warn(
+        {
+          src: "plugin:whatsapp",
+          agentId: this.runtime.agentId,
+          accountId,
+          externalMessageId: params.externalMessageId,
+          error: dedupeError instanceof Error ? dedupeError.message : String(dedupeError),
+        },
+        "WhatsApp inbound idempotency storage check failed; proceeding with normal processing"
+      );
+    }
+
+    try {
     const accountConfig = {
       dmPolicy: config?.dmPolicy,
       groupPolicy: config?.groupPolicy,
@@ -1334,6 +1476,9 @@ export class WhatsAppConnectorService extends Service {
     }
 
     await this.runtime.messageService.handleMessage(this.runtime, inboundMemory, callback);
+    } finally {
+      this.inflightInboundMessageIds.delete(dedupeKey);
+    }
   }
 
   private async sendTextMessage(

--- a/plugins/plugin-whatsapp/src/runtime-service.ts
+++ b/plugins/plugin-whatsapp/src/runtime-service.ts
@@ -40,6 +40,7 @@ import {
 } from "./accounts";
 import { WhatsAppClient } from "./client";
 import { BaileysClient } from "./clients/baileys-client";
+import { completeClaim, failClaim, type InboundClaimState, tryClaim } from "./inbound-claim";
 import {
   buildWhatsAppUserJid,
   chunkWhatsAppText,
@@ -623,12 +624,13 @@ export class WhatsAppConnectorService extends Service {
   private knownTargets: Map<string, KnownWhatsAppTarget> = new Map();
 
   /**
-   * In-process inbound delivery guard. Meta redelivers a webhook when it does
-   * not see a 200 quickly enough, and a single webhook batch can contain the
-   * same message id twice. This set prevents duplicate side effects (replies,
-   * memory writes, connection records) across concurrent redelivery within one
-   * process lifetime; the durable check in `processIncomingMessage` covers
-   * restarts. Bounded: entries are cleared once a turn finishes.
+   * In-process inbound delivery guard for concurrent redelivery within one
+   * process lifetime. Meta redelivers a webhook when it does not see a 200
+   * quickly, and a single webhook batch can repeat a message id. This set
+   * is the fast path — it collapses concurrent redelivery before any side
+   * effect fires. The durable staged claim in `processIncomingMessage`
+   * (`inbound-claim.ts`) covers restarts and multi-host scenarios. Bounded:
+   * entries are cleared once the turn finishes.
    */
   private inflightInboundMessageIds: Set<string> = new Set();
 
@@ -1205,15 +1207,15 @@ export class WhatsAppConnectorService extends Service {
     const normalizedSender = normalizeWhatsAppTarget(params.senderId) ?? params.senderId;
 
     // Delivery idempotency: Meta redelivers a webhook when it does not see a
-    // 200 quickly, and a single batch can repeat a message id. The inbound
-    // memory id is a deterministic function of (accountId, chatId, external
-    // message id), so a duplicate maps to the same UUID. Guard two layers:
-    //   1. in-process set — collapses concurrent redelivery before any side
-    //      effect fires, and is cleared once the turn completes;
-    //   2. durable getMemoryById — survives restarts and process recycling.
-    // Both checks run before ensureConnection / room / reply side effects, so a
-    // redelivered message creates no duplicate contact, room, model input, or
-    // auto-reply. Policy-denied messages still return early below.
+    // 200 quickly, and a single batch can repeat a message id. Guard three
+    // layers, all before ensureConnection / room / reply side effects:
+    //   1. in-process set — fast path for concurrent redelivery within one
+    //      process, cleared once the turn completes;
+    //   2. durable staged claim (`inbound-claim.ts`) — survives restarts and
+    //      multi-host deployments with generation fencing and restart
+    //      convergence;
+    //   3. inbound message existence — the deterministic message id catches
+    //      a prior successful delivery that pre-dates the claim table.
     const chatKey =
       accountId === DEFAULT_ACCOUNT_ID ? params.chatId : `${accountId}:${params.chatId}`;
     const dedupeKey = `${accountId}:${params.externalMessageId}`;
@@ -1230,23 +1232,33 @@ export class WhatsAppConnectorService extends Service {
       return;
     }
     this.inflightInboundMessageIds.add(dedupeKey);
+    let claim: InboundClaimState | null = null;
+    let claimHandled = false;
     try {
+      // Durable staged claim: atomically acquire a processing claim in the
+      // memory store. Returns won=false if another host or prior delivery
+      // already completed or is actively processing this message.
       const inboundMemoryId = toMemoryId(this.runtime, chatKey, params.externalMessageId);
-      if (typeof this.runtime.getMemoryById === "function") {
-        const existing = await this.runtime.getMemoryById(inboundMemoryId);
-        if (existing) {
-          this.runtime.logger.debug(
-            {
-              src: "plugin:whatsapp",
-              agentId: this.runtime.agentId,
-              accountId,
-              externalMessageId: params.externalMessageId,
-            },
-            "WhatsApp inbound message already ingested; skipping duplicate delivery"
-          );
-          return;
-        }
+      const claimResult = await tryClaim(
+        this.runtime,
+        inboundMemoryId,
+        accountId,
+        params.externalMessageId
+      );
+      if (!claimResult.won) {
+        this.runtime.logger.debug(
+          {
+            src: "plugin:whatsapp",
+            agentId: this.runtime.agentId,
+            accountId,
+            externalMessageId: params.externalMessageId,
+            claimStage: claimResult.state?.stage,
+          },
+          "WhatsApp inbound message already claimed or processed; skipping duplicate delivery"
+        );
+        return;
       }
+      claim = claimResult.state;
 
       const accountConfig = {
         dmPolicy: config?.dmPolicy,
@@ -1456,7 +1468,28 @@ export class WhatsAppConnectorService extends Service {
       }
 
       await this.runtime.messageService.handleMessage(this.runtime, inboundMemory, callback);
+    } catch (err) {
+      // Transition the durable claim to failed before re-throwing, so a
+      // restart or second host can retry. Generation fencing prevents a
+      // zombie from overwriting a successor's state.
+      claimHandled = true;
+      const claimId = toMemoryId(this.runtime, chatKey, params.externalMessageId);
+      if (claim) {
+        await failClaim(
+          this.runtime,
+          claimId,
+          claim,
+          err instanceof Error ? err.message : String(err)
+        ).catch(() => {});
+      }
+      throw err;
     } finally {
+      // On the success path, transition the claim to processed. The error
+      // path is handled by the catch block above (claimHandled flag).
+      if (!claimHandled && claim) {
+        const claimId = toMemoryId(this.runtime, chatKey, params.externalMessageId);
+        await completeClaim(this.runtime, claimId, claim).catch(() => {});
+      }
       this.inflightInboundMessageIds.delete(dedupeKey);
     }
   }

--- a/plugins/plugin-whatsapp/src/runtime-service.ts
+++ b/plugins/plugin-whatsapp/src/runtime-service.ts
@@ -1048,9 +1048,7 @@ export class WhatsAppConnectorService extends Service {
    */
   private resolveWebhookAccountId(phoneNumberId?: string | null): string | null {
     const normalizedPhoneNumberId =
-      typeof phoneNumberId === "string" && phoneNumberId.trim()
-        ? phoneNumberId.trim()
-        : undefined;
+      typeof phoneNumberId === "string" && phoneNumberId.trim() ? phoneNumberId.trim() : undefined;
 
     if (normalizedPhoneNumberId) {
       for (const [accountId, config] of this.configs) {
@@ -1249,233 +1247,215 @@ export class WhatsAppConnectorService extends Service {
           return;
         }
       }
-    } catch (dedupeError) {
-      // A transient storage failure must not drop the message; fall through to
-      // normal processing. The in-process guard still collapses concurrent
-      // redelivery within this process.
-      this.runtime.logger.warn(
-        {
-          src: "plugin:whatsapp",
-          agentId: this.runtime.agentId,
-          accountId,
-          externalMessageId: params.externalMessageId,
-          error: dedupeError instanceof Error ? dedupeError.message : String(dedupeError),
-        },
-        "WhatsApp inbound idempotency storage check failed; proceeding with normal processing"
-      );
-    }
 
-    try {
-    const accountConfig = {
-      dmPolicy: config?.dmPolicy,
-      groupPolicy: config?.groupPolicy,
-      allowFrom: config?.allowFrom,
-      groupAllowFrom: config?.groupAllowFrom,
-    };
+      const accountConfig = {
+        dmPolicy: config?.dmPolicy,
+        groupPolicy: config?.groupPolicy,
+        allowFrom: config?.allowFrom,
+        groupAllowFrom: config?.groupAllowFrom,
+      };
 
-    const access = await checkWhatsAppUserAccess({
-      runtime: this.runtime,
-      identifier: normalizedSender,
-      accountConfig,
-      isGroup,
-      ...(isGroup ? { groupId: params.chatId } : {}),
-      metadata: { accountId, senderId: normalizedSender },
-    });
-
-    if (!access.allowed) {
-      if (access.replyMessage) {
-        await this.sendTextMessage(params.chatId, access.replyMessage, undefined, accountId);
-      }
-      return;
-    }
-
-    const channelType = isGroup ? ChannelType.GROUP : ChannelType.DM;
-    const roomId = this.roomIdFor(params.chatId, accountId);
-    const worldId = this.worldIdFor(params.chatId, accountId);
-    const entityId = this.entityIdFor(normalizedSender, accountId);
-    const inboundMemoryId = toMemoryId(
-      this.runtime,
-      accountId === DEFAULT_ACCOUNT_ID ? params.chatId : `${accountId}:${params.chatId}`,
-      params.externalMessageId
-    );
-
-    await this.runtime.ensureConnection({
-      entityId,
-      roomId,
-      userId: normalizedSender,
-      userName: normalizedSender,
-      name: normalizedSender,
-      source: "whatsapp",
-      channelId: params.chatId,
-      type: channelType,
-      worldId,
-      worldName: resolveWhatsAppSystemLocation({
-        chatType: isGroup ? "group" : "user",
-        chatId: params.chatId,
-      }),
-      metadata: {
-        accountId,
-        chatId: params.chatId,
+      const access = await checkWhatsAppUserAccess({
+        runtime: this.runtime,
+        identifier: normalizedSender,
+        accountConfig,
         isGroup,
-      },
-    });
-    if (typeof this.runtime.ensureRoomExists === "function") {
-      await this.runtime.ensureRoomExists({
-        id: roomId,
-        name: resolveWhatsAppSystemLocation({
+        ...(isGroup ? { groupId: params.chatId } : {}),
+        metadata: { accountId, senderId: normalizedSender },
+      });
+
+      if (!access.allowed) {
+        if (access.replyMessage) {
+          await this.sendTextMessage(params.chatId, access.replyMessage, undefined, accountId);
+        }
+        return;
+      }
+
+      const channelType = isGroup ? ChannelType.GROUP : ChannelType.DM;
+      const roomId = this.roomIdFor(params.chatId, accountId);
+      const worldId = this.worldIdFor(params.chatId, accountId);
+      const entityId = this.entityIdFor(normalizedSender, accountId);
+
+      await this.runtime.ensureConnection({
+        entityId,
+        roomId,
+        userId: normalizedSender,
+        userName: normalizedSender,
+        name: normalizedSender,
+        source: "whatsapp",
+        channelId: params.chatId,
+        type: channelType,
+        worldId,
+        worldName: resolveWhatsAppSystemLocation({
           chatType: isGroup ? "group" : "user",
           chatId: params.chatId,
         }),
-        agentId: this.runtime.agentId,
-        source: "whatsapp",
-        type: channelType,
-        channelId: params.chatId,
-        worldId,
         metadata: {
           accountId,
           chatId: params.chatId,
           isGroup,
         },
-      } as Room);
-    }
-
-    this.rememberTarget({
-      accountId,
-      chatId: params.chatId,
-      senderId: normalizedSender,
-      label: resolveWhatsAppSystemLocation({
-        chatType: isGroup ? "group" : "user",
-        chatId: params.chatId,
-      }),
-      isGroup,
-      lastMessageAt: params.createdAt,
-      roomId,
-    });
-
-    const inboundMemory: Memory = {
-      id: inboundMemoryId,
-      entityId,
-      agentId: this.runtime.agentId,
-      roomId,
-      content: {
-        text: params.text,
-        source: "whatsapp",
-        channelType,
-        from: normalizedSender,
-        messageId: params.externalMessageId,
-        ...(params.replyToExternalMessageId
-          ? {
-              inReplyTo: toMemoryId(
-                this.runtime,
-                accountId === DEFAULT_ACCOUNT_ID ? params.chatId : `${accountId}:${params.chatId}`,
-                params.replyToExternalMessageId
-              ),
-            }
-          : {}),
-      },
-      metadata: {
-        type: "message",
-        source: "whatsapp",
-        provider: "whatsapp",
-        accountId,
-        timestamp: params.createdAt,
-        entityName: normalizedSender,
-        entityUserName: normalizedSender,
-        fromBot: false,
-        fromId: normalizedSender,
-        sourceId: entityId,
-        chatType: channelType,
-        messageIdFull: params.externalMessageId,
-        sender: {
-          id: normalizedSender,
-          name: normalizedSender,
-          username: normalizedSender,
-        },
-        whatsapp: {
-          contactId: normalizedSender,
-          messageId: params.externalMessageId,
-        },
-        rawChatId: params.chatId,
-        rawSenderId: params.senderId,
-      } satisfies Memory["metadata"],
-      createdAt: params.createdAt,
-    };
-
-    const callback = async (content: Content): Promise<Memory[]> => {
-      const text = typeof content.text === "string" ? content.text.trim() : "";
-      if (!text) {
-        return [];
-      }
-
-      const chunks = chunkWhatsAppText(text);
-      const responseMemories: Memory[] = [];
-
-      for (const [index, chunk] of chunks.entries()) {
-        const response = await this.sendTextMessage(
-          params.chatId,
-          chunk,
-          params.externalMessageId,
-          accountId
-        );
-        const externalResponseId =
-          response.messages[0]?.id ?? `${params.externalMessageId}:response:${index}:${Date.now()}`;
-
-        responseMemories.push({
-          id: toMemoryId(
-            this.runtime,
-            accountId === DEFAULT_ACCOUNT_ID ? params.chatId : `${accountId}:${params.chatId}`,
-            externalResponseId
-          ),
-          entityId: this.runtime.agentId,
+      });
+      if (typeof this.runtime.ensureRoomExists === "function") {
+        await this.runtime.ensureRoomExists({
+          id: roomId,
+          name: resolveWhatsAppSystemLocation({
+            chatType: isGroup ? "group" : "user",
+            chatId: params.chatId,
+          }),
           agentId: this.runtime.agentId,
-          roomId,
-          content: {
-            ...content,
-            text: chunk,
-            source: "whatsapp",
-            channelType,
-            inReplyTo: inboundMemoryId,
-          },
+          source: "whatsapp",
+          type: channelType,
+          channelId: params.chatId,
+          worldId,
           metadata: {
-            type: "message",
-            source: "whatsapp",
-            provider: "whatsapp",
             accountId,
-            timestamp: Date.now(),
-            fromBot: true,
-            fromId: this.runtime.agentId,
-            sourceId: this.runtime.agentId,
-            chatType: channelType,
-            messageIdFull: externalResponseId,
-            whatsapp: {
-              contactId: params.chatId,
-              messageId: externalResponseId,
-            },
-            rawChatId: params.chatId,
-            externalMessageId: externalResponseId,
-          } satisfies Memory["metadata"],
-          createdAt: Date.now(),
-        });
+            chatId: params.chatId,
+            isGroup,
+          },
+        } as Room);
       }
 
-      return responseMemories;
-    };
+      this.rememberTarget({
+        accountId,
+        chatId: params.chatId,
+        senderId: normalizedSender,
+        label: resolveWhatsAppSystemLocation({
+          chatType: isGroup ? "group" : "user",
+          chatId: params.chatId,
+        }),
+        isGroup,
+        lastMessageAt: params.createdAt,
+        roomId,
+      });
 
-    // Inbound messages are always ingested into memory. The agent only
-    // auto-generates a reply when WHATSAPP_AUTO_REPLY is explicitly enabled —
-    // default-off prevents the runtime from speaking on the user's behalf to
-    // real WhatsApp contacts.
-    const autoReplyRaw = this.runtime.getSetting("WHATSAPP_AUTO_REPLY");
-    const autoReply =
-      !lifeOpsPassiveConnectorsEnabled(this.runtime) &&
-      (autoReplyRaw === true || autoReplyRaw === "true");
+      const inboundMemory: Memory = {
+        id: inboundMemoryId,
+        entityId,
+        agentId: this.runtime.agentId,
+        roomId,
+        content: {
+          text: params.text,
+          source: "whatsapp",
+          channelType,
+          from: normalizedSender,
+          messageId: params.externalMessageId,
+          ...(params.replyToExternalMessageId
+            ? {
+                inReplyTo: toMemoryId(
+                  this.runtime,
+                  accountId === DEFAULT_ACCOUNT_ID
+                    ? params.chatId
+                    : `${accountId}:${params.chatId}`,
+                  params.replyToExternalMessageId
+                ),
+              }
+            : {}),
+        },
+        metadata: {
+          type: "message",
+          source: "whatsapp",
+          provider: "whatsapp",
+          accountId,
+          timestamp: params.createdAt,
+          entityName: normalizedSender,
+          entityUserName: normalizedSender,
+          fromBot: false,
+          fromId: normalizedSender,
+          sourceId: entityId,
+          chatType: channelType,
+          messageIdFull: params.externalMessageId,
+          sender: {
+            id: normalizedSender,
+            name: normalizedSender,
+            username: normalizedSender,
+          },
+          whatsapp: {
+            contactId: normalizedSender,
+            messageId: params.externalMessageId,
+          },
+          rawChatId: params.chatId,
+          rawSenderId: params.senderId,
+        } satisfies Memory["metadata"],
+        createdAt: params.createdAt,
+      };
 
-    if (!autoReply) {
-      await this.runtime.createMemory(inboundMemory, "messages");
-      return;
-    }
+      const callback = async (content: Content): Promise<Memory[]> => {
+        const text = typeof content.text === "string" ? content.text.trim() : "";
+        if (!text) {
+          return [];
+        }
 
-    await this.runtime.messageService.handleMessage(this.runtime, inboundMemory, callback);
+        const chunks = chunkWhatsAppText(text);
+        const responseMemories: Memory[] = [];
+
+        for (const [index, chunk] of chunks.entries()) {
+          const response = await this.sendTextMessage(
+            params.chatId,
+            chunk,
+            params.externalMessageId,
+            accountId
+          );
+          const externalResponseId =
+            response.messages[0]?.id ??
+            `${params.externalMessageId}:response:${index}:${Date.now()}`;
+
+          responseMemories.push({
+            id: toMemoryId(
+              this.runtime,
+              accountId === DEFAULT_ACCOUNT_ID ? params.chatId : `${accountId}:${params.chatId}`,
+              externalResponseId
+            ),
+            entityId: this.runtime.agentId,
+            agentId: this.runtime.agentId,
+            roomId,
+            content: {
+              ...content,
+              text: chunk,
+              source: "whatsapp",
+              channelType,
+              inReplyTo: inboundMemoryId,
+            },
+            metadata: {
+              type: "message",
+              source: "whatsapp",
+              provider: "whatsapp",
+              accountId,
+              timestamp: Date.now(),
+              fromBot: true,
+              fromId: this.runtime.agentId,
+              sourceId: this.runtime.agentId,
+              chatType: channelType,
+              messageIdFull: externalResponseId,
+              whatsapp: {
+                contactId: params.chatId,
+                messageId: externalResponseId,
+              },
+              rawChatId: params.chatId,
+              externalMessageId: externalResponseId,
+            } satisfies Memory["metadata"],
+            createdAt: Date.now(),
+          });
+        }
+
+        return responseMemories;
+      };
+
+      // Inbound messages are always ingested into memory. The agent only
+      // auto-generates a reply when WHATSAPP_AUTO_REPLY is explicitly enabled —
+      // default-off prevents the runtime from speaking on the user's behalf to
+      // real WhatsApp contacts.
+      const autoReplyRaw = this.runtime.getSetting("WHATSAPP_AUTO_REPLY");
+      const autoReply =
+        !lifeOpsPassiveConnectorsEnabled(this.runtime) &&
+        (autoReplyRaw === true || autoReplyRaw === "true");
+
+      if (!autoReply) {
+        await this.runtime.createMemory(inboundMemory, "messages");
+        return;
+      }
+
+      await this.runtime.messageService.handleMessage(this.runtime, inboundMemory, callback);
     } finally {
       this.inflightInboundMessageIds.delete(dedupeKey);
     }

--- a/plugins/plugin-whatsapp/src/runtime-service.ts
+++ b/plugins/plugin-whatsapp/src/runtime-service.ts
@@ -20,6 +20,7 @@ import {
   ChannelType,
   type Content,
   createUniqueUuid,
+  ElizaError,
   type IAgentRuntime,
   lifeOpsPassiveConnectorsEnabled,
   type Media,
@@ -29,18 +30,24 @@ import {
   type UUID,
 } from "@elizaos/core";
 import {
+  assertUniqueWhatsAppAccountIds,
   checkWhatsAppUserAccess,
   DEFAULT_ACCOUNT_ID,
-  getMultiAccountConfig,
   listWhatsAppAccountIds,
   normalizeAccountId as normalizeWhatsAppAccountId,
   resolveDefaultWhatsAppAccountId,
   resolveWhatsAppAccount,
-  type WhatsAppAccountRuntimeConfig,
+  resolveWhatsAppAccountConfig,
 } from "./accounts";
 import { WhatsAppClient } from "./client";
 import { BaileysClient } from "./clients/baileys-client";
-import { completeClaim, failClaim, type InboundClaimState, tryClaim } from "./inbound-claim";
+import {
+  completeClaim,
+  createInboundClaimId,
+  failClaim,
+  type InboundClaimState,
+  tryClaim,
+} from "./inbound-claim";
 import {
   buildWhatsAppUserJid,
   chunkWhatsAppText,
@@ -162,33 +169,13 @@ function resolveRuntimeConfig(runtime: IAgentRuntime): RuntimeServiceConfig | nu
   return null;
 }
 
-function configuredAccountForId(
-  config: ReturnType<typeof getMultiAccountConfig>,
-  accountId: string
-): WhatsAppAccountRuntimeConfig {
-  const normalized = normalizeWhatsAppAccountId(accountId);
-  const accountConfig =
-    config.accounts?.[accountId] ??
-    Object.entries(config.accounts ?? {}).find(
-      ([key]) => normalizeWhatsAppAccountId(key) === normalized
-    )?.[1] ??
-    {};
-  return {
-    ...config,
-    accounts: undefined,
-    groups: undefined,
-    ...accountConfig,
-  } as WhatsAppAccountRuntimeConfig;
-}
-
 function resolveRuntimeConfigs(runtime: IAgentRuntime): RuntimeServiceConfig[] {
-  const multiConfig = getMultiAccountConfig(runtime);
   const accountIds = listWhatsAppAccountIds(runtime);
   const configs: RuntimeServiceConfig[] = [];
 
   for (const accountId of accountIds) {
     const normalizedAccountId = normalizeWhatsAppAccountId(accountId);
-    const accountConfig = configuredAccountForId(multiConfig, normalizedAccountId);
+    const accountConfig = resolveWhatsAppAccountConfig(runtime, normalizedAccountId);
     const authDir = accountConfig.authDir?.trim();
     const transport = accountConfig.transport ?? (authDir ? "baileys" : "cloudapi");
 
@@ -910,6 +897,7 @@ export class WhatsAppConnectorService extends Service {
   }
 
   async initialize(): Promise<void> {
+    assertUniqueWhatsAppAccountIds(this.runtime);
     this.defaultAccountId = resolveDefaultWhatsAppAccountId(this.runtime);
     const configs = resolveRuntimeConfigs(this.runtime);
     if (configs.length === 0) {
@@ -1234,14 +1222,15 @@ export class WhatsAppConnectorService extends Service {
     this.inflightInboundMessageIds.add(dedupeKey);
     let claim: InboundClaimState | null = null;
     let claimHandled = false;
+    const inboundMemoryId = toMemoryId(this.runtime, chatKey, params.externalMessageId);
+    const claimId = createInboundClaimId(this.runtime, accountId, params.externalMessageId);
     try {
       // Durable staged claim: atomically acquire a processing claim in the
       // memory store. Returns won=false if another host or prior delivery
       // already completed or is actively processing this message.
-      const inboundMemoryId = toMemoryId(this.runtime, chatKey, params.externalMessageId);
       const claimResult = await tryClaim(
         this.runtime,
-        inboundMemoryId,
+        claimId,
         accountId,
         params.externalMessageId
       );
@@ -1258,7 +1247,28 @@ export class WhatsAppConnectorService extends Service {
         );
         return;
       }
+      if (!claimResult.state) {
+        throw new ElizaError("WhatsApp claim acquisition returned no ownership state", {
+          code: "WHATSAPP_INBOUND_CLAIM_INVALID",
+          context: { accountId, externalMessageId: params.externalMessageId, claimId },
+        });
+      }
       claim = claimResult.state;
+
+      // A previous host may have persisted the real inbound message and died
+      // before committing its claim. Converge on that durable side effect
+      // before creating connections, rooms, replies, or another model turn.
+      const existingInbound = await this.runtime.getMemoryById(inboundMemoryId);
+      const existingMetadata = existingInbound?.metadata as Record<string, unknown> | undefined;
+      if (
+        existingInbound &&
+        existingMetadata?.type === "message" &&
+        existingMetadata.source === "whatsapp"
+      ) {
+        await completeClaim(this.runtime, claimId, claimResult.state);
+        claimHandled = true;
+        return;
+      }
 
       const accountConfig = {
         dmPolicy: config?.dmPolicy,
@@ -1473,24 +1483,48 @@ export class WhatsAppConnectorService extends Service {
       // restart or second host can retry. Generation fencing prevents a
       // zombie from overwriting a successor's state.
       claimHandled = true;
-      const claimId = toMemoryId(this.runtime, chatKey, params.externalMessageId);
       if (claim) {
-        await failClaim(
-          this.runtime,
-          claimId,
-          claim,
-          err instanceof Error ? err.message : String(err)
-        ).catch(() => {});
+        try {
+          await failClaim(
+            this.runtime,
+            claimId,
+            claim,
+            err instanceof Error ? err.message : String(err)
+          );
+        } catch (transitionError) {
+          // error-policy:J2 Report the ownership failure and preserve the
+          // original processing error as the cause returned to the boundary.
+          this.runtime.reportError("plugin:whatsapp:inbound-claim", transitionError, {
+            accountId,
+            externalMessageId: params.externalMessageId,
+            claimId,
+          });
+          throw new ElizaError("WhatsApp inbound processing and claim transition failed", {
+            code: "WHATSAPP_INBOUND_CLAIM_TRANSITION_FAILED",
+            context: {
+              accountId,
+              externalMessageId: params.externalMessageId,
+              claimId,
+              transitionError:
+                transitionError instanceof Error
+                  ? transitionError.message
+                  : String(transitionError),
+            },
+            cause: err,
+          });
+        }
       }
       throw err;
     } finally {
       // On the success path, transition the claim to processed. The error
       // path is handled by the catch block above (claimHandled flag).
-      if (!claimHandled && claim) {
-        const claimId = toMemoryId(this.runtime, chatKey, params.externalMessageId);
-        await completeClaim(this.runtime, claimId, claim).catch(() => {});
+      try {
+        if (!claimHandled && claim) {
+          await completeClaim(this.runtime, claimId, claim);
+        }
+      } finally {
+        this.inflightInboundMessageIds.delete(dedupeKey);
       }
-      this.inflightInboundMessageIds.delete(dedupeKey);
     }
   }
 


### PR DESCRIPTION
+Fixes #16342 by making Cloud API webhook routing account-scoped and inbound processing durably idempotent.

## What changed

- Unknown or missing `metadata.phone_number_id` fails closed whenever Cloud API accounts are configured.
- Duplicate Cloud API phone-number IDs and duplicate normalized account IDs fail startup.
- Named accounts inherit policy defaults only; provider identity, transport, and credentials never leak from the default/base/env account.
- Each inbound delivery uses a distinct deterministic claim document, separate from the real inbound message ID.
- Initial acquisition uses the store's unique insert. Reclaim and terminal transitions use the adapter's atomic document compare-and-swap revision contract.
- Random lease UUIDs fence stale owners; late zombie completion fails with a typed conflict.
- Missing claim storage fails closed before connection, room, model, or Meta side effects.
- Completion/failure transition errors are propagated and reported; none are swallowed.
- If a host persisted the real message but died before completing its claim, redelivery converges on the persisted message without replaying side effects.

## Verification

- `bun run --cwd plugins/plugin-whatsapp lint:check` — pass
- `bun run --cwd plugins/plugin-whatsapp typecheck` — pass
- `bun run --cwd plugins/plugin-whatsapp test` — 10 files, 64 tests passed
- Real PGLite/runtime coverage proves:
  - two simultaneous contenders produce exactly one winner;
  - the claim document and real inbound message persist under distinct IDs;
  - stale reclaim increments the CAS revision and changes the lease token;
  - a fenced owner cannot commit a terminal transition.
- `bun run check:agents-claude` — pass
- Root `bun run verify` — pass: 350/350 Turbo tasks plus build/typecheck, dependency, secret, script-inventory, view-bundle, and focused-test audits.

The redacted live Meta sandbox round trip remains blocked by the existing expired Meta credential (OAuth 190/463). This PR must not claim that provider-visible proof until an authorized Meta operator rotates the token.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.2`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`, `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - external lane (hermes-t3rpz)`; Codex GitHub review workflow
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Evidence Gate

<!-- evidence-head:f5a5dd980762bfae8a217fc2b71ee8d37878078a -->

<!-- evidence-row:before-screenshots -->
- N/A - backend connector service; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- N/A - backend connector service; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- N/A - non-interactive webhook/storage path; behavior is covered by real adapter tests.
<!-- evidence-row:backend-logs -->
- [x] [18892-pr18892-backend-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18892-pr18892-backend-v2.txt)
<!-- evidence-row:frontend-logs -->
- N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- N/A - claim/account routing occurs before and outside model execution.
<!-- evidence-row:domain-artifacts -->
- [x] [18892-pr18892-pglite.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18892-pr18892-pglite.txt)
<!-- evidence-row:ocr-review -->
- N/A - no rendered visual surface.



