### PR TITLE
fix(ui): bind live plugin config state into save actions (#18975)

### DIFF
--- a/packages/agent/src/api/server-helpers-plugin.config-state-binding.test.ts
+++ b/packages/agent/src/api/server-helpers-plugin.config-state-binding.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression for #18975: plugin config forms must bind each declared config
+ * field into the save action via $path references so the UiRenderer resolves
+ * live state values at dispatch time. Without this, the save button sends only
+ * { pluginId } and the client receives an empty config patch.
+ */
+import { describe, expect, it } from "vitest";
+import { resolvePluginConfigReply } from "./server-helpers-plugin.ts";
+
+type FormSpec = {
+  version: number;
+  root: string;
+  elements: Record<string, { type: string; props?: Record<string, unknown> }>;
+  state: Record<string, string>;
+};
+
+function parseForm(reply: string): FormSpec {
+  const match = reply.match(/```json-render\n([\s\S]*?)\n```/);
+  if (!match?.[1]) {
+    throw new Error(
+      `expected json-render form fence, got: ${reply.slice(0, 200)}`,
+    );
+  }
+  return JSON.parse(match[1]) as FormSpec;
+}
+
+describe("resolvePluginConfigReply save action binds config fields via $path", () => {
+  it("save action params include $path references for every config field", async () => {
+    const reply = await resolvePluginConfigReply("configure discord", {
+      config: {},
+      runtime: null,
+    } as never);
+    expect(typeof reply).toBe("string");
+    if (typeof reply !== "string") return;
+
+    const form = parseForm(reply);
+
+    // Find the save button element
+    const saveBtn = form.elements["saveBtn"];
+    expect(saveBtn).toBeDefined();
+    const onPress = (saveBtn.props?.on as Record<string, unknown>)?.press as {
+      action: string;
+      params: Record<string, unknown>;
+    };
+    expect(onPress.action).toBe("plugin:save");
+    expect(onPress.params.pluginId).toBe("discord");
+
+    // Every config.* state key declared in the form must have a $path binding
+    // in the save action params so UiRenderer resolves it at dispatch time.
+    const configStateKeys = Object.keys(form.state).filter((k) =>
+      k.startsWith("config."),
+    );
+    expect(configStateKeys.length).toBeGreaterThan(0);
+
+    for (const stateKey of configStateKeys) {
+      const param = onPress.params[stateKey] as { $path?: string } | undefined;
+      expect(param).toBeDefined();
+      expect(param?.$path).toBe(stateKey);
+    }
+  });
+});

--- a/packages/agent/src/api/server-helpers-plugin.ts
+++ b/packages/agent/src/api/server-helpers-plugin.ts
@@ -125,10 +125,16 @@ export async function resolvePluginConfigReply(
   };
   elements.sep = { type: "Separator", props: {} };
 
+  // Build $path bindings so the UiRenderer resolves live config.* state values
+  // into the save action params at dispatch time. Each param key maps to its
+  // current form value via a dynamic reference resolved by resolveProps.
+  const saveParams: Record<string, { $path: string }> = {};
+
   for (const param of params) {
     const fid = `f_${param.key}`;
     fieldIds.push(fid);
     state[`config.${param.key}`] = "";
+    saveParams[`config.${param.key}`] = { $path: `config.${param.key}` };
     elements[fid] = {
       type: "Input",
       props: {
@@ -149,7 +155,10 @@ export async function resolvePluginConfigReply(
       variant: "default",
       className: "font-semibold",
       on: {
-        press: { action: "plugin:save", params: { pluginId: pluginName } },
+        press: {
+          action: "plugin:save",
+          params: { pluginId: pluginName, ...saveParams },
+        },
       },
     },
   };

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -772,6 +772,14 @@ export function MessageUiSpecBlock({
             }
           }
         }
+        // An empty patch means no fields were filled — do not call the API
+        // and do not report a false success.
+        if (Object.keys(config).length === 0) {
+          void sendActionMessage(
+            `[No configuration entered — nothing to save for ${pluginId}]`,
+          );
+          return;
+        }
         void client
           .updatePlugin(pluginId, { config })
           .then(() =>

--- a/packages/ui/src/components/config-ui/__tests__/ui-renderer-action-params.test.tsx
+++ b/packages/ui/src/components/config-ui/__tests__/ui-renderer-action-params.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Regression for #18975: UiRenderer must resolve $path / $data dynamic
+ * references in action params from live state at dispatch time — the same
+ * resolution applied to element props. Without this, forms that declare
+ * { field: { $path: "form.field" } } in their save action send the literal
+ * { $path } object instead of the typed value.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { UiSpec } from "../../../config/ui-spec";
+import { __setAppValueForTests } from "../../../state/app-store";
+import { AppContext } from "../../../state/useApp";
+import { UiRenderer } from "../ui-renderer";
+
+function renderSpec(spec: unknown) {
+  const appValue = {
+    t: (key: string, vars?: Record<string, unknown>) =>
+      String(vars?.defaultValue ?? key),
+    sendActionMessage: () => {},
+  } as never;
+  __setAppValueForTests(appValue);
+  return render(
+    <AppContext.Provider value={appValue}>
+      <UiRenderer spec={spec as UiSpec} />
+    </AppContext.Provider>,
+  ).container;
+}
+
+afterEach(() => {
+  cleanup();
+  __setAppValueForTests(null);
+});
+
+describe("UiRenderer resolves $path references in action params", () => {
+  it("resolves $path action params from state when a button is pressed", () => {
+    const onAction = vi.fn();
+
+    const spec: UiSpec = {
+      root: "root",
+      elements: {
+        root: {
+          type: "Card",
+          props: {},
+          children: ["email-input", "submit-btn"],
+        },
+        "email-input": {
+          type: "Input",
+          props: {
+            label: "Email",
+            statePath: "form.email",
+          },
+          children: [],
+        },
+        "submit-btn": {
+          type: "Button",
+          props: {
+            text: "Submit",
+            variant: "primary",
+          },
+          children: [],
+          on: {
+            press: {
+              action: "saveForm",
+              params: {
+                email: { $path: "form.email" },
+              },
+            },
+          },
+        },
+      },
+      state: {
+        form: { email: "" },
+      },
+    };
+
+    const { container } = render(
+      <AppContext.Provider
+        value={
+          {
+            t: (key: string) => key,
+            sendActionMessage: () => {},
+            onAction,
+          } as never
+        }
+      >
+        <UiRenderer spec={spec} onAction={onAction} />
+      </AppContext.Provider>,
+    );
+
+    // Type a value into the email field
+    const input = container.querySelector('input[name=""]') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    fireEvent.change(input, { target: { value: "test@example.com" } });
+
+    // Click submit — the action params should resolve $path: "form.email"
+    // to the live state value "test@example.com", not pass the raw { $path }
+    // object.
+    const button = container.querySelector("button") as HTMLButtonElement;
+    expect(button).toBeTruthy();
+    fireEvent.click(button);
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    const [action, params] = onAction.mock.calls[0];
+    expect(action).toBe("saveForm");
+    expect(params).toEqual({ email: "test@example.com" });
+    // The raw $path object must NOT leak through
+    expect(params).not.toEqual({ email: { $path: "form.email" } });
+  });
+});

--- a/packages/ui/src/components/config-ui/ui-renderer.tsx
+++ b/packages/ui/src/components/config-ui/ui-renderer.tsx
@@ -168,8 +168,15 @@ function fireEvent(action: UiAction | undefined, ctx: UiRenderContext) {
         ctx.onAction(action.onSuccess.action, action.onSuccess.params);
       }
     } else if (ctx.onAction) {
+      // Resolve $path / $data dynamic references in action params from live
+      // state, the same resolution applied to element props. Without this,
+      // forms that declare { field: { $path: "form.field" } } in their save
+      // action send the literal { $path } object instead of the typed value.
+      const resolvedParams = action.params
+        ? resolveProps(action.params, ctx)
+        : action.params;
       try {
-        ctx.onAction(action.action, action.params);
+        ctx.onAction(action.action, resolvedParams);
         if (action.onSuccess)
           ctx.onAction(action.onSuccess.action, action.onSuccess.params);
       } catch {


### PR DESCRIPTION
Fixes #18975

## Summary

Plugin config forms emitted by `resolvePluginConfigReply` stored edited values in UiRenderer state, but the save button action dispatched literal params without resolving the documented `$path`/`$data` dynamic references. `MessageUiSpecBlock` then constructed an empty config patch, called `updatePlugin(pluginId, { config: {} })`, and reported success — even though none of the entered values reached the API.

Three fixes:

1. **`UiRenderer.fireEvent`** (`packages/ui/src/components/config-ui/ui-renderer.tsx`): resolves `$path`/`$data` dynamic references in action params from live state before dispatching — the same `resolveProps` resolution already applied to element props.

2. **`resolvePluginConfigReply`** (`packages/agent/src/api/server-helpers-plugin.ts`): save button now emits `$path` bindings for every declared config field into the save action params, so the renderer resolves them at dispatch time.

3. **`MessageUiSpecBlock`** (`packages/ui/src/components/chat/MessageContent.tsx`): an empty config patch (no fields filled) no longer calls `updatePlugin` or reports a false success acknowledgment.

## Regression coverage

- `server-helpers-plugin.config-state-binding.test.ts`: verifies every `config.*` state key declared in the form has a matching `$path` binding in the save action params.
- `ui-renderer-action-params.test.tsx`: exercises the real `UiRenderer` handler — types a value into a form field, presses submit, and asserts the action params resolve the `$path` reference to the live state value.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- AI provider/model: zai/glm-5.2
<!-- attribution-row:client -->
- Client / agent tooling: Hermes Agent
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@c5dedb19c0a78d3551ddfe9e19c33da397a9f53e:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported
— [hermes/t3rpz]