### PR TITLE
fix(plugin-wallet): report 0-decimal SPL token balances without stripping zeros

### DIFF
--- a/plugins/plugin-wallet/src/sdk/tokens/solana.test.ts
+++ b/plugins/plugin-wallet/src/sdk/tokens/solana.test.ts
@@ -1,0 +1,42 @@
+/**
+ * SPL balance formatting (#19013 — 0-decimal balances stripped of significant
+ * zeros). `formatSplBalance` is the exact production path that produces
+ * `SplBalanceResult.humanBalance`; a bug here misreports a wallet's balance by
+ * orders of magnitude. Pin the 0-decimal path (where the trailing-zero trim used
+ * to corrupt multiples of ten), the bigint-exactness above Number.MAX_SAFE_INTEGER,
+ * and the unchanged formatting for tokens with decimals.
+ */
+import { describe, expect, it } from "vitest";
+import { formatSplBalance } from "./solana.ts";
+
+describe("formatSplBalance", () => {
+  it("keeps significant trailing zeros for 0-decimal tokens", () => {
+    // The original `toFixed(0).replace(/\.?0+$/, "")` stripped these to
+    // "1", "12", and "1" respectively.
+    expect(formatSplBalance(100n, 0)).toBe("100");
+    expect(formatSplBalance(1200n, 0)).toBe("1200");
+    expect(formatSplBalance(1_000_000n, 0)).toBe("1000000");
+  });
+
+  it("handles the 0-decimal zero/one boundaries", () => {
+    expect(formatSplBalance(0n, 0)).toBe("0");
+    expect(formatSplBalance(1n, 0)).toBe("1");
+  });
+
+  it("stays exact for 0-decimal balances above Number.MAX_SAFE_INTEGER", () => {
+    // 2^53 + 1 — routing this through Number() would round to
+    // "9007199254740992"; the bigint path keeps it exact.
+    expect(formatSplBalance(9_007_199_254_740_993n, 0)).toBe(
+      "9007199254740993",
+    );
+  });
+
+  it("formats tokens with decimals unchanged", () => {
+    expect(formatSplBalance(1_500_000n, 6)).toBe("1.5");
+    // Whole nonzero-decimal amounts keep their existing "1" rendering
+    // (the decimals path is intentionally untouched by the 0-decimal fix).
+    expect(formatSplBalance(1_000_000n, 6)).toBe("1");
+    // A zero balance on a decimal token falls back to "0".
+    expect(formatSplBalance(0n, 6)).toBe("0");
+  });
+});

--- a/plugins/plugin-wallet/src/sdk/tokens/solana.test.ts
+++ b/plugins/plugin-wallet/src/sdk/tokens/solana.test.ts
@@ -1,10 +1,11 @@
 /**
- * SPL balance formatting (#19013 — 0-decimal balances stripped of significant
- * zeros). `formatSplBalance` is the exact production path that produces
- * `SplBalanceResult.humanBalance`; a bug here misreports a wallet's balance by
- * orders of magnitude. Pin the 0-decimal path (where the trailing-zero trim used
- * to corrupt multiples of ten), the bigint-exactness above Number.MAX_SAFE_INTEGER,
- * and the unchanged formatting for tokens with decimals.
+ * SPL balance formatting (#19013). `formatSplBalance` is the exact production
+ * path that produces `SplBalanceResult.humanBalance`; a bug here misreports a
+ * wallet's balance. It now delegates to the bigint-safe `toHuman`, so pin both
+ * failure modes it removes: 0-decimal balances losing significant trailing zeros
+ * (multiples of ten), and positive-decimal `u64` values above
+ * Number.MAX_SAFE_INTEGER being rounded by a Number() conversion. Also pin the
+ * unchanged spelling for whole and zero decimal balances ("1.0" -> "1").
  */
 import { describe, expect, it } from "vitest";
 import { formatSplBalance } from "./solana.ts";
@@ -38,5 +39,17 @@ describe("formatSplBalance", () => {
     expect(formatSplBalance(1_000_000n, 6)).toBe("1");
     // A zero balance on a decimal token falls back to "0".
     expect(formatSplBalance(0n, 6)).toBe("0");
+  });
+
+  it("stays exact for positive-decimal balances above Number.MAX_SAFE_INTEGER", () => {
+    // A Number() conversion rounds this to "9007199254.740992"; delegating to
+    // the bigint-safe toHuman keeps the trailing 3 exact.
+    expect(formatSplBalance(9_007_199_254_740_993n, 6)).toBe(
+      "9007199254.740993",
+    );
+  });
+
+  it("formats negative decimal amounts", () => {
+    expect(formatSplBalance(-2_500_000n, 6)).toBe("-2.5");
   });
 });

