### PR TITLE
fix(ci): make messaging gateway preflight strict for webhook secrets (#17345)

### DIFF
--- a/.github/workflows/cloud-gateway-discord.yml
+++ b/.github/workflows/cloud-gateway-discord.yml
@@ -71,7 +71,21 @@ jobs:
         run: bun install --frozen-lockfile --no-save && git diff --exit-code -- bun.lock
 
       - name: Run messaging gateway preflight
-        run: bun run preflight:messaging-gateways
+        # Strict: a missing required secret fails the gate rather than printing
+        # "missing" and passing (#17345). Scoped to the channels this CI
+        # exercises (shared + telegram + discord) so unrelated iMessage/WhatsApp
+        # secrets do not gate a Discord-gateway test run.
+        run: bun run preflight:messaging-gateways:strict -- --channels=shared,telegram,discord
+        env:
+          ELIZACLOUD_API_URL: ${{ secrets.ELIZACLOUD_API_URL }}
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          ELIZA_APP_WEBHOOK_GATEWAY_URL: ${{ secrets.ELIZA_APP_WEBHOOK_GATEWAY_URL }}
+          ELIZA_APP_WEBHOOK_GATEWAY_SECRET: ${{ secrets.ELIZA_APP_WEBHOOK_GATEWAY_SECRET }}
+          ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
+          ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
+          ELIZA_APP_DISCORD_APPLICATION_ID: ${{ secrets.ELIZA_APP_DISCORD_APPLICATION_ID }}
+          ELIZA_APP_DISCORD_CLIENT_SECRET: ${{ secrets.ELIZA_APP_DISCORD_CLIENT_SECRET }}
+          ELIZA_APP_DISCORD_BOT_TOKEN: ${{ secrets.ELIZA_APP_DISCORD_BOT_TOKEN }}
 
       - name: Run service tests
         working-directory: packages/cloud/services/gateway-discord

--- a/packages/cloud/shared/scripts/messaging-gateway-preflight.mjs
+++ b/packages/cloud/shared/scripts/messaging-gateway-preflight.mjs
@@ -134,6 +134,30 @@ function checkShared() {
     "Cerebras API key is configured",
     "Set CEREBRAS_API_KEY for the stateless onboarding worker.",
   );
+  // The BFF forwarder in packages/cloud/api/eliza-app/webhook/_forward.ts reads
+  // these as a pair: the URL is the upstream webhook gateway it proxies to, and
+  // the secret is the shared "came from the BFF" proof the gateway validates
+  // (x-eliza-webhook-forwarder-secret). _forward.ts only stamps the header when
+  // the secret is set, so an absent secret silently downgrades the gateway's
+  // trust boundary — surface that here rather than at deploy time.
+  addCheck(
+    "shared",
+    "webhook gateway URL",
+    hasAny([
+      "ELIZA_APP_WEBHOOK_GATEWAY_URL",
+      "WEBHOOK_GATEWAY_URL",
+      "GATEWAY_WEBHOOK_URL",
+    ]),
+    "Webhook gateway upstream URL is configured",
+    "Set ELIZA_APP_WEBHOOK_GATEWAY_URL (or WEBHOOK_GATEWAY_URL / GATEWAY_WEBHOOK_URL) to the gateway-webhook service URL.",
+  );
+  addCheck(
+    "shared",
+    "webhook gateway forwarder secret",
+    hasAny(["ELIZA_APP_WEBHOOK_GATEWAY_SECRET"]),
+    "Webhook gateway forwarder secret is configured",
+    "Set ELIZA_APP_WEBHOOK_GATEWAY_SECRET to the shared BFF→gateway trust secret.",
+  );
 }
 
 if (selectedChannels.has("shared")) checkShared();


### PR DESCRIPTION
Makes the messaging gateway preflight fail closed in CI. Adds required checks for the webhook gateway URL and the BFF→gateway forwarder secret, and flips the Discord gateway workflow to `preflight:messaging-gateways:strict` (scoped to `shared,telegram,discord`) so a missing required secret fails the gate instead of printing "missing" and passing (#17345).

Why the two new shared checks: `packages/cloud/api/eliza-app/webhook/_forward.ts` only stamps the `x-eliza-webhook-forwarder-secret` proof when the secret is set, so an absent secret silently downgrades the gateway's trust boundary — this surfaces it at CI time rather than at deploy time.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.2`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - external lane (hermes-t3rpz)`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Evidence Gate

<!-- evidence-head:299337122beeb048d243bc2036925dc3b0c10cf0 -->

<!-- evidence-row:before-screenshots -->
- N/A - CI workflow + node preflight script; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- N/A - CI workflow + node preflight script; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- N/A - non-interactive CI gate; behavior shown in backend logs below.
<!-- evidence-row:backend-logs -->
- Reviewer-run proof that the gate fails closed on missing required secrets and passes when set (`packages/cloud/shared`, PR head `299337122be`):

<details><summary>strict, NO webhook secrets → exit 1 (fails closed)</summary>

```
$ node scripts/messaging-gateway-preflight.mjs --strict --channels=shared
- [fail] shared: cloud API base - Cloud API base URL is configured
- [fail] shared: Cerebras onboarding model - Cerebras API key is configured
- [fail] shared: webhook gateway URL - Webhook gateway upstream URL is configured
- [fail] shared: webhook gateway forwarder secret - Webhook gateway forwarder secret is configured
4 gateway preflight check(s) failed.
EXIT=1
```
</details>

<details><summary>strict, required secrets set → exit 0; non-strict missing → exit 0 (warn only)</summary>

```
$ ELIZACLOUD_API_URL=... CEREBRAS_API_KEY=... ELIZA_APP_WEBHOOK_GATEWAY_URL=... ELIZA_APP_WEBHOOK_GATEWAY_SECRET=... node scripts/messaging-gateway-preflight.mjs --strict --channels=shared
- [ok] shared: webhook gateway URL - Webhook gateway upstream URL is configured
- [ok] shared: webhook gateway forwarder secret - Webhook gateway forwarder secret is configured
All gateway preflight checks passed.
EXIT=0

$ node scripts/messaging-gateway-preflight.mjs --channels=shared
- [missing] shared: webhook gateway forwarder secret - Webhook gateway forwarder secret is configured
4 check(s) missing. Re-run with --strict in CI to fail closed.
EXIT=0
```
</details>

<!-- evidence-row:frontend-logs -->
- N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- N/A - no agent/model/prompt path changed.
<!-- evidence-row:domain-artifacts -->
N/A - the observable artifact is the process exit code, captured in the backend-logs run above (1 on missing required secret under --strict, 0 otherwise).
<!-- evidence-row:ocr-review -->
- N/A - no rendered visual surface.
