### PR TITLE
fix(scripts): bound test-console run concurrency

### DIFF
--- a/packages/scripts/test-console/__tests__/console-lib.test.ts
+++ b/packages/scripts/test-console/__tests__/console-lib.test.ts
@@ -6,10 +6,13 @@
  */
 
 import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
+import { fileURLToPath } from "node:url";
 
 import {
   classifyResult,
@@ -213,6 +216,78 @@ describe("registry (real plan discovery)", () => {
     });
     expect(suiteState(withKey)).toBe("armed");
   }, 30_000);
+});
+
+describe("server entrypoint", () => {
+  test("starts through a symlinked path containing spaces", async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza test-console-entrypoint-"),
+    );
+    const linkedServer = path.join(tempDir, "linked server.mjs");
+    fs.symlinkSync(
+      fileURLToPath(new URL("../server.mjs", import.meta.url)),
+      linkedServer,
+    );
+
+    const child = spawn("node", [linkedServer], {
+      env: {
+        ...process.env,
+        ELIZA_TEST_CONSOLE_DIR: path.join(tempDir, "state"),
+        ELIZA_TEST_CONSOLE_PORT: "0",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    let startupTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        new Promise<void>((resolve) => {
+          child.stdout.on("data", () => {
+            if (stdout.includes("[TestConsole] listening")) resolve();
+          });
+        }),
+        new Promise<never>((_, reject) => {
+          child.once("exit", (code, signal) => {
+            reject(
+              new Error(
+                `test console exited before listening (code=${code}, signal=${signal}, stderr=${stderr})`,
+              ),
+            );
+          });
+        }),
+        new Promise<never>((_, reject) => {
+          startupTimer = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `timed out waiting for test console startup (stdout=${stdout}, stderr=${stderr})`,
+                ),
+              ),
+            5_000,
+          );
+        }),
+      ]);
+      expect(child.exitCode).toBeNull();
+    } finally {
+      if (startupTimer) clearTimeout(startupTimer);
+      if (child.exitCode === null) {
+        child.kill("SIGTERM");
+        await once(child, "exit");
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }, 10_000);
 });
 
 describe("route: POST /api/run rejects invalid concurrency before live-lane side effects", () => {

--- a/packages/scripts/test-console/__tests__/console-lib.test.ts
+++ b/packages/scripts/test-console/__tests__/console-lib.test.ts
@@ -5,10 +5,11 @@
  * one slow test — it shells the actual run-all-tests plan, no mocks).
  */
 
-import { beforeAll, describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, mock, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
 
 import {
   classifyResult,
@@ -212,4 +213,74 @@ describe("registry (real plan discovery)", () => {
     });
     expect(suiteState(withKey)).toBe("armed");
   }, 30_000);
+});
+
+describe("route: POST /api/run rejects invalid concurrency before live-lane side effects", () => {
+  const refreshGoogleAccessTokenMock = mock(async () => ({
+    accessToken: "fake-access-token",
+  }));
+
+  let store: typeof import("../lib/store.mjs");
+  let server: typeof import("../server.mjs");
+
+  beforeAll(async () => {
+    const testConsoleDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza-test-console-route-"),
+    );
+    process.env.ELIZA_TEST_CONSOLE_DIR = testConsoleDir;
+
+    // Stub the Google OAuth client so a request that *does* reach the
+    // refresh step would succeed and persist a token — proving the ordering
+    // fix (not an unreachable network call) is what keeps it from firing.
+    mock.module("../lib/oauth.mjs", () => ({
+      completeGoogleFlow: mock(),
+      DEFAULT_CLOUD_BASE_URL: "https://cloud.example.test",
+      pollCloudLogin: mock(),
+      refreshGoogleAccessToken: refreshGoogleAccessTokenMock,
+      startCloudLogin: mock(),
+      startGoogleFlow: mock(),
+    }));
+
+    store = await import("../lib/store.mjs");
+    store.setConnection("google-oauth", {
+      GOOGLE_CLIENT_ID: "test-client-id",
+      GOOGLE_CLIENT_SECRET: "test-client-secret",
+      GOOGLE_OAUTH_REFRESH_TOKEN: "test-refresh-token",
+    });
+
+    server = await import("../server.mjs");
+  });
+
+  function postRun(body: unknown): Promise<{ status: number }> {
+    return new Promise((resolve, reject) => {
+      const req = Readable.from([Buffer.from(JSON.stringify(body))]);
+      let status = 0;
+      const res = {
+        writeHead(code: number) {
+          status = code;
+        },
+        end() {
+          resolve({ status });
+        },
+      };
+      Promise.resolve(
+        server.routes["POST /api/run"](req as never, res as never),
+      ).catch(reject);
+    });
+  }
+
+  test("returns 400 without ever refreshing/persisting Google credentials or starting a run", async () => {
+    refreshGoogleAccessTokenMock.mockClear();
+
+    const result = await postRun({
+      mode: "all",
+      lane: "live",
+      concurrency: "Infinity",
+    });
+
+    expect(result.status).toBe(400);
+    expect(refreshGoogleAccessTokenMock).not.toHaveBeenCalled();
+    expect(store.loadCredentials()["google-calendar"]).toBeUndefined();
+    expect(server.runManager.isRunning()).toBe(false);
+  });
 });

