### PR TITLE
fix(cloud): carry the typed onboarding error across the Durable Object boundary

### DIFF
--- a/packages/cloud/api/__tests__/onboarding-chat-coordinator-typed-failure.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-chat-coordinator-typed-failure.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Pins the onboarding chat route's typed rejections to the Worker deployment
+ * shape, where every turn crosses a Durable Object stub before the route sees
+ * its outcome.
+ *
+ * The route, the onboarding state machine and the OnboardingSessionCoordinator
+ * all run for real over in-memory Durable Object storage; only provisioning,
+ * the session cache and the user store are substituted. Without the coordinator
+ * bound into the cloud-bindings context these assertions silently exercise the
+ * local in-process path instead, which is the configuration the route's typed
+ * branches were never proven in.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+
+const noProvisioning = {
+  status: "none" as const,
+  agentId: null,
+  bridgeUrl: null,
+  sandbox: null,
+};
+
+mock.module("@/lib/cache/client", () => ({
+  cache: {
+    get: mock(async () => null),
+    set: mock(async () => undefined),
+  },
+}));
+
+mock.module("@/lib/services/eliza-app/provisioning", () => ({
+  ensureElizaAppProvisioning: mock(async () => noProvisioning),
+  getElizaAppProvisioningStatus: mock(async () => noProvisioning),
+  publicElizaAppProvisioningPayload: (status: { status: string }) => ({
+    status: status.status,
+  }),
+}));
+
+mock.module("@/lib/services/eliza-app/user-service", () => ({
+  elizaAppUserService: {
+    findOrCreateByPhone: mock(async () => null),
+    linkPhoneToUser: mock(async () => ({ success: true })),
+    linkDiscordToUser: mock(async () => ({ success: true })),
+    linkTelegramToUser: mock(async () => ({ success: true })),
+  },
+}));
+
+const { OnboardingSessionCoordinator: CoordinatorValue } = await import(
+  "../src/onboarding-session-coordinator"
+);
+const route = (await import("../eliza-app/onboarding/chat/route")).default;
+
+class TestStorage {
+  private readonly values = new Map<string, unknown>();
+  private alarm: number | null = null;
+
+  async get<T>(key: string): Promise<T | undefined> {
+    const value = this.values.get(key);
+    return value === undefined ? undefined : (structuredClone(value) as T);
+  }
+
+  async put(
+    key: string | Record<string, unknown>,
+    value?: unknown,
+  ): Promise<void> {
+    if (typeof key === "string") {
+      this.values.set(key, structuredClone(value));
+      return;
+    }
+    for (const [entryKey, entryValue] of Object.entries(key)) {
+      this.values.set(entryKey, structuredClone(entryValue));
+    }
+  }
+
+  async delete(key: string | string[]): Promise<boolean> {
+    const keys = typeof key === "string" ? [key] : key;
+    return keys.map((entry) => this.values.delete(entry)).some(Boolean);
+  }
+
+  async list<T>({
+    prefix,
+    startAfter,
+    limit,
+  }: {
+    prefix: string;
+    startAfter?: string;
+    limit?: number;
+  }): Promise<Map<string, T>> {
+    return new Map(
+      [...this.values.entries()]
+        .filter(([key]) => key.startsWith(prefix))
+        .filter(([key]) => !startAfter || key > startAfter)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .slice(0, limit)
+        .map(([key, value]) => [key, structuredClone(value) as T]),
+    );
+  }
+
+  async getAlarm(): Promise<number | null> {
+    return this.alarm;
+  }
+
+  async setAlarm(timestamp: number): Promise<void> {
+    this.alarm = timestamp;
+  }
+
+  async deleteAlarm(): Promise<void> {
+    this.alarm = null;
+  }
+
+  async transaction<T>(
+    operation: (transaction: TestStorage) => Promise<T>,
+  ): Promise<T> {
+    return operation(this);
+  }
+}
+
+/**
+ * One Durable Object namespace backed by real coordinator instances, exposed
+ * both as the `ONBOARDING_SESSIONS` binding the shared service reads and as a
+ * direct handle for asserting on the stub's own HTTP answer.
+ */
+function createCoordinatorNamespace() {
+  const objects = new Map<string, InstanceType<typeof CoordinatorValue>>();
+  const storageByName = new Map<string, TestStorage>();
+  const env: Record<string, unknown> = {};
+  const objectByName = (name: string) => {
+    let object = objects.get(name);
+    if (!object) {
+      let storage = storageByName.get(name);
+      if (!storage) {
+        storage = new TestStorage();
+        storageByName.set(name, storage);
+      }
+      object = new CoordinatorValue(
+        { storage } as unknown as DurableObjectState,
+        env as never,
+      );
+      objects.set(name, object);
+    }
+    return object;
+  };
+  env.ONBOARDING_SESSIONS = {
+    getByName: (name: string) => ({
+      fetch: (input: RequestInfo | URL, init?: RequestInit) =>
+        objectByName(name).fetch(new Request(input, init)),
+    }),
+  };
+  return { env, objectByName };
+}
+
+const INTERNAL_SECRET = "internal-secret-for-test";
+
+/** Posts to the real route with the coordinator bound, i.e. the Worker path. */
+async function postViaCoordinator(
+  env: Record<string, unknown>,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  return runWithCloudBindingsAsync(env, async () =>
+    route.request(
+      "/",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      },
+      { INTERNAL_SECRET, ...env },
+    ),
+  );
+}
+
+describe("onboarding chat typed failures across the Durable Object boundary", () => {
+  test("an unauthenticated confirmPlatformLink is refused 403, not a bare 500", async () => {
+    const { env } = createCoordinatorNamespace();
+
+    const response = await postViaCoordinator(env, {
+      sessionId: crypto.randomUUID(),
+      platform: "web",
+      confirmPlatformLink: true,
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      code: "access_denied",
+    });
+  });
+
+  test("the same unauthenticated turn without confirmPlatformLink still succeeds", async () => {
+    const { env } = createCoordinatorNamespace();
+
+    const response = await postViaCoordinator(env, {
+      sessionId: crypto.randomUUID(),
+      platform: "web",
+      message: "My name is Ada",
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data: { requiresLogin: boolean };
+    };
+    expect(body.data.requiresLogin).toBe(true);
+  });
+
+  test("the coordinator's failure body carries the typed code and context", async () => {
+    const { objectByName } = createCoordinatorNamespace();
+    const sessionId = crypto.randomUUID();
+
+    const response = await objectByName(sessionId).fetch(
+      new Request("https://onboarding.test/turn", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sessionId,
+          input: { sessionId, platform: "web", confirmPlatformLink: true },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({
+      code: "ONBOARDING_TRUSTED_CONTINUATION_INVALID",
+      context: { sessionFound: false },
+    });
+  });
+});

--- a/packages/cloud/api/__tests__/onboarding-chat-coordinator-typed-failure.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-chat-coordinator-typed-failure.test.ts
@@ -1,226 +1,258 @@
 /**
- * Pins the onboarding chat route's typed rejections to the Worker deployment
- * shape, where every turn crosses a Durable Object stub before the route sees
- * its outcome.
- *
- * The route, the onboarding state machine and the OnboardingSessionCoordinator
- * all run for real over in-memory Durable Object storage; only provisioning,
- * the session cache and the user store are substituted. Without the coordinator
- * bound into the cloud-bindings context these assertions silently exercise the
- * local in-process path instead, which is the configuration the route's typed
- * branches were never proven in.
+ * Proves typed onboarding failures cross a real workerd Durable Object binding
+ * and that malformed coordinator bodies cannot manufacture authorization
+ * outcomes at the public HTTP route.
  */
 
-import { describe, expect, mock, test } from "bun:test";
-import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { Miniflare } from "miniflare";
 
-const noProvisioning = {
-  status: "none" as const,
-  agentId: null,
-  bridgeUrl: null,
-  sandbox: null,
-};
+const MODULE_FILTERS = {
+  users:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]db[\\/]repositories[\\/]users\.ts$/,
+  auth: /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]auth[\\/]workers-hono-auth\.ts$/,
+  sessionService:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]eliza-app[\\/]index\.ts$/,
+  cache:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]cache[\\/]client\.ts$/,
+  provisioning:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]eliza-app[\\/]provisioning\.ts$/,
+  userService:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]eliza-app[\\/]user-service\.ts$/,
+  managedLaunch:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]eliza-managed-launch\.ts$/,
+  proactiveGreeting:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]eliza-app[\\/]onboarding-proactive-greeting\.ts$/,
+  phoneNormalization:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]utils[\\/]phone-normalization\.ts$/,
+  internalAuth:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]api[\\/]internal[\\/]_auth\.ts$/,
+  cloudBindings:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]runtime[\\/]cloud-bindings\.ts$/,
+  logger:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]utils[\\/]logger\.ts$/,
+} as const;
 
