### PR TITLE
fix(app): validate capture duration before setup

### DIFF
--- a/packages/app/scripts/capture-android-emu.mjs
+++ b/packages/app/scripts/capture-android-emu.mjs
@@ -160,6 +160,7 @@ function captureLogcat(adb, serial, outPath) {
 
 async function main() {
   const flags = parseFlags();
+  const durationSec = resolveCaptureDurationSeconds(flags);
 
   let adb;
   try {
@@ -184,7 +185,6 @@ async function main() {
     slug: flags.slug,
     platform: PLATFORM,
   });
-  const durationSec = resolveCaptureDurationSeconds(flags);
 
   const pngPath = evidencePath(base, "png");
   if (captureScreenshot(adb, serial, pngPath)) {

--- a/packages/app/scripts/capture-duration-entrypoint.test.mjs
+++ b/packages/app/scripts/capture-duration-entrypoint.test.mjs
@@ -5,8 +5,8 @@
  */
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 const SCRIPTS = [
   "capture-android-emu.mjs",
@@ -20,7 +20,7 @@ for (const script of SCRIPTS) {
   test(`${script} rejects malformed duration before platform setup`, () => {
     const result = spawnSync(
       process.execPath,
-      [path.resolve("packages/app/scripts", script), "--duration", "junk"],
+      [fileURLToPath(new URL(script, import.meta.url)), "--duration", "junk"],
       {
         encoding: "utf8",
         timeout: 5_000,

--- a/packages/app/scripts/capture-duration-entrypoint.test.mjs
+++ b/packages/app/scripts/capture-duration-entrypoint.test.mjs
@@ -1,0 +1,34 @@
+/**
+ * Real-process regression for the five platform capture CLI entrypoints.
+ * Each child receives malformed --duration input and must reject it before
+ * probing a platform, device, display, or capture tool; no lifecycle is mocked.
+ */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+
+const SCRIPTS = [
+  "capture-android-emu.mjs",
+  "capture-ios-sim.mjs",
+  "capture-macos-desktop.mjs",
+  "capture-windows-desktop.mjs",
+  "capture-linux-desktop.mjs",
+];
+
+for (const script of SCRIPTS) {
+  test(`${script} rejects malformed duration before platform setup`, () => {
+    const result = spawnSync(
+      process.execPath,
+      [path.resolve("packages/app/scripts", script), "--duration", "junk"],
+      {
+        encoding: "utf8",
+        timeout: 5_000,
+      },
+    );
+
+    assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+    assert.match(`${result.stdout}\n${result.stderr}`, /--duration/);
+    assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /\[skip\]/i);
+  });
+}

--- a/packages/app/scripts/capture-ios-sim.mjs
+++ b/packages/app/scripts/capture-ios-sim.mjs
@@ -83,6 +83,7 @@ async function recordVideo(udid, outPath, durationSec) {
 
 async function main() {
   const flags = parseFlags();
+  const durationSec = resolveCaptureDurationSeconds(flags);
   if (process.platform !== "darwin") {
     skip(PLATFORM, "not macOS — xcrun simctl unavailable");
   }
@@ -100,7 +101,6 @@ async function main() {
     slug: flags.slug,
     platform: PLATFORM,
   });
-  const durationSec = resolveCaptureDurationSeconds(flags);
 
   const pngPath = evidencePath(base, "png");
   simctl(["io", udid, "screenshot", "--type=png", pngPath]);

--- a/packages/app/scripts/capture-linux-desktop.mjs
+++ b/packages/app/scripts/capture-linux-desktop.mjs
@@ -84,6 +84,8 @@ function recordVideo(ffmpeg, display, size, outPath, durationSec) {
 }
 
 async function main() {
+  const flags = parseFlags();
+  const durationSec = resolveCaptureDurationSeconds(flags);
   if (process.platform !== "linux") {
     skip(
       PLATFORM,
@@ -96,13 +98,11 @@ async function main() {
   }
   const ffmpeg = resolveRequiredFfmpeg({ log });
 
-  const flags = parseFlags();
   const base = evidenceBaseName({
     issue: flags.issue,
     slug: flags.slug,
     platform: PLATFORM,
   });
-  const durationSec = resolveCaptureDurationSeconds(flags);
   const size = screenSize(display);
   log(`capturing X11 desktop ${display} @ ${size}`);
 

--- a/packages/app/scripts/capture-macos-desktop.mjs
+++ b/packages/app/scripts/capture-macos-desktop.mjs
@@ -56,6 +56,8 @@ function recordVideo(ffmpeg, outPath, durationSec) {
 }
 
 async function main() {
+  const flags = parseFlags();
+  const durationSec = resolveCaptureDurationSeconds(flags);
   if (process.platform !== "darwin") {
     skip(
       PLATFORM,
@@ -67,13 +69,11 @@ async function main() {
   }
   const ffmpeg = resolveRequiredFfmpeg({ log });
 
-  const flags = parseFlags();
   const base = evidenceBaseName({
     issue: flags.issue,
     slug: flags.slug,
     platform: PLATFORM,
   });
-  const durationSec = resolveCaptureDurationSeconds(flags);
 
   const pngPath = evidencePath(base, "png");
   if (captureScreenshot(pngPath)) {

--- a/packages/app/scripts/capture-windows-desktop.mjs
+++ b/packages/app/scripts/capture-windows-desktop.mjs
@@ -61,6 +61,8 @@ function recordVideo(ffmpeg, outPath, durationSec) {
 }
 
 async function main() {
+  const flags = parseFlags();
+  const durationSec = resolveCaptureDurationSeconds(flags);
   if (process.platform !== "win32") {
     skip(
       PLATFORM,
@@ -69,13 +71,11 @@ async function main() {
   }
   const ffmpeg = resolveRequiredFfmpeg({ log });
 
-  const flags = parseFlags();
   const base = evidenceBaseName({
     issue: flags.issue,
     slug: flags.slug,
     platform: PLATFORM,
   });
-  const durationSec = resolveCaptureDurationSeconds(flags);
   log("capturing windows desktop via gdigrab");
 
   const pngPath = evidencePath(base, "png");


### PR DESCRIPTION
## Summary

- validate  immediately after CLI parsing in all five capture entrypoints
- reject malformed values before platform, device, display, or ffmpeg probes
- add real subprocess regressions for each script

This completes the executable-boundary portion of #18622 while preserving the existing shared duration parser and valid/default behavior.

## Verification

- ✔ capture-android-emu.mjs rejects malformed duration before platform setup (38.576458ms)
✔ capture-ios-sim.mjs rejects malformed duration before platform setup (81.139584ms)
✔ capture-macos-desktop.mjs rejects malformed duration before platform setup (35.033917ms)
✔ capture-windows-desktop.mjs rejects malformed duration before platform setup (34.864083ms)
✔ capture-linux-desktop.mjs rejects malformed duration before platform setup (33.1055ms)
ℹ tests 5
ℹ suites 0
ℹ pass 5
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 264.627041: 5/5
- bun test v1.4.0-canary.1 (2629789a2): 21 passed
- focused Biome check
- 

No UI or capture backend behavior changed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Models: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Client: codex
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Status: self-reported

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 47872301 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [symbiex-batch20]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZWBHQCKKGB7V7QN1D25X1JP","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T01:24:52.756Z","completed_at":"2026-08-13T01:36:59.629Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":1457442,"output_tokens":90507,"cache_creation_tokens":0,"cache_read_tokens":46324352,"total_tokens":47872301,"cost_micro_usd":"30428830","session_count":12},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"w4mZuT1zUAwf4JZEJAbo5Z2DCuo10-FqYPVFoOJLb6CI77Q-EGnIjFM_XEssTPvUNnbauIb-mR905YWHuHwaDA"}} -->

<!-- evidence-head:db4d90184f0eb17f469d2a0189a0d86c99a222df -->