### PR TITLE
fix(agent): stop VIEWS from hijacking workout and times-per-day intents (#17028)

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -1038,8 +1038,8 @@ describe("bare view-name voice navigation inference (#9950)", () => {
 // token ("times"), injected VIEWS, escalated the turn to a tool-REQUIRED
 // planner surface, rejected the planner's correct terminal answer
 // maxRequiredToolMisses times, and shipped the generic transient-failure
-// apology while discarding "391". The fix suppresses ONLY the weak
-// view-capability inference on that exact Stage-1 shape; model-emitted
+// apology while discarding "391". Multiword view capabilities now require the
+// full phrase, so incidental overlap never infers VIEWS; model-emitted
 // candidates, shell/coding/web inferences, explicit-surface view asks, and
 // bare-noun voice navigation keep today's escalation.
 describe("VIEWS hijack of answered simple turns (tj-501e594bfb23a7)", () => {
@@ -1109,7 +1109,7 @@ describe("VIEWS hijack of answered simple turns (tj-501e594bfb23a7)", () => {
 		expect(routed.plan.candidateActions).toContain("VIEWS");
 	});
 
-	it("suppression is keyed on the answered shape — an unanswered turn still escalates", () => {
+	it("does not infer VIEWS from arithmetic even when Stage 1 left it unanswered", () => {
 		const routed = messageHandlerFromFieldResult(
 			stageOneAnswered(""),
 			undefined,
@@ -1119,8 +1119,8 @@ describe("VIEWS hijack of answered simple turns (tj-501e594bfb23a7)", () => {
 			},
 		);
 
-		expect(routed.plan.requiresTool).toBe(true);
-		expect(routed.plan.candidateActions).toContain("VIEWS");
+		expect(routed.plan.requiresTool).toBe(false);
+		expect(routed.plan.candidateActions ?? []).toEqual([]);
 	});
 
 	it("the simple_registered_action_request evaluator does not re-promote the answered turn", () => {

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -560,15 +560,19 @@ describe("inferDirectCurrentRequestCandidateInference kinds", () => {
 		],
 	};
 
-	it("classifies the live hijack message as weak view-capability evidence", () => {
-		// "whats" bypasses the instructional-question guard ("what is" does not)
-		// and "times" singularizes to TIME, matching the "screen-time" tag.
+	it("does NOT classify the live hijack message as view-capability evidence (multiword specificity)", () => {
+		// #17028: "whats 17 times 23?" previously matched VIEWS because the
+		// "screen-time" tag tokenized to [SCREEN, TIME], SCREEN was filtered as
+		// generic, and the remaining TIME matched "times". The multiword-specificity
+		// fix requires the FULL phrase ("screen time") to appear in the message,
+		// so scattered token overlap no longer hijacks the turn. "times" alone is
+		// not "screen time".
 		expect(
 			inferDirectCurrentRequestCandidateInference(
 				[viewsAction],
 				"whats 17 times 23?",
 			),
-		).toEqual({ names: ["VIEWS"], kind: "view-capability" });
+		).toEqual({ names: [], kind: null });
 	});
 
 	it("classifies explicit surface asks and bare-noun navigation as strong evidence", () => {
@@ -750,6 +754,144 @@ describe("inferDirectCurrentRequestCandidateInference kinds", () => {
 				),
 			).toEqual({ names: [], kind: null });
 		});
+	});
+});
+
+// Regression fence for #17028: VIEWS' over-broad capability tags (routines,
+// habits, health, screen-time, tasks, todos) hijacked owner habit/routine
+// mutation turns via incidental token overlap. "25 pushups, 3 times a day"
+// matched the "screen-time" tag because TIME ← "times" and GET ← "get them in"
+// counted as a read operation. The fix gives owner routine mutations
+// PRECEDENCE over view navigation and preserves multiword capability
+// specificity so a scattered single token ("times") is not "screen time".
+describe("owner routine mutation precedence over VIEWS (#17028)", () => {
+	const viewsAction: Pick<Action, "name" | "similes" | "tags"> = {
+		name: "VIEWS",
+		similes: ["VIEW", "SHOW_VIEW", "OPEN_VIEW", "OPEN_SETTINGS"],
+		tags: [
+			"views",
+			"ui",
+			"panel",
+			"app",
+			"layout",
+			"view-capability",
+			"routines",
+			"reminders",
+			"habits",
+			"health",
+			"screen-time",
+			"todos",
+			"tasks",
+			"settings",
+		],
+	};
+	const ownerRoutinesAction: Pick<Action, "name" | "similes" | "tags"> = {
+		name: "OWNER_ROUTINES",
+		similes: [
+			"HABIT",
+			"HABITS",
+			"ROUTINE",
+			"ROUTINES",
+			"SAVE_HABIT",
+			"CREATE_HABIT",
+			"TRACK_HABIT",
+			"CREATE_ROUTINE",
+		],
+		tags: [],
+	};
+
+	it("routes the exact workout transcript to OWNER_ROUTINES, never VIEWS", () => {
+		for (const message of [
+			"25 pushups, 3 times a day, doesnt matter when i just need to get them in",
+			"25 pushups, 3 times a day",
+			"3 times a day, 25 pushups",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[viewsAction, ownerRoutinesAction],
+					message,
+				),
+			).toEqual({ names: ["OWNER_ROUTINES"], kind: "owner-routines" });
+		}
+	});
+
+	it("'N times a day/week' with a concrete activity routes to OWNER_ROUTINES", () => {
+		for (const message of [
+			"remind me to do 50 squats 2 times a week",
+			"track 10 minutes of meditation once a day",
+			"log 5km runs three times a week",
+			"walk 10000 steps every day",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[viewsAction, ownerRoutinesAction],
+					message,
+				),
+			).toEqual({ names: ["OWNER_ROUTINES"], kind: "owner-routines" });
+		}
+	});
+
+	it("domain mutations win over view navigation even with a matching view installed", () => {
+		for (const message of [
+			"track this habit",
+			"schedule pushups daily",
+			"remind me daily to stretch",
+			"create a new morning workout routine",
+			"save this habit",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[viewsAction, ownerRoutinesAction],
+					message,
+				),
+			).toEqual({ names: ["OWNER_ROUTINES"], kind: "owner-routines" });
+		}
+	});
+
+	it("arithmetic with 'times' and 'get time' do not match screen-time", () => {
+		// The multiword-specificity fix: TIME alone (from "times") is not
+		// "screen time" — the full phrase must appear.
+		for (const message of [
+			"whats 17 times 23?",
+			"3 times 4",
+			"get time on the project",
+			"what times are available",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[viewsAction],
+					message,
+				),
+			).toEqual({ names: [], kind: null });
+		}
+	});
+
+	it("explicit navigation still selects VIEWS", () => {
+		for (const message of [
+			"show my screen time",
+			"open the health view",
+			"list views",
+			"show my routines",
+			"go to the habits panel",
+		]) {
+			const result = inferDirectCurrentRequestCandidateInference(
+				[viewsAction, ownerRoutinesAction],
+				message,
+			);
+			expect(result.names).toContain("VIEWS");
+			expect(result.kind).not.toBe("owner-routines");
+		}
+	});
+
+	it("yields no candidate (not VIEWS) when OWNER_ROUTINES is unregistered", () => {
+		// A runtime without OWNER_ROUTINES must fall back to an explicit
+		// unavailable path, not be captured by VIEWS.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction],
+				"25 pushups, 3 times a day",
+			),
+		).toEqual({ names: [], kind: null });
 	});
 });
 

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -520,6 +520,21 @@ describe("inferDirectCurrentRequestCandidateActions owner-goal routing", () => {
 			),
 		).toEqual([]);
 	});
+
+	it("routes owner-goal mutations ahead of matching VIEWS capability tags", () => {
+		const viewsAction = {
+			name: "VIEWS",
+			similes: [],
+			tags: ["goals", "savings"],
+		} as unknown as Pick<Action, "name" | "similes" | "tags">;
+
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, ...actions],
+				"add a savings goal to save 500 dollars by march",
+			),
+		).toEqual({ names: ["OWNER_GOALS"], kind: "owner-goals" });
+	});
 });
 
 describe("shell-direct coupling grep guard (#12636)", () => {
@@ -573,6 +588,27 @@ describe("inferDirectCurrentRequestCandidateInference kinds", () => {
 				"whats 17 times 23?",
 			),
 		).toEqual({ names: [], kind: null });
+	});
+
+	it("matches plural multiword capability phrases after token normalization", () => {
+		const savedItemsView: Pick<Action, "name" | "similes" | "tags"> = {
+			name: "VIEWS",
+			similes: [],
+			tags: ["saved-items"],
+		};
+
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[savedItemsView],
+				"show saved items",
+			),
+		).toEqual({ names: ["VIEWS"], kind: "view-capability" });
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[savedItemsView],
+				"show saved item",
+			),
+		).toEqual({ names: ["VIEWS"], kind: "view-capability" });
 	});
 
 	it("classifies explicit surface asks and bare-noun navigation as strong evidence", () => {
@@ -848,6 +884,23 @@ describe("owner routine mutation precedence over VIEWS (#17028)", () => {
 		}
 	});
 
+	it("does not classify unrelated activity words as owner-routine mutations", () => {
+		for (const message of [
+			"what do you think about yoga?",
+			"how many hours are in every day?",
+			"set backups every day",
+			"do running tests",
+			"log running errors",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[ownerRoutinesAction],
+					message,
+				),
+			).toEqual({ names: [], kind: null });
+		}
+	});
+
 	it("arithmetic with 'times' and 'get time' do not match screen-time", () => {
 		// The multiword-specificity fix: TIME alone (from "times") is not
 		// "screen time" — the full phrase must appear.
@@ -887,6 +940,12 @@ describe("owner routine mutation precedence over VIEWS (#17028)", () => {
 			inferDirectCurrentRequestCandidateInference(
 				[viewsAction],
 				"25 pushups, 3 times a day",
+			),
+		).toEqual({ names: [], kind: null });
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction],
+				"add this habit",
 			),
 		).toEqual({ names: [], kind: null });
 	});

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -858,10 +858,7 @@ describe("owner routine mutation precedence over VIEWS (#17028)", () => {
 			"what times are available",
 		]) {
 			expect(
-				inferDirectCurrentRequestCandidateInference(
-					[viewsAction],
-					message,
-				),
+				inferDirectCurrentRequestCandidateInference([viewsAction], message),
 			).toEqual({ names: [], kind: null });
 		}
 	});

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -593,7 +593,8 @@ function looksLikeOwnerRoutineWriteRequest(text: string): boolean {
 	const isExplicitViewNavigation =
 		/\b(?:show|open|go\s+to|navigate\s+to|switch\s+to|list|view|browse|see)\b/iu.test(
 			normalized,
-		) && !/\b(?:create|track|schedule|remind|add|save|set|start|do)\b/iu.test(
+		) &&
+		!/\b(?:create|track|schedule|remind|add|save|set|start|do)\b/iu.test(
 			normalized,
 		);
 	if (isExplicitViewNavigation) return false;
@@ -603,7 +604,7 @@ function looksLikeOwnerRoutineWriteRequest(text: string): boolean {
 			normalized,
 		);
 	const hasHabitDomain =
-		/\b(?:habit|habits|routine|routines|workout|workouts|pushup|pushups|push[- ]?up|push[- ]?ups|exercise|exercises|meditate|meditation|gym|run|running|jog|yoga|stretch|walk|walking|habitual|discipline)\b/iu.test(
+		/\b(?:habit|habits|routine|routines|workout|workouts|pushup|pushups|push[- ]?up|push[- ]?ups|exercise|exercises|meditate|meditation|gym|run|runs|running|jog|yoga|stretch|walk|walking|habitual|discipline)\b/iu.test(
 			normalized,
 		);
 	// "N times a day/week" is a strong recurring-frequency signal on its own —
@@ -1144,7 +1145,7 @@ function findViewCapabilityActionName(
 			// appear in the message text as an adjacent phrase. This keeps
 			// "show my screen time" matching (the phrase is there) while blocking
 			// the "times"-only overlap.
-			if (targetTokens.length === 1) {
+			if (aliasTokens.length === 1) {
 				if (messageTokenSet.has(targetTokens[0])) {
 					return viewActionName;
 				}
@@ -1153,10 +1154,11 @@ function findViewCapabilityActionName(
 			if (!targetTokens.every((token) => messageTokenSet.has(token))) {
 				continue;
 			}
-			// Multiword capability: require the phrase (normalized to allow a
-			// single separator: hyphen, space, or nothing) to appear in the
-			// message as adjacent words.
-			const aliasPhraseRegex = multiwordCapabilityPhraseRegex(targetTokens);
+			// Multiword capability: require the complete alias phrase, including
+			// generic tokens such as SCREEN, to appear as adjacent words.
+			const aliasPhraseRegex = multiwordCapabilityPhraseRegex(
+				aliasTokens.map(normalizeSingularToken),
+			);
 			if (aliasPhraseRegex.test(messageText)) {
 				return viewActionName;
 			}
@@ -1169,9 +1171,7 @@ function findViewCapabilityActionName(
 // an adjacent phrase in the message, allowing a single optional separator
 // (hyphen, space, or underscore) between them. "screen-time" → matches
 // "screen time", "screen-time", "screentime"; does NOT match "3 times a day".
-function multiwordCapabilityPhraseRegex(
-	tokens: readonly string[],
-): RegExp {
+function multiwordCapabilityPhraseRegex(tokens: readonly string[]): RegExp {
 	const parts = tokens.map((token) => escapeRegex(token));
 	// Allow an optional separator between each token: the capability may be
 	// written as "screen time" (space), "screen-time" (hyphen), or "screentime".

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -484,6 +484,7 @@ function looksLikeGoalDetailFollowup(text: string): boolean {
 }
 
 function looksLikeGoalDraftConfirmation(text: string): boolean {
+	if (/\b(?:habit|routine)s?\b/iu.test(text)) return false;
 	return /\b(?:ok(?:ay)?|yes|yep|yeah|sure)?\s*(?:save|set|confirm|approve)\s+(?:that|this|it|that\s+one|this\s+one)(?:\s+goal)?\b/iu.test(
 		text,
 	);
@@ -600,7 +601,7 @@ function looksLikeOwnerRoutineWriteRequest(text: string): boolean {
 	if (isExplicitViewNavigation) return false;
 
 	const hasMutationVerb =
-		/\b(?:create|schedule|track|remind|complete|add|save|set|start|do|repeat|log|build|practice|keep\s+up)\b/iu.test(
+		/\b(?:create|schedule|track|remind|complete|add|save|set|start|repeat)\b/iu.test(
 			normalized,
 		);
 	const hasHabitDomain =
@@ -622,7 +623,7 @@ function looksLikeOwnerRoutineWriteRequest(text: string): boolean {
 	// without an explicit mutation verb ("25 pushups, 3 times a day").
 	if (hasFrequencyClause) {
 		const hasConcreteActivity =
-			/\b(?:pushup|pushups|push[- ]?up|push[- ]?ups|situp|situps|sit[- ]?up|sit[- ]?ups|squat|squats|rep|reps|set|sets|lap|laps|mile|miles|km|minute|minutes|hour|hours|walk|run|jog|meditate|stretch|yoga|exercise|workout|gym|repetition|repetitions)\b/iu.test(
+			/\b(?:pushup|pushups|push[- ]?up|push[- ]?ups|situp|situps|sit[- ]?up|sit[- ]?ups|squat|squats|rep|reps|lap|laps|mile|miles|km|walk|run|jog|meditate|stretch|yoga|exercise|workout|gym|repetition|repetitions)\b/iu.test(
 				normalized,
 			) || hasHabitDomain;
 		if (hasConcreteActivity) return true;
@@ -681,19 +682,27 @@ export function inferDirectCurrentRequestCandidateInference(
 			return { names: [settingsAction], kind: "settings-write" };
 		}
 	}
+	// Owner goal mutations must win precedence over matching VIEWS tags.
+	if (looksLikeOwnerGoalWriteRequest(messageText)) {
+		const ownerGoalsAction = findOwnerGoalsActionName(actions);
+		if (ownerGoalsAction) {
+			return { names: [ownerGoalsAction], kind: "owner-goals" };
+		}
+		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
+	}
 	// Owner habit/routine mutations must win PRECEDENCE over view navigation.
 	// VIEWS declares `routines`, `habits`, `health`, `screen-time`, `tasks` as
 	// capability tags and says to navigate "when in doubt", so without this leg
 	// a workout turn ("25 pushups, 3 times a day") is hijacked by incidental
 	// token overlap (TIME ← "times") into the view-capability path. Resolved
-	// against a registered OWNER_ROUTINES action; a runtime without it yields no
-	// candidate here so the turn falls back to the planner's own recovery path
-	// instead of being captured by VIEWS (#17028).
+	// against a registered OWNER_ROUTINES action; a runtime without it terminates
+	// with no candidate instead of being captured by VIEWS (#17028).
 	if (looksLikeOwnerRoutineWriteRequest(messageText)) {
 		const ownerRoutinesAction = findOwnerRoutinesActionName(actions);
 		if (ownerRoutinesAction) {
 			return { names: [ownerRoutinesAction], kind: "owner-routines" };
 		}
+		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
 	}
 	const viewShellAction = findViewShellActionName(actions, messageText);
 	if (viewShellAction) {
@@ -742,12 +751,6 @@ export function inferDirectCurrentRequestCandidateInference(
 	if (looksLikeWebSearchRequest(messageText)) {
 		const lookupActions = findWebLookupActionNames(actions);
 		if (lookupActions.length > 0) return { names: lookupActions, kind: "web" };
-	}
-	if (looksLikeOwnerGoalWriteRequest(messageText)) {
-		const ownerGoalsAction = findOwnerGoalsActionName(actions);
-		if (ownerGoalsAction) {
-			return { names: [ownerGoalsAction], kind: "owner-goals" };
-		}
 	}
 	return EMPTY_DIRECT_CANDIDATE_INFERENCE;
 }
@@ -1156,10 +1159,9 @@ function findViewCapabilityActionName(
 			}
 			// Multiword capability: require the complete alias phrase, including
 			// generic tokens such as SCREEN, to appear as adjacent words.
-			const aliasPhraseRegex = multiwordCapabilityPhraseRegex(
-				aliasTokens.map(normalizeSingularToken),
-			);
-			if (aliasPhraseRegex.test(messageText)) {
+			if (
+				containsContiguousNormalizedTokenSequence(messageTokens, aliasTokens)
+			) {
 				return viewActionName;
 			}
 		}
@@ -1167,22 +1169,18 @@ function findViewCapabilityActionName(
 	return undefined;
 }
 
-// Build a case-insensitive regex that matches the multiword capability tokens as
-// an adjacent phrase in the message, allowing a single optional separator
-// (hyphen, space, or underscore) between them. "screen-time" → matches
-// "screen time", "screen-time", "screentime"; does NOT match "3 times a day".
-function multiwordCapabilityPhraseRegex(tokens: readonly string[]): RegExp {
-	const parts = tokens.map((token) => escapeRegex(token));
-	// Allow an optional separator between each token: the capability may be
-	// written as "screen time" (space), "screen-time" (hyphen), or "screentime".
-	const body = parts.join("[-\\s_]*");
-	// Match case-insensitively against the original message text (not the
-	// tokenized/uppercased form) so ordinary casing works.
-	return new RegExp(`\\b${body}\\b`, "iu");
-}
-
-function escapeRegex(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function containsContiguousNormalizedTokenSequence(
+	messageTokens: readonly string[],
+	aliasTokens: readonly string[],
+): boolean {
+	const normalizedMessageTokens = messageTokens.map(normalizeSingularToken);
+	const normalizedAliasTokens = aliasTokens.map(normalizeSingularToken);
+	return normalizedMessageTokens.some((_, startIndex) =>
+		normalizedAliasTokens.every(
+			(aliasToken, offset) =>
+				normalizedMessageTokens[startIndex + offset] === aliasToken,
+		),
+	);
 }
 
 function looksLikeInstructionalViewQuestion(messageText: string): boolean {

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -369,6 +369,7 @@ export type DirectCurrentRequestCandidateKind =
 	| "coding"
 	| "settings-write"
 	| "owner-goals"
+	| "owner-routines"
 	| "view-surface"
 	| "view-navigation"
 	| "view-capability"
@@ -548,6 +549,98 @@ function findOwnerGoalsActionName(
 	return findAvailableActionName(actions, OWNER_GOALS_ACTION_NAMES);
 }
 
+// Owner habit/routine mutation action names, in preference order. Stage-1 models
+// frequently invent HABIT/ROUTINE names; these resolve to OWNER_ROUTINES when it
+// is registered, or yield nothing on a runtime without it — the workout turn
+// then falls back to the planner's own recovery path instead of being hijacked
+// by VIEWS' over-broad capability tags (#17028).
+const OWNER_ROUTINES_ACTION_NAMES = [
+	"OWNER_ROUTINES",
+	"ROUTINES",
+	"ROUTINE",
+	"HABIT",
+	"HABITS",
+	"CREATE_HABIT",
+	"SAVE_HABIT",
+	"TRACK_HABIT",
+	"SET_HABIT",
+	"NEW_HABIT",
+	"DAILY_HABIT",
+	"CREATE_ROUTINE",
+	"RECURRING_TASK",
+] as const;
+
+function findOwnerRoutinesActionName(
+	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
+): string | undefined {
+	return findAvailableActionName(actions, OWNER_ROUTINES_ACTION_NAMES);
+}
+
+// Detects owner habit/routine MUTATION requests — the workout/tracking turns that
+// VIEWS' over-broad capability tags (`routines`, `habits`, `health`,
+// `screen-time`, `tasks`) otherwise hijack via incidental token overlap (#17028).
+// Demands an explicit mutation verb (create/schedule/track/remind/complete/do)
+// alongside habit/routine phrasing OR a "N times a day/week" frequency clause,
+// so a bare "show my routines" still routes to the views navigation surface.
+// The mutation wins PRECEDENCE over navigation because the user is committing to
+// a recurring action, not browsing a UI.
+function looksLikeOwnerRoutineWriteRequest(text: string): boolean {
+	const normalized = text.toLowerCase();
+	if (!normalized.trim()) return false;
+
+	// A read/navigation-only ask ("show my habits", "what routines do I have",
+	// "open the health view") is not a mutation — leave it to ordinary routing.
+	const isExplicitViewNavigation =
+		/\b(?:show|open|go\s+to|navigate\s+to|switch\s+to|list|view|browse|see)\b/iu.test(
+			normalized,
+		) && !/\b(?:create|track|schedule|remind|add|save|set|start|do)\b/iu.test(
+			normalized,
+		);
+	if (isExplicitViewNavigation) return false;
+
+	const hasMutationVerb =
+		/\b(?:create|schedule|track|remind|complete|add|save|set|start|do|repeat|log|build|practice|keep\s+up)\b/iu.test(
+			normalized,
+		);
+	const hasHabitDomain =
+		/\b(?:habit|habits|routine|routines|workout|workouts|pushup|pushups|push[- ]?up|push[- ]?ups|exercise|exercises|meditate|meditation|gym|run|running|jog|yoga|stretch|walk|walking|habitual|discipline)\b/iu.test(
+			normalized,
+		);
+	// "N times a day/week" is a strong recurring-frequency signal on its own —
+	// the exact workout transcript ("25 pushups, 3 times a day") carries this
+	// clause and a concrete activity, which is unambiguously a habit mutation.
+	const hasFrequencyClause =
+		/\b(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|once|twice|a\s+couple)\s+times?\s+(?:a|per|each|every)\s+(?:day|week|month|morning|evening|night)\b/iu.test(
+			normalized,
+		) ||
+		/\b(?:every|each|daily|weekly)\s+(?:day|morning|evening|night|week|month)\b/iu.test(
+			normalized,
+		);
+
+	// A frequency clause plus a concrete activity is a habit mutation even
+	// without an explicit mutation verb ("25 pushups, 3 times a day").
+	if (hasFrequencyClause) {
+		const hasConcreteActivity =
+			/\b(?:pushup|pushups|push[- ]?up|push[- ]?ups|situp|situps|sit[- ]?up|sit[- ]?ups|squat|squats|rep|reps|set|sets|lap|laps|mile|miles|km|minute|minutes|hour|hours|walk|run|jog|meditate|stretch|yoga|exercise|workout|gym|repetition|repetitions)\b/iu.test(
+				normalized,
+			) || hasHabitDomain;
+		if (hasConcreteActivity) return true;
+	}
+
+	// Mutation verb + habit/routine domain.
+	if (hasMutationVerb && hasHabitDomain) return true;
+
+	// Explicit habit-save phrasing.
+	if (
+		/\b(?:save|create|add|set|track|start)\b[^\n]{0,80}\b(?:habit|routine)\b/iu.test(
+			normalized,
+		)
+	)
+		return true;
+
+	return false;
+}
+
 export function inferDirectCurrentRequestCandidateActions(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
 	messageText: string,
@@ -585,6 +678,20 @@ export function inferDirectCurrentRequestCandidateInference(
 		const settingsAction = findSettingsWriteActionName(actions);
 		if (settingsAction) {
 			return { names: [settingsAction], kind: "settings-write" };
+		}
+	}
+	// Owner habit/routine mutations must win PRECEDENCE over view navigation.
+	// VIEWS declares `routines`, `habits`, `health`, `screen-time`, `tasks` as
+	// capability tags and says to navigate "when in doubt", so without this leg
+	// a workout turn ("25 pushups, 3 times a day") is hijacked by incidental
+	// token overlap (TIME ← "times") into the view-capability path. Resolved
+	// against a registered OWNER_ROUTINES action; a runtime without it yields no
+	// candidate here so the turn falls back to the planner's own recovery path
+	// instead of being captured by VIEWS (#17028).
+	if (looksLikeOwnerRoutineWriteRequest(messageText)) {
+		const ownerRoutinesAction = findOwnerRoutinesActionName(actions);
+		if (ownerRoutinesAction) {
+			return { names: [ownerRoutinesAction], kind: "owner-routines" };
 		}
 	}
 	const viewShellAction = findViewShellActionName(actions, messageText);
@@ -1025,12 +1132,57 @@ function findViewCapabilityActionName(
 						!VIEW_REQUEST_GENERIC_TOKENS.has(token),
 				);
 			if (targetTokens.length === 0) continue;
-			if (targetTokens.every((token) => messageTokenSet.has(token))) {
+			// PRESERVE MULTIWORD CAPABILITY SPECIFICITY (#17028). A multiword
+			// capability tag like "screen-time" must NOT match when only one of
+			// its tokens appears in the message: tokenizing "screen-time" to
+			// [SCREEN, TIME], then filtering SCREEN as generic, left only [TIME]
+			// — which matched "times" in "25 pushups, 3 times a day" and hijacked
+			// the workout turn into the VIEWS catalog. Require the FULL multiword
+			// capability to be present: either the alias is a single token
+			// (unchanged behavior), or every non-generic target token must be in
+			// the message AND, when there are 2+ tokens, the phrase itself must
+			// appear in the message text as an adjacent phrase. This keeps
+			// "show my screen time" matching (the phrase is there) while blocking
+			// the "times"-only overlap.
+			if (targetTokens.length === 1) {
+				if (messageTokenSet.has(targetTokens[0])) {
+					return viewActionName;
+				}
+				continue;
+			}
+			if (!targetTokens.every((token) => messageTokenSet.has(token))) {
+				continue;
+			}
+			// Multiword capability: require the phrase (normalized to allow a
+			// single separator: hyphen, space, or nothing) to appear in the
+			// message as adjacent words.
+			const aliasPhraseRegex = multiwordCapabilityPhraseRegex(targetTokens);
+			if (aliasPhraseRegex.test(messageText)) {
 				return viewActionName;
 			}
 		}
 	}
 	return undefined;
+}
+
+// Build a case-insensitive regex that matches the multiword capability tokens as
+// an adjacent phrase in the message, allowing a single optional separator
+// (hyphen, space, or underscore) between them. "screen-time" → matches
+// "screen time", "screen-time", "screentime"; does NOT match "3 times a day".
+function multiwordCapabilityPhraseRegex(
+	tokens: readonly string[],
+): RegExp {
+	const parts = tokens.map((token) => escapeRegex(token));
+	// Allow an optional separator between each token: the capability may be
+	// written as "screen time" (space), "screen-time" (hyphen), or "screentime".
+	const body = parts.join("[-\\s_]*");
+	// Match case-insensitively against the original message text (not the
+	// tokenized/uppercased form) so ordinary casing works.
+	return new RegExp(`\\b${body}\\b`, "iu");
+}
+
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function looksLikeInstructionalViewQuestion(messageText: string): boolean {


### PR DESCRIPTION
Screen-time token matches 'times' in workout messages. Adds owner-routines detector before view detectors with multiword phrase matching.

---
AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Lane: hermes-t3rpz