### PR TITLE
fix(core): reject empty embedding provider output

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -10939,9 +10939,25 @@ ${section_end}`;
 			this.warnEmbeddingGenerationSkipped();
 			return memory;
 		}
-		memory.embedding = await this.useModel(ModelType.TEXT_EMBEDDING, {
+		const embedding = await this.useModel(ModelType.TEXT_EMBEDDING, {
 			text: memoryText,
 		});
+		if (!Array.isArray(embedding) || embedding.length === 0) {
+			throw new ElizaError(
+				"TEXT_EMBEDDING provider returned no usable vector",
+				{
+					code: "EMBEDDING_MODEL_OUTPUT_INVALID",
+					context: {
+						memoryId: memory.id,
+						outputKind: Array.isArray(embedding)
+							? "empty-array"
+							: typeof embedding,
+					},
+					severity: "fatal",
+				},
+			);
+		}
+		memory.embedding = embedding;
 		return memory;
 	}
 

--- a/packages/core/src/runtime/__tests__/embedding-dimension.test.ts
+++ b/packages/core/src/runtime/__tests__/embedding-dimension.test.ts
@@ -22,6 +22,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import type { ElizaError } from "../../errors";
 import {
 	AgentRuntime,
 	EmbeddingDimensionProbeError,
@@ -94,6 +95,39 @@ describe("AgentRuntime.ensureEmbeddingDimension provider failover", () => {
 		);
 		expect(existing.embedding).toEqual([9]);
 		expect(embedHandler).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects an empty provider result before a caller can persist the memory", async () => {
+		const runtime = makeRuntime();
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING,
+			async () => [],
+			"direct",
+			0,
+		);
+		const memory = {
+			...makeMemory("provider returned no vector"),
+			id: "00000000-0000-0000-0000-000000000003" as UUID,
+		};
+		const createMemory = vi.spyOn(runtime, "createMemory");
+
+		const embedThenPersist = async (): Promise<void> => {
+			await runtime.addEmbeddingToMemory(memory);
+			await runtime.createMemory(memory, "documents");
+		};
+
+		await expect(embedThenPersist()).rejects.toMatchObject<Partial<ElizaError>>(
+			{
+				code: "EMBEDDING_MODEL_OUTPUT_INVALID",
+				severity: "fatal",
+				context: {
+					memoryId: memory.id,
+					outputKind: "empty-array",
+				},
+			},
+		);
+		expect(createMemory).not.toHaveBeenCalled();
+		await expect(runtime.getMemoryById(memory.id)).resolves.toBeNull();
 	});
 
 	it("queues empty vectors while skipping non-empty vectors", async () => {


### PR DESCRIPTION
# Relates to

Closes #18874.

Corrective follow-up to #18875: that merge fixed existing `embedding: []` idempotency gates but still allowed a `TEXT_EMBEDDING` provider to return `[]`, after which `AgentRuntime.addEmbeddingToMemory()` assigned it and document callers persisted it as complete.

# What changed

- Validate the provider result at the runtime boundary before mutating `memory.embedding`.
- Reject an empty/non-array result with typed `ElizaError` code `EMBEDDING_MODEL_OUTPUT_INVALID` and actionable context.
- Add a real `AgentRuntime` + `InMemoryDatabaseAdapter` regression that runs the actual embed-then-create sequence and proves `createMemory` is never reached and no row is stored.
- Preserve valid-vector idempotency, empty-input regeneration, queue behavior, and degraded embedding mode from #18875.

# Verification

Exact head: `e3141e74ed7bdb6bb21fcd65ef1ef95af4358bcd`
Base: `origin/develop@54a5c1c50dd8b760dc67a97bda839616af5a729e`

- `bun install --frozen-lockfile --ignore-scripts`: passed, no changes.
- Focused runtime suite: 1 file / 13 tests passed.
- Core typecheck: passed.
- Changed-file Biome and `git diff --check`: passed.
- `bun run verify`: 350/350 workspace tasks and every repository audit passed.

# Evidence Gate

<!-- evidence-head:e3141e74ed7bdb6bb21fcd65ef1ef95af4358bcd -->

- [x] N/A — no rendered UI, media, external integration, or model trajectory changed.
- [x] Domain proof — the focused regression uses the real runtime and in-memory adapter and asserts the rejected memory is absent after the attempted embed-then-persist flow.
