### PR TITLE
fix(skills): document malformed frontmatter contract

### DIFF
--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -152,8 +152,11 @@ Detailed instructions for the AI agent...
 
 ### Frontmatter
 
-- `parseFrontmatter(content)` - Parse YAML frontmatter from markdown string
-- `stripFrontmatter(content)` - Return body without frontmatter
+- `parseFrontmatter(content)` - Parse YAML frontmatter from a markdown string;
+  malformed YAML throws `ElizaError` with code
+  `INVALID_SKILL_FRONTMATTER_YAML`
+- `stripFrontmatter(content)` - Return the body without frontmatter; malformed
+  YAML throws the same typed error
 - `serializeSkillFile(frontmatter, body)` - Re-serialize frontmatter + body (learning loop)
 - `resolveSkillMetadata(frontmatter)` - Resolve `SkillMetadata` from frontmatter
 - `resolveSkillInvocationPolicy(frontmatter)` - Resolve `SkillInvocationPolicy`

--- a/packages/skills/src/frontmatter.ts
+++ b/packages/skills/src/frontmatter.ts
@@ -78,6 +78,12 @@ function extractFrontmatter(content: string): {
   };
 }
 
+/**
+ * Parse a markdown document's YAML frontmatter and body.
+ *
+ * @throws {ElizaError} With code `INVALID_SKILL_FRONTMATTER_YAML` when the
+ * frontmatter is syntactically invalid YAML.
+ */
 export function parseFrontmatter<
   T extends Record<string, unknown> = Record<string, unknown>,
 >(content: string): ParsedFrontmatter<T> {
@@ -102,6 +108,12 @@ export function parseFrontmatter<
   return { frontmatter: {} as T, body };
 }
 
+/**
+ * Return a markdown document's body without its YAML frontmatter.
+ *
+ * @throws {ElizaError} With code `INVALID_SKILL_FRONTMATTER_YAML` when the
+ * frontmatter is syntactically invalid YAML.
+ */
 export function stripFrontmatter(content: string): string {
   return parseFrontmatter(content).body;
 }

--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -105,7 +105,7 @@ function loadSkillFromFile(
   try {
     ({ frontmatter } = parseFrontmatter<SkillFrontmatter>(rawContent));
   } catch (error: unknown) {
-    // error-policy:J1 skill discovery translates its known parser failure into a warning diagnostic
+    // error-policy:J3 malformed skill YAML becomes an explicit warning diagnostic and no skill
     if (!isElizaError(error) || error.code !== INVALID_SKILL_FRONTMATTER_YAML) {
       throw error;
     }

--- a/packages/skills/test/frontmatter.test.ts
+++ b/packages/skills/test/frontmatter.test.ts
@@ -4,8 +4,8 @@
  * non-plain collection roots, CRLF, and metadata/policy extraction.
  */
 import assert from "node:assert";
-import { ElizaError } from "@elizaos/core";
 import { describe, it } from "node:test";
+import { ElizaError } from "@elizaos/core";
 import {
   INVALID_SKILL_FRONTMATTER_YAML,
   parseFrontmatter,
@@ -103,7 +103,10 @@ Body content`;
       (error: unknown) => {
         assert.ok(error instanceof ElizaError);
         assert.strictEqual(error.code, INVALID_SKILL_FRONTMATTER_YAML);
-        assert.strictEqual(error.message, "Skill frontmatter contains invalid YAML");
+        assert.strictEqual(
+          error.message,
+          "Skill frontmatter contains invalid YAML",
+        );
         assert.ok(error.cause instanceof Error);
         return true;
       },

--- a/packages/skills/test/loader.test.ts
+++ b/packages/skills/test/loader.test.ts
@@ -4,13 +4,7 @@
  * dangling symlinks and read errors.
  */
 import assert from "node:assert";
-import {
-  mkdirSync,
-  rmdirSync,
-  rmSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";


### PR DESCRIPTION
# Relates to

Closes #18910.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] This keeps the #18879 runtime behavior unchanged and finishes its public contract/policy cleanup.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@9da0daa68b91dcefe274783e33cf9f5320aea0b1`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 tasks with 0 cache hits, followed by all repository audits.

# Risks

Minimal. This intentionally changes no runtime behavior. It corrects one error-policy annotation, adds caller-facing documentation for the existing typed failure, and applies Biome-requested test import/format cleanup including removal of one unused import.

# Background

## What does this PR do?

PR #18879 fixed malformed skill-frontmatter handling behaviorally. A post-merge exact-current audit found three remaining repository-contract gaps:

- The loader's explicit malformed-input result was labeled J1 instead of J3.
- Public README and exported-symbol JSDoc did not document the stable `INVALID_SKILL_FRONTMATTER_YAML` typed throw.
- Direct Biome still requested import ordering, formatting, and removal of a stale test import.

This PR closes only those gaps. The loader still rejects malformed skills with the same accurate warning, and unexpected errors still propagate.

## What kind of change is this?

Public contract, policy annotation, and test hygiene cleanup.

# Documentation changes needed?

Included. The package README and exported `parseFrontmatter` / `stripFrontmatter` JSDoc now describe the typed malformed-YAML failure and stable code.

# Testing

## Where should a reviewer start?

- `packages/skills/src/frontmatter.ts`
- `packages/skills/src/loader.ts`
- `packages/skills/README.md`
- `packages/skills/test/frontmatter.test.ts`
- `packages/skills/test/loader.test.ts`

## Detailed testing steps

```text
bunx biome check <four changed source/test files>
4 files checked; no fixes required

bun run --cwd packages/skills test
6 files; 101 tests passed

bun run --cwd packages/skills typecheck
pass

bun run --cwd packages/skills lint:check
6 source files checked; no fixes required

bun run --cwd packages/skills build
pass

bun run check:agents-claude
154 tracked guide pairs byte-identical

bun run verify
350 successful, 350 total, 0 cached; all repository audits passed
```

# Evidence Gate

<!-- evidence-head:b43f2ae00010c8c9103b4787eff0229814027d6c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this cleanup has no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no view, style, layout, or visual asset changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive behavior changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend process, route, transport, or runtime behavior changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no action, provider, prompt, planner, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] The real temporary-filesystem malformed-skill regression remains green in the 101-test package suite, while direct Biome and public-contract inspection prove the requested cleanup.

```text
malformed SKILL.md on a real temporary filesystem: skills=[]
diagnostic: "Skill frontmatter contains invalid YAML"
misleading downstream "description is required" diagnostic: absent
unexpected error handling: still propagates; only INVALID_SKILL_FRONTMATTER_YAML becomes an explicit invalid result
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered UI changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing or planner behavior changes.

## Backend + frontend logs

N/A - this is documentation, policy annotation, and test hygiene on an already-tested deterministic parser/loader boundary.

## Screenshots (before / after) + video walkthrough

N/A - no rendered files or UI flows are changed.

## Audio / voice walkthrough

N/A - no audio or voice behavior changes.

## Known gaps / failures

None. The real filesystem regression, complete package suite, direct Biome check, typecheck, source lint, build, guide parity, diff checks, pinned install, and full uncached root verification pass on the synchronized head.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"N/A"} -->