--- a/plugins/plugin-wallet/src/sdk/tokens/solana.ts
+++ b/plugins/plugin-wallet/src/sdk/tokens/solana.ts
@@ -145,6 +145,25 @@ export interface SolanaTxResult {
 }
 
 /**
+ * Format a raw on-chain SPL token amount into a human-readable string.
+ *
+ * A 0-decimal token has no fractional part, so `toFixed(0)` produces a plain
+ * integer with no decimal point and the trailing-zero trim would strip
+ * significant zeros (100 -> "1", 1200 -> "12"). Return the exact integer for
+ * 0-decimal tokens (matching `toHuman(amount, 0)` in ./decimals.ts); `rawBalance`
+ * is a bigint so this stays exact even above Number.MAX_SAFE_INTEGER. Tokens with
+ * decimals keep the existing formatting unchanged.
+ */
+export function formatSplBalance(rawBalance: bigint, decimals: number): string {
+  if (decimals === 0) return rawBalance.toString();
+  return (
+    (Number(rawBalance) / 10 ** decimals)
+      .toFixed(decimals)
+      .replace(/\.?0+$/, "") || "0"
+  );
+}
+
+/**
  * Solana wallet for native SOL and SPL token operations.
  * Uses @solana/web3.js (optional peer dependency, dynamically imported).
  */
@@ -258,16 +277,7 @@ export class SolanaWallet {
       // Token account doesn't exist — balance is 0
     }
 
-    // A 0-decimal token has no fractional part, so `toFixed(0)` produces a plain
-    // integer with no decimal point and the trailing-zero trim would strip
-    // significant zeros (100 -> "1"). Format it as the exact integer, matching
-    // `toHuman(amount, 0)` in ./decimals.ts.
-    const humanBalance =
-      decimals === 0
-        ? rawBalance.toString()
-        : (Number(rawBalance) / 10 ** decimals)
-            .toFixed(decimals)
-            .replace(/\.?0+$/, "") || "0";
+    const humanBalance = formatSplBalance(rawBalance, decimals);
 
     return { mint: mintAddress, rawBalance, humanBalance, decimals };
   }

--- a/plugins/plugin-wallet/src/sdk/tokens/solana.ts
+++ b/plugins/plugin-wallet/src/sdk/tokens/solana.ts
@@ -258,10 +258,16 @@ export class SolanaWallet {
       // Token account doesn't exist — balance is 0
     }
 
+    // A 0-decimal token has no fractional part, so `toFixed(0)` produces a plain
+    // integer with no decimal point and the trailing-zero trim would strip
+    // significant zeros (100 -> "1"). Format it as the exact integer, matching
+    // `toHuman(amount, 0)` in ./decimals.ts.
     const humanBalance =
-      (Number(rawBalance) / 10 ** decimals)
-        .toFixed(decimals)
-        .replace(/\.?0+$/, "") || "0";
+      decimals === 0
+        ? rawBalance.toString()
+        : (Number(rawBalance) / 10 ** decimals)
+            .toFixed(decimals)
+            .replace(/\.?0+$/, "") || "0";
 
     return { mint: mintAddress, rawBalance, humanBalance, decimals };
   }

--- a/plugins/plugin-wallet/src/sdk/tokens/solana.ts
+++ b/plugins/plugin-wallet/src/sdk/tokens/solana.ts
@@ -13,6 +13,7 @@
 
 import type { TransactionInstruction } from "@solana/web3.js";
 import bs58 from "bs58";
+import { toHuman } from "./decimals.js";
 
 type SolanaWeb3Module = typeof import("@solana/web3.js");
 type SplTokenModule = typeof import("@solana/spl-token");
