### PR TITLE
fix(cloud): resolve dedicated runtime agent id

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../src/server-router";
 
 const AGENT_ID = "4602b3be-2c01-4e7e-9cdc-849604e1bef7";
+const RUNTIME_AGENT_ID = "b850bc30-45f8-0041-a00a-83df46d8555d";
 const originalFetch = globalThis.fetch;
 
 afterEach(() => {
@@ -47,6 +48,52 @@ describe("canonical agent forwarding fallback", () => {
     expect(requests).toEqual([
       `http://stale-sandbox.example/api/agents/${AGENT_ID}/message`,
       `https://${AGENT_ID}.elizacloud.ai/api/agents/${AGENT_ID}/message`,
+    ]);
+  });
+
+  test("discovers the sole running dedicated runtime when its id differs", async () => {
+    const requests: string[] = [];
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = input instanceof Request ? input.url : String(input);
+      requests.push(url);
+      if (url.startsWith("http://stale-sandbox.example")) {
+        throw new TypeError("connection timed out");
+      }
+      if (url.endsWith(`/agents/${AGENT_ID}/message`)) {
+        return new Response(JSON.stringify({ error: "Agent not found" }), {
+          status: 404,
+        });
+      }
+      if (url.endsWith("/api/agents")) {
+        return new Response(
+          JSON.stringify({
+            agents: [
+              { id: RUNTIME_AGENT_ID, name: "Eliza", status: "running" },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ response: "runtime is live" }), {
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    await expect(
+      forwardToServer(
+        "http://stale-sandbox.example/api",
+        "sandbox-stale",
+        AGENT_ID,
+        "user-1",
+        "hello",
+      ),
+    ).resolves.toBe("runtime is live");
+
+    expect(requests).toEqual([
+      `http://stale-sandbox.example/api/agents/${AGENT_ID}/message`,
+      `https://${AGENT_ID}.elizacloud.ai/api/agents/${AGENT_ID}/message`,
+      `https://${AGENT_ID}.elizacloud.ai/api/agents`,
+      `https://${AGENT_ID}.elizacloud.ai/api/agents/${RUNTIME_AGENT_ID}/message`,
     ]);
   });
 });

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -416,7 +416,77 @@ export async function forwardEventToServer(
 
 type TargetResult =
   | { ok: true; response: string }
-  | { ok: false; error: Error; isConnectionError: boolean };
+  | {
+      ok: false;
+      error: Error;
+      isConnectionError: boolean;
+      status?: number;
+    };
+
+const RUNTIME_AGENT_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Dedicated app hosts can expose a runtime agent id that differs from the
+ * cloud sandbox id used for routing. Resolve that id only from the authenticated
+ * canonical host, and only when exactly one running runtime is present.
+ */
+async function discoverCanonicalRuntimeAgentId(
+  canonicalBaseUrl: string,
+): Promise<string | null> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FORWARD_TIMEOUT_MS);
+  const headers: Record<string, string> = {};
+  const sharedSecret = process.env.AGENT_SERVER_SHARED_SECRET;
+  if (sharedSecret) headers["X-Server-Token"] = sharedSecret;
+
+  try {
+    const res = await fetch(`${canonicalBaseUrl.replace(/\/$/, "")}/agents`, {
+      headers,
+      signal: controller.signal,
+    });
+    if (!res.ok) return null;
+
+    const data = (await res.json()) as {
+      agents?: Array<{ id?: unknown; status?: unknown }>;
+    };
+    const running = (data.agents ?? []).filter(
+      (agent): agent is { id: string; status?: unknown } =>
+        typeof agent.id === "string" &&
+        RUNTIME_AGENT_ID_PATTERN.test(agent.id) &&
+        agent.status === "running",
+    );
+    return running.length === 1 ? running[0].id : null;
+  } catch {
+    // error-policy:J4 Discovery is an optional compatibility path; the caller
+    // retains and reports the original canonical forwarding failure.
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function tryCanonicalTarget(
+  canonicalBaseUrl: string,
+  endpointPath: string,
+  body: string,
+): Promise<TargetResult> {
+  const direct = await tryTarget(canonicalBaseUrl, endpointPath, body);
+  if (direct.ok || direct.status !== 404) return direct;
+
+  const match = endpointPath.match(/^\/agents\/[^/]+\/(message|event)$/);
+  if (!match) return direct;
+
+  const runtimeAgentId =
+    await discoverCanonicalRuntimeAgentId(canonicalBaseUrl);
+  if (!runtimeAgentId) return direct;
+
+  return tryTarget(
+    canonicalBaseUrl,
+    `/agents/${encodeURIComponent(runtimeAgentId)}/${match[1]}`,
+    body,
+  );
+}
 
 /**
  * Generic retry loop with hash-ring routing and KEDA wake-on-zero.
@@ -468,7 +538,7 @@ async function forwardWithRetry(
       targets[0].replace(/\/$/, "") !==
         connectionFallbackBaseUrl.replace(/\/$/, "")
     ) {
-      const canonical = await tryTarget(
+      const canonical = await tryCanonicalTarget(
         connectionFallbackBaseUrl,
         endpointPath,
         body,
@@ -537,6 +607,7 @@ async function tryTarget(
       ok: false,
       error: new Error(`Server returned ${res.status}: ${await res.text()}`),
       isConnectionError: false,
+      status: res.status,
     };
   } catch (err) {
     return {


### PR DESCRIPTION
Closes #19007

## Production finding

The stale raw sandbox route now reaches the healthy canonical host, but dedicated app sandboxes expose a runtime agent ID that can differ from the cloud sandbox ID. In the live iMessage account:

- cloud sandbox: `4602b3be-2c01-4e7e-9cdc-849604e1bef7`
- sole running runtime: `b850bc30-45f8-0041-a00a-83df46d8555d`
- canonical cloud-ID message route: HTTP 404 `Agent not found`
- authenticated discovered runtime route: HTTP 200 with a valid agent response

## Fix

When and only when the primary route has a transport failure and the canonical host returns 404, the gateway:

1. queries that same authenticated canonical host's `/api/agents` endpoint;
2. accepts exactly one `running` runtime with a validated UUID-shaped ID;
3. retries the original message/event operation using that runtime ID.

Ambiguous, invalid, unauthenticated, or non-404 cases retain the existing failure. The hostname remains the fixed canonical domain derived from a validated cloud UUID.

## Verification

- focused fallback tests: 3/3 pass
- full gateway suite: 101/101 pass
- gateway typecheck: pass
- gateway lint: pass
- direct production diagnostic against the discovered runtime route: HTTP 200

<details>
<summary>Provenance</summary>

Follow-up to #19010 / main `3197337fd8143abad2be42c7d4a6935304b8edcf` after live iMessage testing exposed the dedicated runtime ID mismatch.

</details>
