### PR TITLE
fix(elizaos): reject non-finite migrate-agent memory windows

### DIFF
--- a/packages/elizaos/src/commands/migrate-agent.ts
+++ b/packages/elizaos/src/commands/migrate-agent.ts
@@ -42,6 +42,11 @@ export interface MigrateAgentOptions {
  */
 let quiet = false;
 
+export function parseMemoryDays(value: string | undefined): number | null {
+  const parsed = value ? Number(value) : 14;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
 function fail(msg: string): never {
   if (quiet) {
     process.stderr.write(`${msg}\n`);
@@ -92,10 +97,9 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
   if (!fs.existsSync(sourceHome)) fail(`Home not found: ${sourceHome}`);
 
   const firewall = opts.noFirewall ? false : (opts.firewall ?? true);
-  const memoryDays = opts.memoryDays ? Number(opts.memoryDays) : 14;
-  if (Number.isNaN(memoryDays) || memoryDays < 0) {
-    fail("--memory-days must be a non-negative number.");
-  }
+  const memoryDays = parseMemoryDays(opts.memoryDays);
+  if (memoryDays === null)
+    fail("--memory-days must be a finite non-negative number.");
 
   if (!quiet) clack.intro(pc.cyan(`migrate-agent: ${sourceAgentId}`));
 

--- a/packages/elizaos/src/migrate/migrate.test.ts
+++ b/packages/elizaos/src/migrate/migrate.test.ts
@@ -13,7 +13,7 @@ import * as path from "node:path";
 // REAL importer, proving cross-package `.eliza-agent` format compatibility.
 import { importAgent } from "@elizaos/agent/services/agent-export";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { migrateAgent } from "../commands/migrate-agent.js";
+import { migrateAgent, parseMemoryDays } from "../commands/migrate-agent.js";
 import { buildElizaAgentArchive } from "./archive-format.js";
 import { assemblePayload } from "./archive-writer.js";
 import { mapToCharacter } from "./character-mapper.js";
@@ -664,5 +664,19 @@ describe("migrate-agent --json stdout purity (GAP E)", () => {
     expect(parsed.memoryCount).toBeGreaterThan(0);
     expect(parsed.summary).toHaveProperty("sqliteStores");
     expect(parsed.summary).toHaveProperty("warnings");
+  });
+});
+
+describe("migrate-agent memory-days validation", () => {
+  it("rejects non-finite values before they reach memory tiering", () => {
+    expect(parseMemoryDays("Infinity")).toBeNull();
+    expect(parseMemoryDays("-Infinity")).toBeNull();
+  });
+
+  it("preserves valid zero and default behavior", () => {
+    expect(parseMemoryDays("0")).toBe(0);
+    expect(parseMemoryDays(" ")).toBe(0);
+    expect(parseMemoryDays("14.5")).toBe(14.5);
+    expect(parseMemoryDays(undefined)).toBe(14);
   });
 });


### PR DESCRIPTION
# Relates to

Self-found bug; no numbered issue exists.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      focused regression tests and CLI reproduction below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. `--memory-days` is the only input affected; only `Infinity`/`-Infinity`
change behavior (from silently accepted to rejected). Every other input —
omitted default, `"0"`, whitespace-padded, decimal, scientific-notation,
negative, non-numeric — is byte-identical to before, independently verified
below.

# Background

## What does this PR do?

`elizaos migrate-agent --memory-days Infinity` previously passed validation:
the check was `Number.isNaN(memoryDays) || memoryDays < 0`, and `Infinity` is
neither `NaN` nor negative. The value then flows to
`packages/elizaos/src/migrate/memory-tiering.ts:143-175`, where
`Infinity * DAY_MS` produces a `-Infinity` tiering cutoff — every historical
daily log is classified as "recent" and seeded verbatim, regardless of the
window the operator actually requested.

Traced live call chain:
- CLI registration: `packages/elizaos/src/cli.ts:110-141`
- Validation (this fix): `packages/elizaos/src/commands/migrate-agent.ts:45,95-109`
- Final consumer: `packages/elizaos/src/migrate/memory-tiering.ts:143-175`

`parseMemoryDays` now requires `Number.isFinite` in addition to the existing
non-negative check, returning `null` (which the caller treats as a validation
failure) instead of a silently-accepted `Infinity`.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

1. `packages/elizaos/src/commands/migrate-agent.ts:45` (`parseMemoryDays`)
2. `packages/elizaos/src/migrate/migrate.test.ts:669`

## Detailed testing steps

```text
bun run --cwd packages/elizaos test -- src/migrate/migrate.test.ts
Test Files  1 passed (1)
     Tests  25 passed (25)

bunx @biomejs/biome check packages/elizaos/src/commands/migrate-agent.ts packages/elizaos/src/migrate/migrate.test.ts
Checked 2 files. No fixes applied.

bun run --cwd packages/elizaos typecheck
exit 0
```

All independently re-run and confirmed after rebase.

Real built-CLI reproduction (not just a unit test):

```text
node packages/elizaos/dist/cli.js migrate-agent \
  --from packages/elizaos/src/migrate/__tests__/fixtures/oc-home \
  --agent-id tess \
  --memory-days Infinity \
  --no-firewall --dry-run --json

exit=1
stderr=--memory-days must be a finite non-negative number.
```

Independent old-vs-new input sweep (manual, beyond the automated suite):

```text
memoryDays(undefined)      old=14         new=14
memoryDays("0")            old=0          new=0
memoryDays(" ")            old=0          new=0
memoryDays("14.5")         old=14.5       new=14.5
memoryDays("1e3")          old=1000       new=1000
memoryDays("  20  ")       old=20         new=20
memoryDays("-5")           old=REJECTED   new=REJECTED
memoryDays("abc")          old=REJECTED   new=REJECTED
memoryDays("-Infinity")    old=REJECTED   new=REJECTED
memoryDays("Infinity")     old=Infinity   new=REJECTED   <- fixed
```
Only `"Infinity"` changes; every other input is unchanged.

# Evidence Gate

<!-- evidence-head:9b49365991c923959ed10d839d8369df13394b74 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - CLI/backend logic, no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - CLI/backend logic, no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - non-interactive CLI validation change.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no server/runtime deployment path changed.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real built-CLI reproduction, exit code and stderr captured directly:
  ```text
  node packages/elizaos/dist/cli.js migrate-agent \
    --from packages/elizaos/src/migrate/__tests__/fixtures/oc-home \
    --agent-id tess \
    --memory-days Infinity \
    --no-firewall --dry-run --json

  exit=1
  stderr=--memory-days must be a finite non-negative number.
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface.

# Known gaps / failures

Full root `bun run verify` was not run locally; the focused package tests,
typecheck, Biome, and a real built-CLI reproduction all passed on the changed
files.

CI's `lint` and `Quality` checks currently fail on this PR, but both fail at
the identical, single root cause: a pre-existing Biome formatting error in
`packages/cloud/shared/scripts/messaging-gateway-preflight.mjs` — a file
this PR does not touch, in a package (`@elizaos/cloud-shared`) this PR does
not touch. Confirmed by reproducing the exact same failure against unmodified
`origin/develop` content for that file. Every check scoped to the actual
changed files (`packages/elizaos/src/commands/migrate-agent.ts`,
`packages/elizaos/src/migrate/migrate.test.ts`) passes — see Testing above.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [hunt-and-implement-4]

