### PR TITLE
chore(release): promote legacy agent proxy hotfix to main

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -4,6 +4,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 import cloudApiWorker, {
   getFrontendAliasApiProxyTarget,
   getFrontendAliasProxyTarget,
+  getGeneratedAgentId,
   getHostedFrontendServeRewrite,
   isCanonicalInferencePath,
   isThinInferenceEnabled,
@@ -395,7 +396,7 @@ describe("cloud-api worker entrypoint", () => {
     }
   });
 
-  test("redirects legacy UUID agent and public service hosts", () => {
+  test("keeps legacy UUID agents proxied while redirecting public service hosts", () => {
     const response = redirectFrontendHost(
       new URL(
         "https://e06bb509-6c52-4c33-a9f7-66addc43e8c8.elizacloud.ai/chat?room=1",
@@ -403,10 +404,7 @@ describe("cloud-api worker entrypoint", () => {
       { ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app" },
     );
 
-    expect(response?.status).toBe(308);
-    expect(response?.headers.get("location")).toBe(
-      "https://e06bb509-6c52-4c33-a9f7-66addc43e8c8.cloud.eliza.app/chat?room=1",
-    );
+    expect(response).toBeNull();
     const serviceCases = [
       [
         "https://blob.elizacloud.ai/object.bin",
@@ -441,6 +439,27 @@ describe("cloud-api worker entrypoint", () => {
       expect(serviceResponse?.status).toBe(308);
       expect(serviceResponse?.headers.get("location")).toBe(canonicalUrl);
     }
+  });
+
+  test("extracts canonical and legacy UUID hosts for the dedicated-agent proxy", () => {
+    const env = { ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app" };
+    const agentId = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
+
+    expect(
+      getGeneratedAgentId(
+        new URL(`https://${agentId}.cloud.eliza.app/api/health`),
+        env,
+      ),
+    ).toBe(agentId);
+    expect(
+      getGeneratedAgentId(
+        new URL(`https://${agentId}.elizacloud.ai/api/health`),
+        env,
+      ),
+    ).toBe(agentId);
+    expect(
+      getGeneratedAgentId(new URL("https://blob.elizacloud.ai/object"), env),
+    ).toBeNull();
   });
 
   test("proxies canonical staging marketing to the unified Pages develop branch", () => {

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -345,7 +345,7 @@ function normalizeHostname(hostname: string | undefined): string | null {
   return normalized || null;
 }
 
-function getGeneratedAgentId(
+export function getGeneratedAgentId(
   url: URL,
   env: AgentDomainBindings,
 ): string | null {
@@ -354,9 +354,21 @@ function getGeneratedAgentId(
     DEFAULT_AGENT_BASE_DOMAIN;
   const suffix = `.${baseDomain}`;
   const hostname = normalizeHostname(url.hostname);
-  if (!hostname?.endsWith(suffix)) return null;
-  const subdomain = hostname.slice(0, -suffix.length);
-  return AGENT_ID_RE.test(subdomain) ? subdomain : null;
+  if (hostname?.endsWith(suffix)) {
+    const subdomain = hostname.slice(0, -suffix.length);
+    if (AGENT_ID_RE.test(subdomain)) return subdomain;
+  }
+
+  // Keep legacy UUID agent hosts on the authenticated dedicated-agent proxy
+  // until the canonical nested-wildcard DNS and certificate cutover is live.
+  // Redirecting these bridge requests first strips them from the only working
+  // host and makes fail-closed snapshots/restarts time out (#19047).
+  const classified = hostname ? classifyElizaHostname(hostname) : null;
+  return classified?.role === "legacy-dedicated-agent" &&
+    classified.agentId &&
+    AGENT_ID_RE.test(classified.agentId)
+    ? classified.agentId
+    : null;
 }
 
 export function redirectFrontendHost(
@@ -404,9 +416,10 @@ export function redirectFrontendHost(
     classified.agentId &&
     AGENT_ID_RE.test(classified.agentId)
   ) {
-    // Only UUID hosts are managed agents. Reserved service labels such as
-    // blob/plugins/x402 remain on their dedicated compatibility handlers.
-    canonicalHostname = classified.canonicalHostname;
+    // UUID agent hosts remain on the legacy hostname until the canonical
+    // nested-wildcard DNS/certificate cutover is complete. The worker proxies
+    // them below through the same authenticated dedicated-agent path.
+    return null;
   } else {
     canonicalHostname = canonicalElizaServiceHostname(hostname);
     if (!canonicalHostname && hostname === "os.elizacloud.ai") {


### PR DESCRIPTION
Promotes the exact `origin/develop` tree after #19048.

Production incident hotfix: preserve working legacy UUID dedicated-agent proxy traffic until canonical wildcard DNS/certificates are ready.

Verification completed on develop tree:
- focused Worker routing tests
- Cloud API typecheck and lint
- root `bun run verify`

Tree equality with `origin/develop` was checked before push.