### PR TITLE
fix(plugin-workflow): converge the spawned-worker Effect prerelease family

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3370,6 +3370,7 @@
     "@ai-sdk/openai": "3.0.58",
     "@clack/prompts": "1.3.0",
     "@cloudflare/workerd-darwin-arm64": "1.20260611.1",
+    "@effect/platform-node-shared": "4.0.0-beta.102",
     "@electric-sql/client": "1.0.14",
     "@electric-sql/experimental": "1.0.14",
     "@electric-sql/pglite": "^0.4.5",
@@ -3803,7 +3804,7 @@
 
     "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.102", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.102" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-hTIb0jjTfXhNgnDq2OX5wrigc0OSvTT0VWWb1PLpMM395RJPu8rCIbTlGhy0NS7kZOd8FfgNi9e0sDhgyu+5Ag=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.107", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.107" } }, "sha512-y6BqcRi86BfTJv+tvDrob4ozYVHxxlHYcn/zIQqZjXI9CvKnkgD6ng+38G1o45c4f2ucU+6HRI9POCmFdMoVGA=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.102", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-gVd793I72MrkX4dXo7eYtRKfNj0RW4eMRfVEKEJI16h2+mBDCzQ+gqMrog2hSTHQnaIbvbYShNQ4TVGuRCYZeQ=="],
 
     "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-beta.102", "", { "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-pBO6FBJ+a21j2qHmzJDK1DeJsxm7HpUQBgucw6prHQXLMUBkhOsfZofhw1FKEdGRDEhO0sGTjffa2KP7iOuDIg=="],
 
@@ -10192,8 +10193,6 @@
     "@discordjs/ws/ws": ["ws@8.21.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw=="],
 
     "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
-
-    "@effect/platform-node-shared/ws": ["ws@8.21.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw=="],
 
     "@elevenlabs/elevenlabs-js/ws": ["ws@8.21.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw=="],
 

--- a/package.json
+++ b/package.json
@@ -308,6 +308,7 @@
     "@elizaos/app-core": "workspace:*",
     "@elizaos/agent": "workspace:*",
     "@elizaos/plugin-solana": "2.0.0-alpha.3",
+    "@effect/platform-node-shared": "4.0.0-beta.102",
     "playwright": "1.61.1",
     "playwright-core": "1.61.1",
     "@playwright/test": "1.61.1",

--- a/plugins/plugin-workflow/__tests__/integration/smithers-runner.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/smithers-runner.test.ts
@@ -1,7 +1,11 @@
-/** Exercises a real smthrs workflow through the isolated elizaOS runner and model bridge. */
+/**
+ * Exercises a real smthrs workflow through the isolated elizaOS runner and
+ * model bridge, including durable output and child-resource teardown.
+ */
 
+import { Database } from 'bun:sqlite';
 import { afterAll, describe, expect, test } from 'bun:test';
