### PR TITLE
fix(cloud): seed the credential-scoped authorization cache at shared-agent create so fresh-create → immediate-send stops 503ing (#18807)

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-create-prewarm.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-create-prewarm.test.ts
@@ -27,6 +27,7 @@ import { Hono } from "hono";
 const requireUserOrApiKeyWithOrg = mock(async () => ({
   id: "user-1",
   organization_id: "org-1",
+  steward_id: "steward-user-1",
 }));
 
 const createAgent = mock();
@@ -228,9 +229,20 @@ describe("POST /api/v1/eliza/agents — shared create schedules the turn-cache p
     await Promise.all(registered.promises);
     expect(prewarmSharedAgentTurnCaches).toHaveBeenCalledTimes(1);
     const [prewarmedAgent, prewarmOptions] = prewarmSharedAgentTurnCaches.mock
-      .calls[0] as unknown as [{ id: string }, { namespace?: unknown }];
+      .calls[0] as unknown as [
+      { id: string },
+      {
+        namespace?: unknown;
+        requestContext?: { req?: unknown };
+        stewardUserId?: string;
+      },
+    ];
     expect(prewarmedAgent.id).toBe(agent.id);
     expect(prewarmOptions.namespace).toBe(NAMESPACE);
+    // The creating request's credential/context reaches the prewarm so it can
+    // seed the credential-scoped authorization entry the first message reads.
+    expect(prewarmOptions.requestContext?.req).toBeDefined();
+    expect(prewarmOptions.stewardUserId).toBe("steward-user-1");
   });
 
   test("response does not await the prewarm (off the response path)", async () => {

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -501,7 +501,10 @@ app.post("/", async (c) => {
           createExecutionCtx = candidate;
         }
       } catch {
-        // Hono throws outside Workers (tests, node runtimes); skip the prewarm.
+        // error-policy:J4 Hono intentionally throws when executionCtx is read
+        // outside Workers (tests, node runtimes); the create degrades to no
+        // prewarm and the turn path's retryable warming 503s remain the
+        // fallback.
         createExecutionCtx = undefined;
       }
       if (createExecutionCtx) {
@@ -510,6 +513,11 @@ app.post("/", async (c) => {
             ({ prewarmSharedAgentTurnCaches }) =>
               prewarmSharedAgentTurnCaches(agent, {
                 namespace: c.env?.SHARED_RUNTIME_CONVERSATIONS,
+                // The creating request's credential is the one the immediate
+                // first message presents; it lets the prewarm seed the exact
+                // credential-scoped authorization entry that message consults.
+                requestContext: c,
+                stewardUserId: user.steward_id ?? undefined,
               }),
           ),
         );

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.test.ts
@@ -23,6 +23,9 @@ const warmInferenceAdmissionSnapshot = mock(async () => {
   calls.push("admission");
 });
 const coordinateSharedHistory = mock(async () => [] as unknown[]);
+const seedSharedAgentScopeCache = mock(async () => {
+  calls.push("authorization-scope");
+});
 const loggerWarn = mock(() => {});
 
 mock.module("../../pricing", () => ({
@@ -34,6 +37,9 @@ mock.module("../characters/characters", () => ({ charactersService: { getById } 
 mock.module("../inference-admission-snapshot", () => ({ warmInferenceAdmissionSnapshot }));
 mock.module("./conversation-coordinator", () => ({
   coordinateSharedHistory,
+}));
+mock.module("./resolve-shared-agent", () => ({
+  seedSharedAgentScopeCache,
 }));
 mock.module("../../utils/logger", () => ({
   logger: { debug: mock(), error: mock(), info: mock(), warn: loggerWarn },
@@ -67,6 +73,10 @@ beforeEach(() => {
   warmInferenceAdmissionSnapshot.mockClear();
   coordinateSharedHistory.mockClear();
   coordinateSharedHistory.mockImplementation(async () => []);
+  seedSharedAgentScopeCache.mockClear();
+  seedSharedAgentScopeCache.mockImplementation(async () => {
+    calls.push("authorization-scope");
+  });
   loggerWarn.mockClear();
 });
 
@@ -106,6 +116,47 @@ describe("prewarmSharedAgentTurnCaches model pricing", () => {
     expect(getById).toHaveBeenCalledWith("character-1");
     expect(calculateCost).toHaveBeenCalledWith("gpt-oss-120b", "cerebras", 1, 1, "bitrouter");
     expect(calls.indexOf("character")).toBeLessThan(calls.indexOf("pricing:cerebras:gpt-oss-120b"));
+  });
+
+  test("requestContext runs the authorization-scope leg with the creating credential + steward id", async () => {
+    const requestContext = { req: { header: () => undefined } };
+
+    await prewarmSharedAgentTurnCaches(agent({}), {
+      requestContext: requestContext as never,
+      stewardUserId: "steward-user-1",
+    });
+
+    expect(seedSharedAgentScopeCache).toHaveBeenCalledTimes(1);
+    const [ctx, seededAgent, stewardUserId] = seedSharedAgentScopeCache.mock
+      .calls[0] as unknown as [unknown, { id: string }, string | undefined];
+    expect(ctx).toBe(requestContext);
+    expect(seededAgent.id).toBe("agent-1");
+    expect(stewardUserId).toBe("steward-user-1");
+  });
+
+  test("without a requestContext the authorization-scope leg is skipped", async () => {
+    await prewarmSharedAgentTurnCaches(agent({}));
+    expect(seedSharedAgentScopeCache).not.toHaveBeenCalled();
+  });
+
+  test("logs an authorization-scope seeding rejection observed by allSettled", async () => {
+    const error = new Error("cache backend unavailable");
+    seedSharedAgentScopeCache.mockRejectedValue(error);
+
+    await expect(
+      prewarmSharedAgentTurnCaches(agent({}), {
+        requestContext: { req: { header: () => undefined } } as never,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "[shared-runtime prewarm] leg failed; first turn falls back to warming 503s",
+      expect.objectContaining({
+        agentId: "agent-1",
+        leg: "authorization-scope",
+        error: error.message,
+      }),
+    );
   });
 
   test("logs a conversation hydration rejection observed by allSettled", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
@@ -24,12 +24,15 @@
  * Callers must keep it off the response path (Worker executionCtx.waitUntil).
  */
 
+import type { Context } from "hono";
+
 import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
-import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
+import type { AppEnv, RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
 import { calculateCost, getProviderFromModel, normalizeModelName } from "../../pricing";
 import { logger } from "../../utils/logger";
 import { warmInferenceAdmissionSnapshot } from "../inference-admission-snapshot";
 import { coordinateSharedHistory } from "./conversation-coordinator";
+import { seedSharedAgentScopeCache } from "./resolve-shared-agent";
 import { resolveSharedAgentTurnModel } from "./run-shared-agent-turn";
 import { projectSharedAgentCharacter } from "./shared-agent-character";
 
@@ -40,6 +43,19 @@ export interface PrewarmSharedAgentOptions {
    * it only the conversation-object leg is skipped.
    */
   namespace?: RuntimeDurableObjectNamespace;
+  /**
+   * The creating request's Hono context — the credential it carries is the one
+   * the immediate first message will present, so it is what the authorization
+   * scope leg needs to derive `CacheKeys.sharedAgentScope.resolve(<prefix>,
+   * agentId)`. Without it that leg is skipped and the first send pays the
+   * "authorization cache is warming" 503.
+   */
+  requestContext?: Context<AppEnv>;
+  /**
+   * The creating user's steward id, for a session-keyed scope entry to pass
+   * its hit-time same-user re-verification. Ignored on the API-key path.
+   */
+  stewardUserId?: string;
 }
 
 /**
@@ -98,6 +114,18 @@ export async function prewarmSharedAgentTurnCaches(
     legs.push({
       leg: "conversation-object",
       run: coordinateSharedHistory(agent.id, agent.id, { namespace: options.namespace }),
+    });
+  }
+
+  // 4. Credential-scoped authorization entry ("Agent authorization cache is
+  //    warming"). The first message route resolves the agent cache-only against
+  //    the creator's own credential; seeding that exact entry here is what lets
+  //    a fresh create take an immediate send. Hits still re-run the
+  //    per-request credential gate, so this leg only removes latency.
+  if (options.requestContext) {
+    legs.push({
+      leg: "authorization-scope",
+      run: seedSharedAgentScopeCache(options.requestContext, agent, options.stewardUserId),
     });
   }
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
@@ -112,9 +112,8 @@ mock.module("../../utils/logger", () => ({
   logger: { debug: () => {}, warn: () => {}, error: () => {}, info: () => {} },
 }));
 
-const { resolveSharedAgent, resetSharedAgentScopeMemoryCacheForTests } = await import(
-  "./resolve-shared-agent"
-);
+const { resolveSharedAgent, resetSharedAgentScopeMemoryCacheForTests, seedSharedAgentScopeCache } =
+  await import("./resolve-shared-agent");
 const { CacheTTL, CacheKeys } = await import("../../cache/keys");
 
 function contextWithAgentId(agentId?: string, headers: Record<string, string> = {}) {
@@ -980,5 +979,106 @@ describe("resolveSharedAgent SESSION scope cache (SHADOW-ACCOUNT-DEBUG)", () => 
         value: "not-a-timestamp",
       });
     });
+  });
+});
+
+describe("seedSharedAgentScopeCache (fresh-create -> immediate-send)", () => {
+  const validationKey = () =>
+    CacheKeys.apiKey.validation(
+      createHash("sha256").update("eliza_testkey").digest("hex").substring(0, 16),
+    );
+
+  test("API-key path: a seeded fresh create takes an immediate cache-only send without 503 or DB hydration", async () => {
+    // The create request's own auth already validated the key (and cached it);
+    // the seeder writes the scope entry that same request derives.
+    cacheStore.set(validationKey(), {
+      is_active: true,
+      organization_id: "org-1",
+      expires_at: null,
+    });
+    await seedSharedAgentScopeCache(apiKeyContext("agent-1") as never, agent() as never);
+
+    // The immediate send may land on a DIFFERENT isolate: only the distributed
+    // entry may carry the hit.
+    resetSharedAgentScopeMemoryCacheForTests();
+
+    await expect(
+      resolveSharedAgent(apiKeyContext("agent-1") as never, {
+        cacheOnly: true,
+        executionCtx: { waitUntil: () => undefined },
+      }),
+    ).resolves.toMatchObject({ agentId: "agent-1", orgId: "org-1" });
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+    expect(requireUserOrApiKeyWithOrgLookup).not.toHaveBeenCalled();
+  });
+
+  test("session path: the seeded entry carries the steward user id and serves the immediate send", async () => {
+    scopeHashPrefixBehavior = async () => null;
+    sessionHashPrefixBehavior = async () => "sesshashpref0000";
+    // The create request's auth hydrated the lifecycle-invalidated user entry.
+    cacheStore.set(CacheKeys.user.byStewardId("steward-user-1"), {
+      is_active: true,
+      organization_id: "org-1",
+      organization: { is_active: true },
+    });
+    await seedSharedAgentScopeCache(
+      contextWithAgentId("agent-1") as never,
+      agent() as never,
+      "steward-user-1",
+    );
+    const seeded = cacheStore.get(
+      CacheKeys.sharedAgentScope.resolve("s:sesshashpref0000", "agent-1"),
+    ) as { stewardUserId?: string };
+    expect(seeded.stewardUserId).toBe("steward-user-1");
+
+    resetSharedAgentScopeMemoryCacheForTests();
+
+    await expect(
+      resolveSharedAgent(contextWithAgentId("agent-1") as never, {
+        cacheOnly: true,
+        executionCtx: { waitUntil: () => undefined },
+      }),
+    ).resolves.toMatchObject({ agentId: "agent-1", orgId: "org-1" });
+    expect(revalidateSessionScope).toHaveBeenCalledWith(
+      expect.anything(),
+      "steward-user-1",
+      "org-1",
+    );
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+  });
+
+  test("seeding does NOT bypass the per-request credential gate: a re-scoped key falls back to warming", async () => {
+    await seedSharedAgentScopeCache(apiKeyContext("agent-1") as never, agent() as never);
+    resetSharedAgentScopeMemoryCacheForTests();
+    // The presented key now validates to a DIFFERENT org (revoke/re-scope).
+    cacheStore.set(validationKey(), {
+      is_active: true,
+      organization_id: "org-2",
+      expires_at: null,
+    });
+
+    const waited: Promise<unknown>[] = [];
+    await expect(
+      resolveSharedAgent(apiKeyContext("agent-1") as never, {
+        cacheOnly: true,
+        executionCtx: { waitUntil: (promise) => waited.push(promise) },
+      }),
+    ).resolves.toMatchObject({ status: 503 });
+    await Promise.all(waited);
+  });
+
+  test("a request with no supported credential seeds nothing", async () => {
+    scopeHashPrefixBehavior = async () => null;
+    sessionHashPrefixBehavior = async () => null;
+    await seedSharedAgentScopeCache(contextWithAgentId("agent-1") as never, agent() as never);
+    expect(cacheSet).not.toHaveBeenCalled();
+  });
+
+  test("a non-shared agent is never seeded", async () => {
+    await seedSharedAgentScopeCache(
+      apiKeyContext("agent-1") as never,
+      agent({ execution_tier: "dedicated-lazy" }) as never,
+    );
+    expect(cacheSet).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
@@ -611,3 +611,40 @@ export async function resolveSharedAgent(
 
   return { agent, agentId, orgId: entry.orgId, agentName: agent.agent_name ?? "Eliza" };
 }
+
+/**
+ * Seed the credential-scoped authorization entry the cache-only turn gate
+ * consults, from a request that ALREADY passed the authoritative create gate
+ * for this exact agent (CHAT-CORE-LATENCY §6: the fresh-create → immediate-send
+ * path otherwise misses `CacheKeys.sharedAgentScope.resolve` and bounces off
+ * "Agent authorization cache is warming" 503s). Derives the key with the SAME
+ * prefix functions `resolveSharedAgent` uses, so the seeded entry is the one
+ * the first message reads.
+ *
+ * This cannot weaken authorization: the entry is keyed by the creator's own
+ * credential, carries the org the agent row itself belongs to, and every hit
+ * still re-runs the per-request credential gate (`revalidateResolvedScope`)
+ * before being served. Requests carrying no supported credential seed nothing.
+ * `stewardUserId` must be the creating user's steward id on the session path;
+ * without it a session hit safely falls back to authoritative hydration.
+ */
+export async function seedSharedAgentScopeCache(
+  c: Context<AppEnv>,
+  agent: AgentSandbox,
+  stewardUserId?: string,
+): Promise<void> {
+  if (agent.execution_tier !== "shared") return;
+  const apiKeyPrefix = await apiKeyScopeHashPrefix(c);
+  const sessionPrefix = apiKeyPrefix ? null : await sessionScopeHashPrefix(c);
+  const scopeKeyPrefix = apiKeyPrefix ?? (sessionPrefix ? `s:${sessionPrefix}` : null);
+  if (!scopeKeyPrefix) return;
+  const scopeCacheKey = CacheKeys.sharedAgentScope.resolve(scopeKeyPrefix, agent.id);
+  const entry: CachedSharedAgentScope = {
+    orgId: agent.organization_id,
+    agent,
+    ...(apiKeyPrefix == null && stewardUserId ? { stewardUserId } : {}),
+    firstWrittenAtMs: Date.now(),
+  };
+  sharedAgentScopeMemoryCache.set(scopeCacheKey, entry);
+  await cache.set(scopeCacheKey, entry, CacheTTL.sharedAgentScope.resolve);
+}


### PR DESCRIPTION
## What

Closes the remaining fresh-create → immediate-send gap in #18807 (post-#18824 scope, per the 2026-08-12 status comment). **Does not close the issue** — the staging identity/billing/no-duplicate proof residual stays open on purpose.

The first message on a freshly created shared agent resolves cache-only against `CacheKeys.sharedAgentScope.resolve(<credential-prefix>, agentId)`. The create-time prewarm warmed the admission snapshot, pricing, character, and conversation object — but never that authorization entry — so the immediate send returned the retryable 503 `"Agent authorization cache is warming. Retry shortly."` before reaching any warmed leg.

## How

- `prewarmSharedAgentTurnCaches` now accepts the creating request's context (`requestContext`) plus the creator's steward id, and runs a fourth `authorization-scope` leg (`packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts`).
- New `seedSharedAgentScopeCache` in `resolve-shared-agent.ts` derives the key with the **same** `apiKeyScopeHashPrefix` / `sessionScopeHashPrefix` functions the turn gate uses and writes the exact `CachedSharedAgentScope` entry (org from the agent row itself, `stewardUserId` on the session path, `firstWrittenAtMs` for the sliding-refresh cap) to the isolate LRU + distributed cache with the standard 30s `CacheTTL.sharedAgentScope.resolve`.
- The create route passes `requestContext: c` and `stewardUserId` into the prewarm, and its `c.executionCtx` catch is now annotated `// error-policy:J4` (`packages/cloud/api/v1/eliza/agents/route.ts`).

**Per-request credential checks are not weakened.** The seeded entry is keyed by the creator's own credential; every hit still runs `revalidateResolvedScope` (API-key: revoke-invalidated validation + org match; session: JWT re-verify + same-user + lifecycle-invalidated user state) before being served. A request with no supported credential, or a non-shared agent, seeds nothing. The other caches the hit-time gate consults (`apiKey.validation`, `user:steward:<id>`, admission snapshot) are already written by the create request's own auth + the existing prewarm legs.

## Verification (head `3676515`)

```
cd packages/cloud/shared && bun test --isolate \
  src/lib/services/shared-runtime/resolve-shared-agent.test.ts \
  src/lib/services/shared-runtime/prewarm-shared-agent.test.ts
# 49 pass, 0 fail (135 expect() calls)

cd packages/cloud/api && bun test __tests__/eliza-agents-create-prewarm.test.ts
# 5 pass, 0 fail (16 expect() calls)

bun run --cwd packages/cloud/shared typecheck   # no errors in touched files
bun run --cwd packages/cloud/api typecheck      # no TS errors
bunx biome check <6 touched files>              # clean
```

Direct full-boundary tests added at the gate that 503'd:

- **API-key path:** seed at create, reset the isolate LRU (immediate send may land on a different isolate), then `resolveSharedAgent({cacheOnly: true})` returns the agent — no 503, no DB hydration (`findByIdAndOrg` / `requireUserOrApiKeyWithOrgLookup` never called).
- **Session path:** seeded entry carries the steward id and serves the immediate send through the JWT re-verify + user-state gates.
- **Adversarial:** a key re-scoped to another org after seeding is *not* served the entry (falls back to warming/authoritative hydration); credential-less requests and non-shared agents seed nothing.
- Prewarm leg failure is observed by `Promise.allSettled` and logged; the warming-503 fallback remains.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - Cloudflare Worker cloud route (packages/cloud), no UI surface touched.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - Cloudflare Worker cloud route (packages/cloud), no UI surface touched.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-visible flow changed; the change removes a retryable 503 on a backend cache gate.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - this environment has no staging deploy/log access (deploys gate on cloud-cf-deploy.yml from develop); the real code path is exercised by the full-boundary test transcript below, and the deployed staging proof is the residual deliberately left open on #18807.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior change; authorization-cache seeding only.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: full-boundary test transcript + junit XML (54 named tests): https://gist.github.com/Uuriko/03d199982bbaf08e8175dcc6a78535d3
<details>
<summary>Test transcript — 54 named tests, 0 fail (bun test, head 3676515)</summary>

```
packages/cloud/shared (bun test --isolate): 49 pass, 0 fail, 135 expect() calls
packages/cloud/api: 5 pass, 0 fail, 16 expect() calls

resolve-shared-agent.test.ts / prewarm-shared-agent.test.ts / eliza-agents-create-prewarm.test.ts:
  returns 400 without auth or repository work when the route param is missing
  uses the overlapped org lookup to resolve a shared agent
  cache-only miss warms in waitUntil and performs no inline DB hydration
  warm isolate performs only the credential-validity cache read
  cache-only does not freeze a non-shared decision after the agent becomes shared
  cache-only returns a permanent non-shared decision on the retry
  cache-only converges for a bootstrap-window dedicated agent: retry is served authoritatively
  ... (full resolver suite: 43 tests)
  API-key path: a seeded fresh create takes an immediate cache-only send without 503 or DB hydration
  session path: the seeded entry carries the steward user id and serves the immediate send
  seeding does NOT bypass the per-request credential gate: a re-scoped key falls back to warming
  a request with no supported credential seeds nothing
  a non-shared agent is never seeded
  requestContext runs the authorization-scope leg with the creating credential + steward id
  without a requestContext the authorization-scope leg is skipped
  logs an authorization-scope seeding rejection observed by allSettled
  fresh shared create registers the prewarm under executionCtx.waitUntil with the agent + DO namespace
  response does not await the prewarm (off the response path)
  idempotent reuse does NOT schedule a prewarm (the agent already served turns)
  dedicated create does NOT schedule the shared prewarm
  missing execution context (non-Worker runtime) degrades to no prewarm, create still succeeds
```

</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

## Residuals (left open deliberately)

- Deployed staging proof of fresh-create → immediate-send with identity/billing/no-duplicate inspection. #18807 should stay open until that lands.

Refs #18807

---
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [claude-18807]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZWRD84PDHZP5PYJM6J2ZH76","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T05:09:37.558Z","completed_at":"2026-08-13T05:17:27.337Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA1wup-TpOQbidV6XOR-nWj5-01vmuc1Uuv5emKqsM8iA","device_key_id":"dbd0806ed31cfab14a18eeb4990c66497a5ce64fdb0d37d3c878b8f5e6227484","device_signature":"JcYXcvNPiaQkBQzv25CvkpCl3TSPk8K4PuNY1-8sRwjmAULO9ReT08P0MPI6YXEjEBDOSWXaF0MmGdjcl5wOBw"}} -->
