### PR TITLE
fix(cloud): reconcile orphaned deletion_pending sandboxes every maintenance sweep

### DIFF
--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.deletion-reconcile.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.deletion-reconcile.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Daemon-phase wiring for the deletion reconciliation cycle: the infra
+ * maintenance sweep must drive `provisioningJobService.reEnqueueFailedDeletions`
+ * with the bounded phase args, gate itself on `DELETION_RECONCILE_ENABLED`,
+ * log the summary only when the sweep found work, and stay error-isolated so a
+ * reconciler failure never aborts the rest of the sweep. Deterministic: worker
+ * deps are injected via `__setDepsForTests`; the sweep's own DB behavior is
+ * pinned in `provisioning-jobs-delete-enqueue.test.ts`.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { withTimeout } from "@elizaos/cloud-shared/lib/utils/with-timeout";
+import {
+  __setDepsForTests,
+  processDeletionReconcileCycle,
+  readWorkerConfig,
+  runInfraMaintenanceCycle,
+} from "./provisioning-worker";
+
+type WorkerConfig = ReturnType<typeof readWorkerConfig>;
+type WorkerLogger = Parameters<typeof runInfraMaintenanceCycle>[0];
+
+const EXPECTED_ARGS = { minAgeMs: 10 * 60_000, maxAgents: 200 };
+
+function makeLogger(): WorkerLogger {
+  return {
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    debug: mock(() => {}),
+  } as unknown as WorkerLogger;
+}
+
+function makeConfig(
+  env: NodeJS.ProcessEnv = {} as NodeJS.ProcessEnv,
+): WorkerConfig {
+  return readWorkerConfig(env, []);
+}
+
+/**
+ * Minimal deps bag: real `withTimeout` (so phase bounding is exercised), a
+ * mock logger, and a provisioningJobService whose reconciler is the mock under
+ * test. Every OTHER maintenance phase finds its dependency missing, throws,
+ * and is isolated by runBoundedPhase — the cycle completing anyway is itself
+ * part of the contract under test.
+ */
+function fakeDeps(
+  reEnqueueImpl: () => Promise<{
+    scanned: number;
+    reEnqueued: number;
+    failed: number;
+    abandoned: number;
+  }>,
+) {
+  const reEnqueueFailedDeletions = mock(reEnqueueImpl);
+  const logger = makeLogger();
+  const deps = {
+    logger,
+    withTimeout,
+    provisioningJobService: { reEnqueueFailedDeletions },
+  } as unknown as Parameters<typeof __setDepsForTests>[0];
+  return { deps, logger, reEnqueueFailedDeletions };
+}
+
+function summaryLogCalls(logger: WorkerLogger): unknown[][] {
+  const info = logger.info as unknown as { mock: { calls: unknown[][] } };
+  return info.mock.calls.filter(
+    (call) =>
+      call[0] ===
+      "[provisioning-worker] deletion reconciliation cycle complete",
+  );
+}
+
+afterEach(() => {
+  __setDepsForTests(null);
+});
+
+describe("readWorkerConfig (deletion reconcile gate)", () => {
+  test("defaults ON; DELETION_RECONCILE_ENABLED=0/false opts out", () => {
+    expect(makeConfig().deletionReconcileEnabled).toBe(true);
+    expect(
+      makeConfig({ DELETION_RECONCILE_ENABLED: "1" } as NodeJS.ProcessEnv)
+        .deletionReconcileEnabled,
+    ).toBe(true);
+    expect(
+      makeConfig({ DELETION_RECONCILE_ENABLED: "0" } as NodeJS.ProcessEnv)
+        .deletionReconcileEnabled,
+    ).toBe(false);
+    expect(
+      makeConfig({ DELETION_RECONCILE_ENABLED: "false" } as NodeJS.ProcessEnv)
+        .deletionReconcileEnabled,
+    ).toBe(false);
+  });
+});
+
+describe("processDeletionReconcileCycle (daemon phase wiring)", () => {
+  test("delegates to reEnqueueFailedDeletions with the bounded sweep args", async () => {
+    const summary = { scanned: 47, reEnqueued: 45, failed: 1, abandoned: 1 };
+    const { deps, reEnqueueFailedDeletions } = fakeDeps(async () => summary);
+    __setDepsForTests(deps);
+
+    const result = await processDeletionReconcileCycle(makeConfig());
+
+    expect(reEnqueueFailedDeletions).toHaveBeenCalledTimes(1);
+    expect(reEnqueueFailedDeletions).toHaveBeenCalledWith(EXPECTED_ARGS);
+    expect(result).toEqual(summary);
+  });
+
+  test("skips the service entirely when the env gate is off", async () => {
+    const { deps, reEnqueueFailedDeletions } = fakeDeps(async () => ({
+      scanned: 0,
+      reEnqueued: 0,
+      failed: 0,
+      abandoned: 0,
+    }));
+    __setDepsForTests(deps);
+
+    const result = await processDeletionReconcileCycle(
+      makeConfig({ DELETION_RECONCILE_ENABLED: "0" } as NodeJS.ProcessEnv),
+    );
+
+    expect(result).toBeNull();
+    expect(reEnqueueFailedDeletions).not.toHaveBeenCalled();
+  });
+
+  test("propagates a service throw so runBoundedPhase can log-and-isolate it", async () => {
+    const { deps } = fakeDeps(async () => {
+      throw new Error("database unreachable");
+    });
+    __setDepsForTests(deps);
+
+    await expect(processDeletionReconcileCycle(makeConfig())).rejects.toThrow(
+      "database unreachable",
+    );
+  });
+});
+
+describe("runInfraMaintenanceCycle (deletion reconciliation phase)", () => {
+  test("runs the phase during a maintenance sweep and logs the summary", async () => {
+    const { deps, logger, reEnqueueFailedDeletions } = fakeDeps(async () => ({
+      scanned: 3,
+      reEnqueued: 2,
+      failed: 0,
+      abandoned: 1,
+    }));
+    __setDepsForTests(deps);
+
+    await runInfraMaintenanceCycle(logger, makeConfig());
+
+    expect(reEnqueueFailedDeletions).toHaveBeenCalledTimes(1);
+    expect(reEnqueueFailedDeletions).toHaveBeenCalledWith(EXPECTED_ARGS);
+    const logged = summaryLogCalls(logger);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]?.[1]).toEqual({
+      event: "deletion_reconcile.cycle",
+      scanned: 3,
+      reEnqueued: 2,
+      failed: 0,
+      abandoned: 1,
+    });
+  });
+
+  test("stays quiet when the sweep found nothing to re-arm", async () => {
+    const { deps, logger } = fakeDeps(async () => ({
+      scanned: 0,
+      reEnqueued: 0,
+      failed: 0,
+      abandoned: 0,
+    }));
+    __setDepsForTests(deps);
+
+    await runInfraMaintenanceCycle(logger, makeConfig());
+
+    expect(summaryLogCalls(logger)).toHaveLength(0);
+  });
+
+  test("skips the reconciler for the whole sweep when the env gate is off", async () => {
+    const { deps, logger, reEnqueueFailedDeletions } = fakeDeps(async () => ({
+      scanned: 5,
+      reEnqueued: 5,
+      failed: 0,
+      abandoned: 0,
+    }));
+    __setDepsForTests(deps);
+
+    await runInfraMaintenanceCycle(
+      logger,
+      makeConfig({ DELETION_RECONCILE_ENABLED: "false" } as NodeJS.ProcessEnv),
+    );
+
+    expect(reEnqueueFailedDeletions).not.toHaveBeenCalled();
+    expect(summaryLogCalls(logger)).toHaveLength(0);
+  });
+
+  test("a reconciler failure is isolated: the sweep completes and logs the error", async () => {
+    const { deps, logger, reEnqueueFailedDeletions } = fakeDeps(async () => {
+      throw new Error("neon stalled");
+    });
+    __setDepsForTests(deps);
+
+    // Must resolve — a throw escaping here would abort the node-maintenance
+    // sweep, which is exactly what runBoundedPhase exists to prevent.
+    await runInfraMaintenanceCycle(logger, makeConfig());
+
+    expect(reEnqueueFailedDeletions).toHaveBeenCalledTimes(1);
+    expect(summaryLogCalls(logger)).toHaveLength(0);
+    const error = logger.error as unknown as { mock: { calls: unknown[][] } };
+    const phaseFailures = error.mock.calls.filter(
+      (call) =>
+        call[0] ===
+        "[provisioning-worker] deletion reconciliation cycle failed",
+    );
+    expect(phaseFailures).toHaveLength(1);
+    expect(phaseFailures[0]?.[1]).toEqual({ error: "neon stalled" });
+  });
+});

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts
@@ -202,6 +202,12 @@ describe("real one-shot daemon entrypoint", () => {
       created: true,
       job: { id: "canary-safe-upgrade" },
     }));
