### PR TITLE
feat(registry): add @zkp2p/plugin-peer-cash community entry

### DIFF
--- a/packages/registry/entries/third-party/zkp2p__plugin-peer-cash.json
+++ b/packages/registry/entries/third-party/zkp2p__plugin-peer-cash.json
@@ -1,0 +1,9 @@
+{
+  "package": "@zkp2p/plugin-peer-cash",
+  "repository": "github:ADWilkinson/plugin-peer-cash",
+  "kind": "plugin",
+  "description": "Peer Cash offramp actions: cash out Base USDC to Venmo, Revolut, Wise, Zelle, and more at the live oracle market rate, with order tracking, withdraw, and top-up.",
+  "homepage": "https://peer.xyz/cash-sdk",
+  "version": "0.1.0",
+  "tags": ["offramp", "usdc", "base", "crypto-to-fiat", "payments", "zkp2p"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -994,6 +994,52 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@zkp2p/plugin-peer-cash": {
+      "git": {
+        "repo": "ADWilkinson/plugin-peer-cash",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@zkp2p/plugin-peer-cash",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Peer Cash offramp actions: cash out Base USDC to Venmo, Revolut, Wise, Zelle, and more at the live oracle market rate, with order tracking, withdraw, and top-up.",
+      "homepage": "https://peer.xyz/cash-sdk",
+      "topics": [
+        "offramp",
+        "usdc",
+        "base",
+        "crypto-to-fiat",
+        "payments",
+        "zkp2p"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "blackwall-eliza-guardrail": {
       "git": {
         "repo": "bluetieroperations-create/blackwall-eliza-guardrail",


### PR DESCRIPTION
hey team, Andrew from Peer here. this PR adds a community registry entry for `@zkp2p/plugin-peer-cash`, an elizaOS plugin that lets an agent cash out its Base USDC to real payment apps.

## What is Peer Cash

Peer Cash is a self serve TypeScript SDK for cashing out Base USDC to the user's payment app (Venmo, Revolut, Wise, Zelle and more) through the Peer P2P protocol. It's non-custodial: funds sit in the protocol escrow contract, a buyer pays the fiat and proves it, and the protocol releases the USDC. No API keys, completely self serve and really easy to integrate. It's live in production on peer.xyz.

## What this PR adds

One registry entry at `packages/registry/entries/third-party/zkp2p__plugin-peer-cash.json` plus the regenerated `generated-registry.json`, following the flow in the registry README.

The plugin itself lives at https://github.com/ADWilkinson/plugin-peer-cash and gives an agent seven actions:

- `PEER_CASH_CAPABILITIES`: payout platforms, currencies, payee formats, amount bounds, 30 day fill evidence
- `PEER_CASH_ESTIMATE`: live oracle rate and receive amount for a USDC amount. always labeled an estimate, never a locked quote
- `PEER_CASH_CASHOUT`: create a cash-out order (amount, platform, currency, payee)
- `PEER_CASH_ORDER_STATUS`: one order by deposit id, with state and next actions
- `PEER_CASH_ORDERS`: list orders for a wallet
- `PEER_CASH_WITHDRAW`: unwind, full close or partial with an amount
- `PEER_CASH_TOP_UP`: add USDC to a live order

## How it works

The wallet stays with the agent. The plugin looks for a registered wallet backend service first (the `wallet-backend` service type from plugin-wallet, duck-typed so there's no hard dependency) and falls back to `EVM_PRIVATE_KEY`. Every funds-moving action goes through core's `requireConfirmation` with a pending key derived from the actual amount, platform, payee and deposit id, same pattern as plugin-wallet's financial gate. A yes on a later turn is the only thing that submits.

Pricing is the live Chainlink oracle rate at fill time with 0% spread. There are no locked quotes in the protocol, so the plugin never presents one. Errors come through typed: every failure surfaces the SDK's error code, whether it's retryable, and a remediation sentence, including recovery evidence for uncertain transaction states.

For hosts that keep custody elsewhere, the underlying SDK has an unsigned prepare path (`prepare()`, `prepareWithdraw()`, `prepareTopUp()`) that returns unsigned transactions with readable step labels. The plugin covers the common case where the agent runtime holds the signer.

## Config

| Variable | Required | Default | Notes |
| --- | --- | --- | --- |
| `PEER_CASH_ENVIRONMENT` | No | `production` | `production`, `preproduction`, or `staging` |
| `PEER_CASH_REFERRAL_CODE` | No | none | six character Peer referral code, see below |
| `PEER_CASH_REFERRER` | No | none | analytics-only ERC-8021 attribution code |
| `PEER_CASH_RPC_URL` | No | public Base RPC | Base RPC override for reads |
| `EVM_PRIVATE_KEY` | No | none | fallback signer when no wallet backend service is registered |

All declared in `agentConfig.pluginParameters`. Invalid config fails plugin init with the exact problem.

## How integrators earn

Anyone running this plugin can set `PEER_CASH_REFERRAL_CODE` to the six character code from their own Peer app. The SDK stamps `peer-ref-XXXXXX` into ERC-8021 attribution on each deposit transaction, and when that liquidity fills, the protocol's curator pays the code owner 50 bps of the fill, capped by the configured Peer service fee. The mapping is permanent for open deposits and needs no registration transaction. The separate `referrer` option is analytics only and carries no fee share.

## Testing done

All in the plugin repo, on the exact code the entry points at:

```
bun run typecheck      # tsc, pass
bun run lint:check     # biome, 34 files, pass
bun run format:check   # pass
bun run test           # 52 component tests + 6 e2e tests, all passing
bun run build          # bun bundle + d.ts emit, pass
npm publish --dry-run  # 50 files, dist only
```

Component tests mock the cash client surface and cover a happy path and an error path per action, plus the confirmation gate (pending, confirmed, cancelled, and changed-parameters cases). The e2e lane runs the plugin's TestSuite against a real in-memory `AgentRuntime` from `@elizaos/core@2.0.3-beta.7` with no network reads. I also packed the tarball and loaded it in a clean project to check the exports resolve.

In this repo I ran the two commands the registry README asks for:

```
bun run --cwd packages/registry validate    # 42 third-party entries validated
bun run --cwd packages/registry generate    # regenerated generated-registry.json
```

I didn't run the full monorepo verify for a one file entry addition. Happy to if you want it.

One note on npm: `@zkp2p/plugin-peer-cash@0.1.0` is not on npm yet. I publish under the `@zkp2p` scope and will have 0.1.0 live before this merges. If you'd rather see the npm listing first, say so and I'll ping when it's up.

## Links

SDK → https://www.npmjs.com/package/@zkp2p/cash
Docs → https://docs.peer.xyz/developer/peer-cash
Prompt → https://peer.xyz/cash-sdk
Builders Club → https://t.me/zk_p2p/167174

## Support

I maintain this. Questions or issues, ask in the Builders Club or ping @andrewwilkinson on X. I'll address review feedback here promptly.