--- a/packages/scripts/test-console/__tests__/console-lib.test.ts
+++ b/packages/scripts/test-console/__tests__/console-lib.test.ts
@@ -10,7 +10,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { classifyResult, countStatuses } from "../lib/runner.mjs";
+import {
+  classifyResult,
+  countStatuses,
+  normalizeRunConcurrency,
+} from "../lib/runner.mjs";
 
 const LABEL = "@elizaos/logger (packages/logger)#test";
 
@@ -104,6 +108,29 @@ describe("classifyResult", () => {
         { status: "failed" },
       ]),
     ).toEqual({ passed: 2, failed: 1 });
+  });
+});
+
+describe("normalizeRunConcurrency", () => {
+  test("preserves the default and ordinary positive integer inputs", () => {
+    expect(normalizeRunConcurrency(undefined)).toBe(3);
+    expect(normalizeRunConcurrency(4)).toBe(4);
+    expect(normalizeRunConcurrency("04")).toBe(4);
+  });
+
+  test("rejects values that could disable or exhaust the worker bound", () => {
+    for (const value of [
+      0,
+      -1,
+      "1e3",
+      "4workers",
+      33,
+      Number.MAX_SAFE_INTEGER,
+    ]) {
+      expect(() => normalizeRunConcurrency(value)).toThrow(
+        "concurrency must be a positive integer from 1 to 32",
+      );
+    }
   });
 });
 

--- a/packages/scripts/test-console/lib/runner.mjs
+++ b/packages/scripts/test-console/lib/runner.mjs
@@ -37,6 +37,34 @@ function taskSlug(label) {
 }
 
 const CLOUD_LABEL = "cloud#test";
+export const MAX_RUN_CONCURRENCY = 32;
+
+/**
+ * Normalize the API's optional worker count before it reaches the pool.
+ * Missing and blank values preserve the console's default; supplied values
+ * must be bounded positive decimal integers so one request cannot fan out the
+ * entire repository test plan at once.
+ */
+export function normalizeRunConcurrency(value, fallback = 3) {
+  if (value === undefined || value === null || value === "") return fallback;
+  const raw = typeof value === "number" ? String(value) : value;
+  if (typeof raw !== "string" || !/^\d+$/.test(raw)) {
+    throw new TypeError(
+      `concurrency must be a positive integer from 1 to ${MAX_RUN_CONCURRENCY}`,
+    );
+  }
+  const parsed = Number(raw);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < 1 ||
+    parsed > MAX_RUN_CONCURRENCY
+  ) {
+    throw new TypeError(
+      `concurrency must be a positive integer from 1 to ${MAX_RUN_CONCURRENCY}`,
+    );
+  }
+  return parsed;
+}
 
 export class RunManager extends EventEmitter {
   constructor() {

--- a/packages/scripts/test-console/server.mjs
+++ b/packages/scripts/test-console/server.mjs
@@ -358,9 +358,9 @@ const server = http.createServer(async (req, res) => {
   }
 });
 
-// Guard the listen so importing this module (route-level tests) never binds
-// a real port; only running it directly (`bun run test:console`) starts it.
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Keep route imports side-effect free while preserving startup through
+// canonical, symlinked, and URL-escaped entrypoint paths.
+if (import.meta.main) {
   server.listen(PORT, HOST, () => {
     console.log(`[TestConsole] listening on http://${HOST}:${PORT}`);
     console.log(`[TestConsole] state dir: ${consoleDir()}`);

--- a/packages/scripts/test-console/server.mjs
+++ b/packages/scripts/test-console/server.mjs
@@ -57,7 +57,7 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const PORT = Number(process.env.ELIZA_TEST_CONSOLE_PORT || 31338);
 const HOST = "127.0.0.1";
 
-const runManager = new RunManager();
+export const runManager = new RunManager();
 const sseClients = new Set();
 
 runManager.on("event", (event) => {
@@ -133,7 +133,7 @@ function selectTasks({ mode, labels }) {
   return all;
 }
 
-const routes = {
+export const routes = {
   "GET /api/state": (req, res) => json(res, 200, currentState()),
 
   "POST /api/gates": async (req, res) => {
@@ -153,6 +153,17 @@ const routes = {
     } = await readBody(req);
     if (runManager.isRunning())
       return json(res, 409, { error: "run already in progress" });
+    let normalizedConcurrency;
+    try {
+      normalizedConcurrency = normalizeRunConcurrency(concurrency);
+    } catch (error) {
+      // error-policy:J1 API boundary — reject an invalid worker count before
+      // any live-lane side effect (task discovery, credential reads, token
+      // refresh/persist) runs.
+      return json(res, 400, {
+        error: error instanceof Error ? error.message : "invalid concurrency",
+      });
+    }
     const tasks = selectTasks({ mode, labels });
     if (tasks.length === 0)
       return json(res, 400, { error: "no tasks selected" });
@@ -189,16 +200,6 @@ const routes = {
           message: `Google token refresh failed: ${error?.message ?? error}`,
         });
       }
-    }
-    let normalizedConcurrency;
-    try {
-      normalizedConcurrency = normalizeRunConcurrency(concurrency);
-    } catch (error) {
-      // error-policy:J1 API boundary — reject an invalid worker count before
-      // it can fan out repository test processes.
-      return json(res, 400, {
-        error: error instanceof Error ? error.message : "invalid concurrency",
-      });
     }
     const runId = runManager.startRun({
       tasks,
@@ -357,7 +358,11 @@ const server = http.createServer(async (req, res) => {
   }
 });
 
-server.listen(PORT, HOST, () => {
-  console.log(`[TestConsole] listening on http://${HOST}:${PORT}`);
-  console.log(`[TestConsole] state dir: ${consoleDir()}`);
-});
+// Guard the listen so importing this module (route-level tests) never binds
+// a real port; only running it directly (`bun run test:console`) starts it.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  server.listen(PORT, HOST, () => {
+    console.log(`[TestConsole] listening on http://${HOST}:${PORT}`);
+    console.log(`[TestConsole] state dir: ${consoleDir()}`);
+  });
+}

--- a/packages/scripts/test-console/server.mjs
+++ b/packages/scripts/test-console/server.mjs
@@ -37,7 +37,7 @@ import {
   startGoogleFlow,
 } from "./lib/oauth.mjs";
 import { buildRegistry, discoverPlan } from "./lib/registry.mjs";
-import { RunManager } from "./lib/runner.mjs";
+import { normalizeRunConcurrency, RunManager } from "./lib/runner.mjs";
 import {
   consoleDir,
   credentialsToEnv,
@@ -190,11 +190,21 @@ const routes = {
         });
       }
     }
+    let normalizedConcurrency;
+    try {
+      normalizedConcurrency = normalizeRunConcurrency(concurrency);
+    } catch (error) {
+      // error-policy:J1 API boundary — reject an invalid worker count before
+      // it can fan out repository test processes.
+      return json(res, 400, {
+        error: error instanceof Error ? error.message : "invalid concurrency",
+      });
+    }
     const runId = runManager.startRun({
       tasks,
       lane,
       extraEnv,
-      concurrency: Number(concurrency) || 3,
+      concurrency: normalizedConcurrency,
     });
     json(res, 200, { runId, taskCount: tasks.length });
   },


### PR DESCRIPTION
# Relates to

Fixes #18979

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      focused regression tests and CLI reproduction below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The test console's optional `concurrency` worker count is validated at its
HTTP boundary; default and ordinary positive values retain their prior
behavior. Independently re-verified below.

# Background

## What does this PR do?

`POST /api/run` on the local test console previously coerced `concurrency` with
`Number(concurrency) || 3` and passed it straight to `RunManager.drive`, which
sizes its worker array off it directly. Inputs such as `"1e3"`, `"Infinity"`, or
`Number.MAX_SAFE_INTEGER` were silently accepted and would size one worker per
parallel-safe task in the submitted run, with zero throttling.

Traced live call chain:
- `packages/scripts/test-console/server.mjs:193-207` parses the request and
  passes the value to `runManager.startRun`.
- `packages/scripts/test-console/lib/runner.mjs:142`, inside
  `async drive(run, { extraEnv, concurrency })`:
  `{ length: Math.max(1, Math.min(concurrency, parallel.length || 1)) }` — the
  clamp bounds against `parallel.length` (the number of tasks in the submitted
  run, not a small fixed ceiling), so an unbounded `concurrency` was never
  neutralized downstream.

`normalizeRunConcurrency` now requires a positive safe decimal integer from 1
through 32 (`MAX_RUN_CONCURRENCY`), preserving the default (`3`) and ordinary
leading-zero/positive values, and rejecting everything else. `server.mjs`
wraps the `POST /api/run` parse in try/catch and returns HTTP 400 on invalid
input instead of the old silent fallback.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

1. `packages/scripts/test-console/lib/runner.mjs` (`normalizeRunConcurrency`,
   `MAX_RUN_CONCURRENCY`)
2. `packages/scripts/test-console/server.mjs:193-207` (`POST /api/run`)
3. `packages/scripts/test-console/__tests__/console-lib.test.ts:114-135`

## Detailed testing steps

```text
bun test packages/scripts/test-console/__tests__/console-lib.test.ts
12 pass
0 fail
27 expect() calls

bunx @biomejs/biome check packages/scripts/test-console/lib/runner.mjs \
  packages/scripts/test-console/server.mjs \
  packages/scripts/test-console/__tests__/console-lib.test.ts
Found 10 warnings.
```

All 10 Biome warnings are pre-existing on unmodified `origin/develop`
(`server.mjs`, unrelated `noUndeclaredEnvVars`/`noUnusedFunctionParameters`
findings at identical line numbers) — independently confirmed by stashing this
diff and re-running Biome against clean `develop` content. None are
attributable to this change; no new warnings introduced.

`packages/scripts/test-console` is plain `.mjs` with no local `package.json`/
`tsconfig` — no `typecheck` step applies to these files.

Independent old-vs-new input sweep (manual, beyond the automated suite):

```text
concurrency(undefined)              old=3          new=3
concurrency("")                     old=3          new=3
concurrency("3")                    old=3          new=3
concurrency("04")                   old=4          new=4
concurrency("0")                    old=3          new=REJECTED (400)
concurrency("-5")                   old=-5         new=REJECTED (400)
concurrency("1e3")                  old=1000       new=REJECTED (400)
concurrency("Infinity")             old=Infinity   new=REJECTED (400)
concurrency("32")                   old=32         new=32
concurrency("33")                   old=33         new=REJECTED (400)
concurrency("9007199254740991")     old=<huge>     new=REJECTED (400)
concurrency("abc")                  old=3          new=REJECTED (400)
concurrency(" 5 ")                  old=5          new=REJECTED (400)
```

Only the default and ordinary positive integers (`3`, `4`, `32`) are
unchanged; every previously-unbounded or malformed input is now rejected at
the HTTP boundary with a 400 instead of reaching the worker-array sizing.

## Update — addressed review feedback (commit `9da2fce2`)

Reviewer `startrack3r` correctly flagged (P1, CHANGES_REQUESTED): the original
diff validated `concurrency` *after* `selectTasks()`, settings/credential
loads, and the live-lane Google OAuth refresh block, so an invalid
`concurrency` submitted with `lane: "live"` could still trigger
`refreshGoogleAccessToken()` and persist the token via `setConnection()`
before the route finally rejected the request with 400.

Fixed: `normalizeRunConcurrency` now runs immediately after the active-run
guard, before any task discovery or credential/OAuth side effect. Added a
route-level regression (`packages/scripts/test-console/__tests__/console-lib.test.ts`,
"route: POST /api/run rejects invalid concurrency before live-lane side
effects") that seeds fake Google OAuth credentials into an isolated store,
stubs `refreshGoogleAccessToken` to succeed if reached, sends `lane: "live"`
with `concurrency: "Infinity"`, and asserts: HTTP 400, the refresh mock never
called, no `google-calendar` credential persisted, and `runManager.isRunning()`
stays `false`.

Independently confirmed both directions before pushing:

```text
$ bun test packages/scripts/test-console/__tests__/console-lib.test.ts
13 pass, 0 fail, 31 expect() calls

Reverted only the ordering fix (kept the new test) and re-ran:
12 pass, 1 fail — the new route-level test fails exactly as expected against
the pre-fix ordering, confirming it's a genuine regression test and not
vacuous.
```

Also required exporting `routes` and `runManager` from `server.mjs`, and
guarding `server.listen()` behind an `import.meta.url === file://${process.argv[1]}`
check so importing the module for this test never binds a real port — no
behavior change when run directly via `bun run test:console`.

Biome re-checked post-fix: still the same 10 pre-existing warnings at shifted
line numbers, none new.

# Evidence Gate

<!-- evidence-head:35022aae435b0e56b48f71314ca8c364435898b9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend/script-only change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend/script-only change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - backend/script-only change; no rendered UI flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - focused deterministic regression test exercises the validation helper directly; no external service required.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend or network state changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real regression run and manual sweep, output captured directly:
  ```text
  bun test packages/scripts/test-console/__tests__/console-lib.test.ts
  13 pass
  0 fail
  31 expect() calls

  Manual old-vs-new sweep (13 inputs incl. 0, -5, 1e3, Infinity, 33,
  MAX_SAFE_INTEGER, non-numeric, whitespace-padded) — see Testing above.

  Route-level regression (added post-review): 400 returned, Google OAuth
  refresh stub never invoked, no google-calendar credential persisted, no run
  started — confirmed to fail against the pre-fix ordering and pass against
  this fix. See "Update — addressed review feedback" above.
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface.

# Known gaps / failures

Full root `bun run verify` was not run locally (unrelated to this change: the
sandbox's `bun run test:scripts` lane hits release-integration tests that fail
on npm-cache write permissions under `~/.npm/_cacache`, unrelated to
test-console). The focused package tests, Biome, and a manual edge-case sweep
on the changed files all pass — see Testing above.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [hunt-and-implement-5]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZWX3DFJ56S49TQYWRAK62D9","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T06:31:38.226Z","completed_at":"2026-08-13T06:35:58.236Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAVq8Ggvxg2RCIBwXtE9az5b_tYKj9qVj_3nvqPhhTcAA","device_key_id":"e60c0d298778b55b0d73aec8f38dfc80913a79223c40de61bea259417fe35ec3","device_signature":"Bt8_MhBjQHcGrB7V_xK7_wj5tmPrtRMf2un4LTNV-MRjvi1kMJpbht1__UkBFfjkZN-H9PyucuHcayvy-1ygBQ"}} -->

## Maintainer repair — exact head `35022aae`

Rebased onto `origin/develop@a181693f125505dbdf2d46723cb6c246db37b715`, linked scoped issue #18979, and replaced the path-string main-module guard with the pinned runtime's native `import.meta.main` contract. Added a real Node child-process regression that starts the console through a symlink whose path contains spaces, waits for the listener, and then tears it down.

Exact-head proof: full test-console suite 18 passed / 0 failed / 108 assertions; focused Biome check completed with only the same 10 pre-existing warnings; `git diff --check` passed.