### PR TITLE
fix(ui): bind live plugin config state into save actions

### DIFF
--- a/packages/agent/src/api/server-helpers-plugin.discord-params.test.ts
+++ b/packages/agent/src/api/server-helpers-plugin.discord-params.test.ts
@@ -9,7 +9,17 @@ import { resolvePluginConfigReply } from "./server-helpers-plugin.ts";
 type FormSpec = {
   version: number;
   root: string;
-  elements: Record<string, { type: string; props?: Record<string, unknown> }>;
+  elements: Record<
+    string,
+    {
+      type: string;
+      props?: Record<string, unknown>;
+      children: string[];
+      on?: {
+        press?: { action: string; params?: Record<string, unknown> };
+      };
+    }
+  >;
   state: Record<string, string>;
 };
 
@@ -55,6 +65,51 @@ describe("resolvePluginConfigReply discord ownership fields", () => {
         "DM allowlist (comma-separated Discord user IDs)",
       ]),
     );
+
+    expect(form.elements.root?.children).toEqual([
+      "title",
+      "sep",
+      "fields",
+      "actions",
+    ]);
+    expect(form.elements.fields?.children).toEqual([
+      "f_DISCORD_API_TOKEN",
+      "f_DISCORD_APPLICATION_ID",
+      "f_ELIZA_DISCORD_OWNER_USER_IDS_JSON",
+      "f_DISCORD_DM_POLICY",
+      "f_DISCORD_ALLOW_FROM",
+    ]);
+    expect(form.elements.actions?.children).toEqual(["saveBtn"]);
+    for (const element of Object.values(form.elements)) {
+      expect(Array.isArray(element.children)).toBe(true);
+      expect(element.props).not.toHaveProperty("children");
+    }
+
+    const save = Object.values(form.elements).find(
+      (element) => element.type === "Button",
+    );
+    expect(save?.props?.label).toBe("Save configuration");
+    expect(save?.on?.press).toEqual({
+      action: "plugin:save",
+      params: {
+        pluginId: "discord",
+        "config.DISCORD_API_TOKEN": {
+          $path: "config.DISCORD_API_TOKEN",
+        },
+        "config.DISCORD_APPLICATION_ID": {
+          $path: "config.DISCORD_APPLICATION_ID",
+        },
+        "config.ELIZA_DISCORD_OWNER_USER_IDS_JSON": {
+          $path: "config.ELIZA_DISCORD_OWNER_USER_IDS_JSON",
+        },
+        "config.DISCORD_DM_POLICY": {
+          $path: "config.DISCORD_DM_POLICY",
+        },
+        "config.DISCORD_ALLOW_FROM": {
+          $path: "config.DISCORD_ALLOW_FROM",
+        },
+      },
+    });
   });
 
   it("returns null for prompts that are not plugin config intents", async () => {

--- a/packages/agent/src/api/server-helpers-plugin.ts
+++ b/packages/agent/src/api/server-helpers-plugin.ts
@@ -2,6 +2,7 @@
  * Plugin config/form helpers extracted from server.ts.
  */
 
+import type { UiElement, UiSpec } from "@elizaos/shared";
 import { isBlockedEnvKey } from "./plugin-discovery-helpers.ts";
 import type { ServerState } from "./server-types.ts";
 
@@ -115,20 +116,25 @@ export async function resolvePluginConfigReply(
   if (!params) return null;
 
   const displayName = pluginName.charAt(0).toUpperCase() + pluginName.slice(1);
-  const elements: Record<string, unknown> = {};
+  const elements: Record<string, UiElement> = {};
   const fieldIds: string[] = [];
   const state: Record<string, string> = { pluginId: pluginName };
+  const saveParams: Record<string, unknown> = { pluginId: pluginName };
 
   elements.title = {
     type: "Heading",
     props: { level: 3, text: `Configure ${displayName}` },
+    children: [],
   };
-  elements.sep = { type: "Separator", props: {} };
+  elements.sep = { type: "Separator", props: {}, children: [] };
 
   for (const param of params) {
     const fid = `f_${param.key}`;
     fieldIds.push(fid);
     state[`config.${param.key}`] = "";
+    saveParams[`config.${param.key}`] = {
+      $path: `config.${param.key}`,
+    };
     elements[fid] = {
       type: "Input",
       props: {
@@ -138,34 +144,46 @@ export async function resolvePluginConfigReply(
         type: param.secret ? "password" : "text",
         className: "font-mono text-xs",
       },
+      children: [],
     };
   }
 
-  elements.fields = { type: "Stack", props: { gap: "3", children: fieldIds } };
+  elements.fields = {
+    type: "Stack",
+    props: { gap: "3" },
+    children: fieldIds,
+  };
   elements.saveBtn = {
     type: "Button",
     props: {
-      text: "Save & Enable",
+      label: "Save configuration",
       variant: "default",
       className: "font-semibold",
-      on: {
-        press: { action: "plugin:save", params: { pluginId: pluginName } },
-      },
     },
+    on: {
+      press: { action: "plugin:save", params: saveParams },
+    },
+    children: [],
   };
   elements.actions = {
     type: "Stack",
-    props: { direction: "row", gap: "2", children: ["saveBtn"] },
+    props: { direction: "row", gap: "2" },
+    children: ["saveBtn"],
   };
   elements.root = {
     type: "Card",
     props: {
-      children: ["title", "sep", "fields", "actions"],
       className: "p-4 space-y-3",
     },
+    children: ["title", "sep", "fields", "actions"],
   };
 
-  const spec = JSON.stringify({ version: 1, root: "root", elements, state });
+  const spec = JSON.stringify({
+    version: 1,
+    root: "root",
+    elements,
+    state,
+  } satisfies UiSpec & { version: number });
   return `here's the config form for ${displayName} — fill in your credentials and hit save:\n\n\`\`\`json-render\n${spec}\n\`\`\``;
 }
 

--- a/packages/agent/src/api/server-helpers-plugin.ui-render.test.tsx
+++ b/packages/agent/src/api/server-helpers-plugin.ui-render.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Renders the actual plugin-config reply through the shared UiRenderer and
+ * verifies its live-state save action at the agent/UI package boundary.
+ * Deterministic jsdom integration; only the final action callback is mocked.
+ */
+// @vitest-environment jsdom
+
+import type { UiSpec } from "@elizaos/shared";
+import { UiRenderer } from "@elizaos/ui/components/config-ui";
+import { __setAppValueForTests } from "@elizaos/ui/state/app-store";
+import { AppContext } from "@elizaos/ui/state/useApp";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolvePluginConfigReply } from "./server-helpers-plugin.ts";
+
+function parseForm(reply: string): UiSpec {
+  const match = reply.match(/```json-render\n([\s\S]*?)\n```/);
+  if (!match?.[1]) {
+    throw new Error(
+      `expected json-render form fence, got: ${reply.slice(0, 200)}`,
+    );
+  }
+  return JSON.parse(match[1]) as UiSpec;
+}
+
+describe("resolvePluginConfigReply UiRenderer integration", () => {
+  afterEach(() => {
+    cleanup();
+    __setAppValueForTests(null);
+  });
+
+  it("renders the emitted Discord fields and dispatches their edited state", async () => {
+    const reply = await resolvePluginConfigReply("configure discord", {
+      config: {},
+      runtime: null,
+    } as never);
+    if (typeof reply !== "string") {
+      throw new Error("expected configure discord to return a form string");
+    }
+
+    const onAction = vi.fn();
+    const appValue = {
+      t: (key: string, vars?: Record<string, unknown>) =>
+        String(vars?.defaultValue ?? key),
+    } as never;
+    __setAppValueForTests(appValue);
+    const { container } = render(
+      <AppContext.Provider value={appValue}>
+        <UiRenderer spec={parseForm(reply)} onAction={onAction} />
+      </AppContext.Provider>,
+    );
+
+    const inputs = container.querySelectorAll("input");
+    expect(inputs).toHaveLength(5);
+    fireEvent.change(inputs[0] as HTMLInputElement, {
+      target: { value: "live-token" },
+    });
+    fireEvent.change(inputs[3] as HTMLInputElement, {
+      target: { value: "allowlist" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    expect(onAction).toHaveBeenCalledWith(
+      "plugin:save",
+      {
+        pluginId: "discord",
+        "config.DISCORD_API_TOKEN": "live-token",
+        "config.DISCORD_APPLICATION_ID": "",
+        "config.ELIZA_DISCORD_OWNER_USER_IDS_JSON": "",
+        "config.DISCORD_DM_POLICY": "allowlist",
+        "config.DISCORD_ALLOW_FROM": "",
+      },
+      {
+        historySafeParams: {
+          pluginId: "discord",
+          "config.DISCORD_APPLICATION_ID": "",
+          "config.ELIZA_DISCORD_OWNER_USER_IDS_JSON": "",
+          "config.DISCORD_DM_POLICY": "allowlist",
+          "config.DISCORD_ALLOW_FROM": "",
+        },
+      },
+    );
+  });
+});

--- a/packages/ui/src/browser.ts
+++ b/packages/ui/src/browser.ts
@@ -65,6 +65,7 @@ export {
   sanitizeLinkHref,
 } from "./components/config-ui/ui-renderer.helpers.ts";
 export {
+  type UiActionDispatchMetadata,
   UiRenderer,
   type UiRendererProps,
 } from "./components/config-ui/ui-renderer.tsx";

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -48,7 +48,10 @@ import {
 import { renderPermissionCardFromPayload } from "../composites/chat/permission-card.render";
 import { ConfigRenderer } from "../config-ui/config-renderer";
 import { defaultRegistry } from "../config-ui/config-renderer.helpers";
-import { UiRenderer } from "../config-ui/ui-renderer";
+import {
+  type UiActionDispatchMetadata,
+  UiRenderer,
+} from "../config-ui/ui-renderer";
 import { ToolCallEventLog } from "../tool-events/ToolCallEventLog";
 import { Button } from "../ui/button";
 import { CodeBlock } from "../ui/code-block";
@@ -756,10 +759,20 @@ export function MessageUiSpecBlock({
   const [showRaw, setShowRaw] = useState(false);
 
   const handleAction = useCallback(
-    (action: string, params?: Record<string, unknown>) => {
+    (
+      action: string,
+      params?: Record<string, unknown>,
+      metadata?: UiActionDispatchMetadata,
+    ) => {
       // Plugin actions are handled directly via the API instead of
       // being sent back as chat messages.
-      if (action === "plugin:save" && params?.pluginId) {
+      if (action === "plugin:save") {
+        if (!params?.pluginId) {
+          void sendActionMessage(
+            "[Failed to save plugin config: pluginId is required]",
+          );
+          return;
+        }
         const pluginId = String(params.pluginId);
         const config: Record<string, string> = {};
         // Collect all config.* state values
@@ -773,6 +786,12 @@ export function MessageUiSpecBlock({
               config[key.slice(7)] = value.trim();
             }
           }
+        }
+        if (Object.keys(config).length === 0) {
+          void sendActionMessage(
+            "[Failed to save plugin config: no configuration values were provided]",
+          );
+          return;
         }
         void client
           .updatePlugin(pluginId, { config })
@@ -815,7 +834,15 @@ export function MessageUiSpecBlock({
         );
         return;
       }
-      const paramsStr = params ? ` ${JSON.stringify(params)}` : "";
+      // Generic UiSpec actions remain planner-readable, including literal and
+      // live non-secret params. The renderer supplies a history-safe copy when
+      // a payload contains values sourced from password fields; direct
+      // allowlisted handlers above still receive the complete resolved params.
+      const historySafeParams = metadata?.historySafeParams ?? params;
+      const paramsStr =
+        historySafeParams && Object.keys(historySafeParams).length > 0
+          ? ` ${JSON.stringify(historySafeParams)}`
+          : "";
       void sendActionMessage(`[action:${action}]${paramsStr}`);
     },
     [sendActionMessage],

--- a/packages/ui/src/components/chat/MessageContent.uispec-actions.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.uispec-actions.test.tsx
@@ -291,6 +291,46 @@ describe("MessageUiSpecBlock plugin actions", () => {
     );
   });
 
+  it("redacts a secret-declared field that is not a password input", async () => {
+    // A seed phrase in a Textarea, or a text Input labelled "Private key",
+    // cannot use `type: "password"`. Declaring `secret` must keep it out of
+    // durable chat history just as a password input does.
+    const spec = pluginConfigSpec();
+    spec.elements.application.props = {
+      label: "Recovery phrase",
+      statePath: "config.DISCORD_APPLICATION_ID",
+      secret: true,
+    };
+    spec.elements.save.on = {
+      press: {
+        action: "sendBnb",
+        params: {
+          network: "bsc",
+          phrase: { $path: "config.DISCORD_APPLICATION_ID" },
+        },
+      },
+    };
+    const { container, sendActionMessage } = withApp(
+      <MessageUiSpecBlock spec={spec} raw={JSON.stringify(spec)} />,
+    );
+
+    const secretValue = "correct horse battery staple";
+    fireEvent.change(
+      container.querySelectorAll("input")[1] as HTMLInputElement,
+      { target: { value: secretValue } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    await waitFor(() => {
+      expect(sendActionMessage).toHaveBeenCalledWith(
+        '[action:sendBnb] {"network":"bsc"}',
+      );
+    });
+    expect(sendActionMessage).not.toHaveBeenCalledWith(
+      expect.stringContaining(secretValue),
+    );
+  });
+
   it("rejects plugin saves without an id without serializing config state", async () => {
     const spec = pluginConfigSpec();
     spec.elements.save.on = {

--- a/packages/ui/src/components/chat/MessageContent.uispec-actions.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.uispec-actions.test.tsx
@@ -291,6 +291,32 @@ describe("MessageUiSpecBlock plugin actions", () => {
     );
   });
 
+  it("dispatches an action when another element omits props", async () => {
+    const spec = pluginConfigSpec();
+    (spec.elements.application as { props?: Record<string, unknown> }).props =
+      undefined;
+    spec.elements.save.on = {
+      press: {
+        action: "inspect",
+        params: { network: "bsc" },
+      },
+    };
+    const { sendActionMessage } = withApp(
+      <MessageUiSpecBlock spec={spec} raw={JSON.stringify(spec)} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    await waitFor(() => {
+      expect(sendActionMessage).toHaveBeenCalledWith(
+        '[action:inspect] {"network":"bsc"}',
+      );
+    });
+    expect(
+      screen.queryByRole("alert", { name: "Interactive action unavailable" }),
+    ).toBeNull();
+  });
+
   it("redacts a secret-declared field that is not a password input", async () => {
     // A seed phrase in a Textarea, or a text Input labelled "Private key",
     // cannot use `type: "password"`. Declaring `secret` must keep it out of

--- a/packages/ui/src/components/chat/MessageContent.uispec-actions.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.uispec-actions.test.tsx
@@ -1,0 +1,329 @@
+/**
+ * Exercises UiSpec plugin actions through the real renderer and chat action
+ * boundary while replacing only the outbound HTTP client.
+ */
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UiSpec } from "../../config/ui-spec";
+import { __setAppValueForTests } from "../../state/app-store";
+import { AppContext } from "../../state/useApp";
+import { UiRenderer } from "../config-ui";
+
+const { clientMock } = vi.hoisted(() => ({
+  clientMock: {
+    updatePlugin: vi.fn(),
+  },
+}));
+
+vi.mock("../../api/client", () => ({ client: clientMock }));
+
+import { MessageUiSpecBlock } from "./MessageContent";
+
+function withApp(node: React.ReactElement) {
+  const sendActionMessage = vi.fn();
+  const appValue = {
+    t: (key: string, vars?: Record<string, unknown>) =>
+      String(vars?.defaultValue ?? key),
+    sendActionMessage,
+  } as never;
+  __setAppValueForTests(appValue);
+  return {
+    ...render(
+      <AppContext.Provider value={appValue}>{node}</AppContext.Provider>,
+    ),
+    sendActionMessage,
+  };
+}
+
+function pluginConfigSpec(): UiSpec {
+  return {
+    version: 1,
+    root: "root",
+    state: {
+      pluginId: "discord",
+      "config.DISCORD_API_TOKEN": "",
+      "config.DISCORD_APPLICATION_ID": "",
+    },
+    elements: {
+      root: {
+        type: "Stack",
+        props: {},
+        children: ["token", "application", "save"],
+      },
+      token: {
+        type: "Input",
+        props: {
+          label: "Bot Token",
+          statePath: "config.DISCORD_API_TOKEN",
+          type: "password",
+        },
+        children: [],
+      },
+      application: {
+        type: "Input",
+        props: {
+          label: "Application ID",
+          statePath: "config.DISCORD_APPLICATION_ID",
+        },
+        children: [],
+      },
+      save: {
+        type: "Button",
+        props: { label: "Save configuration" },
+        children: [],
+        on: {
+          press: {
+            action: "plugin:save",
+            params: {
+              pluginId: "discord",
+              "config.DISCORD_API_TOKEN": {
+                $path: "config.DISCORD_API_TOKEN",
+              },
+              "config.DISCORD_APPLICATION_ID": {
+                $path: "config.DISCORD_APPLICATION_ID",
+              },
+            },
+          },
+        },
+      },
+    },
+  } as UiSpec;
+}
+
+describe("MessageUiSpecBlock plugin actions", () => {
+  beforeEach(() => {
+    clientMock.updatePlugin.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    __setAppValueForTests(null);
+  });
+
+  it("sends edited UiSpec state as the plugin config patch", async () => {
+    clientMock.updatePlugin.mockResolvedValue({ ok: true });
+    const spec = pluginConfigSpec();
+    const { container, sendActionMessage } = withApp(
+      <MessageUiSpecBlock spec={spec} raw={JSON.stringify(spec)} />,
+    );
+    const inputs = container.querySelectorAll("input");
+    expect(inputs).toHaveLength(2);
+
+    fireEvent.change(inputs[0] as HTMLInputElement, {
+      target: { value: "token-value" },
+    });
+    fireEvent.change(inputs[1] as HTMLInputElement, {
+      target: { value: "application-id-value" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    await waitFor(() => {
+      expect(clientMock.updatePlugin).toHaveBeenCalledWith("discord", {
+        config: {
+          DISCORD_API_TOKEN: "token-value",
+          DISCORD_APPLICATION_ID: "application-id-value",
+        },
+      });
+    });
+    expect(sendActionMessage).toHaveBeenCalledWith(
+      "[Plugin discord configuration saved successfully]",
+    );
+  });
+
+  it("rejects a plugin config save with no entered values", async () => {
+    const spec = pluginConfigSpec();
+    const { sendActionMessage } = withApp(
+      <MessageUiSpecBlock spec={spec} raw={JSON.stringify(spec)} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    await waitFor(() => {
+      expect(sendActionMessage).toHaveBeenCalledWith(
+        "[Failed to save plugin config: no configuration values were provided]",
+      );
+    });
+    expect(clientMock.updatePlugin).not.toHaveBeenCalled();
+    expect(sendActionMessage).not.toHaveBeenCalledWith(
+      "[Plugin discord configuration saved successfully]",
+    );
+  });
+
+  it("omits untouched empty fields from a partial config save", async () => {
+    clientMock.updatePlugin.mockResolvedValue({ ok: true });
+    const spec = pluginConfigSpec();
+    const { container } = withApp(
+      <MessageUiSpecBlock spec={spec} raw={JSON.stringify(spec)} />,
+    );
+
+    const inputs = container.querySelectorAll("input");
+    fireEvent.change(inputs[0] as HTMLInputElement, {
+      target: { value: "token-only" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    await waitFor(() => {
+      expect(clientMock.updatePlugin).toHaveBeenCalledWith("discord", {
+        config: { DISCORD_API_TOKEN: "token-only" },
+      });
+    });
+  });
+
+  it("resolves documented action bindings without rewriting literal path payloads", async () => {
+    const spec = pluginConfigSpec();
+    spec.state.dynamicValue = "live-value";
+    spec.elements.save.on = {
+      press: {
+        action: "inspect",
+        params: {
+          fromPath: { $path: "dynamicValue" },
+          fromData: "$data.dynamicValue",
+          literalTarget: { path: "/literal/target" },
+        },
+      },
+    };
+    const onAction = vi.fn();
+    withApp(<UiRenderer spec={spec} onAction={onAction} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    await waitFor(() => {
+      expect(onAction).toHaveBeenCalledWith("inspect", {
+        fromPath: "live-value",
+        fromData: "live-value",
+        literalTarget: { path: "/literal/target" },
+      });
+    });
+  });
+
+  it("rejects malformed action bindings through the declared error action", async () => {
+    const spec = pluginConfigSpec();
+    spec.elements.save.on = {
+      press: {
+        action: "inspect",
+        params: { invalid: { $path: 42 } },
+        onError: { action: "invalid-binding" },
+      },
+    };
+    const { sendActionMessage } = withApp(
+      <MessageUiSpecBlock spec={spec} raw={JSON.stringify(spec)} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    await waitFor(() => {
+      expect(sendActionMessage).toHaveBeenCalledWith(
+        "[action:invalid-binding]",
+      );
+      expect(sendActionMessage).not.toHaveBeenCalledWith(
+        expect.stringContaining("[action:inspect]"),
+      );
+    });
+  });
+
+  it("surfaces malformed action bindings when no error action is declared", async () => {
+    const spec = pluginConfigSpec();
+    spec.elements.save.on = {
+      press: {
+        action: "inspect",
+        params: { invalid: { $path: 42 } },
+      },
+    };
+    const { sendActionMessage } = withApp(
+      <MessageUiSpecBlock spec={spec} raw={JSON.stringify(spec)} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    const alert = await screen.findByRole("alert", {
+      name: "Interactive action unavailable",
+    });
+    expect(alert.textContent).toContain(
+      "This action is unavailable because its dynamic parameters are invalid.",
+    );
+    expect(sendActionMessage).not.toHaveBeenCalled();
+  });
+
+  it("preserves generic non-secret params without serializing password state", async () => {
+    const spec = pluginConfigSpec();
+    spec.state.amount = 0.25;
+    spec.elements.save.on = {
+      press: {
+        action: "sendBnb",
+        params: {
+          amount: { $path: "amount" },
+          address: "$data.config.DISCORD_APPLICATION_ID",
+          network: "bsc",
+          token: { $path: "config.DISCORD_API_TOKEN" },
+        },
+      },
+    };
+    const { container, sendActionMessage } = withApp(
+      <MessageUiSpecBlock spec={spec} raw={JSON.stringify(spec)} />,
+    );
+
+    const secretValue = "entered-secret-value";
+    const inputs = container.querySelectorAll("input");
+    fireEvent.change(inputs[0] as HTMLInputElement, {
+      target: { value: secretValue },
+    });
+    fireEvent.change(inputs[1] as HTMLInputElement, {
+      target: { value: "0xrecipient" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    await waitFor(() => {
+      expect(sendActionMessage).toHaveBeenCalledWith(
+        '[action:sendBnb] {"amount":0.25,"address":"0xrecipient","network":"bsc"}',
+      );
+    });
+    expect(sendActionMessage).not.toHaveBeenCalledWith(
+      expect.stringContaining(secretValue),
+    );
+  });
+
+  it("rejects plugin saves without an id without serializing config state", async () => {
+    const spec = pluginConfigSpec();
+    spec.elements.save.on = {
+      press: {
+        action: "plugin:save",
+        params: {
+          "config.DISCORD_API_TOKEN": {
+            $path: "config.DISCORD_API_TOKEN",
+          },
+        },
+      },
+    };
+    const { container, sendActionMessage } = withApp(
+      <MessageUiSpecBlock spec={spec} raw={JSON.stringify(spec)} />,
+    );
+
+    const secretValue = "malformed-save-secret";
+    fireEvent.change(
+      container.querySelectorAll("input")[0] as HTMLInputElement,
+      {
+        target: { value: secretValue },
+      },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    await waitFor(() => {
+      expect(sendActionMessage).toHaveBeenCalledWith(
+        "[Failed to save plugin config: pluginId is required]",
+      );
+    });
+    expect(clientMock.updatePlugin).not.toHaveBeenCalled();
+    expect(sendActionMessage).not.toHaveBeenCalledWith(
+      expect.stringContaining(secretValue),
+    );
+  });
+});

--- a/packages/ui/src/components/config-ui/index.ts
+++ b/packages/ui/src/components/config-ui/index.ts
@@ -4,7 +4,11 @@ export * from "./config-control-primitives.helpers";
 export * from "./config-field";
 export * from "./config-renderer";
 export * from "./config-renderer.helpers";
-export { UiRenderer, type UiRendererProps } from "./ui-renderer";
+export {
+  type UiActionDispatchMetadata,
+  UiRenderer,
+  type UiRendererProps,
+} from "./ui-renderer";
 export {
   evaluateUiVisibility,
   getSupportedComponents,

--- a/packages/ui/src/components/config-ui/ui-renderer.tsx
+++ b/packages/ui/src/components/config-ui/ui-renderer.tsx
@@ -3,9 +3,12 @@
  * tree) into React. Walks the spec's element graph from its root, resolves
  * bound props / state paths / visibility conditions against a live state store,
  * runs field validators, and fires `UiAction`s back through the `onAction`
- * callback. Link hrefs are sanitized (`sanitizeLinkHref`) and only supported
- * component types render; the spec is data, not code. Contrast with
- * `ConfigRenderer`, which drives a JSON-Schema config form rather than a spec tree.
+ * callback. Action metadata keeps password-sourced values out of durable
+ * history without withholding them from direct handlers, while malformed
+ * bindings render an explicit unavailable state. Link hrefs are sanitized
+ * (`sanitizeLinkHref`) and only supported component types render; the spec is
+ * data, not code. Contrast with `ConfigRenderer`, which drives a JSON-Schema
+ * config form rather than a spec tree.
  */
 import type React from "react";
 import {
@@ -49,9 +52,26 @@ import {
   sanitizeLinkHref,
 } from "./ui-renderer.helpers";
 
-const UiContext = createContext<UiRenderContext | null>(null);
+export interface UiActionDispatchMetadata {
+  /** Resolved params safe to persist in chat or another durable history. */
+  historySafeParams: Record<string, unknown>;
+}
 
-function useUiCtx(): UiRenderContext {
+type UiRendererActionHandler = (
+  action: string,
+  params?: Record<string, unknown>,
+  metadata?: UiActionDispatchMetadata,
+) => void;
+
+type UiRendererContext = Omit<UiRenderContext, "onAction"> & {
+  onAction?: UiRendererActionHandler;
+  clearActionError: () => void;
+  reportActionError: (error: Error) => void;
+};
+
+const UiContext = createContext<UiRendererContext | null>(null);
+
+function useUiCtx(): UiRendererContext {
   const ctx = useContext(UiContext);
   if (!ctx) throw new Error("UiRenderer context missing");
   return ctx;
@@ -59,7 +79,11 @@ function useUiCtx(): UiRenderContext {
 
 // ── Dynamic value resolution ────────────────────────────────────────
 
-function resolveProp(value: unknown, ctx: UiRenderContext): unknown {
+function resolveProp(
+  value: unknown,
+  ctx: UiRendererContext,
+  resolveLegacyPath = true,
+): unknown {
   if (value == null) return value;
 
   // $data.path string prefix (simpler syntax for AI)
@@ -76,7 +100,10 @@ function resolveProp(value: unknown, ctx: UiRenderContext): unknown {
     typeof value === "object" &&
     "$path" in (value as Record<string, unknown>)
   ) {
-    const path = (value as { $path: string }).$path;
+    const path = (value as { $path: unknown }).$path;
+    if (typeof path !== "string") {
+      throw new TypeError("UiSpec $path binding must be a string");
+    }
     if (path.startsWith("$item/") && ctx.repeatItem) {
       return ctx.repeatItem[path.slice(6)];
     }
@@ -93,30 +120,35 @@ function resolveProp(value: unknown, ctx: UiRenderContext): unknown {
     let result = false;
 
     if (cond.eq) {
-      const [a, b] = cond.eq.map((v) => resolveProp(v, ctx));
+      const [a, b] = cond.eq.map((v) => resolveProp(v, ctx, resolveLegacyPath));
       result = a === b;
     } else if (cond.neq) {
-      const [a, b] = cond.neq.map((v) => resolveProp(v, ctx));
+      const [a, b] = cond.neq.map((v) =>
+        resolveProp(v, ctx, resolveLegacyPath),
+      );
       result = a !== b;
     } else if (cond.gt) {
-      const [a, b] = cond.gt.map((v) => resolveProp(v, ctx));
+      const [a, b] = cond.gt.map((v) => resolveProp(v, ctx, resolveLegacyPath));
       result = Number(a) > Number(b);
     } else if (cond.lt) {
-      const [a, b] = cond.lt.map((v) => resolveProp(v, ctx));
+      const [a, b] = cond.lt.map((v) => resolveProp(v, ctx, resolveLegacyPath));
       result = Number(a) < Number(b);
     } else if (cond.truthy) {
-      result = !!resolveProp(cond.truthy, ctx);
+      result = !!resolveProp(cond.truthy, ctx, resolveLegacyPath);
     } else if (cond.falsy) {
-      result = !resolveProp(cond.falsy, ctx);
+      result = !resolveProp(cond.falsy, ctx, resolveLegacyPath);
     } else if (cond.path) {
       result = !!getByPath(ctx.state, cond.path);
     }
 
-    return result ? resolveProp(expr.$then, ctx) : resolveProp(expr.$else, ctx);
+    return result
+      ? resolveProp(expr.$then, ctx, resolveLegacyPath)
+      : resolveProp(expr.$else, ctx, resolveLegacyPath);
   }
 
   // Object with path references
   if (
+    resolveLegacyPath &&
     typeof value === "object" &&
     value !== null &&
     "path" in (value as Record<string, unknown>)
@@ -133,18 +165,135 @@ function resolveProp(value: unknown, ctx: UiRenderContext): unknown {
 
 function resolveProps(
   props: Record<string, unknown>,
-  ctx: UiRenderContext,
+  ctx: UiRendererContext,
+  resolveLegacyPath = true,
 ): Record<string, unknown> {
   const resolved: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(props)) {
-    resolved[k] = resolveProp(v, ctx);
+    resolved[k] = resolveProp(v, ctx, resolveLegacyPath);
   }
   return resolved;
 }
 
+type ActionParamsResolution =
+  | {
+      ok: true;
+      params: Record<string, unknown> | undefined;
+      metadata?: UiActionDispatchMetadata;
+    }
+  | { ok: false; error: Error };
+
+function pathTouchesSensitiveState(
+  path: string,
+  sensitivePaths: ReadonlySet<string>,
+): boolean {
+  for (const sensitivePath of sensitivePaths) {
+    if (
+      path === sensitivePath ||
+      path.startsWith(`${sensitivePath}.`) ||
+      sensitivePath.startsWith(`${path}.`)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function referencesSensitiveState(
+  value: unknown,
+  sensitivePaths: ReadonlySet<string>,
+  seen = new Set<object>(),
+): boolean {
+  if (typeof value === "string") {
+    return (
+      value.startsWith("$data.") &&
+      pathTouchesSensitiveState(value.slice(6), sensitivePaths)
+    );
+  }
+  if (value === null || typeof value !== "object") return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.some((entry) =>
+      referencesSensitiveState(entry, sensitivePaths, seen),
+    );
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.$path === "string" &&
+    pathTouchesSensitiveState(record.$path, sensitivePaths)
+  ) {
+    return true;
+  }
+  const conditionalPath = (record.$cond as { path?: unknown } | undefined)
+    ?.path;
+  if (
+    typeof conditionalPath === "string" &&
+    pathTouchesSensitiveState(conditionalPath, sensitivePaths)
+  ) {
+    return true;
+  }
+  return Object.values(record).some((entry) =>
+    referencesSensitiveState(entry, sensitivePaths, seen),
+  );
+}
+
+function sensitiveStatePaths(ctx: UiRendererContext): ReadonlySet<string> {
+  const paths = new Set<string>();
+  for (const element of Object.values(ctx.spec.elements)) {
+    const statePath = element.props.statePath;
+    if (element.props.type === "password" && typeof statePath === "string") {
+      paths.add(statePath);
+    }
+  }
+  return paths;
+}
+
+function resolveActionParams(
+  params: Record<string, unknown> | undefined,
+  ctx: UiRendererContext,
+): ActionParamsResolution {
+  if (!params) return { ok: true, params: undefined };
+
+  try {
+    // Action payloads have historically allowed literal objects containing a
+    // `path` field. Resolve only the documented `$path`/`$data`/`$cond`
+    // bindings here; the legacy bare `{ path }` prop shorthand remains scoped
+    // to element props so existing action contracts are not reinterpreted.
+    const resolvedParams = resolveProps(params, ctx, false);
+    const sensitivePaths = sensitiveStatePaths(ctx);
+    const historySafeParams: Record<string, unknown> = {};
+    let redacted = false;
+    for (const [key, value] of Object.entries(params)) {
+      if (referencesSensitiveState(value, sensitivePaths)) {
+        redacted = true;
+      } else {
+        historySafeParams[key] = resolvedParams[key];
+      }
+    }
+    return {
+      ok: true,
+      params: resolvedParams,
+      metadata: redacted ? { historySafeParams } : undefined,
+    };
+  } catch (error) {
+    // error-policy:J3 malformed dynamic bindings reject the action instead of
+    // dispatching a partially resolved payload or escaping the click handler.
+    return {
+      ok: false,
+      error:
+        error instanceof Error
+          ? error
+          : new TypeError("UiSpec action parameters are invalid"),
+    };
+  }
+}
+
 // ── State helpers ───────────────────────────────────────────────────
 
-function useStatePath(statePath: string | undefined, ctx: UiRenderContext) {
+function useStatePath(statePath: string | undefined, ctx: UiRendererContext) {
   const value = statePath ? getByPath(ctx.state, statePath) : undefined;
   const setValue = useCallback(
     (v: unknown) => {
@@ -157,24 +306,48 @@ function useStatePath(statePath: string | undefined, ctx: UiRenderContext) {
 
 // ── Fire event action ───────────────────────────────────────────────
 
-function fireEvent(action: UiAction | undefined, ctx: UiRenderContext) {
+function fireEvent(action: UiAction | undefined, ctx: UiRendererContext) {
   if (!action) return;
 
   const execute = () => {
-    if (action.action === "setState" && action.params) {
-      const p = action.params as { path: string; value: unknown };
+    ctx.clearActionError();
+    const resolution = resolveActionParams(action.params, ctx);
+    if (!resolution.ok) {
+      if (action.onError && ctx.onAction) {
+        ctx.onAction(action.onError.action, action.onError.params);
+      } else {
+        ctx.reportActionError(resolution.error);
+      }
+      return;
+    }
+    const { params } = resolution;
+    if (action.action === "setState" && params) {
+      const p = params as { path: string; value: unknown };
       ctx.setState(p.path, p.value);
       if (action.onSuccess && ctx.onAction) {
         ctx.onAction(action.onSuccess.action, action.onSuccess.params);
       }
     } else if (ctx.onAction) {
       try {
-        ctx.onAction(action.action, action.params);
+        if (resolution.metadata) {
+          ctx.onAction(action.action, params, resolution.metadata);
+        } else {
+          ctx.onAction(action.action, params);
+        }
         if (action.onSuccess)
           ctx.onAction(action.onSuccess.action, action.onSuccess.params);
-      } catch {
-        if (action.onError && ctx.onAction)
+      } catch (error) {
+        // error-policy:J4 action callback failures become an explicit renderer
+        // error unless the spec declares its own error action.
+        if (action.onError && ctx.onAction) {
           ctx.onAction(action.onError.action, action.onError.params);
+        } else {
+          ctx.reportActionError(
+            error instanceof Error
+              ? error
+              : new Error("UiSpec action execution failed"),
+          );
+        }
       }
     }
   };
@@ -243,7 +416,7 @@ const TAP_FLOOR = "pointer-coarse:min-h-touch pointer-coarse:min-w-touch";
 type ComponentFn = (
   props: Record<string, unknown>,
   children: React.ReactNode,
-  ctx: UiRenderContext,
+  ctx: UiRendererContext,
   el: UiElement,
 ) => React.ReactNode;
 
@@ -1536,13 +1709,13 @@ function RepeatItemRenderer({
   component,
   resolvedProps,
 }: {
-  ctx: UiRenderContext;
+  ctx: UiRendererContext;
   item: Record<string, unknown>;
   el: UiElement;
   component: ComponentFn;
   resolvedProps: Record<string, unknown>;
 }) {
-  const itemCtx = useMemo<UiRenderContext>(
+  const itemCtx = useMemo<UiRendererContext>(
     () => ({ ...ctx, repeatItem: item }),
     [ctx, item],
   );
@@ -1624,7 +1797,7 @@ function ElementRenderer({ elementId }: { elementId: string }) {
 
 export interface UiRendererProps {
   spec: UiSpec;
-  onAction?: (action: string, params?: Record<string, unknown>) => void;
+  onAction?: UiRendererActionHandler;
   loading?: boolean;
   auth?: AuthState;
   validators?: Record<
@@ -1647,6 +1820,16 @@ export function UiRenderer({
     ...spec.state,
   }));
   const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({});
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const clearActionError = useCallback(() => setActionError(null), []);
+  const reportActionError = useCallback((error: Error) => {
+    setActionError(
+      error instanceof TypeError
+        ? "This action is unavailable because its dynamic parameters are invalid."
+        : "This action could not be completed.",
+    );
+  }, []);
 
   const setState = useCallback((path: string, value: unknown) => {
     setStateRaw((prev) => {
@@ -1671,7 +1854,7 @@ export function UiRenderer({
     [spec.elements, state, validators],
   );
 
-  const ctx = useMemo<UiRenderContext>(
+  const ctx = useMemo<UiRendererContext>(
     () => ({
       spec,
       state,
@@ -1682,6 +1865,8 @@ export function UiRenderer({
       validators,
       fieldErrors,
       validateField,
+      clearActionError,
+      reportActionError,
     }),
     [
       spec,
@@ -1693,6 +1878,8 @@ export function UiRenderer({
       validators,
       fieldErrors,
       validateField,
+      clearActionError,
+      reportActionError,
     ],
   );
 
@@ -1713,6 +1900,15 @@ export function UiRenderer({
   return (
     <UiContext.Provider value={ctx}>
       <ElementRenderer elementId={spec.root} />
+      {actionError && (
+        <div
+          role="alert"
+          aria-label="Interactive action unavailable"
+          className="mt-2 rounded-sm border border-danger/30 bg-danger/5 px-3 py-2 text-xs text-danger"
+        >
+          {actionError}
+        </div>
+      )}
     </UiContext.Provider>
   );
 }

--- a/packages/ui/src/components/config-ui/ui-renderer.tsx
+++ b/packages/ui/src/components/config-ui/ui-renderer.tsx
@@ -251,11 +251,11 @@ function referencesSensitiveState(
 function sensitiveStatePaths(ctx: UiRendererContext): ReadonlySet<string> {
   const paths = new Set<string>();
   for (const element of Object.values(ctx.spec.elements)) {
-    const statePath = element.props.statePath;
+    const props = element.props ?? {};
+    const statePath = props.statePath;
     if (typeof statePath !== "string") continue;
-    const props = element.props as { secret?: unknown; sensitive?: unknown };
     if (
-      element.props.type === "password" ||
+      props.type === "password" ||
       props.secret === true ||
       props.sensitive === true
     ) {

--- a/packages/ui/src/components/config-ui/ui-renderer.tsx
+++ b/packages/ui/src/components/config-ui/ui-renderer.tsx
@@ -240,11 +240,25 @@ function referencesSensitiveState(
   );
 }
 
+// Generic-action serialization writes resolved params into durable chat
+// history, so a field is excluded from that payload only if the spec declares
+// it secret. UiSpecs are plugin- and model-authored, and `type: "password"`
+// alone is a rendering choice a non-input element (a Textarea holding a seed
+// phrase, a text Input labelled "Private key") can silently miss. An explicit
+// `secret`/`sensitive` prop is therefore honored as well, so an author who
+// cannot use a password input still has a declarative way to stay out of
+// history. Anything a secret-bearing field feeds is redacted by whole key.
 function sensitiveStatePaths(ctx: UiRendererContext): ReadonlySet<string> {
   const paths = new Set<string>();
   for (const element of Object.values(ctx.spec.elements)) {
     const statePath = element.props.statePath;
-    if (element.props.type === "password" && typeof statePath === "string") {
+    if (typeof statePath !== "string") continue;
+    const props = element.props as { secret?: unknown; sensitive?: unknown };
+    if (
+      element.props.type === "password" ||
+      props.secret === true ||
+      props.sensitive === true
+    ) {
       paths.add(statePath);
     }
   }


### PR DESCRIPTION
# Relates to

Closes #18975.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`; GitHub reports the exact pushed head mergeable with zero conflicts.
- [x] `bun install` and `bun run verify` were run after the final sync.
- [x] A reviewer can confirm the changed code path from exact-head contract and integration tests.
- [x] Issue-specific desktop/mobile screenshots, walkthrough video, request/error metadata, producer log, and OCR review are attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@efb2c8da4310c3f91e3b0120d6cbc9295c2a7c71:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Final verification cut rebased onto `origin/develop` at `d5f48ce311a482148b907b535a6cdd8799cd4491`; zero conflicts.
- [x] Exact pushed head: `216f179473d720427925748ceb498519e2ec0dba`.
- [x] Branch history is three scoped commits: the feature repair, maintainer-added secret-declaration hardening, and the prop-less action-element crash guard.
- [x] GitHub reports the exact pushed head mergeable; the verified cut is directly based on `d5f48ce311a482148b907b535a6cdd8799cd4491`.

# What does this PR do?

- Emits the server-generated plugin form with canonical element-level `children`, button `label`, and `on.press`.
- Typechecks the producer against `UiElement` / `UiSpec` so invalid tree placement fails at compile time.
- Resolves documented `$path` / `$data` / `$cond` action bindings against current form state without reinterpreting literal `{ path: ... }` payloads.
- Saves partial non-empty configuration patches and rejects empty-string-only saves.
- Preserves resolved literal and dynamic non-secret params for generic actions while omitting values sourced from password fields or fields explicitly declared `secret`/`sensitive` from persisted chat. Direct allowlisted handlers still receive the full authenticated payload.
- Surfaces malformed bindings through their declared `onError` action or an accessible unavailable alert when no handler is declared.
- Treats model-emitted elements without `props` as empty-prop elements, preventing secret-history inspection from crashing unrelated actions.
- Labels the action accurately as **Save configuration**; it does not claim to enable the plugin.
- Adds server-emitter, real producer-to-renderer, and chat/API-boundary regression coverage.

# Reviewer findings addressed

The current head resolves every code blocker raised on the earlier revisions:

1. The real server-emitted card now uses canonical `element.children`, so the shared renderer displays all five fields.
2. Action bindings preserve arbitrary literal `path` objects and reject malformed bindings instead of silently dispatching unresolved data.
3. Empty strings are stripped before the empty-patch guard; partial non-empty saves remain supported.
4. Missing `pluginId` fails instead of falling through with resolved config.
5. Generic fallback preserves documented non-secret params while renderer metadata omits password-sourced or explicitly secret/sensitive top-level params from persisted history.
6. Malformed bindings dispatch the declared `onError` action or display an accessible unavailable alert when no error handler exists.
7. The submitted duplicate PR #19028 is closed, leaving this PR as the active implementation for #18975.
8. Prop-less elements are normalized before sensitive-path inspection, so a valid neighboring action still dispatches when an LLM omits `props` elsewhere in the tree.

# Testing

## Where should a reviewer start?

- `packages/agent/src/api/server-helpers-plugin.ui-render.test.tsx` feeds the actual server reply through the real shared `UiRenderer`, verifies five rendered inputs, edits live state, and clicks the emitted action.
- `packages/ui/src/components/chat/MessageContent.uispec-actions.test.tsx` covers the real renderer/chat/API boundary, partial and empty saves, `$path`, `$data`, literal `path` compatibility, declared and undeclared malformed-binding failures, missing `pluginId`, non-secret generic params, password-source redaction, and action dispatch when another element omits `props`.
- `packages/agent/src/api/server-helpers-plugin.discord-params.test.ts` locks the canonical emitted tree and all five Discord bindings.

## Exact pushed-head results

- Focused agent regressions: 2 files, 3 tests passed.
- Focused UI regressions: 1 file, 10 tests passed.
- Affected total: 13/13 tests passed.
- Official gitleaks v8.30.1 passed on the prior two-commit cut; the updated exact-head hosted scan is queued.
- Agent typecheck, lint, and build: passed.
- UI typecheck, lint, and build: passed (8 pre-existing cookie warnings).
- `bun install`: completed with no source changes.
- `bun run verify`: passed end-to-end at the exact pushed head: 350/350 workspace tasks, all downstream audits, 61 Hetzner routing selectors, and 8,023 test files with zero focused or orphaned skips.
- Exact pushed head `216f179473d720427925748ceb498519e2ec0dba` passed `bun run --cwd packages/app audit:app`: 219/219 captures, broken=0, needs-work=0, hover failures=0.
- Packaged OCR: 216 views; verified=200, broken=0, needs-eyeball=16.

# Evidence Gate

<!-- evidence-head:030eceac748062ba2cb97554187e54b515bab237 -->

The bounded capture was recorded against feature head `4e32c66a9` and directly demonstrates the ticket-specific fixed producer/render/save path: the empty pre-fix card becomes a five-field form and performs one authenticated save. Subsequent exact-head changes are limited to generic-action history-redaction metadata, an accessible malformed-binding failure state, maintainer-added support for explicit `secret`/`sensitive` field declarations, and a nonvisual guard for model-emitted elements without `props`; they preserve the plugin form DOM and save behavior shown here. Exact-head focused tests and the runtime-view cut's full app audit cover those later changes.

<!-- evidence-row:before-screenshots -->
- [x] Before desktop/mobile composite (empty pre-fix server-emitted card): ![Before desktop and mobile composite](https://github.com/user-attachments/assets/62dbb34e-6f63-42bf-817f-fcc74be3e23c)
<!-- evidence-row:after-screenshots -->
- [x] After desktop/mobile composite (five rendered configuration fields and **Save configuration**): ![After desktop and mobile composite](https://github.com/user-attachments/assets/01302a9a-4789-41e6-bfc8-043f8f6beef1)
<!-- evidence-row:walkthrough-video -->
- [x] [MP4 walkthrough: empty card to filled masked-secret form to successful save](https://github.com/user-attachments/assets/4b7329b5-476f-4198-8588-a09d382b0753)
<!-- evidence-row:backend-logs -->
- [x] [Producer-to-real-renderer integration log](https://github.com/user-attachments/files/31040879/producer-integration-log.txt) — 2 files / 3 tests passed at the verified cut.
<!-- evidence-row:frontend-logs -->
- [x] [Intercepted request, console, and page-error metadata](https://github.com/user-attachments/files/31040875/capture-metadata.json) — exactly one `PUT /api/plugins/discord`, fixture-only payload, success response, and empty page-error list.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, planner, or agent behavior changes; this is deterministic server-emitted form and authenticated UI request handling.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, schedule, wallet, chain, audio, or generated domain artifact behavior changes in this patch.
<!-- evidence-row:ocr-review -->
- [x] [OCR review for before, after, and success frames](https://github.com/user-attachments/files/31040883/ocr-review.txt) — confirms the pre-fix empty state, five post-fix labels, masked token field, and success notice.

# Known gaps / failures

- No live Discord connector is required: the changed contracts are server-emitted form structure and the authenticated UI save request, not connector authorization or gateway behavior.
- Root `bun run verify` passes end-to-end at the exact pushed head.
- Permission-priming fixture repair PR #19201 is merged. Its exact path passes locally on this head: 10 desktop/mobile assertions, 8 screenshots, one WebM, and zero page errors. Hosted checks and maintainer re-review remain queued; no local code, conflict, package-test, root-verify, app-audit, fixture, or evidence blocker remains.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@efb2c8da4310c3f91e3b0120d6cbc9295c2a7c71:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [rndrntwrk-codex-pr19042-fixture-refresh]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@efb2c8da4310c3f91e3b0120d6cbc9295c2a7c71:packages/skills/skills/contribute-to-eliza"} -->








