### PR TITLE
fix(models): prevent boot-seeded provider defaults from masking per-agent model pairs (#16592)

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -154,6 +154,7 @@ import {
   type Plugin,
   type Provider,
   type RuntimeStopOptions,
+  readCanonicalModel,
   requireConfirmedSendHandlerDelivery,
   type ServiceClass,
   stringToUuid,
@@ -3280,10 +3281,40 @@ export function installRuntimeMethodBindings(runtime: AgentRuntime): void {
     // to forward to coding agents via this comma-separated key list (e.g. MCP server tokens).
     "CUSTOM_CREDENTIAL_KEYS",
   ]);
+  // Boot-seeded provider model keys (GOOGLE_/GROQ_/CEREBRAS_*_MODEL) that
+  // `applyProviderModelEnvDefaults()` writes into process.env once at boot.
+  // These are process-global, so in a multi-agent process one agent's
+  // boot-seeded lane default can mask another agent's per-agent model choice.
+  // Map them to the canonical pair tier so a per-agent character setting
+  // (ELIZA_MODEL_SMALL / ELIZA_MODEL_LARGE) outranks the boot-seeded value.
+  const BOOT_SEEDED_MODEL_KEY_TIER: Record<string, "small" | "large"> = {
+    GOOGLE_SMALL_MODEL: "small",
+    GOOGLE_LARGE_MODEL: "large",
+    GROQ_SMALL_MODEL: "small",
+    GROQ_LARGE_MODEL: "large",
+    CEREBRAS_SMALL_MODEL: "small",
+    CEREBRAS_LARGE_MODEL: "large",
+  };
+
   const originalGetSetting = runtime.getSetting.bind(runtime);
   runtime.getSetting = (key: string) => {
     const result = originalGetSetting(key);
     if (result !== null && result !== undefined) return result;
+
+    // Before falling back to a process-global boot-seeded env value, honor the
+    // per-agent canonical pair. A character that sets ELIZA_MODEL_SMALL/LARGE
+    // must win over a boot-seeded GOOGLE_/GROQ_/CEREBRAS_*_MODEL default for
+    // the matching tier, so one agent's per-agent selection is never masked by
+    // process-global boot defaults (#16592).
+    const tier = BOOT_SEEDED_MODEL_KEY_TIER[key];
+    if (tier) {
+      const canonical = readCanonicalModel(
+        { getSetting: originalGetSetting },
+        tier,
+      );
+      if (canonical) return canonical;
+    }
+
     if (GETSETTING_ENV_ALLOWLIST.has(key)) {
       const envVal = process.env[key];
       if (envVal !== undefined && envVal.trim() !== "") return envVal;

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -483,6 +483,8 @@ export * from "./utils/read-env";
 export * from "./utils/reference-echo";
 // Canonical runtime-setting → env resolver (per-agent setting first, then env)
 export * from "./utils/resolve-setting";
+// Canonical two-knob model pair (ELIZA_MODEL_SMALL / ELIZA_MODEL_LARGE)
+export * from "./utils/canonical-model";
 export * from "./utils/server-health";
 // Eliza state-dir resolution (ELIZA_STATE_DIR → XDG state home)
 export * from "./utils/state-dir";

--- a/packages/core/src/utils/canonical-model.ts
+++ b/packages/core/src/utils/canonical-model.ts
@@ -1,0 +1,73 @@
+/**
+ * Canonical two-knob model pair: `ELIZA_MODEL_SMALL` / `ELIZA_MODEL_LARGE`.
+ *
+ * Operators think in two knobs — a small/fast model and a large/capable model —
+ * while the runtime juggles a forest of per-provider, per-tier env vars
+ * (`OPENAI_*`, `GOOGLE_*`, `GROQ_*`, `CEREBRAS_*`, bare `*_MODEL` aliases…).
+ * This resolver collapses that forest to the operator's mental model: set the
+ * pair once (env or per-agent character settings) and every lane derives from it.
+ *
+ * ## Precedence (per lane)
+ *
+ * Lane-specific var (escape hatch) → **canonical pair** → bare alias → lane
+ * default. The pair slots *below* every lane-specific var and *above* bare
+ * aliases and hardcoded defaults, so pair-unset is behavior-identical to today.
+ *
+ * ## Why this fixes boot-seed masking (#16592)
+ *
+ * `applyProviderModelEnvDefaults()` seeds `GOOGLE_/GROQ_/CEREBRAS_*_MODEL` into
+ * `process.env` once at boot (process-global). A per-agent character-settings
+ * `ELIZA_MODEL_SMALL/LARGE` could not influence those seeded values because the
+ * boot defaults overwrote the per-agent selection for any agent that did not
+ * also set the specific provider key. Resolving the pair at *read time* from the
+ * per-agent source (character settings / env) lets a character override the
+ * boot-seeded lane default without mutating process-global configuration.
+ */
+
+/** The two canonical knob names. */
+export const CANONICAL_MODEL_SMALL_KEY = "ELIZA_MODEL_SMALL";
+export const CANONICAL_MODEL_LARGE_KEY = "ELIZA_MODEL_LARGE";
+
+export type CanonicalModelTier = "small" | "large";
+
+/** Per-tier canonical key. */
+export function canonicalModelKey(tier: CanonicalModelTier): string {
+	return tier === "small" ? CANONICAL_MODEL_SMALL_KEY : CANONICAL_MODEL_LARGE_KEY;
+}
+
+/**
+ * Minimal structural shape of a runtime/character that can resolve a setting.
+ * Kept local (rather than importing `IAgentRuntime`) so this helper stays
+ * browser/edge-safe and free of the runtime type graph.
+ */
+export interface CanonicalModelSource {
+	getSetting(key: string): string | boolean | number | null;
+}
+
+function normalizeModelValue(value: unknown): string | undefined {
+	if (value === undefined || value === null) return undefined;
+	const str = typeof value === "string" ? value : String(value);
+	const trimmed = str.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Resolve the canonical model for a tier from a per-agent source.
+ *
+ * Reads `ELIZA_MODEL_SMALL` (tier `"small"`) or `ELIZA_MODEL_LARGE`
+ * (tier `"large"`) via the supplied setting reader (typically an
+ * `IAgentRuntime`, whose `getSetting` checks per-agent character settings
+ * before env). Returns the trimmed model id or `undefined` when the pair is
+ * not set for this agent.
+ *
+ * @param source - Per-agent setting reader (runtime). `null`/`undefined` yields
+ *   `undefined` (the caller falls back to lane defaults).
+ * @param tier - Which knob to read.
+ */
+export function readCanonicalModel(
+	source: CanonicalModelSource | null | undefined,
+	tier: CanonicalModelTier,
+): string | undefined {
+	const raw = source?.getSetting(canonicalModelKey(tier));
+	return normalizeModelValue(raw);
+}


### PR DESCRIPTION
## Summary

`applyProviderModelEnvDefaults()` seeds `GOOGLE_/GROQ_/CEREBRAS_*_MODEL` into `process.env` at boot. A per-agent character setting (`ELIZA_MODEL_SMALL/LARGE`) couldn't override these because the eliza.ts `getSetting` wrapper falls back to the boot-seeded env value before any per-agent pair resolution.

## Fix

Adds `canonical-model.ts` — a pure two-knob model pair resolver that reads `ELIZA_MODEL_SMALL`/`ELIZA_MODEL_LARGE` from per-agent character settings. Inserts a canonical-pair check between the core `getSetting` result and the `process.env` fallback, restoring per-agent precedence without mutating process-global state.

---

AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Lane: hermes-t3rpz