### PR TITLE
fix(cloud): fall back to canonical agent route

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
@@ -1,0 +1,52 @@
+/** Exercises the real forwarding boundary with deterministic network responses. */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  forwardToServer,
+  getCanonicalAgentFallbackBase,
+} from "../src/server-router";
+
+const AGENT_ID = "4602b3be-2c01-4e7e-9cdc-849604e1bef7";
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("canonical agent forwarding fallback", () => {
+  test("derives a fixed-domain fallback only for UUID agent ids", () => {
+    expect(getCanonicalAgentFallbackBase(AGENT_ID)).toBe(
+      `https://${AGENT_ID}.elizacloud.ai/api`,
+    );
+    expect(getCanonicalAgentFallbackBase("../../attacker.example")).toBeNull();
+    expect(getCanonicalAgentFallbackBase("not-an-agent-id")).toBeNull();
+  });
+
+  test("uses the canonical agent route after a primary transport failure", async () => {
+    const requests: string[] = [];
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = input instanceof Request ? input.url : String(input);
+      requests.push(url);
+      if (url.startsWith("http://stale-sandbox.example")) {
+        throw new TypeError("connection timed out");
+      }
+      return new Response(JSON.stringify({ response: "agent is live" }), {
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    await expect(
+      forwardToServer(
+        "http://stale-sandbox.example/api",
+        "sandbox-stale",
+        AGENT_ID,
+        "user-1",
+        "hello",
+      ),
+    ).resolves.toBe("agent is live");
+
+    expect(requests).toEqual([
+      `http://stale-sandbox.example/api/agents/${AGENT_ID}/message`,
+      `https://${AGENT_ID}.elizacloud.ai/api/agents/${AGENT_ID}/message`,
+    ]);
+  });
+});

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -11,6 +11,8 @@ const RETRY_ATTEMPTS = 5;
 const RETRY_BASE_DELAY_MS = 2_000;
 const RETRY_INCREMENT_MS = 1_000;
 const IDENTITY_CACHE_TTL_SECONDS = 300;
+const AGENT_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 interface ServerRoute {
   serverName: string;
@@ -29,6 +31,12 @@ export interface ResolvedIdentity {
   // agent yet. Callers must treat this as an onboarding/provisioning condition,
   // never as an agent-server routing target.
   agentId: string | null;
+}
+
+/** Returns the fixed-domain public route for a validated cloud agent id. */
+export function getCanonicalAgentFallbackBase(agentId: string): string | null {
+  if (!AGENT_ID_PATTERN.test(agentId)) return null;
+  return `https://${agentId.toLowerCase()}.elizacloud.ai/api`;
 }
 
 export async function resolveIdentity(
@@ -343,6 +351,7 @@ export async function forwardToServer(
     userId,
     `/agents/${agentId}/message`,
     JSON.stringify(body),
+    getCanonicalAgentFallbackBase(agentId),
   );
   return parseAgentResponse(raw, agentId);
 }
@@ -401,6 +410,7 @@ export async function forwardEventToServer(
     userId,
     `/agents/${agentId}/event`,
     JSON.stringify({ userId, type, payload }),
+    getCanonicalAgentFallbackBase(agentId),
   );
 }
 
@@ -420,6 +430,7 @@ async function forwardWithRetry(
   hashKey: string,
   endpointPath: string,
   body: string,
+  connectionFallbackBaseUrl?: string | null,
 ): Promise<string> {
   let lastError: Error | null = null;
   let woken = false;
@@ -446,6 +457,25 @@ async function forwardWithRetry(
 
     const result = await tryTarget(targets[0], endpointPath, body);
     if (result.ok) return result.response;
+
+    // Dedicated sandboxes can remain healthy behind their canonical hostname
+    // while an old direct host:port is still being refreshed into Redis. Only
+    // a transport failure may use this fixed-domain route: an HTTP response is
+    // authoritative and must not be bypassed through a second ingress.
+    if (
+      result.isConnectionError &&
+      connectionFallbackBaseUrl &&
+      targets[0].replace(/\/$/, "") !==
+        connectionFallbackBaseUrl.replace(/\/$/, "")
+    ) {
+      const canonical = await tryTarget(
+        connectionFallbackBaseUrl,
+        endpointPath,
+        body,
+      );
+      if (canonical.ok) return canonical.response;
+      lastError = canonical.error;
+    }
 
     if (targets.length > 1) {
       await refreshHashRing(serverUrl);


### PR DESCRIPTION
Closes #19007

## What changed

- Keep the Redis-discovered sandbox URL as the primary agent route.
- When that route fails at the transport layer, retry once through the canonical `https://<agent-id>.elizacloud.ai/api` route.
- Validate the agent ID as a UUID before constructing the fixed-domain fallback.
- Apply the same behavior to message and event forwarding; HTTP responses remain authoritative and do not trigger fallback.

## Production incident

The iMessage identity resolved correctly to agent `4602b3be-2c01-4e7e-9cdc-849604e1bef7`, but Redis was continuously refreshing an unreachable raw sandbox address (`136.243.47.243:18799`). The agent's canonical route was healthy and returned `ready: true` / `canRespond: true`. Gateway retries exhausted against the stale primary and dropped the message.

## Verification

- `bun test packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts` — 2/2 pass
- `bun run --cwd packages/cloud/services/gateway-webhook test` — 100/100 pass
- `bun run --cwd packages/cloud/services/gateway-webhook typecheck` — pass
- `bun run --cwd packages/cloud/services/gateway-webhook lint` — pass
- `bun run verify` — gateway work passes; aggregate currently fails on unrelated pre-existing develop errors in `packages/homepage/src/pages/landing.tsx` (invalid `DemoItem` properties and ES lib mismatch) and `plugins/plugin-video/src/services/video.test.ts` (`useLiteralKeys`).

<details>
<summary>Deployment provenance / reproduction</summary>

Production API and app were deployed from main commit `50ac8af481f46540b274cb50be39e6d8164951d0`. Railway gateway deployment `2be3b35e-91a1-402e-8a5e-7563462ac6ca` reproduced the failure. The public canonical agent health endpoint returned HTTP 200 while the Redis-discovered raw host timed out from the gateway container.

After merge, this exact revision will be promoted to main, deployed to the production gateway, and verified with a real iMessage round trip.

</details>
