### PR TITLE
fix(scripts): strict-parse bench-e2e-harvest-runner --limit/--item-timeout-ms/--shard

### DIFF
--- a/scripts/training-harvest/bench-e2e-harvest-runner.mjs
+++ b/scripts/training-harvest/bench-e2e-harvest-runner.mjs
@@ -468,6 +468,7 @@ function isDirectExecution(argvEntry) {
       realpathSync(fileURLToPath(import.meta.url))
     );
   } catch {
+    // error-policy:J3 An unresolvable argv entry is not this module's executable path.
     return false;
   }
 }

--- a/scripts/training-harvest/bench-e2e-harvest-runner.mjs
+++ b/scripts/training-harvest/bench-e2e-harvest-runner.mjs
@@ -68,15 +68,81 @@ function opt(name, fallback) {
   return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
 }
 
+function optRaw(name, fallback) {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? (process.argv[i + 1] ?? "") : fallback;
+}
+
+function parseDecimalInteger(raw, flagName, minimum) {
+  if (typeof raw !== "string" || !/^\d+$/.test(raw)) {
+    throw new Error(
+      `${flagName} must be a decimal integer (got ${JSON.stringify(raw)})`,
+    );
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    throw new Error(
+      `${flagName} must be a safe integer greater than or equal to ${minimum} (got ${JSON.stringify(raw)})`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Parse the bounded item count without allowing JavaScript's permissive
+ * numeric coercion to reinterpret an operator's input. Zero is the explicit
+ * unlimited sentinel used by the runner.
+ */
+export function parseHarvestLimit(raw, flagName = "--limit") {
+  return parseDecimalInteger(raw, flagName, 0);
+}
+
+/** Parse the per-item timeout as a positive, safe decimal integer. */
+export function parseItemTimeoutMs(raw, flagName = "--item-timeout-ms") {
+  return parseDecimalInteger(raw, flagName, 1);
+}
+
+/** Parse an i/n shard where n is positive and i is within [0, n). */
+export function parseHarvestShard(raw, flagName = "--shard") {
+  const match =
+    typeof raw === "string" ? /^(\d+)\/(\d+)$/.exec(raw) : null;
+  if (!match) {
+    throw new Error(
+      `${flagName} must have the form i/n using decimal integers (got ${JSON.stringify(raw)})`,
+    );
+  }
+  const index = Number(match[1]);
+  const count = Number(match[2]);
+  if (!Number.isSafeInteger(index) || !Number.isSafeInteger(count)) {
+    throw new Error(
+      `${flagName} components must be safe integers (got ${JSON.stringify(raw)})`,
+    );
+  }
+  if (count < 1) {
+    throw new Error(
+      `${flagName} count must be at least 1 (got ${JSON.stringify(raw)})`,
+    );
+  }
+  if (index >= count) {
+    throw new Error(
+      `${flagName} index must be less than shard count (got ${JSON.stringify(raw)})`,
+    );
+  }
+  return [index, count];
+}
+
 const DRY_RUN = flag("--dry-run");
 const DETERMINISTIC = flag("--deterministic");
 const RESUME = flag("--resume");
-const LIMIT = Number(opt("--limit", "0")) || 0;
+const LIMIT = parseHarvestLimit(optRaw("--limit", "0"));
 const FAMILY = opt("--family", "e2e");
-const SHARD = opt("--shard", null);
-const [SHARD_I, SHARD_N] = SHARD ? SHARD.split("/").map(Number) : [0, 1];
+const [SHARD_I, SHARD_N] = process.argv.includes("--shard")
+  ? parseHarvestShard(optRaw("--shard", ""))
+  : [0, 1];
 const LANE_FILTER = opt("--lane", null); // e2e lane path substring filter
-const ITEM_TIMEOUT_MS = Number(opt("--item-timeout-ms", "900000")) || 900000;
+const ITEM_TIMEOUT_MS = parseItemTimeoutMs(
+  optRaw("--item-timeout-ms", "900000"),
+);
 const HARVEST_ROOT = path.resolve(
   opt(
     "--harvest-root",
@@ -363,4 +429,9 @@ function main() {
   );
 }
 
-main();
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/scripts/training-harvest/bench-e2e-harvest-runner.mjs
+++ b/scripts/training-harvest/bench-e2e-harvest-runner.mjs
@@ -47,7 +47,13 @@
  *   node bench-e2e-harvest-runner.mjs --family e2e --deterministic --dry-run   # self-test
  */
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -60,17 +66,17 @@ const NATIVE_EXPORT_TS = path.join(
 );
 const CLI_BACKENDS = new Set(["claude", "claude-sdk", "codex", "codex-sdk"]);
 
-function flag(name) {
-  return process.argv.includes(name);
+function flag(argv, name) {
+  return argv.includes(name);
 }
-function opt(name, fallback) {
-  const i = process.argv.indexOf(name);
-  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+function opt(argv, name, fallback) {
+  const i = argv.indexOf(name);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : fallback;
 }
 
-function optRaw(name, fallback) {
-  const i = process.argv.indexOf(name);
-  return i >= 0 ? (process.argv[i + 1] ?? "") : fallback;
+function optRaw(argv, name, fallback) {
+  const i = argv.indexOf(name);
+  return i >= 0 ? (argv[i + 1] ?? "") : fallback;
 }
 
 function parseDecimalInteger(raw, flagName, minimum) {
@@ -104,8 +110,7 @@ export function parseItemTimeoutMs(raw, flagName = "--item-timeout-ms") {
 
 /** Parse an i/n shard where n is positive and i is within [0, n). */
 export function parseHarvestShard(raw, flagName = "--shard") {
-  const match =
-    typeof raw === "string" ? /^(\d+)\/(\d+)$/.exec(raw) : null;
+  const match = typeof raw === "string" ? /^(\d+)\/(\d+)$/.exec(raw) : null;
   if (!match) {
     throw new Error(
       `${flagName} must have the form i/n using decimal integers (got ${JSON.stringify(raw)})`,
@@ -131,24 +136,45 @@ export function parseHarvestShard(raw, flagName = "--shard") {
   return [index, count];
 }
 
-const DRY_RUN = flag("--dry-run");
-const DETERMINISTIC = flag("--deterministic");
-const RESUME = flag("--resume");
-const LIMIT = parseHarvestLimit(optRaw("--limit", "0"));
-const FAMILY = opt("--family", "e2e");
-const [SHARD_I, SHARD_N] = process.argv.includes("--shard")
-  ? parseHarvestShard(optRaw("--shard", ""))
-  : [0, 1];
-const LANE_FILTER = opt("--lane", null); // e2e lane path substring filter
-const ITEM_TIMEOUT_MS = parseItemTimeoutMs(
-  optRaw("--item-timeout-ms", "900000"),
-);
-const HARVEST_ROOT = path.resolve(
-  opt(
-    "--harvest-root",
-    path.join(REPO_ROOT, "reports", "training-harvest", "gpt55", "harvest"),
-  ),
-);
+export function parseRunnerConfig(argv) {
+  const dryRun = flag(argv, "--dry-run");
+  const deterministic = flag(argv, "--deterministic");
+  const resume = flag(argv, "--resume");
+  const limit = parseHarvestLimit(optRaw(argv, "--limit", "0"));
+  const family = opt(argv, "--family", "e2e");
+  const [shardIndex, shardCount] = argv.includes("--shard")
+    ? parseHarvestShard(optRaw(argv, "--shard", ""))
+    : [0, 1];
+  const laneFilter = opt(argv, "--lane", null);
+  const itemTimeoutMs = parseItemTimeoutMs(
+    optRaw(argv, "--item-timeout-ms", "900000"),
+  );
+  const harvestRoot = path.resolve(
+    opt(
+      argv,
+      "--harvest-root",
+      path.join(REPO_ROOT, "reports", "training-harvest", "gpt55", "harvest"),
+    ),
+  );
+
+  return {
+    dryRun,
+    deterministic,
+    resume,
+    limit,
+    family,
+    shardIndex,
+    shardCount,
+    laneFilter,
+    itemTimeoutMs,
+    harvestRoot,
+    providerEnvFile: opt(
+      argv,
+      "--provider-env",
+      process.env.HARVEST_PROVIDER_ENV_FILE,
+    ),
+  };
+}
 
 // ── Corpus definitions ──────────────────────────────────────────────────────
 
@@ -181,15 +207,15 @@ const E2E_HARVESTABLE_LANES = [
 
 // ── Provider env (shared precedence with harvest-runner.mjs) ─────────────────
 
-function loadProviderEnv() {
-  const file = opt("--provider-env", process.env.HARVEST_PROVIDER_ENV_FILE);
+function loadProviderEnv(config) {
+  const file = config.providerEnvFile;
   if (file && existsSync(file)) {
     return {
       source: `file:${file}`,
       env: JSON.parse(readFileSync(file, "utf8")),
     };
   }
-  if (DETERMINISTIC) {
+  if (config.deterministic) {
     return { source: "deterministic-enumerate-only", env: {} };
   }
   if (process.env.ELIZA_CHAT_VIA_CLI) {
@@ -260,14 +286,14 @@ function nativeExport(runDir, outPath) {
 
 // ── E2E family ───────────────────────────────────────────────────────────────
 
-function runE2eItem(laneRel, runEnv) {
+function runE2eItem(laneRel, runEnv, config) {
   // These lanes run through the package's own vitest config (which mirrors the
   // workspace `exports` so @elizaos/* resolves to source with dist absent), via
   // the shared run-vitest.mjs wrapper (resolves an external Node — the codex
   // bundled Node cannot run Vitest). The harvestable set is app-core-only.
   const pkgDir = path.join(REPO_ROOT, laneRel.split("/").slice(0, 2).join("/"));
   const runVitest = path.join(REPO_ROOT, "packages/scripts/run-vitest.mjs");
-  const itemDir = path.join(HARVEST_ROOT, "e2e", slug(laneRel));
+  const itemDir = path.join(config.harvestRoot, "e2e", slug(laneRel));
   const trajDir = path.join(itemDir, "run", "trajectories");
   mkdirSync(trajDir, { recursive: true });
   const laneAbs = path.join(REPO_ROOT, laneRel);
@@ -287,7 +313,7 @@ function runE2eItem(laneRel, runEnv) {
     {
       cwd: pkgDir,
       encoding: "utf8",
-      timeout: ITEM_TIMEOUT_MS,
+      timeout: config.itemTimeoutMs,
       env: {
         ...process.env,
         ...runEnv,
@@ -364,52 +390,57 @@ function writeVerdict(itemDir, verdict) {
 
 // ── Main ─────────────────────────────────────────────────────────────────────
 
-function main() {
-  const provider = loadProviderEnv();
+function main(argv = process.argv) {
+  const config = parseRunnerConfig(argv);
+  const provider = loadProviderEnv(config);
   const runEnv = withCliRunEnv(provider.env);
-  mkdirSync(HARVEST_ROOT, { recursive: true });
+  mkdirSync(config.harvestRoot, { recursive: true });
 
-  if (FAMILY !== "e2e") {
+  if (config.family !== "e2e") {
     throw new Error(
-      `unknown --family ${FAMILY} (expected e2e; the benchmark family moved to https://github.com/elizaOS/benchmarks)`,
+      `unknown --family ${config.family} (expected e2e; the benchmark family moved to https://github.com/elizaOS/benchmarks)`,
     );
   }
   const corpus = E2E_HARVESTABLE_LANES.filter(
-    (lane) => !LANE_FILTER || lane.includes(LANE_FILTER),
+    (lane) => !config.laneFilter || lane.includes(config.laneFilter),
   ).map((lane) => ({ lane }));
 
   const summary = {
     startedAt: new Date().toISOString(),
-    family: FAMILY,
-    harvestRoot: HARVEST_ROOT,
+    family: config.family,
+    harvestRoot: config.harvestRoot,
     providerSource: provider.source,
     providerEnvKeys: Object.keys(runEnv),
     totalDiscovered: corpus.length,
-    shard: `${SHARD_I}/${SHARD_N}`,
-    dryRun: DRY_RUN,
-    limit: LIMIT,
+    shard: `${config.shardIndex}/${config.shardCount}`,
+    dryRun: config.dryRun,
+    limit: config.limit,
     items: [],
   };
 
   let ran = 0;
   for (let gi = 0; gi < corpus.length; gi += 1) {
-    if (SHARD_N > 1 && gi % SHARD_N !== SHARD_I) continue;
-    if (LIMIT && ran >= LIMIT) break;
+    if (config.shardCount > 1 && gi % config.shardCount !== config.shardIndex) {
+      continue;
+    }
+    if (config.limit && ran >= config.limit) break;
     const item = corpus[gi];
     const id = item.lane;
-    const itemDir = path.join(HARVEST_ROOT, "e2e", slug(id));
-    if (RESUME && existsSync(path.join(itemDir, "verdict.json"))) {
-      console.log(`[resume] skip (already harvested) ${FAMILY} :: ${id}`);
+    const itemDir = path.join(config.harvestRoot, "e2e", slug(id));
+    if (config.resume && existsSync(path.join(itemDir, "verdict.json"))) {
+      console.log(
+        `[resume] skip (already harvested) ${config.family} :: ${id}`,
+      );
       continue;
     }
     ran += 1;
-    if (DRY_RUN || DETERMINISTIC) {
-      console.log(`[dry-run] would harvest ${FAMILY} :: ${id}`);
+    if (config.dryRun || config.deterministic) {
+      console.log(`[dry-run] would harvest ${config.family} :: ${id}`);
       summary.items.push({ item: id, gi, planned: true });
       continue;
     }
-    console.log(`[harvest #${gi}] ${FAMILY} :: ${id}`);
-    const verdict = runE2eItem(id, runEnv);
+    console.log(`[harvest #${gi}] ${config.family} :: ${id}`);
+    const verdict = runE2eItem(id, runEnv, config);
     summary.items.push(verdict);
     console.log(
       `[harvest]   → status=${verdict.status} rows=${verdict.rows} exit=${verdict.exitCode}`,
@@ -419,19 +450,28 @@ function main() {
   summary.finishedAt = new Date().toISOString();
   summary.count = summary.items.length;
   const summaryPath = path.join(
-    HARVEST_ROOT,
-    `harvest-${FAMILY}-summary-${DRY_RUN || DETERMINISTIC ? "dryrun" : "run"}-${Date.now()}.json`,
+    config.harvestRoot,
+    `harvest-${config.family}-summary-${config.dryRun || config.deterministic ? "dryrun" : "run"}-${Date.now()}.json`,
   );
   writeFileSync(summaryPath, JSON.stringify(summary, null, 2));
   console.log(`\nsummary → ${summaryPath}`);
   console.log(
-    `family=${FAMILY} items=${summary.count} provider=${provider.source}`,
+    `family=${config.family} items=${summary.count} provider=${provider.source}`,
   );
 }
 
-if (
-  process.argv[1] &&
-  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
-) {
+function isDirectExecution(argvEntry) {
+  if (!argvEntry) return false;
+  try {
+    return (
+      realpathSync(path.resolve(argvEntry)) ===
+      realpathSync(fileURLToPath(import.meta.url))
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectExecution(process.argv[1])) {
   main();
 }

--- a/scripts/training-harvest/bench-e2e-harvest-runner.test.mjs
+++ b/scripts/training-harvest/bench-e2e-harvest-runner.test.mjs
@@ -5,8 +5,11 @@
  */
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   parseHarvestLimit,
   parseHarvestShard,
@@ -93,16 +96,43 @@ test("parseHarvestShard rejects malformed, unsafe, and out-of-range shards", () 
 test("invalid CLI input fails before deterministic planning", () => {
   const result = spawnSync(
     process.execPath,
-    [
-      runner,
-      "--dry-run",
-      "--deterministic",
-      "--item-timeout-ms",
-      "1e2",
-    ],
+    [runner, "--dry-run", "--deterministic", "--item-timeout-ms", "1e2"],
     { encoding: "utf8" },
   );
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /--item-timeout-ms/);
+  assert.doesNotMatch(result.stdout, /would harvest|summary/);
+});
+
+test("import ignores poisoned ambient argv and does not run main", async () => {
+  const originalArgv = [...process.argv];
+  process.argv.splice(1, process.argv.length - 1, "--limit", "not-a-number");
+  try {
+    const imported = await import(
+      `${pathToFileURL(runner).href}?ambient-argv=${Date.now()}`
+    );
+    assert.equal(typeof imported.parseRunnerConfig, "function");
+  } finally {
+    process.argv.splice(0, process.argv.length, ...originalArgv);
+  }
+});
+
+test("direct execution works through a symlink in a spaced path", (t) => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "eliza harvest "));
+  t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+  const linkedRunner = path.join(tempDir, "runner link.mjs");
+  symlinkSync(runner, linkedRunner);
+  assert.equal(realpathSync(linkedRunner), realpathSync(runner));
+
+  const result = spawnSync(
+    process.execPath,
+    [linkedRunner, "--limit", "not-a-number"],
+    { encoding: "utf8" },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /--limit must be a decimal integer \(got "not-a-number"\)/,
+  );
   assert.doesNotMatch(result.stdout, /would harvest|summary/);
 });

--- a/scripts/training-harvest/bench-e2e-harvest-runner.test.mjs
+++ b/scripts/training-harvest/bench-e2e-harvest-runner.test.mjs
@@ -1,0 +1,108 @@
+/**
+ * Deterministic parser and real child-process CLI boundary tests for the E2E
+ * training-harvest runner. Invalid CLI input fails before provider or network
+ * access.
+ */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  parseHarvestLimit,
+  parseHarvestShard,
+  parseItemTimeoutMs,
+} from "./bench-e2e-harvest-runner.mjs";
+
+const runner = fileURLToPath(
+  new URL("./bench-e2e-harvest-runner.mjs", import.meta.url),
+);
+const maxSafe = String(Number.MAX_SAFE_INTEGER);
+const overflow = `${maxSafe}0`;
+const invalidDecimalIntegers = [
+  "",
+  " ",
+  " 12",
+  "12 ",
+  "-1",
+  "+1",
+  "1.5",
+  "1e2",
+  "12junk",
+  "Infinity",
+  overflow,
+];
+
+test("parseHarvestLimit accepts the unlimited sentinel and safe bounds", () => {
+  assert.equal(parseHarvestLimit("0"), 0);
+  assert.equal(parseHarvestLimit("12"), 12);
+  assert.equal(parseHarvestLimit("00012"), 12);
+  assert.equal(parseHarvestLimit(maxSafe), Number.MAX_SAFE_INTEGER);
+});
+
+test("parseHarvestLimit rejects non-decimal and unsafe values", () => {
+  for (const raw of invalidDecimalIntegers) {
+    assert.throws(() => parseHarvestLimit(raw), /--limit.*got/);
+  }
+});
+
+test("parseItemTimeoutMs accepts positive safe decimal integers", () => {
+  assert.equal(parseItemTimeoutMs("1"), 1);
+  assert.equal(parseItemTimeoutMs("12"), 12);
+  assert.equal(parseItemTimeoutMs("00012"), 12);
+  assert.equal(parseItemTimeoutMs(maxSafe), Number.MAX_SAFE_INTEGER);
+});
+
+test("parseItemTimeoutMs rejects zero, non-decimal, and unsafe values", () => {
+  for (const raw of ["0", "000", ...invalidDecimalIntegers]) {
+    assert.throws(() => parseItemTimeoutMs(raw), /--item-timeout-ms.*got/);
+  }
+});
+
+test("parseHarvestShard accepts valid shard coordinates and safe bounds", () => {
+  assert.deepEqual(parseHarvestShard("0/1"), [0, 1]);
+  assert.deepEqual(parseHarvestShard("1/2"), [1, 2]);
+  assert.deepEqual(parseHarvestShard("01/02"), [1, 2]);
+  assert.deepEqual(parseHarvestShard(`0/${maxSafe}`), [
+    0,
+    Number.MAX_SAFE_INTEGER,
+  ]);
+});
+
+test("parseHarvestShard rejects malformed, unsafe, and out-of-range shards", () => {
+  for (const raw of [
+    "",
+    " ",
+    " 1/2",
+    "1/2 ",
+    "+1/2",
+    "1.0/2",
+    "1e0/2",
+    "1junk/2",
+    "Infinity/2",
+    `0/${overflow}`,
+    "1/0",
+    "5/2",
+    "-1/2",
+    "1/2/3",
+    "a/b",
+  ]) {
+    assert.throws(() => parseHarvestShard(raw), /--shard.*got/);
+  }
+});
+
+test("invalid CLI input fails before deterministic planning", () => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      runner,
+      "--dry-run",
+      "--deterministic",
+      "--item-timeout-ms",
+      "1e2",
+    ],
+    { encoding: "utf8" },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--item-timeout-ms/);
+  assert.doesNotMatch(result.stdout, /would harvest|summary/);
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18953

# Summary

Strictly validate the E2E training-harvest runner's numeric controls before any planning, provider, or filesystem work:

- `--limit`: complete digit-only safe integer; `0` remains unlimited.
- `--item-timeout-ms`: complete digit-only positive safe integer.
- `--shard`: exact `i/n`, safe components, `n >= 1`, and `0 <= i < n`.
- Imports are side-effect free even when ambient `process.argv` is poisoned.
- Direct execution remains reliable through symlinked paths and paths containing spaces.

The implementation keeps parsing in an explicit config boundary and threads that typed configuration through the runner instead of relying on module-scope CLI state.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@3989c04066e5c364bfe33088cd12b238a5eed642:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@33d82309e02e7d3b07a196e1dec91955026b5bce`; zero conflicts.
- [x] Focused tests and touched-file formatting were rerun after the final rebase.
- [x] Root script audits pass. Full `bun run verify` passed all pre-Turbo repository gates and made substantial package progress, then was stopped after the unchanged `plugin-phone` Vite view build sat idle for more than four minutes; this infrastructure hang is recorded below rather than represented as success.

# Risks

Low and fail-closed. Previously valid canonical inputs retain their values, including zero-padded values and the `--limit 0` sentinel. Malformed values now stop before planning. The only filesystem work in successful validation was a disposable dry-run summary under `/tmp`.

# Background

## What does this PR do?

It replaces permissive numeric coercion and module-scope argv-derived constants with exported strict parsers plus `parseRunnerConfig(argv)`. A realpath-safe executable guard preserves normal and symlinked invocation while leaving imports inert. The direct-execution catch is explicitly categorized as untrusted-input sanitization under the repository error policy.

## What kind of change is this?

Bug fix (non-breaking for documented valid input).

# Documentation changes needed?

No public command or option changed; the existing operational contract is now enforced.

# Testing

## Where should a reviewer start?

1. `scripts/training-harvest/bench-e2e-harvest-runner.test.mjs`
2. `scripts/training-harvest/bench-e2e-harvest-runner.mjs`

## Detailed testing steps

```bash
node --check scripts/training-harvest/bench-e2e-harvest-runner.mjs
node --test scripts/training-harvest/bench-e2e-harvest-runner.test.mjs
bunx biome check scripts/training-harvest/bench-e2e-harvest-runner.mjs scripts/training-harvest/bench-e2e-harvest-runner.test.mjs
bun run audit:scripts
bun run audit:scripts:inventory
node scripts/training-harvest/bench-e2e-harvest-runner.mjs --dry-run --deterministic --limit 1 --shard 0/1 --item-timeout-ms 1 --harvest-root /tmp/eliza-pr-18955-valid
```

Observed on exact head `0827374e6c1a8e8136eeeb70a7ec831ea18fba07`:

- Node parser/real-process suite: 9 passed, 0 failed.
- Syntax check: passed.
- Touched-file Biome: no errors or formatting changes; only six pre-existing warnings in the runner.
- Root script integrity and inventory audits: passed.
- Real positive CLI dry run: one planned item and a valid summary.
- Full root gate: no code failure; stopped on an unchanged idle `plugin-phone` Vite build after more than four minutes.

# Evidence Gate

<!-- evidence-head:0827374e6c1a8e8136eeeb70a7ec831ea18fba07 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - no UI surface; CLI parser only`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - no UI surface; CLI parser only`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no visual flow; real child-process tests cover the executable boundary`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - standalone offline runner; focused output and dry-run proof are recorded above`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend code or request path`.
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: `N/A - invalid input exits before provider/model access`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the real dry-run summary and terminal test output prove the changed path.
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - no rendered surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - startup validation only; no model path changes.

## Backend + frontend logs

The spawned CLI rejects malformed timeout input with nonzero status, names the offending flag, and emits no planning or summary output. The positive dry run plans one real corpus item and writes a summary.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no audio path.

## Known gaps / failures

The complete root gate did not finish because an unchanged `plugin-phone` Vite build became idle during Turbo dependency work. All pre-Turbo repository gates, the affected script audits, the real executable paths, syntax, and touched-file formatting passed. No failure was attributed to this PR.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@3989c04066e5c364bfe33088cd12b238a5eed642:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [shabbydev]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@3989c04066e5c364bfe33088cd12b238a5eed642:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZWQYG27SSHTNXK0N7Y079CA","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T05:01:34.151Z","completed_at":"2026-08-13T05:34:47.735Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAacOKoLmIcyfrBHxaOpZ7Z4FtVHvBHJPhxC03phvZLCE","device_key_id":"f3c1604b7a4071ac0c98cd8fb18006f5154a39686dc2385c92295553a1f17bb3","device_signature":"AaMPdV73efeMdKYtj0oT5x4PxmuoHTOOwt8dvxKCfXj_YfRdllZuvPgxCPc6a1ULOAOq2ORPwFlEeki6LrEnAQ"}} -->
