### PR TITLE
fix(cloud): warm-pool health sweep tolerates transient probe misses

### DIFF
--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-forecast.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-forecast.ts
@@ -99,6 +99,16 @@ export interface WarmPoolPolicy {
   replenishCooldownMs: number;
   /** Max pool entries created in a single replenish tick. */
   replenishBurstLimit: number;
+  /**
+   * Health probes per ready entry per sweep before it is declared dead. The
+   * probe crosses the headscale mesh, which routinely has >5s transient
+   * hiccups — the creator's own birth-polling observes several consecutive
+   * misses before the first success on the same URL — so a single missed
+   * probe must never reap a healthy container.
+   */
+  healthProbeAttempts: number;
+  /** Spacing between those retry probes for a still-failing entry. */
+  healthProbeRetryDelayMs: number;
 }
 
 export const DEFAULT_WARM_POOL_POLICY: WarmPoolPolicy = {
@@ -111,4 +121,9 @@ export const DEFAULT_WARM_POOL_POLICY: WarmPoolPolicy = {
   stuckProvisioningMs: 10 * 60 * 1000,
   replenishCooldownMs: 60 * 1000,
   replenishBurstLimit: 3,
+  // Retries run concurrently across failing rows, so the sweep's worst-case
+  // extra time is (attempts - 1) × (delay + 5s probe timeout) = 18s — well
+  // inside the provisioning worker's 60s phase budget.
+  healthProbeAttempts: 3,
+  healthProbeRetryDelayMs: 4 * 1000,
 };

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.error-policy.test.ts
@@ -11,11 +11,16 @@
  *   - a probe THROW propagates and destroys NOTHING (fail-closed);
  *   - a designed `false` (unreachable) reaps the row (destroy called);
  *   - a `true` probe keeps the row alive.
- * It also pins the J6 teardown branch: a destroy failure is recorded, not thrown.
+ * It also pins the J6 teardown branch (a destroy failure is recorded, not
+ * thrown) and the retry round: the probe crosses the headscale mesh, whose
+ * transient >5s hiccups made one-strike reaping destroy every ready entry, so
+ * a row is reaped only after `healthProbeAttempts` consecutive misses, retried
+ * concurrently with the fixed policy spacing and nothing else.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { PoolContainerCreator } from "./agent-warm-pool";
+import { DEFAULT_WARM_POOL_POLICY } from "./agent-warm-pool-forecast";
 
 const repo = {
   listClaimablePool: mock(async () => [] as Array<{ id: string }>),
@@ -62,6 +67,27 @@ function fakeCreator(overrides: Partial<PoolContainerCreator> = {}): {
   return { creator, destroy, probe };
 }
 
+/** Instant sleep spy — records requested delays, never waits real time. */
+function instantSleep(): { sleepFn: (ms: number) => Promise<void>; delays: number[] } {
+  const delays: number[] = [];
+  return {
+    delays,
+    sleepFn: async (ms: number) => {
+      delays.push(ms);
+    },
+  };
+}
+
+const now = () => Date.now();
+
+/** Bounded poll for an async condition — the suite never waits unboundedly. */
+async function waitFor(cond: () => boolean, label: string): Promise<void> {
+  for (let i = 0; i < 500 && !cond(); i++) {
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  if (!cond()) throw new Error(`timed out waiting for ${label}`);
+}
+
 beforeEach(() => {
   warmPoolEnabled = true;
   repo.listClaimablePool.mockReset();
@@ -96,20 +122,24 @@ describe("healthCheck fails closed on an internal probe failure", () => {
 });
 
 describe("healthCheck designed paths stay distinct from the failure", () => {
-  test("a designed `false` (unreachable) reaps the row — destroy IS called", async () => {
+  test("a designed `false` on EVERY attempt reaps the row — destroy IS called", async () => {
     const { WarmPoolManager } = await load();
     repo.listClaimablePool.mockResolvedValue([{ id: "dead-1" }]);
 
     const destroy = mock(async () => undefined);
     const probe = mock(async () => false);
     const { creator } = fakeCreator({ destroyPoolContainer: destroy, healthProbe: probe });
-    const manager = new WarmPoolManager(creator);
+    const { sleepFn } = instantSleep();
+    const manager = new WarmPoolManager(creator, DEFAULT_WARM_POOL_POLICY, now, sleepFn);
 
     const result = await manager.healthCheck();
+    expect(probe).toHaveBeenCalledTimes(DEFAULT_WARM_POOL_POLICY.healthProbeAttempts);
     expect(destroy).toHaveBeenCalledTimes(1);
     expect(destroy).toHaveBeenCalledWith("dead-1");
     expect(result.alive).toBe(0);
-    expect(result.removed).toEqual([{ id: "dead-1", reason: "health probe failed" }]);
+    expect(result.removed).toEqual([
+      { id: "dead-1", reason: "health probe failed after 3 attempts" },
+    ]);
   });
 
   test("a `true` probe keeps the row alive — destroy NOT called", async () => {
@@ -137,7 +167,8 @@ describe("healthCheck designed paths stay distinct from the failure", () => {
       throw new Error("ssh timeout");
     });
     const { creator } = fakeCreator({ destroyPoolContainer: destroy, healthProbe: probe });
-    const manager = new WarmPoolManager(creator);
+    const { sleepFn } = instantSleep();
+    const manager = new WarmPoolManager(creator, DEFAULT_WARM_POOL_POLICY, now, sleepFn);
 
     // Teardown is best-effort: the pass completes and the failure is surfaced in
     // the reason (retried next pass), NOT swallowed into a clean removal.
@@ -145,6 +176,138 @@ describe("healthCheck designed paths stay distinct from the failure", () => {
     expect(result.removed).toHaveLength(1);
     expect(result.removed[0]?.id).toBe("dead-2");
     expect(result.removed[0]?.reason).toContain("destroy errored: ssh timeout");
+  });
+});
+
+describe("healthCheck retry round tolerates transient mesh hiccups", () => {
+  test("a transient miss (fail, fail, pass) RETAINS the entry — destroy NOT called", async () => {
+    const { WarmPoolManager } = await load();
+    repo.listClaimablePool.mockResolvedValue([{ id: "flaky-1" }]);
+
+    let calls = 0;
+    const probe = mock(async () => {
+      calls++;
+      return calls >= 3; // first probe + first retry miss, second retry answers
+    });
+    const destroy = mock(async () => undefined);
+    const { creator } = fakeCreator({ destroyPoolContainer: destroy, healthProbe: probe });
+    const { sleepFn, delays } = instantSleep();
+    const manager = new WarmPoolManager(creator, DEFAULT_WARM_POOL_POLICY, now, sleepFn);
+
+    const result = await manager.healthCheck();
+    expect(probe).toHaveBeenCalledTimes(3);
+    expect(destroy).not.toHaveBeenCalled();
+    expect(result.alive).toBe(1);
+    expect(result.removed).toEqual([]);
+    // Each retry waited exactly the fixed policy spacing.
+    expect(delays).toEqual([
+      DEFAULT_WARM_POOL_POLICY.healthProbeRetryDelayMs,
+      DEFAULT_WARM_POOL_POLICY.healthProbeRetryDelayMs,
+    ]);
+  });
+
+  test("retry waits are BOUNDED: exactly attempts-1 spaced probes per failing row, never more", async () => {
+    const { WarmPoolManager } = await load();
+    repo.listClaimablePool.mockResolvedValue([{ id: "dead-3" }]);
+
+    const probe = mock(async () => false);
+    const destroy = mock(async () => undefined);
+    const { creator } = fakeCreator({ destroyPoolContainer: destroy, healthProbe: probe });
+    const { sleepFn, delays } = instantSleep();
+    const manager = new WarmPoolManager(creator, DEFAULT_WARM_POOL_POLICY, now, sleepFn);
+
+    const result = await manager.healthCheck();
+    // 3 attempts total: 1 first-pass probe + 2 retries, each behind one wait.
+    expect(probe).toHaveBeenCalledTimes(DEFAULT_WARM_POOL_POLICY.healthProbeAttempts);
+    expect(delays).toEqual([
+      DEFAULT_WARM_POOL_POLICY.healthProbeRetryDelayMs,
+      DEFAULT_WARM_POOL_POLICY.healthProbeRetryDelayMs,
+    ]);
+    expect(result.removed).toEqual([
+      { id: "dead-3", reason: "health probe failed after 3 attempts" },
+    ]);
+  });
+
+  test("suspect rows retry CONCURRENTLY — both waits open before either resolves", async () => {
+    const { WarmPoolManager } = await load();
+    repo.listClaimablePool.mockResolvedValue([{ id: "s-1" }, { id: "s-2" }]);
+
+    const pending: Array<() => void> = [];
+    const delays: number[] = [];
+    const sleepFn = (ms: number) =>
+      new Promise<void>((resolve) => {
+        delays.push(ms);
+        pending.push(resolve);
+      });
+
+    // The sequential first pass misses both rows; every retry probe answers.
+    let firstPass = 0;
+    const probe = mock(async () => {
+      if (firstPass < 2) {
+        firstPass++;
+        return false;
+      }
+      return true;
+    });
+    const destroy = mock(async () => undefined);
+    const { creator } = fakeCreator({ destroyPoolContainer: destroy, healthProbe: probe });
+    const manager = new WarmPoolManager(creator, DEFAULT_WARM_POOL_POLICY, now, sleepFn);
+
+    const resultPromise = manager.healthCheck();
+    // Sequential retries would open one wait at a time; the sweep's bounded
+    // worst case relies on all suspects waiting simultaneously.
+    await waitFor(() => pending.length === 2, "both suspects' retry waits to open");
+    expect(delays).toEqual([
+      DEFAULT_WARM_POOL_POLICY.healthProbeRetryDelayMs,
+      DEFAULT_WARM_POOL_POLICY.healthProbeRetryDelayMs,
+    ]);
+    for (const release of pending.splice(0)) release();
+
+    const result = await resultPromise;
+    expect(result.alive).toBe(2);
+    expect(destroy).not.toHaveBeenCalled();
+    expect(result.removed).toEqual([]);
+  });
+
+  test("an internal throw during a RETRY propagates and destroys NOTHING — even a confirmed-dead sibling", async () => {
+    const { WarmPoolManager } = await load();
+    repo.listClaimablePool.mockResolvedValue([{ id: "flaky-2" }, { id: "dead-4" }]);
+
+    const dbError = new Error("findById: connection reset");
+    let flakyCalls = 0;
+    const probe = mock(async (id: string) => {
+      if (id === "dead-4") return false; // misses every attempt
+      flakyCalls++;
+      if (flakyCalls === 1) return false; // first pass misses…
+      throw dbError; // …then its retry hits an internal failure
+    });
+    const destroy = mock(async () => undefined);
+    const { creator } = fakeCreator({ destroyPoolContainer: destroy, healthProbe: probe });
+    const { sleepFn } = instantSleep();
+    const manager = new WarmPoolManager(creator, DEFAULT_WARM_POOL_POLICY, now, sleepFn);
+
+    // Indeterminate sweep ⇒ fail closed: the error surfaces and NO row is
+    // reaped, including the sibling whose probes all designed-failed.
+    await expect(manager.healthCheck()).rejects.toBe(dbError);
+    expect(destroy).not.toHaveBeenCalled();
+  });
+
+  test("zero claimable rows ⇒ no probes and no retry waits", async () => {
+    const { WarmPoolManager } = await load();
+    repo.listClaimablePool.mockResolvedValue([]);
+
+    const destroy = mock(async () => undefined);
+    const probe = mock(async () => true);
+    const { creator } = fakeCreator({ destroyPoolContainer: destroy, healthProbe: probe });
+    const { sleepFn, delays } = instantSleep();
+    const manager = new WarmPoolManager(creator, DEFAULT_WARM_POOL_POLICY, now, sleepFn);
+
+    const result = await manager.healthCheck();
+    expect(probe).not.toHaveBeenCalled();
+    expect(delays).toEqual([]);
+    expect(destroy).not.toHaveBeenCalled();
+    expect(result.probed).toBe(0);
+    expect(result.removed).toEqual([]);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
@@ -214,6 +214,8 @@ export class WarmPoolManager {
     private readonly creator: PoolContainerCreator,
     private readonly policy: WarmPoolPolicy = DEFAULT_WARM_POOL_POLICY,
     private readonly nowFn: () => number = () => Date.now(),
+    private readonly sleepFn: (ms: number) => Promise<void> = (ms) =>
+      new Promise((resolve) => setTimeout(resolve, ms)),
   ) {}
 
   /**
@@ -350,6 +352,11 @@ export class WarmPoolManager {
     const removed: Array<{ id: string; reason: string }> = [...reconciliation.reaped];
     let alive = reconciliation.promoted.length;
 
+    // A single missed probe no longer reaps a row: the probe crosses the
+    // headscale mesh, whose routine >5s transient hiccups made one-strike
+    // reaping destroy every ready entry within a couple of sweeps. Rows that
+    // miss the first probe get a bounded, spaced retry round instead.
+    const suspects: Array<{ id: string }> = [];
     for (const row of rows) {
       // `healthProbe` is contracted to return false for an unreachable
       // container and only throws on an internal failure (its lookup/DB read).
@@ -361,15 +368,24 @@ export class WarmPoolManager {
         alive++;
         continue;
       }
+      suspects.push({ id: row.id });
+    }
+
+    const confirmedDead = await this.retrySuspectProbes(suspects);
+    alive += suspects.length - confirmedDead.length;
+    const attempts = Math.max(1, this.policy.healthProbeAttempts);
+    const deadReason =
+      attempts === 1 ? "health probe failed" : `health probe failed after ${attempts} attempts`;
+    for (const row of confirmedDead) {
       try {
         await this.creator.destroyPoolContainer(row.id);
-        removed.push({ id: row.id, reason: "health probe failed" });
+        removed.push({ id: row.id, reason: deadReason });
       } catch (err) {
         // error-policy:J6 best-effort teardown — destroy is idempotent and the
         // next health-check pass retries; record the failure in the reason.
         removed.push({
           id: row.id,
-          reason: `probe failed; destroy errored: ${err instanceof Error ? err.message : String(err)}`,
+          reason: `${deadReason}; destroy errored: ${err instanceof Error ? err.message : String(err)}`,
         });
       }
     }
@@ -415,6 +431,42 @@ export class WarmPoolManager {
       reconciliation,
       removed,
     };
+  }
+
+  /**
+   * Re-probe ready entries that missed their first health probe, up to
+   * `healthProbeAttempts - 1` extra times spaced `healthProbeRetryDelayMs`
+   * apart, and return only the rows that failed every attempt. Suspects retry
+   * concurrently so the sweep's worst case stays (attempts - 1) × (delay +
+   * probe timeout) regardless of row count — bounded inside the daemon's
+   * phase budget. `healthProbe`'s contract is preserved: an internal throw
+   * from any attempt propagates (via allSettled + rethrow, so a sibling row's
+   * in-flight probe can never become an unhandled rejection) and NOTHING is
+   * reaped from an indeterminate sweep.
+   */
+  private async retrySuspectProbes(
+    suspects: Array<{ id: string }>,
+  ): Promise<Array<{ id: string }>> {
+    if (suspects.length === 0) return [];
+    const retries = Math.max(0, this.policy.healthProbeAttempts - 1);
+    if (retries === 0) return suspects;
+
+    const outcomes = await Promise.allSettled(
+      suspects.map(async (row) => {
+        for (let attempt = 0; attempt < retries; attempt++) {
+          await this.sleepFn(this.policy.healthProbeRetryDelayMs);
+          if (await this.creator.healthProbe(row.id)) return null;
+        }
+        return row;
+      }),
+    );
+    const rejection = outcomes.find(
+      (outcome): outcome is PromiseRejectedResult => outcome.status === "rejected",
+    );
+    if (rejection) throw rejection.reason;
+    return outcomes.flatMap((outcome) =>
+      outcome.status === "fulfilled" && outcome.value !== null ? [outcome.value] : [],
+    );
   }
 
   async rollout(image: string): Promise<RolloutResult> {


### PR DESCRIPTION
## Problem
`WarmPoolManager.healthCheck()`'s ready-entry sweep probes each claimable warm-pool entry with a **single** `fetch(health_url)` (5s abort) over the headscale mesh and **destroys the entry on one miss** ("health probe failed"). The mesh routinely shows >5s transient hiccups — the creator's own birth-polling observes 5–6 consecutive misses over ~20–30s before the first pass, at low node load. Verified on prod tonight: healthy entries reached full readiness in ~40–75s, then were destroyed by the sweep within ~5–10 minutes (journal receipts; direct in-process `deleteAgent`, no job row), so the pool never held entries, replenish logged `total 0 < target 2; creating 2` every cycle (~16 spawns/hr), and onboarding lost its warm pool. This was the final layer of tonight's churn stack, alongside the CI-runner co-location (remediated operationally) and the provision-path fencing (#18933's sibling findings).

## Fix — tolerate transient misses before destroying
First probe pass is unchanged (sequential; internal throws still propagate). A missed first probe now marks the row a **suspect** instead of destroying it; suspects get a bounded, **concurrent** retry round — up to `healthProbeAttempts` (default 3) total probes spaced `healthProbeRetryDelayMs` (default 4s) — and only rows failing every attempt are destroyed, with reason `health probe failed after 3 attempts`. Knobs live on `WarmPoolPolicy` (flow through `envWarmPoolPolicy()`); an injectable `sleepFn` keeps tests deterministic. Worst-case sweep overhead is (attempts−1)×(delay+probe timeout) ≈ 18s regardless of row count — inside the daemon's 60s phase budget. A throw from any retry propagates and **nothing is reaped from an indeterminate sweep** (strictly safer than the old destroy-then-throw ordering). `healthProbeAttempts: 1` degrades to exact legacy behavior. `reconcileUnclaimable` deliberately keeps its single probe (CAS-fenced rare-crash repair on the replenish path, not standing capacity). No changes to `eliza-sandbox.ts`, the deletion pipeline, or schemas.

## Tests
5 new + 2 updated in `agent-warm-pool.error-policy.test.ts` (drives the real `healthCheck()`): transient fail-fail-pass → retained; persistent → destroyed with after-N reason; retry-throw → propagates by identity and reaps nothing; bounded + concurrent retry timing (waits open simultaneously); zero rows → zero probes. Suites: brief command **24/0**, error-policy **10/0**, full `provisioning-worker.*.test.ts` **64/0**; biome + tsc clean on touched files. (Known pre-existing: running the four shared warm-pool suites in one non-isolated bun process leaks `mock.module` — reproduced identically on pristine develop; the package runner uses `--isolate`.)

## Do not merge yet
Candidate for @0xSolace's review, merge **post-launch**. Sibling of #18933 (orphan sweeper); together with the CI-runner separation these close the warm-pool churn.

## Evidence Gate

<!-- evidence-head:2ec14af829cd4465f728f32b0a13d7c25dfe68ea -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend warm-pool manager change touches no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - the change edits control-plane pool-sweep logic and produces no application pixels to capture.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a deterministic health-sweep retry policy with no interactive user flow to record.
<!-- evidence-row:backend-logs -->
- [x] N/A - the retry behavior is proven by the ten error-policy tests driving the real healthCheck and is green in the PR checks; a live sweep log is only producible after a production deploy of the provisioning worker, which is the reviewer merge and deploy lane.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path is exercised by this pool-sweep change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, action, or agent behavior changes here, so this deterministic infrastructure sweep policy invokes no language model.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the change creates no runtime domain state and the sweep policy is exercised entirely by the added unit tests.

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored via an internal Fable build workflow, not the pinned contribute-to-eliza skill
<!-- attribution-row:status -->
- Attribution status: self-reported
