### PR TITLE
fix(registry): remove unpublished peer-cash entry

### DIFF
--- a/packages/registry/entries/third-party/zkp2p__plugin-peer-cash.json
+++ b/packages/registry/entries/third-party/zkp2p__plugin-peer-cash.json
@@ -1,9 +1,0 @@
-{
-  "package": "@zkp2p/plugin-peer-cash",
-  "repository": "github:ADWilkinson/plugin-peer-cash",
-  "kind": "plugin",
-  "description": "Peer Cash offramp actions: cash out Base USDC to Venmo, Revolut, Wise, Zelle, and more at the live oracle market rate, with order tracking, withdraw, and top-up.",
-  "homepage": "https://peer.xyz/cash-sdk",
-  "version": "0.1.0",
-  "tags": ["offramp", "usdc", "base", "crypto-to-fiat", "payments", "zkp2p"]
-}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -994,52 +994,6 @@
       "registryKind": "plugin",
       "directory": null
     },
-    "@zkp2p/plugin-peer-cash": {
-      "git": {
-        "repo": "ADWilkinson/plugin-peer-cash",
-        "v0": {
-          "branch": null
-        },
-        "v1": {
-          "branch": null
-        },
-        "v2": {
-          "branch": "main"
-        }
-      },
-      "npm": {
-        "repo": "@zkp2p/plugin-peer-cash",
-        "v0": null,
-        "v1": null,
-        "v2": "0.1.0"
-      },
-      "supports": {
-        "v0": false,
-        "v1": false,
-        "v2": true
-      },
-      "description": "Peer Cash offramp actions: cash out Base USDC to Venmo, Revolut, Wise, Zelle, and more at the live oracle market rate, with order tracking, withdraw, and top-up.",
-      "homepage": "https://peer.xyz/cash-sdk",
-      "topics": [
-        "offramp",
-        "usdc",
-        "base",
-        "crypto-to-fiat",
-        "payments",
-        "zkp2p"
-      ],
-      "stargazers_count": 0,
-      "language": "TypeScript",
-      "origin": "third-party",
-      "source": "community",
-      "support": "community",
-      "builtIn": false,
-      "firstParty": false,
-      "thirdParty": true,
-      "kind": "plugin",
-      "registryKind": "plugin",
-      "directory": null
-    },
     "blackwall-eliza-guardrail": {
       "git": {
         "repo": "bluetieroperations-create/blackwall-eliza-guardrail",


### PR DESCRIPTION
# Relates to

Closes #19031.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated homepage blocker is recorded below.
- [x] A reviewer can confirm the change from the generated registry diff and validation evidence.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated homepage typecheck blocker is documented below.

# Risks

Low. This removes one unpublished third-party package from the registry source and regenerated output. If the package is published later, its preserved metadata can be restored from issue #19031 or Git history after npm availability is verified.

# Background

## What does this PR do?

Removes `@zkp2p/plugin-peer-cash@0.1.0` from the publish-first registry because npm returns `E404` for that exact package version. The generated registry is regenerated from source, with no unrelated churn.

## What kind of change is this?

Bug fix (non-breaking): prevents users from discovering an installation target that does not exist.

# Documentation changes needed?

No. This restores the registry to its already-documented publish-first contract.

# Testing

## Where should a reviewer start?

Review the two-file deletion-only diff, then inspect the attached registry validation artifact.

## Detailed testing steps

1. Run `npm view @zkp2p/plugin-peer-cash@0.1.0 version --json`; npm returns `E404`.
2. Run `bun run --cwd packages/registry generate`; a second run produces no further changes.
3. Run `bun run --cwd packages/registry validate` and confirm all 41 remaining entries validate.
4. Run the registry test, typecheck, lint, format, and first-party generated-artifact checks listed in the evidence artifact.

# Evidence Gate

<!-- evidence-head:ce4ee6ba255f09eea51e9d19c72f23355c99e4d4 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - registry JSON has no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - registry JSON has no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - static registry-data correction has no interactive flow
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime path changes; registry validation is attached as a domain artifact
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or network behavior changes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes
<!-- evidence-row:domain-artifacts -->
- [x] [19034-registry-validation-19031.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19034-registry-validation-19031.json)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model changes.

## Backend + frontend logs

N/A - this changes only static registry source and generated JSON.

## Screenshots (before / after) + video walkthrough

N/A - registry data has no rendered UI surface.

## Known gaps / failures

`bun run verify` reached **249 successful of 348 Turbo tasks** before the sole failing task, `eliza-app#typecheck`. The same failure reproduces directly in the untouched homepage package on current `origin/develop`:

```text
packages/homepage/src/pages/landing.tsx:256,264,268
TS2353: DemoItem union construction rejects text/card fields

packages/homepage/src/pages/landing.tsx:461
TS2550: Array.prototype.at is outside the configured lib target
```

This PR changes only `packages/registry` data. Its owning-package gates pass: validation (41 entries), generated first-party artifact check, 36/36 tests, typecheck, lint, format, deterministic regeneration, and `git diff --check`.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-issue-triage]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->


