### PR TITLE
fix(homepage): restore landing demo typecheck

### DIFF
--- a/packages/homepage/src/pages/landing.tsx
+++ b/packages/homepage/src/pages/landing.tsx
@@ -51,6 +51,10 @@ type DemoItem =
   | { id: number; from: "eliza" | "user"; kind: "text"; text: string }
   | { id: number; from: "eliza"; kind: "card"; card: DemoCard };
 
+type DemoItemInput =
+  | { from: "eliza" | "user"; kind: "text"; text: string }
+  | { from: "eliza"; kind: "card"; card: DemoCard };
+
 const DEMO_INTRO: DemoStep[] = [
   { kind: "eliza", text: "Hey, it's Eliza — your new assistant." },
   { kind: "user", text: "what can you do?" },
@@ -231,12 +235,12 @@ function PhoneMockup() {
     let cancelled = false;
     const sleep = (ms: number) =>
       new Promise<void>((resolve) => setTimeout(resolve, ms));
-    const append = (item: Omit<DemoItem, "id">) => {
+    const append = (item: DemoItemInput) => {
       const id = nextIdRef.current;
       nextIdRef.current += 1;
       setItems((prev) => [
         ...prev.slice(-(MAX_RENDERED_ITEMS - 1)),
-        { ...item, id } as DemoItem,
+        { ...item, id },
       ]);
     };
 
@@ -458,7 +462,8 @@ const KEYBOARD_ROWS = ["qwertyuiop", "asdfghjkl", "zxcvbnm"] as const;
 function DemoKeyboard({ composerText }: { composerText: string }) {
   const open = composerText !== "";
   const lastChar = composerText.slice(-1).toLowerCase();
-  const lastWord = composerText.split(/\s+/).at(-1) ?? "";
+  const words = composerText.split(/\s+/);
+  const lastWord = words[words.length - 1] ?? "";
   return (
     <div className="landing-keyboard" data-open={open}>
       <div className="landing-keyboard-inner">


### PR DESCRIPTION
# Relates to

Closes #19008.

#19009 was opened while this implementation was already in progress and is a duplicate of #19008; it will be closed in favor of this canonical issue.

- [x] Targets `develop` from exact base `70376f7c419baab3c736a37d8ee450ff0de73737` with zero conflicts.
- [x] `bun run verify` passed after sync.
- [x] Evidence below lets a reviewer confirm the fix without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on latest `origin/develop` at implementation time; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 Turbo tasks and all repository audits.

# Risks

Low. This changes only TypeScript modeling and replaces `Array.prototype.at` with target-compatible indexing. Runtime markup, CSS, data, timing, and behavior are unchanged.

# Background

## What does this PR do?

- Restores discriminated-union checking for landing demo items with an explicit input union instead of `Omit` over the union.
- Removes the now-unnecessary assertion when appending an item ID.
- Uses index-based last-word lookup compatible with the homepage TypeScript target.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is needed; no public API or operator workflow changes.

# Testing

## Where should a reviewer start?

Run `bun run --cwd packages/homepage typecheck`; the four errors from #19009 are gone. Then compare the attached before/after captures, which demonstrate unchanged rendering.

## Detailed testing steps

- `bun run --cwd packages/homepage typecheck` — PASS
- `bun run --cwd packages/homepage lint:check` — PASS, 97 files checked
- Focused landing/screenshot/snapshot tests — 22/24 on the exact base; both failures are the new base's missing landing/leaderboard snapshot files, unrelated to this one-file type fix (details below)
- `bun run --cwd packages/homepage build` — PASS, 2,470 modules transformed
- `bun run verify` — PASS, 350/350 tasks plus all audits
- Full command transcript: [verification log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/issue-19009-verification.txt)

# Evidence Gate

<!-- evidence-head:39679113ed495862a3628799e4b8a5e46e96e891 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots attached for landing desktop and mobile.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots attached for landing desktop and mobile.
<!-- evidence-row:walkthrough-video -->
- [x] MP4 walkthrough attached.
<!-- evidence-row:backend-logs -->
- [x] N/A — static homepage type fix has no backend path.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no request, response, or client state transition changed; production build and browser captures exercise the rendered path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Production build output and root verification transcript attached above.
<!-- evidence-row:ocr-review -->
- [x] OCR output attached for desktop and mobile captures.

# Evidence Details

## Screenshots (before / after) + video walkthrough

### Before

Desktop:

![Before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/issue-19009-before-desktop.png)

Mobile:

![Before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/issue-19009-before-mobile.png)

### After

Desktop:

![After desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/issue-19009-landing-desktop.png)

Mobile:

![After mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/issue-19009-landing-mobile.png)

### Walkthrough video

[MP4 landing walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/issue-19009-walkthrough.mp4)

### OCR

- [Desktop OCR](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/issue-19009-ocr-desktop.txt)
- [Mobile OCR](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/issue-19009-ocr-mobile.txt)

## Known gaps / failures

- `bun run --cwd packages/homepage test:audit`: 12/16 route audits pass. Landing and its `/leaderboard` alias fail the pre-existing blanket corner-radius policy introduced with the base redesign; the rule flags the phone shell, screen, chat bubble, composer, and keyboard keys. The same failure reproduces before and after this patch, and the attached captures show pixel-equivalent output.
- On the original redesign base, the focused landing, screenshot-stability, and snapshot-inventory contracts passed 24/24. Latest `develop@70376f7c419` added landing and leaderboard back to the visual matrix without committing their four Linux baselines; the exact-base rerun is therefore 22/24, with only those four missing-file assertions failing. This patch does not change the visual matrix or snapshots.
- The aggregate homepage test command was stopped after its existing provisioning-hook lane hung; multiple independent worktrees have identical long-running Bun processes. All completed cases were green.

— [codex-homepage-typecheck]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no repository contribution skill used","attribution_status":"self-reported"} -->
