### PR TITLE
fix(app): reject invalid audit view-soak timing overrides

### DIFF
--- a/packages/app/scripts/audit-views-soak-navigation.test.mjs
+++ b/packages/app/scripts/audit-views-soak-navigation.test.mjs
@@ -29,7 +29,7 @@ test("navigation uses an independent cold-load timeout with target diagnostics",
   expect(source).toContain("resolveSoakTiming");
   expect(source).toContain("DEFAULT_NAV_TIMEOUT_MS");
   expect(source).toContain(
-    "{ timeout: Math.max(NAV_TIMEOUT_MS, NAV_WAIT_MS * 3) }",
+    "{ timeout: resolveNavigationTimeoutMs(NAV_TIMEOUT_MS, NAV_WAIT_MS) }",
   );
   expect(source).toContain("navigation to view");
   expect(source).toContain("did not reach");

--- a/packages/app/scripts/audit-views-soak-timing.test.mjs
+++ b/packages/app/scripts/audit-views-soak-timing.test.mjs
@@ -11,8 +11,10 @@ import {
   DEFAULT_NAV_TIMEOUT_MS,
   DEFAULT_NAV_WAIT_MS,
   DEFAULT_ROUNDS,
+  MAX_NAV_WAIT_MS,
   MAX_TIMER_DELAY_MS,
   parsePositiveSafeInteger,
+  resolveNavigationTimeoutMs,
   resolveSoakTiming,
 } from "./audit-views-soak.mjs";
 
@@ -42,6 +44,8 @@ describe("parsePositiveSafeInteger", () => {
       "  ",
       "abc",
       "6junk",
+      " 6 ",
+      "700\n",
       "1.5",
       "+3",
       "-1",
@@ -55,8 +59,8 @@ describe("parsePositiveSafeInteger", () => {
       );
     }
     expect(() =>
-      parsePositiveSafeInteger(String(MAX_TIMER_DELAY_MS + 1), "NAV_WAIT_MS", {
-        max: MAX_TIMER_DELAY_MS,
+      parsePositiveSafeInteger(String(MAX_NAV_WAIT_MS + 1), "NAV_WAIT_MS", {
+        max: MAX_NAV_WAIT_MS,
       }),
     ).toThrow(/NAV_WAIT_MS must be a positive safe-integer decimal/);
   });
@@ -98,6 +102,10 @@ describe("resolveSoakTiming", () => {
     expect(() => resolveSoakTiming({ NAV_WAIT_MS: "1.5" })).toThrow(
       /NAV_WAIT_MS/,
     );
+    expect(() => resolveSoakTiming({ ROUNDS: " 6 " })).toThrow(/ROUNDS/);
+    expect(() => resolveSoakTiming({ NAV_WAIT_MS: "700\n" })).toThrow(
+      /NAV_WAIT_MS/,
+    );
     expect(() => resolveSoakTiming({ NAV_TIMEOUT_MS: "10s" })).toThrow(
       /NAV_TIMEOUT_MS/,
     );
@@ -106,6 +114,27 @@ describe("resolveSoakTiming", () => {
         NAV_TIMEOUT_MS: String(MAX_TIMER_DELAY_MS + 1),
       }),
     ).toThrow(/NAV_TIMEOUT_MS/);
+    expect(() =>
+      resolveSoakTiming({ NAV_WAIT_MS: String(MAX_NAV_WAIT_MS + 1) }),
+    ).toThrow(/NAV_WAIT_MS/);
+  });
+});
+
+describe("resolveNavigationTimeoutMs", () => {
+  it("returns the exact bounded timeout passed to Playwright", () => {
+    expect(resolveNavigationTimeoutMs(10_000, 700)).toBe(10_000);
+    expect(resolveNavigationTimeoutMs(1, MAX_NAV_WAIT_MS)).toBe(
+      MAX_NAV_WAIT_MS * 3,
+    );
+    expect(resolveNavigationTimeoutMs(MAX_TIMER_DELAY_MS, 1)).toBe(
+      MAX_TIMER_DELAY_MS,
+    );
+  });
+
+  it("rejects a derived timeout above Node's timer ceiling", () => {
+    expect(() => resolveNavigationTimeoutMs(1, MAX_NAV_WAIT_MS + 1)).toThrow(
+      /derived navigation timeout/,
+    );
   });
 });
 
