### PR TITLE
fix(web-search): bound page info HTML reads

### DIFF
--- a/plugins/plugin-web-search/src/services/webSearchService.test.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.test.ts
@@ -4,7 +4,7 @@
  * SSRF-closed page fetches via the real shared guard with an injected
  * transport (never stub the guard away).
  */
-import { type IAgentRuntime, SsrfBlockedError } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime, SsrfBlockedError } from "@elizaos/core";
 import fc from "fast-check";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SearchOptions } from "../types";
@@ -326,6 +326,107 @@ describe("WebSearchService", () => {
             "https://other.test/about",
         ]);
         expect(fetchImpl).toHaveBeenCalledOnce();
+    });
+
+    it("decodes astral numeric entities and preserves invalid Unicode code points", async () => {
+        const html = `<title>&#128512; &#x1F680; &#0; &#xD800; &#1114112;</title>`;
+        setPageInfoHttpTransportForTests({
+            fetchImpl: vi.fn(async () => new Response(html)),
+        });
+        const service = await WebSearchService.start(runtime({ TAVILY_API_KEY: "tvly-test" }));
+
+        const pageInfo = await service.getPageInfo("https://example.test/entities");
+
+        expect(pageInfo.title).toBe("😀 🚀 &#0; &#xD800; &#1114112;");
+    });
+
+    it("accepts page HTML exactly at the byte limit", async () => {
+        const exactLimitHtml = "a".repeat(1024 * 1024);
+        setPageInfoHttpTransportForTests({
+            fetchImpl: vi.fn(
+                async () =>
+                    new Response(exactLimitHtml, {
+                        headers: { "content-length": String(1024 * 1024) },
+                    })
+            ),
+        });
+        const service = await WebSearchService.start(runtime({ TAVILY_API_KEY: "tvly-test" }));
+
+        const pageInfo = await service.getPageInfo("https://example.test/exact-limit");
+
+        expect(pageInfo.content).toHaveLength(1024 * 1024);
+    });
+
+    it("rejects and cancels a body whose declared length exceeds the byte limit", async () => {
+        const cancel = vi.fn();
+        const pull = vi.fn();
+        const body = new ReadableStream<Uint8Array>({ cancel, pull });
+        setPageInfoHttpTransportForTests({
+            fetchImpl: vi.fn(
+                async () =>
+                    new Response(body, {
+                        headers: { "content-length": String(1024 * 1024 + 1) },
+                    })
+            ),
+        });
+        const service = await WebSearchService.start(runtime({ TAVILY_API_KEY: "tvly-test" }));
+
+        const error = await service
+            .getPageInfo("https://example.test/declared-oversize")
+            .catch((cause: unknown) => cause);
+
+        expect(error).toBeInstanceOf(ElizaError);
+        expect((error as ElizaError).code).toBe("PAGE_INFO_HTML_TOO_LARGE");
+        expect(cancel).toHaveBeenCalledWith("page info HTML exceeded size limit");
+    });
+
+    it("stops reading and cancels a streamed body as soon as it crosses the byte limit", async () => {
+        const cancel = vi.fn();
+        const chunks = [new Uint8Array(1024 * 1024), new Uint8Array([1])];
+        const body = new ReadableStream<Uint8Array>(
+            {
+                cancel,
+                pull(controller) {
+                    const chunk = chunks.shift();
+                    if (chunk) controller.enqueue(chunk);
+                    else controller.close();
+                },
+            },
+            { highWaterMark: 0 }
+        );
+        setPageInfoHttpTransportForTests({
+            fetchImpl: vi.fn(async () => new Response(body)),
+        });
+        const service = await WebSearchService.start(runtime({ TAVILY_API_KEY: "tvly-test" }));
+
+        const error = await service
+            .getPageInfo("https://example.test/streamed-oversize")
+            .catch((cause: unknown) => cause);
+
+        expect(error).toBeInstanceOf(ElizaError);
+        expect((error as ElizaError).code).toBe("PAGE_INFO_HTML_TOO_LARGE");
+        expect(cancel).toHaveBeenCalledWith("page info HTML exceeded size limit");
+    });
+
+    it("preserves a streamed body read failure as a typed boundary error", async () => {
+        const readFailure = new Error("socket reset");
+        const body = new ReadableStream<Uint8Array>({
+            pull() {
+                throw readFailure;
+            },
+        });
+        setPageInfoHttpTransportForTests({
+            fetchImpl: vi.fn(async () => new Response(body)),
+        });
+        const service = await WebSearchService.start(runtime({ TAVILY_API_KEY: "tvly-test" }));
+
+        const error = await service
+            .getPageInfo("https://example.test/read-failure")
+            .catch((cause: unknown) => cause);
+
+        expect(error).toBeInstanceOf(ElizaError);
+        expect((error as ElizaError).code).toBe("PAGE_INFO_BODY_READ_FAILED");
+        expect((error as ElizaError).cause).toBe(readFailure);
     });
 
     it("falls back to og:description when standard description meta tag is absent", async () => {

--- a/plugins/plugin-web-search/src/services/webSearchService.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.ts
@@ -8,11 +8,13 @@
  * rather than crashing boot. `getPageInfo` scrapes title, description, meta
  * tags, images, and links from untrusted HTML; the page bytes are always
  * fetched through `fetchWithSsrfGuard` so private / loopback / link-local
- * targets fail closed and redirect hops are revalidated. Videos reuse web
- * search since Tavily has no video endpoint.
+ * targets fail closed, redirect hops are revalidated, and response bodies are
+ * streamed through a byte cap before parsing. Videos reuse web search since
+ * Tavily has no video endpoint.
  */
 
 import {
+    ElizaError,
     fetchWithSsrfGuard,
     type IAgentRuntime,
     IWebSearchService,
@@ -35,6 +37,8 @@ export type TavilyClient = ReturnType<typeof tavily>;
 const PAGE_INFO_HTTP_TIMEOUT_MS = 15_000;
 /** Cap redirect hops so a hostile chain cannot spin the guard forever. */
 const PAGE_INFO_HTTP_MAX_REDIRECTS = 5;
+/** Bound untrusted page HTML before it reaches the regex extraction layer. */
+const PAGE_INFO_MAX_HTML_BYTES = 1024 * 1024;
 
 /**
  * Deterministic-test seam for the SSRF-guarded page-info transport.
@@ -203,6 +207,19 @@ function freshnessToDays(freshness: NewsSearchOptions["freshness"]): number {
 }
 
 function decodeHtmlEntities(text: string): string {
+    const decodeNumericEntity = (entity: string, digits: string, radix: number): string => {
+        const codePoint = Number.parseInt(digits, radix);
+        if (
+            !Number.isSafeInteger(codePoint) ||
+            codePoint <= 0 ||
+            codePoint > 0x10ffff ||
+            (codePoint >= 0xd800 && codePoint <= 0xdfff)
+        ) {
+            return entity;
+        }
+        return String.fromCodePoint(codePoint);
+    };
+
     return text
         .replace(/&amp;/g, "&")
         .replace(/&lt;/g, "<")
@@ -210,14 +227,85 @@ function decodeHtmlEntities(text: string): string {
         .replace(/&quot;/g, '"')
         .replace(/&#39;/g, "'")
         .replace(/&apos;/g, "'")
-        .replace(/&#(\d+);/g, (_, code) => {
-            const num = Number(code);
-            return Number.isFinite(num) ? String.fromCharCode(num) : _;
-        })
-        .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => {
-            const num = parseInt(hex, 16);
-            return Number.isFinite(num) ? String.fromCharCode(num) : _;
+        .replace(/&#(\d+);/g, (entity, digits: string) => decodeNumericEntity(entity, digits, 10))
+        .replace(/&#x([0-9a-fA-F]+);/g, (entity, digits: string) =>
+            decodeNumericEntity(entity, digits, 16)
+        );
+}
+
+type PageBodyCanceller = {
+    cancel(reason?: unknown): Promise<void>;
+};
+
+function pageInfoTooLargeError(cause?: unknown): ElizaError {
+    return new ElizaError("Page info HTML exceeds the response-size limit.", {
+        code: "PAGE_INFO_HTML_TOO_LARGE",
+        context: { limit: PAGE_INFO_MAX_HTML_BYTES },
+        cause,
+        severity: "fatal",
+    });
+}
+
+async function rejectOversizePageHtml(canceller?: PageBodyCanceller): Promise<never> {
+    if (canceller) {
+        try {
+            await canceller.cancel("page info HTML exceeded size limit");
+        } catch (cause) {
+            // error-policy:J2 Keep the size violation authoritative while
+            // preserving a transport cancellation failure for diagnostics.
+            throw pageInfoTooLargeError(cause);
+        }
+    }
+    throw pageInfoTooLargeError();
+}
+
+async function readBoundedPageHtml(response: Response): Promise<string> {
+    const declaredLength = response.headers.get("content-length");
+    if (
+        declaredLength &&
+        /^\d+$/.test(declaredLength) &&
+        Number(declaredLength) > PAGE_INFO_MAX_HTML_BYTES
+    ) {
+        return rejectOversizePageHtml(response.body ?? undefined);
+    }
+    if (!response.body) {
+        throw new ElizaError("Page info response has no body.", {
+            code: "PAGE_INFO_BODY_MISSING",
+            severity: "fatal",
         });
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let byteLength = 0;
+    let content = "";
+
+    try {
+        while (true) {
+            let chunk: ReadableStreamReadResult<Uint8Array>;
+            try {
+                chunk = await reader.read();
+            } catch (cause) {
+                // error-policy:J2 Preserve the transport failure while naming
+                // the page-info boundary that could not finish reading.
+                throw new ElizaError("Page info response body read failed.", {
+                    code: "PAGE_INFO_BODY_READ_FAILED",
+                    cause,
+                    severity: "ephemeral",
+                });
+            }
+            if (chunk.done) break;
+            byteLength += chunk.value.byteLength;
+            if (byteLength > PAGE_INFO_MAX_HTML_BYTES) {
+                return rejectOversizePageHtml(reader);
+            }
+            content += decoder.decode(chunk.value, { stream: true });
+        }
+        content += decoder.decode();
+        return content;
+    } finally {
+        reader.releaseLock();
+    }
 }
 
 function extractTitle(content: string, fallbackUrl: string): string {
@@ -470,7 +558,7 @@ export class WebSearchService extends IWebSearchService {
                     `Failed to fetch page info: ${guarded.response.status} ${guarded.response.statusText}`
                 );
             }
-            const content = await guarded.response.text();
+            const content = await readBoundedPageHtml(guarded.response);
             // Prefer the post-redirect URL for relative image/link resolution.
             let baseUrl = parsedUrl;
             try {


### PR DESCRIPTION
# Relates to

Closes #18677.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can reproduce the guarded page-info boundary and Unicode entity behavior below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@981a0ffef0959eaf39cf33507a26a959b4888181`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 tasks with 0 cache hits, followed by all repository audits.

# Risks

Low and bounded. Page metadata reads now reject missing, failed, or oversized bodies with typed `ElizaError` failures instead of buffering an unbounded response. The one-mebibyte ceiling is deliberately enforced on bytes rather than decoded characters. Existing SSRF checks remain the only network admission path.

# Background

## What does this PR do?

The original fix in #18678 improved multiline title, entity, metadata, and link parsing, but exact verification found two residual boundary bugs: numeric astral entities were decoded with `String.fromCharCode`, and `response.text()` allowed an attacker-controlled page to be buffered without a limit.

This change:

- Decodes validated decimal and hexadecimal numeric entities with `String.fromCodePoint`, including astral Unicode, while preserving invalid scalar references literally.
- Reads HTML as a byte-counted stream with a one-mebibyte limit and cancels the reader immediately when that limit is crossed.
- Rejects oversized declared content before reading it.
- Uses typed failures for missing bodies, stream failures, and oversized HTML; stream failures preserve their original cause.
- Adds exact-limit, declared-oversize, streamed-oversize, cancellation, read-failure, astral-code-point, and invalid-scalar regressions.

## What kind of change is this?

Bug fix and untrusted-input boundary hardening.

# Documentation changes needed?

No. This corrects the internal page-info service contract and does not add or alter a public configuration surface.

# Testing

## Where should a reviewer start?

- `plugins/plugin-web-search/src/services/webSearchService.ts`
- `plugins/plugin-web-search/src/services/webSearchService.test.ts`

## Detailed testing steps

```text
bun run --cwd plugins/plugin-web-search test
3 files passed, 1 intentionally skipped; 20 tests passed, 1 skipped

bun run --cwd plugins/plugin-web-search typecheck
pass

bun run --cwd plugins/plugin-web-search lint
pass

bun run --cwd plugins/plugin-web-search build
pass

bun run verify
350 successful, 350 total, 0 cached; all repository audits passed
```

# Evidence Gate

<!-- evidence-head:a061d8796edf2f7b5fd767f9b981bdc1211334be -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this is a service/parser boundary with no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no view, style, layout, or visual asset changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - behavior is exercised through direct deterministic service calls and a real guarded network fetch.
<!-- evidence-row:backend-logs -->
- [x] Real guarded network-path output is included below.

```text
boundary: repository SSRF guard followed by the changed byte-limited stream reader
request: WebSearchService.getPageInfo("https://example.com/")
result: {"title":"Example Domain","bytes":559,"links":1}
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the plugin registers only a service/search category for this path; no action, provider, evaluator, route, prompt, planner, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Boundary regressions cover exact-size success, early declared rejection, streaming rejection/cancellation, typed read failure, Unicode astral entities, and invalid scalar preservation.

```text
real request: WebSearchService.getPageInfo("https://example.com/")
result: {"title":"Example Domain","bytes":559,"links":1}

&#128512; and &#x1F680; => 😀 🚀
invalid scalar entities (zero, surrogate, > U+10FFFF) => preserved literally
1 MiB body => accepted
declared or streamed body over 1 MiB => PAGE_INFO_HTML_TOO_LARGE and reader cancelled
reader failure => PAGE_INFO_BODY_READ_FAILED with original cause
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered UI changes.

# Evidence Details

## Real LLM-call trajectory

N/A - this is a direct guarded-fetch and HTML parsing service boundary, not a provider-to-model path.

## Backend + frontend logs

The real `https://example.com/` request traversed the repository SSRF guard and the changed stream/parser path, returning the title, 559 HTML bytes, and one page link shown above. Frontend logs are not applicable.

## Screenshots (before / after) + video walkthrough

N/A - no rendered files or UI flows are changed.

## Audio / voice walkthrough

N/A - no audio or voice behavior changes.

## Known gaps / failures

None. Boundary regressions, the real guarded internet request, package lint/typecheck/test/build lanes, diff checks, and full uncached root verification pass on the synchronized head.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"N/A"} -->