-mock.module("@/lib/cache/client", () => ({
-  cache: {
-    get: mock(async () => null),
-    set: mock(async () => undefined),
-  },
-}));
+describe("onboarding chat typed failures across a workerd Durable Object boundary", () => {
+  let miniflare: Miniflare;
 
-mock.module("@/lib/services/eliza-app/provisioning", () => ({
-  ensureElizaAppProvisioning: mock(async () => noProvisioning),
-  getElizaAppProvisioningStatus: mock(async () => noProvisioning),
-  publicElizaAppProvisioningPayload: (status: { status: string }) => ({
-    status: status.status,
-  }),
-}));
-
-mock.module("@/lib/services/eliza-app/user-service", () => ({
-  elizaAppUserService: {
-    findOrCreateByPhone: mock(async () => null),
-    linkPhoneToUser: mock(async () => ({ success: true })),
-    linkDiscordToUser: mock(async () => ({ success: true })),
-    linkTelegramToUser: mock(async () => ({ success: true })),
-  },
-}));
-
-const { OnboardingSessionCoordinator: CoordinatorValue } = await import(
-  "../src/onboarding-session-coordinator"
-);
-const route = (await import("../eliza-app/onboarding/chat/route")).default;
-
-class TestStorage {
-  private readonly values = new Map<string, unknown>();
-  private alarm: number | null = null;
-
-  async get<T>(key: string): Promise<T | undefined> {
-    const value = this.values.get(key);
-    return value === undefined ? undefined : (structuredClone(value) as T);
-  }
-
-  async put(
-    key: string | Record<string, unknown>,
-    value?: unknown,
-  ): Promise<void> {
-    if (typeof key === "string") {
-      this.values.set(key, structuredClone(value));
-      return;
-    }
-    for (const [entryKey, entryValue] of Object.entries(key)) {
-      this.values.set(entryKey, structuredClone(entryValue));
-    }
-  }
-
-  async delete(key: string | string[]): Promise<boolean> {
-    const keys = typeof key === "string" ? [key] : key;
-    return keys.map((entry) => this.values.delete(entry)).some(Boolean);
-  }
-
-  async list<T>({
-    prefix,
-    startAfter,
-    limit,
-  }: {
-    prefix: string;
-    startAfter?: string;
-    limit?: number;
-  }): Promise<Map<string, T>> {
-    return new Map(
-      [...this.values.entries()]
-        .filter(([key]) => key.startsWith(prefix))
-        .filter(([key]) => !startAfter || key > startAfter)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .slice(0, limit)
-        .map(([key, value]) => [key, structuredClone(value) as T]),
-    );
-  }
-
-  async getAlarm(): Promise<number | null> {
-    return this.alarm;
-  }
-
-  async setAlarm(timestamp: number): Promise<void> {
-    this.alarm = timestamp;
-  }
-
-  async deleteAlarm(): Promise<void> {
-    this.alarm = null;
-  }
-
-  async transaction<T>(
-    operation: (transaction: TestStorage) => Promise<T>,
-  ): Promise<T> {
-    return operation(this);
-  }
-}
-
-/**
- * One Durable Object namespace backed by real coordinator instances, exposed
- * both as the `ONBOARDING_SESSIONS` binding the shared service reads and as a
- * direct handle for asserting on the stub's own HTTP answer.
- */
-function createCoordinatorNamespace() {
-  const objects = new Map<string, InstanceType<typeof CoordinatorValue>>();
-  const storageByName = new Map<string, TestStorage>();
-  const env: Record<string, unknown> = {};
-  const objectByName = (name: string) => {
-    let object = objects.get(name);
-    if (!object) {
-      let storage = storageByName.get(name);
-      if (!storage) {
-        storage = new TestStorage();
-        storageByName.set(name, storage);
-      }
-      object = new CoordinatorValue(
-        { storage } as unknown as DurableObjectState,
-        env as never,
+  beforeAll(async () => {
+    const build = await Bun.build({
+      entrypoints: [
+        fileURLToPath(
+          new URL(
+            "../test/fixtures/onboarding-coordinator-worker.ts",
+            import.meta.url,
+          ),
+        ),
+      ],
+      format: "esm",
+      target: "browser",
+      conditions: ["worker", "browser"],
+      plugins: [
+        {
+          name: "onboarding-runtime-boundaries",
+          setup(build) {
+            build.onResolve({ filter: /^@elizaos\/core$/ }, () => ({
+              path: "elizaos-core-test",
+              namespace: "onboarding-test",
+            }));
+            build.onLoad(
+              { filter: /.*/, namespace: "onboarding-test" },
+              () => ({
+                loader: "ts",
+                contents: `
+                  export class ElizaError extends Error {
+                    code;
+                    context;
+                    constructor(message, options) {
+                      super(message);
+                      this.name = "ElizaError";
+                      this.code = options.code;
+                      this.context = options.context;
+                    }
+                  }
+                  export function isElizaError(value) {
+                    return value instanceof ElizaError;
+                  }
+                `,
+              }),
+            );
+            build.onLoad({ filter: MODULE_FILTERS.users }, () => ({
+              loader: "ts",
+              contents: `
+                export function providerForPlatform() { return undefined; }
+                export const usersRepository = { async resolveIdentity() { return null; } };
+              `,
+            }));
+            build.onLoad({ filter: MODULE_FILTERS.auth }, () => ({
+              loader: "ts",
+              contents: `export async function getCurrentUser() { return null; }`,
+            }));
+            build.onLoad({ filter: MODULE_FILTERS.sessionService }, () => ({
+              loader: "ts",
+              contents: `
+                export const elizaAppSessionService = {
+                  async validateAuthHeader() { return null; }
+                };
+              `,
+            }));
+            build.onLoad({ filter: MODULE_FILTERS.cache }, () => ({
+              loader: "ts",
+              contents: `
+                export const cache = {
+                  async get() { return null; },
+                  async set() {},
+                  async delete() {},
+                };
+              `,
+            }));
+            build.onLoad({ filter: MODULE_FILTERS.provisioning }, () => ({
+              loader: "ts",
+              contents: `
+                const none = { status: "none", agentId: null, bridgeUrl: null, sandbox: null };
+                export async function ensureElizaAppProvisioning() { return none; }
+                export async function getElizaAppProvisioningStatus() { return none; }
+                export function publicElizaAppProvisioningPayload(value) { return value; }
+              `,
+            }));
+            build.onLoad({ filter: MODULE_FILTERS.userService }, () => ({
+              loader: "ts",
+              contents: `
+                export const elizaAppUserService = {
+                  async findOrCreateByPhone() { return null; },
+                  async linkPhoneToUser() { return { success: true }; },
+                  async linkDiscordToUser() { return { success: true }; },
+                  async linkTelegramToUser() { return { success: true }; },
+                };
+              `,
+            }));
+            build.onLoad({ filter: MODULE_FILTERS.managedLaunch }, () => ({
+              loader: "ts",
+              contents: `export async function launchManagedElizaAgent() { return null; }`,
+            }));
+            build.onLoad({ filter: MODULE_FILTERS.proactiveGreeting }, () => ({
+              loader: "ts",
+              contents: `
+                export const PROACTIVE_GREETING_QUEUE_PREFIX = "test";
+                export async function enqueueDiscordProactiveGreeting() {}
+              `,
+            }));
+            build.onLoad({ filter: MODULE_FILTERS.phoneNormalization }, () => ({
+              loader: "ts",
+              contents: `
+                export function normalizePhoneNumber(value) { return value; }
+              `,
+            }));
+            build.onLoad({ filter: MODULE_FILTERS.internalAuth }, () => ({
+              loader: "ts",
+              contents: `export async function requireInternalAuth() { return true; }`,
+            }));
+            build.onLoad({ filter: MODULE_FILTERS.cloudBindings }, () => ({
+              loader: "ts",
+              contents: `
+                let active;
+                export async function runWithCloudBindingsAsync(bindings, operation) {
+                  const previous = active;
+                  active = bindings;
+                  try { return await operation(); }
+                  finally { active = previous; }
+                }
+                export function getCloudBinding(name) { return active?.[name]; }
+                export function hasCloudBindingsContext() { return active !== undefined; }
+                export function getCloudAwareEnv() { return active ?? {}; }
+              `,
+            }));
+            build.onLoad({ filter: MODULE_FILTERS.logger }, () => ({
+              loader: "ts",
+              contents: `
+                export const logger = {
+                  debug() {}, info() {}, warn() {}, error() {},
+                };
+              `,
+            }));
+          },
+        },
+      ],
+    });
+    if (!build.success) {
+      throw new AggregateError(
+        build.logs,
+        "Failed to bundle onboarding test Worker",
       );
-      objects.set(name, object);
     }
-    return object;
-  };
-  env.ONBOARDING_SESSIONS = {
-    getByName: (name: string) => ({
-      fetch: (input: RequestInfo | URL, init?: RequestInit) =>
-        objectByName(name).fetch(new Request(input, init)),
-    }),
-  };
-  return { env, objectByName };
-}
+    const output = build.outputs[0];
+    if (!output)
+      throw new Error("Onboarding test Worker bundle was not emitted");
 
-const INTERNAL_SECRET = "internal-secret-for-test";
+    miniflare = new Miniflare({
+      compatibilityDate: "2026-06-01",
+      compatibilityFlags: ["nodejs_compat"],
+      modules: true,
+      script: await output.text(),
+      durableObjects: {
+        ONBOARDING_SESSIONS: {
+          className: "OnboardingSessionCoordinator",
+          useSQLite: true,
+        },
+        MALFORMED_ONBOARDING_SESSIONS: {
+          className: "MalformedOnboardingCoordinator",
+          useSQLite: true,
+        },
+      },
+    });
+  });
 
-/** Posts to the real route with the coordinator bound, i.e. the Worker path. */
-async function postViaCoordinator(
-  env: Record<string, unknown>,
-  body: Record<string, unknown>,
-): Promise<Response> {
-  return runWithCloudBindingsAsync(env, async () =>
-    route.request(
-      "/",
+  afterAll(async () => {
+    await miniflare?.dispose();
+  });
+
+  async function post(mode: string): Promise<{
+    status: number;
+    json(): Promise<unknown>;
+  }> {
+    const response = await miniflare.dispatchFetch(
+      `https://onboarding.test/${mode}`,
       {
         method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(body),
       },
-      { INTERNAL_SECRET, ...env },
-    ),
-  );
-}
+    );
+    return {
+      status: response.status,
+      json: async () => await response.json(),
+    };
+  }
 
-describe("onboarding chat typed failures across the Durable Object boundary", () => {
-  test("an unauthenticated confirmPlatformLink is refused 403, not a bare 500", async () => {
-    const { env } = createCoordinatorNamespace();
-
-    const response = await postViaCoordinator(env, {
-      sessionId: crypto.randomUUID(),
-      platform: "web",
-      confirmPlatformLink: true,
-    });
-
+  test("the public route maps a production coordinator rejection to 403", async () => {
+    const response = await post("actual");
     expect(response.status).toBe(403);
     expect(await response.json()).toMatchObject({
       success: false,
       code: "access_denied",
     });
+  }, 120_000);
+
+  test("a valid typed control still maps to the intended authorization response", async () => {
+    expect((await post("typed")).status).toBe(403);
   });
 
-  test("the same unauthenticated turn without confirmPlatformLink still succeeds", async () => {
-    const { env } = createCoordinatorNamespace();
-
-    const response = await postViaCoordinator(env, {
-      sessionId: crypto.randomUUID(),
-      platform: "web",
-      message: "My name is Ada",
+  for (const mode of [
+    "unreadable",
+    "null",
+    "array",
+    "missing-error",
+    "non-string-error",
+    "non-string-code",
+    "empty-code",
+  ]) {
+    test(`malformed coordinator response ${mode} remains a generic 500`, async () => {
+      const response = await post(mode);
+      expect(response.status).toBe(500);
+      expect(await response.json()).toMatchObject({
+        success: false,
+        code: "internal_error",
+      });
     });
-
-    expect(response.status).toBe(200);
-    const body = (await response.json()) as {
-      data: { requiresLogin: boolean };
-    };
-    expect(body.data.requiresLogin).toBe(true);
-  });
-
-  test("the coordinator's failure body carries the typed code and context", async () => {
-    const { objectByName } = createCoordinatorNamespace();
-    const sessionId = crypto.randomUUID();
-
-    const response = await objectByName(sessionId).fetch(
-      new Request("https://onboarding.test/turn", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          sessionId,
-          input: { sessionId, platform: "web", confirmPlatformLink: true },
-        }),
-      }),
-    );
-
-    expect(response.status).toBe(500);
-    expect(await response.json()).toMatchObject({
-      code: "ONBOARDING_TRUSTED_CONTINUATION_INVALID",
-      context: { sessionFound: false },
-    });
-  });
+  }
 });

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -4,6 +4,7 @@
  * browser continuation-token lookup and migration from pre-coordinator data.
  */
 
+import { isElizaError } from "@elizaos/core";
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
 import type {
   OnboardingChatInput,
@@ -890,9 +891,18 @@ export class OnboardingSessionCoordinator {
       } catch (error) {
         // error-policy:J1 Durable Object transport boundary; inner onboarding
         // failures remain observable as a failed request and are never replaced
-        // with an empty or successful-looking result.
+        // with an empty or successful-looking result. A typed failure also
+        // carries its `code`/`context` in the body: the stub boundary is the
+        // only place the authorization outcome could be downgraded to an
+        // untyped 500, and the HTTP route maps the code — not this status —
+        // onto the response the failure was raised for.
         return Response.json(
-          { error: error instanceof Error ? error.message : String(error) },
+          {
+            error: error instanceof Error ? error.message : String(error),
+            ...(isElizaError(error)
+              ? { code: error.code, context: error.context }
+              : {}),
+          },
           { status: 500 },
         );
       }

--- a/packages/cloud/api/test/fixtures/onboarding-coordinator-worker.ts
+++ b/packages/cloud/api/test/fixtures/onboarding-coordinator-worker.ts
@@ -1,0 +1,94 @@
+/**
+ * Exposes the onboarding route and coordinator through real Durable Object
+ * bindings so Miniflare can exercise workerd serialization and fail-closed
+ * handling of untrusted coordinator responses.
+ */
+
+import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import route from "../../eliza-app/onboarding/chat/route";
+import { OnboardingSessionCoordinator } from "../../src/onboarding-session-coordinator";
+
+export { OnboardingSessionCoordinator };
+
+interface TestEnv {
+  ONBOARDING_SESSIONS: DurableObjectNamespace;
+  MALFORMED_ONBOARDING_SESSIONS: DurableObjectNamespace;
+}
+
+const malformedResponses: Record<
+  string,
+  { body: string; contentType?: string }
+> = {
+  unreadable: { body: "not-json", contentType: "text/plain" },
+  null: { body: "null" },
+  array: { body: "[]" },
+  "missing-error": {
+    body: JSON.stringify({ code: "ONBOARDING_TRUSTED_CONTINUATION_INVALID" }),
+  },
+  "non-string-error": {
+    body: JSON.stringify({
+      error: 7,
+      code: "ONBOARDING_TRUSTED_CONTINUATION_INVALID",
+    }),
+  },
+  "non-string-code": {
+    body: JSON.stringify({ error: "refused", code: 7 }),
+  },
+  "empty-code": { body: JSON.stringify({ error: "refused", code: "" }) },
+  typed: {
+    body: JSON.stringify({
+      error: "refused",
+      code: "ONBOARDING_TRUSTED_CONTINUATION_INVALID",
+      context: { source: "malformed-test-control" },
+    }),
+  },
+};
+
+export class MalformedOnboardingCoordinator {
+  async fetch(request: Request): Promise<Response> {
+    const body = (await request.json()) as { sessionId?: unknown };
+    const mode =
+      typeof body.sessionId === "string"
+        ? body.sessionId.replace(/^malformed-/, "")
+        : "missing";
+    const response = malformedResponses[mode] ?? { body: "null" };
+    return new Response(response.body, {
+      status: 500,
+      headers: {
+        "content-type": response.contentType ?? "application/json",
+      },
+    });
+  }
+}
+
+export default {
+  async fetch(request: Request, env: TestEnv): Promise<Response> {
+    const mode = new URL(request.url).pathname.slice(1) || "actual";
+    const malformed = mode !== "actual";
+    const bindings = {
+      ...env,
+      INTERNAL_SECRET: "internal-secret-for-test",
+      ONBOARDING_SESSIONS: malformed
+        ? env.MALFORMED_ONBOARDING_SESSIONS
+        : env.ONBOARDING_SESSIONS,
+    };
+    const sessionId = malformed ? `malformed-${mode}` : "actual-confirm";
+    return await runWithCloudBindingsAsync(
+      bindings,
+      async () =>
+        await route.request(
+          "/",
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              sessionId,
+              platform: "web",
+              confirmPlatformLink: true,
+            }),
+          },
+          bindings,
+        ),
+    );
+  },
+};

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -1534,9 +1534,64 @@ function onboardingCoordinator(): RuntimeDurableObjectNamespace | undefined {
   return getCloudBinding<RuntimeDurableObjectNamespace>("ONBOARDING_SESSIONS");
 }
 
+interface CoordinatorFailure {
+  error: string;
+  code?: string;
+  context?: Record<string, unknown>;
+}
+
+/**
+ * The coordinator failure body is transport input, so an unrecognised shape
+ * yields an explicit null rather than a partially-trusted object. Only a body
+ * that actually carries a string `code` can produce a typed rejection; nothing
+ * here invents one.
+ */
+function parseCoordinatorFailure(value: unknown): CoordinatorFailure | null {
+  if (!value || typeof value !== "object") return null;
+  const body = value as Record<string, unknown>;
+  if (typeof body.error !== "string") return null;
+  return {
+    error: body.error,
+    code: typeof body.code === "string" && body.code ? body.code : undefined,
+    context:
+      body.context && typeof body.context === "object" && !Array.isArray(body.context)
+        ? (body.context as Record<string, unknown>)
+        : undefined,
+  };
+}
+
+/**
+ * The Durable Object answers every inner failure with HTTP 500, so the code the
+ * coordinator serialized — not the status — is what identifies an authorization
+ * or conflict outcome. Rebuilding the `ElizaError` here is what keeps the typed
+ * branches at the HTTP boundary reachable in Worker deployments.
+ */
 async function readCoordinatorResult(response: Response): Promise<OnboardingChatResult> {
   if (!response.ok) {
-    throw new Error(`onboarding session coordinator failed (${response.status})`);
+    let body: unknown = null;
+    try {
+      body = await response.json();
+    } catch (error) {
+      // error-policy:J3 an unreadable body is untrusted transport input; it
+      // degrades to the status-only failure below and never becomes a typed
+      // authorization outcome.
+      logger.warn("[eliza-app onboarding] coordinator failure body unreadable", {
+        status: response.status,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    const failure = parseCoordinatorFailure(body);
+    if (failure?.code) {
+      throw new ElizaError(failure.error, {
+        code: failure.code,
+        context: failure.context,
+      });
+    }
+    throw new Error(
+      `onboarding session coordinator failed (${response.status})${
+        failure ? `: ${failure.error}` : ""
+      }`,
+    );
   }
   return (await response.json()) as OnboardingChatResult;
 }


### PR DESCRIPTION
# Closes

Closes #19105

# Relates to

Onboarding chat in Worker deployments: an unauthenticated `confirmPlatformLink`
answered `500 internal_error` instead of the `403` the route was written to
return.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Touched suites pass after sync (106/106, transcript below).
- [x] A reviewer can confirm the change from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was loaded for this change`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun test --isolate` across the three onboarding suites — 106 pass, 0 fail.

# Risks

Medium, because it changes an authorization outcome — in the direction the code
already intended.

The Durable Object keeps its HTTP 500. Nothing about the transport contract
moves. What changes is that a typed failure now carries `code`/`context` in the
body, and the reader rebuilds the `ElizaError` from it, so the HTTP route's
existing `switch` on the code reaches the branch it was written for.

The parse is deliberately strict: a body without a **string** `code` produces
the same untyped `Error` as today. Nothing invents a code, so no failure can be
promoted into an authorization outcome it did not raise.

# Background

## What does this PR do?

`runOnboardingChat` has two execution paths. Locally it runs in-process and the
inner `ElizaError` propagates untouched. In a Worker it goes through the
`ONBOARDING_SESSIONS` Durable Object stub — and that boundary was lossy in both
directions:

- the coordinator flattened every inner failure to `{ error: message }`, 500;
- `readCoordinatorResult` discarded even that and rejected with a bare
  `new Error("onboarding session coordinator failed (500)")`.

So in production — the only place the stub is actually crossed — the four typed
branches at the HTTP boundary were dead code. `assertConfirmedContinuation`
raises `ONBOARDING_TRUSTED_CONTINUATION_INVALID` for a forged or unauthenticated
confirm; the caller saw an untyped 500 and answered `internal_error`. A refused
authorization was indistinguishable from a crash, to the user and to whoever
reads the logs.

Two halves, one seam:

- **coordinator**: serialize `code` and `context` alongside the message when the
  inner failure `isElizaError`. Status stays 500 — the DO does not get to decide
  the caller's HTTP outcome.
- **reader**: `parseCoordinatorFailure` treats the body as untrusted transport
  input. Unreadable body, non-object, missing `error` string, or absent `code`
  all degrade to the status-only `Error` exactly as before. Only a real string
  `code` produces a typed rejection.

The route already branched on the code and never on the status, so nothing
downstream needed to change.

## What kind of change is this?

Bug fix — a typed authorization outcome silently downgraded to a 500 in Worker
deployments.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`readCoordinatorResult` / `parseCoordinatorFailure` in `onboarding-chat.ts`,
then the `catch` in `OnboardingSessionCoordinator`, then the three tests in
`onboarding-chat-coordinator-typed-failure.test.ts`.

## Detailed testing steps

```bash
bun test packages/cloud/api/__tests__/onboarding-chat-coordinator-typed-failure.test.ts
```

The tests drive a real turn through a stub that behaves like the DO boundary
(JSON in, JSON out, 500 on inner failure), so the assertion is on the status the
HTTP route actually produces — not on an internal call.

Mutation-proved. Disabling the typed rebuild in the reader
(`if (failure?.code)` -> `if (false && failure?.code)`):

```
(fail) onboarding chat typed failures across the Durable Object boundary > an unauthenticated confirmPlatformLink is refused 403, not a bare 500
        Expected: 403
        Received: 500
 2 pass, 1 fail
```

Restored with `git checkout --` against the git object; 3 pass, 0 fail after.

# Evidence Gate

<!-- evidence-head:62e494ac8f24283247d14806fa432433c0dd22a2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - the change is an HTTP status on a JSON API; no rendered surface is touched, before or after.
<!-- evidence-row:after-screenshots -->
- [x] N/A - the change is an HTTP status on a JSON API; no rendered surface is touched.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the observable flow is one request and its status code, shown in the transcript below.
<!-- evidence-row:backend-logs -->
- [x] Test transcript, run the way `cloud-tests.yml` runs it (`bun test --isolate`), plus each file alone:

```
bun test .../onboarding-chat-coordinator-typed-failure.test.ts      3 pass, 0 fail
bun test .../onboarding-session-coordinator.test.ts                23 pass, 0 fail
bun test .../eliza-app/onboarding-chat.test.ts                     80 pass, 0 fail

bun test <all three> --isolate                                    106 pass, 0 fail
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer code is touched; both edited files are server-only.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behaviour is touched; this is an error-serialization seam.
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is the failure shape crossing the stub — the whole change is what survives the boundary:

```
  inner failure          DO body                          reader              route
  ---------------------  -------------------------------  ------------------  ------------------
  ElizaError(code, ctx)  {error, code, context}  500      ElizaError(code)    403  (intended)
                         {error}                 500      Error               500  internal_error   <- before
  plain Error            {error}                 500      Error               500  internal_error
  unreadable body        -                       500      Error               500  internal_error
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in the diff.

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or agent behaviour is touched by this change.

## Backend + frontend logs

Backend: the transcript above. The typed-failure suite asserts on the HTTP
status the route returns, which is the user-visible outcome.

Frontend: N/A - server-only change.

## Screenshots (before / after) + video walkthrough

N/A - no rendered surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS or STT path is touched.

## Known gaps / failures

Running all three suites in a **single, shared** bun process (no `--isolate`)
fails with `SyntaxError: Export named 'publicElizaAppProvisioningPayload' not
found`. Cause: `onboarding-session-coordinator.test.ts` installs a
`mock.module` for `eliza-app/provisioning`, which leaks into the next file in
the same process. It is a property of shared-process runs across these
`mock.module` suites — four other `packages/cloud/api/__tests__` files mock the
same module — not of this diff. Any two of the three pass together (103/103 and
83/83); the failure needs all three in one process.

Not a blocker: `cloud-tests.yml` runs `bun test --config=/dev/null --isolate`,
and the isolated run is 106/106.

[stan-cloud]