@@ -116,18 +145,33 @@ describe("audit-views-soak CLI boundary", () => {
     expect(result.stderr).toMatch(/ROUNDS/);
     expect(result.stdout + result.stderr).not.toMatch(/audit:views soak/);
     expect(result.stdout + result.stderr).not.toMatch(/\/api\/views/);
-  });
+  }, 15_000);
 
   it("rejects invalid NAV_TIMEOUT_MS before soak work starts", () => {
     const result = runCli({ NAV_TIMEOUT_MS: "1.5" });
     expect(result.status).toBe(1);
     expect(result.stderr).toMatch(/NAV_TIMEOUT_MS/);
     expect(result.stdout + result.stderr).not.toMatch(/audit:views soak/);
-  });
+  }, 15_000);
+
+  it.each([
+    ["ROUNDS", " 6 "],
+    ["NAV_WAIT_MS", "700\n"],
+  ])(
+    "rejects padded %s before soak work starts",
+    (key, value) => {
+      const result = runCli({ [key]: value });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toMatch(new RegExp(key));
+      expect(result.stdout + result.stderr).not.toMatch(/audit:views soak/);
+      expect(result.stdout + result.stderr).not.toMatch(/\/api\/views/);
+    },
+    15_000,
+  );
 
   it("rejects zero ROUNDS instead of silently running zero churn", () => {
     const result = runCli({ ROUNDS: "0" });
     expect(result.status).toBe(1);
     expect(result.stderr).toMatch(/ROUNDS/);
-  });
+  }, 15_000);
 });

--- a/packages/app/scripts/audit-views-soak.mjs
+++ b/packages/app/scripts/audit-views-soak.mjs
@@ -52,6 +52,9 @@ export const DEFAULT_NAV_TIMEOUT_MS = 10_000;
 /** Node clamps `setTimeout` / Playwright timer delays above this to 1 ms. */
 export const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
+/** Largest settle wait whose three-times navigation allowance remains safe. */
+export const MAX_NAV_WAIT_MS = Math.floor(MAX_TIMER_DELAY_MS / 3);
+
 /**
  * Accept only complete positive safe-integer decimal strings (or numbers).
  * Rejects partial numbers, signed values, fractions, zero, and values above
@@ -77,7 +80,7 @@ export function parsePositiveSafeInteger(value, label, options = {}) {
     }
     return value;
   }
-  const raw = String(value ?? "").trim();
+  const raw = String(value ?? "");
   if (!/^\d+$/.test(raw)) {
     throw new Error(
       `${label} must be ${rangeHint} (received ${received(value)})`,
@@ -118,7 +121,7 @@ export function resolveSoakTiming(env = process.env) {
     navWaitRaw == null || String(navWaitRaw).trim() === ""
       ? DEFAULT_NAV_WAIT_MS
       : parsePositiveSafeInteger(navWaitRaw, "NAV_WAIT_MS", {
-          max: MAX_TIMER_DELAY_MS,
+          max: MAX_NAV_WAIT_MS,
         });
 
   const navTimeoutMs =
@@ -129,6 +132,23 @@ export function resolveSoakTiming(env = process.env) {
         });
 
   return { rounds, navWaitMs, navTimeoutMs };
+}
+
+/**
+ * Resolve the exact Playwright navigation timeout without exceeding Node's
+ * timer ceiling when the settle wait contributes a three-times allowance.
+ * @param {number} navTimeoutMs
+ * @param {number} navWaitMs
+ * @returns {number}
+ */
+export function resolveNavigationTimeoutMs(navTimeoutMs, navWaitMs) {
+  const timeoutMs = Math.max(navTimeoutMs, navWaitMs * 3);
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs > MAX_TIMER_DELAY_MS) {
+    throw new Error(
+      `derived navigation timeout must be at most ${MAX_TIMER_DELAY_MS} ms`,
+    );
+  }
+  return timeoutMs;
 }
 
 const UI = process.env.UI || "http://127.0.0.1:2138";
@@ -731,7 +751,7 @@ async function main() {
           return normalized === target;
         },
         targetPath,
