### PR TITLE
docs(cloud): codify CI-runner / agent-node placement policy

### DIFF
--- a/packages/cloud/infra/RUNNER-PLACEMENT.md
+++ b/packages/cloud/infra/RUNNER-PLACEMENT.md
@@ -1,0 +1,46 @@
+# CI runner placement policy
+
+**Rule: GitHub Actions self-hosted runners MUST NOT run on hosts that serve as
+agent docker-nodes (rows in `docker_nodes` hosting `agent-*` containers).**
+
+## Why (incident, 2026-08-13)
+
+Four production agent nodes (`eliza-core-prod-3/4/5/6`) each also hosted four
+Actions runners. Launch-window PR volume ran Playwright browser farms on them,
+pinning 12-core hosts at load 10–20. The saturation made `docker stop/rm`
+exceed the deliberately bounded `STOP_CMD_TIMEOUT_MS` (25s — protects the
+provisioning-worker cycle and its DB advisory lock), which cascaded:
+half-failed warm-pool provisions self-fenced (`replacement_cleanup_sandbox_id`
+pointing at their own container), were reaped at the reconciliation deadline,
+orphaned, and drove the pool to respawn ~16 agents/hour against a target of 2 —
+degrading real user onboarding provisions ("Registered Docker nodes exist but
+none available", provision/health-check timeouts). A secondary defect amplified
+it: the pool health sweep destroyed ready entries on a single missed 5s probe
+(fixed by the probe-retry change alongside the per-cycle deletion reconcile
+sweep in the provisioning worker).
+
+Full evidence chain: elizaOS/eliza discussion #18309 (2026-08-13 comments).
+
+## Enforcement state
+
+Runner installations live OUTSIDE this repo (hand-provisioned on the Hetzner
+robot hosts), so this policy cannot be enforced by repo code today. The
+2026-08-13 remediation enforced it at three operational levels on the four
+affected hosts: runner services **stopped**, **disabled** (reboot-safe, with
+`/opt/actions-runners/WHY-DISABLED-20260813.md` on each box), and
+**deregistered** from the repository runner registry. Re-adding CI capacity to
+any agent node therefore requires a deliberate re-registration — do not, unless
+the host no longer appears in `docker_nodes` or no longer hosts `agent-*`
+containers.
+
+Dedicated CI capacity: the `eliza-robot-*` runner farm (no co-located agents).
+Emergency fallback if self-hosted capacity drains: set the repository variable
+`HETZNER_FLEET_ONLINE=false` — every workflow lane falls back to GitHub-hosted
+runners by design.
+
+## If you provision new nodes or new runners
+
+- New agent docker-node → never install an Actions runner on it.
+- New runner host → keep it out of `docker_nodes`.
+- If a host must change roles, remove it from one plane before adding it to the
+  other, and update this document.


### PR DESCRIPTION
## What
Codifies in-repo the placement rule proven by the 2026-08-13 incident: **CI self-hosted runners must not share hosts with agent docker-nodes.** Documents the incident chain (runner browser farms → node saturation → docker-op timeouts → warm-pool self-fence/reap churn → onboarding provision failures), the three-level operational enforcement applied (stop + disable + registry deregistration), the dedicated `eliza-robot-*` farm, the `HETZNER_FLEET_ONLINE=false` designed fallback, and rules for provisioning new nodes/runners. Runner installs live outside this repo, so a policy doc where infra work happens is the strongest in-repo formalization available; sibling of #18933/#18941.

## Evidence Gate

<!-- evidence-head:edc3b31ee4e78f98687adfc67c754b05575e7085 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - documentation-only infra policy file renders no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - a markdown policy document captures no application pixels.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - a static policy document has no interactive user flow to record.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime code path changes; the referenced incident evidence lives in discussion 18309.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network behavior is touched by a docs-only change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, action, or agent behavior changes in a documentation-only commit.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the policy document itself is the reviewed source diff and creates no runtime state.

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored directly in session, not via the pinned contribute-to-eliza skill
<!-- attribution-row:status -->
- Attribution status: self-reported