@@ -147,20 +148,16 @@ export interface SolanaTxResult {
 /**
  * Format a raw on-chain SPL token amount into a human-readable string.
  *
- * A 0-decimal token has no fractional part, so `toFixed(0)` produces a plain
- * integer with no decimal point and the trailing-zero trim would strip
- * significant zeros (100 -> "1", 1200 -> "12"). Return the exact integer for
- * 0-decimal tokens (matching `toHuman(amount, 0)` in ./decimals.ts); `rawBalance`
- * is a bigint so this stays exact even above Number.MAX_SAFE_INTEGER. Tokens with
- * decimals keep the existing formatting unchanged.
+ * Delegates to the bigint-safe `toHuman` in ./decimals.js so every balance is
+ * exact: 0-decimal tokens no longer lose significant trailing zeros
+ * (100 became "1"), and positive-decimal `u64` values above
+ * Number.MAX_SAFE_INTEGER are no longer silently rounded by a Number()
+ * conversion. `toHuman` keeps a single trailing ".0" for whole positive-decimal
+ * amounts; the existing wallet spelling drops it ("1.0" -> "1", "0.0" -> "0").
  */
 export function formatSplBalance(rawBalance: bigint, decimals: number): string {
-  if (decimals === 0) return rawBalance.toString();
-  return (
-    (Number(rawBalance) / 10 ** decimals)
-      .toFixed(decimals)
-      .replace(/\.?0+$/, "") || "0"
-  );
+  const formatted = toHuman(rawBalance, decimals);
+  return formatted.endsWith(".0") ? formatted.slice(0, -2) : formatted;
 }
 
 /**


### PR DESCRIPTION
# Relates to

Fixes #19029

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install`, focused checks, package gates, and full `bun run verify` pass on the exact rebased head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used, direct repository fix`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes on the exact rebased head.

# Risks

Low. The change is confined to `getSplTokenBalance` balance formatting in `plugins/plugin-wallet`, which now delegates to the bigint-safe `toHuman`. Observable output is unchanged for existing balances (pinned in the tests); the only behavioral difference is that 0-decimal tokens and very large positive-decimal balances are now reported exactly instead of being corrupted or rounded. No new inputs, network calls, or privileges.

# Background

## What does this PR do?

Fixes `getSplTokenBalance` reporting the wrong `humanBalance`. For 0-decimal SPL tokens the trailing-zero trim stripped significant zeros (`100` became `"1"`, `1200` became `"12"`). The formatting is now a pure exported `formatSplBalance(rawBalance, decimals)` that delegates to the bigint-safe `toHuman` in `./decimals.js`, so every balance is exact: 0-decimal tokens keep their zeros, and positive-decimal `u64` values above `Number.MAX_SAFE_INTEGER` are no longer silently rounded by a `Number()` conversion. The existing wallet spelling is preserved by dropping `toHuman`'s trailing `.0` for whole amounts (`"1.0"` becomes `"1"`, `"0.0"` becomes `"0"`).

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-wallet/src/sdk/tokens/solana.test.ts` covers the changed production path (`formatSplBalance`). From `plugins/plugin-wallet`, run `bun x vitest run src/sdk/tokens/solana.test.ts`.

## Detailed testing steps

- 0-decimal multiples of ten keep their zeros: `100n` gives `"100"`, `1200n` gives `"1200"`, `1000000n` gives `"1000000"`.
- Boundaries hold: `0n` gives `"0"`, `1n` gives `"1"`.
- 0-decimal exactness above `Number.MAX_SAFE_INTEGER`: `9007199254740993n` gives `"9007199254740993"`.
- Positive-decimal exactness above `Number.MAX_SAFE_INTEGER`: `9007199254740993n` at 6 decimals gives `"9007199254.740993"` (a `Number()` conversion would round to `"9007199254.740992"`).
- Existing spelling preserved: `1500000n` at 6 decimals stays `"1.5"`, `1000000n` gives `"1"`, `0n` gives `"0"`, and negatives format (`-2500000n` gives `"-2.5"`).
- `vitest run` passes (6/6).

Observed on exact head `5e598a1c7c1cbc646bfc9092da18d424be336290` rebased on `origin/develop@0c1593ad5f`:

- Focused Solana tests: **6 / 6 pass**
- Wallet Node and UI typechecks: **pass**
- Wallet lint: **281 files clean**
- Full `bun run verify`: **350 / 350 tasks**; anti-larp **7,966 / 7,966 clean**
- `git range-diff` confirms all three contributor commits are patch-identical after the rebase.

# Evidence Gate

<!-- evidence-head:5e598a1c7c1cbc646bfc9092da18d424be336290 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - SDK balance helper, no UI surface in this diff`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - SDK balance helper, no UI surface in this diff`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - SDK balance helper, no user-facing flow to record`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - pure formatting helper with no runtime service log path, covered by solana.test.ts`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - no frontend change in this diff`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - no agent, action, provider, prompt, or model path is touched`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - no schema, database, or on-chain artifact produced, output asserted in solana.test.ts`.
<!-- evidence-row:ocr-review -->
- [x] OCR review `N/A - backend-only change has no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model path is touched by this change.

## Backend + frontend logs

N/A - pure formatting helper; the changed production path is asserted directly by `solana.test.ts` (6/6 passing under `vitest run`).

## Screenshots (before / after) + video walkthrough

N/A - SDK balance helper with no rendered UI surface.

## Known gaps / failures

No known gap remains in the delivered scope. Every visual/LLM evidence row is `N/A` because this is a backend SDK formatting fix with no rendered or model surface. The changed production path, Node/UI typechecks, package lint, install, exact rebase identity, and full root verification all pass on the exact evidence head.

---

AI provider/model: anthropic/claude-opus-4-8
Client / agent tooling: Claude Code
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported

