### PR TITLE
fix(agent): terminal user-facing hygiene — no raw stdout prepend, size-capped relay, secret redaction

### DIFF
--- a/packages/agent/src/actions/terminal-effect-receipt.test.ts
+++ b/packages/agent/src/actions/terminal-effect-receipt.test.ts
@@ -218,3 +218,48 @@ describe("terminal action effect proof", () => {
     });
   });
 });
+
+describe("terminal command-line secret hygiene", () => {
+  beforeEach(() => {
+    vi.stubEnv("ELIZA_BUILD_VARIANT", "direct");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("redacts secrets embedded in the command line before any consumer sees it", async () => {
+    const secret = "sk-proj-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const leakyCommand = `curl -H "Authorization: Bearer ${secret}" https://api.example.com`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        terminalResponse({ command: leakyCommand, stdout: "ok\n" }),
+      ),
+    );
+
+    const createMemory = vi.fn(
+      async () => "00000000-0000-0000-0000-000000000004",
+    );
+    const rt = {
+      agentId: "00000000-0000-0000-0000-000000000001",
+      createMemory,
+    } as unknown as IAgentRuntime;
+
+    const result = (await terminalAction.handler(
+      rt,
+      message(),
+      undefined,
+      options(leakyCommand),
+    )) as { text?: string; data?: unknown };
+
+    const surfaces = [
+      result.text ?? "",
+      JSON.stringify(result.data ?? {}),
+      JSON.stringify(createMemory.mock.calls),
+    ].join("\n");
+    expect(surfaces).not.toContain(secret);
+    expect(surfaces).toContain("curl");
+  });
+});

--- a/packages/agent/src/actions/terminal-effect-receipt.test.ts
+++ b/packages/agent/src/actions/terminal-effect-receipt.test.ts
@@ -74,7 +74,7 @@ describe("terminal action effect proof", () => {
     expect(result).toMatchObject({
       success: true,
       userFacingText: "hello",
-      verifiedUserFacing: true,
+      verifiedUserFacing: false,
       userFacingEffectReceiptIds: [
         "terminal-run:run-7f72b2d2-741f-48d9-8571-4ac9918d6a6e",
       ],
@@ -115,6 +115,7 @@ describe("terminal action effect proof", () => {
       success: false,
       error: "TERMINAL_EXECUTION_FAILED",
       userFacingText: "The command failed with exit code 7.",
+      verifiedUserFacing: true,
       effectReceipts: [
         {
           outcome: "failed",
@@ -125,6 +126,59 @@ describe("terminal action effect proof", () => {
           },
         },
       ],
+    });
+  });
+
+  it("does not stamp raw stdout as verified user-facing text", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        terminalResponse({
+          command:
+            "git ls-remote --heads https://github.com/elizaOS/eliza develop",
+          stdout:
+            "ebcf7fff00000000000000000000000000000000\trefs/heads/develop\n",
+        }),
+      ),
+    );
+
+    const result = await terminalAction.handler(
+      runtime(),
+      message(),
+      undefined,
+      options("git ls-remote --heads https://github.com/elizaOS/eliza develop"),
+    );
+
+    // Kept as the deterministic fallback relay…
+    expect(result).toMatchObject({
+      success: true,
+      userFacingText:
+        "ebcf7fff00000000000000000000000000000000\trefs/heads/develop",
+    });
+    // …but never verbatim-verified: that stamp is what let the relay ship the
+    // raw SHA line as a standalone leading paragraph before the natural reply.
+    expect(
+      (result as { verifiedUserFacing?: boolean }).verifiedUserFacing,
+    ).toBe(false);
+  });
+
+  it("keeps the deterministic empty-stdout success sentence verified", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => terminalResponse({ stdout: "" })),
+    );
+
+    const result = await terminalAction.handler(
+      runtime(),
+      message(),
+      undefined,
+      options("true"),
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      userFacingText: "The command finished successfully with exit code 0.",
+      verifiedUserFacing: true,
     });
   });
 

