### PR TITLE
fix(ui): reject invalid check-stories numeric flags

### DIFF
--- a/packages/ui/stories/check-stories.mjs
+++ b/packages/ui/stories/check-stories.mjs
@@ -11,13 +11,26 @@ const arg = (name, def) => {
   const i = process.argv.indexOf(name);
   return i >= 0 ? process.argv[i + 1] : def;
 };
+const integerArg = (name, def, min, max = Number.MAX_SAFE_INTEGER) => {
+  const i = process.argv.indexOf(name);
+  if (i < 0) return def;
+  const raw = process.argv[i + 1];
+  if (raw === undefined || !/^(0|[1-9]\d*)$/.test(raw)) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}`);
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}`);
+  }
+  return value;
+};
 const base = arg("--base", "http://localhost:6006");
-const limit = Number(arg("--limit", "0")) || 0;
+const limit = integerArg("--limit", 0, 1);
 const filter = arg("--filter", "");
 const globals = arg("--globals", "");
 
 const idsFile = arg("--ids-file", "");
-const settle = Number(arg("--settle", "600")) || 600;
+const settle = integerArg("--settle", 600, 0, 2_147_483_647);
 const isTransientNavigationError = (message) =>
   /net::ERR_(ABORTED|CONNECTION_REFUSED)|Execution context was destroyed/i.test(
     message,

--- a/packages/ui/stories/check-stories.mjs
+++ b/packages/ui/stories/check-stories.mjs
@@ -3,7 +3,7 @@
  * render errors (SB error overlay, page errors, console.error).
  *
  * Usage:
- *   node stories/check-stories.mjs [--base http://localhost:6006] [--limit N] [--filter substr] [--globals theme:light]
+ *   node stories/check-stories.mjs [--base http://localhost:6006] [--limit N] [--filter substr] [--globals theme:light] [--print-options]
  */
 import { chromium } from "playwright";
 
@@ -31,6 +31,10 @@ const globals = arg("--globals", "");
 
 const idsFile = arg("--ids-file", "");
 const settle = integerArg("--settle", 600, 0, 2_147_483_647);
+if (process.argv.includes("--print-options")) {
+  console.log(JSON.stringify({ limit, settle }));
+  process.exit(0);
+}
 const isTransientNavigationError = (message) =>
   /net::ERR_(ABORTED|CONNECTION_REFUSED)|Execution context was destroyed/i.test(
     message,

--- a/packages/ui/test/check-stories-cli.test.mjs
+++ b/packages/ui/test/check-stories-cli.test.mjs
@@ -1,0 +1,102 @@
+/**
+ * Exercises the headless story checker's numeric CLI boundary in real Node
+ * processes, proving malformed bounds fail before file, network, or browser work.
+ */
+
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const checker = resolve(here, "../stories/check-stories.mjs");
+const unreachableBase = "http://127.0.0.1:1";
+
+function run(...args) {
+  return spawnSync(process.execPath, [checker, ...args], {
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+}
+
+describe("check-stories numeric CLI validation (#18934)", () => {
+  it.each([
+    "0",
+    "-1",
+    "+1",
+    "1.5",
+    "1junk",
+    "NaN",
+    "Infinity",
+    "01",
+    "9007199254740992",
+  ])("rejects invalid --limit %j before external work", (value) => {
+    const result = run("--limit", value, "--ids-file", "/does/not/exist");
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("--limit must be an integer between 1");
+    expect(result.stderr).not.toContain("ENOENT");
+  });
+
+  it.each([
+    "-1",
+    "+1",
+    "1.5",
+    "1junk",
+    "NaN",
+    "Infinity",
+    "01",
+    "2147483648",
+    "9007199254740992",
+  ])("rejects invalid --settle %j before external work", (value) => {
+    const result = run("--settle", value, "--ids-file", "/does/not/exist");
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "--settle must be an integer between 0 and 2147483647",
+    );
+    expect(result.stderr).not.toContain("ENOENT");
+  });
+
+  it.each(["--limit", "--settle"])(
+    "rejects a missing value for %s before external work",
+    (flag) => {
+      const result = run(flag);
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(`${flag} must be an integer between`);
+      expect(result.stderr).not.toContain("fetch failed");
+    },
+  );
+
+  it("rejects an adjacent flag as a missing numeric value", () => {
+    const result = run("--limit", "--settle", "0");
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("--limit must be an integer between 1");
+    expect(result.stderr).not.toContain("fetch failed");
+  });
+
+  it.each([
+    ["omitted defaults", ["--base", unreachableBase]],
+    [
+      "--limit 7 with --settle 0",
+      ["--limit", "7", "--settle", "0", "--base", unreachableBase],
+    ],
+    [
+      "the maximum safe --limit",
+      ["--limit", "9007199254740991", "--base", unreachableBase],
+    ],
+    [
+      "the maximum Node timer --settle",
+      ["--settle", "2147483647", "--base", unreachableBase],
+    ],
+  ])("accepts %s", (_label, args) => {
+    const result = run(...args);
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.status).not.toBe(0);
+    expect(output).toContain(`${unreachableBase}/index.json`);
+    expect(output).not.toContain("must be an integer between");
+  });
+});

--- a/packages/ui/test/check-stories-cli.test.mjs
+++ b/packages/ui/test/check-stories-cli.test.mjs
@@ -10,7 +10,6 @@ import { describe, expect, it } from "vitest";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const checker = resolve(here, "../stories/check-stories.mjs");
-const unreachableBase = "http://127.0.0.1:1";
 
 function run(...args) {
   return spawnSync(process.execPath, [checker, ...args], {
@@ -21,6 +20,7 @@ function run(...args) {
 
 describe("check-stories numeric CLI validation (#18934)", () => {
   it.each([
+    "",
     "0",
     "-1",
     "+1",
@@ -39,6 +39,7 @@ describe("check-stories numeric CLI validation (#18934)", () => {
   });
 
   it.each([
+    "",
     "-1",
     "+1",
     "1.5",
@@ -78,25 +79,27 @@ describe("check-stories numeric CLI validation (#18934)", () => {
   });
 
   it.each([
-    ["omitted defaults", ["--base", unreachableBase]],
+    ["omitted defaults", [], { limit: 0, settle: 600 }],
     [
       "--limit 7 with --settle 0",
-      ["--limit", "7", "--settle", "0", "--base", unreachableBase],
+      ["--limit", "7", "--settle", "0"],
+      { limit: 7, settle: 0 },
     ],
     [
       "the maximum safe --limit",
-      ["--limit", "9007199254740991", "--base", unreachableBase],
+      ["--limit", "9007199254740991"],
+      { limit: 9007199254740991, settle: 600 },
     ],
     [
       "the maximum Node timer --settle",
-      ["--settle", "2147483647", "--base", unreachableBase],
+      ["--settle", "2147483647"],
+      { limit: 0, settle: 2147483647 },
     ],
-  ])("accepts %s", (_label, args) => {
-    const result = run(...args);
-    const output = `${result.stdout}\n${result.stderr}`;
+  ])("accepts %s", (_label, args, expected) => {
+    const result = run(...args, "--print-options");
 
-    expect(result.status).not.toBe(0);
-    expect(output).toContain(`${unreachableBase}/index.json`);
-    expect(output).not.toContain("must be an integer between");
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual(expected);
+    expect(result.stderr).toBe("");
   });
 });


### PR DESCRIPTION
# Relates to

Closes #18934

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto `origin/develop` at `e47d306814d`; zero conflicts. Later unrelated commits landed while the exact-head gate ran.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code from the process-boundary test evidence below, including direct observation of parsed defaults and explicit zero.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@e47d306814d`; zero conflicts.
- [x] `bun run verify` passes post-sync on exact PR head `408a164701405182b0d512669603c63fd09338dd`.

# Risks

Low. The change is isolated to numeric CLI parsing for a maintainer-only story checker. It preserves omitted defaults, `--settle 0`, positive limits, and documented upper bounds while rejecting ambiguous or unsafe numeric spellings before file, network, or browser work.

# Background

## What does this PR do?

- replaces permissive `parseInt` handling for `--limit` and `--settle` with one fail-fast integer boundary
- rejects missing values, signs, fractions, partial parses, leading zeroes, non-finite values, unsafe integers, and timer values above Node's supported maximum
- adds real-process tests covering invalid and empty inputs, plus a diagnostic `--print-options` path that directly proves defaults, explicit zero, and both upper bounds after parsing
- keeps the production change to 15 added lines plus two call-site replacements

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No. This hardens an internal maintainer CLI and does not change a supported user-facing interface.

# Testing

## Where should a reviewer start?

`packages/ui/test/check-stories-cli.test.mjs` exercises the actual script as a child process. Invalid values use a nonexistent ids file to prove validation wins before filesystem access. Accepted values use the real `--print-options` diagnostic path to observe parsed values directly before external work.

## Detailed testing steps

```bash
bun install
bun test packages/ui/test/check-stories-cli.test.mjs
bunx biome check packages/ui/stories/check-stories.mjs packages/ui/test/check-stories-cli.test.mjs
bun run verify
```

Results on the exact PR head:

```text
27 pass, 0 fail, 81 assertions
350 successful, 350 total workspace tasks
build/typecheck audit: PASS
script inventory: 0 orphan scripts
anti-larp: 7,997 test files; 0 focused; 0 orphaned skips
```

# Evidence Gate

<!-- evidence-head:408a164701405182b0d512669603c63fd09338dd -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - this changes a headless maintainer CLI and has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - this changes a headless maintainer CLI and has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the complete behavior is a noninteractive CLI boundary covered by real-process tests.
<!-- evidence-row:backend-logs -->
- [ ] N/A - this headless local CLI does not start or exercise a backend service; real process-boundary output is included below.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime, request, response, or state changes.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, scheduled task, wallet, media, or generated domain artifact changed.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

```text
bun test packages/ui/test/check-stories-cli.test.mjs
(pass) rejects invalid --limit: 0, -1, +1, 1.5, 1junk, NaN, Infinity, 01, 9007199254740992
(pass) rejects invalid --settle: -1, +1, 1.5, 1junk, NaN, Infinity, 01, 2147483648, 9007199254740992
(pass) rejects missing --limit / --settle and adjacent flag values
(pass) accepts omitted defaults, --limit 7 with --settle 0, max-safe limit, and max Node timer settle
27 pass; 0 fail; 81 assertions
```

Frontend logs: N/A - no frontend runtime is involved.

## Screenshots (before / after) + video walkthrough

N/A - the affected artifact is a headless `.mjs` maintainer command with no visual surface. Screenshots, OCR, and video would not provide behavioral evidence.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

- Review correctly identified that reaching fetch did not prove `--settle 0` survived parsing. The real entry point now exposes parsed numeric options through `--print-options`; tests assert `{ limit: 7, settle: 0 }`, omitted `{ limit: 0, settle: 600 }`, both maxima, and empty-string rejection without network timing or error-text coupling.
- The final head is rebased on `origin/develop@e47d306814d`; focused tests, changed-file Biome, and root `bun run verify` all pass at that exact head.
- Visual, frontend, LLM, domain, and audio evidence are inapplicable because this is a headless CLI-only change.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex]



