### PR TITLE
fix(app-core): reject invalid voice-latency-report --limit

### DIFF
--- a/packages/app-core/scripts/lib/voice-latency-report-limit.mjs
+++ b/packages/app-core/scripts/lib/voice-latency-report-limit.mjs
@@ -1,0 +1,35 @@
+/**
+ * Shared --limit parser for voice-latency-report CLI.
+ * Kept separate so the executable script can stay a plain top-level-await CLI
+ * without ESM named-export + top-level-await interaction quirks under Node.
+ */
+
+/** Largest delay Node accepts without clamping (2^31-1). */
+export const MAX_SAFE_LIMIT = 2_147_483_647;
+
+/**
+ * Accept only a complete positive decimal integer string in [1, MAX_SAFE_LIMIT].
+ * Rejects missing, fractional, signed, partial, zero, and non-finite values.
+ */
+export function parsePositiveLimit(raw) {
+  if (raw === undefined || raw === null) {
+    throw new Error(`--limit requires a positive integer 1..${MAX_SAFE_LIMIT}`);
+  }
+  const value = String(raw);
+  // Missing value that stole the next flag (e.g. `--limit --json`).
+  if (value.startsWith("--")) {
+    throw new Error(`--limit requires a value`);
+  }
+  if (!/^[1-9]\d*$/.test(value)) {
+    throw new Error(
+      `--limit must be a positive integer 1..${MAX_SAFE_LIMIT} (received ${JSON.stringify(value)})`,
+    );
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > MAX_SAFE_LIMIT) {
+    throw new Error(
+      `--limit must be a positive integer 1..${MAX_SAFE_LIMIT} (received ${JSON.stringify(value)})`,
+    );
+  }
+  return parsed;
+}

--- a/packages/app-core/scripts/lib/voice-latency-report-limit.mjs
+++ b/packages/app-core/scripts/lib/voice-latency-report-limit.mjs
@@ -1,19 +1,21 @@
 /**
- * Shared --limit parser for voice-latency-report CLI.
- * Kept separate so the executable script can stay a plain top-level-await CLI
- * without ESM named-export + top-level-await interaction quirks under Node.
+ * Validates trace-count limits accepted by the voice latency report CLI.
+ * It stays separate so the executable remains a plain top-level-await script
+ * while tests exercise the same parser used by the process boundary.
  */
 
-/** Largest delay Node accepts without clamping (2^31-1). */
-export const MAX_SAFE_LIMIT = 2_147_483_647;
+/** Upper bound defined by the voice latency report CLI contract. */
+const MAX_REPORT_LIMIT = 2_147_483_647;
 
 /**
- * Accept only a complete positive decimal integer string in [1, MAX_SAFE_LIMIT].
+ * Accept only a complete positive decimal integer in [1, MAX_REPORT_LIMIT].
  * Rejects missing, fractional, signed, partial, zero, and non-finite values.
  */
 export function parsePositiveLimit(raw) {
   if (raw === undefined || raw === null) {
-    throw new Error(`--limit requires a positive integer 1..${MAX_SAFE_LIMIT}`);
+    throw new Error(
+      `--limit requires a positive integer 1..${MAX_REPORT_LIMIT}`,
+    );
   }
   const value = String(raw);
   // Missing value that stole the next flag (e.g. `--limit --json`).
@@ -22,13 +24,17 @@ export function parsePositiveLimit(raw) {
   }
   if (!/^[1-9]\d*$/.test(value)) {
     throw new Error(
-      `--limit must be a positive integer 1..${MAX_SAFE_LIMIT} (received ${JSON.stringify(value)})`,
+      `--limit must be a positive integer 1..${MAX_REPORT_LIMIT} (received ${JSON.stringify(value)})`,
     );
   }
   const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > MAX_SAFE_LIMIT) {
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < 1 ||
+    parsed > MAX_REPORT_LIMIT
+  ) {
     throw new Error(
-      `--limit must be a positive integer 1..${MAX_SAFE_LIMIT} (received ${JSON.stringify(value)})`,
+      `--limit must be a positive integer 1..${MAX_REPORT_LIMIT} (received ${JSON.stringify(value)})`,
     );
   }
   return parsed;

