### PR TITLE
fix(plugin-coding-tools): reject malformed shell numeric configuration

### DIFF
--- a/plugins/plugin-coding-tools/AGENTS.md
+++ b/plugins/plugin-coding-tools/AGENTS.md
@@ -106,6 +106,20 @@ All settings are read via `runtime.getSetting(key)` or `process.env`. None are r
 | `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | Pre-stat byte cap on FILE action=read. Larger files are rejected. |
 | `CODING_TOOLS_GREP_HEAD_LIMIT` | `250` | Default `head_limit` for GREP output. Set to 0 to disable. |
 
+The folded `ShellService` also retains compatibility settings for external
+consumers of `runtime.getService("shell").exec()` / `executeCommand()`. The
+canonical SHELL action above continues to use the `CODING_TOOLS_*` settings.
+
+| Compatibility setting | Default | Accepted values / effect |
+|---|---:|---|
+| `SHELL_ALLOWED_DIRECTORY` | `process.cwd()` | Existing directory exposed to the compatibility service. |
+| `SHELL_TIMEOUT` | `30000` | Exact decimal milliseconds, `1..2147483647`, for simple command execution. |
+| `SHELL_MAX_OUTPUT_CHARS` | `200000` | Exact decimal retained-session cap, `1..1000000`. |
+| `SHELL_PENDING_MAX_OUTPUT_CHARS` | `200000` | Exact decimal unread-output cap, `1..1000000` (also bounded by the retained-session cap). |
+| `SHELL_BACKGROUND_MS` | `10000` | Exact decimal foreground yield window, `10..120000`. |
+| `SHELL_ALLOW_BACKGROUND` | `true` | Set to exact `false` to disable compatibility-service background/yield behavior. |
+| `SHELL_FORBIDDEN_COMMANDS` | — | Comma-separated additions to the built-in forbidden-command set. |
+
 Auto-enable keys (in agent `config.features`):
 - `config.features.codingTools` (canonical) — `true` or `{ enabled: true }`.
 - `config.features["coding-agent"]` (legacy alias).

--- a/plugins/plugin-coding-tools/CLAUDE.md
+++ b/plugins/plugin-coding-tools/CLAUDE.md
@@ -106,6 +106,20 @@ All settings are read via `runtime.getSetting(key)` or `process.env`. None are r
 | `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | Pre-stat byte cap on FILE action=read. Larger files are rejected. |
 | `CODING_TOOLS_GREP_HEAD_LIMIT` | `250` | Default `head_limit` for GREP output. Set to 0 to disable. |
 
+The folded `ShellService` also retains compatibility settings for external
+consumers of `runtime.getService("shell").exec()` / `executeCommand()`. The
+canonical SHELL action above continues to use the `CODING_TOOLS_*` settings.
+
+| Compatibility setting | Default | Accepted values / effect |
+|---|---:|---|
+| `SHELL_ALLOWED_DIRECTORY` | `process.cwd()` | Existing directory exposed to the compatibility service. |
+| `SHELL_TIMEOUT` | `30000` | Exact decimal milliseconds, `1..2147483647`, for simple command execution. |
+| `SHELL_MAX_OUTPUT_CHARS` | `200000` | Exact decimal retained-session cap, `1..1000000`. |
+| `SHELL_PENDING_MAX_OUTPUT_CHARS` | `200000` | Exact decimal unread-output cap, `1..1000000` (also bounded by the retained-session cap). |
+| `SHELL_BACKGROUND_MS` | `10000` | Exact decimal foreground yield window, `10..120000`. |
+| `SHELL_ALLOW_BACKGROUND` | `true` | Set to exact `false` to disable compatibility-service background/yield behavior. |
+| `SHELL_FORBIDDEN_COMMANDS` | — | Comma-separated additions to the built-in forbidden-command set. |
+
 Auto-enable keys (in agent `config.features`):
 - `config.features.codingTools` (canonical) — `true` or `{ enabled: true }`.
 - `config.features["coding-agent"]` (legacy alias).

