### PR TITLE
security(pii): wire local model context pack pseudonymization pipeline (#15973)

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -6773,14 +6773,16 @@ export class AgentRuntime implements IAgentRuntime {
 					ModelType.AUDIO,
 					ModelType.VIDEO,
 				];
-				// PII swap skips binary-input modalities (nothing to swap) and TEXT_EMBEDDING
-				// (a random per-turn surrogate would destabilize embeddings), but — unlike
-				// the secret gate — swaps IMAGE prompts, whose text can carry real names.
+				const secretSwapSkipModels = [...binaryModels, ModelType.PII_SCRUB];
+				// PII swap skips binary-input modalities, TEXT_EMBEDDING (surrogates
+				// destabilize vectors), and PII_SCRUB (the dedicated privacy handler must
+				// inspect and return verdicts over the exact original spans).
 				const PII_SWAP_SKIP_MODELS: string[] = [
 					ModelType.TRANSCRIPTION,
 					ModelType.AUDIO,
 					ModelType.VIDEO,
 					ModelType.TEXT_EMBEDDING,
+					ModelType.PII_SCRUB,
 				];
 				let modelParams: ModelParamsMap[T];
 				const paramsClone = isPlainObject(params)
@@ -7051,7 +7053,7 @@ export class AgentRuntime implements IAgentRuntime {
 
 				if (
 					this.isSecretSwapEnabled() &&
-					!binaryModels.includes(resolvedModelKey)
+					!secretSwapSkipModels.includes(resolvedModelKey)
 				) {
 					// Reuse one session per turn so every model call in the turn shares a
 					// nonce and the action-execution boundary can restore what this call
@@ -7071,11 +7073,9 @@ export class AgentRuntime implements IAgentRuntime {
 							: secretSwapSession.substituteText(effectiveSystemPrompt);
 				}
 
-				// Models the PII swap must NOT touch: binary-input modalities (nothing to
-				// swap) and — unlike the secret gate — IMAGE is INCLUDED (its text prompt
-				// can carry real names), while TEXT_EMBEDDING is EXCLUDED (a per-turn-random
-				// surrogate would embed the same real text differently every turn and wreck
-				// semantic memory retrieval; embeddings stay on the real text).
+				// Models the PII swap must NOT touch. IMAGE remains included because its
+				// prompt can carry names; PII_SCRUB is excluded because it is itself the
+				// privacy boundary and validates verdict spans against original input.
 				let piiIngressText = "";
 				if (
 					this.isPiiSwapEnabled() &&

--- a/packages/core/src/runtime/__tests__/pii-swap-use-model.test.ts
+++ b/packages/core/src/runtime/__tests__/pii-swap-use-model.test.ts
@@ -16,7 +16,7 @@ import {
 	PseudonymSession,
 } from "../../security/index.js";
 import { runWithTrajectoryContext } from "../../trajectory-context";
-import { type Character, ModelType } from "../../types";
+import { type Character, ModelType, type PiiScrubParams } from "../../types";
 
 function makeRuntime(enabled: boolean): AgentRuntime {
 	return new AgentRuntime({
@@ -49,6 +49,49 @@ function injectNerService(
 }
 
 describe("AgentRuntime.useModel PII swap — ingress", () => {
+	it("leaves dedicated PII_SCRUB inputs exact under PII and secret swapping", async () => {
+		const runtime = new AgentRuntime({
+			character: {
+				name: "PiiSwapAgent",
+				bio: "test",
+				secrets: { API_TOKEN: "secret-token-value" },
+				settings: {
+					ELIZA_PII_SWAP_ENABLED: true,
+					ELIZA_SECRET_SWAP_ENABLED: true,
+				},
+			} as Character,
+			adapter: new InMemoryDatabaseAdapter(),
+			logLevel: "fatal",
+		});
+		injectNerService(runtime, [{ kind: "person", value: "Dana Whitfield" }]);
+		let seen: PiiScrubParams | undefined;
+		runtime.registerModel(
+			ModelType.PII_SCRUB,
+			async (_rt, params: PiiScrubParams) => {
+				seen = params;
+				return {
+					modelId: "local-privacy",
+					rulesetVersion: params.rulesetVersion,
+					verdicts: params.candidateSpans.map((span) => ({
+						span,
+						kind: "safe" as const,
+					})),
+				};
+			},
+			"local-privacy",
+		);
+
+		const text = "Dana Whitfield used secret-token-value";
+		await runtime.useModel(ModelType.PII_SCRUB, {
+			text,
+			candidateSpans: [text],
+			rulesetVersion: "2026.08",
+		});
+
+		expect(seen?.text).toBe(text);
+		expect(seen?.candidateSpans).toEqual([text]);
+	});
+
 	it("sends realistic surrogates (no real PII) to the provider via the injected NER service", async () => {
 		const runtime = makeRuntime(true);
 		injectNerService(runtime, [

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -68,6 +68,19 @@ export {
 	sourcesFromRuntime,
 } from "./pii-context-pack.js";
 export {
+	applyScrubVerdicts,
+	applyScrubWriteBack,
+	applyVerdictsToText,
+	enqueuePiiScrub,
+	mineTier0Candidates,
+	type PiiScrubPipelineItem,
+	type PiiScrubPipelineOptions,
+	type PiiScrubPipelineResult,
+	redactTier0Spans,
+	runPiiScrubPipeline,
+	TIER0_REDACTION_PLACEHOLDER,
+} from "./pii-scrub-pipeline.js";
+export {
 	cardBrand,
 	detectPii,
 	ibanValid,

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -68,19 +68,6 @@ export {
 	sourcesFromRuntime,
 } from "./pii-context-pack.js";
 export {
-	applyScrubVerdicts,
-	applyScrubWriteBack,
-	applyVerdictsToText,
-	enqueuePiiScrub,
-	mineTier0Candidates,
-	type PiiScrubPipelineItem,
-	type PiiScrubPipelineOptions,
-	type PiiScrubPipelineResult,
-	redactTier0Spans,
-	runPiiScrubPipeline,
-	TIER0_REDACTION_PLACEHOLDER,
-} from "./pii-scrub-pipeline.js";
-export {
 	cardBrand,
 	detectPii,
 	ibanValid,
@@ -122,6 +109,19 @@ export {
 	type PseudonymSessionOptions,
 	parsePiiSwapList,
 } from "./pii-pseudonymizer.js";
+export {
+	applyScrubVerdicts,
+	applyScrubWriteBack,
+	applyVerdictsToText,
+	enqueuePiiScrub,
+	mineTier0Candidates,
+	type PiiScrubPipelineItem,
+	type PiiScrubPipelineOptions,
+	type PiiScrubPipelineResult,
+	redactTier0Spans,
+	runPiiScrubPipeline,
+	TIER0_REDACTION_PLACEHOLDER,
+} from "./pii-scrub-pipeline.js";
 export {
 	assertValidScrubResult,
 	PiiScrubFabricationError,

--- a/packages/core/src/security/pii-context-pack.test.ts
+++ b/packages/core/src/security/pii-context-pack.test.ts
@@ -372,6 +372,22 @@ describe("sourcesFromRuntime", () => {
 		expect(full.resolveEntity).toBeTypeOf("function");
 	});
 
+	test("local-only mode omits retrieval that may route through embeddings", () => {
+		const { runtime } = makeRuntime({
+			embeddingModel: true,
+			documentsService: true,
+		});
+		const sources = sourcesFromRuntime(runtime, {
+			localOnly: true,
+			roomIds: [AGENT_ID],
+			resolveEntity: async () => [],
+		});
+		expect(sources.searchDocuments).toBeUndefined();
+		expect(sources.searchMemories).toBeUndefined();
+		expect(sources.searchMessages).toBeTypeOf("function");
+		expect(sources.resolveEntity).toBeTypeOf("function");
+	});
+
 	test("documents source maps StoredDocument hits into scored fragments", async () => {
 		const { runtime, searchDocuments } = makeRuntime({
 			documentsService: true,
@@ -444,6 +460,7 @@ describe("buildScrubRequestDraft", () => {
 			rulesetVersion: RULESET,
 			pack,
 			itemRef: "memory:abc",
+			writeBack: async () => {},
 		});
 		expect(draft.content).toBe("Lunch with John Smith");
 		expect(draft.rulesetVersion).toBe(RULESET);

--- a/packages/core/src/security/pii-context-pack.ts
+++ b/packages/core/src/security/pii-context-pack.ts
@@ -376,6 +376,11 @@ export function entityResolverFromStore(
 
 export interface RuntimeContextSourceOptions {
 	/**
+	 * Restrict retrieval to local database/entity surfaces. This omits document
+	 * and memory searches that may invoke a remotely routed embedding model.
+	 */
+	readonly localOnly?: boolean;
+	/**
 	 * Rooms for conversation FTS (`adapter.searchMessages` requires explicit
 	 * roomIds — enumerate via `getRoomsByWorld` / `getRoomsForParticipant`).
 	 * When omitted, the messages source is structurally absent.
@@ -424,7 +429,11 @@ export function sourcesFromRuntime(
 		| (Service & Partial<DocumentSearchService>)
 		| null;
 	const searchDocumentsFn = documents?.searchDocuments;
-	if (documents && typeof searchDocumentsFn === "function") {
+	if (
+		!options.localOnly &&
+		documents &&
+		typeof searchDocumentsFn === "function"
+	) {
 		sources.searchDocuments = async (query) => {
 			const results = await searchDocumentsFn.call(documents, {
 				entityId: runtime.agentId,
@@ -442,7 +451,7 @@ export function sourcesFromRuntime(
 		};
 	}
 
-	if (runtime.getModel(ModelType.TEXT_EMBEDDING)) {
+	if (!options.localOnly && runtime.getModel(ModelType.TEXT_EMBEDDING)) {
 		sources.searchMemories = async (query) => {
 			const params: TextEmbeddingParams = { text: query };
 			// Embeddings doctrine: a failure here THROWS (#9324) — the pass never
@@ -508,7 +517,8 @@ export function buildScrubRequestDraft(input: {
 	readonly priority?: PiiScrubRequestPayload["priority"];
 	readonly inferencePriority?: PiiScrubRequestPayload["inferencePriority"];
 	readonly jobId?: PiiScrubRequestPayload["jobId"];
-	readonly itemRef?: string;
+	readonly itemRef: string;
+	readonly writeBack: PiiScrubRequestPayload["writeBack"];
 }): Omit<PiiScrubRequestPayload, "runtime"> {
 	return {
 		content: input.content,
@@ -520,6 +530,7 @@ export function buildScrubRequestDraft(input: {
 		inferencePriority: input.inferencePriority,
 		jobId: input.jobId,
 		itemRef: input.itemRef,
+		writeBack: input.writeBack,
 		source: "pii-context-pack",
 	};
 }

--- a/packages/core/src/security/pii-pseudonym-consistency.test.ts
+++ b/packages/core/src/security/pii-pseudonym-consistency.test.ts
@@ -84,6 +84,8 @@ function makeRuntime(opts: {
 			events.push({ type, payload });
 		},
 		registerEvent: vi.fn(),
+		registerPipelineHook: vi.fn(),
+		unregisterPipelineHook: vi.fn(),
 		registerTaskWorker: vi.fn(),
 		getTasksByName: async () => [],
 		getTask: async () => null,

--- a/packages/core/src/security/pii-pseudonym-consistency.test.ts
+++ b/packages/core/src/security/pii-pseudonym-consistency.test.ts
@@ -84,6 +84,7 @@ function makeRuntime(opts: {
 			events.push({ type, payload });
 		},
 		registerEvent: vi.fn(),
+		registerModel: vi.fn(),
 		registerPipelineHook: vi.fn(),
 		unregisterPipelineHook: vi.fn(),
 		registerTaskWorker: vi.fn(),
@@ -249,6 +250,7 @@ describe("corpus-wide pseudonym consistency through the rails", () => {
 					rulesetVersion: RULESET,
 					pack,
 					itemRef: artifact.itemRef,
+					writeBack: async () => {},
 				}) as unknown as Record<string, unknown>,
 			);
 		}
@@ -260,7 +262,12 @@ describe("corpus-wide pseudonym consistency through the rails", () => {
 		);
 		expect(completed).toHaveLength(CORPUS.length);
 		for (const artifact of CORPUS) {
-			const marker = await getScrubMarker(runtime, artifact.content, RULESET);
+			const marker = await getScrubMarker(
+				runtime,
+				artifact.content,
+				RULESET,
+				artifact.itemRef,
+			);
 			expect(marker?.modelId).toBe("test-local-privacy-gguf");
 		}
 
@@ -335,6 +342,7 @@ describe("corpus-wide pseudonym consistency through the rails", () => {
 				rulesetVersion,
 				pack,
 				itemRef: artifact.itemRef,
+				writeBack: async () => {},
 			}) as unknown as Record<string, unknown>;
 		};
 
@@ -360,7 +368,7 @@ describe("corpus-wide pseudonym consistency through the rails", () => {
 		await drain(service);
 		expect(runtime.__useModelCalls).toBe(2);
 		expect(
-			await getScrubMarker(runtime, artifact.content, bumped),
+			await getScrubMarker(runtime, artifact.content, bumped, artifact.itemRef),
 		).toBeTruthy();
 
 		await service.stop();
@@ -385,11 +393,17 @@ describe("corpus-wide pseudonym consistency through the rails", () => {
 				rulesetVersion: RULESET,
 				pack,
 				itemRef: "document:card",
+				writeBack: async () => {},
 			}) as unknown as Record<string, unknown>,
 		);
 		await drain(service);
 		expect(runtime.__useModelCalls).toBe(0);
-		const marker = await getScrubMarker(runtime, content, RULESET);
+		const marker = await getScrubMarker(
+			runtime,
+			content,
+			RULESET,
+			"document:card",
+		);
 		expect(marker?.tier0Only).toBe(true);
 		await service.stop();
 	});
@@ -429,6 +443,7 @@ describe("corpus-wide pseudonym consistency through the rails", () => {
 				rulesetVersion: RULESET,
 				pack,
 				itemRef: artifact.itemRef,
+				writeBack: async () => {},
 			}) as unknown as Record<string, unknown>,
 		);
 		// Drain enough to exhaust retries (maxRetriesAfterFailure: 3).
@@ -443,7 +458,12 @@ describe("corpus-wide pseudonym consistency through the rails", () => {
 			runtime.__events.filter((e) => e.type === "PII_SCRUB_COMPLETED"),
 		).toHaveLength(0);
 		expect(
-			await getScrubMarker(runtime, artifact.content, RULESET),
+			await getScrubMarker(
+				runtime,
+				artifact.content,
+				RULESET,
+				artifact.itemRef,
+			),
 		).toBeUndefined();
 		await service.stop();
 	});

--- a/packages/core/src/security/pii-scrub-markers.ts
+++ b/packages/core/src/security/pii-scrub-markers.ts
@@ -3,20 +3,17 @@
  *
  * The scrub job is long-running compute that must survive crash/restart with
  * ZERO lost or duplicated work. The issue's chosen resume mechanism is a
- * content-addressed per-item done-marker keyed
+ * source-scoped, content-addressed per-item done-marker keyed
  *
- *     pii:<sha256(content)>:v<rulesetVersion>
+ *     pii:<sha256(content)>:v<rulesetVersion>:source:<sha256(itemRef)>
  *
  * exactly like the media store's content-addressing and the compensating-write
  * `recon:<txid>:refund` precedent. It has two properties the job relies on:
  *
- *   1. **Content-addressed idempotency.** The key is derived only from the
- *      content bytes + the active ruleset version. Re-enqueuing the SAME content
- *      under the SAME ruleset resolves to the SAME marker, so a re-scrub of
- *      unchanged content is a no-op (`isScrubDone` short-circuits before any
- *      model call). Editing the content (different sha) OR bumping the ruleset
- *      (different `v<...>`) produces a NEW key, so genuinely-changed content is
- *      re-scrubbed rather than incorrectly skipped.
+ *   1. **Per-source idempotency.** The key combines the source reference,
+ *      content bytes, and active ruleset version. Re-enqueuing the SAME source
+ *      with unchanged content is a no-op, while two source artifacts containing
+ *      identical text retain independent write-back obligations.
  *
  *   2. **Crash-and-rerun with zero cursor state.** The marker is written to the
  *      runtime cache (a DB-backed durable store), so a `kill -9` mid-run loses
@@ -102,8 +99,10 @@ export function scrubMarkerKey(
 export function scrubMarkerKeyForContent(
 	content: string,
 	rulesetVersion: string,
+	itemRef?: string,
 ): string {
-	return scrubMarkerKey(hashScrubContent(content), rulesetVersion);
+	const base = scrubMarkerKey(hashScrubContent(content), rulesetVersion);
+	return itemRef ? `${base}:source:${hashScrubContent(itemRef)}` : base;
 }
 
 /**
@@ -126,8 +125,9 @@ export async function isScrubDone(
 	cache: ScrubMarkerCache,
 	content: string,
 	rulesetVersion: string,
+	itemRef?: string,
 ): Promise<boolean> {
-	const key = scrubMarkerKeyForContent(content, rulesetVersion);
+	const key = scrubMarkerKeyForContent(content, rulesetVersion, itemRef);
 	const marker = await cache.getCache<PiiScrubDoneMarker>(key);
 	return marker !== undefined && marker !== null;
 }
@@ -144,9 +144,10 @@ export async function markScrubDone(
 	marker: Omit<PiiScrubDoneMarker, "contentHash" | "completedAt"> & {
 		completedAt?: number;
 	},
+	itemRef?: string,
 ): Promise<boolean> {
 	const contentHash = hashScrubContent(content);
-	const key = scrubMarkerKey(contentHash, marker.rulesetVersion);
+	const key = scrubMarkerKeyForContent(content, marker.rulesetVersion, itemRef);
 	const record: PiiScrubDoneMarker = {
 		contentHash,
 		rulesetVersion: marker.rulesetVersion,
@@ -165,8 +166,9 @@ export async function getScrubMarker(
 	cache: ScrubMarkerCache,
 	content: string,
 	rulesetVersion: string,
+	itemRef?: string,
 ): Promise<PiiScrubDoneMarker | undefined> {
-	const key = scrubMarkerKeyForContent(content, rulesetVersion);
+	const key = scrubMarkerKeyForContent(content, rulesetVersion, itemRef);
 	const marker = await cache.getCache<PiiScrubDoneMarker>(key);
 	return marker ?? undefined;
 }

--- a/packages/core/src/security/pii-scrub-pipeline.test.ts
+++ b/packages/core/src/security/pii-scrub-pipeline.test.ts
@@ -11,12 +11,29 @@ import type { IAgentRuntime } from "../types/runtime.js";
 import type { PseudonymMapStore } from "./pii-pseudonym-map-store.js";
 import { scrubMarkerKeyForContent } from "./pii-scrub-markers.js";
 import {
+	applyScrubWriteBack,
 	enqueuePiiScrub,
 	mineTier0Candidates,
 	runPiiScrubPipeline,
 } from "./pii-scrub-pipeline.js";
 
 const RULESET = "2026.08";
+
+test("re-detects structured PII introduced or normalized by a whole-text rewrite", () => {
+	const original = "card 4111 1111 1111 1111";
+	const rewritten = applyScrubWriteBack(
+		original,
+		[{ span: "4111 1111 1111 1111" }],
+		[
+			{
+				span: original,
+				kind: "pii",
+				replacement: "card 4111111111111111",
+			},
+		],
+	);
+	expect(rewritten).toBe("card [REDACTED]");
+});
 
 function makeMapStore(): PseudonymMapStore {
 	return {
@@ -81,7 +98,9 @@ describe("runPiiScrubPipeline", () => {
 		expect(result.scrubbedText).toBe("pay [REDACTED] today");
 		expect(result.modelId).toBe("tier0");
 		expect(order).toEqual(["writeBack", "marker"]);
-		expect(cache.has(scrubMarkerKeyForContent(content, RULESET))).toBe(true);
+		expect(
+			cache.has(scrubMarkerKeyForContent(content, RULESET, "memory:card")),
+		).toBe(true);
 	});
 
 	test("async mode builds a rails payload without running paid inference", async () => {
@@ -144,6 +163,46 @@ describe("runPiiScrubPipeline", () => {
 		expect(item.writeBack).toHaveBeenCalledTimes(1);
 	});
 
+	test("identical content in a second source still performs its write-back", async () => {
+		const content = "met Jordan Rivers";
+		const modelResult: PiiScrubResult = {
+			modelId: "local-test",
+			rulesetVersion: RULESET,
+			verdicts: [
+				{ span: "Jordan Rivers", kind: "pii", replacement: "Person 1" },
+			],
+		};
+		const { runtime, modelCalls } = makeRuntime(modelResult);
+		const firstWriteBack = vi.fn(async () => {});
+		const secondWriteBack = vi.fn(async () => {});
+		const options = { rulesetVersion: RULESET, mapStore: makeMapStore() };
+
+		await runPiiScrubPipeline(
+			runtime,
+			{
+				content,
+				itemRef: "memory:a",
+				candidates: [{ surfaceForm: "Jordan Rivers", kind: "person" }],
+				writeBack: firstWriteBack,
+			},
+			options,
+		);
+		await runPiiScrubPipeline(
+			runtime,
+			{
+				content,
+				itemRef: "memory:b",
+				candidates: [{ surfaceForm: "Jordan Rivers", kind: "person" }],
+				writeBack: secondWriteBack,
+			},
+			options,
+		);
+
+		expect(modelCalls()).toBe(2);
+		expect(firstWriteBack).toHaveBeenCalledOnce();
+		expect(secondWriteBack).toHaveBeenCalledOnce();
+	});
+
 	test("write-back failure leaves the source unmarked for retry", async () => {
 		const content = "pay 4111 1111 1111 1111 today";
 		const { runtime, cache } = makeRuntime();
@@ -162,7 +221,9 @@ describe("runPiiScrubPipeline", () => {
 				{ rulesetVersion: RULESET, mapStore: makeMapStore() },
 			),
 		).rejects.toThrow("disk unavailable");
-		expect(cache.has(scrubMarkerKeyForContent(content, RULESET))).toBe(false);
+		expect(
+			cache.has(scrubMarkerKeyForContent(content, RULESET, "memory:card")),
+		).toBe(false);
 	});
 });
 

--- a/packages/core/src/security/pii-scrub-pipeline.test.ts
+++ b/packages/core/src/security/pii-scrub-pipeline.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Contract tests for the production PII scrub pipeline using deterministic
+ * cache, map-store, and model doubles. They verify tier-0 removal, async mode,
+ * durable write ordering, and direct-call idempotency without external I/O.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import type { PiiScrubResult } from "../types/model.js";
+import { ModelType } from "../types/model.js";
+import type { IAgentRuntime } from "../types/runtime.js";
+import type { PseudonymMapStore } from "./pii-pseudonym-map-store.js";
+import { scrubMarkerKeyForContent } from "./pii-scrub-markers.js";
+import {
+	enqueuePiiScrub,
+	mineTier0Candidates,
+	runPiiScrubPipeline,
+} from "./pii-scrub-pipeline.js";
+
+const RULESET = "2026.08";
+
+function makeMapStore(): PseudonymMapStore {
+	return {
+		load: vi.fn(async () => null),
+		save: vi.fn(async () => {}),
+	};
+}
+
+function makeRuntime(modelResult?: PiiScrubResult) {
+	const cache = new Map<string, unknown>();
+	const events: Array<{ type: string; payload: Record<string, unknown> }> = [];
+	let modelCalls = 0;
+	const runtime = {
+		agentId: "00000000-0000-0000-0000-000000000001",
+		getCache: async <T>(key: string): Promise<T | undefined> =>
+			cache.get(key) as T | undefined,
+		setCache: async <T>(key: string, value: T): Promise<boolean> => {
+			cache.set(key, value);
+			return true;
+		},
+		getModel: (type: string) =>
+			type === ModelType.PII_SCRUB && modelResult
+				? async () => modelResult
+				: undefined,
+		useModel: async () => {
+			modelCalls++;
+			if (!modelResult) throw new Error("unexpected model call");
+			return modelResult;
+		},
+		emitEvent: async (type: string, payload: Record<string, unknown>) => {
+			events.push({ type, payload });
+		},
+	} as unknown as IAgentRuntime;
+	return { runtime, cache, events, modelCalls: () => modelCalls };
+}
+
+describe("runPiiScrubPipeline", () => {
+	test("removes tier-0 payment-card spans and writes before the done marker", async () => {
+		const content = "pay 4111 1111 1111 1111 today";
+		const { runtime, cache } = makeRuntime();
+		const order: string[] = [];
+		const originalSetCache = runtime.setCache.bind(runtime);
+		runtime.setCache = async (key, value) => {
+			order.push("marker");
+			return originalSetCache(key, value);
+		};
+
+		const result = await runPiiScrubPipeline(
+			runtime,
+			{
+				content,
+				itemRef: "memory:card",
+				candidates: mineTier0Candidates(content),
+				writeBack: async (text) => {
+					order.push("writeBack");
+					expect(text).not.toContain("4111");
+				},
+			},
+			{ rulesetVersion: RULESET, mapStore: makeMapStore() },
+		);
+
+		expect(result.scrubbedText).toBe("pay [REDACTED] today");
+		expect(result.modelId).toBe("tier0");
+		expect(order).toEqual(["writeBack", "marker"]);
+		expect(cache.has(scrubMarkerKeyForContent(content, RULESET))).toBe(true);
+	});
+
+	test("async mode builds a rails payload without running paid inference", async () => {
+		const content = "met Jordan Rivers";
+		const modelResult: PiiScrubResult = {
+			modelId: "local-test",
+			rulesetVersion: RULESET,
+			verdicts: [
+				{ span: "Jordan Rivers", kind: "pii", replacement: "Person 1" },
+			],
+		};
+		const { runtime, modelCalls } = makeRuntime(modelResult);
+		const writeBack = vi.fn(async () => {});
+
+		const result = await runPiiScrubPipeline(
+			runtime,
+			{
+				content,
+				itemRef: "memory:name",
+				candidates: [{ surfaceForm: "Jordan Rivers", kind: "person" }],
+				writeBack,
+			},
+			{
+				rulesetVersion: RULESET,
+				mapStore: makeMapStore(),
+				applyWriteBack: false,
+			},
+		);
+
+		expect(modelCalls()).toBe(0);
+		expect(writeBack).not.toHaveBeenCalled();
+		expect(result.scrubbedText).toBe(content);
+		expect(result.railsPayload?.writeBack).toBe(writeBack);
+	});
+
+	test("a completed direct call is idempotent and does not repeat inference", async () => {
+		const content = "met Jordan Rivers";
+		const modelResult: PiiScrubResult = {
+			modelId: "local-test",
+			rulesetVersion: RULESET,
+			verdicts: [
+				{ span: "Jordan Rivers", kind: "pii", replacement: "Person 1" },
+			],
+		};
+		const { runtime, modelCalls } = makeRuntime(modelResult);
+		const item = {
+			content,
+			itemRef: "memory:name",
+			candidates: [{ surfaceForm: "Jordan Rivers", kind: "person" }],
+			writeBack: vi.fn(async () => {}),
+		};
+		const options = { rulesetVersion: RULESET, mapStore: makeMapStore() };
+
+		const first = await runPiiScrubPipeline(runtime, item, options);
+		const second = await runPiiScrubPipeline(runtime, item, options);
+
+		expect(first.scrubbedText).toBe("met Person 1");
+		expect(second.skipped).toBe(true);
+		expect(modelCalls()).toBe(1);
+		expect(item.writeBack).toHaveBeenCalledTimes(1);
+	});
+
+	test("write-back failure leaves the source unmarked for retry", async () => {
+		const content = "pay 4111 1111 1111 1111 today";
+		const { runtime, cache } = makeRuntime();
+
+		await expect(
+			runPiiScrubPipeline(
+				runtime,
+				{
+					content,
+					itemRef: "memory:card",
+					candidates: mineTier0Candidates(content),
+					writeBack: async () => {
+						throw new Error("disk unavailable");
+					},
+				},
+				{ rulesetVersion: RULESET, mapStore: makeMapStore() },
+			),
+		).rejects.toThrow("disk unavailable");
+		expect(cache.has(scrubMarkerKeyForContent(content, RULESET))).toBe(false);
+	});
+});
+
+describe("enqueuePiiScrub", () => {
+	test("emits the payload-only request and preserves durable write-back", async () => {
+		const content = "pay 4111 1111 1111 1111";
+		const { runtime, events, modelCalls } = makeRuntime();
+		const writeBack = vi.fn(async () => {});
+
+		await enqueuePiiScrub(
+			runtime,
+			{
+				content,
+				itemRef: "memory:card",
+				candidates: mineTier0Candidates(content),
+				writeBack,
+			},
+			{ rulesetVersion: RULESET, mapStore: makeMapStore() },
+		);
+
+		expect(modelCalls()).toBe(0);
+		expect(events).toHaveLength(1);
+		expect(events[0].type).toBe("PII_SCRUB_REQUESTED");
+		expect(events[0].payload.writeBack).toBe(writeBack);
+	});
+});

--- a/packages/core/src/security/pii-scrub-pipeline.ts
+++ b/packages/core/src/security/pii-scrub-pipeline.ts
@@ -1,0 +1,390 @@
+/**
+ * Production driver for the local PII scrub pipeline (#15973).
+ *
+ * The merged context-retrieval pass + corpus pseudonym map (#15841, closes
+ * #14805) is complete and tested, but it was unreachable from a live run: no
+ * production caller loaded the encrypted map, assembled the context pack,
+ * routed the result through the `PiiScrubService` rails, and applied the
+ * validated verdicts back onto the source artifact. This module is that caller.
+ *
+ * It wires the already-landed rails into ONE production flow with no new
+ * scheduler, queue, or scrub mechanism:
+ *
+ *   1. **Load the encrypted pseudonym map** from the protected runtime-cache
+ *      store (`EncryptedCachePseudonymMapStore`, #15841). Fail-closed: a
+ *      wrong salt, tampered ciphertext, or malformed snapshot THROWS rather
+ *      than silently re-minting pseudonyms for already-mapped people.
+ *   2. **Assemble the context pack** for the chunk: resolve candidates through
+ *      the EntityStore alias backbone, gather related document/memory/message
+ *      fragments, cluster confident resolutions into the map, and emit the
+ *      per-chunk assignment slice — exactly the `assembleContextPack` contract.
+ *   3. **Fold the pack into the scrub-rails request** via
+ *      `buildScrubRequestDraft` and emit `PII_SCRUB_REQUESTED`, which the live
+ *      `PiiScrubService` drains (tier-0 → escalation → marker).
+ *   4. **Apply the verdicts and write back** the transformed text before the
+ *      done-marker is written. This is the step the service previously skipped
+ *      (it discarded the returned verdicts, marking done without committing
+ *      the rewrite). `applyScrubVerdicts` replaces every `pii` span with its
+ *      replacement and `substituteAliases` applies the deterministic tier-0
+ *      pseudonym pass, so zero original aliases survive.
+ *
+ * The module is deliberately LOCAL-only (the issue's narrowed scope): no cloud
+ * corpus upload, no second scrub workflow, no new knowledge store. It owns the
+ * candidate → EntityStore → context pack → encrypted map → scrub → write-back
+ * transformation on the existing local rails. The cloud lane (#14808) remains
+ * a separate sibling scope.
+ */
+
+import type { PiiScrubRequestPayload } from "../types/events.js";
+import { EventType } from "../types/events.js";
+import type { PiiScrubResult, PiiScrubVerdict } from "../types/model.js";
+import type { IAgentRuntime } from "../types/runtime.js";
+import { detectPii } from "./pii-detectors.js";
+import {
+	assembleContextPack,
+	type PiiContextSources,
+	type PiiScrubCandidate,
+} from "./pii-context-pack.js";
+import { CorpusPseudonymMap } from "./pii-pseudonym-map.js";
+import {
+	EncryptedCachePseudonymMapStore,
+	type PseudonymMapStore,
+} from "./pii-pseudonym-map-store.js";
+import { scrubWithEscalation } from "./pii-scrub-seam.js";
+
+/**
+ * One item the pipeline is asked to scrub. The caller (memory ingestion,
+ * document indexing, conversation persistence) owns mining `candidates` and
+ * supplying the `itemRef` that lets write-back target the source row.
+ */
+export interface PiiScrubPipelineItem {
+	/** The exact content to scrub. */
+	readonly content: string;
+	/** Caller-scoped stable reference (e.g. the memory/document id). */
+	readonly itemRef: string;
+	/** Mined candidates for this chunk (may be empty). */
+	readonly candidates: readonly PiiScrubCandidate[];
+	/** Rooms for conversation FTS, when the caller has them. */
+	readonly roomIds?: readonly string[];
+}
+
+/** The transformed output of scrubbing one item. */
+export interface PiiScrubPipelineResult {
+	/** The scrubbed text with all PII replaced / pseudonymized. */
+	readonly scrubbedText: string;
+	/** True when the model seam was invoked (residue existed). */
+	readonly escalated: boolean;
+	/** The verdicts returned by the scrub seam (empty when tier-0 only). */
+	readonly verdicts: readonly PiiScrubVerdict[];
+	/** The model id that served the scrub (or `"tier0"`). */
+	readonly modelId: string;
+	/** Whether the content was already marker-done (idempotent skip). */
+	readonly skipped: boolean;
+	/**
+	 * The scrub-rails request payload, ready to emit as
+	 * `PII_SCRUB_REQUESTED` so the live `PiiScrubService` drains it (marker,
+	 * retry, observability). `null` when the pipeline applied the scrub
+	 * directly (e.g. tier-0-only content that needs no rails drain) — callers
+	 * that want the async rails to own the marker emit this payload instead.
+	 */
+	readonly railsPayload: Omit<PiiScrubRequestPayload, "runtime"> | null;
+}
+
+export interface PiiScrubPipelineOptions {
+	/** Active ruleset version — half of every done-marker key. */
+	readonly rulesetVersion: string;
+	/**
+	 * The protected pseudonym-map store. Defaults to
+	 * {@link EncryptedCachePseudonymMapStore} on the runtime cache. Inject a
+	 * test double for unit tests.
+	 */
+	readonly mapStore?: PseudonymMapStore;
+	/**
+	 * The context-retrieval sources (entity resolver, document/memory/message
+	 * search). Build with `sourcesFromRuntime` + `entityResolverFromStore` in
+	 * production. When omitted, the pipeline runs tier-0 + pseudonym-map
+	 * substitution only (no retrieval context) — the safe minimum.
+	 */
+	readonly sources?: PiiContextSources;
+	/**
+	 * When `true` (default), apply verdicts + pseudonym substitution and return
+	 * the transformed text. When `false`, only build the rails payload (the
+	 * service applies the rewrite at drain time).
+	 */
+	readonly applyWriteBack?: boolean;
+	/**
+	 * Drain priority for the rails payload. Defaults to `low` (background
+	 * autonomous work).
+	 */
+	readonly priority?: PiiScrubRequestPayload["priority"];
+	/** Inference priority forwarded to the seam. Defaults to `background`. */
+	readonly inferencePriority?: PiiScrubRequestPayload["inferencePriority"];
+}
+
+/**
+ * Apply model verdicts to text: replace every `pii` span with its replacement.
+ * This is the lightweight write-back that needs no corpus map — the verdicts
+ * carry their own replacements. Pair with {@link redactTier0Spans} for full
+ * scrub coverage (tier-0 structured PII + model-judged residue).
+ */
+export function applyVerdictsToText(
+	text: string,
+	verdicts: readonly PiiScrubVerdict[],
+): string {
+	let result = text;
+	for (const verdict of verdicts) {
+		if (verdict.kind === "pii" && verdict.replacement) {
+			result = result.split(verdict.span).join(verdict.replacement);
+		}
+	}
+	return result;
+}
+
+/**
+ * The tier-0 deterministic redaction placeholder for structured PII (credit
+ * cards, SSNs, API keys, …) that the detectors fully cover without a model.
+ */
+export const TIER0_REDACTION_PLACEHOLDER = "[REDACTED]";
+
+/**
+ * Redact tier-0 deterministic spans in text. Each matched span is replaced
+ * with {@link TIER0_REDACTION_PLACEHOLDER}. Runs before model-verdict
+ * application so a structured value a detector caught is never left in place.
+ */
+export function redactTier0Spans(
+	text: string,
+	tier0Spans: readonly { readonly span: string }[],
+): string {
+	let result = text;
+	for (const match of tier0Spans) {
+		if (match.span) {
+			result = result.split(match.span).join(TIER0_REDACTION_PLACEHOLDER);
+		}
+	}
+	return result;
+}
+
+/**
+ * Full write-back transform: tier-0 redaction + model verdict application.
+ * Produces the artifact that replaces the original — guaranteed to contain
+ * zero surviving PII when the detectors + verdicts cover all sensitive spans.
+ */
+export function applyScrubWriteBack(
+	text: string,
+	tier0Spans: readonly { readonly span: string }[],
+	verdicts: readonly PiiScrubVerdict[],
+): string {
+	return applyVerdictsToText(redactTier0Spans(text, tier0Spans), verdicts);
+}
+
+/**
+ * Apply a scrub result's verdicts to the source text: replace every `pii`
+ * span with its replacement. `safe` verdicts are left untouched. This is the
+ * write-back transform — it produces the artifact that replaces the original.
+ *
+ * Tier-0 deterministic replacements are applied first via the pseudonym map's
+ * `substituteAliases` (so structured PII already caught by detectors and
+ * mapped aliases are swapped in one pass), then model verdicts for the residue
+ * are layered on top. The result is guaranteed to contain zero original
+ * candidate aliases when the map + verdicts cover them all (the consistency
+ * suite's hard gate).
+ */
+export function applyScrubVerdicts(
+	text: string,
+	verdicts: readonly PiiScrubVerdict[],
+	map: CorpusPseudonymMap,
+): string {
+	// 1. Deterministic tier-0 pseudonym substitution: replace every unambiguous
+	//    mapped alias with its cluster's pseudonym.
+	const substitution = map.substituteAliases(text);
+	let result = substitution.text;
+
+	// 2. Layer model verdicts for the residue: replace each `pii` span.
+	for (const verdict of verdicts) {
+		if (verdict.kind === "pii" && verdict.replacement) {
+			// Escape regex special characters in the span for a safe split-join.
+			result = result.split(verdict.span).join(verdict.replacement);
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Run the production PII scrub pipeline on one item. This is the single entry
+ * point that wires the context pack + encrypted pseudonym map + scrub seam +
+ * write-back into a live flow.
+ *
+ * The flow:
+ *   load map → assemble context pack → scrubWithEscalation → apply verdicts →
+ *   persist map → return transformed text + rails payload.
+ *
+ * Fail-closed throughout: a map-store error (wrong salt, tamper, malformed),
+ * a seam throw (no handler for residue, fabricated result), or a model error
+ * propagates — the caller does NOT mark the item done, and the content stays
+ * quarantined.
+ */
+export async function runPiiScrubPipeline(
+	runtime: IAgentRuntime,
+	item: PiiScrubPipelineItem,
+	options: PiiScrubPipelineOptions,
+): Promise<PiiScrubPipelineResult> {
+	const {
+		rulesetVersion,
+		sources,
+		applyWriteBack = true,
+		priority,
+		inferencePriority,
+	} = options;
+
+	// 1. Load the encrypted pseudonym map (fail-closed). When no map exists
+	//    yet, start from an empty one — the context pack populates it as
+	//    entities resolve.
+	const mapStore =
+		options.mapStore ?? new EncryptedCachePseudonymMapStore(runtime);
+	const snapshot = await mapStore.load();
+	const map = snapshot
+		? CorpusPseudonymMap.fromSnapshot(snapshot)
+		: new CorpusPseudonymMap();
+
+	// 2. Assemble the context pack: resolve candidates, gather fragments,
+	//    cluster confident resolutions into the map, emit the assignment slice.
+	const pack = await assembleContextPack(sources ?? {}, {
+		chunk: item.content,
+		candidates: item.candidates,
+		map,
+		rulesetVersion,
+	});
+
+	// 3. Run the scrub seam: tier-0 deterministic detectors first, then
+	//    escalate the residue to the PII_SCRUB model. Fail-closed: a missing
+	//    handler for residue, a fabricated result, or a model error throws.
+	const escalation = await scrubWithEscalation(runtime, {
+		text: item.content,
+		candidateSpans: pack.candidateSpans,
+		rulesetVersion,
+		contextPack: pack.contextPack,
+		pseudonymAssignments: pack.assignments,
+		priority: inferencePriority ?? "background",
+	});
+
+	// 4. The map was mutated by the context pack (new clusters assigned). Persist
+	//    it back to the encrypted store so the next item / next run sees the same
+	//    pseudonyms. Fail-closed: a save failure propagates.
+	if (map.size > 0) {
+		await mapStore.save(map.toSnapshot());
+	}
+
+	const verdicts = escalation.escalation?.verdicts ?? [];
+	const modelId = escalation.escalation?.modelId ?? "tier0";
+	const scrubbedText = applyWriteBack
+		? applyScrubVerdicts(item.content, verdicts, map)
+		: item.content;
+
+	// 5. Build the rails payload so a caller can emit PII_SCRUB_REQUESTED and
+	//    let the live PiiScrubService own the marker / retry / observability.
+	//    The pipeline applied the scrub directly; the payload carries the pack
+	//    data for the service's drain-time idempotency check.
+	const railsPayload: Omit<PiiScrubRequestPayload, "runtime"> | null =
+		applyWriteBack
+			? {
+					content: item.content,
+					rulesetVersion,
+					candidateSpans: pack.candidateSpans,
+					contextPack: pack.contextPack,
+					pseudonymAssignments: pack.assignments,
+					priority,
+					inferencePriority,
+					itemRef: item.itemRef,
+					source: "pii-scrub-pipeline",
+				}
+			: null;
+
+	return {
+		scrubbedText,
+		escalated: escalation.escalated,
+		verdicts,
+		modelId,
+		skipped: false,
+		railsPayload,
+	};
+}
+
+/**
+ * Enqueue an item onto the live scrub rails by emitting
+ * `PII_SCRUB_REQUESTED`. The `PiiScrubService` drains this on its priority
+ * BatchQueue: tier-0 → escalation → marker, with retry and crash-resume.
+ *
+ * This is the production trigger that makes the scrub reachable from a live
+ * run. Call it from memory ingestion, document indexing, or conversation
+ * persistence after mining candidates. The service owns the WHEN; this owns
+ * the WHAT (content + candidates + context pack).
+ */
+export async function enqueuePiiScrub(
+	runtime: IAgentRuntime,
+	item: PiiScrubPipelineItem,
+	options: PiiScrubPipelineOptions,
+): Promise<void> {
+	const {
+		rulesetVersion,
+		sources,
+		priority,
+		inferencePriority,
+	} = options;
+
+	// Load the map so the context pack can cluster resolved entities and emit
+	// consistent assignment slices. The service's drain re-runs the seam, but
+	// the pack is assembled HERE (the caller has the candidates + retrieval
+	// sources; the drain-time service only has the payload).
+	const mapStore =
+		options.mapStore ?? new EncryptedCachePseudonymMapStore(runtime);
+	const snapshot = await mapStore.load();
+	const map = snapshot
+		? CorpusPseudonymMap.fromSnapshot(snapshot)
+		: new CorpusPseudonymMap();
+
+	const pack = await assembleContextPack(sources ?? {}, {
+		chunk: item.content,
+		candidates: item.candidates,
+		map,
+		rulesetVersion,
+	});
+
+	// Persist the map if the context pack added clusters.
+	if (map.size > 0) {
+		await mapStore.save(map.toSnapshot());
+	}
+
+	const payload: PiiScrubRequestPayload = {
+		runtime,
+		content: item.content,
+		rulesetVersion,
+		candidateSpans: pack.candidateSpans,
+		contextPack: pack.contextPack,
+		pseudonymAssignments: pack.assignments,
+		priority,
+		inferencePriority,
+		itemRef: item.itemRef,
+		source: "pii-scrub-pipeline",
+	};
+
+	await runtime.emitEvent(EventType.PII_SCRUB_REQUESTED, payload);
+}
+
+/**
+ * Mine candidate spans from text using the deterministic tier-0 detectors.
+ * This is the production candidate-mining step for structured PII: emails,
+ * phone numbers, credit cards, SSNs, etc. The context pack + model seam handle
+ * the unstructured residue (names, orgs in ambiguous context).
+ *
+ * Returns the surface forms of detected PII, ready to feed as
+ * `PiiScrubCandidate[]` into the pipeline.
+ */
+export function mineTier0Candidates(text: string): PiiScrubCandidate[] {
+	const matches = detectPii(text);
+	return matches.map((match) => ({
+		surfaceForm: match.value,
+		kind: match.kind,
+		span: { start: match.start, end: match.end },
+	}));
+}

--- a/packages/core/src/security/pii-scrub-pipeline.ts
+++ b/packages/core/src/security/pii-scrub-pipeline.ts
@@ -138,7 +138,9 @@ export function applyVerdictsToText(
 	verdicts: readonly PiiScrubVerdict[],
 ): string {
 	let result = text;
-	for (const verdict of verdicts) {
+	for (const verdict of [...verdicts].sort(
+		(a, b) => b.span.length - a.span.length,
+	)) {
 		if (verdict.kind === "pii" && verdict.replacement) {
 			result = result.split(verdict.span).join(verdict.replacement);
 		}
@@ -154,8 +156,7 @@ export const TIER0_REDACTION_PLACEHOLDER = "[REDACTED]";
 
 /**
  * Redact tier-0 deterministic spans in text. Each matched span is replaced
- * with {@link TIER0_REDACTION_PLACEHOLDER}. Runs before model-verdict
- * application so a structured value a detector caught is never left in place.
+ * with {@link TIER0_REDACTION_PLACEHOLDER}.
  */
 export function redactTier0Spans(
 	text: string,
@@ -171,7 +172,10 @@ export function redactTier0Spans(
 }
 
 /**
- * Full write-back transform: tier-0 redaction + model verdict application.
+ * Full write-back transform: longest model verdicts first, then tier-0
+ * redaction, followed by a fresh deterministic scan of the rewritten output.
+ * Whole-chunk verdicts can therefore rewrite unstructured PII without allowing
+ * a normalized structured value to evade the original detector spans.
  * Produces the artifact that replaces the original — guaranteed to contain
  * zero surviving PII when the detectors + verdicts cover all sensitive spans.
  */
@@ -180,7 +184,14 @@ export function applyScrubWriteBack(
 	tier0Spans: readonly { readonly span: string }[],
 	verdicts: readonly PiiScrubVerdict[],
 ): string {
-	return applyVerdictsToText(redactTier0Spans(text, tier0Spans), verdicts);
+	const rewritten = redactTier0Spans(
+		applyVerdictsToText(text, verdicts),
+		tier0Spans,
+	);
+	const rewrittenTier0 = detectPii(rewritten).map((match) => ({
+		span: match.value,
+	}));
+	return redactTier0Spans(rewritten, rewrittenTier0);
 }
 
 /**
@@ -206,7 +217,9 @@ export function applyScrubVerdicts(
 	let result = substitution.text;
 
 	// 2. Layer model verdicts for the residue: replace each `pii` span.
-	for (const verdict of verdicts) {
+	for (const verdict of [...verdicts].sort(
+		(a, b) => b.span.length - a.span.length,
+	)) {
 		if (verdict.kind === "pii" && verdict.replacement) {
 			// Escape regex special characters in the span for a safe split-join.
 			result = result.split(verdict.span).join(verdict.replacement);
@@ -245,7 +258,7 @@ export async function runPiiScrubPipeline(
 
 	// Marker checks happen before context retrieval or inference. Repeated direct
 	// calls and repeated enqueue attempts therefore perform zero paid work.
-	if (await isScrubDone(runtime, item.content, rulesetVersion)) {
+	if (await isScrubDone(runtime, item.content, rulesetVersion, item.itemRef)) {
 		return {
 			scrubbedText: item.content,
 			escalated: false,
@@ -318,11 +331,16 @@ export async function runPiiScrubPipeline(
 	// The source artifact is committed before the marker. A failed write never
 	// becomes an idempotency hit and can safely retry.
 	await item.writeBack(scrubbedText);
-	await markScrubDone(runtime, item.content, {
-		rulesetVersion,
-		modelId,
-		tier0Only: !escalation.escalated,
-	});
+	await markScrubDone(
+		runtime,
+		item.content,
+		{
+			rulesetVersion,
+			modelId,
+			tier0Only: !escalation.escalated,
+		},
+		item.itemRef,
+	);
 
 	return {
 		scrubbedText,

--- a/packages/core/src/security/pii-scrub-pipeline.ts
+++ b/packages/core/src/security/pii-scrub-pipeline.ts
@@ -37,19 +37,20 @@
 
 import type { PiiScrubRequestPayload } from "../types/events.js";
 import { EventType } from "../types/events.js";
-import type { PiiScrubResult, PiiScrubVerdict } from "../types/model.js";
+import type { PiiScrubVerdict } from "../types/model.js";
 import type { IAgentRuntime } from "../types/runtime.js";
-import { detectPii } from "./pii-detectors.js";
 import {
 	assembleContextPack,
 	type PiiContextSources,
 	type PiiScrubCandidate,
 } from "./pii-context-pack.js";
+import { detectPii } from "./pii-detectors.js";
 import { CorpusPseudonymMap } from "./pii-pseudonym-map.js";
 import {
 	EncryptedCachePseudonymMapStore,
 	type PseudonymMapStore,
 } from "./pii-pseudonym-map-store.js";
+import { isScrubDone, markScrubDone } from "./pii-scrub-markers.js";
 import { scrubWithEscalation } from "./pii-scrub-seam.js";
 
 /**
@@ -64,6 +65,12 @@ export interface PiiScrubPipelineItem {
 	readonly itemRef: string;
 	/** Mined candidates for this chunk (may be empty). */
 	readonly candidates: readonly PiiScrubCandidate[];
+	/**
+	 * Persist the transformed text to the source artifact. The promise must not
+	 * resolve until the write is durable; throwing keeps the item unmarked so it
+	 * can be retried.
+	 */
+	readonly writeBack: (scrubbedText: string) => Promise<void>;
 	/** Rooms for conversation FTS, when the caller has them. */
 	readonly roomIds?: readonly string[];
 }
@@ -82,10 +89,9 @@ export interface PiiScrubPipelineResult {
 	readonly skipped: boolean;
 	/**
 	 * The scrub-rails request payload, ready to emit as
-	 * `PII_SCRUB_REQUESTED` so the live `PiiScrubService` drains it (marker,
-	 * retry, observability). `null` when the pipeline applied the scrub
-	 * directly (e.g. tier-0-only content that needs no rails drain) — callers
-	 * that want the async rails to own the marker emit this payload instead.
+	 * `PII_SCRUB_REQUESTED` so the live `PiiScrubService` owns inference,
+	 * write-back, marker, retry, and observability. `null` for direct write-back
+	 * and idempotent skips.
 	 */
 	readonly railsPayload: Omit<PiiScrubRequestPayload, "runtime"> | null;
 }
@@ -107,9 +113,9 @@ export interface PiiScrubPipelineOptions {
 	 */
 	readonly sources?: PiiContextSources;
 	/**
-	 * When `true` (default), apply verdicts + pseudonym substitution and return
-	 * the transformed text. When `false`, only build the rails payload (the
-	 * service applies the rewrite at drain time).
+	 * When `true` (default), run inference, durably write the transformed text,
+	 * and mark the source complete. When `false`, perform no inference and only
+	 * build the rails payload; the service owns the entire paid/durable path.
 	 */
 	readonly applyWriteBack?: boolean;
 	/**
@@ -237,9 +243,19 @@ export async function runPiiScrubPipeline(
 		inferencePriority,
 	} = options;
 
-	// 1. Load the encrypted pseudonym map (fail-closed). When no map exists
-	//    yet, start from an empty one — the context pack populates it as
-	//    entities resolve.
+	// Marker checks happen before context retrieval or inference. Repeated direct
+	// calls and repeated enqueue attempts therefore perform zero paid work.
+	if (await isScrubDone(runtime, item.content, rulesetVersion)) {
+		return {
+			scrubbedText: item.content,
+			escalated: false,
+			verdicts: [],
+			modelId: "skipped",
+			skipped: true,
+			railsPayload: null,
+		};
+	}
+
 	const mapStore =
 		options.mapStore ?? new EncryptedCachePseudonymMapStore(runtime);
 	const snapshot = await mapStore.load();
@@ -247,8 +263,6 @@ export async function runPiiScrubPipeline(
 		? CorpusPseudonymMap.fromSnapshot(snapshot)
 		: new CorpusPseudonymMap();
 
-	// 2. Assemble the context pack: resolve candidates, gather fragments,
-	//    cluster confident resolutions into the map, emit the assignment slice.
 	const pack = await assembleContextPack(sources ?? {}, {
 		chunk: item.content,
 		candidates: item.candidates,
@@ -256,9 +270,34 @@ export async function runPiiScrubPipeline(
 		rulesetVersion,
 	});
 
-	// 3. Run the scrub seam: tier-0 deterministic detectors first, then
-	//    escalate the residue to the PII_SCRUB model. Fail-closed: a missing
-	//    handler for residue, a fabricated result, or a model error throws.
+	if (map.size > 0) {
+		await mapStore.save(map.toSnapshot());
+	}
+
+	// Async mode is payload-only. Inference happens exactly once when the
+	// service drains this payload.
+	if (!applyWriteBack) {
+		return {
+			scrubbedText: item.content,
+			escalated: false,
+			verdicts: [],
+			modelId: "pending",
+			skipped: false,
+			railsPayload: {
+				content: item.content,
+				rulesetVersion,
+				candidateSpans: pack.candidateSpans,
+				contextPack: pack.contextPack,
+				pseudonymAssignments: pack.assignments,
+				priority,
+				inferencePriority,
+				itemRef: item.itemRef,
+				writeBack: item.writeBack,
+				source: "pii-scrub-pipeline",
+			},
+		};
+	}
+
 	const escalation = await scrubWithEscalation(runtime, {
 		text: item.content,
 		candidateSpans: pack.candidateSpans,
@@ -267,38 +306,23 @@ export async function runPiiScrubPipeline(
 		pseudonymAssignments: pack.assignments,
 		priority: inferencePriority ?? "background",
 	});
-
-	// 4. The map was mutated by the context pack (new clusters assigned). Persist
-	//    it back to the encrypted store so the next item / next run sees the same
-	//    pseudonyms. Fail-closed: a save failure propagates.
-	if (map.size > 0) {
-		await mapStore.save(map.toSnapshot());
-	}
-
 	const verdicts = escalation.escalation?.verdicts ?? [];
 	const modelId = escalation.escalation?.modelId ?? "tier0";
-	const scrubbedText = applyWriteBack
-		? applyScrubVerdicts(item.content, verdicts, map)
-		: item.content;
+	const redacted = applyScrubWriteBack(
+		item.content,
+		escalation.tier0,
+		verdicts,
+	);
+	const scrubbedText = map.substituteAliases(redacted).text;
 
-	// 5. Build the rails payload so a caller can emit PII_SCRUB_REQUESTED and
-	//    let the live PiiScrubService own the marker / retry / observability.
-	//    The pipeline applied the scrub directly; the payload carries the pack
-	//    data for the service's drain-time idempotency check.
-	const railsPayload: Omit<PiiScrubRequestPayload, "runtime"> | null =
-		applyWriteBack
-			? {
-					content: item.content,
-					rulesetVersion,
-					candidateSpans: pack.candidateSpans,
-					contextPack: pack.contextPack,
-					pseudonymAssignments: pack.assignments,
-					priority,
-					inferencePriority,
-					itemRef: item.itemRef,
-					source: "pii-scrub-pipeline",
-				}
-			: null;
+	// The source artifact is committed before the marker. A failed write never
+	// becomes an idempotency hit and can safely retry.
+	await item.writeBack(scrubbedText);
+	await markScrubDone(runtime, item.content, {
+		rulesetVersion,
+		modelId,
+		tier0Only: !escalation.escalated,
+	});
 
 	return {
 		scrubbedText,
@@ -306,7 +330,7 @@ export async function runPiiScrubPipeline(
 		verdicts,
 		modelId,
 		skipped: false,
-		railsPayload,
+		railsPayload: null,
 	};
 }
 
@@ -325,50 +349,18 @@ export async function enqueuePiiScrub(
 	item: PiiScrubPipelineItem,
 	options: PiiScrubPipelineOptions,
 ): Promise<void> {
-	const {
-		rulesetVersion,
-		sources,
-		priority,
-		inferencePriority,
-	} = options;
-
-	// Load the map so the context pack can cluster resolved entities and emit
-	// consistent assignment slices. The service's drain re-runs the seam, but
-	// the pack is assembled HERE (the caller has the candidates + retrieval
-	// sources; the drain-time service only has the payload).
-	const mapStore =
-		options.mapStore ?? new EncryptedCachePseudonymMapStore(runtime);
-	const snapshot = await mapStore.load();
-	const map = snapshot
-		? CorpusPseudonymMap.fromSnapshot(snapshot)
-		: new CorpusPseudonymMap();
-
-	const pack = await assembleContextPack(sources ?? {}, {
-		chunk: item.content,
-		candidates: item.candidates,
-		map,
-		rulesetVersion,
+	const result = await runPiiScrubPipeline(runtime, item, {
+		...options,
+		applyWriteBack: false,
 	});
-
-	// Persist the map if the context pack added clusters.
-	if (map.size > 0) {
-		await mapStore.save(map.toSnapshot());
+	if (result.skipped || !result.railsPayload) {
+		return;
 	}
 
-	const payload: PiiScrubRequestPayload = {
+	await runtime.emitEvent(EventType.PII_SCRUB_REQUESTED, {
 		runtime,
-		content: item.content,
-		rulesetVersion,
-		candidateSpans: pack.candidateSpans,
-		contextPack: pack.contextPack,
-		pseudonymAssignments: pack.assignments,
-		priority,
-		inferencePriority,
-		itemRef: item.itemRef,
-		source: "pii-scrub-pipeline",
-	};
-
-	await runtime.emitEvent(EventType.PII_SCRUB_REQUESTED, payload);
+		...result.railsPayload,
+	});
 }
 
 /**

--- a/packages/core/src/services/pii-scrub.test.ts
+++ b/packages/core/src/services/pii-scrub.test.ts
@@ -15,8 +15,11 @@
 
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { hashScrubContent } from "../security/pii-scrub-markers.js";
+import type { Memory } from "../types/memory.js";
 import type { PiiScrubResult } from "../types/model.js";
 import { ModelType } from "../types/model.js";
+import type { PipelineHookSpec } from "../types/pipeline-hooks.js";
+import type { UUID } from "../types/primitives.js";
 import type { IAgentRuntime } from "../types/runtime.js";
 import { PiiScrubService } from "./pii-scrub.js";
 
@@ -70,6 +73,8 @@ function makeRuntime(opts: RuntimeMockOpts = {}): MockRuntime {
 			events.push({ type, payload });
 		},
 		registerEvent: vi.fn(),
+		registerPipelineHook: vi.fn(),
+		unregisterPipelineHook: vi.fn(),
 		registerTaskWorker: vi.fn(),
 		getTasksByName: async () => [],
 		getTask: async () => null,
@@ -141,6 +146,51 @@ describe("PiiScrubService drain config", () => {
 			expect.any(Function),
 		);
 	});
+
+	test("scrubs persisted memories through the production hook and durable write-back", async () => {
+		const runtime = makeRuntime();
+		const service = (await PiiScrubService.start(runtime)) as PiiScrubService;
+		const memoryId = "00000000-0000-0000-0000-000000000010" as UUID;
+		let stored: Memory = {
+			id: memoryId,
+			entityId: "00000000-0000-0000-0000-000000000011" as UUID,
+			roomId: "00000000-0000-0000-0000-000000000012" as UUID,
+			content: { text: "pay 4111 1111 1111 1111" },
+		};
+		runtime.getMemoryById = vi.fn(async () => stored);
+		runtime.updateMemory = vi.fn(
+			async (update: Parameters<IAgentRuntime["updateMemory"]>[0]) => {
+				stored = { ...stored, ...update };
+				return true;
+			},
+		);
+		const registered = runtime.registerPipelineHook as unknown as {
+			mock: { calls: Array<[PipelineHookSpec]> };
+		};
+		const hook = registered.mock.calls
+			.map(([spec]) => spec)
+			.find((spec) => spec.id === "core:pii-scrub:after-memory-persisted");
+		expect(hook).toBeDefined();
+
+		await hook?.handler(runtime, {
+			phase: "after_memory_persisted",
+			memory: stored,
+			tableName: "memories",
+			memoryId,
+		});
+		const requested = runtime.__events.find(
+			(event) => event.type === "PII_SCRUB_REQUESTED",
+		);
+		expect(requested).toBeDefined();
+		await enqueue(service, requested?.payload ?? {});
+		await drain(service);
+
+		expect(stored.content.text).toBe("pay [REDACTED]");
+		expect(
+			await service.getMarker("pay 4111 1111 1111 1111", "2026.08"),
+		).toBeDefined();
+		await service.stop();
+	});
 });
 
 describe("PiiScrubService enqueue -> drain -> scrub applied", () => {
@@ -166,6 +216,35 @@ describe("PiiScrubService enqueue -> drain -> scrub applied", () => {
 		);
 		expect(completed).toHaveLength(1);
 		expect(completed[0].payload.tier0Only).toBe(true);
+		await service.stop();
+	});
+
+	test("durably writes tier-0 output before marking and emits the transformed text", async () => {
+		const runtime = makeRuntime();
+		const service = (await PiiScrubService.start(runtime)) as PiiScrubService;
+		const content = "my card is 4111 1111 1111 1111";
+		const order: string[] = [];
+		const setCache = runtime.setCache.bind(runtime);
+		runtime.setCache = async (key, value) => {
+			order.push("marker");
+			return setCache(key, value);
+		};
+
+		await enqueue(service, {
+			content,
+			rulesetVersion: RULESET,
+			writeBack: async (scrubbedText: string) => {
+				order.push("writeBack");
+				expect(scrubbedText).toBe("my card is [REDACTED]");
+			},
+		});
+		await drain(service);
+
+		expect(order).toEqual(["writeBack", "marker"]);
+		const completed = runtime.__events.find(
+			(event) => event.type === "PII_SCRUB_COMPLETED",
+		);
+		expect(completed?.payload.scrubbedText).toBe("my card is [REDACTED]");
 		await service.stop();
 	});
 

--- a/packages/core/src/services/pii-scrub.test.ts
+++ b/packages/core/src/services/pii-scrub.test.ts
@@ -48,17 +48,25 @@ function makeRuntime(opts: RuntimeMockOpts = {}): MockRuntime {
 	const runtime = {
 		agentId: AGENT_ID,
 		logger: { info: noop, warn: noop, debug: noop, error: noop },
-		getModel: (type: string) =>
-			type === ModelType.PII_SCRUB && opts.scrubHandler
-				? opts.scrubHandler
-				: undefined,
-		useModel: async (type: string, params: unknown) => {
-			if (type !== ModelType.PII_SCRUB || !opts.scrubHandler) {
-				throw new Error(`No handler for ${type}`);
+		getModel: (type: string) => {
+			if (type === ModelType.PII_SCRUB) {
+				if (opts.scrubHandler) {
+					return async (_runtime: IAgentRuntime, params: unknown) =>
+						opts.scrubHandler?.(params);
+				}
 			}
-			useModelCalls++;
-			return opts.scrubHandler(params);
+			return undefined;
 		},
+		useModel: async (type: string, params: unknown) => {
+			if (type === ModelType.PII_SCRUB) {
+				useModelCalls++;
+				if (opts.scrubHandler) return opts.scrubHandler(params);
+			}
+			throw new Error(`No handler for ${type}`);
+		},
+		getService: () => null,
+		getEntityById: async () => null,
+		adapter: { searchMessages: vi.fn(async () => []) },
 		getCache: async <T>(key: string): Promise<T | undefined> =>
 			cache.has(key) ? (cache.get(key) as T) : undefined,
 		setCache: async <T>(key: string, value: T): Promise<boolean> => {
@@ -113,7 +121,11 @@ async function enqueue(
 	payload: Record<string, unknown>,
 ): Promise<void> {
 	// biome-ignore lint/suspicious/noExplicitAny: exercise the event handler directly
-	await (service as any).handleScrubRequest(payload);
+	await (service as any).handleScrubRequest({
+		itemRef: "test:item",
+		writeBack: async () => {},
+		...payload,
+	});
 }
 
 describe("PiiScrubService drain config", () => {
@@ -148,14 +160,17 @@ describe("PiiScrubService drain config", () => {
 	});
 
 	test("scrubs persisted memories through the production hook and durable write-back", async () => {
-		const runtime = makeRuntime();
+		const originalText = "pay 4111 1111 1111 1111";
+		const runtime = makeRuntime({
+			scrubHandler: async () => cleanResult(originalText, "2026.08"),
+		});
 		const service = (await PiiScrubService.start(runtime)) as PiiScrubService;
 		const memoryId = "00000000-0000-0000-0000-000000000010" as UUID;
 		let stored: Memory = {
 			id: memoryId,
 			entityId: "00000000-0000-0000-0000-000000000011" as UUID,
 			roomId: "00000000-0000-0000-0000-000000000012" as UUID,
-			content: { text: "pay 4111 1111 1111 1111" },
+			content: { text: originalText },
 		};
 		runtime.getMemoryById = vi.fn(async () => stored);
 		runtime.updateMemory = vi.fn(
@@ -187,7 +202,69 @@ describe("PiiScrubService drain config", () => {
 
 		expect(stored.content.text).toBe("pay [REDACTED]");
 		expect(
-			await service.getMarker("pay 4111 1111 1111 1111", "2026.08"),
+			await service.getMarker(originalText, "2026.08", memoryId),
+		).toBeDefined();
+		await service.stop();
+	});
+
+	test("routes lowercase free text through live context and the dedicated PII model", async () => {
+		const runtime = makeRuntime({
+			scrubHandler: async () => ({
+				modelId: "test-local-privacy-gguf",
+				rulesetVersion: "2026.08",
+				verdicts: [
+					{
+						span: "met jordan yesterday",
+						kind: "pii",
+						replacement: "met Person 1 yesterday",
+					},
+				],
+			}),
+		});
+		const service = (await PiiScrubService.start(runtime)) as PiiScrubService;
+		const memoryId = "00000000-0000-0000-0000-000000000020" as UUID;
+		let stored: Memory = {
+			id: memoryId,
+			entityId: "00000000-0000-0000-0000-000000000021" as UUID,
+			roomId: "00000000-0000-0000-0000-000000000022" as UUID,
+			content: { text: "met jordan yesterday" },
+		};
+		runtime.getMemoryById = vi.fn(async () => stored);
+		runtime.updateMemory = vi.fn(
+			async (update: Parameters<IAgentRuntime["updateMemory"]>[0]) => {
+				stored = { ...stored, ...update };
+				return true;
+			},
+		);
+		const registered = runtime.registerPipelineHook as unknown as {
+			mock: { calls: Array<[PipelineHookSpec]> };
+		};
+		const hook = registered.mock.calls
+			.map(([spec]) => spec)
+			.find((spec) => spec.id === "core:pii-scrub:after-memory-persisted");
+
+		await hook?.handler(runtime, {
+			phase: "after_memory_persisted",
+			memory: stored,
+			tableName: "memories",
+			memoryId,
+		});
+		const requested = runtime.__events.find(
+			(event) => event.type === "PII_SCRUB_REQUESTED",
+		);
+		expect(requested?.payload.candidateSpans).toEqual(["met jordan yesterday"]);
+		expect(requested?.payload.contextPack).toEqual(expect.any(String));
+
+		await enqueue(service, requested?.payload ?? {});
+		await drain(service);
+
+		expect(runtime.__useModelCalls).toBe(1);
+		expect(stored.content.text).toBe("met Person 1 yesterday");
+		expect(
+			await service.getMarker(stored.content.text, "2026.08", memoryId),
+		).toBeUndefined();
+		expect(
+			await service.getMarker("met jordan yesterday", "2026.08", memoryId),
 		).toBeDefined();
 		await service.stop();
 	});
@@ -205,7 +282,7 @@ describe("PiiScrubService enqueue -> drain -> scrub applied", () => {
 		await drain(service);
 
 		expect(runtime.__useModelCalls).toBe(0);
-		const marker = await service.getMarker(content, RULESET);
+		const marker = await service.getMarker(content, RULESET, "test:item");
 		expect(marker).toBeDefined();
 		expect(marker?.tier0Only).toBe(true);
 		expect(marker?.modelId).toBe("tier0");
@@ -264,7 +341,7 @@ describe("PiiScrubService enqueue -> drain -> scrub applied", () => {
 		await drain(service);
 
 		expect(runtime.__useModelCalls).toBe(1);
-		const marker = await service.getMarker(content, RULESET);
+		const marker = await service.getMarker(content, RULESET, "test:item");
 		expect(marker?.tier0Only).toBe(false);
 		expect(marker?.modelId).toBe("test-local-gguf");
 		expect(
@@ -275,6 +352,53 @@ describe("PiiScrubService enqueue -> drain -> scrub applied", () => {
 });
 
 describe("PiiScrubService content-hash idempotency", () => {
+	test("requires a source reference and durable write-back before enqueue", async () => {
+		const runtime = makeRuntime();
+		const service = (await PiiScrubService.start(runtime)) as PiiScrubService;
+		await expect(
+			enqueue(service, {
+				content: "my card is 4111 1111 1111 1111",
+				rulesetVersion: RULESET,
+				writeBack: undefined,
+			}),
+		).rejects.toMatchObject({ code: "PII_SCRUB_WRITE_BACK_REQUIRED" });
+		await service.stop();
+	});
+
+	test("scrubs identical content independently for distinct source artifacts", async () => {
+		const runtime = makeRuntime({
+			scrubHandler: async () => cleanResult("Alex Doe"),
+		});
+		const service = (await PiiScrubService.start(runtime)) as PiiScrubService;
+		const content = "met Alex Doe";
+		const firstWriteBack = vi.fn(async () => {});
+		const secondWriteBack = vi.fn(async () => {});
+
+		await enqueue(service, {
+			content,
+			rulesetVersion: RULESET,
+			candidateSpans: ["Alex Doe"],
+			itemRef: "memory:a",
+			writeBack: firstWriteBack,
+		});
+		await drain(service);
+		await enqueue(service, {
+			content,
+			rulesetVersion: RULESET,
+			candidateSpans: ["Alex Doe"],
+			itemRef: "memory:b",
+			writeBack: secondWriteBack,
+		});
+		await drain(service);
+
+		expect(runtime.__useModelCalls).toBe(2);
+		expect(firstWriteBack).toHaveBeenCalledOnce();
+		expect(secondWriteBack).toHaveBeenCalledOnce();
+		expect(await service.getMarker(content, RULESET, "memory:a")).toBeDefined();
+		expect(await service.getMarker(content, RULESET, "memory:b")).toBeDefined();
+		await service.stop();
+	});
+
 	test("re-enqueue of UNCHANGED content skips before the queue (no drain work)", async () => {
 		const runtime = makeRuntime({
 			scrubHandler: async () => cleanResult("Alex Doe"),
@@ -329,6 +453,8 @@ describe("PiiScrubService content-hash idempotency", () => {
 			candidateSpans: ["Sam Vale"],
 			priority: "low",
 			inferencePriority: "background",
+			itemRef: "test:item",
+			writeBack: async () => {},
 		});
 		expect(service.getQueueSize()).toBe(1);
 		await drain(service);
@@ -362,8 +488,12 @@ describe("PiiScrubService content-hash idempotency", () => {
 		});
 		await drain(service);
 		expect(runtime.__useModelCalls).toBe(2);
-		expect(await service.getMarker(content, "2026.07")).toBeDefined();
-		expect(await service.getMarker(content, "2026.08")).toBeDefined();
+		expect(
+			await service.getMarker(content, "2026.07", "test:item"),
+		).toBeDefined();
+		expect(
+			await service.getMarker(content, "2026.08", "test:item"),
+		).toBeDefined();
 		await service.stop();
 	});
 });
@@ -389,7 +519,9 @@ describe("PiiScrubService crash/retry safety (fail-closed)", () => {
 
 		// The content is NEVER marked done: it stays quarantined for a later
 		// retry once a model is registered.
-		expect(await service.getMarker(content, RULESET)).toBeUndefined();
+		expect(
+			await service.getMarker(content, RULESET, "test:item"),
+		).toBeUndefined();
 		// Exhaustion surfaced a FAILED event + a reportError.
 		expect(runtime.__events.some((e) => e.type === "PII_SCRUB_FAILED")).toBe(
 			true,
@@ -423,7 +555,7 @@ describe("PiiScrubService crash/retry safety (fail-closed)", () => {
 		});
 
 		await drain(service);
-		const marker = await service.getMarker(content, RULESET);
+		const marker = await service.getMarker(content, RULESET, "test:item");
 		expect(marker).toBeDefined();
 		expect(marker?.tier0Only).toBe(false);
 		expect(attempts).toBeGreaterThanOrEqual(2);

--- a/packages/core/src/services/pii-scrub.ts
+++ b/packages/core/src/services/pii-scrub.ts
@@ -38,16 +38,21 @@
  * the model seam itself (already merged).
  */
 
-import { applyScrubWriteBack } from "../security/pii-scrub-pipeline.js";
+import { ElizaError } from "../errors.js";
 import {
 	getScrubMarker,
 	isScrubDone,
 	markScrubDone,
 } from "../security/pii-scrub-markers.js";
 import {
+	applyScrubWriteBack,
+	enqueuePiiScrub,
+	mineTier0Candidates,
+} from "../security/pii-scrub-pipeline.js";
+import {
 	PiiScrubFabricationError,
-	type Tier0Span,
 	scrubWithEscalation,
+	type Tier0Span,
 } from "../security/pii-scrub-seam.js";
 import type { PiiScrubRequestPayload } from "../types/events.js";
 import { EventType } from "../types/events.js";
@@ -67,9 +72,12 @@ interface PiiScrubQueueItem {
 	inferencePriority: "interactive" | "background";
 	jobId?: string;
 	itemRef?: string;
+	writeBack?: PiiScrubRequestPayload["writeBack"];
 }
 
 const SRC = "plugin:basic-capabilities:service:pii-scrub";
+const MEMORY_HOOK_ID = "core:pii-scrub:after-memory-persisted";
+export const PII_SCRUB_RULESET_VERSION = "2026.08";
 
 /**
  * Service responsible for running the corpus PII scrub asynchronously on the
@@ -109,6 +117,65 @@ export class PiiScrubService extends Service {
 			EventType.PII_SCRUB_REQUESTED,
 			this.handleScrubRequest.bind(this),
 		);
+		this.runtime.registerPipelineHook({
+			id: MEMORY_HOOK_ID,
+			phase: "after_memory_persisted",
+			schedule: "serial",
+			mutatesPrimary: false,
+			handler: async (_runtime, ctx) => {
+				if (ctx.phase !== "after_memory_persisted") return;
+				const originalText = ctx.memory.content.text;
+				if (typeof originalText !== "string" || originalText.length === 0) {
+					return;
+				}
+				const candidates = mineTier0Candidates(originalText);
+				if (candidates.length === 0) return;
+
+				await enqueuePiiScrub(
+					this.runtime,
+					{
+						content: originalText,
+						itemRef: ctx.memoryId,
+						candidates,
+						writeBack: async (scrubbedText) => {
+							const current = await this.runtime.getMemoryById(ctx.memoryId);
+							if (!current) {
+								throw new ElizaError(
+									"PII scrub source memory no longer exists",
+									{
+										code: "PII_SCRUB_SOURCE_MISSING",
+										context: { memoryId: ctx.memoryId },
+									},
+								);
+							}
+							if (current.content.text !== originalText) {
+								throw new ElizaError(
+									"PII scrub source changed before write-back",
+									{
+										code: "PII_SCRUB_SOURCE_CHANGED",
+										context: { memoryId: ctx.memoryId },
+									},
+								);
+							}
+							const updated = await this.runtime.updateMemory({
+								id: ctx.memoryId,
+								content: { ...current.content, text: scrubbedText },
+							});
+							if (!updated) {
+								throw new ElizaError(
+									"PII scrub source write-back was rejected",
+									{
+										code: "PII_SCRUB_WRITE_BACK_REJECTED",
+										context: { memoryId: ctx.memoryId },
+									},
+								);
+							}
+						},
+					},
+					{ rulesetVersion: PII_SCRUB_RULESET_VERSION },
+				);
+			},
+		});
 
 		// Same drain/retry/priority model as the embedding service - the task
 		// system owns WHEN (repeat PII_SCRUB_DRAIN tick), we own WHAT (dequeue,
@@ -193,6 +260,7 @@ export class PiiScrubService extends Service {
 			inferencePriority: payload.inferencePriority ?? "background",
 			jobId: payload.jobId,
 			itemRef: payload.itemRef,
+			writeBack: payload.writeBack,
 		};
 
 		this.batchQueue.enqueue(item);
@@ -273,6 +341,12 @@ export class PiiScrubService extends Service {
 			verdicts,
 		);
 
+		// The source adapter must confirm its durable write before this item can
+		// become an idempotency hit. Rejections throw into the queue retry path.
+		if (item.writeBack) {
+			await item.writeBack(scrubbedText);
+		}
+
 		// Success: write the content-addressed done-marker so a re-scrub of this
 		// exact content under this ruleset no-ops, and a crash-restart resumes
 		// past it with zero duplicate work.
@@ -325,6 +399,7 @@ export class PiiScrubService extends Service {
 		if (this.isDisabled || !this.batchQueue) {
 			return;
 		}
+		this.runtime.unregisterPipelineHook(MEMORY_HOOK_ID);
 		const remaining = this.batchQueue.size;
 		const fastShutdown = process.env.ELIZA_FAST_SHUTDOWN === "1";
 		if (fastShutdown) {

--- a/packages/core/src/services/pii-scrub.ts
+++ b/packages/core/src/services/pii-scrub.ts
@@ -38,6 +38,7 @@
  * the model seam itself (already merged).
  */
 
+import { applyScrubWriteBack } from "../security/pii-scrub-pipeline.js";
 import {
 	getScrubMarker,
 	isScrubDone,
@@ -45,10 +46,12 @@ import {
 } from "../security/pii-scrub-markers.js";
 import {
 	PiiScrubFabricationError,
+	type Tier0Span,
 	scrubWithEscalation,
 } from "../security/pii-scrub-seam.js";
 import type { PiiScrubRequestPayload } from "../types/events.js";
 import { EventType } from "../types/events.js";
+import type { PiiScrubVerdict } from "../types/model.js";
 import type { IAgentRuntime } from "../types/runtime.js";
 import { Service } from "../types/service.js";
 import { BatchQueue } from "../utils/batch-queue.js";
@@ -224,6 +227,8 @@ export class PiiScrubService extends Service {
 
 		let escalated: boolean;
 		let modelId: string;
+		let verdicts: readonly PiiScrubVerdict[] = [];
+		let tier0Spans: readonly Tier0Span[] = [];
 		try {
 			const result = await scrubWithEscalation(this.runtime, {
 				text: item.content,
@@ -235,6 +240,8 @@ export class PiiScrubService extends Service {
 			});
 			escalated = result.escalated;
 			modelId = result.escalation?.modelId ?? "tier0";
+			verdicts = result.escalation?.verdicts ?? [];
+			tier0Spans = result.tier0;
 		} catch (error) {
 			// error-policy:J2 Queue retry policy owns recovery; this layer adds job
 			// diagnostics and rethrows without manufacturing a scrubbed result.
@@ -255,6 +262,17 @@ export class PiiScrubService extends Service {
 			throw error;
 		}
 
+		// Apply the validated verdicts + tier-0 redaction to produce the scrubbed
+		// text — the write-back transform. This closes the gap where the service
+		// discarded verdicts and marked done without committing the rewrite. The
+		// scrubbedText is emitted on PII_SCRUB_COMPLETED so write-back listeners
+		// (memory/document updaters) can commit the transformed artifact.
+		const scrubbedText = applyScrubWriteBack(
+			item.content,
+			tier0Spans,
+			verdicts,
+		);
+
 		// Success: write the content-addressed done-marker so a re-scrub of this
 		// exact content under this ruleset no-ops, and a crash-restart resumes
 		// past it with zero duplicate work.
@@ -267,6 +285,8 @@ export class PiiScrubService extends Service {
 		await this.runtime.emitEvent(EventType.PII_SCRUB_COMPLETED, {
 			runtime: this.runtime,
 			content: item.content,
+			scrubbedText,
+			verdicts,
 			rulesetVersion: item.rulesetVersion,
 			jobId: item.jobId,
 			itemRef: item.itemRef,

--- a/packages/core/src/services/pii-scrub.ts
+++ b/packages/core/src/services/pii-scrub.ts
@@ -10,11 +10,9 @@
  * No new scheduler, no new queue - the rails already exist in-repo.
  *
  * Per item it:
- *   1. Computes the content-addressed done-marker
- *      `pii:<sha256(content)>:v<rulesetVersion>` and SKIPS if already present
- *      (idempotency: a re-scrub of unchanged content is a no-op - zero model
- *      calls, zero duplicate writes). This is what makes crash-and-rerun safe
- *      with zero cursor state.
+ *   1. Computes the source-scoped done-marker
+ *      `pii:<sha256(content)>:v<rulesetVersion>:source:<sha256(itemRef)>` and
+ *      skips only when that source artifact is already complete.
  *   2. Escalates through the merged seam
  *      (`scrubWithEscalation`, #14980/#14809): tier-0 deterministic detectors
  *      run first (free, no model call); only residue candidates hit the
@@ -28,17 +26,27 @@
  *      `PII_SCRUB_FAILED` and are surfaced via `runtime.reportError`
  *      (RECENT_ERRORS provider + owner escalation).
  *
- * When no `PII_SCRUB` model is registered the service still starts (tier-0-only
- * content - fully-covered structured PII - completes without a model), matching
- * the embedding service's "start even when no model" behavior; content with
- * un-inspectable residue then fails-closed at the seam, as intended.
+ * `PII_SCRUB` is supplied by a dedicated privacy provider such as the
+ * local-inference plugin. If no dedicated handler can inspect residue, the item
+ * fails closed and remains unmarked; core never forwards raw PII through a
+ * general-purpose text route.
  *
  * OUT OF SCOPE for this service (sibling issues / later slices): the CLOUD lane
- * (routing/resolve/jobsRepository/Redis+cron), the scrub prompt/semantics, and
- * the model seam itself (already merged).
+ * (routing/resolve/jobsRepository/Redis+cron) and alternate provider-specific
+ * scrub handlers.
  */
 
 import { ElizaError } from "../errors.js";
+import {
+	PII_ENTITY_RECOGNIZER_SERVICE,
+	type PiiEntityRecognizerService,
+} from "../security/entity-recognizer.js";
+import {
+	entityResolverFromStore,
+	type PiiEntityResolverStore,
+	type PiiScrubCandidate,
+	sourcesFromRuntime,
+} from "../security/pii-context-pack.js";
 import {
 	getScrubMarker,
 	isScrubDone,
@@ -71,13 +79,86 @@ interface PiiScrubQueueItem {
 	priority: "high" | "normal" | "low";
 	inferencePriority: "interactive" | "background";
 	jobId?: string;
-	itemRef?: string;
-	writeBack?: PiiScrubRequestPayload["writeBack"];
+	itemRef: string;
+	writeBack: PiiScrubRequestPayload["writeBack"];
 }
 
 const SRC = "plugin:basic-capabilities:service:pii-scrub";
 const MEMORY_HOOK_ID = "core:pii-scrub:after-memory-persisted";
 export const PII_SCRUB_RULESET_VERSION = "2026.08";
+
+interface KnowledgeGraphServiceView extends Service {
+	getEntityStore(): PiiEntityResolverStore;
+}
+
+const PROPER_NAME_PATTERN =
+	/\b[A-Z][\p{L}'-]{1,}(?:\s+[A-Z][\p{L}'-]{1,}){1,3}\b/gu;
+
+function addCandidate(
+	candidates: PiiScrubCandidate[],
+	seen: Set<string>,
+	candidate: PiiScrubCandidate,
+): void {
+	const value = candidate.surfaceForm.trim();
+	if (!value || seen.has(value)) return;
+	seen.add(value);
+	candidates.push({ ...candidate, surfaceForm: value });
+}
+
+async function mineLiveCandidates(
+	runtime: IAgentRuntime,
+	text: string,
+	entityId: string,
+): Promise<PiiScrubCandidate[]> {
+	const candidates: PiiScrubCandidate[] = [];
+	const seen = new Set<string>();
+	for (const candidate of mineTier0Candidates(text)) {
+		addCandidate(candidates, seen, candidate);
+	}
+
+	const recognizerService = runtime.getService<
+		Service & PiiEntityRecognizerService
+	>(PII_ENTITY_RECOGNIZER_SERVICE);
+	const recognizer = recognizerService?.getRecognizer();
+	if (recognizer) {
+		for (const span of await recognizer.recognize(text)) {
+			addCandidate(candidates, seen, {
+				surfaceForm: span.value,
+				kind: span.kind,
+				...(span.start !== undefined && span.end !== undefined
+					? { span: { start: span.start, end: span.end } }
+					: {}),
+			});
+		}
+	}
+
+	const sourceEntity = await runtime.getEntityById(entityId);
+	for (const name of sourceEntity?.names ?? []) {
+		const start = text.indexOf(name);
+		if (start >= 0) {
+			addCandidate(candidates, seen, {
+				surfaceForm: name,
+				kind: "person",
+				span: { start, end: start + name.length },
+			});
+		}
+	}
+
+	for (const match of text.matchAll(PROPER_NAME_PATTERN)) {
+		const start = match.index;
+		addCandidate(candidates, seen, {
+			surfaceForm: match[0],
+			kind: "person",
+			span: { start, end: start + match[0].length },
+		});
+	}
+	addCandidate(candidates, seen, {
+		surfaceForm: text,
+		kind: "free_text",
+		span: { start: 0, end: text.length },
+	});
+	return candidates;
+}
 
 /**
  * Service responsible for running the corpus PII scrub asynchronously on the
@@ -86,7 +167,7 @@ export const PII_SCRUB_RULESET_VERSION = "2026.08";
 export class PiiScrubService extends Service {
 	static serviceType = "pii-scrub";
 	capabilityDescription =
-		"Runs the corpus PII scrub asynchronously on the core task queue (content-hash idempotent, non-blocking)";
+		"Runs the corpus PII scrub asynchronously on the core task queue (source-scoped idempotency, non-blocking)";
 
 	private batchQueue: BatchQueue<PiiScrubQueueItem> | null = null;
 	private isDisabled = false;
@@ -128,8 +209,26 @@ export class PiiScrubService extends Service {
 				if (typeof originalText !== "string" || originalText.length === 0) {
 					return;
 				}
-				const candidates = mineTier0Candidates(originalText);
-				if (candidates.length === 0) return;
+				const candidates = await mineLiveCandidates(
+					this.runtime,
+					originalText,
+					ctx.memory.entityId,
+				);
+				const knowledgeGraph =
+					this.runtime.getService<KnowledgeGraphServiceView>(
+						"eliza_knowledge_graph",
+					);
+				const sources = sourcesFromRuntime(this.runtime, {
+					roomIds: [ctx.memory.roomId],
+					localOnly: true,
+					...(knowledgeGraph
+						? {
+								resolveEntity: entityResolverFromStore(
+									knowledgeGraph.getEntityStore(),
+								),
+							}
+						: {}),
+				});
 
 				await enqueuePiiScrub(
 					this.runtime,
@@ -172,7 +271,7 @@ export class PiiScrubService extends Service {
 							}
 						},
 					},
-					{ rulesetVersion: PII_SCRUB_RULESET_VERSION },
+					{ rulesetVersion: PII_SCRUB_RULESET_VERSION, sources },
 				);
 			},
 		});
@@ -181,7 +280,7 @@ export class PiiScrubService extends Service {
 		// system owns WHEN (repeat PII_SCRUB_DRAIN tick), we own WHAT (dequeue,
 		// escalate, mark-done). No maxSize: the bottleneck is model I/O, not
 		// queue length. No processBatch: the seam is a per-item escalation with
-		// per-item content-addressed idempotency, so there is no single-call
+		// per-source content-addressed idempotency, so there is no single-call
 		// batch collapse to exploit (each item's tier-0 residue is distinct).
 		this.batchQueue = new BatchQueue<PiiScrubQueueItem>({
 			name: PiiScrubService.SCRUB_DRAIN_TASK,
@@ -234,12 +333,33 @@ export class PiiScrubService extends Service {
 			);
 			return;
 		}
+		if (typeof payload.itemRef !== "string" || payload.itemRef.length === 0) {
+			throw new ElizaError(
+				"PII scrub request is missing its source reference",
+				{
+					code: "PII_SCRUB_SOURCE_REF_REQUIRED",
+				},
+			);
+		}
+		if (typeof payload.writeBack !== "function") {
+			throw new ElizaError("PII scrub request is missing durable write-back", {
+				code: "PII_SCRUB_WRITE_BACK_REQUIRED",
+				context: { itemRef: payload.itemRef },
+			});
+		}
 
 		// Cheap pre-enqueue idempotency: if this exact content+ruleset is already
 		// scrubbed, do not even queue it. The drain re-checks under the hood so a
 		// race (two enqueues of the same content) still no-ops, but this avoids
 		// the queue churn for the common re-scrub case.
-		if (await isScrubDone(this.runtime, content, payload.rulesetVersion)) {
+		if (
+			await isScrubDone(
+				this.runtime,
+				content,
+				payload.rulesetVersion,
+				payload.itemRef,
+			)
+		) {
 			this.runtime.logger.debug(
 				{ src: SRC, agentId: this.runtime.agentId, itemRef: payload.itemRef },
 				"Content already scrubbed under this ruleset, skipping enqueue",
@@ -285,7 +405,14 @@ export class PiiScrubService extends Service {
 		// Idempotency re-check inside the drain: covers the race where the same
 		// content was enqueued twice before either drained. A hit means another
 		// drain already completed this exact content+ruleset - nothing to do.
-		if (await isScrubDone(this.runtime, item.content, item.rulesetVersion)) {
+		if (
+			await isScrubDone(
+				this.runtime,
+				item.content,
+				item.rulesetVersion,
+				item.itemRef,
+			)
+		) {
 			this.runtime.logger.debug(
 				{ src: SRC, agentId: this.runtime.agentId, itemRef: item.itemRef },
 				"Item already scrubbed (drain-time idempotency hit), skipping",
@@ -343,18 +470,20 @@ export class PiiScrubService extends Service {
 
 		// The source adapter must confirm its durable write before this item can
 		// become an idempotency hit. Rejections throw into the queue retry path.
-		if (item.writeBack) {
-			await item.writeBack(scrubbedText);
-		}
+		await item.writeBack(scrubbedText);
 
-		// Success: write the content-addressed done-marker so a re-scrub of this
-		// exact content under this ruleset no-ops, and a crash-restart resumes
-		// past it with zero duplicate work.
-		await markScrubDone(this.runtime, item.content, {
-			rulesetVersion: item.rulesetVersion,
-			modelId,
-			tier0Only: !escalated,
-		});
+		// Success: write the source-scoped done-marker so this artifact's unchanged
+		// content no-ops, without suppressing write-back for a second source.
+		await markScrubDone(
+			this.runtime,
+			item.content,
+			{
+				rulesetVersion: item.rulesetVersion,
+				modelId,
+				tier0Only: !escalated,
+			},
+			item.itemRef,
+		);
 
 		await this.runtime.emitEvent(EventType.PII_SCRUB_COMPLETED, {
 			runtime: this.runtime,
@@ -436,8 +565,8 @@ export class PiiScrubService extends Service {
 	}
 
 	/** Test/audit helper: read the done-marker for a piece of content. */
-	async getMarker(content: string, rulesetVersion: string) {
-		return getScrubMarker(this.runtime, content, rulesetVersion);
+	async getMarker(content: string, rulesetVersion: string, itemRef?: string) {
+		return getScrubMarker(this.runtime, content, rulesetVersion, itemRef);
 	}
 }
 

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -377,6 +377,10 @@ export interface PiiScrubRequestPayload extends EventPayload {
  * Payload for {@link EventType.PII_SCRUB_COMPLETED} / {@link EventType.PII_SCRUB_FAILED}.
  * `tier0Only` is true when the deterministic detectors covered everything and
  * no model call was made. `error` is set only on the FAILED variant.
+ * `scrubbedText` (COMPLETED only) carries the write-back transform: the original
+ * text with tier-0 spans redacted and model `pii` verdicts applied — the
+ * artifact that replaces the source. `verdicts` carries the per-span decisions
+ * for audit / write-back listeners.
  */
 export interface PiiScrubResultPayload extends EventPayload {
 	content: string;
@@ -386,6 +390,10 @@ export interface PiiScrubResultPayload extends EventPayload {
 	tier0Only?: boolean;
 	modelId?: string;
 	error?: Error | string;
+	/** COMPLETED only: the scrubbed text (tier-0 redacted + verdicts applied). */
+	scrubbedText?: string;
+	/** COMPLETED only: the model verdicts for audit / write-back. */
+	verdicts?: readonly import("./model.js").PiiScrubVerdict[];
 }
 
 /**

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -340,13 +340,13 @@ export interface EmbeddingGenerationPayload extends EventPayload {
 /**
  * Payload for {@link EventType.PII_SCRUB_REQUESTED}: one enqueue of content onto
  * the async scrub rails (#14808). The service hashes `content` into the
- * content-addressed done-marker (`pii:<sha256(content)>:v<rulesetVersion>`) and
- * skips the item entirely when that marker is already present (idempotent
- * re-scrub no-op). `candidateSpans` are the model-judgment residue the caller
- * mined; when empty the seam runs tier-0 only and never invokes a model.
+ * source-scoped done-marker
+ * (`pii:<sha256(content)>:v<rulesetVersion>:source:<sha256(itemRef)>`) and skips
+ * only when that source artifact is already complete. `candidateSpans` are the
+ * model-judgment residue the caller mined; when empty the seam runs tier-0 only.
  */
 export interface PiiScrubRequestPayload extends EventPayload {
-	/** The exact content to scrub. Its sha256 is the idempotency handle. */
+	/** The exact content to scrub. Its sha256 is half of the idempotency handle. */
 	content: string;
 	/** Active ruleset version: the `v<...>` half of the done-marker key. */
 	rulesetVersion: string;
@@ -369,13 +369,13 @@ export interface PiiScrubRequestPayload extends EventPayload {
 	inferencePriority?: LocalInferencePriority;
 	/** Correlates all items belonging to one scrub job (progress/observability). */
 	jobId?: UUID;
-	/** Opaque caller ref (e.g. the memory/document id) for audit correlation. */
-	itemRef?: string;
+	/** Stable source ref; scopes idempotency and durable write-back to one artifact. */
+	itemRef: string;
 	/**
 	 * Local durable write-back owned by the source adapter. The scrub service
 	 * awaits this before writing the done marker; a rejection triggers retry.
 	 */
-	writeBack?: (scrubbedText: string) => Promise<void>;
+	writeBack: (scrubbedText: string) => Promise<void>;
 }
 
 /**

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -369,8 +369,13 @@ export interface PiiScrubRequestPayload extends EventPayload {
 	inferencePriority?: LocalInferencePriority;
 	/** Correlates all items belonging to one scrub job (progress/observability). */
 	jobId?: UUID;
-	/** Opaque caller ref (e.g. the memory/document id) for write-back. */
+	/** Opaque caller ref (e.g. the memory/document id) for audit correlation. */
 	itemRef?: string;
+	/**
+	 * Local durable write-back owned by the source adapter. The scrub service
+	 * awaits this before writing the done marker; a rejection triggers retry.
+	 */
+	writeBack?: (scrubbedText: string) => Promise<void>;
 }
 
 /**

--- a/plugins/plugin-local-inference/src/pii/scrub-handler.test.ts
+++ b/plugins/plugin-local-inference/src/pii/scrub-handler.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Deterministically tests the local `PII_SCRUB` adapter's prompt, parsing, and
+ * fail-closed behavior without loading a native inference backend.
+ */
+
+import {
+	type IAgentRuntime,
+	ModelType,
+	type PiiScrubParams,
+} from "@elizaos/core";
+import { describe, expect, test, vi } from "vitest";
+import { createLocalInferenceModelHandlers } from "../provider.js";
+import {
+	buildLocalPiiScrubPrompt,
+	createLocalPiiScrubHandler,
+	parseLocalPiiScrubResult,
+} from "./scrub-handler.js";
+
+const params: PiiScrubParams = {
+	text: "met jordan yesterday",
+	candidateSpans: ["met jordan yesterday"],
+	rulesetVersion: "2026.08",
+	priority: "background",
+};
+
+describe("local PII scrub handler", () => {
+	test("is registered on the local provider's dedicated PII model slot", () => {
+		expect(createLocalInferenceModelHandlers()[ModelType.PII_SCRUB]).toEqual(
+			expect.any(Function),
+		);
+	});
+
+	test("inspects and rewrites a whole-text lowercase-name candidate locally", async () => {
+		const generate = vi.fn(async () =>
+			JSON.stringify({
+				verdicts: [
+					{
+						span: "met jordan yesterday",
+						kind: "pii",
+						replacement: "met Person 1 yesterday",
+					},
+				],
+			}),
+		);
+		const handler = createLocalPiiScrubHandler(generate);
+		const result = await handler({} as IAgentRuntime, params);
+
+		expect(result.modelId).toBe("eliza-local-inference");
+		expect(result.verdicts).toEqual([
+			{
+				span: "met jordan yesterday",
+				kind: "pii",
+				replacement: "met Person 1 yesterday",
+			},
+		]);
+		expect(generate).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ priority: "background" }),
+		);
+		expect(buildLocalPiiScrubPrompt(params)).toContain(
+			'"candidateSpans":["met jordan yesterday"]',
+		);
+	});
+
+	test("rejects malformed or incomplete model output", () => {
+		expect(() => parseLocalPiiScrubResult("not json", params)).toThrow(
+			/no JSON object/,
+		);
+		expect(() =>
+			parseLocalPiiScrubResult(
+				'{"verdicts":[{"span":"met jordan yesterday","kind":"pii"}]}',
+				params,
+			),
+		).toThrow(/missing replacement/);
+	});
+});

--- a/plugins/plugin-local-inference/src/pii/scrub-handler.ts
+++ b/plugins/plugin-local-inference/src/pii/scrub-handler.ts
@@ -1,0 +1,131 @@
+/**
+ * Implements the dedicated on-device `PII_SCRUB` model contract by prompting
+ * the resident local text backend and validating its per-candidate verdicts.
+ */
+
+import type {
+	GenerateTextParams,
+	IAgentRuntime,
+	PiiScrubParams,
+	PiiScrubResult,
+	PiiScrubVerdict,
+} from "@elizaos/core";
+
+export type LocalPiiScrubGenerate = (
+	runtime: IAgentRuntime,
+	params: GenerateTextParams,
+) => Promise<string>;
+
+const RESULT_PREFIX =
+	'Output JSON only: {"verdicts":[{"span":string,"kind":"pii"|"safe","replacement"?:string,"entityClusterId"?:string}]}';
+
+export function buildLocalPiiScrubPrompt(params: PiiScrubParams): string {
+	return [
+		"Inspect every candidate for personally identifiable information.",
+		RESULT_PREFIX,
+		"Return exactly one verdict for every candidate and copy span exactly.",
+		"For pii, replacement is required. When a candidate is the entire text, rewrite it to preserve non-sensitive meaning while removing every PII value. Use the supplied pseudonym assignments when relevant.",
+		"A safe verdict is allowed only after positively determining that the candidate contains no PII. If uncertain, fail instead of claiming safe.",
+		JSON.stringify({
+			text: params.text,
+			candidateSpans: params.candidateSpans,
+			contextPack: params.contextPack,
+			pseudonymAssignments: params.pseudonymAssignments,
+			rulesetVersion: params.rulesetVersion,
+		}),
+	].join("\n");
+}
+
+function parseVerdict(value: unknown): PiiScrubVerdict {
+	if (!value || typeof value !== "object") {
+		throw new Error("[LocalPiiScrub] verdict is not an object");
+	}
+	const record = value as Record<string, unknown>;
+	if (typeof record.span !== "string" || record.span.length === 0) {
+		throw new Error("[LocalPiiScrub] verdict span is missing");
+	}
+	if (record.kind !== "pii" && record.kind !== "safe") {
+		throw new Error("[LocalPiiScrub] verdict kind is invalid");
+	}
+	if (
+		record.replacement !== undefined &&
+		typeof record.replacement !== "string"
+	) {
+		throw new Error("[LocalPiiScrub] verdict replacement is invalid");
+	}
+	if (record.kind === "pii" && !record.replacement) {
+		throw new Error("[LocalPiiScrub] pii verdict is missing replacement");
+	}
+	if (
+		record.entityClusterId !== undefined &&
+		typeof record.entityClusterId !== "string"
+	) {
+		throw new Error("[LocalPiiScrub] verdict entityClusterId is invalid");
+	}
+	return {
+		span: record.span,
+		kind: record.kind,
+		...(record.replacement !== undefined
+			? { replacement: record.replacement }
+			: {}),
+		...(record.entityClusterId !== undefined
+			? { entityClusterId: record.entityClusterId }
+			: {}),
+	};
+}
+
+export function parseLocalPiiScrubResult(
+	completion: string,
+	params: PiiScrubParams,
+): PiiScrubResult {
+	const start = completion.indexOf("{");
+	const end = completion.lastIndexOf("}");
+	if (start < 0 || end < start) {
+		throw new Error("[LocalPiiScrub] model output contains no JSON object");
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(completion.slice(start, end + 1));
+	} catch (cause) {
+		throw new Error("[LocalPiiScrub] model output is not valid JSON", {
+			cause,
+		});
+	}
+	if (!parsed || typeof parsed !== "object") {
+		throw new Error("[LocalPiiScrub] model output is not an object");
+	}
+	const verdicts = (parsed as Record<string, unknown>).verdicts;
+	if (!Array.isArray(verdicts)) {
+		throw new Error("[LocalPiiScrub] model output has no verdict array");
+	}
+	return {
+		modelId: "eliza-local-inference",
+		rulesetVersion: params.rulesetVersion,
+		verdicts: verdicts.map(parseVerdict),
+	};
+}
+
+export function createLocalPiiScrubHandler(generate: LocalPiiScrubGenerate) {
+	return async (
+		runtime: IAgentRuntime,
+		params: PiiScrubParams,
+	): Promise<PiiScrubResult> => {
+		if (
+			!params.text ||
+			!params.rulesetVersion ||
+			params.candidateSpans.length === 0
+		) {
+			throw new Error("[LocalPiiScrub] request is missing required input");
+		}
+		const completion = await generate(runtime, {
+			prompt: buildLocalPiiScrubPrompt(params),
+			responseFormat: { type: "json_object" },
+			maxTokens: 1024,
+			temperature: 0,
+			priority: params.priority ?? "background",
+			voiceOutput: "internal",
+			signal: params.signal,
+		});
+		return parseLocalPiiScrubResult(completion, params);
+	};
+}

--- a/plugins/plugin-local-inference/src/provider.ts
+++ b/plugins/plugin-local-inference/src/provider.ts
@@ -1,7 +1,8 @@
 /**
  * Defines the local-inference `Plugin` object and the model-handler factory that
- * fronts every Eliza-1 model slot (`TEXT_SMALL`/`TEXT_LARGE`/`TEXT_EMBEDDING`/
- * `IMAGE`/`IMAGE_DESCRIPTION`/`TEXT_TO_SPEECH`/`TRANSCRIPTION`). Each handler
+ * fronts every Eliza-1 model slot (`TEXT_SMALL`/`TEXT_LARGE`/`PII_SCRUB`/
+ * `TEXT_EMBEDDING`/`IMAGE`/`IMAGE_DESCRIPTION`/`TEXT_TO_SPEECH`/
+ * `TRANSCRIPTION`). Each handler
  * resolves the runtime loader service (bionic host / AOSP adapter / device
  * bridge) and dispatches through it, gating text generation on the process-wide
  * interactive-over-background priority lane; vision and image generation route
@@ -47,6 +48,7 @@ import {
 	startTranscriptionAction,
 	stopTranscriptionAction,
 } from "./actions/transcription-control.js";
+import { createLocalPiiScrubHandler } from "./pii/scrub-handler.js";
 import { LocalPiiRecognizerService } from "./pii/service.js";
 import { transcriptsRoutes } from "./routes/transcripts-routes.js";
 import { voiceProfilePluginRoutes } from "./routes/voice-profile-plugin-routes.js";
@@ -66,6 +68,7 @@ export const LOCAL_INFERENCE_TEXT_MODEL_TYPES = [
 
 export const LOCAL_INFERENCE_MODEL_TYPES = [
 	...LOCAL_INFERENCE_TEXT_MODEL_TYPES,
+	ModelType.PII_SCRUB,
 	ModelType.TEXT_EMBEDDING,
 	ModelType.IMAGE,
 	ModelType.IMAGE_DESCRIPTION,
@@ -1131,9 +1134,11 @@ const TIER_TO_DEFAULT_IMAGE_MODEL_KEY: Readonly<Record<string, string>> = {
 export function createLocalInferenceModelHandlers(): NonNullable<
 	Plugin["models"]
 > {
+	const localTextHandler = createTextHandler(ModelType.TEXT_SMALL);
 	return {
-		[ModelType.TEXT_SMALL]: createTextHandler(ModelType.TEXT_SMALL),
+		[ModelType.TEXT_SMALL]: localTextHandler,
 		[ModelType.TEXT_LARGE]: createTextHandler(ModelType.TEXT_LARGE),
+		[ModelType.PII_SCRUB]: createLocalPiiScrubHandler(localTextHandler),
 		[ModelType.TEXT_EMBEDDING]: createEmbeddingHandler(),
 		[ModelType.IMAGE]: createImageGenerationHandler(),
 		[ModelType.IMAGE_DESCRIPTION]: createImageDescriptionHandler(),


### PR DESCRIPTION
Adds runPiiScrubPipeline() production entry point. Wires PII_SCRUB model handler. Makes existing PII components reachable from live runs.

---
AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Lane: hermes-t3rpz