+    const reEnqueueFailedDeletions = mock(async () => ({
+      scanned: 1,
+      reEnqueued: 1,
+      failed: 0,
+      abandoned: 0,
+    }));
     const healthCheckAll = mock(
       async () =>
         new Map([
@@ -283,6 +289,7 @@ describe("real one-shot daemon entrypoint", () => {
           reconcileWarmClaimCredentialFences,
           reconcileReplacementCleanupFences,
           enqueueAgentUpgradeOnce,
+          reEnqueueFailedDeletions,
         },
       },
       "@elizaos/cloud-shared/lib/utils/logger": { logger },
@@ -436,6 +443,11 @@ describe("real one-shot daemon entrypoint", () => {
           "agent_admin_canary_image",
         ]);
         expect(enqueueAgentUpgradeOnce).toHaveBeenCalledTimes(1);
+        expect(reEnqueueFailedDeletions).toHaveBeenCalledTimes(1);
+        expect(reEnqueueFailedDeletions).toHaveBeenCalledWith({
+          minAgeMs: 10 * 60_000,
+          maxAgents: 200,
+        });
         expect(healthCheckAll).toHaveBeenCalledTimes(1);
         expect(syncAllocatedCounts).toHaveBeenCalledTimes(1);
         expect(prePullAgentImageOnAvailableNodes).toHaveBeenCalledWith(

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
@@ -135,6 +135,16 @@ export interface ProvisioningWorkerConfig {
    */
   orphanReconcilerEnabled: boolean;
   /**
+   * When true (default), the infra-maintenance sweep re-arms orphaned
+   * `deletion_pending` / `deletion_failed` sandboxes via
+   * `reEnqueueFailedDeletions` so their teardown actually runs and the node
+   * slots they clog are freed within one sweep instead of dwelling until the
+   * 6-hourly agent-backups cron. Idempotent, capped DB writes only — no
+   * container teardown happens here. Opt-out via `DELETION_RECONCILE_ENABLED`
+   * (`0`/`false` disables, e.g. while ops investigates a deletion storm).
+   */
+  deletionReconcileEnabled: boolean;
+  /**
    * DB liveness threshold (#15160): when the newest `jobs` row is older than
    * this many hours, the worker logs a loud error naming the DB host —
    * "this database looks abandoned; check DATABASE_URL points where the API
@@ -225,6 +235,9 @@ export function readWorkerConfig(
       DEFAULT_WATCHDOG_CONSECUTIVE_TICKS,
     ),
     orphanReconcilerEnabled: env.ORPHAN_RECONCILER_ENABLED === "1",
+    deletionReconcileEnabled: parseBooleanDefaultTrue(
+      env.DELETION_RECONCILE_ENABLED,
+    ),
     dbLivenessMaxAgeHours: parsePositiveInt(
       env.CONTAINERS_DB_LIVENESS_MAX_AGE_HOURS,
       DEFAULT_DB_LIVENESS_MAX_AGE_HOURS,
@@ -858,6 +871,50 @@ export async function processBackupVerificationCycle(): Promise<
 > {
   const { runBackupVerificationCycle } = await loadDeps();
   return runBackupVerificationCycle();
+}
+
+/**
+ * Grace period before an orphaned deletion row is re-armed. Long enough that a
+ * delete whose job is mid-retry settles first (the sweep's NOT-EXISTS predicate
+ * already skips rows with an active agent_delete job; the age cutoff keeps it
+ * clear of a just-flipped row), short enough that an orphan dwells minutes —
+ * not the hours the 6-hourly agent-backups cron allowed.
+ */
+const DELETION_RECONCILE_MIN_AGE_MS = 10 * 60_000;
+
+/**
+ * Per-sweep cap on re-armed rows. Sized to clear the observed prod backlog
+ * (47 of 73 sandboxes orphaned) in a single sweep with headroom; each item is
+ * one idempotent enqueue (a cheap DB write), and the phase budget bounds the
+ * sweep's wall clock regardless.
+ */
+const DELETION_RECONCILE_MAX_AGENTS = 200;
+
+type DeletionReconcileSummary = Awaited<
+  ReturnType<WorkerService["reEnqueueFailedDeletions"]>
+>;
+
+/**
+ * Re-arm sandboxes stranded in `deletion_pending` with no draining
+ * `agent_delete` job (or dead-ended in `deletion_failed`) so the worker
+ * finishes their teardown and frees the node slots they occupy. Warm-pool
+ * rotation mints these orphans faster than the 6-hourly agent-backups cron —
+ * today's only caller of `reEnqueueFailedDeletions` — clears them, and a node
+ * full of them stops hosting new provisions ("Registered Docker nodes exist
+ * but none available"). Running the same idempotent, capped service sweep on
+ * every infra maintenance cycle bounds orphan dwell to minutes. Returns null
+ * without touching the service when `DELETION_RECONCILE_ENABLED` is off.
+ * Exported for the daemon-phase wiring test.
+ */
+export async function processDeletionReconcileCycle(
+  config: ProvisioningWorkerConfig,
+): Promise<DeletionReconcileSummary | null> {
+  if (!config.deletionReconcileEnabled) return null;
+  const { provisioningJobService } = await loadDeps();
+  return provisioningJobService.reEnqueueFailedDeletions({
+    minAgeMs: DELETION_RECONCILE_MIN_AGE_MS,
+    maxAgents: DELETION_RECONCILE_MAX_AGENTS,
+  });
 }
 
 /**
@@ -1663,7 +1720,8 @@ async function pollCycle(
   }
 }
 
-async function runInfraMaintenanceCycle(
+/** Exported for the daemon-phase wiring tests; production entry is pollCycle. */
+export async function runInfraMaintenanceCycle(
   logger: WorkerLogger,
   config: ProvisioningWorkerConfig,
 ): Promise<void> {
@@ -1740,6 +1798,32 @@ async function runInfraMaintenanceCycle(
             oversizeSkipped: summary.oversizeSkipped,
             budgetDeferred: summary.budgetDeferred,
             escalated: summary.escalated,
+          },
+        );
+      }
+    },
+  );
+
+  // Deletion reconciliation: re-arm `deletion_pending`/`deletion_failed`
+  // orphans so their teardown drains and the node slots they clog free up
+  // within one sweep. DB writes only (idempotent enqueues, capped per sweep) —
+  // the actual container teardown runs through the normal agent_delete job
+  // path with all its safety checks. Self-gated by DELETION_RECONCILE_ENABLED
+  // (default on) inside the phase, which reports null when off.
+  await runBoundedPhase(
+    logger,
+    "deletion reconciliation cycle",
+    () => processDeletionReconcileCycle(config),
+    (summary) => {
+      if (summary && summary.scanned > 0) {
+        logger.info(
+          "[provisioning-worker] deletion reconciliation cycle complete",
+          {
+            event: "deletion_reconcile.cycle",
+            scanned: summary.scanned,
+            reEnqueued: summary.reEnqueued,
+            failed: summary.failed,
+            abandoned: summary.abandoned,
           },
         );
       }


### PR DESCRIPTION
## Problem
Warm-pool rotation leaves agent sandboxes in `deletion_pending` with no draining `agent_delete` job (orphans). The only thing that re-arms them — `reEnqueueFailedDeletions` — runs **only on the 6-hourly agent-backups cron**, so orphans dwell for hours. On prod this reached **47 of 73 sandboxes (64%) orphaned**, clogging nodes (`eliza-core-prod-4` 17/18, `prod-3` 14/15), which produced onboarding provision failures (`Registered Docker nodes exist but none available`, provision/health-check timeouts). Under launch signup traffic this mass-fails onboarding.

## This PR — Part 2 (the safe half): reconcile every maintenance sweep
Adds a bounded **"deletion reconciliation cycle"** phase to `runInfraMaintenanceCycle` (runs ~every 5 min) that calls the sanctioned `provisioningJobService.reEnqueueFailedDeletions({ minAgeMs: 10min, maxAgents: 200 })` through the existing `loadDeps()`/`__setDepsForTests` DI seam. So orphans drain **every ~5 min instead of every 6 h** and nodes stop clogging. It:
- runs under `runBoundedPhase`/`PHASE_TIMEOUT_MS` (60s) like every sibling phase — can't stall the sweep,
- is error-isolated (a reconciler throw is logged, never breaks the cycle),
- is opt-out via `DELETION_RECONCILE_ENABLED` (default ON, `parseBooleanDefaultTrue`, same as `BACKUP_VERIFICATION_ENABLED`),
- logs `{scanned, reEnqueued, failed, abandoned}` under `deletion_reconcile.cycle` only when there's something to report.

This automates a manual stopgap that was run against prod several times today.

## ⚠️ Part 1 (the delicate half) is NOT in this PR — @0xSolace's lane
The root cause (stop *minting* orphans) is in `eliza-sandbox.ts` `prepareAgentDelete` (~L2214), a multi-phase delete with subtle invariants (`deletion_allocation_counted`/`holdsCountedNodeSlot`, `deletion_attempt_id` continuation, lifecycle_revision, replacement_cleanup guard, #17185 sibling-slot). Deliberately **left untouched** — that fix belongs to the warm-pool lane owner. Spec: the warm-pool rotation caller must enqueue `enqueueAgentDeleteOnce` atomically with the `deletion_pending` mark. This PR is the safety-net half only.

## Tests
`bun test packages/cloud/scripts/admin/daemons/provisioning-worker.*.test.ts` → **21 pass / 0 fail** (broader sweep 84/0). New `provisioning-worker.deletion-reconcile.test.ts` (8 tests: gate parse, args+summary passthrough, gate-off skip on phase and full cycle, quiet-when-zero, throw propagation, error isolation) + extended the real daemon-entrypoint test. Biome + typecheck clean on touched files.

## Do not merge yet
Opened as a **candidate for @0xSolace's review**, to merge **post-launch** (mid-launch: no develop churn). Not urgent to merge — the manual stopgap + the launch-riding warm-pool floor fix (#18581) already relieve the funnel.

## Evidence Gate

<!-- evidence-head:6ed549d7e57aec39c7e9ab8b496eb163bc9ad29f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend provisioning-worker maintenance-cycle change touches no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - the change edits control-plane daemon code and produces no application pixels to capture.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a deterministic worker reconciliation phase with no interactive user flow to record.
<!-- evidence-row:backend-logs -->
- [x] N/A - the phase behavior is proven by the eight added unit tests plus the extended real daemon-entrypoint test and is green in the PR checks; a live reconcile log is only producible after a production deploy of the provisioning worker, which is the reviewer merge and deploy lane.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path is exercised by this worker-phase change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, action, or agent behavior changes here, so this deterministic infrastructure reconciliation scheduling invokes no language model.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the change creates no runtime domain state and the reconcile phase is exercised entirely by the added unit tests.

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5, anthropic/claude-opus-4-8
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored via an internal Fable build workflow, not the pinned contribute-to-eliza skill
<!-- attribution-row:status -->
- Attribution status: self-reported