--- a/packages/app-core/scripts/voice-latency-report.mjs
+++ b/packages/app-core/scripts/voice-latency-report.mjs
@@ -48,6 +48,8 @@ for (let i = 0; i < argv.length; i += 1) {
     try {
       limit = parsePositiveLimit(argv[i]);
     } catch (err) {
+      // error-policy:J1 CLI boundary translates invalid operator input to a
+      // diagnostic and non-zero process exit before any network request.
       console.error(
         `[voice-latency-report] ${err instanceof Error ? err.message : String(err)}`,
       );

--- a/packages/app-core/scripts/voice-latency-report.mjs
+++ b/packages/app-core/scripts/voice-latency-report.mjs
@@ -12,13 +12,14 @@
  *
  * Exit codes:
  *   0  — payload fetched (regardless of whether any traces exist).
- *   1  — API not reachable / endpoint errored.
+ *   1  — API not reachable / endpoint errored / invalid --limit.
  */
 
 import {
   fetchAndRenderVoiceLatency,
   renderVoiceLatencyReport,
 } from "./lib/voice-latency-report.mjs";
+import { parsePositiveLimit } from "./lib/voice-latency-report-limit.mjs";
 
 function parsePositivePort(value) {
   const n = Number(value);
@@ -44,7 +45,14 @@ for (let i = 0; i < argv.length; i += 1) {
   if (a === "--json") json = true;
   else if (a === "--limit") {
     i += 1;
-    limit = Number(argv[i]);
+    try {
+      limit = parsePositiveLimit(argv[i]);
+    } catch (err) {
+      console.error(
+        `[voice-latency-report] ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(1);
+    }
   } else if (a === "--base") {
     i += 1;
     base = argv[i];
@@ -59,7 +67,7 @@ for (let i = 0; i < argv.length; i += 1) {
 const baseUrl = resolveApiBase(process.env, base);
 
 const result = await fetchAndRenderVoiceLatency(baseUrl, {
-  limit: Number.isInteger(limit) && limit > 0 ? limit : undefined,
+  limit,
 });
 
 if (!result.ok) {
@@ -81,7 +89,7 @@ if (json) {
   // threading the raw payload back through — and this path is for humans
   // anyway; --json is a convenience.
   const url = new URL("/api/dev/voice-latency", baseUrl);
-  if (Number.isInteger(limit) && limit > 0) {
+  if (limit !== undefined) {
     url.searchParams.set("limit", String(limit));
   }
   const res = await fetch(url.toString());

--- a/packages/app-core/scripts/voice-latency-report.test.ts
+++ b/packages/app-core/scripts/voice-latency-report.test.ts
@@ -1,5 +1,6 @@
 /** Exercises voice latency report behavior with deterministic app-core test fixtures. */
-import { spawnSync } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
+import { createServer } from "node:http";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
@@ -11,6 +12,19 @@ import { parsePositiveLimit } from "./lib/voice-latency-report-limit.mjs";
 const SCRIPT_PATH = fileURLToPath(
   new URL("./voice-latency-report.mjs", import.meta.url),
 );
+const INVALID_LIMIT_CASES = [
+  { label: "missing", raw: undefined, args: [] },
+  { label: "empty", raw: "", args: [""] },
+  { label: "zero", raw: "0", args: ["0"] },
+  { label: "negative", raw: "-3", args: ["-3"] },
+  { label: "fractional", raw: "1.5", args: ["1.5"] },
+  { label: "partial", raw: "10junk", args: ["10junk"] },
+  { label: "NaN", raw: "NaN", args: ["NaN"] },
+  { label: "infinite", raw: "Infinity", args: ["Infinity"] },
+  { label: "signed", raw: "+1", args: ["+1"] },
+  { label: "next flag", raw: "--json", args: ["--json"] },
+  { label: "out of range", raw: "2147483648", args: ["2147483648"] },
+];
 const SAMPLE_PAYLOAD = {
   generatedAtEpochMs: 1_700_000_000_000,
   checkpoints: ["vad-trigger", "llm-first-token", "tts-first-audio-chunk"],
@@ -73,6 +87,30 @@ const SAMPLE_PAYLOAD = {
     },
   },
 };
+
+function runCli(args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      process.execPath,
+      [SCRIPT_PATH, ...args],
+      {
+        encoding: "utf8",
+        env: { ...process.env, ELIZA_API_PORT: "1" },
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(
+            new Error(
+              `voice-latency-report failed: ${error.message}\n${stdout}${stderr}`,
+            ),
+          );
+          return;
+        }
+        resolve({ stdout, stderr });
+      },
+    );
+  });
+}
 
 describe("renderVoiceLatencyReport", () => {
   it("renders histograms and traces with — for null values", () => {
@@ -189,37 +227,59 @@ describe("voice-latency-report --limit validation", () => {
     expect(parsePositiveLimit("2147483647")).toBe(2147483647);
   });
 
-  it.each([
-    undefined,
-    "",
-    "0",
-    "-3",
-    "1.5",
-    "10junk",
-    "NaN",
-    "Infinity",
-    "+1",
-    "--json",
-    "2147483648",
-  ])("rejects invalid --limit %p", (value) => {
-    expect(() => parsePositiveLimit(value as string | undefined)).toThrow(
-      /--limit/,
-    );
+  it.each(INVALID_LIMIT_CASES)("rejects invalid --limit: $label", ({ raw }) => {
+    expect(() => parsePositiveLimit(raw)).toThrow(/--limit/);
   });
 
-  it("CLI exits non-zero before fetch for malformed --limit", () => {
-    const result = spawnSync(
-      process.execPath,
-      [SCRIPT_PATH, "--limit", "junk"],
-      {
-        encoding: "utf8",
-        env: { PATH: process.env.PATH ?? "", ELIZA_API_PORT: "1" },
-      },
-    );
-    expect(result.status).toBe(1);
-    expect(result.stderr).toMatch(/--limit/);
-    expect(result.stdout + result.stderr).not.toMatch(
-      /could not fetch|ECONNREFUSED/i,
-    );
+  it.each(INVALID_LIMIT_CASES)(
+    "real CLI rejects $label before fetching",
+    ({ args }) => {
+      const result = spawnSync(
+        process.execPath,
+        [SCRIPT_PATH, "--limit", ...args],
+        {
+          encoding: "utf8",
+          env: { PATH: process.env.PATH ?? "", ELIZA_API_PORT: "1" },
+        },
+      );
+      expect(result.status).toBe(1);
+      expect(result.stderr).toMatch(/--limit/);
+      expect(result.stdout + result.stderr).not.toMatch(
+        /could not fetch|ECONNREFUSED/i,
+      );
+    },
+  );
+
+  it("real CLI sends a valid limit to the endpoint", async () => {
+    let seenUrl = "";
+    const server = createServer((req, res) => {
+      seenUrl = req.url ?? "";
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(SAMPLE_PAYLOAD));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("voice latency test server did not expose a TCP port");
+      }
+      const result = await runCli([
+        "--limit",
+        "7",
+        "--base",
+        `http://127.0.0.1:${address.port}`,
+      ]);
+
+      expect(seenUrl).toBe("/api/dev/voice-latency?limit=7");
+      expect(result.stdout).toContain("2 trace(s)");
+      expect(result.stderr).toBe("");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 });

--- a/packages/app-core/scripts/voice-latency-report.test.ts
+++ b/packages/app-core/scripts/voice-latency-report.test.ts
@@ -1,10 +1,16 @@
 /** Exercises voice latency report behavior with deterministic app-core test fixtures. */
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   fetchAndRenderVoiceLatency,
   renderVoiceLatencyReport,
 } from "./lib/voice-latency-report.mjs";
+import { parsePositiveLimit } from "./lib/voice-latency-report-limit.mjs";
 
+const SCRIPT_PATH = fileURLToPath(
+  new URL("./voice-latency-report.mjs", import.meta.url),
+);
 const SAMPLE_PAYLOAD = {
   generatedAtEpochMs: 1_700_000_000_000,
   checkpoints: ["vad-trigger", "llm-first-token", "tts-first-audio-chunk"],
@@ -173,5 +179,47 @@ describe("fetchAndRenderVoiceLatency", () => {
     });
     expect(seenUrl).toContain("limit=7");
     expect(seenUrl).toContain("/api/dev/voice-latency");
+  });
+});
+
+describe("voice-latency-report --limit validation", () => {
+  it("accepts complete positive integers", () => {
+    expect(parsePositiveLimit("1")).toBe(1);
+    expect(parsePositiveLimit("7")).toBe(7);
+    expect(parsePositiveLimit("2147483647")).toBe(2147483647);
+  });
+
+  it.each([
+    undefined,
+    "",
+    "0",
+    "-3",
+    "1.5",
+    "10junk",
+    "NaN",
+    "Infinity",
+    "+1",
+    "--json",
+    "2147483648",
+  ])("rejects invalid --limit %p", (value) => {
+    expect(() => parsePositiveLimit(value as string | undefined)).toThrow(
+      /--limit/,
+    );
+  });
+
+  it("CLI exits non-zero before fetch for malformed --limit", () => {
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT_PATH, "--limit", "junk"],
+      {
+        encoding: "utf8",
+        env: { PATH: process.env.PATH ?? "", ELIZA_API_PORT: "1" },
+      },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/--limit/);
+    expect(result.stdout + result.stderr).not.toMatch(
+      /could not fetch|ECONNREFUSED/i,
+    );
   });
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18982

