### PR TITLE
fix(scripts): bound test-console run concurrency before live side effects (#18979)

### DIFF
--- a/packages/scripts/test-console/__tests__/run-endpoint.test.ts
+++ b/packages/scripts/test-console/__tests__/run-endpoint.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Coverage for the console's `POST /api/run` validation boundary and the
+ * server entrypoint contract. The validation matrix runs against the exported
+ * `validateRunRequest`; the ordering and startup suites spawn the real
+ * server.mjs as a subprocess (no mocking) with the console state redirected
+ * to a temp dir, so they prove what an operator's process actually does:
+ * invalid concurrency is rejected before task discovery or any state-dir
+ * write, and the direct Node entrypoint boots from canonical, symlinked, and
+ * space-containing checkout paths.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { type ChildProcess, spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  CONCURRENCY_DEFAULT,
+  CONCURRENCY_MAX,
+  CONCURRENCY_MIN,
+  validateRunRequest,
+} from "../server.mjs";
+
+const SERVER_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "server.mjs",
+);
+
+describe("validateRunRequest concurrency matrix", () => {
+  test("omitted concurrency selects the default and preserves the rest", () => {
+    const parsed = validateRunRequest({ mode: "selection", labels: ["x"] });
+    expect(parsed).toEqual({
+      ok: true,
+      mode: "selection",
+      lane: "pr",
+      labels: ["x"],
+      concurrency: CONCURRENCY_DEFAULT,
+    });
+  });
+
+  test("accepts every integer across the documented range", () => {
+    for (let n = CONCURRENCY_MIN; n <= CONCURRENCY_MAX; n += 1) {
+      const parsed = validateRunRequest({ concurrency: n });
+      expect(parsed.ok).toBe(true);
+      if (parsed.ok) expect(parsed.concurrency).toBe(n);
+    }
+  });
+
+  test("rejects everything outside the documented contract", () => {
+    const invalid: unknown[] = [
+      0,
+      -3,
+      2.5,
+      CONCURRENCY_MAX + 1,
+      1_000_000,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      "4",
+      "junk",
+      "",
+      null,
+      true,
+      false,
+      [],
+      {},
+    ];
+    for (const concurrency of invalid) {
+      const parsed = validateRunRequest({ concurrency });
+      expect(parsed.ok).toBe(false);
+      if (!parsed.ok) expect(parsed.error).toContain("concurrency");
+    }
+  });
+
+  test("tolerates a missing body", () => {
+    const parsed = validateRunRequest(undefined);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) expect(parsed.concurrency).toBe(CONCURRENCY_DEFAULT);
+  });
+});
+
+/** Spawns server.mjs and resolves the ephemeral port it reports. */
+function startConsole(entryPath: string, stateDir: string) {
+  const child = spawn(process.execPath, [entryPath], {
+    env: {
+      ...process.env,
+      ELIZA_TEST_CONSOLE_PORT: "0",
+      ELIZA_TEST_CONSOLE_DIR: stateDir,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const port = new Promise<number>((resolve, reject) => {
+    let out = "";
+    const timer = setTimeout(
+      () => reject(new Error(`server did not report a port; output: ${out}`)),
+      15_000,
+    );
+    child.stdout.on("data", (chunk: Buffer) => {
+      out += chunk.toString();
+      const match = out.match(/listening on http:\/\/127\.0\.0\.1:(\d+)/);
+      if (match) {
+        clearTimeout(timer);
+        resolve(Number(match[1]));
+      }
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      reject(new Error(`server exited early (code ${code}); output: ${out}`));
+    });
+  });
+  return { child, port };
+}
+
+describe("POST /api/run boundary ordering (real subprocess)", () => {
+  let child: ChildProcess;
+  let base: string;
+  let stateDir: string;
+
+  beforeAll(async () => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-console-run-"));
+    const started = startConsole(SERVER_PATH, stateDir);
+    child = started.child;
+    base = `http://127.0.0.1:${await started.port}`;
+  });
+
+  afterAll(() => {
+    child?.kill("SIGTERM");
+  });
+
+  test("invalid concurrency is rejected before task discovery or any state write", async () => {
+    // A selection of a nonexistent label would produce "no tasks selected"
+    // if discovery ran first — so a concurrency-shaped error proves the
+    // validation boundary fired before discovery.
+    const res = await fetch(`${base}/api/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        mode: "selection",
+        labels: ["no-such-task-label"],
+        concurrency: 99,
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("concurrency");
+    expect(body.error).not.toContain("no tasks");
+    // No run was created and no credential/state file was persisted.
+    expect(fs.existsSync(path.join(stateDir, "runs"))).toBe(false);
+    expect(fs.existsSync(path.join(stateDir, "credentials.json"))).toBe(false);
+  });
+
+  test("string and zero concurrency values also fail closed with 400", async () => {
+    for (const concurrency of ["4", 0]) {
+      const res = await fetch(`${base}/api/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ concurrency }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain("concurrency");
+    }
+  });
+
+  test("valid concurrency passes the boundary and reaches task selection", async () => {
+    // An empty selection with an in-range concurrency must fail on the NEXT
+    // stage (task selection), proving valid values flow through.
+    const res = await fetch(`${base}/api/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        mode: "selection",
+        labels: [],
+        concurrency: CONCURRENCY_MIN,
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("no tasks selected");
+  }, 60_000);
+});
+
+describe("direct entrypoint startup paths", () => {
+  test("boots from the canonical checkout path", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-console-a-"));
+    const { child, port } = startConsole(SERVER_PATH, stateDir);
+    try {
+      expect(await port).toBeGreaterThan(0);
+    } finally {
+      child.kill("SIGTERM");
+    }
+  });
+
+  test("boots from a symlinked, space-containing path", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-console-b-"));
+    const linkRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza console link-"),
+    );
+    const linkedDir = path.join(linkRoot, "console via symlink");
+    fs.symlinkSync(path.dirname(SERVER_PATH), linkedDir);
+    const { child, port } = startConsole(
+      path.join(linkedDir, "server.mjs"),
+      stateDir,
+    );
+    try {
+      expect(await port).toBeGreaterThan(0);
+    } finally {
+      child.kill("SIGTERM");
+    }
+  });
+});

--- a/packages/scripts/test-console/server.mjs
+++ b/packages/scripts/test-console/server.mjs
@@ -16,6 +16,9 @@
  *   POST /api/connections/:id/verify   live probe
  *   POST /api/gates             toggle an opt-in gate
  *   POST /api/run               start a run {mode, lane, labels?, concurrency?}
+ *                               concurrency is an integer 1..8 (default 3);
+ *                               anything else is rejected 400 before any
+ *                               discovery, credential, or OAuth side effect
  *   POST /api/run/cancel        cancel the active run
  *   GET  /api/runs/:id/log?task=<label>  persisted log text
  *   POST /api/cloud/login/start + GET /api/cloud/login/poll   device-code login
@@ -111,6 +114,38 @@ function currentState() {
   };
 }
 
+export const CONCURRENCY_DEFAULT = 3;
+export const CONCURRENCY_MIN = 1;
+export const CONCURRENCY_MAX = 8;
+
+/**
+ * Validates an operator-supplied `POST /api/run` body before anything with
+ * side effects runs. The concurrency field drives process fan-out, so it is
+ * bounded fail-closed: only an integer JSON number in
+ * [CONCURRENCY_MIN, CONCURRENCY_MAX] is accepted; omitting it selects the
+ * default. Every other shape (strings, fractions, zero, negatives, out of
+ * range, null, booleans) is rejected so a malformed request can never reach
+ * task discovery, credential reads, OAuth refresh, or run creation.
+ */
+export function validateRunRequest(body) {
+  const { mode = "all", lane = "pr", labels, concurrency } = body ?? {};
+  if (concurrency === undefined) {
+    return { ok: true, mode, lane, labels, concurrency: CONCURRENCY_DEFAULT };
+  }
+  if (
+    typeof concurrency !== "number" ||
+    !Number.isInteger(concurrency) ||
+    concurrency < CONCURRENCY_MIN ||
+    concurrency > CONCURRENCY_MAX
+  ) {
+    return {
+      ok: false,
+      error: `concurrency must be an integer between ${CONCURRENCY_MIN} and ${CONCURRENCY_MAX}`,
+    };
+  }
+  return { ok: true, mode, lane, labels, concurrency };
+}
+
 function selectTasks({ mode, labels }) {
   const plan = discoverPlan();
   const history = loadHistory();
@@ -145,12 +180,9 @@ const routes = {
   },
 
   "POST /api/run": async (req, res) => {
-    const {
-      mode = "all",
-      lane = "pr",
-      labels,
-      concurrency,
-    } = await readBody(req);
+    const parsed = validateRunRequest(await readBody(req));
+    if (!parsed.ok) return json(res, 400, { error: parsed.error });
+    const { mode, lane, labels, concurrency } = parsed;
     if (runManager.isRunning())
       return json(res, 409, { error: "run already in progress" });
     const tasks = selectTasks({ mode, labels });
@@ -347,7 +379,35 @@ const server = http.createServer(async (req, res) => {
   }
 });
 
-server.listen(PORT, HOST, () => {
-  console.log(`[TestConsole] listening on http://${HOST}:${PORT}`);
-  console.log(`[TestConsole] state dir: ${consoleDir()}`);
-});
+/**
+ * True when this file is the process entrypoint. Compared via realpath on
+ * both sides: Node resolves `import.meta.url` through symlinks while argv[1]
+ * keeps the spelling the operator launched, so a URL/string comparison breaks
+ * for symlinked checkouts, and file-URL escaping breaks it for paths with
+ * spaces. Realpath-vs-realpath is stable across all of those.
+ */
+function isMainEntrypoint() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return (
+      fs.realpathSync(entry) === fs.realpathSync(fileURLToPath(import.meta.url))
+    );
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — an unresolvable argv[1]
+    // yields an explicit "not the entrypoint", never a throw at import time.
+    return false;
+  }
+}
+
+/** Binds the console; exported so tests can import routes without listening. */
+export function startServer() {
+  server.listen(PORT, HOST, () => {
+    const { port } = server.address();
+    console.log(`[TestConsole] listening on http://${HOST}:${port}`);
+    console.log(`[TestConsole] state dir: ${consoleDir()}`);
+  });
+  return server;
+}
+
+if (isMainEntrypoint()) startServer();


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18979

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run; **verify passes green on this head**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes on this head.

# Risks

Low. One local-only dev tool (the test console binds 127.0.0.1). The operator-visible change is exactly the requested contract: out-of-contract `concurrency` now 400s instead of silently coercing, and the reject fires before any discovery/credential/OAuth/persistence stage. The entrypoint restructure (listen only when server.mjs is the process entrypoint) is proven by real-subprocess boots from canonical and symlinked space-containing paths.

# Background

## What does this PR do?

`POST /api/run` coerced the operator-supplied worker count with `Number(concurrency) || 3`: garbage silently became the default, while negative, fractional, and arbitrarily large values flowed into run fan-out — and the only check ran after task discovery, credential reads, Google OAuth refresh, and token persistence had already executed. This PR validates the body first: `concurrency` must be an integer JSON number in 1..8 (default 3 when omitted); everything else is rejected with HTTP 400 before any side-effectful stage. `server.listen` now runs only when `server.mjs` is the actual process entrypoint (realpath comparison, stable for symlinked and space-containing checkouts), so the route surface is importable by tests, and startup logs the real bound port.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. (The documented API surface — the header comment in `server.mjs` — now states the 1..8 range and default.)

# Testing

## Where should a reviewer start?

`validateRunRequest` in `packages/scripts/test-console/server.mjs`, then the ordering suite in `__tests__/run-endpoint.test.ts` — the subprocess tests prove the boundary from outside the process.

## Detailed testing steps

```bash
bun test packages/scripts/test-console/__tests__/
```

# Evidence Gate

<!-- evidence-head:c28ae2be55838834a9ca35156caaf3ec69cbfc56 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - localhost dev-tool HTTP API; no product UI surface changed`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - localhost dev-tool HTTP API; no product UI surface changed`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - request/response contract; pinned end-to-end by the real-subprocess suite below`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — the suite on this head (real `node server.mjs` subprocesses, no mocking):

  <details><summary>bun test run</summary>

  ```
  validateRunRequest concurrency matrix — 4 pass
    (omitted -> default 3; every integer 1..8 accepted; 15 malformed shapes rejected; missing body tolerated)
  POST /api/run boundary ordering (real subprocess) — 3 pass
    invalid concurrency 400s BEFORE task discovery or any state write
    string and zero concurrency fail closed with 400
    valid concurrency passes the boundary and reaches task selection
  direct entrypoint startup paths — 2 pass
    boots from the canonical checkout path
    boots from a symlinked, space-containing path
  9 pass, 0 fail, 62 expect() calls
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - the console UI never sends the concurrency field; no browser surface changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - deterministic request validation in a dev tool; no model, prompt, or action behavior involved`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the request/outcome contract the subprocess suite pins:

  <details><summary>POST /api/run input/outcome contract</summary>

  ```
  concurrency omitted        -> default 3, request proceeds to task selection
  concurrency 1..8 (integer) -> accepted, proceeds to task selection
  concurrency 99             -> 400 "concurrency must be an integer between 1 and 8"
                                issued before discovery: error wins over the later
                                "no tasks selected" stage, and the state dir shows
                                no runs/ and no credentials.json afterward
  concurrency "4", 0, -3,
  2.5, null, true, [], {}    -> 400, same boundary
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Evidence Details

All evidence is inline above.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZX22TSCCCTWG5N0X1T81PPM","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T07:58:41.964Z","completed_at":"2026-08-13T08:09:43.033Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"_NdXpU2aiLjdy982NMbZabtxeVr5rFQgY_a9hlTBJ55OwCm02D4Ang0Zrm5dlA3F8fY7-_PWfc2ZcBoLcPa5AQ"}} -->

