### PR TITLE
fix(cloud): enforce atomic org egress and concurrency limits in HF proxy (#13115)

### DIFF
--- a/packages/cloud/api/__tests__/hf-proxy-gate.test.ts
+++ b/packages/cloud/api/__tests__/hf-proxy-gate.test.ts
@@ -8,14 +8,15 @@ import { describe, expect, test } from "bun:test";
 import { HfProxyGate } from "../src/hf-proxy-gate";
 
 interface StoredLedger {
-  monthBucket: string;
-  usedBytes: number;
+  currentMonthBucket: string;
+  monthUsedBytes: Record<string, number>;
   activeDownloads: number;
 }
 
 class TestStorage {
   private readonly values = new Map<string, unknown>();
   failNextPut = false;
+  alarm: number | null = null;
 
   async get<T>(key: string): Promise<T | undefined> {
     const value = this.values.get(key);
@@ -28,6 +29,14 @@ class TestStorage {
       throw new Error("injected storage failure");
     }
     this.values.set(key, structuredClone(value));
+  }
+
+  async setAlarm(scheduledTime: number): Promise<void> {
+    this.alarm = scheduledTime;
+  }
+
+  async deleteAlarm(): Promise<void> {
+    this.alarm = null;
   }
 
   read<T>(key: string): T | undefined {
@@ -45,7 +54,7 @@ function createGate(storage = new TestStorage()): HfProxyGate {
 
 function post(
   gate: HfProxyGate,
-  path: "/reserve" | "/settle" | "/cancel",
+  path: "/reserve" | "/settle" | "/cancel" | "/heartbeat",
   body: Record<string, unknown>,
 ): Promise<Response> {
   return gate.fetch(
@@ -90,8 +99,8 @@ describe("HfProxyGate", () => {
     });
 
     expect(storage.read<StoredLedger>("ledger")).toMatchObject({
-      monthBucket: "2026-08",
-      usedBytes: 8,
+      currentMonthBucket: "2026-08",
+      monthUsedBytes: { "2026-08": 8 },
       activeDownloads: 2,
     });
   });
@@ -118,17 +127,23 @@ describe("HfProxyGate", () => {
     expect((await post(gate, "/cancel", cancellation)).status).toBe(200);
 
     expect(storage.read<StoredLedger>("ledger")).toMatchObject({
-      usedBytes: 4,
+      monthUsedBytes: { "2026-08": 4 },
       activeDownloads: 0,
     });
   });
 
-  test("late prior-month operations cannot replace a newer ledger", async () => {
+  test("preserves and settles active prior-month reservations", async () => {
     const storage = new TestStorage();
     const gate = createGate(storage);
 
     expect((await reserve(gate, "august", 7)).status).toBe(200);
     expect((await reserve(gate, "september", 3, "2026-09")).status).toBe(200);
+
+    expect(storage.read<StoredLedger>("ledger")).toMatchObject({
+      currentMonthBucket: "2026-09",
+      monthUsedBytes: { "2026-08": 7, "2026-09": 3 },
+      activeDownloads: 2,
+    });
 
     expect(
       (
@@ -149,10 +164,49 @@ describe("HfProxyGate", () => {
     ).toBe(200);
 
     expect(storage.read<StoredLedger>("ledger")).toMatchObject({
-      monthBucket: "2026-09",
-      usedBytes: 3,
+      currentMonthBucket: "2026-09",
+      monthUsedBytes: { "2026-08": 7, "2026-09": 3 },
       activeDownloads: 1,
     });
+  });
+
+  test("heartbeats keep active downloads leased and alarms reap abandoned slots", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    const realNow = Date.now;
+    let now = 1_000;
+    Date.now = () => now;
+    try {
+      expect((await reserve(gate, "active", 4)).status).toBe(200);
+      expect(storage.alarm).toBe(now + 30 * 60_000);
+
+      now += 20 * 60_000;
+      expect(
+        (
+          await post(gate, "/heartbeat", {
+            requestId: "active",
+            monthBucket: "2026-08",
+          })
+        ).status,
+      ).toBe(200);
+
+      now += 20 * 60_000;
+      await gate.alarm();
+      expect(storage.read<StoredLedger>("ledger")).toMatchObject({
+        monthUsedBytes: { "2026-08": 4 },
+        activeDownloads: 1,
+      });
+
+      now += 11 * 60_000;
+      await gate.alarm();
+      expect(storage.read<StoredLedger>("ledger")).toMatchObject({
+        monthUsedBytes: { "2026-08": 4 },
+        activeDownloads: 0,
+      });
+      expect(storage.alarm).toBeNull();
+    } finally {
+      Date.now = realNow;
+    }
   });
 
   test("storage failures fail closed without mutating cached accounting", async () => {
@@ -165,7 +219,7 @@ describe("HfProxyGate", () => {
 
     expect((await reserve(gate, "request-a", 4)).status).toBe(200);
     expect(storage.read<StoredLedger>("ledger")).toMatchObject({
-      usedBytes: 4,
+      monthUsedBytes: { "2026-08": 4 },
       activeDownloads: 1,
     });
   });
@@ -173,8 +227,8 @@ describe("HfProxyGate", () => {
   test("corrupt persisted accounting fails closed", async () => {
     const storage = new TestStorage();
     await storage.put("ledger", {
-      monthBucket: "2026-08",
-      usedBytes: -1,
+      currentMonthBucket: "2026-08",
+      monthUsedBytes: { "2026-08": -1 },
       activeDownloads: 0,
       slots: {},
       terminalRequestIds: [],

--- a/packages/cloud/api/__tests__/hf-proxy-gate.test.ts
+++ b/packages/cloud/api/__tests__/hf-proxy-gate.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Exercises HuggingFace proxy egress admission against in-memory Durable
+ * Object storage, including atomic reservation adjustment, month rollover,
+ * terminal idempotency, and storage failures.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { HfProxyGate } from "../src/hf-proxy-gate";
+
+interface StoredLedger {
+  monthBucket: string;
+  usedBytes: number;
+  activeDownloads: number;
+}
+
+class TestStorage {
+  private readonly values = new Map<string, unknown>();
+  failNextPut = false;
+
+  async get<T>(key: string): Promise<T | undefined> {
+    const value = this.values.get(key);
+    return value === undefined ? undefined : (structuredClone(value) as T);
+  }
+
+  async put(key: string, value: unknown): Promise<void> {
+    if (this.failNextPut) {
+      this.failNextPut = false;
+      throw new Error("injected storage failure");
+    }
+    this.values.set(key, structuredClone(value));
+  }
+
+  read<T>(key: string): T | undefined {
+    const value = this.values.get(key);
+    return value === undefined ? undefined : (structuredClone(value) as T);
+  }
+}
+
+function createGate(storage = new TestStorage()): HfProxyGate {
+  return new HfProxyGate(
+    { storage } as unknown as DurableObjectState,
+    {} as never,
+  );
+}
+
+function post(
+  gate: HfProxyGate,
+  path: "/reserve" | "/settle" | "/cancel",
+  body: Record<string, unknown>,
+): Promise<Response> {
+  return gate.fetch(
+    new Request(`https://gate.test${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function reserve(
+  gate: HfProxyGate,
+  requestId: string,
+  estimatedBytes: number,
+  monthBucket = "2026-08",
+): Promise<Response> {
+  return post(gate, "/reserve", {
+    requestId,
+    estimatedBytes,
+    limitBytes: 10,
+    maxConcurrent: 4,
+    monthBucket,
+  });
+}
+
+describe("HfProxyGate", () => {
+  test("atomically adjusts active reservations against the shared budget", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+
+    expect((await reserve(gate, "request-a", 0)).status).toBe(200);
+    expect((await reserve(gate, "request-b", 0)).status).toBe(200);
+    expect((await reserve(gate, "request-a", 8)).status).toBe(200);
+
+    const rejected = await reserve(gate, "request-b", 8);
+    expect(rejected.status).toBe(429);
+    expect(await rejected.json()).toMatchObject({
+      admitted: false,
+      usedBytes: 8,
+      activeDownloads: 2,
+    });
+
+    expect(storage.read<StoredLedger>("ledger")).toMatchObject({
+      monthBucket: "2026-08",
+      usedBytes: 8,
+      activeDownloads: 2,
+    });
+  });
+
+  test("settlement and cancellation retries are idempotent", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+
+    expect((await reserve(gate, "settled", 6)).status).toBe(200);
+    const settlement = {
+      requestId: "settled",
+      actualBytes: 4,
+      monthBucket: "2026-08",
+    };
+    expect((await post(gate, "/settle", settlement)).status).toBe(200);
+    expect((await post(gate, "/settle", settlement)).status).toBe(200);
+
+    expect((await reserve(gate, "cancelled", 3)).status).toBe(200);
+    const cancellation = {
+      requestId: "cancelled",
+      monthBucket: "2026-08",
+    };
+    expect((await post(gate, "/cancel", cancellation)).status).toBe(200);
+    expect((await post(gate, "/cancel", cancellation)).status).toBe(200);
+
+    expect(storage.read<StoredLedger>("ledger")).toMatchObject({
+      usedBytes: 4,
+      activeDownloads: 0,
+    });
+  });
+
+  test("late prior-month operations cannot replace a newer ledger", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+
+    expect((await reserve(gate, "august", 7)).status).toBe(200);
+    expect((await reserve(gate, "september", 3, "2026-09")).status).toBe(200);
+
+    expect(
+      (
+        await post(gate, "/settle", {
+          requestId: "august",
+          actualBytes: 7,
+          monthBucket: "2026-08",
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await post(gate, "/cancel", {
+          requestId: "august",
+          monthBucket: "2026-08",
+        })
+      ).status,
+    ).toBe(200);
+
+    expect(storage.read<StoredLedger>("ledger")).toMatchObject({
+      monthBucket: "2026-09",
+      usedBytes: 3,
+      activeDownloads: 1,
+    });
+  });
+
+  test("storage failures fail closed without mutating cached accounting", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    storage.failNextPut = true;
+
+    expect((await reserve(gate, "request-a", 4)).status).toBe(503);
+    expect(storage.read("ledger")).toBeUndefined();
+
+    expect((await reserve(gate, "request-a", 4)).status).toBe(200);
+    expect(storage.read<StoredLedger>("ledger")).toMatchObject({
+      usedBytes: 4,
+      activeDownloads: 1,
+    });
+  });
+
+  test("corrupt persisted accounting fails closed", async () => {
+    const storage = new TestStorage();
+    await storage.put("ledger", {
+      monthBucket: "2026-08",
+      usedBytes: -1,
+      activeDownloads: 0,
+      slots: {},
+      terminalRequestIds: [],
+    });
+    const gate = createGate(storage);
+
+    expect((await reserve(gate, "request-a", 1)).status).toBe(503);
+  });
+});

--- a/packages/cloud/api/__tests__/hf-proxy-route.test.ts
+++ b/packages/cloud/api/__tests__/hf-proxy-route.test.ts
@@ -98,10 +98,7 @@ const RESOLVE_PATH = "elizaos/eliza-1/resolve/main/model.gguf";
  * atomic accounting behavior.
  */
 function fakeGateStub() {
-  const slots = new Map<
-    string,
-    { reservedBytes: number; startedAt: number }
-  >();
+  const slots = new Map<string, { reservedBytes: number; startedAt: number }>();
   let usedBytes = 0;
   const settleCalls: Array<{ requestId: string; actualBytes: number }> = [];
   const cancelCalls: string[] = [];
@@ -118,8 +115,24 @@ function fakeGateStub() {
         const limitBytes = body.limitBytes as number;
         const maxConcurrent = body.maxConcurrent as number;
 
-        // Idempotent
-        if (slots.has(requestId)) {
+        const existingSlot = slots.get(requestId);
+        if (existingSlot) {
+          const projectedBytes =
+            usedBytes - existingSlot.reservedBytes + estimatedBytes;
+          if (projectedBytes > limitBytes) {
+            return Response.json(
+              {
+                admitted: false,
+                usedBytes,
+                limitBytes,
+                activeDownloads: slots.size,
+                maxConcurrent,
+              },
+              { status: 429 },
+            );
+          }
+          usedBytes = projectedBytes;
+          existingSlot.reservedBytes = estimatedBytes;
           return Response.json({
             admitted: true,
             usedBytes,
@@ -266,10 +279,10 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
 
   test("rejects a non-/resolve/ path with 400", async () => {
     const gate = fakeGateStub();
-    const res = await app.fetch(
-      makeRequest("elizaos/eliza-1/tree/main"),
-      { HF_TOKEN: "hf-secret", HF_PROXY_GATES: fakeGateNamespace(gate) },
-    );
+    const res = await app.fetch(makeRequest("elizaos/eliza-1/tree/main"), {
+      HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: fakeGateNamespace(gate),
+    });
 
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error?: string };
@@ -442,9 +455,8 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
     // Wait for settle.
     await Promise.resolve();
 
-    // Second request: 8 bytes already used, limit 12 — reserve sees
-    // projectedBytes (0 estimate) pass, but content-length pre-flight check
-    // catches 8 + 8 = 16 > 12.
+    // Second request: 8 bytes already used, limit 12. The atomic reservation
+    // adjustment rejects Content-Length 8 before any body byte is forwarded.
     const second = await app.fetch(makeRequest(RESOLVE_PATH), env);
     expect(second.status).toBe(429);
     const body = (await second.json()) as {
@@ -489,6 +501,64 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
     expect(body.code).toBe("HF_PROXY_CONCURRENCY_LIMIT");
     expect(body.active_downloads).toBe(2);
     expect(body.max_concurrent).toBe(2);
+  });
+
+  test("atomically pre-charges concurrent Content-Length responses", async () => {
+    const gate = fakeGateStub();
+    mockUpstream("12345678");
+    const env = {
+      HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: fakeGateNamespace(gate),
+      HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES: "12",
+    };
+
+    const first = await app.fetch(makeRequest(RESOLVE_PATH), env);
+    expect(first.status).toBe(200);
+    expect(gate._usedBytes()).toBe(8);
+
+    const second = await app.fetch(makeRequest(RESOLVE_PATH), env);
+    expect(second.status).toBe(429);
+    expect(await second.json()).toMatchObject({
+      code: "HF_PROXY_EGRESS_LIMIT",
+      used_bytes: 8,
+    });
+
+    expect(await first.text()).toBe("12345678");
+  });
+
+  test("reserves unknown-length chunks before forwarding them", async () => {
+    const gate = fakeGateStub();
+    const upstreamStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("AAAA"));
+        controller.enqueue(new TextEncoder().encode("BBBB"));
+        controller.close();
+      },
+    });
+    globalThis.fetch = mock(
+      async () =>
+        new Response(upstreamStream, {
+          status: 200,
+          headers: { "content-type": "application/octet-stream" },
+        }),
+    ) as unknown as typeof fetch;
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), {
+      HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: fakeGateNamespace(gate),
+      HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES: "6",
+    });
+    const reader = res.body!.getReader();
+
+    expect(new TextDecoder().decode((await reader.read()).value)).toBe("AAAA");
+    await expect(reader.read()).rejects.toThrow(
+      "HF proxy egress limit reached while streaming",
+    );
+    expect(gate._usedBytes()).toBe(4);
+    expect(gate._settleCalls).toContainEqual({
+      requestId: expect.any(String),
+      actualBytes: 4,
+    });
   });
 
   test("charges actual bytes on cancelled partial streams", async () => {
@@ -563,6 +633,25 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
     expect(settleCall!.actualBytes).toBe(data.length);
   });
 
+  test("settles a bodyless upstream response", async () => {
+    const gate = fakeGateStub();
+    globalThis.fetch = mock(
+      async () => new Response(null, { status: 204 }),
+    ) as unknown as typeof fetch;
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), {
+      HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: fakeGateNamespace(gate),
+    });
+
+    expect(res.status).toBe(204);
+    expect(gate._settleCalls).toContainEqual({
+      requestId: expect.any(String),
+      actualBytes: 0,
+    });
+    expect(gate._slots.size).toBe(0);
+  });
+
   test("releases the slot when upstream fetch throws", async () => {
     const gate = fakeGateStub();
     globalThis.fetch = mock(async () => {
@@ -579,6 +668,79 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
     expect(res.status).toBeGreaterThanOrEqual(500);
     // The slot must be cancelled so it doesn't leak.
     expect(gate._cancelCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("does not treat non-2xx cancellation responses as success", async () => {
+    const slots = new Set<string>();
+    const stub = {
+      fetch: mock(async (request: Request) => {
+        const path = new URL(request.url).pathname;
+        const body = (await request.json()) as { requestId: string };
+        if (path === "/reserve") {
+          slots.add(body.requestId);
+          return Response.json({
+            admitted: true,
+            usedBytes: 0,
+            limitBytes: 100,
+            activeDownloads: slots.size,
+            maxConcurrent: 4,
+          });
+        }
+        if (path === "/cancel") {
+          return Response.json(
+            { error: "storage unavailable" },
+            { status: 503 },
+          );
+        }
+        return Response.json({ settled: true });
+      }),
+    };
+    globalThis.fetch = mock(
+      async () => new Response("private", { status: 403 }),
+    ) as unknown as typeof fetch;
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), {
+      HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: { getByName: () => stub },
+    });
+
+    expect(res.status).toBeGreaterThanOrEqual(500);
+  });
+
+  test("surfaces non-2xx settlement responses to the stream consumer", async () => {
+    const stub = {
+      fetch: mock(async (request: Request) => {
+        const path = new URL(request.url).pathname;
+        if (path === "/settle") {
+          return Response.json(
+            { error: "storage unavailable" },
+            { status: 503 },
+          );
+        }
+        return Response.json({
+          admitted: true,
+          usedBytes: 4,
+          limitBytes: 100,
+          activeDownloads: 1,
+          maxConcurrent: 4,
+        });
+      }),
+    };
+    mockUpstream("data");
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), {
+      HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: { getByName: () => stub },
+    });
+    const reader = res.body!.getReader();
+    expect(new TextDecoder().decode((await reader.read()).value)).toBe("data");
+    await expect(reader.read()).rejects.toThrow(
+      "HF proxy gate settlement failed with status 503",
+    );
+    expect(loggerInfo).not.toHaveBeenCalledWith(
+      "[hf-proxy] egress metric",
+      expect.anything(),
+    );
   });
 
   test("returns 429 when the gate itself rejects with egress exhausted", async () => {
@@ -598,8 +760,9 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
       ),
     };
 
-    globalThis.fetch = mock(async () => new Response("x", { status: 200 })) as
-      unknown as typeof fetch;
+    globalThis.fetch = mock(
+      async () => new Response("x", { status: 200 }),
+    ) as unknown as typeof fetch;
 
     const res = await app.fetch(makeRequest(RESOLVE_PATH), {
       HF_TOKEN: "hf-secret",

--- a/packages/cloud/api/__tests__/hf-proxy-route.test.ts
+++ b/packages/cloud/api/__tests__/hf-proxy-route.test.ts
@@ -395,9 +395,15 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
 
   test("returns structured HF_GATED for upstream 401/403 and cancels the slot", async () => {
     const gate = fakeGateStub();
+    let upstreamCancelled = false;
+    const upstreamBody = new ReadableStream<Uint8Array>({
+      cancel() {
+        upstreamCancelled = true;
+      },
+    });
     globalThis.fetch = mock(
       async () =>
-        new Response("private", {
+        new Response(upstreamBody, {
           status: 403,
           headers: { "content-type": "text/plain" },
         }),
@@ -421,6 +427,34 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
     });
     // A gated upstream must release the concurrency slot.
     expect(gate._cancelCalls.length).toBeGreaterThanOrEqual(1);
+    expect(upstreamCancelled).toBe(true);
+  });
+
+  test("strictly parses numeric configuration and Content-Length", async () => {
+    const gate = fakeGateStub();
+    globalThis.fetch = mock(
+      async () =>
+        new Response("12345678", {
+          status: 200,
+          headers: {
+            "content-length": "9007199254740992",
+          },
+        }),
+    ) as unknown as typeof fetch;
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), {
+      HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: fakeGateNamespace(gate),
+      HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES: "4junk",
+      HF_PROXY_MAX_CONCURRENT_DOWNLOADS: "2junk",
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("12345678");
+    expect(gate._settleCalls).toContainEqual({
+      requestId: expect.any(String),
+      actualBytes: 8,
+    });
   });
 
   test("enforces per-org monthly egress budget before streaming", async () => {
@@ -524,6 +558,86 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
     });
 
     expect(await first.text()).toBe("12345678");
+  });
+
+  test("cancels the upstream body when Content-Length exceeds the budget", async () => {
+    const gate = fakeGateStub();
+    let upstreamCancelled = false;
+    const upstreamBody = new ReadableStream<Uint8Array>({
+      cancel() {
+        upstreamCancelled = true;
+      },
+    });
+    globalThis.fetch = mock(
+      async () =>
+        new Response(upstreamBody, {
+          status: 200,
+          headers: { "content-length": "8" },
+        }),
+    ) as unknown as typeof fetch;
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), {
+      HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: fakeGateNamespace(gate),
+      HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES: "4",
+    });
+
+    expect(res.status).toBe(429);
+    expect(upstreamCancelled).toBe(true);
+    expect(gate._cancelCalls).toHaveLength(1);
+  });
+
+  test("cancels upstream and the slot when Content-Length sizing fails", async () => {
+    const cancelCalls: string[] = [];
+    let reserveCalls = 0;
+    const stub = {
+      fetch: mock(async (request: Request) => {
+        const path = new URL(request.url).pathname;
+        const body = (await request.json()) as { requestId: string };
+        if (path === "/reserve") {
+          reserveCalls += 1;
+          if (reserveCalls === 2) {
+            return Response.json(
+              { error: "storage unavailable" },
+              { status: 503 },
+            );
+          }
+          return Response.json({
+            admitted: true,
+            usedBytes: 0,
+            limitBytes: 100,
+            activeDownloads: 1,
+            maxConcurrent: 4,
+          });
+        }
+        if (path === "/cancel") {
+          cancelCalls.push(body.requestId);
+          return Response.json({ cancelled: true });
+        }
+        return Response.json({ renewed: true });
+      }),
+    };
+    let upstreamCancelled = false;
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            cancel() {
+              upstreamCancelled = true;
+            },
+          }),
+          { status: 200, headers: { "content-length": "8" } },
+        ),
+    ) as unknown as typeof fetch;
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), {
+      HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: { getByName: () => stub },
+    });
+
+    expect(res.status).toBeGreaterThanOrEqual(500);
+    expect(upstreamCancelled).toBe(true);
+    expect(cancelCalls).toHaveLength(1);
   });
 
   test("reserves unknown-length chunks before forwarding them", async () => {

--- a/packages/cloud/api/__tests__/hf-proxy-route.test.ts
+++ b/packages/cloud/api/__tests__/hf-proxy-route.test.ts
@@ -6,6 +6,11 @@
  * genuine `/resolve/` download paths, refuses to run without the cloud-side
  * `HF_TOKEN`, and otherwise streams the upstream HuggingFace response straight
  * through with the cloud token attached.
+ *
+ * Egress accounting and concurrency limits are enforced atomically by a
+ * per-organization Durable Object (`HF_PROXY_GATES`). These tests exercise the
+ * reserve → stream → settle/cancel lifecycle, concurrent requests, cancelled
+ * partial streams, and adversarial gate failures.
  */
 
 import {
@@ -87,20 +92,128 @@ afterAll(() => {
 
 const RESOLVE_PATH = "elizaos/eliza-1/resolve/main/model.gguf";
 
-function fakeKv() {
-  const map = new Map<string, string>();
-  return {
-    get: async (key: string) => map.get(key) ?? null,
-    put: async (key: string, value: string) => {
-      map.set(key, value);
-    },
-    delete: async (key: string) => {
-      map.delete(key);
-    },
-    list: async () => ({
-      keys: [...map.keys()].map((name) => ({ name })),
-      list_complete: true,
+/**
+ * A fake Durable Object stub that simulates the per-org gate. It tracks
+ * reservations, settlements, and cancels in-memory so tests can assert on
+ * atomic accounting behavior.
+ */
+function fakeGateStub() {
+  const slots = new Map<
+    string,
+    { reservedBytes: number; startedAt: number }
+  >();
+  let usedBytes = 0;
+  const settleCalls: Array<{ requestId: string; actualBytes: number }> = [];
+  const cancelCalls: string[] = [];
+
+  const stub = {
+    fetch: mock(async (request: Request) => {
+      const url = new URL(request.url);
+      const body = (await request.json()) as Record<string, unknown>;
+      const path = url.pathname;
+
+      if (path === "/reserve") {
+        const requestId = body.requestId as string;
+        const estimatedBytes = body.estimatedBytes as number;
+        const limitBytes = body.limitBytes as number;
+        const maxConcurrent = body.maxConcurrent as number;
+
+        // Idempotent
+        if (slots.has(requestId)) {
+          return Response.json({
+            admitted: true,
+            usedBytes,
+            limitBytes,
+            activeDownloads: slots.size,
+            maxConcurrent,
+          });
+        }
+
+        const projectedBytes = usedBytes + estimatedBytes;
+        if (slots.size >= maxConcurrent) {
+          return Response.json(
+            {
+              admitted: false,
+              usedBytes,
+              limitBytes,
+              activeDownloads: slots.size,
+              maxConcurrent,
+            },
+            { status: 429 },
+          );
+        }
+        if (projectedBytes > limitBytes) {
+          return Response.json(
+            {
+              admitted: false,
+              usedBytes,
+              limitBytes,
+              activeDownloads: slots.size,
+              maxConcurrent,
+            },
+            { status: 429 },
+          );
+        }
+
+        usedBytes = projectedBytes;
+        slots.set(requestId, {
+          reservedBytes: estimatedBytes,
+          startedAt: Date.now(),
+        });
+        return Response.json({
+          admitted: true,
+          usedBytes,
+          limitBytes,
+          activeDownloads: slots.size,
+          maxConcurrent,
+        });
+      }
+
+      if (path === "/settle") {
+        const requestId = body.requestId as string;
+        const actualBytes = body.actualBytes as number;
+        settleCalls.push({ requestId, actualBytes });
+        const slot = slots.get(requestId);
+        if (slot) {
+          usedBytes = Math.max(0, usedBytes - slot.reservedBytes);
+          usedBytes += actualBytes;
+          slots.delete(requestId);
+        } else {
+          usedBytes += actualBytes;
+        }
+        return Response.json({ settled: true });
+      }
+
+      if (path === "/cancel") {
+        const requestId = body.requestId as string;
+        cancelCalls.push(requestId);
+        const slot = slots.get(requestId);
+        if (slot) {
+          usedBytes = Math.max(0, usedBytes - slot.reservedBytes);
+          slots.delete(requestId);
+        }
+        return Response.json({ cancelled: true });
+      }
+
+      return new Response("Not found", { status: 404 });
     }),
+    _slots: slots,
+    _usedBytes: () => usedBytes,
+    _settleCalls: settleCalls,
+    _cancelCalls: cancelCalls,
+    _reset: () => {
+      slots.clear();
+      usedBytes = 0;
+      settleCalls.length = 0;
+      cancelCalls.length = 0;
+    },
+  };
+  return stub;
+}
+
+function fakeGateNamespace(stub: ReturnType<typeof fakeGateStub>) {
+  return {
+    getByName: (_name: string) => stub,
   };
 }
 
@@ -114,9 +227,28 @@ function makeRequest(
   });
 }
 
+function mockUpstream(
+  body: string,
+  status = 200,
+  extraHeaders: Record<string, string> = {},
+) {
+  globalThis.fetch = mock(
+    async () =>
+      new Response(body, {
+        status,
+        headers: {
+          "content-type": "application/octet-stream",
+          "content-length": String(body.length),
+          "accept-ranges": "bytes",
+          ...extraHeaders,
+        },
+      }),
+  ) as unknown as typeof fetch;
+}
+
 describe("GET /api/v1/hf-proxy/[...path]", () => {
   test("requires authentication", async () => {
-    // An unauthenticated request throws from the auth gate before any proxying.
+    const gate = fakeGateStub();
     requireUserOrApiKeyWithOrg.mockRejectedValueOnce(
       Object.assign(new Error("Authentication required"), {
         name: "AuthenticationError",
@@ -125,6 +257,7 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
 
     const res = await app.fetch(makeRequest(RESOLVE_PATH), {
       HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: fakeGateNamespace(gate),
     });
 
     expect(res.status).toBe(401);
@@ -132,9 +265,11 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
   });
 
   test("rejects a non-/resolve/ path with 400", async () => {
-    const res = await app.fetch(makeRequest("elizaos/eliza-1/tree/main"), {
-      HF_TOKEN: "hf-secret",
-    });
+    const gate = fakeGateStub();
+    const res = await app.fetch(
+      makeRequest("elizaos/eliza-1/tree/main"),
+      { HF_TOKEN: "hf-secret", HF_PROXY_GATES: fakeGateNamespace(gate) },
+    );
 
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error?: string };
@@ -142,8 +277,7 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
   });
 
   test("rejects a resolve path for a repo outside the curated catalog with 403", async () => {
-    // A well-formed resolve path, but for an arbitrary non-elizaos repo — the
-    // cloud HF_TOKEN must not be spent proxying it.
+    const gate = fakeGateStub();
     let fetchCalled = false;
     globalThis.fetch = mock(async () => {
       fetchCalled = true;
@@ -152,7 +286,7 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
 
     const res = await app.fetch(
       makeRequest("someuser/gated-model/resolve/main/weights.gguf"),
-      { HF_TOKEN: "hf-secret" },
+      { HF_TOKEN: "hf-secret", HF_PROXY_GATES: fakeGateNamespace(gate) },
     );
 
     expect(res.status).toBe(403);
@@ -160,12 +294,14 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
     expect(body.error).toBe(
       "This HuggingFace repo is not available through the proxy.",
     );
-    // Never reaches upstream HuggingFace for a disallowed repo.
     expect(fetchCalled).toBe(false);
   });
 
   test("returns 503 when HF_TOKEN is not configured", async () => {
-    const res = await app.fetch(makeRequest(RESOLVE_PATH), {});
+    const gate = fakeGateStub();
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), {
+      HF_PROXY_GATES: fakeGateNamespace(gate),
+    });
 
     expect(res.status).toBe(503);
     const body = (await res.json()) as { error?: string };
@@ -174,7 +310,19 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
     );
   });
 
+  test("returns 503 when HF_PROXY_GATES binding is missing", async () => {
+    mockUpstream("GGUF-BYTES");
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), {
+      HF_TOKEN: "hf-secret",
+    });
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("HF_PROXY_GATE_UNAVAILABLE");
+  });
+
   test("proxies a valid /resolve/ request through to HuggingFace with the cloud token", async () => {
+    const gate = fakeGateStub();
     let capturedUrl: string | undefined;
     let capturedAuth: string | null | undefined;
     let capturedRange: string | null | undefined;
@@ -196,26 +344,22 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
 
     const res = await app.fetch(
       makeRequest(`${RESOLVE_PATH}?download=true`, { range: "bytes=0-9" }),
-      { HF_TOKEN: "hf-secret" },
+      { HF_TOKEN: "hf-secret", HF_PROXY_GATES: fakeGateNamespace(gate) },
     );
 
     expect(res.status).toBe(200);
-    // Reconstructs the upstream HuggingFace URL 1:1, preserving the query.
     expect(capturedUrl).toBe(
       `https://huggingface.co/${RESOLVE_PATH}?download=true`,
     );
-    // Attaches the cloud-side HF token, never a client-supplied one.
     expect(capturedAuth).toBe("Bearer hf-secret");
-    // Forwards Range so resumable downloads work.
     expect(capturedRange).toBe("bytes=0-9");
 
-    // Streams the upstream body and preserves download-relevant headers.
     expect(await res.text()).toBe("GGUF-BYTES");
     expect(res.headers.get("content-length")).toBe("10");
     expect(res.headers.get("accept-ranges")).toBe("bytes");
 
     // Cost observability: the proxied transfer is recorded with the repo, path,
-    // status, and byte count so an operator can attribute unmetered downloads.
+    // status, and byte count.
     const usageCall = loggerInfo.mock.calls.find(
       (call) => call[0] === "[hf-proxy] proxied download",
     );
@@ -227,22 +371,17 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
       status: 200,
       bytes: 10,
     });
-    // Identity is attached (redacted) so usage is attributable.
     expect(usagePayload.orgId).toBeDefined();
     expect(usagePayload.userId).toBeDefined();
 
-    expect(loggerInfo).toHaveBeenCalledWith(
-      "[hf-proxy] egress metric",
-      expect.objectContaining({
-        organizationId: "org-1",
-        repo: "elizaos/eliza-1",
-        bytes: 10,
-        status: 200,
-      }),
-    );
+    // The stream is settled with the actual byte count.
+    await Promise.resolve(); // let the flush microtask run
+    const settleCall = gate._settleCalls.find((s) => s.actualBytes === 10);
+    expect(settleCall).toBeDefined();
   });
 
-  test("returns structured HF_GATED for upstream 401/403", async () => {
+  test("returns structured HF_GATED for upstream 401/403 and cancels the slot", async () => {
+    const gate = fakeGateStub();
     globalThis.fetch = mock(
       async () =>
         new Response("private", {
@@ -253,6 +392,7 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
 
     const res = await app.fetch(makeRequest(RESOLVE_PATH), {
       HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: fakeGateNamespace(gate),
     });
 
     expect(res.status).toBe(403);
@@ -266,10 +406,18 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
       code: "HF_GATED",
       repo: "elizaos/eliza-1",
     });
+    // A gated upstream must release the concurrency slot.
+    expect(gate._cancelCalls.length).toBeGreaterThanOrEqual(1);
   });
 
-  test("enforces per-org monthly egress budget before streaming the next response", async () => {
-    const kv = fakeKv();
+  test("enforces per-org monthly egress budget before streaming", async () => {
+    const gate = fakeGateStub();
+    // Pre-set the gate to near-limit via a direct settle.
+    // Use the reserve path: we manipulate the stub state directly.
+    gate._slots.set("__seed__", { reservedBytes: 0, startedAt: Date.now() });
+    // Use the fake's internal state to seed usedBytes
+    (gate as unknown as { _usedBytes: () => number })._usedBytes = () => 0;
+
     globalThis.fetch = mock(
       async () =>
         new Response("12345678", {
@@ -283,13 +431,20 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
 
     const env = {
       HF_TOKEN: "hf-secret",
-      CACHE_KV: kv,
+      HF_PROXY_GATES: fakeGateNamespace(gate),
       HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES: "12",
     };
+    // First request succeeds and settles 8 bytes.
     const first = await app.fetch(makeRequest(RESOLVE_PATH), env);
     expect(first.status).toBe(200);
     expect(await first.text()).toBe("12345678");
 
+    // Wait for settle.
+    await Promise.resolve();
+
+    // Second request: 8 bytes already used, limit 12 — reserve sees
+    // projectedBytes (0 estimate) pass, but content-length pre-flight check
+    // catches 8 + 8 = 16 > 12.
     const second = await app.fetch(makeRequest(RESOLVE_PATH), env);
     expect(second.status).toBe(429);
     const body = (await second.json()) as {
@@ -301,14 +456,200 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
     expect(body.limit_bytes).toBe(12);
     expect(body.used_bytes).toBe(8);
   });
+
+  test("enforces per-org concurrency cap", async () => {
+    const gate = fakeGateStub();
+
+    // Simulate max concurrent slots already filled by pre-populating the stub.
+    // maxConcurrent is passed via env as 2; we fill 2 slots manually.
+    gate._slots.set("active-1", { reservedBytes: 0, startedAt: Date.now() });
+    gate._slots.set("active-2", { reservedBytes: 0, startedAt: Date.now() });
+
+    globalThis.fetch = mock(
+      async () =>
+        new Response("data", {
+          status: 200,
+          headers: { "content-length": "4" },
+        }),
+    ) as unknown as typeof fetch;
+
+    const env = {
+      HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: fakeGateNamespace(gate),
+      HF_PROXY_MAX_CONCURRENT_DOWNLOADS: "2",
+    };
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), env);
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as {
+      code?: string;
+      active_downloads?: number;
+      max_concurrent?: number;
+    };
+    expect(body.code).toBe("HF_PROXY_CONCURRENCY_LIMIT");
+    expect(body.active_downloads).toBe(2);
+    expect(body.max_concurrent).toBe(2);
+  });
+
+  test("charges actual bytes on cancelled partial streams", async () => {
+    const gate = fakeGateStub();
+
+    // Create a stream that the consumer will cancel after receiving some bytes.
+    const chunks = ["AAAA", "BBBB", "CCCC", "DDDD"];
+    const upstreamStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(new TextEncoder().encode(chunk));
+        }
+        controller.close();
+      },
+    });
+
+    globalThis.fetch = mock(
+      async () =>
+        new Response(upstreamStream, {
+          status: 200,
+          headers: { "content-type": "application/octet-stream" },
+        }),
+    ) as unknown as typeof fetch;
+
+    const env = {
+      HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: fakeGateNamespace(gate),
+    };
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), env);
+    expect(res.status).toBe(200);
+
+    // Read only the first chunk then cancel.
+    const reader = res.body!.getReader();
+    const { value } = await reader.read();
+    expect(value).toBeDefined();
+    expect(value!.byteLength).toBe(4);
+    // Cancel the stream — simulating a client disconnect.
+    await reader.cancel();
+
+    // Give the cancel callback a chance to run.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // The stream must have been settled with at least the bytes consumed before
+    // cancellation (4 bytes from the first chunk). This is the core fix: the
+    // old code only charged on flush(), so a cancelled stream escaped entirely.
+    const settleCall = gate._settleCalls[0];
+    expect(settleCall).toBeDefined();
+    expect(settleCall!.actualBytes).toBeGreaterThanOrEqual(4);
+  });
+
+  test("settles actual bytes on successful completion", async () => {
+    const gate = fakeGateStub();
+    const data = "COMPLETE-DATA";
+    mockUpstream(data);
+
+    const env = {
+      HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: fakeGateNamespace(gate),
+    };
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), env);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toBe(data);
+
+    // Let the flush microtask run.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const settleCall = gate._settleCalls[0];
+    expect(settleCall).toBeDefined();
+    expect(settleCall!.actualBytes).toBe(data.length);
+  });
+
+  test("releases the slot when upstream fetch throws", async () => {
+    const gate = fakeGateStub();
+    globalThis.fetch = mock(async () => {
+      throw new Error("Network error");
+    }) as unknown as typeof fetch;
+
+    const env = {
+      HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: fakeGateNamespace(gate),
+    };
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), env);
+    // failureResponse handles the thrown error.
+    expect(res.status).toBeGreaterThanOrEqual(500);
+    // The slot must be cancelled so it doesn't leak.
+    expect(gate._cancelCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("returns 429 when the gate itself rejects with egress exhausted", async () => {
+    // A gate stub that always rejects with egress exhausted.
+    const stub = {
+      fetch: mock(async () =>
+        Response.json(
+          {
+            admitted: false,
+            usedBytes: 600,
+            limitBytes: 500,
+            activeDownloads: 0,
+            maxConcurrent: 4,
+          },
+          { status: 429 },
+        ),
+      ),
+    };
+
+    globalThis.fetch = mock(async () => new Response("x", { status: 200 })) as
+      unknown as typeof fetch;
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), {
+      HF_TOKEN: "hf-secret",
+      HF_PROXY_GATES: { getByName: () => stub },
+    });
+
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as {
+      code?: string;
+      limit_bytes?: number;
+      used_bytes?: number;
+    };
+    expect(body.code).toBe("HF_PROXY_EGRESS_LIMIT");
+    expect(body.limit_bytes).toBe(500);
+    expect(body.used_bytes).toBe(600);
+  });
+
+  test("forwards Range header and preserves 206 Partial Content", async () => {
+    const gate = fakeGateStub();
+    let capturedRange: string | null | undefined;
+
+    globalThis.fetch = mock(async (_input: unknown, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      capturedRange = headers.get("range");
+      return new Response("PARTIAL", {
+        status: 206,
+        headers: {
+          "content-type": "application/octet-stream",
+          "content-length": "7",
+          "content-range": "bytes 0-6/100",
+          "accept-ranges": "bytes",
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    const res = await app.fetch(
+      makeRequest(RESOLVE_PATH, { range: "bytes=0-6" }),
+      { HF_TOKEN: "hf-secret", HF_PROXY_GATES: fakeGateNamespace(gate) },
+    );
+
+    expect(res.status).toBe(206);
+    expect(capturedRange).toBe("bytes=0-6");
+    expect(res.headers.get("content-range")).toBe("bytes 0-6/100");
+    expect(res.headers.get("accept-ranges")).toBe("bytes");
+    expect(await res.text()).toBe("PARTIAL");
+  });
 });
 
 describe("ALLOWED_REPO_PREFIX single-source-of-truth", () => {
   test("matches the org segment of ELIZA_1_HF_REPO from @elizaos/shared", async () => {
-    // The route's allowlist prefix is a local literal (kept out of the worker
-    // bundle's import graph on purpose), so it MUST be pinned to the shared
-    // catalog constant — otherwise a rename of ELIZA_1_HF_REPO could silently
-    // un-scope the proxy allowlist. This test is that pin.
     const { ALLOWED_REPO_PREFIX } = (await import(
       "../v1/hf-proxy/[...path]/route"
     )) as { ALLOWED_REPO_PREFIX: string };
@@ -316,8 +657,6 @@ describe("ALLOWED_REPO_PREFIX single-source-of-truth", () => {
       "@elizaos/shared/local-inference"
     )) as { ELIZA_1_HF_REPO: string };
 
-    // ELIZA_1_HF_REPO is `<org>/<repo>` (e.g. "elizaos/eliza-1"); the allowlist
-    // is the `<org>/` prefix. The curated repo must fall inside the allowlist.
     const org = ELIZA_1_HF_REPO.split("/")[0];
     expect(ALLOWED_REPO_PREFIX).toBe(`${org}/`);
     expect(ELIZA_1_HF_REPO.startsWith(ALLOWED_REPO_PREFIX)).toBe(true);

--- a/packages/cloud/api/src/hf-proxy-gate.ts
+++ b/packages/cloud/api/src/hf-proxy-gate.ts
@@ -38,6 +38,8 @@ interface HfProxyLedger {
   activeDownloads: number;
   /** Active download slots keyed by requestId for cancellation/settlement. */
   slots: Record<string, HfProxySlot>;
+  /** Recently terminal request IDs retained to make retries idempotent. */
+  terminalRequestIds: string[];
 }
 
 interface HfProxySlot {
@@ -81,13 +83,14 @@ interface ReserveResponse {
 const LEDGER_KEY = "ledger";
 const SLOT_TTL_MS = 30 * 60_000;
 const MAX_ACTIVE_DOWNLOADS_HARD = 256;
-
-function isFiniteNonNegative(value: unknown): value is number {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0;
-}
+const MAX_TERMINAL_REQUEST_IDS = 2_048;
 
 function validId(value: unknown): value is string {
   return typeof value === "string" && value.length > 0 && value.length <= 256;
+}
+
+function validMonthBucket(value: unknown): value is string {
+  return typeof value === "string" && /^\d{4}-(0[1-9]|1[0-2])$/.test(value);
 }
 
 function jsonError(message: string, status: 400 | 409 | 503): Response {
@@ -104,18 +107,17 @@ function cloneLedger(ledger: HfProxyLedger): HfProxyLedger {
     usedBytes: ledger.usedBytes,
     activeDownloads: ledger.activeDownloads,
     slots,
+    terminalRequestIds: [...ledger.terminalRequestIds],
   };
 }
 
 export class HfProxyGate {
   private readonly state: DurableObjectState;
-  private readonly env: AppEnv["Bindings"];
   private ledger: HfProxyLedger | undefined;
   private operationQueue: Promise<void> = Promise.resolve();
 
-  constructor(state: DurableObjectState, env: AppEnv["Bindings"]) {
+  constructor(state: DurableObjectState, _env: AppEnv["Bindings"]) {
     this.state = state;
-    this.env = env;
   }
 
   /**
@@ -127,24 +129,29 @@ export class HfProxyGate {
     this.ledger ??= await this.state.storage.get<HfProxyLedger>(LEDGER_KEY);
     if (this.ledger) {
       if (
-        !validId(this.ledger.monthBucket) ||
+        !validMonthBucket(this.ledger.monthBucket) ||
         !Number.isSafeInteger(this.ledger.usedBytes) ||
         this.ledger.usedBytes < 0 ||
         !Number.isSafeInteger(this.ledger.activeDownloads) ||
         this.ledger.activeDownloads < 0 ||
         this.ledger.activeDownloads > MAX_ACTIVE_DOWNLOADS_HARD ||
         typeof this.ledger.slots !== "object" ||
-        this.ledger.slots === null
+        this.ledger.slots === null ||
+        !Array.isArray(this.ledger.terminalRequestIds) ||
+        this.ledger.terminalRequestIds.length > MAX_TERMINAL_REQUEST_IDS ||
+        this.ledger.terminalRequestIds.some((requestId) => !validId(requestId))
       ) {
         throw new Error("HF proxy egress ledger is corrupt");
       }
-      // Month rollover: reset the counter and clear stale slots.
-      if (this.ledger.monthBucket !== monthBucket) {
-        this.ledger = {
+      // Month rollover only moves forward. A late settle/cancel from the prior
+      // month must never replace a newer ledger and erase its accounting.
+      if (this.ledger.monthBucket < monthBucket) {
+        return {
           monthBucket,
           usedBytes: 0,
           activeDownloads: 0,
           slots: {},
+          terminalRequestIds: [],
         };
       }
       return this.ledger;
@@ -154,7 +161,15 @@ export class HfProxyGate {
       usedBytes: 0,
       activeDownloads: 0,
       slots: {},
+      terminalRequestIds: [],
     };
+  }
+
+  private markTerminal(ledger: HfProxyLedger, requestId: string): void {
+    ledger.terminalRequestIds.push(requestId);
+    if (ledger.terminalRequestIds.length > MAX_TERMINAL_REQUEST_IDS) {
+      ledger.terminalRequestIds.shift();
+    }
   }
 
   private async save(ledger: HfProxyLedger): Promise<void> {
@@ -187,6 +202,7 @@ export class HfProxyGate {
         // adjusting the byte counter (the actual bytes are unknown).
         delete ledger.slots[requestId];
         ledger.activeDownloads = Math.max(0, ledger.activeDownloads - 1);
+        this.markTerminal(ledger, requestId);
         changed = true;
       }
     }
@@ -202,16 +218,54 @@ export class HfProxyGate {
       request.limitBytes <= 0 ||
       !Number.isSafeInteger(request.maxConcurrent) ||
       request.maxConcurrent <= 0 ||
-      !validId(request.monthBucket)
+      request.maxConcurrent > MAX_ACTIVE_DOWNLOADS_HARD ||
+      !validMonthBucket(request.monthBucket)
     ) {
       return jsonError("Invalid HF proxy reserve request", 400);
     }
 
-    const ledger = await this.load(request.monthBucket);
-    this.gcExpiredSlots(ledger);
+    const loaded = await this.load(request.monthBucket);
+    if (loaded.monthBucket !== request.monthBucket) {
+      return jsonError("HF proxy reserve month is stale", 409);
+    }
+    const ledger = cloneLedger(loaded);
+    if (this.gcExpiredSlots(ledger)) {
+      await this.save(ledger);
+    }
 
-    // Idempotent: duplicate reserve for the same requestId is a no-op.
-    if (ledger.slots[request.requestId]) {
+    if (ledger.terminalRequestIds.includes(request.requestId)) {
+      return jsonError("HF proxy reservation is already terminal", 409);
+    }
+
+    // Re-reserving an active request atomically adjusts its byte reservation.
+    // The route uses this after upstream headers arrive and for each chunk when
+    // Content-Length is unavailable.
+    const existingSlot = ledger.slots[request.requestId];
+    if (existingSlot) {
+      const targetBytes = Math.max(
+        existingSlot.reservedBytes,
+        request.estimatedBytes,
+      );
+      const projectedBytes =
+        ledger.usedBytes - existingSlot.reservedBytes + targetBytes;
+      if (
+        !Number.isSafeInteger(projectedBytes) ||
+        projectedBytes > request.limitBytes
+      ) {
+        return Response.json(
+          {
+            admitted: false,
+            usedBytes: ledger.usedBytes,
+            limitBytes: request.limitBytes,
+            activeDownloads: ledger.activeDownloads,
+            maxConcurrent: request.maxConcurrent,
+          } satisfies ReserveResponse,
+          { status: 429 },
+        );
+      }
+      ledger.usedBytes = projectedBytes;
+      existingSlot.reservedBytes = targetBytes;
+      await this.save(ledger);
       return Response.json({
         admitted: true,
         usedBytes: ledger.usedBytes,
@@ -234,11 +288,12 @@ export class HfProxyGate {
       );
     }
 
-    // Pre-charge the estimated bytes so concurrent requests see the updated
-    // counter. If the download is chunked (estimatedBytes === 0) only the slot
-    // is reserved; the actual charge happens at /settle.
+    // Pre-charge the estimated bytes so concurrent requests see the update.
     const projectedBytes = ledger.usedBytes + request.estimatedBytes;
-    if (projectedBytes > request.limitBytes) {
+    if (
+      !Number.isSafeInteger(projectedBytes) ||
+      projectedBytes > request.limitBytes
+    ) {
       return Response.json(
         {
           admitted: false,
@@ -273,19 +328,22 @@ export class HfProxyGate {
       !validId(request.requestId) ||
       !Number.isSafeInteger(request.actualBytes) ||
       request.actualBytes < 0 ||
-      !validId(request.monthBucket)
+      !validMonthBucket(request.monthBucket)
     ) {
       return jsonError("Invalid HF proxy settle request", 400);
     }
 
-    const ledger = await this.load(request.monthBucket);
+    const loaded = await this.load(request.monthBucket);
+    if (loaded.monthBucket !== request.monthBucket) {
+      return Response.json({ settled: true, stale: true });
+    }
+    const ledger = cloneLedger(loaded);
+    if (ledger.terminalRequestIds.includes(request.requestId)) {
+      return Response.json({ settled: true });
+    }
     const slot = ledger.slots[request.requestId];
     if (!slot) {
-      // Unknown requestId — could be a GC'd expired slot or a double-settle.
-      // Charge the actual bytes defensively and return success.
-      ledger.usedBytes += request.actualBytes;
-      await this.save(ledger);
-      return Response.json({ settled: true });
+      return jsonError("Unknown HF proxy reservation", 409);
     }
 
     // Adjust: remove the pre-charge, add the actual.
@@ -293,24 +351,33 @@ export class HfProxyGate {
     ledger.usedBytes += request.actualBytes;
     delete ledger.slots[request.requestId];
     ledger.activeDownloads = Math.max(0, ledger.activeDownloads - 1);
+    this.markTerminal(ledger, request.requestId);
     await this.save(ledger);
     return Response.json({ settled: true });
   }
 
   private async cancel(request: CancelRequest): Promise<Response> {
-    if (!validId(request.requestId) || !validId(request.monthBucket)) {
+    if (!validId(request.requestId) || !validMonthBucket(request.monthBucket)) {
       return jsonError("Invalid HF proxy cancel request", 400);
     }
 
-    const ledger = await this.load(request.monthBucket);
+    const loaded = await this.load(request.monthBucket);
+    if (loaded.monthBucket !== request.monthBucket) {
+      return Response.json({ cancelled: true, stale: true });
+    }
+    const ledger = cloneLedger(loaded);
+    if (ledger.terminalRequestIds.includes(request.requestId)) {
+      return Response.json({ cancelled: true });
+    }
     const slot = ledger.slots[request.requestId];
     if (!slot) {
-      return Response.json({ cancelled: true });
+      return jsonError("Unknown HF proxy reservation", 409);
     }
     // Remove the pre-charge and release the slot.
     ledger.usedBytes = Math.max(0, ledger.usedBytes - slot.reservedBytes);
     delete ledger.slots[request.requestId];
     ledger.activeDownloads = Math.max(0, ledger.activeDownloads - 1);
+    this.markTerminal(ledger, request.requestId);
     await this.save(ledger);
     return Response.json({ cancelled: true });
   }
@@ -326,6 +393,7 @@ export class HfProxyGate {
         | SettleRequest
         | CancelRequest;
     } catch {
+      // error-policy:J3 Request JSON is untrusted and invalid input is explicit.
       return jsonError("Invalid JSON body", 400);
     }
     if (!body) return jsonError("Invalid JSON body", 400);
@@ -342,6 +410,7 @@ export class HfProxyGate {
         return await this.serialize(() => this.cancel(body as CancelRequest));
       }
     } catch (error) {
+      // error-policy:J1 The Durable Object boundary translates failures to 503.
       // Corrupt ledger or storage failure — fail closed so an org never gets
       // unmetered egress because the counter crashed.
       logger.error("[hf-proxy-gate] operation failed", {
@@ -363,7 +432,8 @@ export class HfProxyGate {
   async alarm(): Promise<void> {
     // GC expired slots so abandoned downloads don't permanently hold a
     // concurrency slot. This runs on the Durable Object's alarm schedule.
-    const ledger = this.ledger ?? await this.state.storage.get<HfProxyLedger>(LEDGER_KEY);
+    const ledger =
+      this.ledger ?? (await this.state.storage.get<HfProxyLedger>(LEDGER_KEY));
     if (!ledger) return;
     const snapshot = cloneLedger(ledger);
     this.gcExpiredSlots(snapshot);

--- a/packages/cloud/api/src/hf-proxy-gate.ts
+++ b/packages/cloud/api/src/hf-proxy-gate.ts
@@ -1,0 +1,373 @@
+/**
+ * Per-organization serialized egress accounting and concurrency for the
+ * HuggingFace proxy route.
+ *
+ * Cloudflare KV is eventually consistent and cannot safely increment a counter
+ * under concurrency — the read/put loop in the route's original KV code lost
+ * increments and let concurrent requests all read the same pre-update value. A
+ * per-organization Durable Object atomically reserves egress and enforces a
+ * concurrent-download cap. Every Worker request goes through a
+ * reserve → stream → settle cycle:
+ *
+ *   1. `/reserve` — atomically checks the monthly egress budget and concurrent
+ *      slot count. If both pass, a slot is held and the estimated bytes
+ *      (content-length if known) are pre-charged. Returns the remaining budget
+ *      and active download count.
+ *   2. `/settle` — records the actual streamed byte count, adjusting the
+ *      reserved estimate and releasing the concurrency slot.
+ *   3. `/cancel` — releases the concurrency slot without charging (used when
+ *      the Worker never reached upstream, e.g. a 4xx/5xx from HuggingFace).
+ *
+ * The Durable Object's single-threaded execution model makes every operation
+ * serial for a given organization, so the reserve and settle steps are atomic
+ * without any application-level locking. A best-effort operation queue
+ * (mirrors `InferenceAdmissionGate`) keeps internal state consistent even when
+ * Cloudflare co-schedules two requests into the same isolate.
+ */
+
+import { logger } from "@/lib/utils/logger";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+/** Per-organization ledger of monthly egress and active downloads. */
+interface HfProxyLedger {
+  /** Month bucket key this ledger covers, e.g. "2026-08". */
+  monthBucket: string;
+  /** Bytes consumed this month (reserved + actual settled). */
+  usedBytes: number;
+  /** Number of active concurrent download slots. */
+  activeDownloads: number;
+  /** Active download slots keyed by requestId for cancellation/settlement. */
+  slots: Record<string, HfProxySlot>;
+}
+
+interface HfProxySlot {
+  requestId: string;
+  /** Bytes reserved at /reserve time (content-length or 0 for chunked). */
+  reservedBytes: number;
+  startedAt: number;
+}
+
+interface ReserveRequest {
+  requestId: string;
+  /** Content-length if known from the upstream HEAD/initial response; else 0. */
+  estimatedBytes: number;
+  /** Monthly egress limit in bytes. */
+  limitBytes: number;
+  /** Max concurrent downloads per org. */
+  maxConcurrent: number;
+  /** Current month bucket key. */
+  monthBucket: string;
+}
+
+interface SettleRequest {
+  requestId: string;
+  actualBytes: number;
+  monthBucket: string;
+}
+
+interface CancelRequest {
+  requestId: string;
+  monthBucket: string;
+}
+
+interface ReserveResponse {
+  admitted: boolean;
+  usedBytes: number;
+  limitBytes: number;
+  activeDownloads: number;
+  maxConcurrent: number;
+}
+
+const LEDGER_KEY = "ledger";
+const SLOT_TTL_MS = 30 * 60_000;
+const MAX_ACTIVE_DOWNLOADS_HARD = 256;
+
+function isFiniteNonNegative(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function validId(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= 256;
+}
+
+function jsonError(message: string, status: 400 | 409 | 503): Response {
+  return Response.json({ success: false, error: message }, { status });
+}
+
+function cloneLedger(ledger: HfProxyLedger): HfProxyLedger {
+  const slots: Record<string, HfProxySlot> = {};
+  for (const [key, slot] of Object.entries(ledger.slots)) {
+    slots[key] = { ...slot };
+  }
+  return {
+    monthBucket: ledger.monthBucket,
+    usedBytes: ledger.usedBytes,
+    activeDownloads: ledger.activeDownloads,
+    slots,
+  };
+}
+
+export class HfProxyGate {
+  private readonly state: DurableObjectState;
+  private readonly env: AppEnv["Bindings"];
+  private ledger: HfProxyLedger | undefined;
+  private operationQueue: Promise<void> = Promise.resolve();
+
+  constructor(state: DurableObjectState, env: AppEnv["Bindings"]) {
+    this.state = state;
+    this.env = env;
+  }
+
+  /**
+   * Validate the cached ledger. Corrupt storage is an explicit failure: the
+   * old KV code silently treated malformed JSON as zero usage, which could
+   * reset an org's monthly counter to zero mid-month.
+   */
+  private async load(monthBucket: string): Promise<HfProxyLedger> {
+    this.ledger ??= await this.state.storage.get<HfProxyLedger>(LEDGER_KEY);
+    if (this.ledger) {
+      if (
+        !validId(this.ledger.monthBucket) ||
+        !Number.isSafeInteger(this.ledger.usedBytes) ||
+        this.ledger.usedBytes < 0 ||
+        !Number.isSafeInteger(this.ledger.activeDownloads) ||
+        this.ledger.activeDownloads < 0 ||
+        this.ledger.activeDownloads > MAX_ACTIVE_DOWNLOADS_HARD ||
+        typeof this.ledger.slots !== "object" ||
+        this.ledger.slots === null
+      ) {
+        throw new Error("HF proxy egress ledger is corrupt");
+      }
+      // Month rollover: reset the counter and clear stale slots.
+      if (this.ledger.monthBucket !== monthBucket) {
+        this.ledger = {
+          monthBucket,
+          usedBytes: 0,
+          activeDownloads: 0,
+          slots: {},
+        };
+      }
+      return this.ledger;
+    }
+    return {
+      monthBucket,
+      usedBytes: 0,
+      activeDownloads: 0,
+      slots: {},
+    };
+  }
+
+  private async save(ledger: HfProxyLedger): Promise<void> {
+    const snapshot = cloneLedger(ledger);
+    await this.state.storage.put(LEDGER_KEY, snapshot);
+    this.ledger = snapshot;
+  }
+
+  /** Serialize operations so internal state stays consistent under co-scheduling. */
+  private async serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.operationQueue;
+    let release: () => void = () => undefined;
+    this.operationQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private gcExpiredSlots(ledger: HfProxyLedger): boolean {
+    const now = Date.now();
+    let changed = false;
+    for (const [requestId, slot] of Object.entries(ledger.slots)) {
+      if (now - slot.startedAt > SLOT_TTL_MS) {
+        // A slot that exceeded the TTL never settled — release it without
+        // adjusting the byte counter (the actual bytes are unknown).
+        delete ledger.slots[requestId];
+        ledger.activeDownloads = Math.max(0, ledger.activeDownloads - 1);
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  private async reserve(request: ReserveRequest): Promise<Response> {
+    if (
+      !validId(request.requestId) ||
+      !Number.isSafeInteger(request.estimatedBytes) ||
+      request.estimatedBytes < 0 ||
+      !Number.isSafeInteger(request.limitBytes) ||
+      request.limitBytes <= 0 ||
+      !Number.isSafeInteger(request.maxConcurrent) ||
+      request.maxConcurrent <= 0 ||
+      !validId(request.monthBucket)
+    ) {
+      return jsonError("Invalid HF proxy reserve request", 400);
+    }
+
+    const ledger = await this.load(request.monthBucket);
+    this.gcExpiredSlots(ledger);
+
+    // Idempotent: duplicate reserve for the same requestId is a no-op.
+    if (ledger.slots[request.requestId]) {
+      return Response.json({
+        admitted: true,
+        usedBytes: ledger.usedBytes,
+        limitBytes: request.limitBytes,
+        activeDownloads: ledger.activeDownloads,
+        maxConcurrent: request.maxConcurrent,
+      } satisfies ReserveResponse);
+    }
+
+    if (ledger.activeDownloads >= request.maxConcurrent) {
+      return Response.json(
+        {
+          admitted: false,
+          usedBytes: ledger.usedBytes,
+          limitBytes: request.limitBytes,
+          activeDownloads: ledger.activeDownloads,
+          maxConcurrent: request.maxConcurrent,
+        } satisfies ReserveResponse,
+        { status: 429 },
+      );
+    }
+
+    // Pre-charge the estimated bytes so concurrent requests see the updated
+    // counter. If the download is chunked (estimatedBytes === 0) only the slot
+    // is reserved; the actual charge happens at /settle.
+    const projectedBytes = ledger.usedBytes + request.estimatedBytes;
+    if (projectedBytes > request.limitBytes) {
+      return Response.json(
+        {
+          admitted: false,
+          usedBytes: ledger.usedBytes,
+          limitBytes: request.limitBytes,
+          activeDownloads: ledger.activeDownloads,
+          maxConcurrent: request.maxConcurrent,
+        } satisfies ReserveResponse,
+        { status: 429 },
+      );
+    }
+
+    ledger.usedBytes = projectedBytes;
+    ledger.activeDownloads += 1;
+    ledger.slots[request.requestId] = {
+      requestId: request.requestId,
+      reservedBytes: request.estimatedBytes,
+      startedAt: Date.now(),
+    };
+    await this.save(ledger);
+    return Response.json({
+      admitted: true,
+      usedBytes: ledger.usedBytes,
+      limitBytes: request.limitBytes,
+      activeDownloads: ledger.activeDownloads,
+      maxConcurrent: request.maxConcurrent,
+    } satisfies ReserveResponse);
+  }
+
+  private async settle(request: SettleRequest): Promise<Response> {
+    if (
+      !validId(request.requestId) ||
+      !Number.isSafeInteger(request.actualBytes) ||
+      request.actualBytes < 0 ||
+      !validId(request.monthBucket)
+    ) {
+      return jsonError("Invalid HF proxy settle request", 400);
+    }
+
+    const ledger = await this.load(request.monthBucket);
+    const slot = ledger.slots[request.requestId];
+    if (!slot) {
+      // Unknown requestId — could be a GC'd expired slot or a double-settle.
+      // Charge the actual bytes defensively and return success.
+      ledger.usedBytes += request.actualBytes;
+      await this.save(ledger);
+      return Response.json({ settled: true });
+    }
+
+    // Adjust: remove the pre-charge, add the actual.
+    ledger.usedBytes = Math.max(0, ledger.usedBytes - slot.reservedBytes);
+    ledger.usedBytes += request.actualBytes;
+    delete ledger.slots[request.requestId];
+    ledger.activeDownloads = Math.max(0, ledger.activeDownloads - 1);
+    await this.save(ledger);
+    return Response.json({ settled: true });
+  }
+
+  private async cancel(request: CancelRequest): Promise<Response> {
+    if (!validId(request.requestId) || !validId(request.monthBucket)) {
+      return jsonError("Invalid HF proxy cancel request", 400);
+    }
+
+    const ledger = await this.load(request.monthBucket);
+    const slot = ledger.slots[request.requestId];
+    if (!slot) {
+      return Response.json({ cancelled: true });
+    }
+    // Remove the pre-charge and release the slot.
+    ledger.usedBytes = Math.max(0, ledger.usedBytes - slot.reservedBytes);
+    delete ledger.slots[request.requestId];
+    ledger.activeDownloads = Math.max(0, ledger.activeDownloads - 1);
+    await this.save(ledger);
+    return Response.json({ cancelled: true });
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    if (request.method !== "POST") {
+      return new Response("Method not allowed", { status: 405 });
+    }
+    let body: ReserveRequest | SettleRequest | CancelRequest;
+    try {
+      body = (await request.json()) as
+        | ReserveRequest
+        | SettleRequest
+        | CancelRequest;
+    } catch {
+      return jsonError("Invalid JSON body", 400);
+    }
+    if (!body) return jsonError("Invalid JSON body", 400);
+
+    const path = new URL(request.url).pathname;
+    try {
+      if (path === "/reserve") {
+        return await this.serialize(() => this.reserve(body as ReserveRequest));
+      }
+      if (path === "/settle") {
+        return await this.serialize(() => this.settle(body as SettleRequest));
+      }
+      if (path === "/cancel") {
+        return await this.serialize(() => this.cancel(body as CancelRequest));
+      }
+    } catch (error) {
+      // Corrupt ledger or storage failure — fail closed so an org never gets
+      // unmetered egress because the counter crashed.
+      logger.error("[hf-proxy-gate] operation failed", {
+        path,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return Response.json(
+        {
+          success: false,
+          code: "hf_proxy_gate_error",
+          error: "HF proxy gate operation failed",
+        },
+        { status: 503 },
+      );
+    }
+    return new Response("Not found", { status: 404 });
+  }
+
+  async alarm(): Promise<void> {
+    // GC expired slots so abandoned downloads don't permanently hold a
+    // concurrency slot. This runs on the Durable Object's alarm schedule.
+    const ledger = this.ledger ?? await this.state.storage.get<HfProxyLedger>(LEDGER_KEY);
+    if (!ledger) return;
+    const snapshot = cloneLedger(ledger);
+    this.gcExpiredSlots(snapshot);
+    await this.state.storage.put(LEDGER_KEY, snapshot);
+    this.ledger = snapshot;
+  }
+}

--- a/packages/cloud/api/src/hf-proxy-gate.ts
+++ b/packages/cloud/api/src/hf-proxy-gate.ts
@@ -30,10 +30,10 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 /** Per-organization ledger of monthly egress and active downloads. */
 interface HfProxyLedger {
-  /** Month bucket key this ledger covers, e.g. "2026-08". */
-  monthBucket: string;
-  /** Bytes consumed this month (reserved + actual settled). */
-  usedBytes: number;
+  /** Latest month bucket admitted by this gate, e.g. "2026-08". */
+  currentMonthBucket: string;
+  /** Bytes consumed per month (reserved + actual settled). */
+  monthUsedBytes: Record<string, number>;
   /** Number of active concurrent download slots. */
   activeDownloads: number;
   /** Active download slots keyed by requestId for cancellation/settlement. */
@@ -46,7 +46,8 @@ interface HfProxySlot {
   requestId: string;
   /** Bytes reserved at /reserve time (content-length or 0 for chunked). */
   reservedBytes: number;
-  startedAt: number;
+  monthBucket: string;
+  lastHeartbeatAt: number;
 }
 
 interface ReserveRequest {
@@ -72,6 +73,11 @@ interface CancelRequest {
   monthBucket: string;
 }
 
+interface HeartbeatRequest {
+  requestId: string;
+  monthBucket: string;
+}
+
 interface ReserveResponse {
   admitted: boolean;
   usedBytes: number;
@@ -81,7 +87,7 @@ interface ReserveResponse {
 }
 
 const LEDGER_KEY = "ledger";
-const SLOT_TTL_MS = 30 * 60_000;
+const SLOT_LEASE_MS = 30 * 60_000;
 const MAX_ACTIVE_DOWNLOADS_HARD = 256;
 const MAX_TERMINAL_REQUEST_IDS = 2_048;
 
@@ -103,8 +109,8 @@ function cloneLedger(ledger: HfProxyLedger): HfProxyLedger {
     slots[key] = { ...slot };
   }
   return {
-    monthBucket: ledger.monthBucket,
-    usedBytes: ledger.usedBytes,
+    currentMonthBucket: ledger.currentMonthBucket,
+    monthUsedBytes: { ...ledger.monthUsedBytes },
     activeDownloads: ledger.activeDownloads,
     slots,
     terminalRequestIds: [...ledger.terminalRequestIds],
@@ -125,13 +131,19 @@ export class HfProxyGate {
    * old KV code silently treated malformed JSON as zero usage, which could
    * reset an org's monthly counter to zero mid-month.
    */
-  private async load(monthBucket: string): Promise<HfProxyLedger> {
+  private async load(): Promise<HfProxyLedger | undefined> {
     this.ledger ??= await this.state.storage.get<HfProxyLedger>(LEDGER_KEY);
     if (this.ledger) {
       if (
-        !validMonthBucket(this.ledger.monthBucket) ||
-        !Number.isSafeInteger(this.ledger.usedBytes) ||
-        this.ledger.usedBytes < 0 ||
+        !validMonthBucket(this.ledger.currentMonthBucket) ||
+        typeof this.ledger.monthUsedBytes !== "object" ||
+        this.ledger.monthUsedBytes === null ||
+        Object.entries(this.ledger.monthUsedBytes).some(
+          ([bucket, usedBytes]) =>
+            !validMonthBucket(bucket) ||
+            !Number.isSafeInteger(usedBytes) ||
+            usedBytes < 0,
+        ) ||
         !Number.isSafeInteger(this.ledger.activeDownloads) ||
         this.ledger.activeDownloads < 0 ||
         this.ledger.activeDownloads > MAX_ACTIVE_DOWNLOADS_HARD ||
@@ -139,30 +151,25 @@ export class HfProxyGate {
         this.ledger.slots === null ||
         !Array.isArray(this.ledger.terminalRequestIds) ||
         this.ledger.terminalRequestIds.length > MAX_TERMINAL_REQUEST_IDS ||
-        this.ledger.terminalRequestIds.some((requestId) => !validId(requestId))
+        this.ledger.terminalRequestIds.some(
+          (requestId) => !validId(requestId),
+        ) ||
+        Object.values(this.ledger.slots).some(
+          (slot) =>
+            !validId(slot.requestId) ||
+            !Number.isSafeInteger(slot.reservedBytes) ||
+            slot.reservedBytes < 0 ||
+            !validMonthBucket(slot.monthBucket) ||
+            !Number.isSafeInteger(slot.lastHeartbeatAt) ||
+            slot.lastHeartbeatAt < 0,
+        ) ||
+        this.ledger.activeDownloads !== Object.keys(this.ledger.slots).length
       ) {
         throw new Error("HF proxy egress ledger is corrupt");
       }
-      // Month rollover only moves forward. A late settle/cancel from the prior
-      // month must never replace a newer ledger and erase its accounting.
-      if (this.ledger.monthBucket < monthBucket) {
-        return {
-          monthBucket,
-          usedBytes: 0,
-          activeDownloads: 0,
-          slots: {},
-          terminalRequestIds: [],
-        };
-      }
       return this.ledger;
     }
-    return {
-      monthBucket,
-      usedBytes: 0,
-      activeDownloads: 0,
-      slots: {},
-      terminalRequestIds: [],
-    };
+    return undefined;
   }
 
   private markTerminal(ledger: HfProxyLedger, requestId: string): void {
@@ -176,6 +183,16 @@ export class HfProxyGate {
     const snapshot = cloneLedger(ledger);
     await this.state.storage.put(LEDGER_KEY, snapshot);
     this.ledger = snapshot;
+    if (snapshot.activeDownloads === 0) {
+      await this.state.storage.deleteAlarm();
+      return;
+    }
+    const nextExpiration = Math.min(
+      ...Object.values(snapshot.slots).map(
+        (slot) => slot.lastHeartbeatAt + SLOT_LEASE_MS,
+      ),
+    );
+    await this.state.storage.setAlarm(nextExpiration);
   }
 
   /** Serialize operations so internal state stays consistent under co-scheduling. */
@@ -197,7 +214,7 @@ export class HfProxyGate {
     const now = Date.now();
     let changed = false;
     for (const [requestId, slot] of Object.entries(ledger.slots)) {
-      if (now - slot.startedAt > SLOT_TTL_MS) {
+      if (now - slot.lastHeartbeatAt >= SLOT_LEASE_MS) {
         // A slot that exceeded the TTL never settled — release it without
         // adjusting the byte counter (the actual bytes are unknown).
         delete ledger.slots[requestId];
@@ -224,14 +241,28 @@ export class HfProxyGate {
       return jsonError("Invalid HF proxy reserve request", 400);
     }
 
-    const loaded = await this.load(request.monthBucket);
-    if (loaded.monthBucket !== request.monthBucket) {
+    const loaded = await this.load();
+    if (loaded && loaded.currentMonthBucket > request.monthBucket) {
       return jsonError("HF proxy reserve month is stale", 409);
     }
-    const ledger = cloneLedger(loaded);
+    const ledger = cloneLedger(
+      loaded ?? {
+        currentMonthBucket: request.monthBucket,
+        monthUsedBytes: { [request.monthBucket]: 0 },
+        activeDownloads: 0,
+        slots: {},
+        terminalRequestIds: [],
+      },
+    );
+    if (request.monthBucket > ledger.currentMonthBucket) {
+      ledger.currentMonthBucket = request.monthBucket;
+      ledger.monthUsedBytes[request.monthBucket] = 0;
+    }
     if (this.gcExpiredSlots(ledger)) {
       await this.save(ledger);
     }
+
+    const usedBytes = ledger.monthUsedBytes[request.monthBucket] ?? 0;
 
     if (ledger.terminalRequestIds.includes(request.requestId)) {
       return jsonError("HF proxy reservation is already terminal", 409);
@@ -246,8 +277,11 @@ export class HfProxyGate {
         existingSlot.reservedBytes,
         request.estimatedBytes,
       );
+      if (existingSlot.monthBucket !== request.monthBucket) {
+        return jsonError("HF proxy reservation month does not match", 409);
+      }
       const projectedBytes =
-        ledger.usedBytes - existingSlot.reservedBytes + targetBytes;
+        usedBytes - existingSlot.reservedBytes + targetBytes;
       if (
         !Number.isSafeInteger(projectedBytes) ||
         projectedBytes > request.limitBytes
@@ -255,7 +289,7 @@ export class HfProxyGate {
         return Response.json(
           {
             admitted: false,
-            usedBytes: ledger.usedBytes,
+            usedBytes,
             limitBytes: request.limitBytes,
             activeDownloads: ledger.activeDownloads,
             maxConcurrent: request.maxConcurrent,
@@ -263,12 +297,13 @@ export class HfProxyGate {
           { status: 429 },
         );
       }
-      ledger.usedBytes = projectedBytes;
+      ledger.monthUsedBytes[request.monthBucket] = projectedBytes;
       existingSlot.reservedBytes = targetBytes;
+      existingSlot.lastHeartbeatAt = Date.now();
       await this.save(ledger);
       return Response.json({
         admitted: true,
-        usedBytes: ledger.usedBytes,
+        usedBytes: projectedBytes,
         limitBytes: request.limitBytes,
         activeDownloads: ledger.activeDownloads,
         maxConcurrent: request.maxConcurrent,
@@ -279,7 +314,7 @@ export class HfProxyGate {
       return Response.json(
         {
           admitted: false,
-          usedBytes: ledger.usedBytes,
+          usedBytes,
           limitBytes: request.limitBytes,
           activeDownloads: ledger.activeDownloads,
           maxConcurrent: request.maxConcurrent,
@@ -289,7 +324,7 @@ export class HfProxyGate {
     }
 
     // Pre-charge the estimated bytes so concurrent requests see the update.
-    const projectedBytes = ledger.usedBytes + request.estimatedBytes;
+    const projectedBytes = usedBytes + request.estimatedBytes;
     if (
       !Number.isSafeInteger(projectedBytes) ||
       projectedBytes > request.limitBytes
@@ -297,7 +332,7 @@ export class HfProxyGate {
       return Response.json(
         {
           admitted: false,
-          usedBytes: ledger.usedBytes,
+          usedBytes,
           limitBytes: request.limitBytes,
           activeDownloads: ledger.activeDownloads,
           maxConcurrent: request.maxConcurrent,
@@ -306,17 +341,18 @@ export class HfProxyGate {
       );
     }
 
-    ledger.usedBytes = projectedBytes;
+    ledger.monthUsedBytes[request.monthBucket] = projectedBytes;
     ledger.activeDownloads += 1;
     ledger.slots[request.requestId] = {
       requestId: request.requestId,
       reservedBytes: request.estimatedBytes,
-      startedAt: Date.now(),
+      monthBucket: request.monthBucket,
+      lastHeartbeatAt: Date.now(),
     };
     await this.save(ledger);
     return Response.json({
       admitted: true,
-      usedBytes: ledger.usedBytes,
+      usedBytes: projectedBytes,
       limitBytes: request.limitBytes,
       activeDownloads: ledger.activeDownloads,
       maxConcurrent: request.maxConcurrent,
@@ -333,10 +369,8 @@ export class HfProxyGate {
       return jsonError("Invalid HF proxy settle request", 400);
     }
 
-    const loaded = await this.load(request.monthBucket);
-    if (loaded.monthBucket !== request.monthBucket) {
-      return Response.json({ settled: true, stale: true });
-    }
+    const loaded = await this.load();
+    if (!loaded) return jsonError("Unknown HF proxy reservation", 409);
     const ledger = cloneLedger(loaded);
     if (ledger.terminalRequestIds.includes(request.requestId)) {
       return Response.json({ settled: true });
@@ -345,10 +379,16 @@ export class HfProxyGate {
     if (!slot) {
       return jsonError("Unknown HF proxy reservation", 409);
     }
+    if (slot.monthBucket !== request.monthBucket) {
+      return jsonError("HF proxy reservation month does not match", 409);
+    }
 
     // Adjust: remove the pre-charge, add the actual.
-    ledger.usedBytes = Math.max(0, ledger.usedBytes - slot.reservedBytes);
-    ledger.usedBytes += request.actualBytes;
+    const usedBytes = ledger.monthUsedBytes[slot.monthBucket];
+    if (usedBytes === undefined)
+      throw new Error("HF proxy month ledger is missing");
+    ledger.monthUsedBytes[slot.monthBucket] =
+      Math.max(0, usedBytes - slot.reservedBytes) + request.actualBytes;
     delete ledger.slots[request.requestId];
     ledger.activeDownloads = Math.max(0, ledger.activeDownloads - 1);
     this.markTerminal(ledger, request.requestId);
@@ -361,10 +401,8 @@ export class HfProxyGate {
       return jsonError("Invalid HF proxy cancel request", 400);
     }
 
-    const loaded = await this.load(request.monthBucket);
-    if (loaded.monthBucket !== request.monthBucket) {
-      return Response.json({ cancelled: true, stale: true });
-    }
+    const loaded = await this.load();
+    if (!loaded) return jsonError("Unknown HF proxy reservation", 409);
     const ledger = cloneLedger(loaded);
     if (ledger.terminalRequestIds.includes(request.requestId)) {
       return Response.json({ cancelled: true });
@@ -373,8 +411,17 @@ export class HfProxyGate {
     if (!slot) {
       return jsonError("Unknown HF proxy reservation", 409);
     }
+    if (slot.monthBucket !== request.monthBucket) {
+      return jsonError("HF proxy reservation month does not match", 409);
+    }
     // Remove the pre-charge and release the slot.
-    ledger.usedBytes = Math.max(0, ledger.usedBytes - slot.reservedBytes);
+    const usedBytes = ledger.monthUsedBytes[slot.monthBucket];
+    if (usedBytes === undefined)
+      throw new Error("HF proxy month ledger is missing");
+    ledger.monthUsedBytes[slot.monthBucket] = Math.max(
+      0,
+      usedBytes - slot.reservedBytes,
+    );
     delete ledger.slots[request.requestId];
     ledger.activeDownloads = Math.max(0, ledger.activeDownloads - 1);
     this.markTerminal(ledger, request.requestId);
@@ -382,16 +429,47 @@ export class HfProxyGate {
     return Response.json({ cancelled: true });
   }
 
+  private async heartbeat(request: HeartbeatRequest): Promise<Response> {
+    if (!validId(request.requestId) || !validMonthBucket(request.monthBucket)) {
+      return jsonError("Invalid HF proxy heartbeat request", 400);
+    }
+    const loaded = await this.load();
+    if (!loaded) return jsonError("Unknown HF proxy reservation", 409);
+    const ledger = cloneLedger(loaded);
+    if (ledger.terminalRequestIds.includes(request.requestId)) {
+      return Response.json({ renewed: true });
+    }
+    const slot = ledger.slots[request.requestId];
+    if (!slot) return jsonError("Unknown HF proxy reservation", 409);
+    if (slot.monthBucket !== request.monthBucket) {
+      return jsonError("HF proxy reservation month does not match", 409);
+    }
+    slot.lastHeartbeatAt = Date.now();
+    await this.save(ledger);
+    return Response.json({ renewed: true });
+  }
+
+  async alarm(): Promise<void> {
+    await this.serialize(async () => {
+      const loaded = await this.load();
+      if (!loaded) return;
+      const ledger = cloneLedger(loaded);
+      this.gcExpiredSlots(ledger);
+      await this.save(ledger);
+    });
+  }
+
   async fetch(request: Request): Promise<Response> {
     if (request.method !== "POST") {
       return new Response("Method not allowed", { status: 405 });
     }
-    let body: ReserveRequest | SettleRequest | CancelRequest;
+    let body: ReserveRequest | SettleRequest | CancelRequest | HeartbeatRequest;
     try {
       body = (await request.json()) as
         | ReserveRequest
         | SettleRequest
-        | CancelRequest;
+        | CancelRequest
+        | HeartbeatRequest;
     } catch {
       // error-policy:J3 Request JSON is untrusted and invalid input is explicit.
       return jsonError("Invalid JSON body", 400);
@@ -408,6 +486,11 @@ export class HfProxyGate {
       }
       if (path === "/cancel") {
         return await this.serialize(() => this.cancel(body as CancelRequest));
+      }
+      if (path === "/heartbeat") {
+        return await this.serialize(() =>
+          this.heartbeat(body as HeartbeatRequest),
+        );
       }
     } catch (error) {
       // error-policy:J1 The Durable Object boundary translates failures to 503.
@@ -427,17 +510,5 @@ export class HfProxyGate {
       );
     }
     return new Response("Not found", { status: 404 });
-  }
-
-  async alarm(): Promise<void> {
-    // GC expired slots so abandoned downloads don't permanently hold a
-    // concurrency slot. This runs on the Durable Object's alarm schedule.
-    const ledger =
-      this.ledger ?? (await this.state.storage.get<HfProxyLedger>(LEDGER_KEY));
-    if (!ledger) return;
-    const snapshot = cloneLedger(ledger);
-    this.gcExpiredSlots(snapshot);
-    await this.state.storage.put(LEDGER_KEY, snapshot);
-    this.ledger = snapshot;
   }
 }

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -20,6 +20,7 @@ import { serveRegistryHostRequest } from "./registry-host";
 import { isThinStewardPublicPath } from "./steward/public-paths";
 
 export { AnonymousChatGate } from "./anonymous-chat-gate";
+export { HfProxyGate } from "./hf-proxy-gate";
 export { InferenceAdmissionGate } from "./inference-admission-gate";
 export { OnboardingSessionCoordinator } from "./onboarding-session-coordinator";
 export { SharedRuntimeConversation } from "./shared-runtime-conversation";

--- a/packages/cloud/api/v1/hf-proxy/[...path]/route.ts
+++ b/packages/cloud/api/v1/hf-proxy/[...path]/route.ts
@@ -41,6 +41,7 @@ const DEFAULT_MONTHLY_EGRESS_LIMIT_BYTES = 500 * 1024 ** 3;
 const DEFAULT_MAX_CONCURRENT_DOWNLOADS = 4;
 const GATE_ORIGIN = "https://hf-proxy-gate.internal";
 const GATE_TIMEOUT_MS = 3_000;
+const GATE_HEARTBEAT_INTERVAL_MS = 5 * 60_000;
 
 /**
  * Only repos under this org may be proxied. The curated eliza-1 catalog lives at
@@ -88,22 +89,26 @@ const app = new Hono<AppEnv>();
 
 // ---- Egress policy helpers ----
 
+function parseSafeInteger(value: unknown, minimum: number): number | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed >= minimum ? parsed : null;
+}
+
 function monthlyEgressLimitBytes(env: AppEnv["Bindings"]): number {
-  const raw = env.HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES;
-  const parsed =
-    typeof raw === "string" ? Number.parseInt(raw.trim(), 10) : Number.NaN;
-  return Number.isFinite(parsed) && parsed > 0
-    ? parsed
-    : DEFAULT_MONTHLY_EGRESS_LIMIT_BYTES;
+  return (
+    parseSafeInteger(env.HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES, 1) ??
+    DEFAULT_MONTHLY_EGRESS_LIMIT_BYTES
+  );
 }
 
 function maxConcurrentDownloads(env: AppEnv["Bindings"]): number {
-  const raw = env.HF_PROXY_MAX_CONCURRENT_DOWNLOADS;
-  const parsed =
-    typeof raw === "string" ? Number.parseInt(raw.trim(), 10) : Number.NaN;
-  return Number.isFinite(parsed) && parsed > 0
-    ? parsed
-    : DEFAULT_MAX_CONCURRENT_DOWNLOADS;
+  return (
+    parseSafeInteger(env.HF_PROXY_MAX_CONCURRENT_DOWNLOADS, 1) ??
+    DEFAULT_MAX_CONCURRENT_DOWNLOADS
+  );
 }
 
 function monthBucket(now = new Date()): string {
@@ -113,8 +118,7 @@ function monthBucket(now = new Date()): string {
 function parseContentLength(headers: Headers): number | null {
   const value = headers.get("content-length");
   if (!value) return null;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  return parseSafeInteger(value, 0);
 }
 
 function cacheStatus(headers: Headers): string | null {
@@ -230,6 +234,71 @@ async function gateCancel(
   }
 }
 
+async function gateHeartbeat(
+  stub: RuntimeDurableObjectStub,
+  requestId: string,
+  bucket: string,
+): Promise<void> {
+  const response = await stub.fetch(
+    new Request(`${GATE_ORIGIN}/heartbeat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ requestId, monthBucket: bucket }),
+      signal: AbortSignal.timeout(GATE_TIMEOUT_MS),
+    }),
+  );
+  if (!response.ok) {
+    throw new HfProxyGateError(
+      `HF proxy gate heartbeat failed with status ${response.status}`,
+    );
+  }
+}
+
+function startGateHeartbeat(
+  stub: RuntimeDurableObjectStub,
+  requestId: string,
+  bucket: string,
+  onFailure: (error: unknown) => void,
+): () => void {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let stopped = false;
+  const schedule = (): void => {
+    if (stopped) return;
+    timer = setTimeout(async () => {
+      try {
+        await gateHeartbeat(stub, requestId, bucket);
+        schedule();
+      } catch (error) {
+        // error-policy:J1 The caller aborts the active upstream operation and
+        // exposes the lease failure at the response boundary.
+        stopped = true;
+        onFailure(error);
+      }
+    }, GATE_HEARTBEAT_INTERVAL_MS);
+  };
+  schedule();
+  return () => {
+    stopped = true;
+    if (timer !== undefined) clearTimeout(timer);
+    timer = undefined;
+  };
+}
+
+async function cancelUpstreamBody(
+  response: Response,
+  reason: string,
+): Promise<void> {
+  try {
+    await response.body?.cancel(reason);
+  } catch (error) {
+    // error-policy:J6 The proxy response is already terminal; upstream body
+    // cancellation is best-effort teardown and must not hide gate cleanup.
+    logger.warn("[hf-proxy] upstream body cancellation failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 class HfProxyGateError extends Error {
   readonly code: string | undefined;
   constructor(message: string, code?: string) {
@@ -292,10 +361,45 @@ function streamWithEgressAccounting(args: {
   let bytes = 0;
   let reservedBytes = args.initialReservedBytes;
   let settled = false;
+  let heartbeatTimer: ReturnType<typeof setTimeout> | undefined;
+  let heartbeatFailure: unknown;
+
+  const stopHeartbeat = (): void => {
+    if (heartbeatTimer !== undefined) clearTimeout(heartbeatTimer);
+    heartbeatTimer = undefined;
+  };
+
+  const scheduleHeartbeat = (): void => {
+    if (settled) return;
+    heartbeatTimer = setTimeout(async () => {
+      try {
+        await gateHeartbeat(args.gateStub, args.requestId, args.monthBucket);
+        scheduleHeartbeat();
+      } catch (error) {
+        // error-policy:J1 The stream boundary exposes heartbeat failure to its
+        // consumer after cancelling the upstream reader here.
+        heartbeatFailure = error;
+        try {
+          await reader.cancel(error);
+        } catch (cancelError) {
+          // error-policy:J6 Heartbeat failure is already preserved for the
+          // consumer; reader cancellation is best-effort teardown.
+          logger.warn("[hf-proxy] upstream reader cancellation failed", {
+            error:
+              cancelError instanceof Error
+                ? cancelError.message
+                : String(cancelError),
+          });
+        }
+      }
+    }, GATE_HEARTBEAT_INTERVAL_MS);
+  };
+  scheduleHeartbeat();
 
   const settleOnce = async (finalBytes: number): Promise<void> => {
     if (settled) return;
     settled = true;
+    stopHeartbeat();
     try {
       await gateSettle(
         args.gateStub,
@@ -328,6 +432,7 @@ function streamWithEgressAccounting(args: {
     async pull(controller) {
       try {
         const result = await reader.read();
+        if (heartbeatFailure) throw heartbeatFailure;
         if (result.done) {
           await settleOnce(bytes);
           controller.close();
@@ -367,6 +472,7 @@ function streamWithEgressAccounting(args: {
       }
     },
     async cancel(reason) {
+      stopHeartbeat();
       try {
         await reader.cancel(reason);
       } finally {
@@ -500,17 +606,31 @@ app.get("/*", async (c) => {
     const range = c.req.header("range");
     if (range) headers.set("range", range);
 
+    const upstreamAbortController = new AbortController();
+    let upstreamHeartbeatFailure: unknown;
+    const stopUpstreamHeartbeat = startGateHeartbeat(
+      gateStub,
+      requestId,
+      bucket,
+      (error) => {
+        upstreamHeartbeatFailure = error;
+        upstreamAbortController.abort(error);
+      },
+    );
+
     let upstreamResponse: Response;
     try {
       upstreamResponse = await fetch(upstream, {
         method: "GET",
         headers,
         redirect: "follow",
+        signal: upstreamAbortController.signal,
       });
     } catch (error) {
       // Upstream fetch failed: release the slot without charging.
+      stopUpstreamHeartbeat();
       await gateCancel(gateStub, requestId, bucket);
-      throw error;
+      throw upstreamHeartbeatFailure ?? error;
     }
 
     if (upstreamResponse.status >= 400) {
@@ -545,6 +665,8 @@ app.get("/*", async (c) => {
         cacheHit: cacheHit(upstreamCacheStatus),
       });
       // Gated/unauthorized: release the concurrency slot without charging.
+      stopUpstreamHeartbeat();
+      await cancelUpstreamBody(upstreamResponse, "HF upstream unauthorized");
       await gateCancel(gateStub, requestId, bucket);
       return c.json(
         {
@@ -560,15 +682,31 @@ app.get("/*", async (c) => {
     // forwarded. Concurrent downloads therefore observe the pre-charge. When
     // length is unknown, the stream reserves each chunk before enqueueing it.
     if (contentLength !== null) {
-      const sizedReserve = await gateReserve(
-        gateStub,
-        requestId,
-        contentLength,
-        limitBytes,
-        maxConcurrent,
-        bucket,
-      );
+      let sizedReserve: ReserveDecision;
+      try {
+        sizedReserve = await gateReserve(
+          gateStub,
+          requestId,
+          contentLength,
+          limitBytes,
+          maxConcurrent,
+          bucket,
+        );
+      } catch (error) {
+        stopUpstreamHeartbeat();
+        await cancelUpstreamBody(
+          upstreamResponse,
+          "HF proxy gate sizing failed",
+        );
+        await gateCancel(gateStub, requestId, bucket);
+        throw error;
+      }
       if (!sizedReserve.admitted) {
+        stopUpstreamHeartbeat();
+        await cancelUpstreamBody(
+          upstreamResponse,
+          "HF proxy egress limit reached",
+        );
         await gateCancel(gateStub, requestId, bucket);
         return c.json(
           egressLimitResponse(
@@ -605,7 +743,9 @@ app.get("/*", async (c) => {
         limitBytes,
         maxConcurrent,
       });
+      stopUpstreamHeartbeat();
     } else {
+      stopUpstreamHeartbeat();
       await gateSettle(gateStub, requestId, 0, bucket);
       logger.info("[hf-proxy] egress metric", {
         organizationId: orgId,

--- a/packages/cloud/api/v1/hf-proxy/[...path]/route.ts
+++ b/packages/cloud/api/v1/hf-proxy/[...path]/route.ts
@@ -18,17 +18,30 @@
  * as an open SSRF relay. The target repo is additionally scoped to the curated
  * eliza-1 org (`ALLOWED_REPO_PREFIX`): the cloud's own `HF_TOKEN` may only be
  * spent proxying the shipping catalog, never an arbitrary user-chosen repo.
+ *
+ * EGRESS & CONCURRENCY: a per-organization Durable Object (`HF_PROXY_GATES`)
+ * atomically reserves bytes and holds a concurrent-download slot for every
+ * request. This replaces the original non-atomic KV read/put counter, which
+ * lost increments under concurrency and let concurrent requests all read the
+ * same pre-update value. The DO also enforces a per-org concurrent-download
+ * cap so one org cannot saturate the Worker's subrequests.
  */
 
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { logger, redact } from "@/lib/utils/logger";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type {
+  AppEnv,
+  RuntimeDurableObjectNamespace,
+  RuntimeDurableObjectStub,
+} from "@/types/cloud-worker-env";
 
 const HF_UPSTREAM_HOST = "https://huggingface.co";
 const DEFAULT_MONTHLY_EGRESS_LIMIT_BYTES = 500 * 1024 ** 3;
-const MONTHLY_EGRESS_TTL_SECONDS = 35 * 24 * 60 * 60;
+const DEFAULT_MAX_CONCURRENT_DOWNLOADS = 4;
+const GATE_ORIGIN = "https://hf-proxy-gate.internal";
+const GATE_TIMEOUT_MS = 3_000;
 
 /**
  * Only repos under this org may be proxied. The curated eliza-1 catalog lives at
@@ -74,12 +87,7 @@ const PASSTHROUGH_RESPONSE_HEADERS = [
 
 const app = new Hono<AppEnv>();
 
-interface EgressCounter {
-  bytes: number;
-  expiresAt: number;
-}
-
-const inMemoryEgressCounters = new Map<string, EgressCounter>();
+// ---- Egress policy helpers ----
 
 function monthlyEgressLimitBytes(env: AppEnv["Bindings"]): number {
   const raw = env.HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES;
@@ -90,64 +98,17 @@ function monthlyEgressLimitBytes(env: AppEnv["Bindings"]): number {
     : DEFAULT_MONTHLY_EGRESS_LIMIT_BYTES;
 }
 
+function maxConcurrentDownloads(env: AppEnv["Bindings"]): number {
+  const raw = env.HF_PROXY_MAX_CONCURRENT_DOWNLOADS;
+  const parsed =
+    typeof raw === "string" ? Number.parseInt(raw.trim(), 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_MAX_CONCURRENT_DOWNLOADS;
+}
+
 function monthBucket(now = new Date()): string {
   return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
-}
-
-function egressKey(organizationId: string, now = new Date()): string {
-  return `hf-proxy:egress:${organizationId}:${monthBucket(now)}`;
-}
-
-async function readMonthlyEgress(
-  env: AppEnv["Bindings"],
-  organizationId: string,
-): Promise<number> {
-  const key = egressKey(organizationId);
-  const kv = env.CACHE_KV;
-  if (kv) {
-    const raw = await kv.get(key);
-    if (!raw) return 0;
-    try {
-      const parsed = JSON.parse(raw) as { bytes?: unknown };
-      return typeof parsed.bytes === "number" ? parsed.bytes : 0;
-    } catch {
-      return 0;
-    }
-  }
-
-  const now = Date.now();
-  const counter = inMemoryEgressCounters.get(key);
-  if (!counter || counter.expiresAt <= now) {
-    inMemoryEgressCounters.delete(key);
-    return 0;
-  }
-  return counter.bytes;
-}
-
-async function addMonthlyEgress(
-  env: AppEnv["Bindings"],
-  organizationId: string,
-  bytes: number,
-): Promise<number> {
-  if (bytes <= 0) return readMonthlyEgress(env, organizationId);
-
-  const key = egressKey(organizationId);
-  const kv = env.CACHE_KV;
-  const current = await readMonthlyEgress(env, organizationId);
-  const next = current + bytes;
-  const value = JSON.stringify({
-    bytes: next,
-    updatedAt: new Date().toISOString(),
-  });
-  if (kv) {
-    await kv.put(key, value, { expirationTtl: MONTHLY_EGRESS_TTL_SECONDS });
-  } else {
-    inMemoryEgressCounters.set(key, {
-      bytes: next,
-      expiresAt: Date.now() + MONTHLY_EGRESS_TTL_SECONDS * 1000,
-    });
-  }
-  return next;
 }
 
 function parseContentLength(headers: Headers): number | null {
@@ -166,6 +127,137 @@ function cacheHit(value: string | null): boolean | null {
   return /\bhit\b/i.test(value);
 }
 
+// ---- Durable Object gate client ----
+
+function getGateStub(env: AppEnv["Bindings"], orgId: string): RuntimeDurableObjectStub | null {
+  const ns = env.HF_PROXY_GATES;
+  if (!ns) return null;
+  return ns.getByName(orgId);
+}
+
+interface ReserveDecision {
+  admitted: boolean;
+  usedBytes: number;
+  limitBytes: number;
+  activeDownloads: number;
+  maxConcurrent: number;
+}
+
+async function gateReserve(
+  stub: RuntimeDurableObjectStub,
+  requestId: string,
+  estimatedBytes: number,
+  limitBytes: number,
+  maxConcurrent: number,
+  bucket: string,
+): Promise<ReserveDecision> {
+  const response = await stub.fetch(
+    new Request(`${GATE_ORIGIN}/reserve`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        requestId,
+        estimatedBytes,
+        limitBytes,
+        maxConcurrent,
+        monthBucket: bucket,
+      }),
+      signal: AbortSignal.timeout(GATE_TIMEOUT_MS),
+    }),
+  );
+  const body = (await response.json()) as Partial<ReserveDecision> & {
+    error?: string;
+    code?: string;
+  };
+  if (response.status === 503) {
+    throw new HfProxyGateError(
+      body.error ?? "HF proxy gate is unavailable",
+      body.code,
+    );
+  }
+  if (!body || typeof body.admitted !== "boolean") {
+    throw new HfProxyGateError("HF proxy gate returned an invalid reserve response");
+  }
+  return body as ReserveDecision;
+}
+
+async function gateSettle(
+  stub: RuntimeDurableObjectStub,
+  requestId: string,
+  actualBytes: number,
+  bucket: string,
+): Promise<void> {
+  try {
+    await stub.fetch(
+      new Request(`${GATE_ORIGIN}/settle`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          requestId,
+          actualBytes,
+          monthBucket: bucket,
+        }),
+        signal: AbortSignal.timeout(GATE_TIMEOUT_MS),
+      }),
+    );
+  } catch (error) {
+    // Settlement is best-effort from the response path's perspective: the DO
+    // already pre-charged the estimate, so a settle failure means the estimate
+    // remains as the charge. Log but do not throw — the user already has the
+    // body they requested.
+    logger.warn("[hf-proxy] egress settle failed", {
+      requestId,
+      actualBytes,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function gateCancel(
+  stub: RuntimeDurableObjectStub,
+  requestId: string,
+  bucket: string,
+): Promise<void> {
+  try {
+    await stub.fetch(
+      new Request(`${GATE_ORIGIN}/cancel`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requestId, monthBucket: bucket }),
+        signal: AbortSignal.timeout(GATE_TIMEOUT_MS),
+      }),
+    );
+  } catch (error) {
+    logger.warn("[hf-proxy] egress cancel failed", {
+      requestId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+class HfProxyGateError extends Error {
+  readonly code: string | undefined;
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = "HfProxyGateError";
+    this.code = code;
+  }
+}
+
+function concurrencyLimitResponse(
+  organizationId: string,
+  activeDownloads: number,
+  maxConcurrent: number,
+) {
+  return {
+    error: "HuggingFace proxy concurrent download limit reached.",
+    code: "HF_PROXY_CONCURRENCY_LIMIT",
+    organization_id: organizationId,
+    active_downloads: activeDownloads,
+    max_concurrent: maxConcurrent,
+  };
+}
+
 function egressLimitResponse(
   organizationId: string,
   limitBytes: number,
@@ -180,46 +272,67 @@ function egressLimitResponse(
   };
 }
 
+/**
+ * Wrap the upstream body so every byte is counted as it flows through, and the
+ * final actual byte count is settled against the gate regardless of whether the
+ * stream completes or is cancelled mid-way. Cancellation handling: the original
+ * code only charged on `flush()`, so a client that cancelled after receiving
+ * 90% of a multi-GB file escaped accounting. Now the `cancel` callback on the
+ * transform charges the actual bytes streamed so far.
+ */
 function streamWithEgressAccounting(args: {
   body: ReadableStream<Uint8Array>;
-  env: AppEnv["Bindings"];
+  gateStub: RuntimeDurableObjectStub;
+  requestId: string;
+  monthBucket: string;
   organizationId: string;
   repo: string;
   path: string;
   status: number;
-  cacheStatus: string | null;
+  cacheStatusValue: string | null;
 }): ReadableStream<Uint8Array> {
   let bytes = 0;
+  let settled = false;
+
+  const settleOnce = (finalBytes: number) => {
+    if (settled) return;
+    settled = true;
+    gateSettle(args.gateStub, args.requestId, finalBytes, args.monthBucket).then(
+      () => {
+        logger.info("[hf-proxy] egress metric", {
+          organizationId: args.organizationId,
+          repo: args.repo,
+          path: args.path,
+          bytes: finalBytes,
+          status: args.status,
+          cacheStatus: args.cacheStatusValue,
+          cacheHit: cacheHit(args.cacheStatusValue),
+        });
+      },
+    );
+  };
+
   return args.body.pipeThrough(
     new TransformStream<Uint8Array, Uint8Array>({
       transform(chunk, controller) {
         bytes += chunk.byteLength;
         controller.enqueue(chunk);
       },
-      async flush() {
-        const record = addMonthlyEgress(
-          args.env,
-          args.organizationId,
-          bytes,
-        ).then((usedBytes) => {
-          logger.info("[hf-proxy] egress metric", {
-            organizationId: args.organizationId,
-            repo: args.repo,
-            path: args.path,
-            bytes,
-            status: args.status,
-            cacheStatus: args.cacheStatus,
-            cacheHit: cacheHit(args.cacheStatus),
-            usedBytes,
-          });
-        });
-        await record;
+      flush() {
+        settleOnce(bytes);
+      },
+      // Called when the consumer cancels the stream (client disconnect). The
+      // original code only charged on flush, so a cancelled partial download
+      // escaped accounting entirely.
+      cancel() {
+        settleOnce(bytes);
       },
     }),
   );
 }
 
 app.get("/*", async (c) => {
+  const requestId = crypto.randomUUID();
   try {
     // Auth: a real cloud session or org API key. We require a valid linked
     // account and capture the identity for usage attribution below.
@@ -264,10 +377,70 @@ app.get("/*", async (c) => {
       );
     }
 
+    // ---- Atomic egress reservation + concurrency check via Durable Object ----
+    const gateStub = getGateStub(c.env, orgId);
+    if (!gateStub) {
+      // No DO binding: fail closed. We never silently fall back to the old
+      // non-atomic KV counter, which could reset an org's budget.
+      logger.error("[hf-proxy] HF_PROXY_GATES binding is missing");
+      return c.json(
+        {
+          error: "HuggingFace proxy egress accounting is not configured.",
+          code: "HF_PROXY_GATE_UNAVAILABLE",
+        },
+        503,
+      );
+    }
+
     const limitBytes = monthlyEgressLimitBytes(c.env);
-    const usedBytes = await readMonthlyEgress(c.env, orgId);
-    if (usedBytes >= limitBytes) {
-      return c.json(egressLimitResponse(orgId, limitBytes, usedBytes), 429);
+    const maxConcurrent = maxConcurrentDownloads(c.env);
+    const bucket = monthBucket();
+
+    // Reserve with zero estimated bytes initially; the actual content-length is
+    // only known after the upstream fetch. We hold the concurrency slot first.
+    let reserve: ReserveDecision;
+    try {
+      reserve = await gateReserve(
+        gateStub,
+        requestId,
+        0,
+        limitBytes,
+        maxConcurrent,
+        bucket,
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error);
+      logger.error("[hf-proxy] egress reserve failed", {
+        requestId,
+        orgId: redact.orgId(orgId),
+        error: message,
+      });
+      return c.json(
+        {
+          error: "HuggingFace proxy egress accounting is unavailable.",
+          code: "HF_PROXY_GATE_UNAVAILABLE",
+        },
+        503,
+      );
+    }
+
+    if (!reserve.admitted) {
+      // Distinguish egress-exhausted from concurrency-exhausted.
+      if (reserve.activeDownloads >= reserve.maxConcurrent) {
+        return c.json(
+          concurrencyLimitResponse(
+            orgId,
+            reserve.activeDownloads,
+            reserve.maxConcurrent,
+          ),
+          429,
+        );
+      }
+      return c.json(
+        egressLimitResponse(orgId, reserve.limitBytes, reserve.usedBytes),
+        429,
+      );
     }
 
     const incomingUrl = new URL(c.req.url);
@@ -281,11 +454,18 @@ app.get("/*", async (c) => {
     const range = c.req.header("range");
     if (range) headers.set("range", range);
 
-    const upstreamResponse = await fetch(upstream, {
-      method: "GET",
-      headers,
-      redirect: "follow",
-    });
+    let upstreamResponse: Response;
+    try {
+      upstreamResponse = await fetch(upstream, {
+        method: "GET",
+        headers,
+        redirect: "follow",
+      });
+    } catch (error) {
+      // Upstream fetch failed: release the slot without charging.
+      await gateCancel(gateStub, requestId, bucket);
+      throw error;
+    }
 
     if (upstreamResponse.status >= 400) {
       logger.warn("[hf-proxy] upstream HuggingFace error", {
@@ -317,8 +497,9 @@ app.get("/*", async (c) => {
         status: upstreamResponse.status,
         cacheStatus: upstreamCacheStatus,
         cacheHit: cacheHit(upstreamCacheStatus),
-        usedBytes,
       });
+      // Gated/unauthorized: release the concurrency slot without charging.
+      await gateCancel(gateStub, requestId, bucket);
       return c.json(
         {
           error: "HuggingFace repo is gated or unauthorized.",
@@ -329,8 +510,14 @@ app.get("/*", async (c) => {
       );
     }
 
-    if (contentLength !== null && usedBytes + contentLength > limitBytes) {
-      return c.json(egressLimitResponse(orgId, limitBytes, usedBytes), 429);
+    // Pre-flight egress check: if content-length is known and exceeds the
+    // remaining budget, cancel the reservation and reject.
+    if (contentLength !== null && reserve.usedBytes + contentLength > limitBytes) {
+      await gateCancel(gateStub, requestId, bucket);
+      return c.json(
+        egressLimitResponse(orgId, limitBytes, reserve.usedBytes),
+        429,
+      );
     }
 
     const responseHeaders = new Headers();
@@ -339,15 +526,19 @@ app.get("/*", async (c) => {
       if (value) responseHeaders.set(name, value);
     }
 
+    const upstreamCacheStatus = cacheStatus(upstreamResponse.headers);
+
     const body = upstreamResponse.body
       ? streamWithEgressAccounting({
           body: upstreamResponse.body,
-          env: c.env,
+          gateStub,
+          requestId,
+          monthBucket: bucket,
           organizationId: orgId,
           repo,
           path,
           status: upstreamResponse.status,
-          cacheStatus: cacheStatus(upstreamResponse.headers),
+          cacheStatusValue: upstreamCacheStatus,
         })
       : null;
 

--- a/packages/cloud/api/v1/hf-proxy/[...path]/route.ts
+++ b/packages/cloud/api/v1/hf-proxy/[...path]/route.ts
@@ -33,7 +33,6 @@ import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { logger, redact } from "@/lib/utils/logger";
 import type {
   AppEnv,
-  RuntimeDurableObjectNamespace,
   RuntimeDurableObjectStub,
 } from "@/types/cloud-worker-env";
 
@@ -129,7 +128,10 @@ function cacheHit(value: string | null): boolean | null {
 
 // ---- Durable Object gate client ----
 
-function getGateStub(env: AppEnv["Bindings"], orgId: string): RuntimeDurableObjectStub | null {
+function getGateStub(
+  env: AppEnv["Bindings"],
+  orgId: string,
+): RuntimeDurableObjectStub | null {
   const ns = env.HF_PROXY_GATES;
   if (!ns) return null;
   return ns.getByName(orgId);
@@ -169,14 +171,16 @@ async function gateReserve(
     error?: string;
     code?: string;
   };
-  if (response.status === 503) {
+  if (!response.ok && response.status !== 429) {
     throw new HfProxyGateError(
       body.error ?? "HF proxy gate is unavailable",
       body.code,
     );
   }
   if (!body || typeof body.admitted !== "boolean") {
-    throw new HfProxyGateError("HF proxy gate returned an invalid reserve response");
+    throw new HfProxyGateError(
+      "HF proxy gate returned an invalid reserve response",
+    );
   }
   return body as ReserveDecision;
 }
@@ -187,29 +191,22 @@ async function gateSettle(
   actualBytes: number,
   bucket: string,
 ): Promise<void> {
-  try {
-    await stub.fetch(
-      new Request(`${GATE_ORIGIN}/settle`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          requestId,
-          actualBytes,
-          monthBucket: bucket,
-        }),
-        signal: AbortSignal.timeout(GATE_TIMEOUT_MS),
+  const response = await stub.fetch(
+    new Request(`${GATE_ORIGIN}/settle`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        requestId,
+        actualBytes,
+        monthBucket: bucket,
       }),
+      signal: AbortSignal.timeout(GATE_TIMEOUT_MS),
+    }),
+  );
+  if (!response.ok) {
+    throw new HfProxyGateError(
+      `HF proxy gate settlement failed with status ${response.status}`,
     );
-  } catch (error) {
-    // Settlement is best-effort from the response path's perspective: the DO
-    // already pre-charged the estimate, so a settle failure means the estimate
-    // remains as the charge. Log but do not throw — the user already has the
-    // body they requested.
-    logger.warn("[hf-proxy] egress settle failed", {
-      requestId,
-      actualBytes,
-      error: error instanceof Error ? error.message : String(error),
-    });
   }
 }
 
@@ -218,20 +215,18 @@ async function gateCancel(
   requestId: string,
   bucket: string,
 ): Promise<void> {
-  try {
-    await stub.fetch(
-      new Request(`${GATE_ORIGIN}/cancel`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ requestId, monthBucket: bucket }),
-        signal: AbortSignal.timeout(GATE_TIMEOUT_MS),
-      }),
+  const response = await stub.fetch(
+    new Request(`${GATE_ORIGIN}/cancel`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ requestId, monthBucket: bucket }),
+      signal: AbortSignal.timeout(GATE_TIMEOUT_MS),
+    }),
+  );
+  if (!response.ok) {
+    throw new HfProxyGateError(
+      `HF proxy gate cancellation failed with status ${response.status}`,
     );
-  } catch (error) {
-    logger.warn("[hf-proxy] egress cancel failed", {
-      requestId,
-      error: error instanceof Error ? error.message : String(error),
-    });
   }
 }
 
@@ -275,10 +270,9 @@ function egressLimitResponse(
 /**
  * Wrap the upstream body so every byte is counted as it flows through, and the
  * final actual byte count is settled against the gate regardless of whether the
- * stream completes or is cancelled mid-way. Cancellation handling: the original
- * code only charged on `flush()`, so a client that cancelled after receiving
- * 90% of a multi-GB file escaped accounting. Now the `cancel` callback on the
- * transform charges the actual bytes streamed so far.
+ * stream completes or is cancelled mid-way. The explicit readable wrapper
+ * observes consumer cancellation reliably and reserves any bytes beyond the
+ * upstream Content-Length before forwarding them.
  */
 function streamWithEgressAccounting(args: {
   body: ReadableStream<Uint8Array>;
@@ -290,45 +284,98 @@ function streamWithEgressAccounting(args: {
   path: string;
   status: number;
   cacheStatusValue: string | null;
+  initialReservedBytes: number;
+  limitBytes: number;
+  maxConcurrent: number;
 }): ReadableStream<Uint8Array> {
+  const reader = args.body.getReader();
   let bytes = 0;
+  let reservedBytes = args.initialReservedBytes;
   let settled = false;
 
-  const settleOnce = (finalBytes: number) => {
+  const settleOnce = async (finalBytes: number): Promise<void> => {
     if (settled) return;
     settled = true;
-    gateSettle(args.gateStub, args.requestId, finalBytes, args.monthBucket).then(
-      () => {
-        logger.info("[hf-proxy] egress metric", {
-          organizationId: args.organizationId,
-          repo: args.repo,
-          path: args.path,
-          bytes: finalBytes,
-          status: args.status,
-          cacheStatus: args.cacheStatusValue,
-          cacheHit: cacheHit(args.cacheStatusValue),
-        });
-      },
-    );
+    try {
+      await gateSettle(
+        args.gateStub,
+        args.requestId,
+        finalBytes,
+        args.monthBucket,
+      );
+      logger.info("[hf-proxy] egress metric", {
+        organizationId: args.organizationId,
+        repo: args.repo,
+        path: args.path,
+        bytes: finalBytes,
+        status: args.status,
+        cacheStatus: args.cacheStatusValue,
+        cacheHit: cacheHit(args.cacheStatusValue),
+      });
+    } catch (error) {
+      // error-policy:J1 The response stream exposes failed settlement instead
+      // of reporting accounting success or silently leaking its slot.
+      logger.warn("[hf-proxy] egress settle failed", {
+        requestId: args.requestId,
+        actualBytes: finalBytes,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
   };
 
-  return args.body.pipeThrough(
-    new TransformStream<Uint8Array, Uint8Array>({
-      transform(chunk, controller) {
-        bytes += chunk.byteLength;
-        controller.enqueue(chunk);
-      },
-      flush() {
-        settleOnce(bytes);
-      },
-      // Called when the consumer cancels the stream (client disconnect). The
-      // original code only charged on flush, so a cancelled partial download
-      // escaped accounting entirely.
-      cancel() {
-        settleOnce(bytes);
-      },
-    }),
-  );
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const result = await reader.read();
+        if (result.done) {
+          await settleOnce(bytes);
+          controller.close();
+          return;
+        }
+
+        const nextBytes = bytes + result.value.byteLength;
+        if (nextBytes > reservedBytes) {
+          const reserve = await gateReserve(
+            args.gateStub,
+            args.requestId,
+            nextBytes,
+            args.limitBytes,
+            args.maxConcurrent,
+            args.monthBucket,
+          );
+          if (!reserve.admitted) {
+            await reader.cancel("HF proxy egress limit reached");
+            await settleOnce(bytes);
+            controller.error(
+              new HfProxyGateError(
+                "HF proxy egress limit reached while streaming",
+              ),
+            );
+            return;
+          }
+          reservedBytes = nextBytes;
+        }
+
+        bytes = nextBytes;
+        controller.enqueue(result.value);
+      } catch (error) {
+        // error-policy:J1 The response stream exposes upstream/accounting
+        // failures to its consumer after settling bytes already delivered.
+        await settleOnce(bytes);
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        // error-policy:J6 Cancellation releases the upstream reader and settles
+        // the partial transfer before teardown completes.
+        await settleOnce(bytes);
+      }
+    },
+  });
 }
 
 app.get("/*", async (c) => {
@@ -409,8 +456,7 @@ app.get("/*", async (c) => {
         bucket,
       );
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : String(error);
+      const message = error instanceof Error ? error.message : String(error);
       logger.error("[hf-proxy] egress reserve failed", {
         requestId,
         orgId: redact.orgId(orgId),
@@ -510,14 +556,29 @@ app.get("/*", async (c) => {
       );
     }
 
-    // Pre-flight egress check: if content-length is known and exceeds the
-    // remaining budget, cancel the reservation and reject.
-    if (contentLength !== null && reserve.usedBytes + contentLength > limitBytes) {
-      await gateCancel(gateStub, requestId, bucket);
-      return c.json(
-        egressLimitResponse(orgId, limitBytes, reserve.usedBytes),
-        429,
+    // Atomically update the slot with Content-Length before any body byte is
+    // forwarded. Concurrent downloads therefore observe the pre-charge. When
+    // length is unknown, the stream reserves each chunk before enqueueing it.
+    if (contentLength !== null) {
+      const sizedReserve = await gateReserve(
+        gateStub,
+        requestId,
+        contentLength,
+        limitBytes,
+        maxConcurrent,
+        bucket,
       );
+      if (!sizedReserve.admitted) {
+        await gateCancel(gateStub, requestId, bucket);
+        return c.json(
+          egressLimitResponse(
+            orgId,
+            sizedReserve.limitBytes,
+            sizedReserve.usedBytes,
+          ),
+          429,
+        );
+      }
     }
 
     const responseHeaders = new Headers();
@@ -528,19 +589,34 @@ app.get("/*", async (c) => {
 
     const upstreamCacheStatus = cacheStatus(upstreamResponse.headers);
 
-    const body = upstreamResponse.body
-      ? streamWithEgressAccounting({
-          body: upstreamResponse.body,
-          gateStub,
-          requestId,
-          monthBucket: bucket,
-          organizationId: orgId,
-          repo,
-          path,
-          status: upstreamResponse.status,
-          cacheStatusValue: upstreamCacheStatus,
-        })
-      : null;
+    let body: ReadableStream<Uint8Array> | null = null;
+    if (upstreamResponse.body) {
+      body = streamWithEgressAccounting({
+        body: upstreamResponse.body,
+        gateStub,
+        requestId,
+        monthBucket: bucket,
+        organizationId: orgId,
+        repo,
+        path,
+        status: upstreamResponse.status,
+        cacheStatusValue: upstreamCacheStatus,
+        initialReservedBytes: contentLength ?? 0,
+        limitBytes,
+        maxConcurrent,
+      });
+    } else {
+      await gateSettle(gateStub, requestId, 0, bucket);
+      logger.info("[hf-proxy] egress metric", {
+        organizationId: orgId,
+        repo,
+        path,
+        bytes: 0,
+        status: upstreamResponse.status,
+        cacheStatus: upstreamCacheStatus,
+        cacheHit: cacheHit(upstreamCacheStatus),
+      });
+    }
 
     // Stream the body straight through — never buffer a multi-GB GGUF.
     return new Response(body, {
@@ -548,6 +624,7 @@ app.get("/*", async (c) => {
       headers: responseHeaders,
     });
   } catch (error) {
+    // error-policy:J1 The HTTP boundary translates route failures.
     return failureResponse(c, error);
   }
 });

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -110,6 +110,10 @@ name = "INFERENCE_ADMISSION_GATES"
 class_name = "InferenceAdmissionGate"
 
 [[durable_objects.bindings]]
+name = "HF_PROXY_GATES"
+class_name = "HfProxyGate"
+
+[[durable_objects.bindings]]
 name = "ANONYMOUS_CHAT_GATES"
 class_name = "AnonymousChatGate"
 
@@ -124,6 +128,10 @@ new_sqlite_classes = ["SharedRuntimeConversation"]
 [[migrations]]
 tag = "inference-admission-gates-v1"
 new_sqlite_classes = ["InferenceAdmissionGate"]
+
+[[migrations]]
+tag = "hf-proxy-gates-v1"
+new_sqlite_classes = ["HfProxyGate"]
 
 [[migrations]]
 tag = "anonymous-chat-gates-v1"
@@ -592,6 +600,10 @@ name = "INFERENCE_ADMISSION_GATES"
 class_name = "InferenceAdmissionGate"
 
 [[env.staging.durable_objects.bindings]]
+name = "HF_PROXY_GATES"
+class_name = "HfProxyGate"
+
+[[env.staging.durable_objects.bindings]]
 name = "ANONYMOUS_CHAT_GATES"
 class_name = "AnonymousChatGate"
 
@@ -786,6 +798,10 @@ class_name = "SharedRuntimeConversation"
 [[env.production.durable_objects.bindings]]
 name = "INFERENCE_ADMISSION_GATES"
 class_name = "InferenceAdmissionGate"
+
+[[env.production.durable_objects.bindings]]
+name = "HF_PROXY_GATES"
+class_name = "HfProxyGate"
 
 [[env.production.durable_objects.bindings]]
 name = "ANONYMOUS_CHAT_GATES"

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -130,16 +130,16 @@ tag = "inference-admission-gates-v1"
 new_sqlite_classes = ["InferenceAdmissionGate"]
 
 [[migrations]]
-tag = "hf-proxy-gates-v1"
-new_sqlite_classes = ["HfProxyGate"]
-
-[[migrations]]
 tag = "anonymous-chat-gates-v1"
 new_sqlite_classes = ["AnonymousChatGate"]
 
 [[migrations]]
 tag = "onboarding-session-coordinator-v1"
 new_sqlite_classes = ["OnboardingSessionCoordinator"]
+
+[[migrations]]
+tag = "hf-proxy-gates-v1"
+new_sqlite_classes = ["HfProxyGate"]
 
 # General API limits and queues may use Railway Redis via REDIS_URL. Inference
 # routes never connect to it: Cloudflare Rate Limiting bindings protect ingress,

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -79,7 +79,14 @@ export interface Bindings {
   INFERENCE_ADMISSION_GATES?: RuntimeDurableObjectNamespace;
 
   /**
-   * One strongly ordered identity/quota cache per anonymous chat session.
+   * One strongly ordered HF proxy coordinator per organization. It enforces
+   * per-org monthly egress budgets and concurrent-download caps atomically;
+   * the route's KV-based read/put loop was non-atomic and lost increments
+   * under concurrency.
+   */
+  HF_PROXY_GATES?: RuntimeDurableObjectNamespace;
+
+  /** One strongly ordered identity/quota cache per anonymous chat session.
    * Postgres hydration and counter mirrors run only outside the response path.
    */
   ANONYMOUS_CHAT_GATES?: RuntimeDurableObjectNamespace;
@@ -233,6 +240,11 @@ export interface Bindings {
    * bytes. Unset uses the route default.
    */
   HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES?: string;
+  /**
+   * Optional per-organization concurrent download cap for the HuggingFace
+   * proxy. Unset uses the route default.
+   */
+  HF_PROXY_MAX_CONCURRENT_DOWNLOADS?: string;
   VERCEL_OIDC_TOKEN?: string;
   /**
    * Public hostname that serves the BLOB R2 bucket. Used to construct sample


### PR DESCRIPTION
Adds HfProxyGate Durable Object for per-org serialized egress reservation. Reserve->stream->settle/cancel lifecycle replaces non-atomic KV read/put. Cancellation charges actual bytes streamed.

---

AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Lane: hermes-t3rpz