### PR TITLE
fix(core): preserve descending BM25 order for partial result sets (#18983)

### DIFF
--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -65,20 +65,41 @@ describe("rankMessageSearch", () => {
 	});
 });
 
-describe("BM25", () => {
-	it("returns results in descending score order when fewer than topK documents match", () => {
-		const bm25 = new BM25([
-			{ content: "alpha beta" },
-			{ content: "alpha alpha alpha alpha alpha" },
-			{ content: "alpha alpha gamma" },
-			{ content: "nothing here" },
-		]);
+describe("BM25.search result ordering", () => {
+	// One "signal" occurrence per short doc scores higher than one occurrence
+	// diluted across a longer doc, so relevance order differs from index order.
+	const docs = [
+		{ body: "signal buried in a much longer document about other topics" },
+		{ body: "irrelevant filler text" },
+		{ body: "signal signal signal" },
+	];
 
-		// Three documents score above zero for "alpha", and topK (4) is larger,
-		// so the fill-phase sort that runs at `results.length === topK` never
-		// fires. The returned array must still be sorted by descending score.
-		const scores = bm25.search("alpha", 4).map((result) => result.score);
+	it("returns descending scores even when fewer matches exist than topK", () => {
+		const bm25 = new BM25(docs);
+		const results = bm25.search("signal", 10);
 
-		expect(scores).toEqual([...scores].sort((a, b) => b - a));
+		expect(results.map((r) => r.index)).toEqual([2, 0]);
+		expect(results[0].score).toBeGreaterThan(results[1].score);
+	});
+
+	it("keeps the bounded top-K path intact when the buffer fills", () => {
+		const bm25 = new BM25(docs);
+		const results = bm25.search("signal", 2);
+
+		expect(results).toHaveLength(2);
+		expect(results.map((r) => r.index)).toEqual([2, 0]);
+	});
+
+	it("breaks score ties in ascending document order on the partial path", () => {
+		const twins = [
+			{ body: "unique filler alpha" },
+			{ body: "echo chamber" },
+			{ body: "echo chamber" },
+		];
+		const bm25 = new BM25(twins);
+		const results = bm25.search("echo", 10);
+
+		expect(results.map((r) => r.index)).toEqual([1, 2]);
+		expect(results[0].score).toBe(results[1].score);
 	});
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Follow-up to #18980 (issue #18983 is already closed).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run; **verify passes green on this head**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop` (`220bc8b30665840a72228081eaed38f624142eda`); zero conflicts.
- [x] `bun run verify` passes on this head. Full `packages/core` vitest: 5809 passed; the 2 failures (`service-character-ingest`, `service-regression-lane` — an ElizaError code mismatch in the documents feature) reproduce identically on clean develop with this change stashed, i.e. pre-existing baseline, unrelated to `search.ts`.

# Risks

Minimal. One conditional stable sort on the partial-result return path of `BM25.search()`. The full-buffer top-K path is untouched (it is already sorted incrementally, so no redundant sort is added), and tie ordering is unchanged: the stable sort keeps equal scores in ascending document order, the same tie behavior the full path produces.

# Background

## What does this PR do?

`BM25.search()` promises descending-score results, but its bounded top-K maintenance sorts the buffer only at the moment it fills to `topK`. Queries matching fewer positive-scoring documents than `topK` skipped that sort and returned document-index order, breaking callers that normalize against the first score or consume relevance order directly. The fix sorts the buffer on return exactly when it never filled (`results.length < topK`).

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The conditional at the end of `BM25.search()` in `packages/core/src/search.ts`, then the "BM25.search result ordering" describe block in `packages/core/src/search.test.ts`.

## Detailed testing steps

```bash
bunx vitest run packages/core/src/search.test.ts --root packages/core
```

# Evidence Gate

<!-- evidence-head:4b64b0c82020f33d8e38725eede514034669f351 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - in-memory ranking function in core; no UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - in-memory ranking function in core; no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - deterministic ordering contract pinned by the regression suite below`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — the regression suite on this head, and the same suite failing against the previous behavior:

  <details><summary>vitest run (this head, then with the search.ts change stashed)</summary>

  ```
  this head:
    BM25.search result ordering — 3 passed
      returns descending scores even when fewer matches exist than topK
      keeps the bounded top-K path intact when the buffer fills
      breaks score ties in ascending document order on the partial path
    file total: 6 passed (6)

  previous behavior (search.ts change stashed, test kept):
    FAIL  returns descending scores even when fewer matches exist than topK
    AssertionError: expected [ +0, 2 ] to deeply equal [ 2, +0 ]
    1 failed | 5 passed
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no browser surface involved`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - deterministic ranking math; no model, prompt, or action behavior involved`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the ordering contract per result-set shape:

  <details><summary>BM25.search input/outcome contract</summary>

  ```
  matches < topK  -> now descending by score (was: document-index order)
  matches = topK  -> unchanged (buffer fill-sort already ran)
  matches > topK  -> unchanged bounded insertion path
  score ties      -> ascending document index on both paths (stable sort)
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Evidence Details

All evidence is inline above.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZX2B3B3FNE7EMB3G64QFA4S","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T08:03:12.868Z","completed_at":"2026-08-13T08:21:14.617Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"3hcVrP6QmkD2FZ4ceAjxhffBN71K3wNaDcpHAwsd51d636e44x7_oIPFFXLyO7sFTG6gYTkrZmqWfyaI-5dUAQ"}} -->

## Maintainer rebase — exact head `4b64b0c8`

#18980 already merged the production fix and closed #18983 while this contribution was in flight. The conflict was resolved by keeping live `develop`'s implementation and retaining this PR's stronger tests, so the exact diff is test-only: explicit partial-order indexes, the full-buffer path, and stable tie order. Exact-head proof: search suite 6 passed, core typecheck passed, focused Biome passed, and `git diff --check` passed.