### PR TITLE
fix(cloud-apps): make deploy image references immutable end-to-end (#13097)

### DIFF
--- a/packages/cloud/scripts/admin/daemons/apps-provisioning-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/apps-provisioning-worker.ts
@@ -125,7 +125,7 @@ export async function armAppsDeployBackend(
   // APPS_IMAGE_REGISTRY set → BUILD-FROM-REPO (buildx on the app node, push to
   // this registry). Unset → prebuilt images (imageTag / APP_DEFAULT_IMAGE).
   const registry = process.env.APPS_IMAGE_REGISTRY;
-  configureAppsDeployBackend({ port, registry });
+  await configureAppsDeployBackend({ port, registry });
   logger.info("[apps-worker] apps deploy backend armed", {
     tenantDbAdminDsn: process.env.APPS_TENANT_ADMIN_DSN
       ? "env-sourced"

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
@@ -1922,7 +1922,7 @@ async function armAppsDeployBackendIfEnabled(
   // user's repo on the app node via buildx and pushes to this registry — the
   // Vercel-like path). Unset → prebuilt images (imageTag/APP_DEFAULT_IMAGE).
   const registry = process.env.APPS_IMAGE_REGISTRY;
-  configureAppsDeployBackend({ port, registry });
+  await configureAppsDeployBackend({ port, registry });
   logger.info("[provisioning-worker] apps deploy backend armed", {
     tenantDbAdminDsn: process.env.APPS_TENANT_ADMIN_DSN
       ? "env-sourced"

--- a/packages/cloud/shared/src/db/apps-immutable-showcase-images-migration.test.ts
+++ b/packages/cloud/shared/src/db/apps-immutable-showcase-images-migration.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Applies the known showcase image migration to real PGlite rows and proves it
+ * preserves unrelated metadata while leaving unknown and pinned refs unchanged.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+
+const MIGRATION_PATH = join(import.meta.dir, "migrations/0199_apps_immutable_showcase_images.sql");
+const EDAD_PINNED =
+  "ghcr.io/elizaos/example-edad@sha256:2c68b639eec00fad1b35e978f5463f1543b392c96680ec496fd0c0a9eddc8241";
+const CLONE_PINNED =
+  "ghcr.io/elizaos/example-clone-ur-crush@sha256:b7e5fd1310a56158ea47ea923eccc7ae4ca067b177bea0cd326d32c4129b60db";
+
+let client: PGlite;
+
+async function applyMigration(): Promise<void> {
+  for (const statement of readFileSync(MIGRATION_PATH, "utf8")
+    .split("--> statement-breakpoint")
+    .map((candidate) => candidate.trim())
+    .filter(Boolean)) {
+    await client.exec(statement);
+  }
+}
+
+beforeAll(async () => {
+  client = new PGlite();
+  await client.exec(`
+    CREATE TABLE apps (
+      id text PRIMARY KEY,
+      metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+    );
+    INSERT INTO apps (id, metadata) VALUES
+      ('edad', '{"imageTag":"ghcr.io/elizaos/example-edad:showcase","keep":"edad"}'),
+      ('clone', '{"imageTag":"ghcr.io/elizaos/example-clone-ur-crush:showcase","keep":"clone"}'),
+      ('unknown', '{"imageTag":"ghcr.io/elizaos/unknown:latest","keep":"unknown"}'),
+      ('pinned', '{"imageTag":"${EDAD_PINNED}","keep":"pinned"}');
+  `);
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+describe("0199 apps immutable showcase images", () => {
+  test("is registered in the migration journal", () => {
+    const journal = JSON.parse(
+      readFileSync(join(import.meta.dir, "migrations/meta/_journal.json"), "utf8"),
+    ) as { entries: Array<{ tag: string }> };
+    expect(
+      journal.entries.some((entry) => entry.tag === "0199_apps_immutable_showcase_images"),
+    ).toBe(true);
+  });
+
+  test("repins only known tags, preserves metadata, and is idempotent", async () => {
+    await applyMigration();
+    await applyMigration();
+
+    const result = await client.query<{ id: string; metadata: Record<string, unknown> }>(
+      "SELECT id, metadata FROM apps ORDER BY id",
+    );
+    expect(result.rows).toEqual([
+      { id: "clone", metadata: { imageTag: CLONE_PINNED, keep: "clone" } },
+      { id: "edad", metadata: { imageTag: EDAD_PINNED, keep: "edad" } },
+      {
+        id: "pinned",
+        metadata: { imageTag: EDAD_PINNED, keep: "pinned" },
+      },
+      {
+        id: "unknown",
+        metadata: { imageTag: "ghcr.io/elizaos/unknown:latest", keep: "unknown" },
+      },
+    ]);
+  });
+});

--- a/packages/cloud/shared/src/db/migrations/0199_apps_immutable_showcase_images.sql
+++ b/packages/cloud/shared/src/db/migrations/0199_apps_immutable_showcase_images.sql
@@ -1,0 +1,17 @@
+UPDATE "apps"
+SET "metadata" = jsonb_set(
+  "metadata",
+  '{imageTag}',
+  '"ghcr.io/elizaos/example-edad@sha256:2c68b639eec00fad1b35e978f5463f1543b392c96680ec496fd0c0a9eddc8241"'::jsonb,
+  false
+)
+WHERE "metadata"->>'imageTag' = 'ghcr.io/elizaos/example-edad:showcase';
+--> statement-breakpoint
+UPDATE "apps"
+SET "metadata" = jsonb_set(
+  "metadata",
+  '{imageTag}',
+  '"ghcr.io/elizaos/example-clone-ur-crush@sha256:b7e5fd1310a56158ea47ea923eccc7ae4ca067b177bea0cd326d32c4129b60db"'::jsonb,
+  false
+)
+WHERE "metadata"->>'imageTag' = 'ghcr.io/elizaos/example-clone-ur-crush:showcase';

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1387,6 +1387,13 @@
       "when": 1786824000000,
       "tag": "0198_docker_nodes_placement_state",
       "breakpoints": true
+    },
+    {
+      "idx": 198,
+      "version": "7",
+      "when": 1786910400000,
+      "tag": "0199_apps_immutable_showcase_images",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -343,19 +343,23 @@ export const containersEnv = {
    * user repo) at create time, so create -> deploy resolves to a prebuilt,
    * allowlisted image instead of failing with "no image to deploy".
    *
-   * Defaults to the retained `:showcase` template image. It sits under
-   * `ghcr.io/elizaos/*`, so the apps-deploy allowlist permits it unchanged.
-   * Override the whole ref via `APP_DEFAULT_TEMPLATE_IMAGE`.
+   * Defaults to the first-party showcase image PINNED to its immutable sha256
+   * digest (#13097): a mutable `:showcase` tag lets the registry swap the bytes
+   * behind an allowed name after the deploy-time allowlist check, so the digest
+   * pin makes the stamped default content-addressed. The image sits under
+   * `ghcr.io/elizaos/*`, so the apps-deploy allowlist permits it unchanged. The
+   * digest-pinned default also passes the armed digest-pin gate
+   * (`CONTAINER_IMAGE_REQUIRE_DIGEST`) unchanged.
    *
-   * TODO(ops, digest-pin): `:showcase` is a MUTABLE tag — the registry could
-   * re-point it after the deploy-time allowlist check. Once a stable showcase
-   * digest is published, pin this default to
-   * `ghcr.io/elizaos/example-edad@sha256:<64hex>` so a future digest-pin gate
-   * (`CONTAINER_IMAGE_REQUIRE_DIGEST`) accepts the template default unchanged.
+   * Override the whole ref via `APP_DEFAULT_TEMPLATE_IMAGE` (operators that
+   * re-pin after a future image publish should pass a `repo@sha256:<digest>`).
    */
   appDefaultTemplateImage(): string {
     const env = getCloudAwareEnv();
-    return pick(env.APP_DEFAULT_TEMPLATE_IMAGE) ?? "ghcr.io/elizaos/example-edad:showcase";
+    return (
+      pick(env.APP_DEFAULT_TEMPLATE_IMAGE) ??
+      "ghcr.io/elizaos/example-edad@sha256:2c68b639eec00fad1b35e978f5463f1543b392c96680ec496fd0c0a9eddc8241"
+    );
   },
 
   /**
@@ -381,6 +385,25 @@ export const containersEnv = {
         env.CONTAINERS_IMAGE_REQUIRE_DIGEST,
       ) === "true"
     );
+  },
+
+  /**
+   * Whether the APPS-DEPLOY lane (Product 2 app deploys) must reject a mutable
+   * `:tag`/implicit-latest image ref even when the global
+   * {@link requireDigestPinnedImages} gate is off.
+   *
+   * SECURITY (#13097): the first-party template default and source-build output
+   * are now digest-pinned end-to-end, so the apps-deploy lane can enforce
+   * immutability by DEFAULT without breaking the GA path. This is ON by default;
+   * an operator that still needs a mutable-tag app deploy can opt out with
+   * `APPS_DEPLOY_REQUIRE_DIGEST=false`. Read via `APPS_DEPLOY_REQUIRE_DIGEST`
+   * (with `ELIZA_` fallback); any value other than `"false"`/`"0"` keeps the
+   * gate armed.
+   */
+  appsDeployRequireDigest(): boolean {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.APPS_DEPLOY_REQUIRE_DIGEST, env.ELIZA_APPS_DEPLOY_REQUIRE_DIGEST);
+    return raw !== "false" && raw !== "0";
   },
 
   /**

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -388,21 +388,6 @@ export const containersEnv = {
   },
 
   /**
-   * Whether the APPS-DEPLOY lane (Product 2 app deploys) must reject a mutable
-   * `:tag`/implicit-latest image ref even when the global
-   * {@link requireDigestPinnedImages} gate is off.
-   *
-   * Source builds are digest-pinned, but supported prebuilt/default image
-   * sources may still use mutable tags. Keep enforcement opt-in until those
-   * operator configurations have been migrated. Only the literal string
-   * `"true"` enables it.
-   */
-  appsDeployRequireDigest(): boolean {
-    const env = getCloudAwareEnv();
-    return pick(env.APPS_DEPLOY_REQUIRE_DIGEST, env.ELIZA_APPS_DEPLOY_REQUIRE_DIGEST) === "true";
-  },
-
-  /**
    * Auto-recover a node whose dockerd image-pull coordinator has wedged: after
    * repeated failed pre-pulls the provisioning worker restarts docker on the
    * node itself (rate-limited) instead of requiring a manual `systemctl

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -392,18 +392,14 @@ export const containersEnv = {
    * `:tag`/implicit-latest image ref even when the global
    * {@link requireDigestPinnedImages} gate is off.
    *
-   * SECURITY (#13097): the first-party template default and source-build output
-   * are now digest-pinned end-to-end, so the apps-deploy lane can enforce
-   * immutability by DEFAULT without breaking the GA path. This is ON by default;
-   * an operator that still needs a mutable-tag app deploy can opt out with
-   * `APPS_DEPLOY_REQUIRE_DIGEST=false`. Read via `APPS_DEPLOY_REQUIRE_DIGEST`
-   * (with `ELIZA_` fallback); any value other than `"false"`/`"0"` keeps the
-   * gate armed.
+   * Source builds are digest-pinned, but supported prebuilt/default image
+   * sources may still use mutable tags. Keep enforcement opt-in until those
+   * operator configurations have been migrated. Only the literal string
+   * `"true"` enables it.
    */
   appsDeployRequireDigest(): boolean {
     const env = getCloudAwareEnv();
-    const raw = pick(env.APPS_DEPLOY_REQUIRE_DIGEST, env.ELIZA_APPS_DEPLOY_REQUIRE_DIGEST);
-    return raw !== "false" && raw !== "0";
+    return pick(env.APPS_DEPLOY_REQUIRE_DIGEST, env.ELIZA_APPS_DEPLOY_REQUIRE_DIGEST) === "true";
   },
 
   /**

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-image-preflight.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-image-preflight.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Exercises the apps-deploy startup image inventory with injected persisted rows
+ * and operator configuration, without connecting to the repository database.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
+import { assertAppsDeployImagesImmutable } from "../app-deploy-image-preflight";
+
+const PINNED = `ghcr.io/elizaos/app@sha256:a${"0".repeat(63)}`;
+const app = (id: string, name: string, imageTag?: unknown) => ({
+  id,
+  name,
+  metadata: imageTag === undefined ? {} : { imageTag },
+});
+
+describe("assertAppsDeployImagesImmutable", () => {
+  test("passes when all sources are absent", async () => {
+    await expect(
+      assertAppsDeployImagesImmutable({ env: {}, listApps: async () => [] }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("passes digest-pinned defaults, map entries, and persisted refs", async () => {
+    await expect(
+      assertAppsDeployImagesImmutable({
+        env: {
+          APP_DEFAULT_IMAGE: PINNED,
+          APP_DEFAULT_TEMPLATE_IMAGE: PINNED,
+          APP_PREBUILT_IMAGES: JSON.stringify({ Showcase: PINNED }),
+        },
+        listApps: async () => [app("app-1", "Pinned", PINNED)],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("rejects a mutable APP_DEFAULT_IMAGE", async () => {
+    await expect(
+      assertAppsDeployImagesImmutable({
+        env: { APP_DEFAULT_IMAGE: "ghcr.io/elizaos/app:latest" },
+        listApps: async () => [],
+      }),
+    ).rejects.toMatchObject({
+      code: "APPS_DEPLOY_IMAGE_PREFLIGHT_FAILED",
+      message: expect.stringContaining("APP_DEFAULT_IMAGE"),
+    });
+  });
+
+  test("rejects malformed and non-object APP_PREBUILT_IMAGES", async () => {
+    for (const raw of ["not-json", "[]"]) {
+      await expect(
+        assertAppsDeployImagesImmutable({
+          env: { APP_PREBUILT_IMAGES: raw },
+          listApps: async () => [],
+        }),
+      ).rejects.toMatchObject({ code: "APPS_DEPLOY_IMAGE_PREFLIGHT_FAILED" });
+    }
+  });
+
+  test("identifies a mutable APP_PREBUILT_IMAGES prefix", async () => {
+    await expect(
+      assertAppsDeployImagesImmutable({
+        env: {
+          APP_PREBUILT_IMAGES: JSON.stringify({
+            "Mutable Showcase": "ghcr.io/elizaos/app:showcase",
+          }),
+        },
+        listApps: async () => [],
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('APP_PREBUILT_IMAGES["Mutable Showcase"]'),
+    });
+  });
+
+  test("aggregates mutable and malformed persisted image tags", async () => {
+    let failure: unknown;
+    try {
+      await assertAppsDeployImagesImmutable({
+        env: {},
+        listApps: async () => [
+          app("app-mutable", "Mutable", "ghcr.io/elizaos/app:v1"),
+          app("app-malformed", "Malformed", 42),
+          app("app-pinned", "Pinned", PINNED),
+        ],
+      });
+    } catch (error) {
+      // error-policy:J1 the test boundary captures the typed failure for one
+      // complete aggregate assertion.
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(ElizaError);
+    const typedFailure = failure as ElizaError;
+    expect(typedFailure.code).toBe("APPS_DEPLOY_IMAGE_PREFLIGHT_FAILED");
+    expect(typedFailure.message).toContain("app-mutable");
+    expect(typedFailure.message).toContain("app-malformed");
+    const violations = typedFailure.context?.violations as string[];
+    expect(violations.some((violation) => violation.includes("app-mutable"))).toBe(true);
+    expect(violations.some((violation) => violation.includes("app-malformed"))).toBe(true);
+  });
+
+  test("rejects a mutable APP_DEFAULT_TEMPLATE_IMAGE override", async () => {
+    await expect(
+      assertAppsDeployImagesImmutable({
+        env: { APP_DEFAULT_TEMPLATE_IMAGE: "ghcr.io/elizaos/example-edad:showcase" },
+        listApps: async () => [],
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining("APP_DEFAULT_TEMPLATE_IMAGE"),
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
@@ -1,15 +1,10 @@
 // Exercises app deploy runner behavior with deterministic cloud-shared lib fixtures.
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { runWithCloudBindingsAsync } from "../../runtime/cloud-bindings";
 import type { AppDeployRunnerDeps } from "../app-deploy-runner";
 import { containerNameForApp, resolveImageRef } from "../app-deploy-runner";
 
-// #13097 — the apps-deploy digest-pin gate is ON by default. Tests that exercise
-// ONLY the allowlist / repo / org-namespace concerns (not the digest concern)
-// opt the gate off so a mutable-tag fixture doesn't trip the digest gate first.
-// Tests that exercise the digest concern use digest-pinned fixtures or arm the
-// gate explicitly.
-const DIGEST_GATE_OFF = { APPS_DEPLOY_REQUIRE_DIGEST: "false" };
+const DIGEST_GATE_ON = { APPS_DEPLOY_REQUIRE_DIGEST: "true" };
 
 // A first-party digest-pinned ref (passes both the allowlist and digest gates).
 const PINNED = `ghcr.io/elizaos/eliza@sha256:a${"0".repeat(63)}`;
@@ -57,15 +52,13 @@ describe("resolveImageRef: build-from-repo-disabled guard", () => {
 
   test("repo app + build off + explicit imageTag -> uses the prebuilt image", async () => {
     process.env.APP_DEFAULT_IMAGE = "ghcr.io/elizaos/app-default:smoke";
-    const img = await runWithCloudBindingsAsync(DIGEST_GATE_OFF, () =>
-      resolveImageRef(buildOff, {
-        ...baseApp,
-        repoUrl: REPO,
-        // Allowlisted first-party namespace (the image allowlist gate runs on the
-        // resolved image — see the gate describe block below).
-        metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
-      }),
-    );
+    const img = await resolveImageRef(buildOff, {
+      ...baseApp,
+      repoUrl: REPO,
+      // Allowlisted first-party namespace (the image allowlist gate runs on the
+      // resolved image — see the gate describe block below).
+      metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+    });
     expect(img).toBe("ghcr.io/elizaos/myapp:v1");
   });
 
@@ -106,12 +99,10 @@ describe("resolveImageRef: image allowlist gate", () => {
   });
 
   test("allows an imageTag inside the default first-party allowlist", async () => {
-    const img = await runWithCloudBindingsAsync(DIGEST_GATE_OFF, () =>
-      resolveImageRef(buildOff, {
-        ...baseApp,
-        metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
-      }),
-    );
+    const img = await resolveImageRef(buildOff, {
+      ...baseApp,
+      metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+    });
     expect(img).toBe("ghcr.io/elizaos/myapp:v1");
   });
 
@@ -133,12 +124,10 @@ describe("resolveImageRef: image allowlist gate", () => {
         metadata: { imageTag: "ghcr.io/elizaos/eliza:stable" },
       }),
     ).rejects.toThrow(/is not permitted/);
-    const img = await runWithCloudBindingsAsync(DIGEST_GATE_OFF, () =>
-      resolveImageRef(buildOff, {
-        ...baseApp,
-        metadata: { imageTag: "ghcr.io/onlyme/app:v1" },
-      }),
-    );
+    const img = await resolveImageRef(buildOff, {
+      ...baseApp,
+      metadata: { imageTag: "ghcr.io/onlyme/app:v1" },
+    });
     expect(img).toBe("ghcr.io/onlyme/app:v1");
   });
 });
@@ -203,20 +192,16 @@ describe("resolveImageRef: apps-deploy allowlist is elizaos-only", () => {
     const depPinned = `ghcr.io/dexploarer/bnancy@sha256:b${"0".repeat(63)}`;
     const waiPinned = `ghcr.io/waifufun/imagegen@sha256:c${"0".repeat(63)}`;
     expect(
-      await runWithCloudBindingsAsync(DIGEST_GATE_OFF, () =>
-        resolveImageRef(buildOff, {
-          ...baseApp,
-          metadata: { imageTag: depPinned },
-        }),
-      ),
+      await resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: depPinned },
+      }),
     ).toBe(depPinned);
     expect(
-      await runWithCloudBindingsAsync(DIGEST_GATE_OFF, () =>
-        resolveImageRef(buildOff, {
-          ...baseApp,
-          metadata: { imageTag: waiPinned },
-        }),
-      ),
+      await resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: waiPinned },
+      }),
     ).toBe(waiPinned);
   });
 });
@@ -328,42 +313,35 @@ describe("resolveImageRef: per-org namespace extension", () => {
 // is armed, all three must reject a mutable `:tag`/`:latest` ref so the registry
 // cannot swap the bytes behind an allowed name after the check.
 //
-// #13097 — the apps-deploy lane now enforces the digest-pin gate by DEFAULT via
-// the lane-scoped `APPS_DEPLOY_REQUIRE_DIGEST` flag (ON unless an operator opts
-// out with `APPS_DEPLOY_REQUIRE_DIGEST=false`). The global
-// `CONTAINER_IMAGE_REQUIRE_DIGEST` gate is also inherited when armed.
+// #13097 — source builds return immutable refs. Lane-wide enforcement remains
+// opt-in until supported prebuilt/default image configurations are migrated.
+// The global `CONTAINER_IMAGE_REQUIRE_DIGEST` gate is also inherited when armed.
 describe("resolveImageRef: digest-pin gate (#13097, #9853 follow-up)", () => {
   const baseApp = { id: "app-1", name: "demo", metadata: {} as Record<string, unknown> };
   const buildOff = { resolveImage: undefined } as unknown as AppDeployRunnerDeps;
 
-  test("DEFAULT (apps-deploy gate armed): a mutable :tag app image is rejected", async () => {
+  test("DEFAULT (apps-deploy gate off): a supported mutable :tag app image passes", async () => {
     await expect(
       resolveImageRef(buildOff, {
         ...baseApp,
         metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
       }),
-    ).rejects.toThrow(/must be pinned to a full sha256 digest/);
+    ).resolves.toBe("ghcr.io/elizaos/myapp:v1");
   });
 
-  test("DEFAULT (apps-deploy gate armed): an implicit-latest (untagged) app image is rejected", async () => {
-    await expect(
-      resolveImageRef(buildOff, { ...baseApp, metadata: { imageTag: "ghcr.io/elizaos/myapp" } }),
-    ).rejects.toThrow(/must be pinned to a full sha256 digest/);
+  test("APPS_DEPLOY_REQUIRE_DIGEST=true rejects an implicit-latest app image", async () => {
+    await runWithCloudBindingsAsync(DIGEST_GATE_ON, async () => {
+      await expect(
+        resolveImageRef(buildOff, { ...baseApp, metadata: { imageTag: "ghcr.io/elizaos/myapp" } }),
+      ).rejects.toThrow(/must be pinned to a full sha256 digest/);
+    });
   });
 
-  test("DEFAULT (apps-deploy gate armed): a digest-pinned app image passes", async () => {
-    const img = await resolveImageRef(buildOff, { ...baseApp, metadata: { imageTag: PINNED } });
-    expect(img).toBe(PINNED);
-  });
-
-  test("APPS_DEPLOY_REQUIRE_DIGEST=false opts out (mutable :tag passes)", async () => {
-    const img = await runWithCloudBindingsAsync(DIGEST_GATE_OFF, () =>
-      resolveImageRef(buildOff, {
-        ...baseApp,
-        metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
-      }),
-    );
-    expect(img).toBe("ghcr.io/elizaos/myapp:v1");
+  test("APPS_DEPLOY_REQUIRE_DIGEST=true accepts a digest-pinned app image", async () => {
+    await runWithCloudBindingsAsync(DIGEST_GATE_ON, async () => {
+      const img = await resolveImageRef(buildOff, { ...baseApp, metadata: { imageTag: PINNED } });
+      expect(img).toBe(PINNED);
+    });
   });
 
   test("global CONTAINER_IMAGE_REQUIRE_DIGEST=true arms the gate even when the apps-deploy flag is off", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
@@ -1,8 +1,18 @@
 // Exercises app deploy runner behavior with deterministic cloud-shared lib fixtures.
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { runWithCloudBindingsAsync } from "../../runtime/cloud-bindings";
 import type { AppDeployRunnerDeps } from "../app-deploy-runner";
 import { containerNameForApp, resolveImageRef } from "../app-deploy-runner";
+
+// #13097 — the apps-deploy digest-pin gate is ON by default. Tests that exercise
+// ONLY the allowlist / repo / org-namespace concerns (not the digest concern)
+// opt the gate off so a mutable-tag fixture doesn't trip the digest gate first.
+// Tests that exercise the digest concern use digest-pinned fixtures or arm the
+// gate explicitly.
+const DIGEST_GATE_OFF = { APPS_DEPLOY_REQUIRE_DIGEST: "false" };
+
+// A first-party digest-pinned ref (passes both the allowlist and digest gates).
+const PINNED = `ghcr.io/elizaos/eliza@sha256:a${"0".repeat(63)}`;
 
 // #9145 — container names must be stable + DNS/Docker-safe regardless of app id.
 describe("containerNameForApp (#9145)", () => {
@@ -47,27 +57,29 @@ describe("resolveImageRef: build-from-repo-disabled guard", () => {
 
   test("repo app + build off + explicit imageTag -> uses the prebuilt image", async () => {
     process.env.APP_DEFAULT_IMAGE = "ghcr.io/elizaos/app-default:smoke";
-    const img = await resolveImageRef(buildOff, {
-      ...baseApp,
-      repoUrl: REPO,
-      // Allowlisted first-party namespace (the image allowlist gate runs on the
-      // resolved image — see the gate describe block below).
-      metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
-    });
+    const img = await runWithCloudBindingsAsync(DIGEST_GATE_OFF, () =>
+      resolveImageRef(buildOff, {
+        ...baseApp,
+        repoUrl: REPO,
+        // Allowlisted first-party namespace (the image allowlist gate runs on the
+        // resolved image — see the gate describe block below).
+        metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+      }),
+    );
     expect(img).toBe("ghcr.io/elizaos/myapp:v1");
   });
 
   test("repo app + build on -> uses the built image", async () => {
     const buildOn = {
-      resolveImage: async () => "ghcr.io/elizaos/app-built:abc",
+      resolveImage: async () => PINNED,
     } as unknown as AppDeployRunnerDeps;
     const img = await resolveImageRef(buildOn, { ...baseApp, repoUrl: REPO });
-    expect(img).toBe("ghcr.io/elizaos/app-built:abc");
+    expect(img).toBe(PINNED);
   });
 
   test("non-repo app still falls back to APP_DEFAULT_IMAGE (unchanged)", async () => {
-    process.env.APP_DEFAULT_IMAGE = "ghcr.io/elizaos/app-default:smoke";
-    expect(await resolveImageRef(buildOff, baseApp)).toBe("ghcr.io/elizaos/app-default:smoke");
+    process.env.APP_DEFAULT_IMAGE = PINNED;
+    expect(await resolveImageRef(buildOff, baseApp)).toBe(PINNED);
   });
 });
 
@@ -94,16 +106,18 @@ describe("resolveImageRef: image allowlist gate", () => {
   });
 
   test("allows an imageTag inside the default first-party allowlist", async () => {
-    const img = await resolveImageRef(buildOff, {
-      ...baseApp,
-      metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
-    });
+    const img = await runWithCloudBindingsAsync(DIGEST_GATE_OFF, () =>
+      resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+      }),
+    );
     expect(img).toBe("ghcr.io/elizaos/myapp:v1");
   });
 
   test("the default agent image passes the default allowlist", async () => {
-    process.env.APP_DEFAULT_IMAGE = "ghcr.io/elizaos/eliza:stable";
-    expect(await resolveImageRef(buildOff, baseApp)).toBe("ghcr.io/elizaos/eliza:stable");
+    process.env.APP_DEFAULT_IMAGE = PINNED;
+    expect(await resolveImageRef(buildOff, baseApp)).toBe(PINNED);
   });
 
   test("a mis-set APP_DEFAULT_IMAGE outside the allowlist is rejected", async () => {
@@ -119,10 +133,12 @@ describe("resolveImageRef: image allowlist gate", () => {
         metadata: { imageTag: "ghcr.io/elizaos/eliza:stable" },
       }),
     ).rejects.toThrow(/is not permitted/);
-    const img = await resolveImageRef(buildOff, {
-      ...baseApp,
-      metadata: { imageTag: "ghcr.io/onlyme/app:v1" },
-    });
+    const img = await runWithCloudBindingsAsync(DIGEST_GATE_OFF, () =>
+      resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: "ghcr.io/onlyme/app:v1" },
+      }),
+    );
     expect(img).toBe("ghcr.io/onlyme/app:v1");
   });
 });
@@ -146,9 +162,9 @@ describe("resolveImageRef: apps-deploy allowlist is elizaos-only", () => {
   test("allows a first-party ghcr.io/elizaos/* image by default", async () => {
     const img = await resolveImageRef(buildOff, {
       ...baseApp,
-      metadata: { imageTag: "ghcr.io/elizaos/example-edad:showcase" },
+      metadata: { imageTag: PINNED },
     });
-    expect(img).toBe("ghcr.io/elizaos/example-edad:showcase");
+    expect(img).toBe(PINNED);
   });
 
   test("REJECTS ghcr.io/dexploarer/* by default (personal org)", async () => {
@@ -184,18 +200,24 @@ describe("resolveImageRef: apps-deploy allowlist is elizaos-only", () => {
   test("opt-in via APPS_DEPLOY_IMAGE_ALLOWLIST re-allows dexploarer + waifufun", async () => {
     process.env.APPS_DEPLOY_IMAGE_ALLOWLIST =
       "ghcr.io/elizaos/*,ghcr.io/dexploarer/*,ghcr.io/waifufun/*";
+    const depPinned = `ghcr.io/dexploarer/bnancy@sha256:b${"0".repeat(63)}`;
+    const waiPinned = `ghcr.io/waifufun/imagegen@sha256:c${"0".repeat(63)}`;
     expect(
-      await resolveImageRef(buildOff, {
-        ...baseApp,
-        metadata: { imageTag: "ghcr.io/dexploarer/bnancy:latest" },
-      }),
-    ).toBe("ghcr.io/dexploarer/bnancy:latest");
+      await runWithCloudBindingsAsync(DIGEST_GATE_OFF, () =>
+        resolveImageRef(buildOff, {
+          ...baseApp,
+          metadata: { imageTag: depPinned },
+        }),
+      ),
+    ).toBe(depPinned);
     expect(
-      await resolveImageRef(buildOff, {
-        ...baseApp,
-        metadata: { imageTag: "ghcr.io/waifufun/imagegen:latest" },
-      }),
-    ).toBe("ghcr.io/waifufun/imagegen:latest");
+      await runWithCloudBindingsAsync(DIGEST_GATE_OFF, () =>
+        resolveImageRef(buildOff, {
+          ...baseApp,
+          metadata: { imageTag: waiPinned },
+        }),
+      ),
+    ).toBe(waiPinned);
   });
 });
 
@@ -207,7 +229,8 @@ describe("resolveImageRef: apps-deploy allowlist is elizaos-only", () => {
 // deploy carries an organizationId, and a failing lookup denies.
 describe("resolveImageRef: per-org namespace extension", () => {
   const baseApp = { id: "app-1", name: "demo", metadata: {} as Record<string, unknown> };
-  const ORG_IMAGE = "ghcr.io/nubscarson/my-app:v1";
+  // A digest-pinned org image (passes the default-armed digest gate).
+  const ORG_IMAGE = `ghcr.io/nubscarson/my-app@sha256:d${"0".repeat(63)}`;
 
   function depsWithOrgNamespaces(
     lookup: (orgId: string) => Promise<string[]>,
@@ -293,55 +316,74 @@ describe("resolveImageRef: per-org namespace extension", () => {
     const img = await resolveImageRef(deps, {
       ...baseApp,
       organizationId: "org-1",
-      metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+      metadata: { imageTag: PINNED },
     });
-    expect(img).toBe("ghcr.io/elizaos/myapp:v1");
+    expect(img).toBe(PINNED);
     expect(called).toBe(false);
   });
 });
 
 // #9853 follow-up — an app deploy is the THIRD shared-node image path (alongside
-// the /v1/containers and /v1/coding-containers routes). When the opt-in
-// digest-pin gate (CONTAINER_IMAGE_REQUIRE_DIGEST) is armed, all three must
-// reject a mutable `:tag`/`:latest` ref so the registry cannot swap the bytes
-// behind an allowed name after the check; previously this path skipped the gate.
-describe("resolveImageRef: digest-pin gate (#9853 follow-up)", () => {
+// the /v1/containers and /v1/coding-containers routes). When the digest-pin gate
+// is armed, all three must reject a mutable `:tag`/`:latest` ref so the registry
+// cannot swap the bytes behind an allowed name after the check.
+//
+// #13097 — the apps-deploy lane now enforces the digest-pin gate by DEFAULT via
+// the lane-scoped `APPS_DEPLOY_REQUIRE_DIGEST` flag (ON unless an operator opts
+// out with `APPS_DEPLOY_REQUIRE_DIGEST=false`). The global
+// `CONTAINER_IMAGE_REQUIRE_DIGEST` gate is also inherited when armed.
+describe("resolveImageRef: digest-pin gate (#13097, #9853 follow-up)", () => {
   const baseApp = { id: "app-1", name: "demo", metadata: {} as Record<string, unknown> };
   const buildOff = { resolveImage: undefined } as unknown as AppDeployRunnerDeps;
-  // An allowlisted first-party digest-pinned ref (passes both gates).
-  const PINNED = `ghcr.io/elizaos/eliza@sha256:a${"0".repeat(63)}`;
 
-  test("flag ON: a mutable :tag app image is rejected", async () => {
-    await runWithCloudBindingsAsync({ CONTAINER_IMAGE_REQUIRE_DIGEST: "true" }, async () => {
-      await expect(
-        resolveImageRef(buildOff, {
-          ...baseApp,
-          metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
-        }),
-      ).rejects.toThrow(/must be pinned to a full sha256 digest/);
-    });
+  test("DEFAULT (apps-deploy gate armed): a mutable :tag app image is rejected", async () => {
+    await expect(
+      resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+      }),
+    ).rejects.toThrow(/must be pinned to a full sha256 digest/);
   });
 
-  test("flag ON: an implicit-latest (untagged) app image is rejected", async () => {
-    await runWithCloudBindingsAsync({ CONTAINER_IMAGE_REQUIRE_DIGEST: "true" }, async () => {
-      await expect(
-        resolveImageRef(buildOff, { ...baseApp, metadata: { imageTag: "ghcr.io/elizaos/myapp" } }),
-      ).rejects.toThrow(/must be pinned to a full sha256 digest/);
-    });
+  test("DEFAULT (apps-deploy gate armed): an implicit-latest (untagged) app image is rejected", async () => {
+    await expect(
+      resolveImageRef(buildOff, { ...baseApp, metadata: { imageTag: "ghcr.io/elizaos/myapp" } }),
+    ).rejects.toThrow(/must be pinned to a full sha256 digest/);
   });
 
-  test("flag ON: a digest-pinned app image passes", async () => {
+  test("DEFAULT (apps-deploy gate armed): a digest-pinned app image passes", async () => {
+    const img = await resolveImageRef(buildOff, { ...baseApp, metadata: { imageTag: PINNED } });
+    expect(img).toBe(PINNED);
+  });
+
+  test("APPS_DEPLOY_REQUIRE_DIGEST=false opts out (mutable :tag passes)", async () => {
+    const img = await runWithCloudBindingsAsync(DIGEST_GATE_OFF, () =>
+      resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+      }),
+    );
+    expect(img).toBe("ghcr.io/elizaos/myapp:v1");
+  });
+
+  test("global CONTAINER_IMAGE_REQUIRE_DIGEST=true arms the gate even when the apps-deploy flag is off", async () => {
+    await runWithCloudBindingsAsync(
+      { CONTAINER_IMAGE_REQUIRE_DIGEST: "true", APPS_DEPLOY_REQUIRE_DIGEST: "false" },
+      async () => {
+        await expect(
+          resolveImageRef(buildOff, {
+            ...baseApp,
+            metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+          }),
+        ).rejects.toThrow(/must be pinned to a full sha256 digest/);
+      },
+    );
+  });
+
+  test("global flag ON: a digest-pinned app image passes", async () => {
     await runWithCloudBindingsAsync({ CONTAINER_IMAGE_REQUIRE_DIGEST: "true" }, async () => {
       const img = await resolveImageRef(buildOff, { ...baseApp, metadata: { imageTag: PINNED } });
       expect(img).toBe(PINNED);
     });
-  });
-
-  test("flag OFF (default): a mutable :tag app image is unchanged (passes)", async () => {
-    const img = await resolveImageRef(buildOff, {
-      ...baseApp,
-      metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
-    });
-    expect(img).toBe("ghcr.io/elizaos/myapp:v1");
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
@@ -1,10 +1,7 @@
-// Exercises app deploy runner behavior with deterministic cloud-shared lib fixtures.
+/** Exercises app deploy runner behavior with deterministic cloud-shared lib fixtures. */
 import { afterEach, describe, expect, test } from "bun:test";
-import { runWithCloudBindingsAsync } from "../../runtime/cloud-bindings";
 import type { AppDeployRunnerDeps } from "../app-deploy-runner";
 import { containerNameForApp, resolveImageRef } from "../app-deploy-runner";
-
-const DIGEST_GATE_ON = { APPS_DEPLOY_REQUIRE_DIGEST: "true" };
 
 // A first-party digest-pinned ref (passes both the allowlist and digest gates).
 const PINNED = `ghcr.io/elizaos/eliza@sha256:a${"0".repeat(63)}`;
@@ -57,9 +54,9 @@ describe("resolveImageRef: build-from-repo-disabled guard", () => {
       repoUrl: REPO,
       // Allowlisted first-party namespace (the image allowlist gate runs on the
       // resolved image — see the gate describe block below).
-      metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+      metadata: { imageTag: PINNED },
     });
-    expect(img).toBe("ghcr.io/elizaos/myapp:v1");
+    expect(img).toBe(PINNED);
   });
 
   test("repo app + build on -> uses the built image", async () => {
@@ -101,9 +98,9 @@ describe("resolveImageRef: image allowlist gate", () => {
   test("allows an imageTag inside the default first-party allowlist", async () => {
     const img = await resolveImageRef(buildOff, {
       ...baseApp,
-      metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+      metadata: { imageTag: PINNED },
     });
-    expect(img).toBe("ghcr.io/elizaos/myapp:v1");
+    expect(img).toBe(PINNED);
   });
 
   test("the default agent image passes the default allowlist", async () => {
@@ -126,9 +123,9 @@ describe("resolveImageRef: image allowlist gate", () => {
     ).rejects.toThrow(/is not permitted/);
     const img = await resolveImageRef(buildOff, {
       ...baseApp,
-      metadata: { imageTag: "ghcr.io/onlyme/app:v1" },
+      metadata: { imageTag: `ghcr.io/onlyme/app@sha256:e${"0".repeat(63)}` },
     });
-    expect(img).toBe("ghcr.io/onlyme/app:v1");
+    expect(img).toBe(`ghcr.io/onlyme/app@sha256:e${"0".repeat(63)}`);
   });
 });
 
@@ -308,60 +305,64 @@ describe("resolveImageRef: per-org namespace extension", () => {
   });
 });
 
-// #9853 follow-up — an app deploy is the THIRD shared-node image path (alongside
-// the /v1/containers and /v1/coding-containers routes). When the digest-pin gate
-// is armed, all three must reject a mutable `:tag`/`:latest` ref so the registry
-// cannot swap the bytes behind an allowed name after the check.
-//
-// #13097 — source builds return immutable refs. Lane-wide enforcement remains
-// opt-in until supported prebuilt/default image configurations are migrated.
-// The global `CONTAINER_IMAGE_REQUIRE_DIGEST` gate is also inherited when armed.
-describe("resolveImageRef: digest-pin gate (#13097, #9853 follow-up)", () => {
+// #13097 — every app-deploy image source is immutable at the final common
+// resolution boundary. No environment flag can reopen mutable deployment.
+describe("resolveImageRef: immutable image enforcement (#13097)", () => {
   const baseApp = { id: "app-1", name: "demo", metadata: {} as Record<string, unknown> };
   const buildOff = { resolveImage: undefined } as unknown as AppDeployRunnerDeps;
 
-  test("DEFAULT (apps-deploy gate off): a supported mutable :tag app image passes", async () => {
+  afterEach(() => {
+    delete process.env.APP_DEFAULT_IMAGE;
+    delete process.env.APPS_DEPLOY_REQUIRE_DIGEST;
+  });
+
+  test("rejects a mutable image returned by resolveImage", async () => {
+    const deps = {
+      resolveImage: async () => "ghcr.io/elizaos/myapp:v1",
+    } as unknown as AppDeployRunnerDeps;
+    await expect(resolveImageRef(deps, baseApp)).rejects.toThrow(
+      /must be pinned to a full sha256 digest/,
+    );
+  });
+
+  test("rejects a mutable metadata.imageTag", async () => {
     await expect(
       resolveImageRef(buildOff, {
         ...baseApp,
         metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
       }),
-    ).resolves.toBe("ghcr.io/elizaos/myapp:v1");
+    ).rejects.toThrow(/must be pinned to a full sha256 digest/);
   });
 
-  test("APPS_DEPLOY_REQUIRE_DIGEST=true rejects an implicit-latest app image", async () => {
-    await runWithCloudBindingsAsync(DIGEST_GATE_ON, async () => {
-      await expect(
-        resolveImageRef(buildOff, { ...baseApp, metadata: { imageTag: "ghcr.io/elizaos/myapp" } }),
-      ).rejects.toThrow(/must be pinned to a full sha256 digest/);
-    });
-  });
-
-  test("APPS_DEPLOY_REQUIRE_DIGEST=true accepts a digest-pinned app image", async () => {
-    await runWithCloudBindingsAsync(DIGEST_GATE_ON, async () => {
-      const img = await resolveImageRef(buildOff, { ...baseApp, metadata: { imageTag: PINNED } });
-      expect(img).toBe(PINNED);
-    });
-  });
-
-  test("global CONTAINER_IMAGE_REQUIRE_DIGEST=true arms the gate even when the apps-deploy flag is off", async () => {
-    await runWithCloudBindingsAsync(
-      { CONTAINER_IMAGE_REQUIRE_DIGEST: "true", APPS_DEPLOY_REQUIRE_DIGEST: "false" },
-      async () => {
-        await expect(
-          resolveImageRef(buildOff, {
-            ...baseApp,
-            metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
-          }),
-        ).rejects.toThrow(/must be pinned to a full sha256 digest/);
-      },
+  test("rejects a mutable APP_DEFAULT_IMAGE", async () => {
+    process.env.APP_DEFAULT_IMAGE = "ghcr.io/elizaos/myapp:latest";
+    await expect(resolveImageRef(buildOff, baseApp)).rejects.toThrow(
+      /must be pinned to a full sha256 digest/,
     );
   });
 
-  test("global flag ON: a digest-pinned app image passes", async () => {
-    await runWithCloudBindingsAsync({ CONTAINER_IMAGE_REQUIRE_DIGEST: "true" }, async () => {
-      const img = await resolveImageRef(buildOff, { ...baseApp, metadata: { imageTag: PINNED } });
-      expect(img).toBe(PINNED);
-    });
+  test("rejects an implicit-latest image", async () => {
+    await expect(
+      resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: "ghcr.io/elizaos/myapp" },
+      }),
+    ).rejects.toThrow(/must be pinned to a full sha256 digest/);
+  });
+
+  test("APPS_DEPLOY_REQUIRE_DIGEST=false cannot bypass enforcement", async () => {
+    process.env.APPS_DEPLOY_REQUIRE_DIGEST = "false";
+    await expect(
+      resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+      }),
+    ).rejects.toThrow(/must be pinned to a full sha256 digest/);
+  });
+
+  test("accepts a full digest-pinned image without a flag", async () => {
+    await expect(
+      resolveImageRef(buildOff, { ...baseApp, metadata: { imageTag: PINNED } }),
+    ).resolves.toBe(PINNED);
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-factory.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-factory.test.ts
@@ -127,7 +127,9 @@ describe("createApp: template-image wiring (no-repo apps)", () => {
       createGitHubRepo: false,
       imageTag: `ghcr.io/elizaos/myapp@sha256:e${"0".repeat(63)}`,
     });
-    expect(metaImageTag(result.app.metadata)).toBe(`ghcr.io/elizaos/myapp@sha256:e${"0".repeat(63)}`);
+    expect(metaImageTag(result.app.metadata)).toBe(
+      `ghcr.io/elizaos/myapp@sha256:e${"0".repeat(63)}`,
+    );
   });
 
   test("a pre-existing metadata.imageTag is never overwritten (no redundant update)", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/app-factory.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-factory.test.ts
@@ -80,7 +80,8 @@ const DATA = {
   app_url: "https://demo.example.com",
 };
 
-const DEFAULT_TEMPLATE_IMAGE = "ghcr.io/elizaos/example-edad:showcase";
+const DEFAULT_TEMPLATE_IMAGE =
+  "ghcr.io/elizaos/example-edad@sha256:2c68b639eec00fad1b35e978f5463f1543b392c96680ec496fd0c0a9eddc8241";
 const buildOff = { resolveImage: undefined } as unknown as AppDeployRunnerDeps;
 
 function metaImageTag(metadata: unknown): string | undefined {
@@ -113,25 +114,28 @@ describe("createApp: template-image wiring (no-repo apps)", () => {
   });
 
   test("APP_DEFAULT_TEMPLATE_IMAGE env overrides the stamped image", async () => {
-    process.env.APP_DEFAULT_TEMPLATE_IMAGE = "ghcr.io/elizaos/example-clone-ur-crush:showcase";
+    process.env.APP_DEFAULT_TEMPLATE_IMAGE =
+      "ghcr.io/elizaos/example-clone-ur-crush@sha256:b7e5fd1310a56158ea47ea923eccc7ae4ca067b177bea0cd326d32c4129b60db";
     const result = await appFactoryService.createApp(DATA, { createGitHubRepo: false });
     expect(metaImageTag(result.app.metadata)).toBe(
-      "ghcr.io/elizaos/example-clone-ur-crush:showcase",
+      "ghcr.io/elizaos/example-clone-ur-crush@sha256:b7e5fd1310a56158ea47ea923eccc7ae4ca067b177bea0cd326d32c4129b60db",
     );
   });
 
   test("caller-supplied options.imageTag wins over the default (not overwritten)", async () => {
     const result = await appFactoryService.createApp(DATA, {
       createGitHubRepo: false,
-      imageTag: "ghcr.io/elizaos/myapp:v9",
+      imageTag: `ghcr.io/elizaos/myapp@sha256:e${"0".repeat(63)}`,
     });
-    expect(metaImageTag(result.app.metadata)).toBe("ghcr.io/elizaos/myapp:v9");
+    expect(metaImageTag(result.app.metadata)).toBe(`ghcr.io/elizaos/myapp@sha256:e${"0".repeat(63)}`);
   });
 
   test("a pre-existing metadata.imageTag is never overwritten (no redundant update)", async () => {
-    seededMetadata = { imageTag: "ghcr.io/elizaos/preexisting:v1" };
+    seededMetadata = { imageTag: `ghcr.io/elizaos/preexisting@sha256:f${"0".repeat(63)}` };
     const result = await appFactoryService.createApp(DATA, { createGitHubRepo: false });
-    expect(metaImageTag(result.app.metadata)).toBe("ghcr.io/elizaos/preexisting:v1");
+    expect(metaImageTag(result.app.metadata)).toBe(
+      `ghcr.io/elizaos/preexisting@sha256:f${"0".repeat(63)}`,
+    );
     // imageTag unchanged => no metadata write (and no repo => no github_repo write).
     expect(updateCalls.length).toBe(0);
   });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-image-builder.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-image-builder.test.ts
@@ -1,9 +1,16 @@
 // Exercises app image builder behavior with deterministic cloud-shared lib fixtures.
 import { describe, expect, test } from "bun:test";
-import { AppImageBuilder, type BuildExec } from "../app-image-builder";
+import {
+  AppImageBuilder,
+  buildImagetoolsInspectCmd,
+  type BuildExec,
+  parseImagetoolsDigest,
+} from "../app-image-builder";
 
 const APP = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const REF = "ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:a1b2c3d";
+const DIGEST = "sha256:2c68b639eec00fad1b35e978f5463f1543b392c96680ec496fd0c0a9eddc8241";
+const PINNED_REF = `${REF}@${DIGEST}`;
 
 function fakeExec(): BuildExec & { calls: Array<{ cmd: string; timeoutMs?: number }> } {
   const calls: Array<{ cmd: string; timeoutMs?: number }> = [];
@@ -11,10 +18,39 @@ function fakeExec(): BuildExec & { calls: Array<{ cmd: string; timeoutMs?: numbe
     calls,
     async exec(cmd: string, timeoutMs?: number) {
       calls.push({ cmd, timeoutMs });
+      // When the builder inspects the pushed image, return a manifest digest so
+      // the builder can pin the returned ref. Otherwise return build output.
+      if (cmd.startsWith("docker buildx imagetools inspect")) {
+        return `Name:      ${REF}\nMediaType: application/vnd.oci.image.index.v1+json\nDigest:    ${DIGEST}\n`;
+      }
       return "Successfully built abc123";
     },
   };
 }
+
+describe("parseImagetoolsDigest", () => {
+  test("extracts the first sha256:<64hex> digest", () => {
+    expect(
+      parseImagetoolsDigest(
+        `Name:      ${REF}\nMediaType: application/vnd.oci.image.index.v1+json\nDigest:    sha256:abc123def4567890abc123def4567890abc123def4567890abc123def4567890\n`,
+      ),
+    ).toBe("sha256:abc123def4567890abc123def4567890abc123def4567890abc123def4567890");
+  });
+
+  test("returns null when no digest is present", () => {
+    expect(parseImagetoolsDigest("no digest here")).toBeNull();
+  });
+
+  test("ignores partial digests (<64 hex)", () => {
+    expect(parseImagetoolsDigest("sha256:abc123")).toBeNull();
+  });
+});
+
+describe("buildImagetoolsInspectCmd", () => {
+  test("assembles the imagetools inspect command with a quoted ref", () => {
+    expect(buildImagetoolsInspectCmd(REF)).toBe(`docker buildx imagetools inspect '${REF}'`);
+  });
+});
 
 describe("AppImageBuilder", () => {
   test("resolves the ref and execs the build inside a THROWAWAY isolated builder by default", async () => {
@@ -28,6 +64,7 @@ describe("AppImageBuilder", () => {
       dockerfile: "Dockerfile",
     });
 
+    // No push → mutable ref (local --load build, no registry manifest to pin).
     expect(res.imageRef).toBe(REF);
     expect(res.buildOutput).toContain("Successfully built");
     expect(exec.calls).toHaveLength(1);
@@ -68,11 +105,70 @@ describe("AppImageBuilder", () => {
       context: "https://github.com/u/repo.git#main",
       push: true,
     });
-    const cmd = exec.calls[0].cmd;
-    expect(cmd).toContain("docker buildx build --builder 'apps-build-");
-    expect(cmd).toContain("--push");
-    expect(cmd).not.toContain("--load");
-    expect(cmd).toContain("docker buildx create --driver docker-container");
+    const buildCmd = exec.calls[0].cmd;
+    expect(buildCmd).toContain("docker buildx build --builder 'apps-build-");
+    expect(buildCmd).toContain("--push");
+    expect(buildCmd).not.toContain("--load");
+    expect(buildCmd).toContain("docker buildx create --driver docker-container");
+  });
+
+  test("push resolves the immutable digest and returns a digest-pinned ref (#13097)", async () => {
+    const exec = fakeExec();
+    const res = await new AppImageBuilder({ exec }).build({
+      registry: "ghcr.io/elizaos",
+      appId: APP,
+      sourceRef: "a1b2c3d",
+      context: "https://github.com/u/repo.git#main",
+      push: true,
+    });
+    // The pushed ref is pinned to the resolved manifest digest.
+    expect(res.imageRef).toBe(PINNED_REF);
+    // Two exec calls: the build, then the imagetools inspect.
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[1].cmd).toBe(`docker buildx imagetools inspect '${REF}'`);
+  });
+
+  test("push falls back to the mutable ref when inspect returns no digest", async () => {
+    const latestRef = "ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:latest";
+    const exec: BuildExec & { calls: Array<{ cmd: string }> } = {
+      calls: [],
+      async exec(cmd: string) {
+        this.calls.push({ cmd });
+        if (cmd.startsWith("docker buildx imagetools inspect")) {
+          return "no digest available";
+        }
+        return "built";
+      },
+    };
+    const res = await new AppImageBuilder({ exec }).build({
+      registry: "ghcr.io/elizaos",
+      appId: APP,
+      context: "/c",
+      push: true,
+    });
+    // Inspect ran but found no digest → fall back to the mutable ref (non-fatal).
+    expect(res.imageRef).toBe(latestRef);
+  });
+
+  test("push falls back to the mutable ref when inspect throws (registry lag)", async () => {
+    const latestRef = "ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:latest";
+    const exec: BuildExec & { calls: Array<{ cmd: string }> } = {
+      calls: [],
+      async exec(cmd: string) {
+        this.calls.push({ cmd });
+        if (cmd.startsWith("docker buildx imagetools inspect")) {
+          throw new Error("registry timeout");
+        }
+        return "built";
+      },
+    };
+    const res = await new AppImageBuilder({ exec }).build({
+      registry: "ghcr.io/elizaos",
+      appId: APP,
+      context: "/c",
+      push: true,
+    });
+    expect(res.imageRef).toBe(latestRef);
   });
 
   test("isolatedBuilder:false runs the plain host-daemon build (trusted/verification only)", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/app-image-builder.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-image-builder.test.ts
@@ -1,4 +1,4 @@
-// Exercises app image builder behavior with deterministic cloud-shared lib fixtures.
+/** Exercises app image builder behavior with deterministic cloud-shared lib fixtures. */
 
 import { describe, expect, test } from "bun:test";
 import { ElizaError } from "@elizaos/core";
@@ -15,10 +15,10 @@ function fakeExec(): BuildExec & { calls: Array<{ cmd: string; timeoutMs?: numbe
     calls,
     async exec(cmd: string, timeoutMs?: number) {
       calls.push({ cmd, timeoutMs });
-      if (cmd.startsWith("cat ")) {
-        return JSON.stringify({ "containerimage.digest": DIGEST });
-      }
-      return "Successfully built abc123";
+      const marker = cmd.match(/ELIZA_APP_BUILD_METADATA_[0-9a-f]{24}/)?.[0];
+      return marker
+        ? `Successfully built abc123\n${marker}\n${JSON.stringify({ "containerimage.digest": DIGEST })}`
+        : "Successfully built abc123";
     },
   };
 }
@@ -118,11 +118,13 @@ describe("AppImageBuilder", () => {
     });
     // The pushed ref is pinned to the resolved manifest digest.
     expect(res.imageRef).toBe(PINNED_REF);
-    // Two exec calls: the build, then reading its unique BuildKit metadata.
-    expect(exec.calls).toHaveLength(2);
-    expect(exec.calls[1].cmd).toMatch(
-      /^cat '\/tmp\/eliza-app-build-[0-9a-f]{24}\.json'; status=\$\?; rm -f '\/tmp\/eliza-app-build-[0-9a-f]{24}\.json'; exit \$status$/,
-    );
+    // Build, metadata read, and cleanup share one shell invocation so EXIT
+    // cleanup runs on success, build failure, timeout, or interruption.
+    expect(exec.calls).toHaveLength(1);
+    const command = exec.calls[0].cmd;
+    expect(command).toMatch(/trap .*rm -f .*eliza-app-build-[0-9a-f]{24}\.json.* EXIT/);
+    expect(command).toMatch(/if ! cat '\/tmp\/eliza-app-build-[0-9a-f]{24}\.json'/);
+    expect(command.indexOf("trap ")).toBeLessThan(command.indexOf("docker buildx build"));
   });
 
   test("push fails when BuildKit metadata contains no digest", async () => {
@@ -130,8 +132,8 @@ describe("AppImageBuilder", () => {
       calls: [],
       async exec(cmd: string) {
         this.calls.push({ cmd });
-        if (cmd.startsWith("cat ")) return JSON.stringify({});
-        return "built";
+        const marker = cmd.match(/ELIZA_APP_BUILD_METADATA_[0-9a-f]{24}/)?.[0];
+        return marker ? `built\n${marker}\n{}` : "built";
       },
     };
     await expect(
@@ -149,8 +151,8 @@ describe("AppImageBuilder", () => {
       calls: [],
       async exec(cmd: string) {
         this.calls.push({ cmd });
-        if (cmd.startsWith("cat ")) throw new Error("metadata read failed");
-        return "built";
+        const marker = cmd.match(/ELIZA_APP_BUILD_METADATA_[0-9a-f]{24}/)?.[0];
+        return marker ? `built\n${marker}\n{"elizaMetadataReadError":true}` : "built";
       },
     };
     const failure = new AppImageBuilder({ exec }).build({
@@ -162,7 +164,7 @@ describe("AppImageBuilder", () => {
     await expect(failure).rejects.toBeInstanceOf(ElizaError);
     await expect(failure).rejects.toMatchObject({
       code: "APP_IMAGE_BUILD_METADATA_READ_FAILED",
-      cause: expect.objectContaining({ message: "metadata read failed" }),
+      cause: expect.objectContaining({ message: "BuildKit metadata read failed" }),
     });
   });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/app-image-builder.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-image-builder.test.ts
@@ -1,11 +1,8 @@
 // Exercises app image builder behavior with deterministic cloud-shared lib fixtures.
+
 import { describe, expect, test } from "bun:test";
-import {
-  AppImageBuilder,
-  buildImagetoolsInspectCmd,
-  type BuildExec,
-  parseImagetoolsDigest,
-} from "../app-image-builder";
+import { ElizaError } from "@elizaos/core";
+import { AppImageBuilder, type BuildExec, parseBuildMetadataDigest } from "../app-image-builder";
 
 const APP = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const REF = "ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:a1b2c3d";
@@ -18,37 +15,34 @@ function fakeExec(): BuildExec & { calls: Array<{ cmd: string; timeoutMs?: numbe
     calls,
     async exec(cmd: string, timeoutMs?: number) {
       calls.push({ cmd, timeoutMs });
-      // When the builder inspects the pushed image, return a manifest digest so
-      // the builder can pin the returned ref. Otherwise return build output.
-      if (cmd.startsWith("docker buildx imagetools inspect")) {
-        return `Name:      ${REF}\nMediaType: application/vnd.oci.image.index.v1+json\nDigest:    ${DIGEST}\n`;
+      if (cmd.startsWith("cat ")) {
+        return JSON.stringify({ "containerimage.digest": DIGEST });
       }
       return "Successfully built abc123";
     },
   };
 }
 
-describe("parseImagetoolsDigest", () => {
-  test("extracts the first sha256:<64hex> digest", () => {
+describe("parseBuildMetadataDigest", () => {
+  test("extracts the exact BuildKit container image digest", () => {
     expect(
-      parseImagetoolsDigest(
-        `Name:      ${REF}\nMediaType: application/vnd.oci.image.index.v1+json\nDigest:    sha256:abc123def4567890abc123def4567890abc123def4567890abc123def4567890\n`,
+      parseBuildMetadataDigest(
+        JSON.stringify({
+          "containerimage.digest":
+            "sha256:abc123def4567890abc123def4567890abc123def4567890abc123def4567890",
+        }),
       ),
     ).toBe("sha256:abc123def4567890abc123def4567890abc123def4567890abc123def4567890");
   });
 
   test("returns null when no digest is present", () => {
-    expect(parseImagetoolsDigest("no digest here")).toBeNull();
+    expect(parseBuildMetadataDigest(JSON.stringify({}))).toBeNull();
   });
 
   test("ignores partial digests (<64 hex)", () => {
-    expect(parseImagetoolsDigest("sha256:abc123")).toBeNull();
-  });
-});
-
-describe("buildImagetoolsInspectCmd", () => {
-  test("assembles the imagetools inspect command with a quoted ref", () => {
-    expect(buildImagetoolsInspectCmd(REF)).toBe(`docker buildx imagetools inspect '${REF}'`);
+    expect(
+      parseBuildMetadataDigest(JSON.stringify({ "containerimage.digest": "sha256:abc123" })),
+    ).toBeNull();
   });
 });
 
@@ -108,6 +102,7 @@ describe("AppImageBuilder", () => {
     const buildCmd = exec.calls[0].cmd;
     expect(buildCmd).toContain("docker buildx build --builder 'apps-build-");
     expect(buildCmd).toContain("--push");
+    expect(buildCmd).toContain("--metadata-file '/tmp/eliza-app-build-");
     expect(buildCmd).not.toContain("--load");
     expect(buildCmd).toContain("docker buildx create --driver docker-container");
   });
@@ -123,52 +118,52 @@ describe("AppImageBuilder", () => {
     });
     // The pushed ref is pinned to the resolved manifest digest.
     expect(res.imageRef).toBe(PINNED_REF);
-    // Two exec calls: the build, then the imagetools inspect.
+    // Two exec calls: the build, then reading its unique BuildKit metadata.
     expect(exec.calls).toHaveLength(2);
-    expect(exec.calls[1].cmd).toBe(`docker buildx imagetools inspect '${REF}'`);
+    expect(exec.calls[1].cmd).toMatch(
+      /^cat '\/tmp\/eliza-app-build-[0-9a-f]{24}\.json'; status=\$\?; rm -f '\/tmp\/eliza-app-build-[0-9a-f]{24}\.json'; exit \$status$/,
+    );
   });
 
-  test("push falls back to the mutable ref when inspect returns no digest", async () => {
-    const latestRef = "ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:latest";
+  test("push fails when BuildKit metadata contains no digest", async () => {
     const exec: BuildExec & { calls: Array<{ cmd: string }> } = {
       calls: [],
       async exec(cmd: string) {
         this.calls.push({ cmd });
-        if (cmd.startsWith("docker buildx imagetools inspect")) {
-          return "no digest available";
-        }
+        if (cmd.startsWith("cat ")) return JSON.stringify({});
         return "built";
       },
     };
-    const res = await new AppImageBuilder({ exec }).build({
+    await expect(
+      new AppImageBuilder({ exec }).build({
+        registry: "ghcr.io/elizaos",
+        appId: APP,
+        context: "/c",
+        push: true,
+      }),
+    ).rejects.toMatchObject({ code: "APP_IMAGE_BUILD_DIGEST_MISSING" });
+  });
+
+  test("push preserves a BuildKit metadata read failure", async () => {
+    const exec: BuildExec & { calls: Array<{ cmd: string }> } = {
+      calls: [],
+      async exec(cmd: string) {
+        this.calls.push({ cmd });
+        if (cmd.startsWith("cat ")) throw new Error("metadata read failed");
+        return "built";
+      },
+    };
+    const failure = new AppImageBuilder({ exec }).build({
       registry: "ghcr.io/elizaos",
       appId: APP,
       context: "/c",
       push: true,
     });
-    // Inspect ran but found no digest → fall back to the mutable ref (non-fatal).
-    expect(res.imageRef).toBe(latestRef);
-  });
-
-  test("push falls back to the mutable ref when inspect throws (registry lag)", async () => {
-    const latestRef = "ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:latest";
-    const exec: BuildExec & { calls: Array<{ cmd: string }> } = {
-      calls: [],
-      async exec(cmd: string) {
-        this.calls.push({ cmd });
-        if (cmd.startsWith("docker buildx imagetools inspect")) {
-          throw new Error("registry timeout");
-        }
-        return "built";
-      },
-    };
-    const res = await new AppImageBuilder({ exec }).build({
-      registry: "ghcr.io/elizaos",
-      appId: APP,
-      context: "/c",
-      push: true,
+    await expect(failure).rejects.toBeInstanceOf(ElizaError);
+    await expect(failure).rejects.toMatchObject({
+      code: "APP_IMAGE_BUILD_METADATA_READ_FAILED",
+      cause: expect.objectContaining({ message: "metadata read failed" }),
     });
-    expect(res.imageRef).toBe(latestRef);
   });
 
   test("isolatedBuilder:false runs the plain host-daemon build (trusted/verification only)", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/app-image-resolver.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-image-resolver.test.ts
@@ -1,4 +1,4 @@
-// Exercises app image resolver behavior with deterministic cloud-shared lib fixtures.
+/** Exercises app image resolver behavior with deterministic cloud-shared lib fixtures. */
 import { describe, expect, test } from "bun:test";
 import { AppImageBuilder, type BuildExec } from "../app-image-builder";
 import {
@@ -15,13 +15,13 @@ function recordingBuilder(): { builder: AppImageBuilder; cmds: string[] } {
     async exec(cmd) {
       cmds.push(cmd);
       // BuildKit records the exact pushed manifest digest in per-build metadata.
-      if (cmd.startsWith("cat ")) {
-        return JSON.stringify({
-          "containerimage.digest":
-            "sha256:abc123def4567890abc123def4567890abc123def4567890abc123def4567890",
-        });
-      }
-      return "built";
+      const marker = cmd.match(/ELIZA_APP_BUILD_METADATA_[0-9a-f]{24}/)?.[0];
+      return marker
+        ? `built\n${marker}\n${JSON.stringify({
+            "containerimage.digest":
+              "sha256:abc123def4567890abc123def4567890abc123def4567890abc123def4567890",
+          })}`
+        : "built";
     },
   };
   return { builder: new AppImageBuilder({ exec, isolatedBuilder: false }), cmds };
@@ -120,8 +120,10 @@ describe("makePrebuiltImageMapResolver", () => {
     await expect(resolve?.({ id: APP, name: "Other App", metadata: {} })).resolves.toBeUndefined();
   });
 
-  test("ignores invalid JSON maps", () => {
-    expect(makePrebuiltImageMapResolver({ APP_PREBUILT_IMAGES: "not-json" })).toBeUndefined();
+  test("rejects invalid JSON maps", () => {
+    expect(() => makePrebuiltImageMapResolver({ APP_PREBUILT_IMAGES: "not-json" })).toThrow(
+      /must be valid JSON/,
+    );
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/app-image-resolver.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-image-resolver.test.ts
@@ -14,10 +14,12 @@ function recordingBuilder(): { builder: AppImageBuilder; cmds: string[] } {
   const exec: BuildExec = {
     async exec(cmd) {
       cmds.push(cmd);
-      // The builder inspects pushed images to resolve the manifest digest
-      // (#13097); return a digest so the resolver yields a pinned ref.
-      if (cmd.startsWith("docker buildx imagetools inspect")) {
-        return `Name:      ref\nDigest:    sha256:abc123def4567890abc123def4567890abc123def4567890abc123def4567890\n`;
+      // BuildKit records the exact pushed manifest digest in per-build metadata.
+      if (cmd.startsWith("cat ")) {
+        return JSON.stringify({
+          "containerimage.digest":
+            "sha256:abc123def4567890abc123def4567890abc123def4567890abc123def4567890",
+        });
       }
       return "built";
     },

--- a/packages/cloud/shared/src/lib/services/__tests__/app-image-resolver.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-image-resolver.test.ts
@@ -14,6 +14,11 @@ function recordingBuilder(): { builder: AppImageBuilder; cmds: string[] } {
   const exec: BuildExec = {
     async exec(cmd) {
       cmds.push(cmd);
+      // The builder inspects pushed images to resolve the manifest digest
+      // (#13097); return a digest so the resolver yields a pinned ref.
+      if (cmd.startsWith("docker buildx imagetools inspect")) {
+        return `Name:      ref\nDigest:    sha256:abc123def4567890abc123def4567890abc123def4567890abc123def4567890\n`;
+      }
       return "built";
     },
   };
@@ -21,7 +26,11 @@ function recordingBuilder(): { builder: AppImageBuilder; cmds: string[] } {
 }
 
 describe("makeBuildFromRepoResolver", () => {
-  test("builds + pushes from app.github_repo and returns the ref", async () => {
+  // The builder pushes and resolves the manifest digest (#13097), so push builds
+  // return a digest-pinned ref: `<mutable-ref>@sha256:<64hex>`.
+  const DIGEST = "sha256:abc123def4567890abc123def4567890abc123def4567890abc123def4567890";
+
+  test("builds + pushes from app.github_repo and returns the digest-pinned ref", async () => {
     const { builder, cmds } = recordingBuilder();
     const resolve = makeBuildFromRepoResolver({ builder, registry: "ghcr.io/elizaos" });
     const ref = await resolve({
@@ -31,7 +40,7 @@ describe("makeBuildFromRepoResolver", () => {
       repoUrl: "https://github.com/u/repo.git",
     });
 
-    expect(ref).toBe("ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:a1b2c3d");
+    expect(ref).toBe(`ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:a1b2c3d@${DIGEST}`);
     expect(cmds[0]).toContain("docker buildx build");
     expect(cmds[0]).toContain("--push");
     expect(cmds[0]).toContain("'https://github.com/u/repo.git#a1b2c3d'");
@@ -41,7 +50,7 @@ describe("makeBuildFromRepoResolver", () => {
     const { builder, cmds } = recordingBuilder();
     const resolve = makeBuildFromRepoResolver({ builder, registry: "r" });
     const ref = await resolve({ id: APP, name: "demo", metadata: { repoUrl: "/local/ctx" } });
-    expect(ref).toBe("r/app-aaaaaaaaaaaa4aaa8aaaaaaa:latest");
+    expect(ref).toBe(`r/app-aaaaaaaaaaaa4aaa8aaaaaaa:latest@${DIGEST}`);
     expect(cmds[0]).toContain("'/local/ctx'");
   });
 
@@ -63,7 +72,7 @@ describe("makeBuildFromRepoResolver", () => {
       repoUrl: "https://github.com/linked/repo.git",
     });
 
-    expect(ref).toBe("r/app-aaaaaaaaaaaa4aaa8aaaaaaa:develop");
+    expect(ref).toBe(`r/app-aaaaaaaaaaaa4aaa8aaaaaaa:develop@${DIGEST}`);
     expect(cmds[0]).toContain("--file 'apps/example/Dockerfile.cloud'");
     expect(cmds[0]).toContain("'https://github.com/elizaOS/eliza.git#develop'");
     expect(cmds[0]).not.toContain("https://github.com/linked/repo.git");

--- a/packages/cloud/shared/src/lib/services/app-build-cmd.ts
+++ b/packages/cloud/shared/src/lib/services/app-build-cmd.ts
@@ -53,6 +53,8 @@ export interface AppBuildCmdParams {
   builderName?: string;
   /** Pass `--no-cache` (untrusted builds skip any shared cache). */
   noCache?: boolean;
+  /** Write BuildKit's exact build result metadata to this file. */
+  metadataFile?: string;
 }
 
 /** Assemble the docker build command for a user app image. */
@@ -69,6 +71,9 @@ export function buildAppImageBuildCmd(params: AppBuildCmdParams): string {
   }
   if (params.noCache) {
     parts.push("--no-cache");
+  }
+  if (params.metadataFile) {
+    parts.push(`--metadata-file ${shellQuote(params.metadataFile)}`);
   }
   for (const [key, value] of Object.entries(params.buildArgs ?? {})) {
     parts.push(`--build-arg ${shellQuote(`${key}=${value}`)}`);

--- a/packages/cloud/shared/src/lib/services/app-deploy-image-preflight.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-image-preflight.ts
@@ -1,0 +1,81 @@
+/**
+ * Inventories every persisted and operator-configured app image before the
+ * node deploy backend is armed, preventing legacy mutable tags from reaching a
+ * deployment job after immutable enforcement becomes mandatory.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import { appsRepository } from "../../db/repositories/apps";
+import { parsePrebuiltImageMap } from "./app-image-resolver";
+import { describeImageReference } from "./containers/image-rollout-status";
+
+interface PreflightApp {
+  id: string;
+  name: string;
+  metadata: unknown;
+}
+
+export interface AppsDeployImagePreflightOptions {
+  env?: NodeJS.ProcessEnv;
+  listApps?: () => Promise<PreflightApp[]>;
+}
+
+function immutable(reference: string): boolean {
+  return describeImageReference(reference).productionSafe;
+}
+
+/** Fail before backend registration when any app deploy source is not immutable. */
+export async function assertAppsDeployImagesImmutable(
+  options: AppsDeployImagePreflightOptions = {},
+): Promise<void> {
+  const env = options.env ?? process.env;
+  const violations: string[] = [];
+
+  for (const variable of ["APP_DEFAULT_IMAGE", "APP_DEFAULT_TEMPLATE_IMAGE"] as const) {
+    const reference = env[variable];
+    if (reference !== undefined && !immutable(reference)) {
+      violations.push(`${variable}=${JSON.stringify(reference)}`);
+    }
+  }
+
+  const rawMap = env.APP_PREBUILT_IMAGES;
+  if (rawMap?.trim()) {
+    try {
+      for (const [prefix, reference] of parsePrebuiltImageMap(rawMap)) {
+        if (!immutable(reference)) {
+          violations.push(
+            `APP_PREBUILT_IMAGES[${JSON.stringify(prefix)}]=${JSON.stringify(reference)}`,
+          );
+        }
+      }
+    } catch (error) {
+      // error-policy:J3 retain the explicit configuration failure in the
+      // aggregated startup inventory rather than treating the map as absent.
+      violations.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  const apps = await (options.listApps ?? (() => appsRepository.listAll()))();
+  for (const app of apps) {
+    if (!app.metadata || typeof app.metadata !== "object" || Array.isArray(app.metadata)) continue;
+    const metadata = app.metadata as Record<string, unknown>;
+    if (!Object.hasOwn(metadata, "imageTag")) continue;
+    const reference = metadata.imageTag;
+    if (typeof reference !== "string" || !immutable(reference)) {
+      violations.push(
+        `app ${app.id} (${JSON.stringify(app.name)}) metadata.imageTag=${JSON.stringify(reference)}`,
+      );
+    }
+  }
+
+  if (violations.length > 0) {
+    throw new ElizaError(
+      `Apps deploy image preflight failed; repin every image to repo@sha256:<64 hex>:\n- ${violations.join("\n- ")}`,
+      {
+        code: "APPS_DEPLOY_IMAGE_PREFLIGHT_FAILED",
+        context: { violations },
+        severity: "fatal",
+      },
+    );
+  }
+}

--- a/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
@@ -179,25 +179,24 @@ export async function resolveImageRef(
         `to grant the namespace to your organization (settings.allowed_image_namespaces).`,
     );
   }
-  // SECURITY (#13097): the apps-deploy lane enforces immutability by DEFAULT via
-  // the lane-scoped `appsDeployRequireDigest()` gate (ON unless an operator opts
-  // out with `APPS_DEPLOY_REQUIRE_DIGEST=false`), AND inherits the global
+  // SECURITY (#13097): the apps-deploy lane can enforce immutability via the
+  // lane-scoped opt-in `appsDeployRequireDigest()` gate, and inherits the global
   // `requireDigestPinnedImages()` gate when armed. Either being on rejects a
   // mutable `:tag`/`:latest` reference so the registry cannot swap the bytes
   // behind an allowed name after this check. This is the SAME gate the two
   // container routes (`/v1/containers`, `/v1/coding-containers`) enforce via the
   // global flag; an app deploy is the third shared-node image path, so it must
   // enforce it too — otherwise the global flag would still let an app deploy run
-  // a mutable tag while the routes reject it. The first-party template default
-  // and source-build output are now digest-pinned, so the armed gate accepts
-  // them unchanged.
+  // a mutable tag while the routes reject it. Source-build output is pinned;
+  // operators must migrate prebuilt/default refs before arming the lane gate.
   const requireDigest =
     containersEnv.appsDeployRequireDigest() || containersEnv.requireDigestPinnedImages();
   if (imageRequiresDigestPin(image, requireDigest)) {
     throw new Error(
       `Image '${image}' for app ${app.id} must be pinned to a full sha256 digest ` +
         `(e.g. repo@sha256:<64 hex>): the digest-pin gate ` +
-        `(CONTAINER_IMAGE_REQUIRE_DIGEST) is enabled and a mutable tag can be ` +
+        `(APPS_DEPLOY_REQUIRE_DIGEST or CONTAINER_IMAGE_REQUIRE_DIGEST) is enabled ` +
+        `and a mutable tag can be ` +
         `swapped after this check.`,
     );
   }

--- a/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
@@ -179,25 +179,15 @@ export async function resolveImageRef(
         `to grant the namespace to your organization (settings.allowed_image_namespaces).`,
     );
   }
-  // SECURITY (#13097): the apps-deploy lane can enforce immutability via the
-  // lane-scoped opt-in `appsDeployRequireDigest()` gate, and inherits the global
-  // `requireDigestPinnedImages()` gate when armed. Either being on rejects a
-  // mutable `:tag`/`:latest` reference so the registry cannot swap the bytes
-  // behind an allowed name after this check. This is the SAME gate the two
-  // container routes (`/v1/containers`, `/v1/coding-containers`) enforce via the
-  // global flag; an app deploy is the third shared-node image path, so it must
-  // enforce it too — otherwise the global flag would still let an app deploy run
-  // a mutable tag while the routes reject it. Source-build output is pinned;
-  // operators must migrate prebuilt/default refs before arming the lane gate.
-  const requireDigest =
-    containersEnv.appsDeployRequireDigest() || containersEnv.requireDigestPinnedImages();
-  if (imageRequiresDigestPin(image, requireDigest)) {
+  // SECURITY (#13097): every production app deploy must use a content-addressed
+  // image. Source builds return the exact pushed digest, while startup preflight
+  // inventories persisted and operator-configured prebuilt refs. Enforce again at
+  // this final common boundary so no flag or alternate source can reopen mutable
+  // `:tag`/implicit-latest deployment after the allowlist check.
+  if (imageRequiresDigestPin(image, true)) {
     throw new Error(
       `Image '${image}' for app ${app.id} must be pinned to a full sha256 digest ` +
-        `(e.g. repo@sha256:<64 hex>): the digest-pin gate ` +
-        `(APPS_DEPLOY_REQUIRE_DIGEST or CONTAINER_IMAGE_REQUIRE_DIGEST) is enabled ` +
-        `and a mutable tag can be ` +
-        `swapped after this check.`,
+        `(e.g. repo@sha256:<64 hex>): mutable app images are not deployable.`,
     );
   }
   return image;

--- a/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
@@ -179,14 +179,21 @@ export async function resolveImageRef(
         `to grant the namespace to your organization (settings.allowed_image_namespaces).`,
     );
   }
-  // SECURITY (opt-in, default OFF): when the digest-pin gate is armed, reject a
+  // SECURITY (#13097): the apps-deploy lane enforces immutability by DEFAULT via
+  // the lane-scoped `appsDeployRequireDigest()` gate (ON unless an operator opts
+  // out with `APPS_DEPLOY_REQUIRE_DIGEST=false`), AND inherits the global
+  // `requireDigestPinnedImages()` gate when armed. Either being on rejects a
   // mutable `:tag`/`:latest` reference so the registry cannot swap the bytes
   // behind an allowed name after this check. This is the SAME gate the two
-  // container routes (`/v1/containers`, `/v1/coding-containers`) enforce; an
-  // app deploy is the third shared-node image path, so it must enforce it too —
-  // otherwise CONTAINER_IMAGE_REQUIRE_DIGEST=true would still let an app deploy
-  // run a mutable tag while the routes reject it.
-  if (imageRequiresDigestPin(image, containersEnv.requireDigestPinnedImages())) {
+  // container routes (`/v1/containers`, `/v1/coding-containers`) enforce via the
+  // global flag; an app deploy is the third shared-node image path, so it must
+  // enforce it too — otherwise the global flag would still let an app deploy run
+  // a mutable tag while the routes reject it. The first-party template default
+  // and source-build output are now digest-pinned, so the armed gate accepts
+  // them unchanged.
+  const requireDigest =
+    containersEnv.appsDeployRequireDigest() || containersEnv.requireDigestPinnedImages();
+  if (imageRequiresDigestPin(image, requireDigest)) {
     throw new Error(
       `Image '${image}' for app ${app.id} must be pinned to a full sha256 digest ` +
         `(e.g. repo@sha256:<64 hex>): the digest-pin gate ` +

--- a/packages/cloud/shared/src/lib/services/app-image-builder.ts
+++ b/packages/cloud/shared/src/lib/services/app-image-builder.ts
@@ -107,12 +107,12 @@ export class AppImageBuilder {
       ? `/tmp/eliza-app-build-${randomBytes(12).toString("hex")}.json`
       : undefined;
 
-    let command: string;
+    let buildCommand: string;
     if (this.isolatedBuilder) {
       // Random per-build suffix so two concurrent untrusted builds never share a
       // BuildKit instance; the script tears the builder down on EXIT.
       const builderName = isolatedBuilderName(req.appId, randomBytes(6).toString("hex"));
-      command = buildIsolatedAppImageScript({
+      buildCommand = buildIsolatedAppImageScript({
         context: req.context,
         dockerfile: req.dockerfile,
         imageRef,
@@ -122,7 +122,7 @@ export class AppImageBuilder {
         metadataFile,
       });
     } else {
-      command = buildAppImageBuildCmd({
+      buildCommand = buildAppImageBuildCmd({
         context: req.context,
         dockerfile: req.dockerfile,
         imageRef,
@@ -132,16 +132,33 @@ export class AppImageBuilder {
       });
     }
 
-    const buildOutput = await this.exec.exec(command, this.timeoutMs);
+    if (!metadataFile) {
+      const buildOutput = await this.exec.exec(buildCommand, this.timeoutMs);
+      return { imageRef, buildOutput };
+    }
 
-    if (!metadataFile) return { imageRef, buildOutput };
+    const metadataMarker = `ELIZA_APP_BUILD_METADATA_${randomBytes(12).toString("hex")}`;
+    const cleanupCommand = `rm -f ${shellQuote(metadataFile)}`;
+    const command = [
+      "set -e",
+      `trap ${shellQuote(cleanupCommand)} EXIT`,
+      "(",
+      buildCommand,
+      ")",
+      `printf '\n%s\n' ${shellQuote(metadataMarker)}`,
+      `if ! cat ${shellQuote(metadataFile)}; then printf '{"elizaMetadataReadError":true}'; fi`,
+    ].join("\n");
+    const output = await this.exec.exec(command, this.timeoutMs);
+    const separator = `\n${metadataMarker}\n`;
+    const markerIndex = output.lastIndexOf(separator);
+    const buildOutput = markerIndex >= 0 ? output.slice(0, markerIndex) : output;
+    const metadataOutput = markerIndex >= 0 ? output.slice(markerIndex + separator.length) : "";
 
     let digest: string | null;
     try {
-      const metadataOutput = await this.exec.exec(
-        `cat ${shellQuote(metadataFile)}; status=$?; rm -f ${shellQuote(metadataFile)}; exit $status`,
-        this.timeoutMs,
-      );
+      const metadata = JSON.parse(metadataOutput) as { elizaMetadataReadError?: unknown };
+      if (metadata.elizaMetadataReadError === true)
+        throw new Error("BuildKit metadata read failed");
       digest = parseBuildMetadataDigest(metadataOutput);
     } catch (error) {
       // error-policy:J2 BuildKit metadata belongs to this exact push; preserve

--- a/packages/cloud/shared/src/lib/services/app-image-builder.ts
+++ b/packages/cloud/shared/src/lib/services/app-image-builder.ts
@@ -20,6 +20,7 @@
  */
 
 import { randomBytes } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
 import {
   buildAppImageBuildCmd,
   buildIsolatedAppImageScript,
@@ -54,8 +55,8 @@ export interface AppImageBuildResult {
    * The resolvable image reference the deploy step runs.
    *
    * When the build PUSHED, this is the immutable digest-pinned ref
-   * (`<registry>/app-<slug>:<tag>@sha256:<64hex>`) resolved from the registry's
-   * pushed manifest via `docker buildx imagetools inspect`. A mutable
+   * (`<registry>/app-<slug>:<tag>@sha256:<64hex>`) captured atomically from
+   * BuildKit's metadata for this exact build. A mutable
    * `<registry>/app-<slug>:<tag>` ref lets the registry swap the bytes behind
    * the name after the deploy-time allowlist check, so the digest pin makes the
    * image content-addressed end-to-end and passes the armed digest-pin gate.
@@ -71,26 +72,15 @@ export interface AppImageBuildResult {
 }
 
 /**
- * Parse the immutable sha256 digest from `docker buildx imagetools inspect`
- * output. The manifest list / manifest digest is reported on the `Digest:`
- * line, e.g.
- *   Name:      ghcr.io/elizaos/app-xxx:tag
- *   MediaType: application/vnd.oci.image.index.v1+json
- *   Digest:    sha256:2c68b639eec00fad1b35e978f5463f1543b392c96680ec496fd0c0a9eddc8241
- *
- * Returns the FIRST full `sha256:<64 hex>` digest found, preferring the
- * top-level manifest digest over the per-platform child digests. Returns null
- * when no digest is present so the caller can fall back to the mutable ref with
- * a warning instead of failing the whole build.
+ * Parse the immutable manifest digest BuildKit records for the exact build.
  */
-export function parseImagetoolsDigest(output: string): string | null {
-  const match = output.match(/sha256:[0-9a-f]{64}/i);
-  return match ? match[0].toLowerCase() : null;
-}
-
-/** Assemble the `docker buildx imagetools inspect <ref>` command. */
-export function buildImagetoolsInspectCmd(imageRef: string): string {
-  return `docker buildx imagetools inspect ${shellQuote(imageRef)}`;
+export function parseBuildMetadataDigest(output: string): string | null {
+  const metadata = JSON.parse(output) as unknown;
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return null;
+  const digest = (metadata as Record<string, unknown>)["containerimage.digest"];
+  return typeof digest === "string" && /^sha256:[0-9a-f]{64}$/i.test(digest)
+    ? digest.toLowerCase()
+    : null;
 }
 
 export class AppImageBuilder {
@@ -113,6 +103,9 @@ export class AppImageBuilder {
       appId: req.appId,
       sourceRef: req.sourceRef,
     });
+    const metadataFile = req.push
+      ? `/tmp/eliza-app-build-${randomBytes(12).toString("hex")}.json`
+      : undefined;
 
     let command: string;
     if (this.isolatedBuilder) {
@@ -126,6 +119,7 @@ export class AppImageBuilder {
         push: req.push,
         buildArgs: req.buildArgs,
         builderName,
+        metadataFile,
       });
     } else {
       command = buildAppImageBuildCmd({
@@ -134,36 +128,39 @@ export class AppImageBuilder {
         imageRef,
         push: req.push,
         buildArgs: req.buildArgs,
+        metadataFile,
       });
     }
 
     const buildOutput = await this.exec.exec(command, this.timeoutMs);
 
-    // When the image was PUSHED, resolve the immutable digest from the registry
-    // so the returned ref is content-addressed end-to-end (#13097). The mutable
-    // `<registry>/app-<slug>:<tag>` ref the build produced lets the registry
-    // swap the bytes behind the name after the deploy-time allowlist check;
-    // pinning the pushed manifest digest defeats that. A failed inspect is
-    // non-fatal — the build succeeded, so fall back to the mutable ref with a
-    // warning rather than throwing away a good build (the digest-pin gate will
-    // reject it downstream when armed, which is the correct escalation).
-    let resolvedRef = imageRef;
-    if (req.push) {
-      try {
-        const inspectOutput = await this.exec.exec(
-          buildImagetoolsInspectCmd(imageRef),
-          this.timeoutMs,
-        );
-        const digest = parseImagetoolsDigest(inspectOutput);
-        if (digest) {
-          resolvedRef = `${imageRef}@${digest}`;
-        }
-      } catch {
-        // Inspect failed (registry lag, transient auth, offline verification).
-        // Keep the mutable ref; the deploy gate handles the mismatch.
-      }
+    if (!metadataFile) return { imageRef, buildOutput };
+
+    let digest: string | null;
+    try {
+      const metadataOutput = await this.exec.exec(
+        `cat ${shellQuote(metadataFile)}; status=$?; rm -f ${shellQuote(metadataFile)}; exit $status`,
+        this.timeoutMs,
+      );
+      digest = parseBuildMetadataDigest(metadataOutput);
+    } catch (error) {
+      // error-policy:J2 BuildKit metadata belongs to this exact push; preserve
+      // the read/parse failure rather than silently returning a mutable tag.
+      throw new ElizaError("Failed to read pushed app image build metadata", {
+        code: "APP_IMAGE_BUILD_METADATA_READ_FAILED",
+        cause: error,
+        context: { appId: req.appId, imageRef },
+        severity: "ephemeral",
+      });
+    }
+    if (!digest) {
+      throw new ElizaError("Pushed app image build metadata did not contain a full digest", {
+        code: "APP_IMAGE_BUILD_DIGEST_MISSING",
+        context: { appId: req.appId, imageRef },
+        severity: "fatal",
+      });
     }
 
-    return { imageRef: resolvedRef, buildOutput };
+    return { imageRef: `${imageRef}@${digest}`, buildOutput };
   }
 }

--- a/packages/cloud/shared/src/lib/services/app-image-builder.ts
+++ b/packages/cloud/shared/src/lib/services/app-image-builder.ts
@@ -26,6 +26,7 @@ import {
   isolatedBuilderName,
 } from "./app-build-cmd";
 import { buildAppImageRef } from "./app-image-ref";
+import { shellQuote } from "./docker-sandbox-utils";
 
 /** Command-exec seam — structurally the same as `AppContainerSsh` (reusable). */
 export interface BuildExec {
@@ -49,10 +50,47 @@ export interface AppImageBuildRequest {
 }
 
 export interface AppImageBuildResult {
-  /** The resolvable `<registry>/app-<slug>:<tag>` the deploy step runs. */
+  /**
+   * The resolvable image reference the deploy step runs.
+   *
+   * When the build PUSHED, this is the immutable digest-pinned ref
+   * (`<registry>/app-<slug>:<tag>@sha256:<64hex>`) resolved from the registry's
+   * pushed manifest via `docker buildx imagetools inspect`. A mutable
+   * `<registry>/app-<slug>:<tag>` ref lets the registry swap the bytes behind
+   * the name after the deploy-time allowlist check, so the digest pin makes the
+   * image content-addressed end-to-end and passes the armed digest-pin gate.
+   *
+   * When the build did NOT push (local `--load`), the pushed-manifest digest is
+   * unavailable, so this is the mutable `<registry>/app-<slug>:<tag>` ref as
+   * before — those are trusted/verification builds that don't traverse the
+   * registry the gate protects.
+   */
   imageRef: string;
   /** Raw build output (stdout+stderr), for logs/diagnostics. */
   buildOutput: string;
+}
+
+/**
+ * Parse the immutable sha256 digest from `docker buildx imagetools inspect`
+ * output. The manifest list / manifest digest is reported on the `Digest:`
+ * line, e.g.
+ *   Name:      ghcr.io/elizaos/app-xxx:tag
+ *   MediaType: application/vnd.oci.image.index.v1+json
+ *   Digest:    sha256:2c68b639eec00fad1b35e978f5463f1543b392c96680ec496fd0c0a9eddc8241
+ *
+ * Returns the FIRST full `sha256:<64 hex>` digest found, preferring the
+ * top-level manifest digest over the per-platform child digests. Returns null
+ * when no digest is present so the caller can fall back to the mutable ref with
+ * a warning instead of failing the whole build.
+ */
+export function parseImagetoolsDigest(output: string): string | null {
+  const match = output.match(/sha256:[0-9a-f]{64}/i);
+  return match ? match[0].toLowerCase() : null;
+}
+
+/** Assemble the `docker buildx imagetools inspect <ref>` command. */
+export function buildImagetoolsInspectCmd(imageRef: string): string {
+  return `docker buildx imagetools inspect ${shellQuote(imageRef)}`;
 }
 
 export class AppImageBuilder {
@@ -100,6 +138,32 @@ export class AppImageBuilder {
     }
 
     const buildOutput = await this.exec.exec(command, this.timeoutMs);
-    return { imageRef, buildOutput };
+
+    // When the image was PUSHED, resolve the immutable digest from the registry
+    // so the returned ref is content-addressed end-to-end (#13097). The mutable
+    // `<registry>/app-<slug>:<tag>` ref the build produced lets the registry
+    // swap the bytes behind the name after the deploy-time allowlist check;
+    // pinning the pushed manifest digest defeats that. A failed inspect is
+    // non-fatal — the build succeeded, so fall back to the mutable ref with a
+    // warning rather than throwing away a good build (the digest-pin gate will
+    // reject it downstream when armed, which is the correct escalation).
+    let resolvedRef = imageRef;
+    if (req.push) {
+      try {
+        const inspectOutput = await this.exec.exec(
+          buildImagetoolsInspectCmd(imageRef),
+          this.timeoutMs,
+        );
+        const digest = parseImagetoolsDigest(inspectOutput);
+        if (digest) {
+          resolvedRef = `${imageRef}@${digest}`;
+        }
+      } catch {
+        // Inspect failed (registry lag, transient auth, offline verification).
+        // Keep the mutable ref; the deploy gate handles the mismatch.
+      }
+    }
+
+    return { imageRef: resolvedRef, buildOutput };
   }
 }

--- a/packages/cloud/shared/src/lib/services/app-image-resolver.ts
+++ b/packages/cloud/shared/src/lib/services/app-image-resolver.ts
@@ -12,7 +12,7 @@
  * repo URL is passed straight through as the build context — no clone step.
  */
 
-import { logger } from "../utils/logger";
+import { ElizaError } from "@elizaos/core";
 import type { AppImageBuilder } from "./app-image-builder";
 
 /**
@@ -59,30 +59,52 @@ function buildContextFor(repo: string, sourceRef?: string): string {
  * and returns the image whose prefix is the LONGEST match for `app.name` (so the
  * showcase specs' timestamped names — "eDad Showcase 1a2b3c" — still match).
  *
- * Returns `undefined` (no resolver) when the env is unset / empty / malformed, so
- * the deploy runner's existing build-from-repo → metadata.imageTag →
- * APP_DEFAULT_IMAGE chain is completely unchanged when an operator has not
- * configured the map.
+ * Returns `undefined` when the env is unset or empty. Malformed maps fail fast
+ * so an operator cannot unknowingly fall through to another image source.
  */
+export function parsePrebuiltImageMap(raw: string): Array<[string, string]> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (error) {
+    // error-policy:J3 operator configuration is untrusted input; reject malformed
+    // JSON explicitly instead of degrading to an absent map.
+    throw new ElizaError("APP_PREBUILT_IMAGES must be valid JSON", {
+      code: "APPS_PREBUILT_IMAGES_INVALID",
+      cause: error,
+      severity: "fatal",
+    });
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ElizaError("APP_PREBUILT_IMAGES must be a JSON object", {
+      code: "APPS_PREBUILT_IMAGES_INVALID",
+      severity: "fatal",
+    });
+  }
+
+  const entries = Object.entries(parsed);
+  for (const [prefix, image] of entries) {
+    if (!prefix.trim() || typeof image !== "string" || !image.trim()) {
+      throw new ElizaError(
+        "APP_PREBUILT_IMAGES keys and image references must be non-empty strings",
+        {
+          code: "APPS_PREBUILT_IMAGES_INVALID",
+          context: { prefix },
+          severity: "fatal",
+        },
+      );
+    }
+  }
+  return entries as Array<[string, string]>;
+}
+
 export function makePrebuiltImageMapResolver(
   env: NodeJS.ProcessEnv = process.env,
 ): AppImageResolver | undefined {
   const raw = env.APP_PREBUILT_IMAGES;
   if (!raw || !raw.trim()) return undefined;
 
-  let entries: Array<[string, string]>;
-  try {
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    entries = Object.entries(parsed).filter(
-      (e): e is [string, string] =>
-        typeof e[0] === "string" && e[0].length > 0 && typeof e[1] === "string" && e[1].length > 0,
-    );
-  } catch {
-    logger.warn(
-      "[AppImageResolver] APP_PREBUILT_IMAGES is not valid JSON; ignoring the per-app prebuilt image map",
-    );
-    return undefined;
-  }
+  const entries = parsePrebuiltImageMap(raw);
   if (entries.length === 0) return undefined;
 
   // Longest prefix first → the most specific configured name wins deterministically.

--- a/packages/cloud/shared/src/lib/services/apps-deploy-backend.ts
+++ b/packages/cloud/shared/src/lib/services/apps-deploy-backend.ts
@@ -28,6 +28,7 @@
 
 import { logger } from "../utils/logger";
 import { setAppDbDeprovisioner } from "./app-db-deprovision-job-service";
+import { assertAppsDeployImagesImmutable } from "./app-deploy-image-preflight";
 import { setAppDeployRunner } from "./app-deploy-job-service";
 import {
   type DefaultAppDeployRunner,
@@ -71,7 +72,9 @@ export interface AppsDeployBackendConfig {
  * unconditionally — provisioning only runs when a real deploy / CONTAINER_* job
  * is processed.
  */
-export function configureAppsDeployBackend(config: AppsDeployBackendConfig): void {
+export async function configureAppsDeployBackend(config: AppsDeployBackendConfig): Promise<void> {
+  await assertAppsDeployImagesImmutable();
+
   // BUILD-FROM-REPO ("Vercel-like": the platform builds the user's repo, no
   // manual image push) is NOT armed by a registry alone. `APPS_IMAGE_REGISTRY`
   // only sets the push/pull target; build-from-repo additionally requires a


### PR DESCRIPTION
Pins image references to digest rather than mutable tags. AppImageBuilder captures pushed digest.

---
AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Lane: hermes-t3rpz