### PR TITLE
fix(plugin-coding-tools): strictly bound shell service numeric configuration (#18988)

### DIFF
--- a/plugins/plugin-coding-tools/src/shell/utils/config.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/config.test.ts
@@ -1,6 +1,11 @@
-/** Verifies shell startup diagnostics and invalid-directory failures at the configuration boundary. */
+/**
+ * Verifies shell startup diagnostics, invalid-directory failures, and the
+ * strict numeric-setting boundary (#18988): each explicit token must be an
+ * exact in-range positive decimal integer, rejected with a typed ElizaError
+ * before any service state exists; unset and blank fall back to defaults.
+ */
 import path from "node:path";
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadShellConfig } from "./config.js";
 
@@ -44,5 +49,94 @@ describe("loadShellConfig", () => {
     expect(() => loadShellConfig()).toThrow(
       `SHELL_ALLOWED_DIRECTORY does not exist: ${missingDirectory}`,
     );
+  });
+});
+
+describe("strictly bounded numeric shell settings (#18988)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function expectConfigError(setting: string, value: string) {
+    vi.stubEnv("SHELL_ALLOWED_DIRECTORY", process.cwd());
+    vi.stubEnv(setting, value);
+    let thrown: unknown;
+    try {
+      loadShellConfig();
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ElizaError);
+    const typed = thrown as ElizaError;
+    expect(typed.code).toBe("SHELL_CONFIG_INVALID");
+    expect(typed.context).toMatchObject({ setting, value });
+    expect(typed.message).toContain(setting);
+    expect(typed.message).toMatch(/between \d+ and \d+/);
+    vi.unstubAllEnvs();
+  }
+
+  it("unset and blank tokens preserve every documented default", () => {
+    vi.stubEnv("SHELL_ALLOWED_DIRECTORY", process.cwd());
+    vi.stubEnv("SHELL_TIMEOUT", "");
+    vi.stubEnv("SHELL_BACKGROUND_MS", "   ");
+
+    const config = loadShellConfig();
+
+    expect(config.timeout).toBe(30000);
+    expect(config.maxOutputChars).toBe(200000);
+    expect(config.pendingMaxOutputChars).toBe(200000);
+    expect(config.defaultBackgroundMs).toBe(10000);
+  });
+
+  it("accepts documented ordinary values and exact range boundaries", () => {
+    vi.stubEnv("SHELL_ALLOWED_DIRECTORY", process.cwd());
+    vi.stubEnv("SHELL_TIMEOUT", "2147483647");
+    vi.stubEnv("SHELL_MAX_OUTPUT_CHARS", "10000000");
+    vi.stubEnv("SHELL_PENDING_MAX_OUTPUT_CHARS", "1");
+    vi.stubEnv("SHELL_BACKGROUND_MS", "120000");
+
+    const upper = loadShellConfig();
+    expect(upper.timeout).toBe(2_147_483_647);
+    expect(upper.maxOutputChars).toBe(10_000_000);
+    expect(upper.pendingMaxOutputChars).toBe(1);
+    expect(upper.defaultBackgroundMs).toBe(120_000);
+
+    vi.stubEnv("SHELL_TIMEOUT", "45000");
+    vi.stubEnv("SHELL_MAX_OUTPUT_CHARS", "200000");
+    vi.stubEnv("SHELL_PENDING_MAX_OUTPUT_CHARS", "200000");
+    vi.stubEnv("SHELL_BACKGROUND_MS", "10");
+
+    const ordinary = loadShellConfig();
+    expect(ordinary.timeout).toBe(45000);
+    expect(ordinary.maxOutputChars).toBe(200000);
+    expect(ordinary.defaultBackgroundMs).toBe(10);
+  });
+
+  it("rejects malformed tokens that parseInt silently truncated", () => {
+    expectConfigError("SHELL_TIMEOUT", "100abc");
+    expectConfigError("SHELL_TIMEOUT", "1e10");
+    expectConfigError("SHELL_TIMEOUT", "junk");
+    expectConfigError("SHELL_MAX_OUTPUT_CHARS", "1.5");
+    expectConfigError("SHELL_BACKGROUND_MS", "+500");
+    expectConfigError("SHELL_BACKGROUND_MS", "-500");
+  });
+
+  it("rejects below-range values instead of passing them live", () => {
+    expectConfigError("SHELL_TIMEOUT", "0");
+    expectConfigError("SHELL_MAX_OUTPUT_CHARS", "0");
+    expectConfigError("SHELL_BACKGROUND_MS", "9");
+  });
+
+  it("rejects above-ceiling values instead of overflowing or clamping", () => {
+    // setTimeout ceiling: 2^31 would overflow and fire the kill timer
+    // immediately.
+    expectConfigError("SHELL_TIMEOUT", "2147483648");
+    // Retained output beyond the per-session ceiling would defeat the
+    // memory cap even though it is a safe integer.
+    expectConfigError("SHELL_MAX_OUTPUT_CHARS", "10000001");
+    expectConfigError("SHELL_PENDING_MAX_OUTPUT_CHARS", "9007199254740991");
+    // The yield-window consumer clamps to 120000ms; a larger configured
+    // default must be rejected, not silently rewritten per call.
+    expectConfigError("SHELL_BACKGROUND_MS", "120001");
   });
 });