# Summary

Reject malformed `voice-latency-report --limit` values before any request is made while preserving the CLI's existing help, unknown-argument, and process-lifecycle behavior.

- Parse only complete decimal integers in the range `1..2147483647`.
- Keep validation inside the existing `--limit` branch instead of rewriting the argument loop.
- Exercise all invalid forms through both the parser and the real CLI process.
- Prove the valid path against a live loopback HTTP server and assert the exact `?limit=7` request.

This supersedes the broader implementation on the earlier reviewed head and addresses that review without expanding the CLI contract.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop` at `d505b7408f08ecdec9a6fd0eb546c2d28ebb6af9`; zero conflicts.
- [x] Focused checks were rerun after the final rebase.
- [x] Full `bun run verify` passed before the final rebase; the intervening upstream delta is homepage-only, and the app-core focused suite, Biome, and typecheck passed again after sync.

# Risks

Low. The change is confined to the existing `--limit` branch and one private parser. Omitting `--limit` still sends no query bound. Help handling, ignored unknown arguments, report rendering, and exit behavior remain unchanged.

The upper bound is an explicit trace-count input contract, not a timer or allocation claim.

# Background

## What does this PR do?

1. Adds a private exact-decimal parser for positive report limits.
2. Applies it at the current CLI boundary and emits a named error with exit code 1 before fetch.
3. Adds adversarial parser/process tests and a live successful request proof.

Net diff against `develop`: 3 files, +163/-4.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No user-facing command or option changed; this enforces the already documented positive-integer contract.

# Testing

## Where should a reviewer start?

1. `packages/app-core/scripts/voice-latency-report.mjs`
2. `packages/app-core/scripts/lib/voice-latency-report-limit.mjs`
3. `packages/app-core/scripts/voice-latency-report.test.ts`

## Detailed testing steps

```bash
bun test packages/app-core/scripts/voice-latency-report.test.ts
bunx biome check packages/app-core/scripts/voice-latency-report.mjs packages/app-core/scripts/lib/voice-latency-report-limit.mjs packages/app-core/scripts/voice-latency-report.test.ts
bun run --cwd packages/app-core typecheck
bun run --cwd packages/app-core build
bun run --cwd packages/app-core lint
bun run verify
```

Observed on exact head `67cd2ba603c0aa917f535854b9b2e3d35641ed99`:

- Focused parser/report/real-process suite: 31 passed, 0 failed.
- Touched-file Biome: passed.
- app-core typecheck: passed.
- app-core build: passed.
- app-core source lint: passed (337 files).
- Root verify: passed; 350/350 workspace tasks plus repository audits.
- Full app-core suite: 217 files and 1773 tests passed; one untouched `server-compat-route-chain.guard.test.ts` expectation failed identically on a clean worktree at current `develop`.

# Evidence Gate

<!-- evidence-head:67cd2ba603c0aa917f535854b9b2e3d35641ed99 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - no UI surface; terminal CLI validation only`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - no UI surface; terminal CLI validation only`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no UI flow; the real child-process and loopback-server tests exercise the complete path`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - invalid inputs are proven not to reach fetch; the valid request is captured by a live loopback server`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend path`.
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused test output and root verification results are recorded above.
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model path.

