### PR TITLE
fix(plugin-google-workspace): fail closed when no durable credential writer is available

### DIFF
--- a/packages/agent/src/api/connector-account-routes.test.ts
+++ b/packages/agent/src/api/connector-account-routes.test.ts
@@ -316,6 +316,7 @@ vi.mock("@elizaos/core", async (importOriginal) => ({
 const { getConnectorAccountManager, InMemoryConnectorAccountStorage } =
   coreMocks;
 
+import { ElizaError } from "@elizaos/core";
 import {
   type ConnectorAccountRouteContext,
   handleConnectorAccountRoutes,
@@ -631,6 +632,52 @@ describe("connector account routes", () => {
     await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
     expect(captured.status, JSON.stringify(captured.body)).toBe(201);
     expect(seen).toEqual(["http://127.0.0.1:2138"]);
+  });
+
+  it("serializes an ElizaError's stable code and context through the callback boundary and fails the flow (#18080)", async () => {
+    const { ctx, captured, runtime, storage } = createConnectorAccountHarness({
+      method: "GET",
+      pathname: "/api/connectors/slack/oauth/callback?state=state-cred&code=ok",
+    });
+    const manager = getConnectorAccountManager(runtime as never, storage);
+    manager.registerProvider({
+      provider: "slack",
+      completeOAuth: () => {
+        throw new ElizaError(
+          "No durable connector credential store or vault writer is available",
+          {
+            code: "CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE",
+            severity: "fatal",
+            context: { provider: "slack", accountId: "acct_cred" },
+          },
+        );
+      },
+    });
+    await storage.createOAuthFlow({
+      id: "flow-cred",
+      provider: "slack",
+      state: "state-cred",
+      status: "pending",
+      createdAt: 1,
+      updatedAt: 1,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
+
+    // The runtime-classifiable structured failure, not prose-only.
+    expect(captured.status).toBe(400);
+    expect(captured.body).toMatchObject({
+      ok: false,
+      code: "CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE",
+      context: { provider: "slack", accountId: "acct_cred" },
+    });
+    expect((captured.body as { error?: string }).error).toMatch(
+      /No durable connector credential store/,
+    );
+    // Failed-flow persistence on provider throw is covered against the REAL
+    // manager in core's account-manager.test.ts and the plugin's
+    // connector-oauth-manager-flow.test.ts; this harness manager is a double.
   });
 
   it("persists OAuth start state through the connector account storage contract", async () => {

--- a/packages/agent/src/api/connector-account-routes.ts
+++ b/packages/agent/src/api/connector-account-routes.ts
@@ -20,6 +20,7 @@ import {
   type ConnectorOAuthFlow,
   DEFAULT_PRIVACY_LEVEL,
   getConnectorAccountManager,
+  isElizaError,
   isPrivacyLevel,
   type Metadata,
 } from "@elizaos/core";
@@ -1000,6 +1001,25 @@ export async function handleConnectorAccountRoutes(
           redirectUrl: result.redirectUrl,
         });
       } catch (err) {
+        // error-policy:J1 Boundary translation: an ElizaError from the
+        // completion path (e.g. CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE from
+        // #18080's fail-closed contract) keeps its stable code and non-secret
+        // context in the structured response so callers can classify the
+        // failure instead of parsing prose.
+        if (isElizaError(err)) {
+          json(
+            res,
+            {
+              provider,
+              ok: false,
+              error: err.message,
+              code: err.code,
+              ...(err.context ? { context: err.context } : {}),
+            },
+            400,
+          );
+          return true;
+        }
         error(
           res,
           err instanceof Error ? err.message : "Failed to complete OAuth flow",

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -4875,7 +4875,7 @@ export async function startEliza(
       await runtime.getServiceLoadPromise("connector_credential_store");
     } catch (err) {
       logger.warn(
-        `[eliza] ConnectorCredentialStoreService failed to start; connector OAuth credential writes will fall back to non-durable storage: ${formatError(err)}`,
+        `[eliza] ConnectorCredentialStoreService failed to start; fail-closed connector OAuth flows (google) will reject completion until it starts, and legacy connector writes fall back to non-durable storage: ${formatError(err)}`,
       );
     }
   };

--- a/packages/agent/src/services/connector-credential-store.runtime.test.ts
+++ b/packages/agent/src/services/connector-credential-store.runtime.test.ts
@@ -163,4 +163,29 @@ describe("ConnectorCredentialStoreService start semantics (real runtime)", () =>
       "restart-surviving-material",
     );
   }, 240_000);
+
+  it("leaves a registered-but-failed store null in getService while still listed in the registry — the exact fail-closed signal (#18080)", async () => {
+    // The shipped store's start() cannot fail organically (it only constructs
+    // over the already-installed bridge vault), so the failure is injected at
+    // the same seam a real environmental fault would hit: the static start the
+    // service loader awaits. Registration and lookup semantics stay real.
+    class FailingConnectorCredentialStoreService extends ConnectorCredentialStoreService {
+      static override async start(): Promise<never> {
+        throw new Error("injected start failure");
+      }
+    }
+
+    const runtime = await bootRuntime(new Map());
+    await runtime.registerService(FailingConnectorCredentialStoreService);
+    await expect(runtime.getServiceLoadPromise(SERVICE_TYPE)).rejects.toThrow(
+      /failed to start/,
+    );
+
+    // The two-sided signal persistConnectorCredentialRefs keys on: getService
+    // resolves null, while the registry still lists the type. Durability was
+    // expected here, so OAuth completion must fail closed instead of demoting
+    // the write to volatile SECRETS.
+    expect(runtime.getService(SERVICE_TYPE)).toBeNull();
+    expect(runtime.getRegisteredServiceTypes()).toContain(SERVICE_TYPE);
+  }, 120_000);
 });

--- a/packages/agent/test/connector-credential-topology.integration.test.ts
+++ b/packages/agent/test/connector-credential-topology.integration.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Standalone-entrypoint topology regression for #18080: connect → full process
+ * restart → credential-state read, on the shipped Cloud image topology. Each
+ * phase spawns the REAL standalone boot (`connector-oauth-topology-child.ts` →
+ * `startElizaProcess`, the same path `bin.js start` runs) as a separate `bun`
+ * process over a shared temp `ELIZA_STATE_DIR`/PGlite store; a restart is a
+ * genuinely new OS process reusing only that durable state. Only Google's
+ * token HTTP response is stubbed via a loopback server + `ELIZA_MOCK_GOOGLE_BASE`;
+ * runtime, plugin resolution, host bridge (no-op vault ⇒ `hasDurableHostVault()`
+ * false, credential store never registers), manager, provider, and SQL storage
+ * are all real.
+ *
+ * Covers both sides of the #18080 product contract:
+ * - Cloud-provisioned (`ELIZA_CLOUD_PROVISIONED=1`): OAuth completion fails
+ *   closed with `CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE`, the consumed flow
+ *   persists as failed (surviving the restart), and no account ever carries a
+ *   credential ref.
+ * - Hostless local desktop/dev (no cloud flag): keep-until-restart — the
+ *   volatile SECRETS write succeeds, the account connects flagged
+ *   `credentialRefStorage.volatile`, and the ref visibly dangles after restart
+ *   (refs persisted, secret material gone with the old process).
+ *
+ * Boots the full runtime twice per case (~30-60s each) — kept in the
+ * integration lane; run with `bun run --cwd packages/agent test:integration`
+ * or target this file directly.
+ */
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(
+  HERE,
+  "fixtures",
+  "connector-oauth-topology-child.ts",
+);
+
+interface AccountSnapshot {
+  id: string;
+  status: string;
+  hasCredentialRefs: boolean;
+  volatile: boolean | null;
+}
+
+interface TopologyResult {
+  mode: string;
+  hasDurableHostVault?: boolean;
+  storeRegistered?: boolean;
+  state?: string;
+  completed?: boolean;
+  completedAccountStatus?: string | null;
+  completionError?: string;
+  completionErrorCode?: string | null;
+  flowStatus?: string | null;
+  flowError?: string | null;
+  flowErrorCode?: string | null;
+  accounts?: AccountSnapshot[];
+  driverError?: string;
+}
+
+function unsignedJwt(payload: Record<string, unknown>): string {
+  const b64 = (value: unknown) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${b64({ alg: "none" })}.${b64(payload)}.`;
+}
+
+let tokenServer: http.Server;
+let mockGoogleBase = "";
+const stateDirs: string[] = [];
+
+beforeAll(async () => {
+  tokenServer = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/token") {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          access_token: "topology-access-token",
+          refresh_token: "topology-refresh-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "https://www.googleapis.com/auth/gmail.readonly",
+          id_token: unsignedJwt({
+            sub: "google-sub-topology",
+            email: "owner@example.com",
+            email_verified: true,
+            name: "Owner",
+          }),
+        }),
+      );
+      return;
+    }
+    res.statusCode = 404;
+    res.end("{}");
+  });
+  await new Promise<void>((resolve) =>
+    tokenServer.listen(0, "127.0.0.1", resolve),
+  );
+  const { port } = tokenServer.address() as AddressInfo;
+  mockGoogleBase = `http://127.0.0.1:${port}/`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    tokenServer.close((err) => (err ? reject(err) : resolve())),
+  );
+  for (const dir of stateDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function newStateDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  stateDirs.push(dir);
+  // Google client config the way a standalone operator supplies it: agent
+  // settings in the state dir's eliza.json (runtime.getSetting deliberately
+  // never reads process.env). The redirect URI is never dereferenced — the
+  // child drives completeOAuth directly, as the callback route would.
+  fs.writeFileSync(
+    path.join(dir, "eliza.json"),
+    JSON.stringify({
+      agents: {
+        list: [
+          {
+            name: "Topology",
+            settings: {
+              GOOGLE_CLIENT_ID: "topology-client",
+              GOOGLE_CLIENT_SECRET: "topology-secret",
+              GOOGLE_REDIRECT_URI:
+                "http://127.0.0.1:39181/api/connectors/google/oauth/callback",
+            },
+          },
+        ],
+      },
+    }),
+  );
+  return dir;
+}
+
+function runChild(
+  stateDir: string,
+  env: Record<string, string>,
+  timeoutMs = 180_000,
+): Promise<TopologyResult> {
+  return new Promise((resolve, reject) => {
+    // The vitest parent env may carry ALLOW_NO_DATABASE (unit-lane default);
+    // this e2e requires the real PGlite-backed adapter, like the deployment.
+    const parentEnv = { ...process.env };
+    delete parentEnv.ALLOW_NO_DATABASE;
+    delete parentEnv.ELIZA_CLOUD_PROVISIONED;
+    const child = spawn("bun", ["--conditions=eliza-source", FIXTURE], {
+      cwd: path.join(HERE, ".."),
+      env: {
+        ...parentEnv,
+        NODE_ENV: "test",
+        LOG_LEVEL: "fatal",
+        ELIZA_STATE_DIR: stateDir,
+        PGLITE_DATA_DIR: path.join(stateDir, "pglite"),
+        GOOGLE_CLIENT_ID: "topology-client",
+        GOOGLE_CLIENT_SECRET: "topology-secret",
+        GOOGLE_REDIRECT_URI:
+          "http://127.0.0.1:39181/api/connectors/google/oauth/callback",
+        ELIZA_MOCK_GOOGLE_BASE: mockGoogleBase,
+        ELIZA_API_PORT: "0",
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`topology child timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.on("exit", () => {
+      clearTimeout(timer);
+      const line = stdout
+        .split("\n")
+        .find((candidate) => candidate.startsWith("TOPOLOGY_RESULT="));
+      if (!line) {
+        reject(
+          new Error(
+            `topology child produced no result. stdout tail: ${stdout.slice(-2000)} stderr tail: ${stderr.slice(-2000)}`,
+          ),
+        );
+        return;
+      }
+      resolve(JSON.parse(line.slice("TOPOLOGY_RESULT=".length)));
+    });
+    child.on("error", reject);
+  });
+}
+
+describe("standalone entrypoint connector-credential topology (#18080)", () => {
+  it("Cloud-provisioned image: OAuth completion fails closed, the failed flow survives a full process restart, no credential ref ever lands", async () => {
+    const stateDir = newStateDir("eliza-18080-cloud-");
+    const cloudEnv = { ELIZA_CLOUD_PROVISIONED: "1" };
+
+    const connect = await runChild(stateDir, {
+      ...cloudEnv,
+      TOPOLOGY_MODE: "connect",
+    });
+    expect(connect.driverError).toBeUndefined();
+    // The shipped Cloud image topology: default no-op vault, store skipped.
+    expect(connect.hasDurableHostVault).toBe(false);
+    expect(connect.storeRegistered).toBe(false);
+    // Completion fails closed with the stable typed code…
+    expect(connect.completed).toBe(false);
+    expect(connect.completionError).toMatch(
+      /No durable connector credential store or vault writer/,
+    );
+    expect(connect.completionErrorCode).toBe(
+      "CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE",
+    );
+    // …and the consumed flow is terminally failed, not pending forever.
+    expect(connect.flowStatus).toBe("failed");
+    expect(connect.flowErrorCode).toBe(
+      "CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE",
+    );
+    expect(connect.accounts?.every((a) => a.status === "pending")).toBe(true);
+    expect(connect.accounts?.every((a) => !a.hasCredentialRefs)).toBe(true);
+
+    // Full process restart: brand-new OS process over the same durable state.
+    const inspect = await runChild(stateDir, {
+      ...cloudEnv,
+      TOPOLOGY_MODE: "inspect",
+      TOPOLOGY_STATE: connect.state ?? "",
+    });
+    expect(inspect.driverError).toBeUndefined();
+    expect(inspect.flowStatus).toBe("failed");
+    expect(inspect.flowError).toMatch(
+      /No durable connector credential store or vault writer/,
+    );
+    expect(inspect.accounts?.every((a) => a.status === "pending")).toBe(true);
+    expect(inspect.accounts?.every((a) => !a.hasCredentialRefs)).toBe(true);
+  }, 420_000);
+
+  it("hostless local desktop/dev: keep-until-restart — connect succeeds flagged volatile, and the ref visibly dangles after a restart", async () => {
+    const stateDir = newStateDir("eliza-18080-desktop-");
+
+    const connect = await runChild(stateDir, { TOPOLOGY_MODE: "connect" });
+    expect(connect.driverError).toBeUndefined();
+    expect(connect.hasDurableHostVault).toBe(false);
+    // Pre-#19038 desktop behavior preserved: the volatile write connects the
+    // account, marked volatile so surfaces can warn about the restart window.
+    expect(connect.completed).toBe(true);
+    expect(connect.completedAccountStatus).toBe("connected");
+    const connected = connect.accounts?.find((a) => a.status === "connected");
+    expect(connected?.hasCredentialRefs).toBe(true);
+    expect(connected?.volatile).toBe(true);
+
+    // Restart: refs persisted durably, secret material died with the process —
+    // the documented keep-until-restart window, now explicit instead of silent.
+    const inspect = await runChild(stateDir, {
+      TOPOLOGY_MODE: "inspect",
+      TOPOLOGY_STATE: connect.state ?? "",
+    });
+    expect(inspect.driverError).toBeUndefined();
+    expect(inspect.flowStatus).toBe("completed");
+    const after = inspect.accounts?.find((a) => a.id === connected?.id);
+    expect(after?.status).toBe("connected");
+    expect(after?.hasCredentialRefs).toBe(true);
+    expect(after?.volatile).toBe(true);
+  }, 420_000);
+});

--- a/packages/agent/test/fixtures/connector-oauth-topology-child.ts
+++ b/packages/agent/test/fixtures/connector-oauth-topology-child.ts
@@ -1,0 +1,108 @@
+/**
+ * Child fixture for the #18080 connector-credential topology e2e: boots the
+ * REAL standalone agent entrypoint (`startElizaProcess`, the same boot
+ * `packages/agent` `serve`/`start` and the Cloud image's `bin.js start` run —
+ * real plugin resolution, real PGlite-backed plugin-sql adapter, real
+ * host-bridge/no-op vault, real `ConnectorAccountManager` and Google provider)
+ * against the `ELIZA_STATE_DIR` the parent points at, then drives or inspects
+ * a Google OAuth flow through the runtime's connector account manager — the
+ * deployed completion path on the standalone image, which mounts no
+ * personal-assistant HTTP routes. Only Google's token HTTP response is stubbed
+ * (parent-owned loopback server via `ELIZA_MOCK_GOOGLE_BASE`).
+ *
+ * `TOPOLOGY_MODE=connect` runs create-account → startOAuth → completeOAuth and
+ * reports the completion outcome; `TOPOLOGY_MODE=inspect` (a fresh process on
+ * the same durable state — a full restart) re-reads flow/account state via
+ * `TOPOLOGY_STATE`. Results print as one `TOPOLOGY_RESULT=<json>` line.
+ */
+import { getConnectorAccountManager } from "@elizaos/core";
+import { startElizaProcess } from "../../src/runtime/eliza.ts";
+import { hasDurableHostVault } from "../../src/runtime/host-bridge.ts";
+
+interface AccountSnapshot {
+  id: string;
+  status: string;
+  hasCredentialRefs: boolean;
+  volatile: boolean | null;
+}
+
+const mode = process.env.TOPOLOGY_MODE ?? "connect";
+const result: Record<string, unknown> = { mode };
+
+try {
+  const runtime = await startElizaProcess({ serverOnly: true });
+  if (!runtime) throw new Error("startElizaProcess returned no runtime");
+
+  result.hasDurableHostVault = hasDurableHostVault();
+  result.storeRegistered = runtime
+    .getRegisteredServiceTypes()
+    .includes("connector_credential_store" as never);
+
+  const manager = getConnectorAccountManager(runtime);
+
+  // plugin-google-workspace loads in the deferred boot wave, which
+  // startElizaProcess does not await; poll until its provider registers.
+  const deadline = Date.now() + 120_000;
+  while (!manager.getProvider("google")) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        "google connector provider never registered (deferred boot)",
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  if (mode === "connect") {
+    const account = await manager.createAccount("google", {
+      status: "pending",
+    });
+    const flow = await manager.startOAuth("google", {
+      accountId: account.id,
+      scopes: ["gmail.read"],
+    });
+    result.state = flow.state;
+    try {
+      const completion = await manager.completeOAuth("google", {
+        state: flow.state,
+        code: "topology-test-code",
+      });
+      result.completed = true;
+      result.completedAccountStatus = completion.account?.status ?? null;
+    } catch (err) {
+      result.completed = false;
+      result.completionError = err instanceof Error ? err.message : String(err);
+      result.completionErrorCode = (err as { code?: string }).code ?? null;
+    }
+    const after = await manager.getOAuthFlow("google", flow.state);
+    result.flowStatus = after?.status ?? null;
+    result.flowError = after?.error ?? null;
+    result.flowErrorCode = after?.metadata?.errorCode ?? null;
+  } else {
+    const state = process.env.TOPOLOGY_STATE ?? "";
+    const flow = state ? await manager.getOAuthFlow("google", state) : null;
+    result.flowStatus = flow?.status ?? null;
+    result.flowError = flow?.error ?? null;
+    result.flowErrorCode = flow?.metadata?.errorCode ?? null;
+  }
+
+  const accounts = await manager.getStorage().listAccounts("google");
+  result.accounts = accounts.map((account): AccountSnapshot => {
+    const metadata = (account.metadata ?? {}) as {
+      credentialRefs?: unknown[];
+      credentialRefStorage?: { volatile?: boolean };
+    };
+    return {
+      id: account.id,
+      status: account.status,
+      hasCredentialRefs:
+        Array.isArray(metadata.credentialRefs) &&
+        metadata.credentialRefs.length > 0,
+      volatile: metadata.credentialRefStorage?.volatile ?? null,
+    };
+  });
+} catch (err) {
+  result.driverError = err instanceof Error ? err.message : String(err);
+}
+
+console.log(`TOPOLOGY_RESULT=${JSON.stringify(result)}`);
+process.exit(result.driverError ? 1 : 0);

--- a/packages/core/src/connectors/account-manager.test.ts
+++ b/packages/core/src/connectors/account-manager.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
+import { ElizaError } from "../errors";
 import type { TargetInfo } from "../types";
 import type {
 	IAgentRuntime,
@@ -201,6 +202,71 @@ describe("ConnectorAccountManager", () => {
 				code: "code-2",
 			}),
 		).rejects.toThrow(/already used|unknown|expired/i);
+	});
+
+	it("persists an explicit failed flow when the provider throws mid-completeOAuth (#18080)", async () => {
+		const runtime = makeRuntime();
+		const manager = getConnectorAccountManager(runtime);
+		manager.registerProvider({
+			provider: "oauth-fail",
+			startOAuth: () => ({ authUrl: "https://auth.example/start" }),
+			completeOAuth: () => {
+				throw new ElizaError("no durable credential writer", {
+					code: "CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE",
+					severity: "fatal",
+				});
+			},
+		});
+		const flow = await manager.startOAuth("oauth-fail");
+
+		await expect(
+			manager.completeOAuth("oauth-fail", {
+				state: flow.state,
+				code: "code-1",
+			}),
+		).rejects.toThrow(/no durable credential writer/);
+
+		// The consumed state must resolve to a terminal, explained failure —
+		// not a flow that reports "pending" forever.
+		const failed = await manager.getOAuthFlow("oauth-fail", flow.state);
+		expect(failed?.status).toBe("failed");
+		expect(failed?.error).toMatch(/no durable credential writer/);
+		expect(failed?.metadata?.errorCode).toBe(
+			"CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE",
+		);
+	});
+
+	it("preserves both failures when the failed-flow write itself fails during completeOAuth", async () => {
+		const runtime = makeRuntime();
+		const manager = getConnectorAccountManager(runtime);
+		manager.registerProvider({
+			provider: "oauth-doublefail",
+			startOAuth: () => ({ authUrl: "https://auth.example/start" }),
+			completeOAuth: () => {
+				throw new Error("provider exploded");
+			},
+		});
+		const flow = await manager.startOAuth("oauth-doublefail");
+
+		const storage = manager.getStorage();
+		const originalUpdate = storage.updateOAuthFlow.bind(storage);
+		storage.updateOAuthFlow = async (provider, flowIdOrState, patch) => {
+			if (patch.status === "failed") {
+				throw new Error("status write exploded");
+			}
+			return originalUpdate(provider, flowIdOrState, patch);
+		};
+
+		const attempt = manager.completeOAuth("oauth-doublefail", {
+			state: flow.state,
+			code: "code-1",
+		});
+		await expect(attempt).rejects.toThrow(AggregateError);
+		const err = (await attempt.catch((e) => e)) as AggregateError;
+		expect(err.errors.map((e) => (e as Error).message)).toEqual([
+			"provider exploded",
+			"status write exploded",
+		]);
 	});
 
 	it("preserves PKCE code verifier through database-backed OAuth flow storage", async () => {

--- a/packages/core/src/connectors/account-manager.ts
+++ b/packages/core/src/connectors/account-manager.ts
@@ -18,6 +18,7 @@
  * process-local map and referenced by an opaque `codeVerifierRef` written to
  * flow metadata, so stored rows never carry the raw secret.
  */
+import { isElizaError } from "../errors";
 import { logger } from "../logger";
 import type { Action, ActionParameters } from "../types/components";
 import type {
@@ -1761,6 +1762,32 @@ export class ConnectorAccountManager extends Service {
 				account,
 				redirectUrl: result.redirectUrl,
 			};
+		} catch (err) {
+			// error-policy:J2 The state was already consumed above, so without a
+			// terminal status the flow would report "pending" forever while every
+			// retry hits the consumed-state guard. Persist the explicit failed
+			// state before preserving the provider failure.
+			try {
+				await this.storage.updateOAuthFlow(providerId, flow.id, {
+					status: "failed",
+					error: err instanceof Error ? err.message : String(err),
+					...(isElizaError(err)
+						? {
+								metadata: {
+									...cloneMetadata(flow.metadata),
+									errorCode: err.code,
+								},
+							}
+						: {}),
+				});
+			} catch (persistenceError) {
+				// error-policy:J2 Preserve both the OAuth and state-write failures.
+				throw new AggregateError(
+					[err, persistenceError],
+					`OAuth completion and failure-state persistence failed for ${providerId}`,
+				);
+			}
+			throw err;
 		} finally {
 			deleteOAuthCodeVerifier(
 				stringMetadataValue(flow.metadata, "codeVerifierRef"),

--- a/plugins/plugin-google-workspace/src/connector-account-provider.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.ts
@@ -45,6 +45,18 @@ import { GOOGLE_SERVICE_NAME } from "./types.js";
 
 const GOOGLE_USERINFO_ENDPOINT = "https://openidconnect.googleapis.com/v1/userinfo";
 
+/**
+ * Resolve an OAuth endpoint, honoring `ELIZA_MOCK_GOOGLE_BASE` (the same
+ * local-mock override the googleapis client factory documents) so tests and
+ * topology regressions can stub only Google's HTTP responses while every
+ * other code path stays real.
+ */
+function googleOAuthEndpoint(realEndpoint: string, mockPath: string): string {
+  const base = process.env.ELIZA_MOCK_GOOGLE_BASE?.trim();
+  if (!base) return realEndpoint;
+  return new URL(mockPath, base.endsWith("/") ? base : `${base}/`).toString();
+}
+
 const GROUP_PURPOSE: Record<GoogleCapabilityGroup, ConnectorAccountPurpose> = {
   gmail: "messaging" as ConnectorAccountPurpose,
   calendar: "calendar" as ConnectorAccountPurpose,
@@ -350,7 +362,7 @@ function parseIdTokenClaims(idToken: string | undefined): GoogleIdentity {
 }
 
 async function fetchGoogleUserInfo(accessToken: string): Promise<GoogleIdentity> {
-  const response = await fetch(GOOGLE_USERINFO_ENDPOINT, {
+  const response = await fetch(googleOAuthEndpoint(GOOGLE_USERINFO_ENDPOINT, "userinfo"), {
     headers: { Authorization: `Bearer ${accessToken}` },
   });
   if (!response.ok) {
@@ -381,11 +393,14 @@ async function exchangeAuthorizationCode(args: {
     params.set("code_verifier", args.codeVerifier);
   }
 
-  const response = await fetch(GOOGLE_OAUTH_PROVIDER_METADATA.tokenEndpoint, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: params.toString(),
-  });
+  const response = await fetch(
+    googleOAuthEndpoint(GOOGLE_OAUTH_PROVIDER_METADATA.tokenEndpoint, "token"),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params.toString(),
+    }
+  );
   if (!response.ok) {
     const body = await response.text();
     throw new Error(`Google token exchange failed with ${response.status}: ${body}`);
@@ -651,6 +666,7 @@ export function createGoogleConnectorAccountProvider(
           credentialRefStorage: {
             vaultAvailable: credentialPersist.vaultAvailable,
             storageAvailable: credentialPersist.storageAvailable,
+            volatile: credentialPersist.volatile,
           },
         },
       };

--- a/plugins/plugin-google-workspace/src/connector-credential-refs.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-credential-refs.test.ts
@@ -3,8 +3,10 @@
  * that a credential persisted through `persistConnectorCredentialRefs` is
  * readable by `DefaultGoogleCredentialResolver` after a simulated process
  * restart, for every service name the writer can target, and that persistence
- * fails closed (no secret, no ref) when only the volatile SECRETS store is
- * available (#18080). Deterministic
+ * enforces the #18080 product contract when only the volatile SECRETS store is
+ * available: fail closed (typed error, no secret, no ref) on Cloud-provisioned
+ * or durability-expected runtimes, keep-until-restart volatile writes flagged
+ * `volatile` on hostless local desktop/dev. Deterministic
  * harness — the runtime, credential store, vault, and SECRETS services are
  * in-memory fakes shaped like their production counterparts; "restart" means
  * new runtime/service instances sharing only the durable backing maps
@@ -17,10 +19,12 @@ import {
   getConnectorAccountManager,
   type IAgentRuntime,
   InMemoryDatabaseAdapter,
+  isElizaError,
 } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
   CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPES,
+  CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE_CODE,
   CONNECTOR_VAULT_SERVICE_TYPES,
   persistConnectorCredentialRefs,
 } from "./connector-credential-refs.js";
@@ -159,17 +163,21 @@ function createVolatileSecretsService() {
 
 function createRuntime(
   storage: ReturnType<typeof createStorage>,
-  services: Record<string, unknown>
+  services: Record<string, unknown>,
+  settings: Record<string, string> = {}
 ): IAgentRuntime {
   return {
     agentId: AGENT_ID,
     getService: (name: string) => services[name] ?? null,
+    // Mirrors the real runtime: a registered-but-failed service stays in the
+    // registry while getService resolves null.
+    getRegisteredServiceTypes: () => Object.keys(services),
     getSetting: (key: string) =>
       key === "GOOGLE_CLIENT_ID"
         ? "client-id"
         : key === "GOOGLE_CLIENT_SECRET"
           ? "client-secret"
-          : undefined,
+          : settings[key],
     adapter: storage,
   } as unknown as IAgentRuntime;
 }
@@ -261,22 +269,29 @@ describe("connector credential persist → restart → resolve round-trip", () =
     }
   });
 
-  it("rejects persistence when only volatile SECRETS is available: no secret written, no dangling ref (#18080)", async () => {
+  it("fails closed on a Cloud-provisioned container when only volatile SECRETS is available: typed error, no secret, no dangling ref (#18080)", async () => {
     const state = newDurableState();
     state.accounts.set(ACCOUNT_ID, connectedAccount(ACCOUNT_ID));
     const storage = createStorage(state);
     const secrets = createVolatileSecretsService();
 
-    await expect(
-      persistConnectorCredentialRefs({
-        runtime: createRuntime(storage, { SECRETS: secrets }),
-        provider: "google",
-        accountIdForRef: ACCOUNT_ID,
-        storageAccountId: ACCOUNT_ID,
-        caller: "test",
-        credentials: [{ credentialType: "oauth.tokens", value: TOKENS_JSON }],
-      })
-    ).rejects.toThrow(/No durable connector credential store or vault writer/);
+    const attempt = persistConnectorCredentialRefs({
+      runtime: createRuntime(storage, { SECRETS: secrets }, { ELIZA_CLOUD_PROVISIONED: "1" }),
+      provider: "google",
+      accountIdForRef: ACCOUNT_ID,
+      storageAccountId: ACCOUNT_ID,
+      caller: "test",
+      credentials: [{ credentialType: "oauth.tokens", value: TOKENS_JSON }],
+    });
+    await expect(attempt).rejects.toThrow(/No durable connector credential store or vault writer/);
+    const err = await attempt.catch((e) => e);
+    expect(isElizaError(err)).toBe(true);
+    expect(err.code).toBe(CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE_CODE);
+    expect(err.context).toMatchObject({
+      provider: "google",
+      accountId: ACCOUNT_ID,
+      cloudProvisioned: true,
+    });
 
     // Fail-closed contract: nothing landed in the volatile store and no
     // credential ref was recorded, so a restart has nothing to dangle.
@@ -285,28 +300,96 @@ describe("connector credential persist → restart → resolve round-trip", () =
     expect(state.vaultEntries.size).toBe(0);
   });
 
-  it("rejects when the credential store failed to start (getService null) instead of demoting to SECRETS (#18080)", async () => {
+  it("keeps hostless local desktop/dev keep-until-restart: volatile SECRETS write succeeds and is flagged volatile (#18080)", async () => {
     const state = newDurableState();
     state.accounts.set(ACCOUNT_ID, connectedAccount(ACCOUNT_ID));
     const storage = createStorage(state);
     const secrets = createVolatileSecretsService();
-    // A registered-but-failed store resolves to null through runtime.getService,
-    // exactly what the boot funnel's start failure produces.
-    const services: Record<string, unknown> = {
-      connector_credential_store: null,
-      SECRETS: secrets,
-    };
+
+    const result = await persistConnectorCredentialRefs({
+      runtime: createRuntime(storage, { SECRETS: secrets }),
+      provider: "google",
+      accountIdForRef: ACCOUNT_ID,
+      storageAccountId: ACCOUNT_ID,
+      caller: "test",
+      credentials: [{ credentialType: "oauth.tokens", value: TOKENS_JSON }],
+    });
+
+    expect(result.volatile).toBe(true);
+    expect(result.vaultAvailable).toBe(false);
+    expect(secrets.entries.size).toBe(1);
+    expect(state.credentialRefs.size).toBe(1);
+  });
+
+  it("fails closed on a hostless runtime when ELIZA_REQUIRE_DURABLE_CONNECTOR_CREDENTIALS=1 (#18080)", async () => {
+    const state = newDurableState();
+    state.accounts.set(ACCOUNT_ID, connectedAccount(ACCOUNT_ID));
+    const storage = createStorage(state);
+    const secrets = createVolatileSecretsService();
 
     await expect(
       persistConnectorCredentialRefs({
-        runtime: createRuntime(storage, services),
+        runtime: createRuntime(
+          storage,
+          { SECRETS: secrets },
+          { ELIZA_REQUIRE_DURABLE_CONNECTOR_CREDENTIALS: "1" }
+        ),
         provider: "google",
         accountIdForRef: ACCOUNT_ID,
         storageAccountId: ACCOUNT_ID,
         caller: "test",
         credentials: [{ credentialType: "oauth.tokens", value: TOKENS_JSON }],
       })
-    ).rejects.toThrow(/Refusing to mark OAuth account connected/);
+    ).rejects.toThrow(/No durable connector credential store or vault writer/);
+    expect(secrets.entries.size).toBe(0);
+    expect(state.credentialRefs.size).toBe(0);
+  });
+
+  it("fails closed when no writer of any kind exists (not even SECRETS)", async () => {
+    const state = newDurableState();
+    state.accounts.set(ACCOUNT_ID, connectedAccount(ACCOUNT_ID));
+    const storage = createStorage(state);
+
+    const attempt = persistConnectorCredentialRefs({
+      runtime: createRuntime(storage, {}),
+      provider: "google",
+      accountIdForRef: ACCOUNT_ID,
+      storageAccountId: ACCOUNT_ID,
+      caller: "test",
+      credentials: [{ credentialType: "oauth.tokens", value: TOKENS_JSON }],
+    });
+    await expect(attempt).rejects.toThrow(/No durable connector credential store or vault writer/);
+    const err = await attempt.catch((e) => e);
+    expect(err.code).toBe(CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE_CODE);
+    expect(err.context?.volatileFallbackAvailable).toBe(false);
+  });
+
+  it("rejects when the credential store registered but failed to start (getService null) instead of demoting to SECRETS (#18080)", async () => {
+    const state = newDurableState();
+    state.accounts.set(ACCOUNT_ID, connectedAccount(ACCOUNT_ID));
+    const storage = createStorage(state);
+    const secrets = createVolatileSecretsService();
+    // A registered-but-failed store stays in the service registry while
+    // runtime.getService resolves null, exactly what the boot funnel's start
+    // failure produces. Durability was expected here, so even a hostless
+    // runtime must not demote the write to volatile SECRETS.
+    const services: Record<string, unknown> = {
+      connector_credential_store: null,
+      SECRETS: secrets,
+    };
+
+    const attempt = persistConnectorCredentialRefs({
+      runtime: createRuntime(storage, services),
+      provider: "google",
+      accountIdForRef: ACCOUNT_ID,
+      storageAccountId: ACCOUNT_ID,
+      caller: "test",
+      credentials: [{ credentialType: "oauth.tokens", value: TOKENS_JSON }],
+    });
+    await expect(attempt).rejects.toThrow(/Refusing to mark OAuth account connected/);
+    const err = await attempt.catch((e) => e);
+    expect(err.code).toBe(CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE_CODE);
+    expect(err.context?.registeredDurableServices).toEqual(["connector_credential_store"]);
     expect(secrets.entries.size).toBe(0);
     expect(state.credentialRefs.size).toBe(0);
   });

--- a/plugins/plugin-google-workspace/src/connector-credential-refs.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-credential-refs.test.ts
@@ -2,7 +2,9 @@
  * Writer/reader parity coverage for connector credential persistence: proves
  * that a credential persisted through `persistConnectorCredentialRefs` is
  * readable by `DefaultGoogleCredentialResolver` after a simulated process
- * restart, for every service name the writer can target. Deterministic
+ * restart, for every service name the writer can target, and that persistence
+ * fails closed (no secret, no ref) when only the volatile SECRETS store is
+ * available (#18080). Deterministic
  * harness — the runtime, credential store, vault, and SECRETS services are
  * in-memory fakes shaped like their production counterparts; "restart" means
  * new runtime/service instances sharing only the durable backing maps
@@ -259,18 +261,54 @@ describe("connector credential persist → restart → resolve round-trip", () =
     }
   });
 
-  it("documents the SECRETS-only fallback as volatile: the persisted ref dangles after a restart", async () => {
+  it("rejects persistence when only volatile SECRETS is available: no secret written, no dangling ref (#18080)", async () => {
     const state = newDurableState();
     state.accounts.set(ACCOUNT_ID, connectedAccount(ACCOUNT_ID));
     const storage = createStorage(state);
     const secrets = createVolatileSecretsService();
 
-    const vaultRef = await persistTokens(createRuntime(storage, { SECRETS: secrets }));
-    expect(secrets.entries.get(vaultRef)).toBe(TOKENS_JSON);
+    await expect(
+      persistConnectorCredentialRefs({
+        runtime: createRuntime(storage, { SECRETS: secrets }),
+        provider: "google",
+        accountIdForRef: ACCOUNT_ID,
+        storageAccountId: ACCOUNT_ID,
+        caller: "test",
+        credentials: [{ credentialType: "oauth.tokens", value: TOKENS_JSON }],
+      })
+    ).rejects.toThrow(/No durable connector credential store or vault writer/);
+
+    // Fail-closed contract: nothing landed in the volatile store and no
+    // credential ref was recorded, so a restart has nothing to dangle.
+    expect(secrets.entries.size).toBe(0);
+    expect(state.credentialRefs.size).toBe(0);
+    expect(state.vaultEntries.size).toBe(0);
+  });
+
+  it("rejects when the credential store failed to start (getService null) instead of demoting to SECRETS (#18080)", async () => {
+    const state = newDurableState();
+    state.accounts.set(ACCOUNT_ID, connectedAccount(ACCOUNT_ID));
+    const storage = createStorage(state);
+    const secrets = createVolatileSecretsService();
+    // A registered-but-failed store resolves to null through runtime.getService,
+    // exactly what the boot funnel's start failure produces.
+    const services: Record<string, unknown> = {
+      connector_credential_store: null,
+      SECRETS: secrets,
+    };
 
     await expect(
-      resolveAfterRestart(state, { SECRETS: createVolatileSecretsService() })
-    ).rejects.toThrow(/could not be read/);
+      persistConnectorCredentialRefs({
+        runtime: createRuntime(storage, services),
+        provider: "google",
+        accountIdForRef: ACCOUNT_ID,
+        storageAccountId: ACCOUNT_ID,
+        caller: "test",
+        credentials: [{ credentialType: "oauth.tokens", value: TOKENS_JSON }],
+      })
+    ).rejects.toThrow(/Refusing to mark OAuth account connected/);
+    expect(secrets.entries.size).toBe(0);
+    expect(state.credentialRefs.size).toBe(0);
   });
 });
 

--- a/plugins/plugin-google-workspace/src/connector-credential-refs.ts
+++ b/plugins/plugin-google-workspace/src/connector-credential-refs.ts
@@ -2,14 +2,17 @@
  * Persists OAuth credential material for a connector account and reads the
  * resulting refs back out. `persistConnectorCredentialRefs` writes each secret
  * to the first available durable vault (connector credential store or vault)
- * and records a `vaultRef` pointer on the account via storage; it refuses to
- * proceed unless both a durable vault writer and a ref writer exist, so an
- * account is never marked connected without durable credentials. The core
- * SECRETS service is deliberately NOT an eligible writer: its global storage
- * mutates `runtime.character.settings.secrets` in process memory only, so a
- * credential written there dies with the process while its vaultRef dangles
- * (#18080). SECRETS remains a read-side probe in `credential-resolver.ts` so
- * refs written before this hardening still resolve within the same process.
+ * and records a `vaultRef` pointer on the account via storage. With no durable
+ * writer the #18080 product contract applies: durability-expected topologies
+ * (Cloud-provisioned containers via `ELIZA_CLOUD_PROVISIONED`, hosts whose
+ * credential store registered but failed to start, or operators who set
+ * `ELIZA_REQUIRE_DURABLE_CONNECTOR_CREDENTIALS=1`) fail closed with a typed
+ * `CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE` error and record neither secret
+ * nor ref, while hostless local desktop/dev runtimes keep the pre-existing
+ * volatile SECRETS keep-until-restart write, flagged `volatile` in the result
+ * and warned in the log (the credential dies with the process). SECRETS also
+ * remains a read-side probe in `credential-resolver.ts` so previously written
+ * refs still resolve within the same process.
  * `credentialRefRecordsFromMetadata` is the read side, extracting ref records
  * from account metadata for the credential resolver. Consumed by the connector
  * account provider on OAuth completion and by `DefaultGoogleCredentialResolver`.
@@ -17,7 +20,10 @@
 import {
   CONNECTOR_ACCOUNT_STORAGE_SERVICE_TYPE,
   type ConnectorAccountManager,
+  ElizaError,
   type IAgentRuntime,
+  logger,
+  resolveSetting,
 } from "@elizaos/core";
 
 type JsonValue =
@@ -49,6 +55,22 @@ export const CONNECTOR_VAULT_SERVICE_TYPES = ["vault", "VAULT"] as const;
 
 export const CORE_SECRETS_SERVICE_TYPE = "SECRETS";
 
+/**
+ * Stable ElizaError code thrown when OAuth completion must fail closed because
+ * no durable credential writer can hold the token material (#18080).
+ */
+export const CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE_CODE =
+  "CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE";
+
+/**
+ * Opt-in strict mode for hostless local runtimes: set to `1`/`true` to fail
+ * OAuth completion closed instead of accepting the volatile keep-until-restart
+ * SECRETS write. Durability-expected topologies (Cloud-provisioned containers,
+ * hosts whose credential store registered) fail closed regardless.
+ */
+export const REQUIRE_DURABLE_CONNECTOR_CREDENTIALS_SETTING =
+  "ELIZA_REQUIRE_DURABLE_CONNECTOR_CREDENTIALS";
+
 export interface ConnectorCredentialRefMetadata extends JsonRecord {
   credentialType: string;
   vaultRef: string;
@@ -69,6 +91,12 @@ export interface ConnectorCredentialPersistResult {
   refs: ConnectorCredentialRefMetadata[];
   vaultAvailable: boolean;
   storageAvailable: boolean;
+  /**
+   * True when the secret landed in the volatile SECRETS store (hostless local
+   * desktop/dev keep-until-restart mode): the credential works now but dies
+   * with the process, and the ref will dangle after a restart.
+   */
+  volatile: boolean;
 }
 
 interface ConnectorCredentialInput {
@@ -102,17 +130,61 @@ export async function persistConnectorCredentialRefs(
   params: PersistConnectorCredentialRefsParams
 ): Promise<ConnectorCredentialPersistResult> {
   const refs: ConnectorCredentialRefMetadata[] = [];
-  const vaultWriters = resolveVaultWriters(params.runtime, {
+  const writerContext = {
     provider: params.provider,
     accountId: params.accountIdForRef,
     caller: params.caller,
-  });
+  };
+  const vaultWriters = resolveVaultWriters(params.runtime, writerContext);
+  let volatileWrite = false;
   if (vaultWriters.length === 0) {
-    throw new Error(
-      `No durable connector credential store or vault writer is available for ${params.provider} account ${params.accountIdForRef}. ` +
-        "Refusing to mark OAuth account connected without persisted credentials: the core SECRETS store is process-memory only, so a credential written there would silently die at the next restart while its vaultRef dangles. " +
-        "Run under a host that installs a durable vault (so the connector credential store service registers), or retry after that service has started."
+    // Product contract from #18080: durability-expected topologies fail
+    // closed; hostless local desktop/dev keeps the pre-existing volatile
+    // keep-until-restart behavior unless the operator opts into strict mode.
+    const cloudProvisioned = flagIsSet(params.runtime, "ELIZA_CLOUD_PROVISIONED");
+    const requireDurable = flagIsSet(params.runtime, REQUIRE_DURABLE_CONNECTOR_CREDENTIALS_SETTING);
+    // A durable store/vault service name that is REGISTERED on the runtime but
+    // resolved no writer means the store failed to start — a transient boot
+    // failure must fail closed, not silently demote persistence.
+    const registeredDurableServices = registeredDurableServiceTypes(params.runtime);
+    const volatileWriter = resolveVolatileSecretsWriter(params.runtime);
+    if (
+      cloudProvisioned ||
+      requireDurable ||
+      registeredDurableServices.length > 0 ||
+      !volatileWriter
+    ) {
+      throw new ElizaError(
+        `No durable connector credential store or vault writer is available for ${params.provider} account ${params.accountIdForRef}. ` +
+          "Refusing to mark OAuth account connected without persisted credentials: the core SECRETS store is process-memory only, so a credential written there would silently die at the next restart while its vaultRef dangles. " +
+          "Run under a host that installs a durable vault (so the connector credential store service registers), or retry after that service has started.",
+        {
+          code: CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE_CODE,
+          severity: "fatal",
+          context: {
+            provider: params.provider,
+            accountId: params.accountIdForRef,
+            caller: params.caller,
+            probedStoreServices: [...CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPES],
+            probedVaultServices: [...CONNECTOR_VAULT_SERVICE_TYPES],
+            registeredDurableServices,
+            cloudProvisioned,
+            requireDurable,
+            volatileFallbackAvailable: Boolean(volatileWriter),
+          },
+        }
+      );
+    }
+    logger.warn(
+      {
+        src: "plugin:google:credential-refs",
+        provider: params.provider,
+        accountId: params.accountIdForRef,
+      },
+      "[persistConnectorCredentialRefs] No durable credential writer; persisting through the volatile SECRETS store (hostless local mode). The credential works until the process restarts. Install a durable host vault, or set ELIZA_REQUIRE_DURABLE_CONNECTOR_CREDENTIALS=1 to fail closed instead."
     );
+    vaultWriters.push(volatileWriter);
+    volatileWrite = true;
   }
   if (!params.storageAccountId) {
     throw new Error(
@@ -152,8 +224,9 @@ export async function persistConnectorCredentialRefs(
 
   return {
     refs,
-    vaultAvailable: vaultWriters.length > 0,
+    vaultAvailable: vaultWriters.length > 0 && !volatileWrite,
     storageAvailable: storageWriters.length > 0,
+    volatile: volatileWrite,
   };
 }
 
@@ -266,9 +339,73 @@ function resolveVaultWriters(
   }
 
   // Deliberately no SECRETS writer here: core SECRETS global storage is
-  // process-memory only, so accepting it records a connected account whose
-  // credential dies at the next restart (#18080). Fail closed instead.
+  // process-memory only, so accepting it as a durable writer records a
+  // connected account whose credential dies at the next restart (#18080).
+  // `persistConnectorCredentialRefs` decides whether the volatile fallback
+  // below is allowed to stand in when this list comes back empty.
   return writers;
+}
+
+/**
+ * Volatile keep-until-restart writer over the core SECRETS store — the
+ * pre-#18080 behavior, now allowed ONLY on hostless local desktop/dev
+ * runtimes where no durability was ever expected.
+ */
+function resolveVolatileSecretsWriter(runtime: IAgentRuntime): VaultWriter | null {
+  const secrets = getService(runtime, CORE_SECRETS_SERVICE_TYPE) as {
+    setGlobal?: (
+      key: string,
+      value: string,
+      config?: { sensitive?: boolean }
+    ) => Promise<boolean> | boolean;
+    set?: (
+      key: string,
+      value: string,
+      context: JsonRecord,
+      config?: { sensitive?: boolean }
+    ) => Promise<boolean> | boolean;
+  } | null;
+  if (typeof secrets?.setGlobal !== "function" && typeof secrets?.set !== "function") {
+    return null;
+  }
+  return {
+    name: "SECRETS",
+    write: async (vaultRef, credential) => {
+      if (typeof secrets.setGlobal === "function") {
+        await secrets.setGlobal(vaultRef, credential.value, { sensitive: true });
+        return vaultRef;
+      }
+      await secrets.set?.(
+        vaultRef,
+        credential.value,
+        { level: "global", agentId: runtime.agentId, requesterId: runtime.agentId },
+        { sensitive: true }
+      );
+      return vaultRef;
+    },
+  };
+}
+
+/**
+ * Durable store/vault service names registered on this runtime, regardless of
+ * whether they resolved to a usable writer. A non-empty result with zero
+ * writers means the durable store failed to start.
+ */
+function registeredDurableServiceTypes(runtime: IAgentRuntime): string[] {
+  const registered = (
+    runtime as { getRegisteredServiceTypes?: () => string[] }
+  ).getRegisteredServiceTypes?.();
+  if (!Array.isArray(registered)) return [];
+  const durableNames = new Set<string>([
+    ...CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPES,
+    ...CONNECTOR_VAULT_SERVICE_TYPES,
+  ]);
+  return registered.filter((name) => durableNames.has(name));
+}
+
+function flagIsSet(runtime: IAgentRuntime, key: string): boolean {
+  const value = resolveSetting(runtime, key)?.toLowerCase();
+  return value === "1" || value === "true";
 }
 
 function resolveCredentialRefWriters(

--- a/plugins/plugin-google-workspace/src/connector-credential-refs.ts
+++ b/plugins/plugin-google-workspace/src/connector-credential-refs.ts
@@ -1,10 +1,15 @@
 /**
  * Persists OAuth credential material for a connector account and reads the
  * resulting refs back out. `persistConnectorCredentialRefs` writes each secret
- * to the first available durable vault (connector credential store, vault, or
- * SECRETS) and records a `vaultRef` pointer on the account via storage; it
- * refuses to proceed unless both a vault writer and a ref writer exist, so an
- * account is never marked connected without durable credentials.
+ * to the first available durable vault (connector credential store or vault)
+ * and records a `vaultRef` pointer on the account via storage; it refuses to
+ * proceed unless both a durable vault writer and a ref writer exist, so an
+ * account is never marked connected without durable credentials. The core
+ * SECRETS service is deliberately NOT an eligible writer: its global storage
+ * mutates `runtime.character.settings.secrets` in process memory only, so a
+ * credential written there dies with the process while its vaultRef dangles
+ * (#18080). SECRETS remains a read-side probe in `credential-resolver.ts` so
+ * refs written before this hardening still resolve within the same process.
  * `credentialRefRecordsFromMetadata` is the read side, extracting ref records
  * from account metadata for the credential resolver. Consumed by the connector
  * account provider on OAuth completion and by `DefaultGoogleCredentialResolver`.
@@ -104,7 +109,9 @@ export async function persistConnectorCredentialRefs(
   });
   if (vaultWriters.length === 0) {
     throw new Error(
-      `No durable connector credential store or vault writer is available for ${params.provider} account ${params.accountIdForRef}. Refusing to mark OAuth account connected without persisted credentials.`
+      `No durable connector credential store or vault writer is available for ${params.provider} account ${params.accountIdForRef}. ` +
+        "Refusing to mark OAuth account connected without persisted credentials: the core SECRETS store is process-memory only, so a credential written there would silently die at the next restart while its vaultRef dangles. " +
+        "Run under a host that installs a durable vault (so the connector credential store service registers), or retry after that service has started."
     );
   }
   if (!params.storageAccountId) {
@@ -258,38 +265,9 @@ function resolveVaultWriters(
     });
   }
 
-  const secrets = getService(runtime, CORE_SECRETS_SERVICE_TYPE) as {
-    setGlobal?: (
-      key: string,
-      value: string,
-      config?: { sensitive?: boolean }
-    ) => Promise<boolean> | boolean;
-    set?: (
-      key: string,
-      value: string,
-      context: JsonRecord,
-      config?: { sensitive?: boolean }
-    ) => Promise<boolean> | boolean;
-  } | null;
-  if (typeof secrets?.setGlobal === "function" || typeof secrets?.set === "function") {
-    writers.push({
-      name: "SECRETS",
-      write: async (vaultRef, credential) => {
-        if (typeof secrets.setGlobal === "function") {
-          await secrets.setGlobal(vaultRef, credential.value, { sensitive: true });
-          return vaultRef;
-        }
-        await secrets.set?.(
-          vaultRef,
-          credential.value,
-          { level: "global", agentId: runtime.agentId, requesterId: runtime.agentId },
-          { sensitive: true }
-        );
-        return vaultRef;
-      },
-    });
-  }
-
+  // Deliberately no SECRETS writer here: core SECRETS global storage is
+  // process-memory only, so accepting it records a connected account whose
+  // credential dies at the next restart (#18080). Fail closed instead.
   return writers;
 }
 

--- a/plugins/plugin-google-workspace/src/connector-oauth-manager-flow.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-oauth-manager-flow.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Manager→provider regression for the #18080 fail-closed contract: drives the
+ * REAL core `ConnectorAccountManager.completeOAuth` (which consumes the
+ * one-time state before calling the provider) into the REAL Google provider.
+ * Only Google's HTTP token response is stubbed, via a loopback server behind
+ * `ELIZA_MOCK_GOOGLE_BASE`; runtime services are in-memory fakes shaped like
+ * their production counterparts. Proves that when the provider throws the
+ * durable-writer ElizaError, the manager persists an explicit failed flow
+ * (status, error text, stable error code) instead of leaving a consumed flow
+ * that reports "pending" forever, and that the pending account is never
+ * patched to connected.
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { getConnectorAccountManager, type IAgentRuntime, isElizaError } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createGoogleConnectorAccountProvider } from "./connector-account-provider.js";
+import { CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE_CODE } from "./connector-credential-refs.js";
+
+const AGENT_ID = "6f110aa9-c169-0e10-8a4f-b4cca439be25";
+
+function unsignedJwt(payload: Record<string, unknown>): string {
+  const b64 = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${b64({ alg: "none" })}.${b64(payload)}.`;
+}
+
+let tokenServer: http.Server;
+let previousMockBase: string | undefined;
+
+beforeAll(async () => {
+  tokenServer = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/token") {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          access_token: "test-access-token",
+          refresh_token: "test-refresh-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "https://www.googleapis.com/auth/gmail.readonly",
+          id_token: unsignedJwt({
+            sub: "google-sub-1",
+            email: "owner@example.com",
+            email_verified: true,
+            name: "Owner",
+          }),
+        })
+      );
+      return;
+    }
+    res.statusCode = 404;
+    res.end("{}");
+  });
+  await new Promise<void>((resolve) => tokenServer.listen(0, "127.0.0.1", resolve));
+  previousMockBase = process.env.ELIZA_MOCK_GOOGLE_BASE;
+  const { port } = tokenServer.address() as AddressInfo;
+  process.env.ELIZA_MOCK_GOOGLE_BASE = `http://127.0.0.1:${port}/`;
+});
+
+afterAll(async () => {
+  if (previousMockBase === undefined) delete process.env.ELIZA_MOCK_GOOGLE_BASE;
+  else process.env.ELIZA_MOCK_GOOGLE_BASE = previousMockBase;
+  await new Promise<void>((resolve, reject) =>
+    tokenServer.close((err) => (err ? reject(err) : resolve()))
+  );
+});
+
+function createRuntime(settings: Record<string, string>): IAgentRuntime {
+  return {
+    agentId: AGENT_ID,
+    getService: () => null,
+    getRegisteredServiceTypes: () => [],
+    getSetting: (key: string) =>
+      key === "GOOGLE_CLIENT_ID"
+        ? "client-id"
+        : key === "GOOGLE_CLIENT_SECRET"
+          ? "client-secret"
+          : key === "GOOGLE_REDIRECT_URI"
+            ? "http://127.0.0.1:2138/api/connectors/google/oauth/callback"
+            : settings[key],
+    getMessageConnectors: () => [],
+    getPostConnectors: () => [],
+    registerMessageConnector: () => undefined,
+    registerPostConnector: () => undefined,
+  } as unknown as IAgentRuntime;
+}
+
+describe("real manager → real Google provider fail-closed flow (#18080)", () => {
+  it("persists an explicit failed flow with the provider's typed error when the durable-writer check throws after the state is consumed", async () => {
+    // Cloud-provisioned topology: no durable writer anywhere → fail closed.
+    const runtime = createRuntime({ ELIZA_CLOUD_PROVISIONED: "1" });
+    const manager = getConnectorAccountManager(runtime);
+    manager.registerProvider(createGoogleConnectorAccountProvider(runtime));
+
+    // The connect UI pre-creates the account row and starts OAuth against it,
+    // exactly like POST /accounts then POST /oauth/start.
+    const created = await manager.createAccount("google", { status: "pending" });
+    const flow = await manager.startOAuth("google", {
+      accountId: created.id,
+      scopes: ["gmail.read"],
+    });
+    expect(flow.status).toBe("pending");
+
+    // First callback: real code exchange (loopback-stubbed response), real
+    // pending-account upsert, then the durable-writer rejection.
+    const attempt = manager.completeOAuth("google", {
+      state: flow.state,
+      code: "test-auth-code",
+    });
+    await expect(attempt).rejects.toThrow(/No durable connector credential store or vault writer/);
+    const err = await attempt.catch((e) => e);
+    expect(isElizaError(err)).toBe(true);
+    expect(err.code).toBe(CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE_CODE);
+
+    // The consumed flow is now terminally failed — actionable, not "pending".
+    const failed = await manager.getOAuthFlow("google", flow.state);
+    expect(failed?.status).toBe("failed");
+    expect(failed?.error).toMatch(/No durable connector credential store/);
+    expect(failed?.metadata?.errorCode).toBe(CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE_CODE);
+
+    // The account created mid-completion stays pending; no credential ref was
+    // recorded, so nothing dangles after a restart.
+    const accounts = await manager.getStorage().listAccounts("google");
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].status).toBe("pending");
+    expect(accounts[0].metadata?.credentialRefs).toBeUndefined();
+
+    // A second callback still reports the consumed state — but the flow record
+    // above now explains why, instead of claiming the flow is pending.
+    await expect(
+      manager.completeOAuth("google", { state: flow.state, code: "test-auth-code" })
+    ).rejects.toThrow(/Unknown, expired, or already used OAuth flow state/);
+  });
+});


