### PR TITLE
test(e2e): repair plugin-workflow route coverage after Smithers integration (#19044)

### DIFF
--- a/plugins/plugin-workflow/__tests__/integration/routes-e2e.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/routes-e2e.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Route-level e2e for plugin-workflow's Smithers-backed `/api/workflow/*`
+ * surface (#19044, restoring the coverage removed with the Smithers Studio
+ * integration). Boots the plugin's rawPath route table through the real
+ * production dispatcher (`tryHandleRuntimePluginRoute`) over a loopback
+ * `http.createServer` — exercising the real auth gate, route matching, JSON
+ * body parsing, id-parameter dispatch, and error translation — with a fake
+ * `WorkflowService` standing in for the only external dependency. No mocked
+ * `json`/`status`: every assertion is on a real HTTP response.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { AgentRuntime } from '@elizaos/core';
+
+import { tryHandleRuntimePluginRoute } from '../../../../packages/agent/src/api/runtime-plugin-routes';
+import { workflowRoutePlugin } from '../../src/plugin-routes';
+import { workflowRoutes } from '../../src/routes/index';
+import { WORKFLOW_SERVICE_TYPE } from '../../src/services/workflow-service';
+
+const servers: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.closeAllConnections?.();
+          server.close(() => resolve());
+        })
+    )
+  );
+  servers.length = 0;
+});
+
+/** Minimal native Smithers workflow payload accepted by `workflowFrom`. */
+function smithersDefinition(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'Route Test Workflow',
+    source: 'export default async function main() { return 1; }',
+    language: 'typescript',
+    ...overrides,
+  };
+}
+
+function workflowResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'wf-001',
+    name: 'Route Test Workflow',
+    active: true,
+    language: 'typescript',
+    source: 'export default async function main() { return 1; }',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+interface ServiceCall {
+  method: string;
+  args: unknown[];
+}
+
+interface FakeServiceState {
+  calls: ServiceCall[];
+}
+
+/**
+ * Fake `WorkflowService` covering only the methods the exercised routes call.
+ * Deterministic, JSON-serializable results so the real HTTP round-trip can be
+ * asserted end to end; every call is recorded with its arguments so the tests
+ * can prove which service boundary each route hit and with which owner.
+ */
+function makeWorkflowService(state: FakeServiceState) {
+  const record =
+    (method: string, result: unknown) =>
+    (...args: unknown[]) => {
+      state.calls.push({ method, args });
+      return Promise.resolve(result);
+    };
+
+  return {
+    listWorkflows: record('listWorkflows', [
+      workflowResponse(),
+      workflowResponse({ id: 'wf-002', name: 'Second', active: false }),
+    ]),
+    getWorkflow: record('getWorkflow', workflowResponse()),
+    deployWorkflow: record('deployWorkflow', workflowResponse()),
+    deleteWorkflow: record('deleteWorkflow', undefined),
+    startWorkflow: record('startWorkflow', {
+      id: 'exec-001',
+      workflowId: 'wf-001',
+      status: 'running',
+      mode: 'manual',
+      startedAt: '2026-01-01T12:00:00.000Z',
+    }),
+    cancelExecution: record('cancelExecution', {
+      id: 'exec-001',
+      workflowId: 'wf-001',
+      status: 'cancelled',
+    }),
+    getExecutionDetail: record('getExecutionDetail', {
+      id: 'exec-001',
+      workflowId: 'wf-001',
+      status: 'success',
+    }),
+    getWorkflowExecutions: record('getWorkflowExecutions', [
+      { id: 'exec-001', workflowId: 'wf-001', status: 'success' },
+    ]),
+  };
+}
+
+function makeRuntime(
+  options: { withService?: boolean; state?: FakeServiceState } = {}
+): AgentRuntime {
+  const { withService = true, state = { calls: [] } } = options;
+  const service = makeWorkflowService(state);
+  return {
+    agentId: 'agent-route-test',
+    character: { name: 'Route Test Agent', settings: {} },
+    routes: [...workflowRoutes, ...(workflowRoutePlugin.routes ?? [])],
+    getSetting: () => null,
+    getService: (key: string) => (withService && key === WORKFLOW_SERVICE_TYPE ? service : null),
+  } as unknown as AgentRuntime;
+}
+
+async function startServer(
+  runtime: AgentRuntime,
+  isAuthorized: () => boolean = () => true
+): Promise<string> {
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    const handled = await tryHandleRuntimePluginRoute({
+      req,
+      res,
+      method: req.method ?? 'GET',
+      pathname: url.pathname,
+      url,
+      runtime,
+      isAuthorized,
+    });
+    if (!handled && !res.headersSent) {
+      res.statusCode = 404;
+      res.end('not found');
+    }
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return `http://127.0.0.1:${port}`;
+}
+
+async function postJson(base: string, path: string, body: unknown) {
+  return fetch(`${base}${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Every exercised route resolves the same owner; capture it from any call. */
+function ownerArg(state: FakeServiceState, method: string): unknown {
+  const call = state.calls.find((candidate) => candidate.method === method);
+  return call?.args[call.args.length - 1];
+}
+
+describe('plugin-workflow rawPath routes through real dispatch (#19044)', () => {
+  test('GET /api/workflow/status answers the Smithers engine descriptor', async () => {
+    const base = await startServer(makeRuntime());
+
+    const res = await fetch(`${base}/api/workflow/status`);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      mode: 'cloud',
+      status: 'ready',
+      platform: 'cloud',
+      engine: 'smthrs',
+    });
+  });
+
+  test('GET /api/workflow/workflows lists via the service with a resolved owner', async () => {
+    const state: FakeServiceState = { calls: [] };
+    const base = await startServer(makeRuntime({ state }));
+
+    const res = await fetch(`${base}/api/workflow/workflows`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { workflows: Array<{ id: string }> };
+    expect(body.workflows.map((w) => w.id)).toEqual(['wf-001', 'wf-002']);
+    const owner = ownerArg(state, 'listWorkflows');
+    expect(typeof owner).toBe('string');
+    expect((owner as string).length).toBeGreaterThan(0);
+  });
+
+  test('POST /api/workflow/workflows deploys the parsed JSON body and answers 201', async () => {
+    const state: FakeServiceState = { calls: [] };
+    const base = await startServer(makeRuntime({ state }));
+
+    const res = await postJson(base, '/api/workflow/workflows', {
+      workflow: smithersDefinition(),
+      activate: true,
+    });
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toMatchObject({ id: 'wf-001' });
+    const deploy = state.calls.find((c) => c.method === 'deployWorkflow');
+    expect(deploy).toBeDefined();
+    expect(deploy?.args[0]).toMatchObject({ name: 'Route Test Workflow' });
+    expect(deploy?.args[2]).toMatchObject({ activate: true });
+  });
+
+  test('POST /api/workflow/workflows rejects a non-Smithers payload with 400', async () => {
+    const state: FakeServiceState = { calls: [] };
+    const base = await startServer(makeRuntime({ state }));
+
+    const res = await postJson(base, '/api/workflow/workflows', {
+      workflow: { name: 'missing source and language' },
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: 'Native Smithers workflow payload is required',
+    });
+    expect(state.calls.find((c) => c.method === 'deployWorkflow')).toBeUndefined();
+  });
+
+  test('GET /api/workflow/workflows/:id dispatches the decoded id parameter', async () => {
+    const state: FakeServiceState = { calls: [] };
+    const base = await startServer(makeRuntime({ state }));
+
+    const res = await fetch(`${base}/api/workflow/workflows/wf-001`);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ id: 'wf-001' });
+    const call = state.calls.find((c) => c.method === 'getWorkflow');
+    expect(call?.args[0]).toBe('wf-001');
+  });
+
+  test('POST /api/workflow/workflows/:id/run starts a manual execution and answers 202', async () => {
+    const state: FakeServiceState = { calls: [] };
+    const base = await startServer(makeRuntime({ state }));
+
+    const res = await postJson(base, '/api/workflow/workflows/wf-001/run', {
+      input: { greeting: 'hello' },
+    });
+
+    expect(res.status).toBe(202);
+    expect(await res.json()).toMatchObject({
+      execution: { id: 'exec-001', status: 'running' },
+    });
+    const call = state.calls.find((c) => c.method === 'startWorkflow');
+    expect(call?.args[0]).toBe('wf-001');
+    expect(call?.args[1]).toMatchObject({
+      mode: 'manual',
+      input: { greeting: 'hello' },
+    });
+  });
+
+  test('POST /api/workflow/executions/:id/cancel answers 202 with the cancelled execution', async () => {
+    const state: FakeServiceState = { calls: [] };
+    const base = await startServer(makeRuntime({ state }));
+
+    const res = await postJson(base, '/api/workflow/executions/exec-001/cancel', {});
+
+    expect(res.status).toBe(202);
+    expect(await res.json()).toMatchObject({
+      execution: { id: 'exec-001', status: 'cancelled' },
+    });
+    const call = state.calls.find((c) => c.method === 'cancelExecution');
+    expect(call?.args[0]).toBe('exec-001');
+  });
+
+  test('the dispatcher auth gate rejects unauthenticated calls before any handler runs', async () => {
+    const state: FakeServiceState = { calls: [] };
+    const base = await startServer(makeRuntime({ state }), () => false);
+
+    const res = await fetch(`${base}/api/workflow/workflows`);
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: 'Unauthorized' });
+    expect(state.calls).toEqual([]);
+  });
+
+  test('a missing WorkflowService degrades to a visible 503, not fabricated success', async () => {
+    const base = await startServer(makeRuntime({ withService: false }));
+
+    const res = await fetch(`${base}/api/workflow/workflows`);
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({
+      error: 'Workflow service is unavailable',
+    });
+  });
+
+  test('paths outside the route table fall through the dispatcher to 404', async () => {
+    const base = await startServer(makeRuntime());
+
+    const res = await fetch(`${base}/api/workflow/not-a-route`);
+
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #19044

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run; **verify passes green on this head**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop` (`3bd820ae38`); zero conflicts.
- [x] `bun run verify` passes on this head.

# Risks

Low. One new test file at the manifest-claimed path; no production code, manifest, or existing test changes. Per the issue's constraint, the manifest is untouched and no unit coverage is relabeled — the restored suite goes through the production dispatcher entry point the ship-gate's anti-larp signal requires.

# Background

## What does this PR do?

The hard e2e coverage ship-gate claims `plugins/plugin-workflow/__tests__/integration/routes-e2e.test.ts`, but the Smithers Studio integration (#19000) removed that file, so `bun run test:scripts` failed on untouched develop. This PR restores real integration-backed route-wiring coverage at the manifested path, written against the current Smithers-backed implementation: the suite boots the plugin's rawPath `/api/workflow/*` route table through `tryHandleRuntimePluginRoute` (the production dispatcher) over a loopback `http.createServer`, so the real auth gate, route matching, JSON body parsing, id-parameter dispatch, and error translation are all in the exercised path. A recorded fake `WorkflowService` is the only stand-in; every assertion is on a real HTTP response.

## What kind of change is this?

Test repair (restores ship-gate coverage; no production code change).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The `startServer` harness in the restored `routes-e2e.test.ts` (real dispatcher over loopback HTTP), then the per-route cases.

## Detailed testing steps

```bash
bun test plugins/plugin-workflow/__tests__/integration/routes-e2e.test.ts
bun test packages/scripts/e2e-coverage/check-e2e-coverage.test.ts
```

# Evidence Gate

<!-- evidence-head:e82b4c169ca4c50a2dfce93effd80973eb00a1d2 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test coverage repair; no UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test coverage repair; no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - deterministic route contract shown in the transcripts below`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — restored suite, ship-gate, and complete lane on this head:

  <details><summary>test transcripts</summary>

  ```
  bun test plugins/plugin-workflow/__tests__/integration/routes-e2e.test.ts
    10 pass, 0 fail, 30 expect() calls (real loopback HTTP round-trips)

  bun test packages/scripts/e2e-coverage/check-e2e-coverage.test.ts
    10 pass, 0 fail, 246 expect() calls
    (on untouched develop this gate fails: plugin-route:plugin-workflow —
     covering artifact(s) not found)

  bun run test:scripts on this head:
    every suite green except the two agent-router CORS preflight tests,
    which are the separate pre-existing #19043 defect — fixed by my open
    PR #19046 and unrelated to this file (verified identical on untouched
    develop)
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no browser surface involved`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - route dispatch contract; the model-facing workflow behavior is unchanged and out of scope`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the route/outcome contract the restored suite pins over real HTTP:

  <details><summary>/api/workflow route contract</summary>

  ```
  GET  /status                       -> 200 Smithers engine descriptor (engine: smthrs)
  GET  /workflows                    -> 200 list via service, owner resolved server-side
  POST /workflows (valid Smithers)   -> 201, deployWorkflow got parsed body + activate flag
  POST /workflows (non-Smithers)     -> 400 before any service call
  GET  /workflows/:id                -> 200, decoded id reaches the service
  POST /workflows/:id/run            -> 202, manual mode + input forwarded
  POST /executions/:id/cancel        -> 202 cancelled execution
  unauthenticated (any route)        -> 401 from the dispatcher gate, zero service calls
  service missing                    -> 503 visible degrade, never a healthy-looking success
  unknown path                       -> 404 fallthrough
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Evidence Details

All evidence is inline above.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZXD58M71T07YZR4JAXQ9H82","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T11:12:16.008Z","completed_at":"2026-08-13T11:22:49.795Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"cBWgqCsaLB8hKo8FsLXDMTP6X5K7xotGk5WOKvPQvt-U3NJWa7Fbi2fccZ3U2PW5gXfHrt1J-Kli_2y-hsr8CA"}} -->

