### PR TITLE
fix(core): gate relative-time week fallback on raw magnitude

### DIFF
--- a/packages/core/src/utils/time-format.test.ts
+++ b/packages/core/src/utils/time-format.test.ts
@@ -73,6 +73,8 @@ describe("formatRelativeTime (compact)", () => {
 	});
 
 	it("falls back to a locale date at a week and beyond", () => {
+		expect(formatRelativeTime(NOW - 7 * DAY)).not.toMatch(/ago|now/);
+		expect(formatRelativeTime(NOW + 7 * DAY)).not.toMatch(/in |now/);
 		expect(formatRelativeTime(NOW - 8 * DAY)).not.toMatch(/ago|now/);
 		expect(formatRelativeTime(NOW + 8 * DAY)).not.toMatch(/in |now/);
 	});

--- a/packages/core/src/utils/time-format.test.ts
+++ b/packages/core/src/utils/time-format.test.ts
@@ -76,6 +76,14 @@ describe("formatRelativeTime (compact)", () => {
 		expect(formatRelativeTime(NOW - 8 * DAY)).not.toMatch(/ago|now/);
 		expect(formatRelativeTime(NOW + 8 * DAY)).not.toMatch(/in |now/);
 	});
+
+	it("keeps a future moment inside the week relative instead of an early date", () => {
+		// A future 6d + 1ms ceils to 7 days but is still inside the week, so it
+		// must render "in 7d" rather than jump to an absolute date a full day
+		// before a week has elapsed (matching the packages/ui WEEK_MS gate).
+		expect(formatRelativeTime(NOW + 6 * DAY + 1)).toBe("in 7d");
+		expect(formatRelativeTime(NOW + 7 * DAY - 1)).toBe("in 7d");
+	});
 });
 
 describe("formatTimestamp (verbose)", () => {

--- a/packages/core/src/utils/time-format.ts
+++ b/packages/core/src/utils/time-format.ts
@@ -67,7 +67,10 @@ function describeRelativeTime(
 	if (days === 1) {
 		return future ? "Tomorrow" : "Yesterday";
 	}
-	if (days < 7) {
+	// Gate the week fallback on the raw magnitude, not the direction-rounded
+	// `days`: a future 6d + 1ms ceils to 7 and would otherwise jump to an
+	// absolute date a full day early. Matches the packages/ui WEEK_MS gate.
+	if (absDiff < 7 * 86400000) {
 		return tense(`${days}d`);
 	}
 	return new Date(time).toLocaleDateString(undefined, {


### PR DESCRIPTION
## Summary

`formatRelativeTime` in `packages/core/src/utils/time-format.ts` gates its week fallback on the direction-rounded `days` count (`if (days < 7)`). Future magnitudes ceil, so a moment 6 days plus a fraction ahead ceils to `days = 7`, fails `days < 7`, and renders an absolute locale date about a full day before a week has elapsed, while the symmetric past magnitude renders `6d ago`.

Concretely, with a frozen clock a future `6d + 1ms` returns a locale date (for example `Jan 22`) while the past `6d + 1ms` returns `6d ago`.

## Change

Gate the week fallback on the raw millisecond magnitude (`absDiff < 7 * 86400000`) instead of the rounded `days`, so a future value still inside the week renders `in 7d` rather than jumping to a date early. This matches the `packages/ui` sibling, which already gates the same fallback on `WEEK_MS` with a comment describing exactly this case, and it matches this module's own raw-millisecond `just now` threshold. The module header already states its intent to match `packages/ui formatRelativeTime`. PR #18483 applies the same fix to `packages/ui`; this brings `packages/core` in line.

## Validation

- `bunx vitest run time-format` in `packages/core` passes, including the added regression test.
- Added test `keeps a future moment inside the week relative instead of an early date`, asserting `NOW + 6d + 1ms` and `NOW + 7d - 1ms` render `in 7d`. It fails before the change (absolute locale date) and passes after.

## Evidence

- Before screenshots: N/A - pure time-string formatting, no UI surface
- After screenshots: N/A - pure time-string formatting, no UI surface
- Walkthrough video: N/A - covered by the added unit test
- Backend logs: N/A - deterministic pure function, covered by the added unit test
- Frontend console/network logs: N/A - no frontend change
- Real-LLM trajectory: N/A - no agent or LLM runtime path touched
- Domain artifacts: N/A - no schema or manifest change

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic/claude-opus-4-8
- Client / agent tooling: Claude Code
- Contribution skill revision: N/A - direct repository fix, not submitted through a Slop contribution skill
- Attribution status: self-reported

## Slop protocol changes

- None - no project manifest, contributor skill, reviewer skill, award, or reward-cycle files are touched.

## Safety review

Pure formatting change: the week fallback is gated on a raw magnitude, one regression test is added, and the behavior now matches the existing `packages/ui` formatter and this module's documented intent to match it. No new inputs, network calls, or privileges.

<!-- evidence-head:d3f0d61277243d100fd7bbbdb4be218474326797 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core-only formatter has no in-repository rendered consumer; app UI uses its separate already-matching formatter

<!-- evidence-row:after-screenshots -->
- [ ] N/A - core-only formatter has no in-repository rendered consumer; app UI uses its separate already-matching formatter

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic frozen-clock unit coverage exercises the formatting boundary

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure synchronous formatter with no I/O or service boundary

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend source, request, or rendered path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no schema, persistence, or external integration changed

<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixels or rendered text surface changed
