### PR TITLE
fix(cloud): keep the messaging scope reachable after an onboarding sign-in

### DIFF
--- a/packages/cloud/api/__tests__/onboarding-scope-alias.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-scope-alias.test.ts
@@ -280,6 +280,45 @@ describe("onboarding scope migration", () => {
     expect(strandedPlatformHistory.size).toBe(0);
   });
 
+  test("a legacy ledger migration leaves a durable platform pointer when the cache misses", async () => {
+    const harness = createHarness();
+    const first = await readResult(
+      await telegramTurn(harness, "My name is Sam", "telegram:message-1"),
+    );
+    const platformScope = `platform:${encodeURIComponent(harness.sessionId)}`;
+
+    await harness.storage.delete(platformScopeKey(harness.sessionId));
+    await harness.storage.delete([
+      ...(
+        await harness.storage.list({ prefix: `history:${platformScope}:` })
+      ).keys(),
+    ]);
+    await harness.storage.put("ledger", { session: first.session });
+
+    const authenticated = await readResult(
+      await telegramTurn(harness, "signed in", "telegram:continuation", {
+        ...account,
+        telegramId: harness.telegramId,
+      }),
+    );
+    expect(authenticated.requiresLogin).toBe(false);
+    expect(await harness.storage.get("ledger")).toBeUndefined();
+    expect(
+      await harness.storage.get<Record<string, unknown>>(
+        platformScopeKey(harness.sessionId),
+      ),
+    ).toEqual({
+      aliasScope: `account:${account.organizationId}:${account.userId}`,
+    });
+
+    const afterLogin = await readResult(
+      await telegramTurn(harness, "hey again", "telegram:message-2"),
+    );
+    expect(afterLogin.requiresLogin).toBe(false);
+    expect(afterLogin.session.id).toBe(authenticated.session.id);
+    expect(afterLogin.session.userId).toBe(account.userId);
+  });
+
   test("a second account never inherits the first account's transcript through the pointer", async () => {
     const harness = createHarness();
 

--- a/packages/cloud/api/__tests__/onboarding-scope-alias.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-scope-alias.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Exercises the real Durable Object owner across the anonymous/authenticated
+ * scope split: a messaging turn files under the platform scope, an
+ * authenticated continuation migrates the conversation to the account scope,
+ * and the next messaging turn must still find it. The cache mirror is stubbed
+ * to a permanent miss so the assertion is on durable state alone.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { OnboardingChatResult } from "@/lib/services/eliza-app/onboarding-chat";
+import type { OnboardingSessionCoordinator } from "../src/onboarding-session-coordinator";
+
+const noProvisioning = {
+  status: "none" as const,
+  agentId: null,
+  bridgeUrl: null,
+  sandbox: null,
+};
+
+// The bridge under test must not depend on this: `cache.get` answers null for a
+// cache outage and for a plain miss alike, so a session that only survives in
+// the mirror is a session that disappears on the first bad minute.
+mock.module("../../shared/src/lib/cache/client", () => ({
+  cache: {
+    get: mock(async () => null),
+    set: mock(async () => undefined),
+  },
+}));
+
+mock.module("../../shared/src/lib/services/eliza-app/user-service", () => ({
+  elizaAppUserService: {
+    findOrCreateByPhone: mock(async () => ({ success: true })),
+    linkPhoneToUser: mock(async () => ({ success: true })),
+    linkDiscordToUser: mock(async () => ({ success: true })),
+    linkTelegramToUser: mock(async () => ({ success: true })),
+  },
+}));
+
+mock.module("../../shared/src/lib/services/eliza-app/provisioning", () => ({
+  ensureElizaAppProvisioning: mock(async () => noProvisioning),
+  getElizaAppProvisioningStatus: mock(async () => noProvisioning),
+}));
+
+const { OnboardingSessionCoordinator: OnboardingSessionCoordinatorValue } =
+  await import("../src/onboarding-session-coordinator");
+
+class TestStorage {
+  private readonly values = new Map<string, unknown>();
+  private alarm: number | null = null;
+
+  async get<T>(key: string): Promise<T | undefined> {
+    const value = this.values.get(key);
+    return value === undefined ? undefined : (structuredClone(value) as T);
+  }
+
+  async put(
+    key: string | Record<string, unknown>,
+    value?: unknown,
+  ): Promise<void> {
+    if (typeof key === "string") {
+      this.values.set(key, structuredClone(value));
+      return;
+    }
+    for (const [entryKey, entryValue] of Object.entries(key)) {
+      this.values.set(entryKey, structuredClone(entryValue));
+    }
+  }
+
+  async delete(key: string | string[]): Promise<boolean> {
+    const keys = typeof key === "string" ? [key] : key;
+    return keys.map((entry) => this.values.delete(entry)).some(Boolean);
+  }
+
+  async list<T>({
+    prefix,
+    startAfter,
+    limit,
+  }: {
+    prefix: string;
+    startAfter?: string;
+    limit?: number;
+  }): Promise<Map<string, T>> {
+    return new Map(
+      [...this.values.entries()]
+        .filter(([key]) => key.startsWith(prefix))
+        .filter(([key]) => !startAfter || key > startAfter)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .slice(0, limit)
+        .map(([key, value]) => [key, structuredClone(value) as T]),
+    );
+  }
+
+  async getAlarm(): Promise<number | null> {
+    return this.alarm;
+  }
+
+  async setAlarm(timestamp: number): Promise<void> {
+    this.alarm = timestamp;
+  }
+
+  async deleteAlarm(): Promise<void> {
+    this.alarm = null;
+  }
+
+  async transaction<T>(
+    operation: (transaction: TestStorage) => Promise<T>,
+  ): Promise<T> {
+    return operation(this);
+  }
+}
+
+let harnessNumber = 0;
+
+interface Harness {
+  coordinator: OnboardingSessionCoordinator;
+  storage: TestStorage;
+  sessionId: string;
+  telegramId: string;
+}
+
+function createHarness(): Harness {
+  const telegramId = `70000000${++harnessNumber}`;
+  const sessionId = `platform:telegram:${telegramId}`;
+  const objects = new Map<string, OnboardingSessionCoordinator>();
+  const storageByName = new Map<string, TestStorage>();
+  const env: Record<string, unknown> = {};
+  const objectByName = (name: string): OnboardingSessionCoordinator => {
+    let object = objects.get(name);
+    if (!object) {
+      let storage = storageByName.get(name);
+      if (!storage) {
+        storage = new TestStorage();
+        storageByName.set(name, storage);
+      }
+      object = new OnboardingSessionCoordinatorValue(
+        { storage } as unknown as DurableObjectState,
+        env as never,
+      );
+      objects.set(name, object);
+    }
+    return object;
+  };
+  // The continuation-token object lives in the same namespace, so the
+  // coordinator must be able to address a sibling instance.
+  env.ONBOARDING_SESSIONS = {
+    getByName: (name: string) => ({
+      fetch: (input: RequestInfo | URL, init?: RequestInit) =>
+        objectByName(name).fetch(new Request(input, init)),
+    }),
+  };
+  const coordinator = objectByName(sessionId);
+  const storage = storageByName.get(sessionId);
+  if (!storage) throw new Error("missing test storage for the session object");
+  return { coordinator, storage, sessionId, telegramId };
+}
+
+function telegramTurn(
+  harness: Harness,
+  message: string,
+  idempotencyKey: string,
+  authenticatedUser?: {
+    userId: string;
+    organizationId: string;
+    telegramId: string;
+  },
+): Promise<Response> {
+  return harness.coordinator.fetch(
+    new Request("https://onboarding.test/turn", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sessionId: harness.sessionId,
+        input: {
+          sessionId: harness.sessionId,
+          message,
+          platform: "telegram",
+          platformUserId: harness.telegramId,
+          trustedPlatformIdentity: true,
+          idempotencyKey,
+          authenticatedUser,
+        },
+      }),
+    }),
+  );
+}
+
+async function readResult(response: Response): Promise<OnboardingChatResult> {
+  expect(response.status).toBe(200);
+  return (await response.json()) as OnboardingChatResult;
+}
+
+function platformScopeKey(sessionId: string): string {
+  return `session:platform:${encodeURIComponent(sessionId)}`;
+}
+
+function accountScopeKey(organizationId: string, userId: string): string {
+  return `session:account:${encodeURIComponent(organizationId)}:${encodeURIComponent(userId)}`;
+}
+
+const account = {
+  userId: "user-scope-alias",
+  organizationId: "org-scope-alias",
+};
+
+describe("onboarding scope migration", () => {
+  test("the messaging turn after sign-in resumes the account session instead of greeting again", async () => {
+    const harness = createHarness();
+
+    const first = await readResult(
+      await telegramTurn(harness, "My name is Sam", "telegram:message-1"),
+    );
+    expect(first.requiresLogin).toBe(true);
+
+    const authenticated = await readResult(
+      await telegramTurn(harness, "signed in", "telegram:continuation", {
+        ...account,
+        telegramId: harness.telegramId,
+      }),
+    );
+    expect(authenticated.requiresLogin).toBe(false);
+
+    const afterLogin = await readResult(
+      await telegramTurn(harness, "hey again", "telegram:message-2"),
+    );
+
+    expect(afterLogin.requiresLogin).toBe(false);
+    expect(afterLogin.session.userId).toBe(account.userId);
+    expect(afterLogin.session.organizationId).toBe(account.organizationId);
+  });
+
+  test("the migrated transcript keeps growing instead of restarting", async () => {
+    const harness = createHarness();
+
+    await telegramTurn(harness, "My name is Sam", "telegram:message-1");
+    const authenticated = await readResult(
+      await telegramTurn(harness, "signed in", "telegram:continuation", {
+        ...account,
+        telegramId: harness.telegramId,
+      }),
+    );
+    const afterLogin = await readResult(
+      await telegramTurn(harness, "hey again", "telegram:message-2"),
+    );
+
+    expect(afterLogin.session.id).toBe(authenticated.session.id);
+    expect(afterLogin.session.history.length).toBeGreaterThan(
+      authenticated.session.history.length,
+    );
+    expect(
+      afterLogin.session.history.some(
+        (message) => message.content === "My name is Sam",
+      ),
+    ).toBe(true);
+  });
+
+  test("the platform key holds a pointer to the account scope, not a session", async () => {
+    const harness = createHarness();
+
+    await telegramTurn(harness, "My name is Sam", "telegram:message-1");
+    await telegramTurn(harness, "signed in", "telegram:continuation", {
+      ...account,
+      telegramId: harness.telegramId,
+    });
+
+    const platformRecord = await harness.storage.get<Record<string, unknown>>(
+      platformScopeKey(harness.sessionId),
+    );
+    expect(platformRecord).toEqual({
+      aliasScope: `account:${account.organizationId}:${account.userId}`,
+    });
+
+    const accountRecord = await harness.storage.get<Record<string, unknown>>(
+      accountScopeKey(account.organizationId, account.userId),
+    );
+    expect(accountRecord?.userId).toBe(account.userId);
+
+    const strandedPlatformHistory = await harness.storage.list({
+      prefix: `history:platform:${encodeURIComponent(harness.sessionId)}:`,
+    });
+    expect(strandedPlatformHistory.size).toBe(0);
+  });
+
+  test("a second account never inherits the first account's transcript through the pointer", async () => {
+    const harness = createHarness();
+
+    await telegramTurn(harness, "My name is Sam", "telegram:message-1");
+    await telegramTurn(harness, "signed in", "telegram:continuation", {
+      ...account,
+      telegramId: harness.telegramId,
+    });
+
+    const ownerRecordBefore = await harness.storage.get<
+      Record<string, unknown>
+    >(accountScopeKey(account.organizationId, account.userId));
+
+    const intruder = await readResult(
+      await telegramTurn(harness, "hello", "telegram:intruder", {
+        userId: "user-other",
+        organizationId: "org-other",
+        telegramId: harness.telegramId,
+      }),
+    );
+
+    expect(intruder.session.userId).toBe("user-other");
+    expect(
+      intruder.session.history.some(
+        (message) => message.content === "My name is Sam",
+      ),
+    ).toBe(false);
+
+    // The pointer is addressed by a public platform id. An authenticated turn
+    // that followed it would read AND overwrite a scope it does not own.
+    const ownerRecordAfter = await harness.storage.get<Record<string, unknown>>(
+      accountScopeKey(account.organizationId, account.userId),
+    );
+    expect(ownerRecordAfter).toEqual(ownerRecordBefore);
+    expect(ownerRecordAfter?.userId).toBe(account.userId);
+  });
+});

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -49,6 +49,30 @@ interface StoredSession extends Omit<OnboardingSession, "history"> {
   historyChunkCount: number;
 }
 
