### PR TITLE
fix(homepage): restore landing typecheck after redesign

### DIFF
--- a/packages/homepage/src/pages/landing.tsx
+++ b/packages/homepage/src/pages/landing.tsx
@@ -51,6 +51,10 @@ type DemoItem =
   | { id: number; from: "eliza" | "user"; kind: "text"; text: string }
   | { id: number; from: "eliza"; kind: "card"; card: DemoCard };
 
+type DemoItemInput =
+  | { from: "eliza" | "user"; kind: "text"; text: string }
+  | { from: "eliza"; kind: "card"; card: DemoCard };
+
 const DEMO_INTRO: DemoStep[] = [
   { kind: "eliza", text: "Hey, it's Eliza — your new assistant." },
   { kind: "user", text: "what can you do?" },
@@ -231,12 +235,12 @@ function PhoneMockup() {
     let cancelled = false;
     const sleep = (ms: number) =>
       new Promise<void>((resolve) => setTimeout(resolve, ms));
-    const append = (item: Omit<DemoItem, "id">) => {
+    const append = (item: DemoItemInput) => {
       const id = nextIdRef.current;
       nextIdRef.current += 1;
       setItems((prev) => [
         ...prev.slice(-(MAX_RENDERED_ITEMS - 1)),
-        { ...item, id } as DemoItem,
+        { ...item, id },
       ]);
     };
 
@@ -458,7 +462,8 @@ const KEYBOARD_ROWS = ["qwertyuiop", "asdfghjkl", "zxcvbnm"] as const;
 function DemoKeyboard({ composerText }: { composerText: string }) {
   const open = composerText !== "";
   const lastChar = composerText.slice(-1).toLowerCase();
-  const lastWord = composerText.split(/\s+/).at(-1) ?? "";
+  const words = composerText.split(/\s+/);
+  const lastWord = words[words.length - 1] ?? "";
   return (
     <div className="landing-keyboard" data-open={open}>
       <div className="landing-keyboard-inner">


### PR DESCRIPTION
# Relates to

Closes #19008.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@8a1d264dd50b026436229170851d5c54e29ec445`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. The patch changes one TypeScript input type and replaces one ES2022 array
lookup with an equivalent index expression supported by the homepage target.
No copy, styles, routes, state transitions, or assets change.

# Background

## What does this PR do?

- Gives the demo append boundary an explicit discriminated `DemoItemInput`
  union, preserving both text and card members without an unchecked cast.
- Replaces `split(...).at(-1)` with the target-compatible indexed last element.
- Restores the homepage package typecheck after #18964.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the declared TypeScript/build contract without changing a
public product or contributor workflow.

# Testing

## Where should a reviewer start?

`packages/homepage/src/pages/landing.tsx`, then the exact current-base pixel
equivalence report and desktop/mobile captures.

## Detailed testing steps

```bash
bun install --frozen-lockfile
bun run --cwd packages/homepage typecheck
bun run --cwd packages/homepage lint:check
bun run --cwd packages/homepage build
bun test packages/homepage/tests/smoke.node.test.mjs \
  packages/homepage/tests/snapshot-inventory.test.ts \
  packages/homepage/tests/contact.test.ts
bun run verify
```

Results on exact head `50fc5c878752eb4c99c8b57a67c6481281215ffa`:
homepage typecheck, lint, build, smoke, and contact tests pass (12/12); root
verify passes 350/350 Turbo tasks plus every repository audit. The snapshot
inventory remains 5 pass/2 fail on the unchanged current base because four
newly required Linux baselines are absent; that separate baseline-only repair
is tracked by #19021.

# Evidence Gate

<!-- evidence-head:50fc5c878752eb4c99c8b57a67c6481281215ffa -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19019-19008-v3-before-desktop-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19019-19008-v3-after-desktop-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19019-19008-v3-walkthrough-desktop-mobile.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or server path changes; the homepage preview is static.
<!-- evidence-row:frontend-logs -->
- [x] [19019-19008-v3-frontend-network-log.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19019-19008-v3-frontend-network-log.json)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [19019-19008-v3-pixel-equivalence-report.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19019-19008-v3-pixel-equivalence-report.txt)
<!-- evidence-row:ocr-review -->
- [x] [19019-19008-v3-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19019-19008-v3-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

Backend: N/A - no backend or server path fires.

Frontend: exact-head console/network capture is attached in the evidence row.
It records 36 successful responses and zero console errors, page errors, failed
requests, or HTTP responses at or above 400. The disclosed warnings are
pre-existing local font-preload, Three.js deprecation, and headless-WebGL
diagnostics.

## Screenshots (before / after) + video walkthrough

Exact full-page desktop (1280 px) and mobile (390 px) captures were produced
from reduced-motion settled builds of current base and head. The two desktop
files are byte-identical; the two mobile files are byte-identical. The attached
montages therefore have the same SHA-256.

### Before

Attached in the evidence row.

### After

Attached in the evidence row.

### Walkthrough video

Attached in the evidence row; H.264/yuv420p MP4, desktop then mobile.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changes.

## Known gaps / failures

- The current base newly requires four Linux landing/leaderboard visual
  baselines that are not committed. The focused inventory is therefore 5
  pass/2 fail on both base and head; #19021 owns that snapshot-only repair.
- Browser capture disclosed pre-existing local font-preload, Three.js
  deprecation, and headless-WebGL warnings. There were zero hard frontend or
  network errors, and base/head pixels are byte-identical.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no repository contribution skill used","attribution_status":"self-reported","lane":"codex-issue-triage"} -->



