### PR TITLE
fix(core): sort BM25 results by descending score when fewer than topK match

### DIFF
--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { rankMessageSearch } from "./search.ts";
+import { BM25, rankMessageSearch } from "./search.ts";
 
 describe("rankMessageSearch", () => {
 	it("matches a typo by trigram similarity, not only exact substrings", () => {
@@ -62,5 +62,23 @@ describe("rankMessageSearch", () => {
 		);
 
 		expect(hits).toEqual([]);
+	});
+});
+
+describe("BM25", () => {
+	it("returns results in descending score order when fewer than topK documents match", () => {
+		const bm25 = new BM25([
+			{ content: "alpha beta" },
+			{ content: "alpha alpha alpha alpha alpha" },
+			{ content: "alpha alpha gamma" },
+			{ content: "nothing here" },
+		]);
+
+		// Three documents score above zero for "alpha", and topK (4) is larger,
+		// so the fill-phase sort that runs at `results.length === topK` never
+		// fires. The returned array must still be sorted by descending score.
+		const scores = bm25.search("alpha", 4).map((result) => result.score);
+
+		expect(scores).toEqual([...scores].sort((a, b) => b - a));
 	});
 });

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1365,10 +1365,9 @@ export class BM25 {
 			results.splice(insertAt, 0, result);
 			results.pop();
 		}
-		// The array is only sorted once it fills to `topK`; when fewer than
-		// `topK` documents score above zero that path never runs, so ensure the
-		// returned array honors the documented descending-score order here.
-		results.sort((a, b) => b.score - a.score);
+		// A full buffer was sorted when it reached `topK`; only the partial path
+		// still retains document-index order.
+		if (results.length < topK) results.sort((a, b) => b.score - a.score);
 		return results;
 	}
 

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1365,6 +1365,10 @@ export class BM25 {
 			results.splice(insertAt, 0, result);
 			results.pop();
 		}
+		// The array is only sorted once it fills to `topK`; when fewer than
+		// `topK` documents score above zero that path never runs, so ensure the
+		// returned array honors the documented descending-score order here.
+		results.sort((a, b) => b.score - a.score);
 		return results;
 	}
 


### PR DESCRIPTION
# Relates to

Fixes #18983

## Summary

`BM25.search` documents that it returns results "sorted by descending BM25 score", but it only sorts the result array at the moment it fills to `topK`. When fewer than `topK` documents score above zero, that path never runs, so `search` returns results in document-index order instead of descending score.

This matters because callers rely on the documented order. For example, a caller that reads `results[0].score` as the maximum (to normalize scores into a `[0, 1]` range) gets an arbitrary match instead of the top one when the result is short, and a reranker that iterates `results` in order emits items by document order rather than by relevance whenever fewer than `topK` documents match, which is the common case when it searches with `topK` equal to the number of candidates.

## Change

Sort the result array by descending score before returning. The array is already kept sorted once it fills to `topK`, so this only corrects the fewer-than-`topK` path.

## Validation

- `bunx vitest run src/search.test.ts` in `packages/core` passes (4 tests), including the added regression test.
- `BM25 > returns results in descending score order when fewer than topK documents match` builds four documents where three score for the query and searches with `topK = 4`, so the fill-phase sort never fires. It fails before the change (results come back in document-index order) and passes after.

## Evidence

- Before screenshots: N/A - pure ranking function, no UI surface
- After screenshots: N/A - pure ranking function, no UI surface
- Walkthrough video: N/A - covered by the added unit test
- Backend logs: N/A - deterministic pure function, covered by the added unit test
- Frontend console/network logs: N/A - no frontend change
- Real-LLM trajectory: N/A - no agent or LLM runtime path touched
- Domain artifacts: N/A - no schema or manifest change

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic/claude-opus-4-8
- Client / agent tooling: Claude Code
- Contribution skill revision: N/A - direct repository fix, not submitted through a Slop contribution skill
- Attribution status: self-reported

## Slop protocol changes

- None - no project manifest, contributor skill, reviewer skill, award, or reward-cycle files are touched.

## Safety review

Pure ranking fix: the result array is sorted by descending score before returning, honoring the method's documented contract. One regression test is added. No new inputs, network calls, or privileges.

## Maintainer review — exact head `06fa5776`

Rebased onto `origin/develop@e66d4dd16fd57915622a6d7db79175e73406be6a`. The return sort now runs only when the result buffer is partial; a full buffer was already sorted on reaching `topK`, avoiding duplicate `O(topK log topK)` work.

Exact-head gates: BM25/search regression 4 passed; core typecheck passed; focused Biome passed; Node, browser, edge, testing-module, and declaration builds passed; `git diff --check` passed. The oversized full core lane also exposed two pre-existing failures in untouched document-ingest tests (`DOCUMENT_FRAGMENT_EMBED_FAILED` expected while the live implementation exposes its nested `EMBEDDING_MODEL_OUTPUT_INVALID` cause); both reproduce in isolation and are unrelated to `search.ts`.

# Evidence Gate

<!-- evidence-head:06fa5776ca88fe962db590a86053194445b10a08 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - pure ranking function; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - pure ranking function; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic unit-level ranking contract.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend process or external integration.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime or network behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or evaluator path changes.
<!-- evidence-row:domain-artifacts -->
- [x] Focused regression output: 4 tests passed; multi-target core build passed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact.