### PR TITLE
fix(ci): stabilize develop workflow contracts

### DIFF
--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -126,6 +126,7 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
           install-command: bun install --frozen-lockfile
+          cache-bun-install: "false"
           install-native-deps: "false"
           skip-avatar-clone: "true"
           no-vision-deps: "true"
@@ -197,6 +198,7 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
           install-command: bun install --frozen-lockfile
+          cache-bun-install: "false"
           install-native-deps: "false"
           skip-avatar-clone: "true"
           no-vision-deps: "true"

--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -187,6 +187,11 @@ export default defineConfig({
     : "./test-results",
   use: {
     baseURL: `http://127.0.0.1:${uiSmokePort}`,
+    // UI smoke owns deterministic route fixtures, while service-worker fetch
+    // behavior has dedicated unit coverage. Blocking the production worker
+    // here also prevents route transitions from turning intentionally aborted
+    // dynamic imports into synthetic 503 "Offline" console errors.
+    serviceWorkers: "block",
     trace: recording ? "on" : "retain-on-failure",
     video: videoMode,
     screenshot: recording ? "on" : "only-on-failure",

--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -166,6 +166,16 @@ if (!process.env.ELIZA_API_PORT) {
   process.env.ELIZA_API_PORT = String(uiSmokeApiPort);
 }
 
+// Functional lanes own deterministic route fixtures, while service-worker fetch
+// behavior has dedicated unit coverage. Blocking the production worker also
+// prevents route transitions from turning intentionally aborted dynamic imports
+// into synthetic 503 "Offline" console errors. This stays project-scoped rather
+// than global: the aesthetic-audit projects photograph the shipped app, so they
+// must keep the production service worker they render with today.
+const BLOCK_PRODUCTION_SERVICE_WORKER = {
+  serviceWorkers: "block" as const,
+};
+
 // CI splits this lane across runners because `workers: 1` is a suite invariant
 // (one live stack per process). Playwright assigns whole spec files while
 // `fullyParallel` is false, so a file's internal order survives the split.
@@ -187,11 +197,6 @@ export default defineConfig({
     : "./test-results",
   use: {
     baseURL: `http://127.0.0.1:${uiSmokePort}`,
-    // UI smoke owns deterministic route fixtures, while service-worker fetch
-    // behavior has dedicated unit coverage. Blocking the production worker
-    // here also prevents route transitions from turning intentionally aborted
-    // dynamic imports into synthetic 503 "Offline" console errors.
-    serviceWorkers: "block",
     trace: recording ? "on" : "retain-on-failure",
     video: videoMode,
     screenshot: recording ? "on" : "only-on-failure",
@@ -219,6 +224,7 @@ export default defineConfig({
       use: {
         ...devices["Desktop Chrome"],
         ...withChromiumLaunchOptions(),
+        ...BLOCK_PRODUCTION_SERVICE_WORKER,
       },
     },
     ...DASHBOARD_E2E_DEVICE_MATRIX.map((viewport) => ({
@@ -230,6 +236,7 @@ export default defineConfig({
         isMobile: viewport.isMobile,
         hasTouch: viewport.hasTouch,
         ...withChromiumLaunchOptions(),
+        ...BLOCK_PRODUCTION_SERVICE_WORKER,
       },
     })),
     {

--- a/packages/app/scripts/measure-anonymous-login-transfer.test.ts
+++ b/packages/app/scripts/measure-anonymous-login-transfer.test.ts
@@ -254,5 +254,5 @@ describe("measure-anonymous-login-transfer CLI", () => {
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/packages/app/test/dev-smoke/bun-dev-onboarding-chat.spec.ts
+++ b/packages/app/test/dev-smoke/bun-dev-onboarding-chat.spec.ts
@@ -30,7 +30,6 @@ test.describe("bun run dev onboarding chat smoke", () => {
 
     await seedCompletedFirstRunStorage(page);
     await page.goto("/");
-    await seedCompletedFirstRunStorage(page);
 
     // Wait until the deferred model provider is registered and produces a real
     // reply, so the asserted turn below is not racing plugin boot.

--- a/packages/app/test/dev-smoke/live-onboarding.ts
+++ b/packages/app/test/dev-smoke/live-onboarding.ts
@@ -256,10 +256,10 @@ function seedCompletedFirstRunStorageForOrigin(): void {
 }
 
 export async function seedCompletedFirstRunStorage(page: Page): Promise<void> {
+  // Seed before the next document installs the surface-realm guard. Executing
+  // the same raw writes after /chat mounts would correctly be rejected as a
+  // view attempting to mutate reserved shell state.
   await page.addInitScript(seedCompletedFirstRunStorageForOrigin);
-  if (page.url() !== "about:blank") {
-    await page.evaluate(seedCompletedFirstRunStorageForOrigin);
-  }
 }
 
 export async function gotoChatComposer(page: Page): Promise<Locator> {

--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -219,6 +219,7 @@ describe("GitHub action supply-chain references", () => {
     expect(source).toContain(
       "ELIZA_VAULT_PASSPHRASE: dev-smoke-headless-vault-only",
     );
+    expect(source.match(/cache-bun-install: "false"/g)).toHaveLength(2);
   });
 
   test("installs both app browser engines before deterministic smoke E2E", () => {

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
@@ -302,6 +302,14 @@ describe("BrowserWorkspaceView fullscreen chrome (Notes/Calendar parity)", () =>
     const iframe = await screen.findByTitle("Apple");
     fireEvent.pointerDown(iframe);
     const address = screen.getByTestId("browser-workspace-address-input");
+    // The iframe can mount before the active-tab URL synchronization effect
+    // has committed. Wait for that initial value so the effect cannot overwrite
+    // the simulated edit on a loaded runner.
+    await waitFor(() =>
+      expect((address as HTMLInputElement).value).toBe(
+        "https://www.apple.com/",
+      ),
+    );
     address.focus();
     fireEvent.change(address, { target: { value: "https://example.com/" } });
     await waitFor(() =>

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -1496,18 +1496,17 @@ async function openSheetToFull(p, pointer) {
 async function scrollReaderUp(p, pointer) {
   const selector = testIdSelector("chat-thread-scroll");
   const before = await threadScrollState(p);
-  let after = before;
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    if (pointer === "mouse") {
-      await p.getByTestId("chat-thread-scroll").hover();
-      await p.mouse.wheel(0, -420);
-    } else {
-      await touchSwipe(p, selector, 0, 280, { steps: 16, stepDelayMs: 16 });
-    }
-    await p.waitForTimeout(360);
-    after = await threadScrollState(p);
-    if (!!before && !!after && after.scrollTop < before.scrollTop - 80) break;
+  // Exactly one gesture: the assertion below IS the contract that a single real
+  // wheel/touch scroll moves the reader into history, so retrying the gesture
+  // would hide the regression it exists to catch.
+  if (pointer === "mouse") {
+    await p.getByTestId("chat-thread-scroll").hover();
+    await p.mouse.wheel(0, -420);
+  } else {
+    await touchSwipe(p, selector, 0, 280, { steps: 16, stepDelayMs: 16 });
   }
+  await p.waitForTimeout(360);
+  const after = await threadScrollState(p);
   assert(
     !!before && !!after && after.scrollTop < before.scrollTop - 80,
     `[${pointer}] AUTOSCROLL real ${pointer === "mouse" ? "wheel" : "touch"} scroll moves reader into history (${Math.round(before?.scrollTop ?? 0)} → ${Math.round(after?.scrollTop ?? 0)})`,

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -3882,26 +3882,21 @@ try {
     await p.waitForTimeout(SETTLE);
 
     // FLICK up from the pill → reaches the chat (history present), not a stop.
-    let after = await chatState(p);
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      if ((await detent(p)) !== "pill") {
-        await gesture(p, -160, { pointer: "touch", slow: false, steps: 1 });
-        await p.waitForTimeout(SETTLE);
-        await settleDetent(p, "pill");
-      }
-      await gesture(p, 140, {
-        pointer: "mouse",
-        slow: false,
-        steps: 2,
-        target: "chat-pill",
-      });
+    // Keep this to one processed gesture: retrying a wrong resulting state can
+    // hide the exact regression this assertion is meant to catch.
+    if ((await detent(p)) !== "pill") {
+      await gesture(p, -160, { pointer: "touch", slow: false, steps: 1 });
       await p.waitForTimeout(SETTLE);
-      after = await chatState(p);
-      if (after === "OPEN_HALF_OR_OVER" || after === "OPEN_UNDER_HALF") break;
-      console.log(
-        `  ℹ PILL-MORPH: flick attempt ${attempt + 1} stopped at ${after} on a loaded renderer — retrying from the pill`,
-      );
+      await settleDetent(p, "pill");
     }
+    await gesture(p, 140, {
+      pointer: "mouse",
+      slow: false,
+      steps: 2,
+      target: "chat-pill",
+    });
+    await p.waitForTimeout(SETTLE);
+    const after = await chatState(p);
     assert(
       after === "OPEN_HALF_OR_OVER" || after === "OPEN_UNDER_HALF",
       `PILL-MORPH: a flick from the pill reaches the chat (got ${after})`,

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -194,7 +194,7 @@ const threadScrollState = (p) =>
       bottomDelta: maxScrollTop - el.scrollTop,
     };
   });
-async function waitForSheetHeightNear(p, expected, tolerance, timeout = 5000) {
+async function waitForSheetHeightNear(p, expected, tolerance, timeout = 15_000) {
   await p
     .waitForFunction(
       ({ expected, tolerance }) => {
@@ -233,6 +233,35 @@ const panelTop = (p) =>
       document.querySelector('[data-testid="chat-sheet"]')?.getBoundingClientRect()
         .top ?? 0,
   );
+async function waitForPanelTopNear(p, expected, tolerance, timeout = 15_000) {
+  await p.waitForFunction(
+    ({ expected, tolerance }) => {
+      const top =
+        document
+          .querySelector('[data-testid="chat-sheet"]')
+          ?.getBoundingClientRect().top ?? 0;
+      return Math.abs(top - expected) <= tolerance;
+    },
+    { expected, tolerance },
+    { timeout },
+  );
+}
+async function waitForPanelEdgeToEdge(p, timeout = 15_000) {
+  await p.waitForFunction(
+    () => {
+      const box = document
+        .querySelector('[data-testid="chat-sheet"]')
+        ?.getBoundingClientRect();
+      return (
+        box !== undefined &&
+        box.x <= 1 &&
+        Math.abs(box.width - window.innerWidth) <= 2
+      );
+    },
+    undefined,
+    { timeout },
+  );
+}
 const panelRadii = (p) =>
   p.evaluate(() => {
     const panel = document.querySelector('[data-testid="chat-sheet"]');
@@ -679,6 +708,7 @@ async function runDragSuite(p, pointer, tag) {
   assert((await detent(p)) === "half", `[${pointer}] flick-up snaps COLLAPSED→HALF`);
   await waitForSheetHeightNear(p, halfH, TOL);
   assert(near(await sheetHeight(p), halfH, TOL), `[${pointer}] HALF height ≈ ${halfH}px (got ${Math.round(await sheetHeight(p))})`);
+  await waitForHeaderShown(p, 15_000);
   await snap(p, `${tag}-half`);
   // #9142 regression guard: the grabber BAR (inner span) must actually PAINT
   // once the sheet is open — a prior regression pinned the bar to `opacity-0`,
@@ -711,6 +741,10 @@ async function runDragSuite(p, pointer, tag) {
   await p.waitForTimeout(SETTLE);
   await settleDetent(p, "full");
   assert((await detent(p)) === "full", `[${pointer}] flick-up snaps HALF→FULL`);
+  // The detent commits before the spring reaches its rendered endpoint. Wait
+  // on the top edge before capturing fullH so a loaded runner cannot freeze an
+  // intermediate frame into the baseline used by the later reset assertion.
+  await waitForPanelTopNear(p, SHEET_TOP_MARGIN, TOL + 12);
   fullH = Math.round(await sheetHeight(p));
   assert(fullH > halfH + 40, `[${pointer}] FULL is taller than HALF (full ${fullH} > half ${halfH})`);
   const top = Math.round(await panelTop(p));
@@ -1092,6 +1126,9 @@ async function runContinuumSuite(p, pointer, tag) {
       .count()) === 1 && (await chatState(p)) === "MAXIMIZED",
     `[${tag}-continuum] releasing the held pill→top drag commits MAXIMIZED`,
   );
+  // State commits before the desktop width spring finishes. Wait for the
+  // painted full-bleed endpoint before evaluating its geometry.
+  await waitForPanelEdgeToEdge(p);
   const maxBox = await p.getByTestId("chat-sheet").boundingBox();
   assert(
     !!maxBox && maxBox.x <= 1 && near(maxBox.width, vw, 2),
@@ -1434,10 +1471,12 @@ async function mutateAssistant(p, hook, text) {
 
 async function openSheetToFull(p, pointer) {
   await p.waitForSelector('[data-testid="chat-sheet"]');
-  await gesture(p, 160, { pointer, slow: false, steps: 1 });
-  await p.waitForTimeout(SETTLE);
-  if ((await detent(p)) !== "full") {
-    await gesture(p, 220, { pointer, slow: false, steps: 1 });
+  for (let attempt = 0; attempt < 4 && (await detent(p)) !== "full"; attempt += 1) {
+    await gesture(p, attempt === 0 ? 160 : 220, {
+      pointer,
+      slow: false,
+      steps: 1,
+    });
     await p.waitForTimeout(SETTLE);
   }
   await settleDetent(p, "full");
@@ -1457,14 +1496,18 @@ async function openSheetToFull(p, pointer) {
 async function scrollReaderUp(p, pointer) {
   const selector = testIdSelector("chat-thread-scroll");
   const before = await threadScrollState(p);
-  if (pointer === "mouse") {
-    await p.getByTestId("chat-thread-scroll").hover();
-    await p.mouse.wheel(0, -420);
-  } else {
-    await touchSwipe(p, selector, 0, 280, { steps: 16, stepDelayMs: 16 });
+  let after = before;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    if (pointer === "mouse") {
+      await p.getByTestId("chat-thread-scroll").hover();
+      await p.mouse.wheel(0, -420);
+    } else {
+      await touchSwipe(p, selector, 0, 280, { steps: 16, stepDelayMs: 16 });
+    }
+    await p.waitForTimeout(360);
+    after = await threadScrollState(p);
+    if (!!before && !!after && after.scrollTop < before.scrollTop - 80) break;
   }
-  await p.waitForTimeout(360);
-  const after = await threadScrollState(p);
   assert(
     !!before && !!after && after.scrollTop < before.scrollTop - 80,
     `[${pointer}] AUTOSCROLL real ${pointer === "mouse" ? "wheel" : "touch"} scroll moves reader into history (${Math.round(before?.scrollTop ?? 0)} → ${Math.round(after?.scrollTop ?? 0)})`,
@@ -1647,11 +1690,17 @@ async function sampleGrabberDrag(
       .catch(() => null);
     return box ? box.y : null;
   };
-  const b = await page.getByTestId(target).boundingBox();
+  const b = await visibleBoxForTestId(page, target);
   const cx = b.x + b.width / 2;
   const startY = b.y + b.height / 2;
   const rows = [];
   await page.mouse.move(cx, startY);
+  // Give Chromium one painted frame at the handle before pressing. Under a
+  // loaded CI renderer an immediate move/down pair can be delivered at the old
+  // pointer position, so the sampled motion never owns the sheet gesture.
+  await page.evaluate(
+    () => new Promise((resolve) => requestAnimationFrame(() => resolve())),
+  );
   await page.mouse.down();
   for (let i = 1; i <= steps; i += 1) {
     const cursorY = startY + ((endY - startY) * i) / steps;
@@ -3833,16 +3882,26 @@ try {
     await p.waitForTimeout(SETTLE);
 
     // FLICK up from the pill → reaches the chat (history present), not a stop.
-    await gesture(p, -160, { pointer: "touch", slow: false, steps: 1 });
-    await p.waitForTimeout(SETTLE);
-    await gesture(p, 140, {
-      pointer: "mouse",
-      slow: false,
-      steps: 2,
-      target: "chat-pill",
-    });
-    await p.waitForTimeout(SETTLE);
-    const after = await chatState(p);
+    let after = await chatState(p);
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      if ((await detent(p)) !== "pill") {
+        await gesture(p, -160, { pointer: "touch", slow: false, steps: 1 });
+        await p.waitForTimeout(SETTLE);
+        await settleDetent(p, "pill");
+      }
+      await gesture(p, 140, {
+        pointer: "mouse",
+        slow: false,
+        steps: 2,
+        target: "chat-pill",
+      });
+      await p.waitForTimeout(SETTLE);
+      after = await chatState(p);
+      if (after === "OPEN_HALF_OR_OVER" || after === "OPEN_UNDER_HALF") break;
+      console.log(
+        `  ℹ PILL-MORPH: flick attempt ${attempt + 1} stopped at ${after} on a loaded renderer — retrying from the pill`,
+      );
+    }
     assert(
       after === "OPEN_HALF_OR_OVER" || after === "OPEN_UNDER_HALF",
       `PILL-MORPH: a flick from the pill reaches the chat (got ${after})`,
@@ -3985,7 +4044,7 @@ try {
       `ROTATION: held mid-crossfade before rotating (content ${midContent})`,
     );
     await p.setViewportSize({ width: 874, height: 402 }); // rotate to landscape
-    await p.waitForTimeout(SETTLE);
+    await settlePillPainted(p);
     {
       const b = await barOpacities(p);
       assert(

--- a/plugins/plugin-anthropic-proxy/__tests__/proxy-server.routing.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/proxy-server.routing.test.ts
@@ -81,5 +81,5 @@ describe("ProxyServer routing", () => {
     } finally {
       await server.stop();
     }
-  });
+  }, 30_000);
 });

--- a/plugins/plugin-local-inference/src/services/voice/mic-source.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/mic-source.test.ts
@@ -153,24 +153,24 @@ describe("DesktopMicSource", () => {
 		});
 		const frames: PcmFrame[] = [];
 		src.onFrame((f) => frames.push(f));
-		const errors: Error[] = [];
-		src.onError((e) => errors.push(e));
-		await src.start();
+		const recorderExited = new Promise<void>((resolve) => {
+			const unsub = src.onError(() => {
+				unsub();
+				resolve();
+			});
+		});
 		// `cat` writes the file to stdout then exits. (A real `arecord`/`sox`
 		// streams forever, so the source treats that exit as an error — fine
 		// for this test, which only cares that the byte→frame path works.)
 		// Wait for cat's exit to propagate: the exit event fires *after* all
 		// stdout data events, so once the error listener fires we know every
-		// frame has been emitted. A 2 s safety-net timeout prevents a hang if
-		// cat somehow never exits.
+		// frame has been emitted. Subscribe before start so a fast `cat` cannot
+		// exit between the spawn and listener registration. A bounded safety
+		// timeout prevents a hang if cat somehow never exits.
+		await src.start();
 		await Promise.race([
-			new Promise<void>((resolve) => {
-				const unsub = src.onError(() => {
-					unsub();
-					resolve();
-				});
-			}),
-			new Promise<void>((resolve) => setTimeout(resolve, 2000)),
+			recorderExited,
+			new Promise<void>((resolve) => setTimeout(resolve, 10_000)),
 		]);
 		await src.stop();
 
@@ -181,7 +181,7 @@ describe("DesktopMicSource", () => {
 		expect(frames[0].pcm[2]).toBeCloseTo(-0.5, 2);
 		expect(frames[0].pcm[3]).toBeCloseTo(1, 1);
 		expect(frames[0].sampleRate).toBe(16_000);
-	});
+	}, 15_000);
 
 	it("surfaces a missing recorder binary as an error (no silent capture)", async () => {
 		const src = new DesktopMicSource({

--- a/plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.test.ts
@@ -10,7 +10,11 @@ function runtime(): IAgentRuntime {
     agentId: "11111111-1111-4111-8111-111111111111",
     character: { name: "Test Agent" },
     getService: vi.fn(() => null),
-    getSetting: vi.fn(() => undefined),
+    getSetting: vi.fn((key: string) =>
+      key === "GOOGLE_REDIRECT_URI"
+        ? "http://127.0.0.1:31437/api/connectors/google/oauth/callback"
+        : undefined,
+    ),
     setSetting: vi.fn(),
   } as IAgentRuntime;
 }


### PR DESCRIPTION
# Relates to

Fixes #18972.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. Three full `bun run verify` runs passed while the branch was being rebased; the exact-head frozen install and dependency audit pass. GitHub merge-ref checks provide final moving-tip validation.
- [x] A reviewer can confirm the change from the failing-run mappings and deterministic tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3bd820ae387e5415bbcaafb1dac3f27f7de145b1:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] Full `bun run verify` passed five times during repair (350/350 tasks plus all audits each time). The final exact head passed `bun run verify` against current `origin/develop`; merge-ref Actions are the final hosted validation.

# Risks

Medium. The changes are confined to test fixtures, E2E synchronization, test timeouts, and the workspace lockfile. Bounded waits and retries now observe real rendered state or input effects; they do not fabricate success. The UI-smoke service-worker block applies only to fixture-owned Playwright runs.

# Background

## What does this PR do?

- Blocks the production service worker in deterministic UI-smoke fixtures so intentionally aborted imports do not become synthetic offline failures.
- Synchronizes browser-address and chat-sheet tests with committed/rendered state, and retries only demonstrably dropped input gestures.
- Registers process-exit observation before starting the fast mic fixture and gives real loopback/CLI tests explicit bounded timeouts.
- Supplies the canonical Google redirect setting in the personal-assistant runtime fixture.
- Adds the missing `packages/elizaresearch` workspace entries to `bun.lock`, which the newest `develop` merge omitted.

## What kind of change is this?

Bug fixes (non-breaking CI and test-contract stabilization).

# Documentation changes needed?

No project documentation change is needed; runtime/public behavior is unchanged.

# Testing

## Where should a reviewer start?

Start with `packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs`, then the one-race regression tests in BrowserWorkspaceView, local inference, personal assistant, Anthropic proxy, and app login-transfer measurement.

## Detailed testing steps

- `bun run verify` — passed five complete runs; each reported 350/350 tasks and clean repository audits.
- `bun install --frozen-lockfile` — passes at `cfb13244316350da3e02d1304b7dd3d0390006be`.
- `bun run fix-deps:check` — 143/143 workspace manifests valid.
- `actionlint -config-file .github/actionlint.yaml -color` — passes.
- Focused regressions passed: app UI-smoke `views-manager`; BrowserWorkspaceView address edit; personal-assistant Google delegates; local-inference mic source; Anthropic proxy routing; chat-sheet autoscroll for mouse and real touch.

# Evidence Gate

<!-- evidence-head:cfb13244316350da3e02d1304b7dd3d0390006be -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI implementation changed; only test/config synchronization changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI implementation changed; only test/config synchronization changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is CI test-harness work with no user flow change.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime path changed; focused test output and GitHub checks are the evidence.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/state behavior changed; Playwright assertions validate fixture behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, scheduled-task, wallet, or generated domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

N/A - this PR changes deterministic tests and their orchestration, not production request handling.

## Screenshots (before / after) + video walkthrough

N/A - no rendered `.tsx`, CSS, SVG, or production view implementation changed.

## Audio / voice walkthrough

N/A - the mic-source change is test listener ordering only; audio capture/runtime code is unchanged.

## Review follow-up (head cfb1324)

Two reviewed defects repaired on top of the original commits:

1. **serviceWorkers scoped off the aesthetic-audit lanes.** The global
   `use.serviceWorkers: "block"` reached every ui-smoke project, including the
   env-gated audit lanes that photograph the shipped app. It now sits on the
   functional lanes that need it. Resolved per-project values verified by
   loading the real config with the audit/WebKit gates enabled:

   ```
   TOP-LEVEL use.serviceWorkers = (unset -> allow)
   chromium: block           dashboard-mobile-portrait: block
   dashboard-mobile-landscape: block   dashboard-desktop-landscape: block
   dashboard-ipad-portrait: block      chromium-voice-mic: (unset -> allow)
   mobile-chromium: (unset -> allow)   webkit: block
   desktop-webkit: block               audit-ai-qa: (unset -> allow)
   audit-app: (unset -> allow)         audit-cloud: (unset -> allow)
   audit-app-dropdown: (unset -> allow)
   ```

2. **`scrollReaderUp` restored to one gesture.** Its 3x retry wrapped the very
   assertion that a single real wheel/touch scroll moves the reader into
   history, turning a one-gesture contract into best-of-three. `openSheetToFull`
   keeps its retry — that is setup, not the contract under test.

Verification at this head: full `packages/ui` `test:chat-sheet-e2e` run **PASSED**
(72 screenshots, 0 page errors, 0 error-level console messages), the
`plugin-personal-assistant` `google-plugin-delegates.test.ts` baseline repair
still passes (2/2), and Biome is clean on both touched files. `packages/app`
typecheck reports no diagnostic in `playwright.ui-smoke.config.ts`.

Note for reviewers: `test/ui-smoke/audit-project-worker-contract.spec.ts` asserts
only `browserName` and project-name propagation — it carries no `serviceWorkers`
assertion on this base, so the scoping above is a deliberate
behavior-preservation fix for the audit lanes rather than a spec repair.

## Known gaps / failures

- `packages/app audit:app` completed 214/215 tests with `broken=0`; its aggregate failure was four pre-existing minimalism-ratchet `needs-work` views unrelated to this test/config-only diff.
- A full local chat-sheet run became invalid under extreme host contention; the scoped mouse + real-touch autoscroll suite passed. The GitHub UI Core Fixture E2E runner is the authoritative full-suite proof.
- The GitHub token lacks `read:project`, so issue #18972 could not be added to the Project board; the issue records that limitation.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@3bd820ae387e5415bbcaafb1dac3f27f7de145b1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex/github-actions-develop]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@3bd820ae387e5415bbcaafb1dac3f27f7de145b1:packages/skills/skills/contribute-to-eliza"} -->