--- a/plugins/plugin-coding-tools/src/shell/utils/config.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/config.ts
@@ -5,9 +5,56 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import { z } from "zod";
 import type { ShellConfig } from "../types";
+
+/**
+ * Ceilings for the numeric shell settings, each tied to the real consumer of
+ * the value rather than an arbitrary sanity number:
+ * - timeout feeds a `setTimeout` (shellService kill timer), whose 32-bit
+ *   signed ceiling is 2^31-1 ms — larger values overflow and fire immediately,
+ *   turning "very long timeout" into "instant kill";
+ * - the yield window consumer clamps to [10, 120_000] ms, so a configured
+ *   default outside that window would be silently rewritten on every call;
+ * - retained-output settings size in-memory per-session buffers, so they get
+ *   a practical per-session ceiling instead of "any safe integer".
+ */
+const SHELL_TIMEOUT_MAX_MS = 2_147_483_647;
+const SHELL_BACKGROUND_MIN_MS = 10;
+const SHELL_BACKGROUND_MAX_MS = 120_000;
+const SHELL_OUTPUT_CHARS_MAX = 10_000_000;
+
+/**
+ * Parses one explicitly-provided env token as an exact positive decimal
+ * integer within [min, max]. Unset and blank both mean "use the default"
+ * (blank-is-unset convention); anything else that is not exactly an in-range
+ * decimal integer throws before any shell service state exists.
+ */
+function parseShellSetting(
+  setting: string,
+  raw: string | undefined,
+  {
+    defaultValue,
+    min,
+    max,
+  }: { defaultValue: number; min: number; max: number },
+): number {
+  if (raw === undefined || raw.trim() === "") return defaultValue;
+  const token = raw.trim();
+  const value = /^\d+$/.test(token) ? Number(token) : Number.NaN;
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new ElizaError(
+      `${setting} must be an integer between ${min} and ${max}; received ${JSON.stringify(raw)}`,
+      {
+        code: "SHELL_CONFIG_INVALID",
+        context: { setting, value: raw, min, max },
+        severity: "fatal",
+      },
+    );
+  }
+  return value;
+}
 
 const configSchema = z.object({
   enabled: z.boolean(),
@@ -50,18 +97,33 @@ export const DEFAULT_FORBIDDEN_COMMANDS: readonly string[] = [
 
 export function loadShellConfig(): ShellConfig {
   const allowedDirectory = process.env.SHELL_ALLOWED_DIRECTORY || process.cwd();
-  const timeout = parseInt(process.env.SHELL_TIMEOUT || "30000", 10);
-  const maxOutputChars = parseInt(
-    process.env.SHELL_MAX_OUTPUT_CHARS || "200000",
-    10,
+  const timeout = parseShellSetting(
+    "SHELL_TIMEOUT",
+    process.env.SHELL_TIMEOUT,
+    {
+      defaultValue: 30000,
+      min: 1,
+      max: SHELL_TIMEOUT_MAX_MS,
+    },
   );
-  const pendingMaxOutputChars = parseInt(
-    process.env.SHELL_PENDING_MAX_OUTPUT_CHARS || "200000",
-    10,
+  const maxOutputChars = parseShellSetting(
+    "SHELL_MAX_OUTPUT_CHARS",
+    process.env.SHELL_MAX_OUTPUT_CHARS,
+    { defaultValue: 200000, min: 1, max: SHELL_OUTPUT_CHARS_MAX },
   );
-  const defaultBackgroundMs = parseInt(
-    process.env.SHELL_BACKGROUND_MS || "10000",
-    10,
+  const pendingMaxOutputChars = parseShellSetting(
+    "SHELL_PENDING_MAX_OUTPUT_CHARS",
+    process.env.SHELL_PENDING_MAX_OUTPUT_CHARS,
+    { defaultValue: 200000, min: 1, max: SHELL_OUTPUT_CHARS_MAX },
+  );
+  const defaultBackgroundMs = parseShellSetting(
+    "SHELL_BACKGROUND_MS",
+    process.env.SHELL_BACKGROUND_MS,
+    {
+      defaultValue: 10000,
+      min: SHELL_BACKGROUND_MIN_MS,
+      max: SHELL_BACKGROUND_MAX_MS,
+    },
   );
   const allowBackground = process.env.SHELL_ALLOW_BACKGROUND !== "false";
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18988

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run; **verify passes green on this head**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop` (`e66d4dd16f`); zero conflicts.
- [x] `bun run verify` passes on this head.

# Risks

Low. One config loader in one plugin, validated before any shell service state exists. Behavior change is exactly the requested fail-closed contract: out-of-contract tokens now throw a typed error at startup instead of becoming silently-truncated or overflow-prone live values. Defaults, blank-is-unset, and documented ordinary values are proven unchanged.

# Background

## What does this PR do?

`loadShellConfig()` read its four numeric settings with permissive `parseInt`: `"100abc"` silently became `100`, `"1e10"` became `1`, and any positive safe integer passed the zod check — including retained-output sizes big enough to defeat the per-session memory cap, timeouts beyond the 32-bit `setTimeout` ceiling (which overflow and fire the shell kill timer immediately), and background yields above the consumer's 120s clamp (silently rewritten on every call). Each explicitly-provided token must now be an exact positive decimal integer inside its consumer-derived range; violations throw `ElizaError` code `SHELL_CONFIG_INVALID` carrying the setting name, offending value, and accepted range. Unset and blank keep the documented defaults.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. (The consumer-derived bounds are documented at the constants in `config.ts`.)

# Testing

## Where should a reviewer start?

`parseShellSetting` and the bound constants in `plugins/plugin-coding-tools/src/shell/utils/config.ts`, then the "#18988" describe block in `config.test.ts`.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-coding-tools test
```

# Evidence Gate

<!-- evidence-head:97af807851cac2ca7a8ec9f47dfa5db52b55f238 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - server-side config parsing; no UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - server-side config parsing; no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - startup config contract pinned by the deterministic suite below`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — the config suite on this head:

  <details><summary>vitest run</summary>

  ```
  strictly bounded numeric shell settings (#18988) — 5 passed:
    unset and blank tokens preserve every documented default
    accepts documented ordinary values and exact range boundaries
    rejects malformed tokens that parseInt silently truncated
    rejects below-range values instead of passing them live
    rejects above-ceiling values instead of overflowing or clamping
  file total: 7 passed (7)
  full plugin suite: Tests 443 passed (443); typecheck, lint, build green
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - server-side plugin module; no browser surface involved`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - deterministic env parsing; no model, prompt, provider, or action behavior involved`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the token/outcome contract per setting:

  <details><summary>shell numeric setting input/outcome contract</summary>

  ```
  unset / blank            -> documented default (30000 / 200000 / 200000 / 10000)
  "100abc" "1e10" "junk"
  "1.5" "+500" "-500"      -> throws ElizaError SHELL_CONFIG_INVALID (was: parseInt truncation)
  SHELL_TIMEOUT 0 / 2147483648            -> throws (ceiling = 32-bit setTimeout max;
                                             2^31 previously overflowed -> instant kill timer)
  SHELL_MAX_OUTPUT_CHARS 0 / 10000001     -> throws (per-session retention ceiling 10000000)
  SHELL_PENDING_MAX_OUTPUT_CHARS 9007199254740991 -> throws (was: passed positive() check)
  SHELL_BACKGROUND_MS 9 / 120001          -> throws (consumer yield clamp is [10, 120000];
                                             was: silently clamped per call)
  boundary values 1 / 2147483647 / 10000000 / 10 / 120000 -> accepted exactly
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Evidence Details

All evidence is inline above.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZX3A5DR4136SD740BR8ECDW","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T08:20:10.808Z","completed_at":"2026-08-13T08:46:57.670Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"Ro6GDn-4XrCyzrJpBCCyHKNVbYn2p3sEb6iO89ZkBsxiMOL6jrYvaPy83J4HugqrNF3Wl2l6WPrhiZFGVQtiCQ"}} -->

