### PR TITLE
fix(plugin-coding-tools): clamp CODING_TOOLS_SHELL_TIMEOUT_MS fallback

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -841,6 +841,33 @@ describeIfPosix("shellAction", () => {
     expect(result.text).toContain("timeout");
   });
 
+  it("clamps a fractional CODING_TOOLS_SHELL_TIMEOUT_MS fallback to the timeout floor", async () => {
+    const { runtime } = await makeRuntime({ shellTimeoutMs: 45.5 });
+    const result = await shellAction.handler?.(
+      runtime,
+      makeMessage(),
+      undefined,
+      { command: "sleep 0.5" },
+    );
+    expect(result.success).toBe(false);
+    // Before the fix this reported the raw floored-but-unclamped value
+    // ("timed out after 45ms"); it must now report the clamped floor.
+    expect(result.text).toContain("timed out after 100ms");
+  });
+
+  it("clamps an unsafe CODING_TOOLS_SHELL_TIMEOUT_MS fallback instead of producing a near-instant broken timer", async () => {
+    const { runtime } = await makeRuntime({
+      shellTimeoutMs: 9_007_199_254_740_992,
+    });
+    const result = await shellAction.handler?.(
+      runtime,
+      makeMessage(),
+      undefined,
+      { command: "sleep 0.2" },
+    );
+    expect(result.success).toBe(true);
+  });
+
   it("times out shell pipelines without waiting for orphaned children", async () => {
     const started = Date.now();
     const { runtime } = await makeRuntime();

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -334,8 +334,13 @@ function getBackgroundShellService(
 }
 
 function clampTimeout(value: number | undefined, fallback: number): number {
-  if (value === undefined || !Number.isFinite(value)) return fallback;
-  return Math.max(TIMEOUT_MIN_MS, Math.min(TIMEOUT_MAX_MS, Math.floor(value)));
+  const candidate =
+    value !== undefined && Number.isFinite(value) ? value : fallback;
+  if (!Number.isFinite(candidate)) return TIMEOUT_MIN_MS;
+  return Math.max(
+    TIMEOUT_MIN_MS,
+    Math.min(TIMEOUT_MAX_MS, Math.floor(candidate)),
+  );
 }
 
 function clampHistoryLimit(value: number | undefined): number {


### PR DESCRIPTION
# Relates to

Fixes #19003. Follow-up to #18978 (merged) — #18978's own linked work item
(#18988) is already closed by that merge and scoped to the legacy
`ShellService` compatibility settings; #19003 is a separate, still-open item
for this canonical SHELL-action gap, opened per review feedback on this PR.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` was run after rebasing; see Testing for the result.
- [x] A reviewer can confirm the change works without reading the code, from the
      focused regression tests and CLI reproduction below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Genuinely rebased onto the latest `origin/develop` (`140d985d6445cdc2ff0065e4768fb81ab53b05ca` at rebase time), which already includes #18978's merged fix; zero conflicts. (The prior push's "rebased" claim was stale — caught by review; re-verified here with `git log --oneline HEAD..origin/develop` returning empty immediately before pushing this revision.)
- [x] Focused package gates (tests, typecheck, Biome) all pass on the changed files, re-run on this exact rebased head.

# Risks

Low. `clampTimeout` is the shared bound already applied to the per-call
`timeout` action parameter; this makes it apply the identical bound to its
`fallback` argument too, instead of returning it unclamped. Normal
configurations (no `CODING_TOOLS_SHELL_TIMEOUT_MS` set, or a sane value) are
byte-identical to before — only malformed/unsafe fallback values change
behavior, independently verified below.

# Background

## What does this PR do?

#18978 fixed permissive numeric parsing in `plugins/plugin-coding-tools/src/shell/utils/config.ts` (the legacy `SHELL_*` env vars consumed by `ShellService`). During review, a second reviewer pass on that PR (before it merged) found the fix didn't cover the actually-supported, documented setting: `CODING_TOOLS_SHELL_TIMEOUT_MS`, read by the live `SHELL` action.

Traced live call chain:
- `plugins/plugin-coding-tools/src/actions/bash.ts:1736` — `readPositiveIntSetting(runtime, "CODING_TOOLS_SHELL_TIMEOUT_MS", DEFAULT_TIMEOUT_MS)` reads the setting via `plugins/plugin-coding-tools/src/lib/format.ts:162-175`, which still uses permissive `Number(v)` parsing with no safe-integer check and no maximum bound (floors fractions, accepts unsafe-huge values).
- `plugins/plugin-coding-tools/src/actions/bash.ts:1740-1743` — `clampTimeout(readNumberParam(options, "timeout"), defaultTimeout)` was supposed to bound the result, but the old implementation returned its `fallback` argument **completely unclamped** whenever no per-call `timeout` override was supplied (the common case) — the `[TIMEOUT_MIN_MS, TIMEOUT_MAX_MS]` bound was only ever applied to the per-call value, never to the setting-derived fallback.
- The result flows straight into `runShell(runtime, { command, cwd, timeoutMs: timeout })`.

Reproduced against the real handler before fixing (matches the review finding exactly):
- `CODING_TOOLS_SHELL_TIMEOUT_MS="45.5"` → floored to `45` by `readPositiveIntSetting`, returned as-is by the old `clampTimeout` → a `sleep 0.2` command failed after ~45ms instead of the intended ~120s default.
- `CODING_TOOLS_SHELL_TIMEOUT_MS="9007199254740992"` (an unsafe-huge but `Number.isFinite` value) → returned as-is by the old `clampTimeout` → Node's internal handling of an out-of-range `setTimeout` delay reduces it to a near-1ms real timer, so even a trivially fast command fails almost instantly.

`clampTimeout` now always runs its `candidate` (per-call value if valid, otherwise the fallback) through the same `[TIMEOUT_MIN_MS, TIMEOUT_MAX_MS]` bound, so both cases above now land inside the documented 100ms–600000ms range instead of reaching `runShell` unclamped.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-coding-tools/src/actions/bash.ts:336-343` (`clampTimeout`)
2. `plugins/plugin-coding-tools/src/actions/bash.test.ts` — new tests under `describeIfPosix("shellAction", ...)`, right after "returns a timeout failure when the command exceeds its budget"

## Detailed testing steps

```text
bun run --cwd plugins/plugin-coding-tools test
Test Files  34 passed (34)
     Tests  455 passed (455)

bun run --cwd plugins/plugin-coding-tools typecheck
exit 0, no output

bunx @biomejs/biome check plugins/plugin-coding-tools/src/actions/bash.ts plugins/plugin-coding-tools/src/actions/bash.test.ts
Checked 2 files. No fixes applied.

bun run verify
(root, full monorepo chain — see Known gaps for result/timing)
```

Independently confirmed both new tests are genuine regressions, not vacuous:
reverted only the `clampTimeout` fix (kept the new tests) and re-ran — both
failed with exactly the reported symptoms (`"timed out after 45ms"` instead
of the clamped `"timed out after 100ms"`; the huge-fallback case failed
instead of succeeding). Restored the fix and re-ran clean before pushing.

Note on the 453 vs 455 count from an earlier review pass: 455 is reproduced
independently, twice, on this exact rebased head (`bun test` reports the
count directly, it isn't hand-counted). The reviewing container was
explicitly no-network/no-credentials/no-writable-host-mounts; the 2-test gap
is most likely a host-capability-gated test elsewhere in this 34-file, 79
describe-block suite (e.g. a sandbox/Docker-backend probe) registering
differently there, not a difference in this diff. Flagging this rather than
silently picking a number — happy to help track down the exact gated test if
it matters for merge.

# Evidence Gate

<!-- evidence-head:e46be55791b70cda34dd05cd909cc0009a3adece -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend action logic, no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend action logic, no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - non-interactive backend timeout-clamping change.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - focused regression tests exercise the real action handler and timer path directly; no external service required.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend or network state changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no LLM/agent decision path is affected by this diff. This row is for evidence that a real model's *reasoning or tool-call decision* changed (`CONTRIBUTING.md`'s trajectory schema requires `provider`+`model`+`input`+`output` from an actual model call) — nothing here touches what a model sees, decides, or how it invokes SHELL. The fix only changes the *result* of an already-dispatched `SHELL` call when the operator's own `CODING_TOOLS_SHELL_TIMEOUT_MS` setting is malformed or unsafe-huge: the same model, given the same conversation, calling SHELL the same way, gets a different outcome only in that misconfigured-settings edge case, which is an ops/config concern, not a model-behavior one. A real handler-level input/action/result trace (no model in the loop, since none is involved) is captured in the domain-artifacts row below instead, since that's what this change actually demonstrates.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real regression run through the live action handler and timer path, output captured directly:
  ```text
  bun run --cwd plugins/plugin-coding-tools test
  Test Files  34 passed (34)
       Tests  455 passed (455)

  New tests (real handler, real setTimeout, real child process):
  - "clamps a fractional CODING_TOOLS_SHELL_TIMEOUT_MS fallback to the timeout
    floor" — sets the setting to 45.5, runs `sleep 0.5` through the real SHELL
    action, asserts the failure message reports the clamped "100ms", not the
    old unclamped "45ms".
  - "clamps an unsafe CODING_TOOLS_SHELL_TIMEOUT_MS fallback instead of
    producing a near-instant broken timer" — sets the setting to
    9007199254740992, runs `sleep 0.2` through the real SHELL action, asserts
    it now succeeds (clamped to the 600000ms ceiling) instead of failing
    almost instantly.

  Both independently confirmed to fail against the pre-fix clampTimeout and
  pass against this fix (temporarily reverted, re-ran, restored).

  Real input/action/result trace through the actual shellAction.handler
  (no model in the loop - direct handler invocation, matching how the
  action is really called):
  INPUT (runtime.getSetting): {"CODING_TOOLS_SHELL_TIMEOUT_MS":9007199254740992}
  ACTION/TOOL CALL: SHELL {"command":"sleep 0.2"}
  RESULT after 222 ms: {"success":true,"text":"$ sleep 0.2\n[exit 0] (cwd=..., took=220ms)\n--- stdout ---\n(empty)\n--- stderr ---\n(empty)"}
  Pre-fix, this exact input/action pair returns success:false almost
  instantly instead (Node's internal handling of the unclamped huge
  timeout).
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface.

# Known gaps / failures

Root `bun run verify` was started after rebasing, per review — it's a full
monorepo chain (typecheck + lint across every package/plugin, plus several
audit scripts and a full build) and was still running past the point this
revision needed to be pushed. Will report its actual result (pass, or the
exact failure) as a follow-up comment once it completes rather than claim a
result that hasn't happened yet. The scoped package gates it doesn't
duplicate any faster (tests, typecheck, Biome) all pass on the exact
rebased head — see Testing above.

`readPositiveIntSetting` in `lib/format.ts` itself remains permissive
(accepts fractional/unsafe-huge values before `clampTimeout` bounds the
result) — left unchanged since `clampTimeout` already fully closes the
reachable defect at its one real consumer, and `readPositiveIntSetting` has
other unrelated callers (`read.ts`, `grep.ts`,
`background-shell-service.ts`) outside this PR's scope.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [hunt-and-implement-review-fix]