-        { timeout: Math.max(NAV_TIMEOUT_MS, NAV_WAIT_MS * 3) },
+        { timeout: resolveNavigationTimeoutMs(NAV_TIMEOUT_MS, NAV_WAIT_MS) },
       );
     } catch (cause) {
       // error-policy:J2 Preserve Playwright's timeout while identifying the


### PR DESCRIPTION
# Relates to

Fixes #18648

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync.
- [x] A reviewer can verify real fail-closed CLI behavior from the attached JSON artifact.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `5f45afb97ca4b5c6140e3131557028e092a685ef`; zero conflicts.
- [x] `bun run verify` passed on the immediately preceding parent (`981a0ffef09`): 350/350 tasks plus all repository audits. The only intervening develop commit changes agent character routes; focused tests, app typecheck, and app lint all passed again on the exact current base.

# Risks

Low. Defaults and valid normal-range overrides are unchanged. The intentional compatibility tightening is that explicit timing tokens must now be exact positive decimal integers, and `NAV_WAIT_MS` is bounded so its derived `3x` Playwright timeout stays under Node's timer ceiling.

# Background

## What does this PR do?

- Rejects partial, padded, signed, fractional, zero, negative, and overflowing `ROUNDS`, `NAV_WAIT_MS`, and `NAV_TIMEOUT_MS` values before any browser or `/api/views` work.
- Keeps historical defaults for unset, empty, or whitespace-only values.
- Bounds the exact derived navigation timeout passed to Playwright, avoiding Node's oversized-timer clamp-to-1ms behavior.
- Updates the existing navigation source-contract test and adds pure boundary plus real-process CLI coverage.
- Gives the CLI subprocess tests an explicit CI-safe timeout; each spawned process retains its stricter 8-second execution timeout.

## What kind of change is this?

Harness correctness fix (non-product, non-rendered behavior).

# Documentation changes needed?

No. This is validation of existing operator-only script knobs; the clear runtime error is the operator contract.

# Testing

## Where should a reviewer start?

Start with `packages/app/scripts/audit-views-soak.mjs`, then review `audit-views-soak-timing.test.mjs` and the updated source contract in `audit-views-soak-navigation.test.mjs`.

## Detailed testing steps

- Focused timing/navigation suite — 24 passed, 0 failed on the exact current base.
- App script suite — 766 passed, 1 skipped.
- App Vitest suite — 84 files and 664 tests passed.
- `bun run --cwd packages/app typecheck` — passed on the exact current base.
- `bun run --cwd packages/app lint` — passed on the exact current base.
- `bun install --frozen-lockfile` — passed with no dependency changes.
- `bun run verify` — 350/350 tasks plus all repository audits passed.
- Real process probes reject `ROUNDS=" 6 "` and `NAV_WAIT_MS="700\n"` with exit 1 before soak work.

# Evidence Gate

<!-- evidence-head:77a055aaf5a1e0047df8daa8b252d9b43e5dfa5c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI is changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI is changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is an operator CLI validation path with no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service is started; real subprocess outcomes are attached as the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime or network request is involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, action, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Real CLI and timer-boundary artifact ([JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18648-view-soak-timing.json), SHA-256 `ab2aeb4166a0cd38b6fdc0e004a506a109355ffdedbaf5937485a1d33a2657f2`).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changed.

## Backend + frontend logs

N/A - no backend or frontend service is involved. The linked JSON records real process exit codes, exact diagnostics, absence of soak work, and the timer-boundary values.

## Screenshots (before / after) + video walkthrough

N/A - the diff changes only an operator script and its tests. The mandated app audit was nevertheless run: 214 checks passed, 1 aggregate check reported four pre-existing untouched minimalism ratchets; broken=0. No changed rendered surface exists to capture.

## Audio / voice walkthrough

N/A - no voice path changed.

## Known gaps / failures

The full app visual audit retains four pre-existing minimalism `needs-work` ratchets in untouched views (`builtin-browser` mobile portrait/landscape, `builtin-plugins` mobile portrait, and `builtin-trajectories` mobile landscape). This PR changes no view, CSS, component, or visual baseline. All applicable behavioral and repository gates pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-issue-triage]