--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -469,8 +469,13 @@ export const terminalAction: Action = {
     // stderr at the source, so no downstream path — the model-facing diagnostic
     // preview, the user-facing chat relay, or the stored output attachment —
     // can echo a plaintext secret that happened to appear in command output.
+    // The command LINE itself is a leak vector too (curl -H "Authorization:
+    // Bearer <token>", psql postgres://user:pass@host): scrub it once here so
+    // every consumer — "Command:" artifact header, attachment title and
+    // description, and the model-facing action text — sees the redacted form.
     const capturedRun: CapturedTerminalRun = {
       ...rawRun,
+      command: redactSensitiveText(rawRun.command, { mode: "tools" }),
       stdout: redactSensitiveText(rawRun.stdout, { mode: "tools" }),
       stderr: redactSensitiveText(rawRun.stderr, { mode: "tools" }),
     };

--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -27,6 +27,7 @@ import {
   ElizaError,
   isLocalCodeExecutionAllowed,
   logger,
+  redactSensitiveText,
   stringToUuid,
 } from "@elizaos/core";
 import { readAliasedEnv, resolveServerOnlyPort } from "@elizaos/shared";
@@ -302,6 +303,15 @@ function terminalEffectReceipt(
   };
 }
 
+// Max raw stdout, in chars, that may be relayed verbatim as the user-facing
+// message. Small single-line results (a SHA, a count, a path) are useful to
+// echo for "run X and tell me the value" turns; anything larger — or with
+// multiple lines — must NOT be dumped to the (possibly shared) channel, or a
+// `cat`/`grep` of a config or secrets file leaks its contents. Larger output
+// stays available to the model through the action's diagnostic `text`, so it
+// can still answer specifics from context without the raw dump.
+const TERMINAL_RELAY_MAX_CHARS = 200;
+
 function terminalUserFacingText(
   result: CapturedTerminalRun,
   cleanStdout: string,
@@ -312,7 +322,14 @@ function terminalUserFacingText(
   if (result.exitCode !== 0) {
     return `The command failed with exit code ${result.exitCode}.`;
   }
-  return cleanStdout || "The command finished successfully with exit code 0.";
+  if (!cleanStdout) {
+    return "The command finished successfully with exit code 0.";
+  }
+  const lineCount = cleanStdout.split("\n").length;
+  if (cleanStdout.length <= TERMINAL_RELAY_MAX_CHARS && lineCount <= 1) {
+    return cleanStdout;
+  }
+  return `The command finished (exit 0) with ${lineCount} line${lineCount === 1 ? "" : "s"} of output; ask me about specifics instead of dumping it into chat.`;
 }
 
 function buildCapturedResponseText(
@@ -446,7 +463,17 @@ export const terminalAction: Action = {
         severity: "fatal",
       });
     }
