### PR TITLE
fix(cloud): reconcile autoscaled capacity on first bootstrap

### DIFF
--- a/packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts
+++ b/packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts
@@ -38,6 +38,10 @@ const EXISTING: StoredNode = {
 
 let stored: StoredNode | null = EXISTING;
 let lastUpdateArg: Partial<StoredNode> | null = null;
+let lastReconcileArg: {
+  data: Partial<StoredNode>;
+  metadataPatch: Record<string, unknown>;
+} | null = null;
 
 const mockFindByNodeId = mock(async (_nodeId: string) => stored);
 const mockUpdate = mock(async (_id: string, data: Partial<StoredNode>) => {
@@ -50,6 +54,20 @@ const mockCreate = mock(async (data: StoredNode) => {
   stored = { ...data, id: "node-row-new" };
   return stored;
 });
+const mockReconcileProvisionalCapacity = mock(
+  async (
+    _id: string,
+    data: Partial<StoredNode>,
+    metadataPatch: Record<string, unknown>,
+  ) => {
+    lastReconcileArg = { data, metadataPatch };
+    if (stored?.metadata.capacityProvisional !== true) return null;
+    const metadata = { ...stored.metadata, ...metadataPatch };
+    delete metadata.capacityProvisional;
+    stored = { ...stored, ...data, metadata };
+    return stored;
+  },
+);
 
 mock.module("@/db/repositories/docker-nodes", () => ({
   ...dockerNodesActual,
@@ -58,6 +76,7 @@ mock.module("@/db/repositories/docker-nodes", () => ({
     findByNodeId: mockFindByNodeId,
     update: mockUpdate,
     create: mockCreate,
+    reconcileProvisionalCapacity: mockReconcileProvisionalCapacity,
   },
 }));
 
@@ -92,13 +111,30 @@ async function post(body: Record<string, unknown>): Promise<Response> {
   );
 }
 
+function useProvisionalAutoscaledNode(requestedCapacity: number | null): void {
+  stored = {
+    ...EXISTING,
+    capacity: 0,
+    host_key_fingerprint: null,
+    metadata: {
+      provider: "hetzner-cloud",
+      autoscaled: true,
+      capacityProvisional: true,
+      capacityRequested: requestedCapacity,
+      capacityPolicyFallback: 8,
+    },
+  };
+}
+
 describe("bootstrap-callback node-identity guard (#12876)", () => {
   beforeEach(() => {
     stored = { ...EXISTING, metadata: { ...EXISTING.metadata } };
     lastUpdateArg = null;
+    lastReconcileArg = null;
     mockUpdate.mockClear();
     mockCreate.mockClear();
     mockFindByNodeId.mockClear();
+    mockReconcileProvisionalCapacity.mockClear();
   });
 
   test("rejects hostname mutation on existing node without the required fingerprint", async () => {
@@ -241,6 +277,133 @@ describe("bootstrap-callback node-identity guard (#12876)", () => {
     expect(mockUpdate).toHaveBeenCalledTimes(1);
     expect(lastUpdateArg).not.toHaveProperty("capacity");
     expect(stored?.capacity).toBe(24);
+  });
+
+  test("reconciles the small autoscaled default row to hardware capacity exactly once", async () => {
+    useProvisionalAutoscaledNode(null);
+
+    const first = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      memTotalMb: 7745,
+      vCpuCount: 4,
+      hostKeyFingerprint: "SHA256:first-real-pin",
+    });
+
+    expect(first.status).toBe(200);
+    expect(mockReconcileProvisionalCapacity).toHaveBeenCalledTimes(1);
+    expect(lastReconcileArg?.data.capacity).toBe(2);
+    expect(lastReconcileArg?.metadataPatch).toMatchObject({
+      memTotalMb: 7745,
+      vCpuCount: 4,
+      capacityBoundBy: "memory",
+      capacityDerivedFromMemory: true,
+    });
+    expect(stored?.capacity).toBe(2);
+    expect(stored?.metadata.capacityProvisional).toBeUndefined();
+
+    stored = { ...stored!, capacity: 5 };
+    const repeat = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      memTotalMb: 257626,
+      vCpuCount: 12,
+      hostKeyFingerprint: "SHA256:first-real-pin",
+    });
+
+    expect(repeat.status).toBe(200);
+    expect(mockReconcileProvisionalCapacity).toHaveBeenCalledTimes(1);
+    expect(stored?.capacity).toBe(5);
+  });
+
+  test("derives 11 slots for a large autoscaled node with no override", async () => {
+    useProvisionalAutoscaledNode(null);
+
+    const res = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      memTotalMb: 257626,
+      vCpuCount: 12,
+      hostKeyFingerprint: "SHA256:first-real-pin",
+    });
+
+    expect(res.status).toBe(200);
+    expect(stored?.capacity).toBe(11);
+  });
+
+  test("preserves an explicit capacity when attested hardware supports it", async () => {
+    useProvisionalAutoscaledNode(8);
+
+    const res = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      capacity: 8,
+      memTotalMb: 257626,
+      vCpuCount: 12,
+      hostKeyFingerprint: "SHA256:first-real-pin",
+    });
+
+    expect(res.status).toBe(200);
+    expect(stored?.capacity).toBe(8);
+    expect(lastReconcileArg?.metadataPatch.capacityDerivedFromMemory).toBe(
+      false,
+    );
+  });
+
+  test("represents insufficient attested hardware with zero usable slots", async () => {
+    useProvisionalAutoscaledNode(null);
+
+    const res = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      memTotalMb: 2048,
+      vCpuCount: 2,
+      hostKeyFingerprint: "SHA256:first-real-pin",
+    });
+
+    expect(res.status).toBe(200);
+    expect(stored?.capacity).toBe(0);
+    expect(stored?.metadata.capacityProvisional).toBeUndefined();
+  });
+
+  test("fails closed when hardware would derive beyond the callback capacity contract", async () => {
+    useProvisionalAutoscaledNode(null);
+
+    const res = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      memTotalMb: 1_000_000,
+      vCpuCount: 512,
+      hostKeyFingerprint: "SHA256:first-real-pin",
+    });
+
+    expect(res.status).toBe(422);
+    expect(mockReconcileProvisionalCapacity).not.toHaveBeenCalled();
+    expect(stored?.capacity).toBe(0);
+    expect(stored?.metadata.capacityProvisional).toBe(true);
+  });
+
+  test("rejects missing or overflowing hardware without consuming the provisional marker", async () => {
+    useProvisionalAutoscaledNode(null);
+
+    const missing = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      memTotalMb: 7745,
+      hostKeyFingerprint: "SHA256:first-real-pin",
+    });
+    expect(missing.status).toBe(422);
+
+    const overflow = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      memTotalMb: 16_777_217,
+      vCpuCount: 4,
+      hostKeyFingerprint: "SHA256:first-real-pin",
+    });
+    expect(overflow.status).toBe(400);
+    expect(mockReconcileProvisionalCapacity).not.toHaveBeenCalled();
+    expect(stored?.metadata.capacityProvisional).toBe(true);
   });
 
   test("brand-new node still gets its capacity stamped from the request", async () => {

--- a/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
+++ b/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
@@ -42,15 +42,18 @@ import { logger } from "@/lib/utils/logger";
  * historical default rather than guessing, and the create path logs the skip.
  */
 const DEFAULT_CALLBACK_CAPACITY = 8;
+const MAX_CALLBACK_CAPACITY = 64;
+/** 16 TiB in MiB: generous hardware headroom while remaining a bounded contract. */
+const MAX_CALLBACK_MEM_TOTAL_MB = 16 * 1024 * 1024;
 
 const callbackSchema = z.object({
   nodeId: z.string().min(1).max(64),
   hostname: z.string().min(1).max(255),
   // No default: an absent capacity means "derive it from the machine", which
   // is not the same request as an explicit 8.
-  capacity: z.number().int().min(1).max(64).optional(),
+  capacity: z.number().int().min(1).max(MAX_CALLBACK_CAPACITY).optional(),
   /** MemTotal reported by the node itself, in MiB. */
-  memTotalMb: z.number().int().min(1).optional(),
+  memTotalMb: z.number().int().min(1).max(MAX_CALLBACK_MEM_TOTAL_MB).optional(),
   /** vCPU the node reports, from nproc. */
   vCpuCount: z.number().int().min(1).max(512).optional(),
   sshPort: z.number().int().min(1).max(65535).optional().default(22),
@@ -168,14 +171,129 @@ async function __hono_POST(request: Request) {
         );
       }
 
+      const existingMetadata = existing.metadata as Record<string, unknown>;
+      if (existingMetadata.capacityProvisional === true) {
+        const persistedRequest = existingMetadata.capacityRequested;
+        if (
+          persistedRequest !== null &&
+          (typeof persistedRequest !== "number" ||
+            !Number.isSafeInteger(persistedRequest) ||
+            persistedRequest < 1 ||
+            persistedRequest > MAX_CALLBACK_CAPACITY)
+        ) {
+          logger.error(
+            "[admin/docker-nodes/bootstrap-callback] provisional capacity metadata is invalid",
+            { nodeId },
+          );
+          return Response.json(
+            {
+              success: false,
+              error: "Provisional capacity metadata is invalid.",
+            },
+            { status: 409 },
+          );
+        }
+        const requestedCapacity =
+          persistedRequest === null ? undefined : persistedRequest;
+        if (capacity !== requestedCapacity) {
+          return Response.json(
+            {
+              success: false,
+              error:
+                "Bootstrap capacity does not match the autoscaler request recorded for this node.",
+            },
+            { status: 409 },
+          );
+        }
+        if (memTotalMb === undefined || vCpuCount === undefined) {
+          return Response.json(
+            {
+              success: false,
+              error:
+                "A provisional autoscaled node must report both memTotalMb and vCpuCount before it can advertise capacity.",
+            },
+            { status: 422 },
+          );
+        }
+
+        const resolved = resolveNodeCapacity({
+          requestedCapacity,
+          memTotalMb,
+          vCpuCount,
+          agentMemoryLimitMb: containersEnv.agentContainerMemoryLimitMb(),
+          fallbackCapacity: DEFAULT_CALLBACK_CAPACITY,
+        });
+        if (resolved.capacity > MAX_CALLBACK_CAPACITY) {
+          logger.error(
+            "[admin/docker-nodes/bootstrap-callback] derived capacity exceeds callback contract",
+            { nodeId, capacity: resolved.capacity, memTotalMb, vCpuCount },
+          );
+          return Response.json(
+            {
+              success: false,
+              error: `Derived capacity exceeds the maximum of ${MAX_CALLBACK_CAPACITY}.`,
+            },
+            { status: 422 },
+          );
+        }
+
+        const attestedAt = new Date().toISOString();
+        const reconciled =
+          await dockerNodesRepository.reconcileProvisionalCapacity(
+            existing.id,
+            {
+              capacity: resolved.capacity,
+              hostname: identityChanged ? hostname : existing.hostname,
+              ssh_port: identityChanged ? sshPort : existing.ssh_port,
+              ssh_user: identityChanged ? sshUser : existing.ssh_user,
+              host_key_fingerprint: hasPinnedFingerprint
+                ? existing.host_key_fingerprint!
+                : hostKeyFingerprint,
+              status: "unknown",
+            },
+            stampDockerNodeEnvironmentMetadata({
+              memTotalMb,
+              vCpuCount,
+              capacityBoundBy: resolved.boundBy,
+              capacityDerivedFromMemory: resolved.derived,
+              capacityAttestedAt: attestedAt,
+              lastBootstrapAt: attestedAt,
+            }),
+          );
+
+        // A concurrent first callback may have consumed the marker after our
+        // read. The repository predicate is the authority; re-read its result
+        // instead of performing a second capacity write.
+        const updated =
+          reconciled ?? (await dockerNodesRepository.findByNodeId(nodeId));
+        logger.info(
+          "[admin/docker-nodes/bootstrap-callback] hardware-attested autoscaled node capacity",
+          {
+            nodeId,
+            capacity: updated?.capacity ?? existing.capacity,
+            reconciled: reconciled !== null,
+          },
+        );
+        return Response.json({
+          success: true,
+          data: {
+            nodeId,
+            hostname: updated?.hostname ?? existing.hostname,
+            action: "updated",
+            node: updated,
+          },
+        });
+      }
+
       // Identity fields are only ever taken from the request on a
       // fingerprint-proven re-bootstrap (identityChanged && verified above);
       // otherwise the server-stored values are preserved verbatim so an
       // unauthenticated re-bootstrap caller cannot silently rewrite them.
       //
-      // `capacity` is deliberately NOT written here: once a node exists, its
-      // slot count is operator-owned (set via the admin PATCH route or a direct
-      // DB tune). The callback default is sized for the small cpx32-class box
+      // `capacity` is deliberately NOT written here once the provisional
+      // marker has been consumed: the slot count is then operator-owned (set
+      // via the admin PATCH route or a direct DB tune). The callback default
+      // is sized for the small cpx32-class box
       // it was born on, so re-writing it on every liveness re-bootstrap would
       // silently reset a hand-tuned value (e.g. a 252 GB robot at capacity=24
       // back to 8). Capacity is stamped only on the create path below.
@@ -217,6 +335,15 @@ async function __hono_POST(request: Request) {
       agentMemoryLimitMb: containersEnv.agentContainerMemoryLimitMb(),
       fallbackCapacity: DEFAULT_CALLBACK_CAPACITY,
     });
+    if (resolved.capacity > MAX_CALLBACK_CAPACITY) {
+      return Response.json(
+        {
+          success: false,
+          error: `Derived capacity exceeds the maximum of ${MAX_CALLBACK_CAPACITY}.`,
+        },
+        { status: 422 },
+      );
+    }
     if (memTotalMb === undefined) {
       logger.warn(
         "[admin/docker-nodes/bootstrap-callback] node did not report its RAM; capacity not derived",

--- a/packages/cloud/shared/src/db/repositories/docker-nodes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/docker-nodes.test.ts
@@ -7,6 +7,7 @@ import { PgDialect } from "drizzle-orm/pg-core";
 import * as realHelpers from "../helpers";
 
 let capturedWhere: SQL | undefined;
+let capturedUpdateWhere: SQL | undefined;
 let capturedSet: Record<string, unknown> | undefined;
 
 const limit = mock(() => []);
@@ -18,7 +19,11 @@ const where = mock((clause: SQL) => {
 const from = mock(() => ({ where }));
 const select = mock(() => ({ from }));
 
-const updateWhere = mock(() => Promise.resolve([]));
+const returning = mock(() => []);
+const updateWhere = mock((clause: SQL) => {
+  capturedUpdateWhere = clause;
+  return { returning };
+});
 const set = mock((values: Record<string, unknown>) => {
   capturedSet = values;
   return { where: updateWhere };
@@ -55,6 +60,7 @@ describe("DockerNodesRepository environment guard", () => {
   beforeEach(() => {
     useRepositoryMocks = true;
     capturedWhere = undefined;
+    capturedUpdateWhere = undefined;
     capturedSet = undefined;
     process.env.ENVIRONMENT = "staging";
   });
@@ -130,5 +136,37 @@ describe("DockerNodesRepository environment guard", () => {
     expect(sql).toContain("capacity");
     expect(sql).toContain("metadata");
     expect(sql).toContain("->>'environment'");
+    expect(sql).toContain("capacityprovisional");
+  });
+
+  test("reconcileProvisionalCapacity consumes the provisional marker atomically", async () => {
+    const { DockerNodesRepository } = await import("./docker-nodes");
+
+    await new DockerNodesRepository().reconcileProvisionalCapacity(
+      "row-1",
+      {
+        capacity: 2,
+        hostname: "203.0.113.10",
+        ssh_port: 22,
+        ssh_user: "root",
+        host_key_fingerprint: "SHA256:node",
+        status: "unknown",
+      },
+      {
+        memTotalMb: 7745,
+        vCpuCount: 4,
+        capacityBoundBy: "memory",
+      },
+    );
+
+    if (!capturedSet || !capturedUpdateWhere) {
+      throw new Error("reconcileProvisionalCapacity did not build an atomic update");
+    }
+    const metadataQuery = new PgDialect().sqlToQuery(capturedSet.metadata as SQL);
+    expect(metadataQuery.sql).toContain("capacityProvisional");
+    expect(metadataQuery.sql).toContain("::jsonb");
+    const whereQuery = new PgDialect().sqlToQuery(capturedUpdateWhere).sql;
+    expect(whereQuery).toContain("capacityProvisional");
+    expect(whereQuery).toContain("= 'true'");
   });
 });

--- a/packages/cloud/shared/src/db/repositories/docker-nodes.ts
+++ b/packages/cloud/shared/src/db/repositories/docker-nodes.ts
@@ -41,6 +41,11 @@ function currentEnvironmentPredicate() {
   )`;
 }
 
+/** Provisional autoscaler capacity must never count as schedulable authority. */
+function capacityAttestedPredicate() {
+  return sql`COALESCE(${dockerNodes.metadata}->>'capacityProvisional', 'false') <> 'true'`;
+}
+
 export class DockerNodesRepository {
   // ============================================================================
   // READ OPERATIONS
@@ -82,6 +87,7 @@ export class DockerNodesRepository {
         and(
           eq(dockerNodes.enabled, true),
           eq(dockerNodes.placement_state, PLACEABLE_NODE_STATE),
+          capacityAttestedPredicate(),
           currentEnvironmentPredicate(),
         ),
       )
@@ -115,6 +121,7 @@ export class DockerNodesRepository {
           eq(dockerNodes.enabled, true),
           eq(dockerNodes.placement_state, PLACEABLE_NODE_STATE),
           eq(dockerNodes.status, "healthy"),
+          capacityAttestedPredicate(),
           currentEnvironmentPredicate(),
           sql`${dockerNodes.allocated_count} < ${dockerNodes.capacity}`,
         ),
@@ -139,6 +146,38 @@ export class DockerNodesRepository {
       .update(dockerNodes)
       .set({ ...data, updated_at: new Date() })
       .where(eq(dockerNodes.id, id))
+      .returning();
+    return r ?? null;
+  }
+
+  /**
+   * Replace an autoscaler's provisional capacity with its first hardware
+   * attestation. The metadata predicate is the exactly-once fence: concurrent
+   * or later callbacks cannot consume the marker twice or overwrite a tune.
+   */
+  async reconcileProvisionalCapacity(
+    id: string,
+    data: {
+      capacity: number;
+      hostname: string;
+      ssh_port: number;
+      ssh_user: string;
+      host_key_fingerprint: string;
+      status: DockerNodeStatus;
+    },
+    metadataPatch: Record<string, unknown>,
+  ): Promise<DockerNode | null> {
+    const patch = JSON.stringify(metadataPatch);
+    const [r] = await dbWrite
+      .update(dockerNodes)
+      .set({
+        ...data,
+        metadata: sql`(${dockerNodes.metadata} - 'capacityProvisional') || ${patch}::jsonb`,
+        updated_at: new Date(),
+      })
+      .where(
+        and(eq(dockerNodes.id, id), sql`${dockerNodes.metadata}->>'capacityProvisional' = 'true'`),
+      )
       .returning();
     return r ?? null;
   }

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -677,14 +677,13 @@ export const containersEnv = {
   },
 
   /**
-   * Per-node agent capacity for newly autoscaled Hetzner Cloud nodes. The
-   * autoscaler stamps this onto a node's `capacity` at creation; the
-   * scheduler then refuses placement once `allocated_count >= capacity`.
+   * Legacy per-node policy fallback for newly autoscaled Hetzner Cloud nodes.
+   * It is retained in provisional metadata for operator visibility, while the
+   * row itself stays at capacity zero until hardware reports RAM and vCPU.
    *
-   * Env-overridable so ops can right-size for a smaller server type without
-   * a code change. Default: 8 — safe alongside the ccx33 default at
-   * ~32 GB / ~4 GB per agent. Lower it explicitly if you set a smaller
-   * server type (e.g. cpx41 16 GB → 4-5; cpx31 8 GB → 2-3) to avoid OOM.
+   * Env-overridable for compatibility with existing fleet configuration.
+   * Default: 8. Hardware-attested capacity is derived by the bootstrap
+   * callback and does not treat this fallback as an explicit request.
    *
    * Clamped to [1, 64].
    */

--- a/packages/cloud/shared/src/lib/services/containers/node-autoscaler.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-autoscaler.test.ts
@@ -201,13 +201,16 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
       expect.objectContaining({
         node_id: "node-test",
         hostname: "203.0.113.10",
-        capacity: 6,
+        capacity: 0,
         enabled: true,
         status: "unknown",
         ssh_user: "root",
         metadata: expect.objectContaining({
           provider: "hetzner-cloud",
           autoscaled: true,
+          capacityProvisional: true,
+          capacityRequested: 6,
+          capacityPolicyFallback: 8,
           hcloudServerId: 4242,
           serverType: "cax21",
           location: "fsn1",
@@ -222,6 +225,33 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
       hcloudServerId: 4242,
       rootPassword: "root-secret",
     });
+  });
+
+  test("persists a fail-closed provisional row while preserving an absent override", async () => {
+    const autoscaler = new NodeAutoscaler(policy);
+
+    await autoscaler.provisionNode(
+      { nodeId: "node-derived" },
+      {
+        controlPlanePublicKey: "ssh-ed25519 AAAAcontrol",
+        registrationUrl: "https://cloud.example.test/register",
+        registrationSecret: "secret",
+      },
+    );
+
+    expect(mocks.buildUserData).toHaveBeenCalledWith(
+      expect.not.objectContaining({ capacity: expect.anything() }),
+    );
+    expect(mocks.createNode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capacity: 0,
+        metadata: expect.objectContaining({
+          capacityProvisional: true,
+          capacityRequested: null,
+          capacityPolicyFallback: 8,
+        }),
+      }),
+    );
   });
 
   test("passes configured Hetzner private network ids to new nodes", async () => {
@@ -458,10 +488,13 @@ describe("NodeAutoscaler full provision\u2192healthy\u2192drain loop (#8920)", (
     expect(booting.healthyNodeCount).toBe(0);
     expect(booting.shouldScaleUp).toBe(true);
 
-    // 4. The server boots (tick advances the action clock) and the periodic
+    // 4. The server boots (tick advances the action clock), its bootstrap
+    //    callback consumes the provisional-capacity marker, and the periodic
     //    health check flips the docker_nodes row to `healthy`.
     fake.tick(1);
     expect((await fake.getServer(serverId))?.status).toBe("active");
+    delete store[0].metadata.capacityProvisional;
+    store[0].capacity = 8;
     store[0].status = "healthy";
 
     // 5. The node now serves its full capacity \u2192 no more scale-up.

--- a/packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts
@@ -55,7 +55,7 @@ export interface AutoscalePolicy {
   defaultLocation: string;
   /** Image used for the OS install (cloud-init compatible). */
   defaultImage: string;
-  /** Default per-node capacity (slot count) for newly provisioned nodes. */
+  /** Policy fallback retained in provisional metadata until hardware attests. */
   defaultCapacity: number;
 }
 
@@ -144,6 +144,7 @@ export class NodeAutoscaler {
     const healthyEnabled = enabled.filter(
       (n) =>
         n.status === "healthy" &&
+        n.metadata.capacityProvisional !== true &&
         isArchitectureCompatibleWithPlatform(
           inferNodeArchitectureFromMetadata(n.metadata),
           requiredPlatform,
@@ -239,7 +240,7 @@ export class NodeAutoscaler {
     const serverType = request.serverType ?? this.policy.defaultServerType;
     const location = request.location ?? this.policy.defaultLocation;
     const image = request.image ?? this.policy.defaultImage;
-    const capacity = request.capacity ?? this.policy.defaultCapacity;
+    const policyCapacity = this.policy.defaultCapacity;
     const prePullImages = request.prePullImages ?? [containersEnv.defaultAgentImage()];
     const networkIds = containersEnv.defaultHcloudNetworkIds();
 
@@ -250,7 +251,7 @@ export class NodeAutoscaler {
       registrationSecret: bootstrap.registrationSecret,
       prePullImages,
       prePullPlatform: containersEnv.defaultAgentImagePlatform(),
-      capacity,
+      ...(request.capacity === undefined ? {} : { capacity: request.capacity }),
     });
 
     const client = this.computeProvider();
@@ -290,7 +291,10 @@ export class NodeAutoscaler {
       node_id: nodeId,
       hostname: ip,
       ssh_port: 22,
-      capacity,
+      // Zero is the data-level fail-closed fence. Several legacy placement
+      // paths still query `allocated_count < capacity` directly, so a
+      // non-zero provisional value could bypass metadata-aware selectors.
+      capacity: 0,
       enabled: true,
       status: "unknown",
       allocated_count: 0,
@@ -304,6 +308,9 @@ export class NodeAutoscaler {
         image,
         architecture: inferArchitectureFromHetznerServerType(serverType),
         provisionedAt: new Date().toISOString(),
+        capacityProvisional: true,
+        capacityRequested: request.capacity ?? null,
+        capacityPolicyFallback: policyCapacity,
       },
     });
 
@@ -313,6 +320,7 @@ export class NodeAutoscaler {
       ip,
       serverType,
       location,
+      capacityProvisional: true,
     });
 
     return {

--- a/packages/cloud/shared/src/lib/services/containers/node-bootstrap.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-bootstrap.test.ts
@@ -126,4 +126,28 @@ describe("buildContainerNodeUserData — ghcr access", () => {
     expect(userData).toContain("host key fingerprint unavailable; refusing self-registration");
     expect(userData).toContain("exit 1");
   });
+
+  test("omits capacity from self-registration when the operator supplied no override", () => {
+    clearRegistryEnv();
+    const userData = buildContainerNodeUserData({
+      ...baseInput,
+      registrationUrl: "https://control.example.test/api/v1/admin/docker-nodes/bootstrap-callback",
+      registrationSecret: "bootstrap-secret",
+    });
+
+    expect(userData).not.toContain('CAPACITY_FIELD=\'"capacity":');
+    expect(userData).toContain("CAPACITY_FIELD=''");
+  });
+
+  test("includes an explicit operator capacity in self-registration", () => {
+    clearRegistryEnv();
+    const userData = buildContainerNodeUserData({
+      ...baseInput,
+      registrationUrl: "https://control.example.test/api/v1/admin/docker-nodes/bootstrap-callback",
+      registrationSecret: "bootstrap-secret",
+      capacity: 8,
+    });
+
+    expect(userData).toContain("CAPACITY_FIELD='\"capacity\":8,'");
+  });
 });

--- a/packages/cloud/shared/src/lib/services/containers/node-bootstrap.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-bootstrap.ts
@@ -48,7 +48,7 @@ export interface NodeBootstrapInput {
   prePullImages?: string[];
   /** Optional Docker image platform used for pre-pulls. */
   prePullPlatform?: string;
-  /** Default capacity advertised at registration. */
+  /** Explicit operator capacity advertised at registration. Omitted when absent. */
   capacity?: number;
 }
 
@@ -58,7 +58,13 @@ export interface NodeBootstrapInput {
  */
 export function buildContainerNodeUserData(input: NodeBootstrapInput): string {
   const network = containersEnv.dockerNetwork();
-  const capacity = input.capacity ?? 8;
+  if (
+    input.capacity !== undefined &&
+    (!Number.isSafeInteger(input.capacity) || input.capacity < 1 || input.capacity > 64)
+  ) {
+    throw new Error("[node-bootstrap] capacity must be a safe integer between 1 and 64");
+  }
+  const capacityField = input.capacity === undefined ? "" : `"capacity":${input.capacity},`;
   const prePull = input.prePullImages ?? [containersEnv.defaultAgentImage()];
   const prePullPlatform = input.prePullPlatform ?? containersEnv.defaultAgentImagePlatform();
   if (prePullPlatform) validateDockerPlatform(prePullPlatform);
@@ -129,13 +135,14 @@ export function buildContainerNodeUserData(input: NodeBootstrapInput): string {
     VCPU_COUNT=$(nproc 2>/dev/null)
     MEM_FIELD=""
     CPU_FIELD=""
+    CAPACITY_FIELD='${capacityField}'
     if [ -n "$VCPU_COUNT" ] && [ "$VCPU_COUNT" -gt 0 ] 2>/dev/null; then
       CPU_FIELD=$(printf '"vCpuCount":%d,' "$VCPU_COUNT")
     fi
     if [ -n "$MEM_TOTAL_MB" ] && [ "$MEM_TOTAL_MB" -gt 0 ] 2>/dev/null; then
       MEM_FIELD=$(printf '"memTotalMb":%d,' "$MEM_TOTAL_MB")
     fi
-    PAYLOAD=$(printf '{"nodeId":"%s","hostname":"%s","capacity":%d,%s%s"sshPort":22,"sshUser":"root","hostKeyFingerprint":"%s"}' '${nodeId}' "$PUBLIC_IP" ${capacity} "$MEM_FIELD" "$CPU_FIELD" "$HOST_KEY_FINGERPRINT")
+    PAYLOAD=$(printf '{"nodeId":"%s","hostname":"%s",%s%s%s"sshPort":22,"sshUser":"root","hostKeyFingerprint":"%s"}' '${nodeId}' "$PUBLIC_IP" "$CAPACITY_FIELD" "$MEM_FIELD" "$CPU_FIELD" "$HOST_KEY_FINGERPRINT")
     curl -fsS -X POST '${registerUrl}' \\
       -H 'Content-Type: application/json' \\
       ${registerSecret ? `-H 'X-Bootstrap-Secret: ${registerSecret}'` : ""} \\

--- a/packages/cloud/shared/src/lib/services/docker-node-capacity-derivation.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-capacity-derivation.test.ts
@@ -108,10 +108,13 @@ describe("deriveNodeCapacity", () => {
     expect(d.byCpu).toBeNull();
   });
 
-  test("never returns zero for a box that can hold something", () => {
+  test("reports zero when the configured agent cannot fit after the host reserve", () => {
     expect(
       deriveNodeCapacity({ memTotalMb: 2048, vCpuCount: 2, agentMemoryLimitMb: AGENT_MB }).capacity,
-    ).toBe(1);
+    ).toBe(0);
+    expect(
+      deriveNodeCapacity({ memTotalMb: 512, vCpuCount: 8, agentMemoryLimitMb: AGENT_MB }),
+    ).toMatchObject({ capacity: 0, byMemory: 0, boundBy: "memory" });
   });
 });
 
@@ -161,5 +164,16 @@ describe("resolveNodeCapacity", () => {
       vCpuCount: ROBOT_VCPU,
     });
     expect(r).toEqual({ capacity: 11, derived: true, boundBy: "cpu" });
+  });
+
+  test("clamps an explicit request to zero when known hardware cannot hold one agent", () => {
+    expect(
+      resolveNodeCapacity({
+        ...base,
+        requestedCapacity: 8,
+        memTotalMb: 2048,
+        vCpuCount: 2,
+      }),
+    ).toEqual({ capacity: 0, derived: false, clampedFrom: 8, boundBy: "memory" });
   });
 });

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -414,8 +414,8 @@ function deriveCapacityDimension(
   if (typeof total !== "number" || !Number.isFinite(total) || total <= 0) return null;
   if (!Number.isFinite(perAgent) || perAgent <= 0) return null;
   const budget = total - hostReserve;
-  if (budget <= 0) return null;
-  return Math.max(1, Math.floor(budget / perAgent));
+  if (budget <= 0) return 0;
+  return Math.floor(budget / perAgent);
 }
 
 export function resolveNodeCapacity(opts: {


### PR DESCRIPTION
# Relates to

Closes #18799.

- [x] This PR targets `develop` and is rebased onto the latest `upstream/develop`
      (`4e62753a7`) with zero conflicts.
- [x] `bun install` was run after sync. The exact-head `bun run verify` equivalent
      reached 345 successful tasks before the newly landed, unrelated homepage
      typecheck failure recorded below.
- [x] A reviewer can confirm the changed behavior from the focused boundary suite
      and exact assertions recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@3989c04066e5c364bfe33088cd12b238a5eed642:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `4e62753a7`; zero conflicts.
- [x] The exact post-sync verify result and unrelated upstream blocker are documented
      in **Known gaps / failures** below.

# Risks

Medium. This changes the autoscaled-node admission boundary: new rows deliberately
advertise zero slots until their first hardware-attested callback. A callback that
cannot prove both RAM and vCPU remains fail-closed. Existing non-provisional nodes
keep their current bootstrap behavior, and repeat callbacks cannot overwrite
operator-owned capacity.

# Background

## What does this PR do?

- Preserves absent versus explicit capacity from the autoscaler through cloud-init.
- Inserts autoscaled rows as provisional with `capacity = 0`, closing repository and
  legacy direct-SQL placement paths until attestation.
- Reconciles capacity, hardware metadata, identity, and liveness in one conditional
  update whose provisional-marker predicate is the exactly-once fence.
- Derives the first capacity from RAM and vCPU, clamps explicit requests to known
  hardware, represents insufficient hardware as zero slots, and rejects values above
  the callback contract.
- Leaves capacity operator-owned after the provisional marker is consumed.

## What kind of change is this?

Bug fix (non-breaking change).

# Documentation changes needed?

No external documentation change is needed. The affected configuration comments were
updated to describe the new provisional/attested contract.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts`
2. `packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts`
3. `packages/cloud/shared/src/db/repositories/docker-nodes.ts`
4. `packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts`

## Detailed testing steps

On exact head `0bbbea1bc0b617e75b637249f2e668bf83cd0062`:

```text
bun test \
  packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts \
  packages/cloud/shared/src/lib/services/containers/node-bootstrap.test.ts \
  packages/cloud/shared/src/lib/services/containers/node-autoscaler.test.ts \
  packages/cloud/shared/src/lib/services/docker-node-capacity-derivation.test.ts \
  packages/cloud/shared/src/db/repositories/docker-nodes.test.ts

58 pass, 0 fail
```

The boundary suite proves:

- 7,745 MiB / 4 vCPU absent override: provisional `0` -> attested `2`;
- 257,626 MiB / 12 vCPU absent override: provisional `0` -> attested `11`;
- explicit `8` remains `8` when hardware supports it;
- a repeat callback after an operator tune leaves capacity unchanged;
- insufficient hardware resolves to zero usable slots;
- missing hardware or a derived value above `64` leaves the provisional marker and
  zero-slot fence intact;
- the repository reconciliation predicate consumes the marker atomically.

Additional exact-head checks:

```text
bunx biome check <all 11 changed files>
Checked 11 files. No fixes applied.

git diff --check
PASS
```

# Evidence Gate

<!-- evidence-head:0bbbea1bc0b617e75b637249f2e668bf83cd0062 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend autoscaler, cloud-init, repository, and callback change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend autoscaler, cloud-init, repository, and callback change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing visual flow; behavior is exercised at the provisioning/callback boundary.
<!-- evidence-row:backend-logs -->
- [x] Exact-head backend boundary transcript (58 pass, 0 fail):

  <details><summary>Focused callback/repository proof</summary>

  ```text
  PASS first attested callback: 7,745 MiB / 4 vCPU, provisional capacity 0 -> capacity 2
  PASS absent override: 257,626 MiB / 12 vCPU, provisional capacity 0 -> capacity 11
  PASS explicit 8 remains 8; repeat callback after operator tune remains 5
  PASS insufficient hardware -> 0; missing/over-limit hardware retains provisional zero-slot fence
  PASS repository reconciliation consumes capacityProvisional with a conditional atomic update
  58 pass, 0 fail
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, console, network, or state surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no authorized staging fleet or mutable production database was available; deterministic callback/repository assertions cover the persisted state transition locally.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text or UI files changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changed.

## Backend + frontend logs

The exact-head focused suite result and its state-transition matrix are included above.
Frontend logs are N/A because the diff has no frontend surface.

## Screenshots (before / after) + video walkthrough

N/A - backend-only diff.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT surface changed.

## Known gaps / failures

- Exact-head staging mutation was not performed because no authorized staging fleet
  or database was available. A maintainer can exercise the same first/repeat callback
  sequence against a disposable staging node if live infrastructure proof is required.
- A full verify passed before the final upstream sync: 350/350 Turbo tasks, all audits,
  and 7,943 test files scanned with no focused or orphaned skips.
- After rebasing onto the then-current `develop` (`d505b7408`), that exact-head gentle
  verify reached 345 successful tasks and failed only in newly landed homepage code,
  outside this PR's file set:

```text
eliza-app:typecheck: src/pages/landing.tsx(256,48): TS2353 `text` is not in Omit<DemoItem, "id">
eliza-app:typecheck: src/pages/landing.tsx(264,49): TS2353 `text` is not in Omit<DemoItem, "id">
eliza-app:typecheck: src/pages/landing.tsx(268,49): TS2353 `card` is not in Omit<DemoItem, "id">
eliza-app:typecheck: src/pages/landing.tsx(461,46): TS2550 Array.prototype.at is not in the configured lib
Tasks: 345 successful, 348 total; Failed: eliza-app#typecheck
```

The base advanced again while that 16-minute gate was running, through `4e62753a7`.
Those additional commits do not touch any of this PR's 11 files; the final rebase was
conflict-free, its mandatory `bun install` was clean, and all 58 focused tests pass on
the final exact head above. No `packages/homepage` file differs between this branch
and its base.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@3989c04066e5c364bfe33088cd12b238a5eed642:skills/contribute-to-eliza
Compute receipt: 40232338 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [codex-node-capacity-bootstrap]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@3989c04066e5c364bfe33088cd12b238a5eed642:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZX3KBZ7HQ2RSDJYPMV5S05A","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T08:25:12.424Z","completed_at":"2026-08-13T09:10:17.406Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":1060424,"output_tokens":87882,"cache_creation_tokens":0,"cache_read_tokens":39084032,"total_tokens":40232338,"cost_micro_usd":"57067565","session_count":4},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAE2P5caag1qiG3Xmhiju6SjqOz3ZPjUdvS7ZK0lvAHQc","device_key_id":"efa2b84ffb535e59e9b9c9628f72a9091124e6f775d9267494cec0746048cf55","device_signature":"GspjzeWtLORhkf9wwhEkTZOIHg4D2YpHJ8CVnRZKvaGxSRNwhBuw5fmt6UPPDzkKZCDJy6Stb9l7VkgowgjwAg"}} -->