### PR TITLE
fix(core): blank runtime embedding-dimension alias falls through to env (#18897)

### DIFF
--- a/packages/core/src/features/documents/config-numeric-validation.test.ts
+++ b/packages/core/src/features/documents/config-numeric-validation.test.ts
@@ -188,6 +188,39 @@ describe("validateModelConfig numeric boundary", () => {
 		});
 	});
 
+	it.each([
+		["EMBEDDING_DIMENSION", "3072", 3072],
+		["OPENAI_EMBEDDING_DIMENSIONS", "3072", 3072],
+	] as const)(
+		"lets a valid %s env value win over a blank runtime alias (#18897)",
+		(setting, envValue, expected) => {
+			vi.stubEnv("EMBEDDING_PROVIDER", "openai");
+			vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
+			vi.stubEnv(setting, envValue);
+			const runtime = {
+				getSetting: (key: string) => (key === setting ? "   " : undefined),
+			} as never;
+
+			expect(validateModelConfig(runtime)).toMatchObject({
+				EMBEDDING_PROVIDER: "openai",
+				EMBEDDING_DIMENSION: expected,
+			});
+		},
+	);
+
+	it("falls to the provider default when the runtime alias is blank and no env alias is set (#18897)", () => {
+		vi.stubEnv("EMBEDDING_PROVIDER", "openai");
+		vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
+		const runtime = {
+			getSetting: (key: string) =>
+				key === "EMBEDDING_DIMENSION" ? "" : undefined,
+		} as never;
+
+		expect(validateModelConfig(runtime)).toMatchObject({
+			EMBEDDING_DIMENSION: 1536,
+		});
+	});
+
 	it("ignores inactive local and OpenAI aliases for Google embeddings", () => {
 		vi.stubEnv("EMBEDDING_PROVIDER", "google");
 		vi.stubEnv("GOOGLE_API_KEY", "test-google-key");

--- a/packages/core/src/features/documents/config.ts
+++ b/packages/core/src/features/documents/config.ts
@@ -53,8 +53,18 @@ export function validateModelConfig(runtime?: IAgentRuntime): ModelConfig {
 		const getNumericSetting = (key: string, defaultValue?: string) => {
 			if (runtime) {
 				const runtimeValue = runtime.getSetting(key);
-				if (runtimeValue !== null && runtimeValue !== undefined) {
-					return runtimeValue;
+				// Blank-is-unset for the RUNTIME value only (#18842, #18897): a blank
+				// runtime alias must fall through to the environment value instead of
+				// short-circuiting the caller's ?? chain with "" and letting the
+				// provider default win. The env value stays raw so a blank env entry
+				// still reaches schema validation (e.g. blank MAX_CONCURRENT_REQUESTS
+				// is rejected, not silently defaulted).
+				const normalizedRuntimeValue =
+					typeof runtimeValue === "string"
+						? normalizeEnvValue(runtimeValue)
+						: (runtimeValue ?? undefined);
+				if (normalizedRuntimeValue !== undefined) {
+					return normalizedRuntimeValue;
 				}
 			}
 			return process.env[key] ?? defaultValue;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18897

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run; **verify passes green on this head**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes on this head. One unrelated test failure exists on clean develop as well (`src/features/documents/service-character-ingest.test.ts` — an embedding error-code mismatch, `DOCUMENT_FRAGMENT_EMBED_FAILED`; verified pre-existing via stash-baseline) — it is outside the repo verify gate lanes and untouched by this diff.

# Risks

Low. One helper in one config module; the normalization applies to the RUNTIME value only, so every env-side behavior (including the deliberate blank-concurrency rejection) is proven unchanged by the existing suite.

# Background

## What does this PR do?

`getNumericSetting` in `packages/core/src/features/documents/config.ts` returned a blank runtime value verbatim, so a blank runtime `EMBEDDING_DIMENSION` short-circuited the caller's `??` chain with `""` and the provider default silently won over a valid environment alias the operator set (`OPENAI_EMBEDDING_DIMENSIONS=3072` → resolved 1536). Per the blank-is-unset convention (#18842, already applied to the sibling `getSetting`), blank runtime aliases now normalize to unset and fall through to the environment value. The env path deliberately stays raw so a blank env entry still reaches schema validation (blank `MAX_CONCURRENT_REQUESTS` keeps rejecting rather than silently defaulting — the existing boundary tests pin this).

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The `getNumericSetting` diff in `packages/core/src/features/documents/config.ts` (runtime-only normalization + the WHY comment), then the three new cases in `config-numeric-validation.test.ts`.

## Detailed testing steps

```bash
bun run --cwd packages/core test -- src/features/documents/config-numeric-validation.test.ts
```

# Evidence Gate

<!-- evidence-head:585e006fbff8226cb184a32afd322be7a90eeeeb -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - config resolution helper; no UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - config resolution helper; no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-visible flow; contract proven by the deterministic suite below`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — the boundary suite on this head (26/26) with the new #18897 cases:

  <details><summary>vitest run</summary>

  ```
✓ src/features/documents/config-numeric-validation.test.ts > validateModelConfig numeric boundary > treats a blank LOCAL_EMBEDDING_DIMENSIONS alias as unset and uses the provider default 0ms
 ✓ src/features/documents/config-numeric-validation.test.ts > validateModelConfig numeric boundary > treats a blank LOCAL_EMBEDDING_DIMENSIONS alias as unset and uses the provider default 0ms
 ✓ src/features/documents/config-numeric-validation.test.ts > validateModelConfig numeric boundary > treats a blank OPENAI_EMBEDDING_DIMENSIONS alias as unset and uses the provider default 0ms
 ✓ src/features/documents/config-numeric-validation.test.ts > validateModelConfig numeric boundary > treats a blank OPENAI_EMBEDDING_DIMENSIONS alias as unset and uses the provider default 0ms
 ✓ src/features/documents/config-numeric-validation.test.ts > validateModelConfig numeric boundary > treats a blank OpenAI alias as unset when OpenAI is inferred 0ms
 ✓ src/features/documents/config-numeric-validation.test.ts > validateModelConfig numeric boundary > lets a valid EMBEDDING_DIMENSION env value win over a blank runtime alias (#18897) 0ms
 ✓ src/features/documents/config-numeric-validation.test.ts > validateModelConfig numeric boundary > lets a valid OPENAI_EMBEDDING_DIMENSIONS env value win over a blank runtime alias (#18897) 0ms
 ✓ src/features/documents/config-numeric-validation.test.ts > validateModelConfig numeric boundary > falls to the provider default when the runtime alias is blank and no env alias is set (#18897) 0ms
Tests: 26 passed (26) — config-numeric-validation.test.ts
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - server-side config module; no browser surface involved`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - deterministic setting resolution; no model, prompt, provider, or action behavior involved`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the resolved config the tests pin at each boundary:

  <details><summary>resolved EMBEDDING_DIMENSION per input shape</summary>

  ```
  runtime "   " + env EMBEDDING_DIMENSION=3072          -> 3072  (env wins, was 1536)
  runtime "   " + env OPENAI_EMBEDDING_DIMENSIONS=3072  -> 3072  (issue repro, was 1536)
  runtime ""    + no env alias                          -> 1536  (provider default)
  env    ""     MAX_CONCURRENT_REQUESTS                 -> still REJECTED by schema
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Evidence Details

All evidence is inline above.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZWDA6479V8QA6SF87DF3DHS","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T01:55:42.856Z","completed_at":"2026-08-13T02:08:06.072Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"GhOsDn2t6lmiDgTBRovUbMpXH_U1hwoL02r5heNyN9RvhJdLOrpnF3Zsuy7s0gH_7o6SwMAES9g4yA5fkTkDBA"}} -->