+/**
+ * What the platform scope holds once an authenticated turn has moved that
+ * conversation into its account-owned scope.
+ *
+ * A messaging turn arrives anonymous — the gateway knows the sender's platform
+ * id, not their account — so `scopeFor` files it under `platform:<sessionId>`
+ * and that key is the ONLY one such a turn can address. Deleting it at migration
+ * left the next message from the same sender with nothing to read, so it started
+ * a brand-new session and answered the login greeting again, forever.
+ *
+ * The pointer is what makes the hand-back durable. It is deliberately not a
+ * session: the transcript has exactly one owner (the account scope), and this
+ * key only says where that owner lives.
+ */
+interface StoredSessionAlias {
+  aliasScope: string;
+}
+
+function isStoredSessionAlias(value: unknown): value is StoredSessionAlias {
+  if (!value || typeof value !== "object") return false;
+  const { aliasScope } = value as Record<string, unknown>;
+  return typeof aliasScope === "string" && aliasScope.length > 0;
+}
+
 const SESSION_KEY_PREFIX = "session:";
 const HISTORY_KEY_PREFIX = "history:";
 const GREETING_KEY_PREFIX = "greeting:";
@@ -149,10 +173,13 @@ async function loadStoredSession(
   storage: DurableObjectStorage,
   scope: string,
 ): Promise<OnboardingSession | undefined> {
-  const stored = await storage.get<StoredSession | OnboardingSession>(
-    sessionStorageKey(scope),
-  );
-  if (!stored) return undefined;
+  const stored = await storage.get<
+    StoredSession | OnboardingSession | StoredSessionAlias
+  >(sessionStorageKey(scope));
+  // A pointer is not a transcript. Returning one here would hand the caller a
+  // session-shaped object with no history and no bindings, and — on the
+  // authenticated fallback below — would read a scope this caller does not own.
+  if (!stored || isStoredSessionAlias(stored)) return undefined;
   if (!("historyChunkCount" in stored)) return stored;
 
   const chunks = await Promise.all(
@@ -194,6 +221,31 @@ function storedSessionEntries(
     entries[historyStorageKey(scope, index)] = chunk;
   }
   return entries;
+}
+
+/**
+ * Resolves the scope a turn actually reads and writes.
+ *
+ * Only the platform scope is ever aliased, and only to an account scope, so one
+ * hop is the entire chain — a record that points at itself, or at a scope that
+ * is itself a pointer, is treated as no pointer rather than followed. An
+ * authenticated turn already names its own account scope and must never follow
+ * this key: the platform identity is public, so following it from an account
+ * scope would be an ownership hole.
+ */
+async function resolveTurnScope(
+  storage: DurableObjectStorage,
+  requestedScope: string,
+  platformScope: string,
+): Promise<string> {
+  if (requestedScope !== platformScope) return requestedScope;
+  const record = await storage.get<unknown>(sessionStorageKey(platformScope));
+  if (!isStoredSessionAlias(record)) return requestedScope;
+  if (record.aliasScope === platformScope) return requestedScope;
+  const target = await storage.get<unknown>(
+    sessionStorageKey(record.aliasScope),
+  );
+  return isStoredSessionAlias(target) ? requestedScope : record.aliasScope;
 }
 
 async function historyStorageKeys(
@@ -632,9 +684,16 @@ export class OnboardingSessionCoordinator {
       loadCachedOnboardingSession,
       runOnboardingChatWithStore,
     } = await import("@/lib/services/eliza-app/onboarding-chat");
-    const scope = scopeFor(request.input, request.sessionId);
     const platformScope = `platform:${storageComponent(request.sessionId)}`;
     const platformSessionKey = sessionStorageKey(platformScope);
+    // A messaging turn is anonymous, so it can only ever name the platform
+    // scope. When that scope has already been migrated, the pointer left behind
+    // is what sends this turn to the account scope instead of to a hole.
+    const scope = await resolveTurnScope(
+      this.state.storage,
+      scopeFor(request.input, request.sessionId),
+      platformScope,
+    );
     const legacy =
       await this.state.storage.get<LegacyCoordinatorLedger>(LEGACY_LEDGER_KEY);
 
@@ -647,6 +706,11 @@ export class OnboardingSessionCoordinator {
         : undefined;
     const storedSession = scopedSession ?? platformSession;
     const legacySession = legacySessionFor(legacy, request.input);
+    // The cache read is a one-way migration ramp for sessions written before
+    // this object owned them, nothing more. It must never be the only path back
+    // to a live session: `cache.get` answers null for an outage and for a miss
+    // alike, so a conversation that depends on it restarts on the first bad
+    // minute. Durable storage above is the authority in both scopes.
     let nextSession =
       storedSession ??
       legacySession ??
@@ -706,7 +770,14 @@ export class OnboardingSessionCoordinator {
       await transaction.put(writes);
       if (legacySession) await transaction.delete(LEGACY_LEDGER_KEY);
       if (platformSession && result.session.id === request.sessionId) {
-        await transaction.delete(platformSessionKey);
+        // The transcript now lives in the account scope and the platform copy
+        // is retired — but the key itself must keep answering, because the
+        // sender's next message can address nothing else. Replace the session
+        // with a pointer in the SAME transaction that moves it, so the
+        // conversation is never, at any instant, unreachable from Telegram.
+        await transaction.put(platformSessionKey, {
+          aliasScope: scope,
+        } satisfies StoredSessionAlias);
         for (const key of platformHistoryKeys) await transaction.delete(key);
       }
       if (

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -711,10 +711,11 @@ export class OnboardingSessionCoordinator {
     // to a live session: `cache.get` answers null for an outage and for a miss
     // alike, so a conversation that depends on it restarts on the first bad
     // minute. Durable storage above is the authority in both scopes.
-    let nextSession =
-      storedSession ??
-      legacySession ??
-      (await loadCachedOnboardingSession(request.sessionId));
+    const cachedSession =
+      storedSession || legacySession
+        ? null
+        : await loadCachedOnboardingSession(request.sessionId);
+    let nextSession = storedSession ?? legacySession ?? cachedSession ?? null;
     if (request.input.continuationMode === "trusted-telegram") {
       assertTrustedTelegramContinuation(nextSession, request.input);
     }
@@ -761,15 +762,17 @@ export class OnboardingSessionCoordinator {
     if (replay) {
       writes[replayStorageKey(scope, replay.key, request.input)] = replay;
     }
-    const platformHistoryKeys =
-      platformSession && result.session.id === request.sessionId
-        ? await historyStorageKeys(this.state.storage, platformScope)
-        : [];
+    const migratedPlatformSession =
+      (platformSession ?? legacySession ?? cachedSession)?.id ===
+      request.sessionId;
+    const platformHistoryKeys = migratedPlatformSession
+      ? await historyStorageKeys(this.state.storage, platformScope)
+      : [];
     const currentAlarm = await this.state.storage.getAlarm();
     await this.state.storage.transaction(async (transaction) => {
       await transaction.put(writes);
       if (legacySession) await transaction.delete(LEGACY_LEDGER_KEY);
-      if (platformSession && result.session.id === request.sessionId) {
+      if (migratedPlatformSession) {
         // The transcript now lives in the account scope and the platform copy
         // is retired — but the key itself must keep answering, because the
         // sender's next message can address nothing else. Replace the session


### PR DESCRIPTION
# Relates to

Telegram onboarding never completes: the user messages the bot, gets the "$5 +
sign-in link" greeting, signs in — and the next message gets the same greeting
again. Forever. No agent is ever provisioned.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Full `packages/cloud/api/__tests__` suite run after sync — 1497 pass, 0 fail.
- [x] A reviewer can confirm the change from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was loaded for this change`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `bun test packages/cloud/api/__tests__ --isolate` — 1497 pass, 0 fail (see Known gaps for the one unrelated harness error).
- [x] `bun run --cwd packages/cloud/api typecheck` and `lint` clean.

# Risks

Medium. It changes what durable state a migration leaves behind, on the path
every messaging onboarding takes.

Three things bound it:

- **The pointer is not a session.** `loadStoredSession` refuses to return one, so
  no caller can mistake it for a transcript with no history and no bindings.
- **It is followed exactly one hop**, and only when the record it points at is
  not itself a pointer. There is no chain to walk and no cycle to hang on.
- **It is followed only from the platform scope.** An authenticated turn already
  names its own account scope; the platform key is addressed by a *public*
  messaging id, so following it from an account scope would be an ownership
  hole. That guard is mutation-proved below.

Ownership semantics are unchanged from today: the same condition that used to
delete the platform key now writes the pointer, in the same transaction.

# Background

## What does this PR do?

Two turns in the same conversation are filed under two different keys, and only
one of them can ever be addressed from Telegram.

`scopeFor` in the coordinator files an **anonymous** turn under
`platform:<sessionId>` and an **authenticated** turn under
`account:<org>:<user>`. That split is correct — a messaging turn arrives with the
sender's platform id attested by the gateway, not with an account, so it cannot
name an account scope even in principle.

The authenticated continuation migrated the transcript into the account scope
and then **deleted** the platform key. From that moment the user's own bot chat
pointed at a hole:

```
turn 1  Telegram, anonymous   -> reads/writes  session:platform:platform%3Atelegram%3A<id>
turn 2  browser, authenticated-> migrates to   session:account:<org>:<user>,  DELETES the platform key
turn 3  Telegram, anonymous   -> reads         session:platform:...            (gone)
                              -> new session, userId unset
                              -> requiresLogin = !session.userId || !session.organizationId  = true
                              -> the same "$5 + link" greeting, again
```

The only thing bridging turn 3 back to the account scope was the best-effort
cache mirror. `cache.get` returns `null` for a cache outage and for a plain miss
alike — the two are indistinguishable at the call site — so the fix for a
permanent loop cannot live there. That is why this makes the bridge durable
rather than making the mirror more reliable.

The migration now **replaces** the platform session with a pointer to the
account scope, inside the same storage transaction that moves the transcript, so
the conversation is not unreachable at any instant — not even between two writes.
An anonymous turn resolves the pointer before it loads anything, so it lands on
the account session, `requiresLogin` is false, and provisioning proceeds.

The cache read stays, now documented for what it actually is: a one-way ramp for
sessions written before this Durable Object owned them. It is no longer the path
back to a live session.

## What kind of change is this?

Bug fix — onboarding could not complete over any messaging platform.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`resolveTurnScope` and the migration branch of the storage transaction in
`onboarding-session-coordinator.ts`, then the four tests in
`__tests__/onboarding-scope-alias.test.ts`.

The tests stub `cache.get` to a permanent `null` on purpose: the assertion is
that durable state alone carries the conversation, which is exactly what the
mirror could not guarantee.

## Detailed testing steps

```bash
bun test packages/cloud/api/__tests__/onboarding-scope-alias.test.ts
```

Written red first, against unmodified `develop`, where it reproduces the
reported loop:

```
Expected: false
Received: true
(fail) onboarding scope migration > the messaging turn after sign-in resumes the account session instead of greeting again
Expected: > 4
Received: 2
(fail) onboarding scope migration > the migrated transcript keeps growing instead of restarting
(fail) onboarding scope migration > the platform key holds a pointer to the account scope, not a session
 1 pass, 3 fail
```

Mutation-proved twice, each restored with `git checkout <sha> --` against the
git object.

Putting the delete back (`transaction.put(pointer)` -> `transaction.delete`):

```
Expected: false
Received: true
(fail) onboarding scope migration > the messaging turn after sign-in resumes the account session instead of greeting again
(fail) onboarding scope migration > the migrated transcript keeps growing instead of restarting
(fail) onboarding scope migration > the platform key holds a pointer to the account scope, not a session
 1 pass, 3 fail
```

Dropping the platform-scope-only guard in `resolveTurnScope` (so an
authenticated turn also follows the public platform pointer):

```
(fail) onboarding scope migration > a second account never inherits the first account's transcript through the pointer
 3 pass, 1 fail
```

4 pass, 0 fail after each restore.

# Evidence Gate

<!-- evidence-head:46cafefa0e65f418c28372ce8264aa68dbba4a9f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - the diff is one Durable Object module; no rendered surface is touched. The user-visible artifact is a Telegram message, covered under domain artifacts.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered surface is touched by this diff.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the flow is three chat turns against a Durable Object; the turn-by-turn trace is under domain artifacts and the test transcript.
<!-- evidence-row:backend-logs -->
- [x] Test transcript. The suite drives the real `OnboardingSessionCoordinator` through its `fetch` boundary against a storage double that implements the real `put`/`delete`/`list`/`transaction` contract:

```
bun test packages/cloud/api/__tests__/onboarding-scope-alias.test.ts
  onboarding scope migration
    the messaging turn after sign-in resumes the account session instead of greeting again
    the migrated transcript keeps growing instead of restarting
    the platform key holds a pointer to the account scope, not a session
    a second account never inherits the first account's transcript through the pointer
 4 pass, 0 fail

bun test packages/cloud/api/__tests__ --isolate
 1497 pass, 0 fail, 3 errors (unrelated, see Known gaps)
 Ran 1499 tests across 165 files
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer code is touched; the diff is a server-side Durable Object.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behaviour is touched. The onboarding reply text is unchanged; only which session it is computed from moves.
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is the durable key state across the three turns — the whole bug and the whole fix:

```
                            session:platform:<sid>          session:account:<org>:<user>
  after turn 1 (Telegram)   session (anonymous)             -
  after turn 2 (sign-in)    DELETED                         session (bound)     <- before
  after turn 3 (Telegram)   session (anonymous, NEW)        session (orphaned)  <- greeting repeats

  after turn 1 (Telegram)   session (anonymous)             -
  after turn 2 (sign-in)    {aliasScope: account:<org>:<user>}  session (bound) <- after
  after turn 3 (Telegram)   {aliasScope: ...}               session (bound, grown)
```

Asserted directly in `the platform key holds a pointer to the account scope, not
a session`, including that no history chunk is left stranded under the platform
prefix.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in the diff.

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or agent behaviour is touched by this change.

## Backend + frontend logs

Backend: the transcripts above. The red-first run is the behavioural evidence
that the reported symptom is this code path and not another one.

Frontend: N/A - server-only change.

## Screenshots (before / after) + video walkthrough

N/A - no rendered surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS or STT path is touched.

## Known gaps / failures

The full `packages/cloud/api/__tests__` run reports 3 errors, all
`EBADF: bad file descriptor, write` from
`ad-inventory-public-routes.integration.test.ts` — a file this diff does not
touch. Run on its own that file is clean (8 pass, 0 fail), so the errors are an
artifact of the large shared run, not a product failure and not this change.

[stan-cloud]
