### PR TITLE
fix(core): honor stage-1 candidate parents in retrieval; route 'remind me at TIME' to reminders

### DIFF
--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -270,6 +270,56 @@ describe("action catalogue and retrieval", () => {
 		});
 	});
 
+	it("treats a canonical candidate parent as an exact hint", () => {
+		const catalog = buildActionCatalog([
+			{
+				name: "CALENDAR",
+				description:
+					"Manage calendar events, meetings, schedules, dates, times, and reminders.",
+			},
+			{
+				name: "OWNER_REMINDERS",
+				description: "Create and manage exact-time owner reminders.",
+			},
+		]);
+
+		for (const messageText of [
+			"remind me in 2 minutes to check the mail",
+			"remind me at 9pm to check the oven",
+		]) {
+			const response = retrieveActions({
+				catalog,
+				messageText,
+				candidateActions: ["owner reminders"],
+			});
+
+			expect(response.query.parentActionHints).toEqual(["owner reminders"]);
+			expect(response.results[0]).toMatchObject({
+				name: "OWNER_REMINDERS",
+				score: 1,
+				matchedBy: expect.arrayContaining(["exact"]),
+			});
+			expect(
+				response.results.findIndex(
+					(result) => result.name === "OWNER_REMINDERS",
+				),
+			).toBeLessThan(
+				response.results.findIndex((result) => result.name === "CALENDAR"),
+			);
+		}
+
+		const appointment = retrieveActions({
+			catalog,
+			messageText: "add a dentist appointment Thursday at 2pm",
+			candidateActions: ["CALENDAR"],
+		});
+		expect(appointment.results[0]).toMatchObject({
+			name: "CALENDAR",
+			score: 1,
+			matchedBy: expect.arrayContaining(["exact"]),
+		});
+	});
+
 	it("matches candidate action namespaces and child names with regex scoring", () => {
 		const catalog = buildActionCatalog(actions);
 		const namespaceResponse = retrieveActions({

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -320,8 +320,17 @@ export function retrieveActions(
 	input: RetrieveActionsInput,
 ): ActionRetrievalResponse {
 	const candidateActions = dedupeNormalizedStrings(input.candidateActions);
+	const catalogParentNames = new Set(
+		input.catalog.parents.map((parent) => parent.normalizedName),
+	);
 	const parentActionHints = dedupeNormalizedStrings([
 		...(input.parentActionHints ?? []),
+		// A Stage-1 candidate that names an exposed parent is already an exact
+		// catalog reference. Preserve that signal instead of forcing it through
+		// fuzzy retrieval, where unrelated keyword-heavy parents can outrank it.
+		...candidateActions.filter((actionName) =>
+			catalogParentNames.has(normalizeActionName(actionName)),
+		),
 		...candidateActions.flatMap((actionName) =>
 			candidateNamespaceParentExists(input.catalog.parents, actionName)
 				? []

--- a/plugins/plugin-personal-assistant/src/lifeops/reminders/direct-routing.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/reminders/direct-routing.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Covers the deterministic owner-reminder creation boundary without replacing
+ * the runtime's role, action-tag, connector, or validation gates.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  createOwnerReminderDirectRoutingRule,
+  looksLikeOwnerReminderCreateRequest,
+} from "./direct-routing";
+
+describe("owner reminder direct routing", () => {
+  it.each([
+    "Remind me in 2 minutes to check the mail.",
+    "Please remind me at 9pm to check the oven.",
+    "Can you remind me tomorrow morning?",
+    "Set a reminder for Friday at noon.",
+    "Create me a reminder to call Pat.",
+  ])("routes explicit reminder creation: %s", (text) => {
+    expect(looksLikeOwnerReminderCreateRequest(text)).toBe(true);
+  });
+
+  it.each([
+    "Add a dentist appointment Thursday at 2pm.",
+    "What reminders do I have?",
+    "How do calendar reminders work?",
+    "Alice reminded me about the meeting.",
+    "Write a story about setting reminders.",
+  ])("does not claim adjacent or read-only intent: %s", (text) => {
+    expect(looksLikeOwnerReminderCreateRequest(text)).toBe(false);
+  });
+
+  it("targets the definition-owning action with structural capability gates", () => {
+    expect(createOwnerReminderDirectRoutingRule()).toMatchObject({
+      id: "lifeops.owner-reminder-create",
+      actionNames: ["OWNER_REMINDERS"],
+      requiredActionTags: expect.arrayContaining([
+        "domain:reminders",
+        "capability:write",
+        "capability:schedule",
+        "effect:receipt-required",
+      ]),
+      contexts: ["tasks", "productivity"],
+    });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/reminders/direct-routing.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/reminders/direct-routing.ts
@@ -1,0 +1,38 @@
+/**
+ * Declares the deterministic owner-reminder creation boundary so explicit
+ * “remind me” requests reach the definition-owning OWNER_REMINDERS surface.
+ * Core still applies role, capability-tag, connector, and action validation
+ * gates before promoting the turn to planning.
+ */
+
+import type { DirectActionRoutingRule } from "@elizaos/core";
+
+const EXPLICIT_REMINDER_CREATE_PATTERNS: readonly RegExp[] = [
+  /\bremind\s+me\b/iu,
+  /\b(?:add|create|schedule|set)\s+(?:me\s+)?(?:an?\s+)?reminder\b/iu,
+];
+
+export function looksLikeOwnerReminderCreateRequest(text: string): boolean {
+  const normalized = text.trim();
+  return (
+    normalized.length > 0 &&
+    EXPLICIT_REMINDER_CREATE_PATTERNS.some((pattern) =>
+      pattern.test(normalized),
+    )
+  );
+}
+
+export function createOwnerReminderDirectRoutingRule(): DirectActionRoutingRule {
+  return {
+    id: "lifeops.owner-reminder-create",
+    actionNames: ["OWNER_REMINDERS"],
+    requiredActionTags: [
+      "domain:reminders",
+      "capability:write",
+      "capability:schedule",
+      "effect:receipt-required",
+    ],
+    contexts: ["tasks", "productivity"],
+    matches: looksLikeOwnerReminderCreateRequest,
+  };
+}

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -196,6 +196,7 @@ import {
   registerFamilyRegistry,
   registerWorkflowStepRegistry,
 } from "./lifeops/registries/index.js";
+import { createOwnerReminderDirectRoutingRule } from "./lifeops/reminders/direct-routing.js";
 import { LifeOpsRepository } from "./lifeops/repository.js";
 import {
   createResourceCapacityAction,
@@ -1039,6 +1040,10 @@ const rawPersonalAssistantPlugin: Plugin = {
     registerDirectActionRoutingRule(
       runtime,
       createTrackedWorkRecapDirectRoutingRule(),
+    );
+    registerDirectActionRoutingRule(
+      runtime,
+      createOwnerReminderDirectRoutingRule(),
     );
 
     // First-party adapters backed by LifeOps services. Gmail and X replace the


### PR DESCRIPTION
# Relates to

Closes #18992.

- [x] Targets `develop` and is rebased onto `origin/develop@69f442836425b8394d5e583c85bbefe68c4cfddc` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` were run after sync.
- [x] The exact retrieval and routing contracts are covered by deterministic tests, with the original live A/B transcript retained below.

# Contribution provenance

The production repair and live A/B run were authored by NubsCarson through Claude Code; the original PR record did not capture that session's exact provider model ID. Codex added the deterministic regressions requested in review, rebased the two commits without changing NubsCarson's authorship, and ran the exact-head verification listed below.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` for the deterministic regression and review repair; the original Claude Code model ID was not recorded by its author
<!-- attribution-row:client -->
- Agent tooling: `Claude Code` for the production patch and live A/B; `Codex desktop` for deterministic coverage and verification
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 Turbo tasks plus all repository audits.

# Risks

Low-to-medium. This changes generic parent-candidate scoring and registers a plugin-owned deterministic creation route. Core still enforces action tags, roles, connector policy, and action validation before planning; deterministic tests pin reminder creation and adjacent/read-only negatives.

# Background

## What does this PR do?

1. Promotes a stage-1 `candidateActions` entry that exactly names a canonical catalog parent into the exact parent-hint path. This prevents a requested reminder action from losing to a lexically greedy calendar action.
2. Registers an explicit reminder-creation direct route in the definition-owning personal-assistant plugin, targeting `OWNER_REMINDERS` while core retains role, capability-tag, connector, and validation gates.
3. Keeps appointment and meeting requests on `CALENDAR`, and excludes reminder reads and adjacent prose from the creation route.
4. Adds deterministic retrieval and plugin-owned routing regressions for the review-requested boundaries.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No external documentation change is needed. The personal-assistant plugin owns the new route and its test contract.

# Testing

## Where should a reviewer start?

- `packages/core/src/runtime/__tests__/action-retrieval.test.ts`
- `plugins/plugin-personal-assistant/src/lifeops/reminders/direct-routing.test.ts`
- `plugins/plugin-personal-assistant/src/plugin.ts`

## Detailed testing steps

Exact head `525fb51057ab5f2325826f60631d08df68a664d4`:

- `bun test packages/core/src/runtime/__tests__/action-retrieval.test.ts plugins/plugin-personal-assistant/src/lifeops/reminders/direct-routing.test.ts` — 36/36 pass.
- Direct-route adversarial matrix covers five explicit reminder creates and five adjacent/read-only negatives.
- `bun run --cwd packages/core typecheck` — pass.
- `bun run --cwd packages/core build` — Node/browser/edge/testing/declarations pass.
- `bun run --cwd plugins/plugin-personal-assistant build` — JavaScript and declarations pass.
- `bunx biome check` across all five changed files — pass.
- `git diff --check` — pass.
- `bun install --frozen-lockfile --ignore-scripts` — pass (6,412 packages).
- `bun run verify` — pass, 350/350 Turbo tasks plus all repository audits.
- Hosted `plugin-tests` on the prior head exposed one unrelated current-`develop` baseline failure in `google-plugin-delegates.test.ts` (`status.connected`, expected true / received false). The same assertion fails from an untouched `origin/develop` checkout; none of this PR’s five changed files participates.

# Evidence Gate

<!-- evidence-head:525fb51057ab5f2325826f60631d08df68a664d4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this backend planner-routing change has no rendered user interface surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this backend planner-routing change has no rendered user interface surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no visual interaction flow or native surface changed by this patch.
<!-- evidence-row:backend-logs -->
- [x] N/A - the original live A/B preserved the user-visible action transcript below, but did not preserve structured backend logger lines.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, console state, network path, or view code changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the original live A/B transcript did not record provider and model metadata, so it is retained as supplementary behavioral evidence rather than represented as a compliant model trajectory.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistence schema or artifact format changes; the live transcript records both scheduled reminders firing at the requested wall-clock time.
<!-- evidence-row:ocr-review -->
- [x] N/A - the diff has no rendered visual text or UI surface.

# Evidence Details

## Live backend path transcript

<details>
<summary>Revert → reproduce → re-apply → exact-time delivery</summary>

```text
[baseline/reverted] user: remind me in 2 minutes to check the mail
[baseline/reverted] bot: calendar's tripping. couldn't set the reminder. (CALENDAR -> 503)
[patched] user: remind me in 2 minutes to check the oven
[patched] bot: Reminder set: "check the oven" — in 2 minutes. (TRIGGER_CREATE)
[patched] bot: check the oven. (fired 23:42:50, exactly on time)
[patched] user: remind me at 02:49 UTC to test the at-time fire
[patched] bot: Reminder set: "test the at-time fire" — in 2 minutes.
[patched] bot: test the at-time fire (fired 02:49:01, exact)
[control] user: add a dentist appointment Thursday at 2pm -> CALENDAR
[control] user: bitcoin price -> WEB_FETCH
```

</details>

## Real LLM-call trajectory

N/A - the original live session did not preserve the provider/model metadata required for a formal trajectory. The transcript above is therefore explicitly supplementary; the exact routing boundaries are independently pinned by deterministic tests.

## Frontend and visual evidence

N/A - no `.tsx`, CSS, SVG, app, homepage, shared UI, or native view file is changed.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no repository contribution skill used","attribution_status":"self-reported","lane":"codex-issue-triage"} -->





