### PR TITLE
fix(skills): document malformed frontmatter contract

### DIFF
--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -152,8 +152,8 @@ Detailed instructions for the AI agent...
 
 ### Frontmatter
 
-- `parseFrontmatter(content)` - Parse YAML frontmatter from markdown string
-- `stripFrontmatter(content)` - Return body without frontmatter
+- `parseFrontmatter(content)` - Parse YAML frontmatter from a markdown string; malformed YAML throws an `ElizaError` with the stable code `INVALID_SKILL_FRONTMATTER_YAML`
+- `stripFrontmatter(content)` - Return the body without frontmatter; malformed YAML throws the same `INVALID_SKILL_FRONTMATTER_YAML` error instead of hiding invalid metadata
 - `serializeSkillFile(frontmatter, body)` - Re-serialize frontmatter + body (learning loop)
 - `resolveSkillMetadata(frontmatter)` - Resolve `SkillMetadata` from frontmatter
 - `resolveSkillInvocationPolicy(frontmatter)` - Resolve `SkillInvocationPolicy`

--- a/packages/skills/src/frontmatter.ts
+++ b/packages/skills/src/frontmatter.ts
@@ -78,6 +78,12 @@ function extractFrontmatter(content: string): {
   };
 }
 
+/**
+ * Parses a Markdown document's YAML frontmatter and returns its body.
+ *
+ * @throws {ElizaError} With code `INVALID_SKILL_FRONTMATTER_YAML` when a
+ * delimited frontmatter block contains malformed YAML.
+ */
 export function parseFrontmatter<
   T extends Record<string, unknown> = Record<string, unknown>,
 >(content: string): ParsedFrontmatter<T> {
@@ -102,6 +108,12 @@ export function parseFrontmatter<
   return { frontmatter: {} as T, body };
 }
 
+/**
+ * Removes a Markdown document's YAML frontmatter and returns its body.
+ *
+ * @throws {ElizaError} With code `INVALID_SKILL_FRONTMATTER_YAML` when a
+ * delimited frontmatter block contains malformed YAML.
+ */
 export function stripFrontmatter(content: string): string {
   return parseFrontmatter(content).body;
 }

--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -105,7 +105,7 @@ function loadSkillFromFile(
   try {
     ({ frontmatter } = parseFrontmatter<SkillFrontmatter>(rawContent));
   } catch (error: unknown) {
-    // error-policy:J1 skill discovery translates its known parser failure into a warning diagnostic
+    // error-policy:J3 malformed untrusted frontmatter becomes an explicit warning/no-skill result
     if (!isElizaError(error) || error.code !== INVALID_SKILL_FRONTMATTER_YAML) {
       throw error;
     }

--- a/packages/skills/test/frontmatter.test.ts
+++ b/packages/skills/test/frontmatter.test.ts
@@ -4,8 +4,8 @@
  * non-plain collection roots, CRLF, and metadata/policy extraction.
  */
 import assert from "node:assert";
-import { ElizaError } from "@elizaos/core";
 import { describe, it } from "node:test";
+import { ElizaError } from "@elizaos/core";
 import {
   INVALID_SKILL_FRONTMATTER_YAML,
   parseFrontmatter,
@@ -103,7 +103,10 @@ Body content`;
       (error: unknown) => {
         assert.ok(error instanceof ElizaError);
         assert.strictEqual(error.code, INVALID_SKILL_FRONTMATTER_YAML);
-        assert.strictEqual(error.message, "Skill frontmatter contains invalid YAML");
+        assert.strictEqual(
+          error.message,
+          "Skill frontmatter contains invalid YAML",
+        );
         assert.ok(error.cause instanceof Error);
         return true;
       },

--- a/packages/skills/test/loader.test.ts
+++ b/packages/skills/test/loader.test.ts
@@ -4,13 +4,7 @@
  * dangling symlinks and read errors.
  */
 import assert from "node:assert";
-import {
-  mkdirSync,
-  rmdirSync,
-  rmSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";


### PR DESCRIPTION
# Relates to

Fixes #18910

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the malformed-file behavior from the attached real temporary-filesystem artifact.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `af61fd3ea68e2b244c53f2ecc99f52774ca5adda`; zero conflicts.
- [x] `bun run verify` passes post-sync (350/350 tasks plus all repository audits).

# Risks

Low. Runtime behavior is intentionally unchanged. The diff corrects an error-policy annotation, documents an existing typed error contract, and applies Biome-requested cleanup to tests.

# Background

## What does this PR do?

- Classifies malformed untrusted skill frontmatter handling as J3.
- Documents the `ElizaError` / `INVALID_SKILL_FRONTMATTER_YAML` throw contract for `parseFrontmatter` and `stripFrontmatter` in public JSDoc and README API reference.
- Makes the changed malformed-frontmatter tests directly Biome-clean without changing assertions or behavior.

## What kind of change is this?

Bug-fix contract cleanup (non-breaking, no product behavior change).

# Documentation changes needed?

Yes. The public README and exported-symbol JSDoc now document the stable malformed-YAML failure contract.

# Testing

## Where should a reviewer start?

Start with `packages/skills/src/frontmatter.ts`, then inspect the malformed YAML cases in `packages/skills/test/frontmatter.test.ts` and `packages/skills/test/loader.test.ts`.

## Detailed testing steps

- `bun run --cwd packages/skills test` — 101 passed, 0 failed.
- `bun run --cwd packages/skills typecheck` — passed.
- `bun run --cwd packages/skills lint:check` — passed.
- `bun run --cwd packages/skills build` — passed.
- Direct Biome check of all changed source/test files — passed.
- `bun run check:agents-claude` — 154 guide pairs passed.
- `bun install --frozen-lockfile` — passed with no dependency changes.
- `bun run verify` — 350/350 tasks and all repository audits passed after rebase.

# Evidence Gate

<!-- evidence-head:29b2454bff815a7697e313366fa91f5f313174d7 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI is changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI is changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a library contract/documentation cleanup with no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service is started; the real package boundary result is attached as a domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request is involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Real temporary-filesystem loader artifact ([JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18910-malformed-frontmatter.json), SHA-256 `980067e2144163e72f757ae82483a3c5bc301b52c5c50ed73489bbabfc6fad2f`).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changed.

## Backend + frontend logs

N/A - no backend or frontend surface changed. The linked JSON records the real loader result for a malformed file: zero loaded skills and one accurate warning diagnostic.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice path changed.

## Known gaps / failures

N/A - all applicable tests, package gates, documentation parity, install, and root verification passed. Visual, frontend, LLM, and audio evidence are inapplicable to this library-only cleanup.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-issue-triage]
