### PR TITLE
fix(openai): keep browser URL transcription on a guarded fetch without Node subpaths

### DIFF
--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -108,6 +108,14 @@ export * from "./model-gateway";
 // Canonical owner is `@elizaos/core`; `@elizaos/shared` re-exports them from
 // this barrel so browser consumers resolve the same implementation.
 export * from "./name-tokens";
+// Literal-host SSRF policy helpers are pure string/IP logic (no Node deps).
+// Browser-target consumers use them to fail closed before fetching
+// caller-supplied media URLs (#18702); DNS pinning itself stays Node-only.
+export {
+	isBlockedHostname,
+	isPrivateIpAddress,
+	SsrfBlockedError,
+} from "./network/ssrf";
 export * from "./prompts";
 export * from "./recent-messages-state";
 export * from "./roles";

--- a/plugins/plugin-openai/__tests__/helpers/browser-consumer-bundle.mjs
+++ b/plugins/plugin-openai/__tests__/helpers/browser-consumer-bundle.mjs
@@ -1,0 +1,43 @@
+/**
+ * Consumer-bundle probe for #18702: bundles the plugin's browser entrypoint
+ * with the same production Bun.build settings as `build.ts` (browser target,
+ * ESM, package.json-derived externals; unminified so identifiers stay
+ * observable) without writing `dist/`, imports core's real browser entry
+ * source, and prints the module-graph facts the regression test asserts on.
+ * Run with bun from the plugin root; output is one JSON object on stdout.
+ */
+import { externalsFromPackageJson } from "../../../plugin-build-externals";
+
+const pluginRoot = new URL("../..", import.meta.url).pathname;
+process.chdir(pluginRoot);
+
+const external = await externalsFromPackageJson("./package.json");
+const result = await Bun.build({
+  entrypoints: ["index.browser.ts"],
+  target: "browser",
+  format: "esm",
+  external,
+});
+
+if (!result.success) {
+  console.log(JSON.stringify({ success: false, logs: result.logs.map((l) => String(l)) }));
+  process.exit(0);
+}
+
+const text = await result.outputs[0].text();
+const core = await import("../../../../packages/core/src/index.browser.ts");
+
+console.log(
+  JSON.stringify({
+    success: true,
+    hasCoreNodeSubpath: text.includes("@elizaos/core/node"),
+    nodeBuiltins: [...new Set([...text.matchAll(/["'](node:[a-z0-9/_-]+)["']/g)].map((m) => m[1]))],
+    registersBrowserFetcher: text.includes("installBrowserTranscriptionUrlFetcher"),
+    registersNodeFetcher: text.includes("installNodeTranscriptionUrlFetcher"),
+    coreBrowserExports: {
+      isBlockedHostname: typeof core.isBlockedHostname,
+      isPrivateIpAddress: typeof core.isPrivateIpAddress,
+      SsrfBlockedError: typeof core.SsrfBlockedError,
+    },
+  })
+);

--- a/plugins/plugin-openai/__tests__/transcription-browser-consumer.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/transcription-browser-consumer.shape.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Consumer-level browser regression for #18702: spawns a bun helper that
+ * bundles the plugin's browser entrypoint with the production Bun.build
+ * settings (browser target, package.json externals) and asserts the emitted
+ * graph never names the `@elizaos/core/node` subpath or a `node:` built-in,
+ * that the browser (not the Node) URL-fetcher registration ships, and that
+ * core's real browser entry source exports the SSRF policy helpers the
+ * boundary imports. Real bundler and real core source — no mocks, no network.
+ */
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const pluginRoot = path.resolve(__dirname, "..");
+const helper = path.join(__dirname, "helpers", "browser-consumer-bundle.mjs");
+
+type BundleProbe = {
+  success: boolean;
+  logs?: string[];
+  hasCoreNodeSubpath?: boolean;
+  nodeBuiltins?: string[];
+  registersBrowserFetcher?: boolean;
+  registersNodeFetcher?: boolean;
+  coreBrowserExports?: Record<string, string>;
+};
+
+describe("browser consumer bundle of @elizaos/plugin-openai", () => {
+  it("bundles the URL-transcription path without Node subpaths or built-ins", () => {
+    const stdout = execFileSync("bun", [helper], {
+      cwd: pluginRoot,
+      encoding: "utf8",
+      timeout: 120_000,
+    });
+    const probe = JSON.parse(stdout.trim().split("\n").pop() ?? "{}") as BundleProbe;
+
+    expect(probe.success, `bundle failed: ${JSON.stringify(probe.logs)}`).toBe(true);
+
+    // The defect Shaw reopened on: the browser graph following the explicit
+    // node subpath into the Node artifact (node:crypto / node:os).
+    expect(probe.hasCoreNodeSubpath).toBe(false);
+    expect(probe.nodeBuiltins).toEqual([]);
+
+    // The browser guarded boundary — not the Node one — is what registers.
+    expect(probe.registersBrowserFetcher).toBe(true);
+    expect(probe.registersNodeFetcher).toBe(false);
+
+    // The boundary's imports must exist on core's browser entry, or a real
+    // consumer fails at module evaluation despite a green plugin build.
+    expect(probe.coreBrowserExports).toEqual({
+      isBlockedHostname: "function",
+      isPrivateIpAddress: "function",
+      SsrfBlockedError: "function",
+    });
+  }, 150_000);
+});

--- a/plugins/plugin-openai/__tests__/transcription-browser-url.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/transcription-browser-url.shape.test.ts
@@ -1,12 +1,14 @@
 /**
  * Unit tests for the browser transcription-URL boundary (#18702): literal
  * private/loopback/link-local/metadata hosts fail closed before any network
- * call, redirect landing hosts are re-validated, the shared byte cap is
- * enforced, and the happy path reaches the guarded fetch → provider flow.
- * Config and `recordLlmCall` are mocked; the transport is a stubbed global
- * fetch — deterministic, no live network.
+ * call, redirects are refused before any hop request is issued, a response
+ * with no final URL fails closed, the shared byte cap is enforced, the
+ * handler works with no `Buffer` global, and the happy path reaches the
+ * guarded fetch → provider flow. Config and `recordLlmCall` are mocked; the
+ * transport is a stubbed global fetch — deterministic, no live network.
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import { SsrfBlockedError } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -59,6 +61,12 @@ function createRuntime(): IAgentRuntime {
   } as unknown as IAgentRuntime;
 }
 
+/** `new Response()` leaves `url` as "" — give mocks the final URL a real fetch exposes. */
+function withUrl(response: Response, url: string): Response {
+  Object.defineProperty(response, "url", { value: url });
+  return response;
+}
+
 describe("browser transcription URL boundary fails closed", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -99,7 +107,34 @@ describe("browser transcription URL boundary fails closed", () => {
     expect(mocks.recordLlmCall).not.toHaveBeenCalled();
   });
 
-  it("blocks a redirect that lands on a private host without posting to the provider", async () => {
+  it("refuses redirects before any hop request can be issued", async () => {
+    const requested: string[] = [];
+    const privateTarget = "http://169.254.169.254/latest/meta-data/";
+    // Emulates the Fetch Standard: the platform performs the redirect hop
+    // internally before fetch() resolves unless redirect is "error"/"manual",
+    // so a mode of "follow" means the hop request has already been sent.
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requested.push(String(input));
+      if (init?.redirect === "follow") {
+        requested.push(privateTarget);
+        const landed = new Response(WAV_BYTES, {
+          status: 200,
+          headers: { "Content-Type": "audio/wav" },
+        });
+        return withUrl(landed, privateTarget);
+      }
+      throw new TypeError("Failed to fetch: unexpected redirect");
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    await expect(
+      handleTranscription(createRuntime(), "https://cdn.example.com/redirects.wav")
+    ).rejects.toThrow();
+    expect(requested).toEqual(["https://cdn.example.com/redirects.wav"]);
+    expect(mocks.recordLlmCall).not.toHaveBeenCalled();
+  });
+
+  it("blocks a response that lands on a private host without posting to the provider", async () => {
     const landed = new Response(WAV_BYTES, {
       status: 200,
       headers: { "Content-Type": "audio/wav" },
@@ -115,14 +150,34 @@ describe("browser transcription URL boundary fails closed", () => {
     expect(mocks.recordLlmCall).not.toHaveBeenCalled();
   });
 
-  it("rejects a declared content length over the shared byte cap", async () => {
-    const oversized = new Response(WAV_BYTES, {
+  it("fails closed when the response exposes no final URL", async () => {
+    // A WhatWG `new Response(bytes)` (and some polyfills) leaves `url` as "".
+    const anonymous = new Response(WAV_BYTES, {
       status: 200,
-      headers: {
-        "Content-Type": "audio/wav",
-        "Content-Length": String(TRANSCRIPTION_AUDIO_MAX_BYTES + 1),
-      },
+      headers: { "Content-Type": "audio/wav" },
     });
+    const cancelSpy = vi.spyOn(anonymous.body as ReadableStream<Uint8Array>, "cancel");
+    const fetchMock = vi.fn(async () => anonymous);
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    await expect(
+      handleTranscription(createRuntime(), "https://cdn.example.com/anonymous.wav")
+    ).rejects.toThrow(SsrfBlockedError);
+    expect(cancelSpy).toHaveBeenCalled();
+    expect(mocks.recordLlmCall).not.toHaveBeenCalled();
+  });
+
+  it("rejects a declared content length over the shared byte cap", async () => {
+    const oversized = withUrl(
+      new Response(WAV_BYTES, {
+        status: 200,
+        headers: {
+          "Content-Type": "audio/wav",
+          "Content-Length": String(TRANSCRIPTION_AUDIO_MAX_BYTES + 1),
+        },
+      }),
+      "https://cdn.example.com/huge.wav"
+    );
     const fetchMock = vi.fn(async () => oversized);
     vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
 
@@ -145,8 +200,11 @@ describe("browser transcription URL boundary fails closed", () => {
         controller.enqueue(chunk);
       },
     });
-    const fetchMock = vi.fn(
-      async () => new Response(body, { status: 200, headers: { "Content-Type": "audio/wav" } })
+    const fetchMock = vi.fn(async () =>
+      withUrl(
+        new Response(body, { status: 200, headers: { "Content-Type": "audio/wav" } }),
+        "https://cdn.example.com/unbounded.wav"
+      )
     );
     vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
 
@@ -171,10 +229,13 @@ describe("browser transcription URL happy path", () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url === "https://cdn.example.com/sample.wav") {
-        return new Response(WAV_BYTES, {
-          status: 200,
-          headers: { "Content-Type": "audio/wav" },
-        });
+        return withUrl(
+          new Response(WAV_BYTES, {
+            status: 200,
+            headers: { "Content-Type": "audio/wav" },
+          }),
+          url
+        );
       }
       return new Response(JSON.stringify({ text: "hello from browser" }), {
         status: 200,
@@ -200,10 +261,13 @@ describe("browser transcription URL happy path", () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url === "https://cdn.example.com/clip.wav") {
-        return new Response(WAV_BYTES, {
-          status: 200,
-          headers: { "Content-Type": "audio/wav" },
-        });
+        return withUrl(
+          new Response(WAV_BYTES, {
+            status: 200,
+            headers: { "Content-Type": "audio/wav" },
+          }),
+          url
+        );
       }
       return new Response(JSON.stringify({ text: "from params" }), {
         status: 200,
@@ -218,6 +282,40 @@ describe("browser transcription URL happy path", () => {
     });
 
     expect(text).toBe("from params");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles CoreTranscriptionParams.audioUrl with no Buffer global (browser runtime)", async () => {
+    // Plain-object responses: Node's undici Response internals use the Buffer
+    // global this test removes, and the SUT is the handler chain, not undici.
+    const audioResponse = {
+      url: "https://cdn.example.com/clip.wav",
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "Content-Type": "audio/wav" }),
+      body: null,
+      arrayBuffer: async () => WAV_BYTES.slice().buffer,
+    } as unknown as Response;
+    const providerResponse = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ text: "no buffer needed" }),
+    } as unknown as Response;
+    // A real browser never defines Buffer; the input classification chain must
+    // not reference it bare (it previously threw before reaching audioUrl).
+    vi.stubGlobal("Buffer", undefined);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) =>
+      String(input) === "https://cdn.example.com/clip.wav" ? audioResponse : providerResponse
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    const text = await handleTranscription(createRuntime(), {
+      audioUrl: "https://cdn.example.com/clip.wav",
+    });
+
+    expect(text).toBe("no buffer needed");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/plugins/plugin-openai/__tests__/transcription-browser-url.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/transcription-browser-url.shape.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for the browser transcription-URL boundary (#18702): literal
+ * private/loopback/link-local/metadata hosts fail closed before any network
+ * call, redirect landing hosts are re-validated, the shared byte cap is
+ * enforced, and the happy path reaches the guarded fetch → provider flow.
+ * Config and `recordLlmCall` are mocked; the transport is a stubbed global
+ * fetch — deterministic, no live network.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  recordLlmCall: vi.fn(),
+  getAuthHeader: vi.fn(() => ({ Authorization: "Bearer test-key" })),
+  getBaseURL: vi.fn(() => "https://api.openai.com/v1"),
+  getTranscriptionModel: vi.fn(() => "gpt-4o-mini-transcribe"),
+}));
+
+vi.mock("@elizaos/core", async (importActual) => {
+  const actual = await importActual<Record<string, unknown>>();
+  return {
+    ...actual,
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    },
+    recordLlmCall: mocks.recordLlmCall,
+  };
+});
+
+vi.mock("../utils/config", () => ({
+  getAuthHeader: mocks.getAuthHeader,
+  getBaseURL: mocks.getBaseURL,
+  getTranscriptionModel: mocks.getTranscriptionModel,
+  getTTSInstructions: vi.fn(() => undefined),
+  getTTSModel: vi.fn(() => "gpt-4o-mini-tts"),
+  getTTSVoice: vi.fn(() => "nova"),
+}));
+
+import { handleTranscription } from "../models/audio";
+import { TRANSCRIPTION_AUDIO_MAX_BYTES } from "../models/transcription-url";
+import { installBrowserTranscriptionUrlFetcher } from "../models/transcription-url.browser";
+
+// The browser entrypoint installs this in production; tests import models
+// directly, so install the same guarded fetcher here.
+installBrowserTranscriptionUrlFetcher();
+
+const WAV_BYTES = new Uint8Array([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74, 0x20,
+  0x10, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x44, 0xac, 0x00, 0x00, 0x88, 0x58, 0x01, 0x00,
+  0x02, 0x00, 0x10, 0x00, 0x64, 0x61, 0x74, 0x61, 0x00, 0x00, 0x00, 0x00,
+]);
+
+function createRuntime(): IAgentRuntime {
+  return {
+    getSetting: vi.fn(() => null),
+  } as unknown as IAgentRuntime;
+}
+
+describe("browser transcription URL boundary fails closed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.recordLlmCall.mockImplementation(async (_runtime, _details, fn) => fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    "http://127.0.0.1/secret.wav",
+    "http://[::1]/secret.wav",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://localhost/internal.wav",
+    "http://10.0.0.5/intranet.wav",
+    "http://192.168.1.1/router.wav",
+    "ftp://cdn.example.com/sample.wav",
+  ])("blocks %s before any network call", async (url) => {
+    const fetchMock = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    await expect(handleTranscription(createRuntime(), url)).rejects.toThrow(
+      /Blocked|Invalid audio URL/i
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.recordLlmCall).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty URL strings before any fetch", async () => {
+    const fetchMock = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    await expect(handleTranscription(createRuntime(), "   ")).rejects.toThrow(
+      "TRANSCRIPTION requires a valid audio URL"
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.recordLlmCall).not.toHaveBeenCalled();
+  });
+
+  it("blocks a redirect that lands on a private host without posting to the provider", async () => {
+    const landed = new Response(WAV_BYTES, {
+      status: 200,
+      headers: { "Content-Type": "audio/wav" },
+    });
+    Object.defineProperty(landed, "url", { value: "http://192.168.1.10/loot.wav" });
+    const fetchMock = vi.fn(async () => landed);
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    await expect(
+      handleTranscription(createRuntime(), "https://cdn.example.com/redirects.wav")
+    ).rejects.toThrow(/Blocked audio redirect target host/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mocks.recordLlmCall).not.toHaveBeenCalled();
+  });
+
+  it("rejects a declared content length over the shared byte cap", async () => {
+    const oversized = new Response(WAV_BYTES, {
+      status: 200,
+      headers: {
+        "Content-Type": "audio/wav",
+        "Content-Length": String(TRANSCRIPTION_AUDIO_MAX_BYTES + 1),
+      },
+    });
+    const fetchMock = vi.fn(async () => oversized);
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    await expect(
+      handleTranscription(createRuntime(), "https://cdn.example.com/huge.wav")
+    ).rejects.toThrow(/exceeds maxBytes/);
+    expect(mocks.recordLlmCall).not.toHaveBeenCalled();
+  });
+
+  it("rejects a streamed body that exceeds the byte cap without a content length", async () => {
+    const chunk = new Uint8Array(8 * 1024 * 1024);
+    let sent = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (sent > TRANSCRIPTION_AUDIO_MAX_BYTES) {
+          controller.close();
+          return;
+        }
+        sent += chunk.byteLength;
+        controller.enqueue(chunk);
+      },
+    });
+    const fetchMock = vi.fn(
+      async () => new Response(body, { status: 200, headers: { "Content-Type": "audio/wav" } })
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    await expect(
+      handleTranscription(createRuntime(), "https://cdn.example.com/unbounded.wav")
+    ).rejects.toThrow(/exceeds maxBytes/);
+    expect(mocks.recordLlmCall).not.toHaveBeenCalled();
+  });
+});
+
+describe("browser transcription URL happy path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.recordLlmCall.mockImplementation(async (_runtime, _details, fn) => fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches allowed audio URLs through the guard then posts to the provider", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://cdn.example.com/sample.wav") {
+        return new Response(WAV_BYTES, {
+          status: 200,
+          headers: { "Content-Type": "audio/wav" },
+        });
+      }
+      return new Response(JSON.stringify({ text: "hello from browser" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    const text = await handleTranscription(createRuntime(), "https://cdn.example.com/sample.wav");
+
+    expect(text).toBe("hello from browser");
+    expect(mocks.recordLlmCall).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [providerUrl, init] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(providerUrl).toBe("https://api.openai.com/v1/audio/transcriptions");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(FormData);
+    const file = (init.body as FormData).get("file") as File;
+    expect(file.type).toBe("audio/wav");
+  });
+
+  it("loads CoreTranscriptionParams.audioUrl through the same browser guard", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://cdn.example.com/clip.wav") {
+        return new Response(WAV_BYTES, {
+          status: 200,
+          headers: { "Content-Type": "audio/wav" },
+        });
+      }
+      return new Response(JSON.stringify({ text: "from params" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    const text = await handleTranscription(createRuntime(), {
+      audioUrl: "https://cdn.example.com/clip.wav",
+      prompt: "focus on speech",
+    });
+
+    expect(text).toBe("from params");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugins/plugin-openai/__tests__/transcription-ssrf.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/transcription-ssrf.shape.test.ts
@@ -17,10 +17,11 @@ const mocks = vi.hoisted(() => ({
   realFetchRemoteMedia: null as null | ((...args: unknown[]) => Promise<unknown>),
 }));
 
-// The handler imports logger/recordLlmCall from `@elizaos/core` but loads
-// `fetchRemoteMedia` lazily from `@elizaos/core/node` so the browser bundle
-// never pulls it in. Under Node both specifiers resolve to the same module
-// file, so both mocks must expose the same full mocked surface.
+// The handler imports logger/recordLlmCall from `@elizaos/core`; the Node
+// URL fetcher (models/transcription-url.node.ts) loads `fetchRemoteMedia`
+// lazily from `@elizaos/core/node` so the browser bundle never pulls it in.
+// Under Node both specifiers resolve to the same module file, so both mocks
+// must expose the same full mocked surface.
 const coreMockFactory = vi.hoisted(
   () => async (importActual: () => Promise<Record<string, unknown>>) => {
     const actual = await importActual();
@@ -59,6 +60,11 @@ vi.mock("../utils/config", () => ({
 }));
 
 import { handleTranscription } from "../models/audio";
+import { installNodeTranscriptionUrlFetcher } from "../models/transcription-url.node";
+
+// The Node entrypoint installs this in production; tests import models
+// directly, so install the same guarded fetcher here.
+installNodeTranscriptionUrlFetcher();
 
 function createRuntime(): IAgentRuntime {
   return {

--- a/plugins/plugin-openai/index.browser.ts
+++ b/plugins/plugin-openai/index.browser.ts
@@ -1,5 +1,12 @@
-/** Browser build entrypoint: re-exports the plugin from `./index` unchanged. */
+/**
+ * Browser build entrypoint: installs the browser guarded transcription-URL
+ * fetcher (literal-host SSRF policy, byte cap, abort timeout — no Node
+ * subpaths), then re-exports the plugin from `./index` (#18702).
+ */
 import pluginDefault from "./index";
+import { installBrowserTranscriptionUrlFetcher } from "./models/transcription-url.browser";
+
+installBrowserTranscriptionUrlFetcher();
 
 export * from "./index";
 export default pluginDefault;

--- a/plugins/plugin-openai/index.node.ts
+++ b/plugins/plugin-openai/index.node.ts
@@ -1,5 +1,13 @@
-/** Node build entrypoint: re-exports the plugin from `./index` unchanged. */
+/**
+ * Node build entrypoint: installs the Node guarded transcription-URL fetcher
+ * (core's DNS-pinned `fetchRemoteMedia`), then re-exports the plugin from
+ * `./index`. The platform split keeps `@elizaos/core/node` out of the browser
+ * bundle (#18702).
+ */
 import pluginDefault from "./index";
+import { installNodeTranscriptionUrlFetcher } from "./models/transcription-url.node";
+
+installNodeTranscriptionUrlFetcher();
 
 export * from "./index";
 export default pluginDefault;

--- a/plugins/plugin-openai/models/audio.ts
+++ b/plugins/plugin-openai/models/audio.ts
@@ -4,8 +4,10 @@
  * filename), and `handleTextToSpeech` synthesizes speech via the TTS endpoint.
  * Both accept the core param shapes as well as raw Blob/File/Buffer input.
  *
- * Caller-supplied audio URLs load only through `fetchRemoteMedia` so agents and
- * tools cannot aim transcription at loopback, link-local, or private hosts.
+ * Caller-supplied audio URLs load only through the platform-installed guarded
+ * fetcher (`models/transcription-url.ts`) so agents and tools cannot aim
+ * transcription at loopback, link-local, or private hosts, and so this shared
+ * module never names a Node-only core subpath a browser bundle would follow.
  * Provider endpoint calls (OpenAI-compatible base URL) stay on the configured
  * API path and are not remote-media fetches.
  */
@@ -32,11 +34,7 @@ import {
   getTTSModel,
   getTTSVoice,
 } from "../utils/config";
-
-/** OpenAI Whisper/upload limit is 25 MB; keep the same hard cap server-side. */
-const TRANSCRIPTION_AUDIO_MAX_BYTES = 25 * 1024 * 1024;
-const TRANSCRIPTION_AUDIO_FETCH_TIMEOUT_MS = 30_000;
-const TRANSCRIPTION_AUDIO_MAX_REDIRECTS = 5;
+import { fetchAudioFromUrl } from "./transcription-url";
 
 type AudioInput = Blob | File | Buffer;
 type TranscriptionInput = AudioInput | LocalTranscriptionParams | CoreTranscriptionParams | string;
@@ -69,26 +67,6 @@ function isCoreTranscriptionParams(value: unknown): value is CoreTranscriptionPa
   );
 }
 
-async function fetchAudioFromUrl(url: string): Promise<Blob> {
-  if (!url || url.trim().length === 0) {
-    throw new Error("TRANSCRIPTION requires a valid audio URL");
-  }
-  // Untrusted agent/tool audio URLs must not hit private or metadata hosts.
-  // `fetchRemoteMedia` is Node-only, and the browser entry re-exports this
-  // module, so it must load lazily from the node entry rather than statically.
-  // @trajectory-allow Fetches caller-provided audio bytes; no model inference happens here.
-  const { fetchRemoteMedia } = await import("@elizaos/core/node");
-  const media = await fetchRemoteMedia({
-    url,
-    maxBytes: TRANSCRIPTION_AUDIO_MAX_BYTES,
-    timeoutMs: TRANSCRIPTION_AUDIO_FETCH_TIMEOUT_MS,
-    maxRedirects: TRANSCRIPTION_AUDIO_MAX_REDIRECTS,
-  });
-  const mimeType = media.contentType?.startsWith("audio/")
-    ? media.contentType
-    : detectAudioMimeType(media.buffer);
-  return new Blob([new Uint8Array(media.buffer)], { type: mimeType });
-}
 export async function handleTranscription(
   runtime: IAgentRuntime,
   input: TranscriptionInput

--- a/plugins/plugin-openai/models/audio.ts
+++ b/plugins/plugin-openai/models/audio.ts
@@ -45,7 +45,8 @@ function isBlobOrFile(value: unknown): value is Blob | File {
 }
 
 function isBuffer(value: unknown): value is Buffer {
-  return Buffer.isBuffer(value);
+  // A real browser has no Buffer global; referencing it bare throws.
+  return typeof Buffer !== "undefined" && Buffer.isBuffer(value);
 }
 
 function isLocalTranscriptionParams(value: unknown): value is LocalTranscriptionParams {

--- a/plugins/plugin-openai/models/transcription-url.browser.ts
+++ b/plugins/plugin-openai/models/transcription-url.browser.ts
@@ -1,0 +1,113 @@
+/**
+ * Browser transcription-URL boundary: a guarded fetch with no Node subpaths so
+ * browser-target consumer bundles can load the documented URL path (#18702).
+ * It fails closed on literal loopback/private/link-local/metadata hosts before
+ * the request using the same core SSRF policy helpers the Node guard uses,
+ * re-validates the final landing host after the browser's opaque redirect
+ * handling, enforces the shared byte cap while streaming, and bounds wall time
+ * with an abort timer. A browser cannot pin DNS, so rebinding defense remains
+ * a Node-path property; same-origin policy/CORS bounds what a page can read.
+ */
+import { isBlockedHostname, isPrivateIpAddress, SsrfBlockedError } from "@elizaos/core";
+import {
+  installTranscriptionUrlFetcher,
+  TRANSCRIPTION_AUDIO_FETCH_TIMEOUT_MS,
+  TRANSCRIPTION_AUDIO_MAX_BYTES,
+  toAudioBlob,
+} from "./transcription-url";
+
+function assertAllowedAudioUrl(raw: string, context: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch (error) {
+    // error-policy:J3 URL text is untrusted input; reject it explicitly.
+    throw new Error(`Invalid ${context}: must be http or https`, { cause: error });
+  }
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error(`Invalid ${context}: must be http or https`);
+  }
+  if (isBlockedHostname(parsed.hostname) || isPrivateIpAddress(parsed.hostname)) {
+    throw new SsrfBlockedError(`Blocked ${context} host: ${parsed.hostname}`);
+  }
+  return parsed;
+}
+
+async function readBodyWithByteCap(response: Response, url: string): Promise<Uint8Array> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength) {
+    const length = Number(contentLength);
+    if (Number.isFinite(length) && length > TRANSCRIPTION_AUDIO_MAX_BYTES) {
+      throw new Error(
+        `Failed to fetch audio from ${url}: content length ${length} exceeds maxBytes ${TRANSCRIPTION_AUDIO_MAX_BYTES}`
+      );
+    }
+  }
+  if (!response.body) {
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > TRANSCRIPTION_AUDIO_MAX_BYTES) {
+      throw new Error(
+        `Failed to fetch audio from ${url}: body exceeds maxBytes ${TRANSCRIPTION_AUDIO_MAX_BYTES}`
+      );
+    }
+    return bytes;
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    total += value.byteLength;
+    if (total > TRANSCRIPTION_AUDIO_MAX_BYTES) {
+      await reader.cancel();
+      throw new Error(
+        `Failed to fetch audio from ${url}: body exceeds maxBytes ${TRANSCRIPTION_AUDIO_MAX_BYTES}`
+      );
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+export function installBrowserTranscriptionUrlFetcher(): void {
+  installTranscriptionUrlFetcher(async (url) => {
+    const parsed = assertAllowedAudioUrl(url, "audio URL");
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TRANSCRIPTION_AUDIO_FETCH_TIMEOUT_MS);
+    try {
+      const response = await fetch(parsed.toString(), {
+        redirect: "follow",
+        signal: controller.signal,
+      });
+      // The browser follows redirects opaquely; the only observable hop is the
+      // final landing URL, so re-run the host policy on it before reading bytes.
+      if (response.url) {
+        try {
+          assertAllowedAudioUrl(response.url, "audio redirect target");
+        } catch (error) {
+          // error-policy:J2 Release the connection before rethrowing the policy failure.
+          await response.body?.cancel();
+          throw error;
+        }
+      }
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch audio from ${url}: HTTP ${response.status} ${response.statusText}`
+        );
+      }
+      const bytes = await readBodyWithByteCap(response, url);
+      return toAudioBlob(bytes, response.headers.get("content-type"));
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+}

--- a/plugins/plugin-openai/models/transcription-url.browser.ts
+++ b/plugins/plugin-openai/models/transcription-url.browser.ts
@@ -3,10 +3,11 @@
  * browser-target consumer bundles can load the documented URL path (#18702).
  * It fails closed on literal loopback/private/link-local/metadata hosts before
  * the request using the same core SSRF policy helpers the Node guard uses,
- * re-validates the final landing host after the browser's opaque redirect
- * handling, enforces the shared byte cap while streaming, and bounds wall time
- * with an abort timer. A browser cannot pin DNS, so rebinding defense remains
- * a Node-path property; same-origin policy/CORS bounds what a page can read.
+ * refuses redirects outright (`redirect: "error"`) so no hop request is ever
+ * issued, fails closed when the response exposes no final URL, enforces the
+ * shared byte cap while streaming, and bounds wall time with an abort timer.
+ * A browser cannot pin DNS, so rebinding defense remains a Node-path property;
+ * same-origin policy/CORS bounds what a page can read.
  */
 import { isBlockedHostname, isPrivateIpAddress, SsrfBlockedError } from "@elizaos/core";
 import {
@@ -84,20 +85,25 @@ export function installBrowserTranscriptionUrlFetcher(): void {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), TRANSCRIPTION_AUDIO_FETCH_TIMEOUT_MS);
     try {
+      // The Fetch Standard performs redirect hops before fetch() resolves, so
+      // a landing-host recheck runs only after the hop request was already
+      // sent. "error" makes any redirect a network failure with no hop issued.
       const response = await fetch(parsed.toString(), {
-        redirect: "follow",
+        redirect: "error",
         signal: controller.signal,
       });
-      // The browser follows redirects opaquely; the only observable hop is the
-      // final landing URL, so re-run the host policy on it before reading bytes.
-      if (response.url) {
-        try {
-          assertAllowedAudioUrl(response.url, "audio redirect target");
-        } catch (error) {
-          // error-policy:J2 Release the connection before rethrowing the policy failure.
-          await response.body?.cancel();
-          throw error;
-        }
+      // Defense in depth: the response must still land on an allowed host,
+      // and a missing final URL is opaque, so it fails closed too.
+      if (!response.url) {
+        await response.body?.cancel();
+        throw new SsrfBlockedError("Blocked audio redirect target: missing final URL");
+      }
+      try {
+        assertAllowedAudioUrl(response.url, "audio redirect target");
+      } catch (error) {
+        // error-policy:J2 Release the connection before rethrowing the policy failure.
+        await response.body?.cancel();
+        throw error;
       }
       if (!response.ok) {
         throw new Error(

--- a/plugins/plugin-openai/models/transcription-url.node.ts
+++ b/plugins/plugin-openai/models/transcription-url.node.ts
@@ -1,0 +1,28 @@
+/**
+ * Node transcription-URL boundary: routes caller-supplied audio URLs through
+ * core's DNS-pinned `fetchRemoteMedia` SSRF guard. Only `index.node.ts`
+ * reaches this module, which keeps the `@elizaos/core/node` subpath — and the
+ * Node built-ins behind it — out of the browser bundle (#18702).
+ */
+import {
+  installTranscriptionUrlFetcher,
+  TRANSCRIPTION_AUDIO_FETCH_TIMEOUT_MS,
+  TRANSCRIPTION_AUDIO_MAX_BYTES,
+  TRANSCRIPTION_AUDIO_MAX_REDIRECTS,
+  toAudioBlob,
+} from "./transcription-url";
+
+export function installNodeTranscriptionUrlFetcher(): void {
+  installTranscriptionUrlFetcher(async (url) => {
+    // Load lazily so the heavy node entry is paid for only on the URL path.
+    // @trajectory-allow Fetches caller-provided audio bytes; no model inference happens here.
+    const { fetchRemoteMedia } = await import("@elizaos/core/node");
+    const media = await fetchRemoteMedia({
+      url,
+      maxBytes: TRANSCRIPTION_AUDIO_MAX_BYTES,
+      timeoutMs: TRANSCRIPTION_AUDIO_FETCH_TIMEOUT_MS,
+      maxRedirects: TRANSCRIPTION_AUDIO_MAX_REDIRECTS,
+    });
+    return toAudioBlob(media.buffer, media.contentType);
+  });
+}

--- a/plugins/plugin-openai/models/transcription-url.ts
+++ b/plugins/plugin-openai/models/transcription-url.ts
@@ -1,0 +1,40 @@
+/**
+ * Platform-split boundary for TRANSCRIPTION audio-URL loading. `models/audio.ts`
+ * is shared by both build targets, so it must never name a platform-specific
+ * core subpath; instead each build entrypoint (`index.node.ts` /
+ * `index.browser.ts`) installs its guarded fetcher here before the plugin is
+ * importable. Loading a URL with no installed fetcher fails closed rather than
+ * falling back to an unguarded fetch.
+ */
+import { detectAudioMimeType } from "../utils/audio";
+
+/** OpenAI Whisper/upload limit is 25 MB; keep the same hard cap server-side. */
+export const TRANSCRIPTION_AUDIO_MAX_BYTES = 25 * 1024 * 1024;
+export const TRANSCRIPTION_AUDIO_FETCH_TIMEOUT_MS = 30_000;
+export const TRANSCRIPTION_AUDIO_MAX_REDIRECTS = 5;
+
+export type TranscriptionUrlFetcher = (url: string) => Promise<Blob>;
+
+let platformFetcher: TranscriptionUrlFetcher | null = null;
+
+export function installTranscriptionUrlFetcher(fetcher: TranscriptionUrlFetcher): void {
+  platformFetcher = fetcher;
+}
+
+/** Wrap fetched audio bytes in a Blob, trusting an `audio/*` content type and sniffing otherwise. */
+export function toAudioBlob(bytes: Uint8Array, contentType?: string | null): Blob {
+  const mimeType = contentType?.startsWith("audio/") ? contentType : detectAudioMimeType(bytes);
+  return new Blob([new Uint8Array(bytes)], { type: mimeType });
+}
+
+export async function fetchAudioFromUrl(url: string): Promise<Blob> {
+  if (!url || url.trim().length === 0) {
+    throw new Error("TRANSCRIPTION requires a valid audio URL");
+  }
+  if (!platformFetcher) {
+    throw new Error(
+      "TRANSCRIPTION audio URLs require the platform build entrypoint (node or browser) to install its guarded fetcher"
+    );
+  }
+  return platformFetcher(url);
+}

--- a/plugins/plugin-openai/utils/audio.ts
+++ b/plugins/plugin-openai/utils/audio.ts
@@ -29,7 +29,7 @@ export type AudioMimeType =
   | "audio/webm"
   | "application/octet-stream";
 
-function matchBytes(buffer: Buffer, offset: number, expected: readonly number[]): boolean {
+function matchBytes(buffer: Uint8Array, offset: number, expected: readonly number[]): boolean {
   for (let i = 0; i < expected.length; i++) {
     const expectedByte = expected[i];
     if (expectedByte === undefined || buffer[offset + i] !== expectedByte) {
@@ -39,7 +39,7 @@ function matchBytes(buffer: Buffer, offset: number, expected: readonly number[])
   return true;
 }
 
-export function detectAudioMimeType(buffer: Buffer): AudioMimeType {
+export function detectAudioMimeType(buffer: Uint8Array): AudioMimeType {
   if (buffer.length < MIN_DETECTION_BUFFER_SIZE) {
     return "application/octet-stream";
   }


### PR DESCRIPTION
# Relates to

Fixes #18702 (Shaw's exact-head reopen 2026-08-13T00:32Z: browser/runtime contract for URL transcription). The Node SSRF path already landed in merged #18703 and is intentionally unchanged here. Sister google-genai residual #18699 is **not** closed by this PR (separate follow-up).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`) — base is the exact head `3326eecc535c039f82582ddf4abafb7e41f78579`.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker. → `bun run install:light` ran clean; root `bun run verify` was **not** run in this measured lane (see **Known gaps / failures**). Package-level gates all pass.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop` (`3326eecc`); zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below. → documented there.

# Risks

Low. The Node URL path keeps the identical `fetchRemoteMedia` guard and bounds (existing `transcription-ssrf.shape.test.ts` suite still passes unchanged in behavior). New surface is browser-only: a guarded fetch installed by the browser entrypoint, plus three pure re-exports on core's browser entry (`isBlockedHostname`, `isPrivateIpAddress`, `SsrfBlockedError` — string/IP logic with no Node deps). A consumer that imports neither entrypoint and calls the URL path now fails closed with an explicit error instead of silently reaching an unguarded fetch.

# Background

## What does this PR do?

`plugins/plugin-openai/models/audio.ts` dynamically imported `@elizaos/core/node` for every transcription URL, so a browser-target consumer bundle followed that explicit subpath into the Node artifact and failed on `node:crypto` / `node:os`. Blob/File/Buffer inputs avoided the branch, but the documented URL-transcription path could not reach the guarded fetch/provider flow in a browser consumer.

This PR splits the URL boundary by platform (Shaw's option 2, using core's shared SSRF policy for option 1's guard semantics):

- `models/transcription-url.ts` — shared registry + bounds (25 MB cap, 30 s timeout, 5 redirects) + empty-URL fail-closed. `models/audio.ts` no longer names any platform subpath.
- `models/transcription-url.node.ts` — installed by `index.node.ts`; identical DNS-pinned `fetchRemoteMedia` behavior as merged #18703.
- `models/transcription-url.browser.ts` — installed by `index.browser.ts`; browser-compatible guarded fetch: literal loopback/private/link-local/metadata hosts fail closed **before** the request via core's pure SSRF helpers, the final redirect landing host is re-validated (browser redirects are opaque), the shared byte cap is enforced while streaming, and an abort timer bounds wall time. DNS rebinding defense remains a Node-path property — a browser has no resolver access; CORS bounds what a page can read.
- `packages/core/src/index.browser.ts` — exports the three pure SSRF policy helpers so the browser boundary shares core's policy instead of duplicating it.
- Consumer-level browser regression: `__tests__/transcription-browser-consumer.shape.test.ts` bundles `index.browser.ts` with the production `Bun.build` settings (browser target, package.json externals, unminified) and asserts the emitted graph contains **no** `@elizaos/core/node` and **no** `node:` built-in specifiers, that the browser (not Node) fetcher registration ships, and that core's browser entry actually exports the helpers. Runtime behavior is covered by `__tests__/transcription-browser-url.shape.test.ts`.

## What kind of change is this?

Bug fix (non-breaking; restores the package's declared browser/runtime contract for URL transcription).

# Documentation changes needed?

None — no documented commands, env vars, or public API names change; the plugin's dual-build contract already documented in `plugins/plugin-openai/CLAUDE.md` now actually holds for the URL path.

# Testing

## Where should a reviewer start?

`plugins/plugin-openai/models/transcription-url.browser.ts` (the new boundary), then `__tests__/transcription-browser-consumer.shape.test.ts` (the consumer-level regression) and its helper `__tests__/helpers/browser-consumer-bundle.mjs`.

## Detailed testing steps

All commands were refreshed on exact head `757b6a3b898f068ed4adf6964ce45f655935ea03` (parent = `origin/develop` `3326eecc535c039f82582ddf4abafb7e41f78579`):

```bash
bun run --cwd plugins/plugin-openai test        # 22 files, 304 tests passed
bun run --cwd plugins/plugin-openai typecheck   # pass
bun run --cwd plugins/plugin-openai lint:check  # pass
bun run --cwd plugins/plugin-openai build       # Node + Browser + d.ts pass
bun run --cwd packages/core build               # Node + browser + edge + d.ts pass
```

Focused lane (the three suites this PR touches/adds):

```bash
bunx vitest run --config ./vitest.config.ts \
  __tests__/transcription-ssrf.shape.test.ts \
  __tests__/transcription-browser-url.shape.test.ts \
  __tests__/transcription-browser-consumer.shape.test.ts
# Test Files  3 passed (3) — Tests  26 passed (26)
```

Red-proof that the consumer regression catches the reopened defect — the same bundle probe run against the pre-fix tree vs this head:

```text
pre-fix : {"success":true,"hasCoreNodeSubpath":true, "registersBrowserFetcher":false,
           "coreBrowserExports":{"isBlockedHostname":"undefined","isPrivateIpAddress":"undefined","SsrfBlockedError":"undefined"}}
post-fix: {"success":true,"hasCoreNodeSubpath":false,"nodeBuiltins":[],"registersBrowserFetcher":true,
           "registersNodeFetcher":false,"coreBrowserExports":{"isBlockedHostname":"function","isPrivateIpAddress":"function","SsrfBlockedError":"function"}}
```

Shipped-artifact scan after `bun run --cwd plugins/plugin-openai build`:

```text
dist/browser/index.browser.js : 0 occurrences of "@elizaos/core/node", no node: imports
dist/node/index.node.js       : 1 occurrence  of "@elizaos/core/node" (expected — Node guard)
```

# Evidence Gate

<!-- evidence-head:757b6a3b898f068ed4adf6964ce45f655935ea03 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - plugin fetch/runtime boundary, no rendered UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - plugin fetch/runtime boundary, no rendered UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - plugin fetch/runtime boundary, no rendered UI or user flow`.
<!-- evidence-row:backend-logs -->
- [x] [18936-plugin-test-logs-757b6a3b.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18936-plugin-test-logs-757b6a3b.txt)
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - plugin fetch/runtime, no rendered UI; browser-consumer proof is the production-bundler graph regression below`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - provider calls mocked by design; the change is the pre-provider fetch boundary and no prompt/model/action behavior changes` (same evidence plan as #18702's issue body and merged #18703).
<!-- evidence-row:domain-artifacts -->
- [x] [18936-consumer-bundle-domain-757b6a3b.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18936-consumer-bundle-domain-757b6a3b.txt)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - provider calls are mocked by design in the focused suites; the contract under change is the pre-provider guarded-fetch boundary, and no prompt/model/action path changes.`

## Backend + frontend logs

<details>
<summary>Focused Vitest transcript (3 files, 26 tests)</summary>

```text
RUN  v4.1.5 /home/potter/src/eliza-18702-claude/plugins/plugin-openai

 ✓ __tests__/transcription-ssrf.shape.test.ts   (9 tests)
 ✓ __tests__/transcription-browser-url.shape.test.ts (13 tests)
 ✓ __tests__/transcription-browser-consumer.shape.test.ts (1 test)

 Test Files  3 passed (3)
      Tests  26 passed (26)
   Duration  8.16s
```

Full unit lane: `bun run --cwd plugins/plugin-openai test` → `Test Files 22 passed (22)`, `Tests 304 passed (304)`, duration 23.77s.

</details>

Frontend: `N/A - no rendered UI; the browser-consumer evidence is the production-bundler graph probe in Testing above.`

## Screenshots (before / after) + video walkthrough

`N/A - plugin fetch/runtime boundary; no rendered UI surface (not a packages/ui / packages/app render path).`

## Audio / voice walkthrough

`N/A - transcription transport/guard boundary only; no STT/TTS quality or audio pipeline behavior changes, and provider calls are mocked in the deterministic suites.`

## Known gaps / failures

- Root `bun run verify` was **not** run (multi-hour full-monorepo gate; this measured lane ran the owning-package gates instead: plugin test/typecheck/lint/build and the full multi-target core build, all passing as listed above). CI runs the full gate on this PR.
- Not verified in a real browser engine: the regression proves the production-bundler module graph (no `node:` / `@elizaos/core/node` in the browser artifact) and the boundary's runtime behavior under Vitest; no Playwright/browser-engine execution of the bundled artifact was performed.
- DNS-rebinding defense is intentionally not claimed for the browser path (no resolver access in a browser); literal-host fail-closed + redirect-landing re-validation + CORS are the browser-side properties, matching core's documented environment-agnostic guard branch.
- `usage.confidence` in the signed receipt below is `unavailable` (ccusage could not attribute this session's tokens), so it is a signed zero receipt per the skill contract — not fabricated usage.

---

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [claude-18702]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZWHH8WKEP5H9NH87CMH6XPW","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T03:09:29.363Z","completed_at":"2026-08-13T03:21:47.466Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA1wup-TpOQbidV6XOR-nWj5-01vmuc1Uuv5emKqsM8iA","device_key_id":"dbd0806ed31cfab14a18eeb4990c66497a5ce64fdb0d37d3c878b8f5e6227484","device_signature":"hOanFwQip8zw-E1WkDD-cSVDjoefwZ-Z9khiBO7aLEeQhWDhhGFTXX6kcwyhui_9RGxNuKdKjD09dCRvgRW3AQ"}} -->


