### PR TITLE
fix(plugin-registry): catalog isSet/configured/isActive consult runtime.getSetting and service health (#18713)

### DIFF
--- a/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
@@ -760,6 +760,61 @@ describe("app plugin compatibility routes", () => {
     );
   });
 
+  it("keeps a live runtime miss unset even when process.env has the token", () => {
+    useDiscordRegistry();
+    process.env.DISCORD_API_TOKEN = "stale-host-token";
+
+    const response = buildPluginListResponse({
+      plugins: [],
+      getSetting: () => null,
+      getService: () => null,
+    } as never);
+
+    const discord = response.plugins.find((plugin) => plugin.id === "discord");
+    expect(discord?.parameters[0]).toEqual(
+      expect.objectContaining({
+        key: "DISCORD_API_TOKEN",
+        isSet: false,
+        currentValue: null,
+      }),
+    );
+    expect(discord).toEqual(expect.objectContaining({ configured: false }));
+    expect(discord?.validationErrors).toEqual([
+      expect.objectContaining({ field: "DISCORD_API_TOKEN" }),
+    ]);
+  });
+
+  it("keeps a live runtime miss unset even when config.env and the saved entry have tokens", () => {
+    useDiscordRegistry();
+    currentConfig = {
+      env: { DISCORD_API_TOKEN: "stale-config-env-token" },
+      plugins: {
+        entries: {
+          discord: {
+            enabled: true,
+            config: { DISCORD_API_TOKEN: "stale-saved-token" },
+          },
+        },
+      },
+    };
+
+    const response = buildPluginListResponse({
+      plugins: [],
+      getSetting: () => null,
+      getService: () => null,
+    } as never);
+
+    const discord = response.plugins.find((plugin) => plugin.id === "discord");
+    expect(discord?.parameters[0]).toEqual(
+      expect.objectContaining({
+        key: "DISCORD_API_TOKEN",
+        isSet: false,
+        currentValue: null,
+      }),
+    );
+    expect(discord).toEqual(expect.objectContaining({ configured: false }));
+  });
+
   it("reports a required param unset when no env, saved, or runtime value exists", () => {
     useDiscordRegistry();
 

--- a/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
@@ -687,6 +687,228 @@ describe("app plugin compatibility routes", () => {
     );
   });
 
+  function makeDiscordRegistryEntry() {
+    return {
+      id: "discord",
+      name: "Discord",
+      npmName: "@elizaos/plugin-discord",
+      description: "",
+      tags: [],
+      kind: "connector",
+      subtype: "chat",
+      config: {
+        DISCORD_API_TOKEN: {
+          type: "secret",
+          label: "Bot token",
+          required: true,
+          sensitive: true,
+        },
+      },
+      render: {},
+      resources: {},
+      version: "1.0.0",
+    };
+  }
+
+  function useDiscordRegistry() {
+    const discordEntry = makeDiscordRegistryEntry();
+    mocks.loadRegistry.mockReturnValue({
+      all: [discordEntry],
+      byId: new Map([["discord", discordEntry]]),
+    });
+  }
+
+  it("marks a required param set from runtime.getSetting without process.env", () => {
+    useDiscordRegistry();
+
+    const response = buildPluginListResponse({
+      plugins: [],
+      getSetting: (key: string) =>
+        key === "DISCORD_API_TOKEN" ? "runtime-token" : undefined,
+      getService: () => null,
+    } as never);
+
+    const discord = response.plugins.find((plugin) => plugin.id === "discord");
+    expect(discord).toEqual(
+      expect.objectContaining({ configured: true, validationErrors: [] }),
+    );
+    expect(discord?.parameters[0]).toEqual(
+      expect.objectContaining({ key: "DISCORD_API_TOKEN", isSet: true }),
+    );
+  });
+
+  it("marks a required param set from the saved plugin entry config", () => {
+    useDiscordRegistry();
+    currentConfig = {
+      env: {},
+      plugins: {
+        entries: {
+          discord: {
+            enabled: true,
+            config: { DISCORD_API_TOKEN: "saved-token" },
+          },
+        },
+      },
+    };
+
+    const response = buildPluginListResponse(null);
+
+    const discord = response.plugins.find((plugin) => plugin.id === "discord");
+    expect(discord).toEqual(expect.objectContaining({ configured: true }));
+    expect(discord?.parameters[0]).toEqual(
+      expect.objectContaining({ key: "DISCORD_API_TOKEN", isSet: true }),
+    );
+  });
+
+  it("reports a required param unset when no env, saved, or runtime value exists", () => {
+    useDiscordRegistry();
+
+    const response = buildPluginListResponse(null);
+
+    const discord = response.plugins.find((plugin) => plugin.id === "discord");
+    expect(discord).toEqual(expect.objectContaining({ configured: false }));
+    expect(discord?.parameters[0]).toEqual(
+      expect.objectContaining({ isSet: false }),
+    );
+  });
+
+  it("does not report a loaded plugin active when its service is unhealthy", () => {
+    useDiscordRegistry();
+
+    const response = buildPluginListResponse({
+      plugins: [{ name: "@elizaos/plugin-discord" }],
+      getSetting: (key: string) =>
+        key === "DISCORD_API_TOKEN" ? "invalid-token" : undefined,
+      getService: (name: string) =>
+        name === "discord" ? { isHealthy: () => false } : null,
+    } as never);
+
+    const discord = response.plugins.find((plugin) => plugin.id === "discord");
+    expect(discord).toEqual(
+      expect.objectContaining({ configured: true, isActive: false }),
+    );
+    expect(discord?.validationWarnings).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining("unhealthy"),
+      }),
+    ]);
+  });
+
+  it("reports a loaded plugin active when its service is healthy", () => {
+    useDiscordRegistry();
+
+    const response = buildPluginListResponse({
+      plugins: [{ name: "@elizaos/plugin-discord" }],
+      getSetting: (key: string) =>
+        key === "DISCORD_API_TOKEN" ? "valid-token" : undefined,
+      getService: (name: string) =>
+        name === "discord" ? { isHealthy: () => true } : null,
+    } as never);
+
+    expect(response.plugins.find((plugin) => plugin.id === "discord")).toEqual(
+      expect.objectContaining({
+        configured: true,
+        isActive: true,
+        validationWarnings: [],
+      }),
+    );
+  });
+
+  it("keeps loaded-name activity for plugins without a health surface", () => {
+    useDiscordRegistry();
+
+    const response = buildPluginListResponse({
+      plugins: [{ name: "@elizaos/plugin-discord" }],
+      getSetting: () => undefined,
+      getService: () => null,
+    } as never);
+
+    expect(response.plugins.find((plugin) => plugin.id === "discord")).toEqual(
+      expect.objectContaining({ isActive: true }),
+    );
+  });
+
+  it("reflects a save into catalog isSet while login failure stays inactive", () => {
+    useDiscordRegistry();
+    const runtimeSettings: Record<string, string> = {};
+
+    const saveResult = persistCompatPluginMutation(
+      "discord",
+      { config: { DISCORD_API_TOKEN: "typo-token" } },
+      makePlugin(),
+    );
+    expect(saveResult.status).toBe(200);
+    // The settings bridge (#18718) folds the save into runtime.getSetting.
+    runtimeSettings.DISCORD_API_TOKEN = "typo-token";
+    currentConfig = clone(savedConfig ?? currentConfig);
+    delete process.env.DISCORD_API_TOKEN;
+
+    const response = buildPluginListResponse({
+      plugins: [{ name: "@elizaos/plugin-discord" }],
+      getSetting: (key: string) => runtimeSettings[key],
+      getService: (name: string) =>
+        name === "discord" ? { isHealthy: () => false } : null,
+    } as never);
+
+    const discord = response.plugins.find((plugin) => plugin.id === "discord");
+    expect(discord?.parameters[0]).toEqual(
+      expect.objectContaining({ isSet: true }),
+    );
+    expect(discord).toEqual(
+      expect.objectContaining({ configured: true, isActive: false }),
+    );
+  });
+
+  it("returns 422 from the test probe when the service reports unhealthy", async () => {
+    const handled = await handlePluginsCompatRoutes(
+      {
+        method: "POST",
+        url: "/api/plugins/discord/test",
+      } as never,
+      {} as never,
+      {
+        current: {
+          plugins: [{ name: "@elizaos/plugin-discord" }],
+          getSetting: () => undefined,
+          getService: (name: string) =>
+            name === "discord" ? { isHealthy: () => false } : null,
+        },
+      } as never,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.sendJson).toHaveBeenCalledWith(
+      expect.anything(),
+      422,
+      expect.objectContaining({ success: false, pluginId: "discord" }),
+    );
+  });
+
+  it("returns success from the test probe when the service reports healthy", async () => {
+    const handled = await handlePluginsCompatRoutes(
+      {
+        method: "POST",
+        url: "/api/plugins/discord/test",
+      } as never,
+      {} as never,
+      {
+        current: {
+          plugins: [{ name: "@elizaos/plugin-discord" }],
+          getSetting: () => undefined,
+          getService: (name: string) =>
+            name === "discord" ? { isHealthy: () => true } : null,
+        },
+      } as never,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.sendJson).toHaveBeenCalledWith(
+      expect.anything(),
+      200,
+      expect.objectContaining({ success: true, pluginId: "discord" }),
+    );
+  });
+
   it("returns 400 instead of throwing on malformed encoded plugin path", async () => {
     const saveCallCount = mocks.saveElizaConfig.mock.calls.length;
 

--- a/plugins/plugin-registry/src/api/app-plugins-routes.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.ts
@@ -947,8 +947,10 @@ function inferSensitiveConfigKey(key: string): boolean {
 /**
  * Reads a declared plugin param through the live runtime's `getSetting`
  * surface. Connectors resolve credentials via `runtime.getSetting()`, which
- * deliberately never falls through to `process.env`, so the catalog must ask
- * the runtime first to report what a connector will actually observe (#18713).
+ * deliberately never falls through to `process.env`, so when this reader
+ * exists it is the only source the catalog may report from — a live miss
+ * stays a miss (#18713). Returning `undefined` here means "no live runtime";
+ * only then may the catalog fall back to env/saved config.
  */
 function createRuntimeSettingReader(
   runtime: AgentRuntime | null,
@@ -1021,13 +1023,15 @@ function buildPluginParamDefs(
   });
 
   return filteredEntries.map(([key, definition]) => {
-    const runtimeValue = getRuntimeSetting?.(key);
+    // A live runtime's getSetting() is authoritative: connectors resolve
+    // credentials only through it and it never falls through to host env, so
+    // a live miss must not be papered over by stale process.env or saved
+    // config (#18713). Env/saved fallbacks serve only runtime-null builds.
     const envValue = process.env[key]?.trim() || undefined;
-    const savedValue = savedValues?.[key];
-    const effectiveValue =
-      runtimeValue ??
-      envValue ??
-      (savedValue ? savedValue.trim() || undefined : undefined);
+    const savedValue = savedValues?.[key]?.trim() || undefined;
+    const effectiveValue = getRuntimeSetting
+      ? getRuntimeSetting(key)
+      : (envValue ?? savedValue);
     const isSet = Boolean(effectiveValue);
     const sensitive =
       typeof definition.sensitive === "boolean"

--- a/plugins/plugin-registry/src/api/app-plugins-routes.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.ts
@@ -944,9 +944,51 @@ function inferSensitiveConfigKey(key: string): boolean {
   );
 }
 
+/**
+ * Reads a declared plugin param through the live runtime's `getSetting`
+ * surface. Connectors resolve credentials via `runtime.getSetting()`, which
+ * deliberately never falls through to `process.env`, so the catalog must ask
+ * the runtime first to report what a connector will actually observe (#18713).
+ */
+function createRuntimeSettingReader(
+  runtime: AgentRuntime | null,
+): ((key: string) => string | undefined) | undefined {
+  if (!runtime || typeof runtime.getSetting !== "function") {
+    return undefined;
+  }
+  return (key: string) => {
+    const value = runtime.getSetting(key);
+    return typeof value === "string" && value.trim() ? value : undefined;
+  };
+}
+
+/**
+ * Consults the plugin's registered runtime service health probe when one
+ * exists. Returns `null` when the plugin exposes no health surface (loaded
+ * state stays authoritative), otherwise the probe result. Discord's init
+ * catches login failures, so a loaded plugin name alone cannot prove a live
+ * gateway (#18713).
+ */
+function resolvePluginServiceHealth(
+  runtime: AgentRuntime | null,
+  pluginId: string,
+): boolean | null {
+  if (!runtime || typeof runtime.getService !== "function") {
+    return null;
+  }
+  const service = runtime.getService(pluginId) as {
+    isHealthy?: () => boolean;
+  } | null;
+  if (!service || typeof service.isHealthy !== "function") {
+    return null;
+  }
+  return Boolean(service.isHealthy());
+}
+
 function buildPluginParamDefs(
   parameters: Record<string, ManifestPluginParameter> | undefined,
   savedValues?: Record<string, string>,
+  getRuntimeSetting?: (key: string) => string | undefined,
 ): Array<{
   key: string;
   type: string;
@@ -979,10 +1021,13 @@ function buildPluginParamDefs(
   });
 
   return filteredEntries.map(([key, definition]) => {
+    const runtimeValue = getRuntimeSetting?.(key);
     const envValue = process.env[key]?.trim() || undefined;
     const savedValue = savedValues?.[key];
     const effectiveValue =
-      envValue ?? (savedValue ? savedValue.trim() || undefined : undefined);
+      runtimeValue ??
+      envValue ??
+      (savedValue ? savedValue.trim() || undefined : undefined);
     const isSet = Boolean(effectiveValue);
     const sensitive =
       typeof definition.sensitive === "boolean"
@@ -1157,6 +1202,7 @@ export function buildPluginListResponse(runtime: AgentRuntime | null): {
 
   const configEntries = config.plugins?.entries ?? {};
   const installEntries = config.plugins?.installs ?? {};
+  const readRuntimeSetting = createRuntimeSettingReader(runtime);
   const plugins = new Map<string, CompatPluginRecord>();
 
   for (const entry of manifest.plugins ?? []) {
@@ -1175,8 +1221,21 @@ export function buildPluginListResponse(runtime: AgentRuntime | null): {
         ? entry.configKeys
         : (bundledMeta?.configKeys ?? []);
     const envKey = entry.envKey ?? findPrimaryEnvKey(configKeys);
+    const paramDefinitions =
+      entry.pluginParameters ?? bundledMeta?.pluginParameters;
+    const savedParamValues = paramDefinitions
+      ? collectAgentScopedPluginParamValues(
+          Object.keys(paramDefinitions).map((key) => ({ key })),
+          {
+            entryConfig: asRecord(asRecord(configEntries[pluginId])?.config),
+            configEnv: asRecord(config.env),
+          },
+        )
+      : undefined;
     const parameters = buildPluginParamDefs(
-      entry.pluginParameters ?? bundledMeta?.pluginParameters,
+      paramDefinitions,
+      savedParamValues,
+      readRuntimeSetting,
     );
     const advancedCapabilityStatus = resolveAdvancedCapabilityCompatStatus(
       pluginId,
@@ -1366,6 +1425,27 @@ export function buildPluginListResponse(runtime: AgentRuntime | null): {
       isActive: isPluginLoaded(pluginId, pluginName, loadedNames),
       icon: null,
     });
+  }
+
+  // Health gate: a loaded plugin name proves module load, not a live
+  // connection. When the plugin's registered service exposes `isHealthy()`
+  // (Discord does — its init catches login failures), an unhealthy probe
+  // demotes the catalog row to inactive so an invalid or unreachable gateway
+  // never reports as active (#18713).
+  for (const plugin of plugins.values()) {
+    if (!plugin.isActive) {
+      continue;
+    }
+    if (resolvePluginServiceHealth(runtime, plugin.id) === false) {
+      plugin.isActive = false;
+      plugin.validationWarnings = [
+        ...(plugin.validationWarnings ?? []),
+        {
+          message:
+            "Service is loaded but reports unhealthy: the connection is not established. Check credentials and connectivity.",
+        },
+      ];
+    }
   }
 
   const pluginList = Array.from(plugins.values()).sort((left, right) =>
@@ -1812,6 +1892,22 @@ export async function handlePluginsCompatRoutes(
           durationMs: Date.now() - startMs,
         });
       }
+      return true;
+    }
+
+    const serviceHealth = resolvePluginServiceHealth(
+      state.current,
+      testPluginId,
+    );
+    if (serviceHealth !== null) {
+      sendJsonResponse(res, serviceHealth ? 200 : 422, {
+        success: serviceHealth,
+        pluginId: testPluginId,
+        message: serviceHealth
+          ? "Service reports healthy: connection established."
+          : "Service is loaded but reports unhealthy: the connection is not established. Check credentials and connectivity.",
+        durationMs: Date.now() - startMs,
+      });
       return true;
     }
 


### PR DESCRIPTION
# Relates to

https://github.com/elizaOS/eliza/issues/18713 — Shaw's reopen (2026-08-12T23:59Z) after #18718: the settings bridge was repaired, but the catalog authority/health contract was not completed. This PR intentionally does **not** use a closing keyword: live-gateway validation is still pending (see Known gaps), so the issue should stay open until a maintainer confirms against a real Discord gateway.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`ac6b8325`); zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below. → documented: pre-existing
      `eliza-app#typecheck` failure in `packages/homepage/src/pages/landing.tsx`
      on current `develop`, untouched by this diff.

# Risks

**Low.** The diff is confined to `plugins/plugin-registry/src/api/app-plugins-routes.ts` (compat catalog builder + test probe) and its test file. Behavioral risk surface:

- With a live runtime, catalog `isSet`/`configured` now derive **only** from `runtime.getSetting()` — a live miss stays a miss and is no longer papered over by stale `process.env` or persisted config. `process.env` / saved-entry fallbacks apply only to runtime-null (offline) catalog builds. The (#18718) settings bridge folds every Settings save into `runtime.setSetting` before the catalog re-reads, so a legitimate save still reports `isSet: true` under a live runtime (covered by the `reflects a save into catalog isSet…` test).
- Catalog `isActive` can become `false` for a loaded plugin whose registered service reports `isHealthy() === false`. Plugins without a health surface are unaffected (probe returns `null`, loaded-name state stays authoritative). This is the intended honesty change: it also makes the existing `inactive_but_enabled` drift diagnostic truthful.

# Background

## What does this PR do?

Completes the catalog authority/health contract from #18713, per the reopen at `develop@c267370f` and the CHANGES_REQUESTED review on `a605c14e`:

| Reopen / review finding | Fix |
| --- | --- |
| `buildPluginParamDefs` derives `isSet` only from `process.env` or saved strings; the catalog caller supplies no runtime setting | `buildPluginParamDefs` now takes a runtime-setting reader, and reader **presence** is preserved separately from reader **output**: when a live runtime exists, the effective value is `runtime.getSetting(key)` alone; `process.env` → saved agent-scoped entry config are consulted only when no live runtime exists (offline catalog construction). |
| Review P1: `runtimeValue ?? envValue ?? savedValue` still reported `isSet: true` / `configured: true` from stale host env or persisted strings when the live `getSetting()` missed | Fixed as above; both adversarial regressions from the review (live miss + `process.env` token, live miss + `config.env` + saved-entry tokens) are now tests, red at the reviewed head and green at this head (transcripts in Evidence). |
| `configured` is required-field presence only | `configured` still derives from required-param validation, but validation now runs against the runtime-authoritative `isSet`, so it reflects what a connector will actually observe through `getSetting()`. |
| `isActive` is loaded-plugin-name presence only | A health gate runs over the fully assembled plugin map (covering all four assembly paths, including the `runtime.plugins` overwrite that forced `isActive = true`): any active row whose registered service exposes `isHealthy()` and reports `false` is demoted to `isActive: false` with a visible validation warning. |
| Neither status consults `runtime.getSetting()` nor `DiscordService.isHealthy()` | Both are now consulted. `DiscordService.isHealthy()` (plugins/plugin-discord/service.ts:1779) checks `_loginFailed` and `client.isReady()`, so a caught login failure or unreachable gateway reports unhealthy. |
| Discord init catches login failure, so invalid/unreachable gateway can still show configured+active | An invalid token can still show `configured: true` (a value is set in `getSetting`), but the row is `isActive: false` with a warning — configured+active can no longer both be reported for a dead gateway. `POST /api/plugins/:id/test` also now consults the same health surface (422 + `success: false` when unhealthy) instead of unconditionally answering "Plugin is loaded". |

The health gate is generic (`runtime.getService(pluginId)` + duck-typed `isHealthy()`), so Discord gets it today and any connector that exposes the same probe inherits it without catalog changes.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The catalog/status contract this implements is the one #18713 specifies.

# Testing

## Where should a reviewer start?

`plugins/plugin-registry/src/api/app-plugins-routes.test.ts` — the eleven cases added for this contract, especially:

- `keeps a live runtime miss unset even when process.env has the token` — the review's first adversarial case: live `getSetting() === null` + `process.env.DISCORD_API_TOKEN` present ⇒ `isSet: false`, `configured: false`, required-field validation error present.
- `keeps a live runtime miss unset even when config.env and the saved entry have tokens` — the review's second adversarial case: live miss + tokens in both `config.env` and `plugins.entries.discord.config` ⇒ still unset.
- `reflects a save into catalog isSet while login failure stays inactive` — the full save→catalog acceptance path: Settings save persists the token, the (#18718) bridge folds it into `getSetting`, catalog shows `isSet: true` / `configured: true`, and the unhealthy service keeps `isActive: false`.
- `does not report a loaded plugin active when its service is unhealthy` — login-failure-still-not-active.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-registry typecheck        # clean
cd plugins/plugin-registry && bunx vitest run           # 3 files, 42 tests pass (2 new adversarial regressions from the review)
bunx biome check src/api/app-plugins-routes.ts src/api/app-plugins-routes.test.ts   # clean
bun run verify                                          # 347/348 tasks pass; sole failure pre-existing on develop (Known gaps)
```

# Evidence Gate

<!-- evidence-head:4bf9b280ed67e9e239feaf988ea3b083a65e8336 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no UI surface touched; change is service/status-only in the compat catalog route handler (no packages/app, packages/ui, or rendered file in the diff)`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - same reason; the UI consumes the corrected isSet/configured/isActive fields unchanged`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-visible flow change to record without a live Discord gateway; catalog JSON change is proven by the route-level tests below`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: full package test transcript at head `4bf9b280` (real `handlePluginsCompatRoutes` / `buildPluginListResponse` code paths, mocked persistence boundary per the suite's established harness):

<details>
<summary>plugin-registry vitest transcript — 3 files, 42 tests pass at 4bf9b280</summary>

```
 RUN  v4.1.5 /home/potter/src/eliza/plugins/plugin-registry

 ✓ src/api/bridge-plugin-settings.test.ts > collectAgentScopedPluginParamValues > prefers entry.config over config.env and skips blanks
 ✓ src/api/bridge-plugin-settings.test.ts > bridgePluginParamsToRuntime > writes trimmed values through setSetting with sensitive flag
 ✓ src/api/bridge-plugin-settings.test.ts > bridgePluginParamsToRuntime > clears blank submitted values with null
 ✓ src/api/bridge-plugin-settings.test.ts > bridgePluginParamsToRuntime > skips non-empty writes for blocked keys but still clears them
 ✓ src/api/bridge-plugin-settings.test.ts > bridgePluginParamsToRuntime > is a no-op without a runtime setSetting
 ✓ src/api/plugin-routes.test.ts > handlePluginRoutes config persistence > persists submitted config to env and plugins.entries
 ✓ src/api/plugin-routes.test.ts > handlePluginRoutes config persistence > preserves entry config when enabling a plugin
 ✓ src/api/plugin-routes.test.ts > handlePluginRoutes config persistence > clears folded credentials when disabling a plugin
 ✓ src/api/plugin-routes.test.ts > handlePluginRoutes config persistence > removes blank optional config values from persisted and process env
 ✓ src/api/plugin-routes.test.ts > handlePluginRoutes config persistence > rejects hostile install package name "../../evil" before installer access
 ✓ src/api/plugin-routes.test.ts > handlePluginRoutes config persistence > rejects hostile install package name "@scope/../evil" before installer access
 ✓ src/api/plugin-routes.test.ts > handlePluginRoutes config persistence > rejects hostile install package name "plugin name" before installer access
 ✓ src/api/plugin-routes.test.ts > handlePluginRoutes config persistence > rejects hostile install package name "" before installer access
 ✓ src/api/plugin-routes.test.ts > handlePluginRoutes config persistence > rejects hostile install package name "   " before installer access
 ✓ src/api/plugin-routes.test.ts > handlePluginRoutes config persistence > returns /api/plugins with best-effort metadata when registry refresh hangs
 ✓ src/api/app-plugins-routes.test.ts > rejects undeclared config keys without saving
 ✓ src/api/app-plugins-routes.test.ts > writes valid config values to env, plugin entry config, and process.env
 ✓ src/api/app-plugins-routes.test.ts > removes optional blank values from persisted and process env
 ✓ src/api/app-plugins-routes.test.ts > mirrors connector enabled state to the compat connector section
 ✓ src/api/app-plugins-routes.test.ts > removes every plugin alias from the allowlist when disabling
 ✓ src/api/app-plugins-routes.test.ts > keeps app plugin entries and the canonical allowlist aligned
 ✓ src/api/app-plugins-routes.test.ts > canonicalizes mismatched runtime and package identities when disabling
 ✓ src/api/app-plugins-routes.test.ts > keeps a canonical disabled entry disabled when the runtime plugin is loaded
 ✓ src/api/app-plugins-routes.test.ts > replaces a stale compatibility alias with the canonical package on enable
 ✓ src/api/app-plugins-routes.test.ts > migrates allow aliases during a config-only update
 ✓ src/api/app-plugins-routes.test.ts > preserves the registry id for config-only bundled feature updates
 ✓ src/api/app-plugins-routes.test.ts > falls back to the registry id for non-plugin package metadata
 ✓ src/api/app-plugins-routes.test.ts > canonicalizes legacy app-package identities in both directions
 ✓ src/api/app-plugins-routes.test.ts > does not mark a plugin active from unrelated loaded-name substrings
 ✓ src/api/app-plugins-routes.test.ts > builds the plugin list once for GET /api/plugins
 ✓ src/api/app-plugins-routes.test.ts > marks a required param set from runtime.getSetting without process.env
 ✓ src/api/app-plugins-routes.test.ts > marks a required param set from the saved plugin entry config
 ✓ src/api/app-plugins-routes.test.ts > keeps a live runtime miss unset even when process.env has the token
 ✓ src/api/app-plugins-routes.test.ts > keeps a live runtime miss unset even when config.env and the saved entry have tokens
 ✓ src/api/app-plugins-routes.test.ts > reports a required param unset when no env, saved, or runtime value exists
 ✓ src/api/app-plugins-routes.test.ts > does not report a loaded plugin active when its service is unhealthy
 ✓ src/api/app-plugins-routes.test.ts > reports a loaded plugin active when its service is healthy
 ✓ src/api/app-plugins-routes.test.ts > keeps loaded-name activity for plugins without a health surface
 ✓ src/api/app-plugins-routes.test.ts > reflects a save into catalog isSet while login failure stays inactive
 ✓ src/api/app-plugins-routes.test.ts > returns 422 from the test probe when the service reports unhealthy
 ✓ src/api/app-plugins-routes.test.ts > returns success from the test probe when the service reports healthy
 ✓ src/api/app-plugins-routes.test.ts > returns 400 instead of throwing on malformed encoded plugin path

 Test Files  3 passed (3)
      Tests  42 passed (42)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend change; response shape is unchanged (existing optional fields only)`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change; HTTP catalog metadata only`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: red/green catalog JSON assertions for both review adversarial cases — red at reviewed head `a605c14e`, green at this head `4bf9b280`:

<details>
<summary>Adversarial regressions: red at a605c14e (the review's false-green reproduced), green at 4bf9b280</summary>

Red run — the two new tests executed against the reviewed head's `app-plugins-routes.ts` (`git show a605c14e:…/app-plugins-routes.ts`), reproducing exactly the review's false-green catalog rows:

```
 × keeps a live runtime miss unset even when process.env has the token
 × keeps a live runtime miss unset even when config.env and the saved entry have tokens
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/api/app-plugins-routes.test.ts > app plugin compatibility routes > keeps a live runtime miss unset even when process.env has the token
AssertionError: expected { key: 'DISCORD_API_TOKEN', …(8) } to deeply equal ObjectContaining{…}
-   "isSet": false,
+   "isSet": true,
 FAIL  src/api/app-plugins-routes.test.ts > app plugin compatibility routes > keeps a live runtime miss unset even when config.env and the saved entry have tokens
AssertionError: expected { key: 'DISCORD_API_TOKEN', …(8) } to deeply equal ObjectContaining{…}
-   "isSet": false,
+   "isSet": true,
 Test Files  1 failed (1)
      Tests  2 failed | 25 skipped (27)
```

Green run — same two tests at this head (fix applied):

```
 ✓ src/api/app-plugins-routes.test.ts > app plugin compatibility routes > keeps a live runtime miss unset even when process.env has the token 6ms
 ✓ src/api/app-plugins-routes.test.ts > app plugin compatibility routes > keeps a live runtime miss unset even when config.env and the saved entry have tokens 1ms
 Test Files  1 passed (1)
      Tests  2 passed | 25 skipped (27)
```

What each green case asserts (see the test source at this head): runtime present with `getSetting() === null`; case 1 sets `process.env.DISCORD_API_TOKEN = "stale-host-token"`, case 2 puts tokens in both `config.env` and `plugins.entries.discord.config`; both assert the catalog row is `{ key: "DISCORD_API_TOKEN", isSet: false, currentValue: null }` and the plugin is `configured: false` (case 1 also asserts the required-field validation error is present).

Offline fallback rows retained and still green (`marks a required param set from the saved plugin entry config`, `reports a required param unset when no env, saved, or runtime value exists` — both with `buildPluginListResponse(null)`).

</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface in the diff`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Backend logs are inline in the Evidence Gate `Backend logs` row above (full 42-test transcript at head `4bf9b280`). Frontend logs: `N/A - no frontend change.`

## Screenshots (before / after) + video walkthrough

`N/A - service/status-only change; no rendered UI file in the diff.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

1. **Live Discord gateway proof: N/A.** This machine has no Discord bot credentials, so save → enable → real login (and the invalid-token live counterpart) could not be exercised against the actual gateway, and no live artifacts are claimed. The login-failure path is covered by unit tests against the real route handlers with `DiscordService.isHealthy()`'s contract (`_loginFailed` / `client.isReady()`), but a maintainer with staging credentials should confirm before closing #18713. **This PR deliberately does not auto-close the issue.**
2. **`bun run verify`: 347/348 tasks pass; sole failure is `eliza-app#typecheck`** — pre-existing TS errors in `packages/homepage/src/pages/landing.tsx` (TS2353/TS2550) on current `develop` (`ac6b8325`), which this diff does not touch (verified: `git diff upstream/develop...HEAD --name-only` is exactly the two files under `plugins/plugin-registry`). Package-scoped gates for the touched workspace (typecheck, biome, full vitest suite) all pass at this head.

---

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [claude-18713]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZWTD5Y43X46ZF39512WB1S0","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T05:44:32.453Z","completed_at":"2026-08-13T05:58:07.762Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA1wup-TpOQbidV6XOR-nWj5-01vmuc1Uuv5emKqsM8iA","device_key_id":"dbd0806ed31cfab14a18eeb4990c66497a5ce64fdb0d37d3c878b8f5e6227484","device_signature":"3fOFP3QZECcB5g6ADkcxekmHaalsZACzV1G0Ag1Yg0gEp4jbYOYIvcX82KrWlwxAzVn0llsFr6eniz-2mPW7AA"}} -->