-import { rm } from 'node:fs/promises';
+import { readdir, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
   resolveSmithersWorkflowDir,
@@ -44,10 +48,11 @@ describe('real Smithers runner', () => {
   test('executes TSX, bridges model generation, and streams native events', async () => {
     const modelRequests: unknown[] = [];
     const events: string[] = [];
+    const runId = `run-${Date.now()}`;
     const result = await runSmithersWorkflow({
       tenantId,
       workflow,
-      runId: `run-${Date.now()}`,
+      runId,
       mode: 'manual',
       input: { request: 'hello' },
       timeoutMs: 20_000,
@@ -64,6 +69,41 @@ describe('real Smithers runner', () => {
     expect(modelRequests).toHaveLength(1);
     expect(events.length).toBeGreaterThan(0);
     expect(result.events.length).toBe(events.length);
-    expect(join('.eliza', 'smthrs')).toBe('.eliza/smthrs');
+
+    const workflowDir = resolveSmithersWorkflowDir(tenantId, workflowId);
+    const databasePath = join(workflowDir, 'runs.sqlite');
+    expect((await stat(databasePath)).isFile()).toBe(true);
+
+    const database = new Database(databasePath);
+    try {
+      const persistedRun = database
+        .query<{ finishedAtMs: number; status: string }, [string]>(
+          `SELECT finished_at_ms AS finishedAtMs, status
+             FROM _smithers_runs
+            WHERE run_id = ?`
+        )
+        .get(runId);
+      expect(persistedRun).toEqual({ finishedAtMs: expect.any(Number), status: 'finished' });
+
+      const persistedOutput = database
+        .query<{ message: string }, [string, string]>(
+          `SELECT message
+             FROM result
+            WHERE run_id = ? AND node_id = ?`
+        )
+        .get(runId, 'run');
+      expect(persistedOutput).toEqual({ message: 'done' });
+
+      // The runner resolves only after the child exits; taking a write lock
+      // proves its SQLite connection has also released the durable store.
+      database.exec('BEGIN IMMEDIATE');
+      database.exec('ROLLBACK');
+    } finally {
+      database.close();
+    }
+
+    const retainedFiles = await readdir(workflowDir);
+    expect(retainedFiles).toContain(`${workflow.versionId}.tsx`);
+    expect(retainedFiles.filter((name) => name.startsWith('.run-'))).toEqual([]);
   }, 45_000);
 });

--- a/plugins/plugin-workflow/__tests__/unit/effect-peer-coherence.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/effect-peer-coherence.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Deterministic peer-coherence gate for the spawned-worker Effect prerelease
+ * family (#18810). Walks the real module-resolution chain the Smithers worker
+ * uses — this plugin → @smthrs/engine → @effect/platform-bun →
+ * @effect/platform-node-shared — through Bun's isolated store, and fails when
+ * any link's declared dependency or peer range on `effect` (or on another
+ * family member) is not satisfied by the version that link actually resolves,
+ * or when two links load `effect` from different installed copies. Offline and
+ * mock-free: the assertions read the exact manifests the runtime would load,
+ * so an invalid lockfile peer resolution fails here instead of as a
+ * FiberRefs/module-identity crash inside a spawned worker. The chain is
+ * seeded with this plugin's own manifest because the worker script imports
+ * `effect` directly, so plugin-level drift against the engine's pins is a
+ * failure this gate must catch.
+ */
+import { describe, expect, test } from 'bun:test';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface FamilyManifest {
+  name: string;
+  version: string;
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+/** Resolve `name` exactly as a module at `fromFile` would, then read the
+ *  manifest of the package that resolution landed in. */
+function resolvedManifest(fromFile: string, name: string): FamilyManifest {
+  const entry = createRequire(fromFile).resolve(name);
+  let dir = path.dirname(entry);
+  for (;;) {
+    const manifestPath = path.join(dir, 'package.json');
+    if (existsSync(manifestPath)) {
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as FamilyManifest;
+      if (manifest.name === name)
+        return { ...manifest, entry } as FamilyManifest & { entry: string };
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error(`no ${name} package.json above ${entry}`);
+    }
+    dir = parent;
+  }
+}
+
+function entryOf(manifest: FamilyManifest): string {
+  return (manifest as FamilyManifest & { entry: string }).entry;
+}
+
+const FAMILY = new Set([
+  'effect',
+  '@effect/platform-bun',
+  '@effect/platform-node-shared',
+  '@effect/sql-sqlite-bun',
+  '@effect/opentelemetry',
+]);
+
+/** Both declaration maps, kept separate so a dependencies range can never be
+ *  silently shadowed by a peer range on the same name. */
+function declaredEdges(manifest: FamilyManifest): Array<[string, string]> {
+  return [
+    ...Object.entries(manifest.dependencies ?? {}),
+    ...Object.entries(manifest.peerDependencies ?? {}),
+  ];
+}
+
+describe('spawned-worker Effect family peer coherence (#18810)', () => {
+  // The worker resolves from the plugin root (smithers-runtime spawns with
+  // cwd=pluginRoot and imports `effect` directly), so the chain is seeded
+  // with the plugin's own manifest — plugin→effect and plugin→engine are
+  // asserted edges, not assumptions.
+  const pluginManifestPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../package.json'
+  );
+  const plugin = {
+    ...(JSON.parse(readFileSync(pluginManifestPath, 'utf8')) as FamilyManifest),
+    entry: pluginManifestPath,
+  } as FamilyManifest & { entry: string };
+  const chain: FamilyManifest[] = [plugin];
+  const seen = new Set<string>([plugin.name]);
+
+  // Breadth-first walk of the family edges reachable from the plugin, always
+  // resolving from the dependent's own entry file so Bun's isolated-store
+  // linkage (including peer placement) is what gets tested. Smithers' own
+  // packages are traversed as intermediates (observability carries the
+  // opentelemetry edge) but only family edges are asserted.
+  for (let index = 0; index < chain.length; index += 1) {
+    const dependent = chain[index];
+    for (const [name] of declaredEdges(dependent)) {
+      if (seen.has(name)) continue;
+      const isFamily = FAMILY.has(name);
+      if (!isFamily && name !== 'smthrs' && !name.startsWith('@smthrs/')) continue;
+      seen.add(name);
+      if (isFamily) {
+        chain.push(resolvedManifest(entryOf(dependent), name));
+        continue;
+      }
+      try {
+        chain.push(resolvedManifest(entryOf(dependent), name));
+      } catch {
+        // error-policy:J3 an intermediate Smithers package that is not
+        // installed (optional tooling such as the CLI's TUI) is out of the
+        // worker chain; only family edges must resolve, and those keep the
+        // hard failure above.
+        seen.delete(name);
+      }
+    }
+  }
+
+  test('the worker chain reaches the whole installed family', () => {
+    const reachedFamily = [...seen].filter((name) => FAMILY.has(name)).sort();
+    expect(reachedFamily).toEqual([...FAMILY].sort());
+  });
+
+  test('every chain member loads effect from one single installed copy', () => {
+    // Range satisfaction alone cannot catch two coexisting effect copies —
+    // the exact FiberRefs/module-identity failure class — so assert that
+    // every dependent that declares effect resolves it to the same realpath.
+    const copies = new Map<string, string>();
+    for (const dependent of chain) {
+      if (!declaredEdges(dependent).some(([name]) => name === 'effect')) {
+        continue;
+      }
+      const entry = createRequire(entryOf(dependent)).resolve('effect');
+      copies.set(dependent.name, realpathSync(entry));
+    }
+    expect(copies.size).toBeGreaterThan(0);
+    const distinct = new Set(copies.values());
+    expect(distinct.size, `multiple effect copies loaded: ${JSON.stringify([...copies])}`).toBe(1);
+  });
+
+  for (let index = 0; index < chain.length; index += 1) {
+    const dependent = chain[index];
+    for (const [name, range] of declaredEdges(dependent)) {
+      if (!FAMILY.has(name)) continue;
+      test(`${dependent.name}@${dependent.version} → ${name} (${range}) resolves to a satisfying version`, () => {
+        // Bun.semver.satisfies is permissive about alias ranges
+        // (workspace:/npm:/catalog:), which would make the assertion pass
+        // vacuously — fail closed on anything that is not plain semver.
+        expect(
+          /^[\^~>=<]*\d/.test(range),
+          `${dependent.name}'s range for ${name} (${range}) is not plain semver`
+        ).toBe(true);
+        const resolved = resolvedManifest(entryOf(dependent), name);
+        expect(
+          Bun.semver.satisfies(resolved.version, range),
+          `${name}@${resolved.version} does not satisfy ${dependent.name}'s range ${range}`
+        ).toBe(true);
+      });
+    }
+  }
+});

--- a/plugins/plugin-workflow/__tests__/unit/effect-peer-coherence.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/effect-peer-coherence.test.ts
@@ -26,28 +26,32 @@ interface FamilyManifest {
   peerDependencies?: Record<string, string>;
 }
 
-/** Resolve `name` exactly as a module at `fromFile` would, then read the
- *  manifest of the package that resolution landed in. */
-function resolvedManifest(fromFile: string, name: string): FamilyManifest {
-  const entry = createRequire(fromFile).resolve(name);
-  let dir = path.dirname(entry);
+interface ResolvedFamilyManifest extends FamilyManifest {
+  entry: string;
+}
+
+/** Resolve the installed manifest that `fromFile` can reach through its
+ *  nearest node_modules chain. Reading the manifest path directly also covers
+ *  packages whose export map intentionally has no root entry point. */
+function resolvedManifest(fromFile: string, name: string): ResolvedFamilyManifest {
+  let dir = path.dirname(fromFile);
   for (;;) {
-    const manifestPath = path.join(dir, 'package.json');
+    const manifestPath = path.join(dir, 'node_modules', name, 'package.json');
     if (existsSync(manifestPath)) {
-      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as FamilyManifest;
-      if (manifest.name === name)
-        return { ...manifest, entry } as FamilyManifest & { entry: string };
+      const entry = realpathSync(manifestPath);
+      const manifest = JSON.parse(readFileSync(entry, 'utf8')) as FamilyManifest;
+      if (manifest.name === name) return { ...manifest, entry };
     }
     const parent = path.dirname(dir);
     if (parent === dir) {
-      throw new Error(`no ${name} package.json above ${entry}`);
+      throw new Error(`cannot resolve ${name}'s package.json from ${fromFile}`);
     }
     dir = parent;
   }
 }
 
-function entryOf(manifest: FamilyManifest): string {
-  return (manifest as FamilyManifest & { entry: string }).entry;
+function entryOf(manifest: ResolvedFamilyManifest): string {
+  return manifest.entry;
 }
 
 const FAMILY = new Set([
@@ -76,15 +80,15 @@ describe('spawned-worker Effect family peer coherence (#18810)', () => {
     path.dirname(fileURLToPath(import.meta.url)),
     '../../package.json'
   );
-  const plugin = {
+  const plugin: ResolvedFamilyManifest = {
     ...(JSON.parse(readFileSync(pluginManifestPath, 'utf8')) as FamilyManifest),
     entry: pluginManifestPath,
-  } as FamilyManifest & { entry: string };
-  const chain: FamilyManifest[] = [plugin];
+  };
+  const chain: ResolvedFamilyManifest[] = [plugin];
   const seen = new Set<string>([plugin.name]);
 
   // Breadth-first walk of the family edges reachable from the plugin, always
-  // resolving from the dependent's own entry file so Bun's isolated-store
+  // resolving from the dependent's own manifest anchor so Bun's isolated-store
   // linkage (including peer placement) is what gets tested. Smithers' own
   // packages are traversed as intermediates (observability carries the
   // opentelemetry edge) but only family edges are asserted.
@@ -95,19 +99,7 @@ describe('spawned-worker Effect family peer coherence (#18810)', () => {
       const isFamily = FAMILY.has(name);
       if (!isFamily && name !== 'smthrs' && !name.startsWith('@smthrs/')) continue;
       seen.add(name);
-      if (isFamily) {
-        chain.push(resolvedManifest(entryOf(dependent), name));
-        continue;
-      }
-      try {
-        chain.push(resolvedManifest(entryOf(dependent), name));
-      } catch {
-        // error-policy:J3 an intermediate Smithers package that is not
-        // installed (optional tooling such as the CLI's TUI) is out of the
-        // worker chain; only family edges must resolve, and those keep the
-        // hard failure above.
-        seen.delete(name);
-      }
+      chain.push(resolvedManifest(entryOf(dependent), name));
     }
   }
 


### PR DESCRIPTION
# Relates to

Closes #18810

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`) —
      including across the #19000 smthrs-studio overhaul that landed mid-work.
- [x] `bun install` and `bun run verify` were run after sync; the verify record
      for this exact head is in the Known gaps section.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

Before publication this change was put through an adversarial self-review round
(three independent agents instructed to refute it). That round found a real
blind spot — the gate originally asserted range satisfaction but not
single-copy module identity — and the gate below includes the resulting
hardening. Disclosed so reviewers know the identity assertion's origin.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; the #19000 rename
      (`@smithers-orchestrator/*` → `@smthrs/*`) changed the engine's package
      identity but not its Effect pins, so the defect and the fix carried over
      unchanged; the failing edge was re-proven on the new base before
      re-applying the pin.
- [x] `bun run verify` on the exact head — record in Known gaps.

# Risks

**Low.** One root-manifest override line, its lockfile consequence, one new
dependency-coherence test, and a strengthened existing worker integration test. The override pins `@effect/platform-node-shared` to
`4.0.0-beta.102`, which is a published member of `@effect/platform-bun`'s own
declared range (`^4.0.0-beta.102`) — nothing is forced outside a declared
contract. Blast radius verified before pinning: `@effect/platform-bun` is the
**sole** dependent of `@effect/platform-node-shared` in the entire lockfile,
and the repository contains no second Effect line the global override could
touch. If a future Smithers release moves its pins, the new gate fails loudly
rather than letting the override silently misapply.

# Background

## What does this PR do?

`@smthrs/engine@0.33.0` pins `effect` and `@effect/platform-bun` at exactly
`4.0.0-beta.102`, but `platform-bun`'s caret dependency on
`@effect/platform-node-shared` (`^4.0.0-beta.102`) resolved to
`4.0.0-beta.107`, whose `effect` peer (`^4.0.0-beta.107`) the pinned `effect`
cannot satisfy — prerelease semver only matches within its own line. The
spawned-workflow-worker path therefore linked an incoherent peer graph: the
family #18533/#18810 identified as the FiberRefs-crash dependency family.

Three changes:

1. **Converge the family**: root `overrides` pins
   `@effect/platform-node-shared: 4.0.0-beta.102`, giving one coherent set at
   `beta.102` across `effect`, `platform-bun`, `platform-node-shared`,
   `sql-sqlite-bun`, and `opentelemetry`.
2. **Keep it converged**: a deterministic gate
   (`plugins/plugin-workflow/__tests__/unit/effect-peer-coherence.test.ts`)
   walks the real resolution chain the worker uses — this plugin →
   `@smthrs/engine` → `platform-bun` → `node-shared`, through Bun's isolated
   store — and fails when any family dependency/peer edge is unsatisfied by
   what actually resolves, when a range is a non-semver alias (which
   `Bun.semver` would otherwise pass vacuously), or when two links load
   `effect` from different installed copies (the module-identity failure class
   that range checks alone cannot see).
3. **Prove the worker contract**: the real runner integration reopens the worker's `runs.sqlite`, verifies the finished run and typed task output, acquires a write lock after child exit, and confirms the transient `.run-*.json` payload was removed.

Why live linkage instead of lockfile text: an **incremental** `bun install`
kept the stale `.107` store symlink even after the lock converged — only a
fresh install rewires it. The gate resolves through the store, so that state
fails instead of shipping.

This matches the maintainer triage posted on the issue (2026-08-13): rebased
on #19000, a deterministic lock/peer assertion retained, the rewritten
plugin's backends proven below, and **no** catch, timeout, or runtime
fallback added around module-identity failures — the diff contains zero
runtime-code changes.

## What kind of change is this?

Bug fix (non-breaking) — dependency-graph correctness plus its regression gate.

# Documentation changes needed?

None. #18810's guide criterion (stale `0.29.0` reference) was overtaken by
#19000's guide rewrite, which removed engine-version claims from both guides
entirely; `bun run check:agents-claude` passes (153 pairs byte-identical).

# Testing

## Where should a reviewer start?

```bash
bun test --isolate plugins/plugin-workflow/__tests__/unit/effect-peer-coherence.test.ts
```

## Detailed testing steps

1. On `origin/develop` without this PR (fresh install): the gate fails —
   31 pass / 1 fail, the failing edge being
   `effect@4.0.0-beta.102 does not satisfy @effect/platform-node-shared's range ^4.0.0-beta.107`.
2. On this branch (fresh install): 33/33 pass, and the lock resolves
   `@effect/platform-node-shared@4.0.0-beta.102`.
3. Full plugin lane on this head: **8/8 isolated test files pass** — the
   entire post-#19000 suite, including the real-runner integration
   (`smithers-runner.test.ts`) and worker-script suites executing actual Bun
   child processes on the converged graph. The runner test also verifies the
   durable SQLite run/output rows and child payload/connection teardown.
4. `bun install --frozen-lockfile` — no changes, exit 0 (lock is CI-valid).

## Backend matrix (issue criterion 3)

Post-#19000, the plugin's test suite is the 8-file studio set. On this host:
SQLite (the spawned worker's own storage via `bun:sqlite`) is exercised by the
real-runner and worker-script suites; PGlite is exercised where the current
suite uses it (`embedded-workflow-lifecycle`); PostgreSQL has no server on
this host — its selection contract (fail-fast when `SMITHERS_DB_URL` is
absent, never silent storage switching) is the documented boundary, per the
issue's stated alternative of an explicit supported-backend matrix.
Observation for a follow-up: the engine optionally declares
`@electric-sql/pglite ^0.5.4` while the root pins `^0.4.5` — a pre-existing
range mismatch outside this PR's scope, noted here so it is not lost.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:bd0881ac8465a167aaceb3a4c7ef973fdeb9ba19 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - dependency manifest, lockfile, and test-file diff; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - same reason as the before row.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - no user flow; the change is a dependency pin and a test gate.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — `N/A - no server path changes; the real execution evidence is the spawned-worker test lane in the domain-artifacts transcript below.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs — `N/A - no frontend code runs.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent, action, provider, prompt, or model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the artifacts are the dependency graph itself and the
      gate verdicts, before and after:

<details>
<summary>gate RED → GREEN on this PR's exact base, plus the full lane</summary>

```
# BEFORE — origin/develop base, fresh install, no pin
$ bun test --isolate __tests__/unit/effect-peer-coherence.test.ts
error: effect@4.0.0-beta.102 does not satisfy @effect/platform-node-shared's range ^4.0.0-beta.107
 31 pass
 1 fail

# AFTER — this branch bd0881ac8, fresh install
$ bun test --isolate __tests__/unit/effect-peer-coherence.test.ts
 33 pass
 0 fail

# lock resolution after the pin
"@effect/platform-node-shared@4.0.0-beta.102"

# full plugin lane on this head (post-#19000 suite, real spawned workers)
$ bun run test
[plugin-workflow:test] passed 8/8 isolated test files

# CI-validity of the lock
$ bun install --frozen-lockfile
Checked 3831 installs across 4132 packages (no changes)
```
</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface in the diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt, or model behavior changes.`

## Backend + frontend logs

`N/A - no server or frontend path changes; real spawned-worker execution is
captured by the plugin lane in the domain-artifacts transcript above.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in the diff.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, or STT path is touched.`

## Known gaps / failures

- `bun run verify` on this exact head (`bd0881ac8`): **exit 0** after rebasing onto current `origin/develop` (`a3e726eee`); guide parity, dependency policy, the repository-wide typecheck/lint fan-out, build-model and Turbo audits, script and view inventories, and the focused-test audit all passed.
- Focused checks on the same head, all green: plugin lane 8/8 files,
  `typecheck` exit 0, Biome check exit 0, `build` exit 0,
  `bun install --frozen-lockfile` no changes, `check:agents-claude` 153 pairs.
- A synthetic dual-effect fixture proving the identity assertion RED was not
  constructed (it would require installing a second `effect` version); the
  assertion's failure path is exercised analytically and its pass path against
  the real store. Flagged for reviewer judgement rather than hidden.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->

