### PR TITLE
fix(plugin-x): fail closed on non-finite tweet timestamps (#18965)

### DIFF
--- a/plugins/plugin-x/src/base.ts
+++ b/plugins/plugin-x/src/base.ts
@@ -580,6 +580,16 @@ export class ClientBase {
             continue;
           }
 
+          // Normalize once per row before any context side effects; a
+          // present-but-unusable timestamp fails the row closed (#18965).
+          const createdAt = getEpochMs(tweet.timestamp);
+          if (createdAt === undefined) {
+            logger.debug(
+              `Skipping cached tweet ${tweet.id}: unusable timestamp`,
+            );
+            continue;
+          }
+
           // Create a world for this Twitter user if it doesn't exist
           const worldId = createUniqueUuid(this.runtime, tweet.userId) as UUID;
           await this.runtime.ensureWorldExists({
@@ -635,9 +645,10 @@ export class ClientBase {
               metadata: buildTwitterMessageMetadata(
                 tweet,
                 entityId,
+                createdAt,
                 this.accountId,
               ),
-              createdAt: getEpochMs(tweet.timestamp),
+              createdAt,
             },
             "messages",
           );
@@ -708,6 +719,14 @@ export class ClientBase {
         continue;
       }
 
+      // Normalize once per row before any context side effects; a
+      // present-but-unusable timestamp fails the row closed (#18965).
+      const createdAt = getEpochMs(tweet.timestamp);
+      if (createdAt === undefined) {
+        logger.debug(`Skipping fetched tweet ${tweet.id}: unusable timestamp`);
+        continue;
+      }
+
       // Create a world for this Twitter user if it doesn't exist
       const worldId = createUniqueUuid(this.runtime, tweet.userId) as UUID;
       await this.runtime.ensureWorldExists({
@@ -762,9 +781,10 @@ export class ClientBase {
           metadata: buildTwitterMessageMetadata(
             tweet,
             entityId,
+            createdAt,
             this.accountId,
           ),
-          createdAt: getEpochMs(tweet.timestamp),
+          createdAt,
         },
         "messages",
       );

--- a/plugins/plugin-x/src/interactions.ts
+++ b/plugins/plugin-x/src/interactions.ts
@@ -385,8 +385,13 @@ export class TwitterInteractionClient {
         continue; // Already processed
       }
 
-      // Skip if tweet is too old (older than 24 hours)
-      const tweetAge = Date.now() - getEpochMs(tweet.timestamp);
+      // Skip if tweet is too old (older than 24 hours). A present but
+      // unusable timestamp fails closed: never engage it as if it were new.
+      const tweetEpochMs = getEpochMs(tweet.timestamp);
+      if (tweetEpochMs === undefined) {
+        continue;
+      }
+      const tweetAge = Date.now() - tweetEpochMs;
       const maxAge = 24 * 60 * 60 * 1000; // 24 hours
 
       if (tweetAge > maxAge) {
@@ -436,9 +441,13 @@ export class TwitterInteractionClient {
       }
 
       const relevantTweets = timelineTweets.filter((tweet) => {
-        // Filter for tweets from the last 12 hours
-        const tweetAge = Date.now() - getEpochMs(tweet.timestamp);
-        return tweetAge < 12 * 60 * 60 * 1000;
+        // Filter for tweets from the last 12 hours; a present but unusable
+        // timestamp fails closed rather than counting as brand-new.
+        const tweetEpochMs = getEpochMs(tweet.timestamp);
+        if (tweetEpochMs === undefined) {
+          return false;
+        }
+        return Date.now() - tweetEpochMs < 12 * 60 * 60 * 1000;
       });
 
       if (relevantTweets.length > 0) {

--- a/plugins/plugin-x/src/interactions.ts
+++ b/plugins/plugin-x/src/interactions.ts
@@ -62,7 +62,7 @@ type ProcessableTweet = ClientTweet & {
   thread: ClientTweet[];
 };
 
-function normalizeTweet(tweet: ClientTweet): ProcessableTweet | null {
+export function normalizeTweet(tweet: ClientTweet): ProcessableTweet | null {
   if (
     typeof tweet.id !== "string" ||
     tweet.id.length === 0 ||
@@ -77,6 +77,13 @@ function normalizeTweet(tweet: ClientTweet): ProcessableTweet | null {
       ? tweet.username
       : "unknown";
 
+  // Normalize the timestamp exactly once at this row boundary: absent values
+  // mean "observed now", present values are unit-normalized to epoch ms, and
+  // a present-but-unusable value fails the whole row closed so it can never
+  // surface as a fresh tweet or an undated memory (#18965).
+  const timestamp = getEpochMs(tweet.timestamp);
+  if (timestamp === undefined) return null;
+
   return {
     ...tweet,
     id: tweet.id,
@@ -85,7 +92,7 @@ function normalizeTweet(tweet: ClientTweet): ProcessableTweet | null {
     name: tweet.name ?? username,
     conversationId: tweet.conversationId ?? tweet.id,
     text: tweet.text ?? "",
-    timestamp: tweet.timestamp ?? Date.now(),
+    timestamp,
     thread: tweet.thread?.length ? tweet.thread : [tweet],
   };
 }
@@ -385,13 +392,9 @@ export class TwitterInteractionClient {
         continue; // Already processed
       }
 
-      // Skip if tweet is too old (older than 24 hours). A present but
-      // unusable timestamp fails closed: never engage it as if it were new.
-      const tweetEpochMs = getEpochMs(tweet.timestamp);
-      if (tweetEpochMs === undefined) {
-        continue;
-      }
-      const tweetAge = Date.now() - tweetEpochMs;
+      // Skip if tweet is too old (older than 24 hours). normalizeTweet already
+      // failed unusable timestamps closed, so this value is validated epoch ms.
+      const tweetAge = Date.now() - tweet.timestamp;
       const maxAge = 24 * 60 * 60 * 1000; // 24 hours
 
       if (tweetAge > maxAge) {
@@ -483,9 +486,10 @@ export class TwitterInteractionClient {
       metadata: buildTwitterMessageMetadata(
         tweet,
         entityId,
+        tweet.timestamp,
         this.client.accountId,
       ),
-      createdAt: getEpochMs(tweet.timestamp),
+      createdAt: tweet.timestamp,
     };
   }
 
@@ -563,9 +567,10 @@ Choose any combination of [LIKE], [RETWEET], [QUOTE], and [REPLY] that are appro
         metadata: buildTwitterMessageMetadata(
           tweet,
           context.entityId,
+          tweet.timestamp,
           this.client.accountId,
         ),
-        createdAt: getEpochMs(tweet.timestamp),
+        createdAt: tweet.timestamp,
       };
 
       await createMemorySafe(this.runtime, tweetMemory, "messages");
@@ -959,9 +964,10 @@ ${tweet.text}`;
           metadata: buildTwitterMessageMetadata(
             tweet,
             entityId,
+            tweet.timestamp,
             this.client.accountId,
           ),
-          createdAt: getEpochMs(tweet.timestamp),
+          createdAt: tweet.timestamp,
         };
 
         logger.log("Saving tweet memory...");

--- a/plugins/plugin-x/src/services/MessageService.ts
+++ b/plugins/plugin-x/src/services/MessageService.ts
@@ -86,6 +86,8 @@ export class TwitterMessageService implements IMessageService {
 
       const messages: Message[] = searchResult.tweets
         .filter((tweet) => typeof tweet.id === "string")
+        // Fail closed: corrupt timestamps never surface as fresh (#18965).
+        .filter((tweet) => getEpochMs(tweet.timestamp) !== undefined)
         .filter((tweet) => {
           const conversationId = tweet.conversationId ?? tweet.id;
           if (!conversationId) return false;
@@ -112,7 +114,7 @@ export class TwitterMessageService implements IMessageService {
             type: tweet.inReplyToStatusId
               ? MessageType.REPLY
               : MessageType.MENTION,
-            timestamp: getEpochMs(tweet.timestamp),
+            timestamp: getEpochMs(tweet.timestamp) ?? Date.now(),
             inReplyTo: tweet.inReplyToStatusId,
             metadata: {
               tweetId,
@@ -192,6 +194,10 @@ export class TwitterMessageService implements IMessageService {
       if (!tweet?.id) return null;
       const conversationId = tweet.conversationId ?? tweet.id;
 
+      // Fail closed on a present-but-unusable timestamp (#18965).
+      const timestamp = getEpochMs(tweet.timestamp);
+      if (timestamp === undefined) return null;
+
       const message: Message = {
         id: tweet.id,
         agentId: agentId,
@@ -200,7 +206,7 @@ export class TwitterMessageService implements IMessageService {
         username: tweet.username ?? "",
         text: tweet.text ?? "",
         type: tweet.inReplyToStatusId ? MessageType.REPLY : MessageType.POST,
-        timestamp: getEpochMs(tweet.timestamp),
+        timestamp,
         inReplyTo: tweet.inReplyToStatusId,
         metadata: {
           tweetId: tweet.id,

--- a/plugins/plugin-x/src/services/MessageService.ts
+++ b/plugins/plugin-x/src/services/MessageService.ts
@@ -84,27 +84,22 @@ export class TwitterMessageService implements IMessageService {
         SearchMode.Latest,
       );
 
-      const messages: Message[] = searchResult.tweets
-        .filter((tweet) => typeof tweet.id === "string")
-        // Fail closed: corrupt timestamps never surface as fresh (#18965).
-        .filter((tweet) => getEpochMs(tweet.timestamp) !== undefined)
-        .filter((tweet) => {
-          const conversationId = tweet.conversationId ?? tweet.id;
-          if (!conversationId) return false;
-          // Filter by room ID if specified
-          if (options.roomId) {
-            const tweetRoomId = createUniqueUuid(
-              this.client.runtime,
-              conversationId,
-            );
-            return tweetRoomId === options.roomId;
-          }
-          return true;
-        })
-        .map((tweet) => {
-          const tweetId = tweet.id as string;
-          const conversationId = tweet.conversationId ?? tweetId;
-          return {
+      const messages: Message[] = searchResult.tweets.flatMap((tweet) => {
+        // Normalize once per row; rows without a usable identity or timestamp
+        // fail closed instead of surfacing as fresh messages (#18965).
+        const timestamp = getEpochMs(tweet.timestamp);
+        if (typeof tweet.id !== "string" || timestamp === undefined) return [];
+        const tweetId = tweet.id;
+        const conversationId = tweet.conversationId ?? tweetId;
+        if (options.roomId) {
+          const tweetRoomId = createUniqueUuid(
+            this.client.runtime,
+            conversationId,
+          );
+          if (tweetRoomId !== options.roomId) return [];
+        }
+        return [
+          {
             id: tweetId,
             agentId: this.client.runtime.agentId,
             roomId: createUniqueUuid(this.client.runtime, conversationId),
@@ -114,14 +109,15 @@ export class TwitterMessageService implements IMessageService {
             type: tweet.inReplyToStatusId
               ? MessageType.REPLY
               : MessageType.MENTION,
-            timestamp: getEpochMs(tweet.timestamp) ?? Date.now(),
+            timestamp,
             inReplyTo: tweet.inReplyToStatusId,
             metadata: {
               tweetId,
               permanentUrl: tweet.permanentUrl,
             },
-          };
-        });
+          },
+        ];
+      });
 
       return messages;
     } catch (error) {

--- a/plugins/plugin-x/src/services/PostService.ts
+++ b/plugins/plugin-x/src/services/PostService.ts
@@ -204,6 +204,10 @@ export class TwitterPostService implements IPostService {
       if (!tweet?.id) return null;
       const tweetId = tweet.id;
 
+      // Fail closed on a present-but-unusable timestamp (#18965).
+      const timestamp = getEpochMs(tweet.timestamp);
+      if (timestamp === undefined) return null;
+
       const post: Post = {
         id: tweetId,
         agentId: agentId,
@@ -214,7 +218,7 @@ export class TwitterPostService implements IPostService {
         userId: tweet.userId ?? "",
         username: tweet.username ?? "",
         text: tweet.text ?? "",
-        timestamp: getEpochMs(tweet.timestamp),
+        timestamp,
         metrics: {
           likes: tweet.likes || 0,
           reposts: tweet.retweets || 0,
@@ -268,6 +272,8 @@ export class TwitterPostService implements IPostService {
 
       const posts: Post[] = tweets
         .filter((tweet) => typeof tweet.id === "string")
+        // Fail closed: corrupt timestamps never surface as fresh (#18965).
+        .filter((tweet) => getEpochMs(tweet.timestamp) !== undefined)
         .map((tweet) => {
           const tweetId = tweet.id as string;
           return {
@@ -280,7 +286,7 @@ export class TwitterPostService implements IPostService {
             userId: tweet.userId ?? "",
             username: tweet.username ?? "",
             text: tweet.text ?? "",
-            timestamp: getEpochMs(tweet.timestamp),
+            timestamp: getEpochMs(tweet.timestamp) ?? Date.now(),
             metrics: {
               likes: tweet.likes || 0,
               reposts: tweet.retweets || 0,
@@ -348,6 +354,8 @@ export class TwitterPostService implements IPostService {
 
       const posts: Post[] = searchResult.tweets
         .filter((tweet) => typeof tweet.id === "string")
+        // Fail closed: corrupt timestamps never surface as fresh (#18965).
+        .filter((tweet) => getEpochMs(tweet.timestamp) !== undefined)
         .map((tweet) => {
           const tweetId = tweet.id as string;
           return {
@@ -360,7 +368,7 @@ export class TwitterPostService implements IPostService {
             userId: tweet.userId ?? "",
             username: tweet.username ?? "",
             text: tweet.text ?? "",
-            timestamp: getEpochMs(tweet.timestamp),
+            timestamp: getEpochMs(tweet.timestamp) ?? Date.now(),
             metrics: {
               likes: tweet.likes || 0,
               reposts: tweet.retweets || 0,

--- a/plugins/plugin-x/src/services/PostService.ts
+++ b/plugins/plugin-x/src/services/PostService.ts
@@ -270,13 +270,14 @@ export class TwitterPostService implements IPostService {
         );
       }
 
-      const posts: Post[] = tweets
-        .filter((tweet) => typeof tweet.id === "string")
-        // Fail closed: corrupt timestamps never surface as fresh (#18965).
-        .filter((tweet) => getEpochMs(tweet.timestamp) !== undefined)
-        .map((tweet) => {
-          const tweetId = tweet.id as string;
-          return {
+      const posts: Post[] = tweets.flatMap((tweet) => {
+        // Normalize once per row; rows without a usable identity or timestamp
+        // fail closed instead of surfacing as fresh posts (#18965).
+        const timestamp = getEpochMs(tweet.timestamp);
+        if (typeof tweet.id !== "string" || timestamp === undefined) return [];
+        const tweetId = tweet.id;
+        return [
+          {
             id: tweetId,
             agentId: options.agentId,
             roomId: createUniqueUuid(
@@ -286,7 +287,7 @@ export class TwitterPostService implements IPostService {
             userId: tweet.userId ?? "",
             username: tweet.username ?? "",
             text: tweet.text ?? "",
-            timestamp: getEpochMs(tweet.timestamp) ?? Date.now(),
+            timestamp,
             metrics: {
               likes: tweet.likes || 0,
               reposts: tweet.retweets || 0,
@@ -304,8 +305,9 @@ export class TwitterPostService implements IPostService {
               conversationId: tweet.conversationId,
               permanentUrl: tweet.permanentUrl,
             },
-          };
-        });
+          },
+        ];
+      });
 
       return posts;
     } catch (error) {
@@ -352,13 +354,14 @@ export class TwitterPostService implements IPostService {
         options?.before,
       );
 
-      const posts: Post[] = searchResult.tweets
-        .filter((tweet) => typeof tweet.id === "string")
-        // Fail closed: corrupt timestamps never surface as fresh (#18965).
-        .filter((tweet) => getEpochMs(tweet.timestamp) !== undefined)
-        .map((tweet) => {
-          const tweetId = tweet.id as string;
-          return {
+      const posts: Post[] = searchResult.tweets.flatMap((tweet) => {
+        // Normalize once per row; rows without a usable identity or timestamp
+        // fail closed instead of surfacing as fresh mentions (#18965).
+        const timestamp = getEpochMs(tweet.timestamp);
+        if (typeof tweet.id !== "string" || timestamp === undefined) return [];
+        const tweetId = tweet.id;
+        return [
+          {
             id: tweetId,
             agentId: agentId,
             roomId: createUniqueUuid(
@@ -368,7 +371,7 @@ export class TwitterPostService implements IPostService {
             userId: tweet.userId ?? "",
             username: tweet.username ?? "",
             text: tweet.text ?? "",
-            timestamp: getEpochMs(tweet.timestamp) ?? Date.now(),
+            timestamp,
             metrics: {
               likes: tweet.likes || 0,
               reposts: tweet.retweets || 0,
@@ -387,8 +390,9 @@ export class TwitterPostService implements IPostService {
               permanentUrl: tweet.permanentUrl,
               isMention: true,
             },
-          };
-        });
+          },
+        ];
+      });
 
       return posts;
     } catch (error) {

--- a/plugins/plugin-x/src/services/timestamp-boundaries.test.ts
+++ b/plugins/plugin-x/src/services/timestamp-boundaries.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Regression coverage for #18965 across every timestamp collection boundary:
+ * mixed valid+corrupt rows through the post/message list services and the
+ * XService search connector must surface only the valid rows (normalized to
+ * epoch ms exactly once), invalid `parseTweetV2ToV1` conversions must fail
+ * closed downstream, and the interaction row normalizer must skip
+ * present-but-unusable timestamps. Deterministic; mocked ClientBase only —
+ * the services under test are real.
+ */
+
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { ClientBase } from "../base";
+import { parseTweetV2ToV1 } from "../client/tweets";
+import { normalizeTweet } from "../interactions";
+import { MessageType } from "./IMessageService";
+import { TwitterMessageService } from "./MessageService";
+import { TwitterPostService } from "./PostService";
+import { XService } from "./x.service";
+
+const NOW = 1_755_000_000_000;
+const VALID_SECONDS = 1_710_969_600; // 2024-03-20T22:40:00Z as Unix seconds
+const VALID_MS = VALID_SECONDS * 1000;
+
+function createRuntime() {
+  return {
+    agentId: "00000000-0000-0000-0000-000000000001" as UUID,
+    getSetting: vi.fn(() => undefined),
+    reportError: vi.fn(),
+  } as unknown as IAgentRuntime;
+}
+
+function rawTweet(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "valid-1",
+    userId: "user-1",
+    username: "alice",
+    name: "Alice",
+    conversationId: "conversation-1",
+    text: "a healthy row",
+    timestamp: VALID_SECONDS,
+    permanentUrl: "https://x.com/alice/status/valid-1",
+    ...overrides,
+  };
+}
+
+function createClient(overrides: Record<string, unknown> = {}): ClientBase {
+  return {
+    accountId: "default",
+    runtime: createRuntime(),
+    profile: { id: "bot-user", username: "bot" },
+    twitterClient: {},
+    fetchSearchTweets: vi.fn(),
+    fetchHomeTimeline: vi.fn(async () => []),
+    ...overrides,
+  } as unknown as ClientBase;
+}
+
+describe("TwitterPostService mixed valid+corrupt collections (#18965)", () => {
+  it("getPosts surfaces only rows with usable timestamps, normalized to ms", async () => {
+    const client = createClient({
+      fetchHomeTimeline: vi.fn(async () => [
+        rawTweet(),
+        rawTweet({ id: "corrupt-1", timestamp: Number.NaN }),
+        rawTweet({ id: "valid-2", timestamp: VALID_MS }),
+      ]),
+    });
+    const service = new TwitterPostService(client);
+
+    const posts = await service.getPosts({
+      agentId: "00000000-0000-0000-0000-000000000001" as UUID,
+    });
+
+    expect(posts.map((p) => p.id)).toEqual(["valid-1", "valid-2"]);
+    expect(posts.map((p) => p.timestamp)).toEqual([VALID_MS, VALID_MS]);
+    // No skipped row may reappear with a "now"-shaped timestamp.
+    for (const post of posts) {
+      expect(post.timestamp).toBeLessThan(NOW);
+    }
+  });
+
+  it("getMentions drops corrupt rows instead of dating them now", async () => {
+    const client = createClient({
+      fetchSearchTweets: vi.fn(async () => ({
+        tweets: [
+          rawTweet({ id: "corrupt-1", timestamp: Number.POSITIVE_INFINITY }),
+          rawTweet(),
+        ],
+      })),
+    });
+    const service = new TwitterPostService(client);
+
+    const mentions = await service.getMentions(
+      "00000000-0000-0000-0000-000000000001" as UUID,
+    );
+
+    expect(mentions.map((p) => p.id)).toEqual(["valid-1"]);
+    expect(mentions[0].timestamp).toBe(VALID_MS);
+  });
+});
+
+describe("TwitterMessageService mixed valid+corrupt collections (#18965)", () => {
+  it("getMessages surfaces only rows with usable timestamps", async () => {
+    const client = createClient({
+      fetchSearchTweets: vi.fn(async () => ({
+        tweets: [
+          rawTweet({ inReplyToStatusId: "root-1" }),
+          rawTweet({ id: "corrupt-1", timestamp: -5 }),
+        ],
+      })),
+    });
+    const service = new TwitterMessageService(client);
+
+    const messages = await service.getMessages({
+      roomId: undefined as unknown as UUID,
+    });
+
+    expect(messages.map((m) => m.id)).toEqual(["valid-1"]);
+    expect(messages[0].timestamp).toBe(VALID_MS);
+    expect(messages[0].type).toBe(MessageType.REPLY);
+  });
+});
+
+describe("XService.searchConnectorPosts boundary (#18965)", () => {
+  it("skips corrupt rows and never emits a memory with undefined createdAt", async () => {
+    const runtime = createRuntime();
+    const service = Object.create(XService.prototype) as XService & {
+      runtime: IAgentRuntime;
+      defaultAccountId: string;
+      getTwitterClientForAccount: (id: string) => Promise<unknown>;
+    };
+    service.runtime = runtime;
+    service.defaultAccountId = "default";
+    service.getTwitterClientForAccount = vi.fn(async () => ({
+      client: createClient({
+        fetchSearchTweets: vi.fn(async () => ({
+          tweets: [
+            rawTweet(),
+            rawTweet({ id: "corrupt-1", timestamp: Number.NaN }),
+          ],
+        })),
+      }),
+    }));
+
+    const memories: Memory[] = await service.searchConnectorPosts(
+      { runtime },
+      { query: "anything" },
+    );
+
+    expect(memories).toHaveLength(1);
+    expect(memories[0].createdAt).toBe(VALID_MS);
+    expect(
+      (memories[0].metadata as { timestamp?: number } | undefined)?.timestamp,
+    ).toBe(VALID_MS);
+  });
+});
+
+describe("invalid parseTweetV2ToV1 conversions fail closed downstream (#18965)", () => {
+  it("a garbage created_at converts to an unusable timestamp that collections skip", async () => {
+    const converted = parseTweetV2ToV1({
+      id: "v2-corrupt",
+      text: "corrupt v2 row",
+      author_id: "user-2",
+      conversation_id: "conversation-2",
+      created_at: "not-a-real-date",
+    } as Parameters<typeof parseTweetV2ToV1>[0]);
+
+    expect(Number.isFinite(converted.timestamp)).toBe(false);
+
+    const client = createClient({
+      fetchHomeTimeline: vi.fn(async () => [rawTweet(), converted]),
+    });
+    const posts = await new TwitterPostService(client).getPosts({
+      agentId: "00000000-0000-0000-0000-000000000001" as UUID,
+    });
+
+    expect(posts.map((p) => p.id)).toEqual(["valid-1"]);
+  });
+});
+
+describe("interaction row normalizer (#18965)", () => {
+  it("skips present-but-unusable timestamps and normalizes valid ones once", () => {
+    expect(normalizeTweet(rawTweet({ timestamp: Number.NaN }))).toBeNull();
+    expect(normalizeTweet(rawTweet({ timestamp: -1 }))).toBeNull();
+
+    const seconds = normalizeTweet(rawTweet());
+    expect(seconds?.timestamp).toBe(VALID_MS);
+
+    const absent = normalizeTweet(rawTweet({ timestamp: undefined }));
+    expect(absent?.timestamp).toBeGreaterThanOrEqual(NOW);
+  });
+});

--- a/plugins/plugin-x/src/services/x.service.ts
+++ b/plugins/plugin-x/src/services/x.service.ts
@@ -774,7 +774,7 @@ export class XService extends Service {
       userId: post.userId || runtime.agentId,
       username: post.username || base.profile?.username || "agent",
       text: post.text,
-      timestamp: post.timestamp,
+      createdAt: post.timestamp,
       inReplyTo: post.inReplyTo,
       roomId: post.roomId,
       metadata: post.metadata,
@@ -944,7 +944,7 @@ export class XService extends Service {
         userId: post.userId,
         username: post.username,
         text: post.text,
-        timestamp: post.timestamp,
+        createdAt: post.timestamp,
         inReplyTo: post.inReplyTo,
         roomId: post.roomId,
         metadata: post.metadata,
@@ -976,23 +976,35 @@ export class XService extends Service {
       SearchMode.Latest,
       params.cursor,
     );
-    return result.tweets.map((tweet) =>
-      this.buildXPostMemory(runtime, {
-        id: tweet.id ?? "unknown",
-        userId: tweet.userId ?? "unknown",
-        username: tweet.username ?? undefined,
-        text: tweet.text ?? "",
-        timestamp: tweet.timestamp,
-        inReplyTo: tweet.inReplyToStatusId,
-        metrics: {
-          likes: tweet.likes,
-          reposts: tweet.retweets,
-          replies: tweet.replies,
-          quotes: tweet.quotes,
-        },
-        accountId,
-      }),
-    );
+    return result.tweets.flatMap((tweet) => {
+      // Normalize once per row: a present-but-unusable timestamp fails the
+      // row closed instead of surfacing a healthy-looking memory with an
+      // undefined or "now" creation time (#18965).
+      const createdAt = getEpochMs(tweet.timestamp);
+      if (createdAt === undefined) {
+        logger.debug(
+          `X searchPosts: skipping tweet ${tweet.id ?? "unknown"} with unusable timestamp`,
+        );
+        return [];
+      }
+      return [
+        this.buildXPostMemory(runtime, {
+          id: tweet.id ?? "unknown",
+          userId: tweet.userId ?? "unknown",
+          username: tweet.username ?? undefined,
+          text: tweet.text ?? "",
+          createdAt,
+          inReplyTo: tweet.inReplyToStatusId,
+          metrics: {
+            likes: tweet.likes,
+            reposts: tweet.retweets,
+            replies: tweet.replies,
+            quotes: tweet.quotes,
+          },
+          accountId,
+        }),
+      ];
+    });
   }
 
   async fetchConnectorMessages(
@@ -1335,6 +1347,12 @@ export class XService extends Service {
     return messages;
   }
 
+  /**
+   * `createdAt` must be an already-validated epoch-milliseconds value: each
+   * caller normalizes its raw timestamp exactly once at the row boundary and
+   * skips rows that fail, so this builder can never emit a healthy-looking
+   * memory with an undefined or unit-drifted timestamp (#18965).
+   */
   private buildXPostMemory(
     runtime: IAgentRuntime,
     post: {
@@ -1342,7 +1360,7 @@ export class XService extends Service {
       userId?: string;
       username?: string;
       text: string;
-      timestamp?: number;
+      createdAt: number;
       inReplyTo?: string;
       roomId?: UUID;
       metrics?: unknown;
@@ -1354,10 +1372,7 @@ export class XService extends Service {
       post.accountId ?? this.defaultAccountId,
     );
     const authorId = post.userId || "unknown";
-    // Route through the shared normalizer so seconds/milliseconds sources do
-    // not drift and a present-but-unusable timestamp fails closed instead of
-    // being recorded as "now" (#18965).
-    const createdAt = getEpochMs(post.timestamp);
+    const createdAt = post.createdAt;
     const entityId =
       authorId === runtime.agentId
         ? runtime.agentId

--- a/plugins/plugin-x/src/services/x.service.ts
+++ b/plugins/plugin-x/src/services/x.service.ts
@@ -43,6 +43,7 @@ import { TwitterPostClient } from "../post";
 import { TwitterTimelineClient } from "../timeline";
 import type { ITwitterClient, TwitterClientState } from "../types";
 import { getSetting } from "../utils/settings";
+import { getEpochMs } from "../utils/time";
 import { TwitterPostService } from "./PostService";
 
 const X_CONNECTOR_CONTEXTS = ["social", "connectors"];
@@ -1353,9 +1354,10 @@ export class XService extends Service {
       post.accountId ?? this.defaultAccountId,
     );
     const authorId = post.userId || "unknown";
-    const createdAt = Number.isFinite(post.timestamp)
-      ? post.timestamp
-      : Date.now();
+    // Route through the shared normalizer so seconds/milliseconds sources do
+    // not drift and a present-but-unusable timestamp fails closed instead of
+    // being recorded as "now" (#18965).
+    const createdAt = getEpochMs(post.timestamp);
     const entityId =
       authorId === runtime.agentId
         ? runtime.agentId

--- a/plugins/plugin-x/src/timeline.ts
+++ b/plugins/plugin-x/src/timeline.ts
@@ -74,6 +74,13 @@ function normalizeTweet(tweet: Tweet): ActionableTweet | null {
       ? tweet.username
       : "unknown";
 
+  // Normalize the timestamp exactly once at this row boundary: absent values
+  // mean "observed now", present values are unit-normalized to epoch ms, and
+  // a present-but-unusable value fails the whole row closed so it can never
+  // surface as a fresh tweet or an undated memory (#18965).
+  const timestamp = getEpochMs(tweet.timestamp);
+  if (timestamp === undefined) return null;
+
   return {
     ...tweet,
     id: tweet.id,
@@ -82,7 +89,7 @@ function normalizeTweet(tweet: Tweet): ActionableTweet | null {
     name: tweet.name ?? username,
     conversationId: tweet.conversationId ?? tweet.id,
     text: tweet.text ?? "",
-    timestamp: tweet.timestamp ?? Date.now(),
+    timestamp,
   };
 }
 
@@ -279,9 +286,10 @@ export class TwitterTimelineClient {
       metadata: buildTwitterMessageMetadata(
         tweet,
         createUniqueUuid(runtime, tweet.userId),
+        tweet.timestamp,
         this.client.accountId,
       ),
-      createdAt: getEpochMs(tweet.timestamp),
+      createdAt: tweet.timestamp,
     };
   }
 
@@ -462,9 +470,10 @@ Choose any combination of [LIKE], [RETWEET], [QUOTE], and [REPLY] that are appro
         metadata: buildTwitterMessageMetadata(
           tweet,
           createUniqueUuid(this.runtime, tweet.userId),
+          tweet.timestamp,
           this.client.accountId,
         ),
-        createdAt: getEpochMs(tweet.timestamp),
+        createdAt: tweet.timestamp,
       };
 
       await createMemorySafe(this.runtime, tweetMemory, "messages");

--- a/plugins/plugin-x/src/utils/memory.ts
+++ b/plugins/plugin-x/src/utils/memory.ts
@@ -15,7 +15,6 @@ import {
   type UUID,
 } from "@elizaos/core";
 import type { Tweet as ClientTweet } from "../client";
-import { getEpochMs } from "./time";
 
 function errorDetail(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -44,15 +43,21 @@ export interface TwitterContextResult {
 
 type TwitterMetadataTweet = Pick<
   ClientTweet,
-  "conversationId" | "id" | "name" | "timestamp" | "userId" | "username"
+  "conversationId" | "id" | "name" | "userId" | "username"
 >;
 
+/**
+ * `createdAt` must be an already-validated epoch-milliseconds value: callers
+ * normalize the raw tweet timestamp exactly once at their row boundary (and
+ * skip the row when it is unusable), so this builder never re-normalizes and
+ * can never emit an undefined timestamp (#18965).
+ */
 export function buildTwitterMessageMetadata(
   tweet: TwitterMetadataTweet,
   entityId: UUID,
+  createdAt: number,
   accountId?: string,
 ): Memory["metadata"] {
-  const createdAt = getEpochMs(tweet.timestamp);
   return {
     type: "message",
     source: "twitter",

--- a/plugins/plugin-x/src/utils/time.test.ts
+++ b/plugins/plugin-x/src/utils/time.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Boundary coverage for getEpochMs (#18965): unit inference for seconds /
+ * milliseconds / microseconds stays intact, genuinely missing values still
+ * fall back to "now", and present-but-unusable values (NaN, Infinity,
+ * negative) fail closed to undefined instead of masquerading as "now".
+ * Deterministic via a frozen clock.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getEpochMs } from "./time";
+
+const NOW = 1_755_000_000_000;
+
+describe("getEpochMs", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("normalizes finite timestamps by inferred unit", () => {
+    expect(getEpochMs(1_710_969_600)).toBe(1_710_969_600_000); // seconds
+    expect(getEpochMs(1_710_969_600_000)).toBe(1_710_969_600_000); // millis
+    expect(getEpochMs(1_710_969_600_000_000)).toBe(1_710_969_600_000); // micros
+  });
+
+  it("falls back to now for genuinely missing values", () => {
+    expect(getEpochMs(undefined)).toBe(NOW);
+    expect(getEpochMs(0)).toBe(NOW);
+  });
+
+  it.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["-Infinity", Number.NEGATIVE_INFINITY],
+    ["negative", -1_710_969_600],
+  ])("fails closed to undefined for %s instead of now", (_label, value) => {
+    expect(getEpochMs(value)).toBeUndefined();
+  });
+
+  it("keeps fractional-second inputs (v2 conversions divide ms by 1000)", () => {
+    expect(getEpochMs(1_710_969_600.123)).toBe(1_710_969_600_123);
+  });
+});

--- a/plugins/plugin-x/src/utils/time.ts
+++ b/plugins/plugin-x/src/utils/time.ts
@@ -2,9 +2,15 @@
  * Normalizes X/Twitter timestamps to epoch milliseconds, inferring the source
  * unit (seconds / millis / micros) from digit count so tweet times from
  * different API surfaces compare correctly.
+ *
+ * Missing values (undefined or 0) fall back to "now" for callers that treat
+ * absence as freshly observed. A PRESENT but non-finite or negative timestamp
+ * fails closed to undefined instead of masquerading as "now" (#18965) —
+ * callers must skip age filtering and omit memory createdAt in that case.
  */
-export function getEpochMs(ts: number | undefined): number {
-  if (!ts) return Date.now();
+export function getEpochMs(ts: number | undefined): number | undefined {
+  if (ts === undefined || ts === 0) return Date.now();
+  if (!Number.isFinite(ts) || ts < 0) return undefined;
   // Possible formats:
   //  • seconds  (10 digits)  e.g., 1710969600
   //  • millis   (13 digits)  e.g., 1710969600000


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18965

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run; **verify passes green on this head**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes on this head.

# Risks

Low–medium. The normalizer's contract widens to `number | undefined` and every consumer was audited: engagement filters skip unusable timestamps explicitly, single-item getters return null, list projections filter the row, and `buildXPostMemory` now routes through the normalizer (fixing a silent seconds-vs-milliseconds drift between the v2 conversion and search paths). Genuinely missing timestamps keep the existing now-fallback, so no behavior changes for well-formed data.

# Background

## What does this PR do?

`getEpochMs` treated every falsy value — including `NaN` from `new Date(invalid).getTime()` — as "now". Corrupt tweets therefore passed the 12–24h engagement age filters as age-0 (the 24h guard is `age > maxAge → skip`, and `NaN > maxAge` is false, so they were KEPT), and memories recorded "now" or wrong-unit `createdAt` values because `buildXPostMemory` bypassed the unit normalizer entirely.

Now: missing (`undefined`/`0`) still falls back to now; present-but-non-finite or negative fails closed to `undefined`; every consumer handles the unusable case per the repo's required-DTO-field policy.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/utils/time.ts` (the contract change + WHY comment), then `src/utils/time.test.ts`, then the consumer audit: `interactions.ts` (both age filters), `services/x.service.ts` (`buildXPostMemory`), `services/MessageService.ts` / `services/PostService.ts` (single-item null returns + list filters).

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-x test
```

# Evidence Gate

<!-- evidence-head:b138c2fc5043092814a63fe35cf08720e7ae84b8 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - server-side timestamp normalization; no UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - server-side timestamp normalization; no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-visible flow; behavior pinned by the deterministic suite below`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — the full plugin suite on this head plus the new boundary cases:

  <details><summary>vitest run</summary>

  ```
  src/utils/time.test.ts — 7 passed (unit inference, missing->now, non-finite
  and negative -> undefined, fractional seconds)

  src/services/timestamp-boundaries.test.ts — 6 passed (review consumer cases):
    getPosts: mixed valid+corrupt rows -> only valid survive, normalized to ms
    getMentions: corrupt row dropped instead of dated now
    getMessages: mixed rows -> only valid survive
    searchConnectorPosts: 2-row search with one NaN timestamp -> exactly one
      memory, createdAt and metadata.timestamp both validated epoch ms
    parseTweetV2ToV1 garbage created_at -> non-finite timestamp -> collection
      skips the converted row
    row normalizer: unusable timestamps skip the row; seconds normalize once

  full plugin suite: Tests 96 passed | 13 skipped (skips pre-existing on develop)
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - server-side plugin module; no browser surface involved`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - deterministic timestamp normalization; no model, prompt, provider, or action behavior involved`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the normalized values the suite pins at each boundary:

  <details><summary>getEpochMs input/output contract</summary>

  ```
  1710969600 (seconds)        -> 1710969600000
  1710969600000 (millis)      -> 1710969600000
  1710969600000000 (micros)   -> 1710969600000
  undefined / 0 (missing)     -> Date.now()   (unchanged fallback)
  NaN / Infinity / -Inf / neg -> undefined    (was Date.now() / raw passthrough)
  engagement filters: undefined -> tweet skipped (was kept as age-0)
  buildXPostMemory / buildTwitterMessageMetadata: require validated
    createdAt: number — normalized once per row at each collection boundary;
    corrupt rows are skipped there (searchConnectorPosts, base.ts save loops,
    interactions/timeline row normalizers, Message/Post list services), and
    every `?? Date.now()` mapper fallback is removed
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Evidence Details

All evidence is inline above.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZWXMR13B2MPJHRW98Z9EW92","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T06:41:06.084Z","completed_at":"2026-08-13T06:52:24.423Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"iCKpayzJnmM9KKGzjjmLCVKRPxpc3JEusOksrROdjGtFrLdx6i-G8xiCLw1uVOyXuugc_IfKTlnDRHjn4DF2DQ"}} -->


