### PR TITLE
fix(cloud): stop managed agents before key rotation

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-managed-launch-warm-claim.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-managed-launch-warm-claim.test.ts
@@ -42,6 +42,20 @@ function claimedSandbox(
   } as unknown as AgentSandbox;
 }
 
+function genericSandbox(status: "running" | "stopped"): AgentSandbox {
+  return {
+    ...claimedSandbox("ready"),
+    agent_name: "Generic Agent",
+    status,
+    claimed_at: null,
+    warm_claim_credential_state: null,
+    warm_claim_key_fingerprint: null,
+    warm_claim_attested_at: null,
+    warm_claim_attested_environment_revision: null,
+    health_url: status === "running" ? "https://old-agent.example" : null,
+  } as unknown as AgentSandbox;
+}
+
 afterEach(() => {
   globalThis.fetch = originalFetch;
 });
@@ -104,6 +118,94 @@ describe("managed launch warm-claim credential boundary", () => {
     } finally {
       getAgent.mockRestore();
       createKey.mockRestore();
+      cacheAvailable.mockRestore();
+      cacheSet.mockRestore();
+    }
+  });
+});
+
+describe("managed launch credential rotation ordering", () => {
+  test("a refused shutdown leaves the running credential untouched", async () => {
+    const running = genericSandbox("running");
+    const getAgent = spyOn(elizaSandboxService, "getAgent").mockResolvedValue(running);
+    const shutdown = spyOn(elizaSandboxService, "shutdown").mockResolvedValue({
+      success: false,
+      error: "Refusing to stop without a current backup",
+    });
+    const prepare = spyOn(elizaSandboxService, "prepareManagedLaunchEnvironment");
+    const provision = spyOn(elizaSandboxService, "provision");
+    try {
+      const error = await launchManagedElizaAgent({
+        agentId: AGENT_ID,
+        organizationId: ORG_ID,
+        userId: USER_ID,
+      }).catch((caught) => caught);
+
+      expect(error).toBeInstanceOf(ManagedElizaLaunchError);
+      expect((error as ManagedElizaLaunchError).status).toBe(409);
+      expect(shutdown).toHaveBeenCalledTimes(1);
+      expect(prepare).not.toHaveBeenCalled();
+      expect(provision).not.toHaveBeenCalled();
+    } finally {
+      getAgent.mockRestore();
+      shutdown.mockRestore();
+      prepare.mockRestore();
+      provision.mockRestore();
+    }
+  });
+
+  test("stops a running generation before rotating and provisioning its replacement", async () => {
+    const running = genericSandbox("running");
+    const stopped = genericSandbox("stopped");
+    const replacement = {
+      ...genericSandbox("running"),
+      health_url: "https://new-agent.example",
+    } as AgentSandbox;
+    const order: string[] = [];
+    const getAgent = spyOn(elizaSandboxService, "getAgent")
+      .mockResolvedValueOnce(running)
+      .mockResolvedValueOnce(stopped);
+    const shutdown = spyOn(elizaSandboxService, "shutdown").mockImplementation(async () => {
+      order.push("shutdown");
+      return { success: true };
+    });
+    const prepare = spyOn(
+      elizaSandboxService,
+      "prepareManagedLaunchEnvironment",
+    ).mockImplementation(async () => {
+      order.push("rotate");
+      return {
+        sandbox: stopped,
+        environment: {
+          apiToken: "replacement-transport-token",
+          agentApiKey: "eliza_replacement_key",
+          changed: true,
+          environmentVars: {},
+          revokedKeyHashes: [],
+        },
+      };
+    });
+    const provision = spyOn(elizaSandboxService, "provision").mockImplementation(async () => {
+      order.push("provision");
+      return { success: true, sandboxRecord: replacement } as never;
+    });
+    const cacheAvailable = spyOn(cache, "isAvailable").mockReturnValue(true);
+    const cacheSet = spyOn(cache, "set").mockResolvedValue(undefined);
+    globalThis.fetch = (async () => Response.json({ complete: true })) as typeof fetch;
+    try {
+      const result = await launchManagedElizaAgent({
+        agentId: AGENT_ID,
+        organizationId: ORG_ID,
+        userId: USER_ID,
+      });
+
+      expect(order).toEqual(["shutdown", "rotate", "provision"]);
+      expect(result.connection.token).toBe("replacement-transport-token");
+    } finally {
+      getAgent.mockRestore();
+      shutdown.mockRestore();
+      prepare.mockRestore();
+      provision.mockRestore();
       cacheAvailable.mockRestore();
       cacheSet.mockRestore();
     }

--- a/packages/cloud/shared/src/lib/services/eliza-managed-launch.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-managed-launch.ts
@@ -1,4 +1,7 @@
-// Coordinates cloud service eliza managed launch behavior behind route handlers.
+/**
+ * Coordinates managed agent launch, credential refresh, provisioning, and
+ * onboarding behind Cloud route handlers.
+ */
 import type { AgentSandbox } from "../../db/schemas/agent-sandboxes";
 import { cache } from "../cache/client";
 import { CEREBRAS_DEFAULT_TEXT_LARGE_MODEL, CEREBRAS_DEFAULT_TEXT_SMALL_MODEL } from "../models";
@@ -209,6 +212,21 @@ export async function launchManagedElizaAgent(params: {
     }
     launchEnvironment = { apiToken, agentApiKey };
   } else {
+    // A running process must be stopped while its current credential is still
+    // valid. Shutdown can refuse when its fail-closed snapshot cannot be
+    // captured; rotating first would then strand that live process with a
+    // revoked key even though the launch itself failed.
+    if (sandbox.status === "running") {
+      const shutdownResult = await elizaSandboxService.shutdown(sandbox.id, params.organizationId);
+      if (!shutdownResult.success) {
+        throw new ManagedElizaLaunchError(
+          shutdownResult.error || "Failed to refresh sandbox environment",
+          shutdownResult.error === "Agent not found" ? 404 : 409,
+        );
+      }
+      sandbox = (await elizaSandboxService.getAgent(sandbox.id, params.organizationId)) ?? sandbox;
+    }
+
     const prepared = await elizaSandboxService.prepareManagedLaunchEnvironment({
       agentId: sandbox.id,
       organizationId: params.organizationId,
@@ -218,22 +236,6 @@ export async function launchManagedElizaAgent(params: {
       throw new ManagedElizaLaunchError("Agent lifecycle changed during launch", 409);
     }
     sandbox = prepared.sandbox;
-    if (prepared.environment.changed) {
-      if (sandbox.status === "running") {
-        const shutdownResult = await elizaSandboxService.shutdown(
-          sandbox.id,
-          params.organizationId,
-        );
-        if (!shutdownResult.success) {
-          throw new ManagedElizaLaunchError(
-            shutdownResult.error || "Failed to refresh sandbox environment",
-            shutdownResult.error === "Agent not found" ? 404 : 409,
-          );
-        }
-        sandbox =
-          (await elizaSandboxService.getAgent(sandbox.id, params.organizationId)) ?? sandbox;
-      }
-    }
     launchEnvironment = prepared.environment;
   }
 


### PR DESCRIPTION
# Relates to

Closes #19037.

- [x] Targets `develop` and was branched from current `origin/develop` (`4e62753a760`).
- [x] `bun install` completed after sync.
- [x] Focused validation is complete; repository-wide results are recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@4e62753a760d1dc59496016acc06f2d753a9ec55:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on latest `origin/develop` at implementation time; zero conflicts.
- [x] `bun run verify` was run post-sync; final result will be updated from the active full run before merge.

# Risks

Low/medium. This changes only generic managed-agent launch ordering. A running non-warm agent is now stopped before credential rotation. A failed fail-closed shutdown therefore preserves the live credential instead of breaking inference. If a later rotation/provision step fails, the agent remains stopped and can be safely retried. Ready warm claims retain their existing attested-key path.

# Background

## What does this PR do?

Moves fail-closed shutdown ahead of managed credential rotation, then provisions the replacement generation. Adds regression coverage proving that a refused shutdown never reaches rotation and that success executes `shutdown → rotate → provision`.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

N/A - behavior correction is covered by inline lifecycle rationale and regression tests; no public contract changes.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/eliza-managed-launch.ts` and the new ordering tests in `eliza-managed-launch-warm-claim.test.ts`.

## Detailed testing steps

- `bun test packages/cloud/shared/src/lib/services/eliza-managed-launch-warm-claim.test.ts packages/cloud/shared/src/lib/services/managed-launch-credential-rotation.pglite.test.ts` — 10/10 pass.
- `bun run --cwd packages/cloud/shared typecheck` — pass.
- `bun run --cwd packages/cloud/shared lint` — pass.
- `bun run --cwd packages/cloud/shared test` — unrelated current-develop failure in `compat-envelope.test.ts`, which still expects the pre-consolidation `elizacloud.ai` agent URL while code returns `cloud.eliza.app`; the changed launch tests pass.
- `bun run verify` — active full run; result will be recorded before merge.

# Evidence Gate

<!-- evidence-head:03bf9fc732bec892ae56f04230db6f7ac10afe67 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:backend-logs -->
- [ ] Production backend and live messaging evidence will be attached after deployment.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [ ] A real post-deploy messaging reply will validate inference through the refreshed credential.
<!-- evidence-row:domain-artifacts -->
- [ ] Production agent generation/uptime and key authorization will be recorded after deployment without exposing secrets.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI change.

# Known gaps / failures

The full cloud-shared suite has one unrelated current-develop assertion expecting the retired `elizacloud.ai` agent URL after the `eliza.app` consolidation. Production evidence is intentionally pending until this commit is merged and deployed.

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@4e62753a760d1dc59496016acc06f2d753a9ec55:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported  
— [codex-managed-launch]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@4e62753a760d1dc59496016acc06f2d753a9ec55:packages/skills/skills/contribute-to-eliza"} -->