### PR TITLE
fix(inbox): cancel unread unsubscribe response bodies

### DIFF
--- a/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
+++ b/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
@@ -197,7 +197,14 @@ async function performHttpUnsubscribe(args: {
       method: args.oneClick ? "http_one_click" : "http_get",
     };
   } finally {
-    await guarded.release();
+    // The unsubscribe boundary only needs the status and final URL. Cancel
+    // any unread body before releasing the guard so attacker-controlled
+    // responses cannot retain an open connection or stream.
+    try {
+      await guarded.response.body?.cancel();
+    } finally {
+      await guarded.release();
+    }
   }
 }
 

--- a/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
+++ b/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
@@ -24,7 +24,7 @@
  */
 
 import crypto from "node:crypto";
-import { fetchWithSsrfGuard, type IAgentRuntime } from "@elizaos/core";
+import { fetchWithSsrfGuard, type IAgentRuntime, logger } from "@elizaos/core";
 import {
   fail,
   type LifeOpsGmailMessageSummary,
@@ -202,6 +202,16 @@ async function performHttpUnsubscribe(args: {
     // responses cannot retain an open connection or stream.
     try {
       await guarded.response.body?.cancel();
+    } catch (error) {
+      // error-policy:J6 The unsubscribe request has already completed; body
+      // cancellation is teardown-only and must not fabricate a remote failure.
+      logger.warn(
+        {
+          src: "inbox-unsubscribe",
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "[InboxUnsubscribeService] Failed to cancel unread unsubscribe response body",
+      );
     } finally {
       await guarded.release();
     }

--- a/plugins/plugin-inbox/test/unsubscribe-service.test.ts
+++ b/plugins/plugin-inbox/test/unsubscribe-service.test.ts
@@ -172,6 +172,19 @@ function makeService(
 
 const fetchSpy = vi.fn();
 
+function trackedResponse(status: number, headers?: HeadersInit) {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1]));
+    },
+  });
+  const cancel = vi.spyOn(body, "cancel");
+  return {
+    response: new Response(body, { status, headers }),
+    cancel,
+  };
+}
+
 describe("InboxUnsubscribeService", () => {
   beforeEach(() => {
     fetchSpy.mockReset();
@@ -252,14 +265,11 @@ describe("InboxUnsubscribeService", () => {
 
   describe("unsubscribeEmailSender execution", () => {
     it("performs an HTTP one-click POST and records success", async () => {
+      const tracked = trackedResponse(200);
       fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
         const url = String(input);
         expect(url).toBe("https://brand.com/unsub");
-        return new Response(null, {
-          status: 200,
-          // Guard reports finalUrl from the request URL; response.url is not
-          // always populated by the Response constructor.
-        });
+        return tracked.response;
       });
       const gateway = makeGateway({
         messages: [
@@ -288,6 +298,31 @@ describe("InboxUnsubscribeService", () => {
       expect(record.httpFinalUrl).toBe("https://brand.com/unsub");
       expect(records).toHaveLength(1);
       expect(records[0]?.metadata.connectorAccountId).toBe("acct-1");
+      expect(tracked.cancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancels a non-success HTTP response body before recording failure", async () => {
+      const tracked = trackedResponse(503);
+      fetchSpy.mockResolvedValue(tracked.response);
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m1",
+            fromEmail: "news@brand.com",
+            listUnsubscribe: "<https://brand.com/unsub>",
+          }),
+        ],
+      });
+      const { service } = makeService(gateway);
+
+      const { record } = await service.unsubscribeEmailSender({
+        senderEmail: "news@brand.com",
+        userAuthorization: true,
+      });
+
+      expect(record.status).toBe("failed");
+      expect(record.httpStatusCode).toBe(503);
+      expect(tracked.cancel).toHaveBeenCalledTimes(1);
     });
 
     it("sends a mailto unsubscribe through the Gmail gateway", async () => {
@@ -426,12 +461,10 @@ describe("InboxUnsubscribeService", () => {
     });
 
     it("fails closed when a public unsubscribe URL redirects to a loopback target", async () => {
-      fetchSpy.mockImplementation(async () => {
-        return new Response(null, {
-          status: 302,
-          headers: { location: "http://127.0.0.1/secret" },
-        });
+      const tracked = trackedResponse(302, {
+        location: "http://127.0.0.1/secret",
       });
+      fetchSpy.mockResolvedValue(tracked.response);
       const gateway = makeGateway({
         messages: [
           gmailMessage({
@@ -453,6 +486,8 @@ describe("InboxUnsubscribeService", () => {
       expect(record.status).toBe("failed");
       expect(record.errorMessage).toMatch(/blocked/i);
       expect(records).toHaveLength(1);
+      await Promise.resolve();
+      expect(tracked.cancel).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/plugins/plugin-inbox/test/unsubscribe-service.test.ts
+++ b/plugins/plugin-inbox/test/unsubscribe-service.test.ts
@@ -172,13 +172,20 @@ function makeService(
 
 const fetchSpy = vi.fn();
 
-function trackedResponse(status: number, headers?: HeadersInit) {
+function trackedResponse(
+  status: number,
+  headers?: HeadersInit,
+  cancelError?: Error,
+) {
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
       controller.enqueue(new Uint8Array([1]));
     },
   });
   const cancel = vi.spyOn(body, "cancel");
+  if (cancelError) {
+    cancel.mockRejectedValueOnce(cancelError);
+  }
   return {
     response: new Response(body, { status, headers }),
     cancel,
@@ -322,6 +329,34 @@ describe("InboxUnsubscribeService", () => {
 
       expect(record.status).toBe("failed");
       expect(record.httpStatusCode).toBe(503);
+      expect(tracked.cancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps a successful unsubscribe successful when body cancellation fails", async () => {
+      const tracked = trackedResponse(
+        200,
+        undefined,
+        new Error("response stream already closed"),
+      );
+      fetchSpy.mockResolvedValue(tracked.response);
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m1",
+            fromEmail: "news@brand.com",
+            listUnsubscribe: "<https://brand.com/unsub>",
+          }),
+        ],
+      });
+      const { service } = makeService(gateway);
+
+      const { record } = await service.unsubscribeEmailSender({
+        senderEmail: "news@brand.com",
+        userAuthorization: true,
+      });
+
+      expect(record.status).toBe("succeeded");
+      expect(record.httpStatusCode).toBe(200);
       expect(tracked.cancel).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
# Relates to

Closes #18687.

# Summary

- Cancels unread HTTP unsubscribe response bodies before releasing the SSRF guard.
- Always releases the SSRF guard, including when body cancellation fails.
- Treats cancellation as teardown-only: a local stream cancellation failure is logged and cannot fabricate a failed remote unsubscribe.
- Covers success, non-success, redirect, and cancellation-failure paths.

# Risks

Low. The HTTP request, redirect policy, status mapping, and repository behavior are unchanged. The only behavioral distinction is that cleanup failure after a completed response remains diagnostic instead of changing the unsubscribe result.

# Verification

Verified on the exact head rebased onto current develop with pinned Bun 1.3.14 and Node 24.15.0:

- plugin-inbox full test suite: 170 passed, 2 skipped
- plugin-inbox typecheck, lint:check, and build: passed
- root bun run verify: 350/350 tasks passed; all repository audits passed
- git diff --check: passed

# Evidence Gate

<!-- evidence-head:23e68477dd79cc9febb94c2d8b5a68883c36bd51 -->

- [x] Before/after screenshots: N/A — server-side resource lifecycle only; no rendered UI changes.
- [x] Walkthrough video: N/A — deterministic HTTP cleanup contract.
- [x] Backend logs: focused and full plugin test output plus root verification completed on this exact head.
- [x] Frontend logs: N/A — no frontend surface changed.
- [x] Real-LLM trajectory: N/A — no model, prompt, or planner behavior changed.
- [x] Domain artifact: tests assert response-body cancellation and that cleanup rejection preserves a succeeded unsubscribe record.
- [x] OCR review: N/A — no visual surface changed.
