### PR TITLE
fix(skills): document malformed frontmatter contract

### DIFF
--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -158,3 +158,8 @@ Detailed instructions for the AI agent...
 - `resolveSkillMetadata(frontmatter)` - Resolve `SkillMetadata` from frontmatter
 - `resolveSkillInvocationPolicy(frontmatter)` - Resolve `SkillInvocationPolicy`
 - `resolveSkillProvenance(frontmatter)` - Resolve `SkillProvenance` (returns `undefined` if missing/malformed)
+
+`parseFrontmatter` and `stripFrontmatter` throw an `ElizaError` with code
+`INVALID_SKILL_FRONTMATTER_YAML` when a frontmatter block contains malformed
+YAML. File-discovery callers translate that typed failure into a warning and do
+not load the invalid skill.

--- a/packages/skills/src/frontmatter.ts
+++ b/packages/skills/src/frontmatter.ts
@@ -78,6 +78,12 @@ function extractFrontmatter(content: string): {
   };
 }
 
+/**
+ * Parse a skill document into a plain frontmatter record and its markdown body.
+ * Malformed YAML throws an {@link ElizaError} with
+ * {@link INVALID_SKILL_FRONTMATTER_YAML}; callers that ingest untrusted files
+ * must translate that typed failure at their boundary.
+ */
 export function parseFrontmatter<
   T extends Record<string, unknown> = Record<string, unknown>,
 >(content: string): ParsedFrontmatter<T> {
@@ -102,6 +108,10 @@ export function parseFrontmatter<
   return { frontmatter: {} as T, body };
 }
 
+/**
+ * Return a skill document's body without its frontmatter block.
+ * Malformed YAML propagates the same typed error as {@link parseFrontmatter}.
+ */
 export function stripFrontmatter(content: string): string {
   return parseFrontmatter(content).body;
 }

--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -105,7 +105,7 @@ function loadSkillFromFile(
   try {
     ({ frontmatter } = parseFrontmatter<SkillFrontmatter>(rawContent));
   } catch (error: unknown) {
-    // error-policy:J1 skill discovery translates its known parser failure into a warning diagnostic
+    // error-policy:J3 malformed untrusted frontmatter becomes an explicit warning and no skill
     if (!isElizaError(error) || error.code !== INVALID_SKILL_FRONTMATTER_YAML) {
       throw error;
     }

--- a/packages/skills/test/frontmatter.test.ts
+++ b/packages/skills/test/frontmatter.test.ts
@@ -4,8 +4,8 @@
  * non-plain collection roots, CRLF, and metadata/policy extraction.
  */
 import assert from "node:assert";
-import { ElizaError } from "@elizaos/core";
 import { describe, it } from "node:test";
+import { ElizaError } from "@elizaos/core";
 import {
   INVALID_SKILL_FRONTMATTER_YAML,
   parseFrontmatter,
@@ -103,7 +103,10 @@ Body content`;
       (error: unknown) => {
         assert.ok(error instanceof ElizaError);
         assert.strictEqual(error.code, INVALID_SKILL_FRONTMATTER_YAML);
-        assert.strictEqual(error.message, "Skill frontmatter contains invalid YAML");
+        assert.strictEqual(
+          error.message,
+          "Skill frontmatter contains invalid YAML",
+        );
         assert.ok(error.cause instanceof Error);
         return true;
       },

--- a/packages/skills/test/loader.test.ts
+++ b/packages/skills/test/loader.test.ts
@@ -4,13 +4,7 @@
  * dangling symlinks and read errors.
  */
 import assert from "node:assert";
-import {
-  mkdirSync,
-  rmdirSync,
-  rmSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";


### PR DESCRIPTION
Closes #18910

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Targets current `develop`.
- [x] Package tests, typecheck, lint, build, guide parity, Biome, and diff checks pass.
- [ ] Root verification reaches an unchanged host-tool failure described below; hosted verification remains required.

# Contribution provenance

<!-- contribution-attribution:v1 -->
- AI assistance: `yes`
- Model(s) used: `openai/gpt-5.6-sol`
- Agent tooling: `codex-desktop`
- Skill path: `github:yeet`
- Provenance status: `self-reported`

# What changed

This is the bounded post-merge cleanup identified after #18879:

- Documents the public `parseFrontmatter` / `stripFrontmatter` typed-throw contract and stable `INVALID_SKILL_FRONTMATTER_YAML` code in JSDoc and the package README.
- Corrects the loader boundary from J1 to J3: malformed untrusted frontmatter becomes an explicit warning and no loaded skill.
- Applies the formatter/import cleanup requested by Biome in the changed tests and removes one unused import.

Runtime behavior is intentionally unchanged. #18709 remains correctly completed; this PR owns only policy/documentation hygiene.

# Testing

- `bun run --cwd packages/skills test`: PASS, 101/101.
- `bun run --cwd packages/skills typecheck`: PASS.
- `bun run --cwd packages/skills lint:check`: PASS.
- `bun run --cwd packages/skills build`: PASS.
- Direct Biome over all five changed files: PASS.
- `bun run check:agents-claude`: PASS, 154 pairs.
- `git diff --check`: PASS.
- `bun run verify`: repository audits and the changed package start cleanly, then the unchanged `@elizaos/capacitor-gateway#lint:check` host lane exits 127 because `node-swiftlint` is unavailable in this disposable linked-dependency checkout. No changed-file failure was emitted.

# Evidence Gate

<!-- evidence-head:7ed230a67ee9cb3fcac988bef5bd4e9c1e278232 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - parser documentation, comments, and test formatting have no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered product output changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic package tests exercise the real temporary-filesystem loader boundary; results are recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, or action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text changes.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: github plugin 0.1.8-2841cf9749ae / yeet
Attribution status: self-reported
— [codex]
