### PR TITLE
fix(ui): preserve Steward authority invalidation

### DIFF
--- a/packages/shared/src/steward-session-client/index.test.ts
+++ b/packages/shared/src/steward-session-client/index.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearStoredStewardToken,
   hasStewardAuthedCookie,
+  readStoredStewardToken,
+  STEWARD_REFRESH_TOKEN_KEY,
   STEWARD_SESSION_CHANGE_EVENT,
   STEWARD_TOKEN_KEY,
   type StewardSessionChangeDetail,
@@ -69,5 +71,91 @@ describe("Steward session storage transitions", () => {
     expect(transitions[1]?.sessionEpoch).toBeGreaterThan(
       transitions[0]?.sessionEpoch ?? 0,
     );
+  });
+
+  it("publishes canonical invalidation before stale refresh-key cleanup can fail", () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "steward-token");
+    localStorage.setItem(STEWARD_REFRESH_TOKEN_KEY, "legacy-refresh-token");
+    const storageFailure = new Error("legacy refresh storage unavailable");
+    const originalRemoveItem = Storage.prototype.removeItem;
+    const removeItem = vi
+      .spyOn(Storage.prototype, "removeItem")
+      .mockImplementation(function (this: Storage, key: string) {
+        if (key === STEWARD_REFRESH_TOKEN_KEY) throw storageFailure;
+        return Reflect.apply(originalRemoveItem, this, [key]);
+      });
+    const transitions: StewardSessionChangeDetail[] = [];
+    const listener = (event: Event) => {
+      transitions.push(
+        (event as CustomEvent<StewardSessionChangeDetail>).detail,
+      );
+    };
+    window.addEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
+
+    try {
+      expect(() => clearStoredStewardToken()).toThrow(storageFailure);
+    } finally {
+      window.removeEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
+      removeItem.mockRestore();
+    }
+
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(STEWARD_REFRESH_TOKEN_KEY)).toBe(
+      "legacy-refresh-token",
+    );
+    expect(transitions.map(({ state }) => state)).toEqual(["cleared"]);
+  });
+
+  it("fails fast without publishing when canonical storage mutations fail", () => {
+    const storageFailure = new Error("canonical storage unavailable");
+    const transitions: StewardSessionChangeDetail[] = [];
+    const listener = (event: Event) => {
+      transitions.push(
+        (event as CustomEvent<StewardSessionChangeDetail>).detail,
+      );
+    };
+    window.addEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw storageFailure;
+      });
+
+    try {
+      expect(() => writeStoredStewardToken("steward-token")).toThrow(
+        storageFailure,
+      );
+    } finally {
+      setItem.mockRestore();
+    }
+
+    const removeItem = vi
+      .spyOn(Storage.prototype, "removeItem")
+      .mockImplementation(() => {
+        throw storageFailure;
+      });
+    try {
+      expect(() => clearStoredStewardToken()).toThrow(storageFailure);
+    } finally {
+      removeItem.mockRestore();
+      window.removeEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
+    }
+
+    expect(transitions).toEqual([]);
+  });
+
+  it("does not disguise a failed canonical read as a missing session", () => {
+    const storageFailure = new Error("canonical storage unavailable");
+    const getItem = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw storageFailure;
+      });
+
+    try {
+      expect(() => readStoredStewardToken()).toThrow(storageFailure);
+    } finally {
+      getItem.mockRestore();
+    }
   });
 });

--- a/packages/shared/src/steward-session-client/index.ts
+++ b/packages/shared/src/steward-session-client/index.ts
@@ -172,37 +172,32 @@ export interface ClearOpts {
 // localStorage helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Reads the canonical access token. Returns `null` for SSR or a missing token;
+ * storage access failures propagate so callers cannot mistake them for logout.
+ */
 export function readStoredStewardToken(): string | null {
   if (typeof window === "undefined") return null;
-  try {
-    return window.localStorage.getItem(STEWARD_TOKEN_KEY);
-  } catch {
-    return null;
-  }
+  return window.localStorage.getItem(STEWARD_TOKEN_KEY);
 }
 
+/** Persists the canonical token and publishes exactly one authority transition. */
 export function writeStoredStewardToken(token: string): void {
   if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(STEWARD_TOKEN_KEY, token);
-  } catch {
-    // localStorage may be disabled (private mode, quota, sandboxed iframe);
-    // callers that need durability should detect this themselves.
-    return;
-  }
+  window.localStorage.setItem(STEWARD_TOKEN_KEY, token);
   dispatchStewardSessionChange("present");
 }
 
+/**
+ * Clears canonical authority before draining the obsolete refresh-token key.
+ * Once the canonical removal succeeds, invalidation is published even if the
+ * legacy cleanup fails; either storage failure remains observable to callers.
+ */
 export function clearStoredStewardToken(): void {
   if (typeof window === "undefined") return;
-  try {
-    window.localStorage.removeItem(STEWARD_TOKEN_KEY);
-    window.localStorage.removeItem(STEWARD_REFRESH_TOKEN_KEY);
-  } catch {
-    // ignore
-    return;
-  }
+  window.localStorage.removeItem(STEWARD_TOKEN_KEY);
   dispatchStewardSessionChange("cleared");
+  window.localStorage.removeItem(STEWARD_REFRESH_TOKEN_KEY);
 }
 
 /**

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
@@ -8,7 +8,11 @@
  * never-ageable — token is cleared on a refresh 401 so the session self-heals.
  */
 