## Backend + frontend logs

The real CLI process rejects every invalid form with exit code 1, names `--limit`, and does not call fetch. A live loopback server observes a valid invocation at exactly `/api/dev/voice-latency?limit=7` and the process renders the returned report.

## Screenshots (before / after) + video walkthrough

N/A - no UI or visual surface.

## Audio / voice walkthrough

N/A - this changes an offline report CLI argument boundary, not voice capture or playback.

## Known gaps / failures

The sole full app-core suite failure is an existing route-order baseline mismatch outside this PR. It reproduces unchanged on a clean worktree at current `develop`; the affected implementation and all focused/package/repository gates are otherwise green.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [hermes-agent-cortex]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZTQ84PMF046HN97RVYM4YFE","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T10:10:52.757Z","completed_at":"2026-08-12T11:02:52.207Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEABCQ_La8E3A-mhoOGQAU1JDjb5V6pW0qzF_zrcALUa7w","device_key_id":"2ca15083498fec081db8f2a4bbc2afcd06af5a23f516c26e16441b7fa6261099","device_signature":"QmJwPNun2wLeyRBhA9-fCuW8cHWtL0YzbTFewPEdhvLIAw3pPMWhhd7q2bFhw9khOjlBXa6f-hpciVgayiSeCw"}} -->
