### PR TITLE
fix(ui): shard Story Gate and fail closed on incomplete coverage

### DIFF
--- a/.github/workflows/ui-story-gate.yml
+++ b/.github/workflows/ui-story-gate.yml
@@ -1,0 +1,155 @@
+name: UI Story Gate
+
+# The complete Storybook catalog is split into deterministic shards so a
+# develop run produces a verdict before the hosted job budget expires. The
+# aggregate job remains fail-closed when a shard is cancelled or incomplete.
+
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - "packages/ui/**"
+      - ".github/workflows/ui-story-gate.yml"
+  push:
+    branches: [develop]
+    paths:
+      - "packages/ui/**"
+      - ".github/workflows/ui-story-gate.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ui-story-gate-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  BUN_VERSION: "1.3.14"
+  NODE_VERSION: "24.15.0"
+  STORY_SHARDS: 8
+
+jobs:
+  build-catalog:
+    name: Build Storybook catalog
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+
+      - uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          install-command: bun install --frozen-lockfile --ignore-scripts
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Build static Storybook catalog
+        run: bun run --cwd packages/ui build-storybook --output-dir storybook-static --quiet
+
+      - name: Upload static Storybook catalog
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: storybook-static
+          path: packages/ui/storybook-static
+          if-no-files-found: ignore
+          retention-days: 3
+
+  story-shard:
+    name: Story shard ${{ matrix.shard }}/8
+    needs: build-catalog
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+
+      - uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          install-command: bun install --frozen-lockfile --ignore-scripts
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Download static Storybook catalog
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: storybook-static
+          path: packages/ui/storybook-static
+
+      - name: Install Playwright Chromium
+        run: PLAYWRIGHT_INSTALL_CWD=packages/ui .github/scripts/install-playwright-browsers.sh chromium
+
+      - name: Run deterministic Story Gate shard
+        run: >-
+          node packages/ui/test/story-gate/run-story-gate.mjs
+          --static-dir packages/ui/storybook-static
+          --out test/story-gate/output
+          --shard ${{ matrix.shard }}/${{ env.STORY_SHARDS }}
+          --concurrency 6
+
+      - name: Upload shard report and evidence
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: story-gate-shard-${{ matrix.shard }}-of-8
+          path: packages/ui/test/story-gate/output
+          if-no-files-found: ignore
+          retention-days: 3
+
+  aggregate:
+    name: Aggregate Story Gate verdict
+    needs: [build-catalog, story-shard]
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+
+      - name: Download static catalog
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: storybook-static
+          path: packages/ui/storybook-static
+
+      - name: Download all shard artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: story-gate-shard-*-of-8
+          path: packages/ui/test/story-gate/shards
+          merge-multiple: false
+
+      - name: Merge and validate complete catalog coverage
+        if: ${{ always() && !cancelled() }}
+        run: >-
+          node packages/ui/test/story-gate/merge-story-gate.mjs
+          --catalog packages/ui/storybook-static/index.json
+          --input packages/ui/test/story-gate/shards
+          --out packages/ui/test/story-gate/output
+          --shards 8
+
+      - name: Upload aggregate Story Gate output
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: story-gate-output
+          path: packages/ui/test/story-gate/output
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/ui-story-gate.yml
+++ b/.github/workflows/ui-story-gate.yml
@@ -63,9 +63,9 @@ jobs:
   story-shard:
     name: Story shard ${{ matrix.shard }}/8
     needs: build-catalog
-    if: ${{ always() && !cancelled() }}
+    if: ${{ always() }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
@@ -94,6 +94,7 @@ jobs:
         run: PLAYWRIGHT_INSTALL_CWD=packages/ui .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Run deterministic Story Gate shard
+        timeout-minutes: 20
         run: >-
           node packages/ui/test/story-gate/run-story-gate.mjs
           --static-dir packages/ui/storybook-static
@@ -102,7 +103,7 @@ jobs:
           --concurrency 6
 
       - name: Upload shard report and evidence
-        if: ${{ always() && !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: story-gate-shard-${{ matrix.shard }}-of-8
@@ -113,7 +114,7 @@ jobs:
   aggregate:
     name: Aggregate Story Gate verdict
     needs: [build-catalog, story-shard]
-    if: ${{ always() && !cancelled() }}
+    if: ${{ always() }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -137,7 +138,7 @@ jobs:
           merge-multiple: false
 
       - name: Merge and validate complete catalog coverage
-        if: ${{ always() && !cancelled() }}
+        if: ${{ always() }}
         run: >-
           node packages/ui/test/story-gate/merge-story-gate.mjs
           --catalog packages/ui/storybook-static/index.json
@@ -146,7 +147,7 @@ jobs:
           --shards 8
 
       - name: Upload aggregate Story Gate output
-        if: ${{ always() && !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: story-gate-output

--- a/packages/ui/test/story-gate/README.md
+++ b/packages/ui/test/story-gate/README.md
@@ -53,6 +53,21 @@ node test/story-gate/run-story-gate.mjs --shard 1/4            # CI shard
 node test/story-gate/run-story-gate.mjs --grep button --no-a11y
 ```
 
+CI runs the catalog as eight deterministic shards. Each shard writes the same
+`report.json` contract plus its screenshots and frontend logs. The aggregate
+job reads `storybook-static/index.json`, requires all eight shard reports, and
+fails closed when a shard is missing, a story is duplicated, a story is missing
+from the union, or an unexpected story id appears. A shard's own failures are
+preserved in the aggregate report before the aggregate job exits non-zero.
+
+```bash
+node test/story-gate/merge-story-gate.mjs \
+  --catalog storybook-static/index.json \
+  --input test/story-gate/shards \
+  --out test/story-gate/output \
+  --shards 8
+```
+
 Useful flags: `--concurrency N`, `--limit N`, `--no-screenshots`, `--no-a11y`,
 `--update-baseline` (regenerate the console + a11y baselines after an
 intentional change).

--- a/packages/ui/test/story-gate/merge-story-gate.mjs
+++ b/packages/ui/test/story-gate/merge-story-gate.mjs
@@ -1,0 +1,322 @@
+import {
+  cp,
+  mkdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const REPORT_SCHEMA = "eliza_story_gate_v1";
+const SHARD_PATTERN = /^[1-9]\d*\/[1-9]\d*$/;
+
+function entriesFromCatalog(catalog) {
+  return Object.values(catalog?.entries ?? catalog?.stories ?? {});
+}
+
+export function storyIdsFromCatalog(catalog) {
+  const ids = entriesFromCatalog(catalog)
+    .filter((entry) => entry?.type === "story" && typeof entry.id === "string")
+    .map((entry) => entry.id)
+    .sort((a, b) => a.localeCompare(b));
+
+  const duplicates = ids.filter((id, index) => ids[index - 1] === id);
+  if (duplicates.length) {
+    throw new Error(`duplicate catalog story ids: ${[...new Set(duplicates)].join(", ")}`);
+  }
+  return ids;
+}
+
+function list(values) {
+  return values.length ? values.join(", ") : "none";
+}
+
+function validateReports(reports, expectedShards) {
+  if (!Array.isArray(reports)) throw new Error("reports must be an array");
+  if (
+    expectedShards.some(
+      (shard) => typeof shard !== "string" || !SHARD_PATTERN.test(shard),
+    )
+  ) {
+    throw new Error("expectedShards must contain valid shard ids");
+  }
+  const expected = new Set(expectedShards);
+  if (expected.size !== expectedShards.length) {
+    throw new Error("expectedShards must not contain duplicates");
+  }
+  const seen = new Set();
+
+  for (const report of reports) {
+    if (!report || typeof report !== "object") {
+      throw new Error("invalid shard report");
+    }
+    if (report.schema !== REPORT_SCHEMA) {
+      throw new Error(`invalid shard report schema: ${report.schema ?? "missing"}`);
+    }
+    if (typeof report.shard !== "string" || !expected.has(report.shard)) {
+      throw new Error(`unexpected shard report: ${report.shard ?? "missing"}`);
+    }
+    if (seen.has(report.shard)) {
+      throw new Error(`duplicate shard report: ${report.shard}`);
+    }
+    if (!Array.isArray(report.results) || !Array.isArray(report.failures)) {
+      throw new Error(`invalid shard report payload: ${report.shard}`);
+    }
+    if (report.totals?.stories !== report.results.length) {
+      throw new Error(`shard story count mismatch: ${report.shard}`);
+    }
+    if (report.totals?.failures !== report.failures.length) {
+      throw new Error(`shard failure count mismatch: ${report.shard}`);
+    }
+    for (const failure of report.failures) {
+      if (
+        !failure ||
+        typeof failure !== "object" ||
+        typeof failure.kind !== "string" ||
+        typeof failure.detail !== "string"
+      ) {
+        throw new Error(`invalid shard failure entry: ${report.shard}`);
+      }
+      if (failure.id !== undefined && typeof failure.id !== "string") {
+        throw new Error(`invalid shard failure entry: ${report.shard}`);
+      }
+      if (failure.kind !== "fatal" && typeof failure.id !== "string") {
+        throw new Error(`invalid shard failure entry: ${report.shard}`);
+      }
+    }
+    seen.add(report.shard);
+  }
+
+  const missing = expectedShards.filter((shard) => !seen.has(shard));
+  if (missing.length) throw new Error(`missing shard report: ${missing.join(", ")}`);
+}
+
+function summarize(results) {
+  return {
+    stories: results.length,
+    good: results.filter((result) => result.verdict === "good").length,
+    broken: results.filter((result) => result.verdict === "broken").length,
+    needsRuntime: results.filter((result) => result.verdict === "needs-runtime").length,
+    withConsoleErrors: results.filter((result) => result.consoleErrors?.length).length,
+    withA11yViolations: results.filter((result) => result.a11y?.length).length,
+    playExpected: results.filter((result) => result.play?.expected).length,
+    playPrepared: results.filter((result) => result.play?.prepared).length,
+  };
+}
+
+export function mergeStoryGateReports({ catalog, reports, expectedShards }) {
+  if (!Array.isArray(expectedShards) || expectedShards.length === 0) {
+    throw new Error("expectedShards must be a non-empty array");
+  }
+  validateReports(reports, expectedShards);
+
+  const catalogIds = storyIdsFromCatalog(catalog);
+  const catalogSet = new Set(catalogIds);
+  const results = reports
+    .flatMap((report) => report.results)
+    .sort((a, b) => String(a.id).localeCompare(String(b.id)));
+  const seen = new Set();
+  const duplicates = [];
+  const unexpected = [];
+
+  for (const result of results) {
+    if (typeof result?.id !== "string") throw new Error("story result is missing an id");
+    if (seen.has(result.id)) duplicates.push(result.id);
+    seen.add(result.id);
+    if (!catalogSet.has(result.id)) unexpected.push(result.id);
+  }
+
+  if (duplicates.length) {
+    throw new Error(`duplicate story id: ${[...new Set(duplicates)].join(", ")}`);
+  }
+  if (unexpected.length) {
+    throw new Error(`unexpected story ids: ${[...new Set(unexpected)].join(", ")}`);
+  }
+
+  const missing = catalogIds.filter((id) => !seen.has(id));
+  if (missing.length) throw new Error(`missing story ids: ${list(missing)}`);
+
+  const failures = reports.flatMap((report) =>
+    report.failures.map((failure) => ({ ...failure, shard: report.shard })),
+  );
+
+  return {
+    schema: REPORT_SCHEMA,
+    aggregation: {
+      expectedShards,
+      receivedShards: reports.map((report) => report.shard).sort(),
+      catalogStories: catalogIds.length,
+    },
+    totals: { ...summarize(results), failures: failures.length },
+    failures,
+    results,
+  };
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+async function writeArtifacts(outDir, merged) {
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(join(outDir, "screenshots"), { recursive: true });
+
+  const cells = merged.results
+    .map(
+      (result) =>
+        `<figure><img loading="lazy" src="screenshots/${escapeHtml(result.id)}.png" alt="${escapeHtml(result.title)}/${escapeHtml(result.name)}"><figcaption>${escapeHtml(result.title)}/${escapeHtml(result.name)}</figcaption></figure>`,
+    )
+    .join("\n");
+  await writeFile(
+    join(outDir, "contact-sheet.html"),
+    `<!doctype html><meta charset="utf-8"><title>Story Gate Contact Sheet</title><style>body{background:#0a0a0a;color:#eee;font-family:system-ui;margin:0;padding:16px}main{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:10px}figure{margin:0;border:1px solid #2d3436;border-radius:6px;overflow:hidden;background:#111}img{width:100%;display:block;min-height:80px;background:#000}figcaption{padding:4px 6px;font:11px monospace}</style><h1>Story Gate - ${merged.results.length} stories</h1><main>${cells}</main>`,
+  );
+
+  const withLogs = merged.results
+    .filter(
+      (result) =>
+        result.consoleErrors?.length || result.issues?.length || result.logCapture,
+    )
+    .map((result) => ({
+      id: result.id,
+      title: `${result.title}/${result.name}`,
+      verdict: result.verdict,
+      consoleErrors: result.consoleErrors ?? [],
+      issues: result.issues ?? [],
+      capture: result.logCapture ?? null,
+    }));
+  await writeFile(
+    join(outDir, "frontend-logs.json"),
+    JSON.stringify(
+      {
+        schema: "eliza_story_gate_frontend_logs_v2",
+        summary: {
+          stories: merged.results.length,
+          withConsoleErrors: merged.results.filter((result) => result.consoleErrors?.length).length,
+          withNetworkFailures: merged.results.filter(
+            (result) =>
+              (result.logCapture?.summary?.failedResponses ?? 0) +
+                (result.logCapture?.summary?.requestFailures ?? 0) >
+              0,
+          ).length,
+          broken: merged.results.filter((result) => result.verdict === "broken").length,
+        },
+        stories: withLogs,
+      },
+      null,
+      2,
+    ),
+  );
+
+  const verdict = merged.failures.length
+    ? `FAIL: ${merged.failures.length} regression(s)`
+    : "PASS: no shard or coverage regressions";
+  await writeFile(
+    join(outDir, "manual-review.md"),
+    `# Story Gate - manual review\n\nGenerated aggregate: ${merged.results.length} stories.\n\n**Verdict:** ${verdict}.\n`,
+  );
+  await writeFile(join(outDir, "report.json"), JSON.stringify(merged, null, 2));
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+export async function mergeStoryGateArtifacts({ catalogPath, inputDir, outDir, shardCount }) {
+  const expectedShards = Array.from(
+    { length: shardCount },
+    (_, index) => `${index + 1}/${shardCount}`,
+  );
+  const reports = [];
+  const screenshotDirs = [];
+  let merged;
+  try {
+    for (let index = 1; index <= shardCount; index++) {
+      const shardDir = join(inputDir, `story-gate-shard-${index}-of-${shardCount}`);
+      const reportPath = join(shardDir, "report.json");
+      const report = await readJson(reportPath).catch(() => {
+        throw new Error(`missing shard report: ${index}/${shardCount}`);
+      });
+      reports.push(report);
+      screenshotDirs.push(join(shardDir, "screenshots"));
+    }
+    merged = mergeStoryGateReports({
+      catalog: await readJson(catalogPath),
+      reports,
+      expectedShards,
+    });
+    await writeArtifacts(outDir, merged);
+  } catch (error) {
+    await rm(outDir, { recursive: true, force: true });
+    await mkdir(outDir, { recursive: true });
+    await writeFile(
+      join(outDir, "report.json"),
+      JSON.stringify(
+        {
+          schema: "eliza_story_gate_aggregate_v1",
+          aggregation: { expectedShards },
+          totals: { stories: 0, failures: 1 },
+          failures: [{ kind: "aggregate-validation", detail: error.message }],
+          results: [],
+        },
+        null,
+        2,
+      ),
+    );
+    throw error;
+  }
+  for (const screenshots of screenshotDirs) {
+    await cp(screenshots, join(outDir, "screenshots"), {
+      recursive: true,
+      force: true,
+    }).catch(() => undefined);
+  }
+  if (merged.failures.length) {
+    const byShard = new Map();
+    for (const failure of merged.failures) {
+      byShard.set(failure.shard, (byShard.get(failure.shard) ?? 0) + 1);
+    }
+    const summary = [...byShard.entries()]
+      .map(([shard, count]) => `${shard}: ${count}`)
+      .join(", ");
+    throw new Error(`shard failures: ${summary}`);
+  }
+  return merged;
+}
+
+function parseCli(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index++) {
+    const flag = argv[index];
+    const value = argv[++index];
+    if (!flag?.startsWith("--") || value === undefined) {
+      throw new Error(`invalid argument: ${flag ?? "missing"}`);
+    }
+    values[flag.slice(2)] = value;
+  }
+  const shardCount = Number(values.shards);
+  if (!Number.isSafeInteger(shardCount) || shardCount < 1) {
+    throw new Error("--shards must be a positive safe integer");
+  }
+  for (const name of ["catalog", "input", "out"]) {
+    if (!values[name]) throw new Error(`--${name} is required`);
+  }
+  return {
+    catalogPath: resolve(values.catalog),
+    inputDir: resolve(values.input),
+    outDir: resolve(values.out),
+    shardCount,
+  };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(import.meta.filename)) {
+  mergeStoryGateArtifacts(parseCli(process.argv.slice(2))).catch((error) => {
+    console.error(`story-gate merge: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/packages/ui/test/story-gate/merge-story-gate.mjs
+++ b/packages/ui/test/story-gate/merge-story-gate.mjs
@@ -8,7 +8,8 @@
  * pass with a smaller manifest: a cancelled or truncated shard must never be
  * able to produce a green run.
  */
-import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { cp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
 const REPORT_SCHEMA = "eliza_story_gate_v1";
@@ -274,6 +275,51 @@ async function readJson(path) {
   return JSON.parse(await readFile(path, "utf8"));
 }
 
+async function readShardReport(reportPath, shard) {
+  try {
+    return await readJson(reportPath);
+  } catch (error) {
+    // error-policy:J2 Identify the failed shard while retaining the filesystem or parse cause.
+    const kind =
+      error?.code === "ENOENT"
+        ? "missing shard report"
+        : error instanceof SyntaxError
+          ? "invalid shard report JSON"
+          : "unreadable shard report";
+    throw new Error(`${kind}: ${shard}`, { cause: error });
+  }
+}
+
+async function copyShardScreenshots({ reports, screenshotDirs, outDir }) {
+  for (let index = 0; index < reports.length; index++) {
+    const report = reports[index];
+    const screenshots = screenshotDirs[index];
+    const required = report.results
+      .filter((result) => result.verdict === "good")
+      .map((result) => `${result.id}.png`);
+
+    if (!existsSync(screenshots)) {
+      if (required.length) {
+        throw new Error(`missing shard screenshots: ${report.shard}`);
+      }
+      continue;
+    }
+
+    const available = new Set(await readdir(screenshots));
+    const missing = required.filter((name) => !available.has(name));
+    if (missing.length) {
+      throw new Error(
+        `missing screenshots for rendered stories in ${report.shard}: ${missing.join(", ")}`,
+      );
+    }
+
+    await cp(screenshots, join(outDir, "screenshots"), {
+      recursive: true,
+      force: true,
+    });
+  }
+}
+
 export async function mergeStoryGateArtifacts({
   catalogPath,
   inputDir,
@@ -294,9 +340,10 @@ export async function mergeStoryGateArtifacts({
         `story-gate-shard-${index}-of-${shardCount}`,
       );
       const reportPath = join(shardDir, "report.json");
-      const report = await readJson(reportPath).catch(() => {
-        throw new Error(`missing shard report: ${index}/${shardCount}`);
-      });
+      const report = await readShardReport(
+        reportPath,
+        `${index}/${shardCount}`,
+      );
       reports.push(report);
       screenshotDirs.push(join(shardDir, "screenshots"));
     }
@@ -306,7 +353,9 @@ export async function mergeStoryGateArtifacts({
       expectedShards,
     });
     await writeArtifacts(outDir, merged);
+    await copyShardScreenshots({ reports, screenshotDirs, outDir });
   } catch (error) {
+    // error-policy:J1 The aggregation boundary emits a durable failure report before rejecting CI.
     await rm(outDir, { recursive: true, force: true });
     await mkdir(outDir, { recursive: true });
     await writeFile(
@@ -324,12 +373,6 @@ export async function mergeStoryGateArtifacts({
       ),
     );
     throw error;
-  }
-  for (const screenshots of screenshotDirs) {
-    await cp(screenshots, join(outDir, "screenshots"), {
-      recursive: true,
-      force: true,
-    }).catch(() => undefined);
   }
   if (merged.failures.length) {
     const byShard = new Map();
@@ -374,6 +417,7 @@ if (
   resolve(process.argv[1]) === resolve(import.meta.filename)
 ) {
   mergeStoryGateArtifacts(parseCli(process.argv.slice(2))).catch((error) => {
+    // error-policy:J1 The CLI boundary translates an aggregate failure into a non-zero process result.
     console.error(`story-gate merge: ${error.message}`);
     process.exit(1);
   });

--- a/packages/ui/test/story-gate/merge-story-gate.mjs
+++ b/packages/ui/test/story-gate/merge-story-gate.mjs
@@ -1,3 +1,13 @@
+/**
+ * Aggregates the sharded Story Gate reports into the single canonical verdict.
+ *
+ * The gate is only meaningful if the merged manifest exactly covers the
+ * Storybook catalog discovered at build time, so every shard report must be
+ * present, well-formed, uniquely identified, and free of duplicate or unknown
+ * story ids. Any of those conditions failing is an aggregation failure, not a
+ * pass with a smaller manifest: a cancelled or truncated shard must never be
+ * able to produce a green run.
+ */
 import {
   cp,
   mkdir,

--- a/packages/ui/test/story-gate/merge-story-gate.mjs
+++ b/packages/ui/test/story-gate/merge-story-gate.mjs
@@ -9,6 +9,7 @@ import { join, resolve } from "node:path";
 
 const REPORT_SCHEMA = "eliza_story_gate_v1";
 const SHARD_PATTERN = /^[1-9]\d*\/[1-9]\d*$/;
+const STORY_VERDICTS = new Set(["good", "broken", "needs-runtime"]);
 
 function entriesFromCatalog(catalog) {
   return Object.values(catalog?.entries ?? catalog?.stories ?? {});
@@ -104,6 +105,18 @@ function summarize(results) {
   };
 }
 
+function validateResult(result) {
+  if (!result || typeof result !== "object") {
+    throw new Error("invalid story result");
+  }
+  if (typeof result.id !== "string" || !result.id) {
+    throw new Error("story result is missing an id");
+  }
+  if (!STORY_VERDICTS.has(result.verdict)) {
+    throw new Error(`invalid story verdict for ${result.id}: ${result.verdict ?? "missing"}`);
+  }
+}
+
 export function mergeStoryGateReports({ catalog, reports, expectedShards }) {
   if (!Array.isArray(expectedShards) || expectedShards.length === 0) {
     throw new Error("expectedShards must be a non-empty array");
@@ -120,7 +133,7 @@ export function mergeStoryGateReports({ catalog, reports, expectedShards }) {
   const unexpected = [];
 
   for (const result of results) {
-    if (typeof result?.id !== "string") throw new Error("story result is missing an id");
+    validateResult(result);
     if (seen.has(result.id)) duplicates.push(result.id);
     seen.add(result.id);
     if (!catalogSet.has(result.id)) unexpected.push(result.id);
@@ -136,6 +149,18 @@ export function mergeStoryGateReports({ catalog, reports, expectedShards }) {
   const missing = catalogIds.filter((id) => !seen.has(id));
   if (missing.length) throw new Error(`missing story ids: ${list(missing)}`);
 
+  const summary = summarize(results);
+  if (
+    results.length > 5 &&
+    summary.good === 0 &&
+    summary.broken === 0 &&
+    summary.needsRuntime === results.length
+  ) {
+    throw new Error(
+      `aggregate self-check failed: all ${results.length} stories are needs-runtime and none rendered good`,
+    );
+  }
+
   const failures = reports.flatMap((report) =>
     report.failures.map((failure) => ({ ...failure, shard: report.shard })),
   );
@@ -147,7 +172,7 @@ export function mergeStoryGateReports({ catalog, reports, expectedShards }) {
       receivedShards: reports.map((report) => report.shard).sort(),
       catalogStories: catalogIds.length,
     },
-    totals: { ...summarize(results), failures: failures.length },
+    totals: { ...summary, failures: failures.length },
     failures,
     results,
   };

--- a/packages/ui/test/story-gate/merge-story-gate.mjs
+++ b/packages/ui/test/story-gate/merge-story-gate.mjs
@@ -8,13 +8,7 @@
  * pass with a smaller manifest: a cancelled or truncated shard must never be
  * able to produce a green run.
  */
-import {
-  cp,
-  mkdir,
-  readFile,
-  rm,
-  writeFile,
-} from "node:fs/promises";
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
 const REPORT_SCHEMA = "eliza_story_gate_v1";
@@ -33,7 +27,9 @@ export function storyIdsFromCatalog(catalog) {
 
   const duplicates = ids.filter((id, index) => ids[index - 1] === id);
   if (duplicates.length) {
-    throw new Error(`duplicate catalog story ids: ${[...new Set(duplicates)].join(", ")}`);
+    throw new Error(
+      `duplicate catalog story ids: ${[...new Set(duplicates)].join(", ")}`,
+    );
   }
   return ids;
 }
@@ -62,7 +58,9 @@ function validateReports(reports, expectedShards) {
       throw new Error("invalid shard report");
     }
     if (report.schema !== REPORT_SCHEMA) {
-      throw new Error(`invalid shard report schema: ${report.schema ?? "missing"}`);
+      throw new Error(
+        `invalid shard report schema: ${report.schema ?? "missing"}`,
+      );
     }
     if (typeof report.shard !== "string" || !expected.has(report.shard)) {
       throw new Error(`unexpected shard report: ${report.shard ?? "missing"}`);
@@ -99,7 +97,8 @@ function validateReports(reports, expectedShards) {
   }
 
   const missing = expectedShards.filter((shard) => !seen.has(shard));
-  if (missing.length) throw new Error(`missing shard report: ${missing.join(", ")}`);
+  if (missing.length)
+    throw new Error(`missing shard report: ${missing.join(", ")}`);
 }
 
 function summarize(results) {
@@ -107,8 +106,10 @@ function summarize(results) {
     stories: results.length,
     good: results.filter((result) => result.verdict === "good").length,
     broken: results.filter((result) => result.verdict === "broken").length,
-    needsRuntime: results.filter((result) => result.verdict === "needs-runtime").length,
-    withConsoleErrors: results.filter((result) => result.consoleErrors?.length).length,
+    needsRuntime: results.filter((result) => result.verdict === "needs-runtime")
+      .length,
+    withConsoleErrors: results.filter((result) => result.consoleErrors?.length)
+      .length,
     withA11yViolations: results.filter((result) => result.a11y?.length).length,
     playExpected: results.filter((result) => result.play?.expected).length,
     playPrepared: results.filter((result) => result.play?.prepared).length,
@@ -123,7 +124,9 @@ function validateResult(result) {
     throw new Error("story result is missing an id");
   }
   if (!STORY_VERDICTS.has(result.verdict)) {
-    throw new Error(`invalid story verdict for ${result.id}: ${result.verdict ?? "missing"}`);
+    throw new Error(
+      `invalid story verdict for ${result.id}: ${result.verdict ?? "missing"}`,
+    );
   }
 }
 
@@ -150,10 +153,14 @@ export function mergeStoryGateReports({ catalog, reports, expectedShards }) {
   }
 
   if (duplicates.length) {
-    throw new Error(`duplicate story id: ${[...new Set(duplicates)].join(", ")}`);
+    throw new Error(
+      `duplicate story id: ${[...new Set(duplicates)].join(", ")}`,
+    );
   }
   if (unexpected.length) {
-    throw new Error(`unexpected story ids: ${[...new Set(unexpected)].join(", ")}`);
+    throw new Error(
+      `unexpected story ids: ${[...new Set(unexpected)].join(", ")}`,
+    );
   }
 
   const missing = catalogIds.filter((id) => !seen.has(id));
@@ -215,7 +222,9 @@ async function writeArtifacts(outDir, merged) {
   const withLogs = merged.results
     .filter(
       (result) =>
-        result.consoleErrors?.length || result.issues?.length || result.logCapture,
+        result.consoleErrors?.length ||
+        result.issues?.length ||
+        result.logCapture,
     )
     .map((result) => ({
       id: result.id,
@@ -232,14 +241,17 @@ async function writeArtifacts(outDir, merged) {
         schema: "eliza_story_gate_frontend_logs_v2",
         summary: {
           stories: merged.results.length,
-          withConsoleErrors: merged.results.filter((result) => result.consoleErrors?.length).length,
+          withConsoleErrors: merged.results.filter(
+            (result) => result.consoleErrors?.length,
+          ).length,
           withNetworkFailures: merged.results.filter(
             (result) =>
               (result.logCapture?.summary?.failedResponses ?? 0) +
                 (result.logCapture?.summary?.requestFailures ?? 0) >
               0,
           ).length,
-          broken: merged.results.filter((result) => result.verdict === "broken").length,
+          broken: merged.results.filter((result) => result.verdict === "broken")
+            .length,
         },
         stories: withLogs,
       },
@@ -262,7 +274,12 @@ async function readJson(path) {
   return JSON.parse(await readFile(path, "utf8"));
 }
 
-export async function mergeStoryGateArtifacts({ catalogPath, inputDir, outDir, shardCount }) {
+export async function mergeStoryGateArtifacts({
+  catalogPath,
+  inputDir,
+  outDir,
+  shardCount,
+}) {
   const expectedShards = Array.from(
     { length: shardCount },
     (_, index) => `${index + 1}/${shardCount}`,
@@ -272,7 +289,10 @@ export async function mergeStoryGateArtifacts({ catalogPath, inputDir, outDir, s
   let merged;
   try {
     for (let index = 1; index <= shardCount; index++) {
-      const shardDir = join(inputDir, `story-gate-shard-${index}-of-${shardCount}`);
+      const shardDir = join(
+        inputDir,
+        `story-gate-shard-${index}-of-${shardCount}`,
+      );
       const reportPath = join(shardDir, "report.json");
       const report = await readJson(reportPath).catch(() => {
         throw new Error(`missing shard report: ${index}/${shardCount}`);
@@ -349,7 +369,10 @@ function parseCli(argv) {
   };
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === resolve(import.meta.filename)) {
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === resolve(import.meta.filename)
+) {
   mergeStoryGateArtifacts(parseCli(process.argv.slice(2))).catch((error) => {
     console.error(`story-gate merge: ${error.message}`);
     process.exit(1);

--- a/packages/ui/test/story-gate/run-story-gate.mjs
+++ b/packages/ui/test/story-gate/run-story-gate.mjs
@@ -1119,6 +1119,7 @@ if (
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
   main().catch(async (err) => {
+    // error-policy:J1 The CLI boundary preserves a shard failure report before exiting non-zero.
     if (args.shard) {
       try {
         await mkdir(outDir, { recursive: true });
@@ -1140,6 +1141,7 @@ if (
           ),
         );
       } catch (writeError) {
+        // error-policy:J1 The process boundary reports failure-artifact loss without masking the original error.
         console.error(
           "story-gate: failed to write fatal shard report",
           writeError,

--- a/packages/ui/test/story-gate/run-story-gate.mjs
+++ b/packages/ui/test/story-gate/run-story-gate.mjs
@@ -1130,7 +1130,9 @@ if (
               shard: args.shard,
               generatedAt: new Date().toISOString(),
               totals: { stories: 0, failures: 1 },
-              failures: [{ kind: "fatal", detail: String(err?.message ?? err) }],
+              failures: [
+                { kind: "fatal", detail: String(err?.message ?? err) },
+              ],
               results: [],
             },
             null,
@@ -1138,7 +1140,10 @@ if (
           ),
         );
       } catch (writeError) {
-        console.error("story-gate: failed to write fatal shard report", writeError);
+        console.error(
+          "story-gate: failed to write fatal shard report",
+          writeError,
+        );
       }
     }
     console.error("story-gate: fatal", err);

--- a/packages/ui/test/story-gate/run-story-gate.mjs
+++ b/packages/ui/test/story-gate/run-story-gate.mjs
@@ -786,8 +786,7 @@ async function detectBlank(pngBuffer, sharp) {
 async function main() {
   const stories = await loadStories();
   if (!stories.length) {
-    console.error("story-gate: no stories matched the filters");
-    process.exit(2);
+    throw new Error("story-gate: no stories matched the filters");
   }
   console.log(
     `story-gate: ${stories.length} stories | concurrency=${args.concurrency}` +
@@ -879,6 +878,7 @@ async function main() {
   const broken = results.filter((r) => r.verdict === "broken");
   const report = {
     schema: "eliza_story_gate_v1",
+    shard: args.shard,
     generatedAt: new Date().toISOString(),
     frozenEpochMs: FROZEN_EPOCH_MS,
     totals: {
@@ -941,7 +941,9 @@ async function main() {
         `matching Storybook's rendered state (sb-show-* class target moved?). ` +
         `The gate is testing nothing. See renderStory() settle logic.`,
     );
-    process.exit(3);
+    throw new Error(
+      `story-gate SELF-CHECK FAILED - all ${results.length} stories classified 'needs-runtime' and zero rendered 'good'`,
+    );
   }
 
   // -------------------------------------------------------------------------
@@ -1116,7 +1118,29 @@ if (
   process.argv[1] &&
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
-  main().catch((err) => {
+  main().catch(async (err) => {
+    if (args.shard) {
+      try {
+        await mkdir(outDir, { recursive: true });
+        await writeFile(
+          join(outDir, "report.json"),
+          JSON.stringify(
+            {
+              schema: "eliza_story_gate_v1",
+              shard: args.shard,
+              generatedAt: new Date().toISOString(),
+              totals: { stories: 0, failures: 1 },
+              failures: [{ kind: "fatal", detail: String(err?.message ?? err) }],
+              results: [],
+            },
+            null,
+            2,
+          ),
+        );
+      } catch (writeError) {
+        console.error("story-gate: failed to write fatal shard report", writeError);
+      }
+    }
     console.error("story-gate: fatal", err);
     process.exit(1);
   });

--- a/packages/ui/test/story-gate/story-gate-merge.test.mjs
+++ b/packages/ui/test/story-gate/story-gate-merge.test.mjs
@@ -216,4 +216,37 @@ describe("story-gate report aggregation", () => {
       }),
     ).toThrow(/invalid shard failure entry/);
   });
+
+  it("rejects a result with no supported verdict", () => {
+    expect(() =>
+      mergeStoryGateReports({
+        catalog: { entries: { a: { type: "story", id: "a--story" } } },
+        reports: [
+          report("1/1", [{ ...story("a--story"), verdict: undefined }]),
+        ],
+        expectedShards: ["1/1"],
+      }),
+    ).toThrow(/invalid story verdict for a--story: missing/);
+  });
+
+  it("rejects a complete catalog when every story is only needs-runtime", () => {
+    const entries = Object.fromEntries(
+      Array.from({ length: 6 }, (_, index) => [
+        `story-${index}`,
+        { type: "story", id: `story-${index}` },
+      ]),
+    );
+    const results = Object.values(entries).map(({ id }) => ({
+      ...story(id),
+      verdict: "needs-runtime",
+    }));
+
+    expect(() =>
+      mergeStoryGateReports({
+        catalog: { entries },
+        reports: [report("1/1", results)],
+        expectedShards: ["1/1"],
+      }),
+    ).toThrow(/aggregate self-check failed/);
+  });
 });

--- a/packages/ui/test/story-gate/story-gate-merge.test.mjs
+++ b/packages/ui/test/story-gate/story-gate-merge.test.mjs
@@ -47,7 +47,12 @@ describe("story-gate report aggregation", () => {
 
   it("merges a complete shard set and preserves every result", () => {
     const merged = mergeStoryGateReports({
-      catalog: { entries: { a: { type: "story", id: "a--story" }, z: { type: "story", id: "z--story" } } },
+      catalog: {
+        entries: {
+          a: { type: "story", id: "a--story" },
+          z: { type: "story", id: "z--story" },
+        },
+      },
       reports: [
         report("1/2", [story("a--story")]),
         report("2/2", [story("z--story")]),
@@ -77,7 +82,12 @@ describe("story-gate report aggregation", () => {
   ])("fails closed when %s", (_label, reports, expected) => {
     expect(() =>
       mergeStoryGateReports({
-        catalog: { entries: { a: { type: "story", id: "a--story" }, z: { type: "story", id: "z--story" } } },
+        catalog: {
+          entries: {
+            a: { type: "story", id: "a--story" },
+            z: { type: "story", id: "z--story" },
+          },
+        },
         reports,
         expectedShards: ["1/2", "2/2"],
       }),
@@ -86,11 +96,18 @@ describe("story-gate report aggregation", () => {
 
   it("retains shard failures for the aggregate gate to reject", () => {
     const merged = mergeStoryGateReports({
-      catalog: { entries: { a: { type: "story", id: "a--story" }, z: { type: "story", id: "z--story" } } },
+      catalog: {
+        entries: {
+          a: { type: "story", id: "a--story" },
+          z: { type: "story", id: "z--story" },
+        },
+      },
       reports: [
-        report("1/2", [story("a--story")], [
-          { id: "a--story", kind: "broken", detail: "render threw" },
-        ]),
+        report(
+          "1/2",
+          [story("a--story")],
+          [{ id: "a--story", kind: "broken", detail: "render threw" }],
+        ),
         report("2/2", [story("z--story")]),
       ],
       expectedShards: ["1/2", "2/2"],
@@ -110,7 +127,9 @@ describe("story-gate report aggregation", () => {
     const outDir = join(root, "output");
 
     try {
-      await mkdir(join(inputDir, "story-gate-shard-1-of-2"), { recursive: true });
+      await mkdir(join(inputDir, "story-gate-shard-1-of-2"), {
+        recursive: true,
+      });
       await writeFile(
         catalogPath,
         JSON.stringify({
@@ -163,9 +182,11 @@ describe("story-gate report aggregation", () => {
       await writeFile(
         join(shardDir, "report.json"),
         JSON.stringify(
-          report("1/1", [story("a--story")], [
-            { id: "a--story", kind: "broken", detail: "render threw" },
-          ]),
+          report(
+            "1/1",
+            [story("a--story")],
+            [{ id: "a--story", kind: "broken", detail: "render threw" }],
+          ),
         ),
       );
 
@@ -178,10 +199,12 @@ describe("story-gate report aggregation", () => {
         }),
       ).rejects.toThrow("shard failures: 1/1: 1");
 
-      expect(await readFile(join(outDir, "manual-review.md"), "utf8")).toContain(
-        "FAIL: 1 regression(s)",
-      );
-      expect(JSON.parse(await readFile(join(outDir, "report.json"), "utf8"))).toMatchObject({
+      expect(
+        await readFile(join(outDir, "manual-review.md"), "utf8"),
+      ).toContain("FAIL: 1 regression(s)");
+      expect(
+        JSON.parse(await readFile(join(outDir, "report.json"), "utf8")),
+      ).toMatchObject({
         totals: { stories: 1, failures: 1 },
       });
     } finally {

--- a/packages/ui/test/story-gate/story-gate-merge.test.mjs
+++ b/packages/ui/test/story-gate/story-gate-merge.test.mjs
@@ -1,3 +1,6 @@
+/**
+ * Exercises sharded Story Gate aggregation with deterministic reports and temporary artifact trees.
+ */
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -179,6 +182,7 @@ describe("story-gate report aggregation", () => {
       );
       const shardDir = join(inputDir, "story-gate-shard-1-of-1");
       await mkdir(join(shardDir, "screenshots"), { recursive: true });
+      await writeFile(join(shardDir, "screenshots", "a--story.png"), "png");
       await writeFile(
         join(shardDir, "report.json"),
         JSON.stringify(
@@ -207,6 +211,65 @@ describe("story-gate report aggregation", () => {
       ).toMatchObject({
         totals: { stories: 1, failures: 1 },
       });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("distinguishes malformed shard JSON from a missing artifact", async () => {
+    const root = await mkdtemp(join(tmpdir(), "story-gate-merge-"));
+    const catalogPath = join(root, "catalog.json");
+    const inputDir = join(root, "shards");
+    const outDir = join(root, "output");
+    const shardDir = join(inputDir, "story-gate-shard-1-of-1");
+
+    try {
+      await mkdir(shardDir, { recursive: true });
+      await writeFile(
+        catalogPath,
+        JSON.stringify({ entries: { a: { type: "story", id: "a--story" } } }),
+      );
+      await writeFile(join(shardDir, "report.json"), "{not-json");
+
+      await expect(
+        mergeStoryGateArtifacts({
+          catalogPath,
+          inputDir,
+          outDir,
+          shardCount: 1,
+        }),
+      ).rejects.toThrow("invalid shard report JSON: 1/1");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when a rendered story has no screenshot evidence", async () => {
+    const root = await mkdtemp(join(tmpdir(), "story-gate-merge-"));
+    const catalogPath = join(root, "catalog.json");
+    const inputDir = join(root, "shards");
+    const outDir = join(root, "output");
+    const shardDir = join(inputDir, "story-gate-shard-1-of-1");
+
+    try {
+      await mkdir(shardDir, { recursive: true });
+      await writeFile(
+        catalogPath,
+        JSON.stringify({ entries: { a: { type: "story", id: "a--story" } } }),
+      );
+      await writeFile(
+        join(shardDir, "report.json"),
+        JSON.stringify(report("1/1", [story("a--story")])),
+      );
+
+      await expect(
+        mergeStoryGateArtifacts({
+          catalogPath,
+          inputDir,
+          outDir,
+          shardCount: 1,
+        }),
+      ).rejects.toThrow("missing shard screenshots: 1/1");
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/ui/test/story-gate/story-gate-merge.test.mjs
+++ b/packages/ui/test/story-gate/story-gate-merge.test.mjs
@@ -1,0 +1,219 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  mergeStoryGateArtifacts,
+  mergeStoryGateReports,
+  storyIdsFromCatalog,
+} from "./merge-story-gate.mjs";
+
+function report(shard, results, failures = []) {
+  return {
+    shard,
+    schema: "eliza_story_gate_v1",
+    totals: { stories: results.length, failures: failures.length },
+    failures,
+    results,
+  };
+}
+
+function story(id) {
+  return {
+    id,
+    title: id,
+    name: "Default",
+    verdict: "good",
+    issues: [],
+    consoleErrors: [],
+    a11y: [],
+    play: { expected: false, prepared: false, phase: null },
+    blank: { expected: false, detected: false },
+  };
+}
+
+describe("story-gate report aggregation", () => {
+  it("extracts only Storybook story entries in deterministic order", () => {
+    expect(
+      storyIdsFromCatalog({
+        entries: {
+          z: { type: "story", id: "z--story" },
+          docs: { type: "docs", id: "docs--page" },
+          a: { type: "story", id: "a--story" },
+        },
+      }),
+    ).toEqual(["a--story", "z--story"]);
+  });
+
+  it("merges a complete shard set and preserves every result", () => {
+    const merged = mergeStoryGateReports({
+      catalog: { entries: { a: { type: "story", id: "a--story" }, z: { type: "story", id: "z--story" } } },
+      reports: [
+        report("1/2", [story("a--story")]),
+        report("2/2", [story("z--story")]),
+      ],
+      expectedShards: ["1/2", "2/2"],
+    });
+
+    expect(merged.results.map((result) => result.id)).toEqual([
+      "a--story",
+      "z--story",
+    ]);
+    expect(merged.totals).toMatchObject({ stories: 2, failures: 0 });
+  });
+
+  it.each([
+    ["a shard is missing", [], /missing shard report: 1\/2/],
+    [
+      "a story is duplicated",
+      [report("1/2", [story("a--story")]), report("2/2", [story("a--story")])],
+      /duplicate story id: a--story/,
+    ],
+    [
+      "a story is missing from the union",
+      [report("1/2", []), report("2/2", [story("z--story")])],
+      /missing story ids: a--story/,
+    ],
+  ])("fails closed when %s", (_label, reports, expected) => {
+    expect(() =>
+      mergeStoryGateReports({
+        catalog: { entries: { a: { type: "story", id: "a--story" }, z: { type: "story", id: "z--story" } } },
+        reports,
+        expectedShards: ["1/2", "2/2"],
+      }),
+    ).toThrow(expected);
+  });
+
+  it("retains shard failures for the aggregate gate to reject", () => {
+    const merged = mergeStoryGateReports({
+      catalog: { entries: { a: { type: "story", id: "a--story" }, z: { type: "story", id: "z--story" } } },
+      reports: [
+        report("1/2", [story("a--story")], [
+          { id: "a--story", kind: "broken", detail: "render threw" },
+        ]),
+        report("2/2", [story("z--story")]),
+      ],
+      expectedShards: ["1/2", "2/2"],
+    });
+
+    expect(merged.totals.failures).toBe(1);
+    expect(merged.failures[0]).toMatchObject({
+      id: "a--story",
+      shard: "1/2",
+    });
+  });
+
+  it("writes an aggregate report when a shard artifact is missing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "story-gate-merge-"));
+    const catalogPath = join(root, "catalog.json");
+    const inputDir = join(root, "shards");
+    const outDir = join(root, "output");
+
+    try {
+      await mkdir(join(inputDir, "story-gate-shard-1-of-2"), { recursive: true });
+      await writeFile(
+        catalogPath,
+        JSON.stringify({
+          entries: {
+            a: { type: "story", id: "a--story" },
+            z: { type: "story", id: "z--story" },
+          },
+        }),
+      );
+      await writeFile(
+        join(inputDir, "story-gate-shard-1-of-2", "report.json"),
+        JSON.stringify(report("1/2", [story("a--story")])),
+      );
+
+      await expect(
+        mergeStoryGateArtifacts({
+          catalogPath,
+          inputDir,
+          outDir,
+          shardCount: 2,
+        }),
+      ).rejects.toThrow("missing shard report: 2/2");
+
+      const aggregate = JSON.parse(
+        await readFile(join(outDir, "report.json"), "utf8"),
+      );
+      expect(aggregate).toMatchObject({
+        schema: "eliza_story_gate_aggregate_v1",
+        totals: { stories: 0, failures: 1 },
+        failures: [{ kind: "aggregate-validation" }],
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("marks manual review as failed before rejecting shard failures", async () => {
+    const root = await mkdtemp(join(tmpdir(), "story-gate-merge-"));
+    const catalogPath = join(root, "catalog.json");
+    const inputDir = join(root, "shards");
+    const outDir = join(root, "output");
+
+    try {
+      await writeFile(
+        catalogPath,
+        JSON.stringify({ entries: { a: { type: "story", id: "a--story" } } }),
+      );
+      const shardDir = join(inputDir, "story-gate-shard-1-of-1");
+      await mkdir(join(shardDir, "screenshots"), { recursive: true });
+      await writeFile(
+        join(shardDir, "report.json"),
+        JSON.stringify(
+          report("1/1", [story("a--story")], [
+            { id: "a--story", kind: "broken", detail: "render threw" },
+          ]),
+        ),
+      );
+
+      await expect(
+        mergeStoryGateArtifacts({
+          catalogPath,
+          inputDir,
+          outDir,
+          shardCount: 1,
+        }),
+      ).rejects.toThrow("shard failures: 1/1: 1");
+
+      expect(await readFile(join(outDir, "manual-review.md"), "utf8")).toContain(
+        "FAIL: 1 regression(s)",
+      );
+      expect(JSON.parse(await readFile(join(outDir, "report.json"), "utf8"))).toMatchObject({
+        totals: { stories: 1, failures: 1 },
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects unexpected story ids instead of silently dropping them", () => {
+    expect(() =>
+      mergeStoryGateReports({
+        catalog: { entries: { a: { type: "story", id: "a--story" } } },
+        reports: [report("1/1", [story("unexpected--story")])],
+        expectedShards: ["1/1"],
+      }),
+    ).toThrow(/unexpected story ids: unexpected--story/);
+  });
+
+  it("rejects duplicate shard expectations and malformed failures", () => {
+    expect(() =>
+      mergeStoryGateReports({
+        catalog: { entries: { a: { type: "story", id: "a--story" } } },
+        reports: [report("1/1", [story("a--story")])],
+        expectedShards: ["1/1", "1/1"],
+      }),
+    ).toThrow(/expectedShards must not contain duplicates/);
+
+    expect(() =>
+      mergeStoryGateReports({
+        catalog: { entries: { a: { type: "story", id: "a--story" } } },
+        reports: [report("1/1", [story("a--story")], [null])],
+        expectedShards: ["1/1"],
+      }),
+    ).toThrow(/invalid shard failure entry/);
+  });
+});

--- a/packages/ui/test/story-gate/story-gate-workflow.test.mjs
+++ b/packages/ui/test/story-gate/story-gate-workflow.test.mjs
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const workflow = readFileSync(
+  new URL("../../../../.github/workflows/ui-story-gate.yml", import.meta.url),
+  "utf8",
+);
+const config = parse(workflow);
+const shardJob = config.jobs["story-shard"];
+const aggregateJob = config.jobs.aggregate;
+const shardUpload = shardJob.steps.find((step) =>
+  step.name?.startsWith("Upload shard report"),
+);
+const aggregateMerge = aggregateJob.steps.find((step) =>
+  step.name?.startsWith("Merge and validate"),
+);
+
+describe("UI Story Gate workflow", () => {
+  it("keeps develop runs queued instead of cancelling an active catalog", () => {
+    expect(config.concurrency).toMatchObject({ "cancel-in-progress": false });
+  });
+
+  it("runs eight shards and uploads shard evidence", () => {
+    expect(shardJob.strategy).toMatchObject({
+      "fail-fast": false,
+      matrix: { shard: [1, 2, 3, 4, 5, 6, 7, 8] },
+    });
+    expect(shardUpload).toMatchObject({
+      if: "${{ always() && !cancelled() }}",
+      with: {
+        name: "story-gate-shard-${{ matrix.shard }}-of-8",
+        path: "packages/ui/test/story-gate/output",
+      },
+    });
+  });
+
+  it("has an aggregate job that preserves fail-closed evidence", () => {
+    expect(aggregateJob.needs).toEqual(["build-catalog", "story-shard"]);
+    expect(aggregateJob.if).toBe("${{ always() && !cancelled() }}");
+    expect(aggregateMerge.if).toBe("${{ always() && !cancelled() }}");
+    expect(aggregateMerge.run).toContain("--shards 8");
+
+    const catalogDownload = aggregateJob.steps.find(
+      (step) => step.name === "Download static catalog",
+    );
+    const shardDownload = aggregateJob.steps.find(
+      (step) => step.name === "Download all shard artifacts",
+    );
+    expect(catalogDownload).toMatchObject({ "continue-on-error": true });
+    expect(shardDownload).toMatchObject({
+      "continue-on-error": true,
+      with: { pattern: "story-gate-shard-*-of-8", "merge-multiple": false },
+    });
+    expect(
+      aggregateJob.steps.find(
+        (step) => step.name === "Upload aggregate Story Gate output",
+      ),
+    ).toMatchObject({
+      if: "${{ always() && !cancelled() }}",
+      with: { name: "story-gate-output" },
+    });
+  });
+});

--- a/packages/ui/test/story-gate/story-gate-workflow.test.mjs
+++ b/packages/ui/test/story-gate/story-gate-workflow.test.mjs
@@ -22,12 +22,16 @@ describe("UI Story Gate workflow", () => {
   });
 
   it("runs eight shards and uploads shard evidence", () => {
+    expect(shardJob["timeout-minutes"]).toBe(35);
+    expect(
+      shardJob.steps.find((step) => step.name === "Run deterministic Story Gate shard"),
+    ).toMatchObject({ "timeout-minutes": 20 });
     expect(shardJob.strategy).toMatchObject({
       "fail-fast": false,
       matrix: { shard: [1, 2, 3, 4, 5, 6, 7, 8] },
     });
     expect(shardUpload).toMatchObject({
-      if: "${{ always() && !cancelled() }}",
+      if: "${{ always() }}",
       with: {
         name: "story-gate-shard-${{ matrix.shard }}-of-8",
         path: "packages/ui/test/story-gate/output",
@@ -37,8 +41,8 @@ describe("UI Story Gate workflow", () => {
 
   it("has an aggregate job that preserves fail-closed evidence", () => {
     expect(aggregateJob.needs).toEqual(["build-catalog", "story-shard"]);
-    expect(aggregateJob.if).toBe("${{ always() && !cancelled() }}");
-    expect(aggregateMerge.if).toBe("${{ always() && !cancelled() }}");
+    expect(aggregateJob.if).toBe("${{ always() }}");
+    expect(aggregateMerge.if).toBe("${{ always() }}");
     expect(aggregateMerge.run).toContain("--shards 8");
 
     const catalogDownload = aggregateJob.steps.find(
@@ -57,7 +61,7 @@ describe("UI Story Gate workflow", () => {
         (step) => step.name === "Upload aggregate Story Gate output",
       ),
     ).toMatchObject({
-      if: "${{ always() && !cancelled() }}",
+      if: "${{ always() }}",
       with: { name: "story-gate-output" },
     });
   });

--- a/packages/ui/test/story-gate/story-gate-workflow.test.mjs
+++ b/packages/ui/test/story-gate/story-gate-workflow.test.mjs
@@ -1,7 +1,12 @@
+/**
+ * Verifies the checked-in Story Gate workflow's shard matrix and fail-closed aggregation wiring.
+ */
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 
+const ALWAYS_EXPRESSION = "$" + "{{ always() }}";
+const MATRIX_SHARD_EXPRESSION = "$" + "{{ matrix.shard }}";
 const workflow = readFileSync(
   new URL("../../../../.github/workflows/ui-story-gate.yml", import.meta.url),
   "utf8",
@@ -33,9 +38,9 @@ describe("UI Story Gate workflow", () => {
       matrix: { shard: [1, 2, 3, 4, 5, 6, 7, 8] },
     });
     expect(shardUpload).toMatchObject({
-      if: "${{ always() }}",
+      if: ALWAYS_EXPRESSION,
       with: {
-        name: "story-gate-shard-${{ matrix.shard }}-of-8",
+        name: `story-gate-shard-${MATRIX_SHARD_EXPRESSION}-of-8`,
         path: "packages/ui/test/story-gate/output",
       },
     });
@@ -43,8 +48,8 @@ describe("UI Story Gate workflow", () => {
 
   it("has an aggregate job that preserves fail-closed evidence", () => {
     expect(aggregateJob.needs).toEqual(["build-catalog", "story-shard"]);
-    expect(aggregateJob.if).toBe("${{ always() }}");
-    expect(aggregateMerge.if).toBe("${{ always() }}");
+    expect(aggregateJob.if).toBe(ALWAYS_EXPRESSION);
+    expect(aggregateMerge.if).toBe(ALWAYS_EXPRESSION);
     expect(aggregateMerge.run).toContain("--shards 8");
 
     const catalogDownload = aggregateJob.steps.find(
@@ -63,7 +68,7 @@ describe("UI Story Gate workflow", () => {
         (step) => step.name === "Upload aggregate Story Gate output",
       ),
     ).toMatchObject({
-      if: "${{ always() }}",
+      if: ALWAYS_EXPRESSION,
       with: { name: "story-gate-output" },
     });
   });

--- a/packages/ui/test/story-gate/story-gate-workflow.test.mjs
+++ b/packages/ui/test/story-gate/story-gate-workflow.test.mjs
@@ -24,7 +24,9 @@ describe("UI Story Gate workflow", () => {
   it("runs eight shards and uploads shard evidence", () => {
     expect(shardJob["timeout-minutes"]).toBe(35);
     expect(
-      shardJob.steps.find((step) => step.name === "Run deterministic Story Gate shard"),
+      shardJob.steps.find(
+        (step) => step.name === "Run deterministic Story Gate shard",
+      ),
     ).toMatchObject({ "timeout-minutes": 20 });
     expect(shardJob.strategy).toMatchObject({
       "fail-fast": false,


### PR DESCRIPTION
## Relates to

Fixes #18097

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - local contribute-to-eliza instructions`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync; it is blocked by the local runtime's missing `bunx` executable in package lint scripts and pre-existing package type-resolution gaps.

## Risks

- Low: CI orchestration and report aggregation only; no runtime product behavior or dependency changes.
- Aggregate output is fail-closed when a shard is missing, malformed, incomplete, duplicated, or reports failures.

## Background

### What does this PR do?

- Splits the exhaustive Story Gate catalog into eight deterministic CI shards.
- Uploads each shard's report and evidence even when the shard fails.
- Merges shard reports against the dynamically discovered Storybook catalog and rejects missing, duplicate, or unexpected story IDs.
- Preserves aggregate `report.json`, frontend logs, contact sheet, screenshots, and an accurate manual-review verdict.

### What kind of change is this?

Bug fix / CI reliability improvement.

## Documentation changes needed?

Documentation updated in `packages/ui/test/story-gate/README.md` with the shard and aggregate contract.

## Testing

### Where should a reviewer start?

Start with `.github/workflows/ui-story-gate.yml`, then `packages/ui/test/story-gate/merge-story-gate.mjs` and its tests.

### Detailed testing steps

- `node --check` for runner, merger, merge tests, and workflow tests: pass.
- `bun x vitest run test/story-gate --config vitest.config.ts` from `packages/ui`: **76 passed, 0 failed**.
- YAML parse and workflow contract checks: pass.
- `bun run --cwd packages/ui build`: pass; runtime export verification passed.
- `git diff --check`: pass.

## Evidence Gate

Evidence matches commit 0916dad1a4eeb433f6d7f0be5de2ebbeaf1797b9.

<!-- evidence-head:0916dad1a4eeb433f6d7f0be5de2ebbeaf1797b9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - CI workflow/reporting change with no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - CI workflow/reporting change with no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing flow; automated CI contract is the behavior under test.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no backend/runtime server path is changed.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - this PR improves the Story Gate artifact contract; shard frontend logs are produced by CI runs.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior is changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no domain data or generated product artifact is changed.`
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface is changed.

## Evidence Details

### Known gaps / failures

- `bun install --frozen-lockfile --ignore-scripts` downloaded dependencies but Windows linking failed with `EPERM` for `@openai/codex@0.133.0-win32-x64`; the existing dependency tree was sufficient for focused tests.
- `bun run --cwd packages/ui typecheck` failed because generated/dependency modules (`@elizaos/cloud-routing` and validation keyword outputs) did not resolve in this local checkout after repository verification generation.
- `bun run --cwd packages/ui lint:check` and the lint phase of `bun run verify` failed because repo scripts invoke `bunx`, which is not exposed by this Windows Bun runtime.
- `bun run verify` passed its initial repository contracts and build-related checks before stopping at the same `bunx` lint blocker.

## Maintainer review

Please review and merge if the CI evidence and aggregate artifact satisfy the acceptance criteria. This PR is not self-approved or self-merged.


## Maintainer re-sync (2026-08-13, lane V)

Re-merged `origin/develop@15c8bc849f219712a084ebf225a777d7d9909e42` so the branch carries #19205 (`646b1f08ddc`). Branches based between #19039 and #19205 fail `audit:hetzner-fleet-routing` deterministically — they get the new `classify-paths.yml` force-hosted selector without the contract script that allows it — which takes `Quality` down regardless of the diff. Verified on this head:

```text
$ bun run audit:hetzner-fleet-routing
[hetzner-fleet-routing] verified 61 selectors across 16 workflows
```

The diff is unchanged at 6 files / +876 −4. The fail-closed matrix and the hosted `UI Story Gate` proof in the comments were produced against this exact content.



## Maintainer repair and exact-head proof (2026-08-14)

- Rebased the contributor series patch-identically onto origin/develop@0eb2e231b99f89f3b1c496161c051a088847ee3a; range-diff is identical for all four contributor commits.
- Added a maintainer repair commit that makes screenshot preservation fail closed, distinguishes malformed shard JSON from a missing artifact while preserving the underlying cause, adds the required test-file responsibility headers, and annotates process-boundary error handling.
- Exact head 0916dad1a4eeb433f6d7f0be5de2ebbeaf1797b9: Story Gate suite 76/76; focused aggregation/workflow contracts 17/17; changed-file Biome clean; Node syntax checks clean; guide parity 153/153; workflow routing 61 selectors; script audit and inventory clean; git diff --check clean.
- The prior hosted UI Story Gate also proved all eight real catalog shards and the aggregate job green. This repair changes only aggregation evidence handling and its deterministic tests; no rendered application surface changed, so packages/app audit evidence remains N/A.
- Because the final repair commit is maintainer-authored, this exact head needs independent approval before merge.
