### PR TITLE
fix(agent): honor view search minimum limit

### DIFF
--- a/packages/agent/src/api/views-routes.search.test.ts
+++ b/packages/agent/src/api/views-routes.search.test.ts
@@ -196,6 +196,10 @@ describe("GET /api/views/search keyword scoring", () => {
     const high = resultsFrom(jsonHigh);
     expect(high.length).toBeLessThanOrEqual(20);
     expect(high.length).toBe(2);
+
+    const { ctx: ctxZero, json: jsonZero } = makeSearchCtx("?q=wallet&limit=0");
+    await expect(handleViewsRoutes(ctxZero)).resolves.toBe(true);
+    expect(resultsFrom(jsonZero)).toHaveLength(1);
   });
 
   it("filters to tui views when viewType=tui is requested", async () => {

--- a/packages/agent/src/api/views-routes.search.test.ts
+++ b/packages/agent/src/api/views-routes.search.test.ts
@@ -201,10 +201,9 @@ describe("GET /api/views/search keyword scoring", () => {
     await expect(handleViewsRoutes(ctxZero)).resolves.toBe(true);
     expect(resultsFrom(jsonZero)).toHaveLength(1);
 
-    // Nonempty values that contain no parseable integer retain the historical
-    // fallback of 5; the zero-specific fix must not turn malformed input into
-    // the minimum page size.
-    for (const malformed of ["abc", "%20", "NaN"]) {
+    // Malformed and partial values retain the historical fallback of 5; the
+    // zero-specific fix must not turn them into the minimum page size.
+    for (const malformed of ["abc", "%20", "NaN", "1junk", "1.5"]) {
       const { ctx, json } = makeSearchCtx(`?q=wallet&limit=${malformed}`);
       await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
       expect(resultsFrom(json)).toHaveLength(2);

--- a/packages/agent/src/api/views-routes.search.test.ts
+++ b/packages/agent/src/api/views-routes.search.test.ts
@@ -200,6 +200,15 @@ describe("GET /api/views/search keyword scoring", () => {
     const { ctx: ctxZero, json: jsonZero } = makeSearchCtx("?q=wallet&limit=0");
     await expect(handleViewsRoutes(ctxZero)).resolves.toBe(true);
     expect(resultsFrom(jsonZero)).toHaveLength(1);
+
+    // Nonempty values that contain no parseable integer retain the historical
+    // fallback of 5; the zero-specific fix must not turn malformed input into
+    // the minimum page size.
+    for (const malformed of ["abc", "%20", "NaN"]) {
+      const { ctx, json } = makeSearchCtx(`?q=wallet&limit=${malformed}`);
+      await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+      expect(resultsFrom(json)).toHaveLength(2);
+    }
   });
 
   it("filters to tui views when viewType=tui is requested", async () => {

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -336,7 +336,15 @@ export async function handleViewsRoutes(
     const query = url.searchParams.get("q") ?? "";
     const limitParam = url.searchParams.get("limit");
     const topK = limitParam
-      ? Math.min(Math.max(parseInt(limitParam, 10) || 1, 1), 20)
+      ? (() => {
+          const parsed = parseInt(limitParam, 10);
+          // Preserve the established fallback for nonempty values that do not
+          // contain a parseable integer while still treating an explicit zero
+          // as the documented minimum page size.
+          return Number.isNaN(parsed)
+            ? 5
+            : Math.min(Math.max(parsed || 1, 1), 20);
+        })()
       : 5;
 
     if (!query.trim()) {

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -336,7 +336,7 @@ export async function handleViewsRoutes(
     const query = url.searchParams.get("q") ?? "";
     const limitParam = url.searchParams.get("limit");
     const topK = limitParam
-      ? Math.min(Math.max(parseInt(limitParam, 10) || 5, 1), 20)
+      ? Math.min(Math.max(parseInt(limitParam, 10) || 1, 1), 20)
       : 5;
 
     if (!query.trim()) {

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -33,6 +33,7 @@ import {
 } from "@elizaos/core";
 import {
   createShellNavigateViewWsFrame,
+  parseClampedInteger,
   type RouteHelpers,
   readJsonBody,
   type ShellNavigateViewPayload,
@@ -335,17 +336,11 @@ export async function handleViewsRoutes(
   if (method === "GET" && pathname === `${PREFIX}/search`) {
     const query = url.searchParams.get("q") ?? "";
     const limitParam = url.searchParams.get("limit");
-    const topK = limitParam
-      ? (() => {
-          const parsed = parseInt(limitParam, 10);
-          // Preserve the established fallback for nonempty values that do not
-          // contain a parseable integer while still treating an explicit zero
-          // as the documented minimum page size.
-          return Number.isNaN(parsed)
-            ? 5
-            : Math.min(Math.max(parsed || 1, 1), 20);
-        })()
-      : 5;
+    const topK = parseClampedInteger(limitParam, {
+      min: 1,
+      max: 20,
+      fallback: 5,
+    });
 
     if (!query.trim()) {
       json(res, { results: [], query });


### PR DESCRIPTION
## Summary

- make explicit `limit=0` on `GET /api/views/search` honor the documented lower clamp of 1
- preserve omitted default 5 and upper clamp behavior
- add deterministic route coverage

Fixes #18925

## Duplicate-work check

No open issue matched the minimum view-search limit boundary; #17028 concerns VIEWS intent hijacking, not pagination. No open PR changed `packages/agent/src/api/views-routes.ts` or its focused search test. No local worktree owned these paths before this lane.

## Verification

- [x] Bun 1.3.14 focused test: `packages/agent/src/api/views-routes.search.test.ts` — 6 passed
- [x] Biome check on both changed files
- [x] `git diff --check`
- [ ] Full agent build/typecheck — not run; isolated route behavior change

## Attribution

- AI assistance: yes
- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Codex
- Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
- Attribution status: self-reported
- — [symbiex-view-search-limit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->

<!-- evidence-head:41322670e6c2ba4356d4568bf27e7ed0d2170f86 -->

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Models: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Client: codex
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Status: self-reported

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 47872301 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [symbiex-batch20]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZWBHQCKKGB7V7QN1D25X1JP","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T01:24:52.756Z","completed_at":"2026-08-13T01:36:59.629Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":1457442,"output_tokens":90507,"cache_creation_tokens":0,"cache_read_tokens":46324352,"total_tokens":47872301,"cost_micro_usd":"30428830","session_count":12},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"w4mZuT1zUAwf4JZEJAbo5Z2DCuo10-FqYPVFoOJLb6CI77Q-EGnIjFM_XEssTPvUNnbauIb-mR905YWHuHwaDA"}} -->

<!-- evidence-head:41322670e6c2ba4356d4568bf27e7ed0d2170f86 -->