-import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import {
+  STEWARD_SESSION_CHANGE_EVENT,
+  STEWARD_TOKEN_KEY,
+  type StewardSessionChangeDetail,
+} from "@elizaos/shared/steward-session-client";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -206,5 +210,49 @@ describe("AuthTokenSync 401 handling", () => {
     mount();
 
     await waitFor(() => expect(storage.getItem(STEWARD_TOKEN_KEY)).toBeNull());
+  });
+
+  it("publishes exactly one present transition when refresh stores a rotated token", async () => {
+    const currentToken = makeJwt({
+      sub: "u1",
+      exp: Math.floor(Date.now() / 1000) + 60,
+    });
+    const rotatedToken = makeJwt({
+      sub: "u1",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    storage.setItem(STEWARD_TOKEN_KEY, currentToken);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        calls.push({ url, method });
+        if (url.includes("steward-refresh")) {
+          return new Response(JSON.stringify({ token: rotatedToken }), {
+            status: 200,
+          });
+        }
+        return new Response(JSON.stringify({}), { status: 401 });
+      }),
+    );
+    const transitions: StewardSessionChangeDetail[] = [];
+    const listener = (event: Event) => {
+      transitions.push(
+        (event as CustomEvent<StewardSessionChangeDetail>).detail,
+      );
+    };
+    window.addEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
+
+    try {
+      mount();
+      await waitFor(() =>
+        expect(storage.getItem(STEWARD_TOKEN_KEY)).toBe(rotatedToken),
+      );
+    } finally {
+      window.removeEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
+    }
+
+    expect(transitions.map(({ state }) => state)).toEqual(["present"]);
   });
 });

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -235,7 +235,6 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
               writeStoredStewardToken(body.token);
               lastSyncedToken.current = body.token;
               wasAuthenticated.current = true;
-              dispatchStewardSessionChange("present");
             }
             try {
               window.dispatchEvent(new CustomEvent("steward-token-sync"));


### PR DESCRIPTION
# Relates to

Closes #18747

- [x] Targets `develop` and is rebased onto `origin/develop@e47d306814d8d1901f6e29907ce4d3be4930cdb9` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` completed successfully.
- [x] Focused behavior tests, package typecheck/lint, and the complete root verification gate pass at the final head.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@e47d306814d8d1901f6e29907ce4d3be4930cdb9`; zero conflicts.
- [x] `bun run verify`: 350/350 Turbo tasks and every repository audit passed.

# Risks

Low. The change deliberately makes browser storage failures observable instead of converting them into fake logout/success states. Callers that encounter disabled or broken `localStorage` now receive the real exception. SSR remains the explicit no-op boundary.

# Background

## What does this PR do?

- Publishes `cleared` immediately after canonical Steward access-token removal, before draining the obsolete refresh-token key. A later cleanup failure therefore cannot leave notification/socket state under stale authority, and the error still propagates.
- Removes silent catches from canonical Steward token reads/writes/clears so storage failure is not disguised as logout or success.
- Removes the duplicate refresh-path `present` dispatch; the canonical writer now publishes exactly once.
- Adds regressions for partial clear, failed canonical storage operations, failed reads, and exact-one rotated-token publication.

## What kind of change is this?

Bug fix (non-breaking behavioral correction).

# Documentation changes needed?

No external documentation change. Exported helper JSDoc states the fail-fast and ordering contracts.

# Testing

## Where should a reviewer start?

Run the shared storage-contract test and the Steward authority runtime test. The assertions cover the real exported writer/clearer and the real `AuthTokenSync` component; only browser storage, fetch, and the third-party Steward SDK boundary are controlled.

## Detailed testing steps

```text
bun run --cwd packages/shared test -- src/steward-session-client/index.test.ts
1 file passed; 7 tests passed

bun run --cwd packages/ui test -- src/cloud/shell/StewardProviderRuntime.test.tsx
1 file passed; 5 tests passed

bun run --cwd packages/shared typecheck
bun run --cwd packages/shared lint
bun run --cwd packages/ui typecheck
bun run --cwd packages/ui lint
bun run verify
350/350 Turbo tasks passed; all repository audits passed
```

# Evidence Gate

<!-- evidence-head:d5e8b3508f83b782d4eff545c3af0d635eb24181 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19022-before-desktop.png)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19022-after-desktop.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19022-steward-no-visual-delta.mp4
<!-- evidence-row:backend-logs -->
- [x] N/A - browser credential storage and notification authority only; no backend path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no rendered, console, or network behavior changed; exact authority transitions are covered by deterministic Vitest artifacts.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, agent, or action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [19022-authority-tests.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19022-authority-tests.json)
<!-- evidence-row:ocr-review -->
- [x] [19022-after-desktop-ocr.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19022-after-desktop-ocr.txt)

# Evidence Details

## Known gaps / failures

The broader trusted-shell batch includes three URL assertions in `client-cloud-trusted-shell-boundary.test.ts` that still expect `api-staging.elizacloud.ai` after `develop` moved the canonical staging API to `api-staging.eliza.app`. All three failures reproduce on untouched `origin/develop@4e62753a760`; this PR does not touch that test or cloud routing. The two PR-owned authority suites pass independently as recorded above.

The previous app visual audit captured 218/219 passing checks and 0 broken views, then hit the existing aggregate minimalism ratchet for unrelated views. This change has no rendered branch, CSS, markup, or layout delta; the attached before/after captures and no-visual-delta walkthrough remain valid.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->