-    const capturedRun = normalizeCapturedRun(command, responseBody);
+    const rawRun = normalizeCapturedRun(command, responseBody);
+    // Secret hygiene: scrub known secret shapes (API keys, tokens, Bearer
+    // headers, PEM private keys, credential env/JSON fields) out of stdout and
+    // stderr at the source, so no downstream path — the model-facing diagnostic
+    // preview, the user-facing chat relay, or the stored output attachment —
+    // can echo a plaintext secret that happened to appear in command output.
+    const capturedRun: CapturedTerminalRun = {
+      ...rawRun,
+      stdout: redactSensitiveText(rawRun.stdout, { mode: "tools" }),
+      stderr: redactSensitiveText(rawRun.stderr, { mode: "tools" }),
+    };
     const boundedRun = {
       ...capturedRun,
       stdout: truncateForData(capturedRun.stdout),
@@ -479,7 +506,14 @@ export const terminalAction: Action = {
       text: buildCapturedResponseText(capturedRun, outputAttachment),
       success: succeeded,
       userFacingText,
-      verifiedUserFacing: true,
+      // Raw stdout stays available as the deterministic fallback relay for
+      // "run X" turns, but must not carry the do-not-paraphrase stamp: verified
+      // text outranks and prepends to the evaluator's prose in the final-message
+      // precedence, which shipped bare command output (e.g. a `git ls-remote`
+      // SHA line) as a leading junk paragraph before the natural reply. Only
+      // the action-owned deterministic sentences (failure, timeout,
+      // empty-stdout success) keep the verbatim-relay promise.
+      verifiedUserFacing: cleanStdout.length === 0,
       effectReceipts: [effectReceipt],
       userFacingEffectReceiptIds: [effectReceipt.receiptId],
       ...(succeeded


### PR DESCRIPTION
## What
Terminal user-facing hygiene: (1) `verifiedUserFacing` only for the action's deterministic sentences so raw stdout stops prepending to replies; (2) size-capped relay — only small single-line output (a SHA, a count) relays verbatim; larger/multi-line output is summarized so a `cat` can't dump file contents into a shared channel; (3) stdout/stderr pass through core `redactSensitiveText(mode: tools)` before model context, chat relay, or stored attachments.

# Evidence Gate

Evidence matches the exact commit reviewed.
<!-- evidence-head:dc6cbb470abb0d97b88b8d7e3afac36e5328538e -->

<!-- evidence-row:before-screenshots -->
N/A - backend-only change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
N/A - backend-only change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
N/A - backend-only change; no rendered UI surface.
<!-- evidence-row:backend-logs -->
```
$ probe: "run `echo hello-from-qa && date -u` and tell me what it printed"
[live agent nubilio, Discord test channel 1490836448755060920]
delivered message (ONE, no `$ cmd / [exit 0] / --- stdout ---` block prepended):
  hello-from-qa
  Thu Aug 13 02:32:40 UTC 2026
before this change the same ask delivered the raw transcript block as its own
message ahead of the answer (two messages, machinery noise first).
```
<!-- evidence-row:frontend-logs -->
N/A - backend-only change; no rendered UI surface.
<!-- evidence-row:llm-trajectory -->
```
{"stage": "planner", "provider": "cerebras", "model": "gemma-4-31b", "input": {"messages": [{"role": "user", "content": "run df -h on / and tell me if the disk is ok"}]}, "output": {"response": null, "toolCalls": [{"name": "TERMINAL_SHELL"}]}}
{"stage": "tool", "provider": "eliza-runtime", "model": "action-dispatch", "input": {"request": {"tool": "TERMINAL_SHELL"}}, "output": {"steps": [{"tool": "TERMINAL_SHELL", "success": true, "turnComplete": null, "verifiedUserFacing": false, "userFacingText": "The command finished (exit 0) with 2 lines of output; ask me about specifics instead of dumping it into chat."}]}}
{"stage": "evaluation", "provider": "cerebras", "model": "gemma-4-31b", "input": {"messages": [{"role": "user", "content": "run df -h on / and tell me if the disk is ok"}]}, "output": {"response": "'''json\n{\n  \"success\": true,\n  \"decision\": \"FINISH\",\n  \"thought\": \"The command 'df -h /' shows the root filesystem is at 86% usage with 57G available. While it's getting full, it's not critical yet.\",\n  \"messageToUser\": \"disk's at 86% (57g free). it's okay for now, but leaning on it.\"\n}\n'''", "toolCalls": []}}
```
<!-- evidence-row:domain-artifacts -->
```
Redaction proven on the live agent with the secret held ONLY in a file (never
in the command text): probe `grep SECRET_TEST_KEY <file>` returned to Discord as
  SECRET_TEST_KEY=***
Channel read back via the Discord REST API (ground truth, not the trajectory).
```
<!-- evidence-row:ocr-review -->
N/A - backend-only change; no rendered UI surface.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

Attribution: authored and live-verified by NubsCarson's agent session on the
live test agent; no other authors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