--- a/plugins/plugin-coding-tools/README.md
+++ b/plugins/plugin-coding-tools/README.md
@@ -56,6 +56,20 @@ All settings are optional. Configure via environment variables or agent settings
 | `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | File size cap for reads (bytes). Larger files are rejected. |
 | `CODING_TOOLS_GREP_HEAD_LIMIT` | `250` | Max output lines for GREP. Set to 0 to disable. |
 
+The folded `ShellService` retains these compatibility settings for external
+callers of `runtime.getService("shell").exec()` / `executeCommand()`; the
+canonical SHELL action continues to use the `CODING_TOOLS_*` settings above.
+
+| Compatibility setting | Default | Accepted values / effect |
+|---|---:|---|
+| `SHELL_ALLOWED_DIRECTORY` | `process.cwd()` | Existing directory exposed to the compatibility service. |
+| `SHELL_TIMEOUT` | `30000` | Exact decimal milliseconds, `1..2147483647`, for simple command execution. |
+| `SHELL_MAX_OUTPUT_CHARS` | `200000` | Exact decimal retained-session cap, `1..1000000`. |
+| `SHELL_PENDING_MAX_OUTPUT_CHARS` | `200000` | Exact decimal unread-output cap, `1..1000000` (also bounded by the retained-session cap). |
+| `SHELL_BACKGROUND_MS` | `10000` | Exact decimal foreground yield window, `10..120000`. |
+| `SHELL_ALLOW_BACKGROUND` | `true` | Set to exact `false` to disable compatibility-service background/yield behavior. |
+| `SHELL_FORBIDDEN_COMMANDS` | — | Comma-separated additions to the built-in forbidden-command set. |
+
 ## Default path blocklist
 
 The following paths are blocked by default (plus platform-specific system directories):

--- a/plugins/plugin-coding-tools/src/shell/utils/config.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/config.test.ts
@@ -45,4 +45,50 @@ describe("loadShellConfig", () => {
       `SHELL_ALLOWED_DIRECTORY does not exist: ${missingDirectory}`,
     );
   });
+
+  it.each([
+    ["SHELL_TIMEOUT", "1oops"],
+    ["SHELL_MAX_OUTPUT_CHARS", "1e3"],
+    ["SHELL_PENDING_MAX_OUTPUT_CHARS", " 200000"],
+    ["SHELL_BACKGROUND_MS", "9007199254740992"],
+  ])("rejects malformed positive integer %s values", (name, value) => {
+    vi.stubEnv(name, value);
+
+    expect(() => loadShellConfig()).toThrow(
+      `Shell plugin configuration error: ${name} must be a positive decimal integer`,
+    );
+  });
+
+  it("preserves valid decimal values across every numeric setting", () => {
+    vi.stubEnv("SHELL_TIMEOUT", "45000");
+    vi.stubEnv("SHELL_MAX_OUTPUT_CHARS", "250000");
+    vi.stubEnv("SHELL_PENDING_MAX_OUTPUT_CHARS", "150000");
+    vi.stubEnv("SHELL_BACKGROUND_MS", "12000");
+
+    expect(loadShellConfig()).toMatchObject({
+      timeout: 45000,
+      maxOutputChars: 250000,
+      pendingMaxOutputChars: 150000,
+      defaultBackgroundMs: 12000,
+    });
+  });
+
+  it.each(["0", "-1"])(
+    "continues to reject non-positive timeout %s",
+    (value) => {
+      vi.stubEnv("SHELL_TIMEOUT", value);
+
+      expect(() => loadShellConfig()).toThrow(
+        "Shell plugin configuration error: SHELL_TIMEOUT must be a positive decimal integer",
+      );
+    },
+  );
+
+  it("rejects timeout values above Node's maximum timer delay", () => {
+    vi.stubEnv("SHELL_TIMEOUT", "2147483648");
+
+    expect(() => loadShellConfig()).toThrow(
+      "Shell plugin configuration error: SHELL_TIMEOUT must be a positive decimal integer no greater than 2147483647",
+    );
+  });
 });

--- a/plugins/plugin-coding-tools/src/shell/utils/config.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/config.test.ts
@@ -1,8 +1,20 @@
-/** Verifies shell startup diagnostics and invalid-directory failures at the configuration boundary. */
+/** Verifies typed shell configuration failures, live numeric bounds, defaults, and startup diagnostics. */
 import path from "node:path";
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadShellConfig } from "./config.js";
+
+function captureConfigError(): ElizaError {
+  try {
+    loadShellConfig();
+  } catch (error) {
+    // error-policy:J3 the test captures the explicit invalid-config result so
+    // it can assert the typed classification and structured boundary context.
+    expect(error).toBeInstanceOf(ElizaError);
+    return error as ElizaError;
+  }
+  throw new Error("Expected loadShellConfig to reject invalid configuration");
+}
 
 describe("loadShellConfig", () => {
   afterEach(() => {
@@ -41,23 +53,32 @@ describe("loadShellConfig", () => {
     );
     vi.stubEnv("SHELL_ALLOWED_DIRECTORY", missingDirectory);
 
-    expect(() => loadShellConfig()).toThrow(
-      `SHELL_ALLOWED_DIRECTORY does not exist: ${missingDirectory}`,
-    );
+    const error = captureConfigError();
+    expect(error).toMatchObject({
+      code: "SHELL_CONFIG_DIRECTORY_MISSING",
+      context: { allowedDirectory: missingDirectory },
+      cause: expect.objectContaining({ code: "ENOENT" }),
+    });
   });
 
   it.each([
-    ["SHELL_TIMEOUT", "1oops"],
-    ["SHELL_MAX_OUTPUT_CHARS", "1e3"],
-    ["SHELL_PENDING_MAX_OUTPUT_CHARS", " 200000"],
-    ["SHELL_BACKGROUND_MS", "9007199254740992"],
-  ])("rejects malformed positive integer %s values", (name, value) => {
-    vi.stubEnv(name, value);
+    ["SHELL_TIMEOUT", "1oops", 1, 2_147_483_647],
+    ["SHELL_MAX_OUTPUT_CHARS", "1e3", 1, 1_000_000],
+    ["SHELL_PENDING_MAX_OUTPUT_CHARS", " 200000", 1, 1_000_000],
+    ["SHELL_BACKGROUND_MS", "9007199254740992", 10, 120_000],
+  ])(
+    "rejects malformed positive integer %s values",
+    (name, value, minimum, maximum) => {
+      vi.stubEnv(name, value);
 
-    expect(() => loadShellConfig()).toThrow(
-      `Shell plugin configuration error: ${name} must be a positive decimal integer`,
-    );
-  });
+      const error = captureConfigError();
+      expect(error).toMatchObject({
+        code: "SHELL_CONFIG_INTEGER_INVALID",
+        context: { setting: name, received: value, minimum, maximum },
+        severity: "fatal",
+      });
+    },
+  );
 
   it("preserves valid decimal values across every numeric setting", () => {
     vi.stubEnv("SHELL_TIMEOUT", "45000");
@@ -78,17 +99,38 @@ describe("loadShellConfig", () => {
     (value) => {
       vi.stubEnv("SHELL_TIMEOUT", value);
 
-      expect(() => loadShellConfig()).toThrow(
-        "Shell plugin configuration error: SHELL_TIMEOUT must be a positive decimal integer",
+      expect(captureConfigError().message).toBe(
+        "Shell plugin configuration error: SHELL_TIMEOUT must be a positive decimal integer no greater than 2147483647",
       );
     },
   );
 
-  it("rejects timeout values above Node's maximum timer delay", () => {
-    vi.stubEnv("SHELL_TIMEOUT", "2147483648");
+  it.each([
+    ["SHELL_TIMEOUT", "2147483648", 1, 2_147_483_647],
+    ["SHELL_MAX_OUTPUT_CHARS", "1000001", 1, 1_000_000],
+    ["SHELL_PENDING_MAX_OUTPUT_CHARS", "1000001", 1, 1_000_000],
+    ["SHELL_BACKGROUND_MS", "9", 10, 120_000],
+    ["SHELL_BACKGROUND_MS", "120001", 10, 120_000],
+  ])("rejects out-of-range %s=%s", (name, value, minimum, maximum) => {
+    vi.stubEnv(name, value);
 
-    expect(() => loadShellConfig()).toThrow(
-      "Shell plugin configuration error: SHELL_TIMEOUT must be a positive decimal integer no greater than 2147483647",
-    );
+    expect(captureConfigError()).toMatchObject({
+      code: "SHELL_CONFIG_INTEGER_INVALID",
+      context: { setting: name, received: value, minimum, maximum },
+    });
+  });
+
+  it("accepts every numeric setting at its live boundary", () => {
+    vi.stubEnv("SHELL_TIMEOUT", "2147483647");
+    vi.stubEnv("SHELL_MAX_OUTPUT_CHARS", "1000000");
+    vi.stubEnv("SHELL_PENDING_MAX_OUTPUT_CHARS", "1");
+    vi.stubEnv("SHELL_BACKGROUND_MS", "120000");
+
+    expect(loadShellConfig()).toMatchObject({
+      timeout: 2_147_483_647,
+      maxOutputChars: 1_000_000,
+      pendingMaxOutputChars: 1,
+      defaultBackgroundMs: 120_000,
+    });
   });
 });

--- a/plugins/plugin-coding-tools/src/shell/utils/config.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/config.ts
@@ -20,6 +20,29 @@ const configSchema = z.object({
   allowBackground: z.boolean().default(true),
 });
 
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+function parsePositiveIntegerEnv(
+  name: string,
+  fallback: number,
+  maximum = Number.MAX_SAFE_INTEGER,
+): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(
+      `Shell plugin configuration error: ${name} must be a positive decimal integer`,
+    );
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed > maximum) {
+    throw new Error(
+      `Shell plugin configuration error: ${name} must be a positive decimal integer no greater than ${maximum}`,
+    );
+  }
+  return parsed;
+}
+
 export const DEFAULT_FORBIDDEN_COMMANDS: readonly string[] = [
   "rm -rf /",
   "rmdir",
@@ -50,18 +73,23 @@ export const DEFAULT_FORBIDDEN_COMMANDS: readonly string[] = [
 
 export function loadShellConfig(): ShellConfig {
   const allowedDirectory = process.env.SHELL_ALLOWED_DIRECTORY || process.cwd();
-  const timeout = parseInt(process.env.SHELL_TIMEOUT || "30000", 10);
-  const maxOutputChars = parseInt(
-    process.env.SHELL_MAX_OUTPUT_CHARS || "200000",
-    10,
+  const timeout = parsePositiveIntegerEnv(
+    "SHELL_TIMEOUT",
+    30000,
+    MAX_TIMER_DELAY_MS,
   );
-  const pendingMaxOutputChars = parseInt(
-    process.env.SHELL_PENDING_MAX_OUTPUT_CHARS || "200000",
-    10,
+  const maxOutputChars = parsePositiveIntegerEnv(
+    "SHELL_MAX_OUTPUT_CHARS",
+    200000,
   );
-  const defaultBackgroundMs = parseInt(
-    process.env.SHELL_BACKGROUND_MS || "10000",
-    10,
+  const pendingMaxOutputChars = parsePositiveIntegerEnv(
+    "SHELL_PENDING_MAX_OUTPUT_CHARS",
+    200000,
+  );
+  const defaultBackgroundMs = parsePositiveIntegerEnv(
+    "SHELL_BACKGROUND_MS",
+    10000,
+    MAX_TIMER_DELAY_MS,
   );
   const allowBackground = process.env.SHELL_ALLOW_BACKGROUND !== "false";
 

--- a/plugins/plugin-coding-tools/src/shell/utils/config.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/config.ts
@@ -1,46 +1,67 @@
 /**
  * Loads and zod-validates the shell configuration from environment variables
  * into a ShellConfig, applying defaults and merging DEFAULT_FORBIDDEN_COMMANDS.
- * Throws when SHELL_ALLOWED_DIRECTORY is missing or does not exist on disk.
+ * Numeric tokens are exact and bounded at their live consumer limits; invalid
+ * directories or numeric settings fail service startup with typed errors.
  */
 import fs from "node:fs";
 import path from "node:path";
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import { z } from "zod";
 import type { ShellConfig } from "../types";
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+const MAX_OUTPUT_CHARS = 1_000_000;
+const MIN_BACKGROUND_MS = 10;
+const MAX_BACKGROUND_MS = 120_000;
 
 const configSchema = z.object({
   enabled: z.boolean(),
   allowedDirectory: z.string(),
-  timeout: z.number().positive().default(30000),
+  timeout: z.number().int().min(1).max(MAX_TIMER_DELAY_MS).default(30000),
   forbiddenCommands: z.array(z.string()),
-  maxOutputChars: z.number().positive().default(200000),
-  pendingMaxOutputChars: z.number().positive().default(200000),
-  defaultBackgroundMs: z.number().positive().default(10000),
+  maxOutputChars: z.number().int().min(1).max(MAX_OUTPUT_CHARS).default(200000),
+  pendingMaxOutputChars: z
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_OUTPUT_CHARS)
+    .default(200000),
+  defaultBackgroundMs: z
+    .number()
+    .int()
+    .min(MIN_BACKGROUND_MS)
+    .max(MAX_BACKGROUND_MS)
+    .default(10000),
   allowBackground: z.boolean().default(true),
 });
-
-const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 function parsePositiveIntegerEnv(
   name: string,
   fallback: number,
-  maximum = Number.MAX_SAFE_INTEGER,
+  maximum: number,
+  minimum = 1,
 ): number {
   const raw = process.env[name];
   if (raw === undefined || raw === "") return fallback;
-  if (!/^[1-9]\d*$/.test(raw)) {
-    throw new Error(
-      `Shell plugin configuration error: ${name} must be a positive decimal integer`,
-    );
+
+  const parsed = /^[1-9]\d*$/.test(raw) ? Number(raw) : Number.NaN;
+  if (Number.isSafeInteger(parsed) && parsed >= minimum && parsed <= maximum) {
+    return parsed;
   }
-  const parsed = Number(raw);
-  if (!Number.isSafeInteger(parsed) || parsed > maximum) {
-    throw new Error(
-      `Shell plugin configuration error: ${name} must be a positive decimal integer no greater than ${maximum}`,
-    );
-  }
-  return parsed;
+
+  const range =
+    minimum === 1
+      ? `a positive decimal integer no greater than ${maximum}`
+      : `a decimal integer from ${minimum} to ${maximum}`;
+  throw new ElizaError(
+    `Shell plugin configuration error: ${name} must be ${range}`,
+    {
+      code: "SHELL_CONFIG_INTEGER_INVALID",
+      context: { setting: name, received: raw, minimum, maximum },
+      severity: "fatal",
+    },
+  );
 }
 
 export const DEFAULT_FORBIDDEN_COMMANDS: readonly string[] = [
@@ -81,15 +102,18 @@ export function loadShellConfig(): ShellConfig {
   const maxOutputChars = parsePositiveIntegerEnv(
     "SHELL_MAX_OUTPUT_CHARS",
     200000,
+    MAX_OUTPUT_CHARS,
   );
   const pendingMaxOutputChars = parsePositiveIntegerEnv(
     "SHELL_PENDING_MAX_OUTPUT_CHARS",
     200000,
+    MAX_OUTPUT_CHARS,
   );
   const defaultBackgroundMs = parsePositiveIntegerEnv(
     "SHELL_BACKGROUND_MS",
     10000,
-    MAX_TIMER_DELAY_MS,
+    MAX_BACKGROUND_MS,
+    MIN_BACKGROUND_MS,
   );
   const allowBackground = process.env.SHELL_ALLOW_BACKGROUND !== "false";
 
@@ -116,14 +140,24 @@ export function loadShellConfig(): ShellConfig {
   if (!parseResult.success) {
     const errorMessage =
       parseResult.error.issues[0]?.message || parseResult.error.toString();
-    throw new Error(`Shell plugin configuration error: ${errorMessage}`);
+    throw new ElizaError(`Shell plugin configuration error: ${errorMessage}`, {
+      code: "SHELL_CONFIG_INVALID",
+      cause: parseResult.error,
+      context: { issue: errorMessage },
+      severity: "fatal",
+    });
   }
 
   try {
     const stats = fs.statSync(allowedDirectory);
     if (!stats.isDirectory()) {
-      throw new Error(
+      throw new ElizaError(
         `SHELL_ALLOWED_DIRECTORY is not a directory: ${allowedDirectory}`,
+        {
+          code: "SHELL_CONFIG_DIRECTORY_INVALID",
+          context: { allowedDirectory },
+          severity: "fatal",
+        },
       );
     }
     config.allowedDirectory = path.resolve(allowedDirectory);
@@ -132,7 +166,7 @@ export function loadShellConfig(): ShellConfig {
         `background: ${allowBackground}, timeout: ${timeout}ms`,
     );
   } catch (error) {
-    // error-policy:J1 config boundary; translate the expected ENOENT into a
+    // error-policy:J2 config boundary; translate the expected ENOENT into a
     // clear "does not exist" message (preserving the original via `cause`) and
     // rethrow every other stat failure unchanged so it is not masked.
     if (
@@ -140,10 +174,13 @@ export function loadShellConfig(): ShellConfig {
       "code" in error &&
       (error as NodeJS.ErrnoException).code === "ENOENT"
     ) {
-      throw new Error(
+      throw new ElizaError(
         `SHELL_ALLOWED_DIRECTORY does not exist: ${allowedDirectory}`,
         {
+          code: "SHELL_CONFIG_DIRECTORY_MISSING",
           cause: error,
+          context: { allowedDirectory },
+          severity: "fatal",
         },
       );
     }


### PR DESCRIPTION
# Relates to

Fixes #18988

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`981a0ffef0959eaf39cf33507a26a959b4888181`); zero conflicts. Branch/commit/push were handled outside the sandbox that produced the fix (git metadata writes are blocked there — `index.lock: Operation not permitted`).
- [x] `bun run verify` was not run in full; the focused package gates below (tests, typecheck, Biome) all pass, and a manual edge-case sweep independently confirms correctness.

# Risks

Low. This is a startup configuration-boundary validation fix in the server-side coding-tools shell plugin. Valid decimal settings retain their previous values; malformed or timer-overflow settings now fail fast instead of reaching runtime timers or output limits.

# Background

## What does this PR do?

Fixes permissive `parseInt` handling in `plugins/plugin-coding-tools/src/shell/utils/config.ts:73-91`. Values such as `SHELL_TIMEOUT=1oops` were silently parsed as `1` and passed directly to the live shell timeout at `plugins/plugin-coding-tools/src/shell/services/shellService.ts:1309-1317`, causing commands to be terminated almost immediately. The same unvalidated pattern affected the live output/background numeric settings in that config.

The exact live import chain is `plugins/plugin-coding-tools/src/index.ts` → `ShellService` → `plugins/plugin-coding-tools/src/shell/utils/config.ts:73` (`loadShellConfig`) → `runCommandSimple` timeout consumer at `plugins/plugin-coding-tools/src/shell/services/shellService.ts:1309-1317`.

## What kind of change is this?

Bug fix (non-breaking change which rejects malformed configuration that previously produced unintended values).

# Documentation changes needed?

Yes. The README and paired package guides now document the folded ShellService compatibility settings, their distinction from the canonical CODING_TOOLS_* action settings, and their exact live ranges.

# Testing

## Where should a reviewer start?

Start at `plugins/plugin-coding-tools/src/shell/utils/config.test.ts`, then inspect `loadShellConfig` and the `ShellService.runCommandSimple` timeout consumer.

## Detailed testing steps

- `bun run --cwd plugins/plugin-coding-tools test -- src/shell/utils/config.test.ts` — 10 passed.
- `bun run --cwd plugins/plugin-coding-tools test` — 34 files, 446 tests passed.
- `bun run --cwd plugins/plugin-coding-tools typecheck` — passed, no output.
- `bunx @biomejs/biome check plugins/plugin-coding-tools/src/shell/utils/config.ts plugins/plugin-coding-tools/src/shell/utils/config.test.ts` — passed, 0 findings.

All four independently re-run after commit; results match exactly.

Independent old-vs-new input sweep on `SHELL_TIMEOUT` (manual, beyond the
automated suite):

```text
SHELL_TIMEOUT(undefined)                  old=30000    new=30000
SHELL_TIMEOUT("")                         old=30000    new=30000
SHELL_TIMEOUT("30000")                    old=30000    new=30000
SHELL_TIMEOUT("2147483647")               old=2147483647  new=2147483647
SHELL_TIMEOUT("1oops")                    old=1        new=REJECTED
SHELL_TIMEOUT("0")                        old=0        new=REJECTED
SHELL_TIMEOUT("-1")                       old=-1       new=REJECTED
SHELL_TIMEOUT("45.5")                     old=45       new=REJECTED
SHELL_TIMEOUT("1e3")                      old=1        new=REJECTED
SHELL_TIMEOUT("007")                      old=7        new=REJECTED
SHELL_TIMEOUT(" 30000")                   old=30000    new=REJECTED
SHELL_TIMEOUT("2147483648")               old=2147483648  new=REJECTED
SHELL_TIMEOUT("9007199254740992")         old=9007199254740992  new=REJECTED
```

Only the default and clean positive decimal values (`30000`, `2147483647`)
are unchanged; every malformed, non-finite, non-integer, whitespace-padded,
leading-zero, or overflow input is now rejected instead of silently
producing a truncated/garbage timeout. (`" 30000"` and `"007"` are stricter
than a human might expect at a glance — this is intentional: the new parser
requires a clean decimal integer, no leading/trailing whitespace and no
leading zeros, consistent with "strict positive-decimal parsing" as the
stated intent, not a side effect that slipped in un-examined.)

# Evidence Gate

<!-- evidence-head:f22317e4015acb55d4b32d6c946dc0a3f6df616a -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - server-side plugin configuration; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - server-side plugin configuration; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - deterministic server-side configuration and shell execution path; no visual flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - focused tests exercise the configuration boundary; no live service deployment is available in this sandbox.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend request or rendered state is involved.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - this changes numeric environment parsing, not an agent/action/provider/prompt/model surface.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no DB, memory, schedule, wallet, generated file, or other persistent domain artifact is produced.

```text
$ bun run --cwd plugins/plugin-coding-tools test -- src/shell/utils/config.test.ts
Test Files  1 passed (1)
Tests  10 passed (10)
$ bun run --cwd plugins/plugin-coding-tools test
Test Files  34 passed (34)
Tests  446 passed (446)
$ bun run --cwd plugins/plugin-coding-tools typecheck
passed
$ bunx @biomejs/biome check plugins/plugin-coding-tools/src/shell/utils/config.ts plugins/plugin-coding-tools/src/shell/utils/config.test.ts
Checked 2 files in 61ms. No fixes applied.
```

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no UI or visual artifact exists.

# Evidence Details

## Backend + frontend logs

Backend structured-log capture is not applicable because this sandbox cannot start the full host; the real configuration and package test paths passed. Frontend logs are not applicable.

## Known gaps / failures

Full root `bun run verify` was not run locally; the focused package's own
test/typecheck/Biome gates and a manual edge-case sweep on the changed files
all pass — see Testing above.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [hunt-and-implement-6]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZWYYYXZY1VRZDNHTR3W57PG","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T07:04:09.407Z","completed_at":"2026-08-13T07:10:57.524Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAVq8Ggvxg2RCIBwXtE9az5b_tYKj9qVj_3nvqPhhTcAA","device_key_id":"e60c0d298778b55b0d73aec8f38dfc80913a79223c40de61bea259417fe35ec3","device_signature":"Ic6qIjE2vL2N9LoMZy3_fRA-76Y9au7GoF4KxwHjmD1sz1LMOr-AwWEw0BqA4QJXD8MLVTXaw7j0B4ynTEqyBw"}} -->

## Maintainer repair — exact head `f22317e4`

Rebased onto `origin/develop@def129e2ebdb33abe40fc7f17dadfb85cb8f4194`. The parser now uses live consumer bounds: timeout `1..2147483647`, retained/pending output `1..1000000`, and background yield `10..120000`. Invalid startup configuration throws typed `ElizaError` values with code, setting, received token, accepted range, and fatal severity. Missing/invalid directories are typed as well. The operator contract is documented in README plus byte-identical CLAUDE/AGENTS guides.

Exact-head gates: configuration tests 15 passed; real ShellService process tests 4 passed; package typecheck, Biome lint, build/declarations, guide parity, and diff checks passed. The full default plugin lane has four failures in two duplicated untouched `bash.ts` path-intent tests (`keeps cd prefixes...` and `respects an explicit cwd...`); they reproduce independently of these config files on the live base. All other 447 default-lane tests pass.