### PR DESCRIPTION
# Relates to

Relates to #18080 (follow-up hardening requested in the #18027 review).
**Deliberately not closing #18080** — the residuals below are left open on
purpose under that issue:

- Sibling connectors (slack, github, x, microsoft calendar) still carry their
  own diverged copies of the volatile SECRETS fallback; follow-up scope under
  #18080.
- Live staging Google OAuth (real hosted consent screen) remains
  credential-gated and is not exercised here.
- #18080 stays open until the review blockers are accepted by the reviewer.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      (current base `develop@e68a5744`; one test-file conflict resolved, see
      **Sync with develop**).
- [x] `bun install` was run after sync; every focused package gate (tests,
      typecheck, Biome) was rerun at the exact current head — results in
      **Evidence Details**. Hosted CI runs the full repository gate on this
      push.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`e68a5744`); one conflict in
      `packages/agent/src/api/connector-account-routes.test.ts` (develop's new
      served-origin tests and this PR's ElizaError-serialization test inserted
      at the same point) resolved by keeping both sides' tests.
- [x] Focused gates for every touched package (core, agent,
      plugin-google-workspace) were rerun at the current head after
      `bun install` and a core rebuild; hosted CI provides the full repository
      gate.

# Risks

Low for durable-host deployments (behavior unchanged: the
`connector_credential_store` service remains the first writer). The #18080
contract is now split by topology (decision recorded on #18080):

- **Durability-expected runtimes fail closed**: Cloud-provisioned containers
  (`ELIZA_CLOUD_PROVISIONED=1`), runtimes where a durable store/vault service
  registered but failed to start, and operators who set
  `ELIZA_REQUIRE_DURABLE_CONNECTOR_CREDENTIALS=1`. OAuth completion rejects
  with a typed `ElizaError` (`CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE`), the
  flow is persisted as terminally failed with that code, and no secret or
  credential ref is recorded.
- **Hostless local desktop/dev keeps its pre-existing behavior**: the volatile
  SECRETS keep-until-restart write still connects the account, now explicitly
  flagged `credentialRefStorage.volatile` in account metadata and warned in
  the log, instead of silently masquerading as durable.

Sibling connectors (slack, github, x, microsoft calendar) still carry their
own diverged copies of the volatile SECRETS fallback and are intentionally out
of scope here — flagged as follow-up in #18080.

# Background

## What does this PR do?

Hardens `persistConnectorCredentialRefs`
(`plugins/plugin-google-workspace/src/connector-credential-refs.ts`) and the
core OAuth completion path against the #18080 dangling-vaultRef window.
`SECRETS` global storage mutates `runtime.character.settings.secrets` in
process memory only
(`packages/core/src/features/secrets/storage/character-store.ts`), so treating
it as a durable writer marked an OAuth account connected while its credential
died with the process and the persisted `vaultRef` dangled forever after.

After this change:

1. **Durability-expected topologies fail closed with a typed error.** On a
   Cloud-provisioned container, when a registered durable store failed to
   start, or under the explicit
   `ELIZA_REQUIRE_DURABLE_CONNECTOR_CREDENTIALS=1` opt-in,
   `persistConnectorCredentialRefs` throws an `ElizaError` with stable code
   `CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE`, fatal severity, and structured
   non-secret context (provider, accountId, probed service names, which
   topology signal triggered fail-closed). The account stays `pending`; no
   secret or credential ref is recorded.
2. **Failed OAuth completion is terminally recorded, not stuck pending.**
   `ConnectorAccountManager.completeOAuth` (packages/core) now persists an
   explicit `status: "failed"` flow — preserving the provider error text and,
   for `ElizaError`s, the stable code in flow metadata — when the provider
   throws after the one-time state is consumed. If the failure-status write
   itself fails, both failures are preserved via `AggregateError`. The
   connector callback route serializes the `ElizaError` code and context in
   its structured 400 response, so callers can classify the failure instead of
   parsing prose.
3. **Hostless local desktop/dev keeps keep-until-restart.** Without any
   durability expectation, the volatile SECRETS write proceeds as it always
   has, now flagged `volatile: true` in the persist result and in
   `credentialRefStorage` account metadata, with a log warning naming the
   restart window and the two remediations (install a durable host vault, or
   opt into fail-closed).
4. **Reads unchanged.** `SECRETS` remains a read-side probe in
   `credential-resolver.ts`, so refs written before this hardening still
   resolve within the same process.

## What kind of change is this?

Bug fix (non-breaking for durable hosts; deliberate fail-closed change for
durability-expected hostless topologies per the product decision recorded on
#18080; hostless desktop/dev behavior preserved).

# Documentation changes needed?

My changes do not require a change to the project documentation. The file
headers of the touched modules document the new contract.

# Testing

## Where should a reviewer start?

`plugins/plugin-google-workspace/src/connector-credential-refs.ts` (the
topology split in `persistConnectorCredentialRefs`), the completeOAuth
catch in `packages/core/src/connectors/account-manager.ts`, and the two new
real-path regressions:
`plugins/plugin-google-workspace/src/connector-oauth-manager-flow.test.ts`
(real manager → real Google provider) and
`packages/agent/test/connector-credential-topology.integration.test.ts`
(real standalone entrypoint, real process restart).

## Detailed testing steps

```bash
# plugin suite (credential refs contract + real manager→provider flow)
bun run --cwd plugins/plugin-google-workspace test
# core manager failed-flow persistence
bun run --cwd packages/core test -- src/connectors/account-manager.test.ts
# callback boundary + store start-failure semantics
cd packages/agent && bunx vitest run src/api/connector-account-routes.test.ts src/services/connector-credential-store.runtime.test.ts
# standalone entrypoint topology e2e (real boot, real restart)
bunx vitest run --config packages/scripts/vitest/integration.config.ts --coverage.enabled=false packages/agent/test/connector-credential-topology.integration.test.ts
```

# Evidence Gate

<!-- evidence-head:357fce44bf90e1c515896e923de64ec471cd91bb -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only credential persistence change with no rendered UI surface in this diff (no .tsx/.css/.svg/.html touched)`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only credential persistence change with no rendered UI surface in this diff (no .tsx/.css/.svg/.html touched)`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-visible flow; the changed path is
      exercised end to end by the standalone-entrypoint topology regression
      below`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: focused Vitest runs at the current head
      `357fce44bf90e1c515896e923de64ec471cd91bb`; transcript pasted below,
      full breakdown in **Evidence Details**.

  ```text
  $ bun run --cwd plugins/plugin-google-workspace test
   RUN  v4.1.5 /home/potter/src/eliza-18080-claude/plugins/plugin-google-workspace
   Test Files  16 passed (16)
        Tests  159 passed (159)
     Start at  12:12:27
     Duration  11.37s (transform 34.55s, setup 0ms, import 70.87s, tests 604ms, environment 5ms)

  $ bun run --cwd packages/core test -- src/connectors/account-manager.test.ts
   RUN  v4.1.5 /home/potter/src/eliza-18080-claude/packages/core
   Test Files  1 passed (1)
        Tests  17 passed (17)
     Start at  12:12:46
     Duration  977ms (transform 611ms, setup 0ms, import 804ms, tests 35ms, environment 0ms)
  ```

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change;
      the credential persistence path makes no model calls`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: flow/account/credential-ref state inspected across a
      genuine process restart in the topology e2e (failed flow with stable
      error code survives restart on the Cloud topology; volatile-flagged ref
      visibly dangles after restart on desktop) — run at this head:

  ```text
  $ bunx vitest run --config packages/scripts/vitest/integration.config.ts --coverage.enabled=false --reporter=verbose packages/agent/test/connector-credential-topology.integration.test.ts
   RUN  v4.1.5 /home/potter/src/eliza-18080-claude
   ✓ packages/agent/test/connector-credential-topology.integration.test.ts > standalone entrypoint connector-credential topology (#18080) > Cloud-provisioned image: OAuth completion fails closed, the failed flow survives a full process restart, no credential ref ever lands 13610ms
   ✓ packages/agent/test/connector-credential-topology.integration.test.ts > standalone entrypoint connector-credential topology (#18080) > hostless local desktop/dev: keep-until-restart — connect succeeds flagged volatile, and the ref visibly dangles after a restart 11935ms
   Test Files  1 passed (1)
        Tests  2 passed (2)
     Start at  12:12:54
     Duration  25.91s (transform 59ms, setup 73ms, import 40ms, tests 25.62s, environment 0ms)
  ```

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change; this path performs no
model calls.`

## Backend + frontend logs

All runs at the exact current head `357fce44bf90e1c515896e923de64ec471cd91bb` (post-rebase onto
`develop@e68a5744`):

- `bun run --cwd plugins/plugin-google-workspace test` — **16 files,
  159 tests, all passing**. Includes the new
  `connector-oauth-manager-flow.test.ts`: the REAL core
  `ConnectorAccountManager.completeOAuth` driving the REAL Google provider
  (only Google's token HTTP response stubbed via a loopback server), proving
  the consumed flow persists as `failed` with
  `CONNECTOR_CREDENTIAL_WRITER_UNAVAILABLE` in metadata, the account stays
  `pending` with no ref, and the credential-refs suite covering all three
  topology outcomes (cloud fail-closed with typed context, desktop volatile
  flag, strict-mode opt-in fail-closed, no-writer-at-all fail-closed).
- `packages/core` `src/connectors/account-manager.test.ts` — **17 tests
  passing**, including failed-flow persistence on provider throw and the
  AggregateError double-failure case.
- `packages/agent` `src/api/connector-account-routes.test.ts` +
  `src/services/connector-credential-store.runtime.test.ts` — **18 tests
  passing** (includes develop's three new served-origin tests merged in the
  rebase), including ElizaError code+context serialization through the
  public callback route boundary and the real-runtime
  registered-but-failed-store signal (`getService` null while the registry
  lists the type).
- Standalone entrypoint topology e2e
  (`packages/agent/test/connector-credential-topology.integration.test.ts`) —
  **2 tests passing**:

```text
✓ standalone entrypoint connector-credential topology (#18080) > Cloud-provisioned image: OAuth completion fails closed, the failed flow survives a full process restart, no credential ref ever lands
✓ standalone entrypoint connector-credential topology (#18080) > hostless local desktop/dev: keep-until-restart — connect succeeds flagged volatile, and the ref visibly dangles after a restart

Test Files  1 passed (1)
     Tests  2 passed (2)
```

  Each phase spawns the REAL standalone boot (`startElizaProcess`, the same
  path `bin.js start` runs) as a separate OS process over a shared temp
  `ELIZA_STATE_DIR`/PGlite store; the "restart" is a genuinely new process
  reusing only durable state. `hasDurableHostVault()` is exercised for real
  (no-op vault ⇒ false, store never registers). Only Google's token HTTP
  response is stubbed (`ELIZA_MOCK_GOOGLE_BASE` loopback).

- Package gates: `typecheck` and Biome clean for `packages/core`,
  `packages/agent`, and `plugins/plugin-google-workspace` at this head
  (plugin typecheck requires the generated core build artifacts:
  `bun run --cwd packages/core build` first).

Frontend logs: `N/A - no frontend change.`

## Screenshots (before / after) + video walkthrough

`N/A - backend-only change with no rendered surface; the CI evidence gate's
UI-diff rule does not apply (no .tsx/.css/.svg touched).`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- Live staging Google OAuth (real Google consent screen): `N/A - no real
  Google OAuth client credentials are available on this machine, so the
  hosted consent flow cannot be driven here. The deployed
  entrypoint/topology contract (connect → full process restart → credential
  read, plus store-start-failure) is now covered by the real
  standalone-entrypoint regression above — real boot, real PGlite state,
  real process restart; only Google's token HTTP response is stubbed.`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [claude-18080-shaw-cr-lock]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZY7VHHYS7VRT2H27T5QX31K","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T18:58:49.022Z","completed_at":"2026-08-13T19:03:31.035Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA1wup-TpOQbidV6XOR-nWj5-01vmuc1Uuv5emKqsM8iA","device_key_id":"dbd0806ed31cfab14a18eeb4990c66497a5ce64fdb0d37d3c878b8f5e6227484","device_signature":"CnD0w2P_B-vqmLVqP4u1NN0srNNZ2V1Slx-5SZnyDDe_Z7vaqC_YBtSZRbh7ZtCNuZl6y216ba-TJR8WatkTAA"}} -->

