### PR TITLE
fix(registry): re-land peer-cash entry under published @davyjones0x scope

### DIFF
--- a/packages/registry/entries/third-party/davyjones0x__plugin-peer-cash.json
+++ b/packages/registry/entries/third-party/davyjones0x__plugin-peer-cash.json
@@ -1,0 +1,9 @@
+{
+  "package": "@davyjones0x/plugin-peer-cash",
+  "repository": "github:ADWilkinson/plugin-peer-cash",
+  "kind": "plugin",
+  "description": "Peer Cash offramp actions: cash out Base USDC to Venmo, Revolut, Wise, Zelle, and more at the live oracle market rate, with order tracking, withdraw, and top-up.",
+  "homepage": "https://peer.xyz/cash-sdk",
+  "version": "0.1.1",
+  "tags": ["offramp", "usdc", "base", "crypto-to-fiat", "payments", "zkp2p"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -92,6 +92,52 @@
       "registryKind": "plugin",
       "directory": "eliza-plugin-agentradar"
     },
+    "@davyjones0x/plugin-peer-cash": {
+      "git": {
+        "repo": "ADWilkinson/plugin-peer-cash",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@davyjones0x/plugin-peer-cash",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.1"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Peer Cash offramp actions: cash out Base USDC to Venmo, Revolut, Wise, Zelle, and more at the live oracle market rate, with order tracking, withdraw, and top-up.",
+      "homepage": "https://peer.xyz/cash-sdk",
+      "topics": [
+        "offramp",
+        "usdc",
+        "base",
+        "crypto-to-fiat",
+        "payments",
+        "zkp2p"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@human.tech/plugin-waap": {
       "git": {
         "repo": "holonym-foundation/eliza-plugin-waap",


### PR DESCRIPTION
# Relates to

Refs #19031 (complements it; #19033 stays the canonical closer). Re-land of #19024 under the published npm scope, addressing both change requests on this PR. Complements #19033, which removes the old unpublished row: this PR is now a pure add and merges cleanly in either order.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The diff is two registry data files: one new third-party entry JSON plus the regenerated wire registry. No runtime code changes. The failure mode is bad install metadata for one plugin row, mitigated by the schema validator and the tarball inspection attached below.

# Background

## What does this PR do?

hey team, Andrew from Peer. This re-lands the peer-cash registry entry from #19024 with both review findings fixed.

Shaw's tarball finding was real: 0.1.0 declared `dist/index.d.ts` but the published tarball shipped only the JS bundle. Root cause was a stale `tsconfig.build.tsbuildinfo` in the plugin's build script: `tsc --emitDeclarationOnly --incremental` saw an up-to-date buildinfo and skipped emitting into the freshly cleaned dist. The build now removes buildinfo files during clean and drops `--incremental`. `@davyjones0x/plugin-peer-cash@0.1.1` is published with the full declaration tree, verified from the public registry tarball below, and this entry points at 0.1.1.

Uuriko's merge-order finding is fixed by restructuring: this branch no longer renames the old `zkp2p__plugin-peer-cash.json` file, it only adds `davyjones0x__plugin-peer-cash.json` on latest `develop`. #19033 can land before or after this PR; the only overlap left is the regenerated registry artifact, which either side regenerates mechanically.

The old row's removal stays with #19033 as claimed in #19031. Until it lands, the registry carries both rows and the validator accepts 43 entries.

## What kind of change is this?

Bug fixes (re-lands a registry row that was blocked on publish order, now pointing at a published and tarball-verified package).

# Documentation changes needed?

None. Plugin documentation lives in the plugin repository readme.

# Testing

## Where should a reviewer start?

`packages/registry/entries/third-party/davyjones0x__plugin-peer-cash.json`, then the matching block in `packages/registry/generated-registry.json`.

## Detailed testing steps

- `bun run --cwd packages/registry validate` prints `43 third-party entries validated`
- `bun run --cwd packages/registry generate` reproduces the committed `generated-registry.json` with no drift
- `npm pack @davyjones0x/plugin-peer-cash@0.1.1` then `tar -tzf` the tarball: `package/dist/index.d.ts` and the full declaration tree are present (transcript below)

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ef06b6b11c5d1430e126c792a58abdf8f9b8292a -->

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank.

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - registry data JSON only, no rendered UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - registry data JSON only, no rendered UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - registry data JSON only, no user flow to walk through`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no backend code path changed; data-only registry entry`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, prompt, provider, or model behavior changed in this repository`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the published npm package this entry points at, inspected from the public registry, plus the registry gates on this branch.

  <details>
  <summary>npm tarball inspection and registry gate transcript</summary>

  ```
  $ npm view @davyjones0x/plugin-peer-cash@0.1.1 version dist.integrity repository.url
  version = '0.1.1'
  dist.integrity = 'sha512-Dsts3zrLryvV50jYbfKhL07fE0PWkY9Y/w0EdWlxDDEZy5j+SelVbXBGLBR7HwUOrVlZFSk6G3i/FyJS6uN5fA=='
  repository.url = 'git+https://github.com/ADWilkinson/plugin-peer-cash.git'

  $ npm pack @davyjones0x/plugin-peer-cash@0.1.1
  davyjones0x-plugin-peer-cash-0.1.1.tgz

  $ tar -tzf davyjones0x-plugin-peer-cash-0.1.1.tgz | grep "dist/index"
  package/dist/index.js
  package/dist/index.d.ts.map
  package/dist/index.js.map
  package/dist/index.d.ts

  $ tar -tzf davyjones0x-plugin-peer-cash-0.1.1.tgz | grep -c "\.d\.ts$"
  22
  $ tar -tzf davyjones0x-plugin-peer-cash-0.1.1.tgz | wc -l
  51

  $ bun run --cwd packages/registry validate
  [registry] 43 third-party entries validated
  $ bun run --cwd packages/registry generate
  Generated packages/registry/generated-registry.json (43 third-party entries)
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface in this change`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, prompt, provider, or model behavior changed in this repository.`

## Backend + frontend logs

`N/A - data-only registry entry; the gate transcript above is the complete execution evidence.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this change.`

## Audio / voice walkthrough

`N/A - no voice or audio surface in this change.`

## Known gaps / failures

- Full monorepo `bun run verify` was not run for this two-file data-only registry change. The registry package's own gates ran green on this branch (validate and generate, transcript above), matching the registry README's documented flow for third-party entries. Happy to run the full verify if you want it.
- On the previous head (`53e27113`), `Tests (scripts)` and `Android release AAB` failed. The diff touches only two registry JSON data files, which neither the script contract suite nor the Android build consumes. I am reproducing `bun run test:scripts` on a clean local checkout of `develop` to confirm the failures are inherited, and will post the result as a comment on this PR alongside the fresh CI run on the current head.

## Links

npm → https://www.npmjs.com/package/@davyjones0x/plugin-peer-cash
Repo → https://github.com/ADWilkinson/plugin-peer-cash
SDK → https://www.npmjs.com/package/@zkp2p/cash
Docs → https://docs.peer.xyz/developer/peer-cash
Builders Club → https://t.me/zk_p2p/167174

I maintain this. Questions or issues, ask in the Builders Club or ping @andrewwilkinson on X. I will address review feedback here promptly.


