### PR TITLE
feat(ui): complete visual workflow studio

### DIFF
--- a/packages/agent/src/__tests__/view-agent-surface-coverage.test.ts
+++ b/packages/agent/src/__tests__/view-agent-surface-coverage.test.ts
@@ -125,7 +125,6 @@ const CONVERTED_SUBCOMPONENTS = [
   "pages/relationships/RelationshipsPersonPanels",
   "pages/skill-detail-panel",
   "pages/skill-installer",
-  "pages/WorkflowGraphViewer",
   "settings/AdvancedSection",
   "settings/AppearanceSettingsSection",
   "settings/AppsManagementSection",

--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -397,6 +397,75 @@ describe("executeTriggerTask", () => {
     expect(handle.updatedTasks).toHaveLength(0);
   });
 
+  it("dispatches only when a nested event filter matches the Smithers event", async () => {
+    const task = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+      eventFilter: {
+        event: {
+          type: "NodeFinished",
+          workflowId: "source-workflow",
+          nodeId: "collect",
+        },
+      },
+    });
+
+    const matching = await executeTriggerTask(handle.runtime, task, {
+      source: "event",
+      event: {
+        kind: "workflow_run_event",
+        payload: {
+          event: {
+            type: "NodeFinished",
+            workflowId: "source-workflow",
+            nodeId: "collect",
+            output: { count: 3 },
+          },
+        },
+      },
+    });
+
+    expect(matching.status).toBe("success");
+    expect(handle.dispatchCalls).toHaveLength(1);
+
+    const nonMatching = await executeTriggerTask(handle.runtime, task, {
+      source: "event",
+      event: {
+        kind: "workflow_run_event",
+        payload: {
+          event: {
+            type: "NodeFinished",
+            workflowId: "source-workflow",
+            nodeId: "publish",
+          },
+        },
+      },
+    });
+
+    expect(nonMatching.status).toBe("skipped");
+    expect(handle.dispatchCalls).toHaveLength(1);
+
+    const nullFilter = makeTriggerTask({
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+      eventFilter: { event: { output: null } },
+    });
+    const nonNullPayload = await executeTriggerTask(
+      handle.runtime,
+      nullFilter,
+      {
+        source: "event",
+        event: {
+          kind: "workflow_run_event",
+          payload: { event: { output: "not-null" } },
+        },
+      },
+    );
+
+    expect(nonNullPayload.status).toBe("skipped");
+    expect(handle.dispatchCalls).toHaveLength(1);
+  });
+
   it("skips a non-event trigger fired from an event source", async () => {
     const task = makeTriggerTask({ triggerType: "interval" });
 

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -140,6 +140,43 @@ function appendRunRecord(
     : runs.slice(runs.length - MAX_TRIGGER_RUN_HISTORY);
 }
 
+/** Match an event payload against a recursive subset filter. */
+function eventFilterMatches(
+  expected: unknown,
+  actual: unknown,
+  depth = 0,
+): boolean {
+  if (depth > 16) return false;
+  if (expected === undefined) return true;
+  if (expected === actual) return true;
+  if (Array.isArray(expected)) {
+    return (
+      Array.isArray(actual) &&
+      actual.length === expected.length &&
+      expected.every((value, index) =>
+        eventFilterMatches(value, actual[index], depth + 1),
+      )
+    );
+  }
+  if (
+    typeof expected === "object" &&
+    expected !== null &&
+    typeof actual === "object" &&
+    actual !== null &&
+    !Array.isArray(actual)
+  ) {
+    return Object.entries(expected as Record<string, unknown>).every(
+      ([key, value]) =>
+        eventFilterMatches(
+          value,
+          (actual as Record<string, unknown>)[key],
+          depth + 1,
+        ),
+    );
+  }
+  return false;
+}
+
 function taskMetadata(task: Task): TriggerTaskMetadata {
   const metadata = task.metadata;
   return metadata && typeof metadata === "object" && !Array.isArray(metadata)
@@ -466,6 +503,16 @@ export async function executeTriggerTask(
   if (
     options.source === "event" &&
     trigger.triggerType !== "event" &&
+    !options.force
+  ) {
+    recordExecutionMetric(runtime.agentId, "skipped", Date.now());
+    return { status: "skipped", taskDeleted: false };
+  }
+
+  if (
+    options.source === "event" &&
+    trigger.triggerType === "event" &&
+    !eventFilterMatches(trigger.eventFilter, options.event?.payload) &&
     !options.force
   ) {
     recordExecutionMetric(runtime.agentId, "skipped", Date.now());
@@ -871,6 +918,7 @@ export function taskToTriggerSummary(task: Task): TriggerSummary | null {
       scheduledAtIso: trigger.scheduledAtIso,
       cronExpression: trigger.cronExpression,
       eventKind: trigger.eventKind,
+      eventFilter: trigger.eventFilter,
       maxRuns: trigger.maxRuns,
       runCount: trigger.runCount,
       nextRunAtMs: trigger.nextRunAtMs,

--- a/packages/agent/src/triggers/scheduling.test.ts
+++ b/packages/agent/src/triggers/scheduling.test.ts
@@ -1,0 +1,47 @@
+/** Verifies event-trigger filters are preserved and reject unsafe recursive input. */
+
+import { describe, expect, it } from "vitest";
+import { normalizeTriggerDraft } from "./scheduling.ts";
+
+function eventDraft(eventFilter: Record<string, unknown>) {
+  return normalizeTriggerDraft({
+    input: {
+      kind: "workflow",
+      workflowId: "target",
+      triggerType: "event",
+      eventKind: "workflow_run_event",
+      eventFilter,
+    },
+    fallback: {
+      displayName: "Step trigger",
+      instructions: "Run workflow",
+      triggerType: "event",
+      wakeMode: "inject_now",
+      enabled: true,
+      createdBy: "test",
+    },
+  });
+}
+
+describe("event trigger normalization", () => {
+  it("preserves a nested Smithers node filter", () => {
+    const eventFilter = {
+      event: {
+        type: "NodeFinished",
+        workflowId: "source",
+        nodeId: "collect",
+      },
+    };
+
+    expect(eventDraft(eventFilter).draft?.eventFilter).toEqual(eventFilter);
+  });
+
+  it("rejects non-finite and excessively deep filters", () => {
+    expect(eventDraft({ count: Number.POSITIVE_INFINITY }).error).toContain(
+      "finite JSON",
+    );
+    let deep: Record<string, unknown> = { value: 1 };
+    for (let index = 0; index < 10; index += 1) deep = { nested: deep };
+    expect(eventDraft(deep).error).toContain("8 levels");
+  });
+});

--- a/packages/agent/src/triggers/scheduling.ts
+++ b/packages/agent/src/triggers/scheduling.ts
@@ -40,6 +40,26 @@ export {
 };
 
 export const MAX_TRIGGER_RUN_HISTORY = 100;
+const MAX_EVENT_FILTER_DEPTH = 8;
+
+function isJsonEventFilter(value: unknown, depth = 0): boolean {
+  if (depth > MAX_EVENT_FILTER_DEPTH) return false;
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return true;
+  }
+  if (typeof value === "number") return Number.isFinite(value);
+  if (Array.isArray(value)) {
+    return value.every((item) => isJsonEventFilter(item, depth + 1));
+  }
+  if (typeof value !== "object") return false;
+  return Object.values(value).every((item) =>
+    isJsonEventFilter(item, depth + 1),
+  );
+}
 
 interface DraftInput {
   displayName?: string;
@@ -53,6 +73,7 @@ interface DraftInput {
   scheduledAtIso?: string;
   cronExpression?: string;
   eventKind?: string;
+  eventFilter?: Record<string, unknown>;
   maxRuns?: number;
   kind?: TriggerKind;
   workflowId?: string;
@@ -94,6 +115,7 @@ export function buildTriggerDedupeKey(parts: {
   scheduledAtIso?: string;
   cronExpression?: string;
   eventKind?: string;
+  eventFilter?: Record<string, unknown>;
   wakeMode: TriggerWakeMode;
   kind: TriggerKind;
   workflowId?: string;
@@ -105,6 +127,7 @@ export function buildTriggerDedupeKey(parts: {
     parts.scheduledAtIso ?? "",
     parts.cronExpression ?? "",
     parts.eventKind ?? "",
+    JSON.stringify(parts.eventFilter ?? {}),
     parts.wakeMode,
     parts.kind,
     parts.workflowId ?? "",
@@ -147,6 +170,10 @@ export function buildTriggerConfig(params: {
         : undefined,
     eventKind:
       params.draft.triggerType === "event" ? params.draft.eventKind : undefined,
+    eventFilter:
+      params.draft.triggerType === "event"
+        ? params.draft.eventFilter
+        : undefined,
     maxRuns: params.draft.maxRuns,
     runCount: previous?.runCount ?? 0,
     dedupeKey: buildTriggerDedupeKey({
@@ -156,6 +183,7 @@ export function buildTriggerConfig(params: {
       scheduledAtIso: params.draft.scheduledAtIso,
       cronExpression: params.draft.cronExpression,
       eventKind: params.draft.eventKind,
+      eventFilter: params.draft.eventFilter,
       wakeMode: params.draft.wakeMode,
       kind: params.draft.kind,
       workflowId: params.draft.workflowId,
@@ -238,6 +266,7 @@ export function normalizeTriggerDraft(params: {
   const scheduledAtIso = params.input.scheduledAtIso?.trim();
   const cronExpression = params.input.cronExpression?.trim();
   const eventKind = params.input.eventKind?.trim();
+  const eventFilter = params.input.eventFilter;
   const maxRuns =
     typeof params.input.maxRuns === "number"
       ? Math.floor(params.input.maxRuns)
@@ -300,6 +329,9 @@ export function normalizeTriggerDraft(params: {
     if (!eventKind) {
       return { error: "eventKind is required for event triggers" };
     }
+    if (eventFilter !== undefined && !isJsonEventFilter(eventFilter)) {
+      return { error: "eventFilter must be finite JSON with at most 8 levels" };
+    }
     return {
       draft: {
         displayName,
@@ -310,6 +342,7 @@ export function normalizeTriggerDraft(params: {
         createdBy,
         timezone,
         eventKind,
+        eventFilter,
         maxRuns,
         kind,
         workflowId,

--- a/packages/agent/src/triggers/types.ts
+++ b/packages/agent/src/triggers/types.ts
@@ -56,6 +56,7 @@ export interface NormalizedTriggerDraft {
   scheduledAtIso?: string;
   cronExpression?: string;
   eventKind?: string;
+  eventFilter?: Record<string, unknown>;
   maxRuns?: number;
   kind: import("@elizaos/core").TriggerKind;
   // Present only for `kind === "workflow"`. `buildTriggerConfig` produces the

--- a/packages/app-core/src/services/trigger-event-bridge.ts
+++ b/packages/app-core/src/services/trigger-event-bridge.ts
@@ -43,6 +43,7 @@ import {
 } from "@elizaos/core";
 
 const DEFAULT_MIN_INTERVAL_MS = 1_000;
+const WORKFLOW_RUN_EVENT_TYPE = "workflow_run_event" as EventType;
 /** TTL for caching trigger task list to avoid repeated DB queries on high-frequency events. */
 const TRIGGER_CACHE_TTL_MS = 500;
 
@@ -57,6 +58,7 @@ export const EXPOSED_EVENTS: readonly EventType[] = [
   EventType.MESSAGE_SENT,
   EventType.REACTION_RECEIVED,
   EventType.ENTITY_JOINED,
+  WORKFLOW_RUN_EVENT_TYPE,
 ];
 
 export interface TriggerEventBridgeOptions {

--- a/packages/app/test/ui-smoke/automations.spec.ts
+++ b/packages/app/test/ui-smoke/automations.spec.ts
@@ -681,7 +681,7 @@ test("automations empty state remains reachable beside chat in short landscape",
   await expect(headline).toBeVisible();
   await expect(
     page.getByText("Ask in chat to set up a workflow and it will run here."),
-  ).toBeVisible();
+  ).toHaveCount(0);
 
   const geometry = await page.evaluate(() => {
     const scroll = document.querySelector<HTMLElement>(

--- a/packages/app/test/ui-smoke/workflow-editor.spec.ts
+++ b/packages/app/test/ui-smoke/workflow-editor.spec.ts
@@ -24,6 +24,7 @@ type WorkflowDefinition = {
     surface: "both";
     component: "status";
   }>;
+  inputSchema?: Record<string, unknown>;
   versionId: string;
   createdAt: string;
   updatedAt: string;
@@ -33,6 +34,8 @@ async function installWorkflowApi(page: Page) {
   let saved: WorkflowDefinition | null = null;
   let createCount = 0;
   let runCount = 0;
+  let trigger: Record<string, unknown> | null = null;
+  let runInput: Record<string, unknown> | null = null;
   let execution: Record<string, unknown> | null = null;
   await page.route("**/api/workflow/workflows**", async (route) => {
     const request = route.request();
@@ -45,6 +48,14 @@ async function installWorkflowApi(page: Page) {
       const now = new Date().toISOString();
       saved = {
         ...body,
+        inputSchema: {
+          type: "object",
+          required: ["topic"],
+          properties: {
+            topic: { type: "string", title: "Topic" },
+            limit: { type: "integer", title: "Limit", default: 5 },
+          },
+        },
         id: "smithers-digest",
         versionId: "v1",
         createdAt: now,
@@ -62,6 +73,8 @@ async function installWorkflowApi(page: Page) {
       request.method() === "POST" &&
       pathname === "/api/workflow/workflows/smithers-digest/run"
     ) {
+      runInput = (request.postDataJSON() as { input: Record<string, unknown> })
+        .input;
       const now = new Date().toISOString();
       execution = {
         id: "run-smithers-digest-1",
@@ -73,7 +86,7 @@ async function installWorkflowApi(page: Page) {
         finished: false,
         startedAt: now,
         stoppedAt: null,
-        input: {},
+        input: runInput,
         events: [
           {
             id: "event-started",
@@ -92,6 +105,19 @@ async function installWorkflowApi(page: Page) {
         status: 202,
         contentType: "application/json",
         body: JSON.stringify({ execution }),
+      });
+      return;
+    }
+    if (
+      request.method() === "POST" &&
+      pathname === "/api/workflow/workflows/smithers-digest/activate" &&
+      saved
+    ) {
+      saved = { ...saved, active: true };
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(saved),
       });
       return;
     }
@@ -127,6 +153,33 @@ async function installWorkflowApi(page: Page) {
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({ currentVersionId: "v1", revisions: [] }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+  await page.route("**/api/triggers**", async (route) => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    if (pathname === "/api/triggers" && request.method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ triggers: trigger ? [trigger] : [] }),
+      });
+      return;
+    }
+    if (pathname === "/api/triggers" && request.method() === "POST") {
+      trigger = {
+        ...(request.postDataJSON() as Record<string, unknown>),
+        id: "trigger-smithers-digest",
+        taskId: "task-trigger-smithers-digest",
+        runCount: 0,
+      };
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ trigger }),
       });
       return;
     }
@@ -174,6 +227,8 @@ async function installWorkflowApi(page: Page) {
     getSaved: () => saved,
     getCreateCount: () => createCount,
     getRunCount: () => runCount,
+    getRunInput: () => runInput,
+    getTrigger: () => trigger,
   };
 }
 
@@ -190,9 +245,8 @@ test("workflow studio creates, executes, inspects, and reloads a Smithers workfl
   await expect(page.getByTestId("automations-shell")).toBeVisible({
     timeout: 60_000,
   });
-  await page.evaluate(() => {
-    window.location.hash = "#automations/__new__";
-  });
+  await page.getByRole("button", { name: "New automation" }).click();
+  await page.getByRole("button", { name: "New workflow" }).click();
 
   await expect(page.getByTestId("workflow-studio")).toBeVisible({
     timeout: 60_000,
@@ -216,8 +270,22 @@ export default smithers(() => <Workflow name="digest"><Task id="digest" output={
   expect(api.getSaved()).not.toHaveProperty("nodes");
   expect(api.getSaved()).not.toHaveProperty("connections");
 
+  await page.getByRole("button", { name: "Add workflow trigger" }).click();
+  await page.getByRole("button", { name: "Event" }).click();
+  await page
+    .getByTestId("workflow-trigger-form")
+    .getByRole("combobox")
+    .selectOption("task.completed");
+  await page.getByRole("button", { name: "Save trigger" }).click();
+  await expect.poll(() => api.getTrigger()?.eventKind).toBe("task.completed");
+  await page.getByRole("button", { name: "Enable workflow" }).click();
+  await expect.poll(() => api.getSaved()?.active).toBe(true);
+
   await page.getByRole("button", { name: "Run", exact: true }).click();
+  await page.getByLabel("Topic").fill("release");
+  await page.getByRole("button", { name: "Run workflow" }).click();
   await expect.poll(api.getRunCount).toBe(1);
+  expect(api.getRunInput()).toEqual({ topic: "release", limit: 5 });
   await expect(page.getByText("run-smithers").first()).toBeVisible();
   await expect(page.getByText("Digest ready")).toBeVisible({
     timeout: 10_000,
@@ -234,7 +302,7 @@ export default smithers(() => <Workflow name="digest"><Task id="digest" output={
     /Create the digest/,
     { timeout: 60_000 },
   );
-  await expect(page.getByRole("button", { name: "Schedule" })).toBeVisible();
+  await expect(page.getByTitle(/task\.completed/)).toBeVisible();
   expect(api.getCreateCount()).toBe(1);
   expect(api.getRunCount()).toBe(1);
 });

--- a/packages/app/test/ui-smoke/workflow-editor.spec.ts
+++ b/packages/app/test/ui-smoke/workflow-editor.spec.ts
@@ -31,6 +31,21 @@ type WorkflowDefinition = {
 };
 
 async function installWorkflowApi(page: Page) {
+  const sourceWorkflow: WorkflowDefinition = {
+    id: "research-pipeline",
+    name: "Research pipeline",
+    description: "",
+    source: "",
+    language: "tsx",
+    active: true,
+    steps: [
+      { id: "collect", label: "Collect", kind: "task", agent: "researcher" },
+    ],
+    widgets: [],
+    versionId: "source-v1",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
   let saved: WorkflowDefinition | null = null;
   let createCount = 0;
   let runCount = 0;
@@ -125,7 +140,9 @@ async function installWorkflowApi(page: Page) {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({ workflows: saved ? [saved] : [] }),
+        body: JSON.stringify({
+          workflows: saved ? [saved, sourceWorkflow] : [sourceWorkflow],
+        }),
       });
       return;
     }
@@ -272,12 +289,20 @@ export default smithers(() => <Workflow name="digest"><Task id="digest" output={
 
   await page.getByRole("button", { name: "Add workflow trigger" }).click();
   await page.getByRole("button", { name: "Event" }).click();
-  await page
-    .getByTestId("workflow-trigger-form")
-    .getByRole("combobox")
-    .selectOption("task.completed");
+  await page.getByLabel("Event source").selectOption("step");
+  await page.getByLabel("Source workflow").selectOption("research-pipeline");
+  await page.getByLabel("Source step").selectOption("collect");
   await page.getByRole("button", { name: "Save trigger" }).click();
-  await expect.poll(() => api.getTrigger()?.eventKind).toBe("task.completed");
+  await expect
+    .poll(() => api.getTrigger()?.eventKind)
+    .toBe("workflow_run_event");
+  expect(api.getTrigger()?.eventFilter).toEqual({
+    event: {
+      type: "NodeFinished",
+      workflowId: "research-pipeline",
+      nodeId: "collect",
+    },
+  });
   await page.getByRole("button", { name: "Enable workflow" }).click();
   await expect.poll(() => api.getSaved()?.active).toBe(true);
 
@@ -302,7 +327,7 @@ export default smithers(() => <Workflow name="digest"><Task id="digest" output={
     /Create the digest/,
     { timeout: 60_000 },
   );
-  await expect(page.getByTitle(/task\.completed/)).toBeVisible();
+  await expect(page.getByTitle(/After Collect/)).toBeVisible();
   expect(api.getCreateCount()).toBe(1);
   expect(api.getRunCount()).toBe(1);
 });

--- a/packages/cloud/services/agent-server/__tests__/unit/workflow-routes.test.ts
+++ b/packages/cloud/services/agent-server/__tests__/unit/workflow-routes.test.ts
@@ -158,6 +158,11 @@ describe("native Smithers Cloud workflow routes", () => {
     expect(await started.json()).toMatchObject({
       execution: { id: "run-1", status: "queued" },
     });
+    expect(service.startWorkflow).toHaveBeenCalledWith(
+      "owned-workflow",
+      { mode: "manual", input: { topic: "AI" } },
+      "owner",
+    );
 
     const approved = await request(
       app,

--- a/packages/cloud/services/agent-server/src/routes.ts
+++ b/packages/cloud/services/agent-server/src/routes.ts
@@ -83,6 +83,7 @@ type WorkflowServiceLike = {
   startWorkflow: (
     workflowId: string,
     options: { mode?: "manual"; input?: Record<string, unknown> } | undefined,
+    userId: string,
   ) => Promise<unknown>;
   listExecutions: (
     params: { workflowId?: string; limit?: number },
@@ -914,12 +915,16 @@ export function createRoutes(manager: AgentManager, sharedSecret: string) {
           set,
           async (service) => {
             await requireWorkflowOwnership(service, userId, params.workflowId);
-            const execution = await service.startWorkflow(params.workflowId, {
-              mode: "manual",
-              ...(isRecord(body) && isRecord(body.input)
-                ? { input: body.input }
-                : {}),
-            });
+            const execution = await service.startWorkflow(
+              params.workflowId,
+              {
+                mode: "manual",
+                ...(isRecord(body) && isRecord(body.input)
+                  ? { input: body.input }
+                  : {}),
+              },
+              userId,
+            );
             set.status = 202;
             return { execution };
           },

--- a/packages/core/src/types/trigger.ts
+++ b/packages/core/src/types/trigger.ts
@@ -35,6 +35,8 @@ interface TriggerConfigBase {
 	scheduledAtIso?: string;
 	cronExpression?: string;
 	eventKind?: string;
+	/** Deep-subset payload match for event triggers. */
+	eventFilter?: Record<string, unknown>;
 	maxRuns?: number;
 	runCount: number;
 	nextRunAtMs?: number;

--- a/packages/shared/src/api/agent-api-types.ts
+++ b/packages/shared/src/api/agent-api-types.ts
@@ -82,6 +82,7 @@ export interface TriggerSummary {
   scheduledAtIso?: string;
   cronExpression?: string;
   eventKind?: string;
+  eventFilter?: Record<string, unknown>;
   maxRuns?: number;
   runCount: number;
   nextRunAtMs?: number;
@@ -117,6 +118,7 @@ export interface CreateTriggerRequest {
   scheduledAtIso?: string;
   cronExpression?: string;
   eventKind?: string;
+  eventFilter?: Record<string, unknown>;
   maxRuns?: number;
   kind?: TriggerKind;
   workflowId?: string;
@@ -134,6 +136,7 @@ export interface UpdateTriggerRequest {
   scheduledAtIso?: string;
   cronExpression?: string;
   eventKind?: string;
+  eventFilter?: Record<string, unknown>;
   maxRuns?: number;
   kind?: TriggerKind;
   workflowId?: string;

--- a/packages/ui/src/api/client-workflow.test.ts
+++ b/packages/ui/src/api/client-workflow.test.ts
@@ -14,12 +14,15 @@ describe("ElizaClient native workflow transport", () => {
     const fetch = vi.fn(async () => ({ execution }));
     client.fetch = fetch as typeof client.fetch;
 
-    await expect(client.runWorkflowDefinition("workflow/1")).resolves.toEqual(
-      execution,
-    );
+    await expect(
+      client.runWorkflowDefinition("workflow/1", { topic: "release" }),
+    ).resolves.toEqual(execution);
     expect(fetch).toHaveBeenCalledWith(
       "/api/workflow/workflows/workflow%2F1/run",
-      { method: "POST" },
+      {
+        method: "POST",
+        body: JSON.stringify({ input: { topic: "release" } }),
+      },
       { timeoutMs: 30_000, skipResume: true },
     );
   });

--- a/packages/ui/src/api/client-workflow.ts
+++ b/packages/ui/src/api/client-workflow.ts
@@ -37,7 +37,10 @@ declare module "./client-base" {
     activateWorkflowDefinition(id: string): Promise<WorkflowDefinition>;
     deactivateWorkflowDefinition(id: string): Promise<WorkflowDefinition>;
     deleteWorkflowDefinition(id: string): Promise<{ ok: boolean }>;
-    runWorkflowDefinition(id: string): Promise<WorkflowExecution>;
+    runWorkflowDefinition(
+      id: string,
+      input?: Record<string, unknown>,
+    ): Promise<WorkflowExecution>;
     getWorkflowExecutions(
       id: string,
       limit?: number,
@@ -166,6 +169,7 @@ ElizaClient.prototype.deleteWorkflowDefinition = async function (
 ElizaClient.prototype.runWorkflowDefinition = async function (
   this: ElizaClient,
   id: string,
+  input?: Record<string, unknown>,
 ): Promise<WorkflowExecution> {
   const result = await workflowSurfaceClient(this).fetch<{
     execution?: WorkflowExecution;
@@ -173,6 +177,7 @@ ElizaClient.prototype.runWorkflowDefinition = async function (
     `/api/workflow/workflows/${encodeURIComponent(id)}/run`,
     {
       method: "POST",
+      body: JSON.stringify({ input: input ?? {} }),
     },
     // This route owns 202 as "execution accepted". Bypass the generic
     // dedicated-agent resume loop or the same workflow POST is retried.

--- a/packages/ui/src/api/workflow-surface-routing.test.ts
+++ b/packages/ui/src/api/workflow-surface-routing.test.ts
@@ -227,8 +227,8 @@ describe("workflowSurfaceClient", () => {
     expect(fetchSpy).toHaveBeenNthCalledWith(
       2,
       "/api/workflow/workflows/wf-1/run",
-      { method: "POST" },
-      { timeoutMs: 11 * 60_000 },
+      { method: "POST", body: JSON.stringify({ input: {} }) },
+      { timeoutMs: 30_000, skipResume: true },
     );
   });
 

--- a/packages/ui/src/components/pages/AutomationsFeed.test.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.test.tsx
@@ -35,6 +35,9 @@ const clientMock = vi.hoisted(() => ({
   listAutomations: vi.fn(),
   listScheduledTasks: vi.fn(),
   applyScheduledTask: vi.fn(),
+  getTriggers: vi.fn(),
+  getWorkflowExecutions: vi.fn(),
+  getWorkflowRevisions: vi.fn(),
   runWorkflowDefinition: vi.fn(),
 }));
 const openExternalUrlMock = vi.hoisted(() => vi.fn(async () => undefined));
@@ -170,6 +173,12 @@ beforeEach(() => {
   clientMock.baseUrl = DEFAULT_AGENT_BASE;
   clientMock.listAutomations.mockResolvedValue(responseFixture());
   clientMock.listScheduledTasks.mockResolvedValue({ tasks: [] });
+  clientMock.getTriggers.mockResolvedValue({ triggers: [] });
+  clientMock.getWorkflowExecutions.mockResolvedValue([]);
+  clientMock.getWorkflowRevisions.mockResolvedValue({
+    currentVersionId: null,
+    revisions: [],
+  });
   clientMock.runWorkflowDefinition.mockResolvedValue({ id: "execution-1" });
 });
 
@@ -183,23 +192,12 @@ afterEach(() => {
 });
 
 describe("AutomationsFeed", () => {
-  it("shows a compact status overview and truthful workflow run action", async () => {
+  it("shows a visual filter strip and truthful workflow run action", async () => {
     render(<AutomationsFeed />);
 
     expect(await screen.findByText("Nightly review")).toBeTruthy();
 
-    expect(
-      within(screen.getByTestId("automation-stat-total")).getByText("3"),
-    ).toBeTruthy();
-    expect(
-      within(screen.getByTestId("automation-stat-active")).getByText("2"),
-    ).toBeTruthy();
-    expect(
-      within(screen.getByTestId("automation-stat-passed")).getByText("1"),
-    ).toBeTruthy();
-    expect(
-      within(screen.getByTestId("automation-stat-failed")).getByText("1"),
-    ).toBeTruthy();
+    expect(screen.queryByTestId("automation-stat-total")).toBeNull();
     expect(screen.getByText("Failed: HTTP request failed")).toBeTruthy();
     expect(screen.getAllByText("Every hour").length).toBeGreaterThan(0);
 
@@ -227,11 +225,15 @@ describe("AutomationsFeed", () => {
     expect(clientMock.listAutomations).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps the feed header focused on status instead of generic creation", async () => {
+  it("creates a workflow from the visible add menu", async () => {
     render(<AutomationsFeed />);
 
     await screen.findByText("Nightly review");
-    expect(screen.queryByRole("button", { name: "New" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "New automation" }));
+    expect(screen.getByTestId("automation-create-menu")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "New workflow" }));
+    expect(await screen.findByTestId("workflow-studio")).toBeTruthy();
+    expect(screen.getByLabelText("Workflow name")).toBeTruthy();
   });
 
   it("never paints one Cloud agent's cached workflows after switching agents", async () => {
@@ -529,12 +531,8 @@ describe("AutomationsFeed", () => {
     expect(
       screen.getByText("Run history unavailable: execution store unavailable"),
     ).toBeTruthy();
-    expect(
-      within(screen.getByTestId("automation-stat-passed")).getByText("0"),
-    ).toBeTruthy();
-    expect(
-      within(screen.getByTestId("automation-stat-failed")).getByText("0"),
-    ).toBeTruthy();
+    expect(screen.queryByTestId("automation-stat-passed")).toBeNull();
+    expect(screen.queryByTestId("automation-stat-failed")).toBeNull();
   });
 
   it("serves mobile-through-cloud rows and keys them to the linked Cloud agent", async () => {

--- a/packages/ui/src/components/pages/AutomationsFeed.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.tsx
@@ -18,6 +18,7 @@ import {
   Plus,
   Rocket,
   Workflow,
+  X,
 } from "lucide-react";
 import {
   type ReactNode,
@@ -250,6 +251,7 @@ export function AutomationsFeed({
     ReadonlySet<string>
   >(() => new Set());
   const [filter, setFilter] = useState<FeedFilter>("all");
+  const [createOpen, setCreateOpen] = useState(false);
   const { link, setLink } = useAutomationDeepLink();
   // Scheduled-task rows open a LifeOps verb panel. They are not part of the
   // workflow/task deep-link schema (they route to the runner, not workflow
@@ -543,37 +545,28 @@ export function AutomationsFeed({
     [allRows],
   );
 
-  const overviewStats = useMemo(
-    () => [
-      {
-        key: "total",
-        label: t("automationsfeed.statTotal", { defaultValue: "Total" }),
-        value: allRows.length,
-      },
-      {
-        key: "active",
-        label: t("automationsfeed.statActive", { defaultValue: "Active" }),
-        value: filterCounts.active,
-      },
-      {
-        key: "passed",
-        label: t("automationsfeed.statPassed", { defaultValue: "Passed" }),
-        value: allRows.filter((row) => row.lastRunStatus === "success").length,
-      },
-      {
-        key: "failed",
-        label: t("automationsfeed.statFailed", { defaultValue: "Failed" }),
-        value: allRows.filter((row) => row.lastRunStatus === "error").length,
-      },
-    ],
-    [allRows, filterCounts.active, t],
-  );
   const newAutomationAction = useAgentElement<HTMLButtonElement>({
     id: "action-new",
     role: "button",
     label: t("automationsfeed.newAutomation", {
       defaultValue: "New automation",
     }),
+    group: "automations-actions",
+    description: "Choose a workflow or prompt automation",
+    onActivate: () => setCreateOpen(true),
+  });
+  const newWorkflowAction = useAgentElement<HTMLButtonElement>({
+    id: "action-new-workflow",
+    role: "button",
+    label: "New workflow",
+    group: "automations-actions",
+    description: "Open the Smithers workflow studio",
+    onActivate: () => setEditor({ kind: "workflow", workflowId: null }),
+  });
+  const newPromptAction = useAgentElement<HTMLButtonElement>({
+    id: "action-new-prompt",
+    role: "button",
+    label: "New prompt automation",
     group: "automations-actions",
     description: "Open the prompt automation editor",
     onActivate: () => setEditor({ kind: "task", taskId: null }),
@@ -656,20 +649,60 @@ export function AutomationsFeed({
         <ViewHeader
           title={t("automationsfeed.title", { defaultValue: "Automations" })}
           right={
-            <Button
-              ref={newAutomationAction.ref}
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              aria-label={t("automationsfeed.addAutomation", {
-                defaultValue: "Add automation",
-              })}
-              className="h-9 w-9 rounded-md text-muted-strong hover:bg-bg-hover hover:text-txt"
-              onClick={() => setEditor({ kind: "task", taskId: null })}
-              {...newAutomationAction.agentProps}
-            >
-              <Plus className="h-4 w-4" aria-hidden />
-            </Button>
+            <div className="relative">
+              <Button
+                ref={newAutomationAction.ref}
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label={t("automationsfeed.addAutomation", {
+                  defaultValue: "Add automation",
+                })}
+                aria-expanded={createOpen}
+                className="h-9 w-9 rounded-md text-muted-strong hover:bg-bg-hover hover:text-txt"
+                onClick={() => setCreateOpen((current) => !current)}
+                {...newAutomationAction.agentProps}
+              >
+                {createOpen ? (
+                  <X className="h-4 w-4" aria-hidden />
+                ) : (
+                  <Plus className="h-4 w-4" aria-hidden />
+                )}
+              </Button>
+              {createOpen ? (
+                <div
+                  className="absolute right-0 top-11 z-30 flex gap-1 rounded-xl border border-border/60 bg-card p-1.5 shadow-xl"
+                  data-testid="automation-create-menu"
+                >
+                  <Button
+                    ref={newWorkflowAction.ref}
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label="New workflow"
+                    title="Workflow"
+                    onClick={() =>
+                      setEditor({ kind: "workflow", workflowId: null })
+                    }
+                    {...newWorkflowAction.agentProps}
+                  >
+                    <Workflow className="h-4 w-4 text-accent-muted dark:text-accent" />
+                  </Button>
+                  <Button
+                    ref={newPromptAction.ref}
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label="New prompt automation"
+                    title="Prompt"
+                    onClick={() => setEditor({ kind: "task", taskId: null })}
+                    {...newPromptAction.agentProps}
+                  >
+                    <CheckCircle2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              ) : null}
+            </div>
           }
         />
         {/* This direct-rendered route has no TabContentView wrapper, so it owns
@@ -686,17 +719,6 @@ export function AutomationsFeed({
           >
             {data && !(workflowServiceIssue && rows.length === 0) ? (
               <>
-                <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                  {overviewStats.map((stat) => (
-                    <OverviewStat
-                      key={stat.key}
-                      statKey={stat.key}
-                      label={stat.label}
-                      value={stat.value}
-                    />
-                  ))}
-                </div>
-
                 {/* Filter chips */}
                 <div className="flex flex-wrap gap-1.5">
                   {(Object.keys(FILTER_LABELS) as FeedFilter[]).map((key) => (
@@ -769,19 +791,11 @@ export function AutomationsFeed({
                   className="flex flex-col items-center gap-5 px-6 py-14 text-center [@media(orientation:landscape)_and_(max-height:520px)]:gap-2 [@media(orientation:landscape)_and_(max-height:520px)]:px-4 [@media(orientation:landscape)_and_(max-height:520px)]:py-3"
                 >
                   <AutomationEmptyIllustration />
-                  <div className="space-y-1">
-                    <p className="text-sm font-medium text-txt">
-                      {t("automationsfeed.emptyHeadline", {
-                        defaultValue: "Nothing scheduled yet",
-                      })}
-                    </p>
-                    <p className="text-xs text-muted-strong">
-                      {t("automationsfeed.emptySub", {
-                        defaultValue:
-                          "Ask in chat to set up a workflow and it will run here.",
-                      })}
-                    </p>
-                  </div>
+                  <p className="text-sm font-medium text-txt">
+                    {t("automationsfeed.emptyHeadline", {
+                      defaultValue: "Nothing scheduled yet",
+                    })}
+                  </p>
                 </div>
               ) : (
                 <ul>
@@ -898,30 +912,6 @@ function WorkflowServiceIssuePanel({
   );
 }
 
-function OverviewStat({
-  statKey,
-  label,
-  value,
-}: {
-  statKey: string;
-  label: string;
-  value: number;
-}) {
-  return (
-    // Flat — no card border/fill (#10710, "no card chrome"): the grid gap +
-    // label/value type hierarchy group the stats; the surrounding surface shows
-    // through, matching the minimal eliza aesthetic (cf. SettingsView flat rows).
-    <div className="py-1" data-testid={`automation-stat-${statKey}`}>
-      <div className="text-2xs font-medium uppercase tracking-normal text-muted-strong">
-        {label}
-      </div>
-      <div className="mt-1 text-lg font-semibold leading-none tabular-nums text-txt">
-        {value}
-      </div>
-    </div>
-  );
-}
-
 function FilterChipButton({
   filter,
   label,
@@ -963,7 +953,15 @@ function FilterChipButton({
       {...agentProps}
     >
       <span className="[&>svg]:h-3.5 [&>svg]:w-3.5">{icon}</span>
-      <span>{label}</span>
+      <span
+        className={
+          isActive
+            ? undefined
+            : "hidden sm:inline [@media(orientation:landscape)_and_(max-height:520px)]:hidden"
+        }
+      >
+        {label}
+      </span>
       {count > 0 ? (
         <span className="text-[0.65rem] font-semibold tabular-nums">
           {count}

--- a/packages/ui/src/components/pages/WorkflowEditor.test.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.test.tsx
@@ -16,12 +16,15 @@ vi.mock("../../api", () => ({
   client: {
     activateWorkflowDefinition: vi.fn(),
     cancelWorkflowExecution: vi.fn(),
+    createTrigger: vi.fn(),
     createWorkflowDefinition: vi.fn(),
     deactivateWorkflowDefinition: vi.fn(),
+    deleteTrigger: vi.fn(),
     decideWorkflowApproval: vi.fn(),
     getWorkflowExecution: vi.fn(),
     getWorkflowExecutions: vi.fn(),
     getWorkflowRevisions: vi.fn(),
+    getTriggers: vi.fn(),
     restoreWorkflowRevision: vi.fn(),
     runWorkflowDefinition: vi.fn(),
     signalWorkflowExecution: vi.fn(),
@@ -60,12 +63,17 @@ function workflow(): WorkflowDefinition {
 beforeEach(() => {
   vi.clearAllMocks();
   api.getWorkflowExecutions.mockResolvedValue([]);
+  api.getTriggers.mockResolvedValue({ triggers: [] });
+  api.createTrigger.mockResolvedValue({ trigger: { id: "trigger-1" } });
   api.getWorkflowRevisions.mockResolvedValue({
     currentVersionId: "v1",
     revisions: [],
   });
   api.createWorkflowDefinition.mockResolvedValue(workflow());
   api.updateWorkflowDefinition.mockResolvedValue(workflow());
+  api.cancelWorkflowExecution.mockResolvedValue({});
+  api.decideWorkflowApproval.mockResolvedValue({});
+  api.restoreWorkflowRevision.mockResolvedValue(workflow());
   api.runWorkflowDefinition.mockResolvedValue({
     id: "run-1",
     workflowId: "workflow-1",
@@ -82,17 +90,33 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("WorkflowEditor", () => {
-  it("renders native source and reveals optional schedule controls on demand", async () => {
+  it("renders native source, visual triggers, and typed widgets", async () => {
     render(<WorkflowEditor initial={workflow()} />);
     expect(screen.getByText("Build digest")).toBeTruthy();
+    expect(screen.getByTitle("Manual")).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add workflow trigger" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Repeat" }));
+    fireEvent.change(screen.getByLabelText("Interval minutes"), {
+      target: { value: "30" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save trigger" }));
+    await waitFor(() =>
+      expect(api.createTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "workflow",
+          workflowId: "workflow-1",
+          triggerType: "interval",
+          intervalMs: 1_800_000,
+        }),
+      ),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Source" }));
     expect(
       (screen.getByTestId("smithers-source-editor") as HTMLTextAreaElement)
         .value,
     ).toMatch(/smthrs\/create/);
-    expect(screen.queryByLabelText("Workflow cron schedule")).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Schedule" }));
-    expect(screen.getByLabelText("Workflow cron schedule")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Widgets" }));
     expect(await screen.findByText("Digest status")).toBeTruthy();
     await waitFor(() => expect(api.getWorkflowExecutions).toHaveBeenCalled());
@@ -106,8 +130,204 @@ describe("WorkflowEditor", () => {
       expect(api.createWorkflowDefinition).toHaveBeenCalledTimes(1),
     );
     await waitFor(() =>
-      expect(api.runWorkflowDefinition).toHaveBeenCalledWith("workflow-1"),
+      expect(api.runWorkflowDefinition).toHaveBeenCalledWith("workflow-1", {}),
     );
     await waitFor(() => expect(api.getWorkflowRevisions).toHaveBeenCalled());
+  });
+
+  it("collects JSON-schema inputs before a run", async () => {
+    const configured = workflow();
+    configured.inputSchema = {
+      type: "object",
+      required: ["topic"],
+      properties: {
+        topic: { type: "string", title: "Topic" },
+        limit: { type: "integer", title: "Limit", default: 5 },
+      },
+    };
+    render(<WorkflowEditor initial={configured} />);
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    fireEvent.change(screen.getByLabelText("Topic"), {
+      target: { value: "release" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Run workflow" }));
+    await waitFor(() =>
+      expect(api.runWorkflowDefinition).toHaveBeenCalledWith("workflow-1", {
+        topic: "release",
+        limit: 5,
+      }),
+    );
+  });
+
+  it("saves dirty source before running the active definition", async () => {
+    render(<WorkflowEditor initial={workflow()} />);
+    fireEvent.change(screen.getByLabelText("Workflow name"), {
+      target: { value: "Updated digest" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    await waitFor(() =>
+      expect(api.updateWorkflowDefinition).toHaveBeenCalled(),
+    );
+    await waitFor(() => expect(api.runWorkflowDefinition).toHaveBeenCalled());
+    expect(
+      api.updateWorkflowDefinition.mock.invocationCallOrder[0],
+    ).toBeLessThan(api.runWorkflowDefinition.mock.invocationCallOrder[0]);
+  });
+
+  it("renders Smithers widget contracts as native visual surfaces", async () => {
+    const configured = workflow();
+    configured.widgets = [
+      {
+        id: "markdown",
+        title: "Summary",
+        surface: "both",
+        component: "markdown",
+        dataPath: "summary",
+      },
+      {
+        id: "table",
+        title: "Rows",
+        surface: "both",
+        component: "data-table",
+        dataPath: "rows",
+      },
+      {
+        id: "chart",
+        title: "Chart",
+        surface: "both",
+        component: "chart",
+        dataPath: "chart",
+      },
+      {
+        id: "issues",
+        title: "Issues",
+        surface: "both",
+        component: "issue-list",
+        dataPath: "issues",
+      },
+    ];
+    api.getWorkflowExecutions.mockResolvedValue([
+      {
+        id: "run-finished",
+        workflowId: "workflow-1",
+        mode: "manual",
+        status: "finished",
+        finished: true,
+        startedAt: now,
+        stoppedAt: now,
+        input: {},
+        events: [],
+        output: {
+          summary: "Release ready",
+          rows: [{ name: "Alpha", score: 9 }],
+          chart: [{ label: "Passed", value: 7 }],
+          issues: ["Review copy"],
+        },
+      },
+    ]);
+    render(<WorkflowEditor initial={configured} />);
+    fireEvent.click(screen.getByRole("button", { name: "Widgets" }));
+    expect(await screen.findByText("Release ready")).toBeTruthy();
+    expect(screen.getByText("Alpha")).toBeTruthy();
+    expect(screen.getByText("Passed")).toBeTruthy();
+    expect(screen.getByText("Review copy")).toBeTruthy();
+  });
+
+  it("arms destructive run cancellation and revision restore", async () => {
+    api.getWorkflowExecutions.mockResolvedValue([
+      {
+        id: "run-live",
+        workflowId: "workflow-1",
+        mode: "manual",
+        status: "running",
+        finished: false,
+        startedAt: now,
+        stoppedAt: null,
+        input: {},
+        events: [],
+      },
+    ]);
+    api.getWorkflowRevisions.mockResolvedValue({
+      currentVersionId: "v1",
+      revisions: [
+        {
+          id: "revision-1",
+          workflowId: "workflow-1",
+          versionId: "v0",
+          name: "Digest",
+          active: false,
+          createdAt: now,
+          updatedAt: now,
+          capturedAt: now,
+          operation: "update",
+        },
+      ],
+    });
+    render(<WorkflowEditor initial={workflow()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Runs" }));
+    expect(
+      await screen.findByRole("button", { name: "Cancel run" }),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel run" }));
+    expect(api.cancelWorkflowExecution).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Confirm cancel run" }));
+    await waitFor(() =>
+      expect(api.cancelWorkflowExecution).toHaveBeenCalledWith("run-live"),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "History" }));
+    expect(
+      await screen.findByRole("button", { name: "Restore revision" }),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Restore revision" }));
+    expect(api.restoreWorkflowRevision).not.toHaveBeenCalled();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Confirm restore revision" }),
+    );
+    await waitFor(() =>
+      expect(api.restoreWorkflowRevision).toHaveBeenCalledWith(
+        "workflow-1",
+        "v0",
+      ),
+    );
+  });
+
+  it("submits the exact Smithers approval node and iteration", async () => {
+    api.getWorkflowExecutions.mockResolvedValue([
+      {
+        id: "run-approval",
+        workflowId: "workflow-1",
+        mode: "manual",
+        status: "waiting-approval",
+        finished: false,
+        startedAt: now,
+        stoppedAt: null,
+        input: {},
+        events: [
+          {
+            id: "event-approval",
+            sequence: 1,
+            runId: "run-approval",
+            workflowId: "workflow-1",
+            timestamp: now,
+            type: "node.waiting-approval",
+            nodeId: "publish",
+            iteration: 2,
+            payload: {},
+          },
+        ],
+      },
+    ]);
+    render(<WorkflowEditor initial={workflow()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Runs" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Approve" }));
+    await waitFor(() =>
+      expect(api.decideWorkflowApproval).toHaveBeenCalledWith(
+        "run-approval",
+        "publish",
+        2,
+        true,
+      ),
+    );
   });
 });

--- a/packages/ui/src/components/pages/WorkflowEditor.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.tsx
@@ -39,8 +39,17 @@ import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Spinner } from "../ui/spinner";
 import { Textarea } from "../ui/textarea";
+import { WorkflowTriggerPanel } from "./WorkflowTriggerPanel";
 
 type StudioTab = "build" | "source" | "runs" | "widgets" | "history";
+
+const STUDIO_TABS = [
+  ["build", "Build", WorkflowIcon],
+  ["source", "Source", Braces],
+  ["runs", "Runs", Activity],
+  ["widgets", "Widgets", LayoutDashboard],
+  ["history", "History", History],
+] as const;
 
 const EMPTY_SOURCE = `/** @jsxImportSource smthrs */
 import { createSmithers } from "smthrs/create";
@@ -98,6 +107,54 @@ function pretty(value: unknown): string {
   }
 }
 
+function dataAtPath(value: unknown, path?: string): unknown {
+  if (!path) return value;
+  return path.split(".").reduce<unknown>((current, segment) => {
+    if (!current || typeof current !== "object") return undefined;
+    return (current as Record<string, unknown>)[segment];
+  }, value);
+}
+
+interface InputField {
+  key: string;
+  type: "string" | "number" | "integer" | "boolean";
+  title: string;
+  required: boolean;
+  defaultValue?: unknown;
+}
+
+function schemaFields(schema?: Record<string, unknown>): InputField[] {
+  const properties = schema?.properties;
+  if (!properties || typeof properties !== "object") return [];
+  const required = new Set(
+    Array.isArray(schema.required)
+      ? schema.required.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : [],
+  );
+  return Object.entries(properties).flatMap(([key, raw]) => {
+    if (!raw || typeof raw !== "object") return [];
+    const property = raw as Record<string, unknown>;
+    const type = property.type;
+    if (
+      !(["string", "number", "integer", "boolean"] as const).includes(
+        type as never,
+      )
+    )
+      return [];
+    return [
+      {
+        key,
+        type: type as InputField["type"],
+        title: typeof property.title === "string" ? property.title : key,
+        required: required.has(key),
+        defaultValue: property.default,
+      },
+    ];
+  });
+}
+
 function hasObjectValues(value: unknown): boolean {
   return Boolean(
     value && typeof value === "object" && Object.keys(value).length > 0,
@@ -119,6 +176,7 @@ function SmithersCanvas({
   steps: WorkflowStepManifest[];
   execution: WorkflowExecution | null;
 }) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const eventTypes = useMemo(() => {
     const map = new Map<string, string>();
     for (const event of execution?.events ?? []) {
@@ -126,6 +184,23 @@ function SmithersCanvas({
     }
     return map;
   }, [execution]);
+  const rows = useMemo(() => {
+    const levelById = new Map<string, number>();
+    const grouped = new Map<number, WorkflowStepManifest[]>();
+    steps.forEach((step, index) => {
+      const dependencies = step.dependsOn ?? [];
+      const level =
+        dependencies.length > 0
+          ? Math.max(...dependencies.map((id) => levelById.get(id) ?? 0)) + 1
+          : index === 0
+            ? 0
+            : Math.max(...levelById.values()) + 1;
+      levelById.set(step.id, level);
+      grouped.set(level, [...(grouped.get(level) ?? []), step]);
+    });
+    return [...grouped.entries()].sort(([a], [b]) => a - b);
+  }, [steps]);
+  const selected = steps.find((step) => step.id === selectedId) ?? null;
   if (steps.length === 0) {
     return (
       <div
@@ -142,49 +217,90 @@ function SmithersCanvas({
       data-testid="smithers-canvas"
       className="min-h-0 overflow-auto bg-[radial-gradient(circle_at_1px_1px,hsl(var(--border)/0.38)_1px,transparent_0)] bg-[size:20px_20px] p-5"
     >
-      <div className="mx-auto flex w-full max-w-xl flex-col items-center">
-        {steps.map((step, index) => {
-          const eventType = eventTypes.get(step.id);
-          const active = Boolean(
-            eventType && !/finish|complete|fail/i.test(eventType),
-          );
-          const failed = Boolean(eventType && /fail|error/i.test(eventType));
-          return (
-            <div key={step.id} className="contents">
-              {index > 0 ? <div className="h-7 w-px bg-border" /> : null}
-              <div
-                className={`w-fit min-w-44 max-w-full rounded-xl border bg-card p-3 shadow-sm transition ${active ? "border-primary shadow-[0_0_0_2px_hsl(var(--primary)/0.12)]" : failed ? "border-destructive/60" : "border-border/60"}`}
-                title={[
-                  step.kind,
-                  step.agent,
-                  step.description,
-                  step.dependsOn?.length
-                    ? `After ${step.dependsOn.join(", ")}`
-                    : null,
-                  eventType,
-                ]
-                  .filter(Boolean)
-                  .join(" · ")}
-              >
-                <div className="flex items-center gap-3">
-                  <div className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary">
-                    <StepIcon kind={step.kind} />
-                  </div>
-                  <p className="min-w-0 flex-1 truncate text-sm font-semibold">
-                    {step.label}
-                  </p>
-                  {eventType ? (
-                    <span
-                      className={`h-2.5 w-2.5 shrink-0 rounded-full ${failed ? "bg-destructive" : active ? "animate-pulse bg-primary" : "bg-emerald-500"}`}
-                    >
-                      <span className="sr-only">{eventType}</span>
-                    </span>
-                  ) : null}
-                </div>
-              </div>
+      <div className="mx-auto flex w-full max-w-3xl flex-col items-center">
+        {rows.map(([level, row], rowIndex) => (
+          <div key={level} className="contents">
+            {rowIndex > 0 ? <div className="h-7 w-px bg-border" /> : null}
+            <div className="flex max-w-full flex-wrap justify-center gap-3">
+              {row.map((step) => {
+                const eventType = eventTypes.get(step.id);
+                const active = Boolean(
+                  eventType && !/finish|complete|fail/i.test(eventType),
+                );
+                const failed = Boolean(
+                  eventType && /fail|error/i.test(eventType),
+                );
+                return (
+                  <button
+                    type="button"
+                    key={step.id}
+                    onClick={() =>
+                      setSelectedId((current) =>
+                        current === step.id ? null : step.id,
+                      )
+                    }
+                    aria-label={`Select step ${step.label}`}
+                    aria-pressed={selectedId === step.id}
+                    className={`w-fit min-w-44 max-w-full rounded-xl border bg-card p-3 text-left shadow-sm transition ${selectedId === step.id ? "border-primary/60 shadow-[0_0_0_2px_hsl(var(--primary)/0.1)]" : active ? "border-primary shadow-[0_0_0_2px_hsl(var(--primary)/0.12)]" : failed ? "border-destructive/60" : "border-border/60"}`}
+                    title={[
+                      step.kind,
+                      step.agent,
+                      step.description,
+                      step.dependsOn?.length
+                        ? `After ${step.dependsOn.join(", ")}`
+                        : null,
+                      eventType,
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary">
+                        <StepIcon kind={step.kind} />
+                      </div>
+                      <p className="min-w-0 flex-1 truncate text-sm font-semibold">
+                        {step.label}
+                      </p>
+                      {eventType ? (
+                        <span
+                          className={`h-2.5 w-2.5 shrink-0 rounded-full ${failed ? "bg-destructive" : active ? "animate-pulse bg-primary" : "bg-emerald-500"}`}
+                        >
+                          <span className="sr-only">{eventType}</span>
+                        </span>
+                      ) : null}
+                    </div>
+                  </button>
+                );
+              })}
             </div>
-          );
-        })}
+          </div>
+        ))}
+        {selected ? (
+          <div className="mt-6 flex max-w-md items-center gap-3 rounded-xl border border-border/60 bg-card/95 px-3 py-2 shadow-lg">
+            <StepIcon kind={selected.kind} />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-xs font-semibold">{selected.label}</p>
+              <p className="truncate text-[10px] text-muted-foreground">
+                {selected.agent ?? selected.kind}
+                {selected.dependsOn?.length
+                  ? ` · ${selected.dependsOn.join(" + ")}`
+                  : ""}
+              </p>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Edit selected step with Eliza"
+              onClick={() =>
+                dispatchChatPrefill({
+                  text: `Edit workflow step ${selected.id}: `,
+                })
+              }
+            >
+              <MessageSquareText className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        ) : null}
       </div>
     </div>
   );
@@ -199,6 +315,21 @@ function WorkflowWidget({
   output: unknown;
   runId?: string;
 }) {
+  const value = dataAtPath(output, widget.dataPath);
+  const rows = Array.isArray(value)
+    ? value.filter(
+        (row): row is Record<string, unknown> =>
+          Boolean(row) && typeof row === "object",
+      )
+    : [];
+  const columns = rows.length > 0 ? Object.keys(rows[0]).slice(0, 6) : [];
+  const chartValues = rows
+    .map((row, index) => ({
+      label: String(row.label ?? row.name ?? index + 1),
+      value: Number(row.value ?? row.count ?? 0),
+    }))
+    .filter((item) => Number.isFinite(item.value));
+  const chartMax = Math.max(1, ...chartValues.map((item) => item.value));
   return (
     <div className="rounded-xl border border-border/60 bg-card p-4 shadow-sm">
       <div className="flex items-start justify-between gap-3">
@@ -212,9 +343,87 @@ function WorkflowWidget({
           <span className="sr-only">{widget.component}</span>
         </span>
       </div>
-      <pre className="mt-4 max-h-64 overflow-auto rounded-lg bg-muted/40 p-3 text-xs leading-relaxed">
-        {pretty(output)}
-      </pre>
+      <div className="mt-4 max-h-72 overflow-auto text-xs leading-relaxed">
+        {widget.component === "status" ? (
+          <div className="flex items-center gap-2 rounded-lg bg-muted/30 p-3">
+            <span
+              className={`h-2.5 w-2.5 rounded-full ${value === false || value === "failed" || value === "error" ? "bg-destructive" : "bg-emerald-500"}`}
+            />
+            <span className="font-medium">
+              {typeof value === "string" || typeof value === "number"
+                ? String(value)
+                : "Ready"}
+            </span>
+          </div>
+        ) : widget.component === "data-table" && columns.length > 0 ? (
+          <table className="w-full border-collapse">
+            <thead>
+              <tr>
+                {columns.map((column) => (
+                  <th
+                    key={column}
+                    className="border-b px-2 py-1 text-left font-medium text-muted-foreground"
+                  >
+                    {column}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, index) => (
+                <tr key={String(row.id ?? index)}>
+                  {columns.map((column) => (
+                    <td
+                      key={column}
+                      className="border-b border-border/40 px-2 py-1.5"
+                    >
+                      {String(row[column] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : widget.component === "chart" && chartValues.length > 0 ? (
+          <div className="space-y-2">
+            {chartValues.map((item) => (
+              <div
+                key={item.label}
+                className="grid grid-cols-[minmax(4rem,auto)_1fr_auto] items-center gap-2"
+              >
+                <span className="truncate text-muted-foreground">
+                  {item.label}
+                </span>
+                <span className="h-2 overflow-hidden rounded-full bg-muted">
+                  <span
+                    className="block h-full rounded-full bg-primary"
+                    style={{ width: `${(item.value / chartMax) * 100}%` }}
+                  />
+                </span>
+                <span className="tabular-nums">{item.value}</span>
+              </div>
+            ))}
+          </div>
+        ) : widget.component === "issue-list" && Array.isArray(value) ? (
+          <ul className="space-y-1.5">
+            {value.map((item) => (
+              <li
+                key={pretty(item)}
+                className="flex gap-2 rounded-lg bg-muted/30 p-2"
+              >
+                <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-primary" />
+                <span>{typeof item === "string" ? item : pretty(item)}</span>
+              </li>
+            ))}
+          </ul>
+        ) : widget.component === "markdown" && typeof value === "string" ? (
+          <div className="whitespace-pre-wrap rounded-lg bg-muted/30 p-3">
+            {value}
+          </div>
+        ) : (
+          <pre className="rounded-lg bg-muted/40 p-3">{pretty(value)}</pre>
+        )}
+      </div>
       {widget.actions?.length ? (
         <div className="mt-3 flex flex-wrap gap-2">
           {widget.actions.map((action) => (
@@ -254,18 +463,30 @@ export function WorkflowEditor({
     () => initial ?? newWorkflow(),
   );
   const [tab, setTab] = useState<StudioTab>("build");
-  const [scheduleOpen, setScheduleOpen] = useState(Boolean(initial?.schedule));
+  const [savedVersion, setSavedVersion] = useState(() =>
+    JSON.stringify(workflow),
+  );
   const [saving, setSaving] = useState(false);
   const [running, setRunning] = useState(false);
+  const [runInputOpen, setRunInputOpen] = useState(false);
+  const [runInput, setRunInput] = useState<Record<string, unknown>>({});
   const [error, setError] = useState<string | null>(null);
   const [executions, setExecutions] = useState<WorkflowExecution[]>([]);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [revisions, setRevisions] = useState<WorkflowRevision[]>([]);
+  const [cancelArmedId, setCancelArmedId] = useState<string | null>(null);
+  const [restoreArmedId, setRestoreArmedId] = useState<string | null>(null);
 
   useEffect(() => {
-    setWorkflow(initial ?? newWorkflow());
-    setScheduleOpen(Boolean(initial?.schedule));
+    const next = initial ?? newWorkflow();
+    setWorkflow(next);
+    setSavedVersion(JSON.stringify(next));
   }, [initial]);
+  const inputFields = useMemo(
+    () => schemaFields(workflow.inputSchema),
+    [workflow.inputSchema],
+  );
+  const dirty = JSON.stringify(workflow) !== savedVersion;
   const selectedRun =
     executions.find((run) => run.id === selectedRunId) ?? executions[0] ?? null;
 
@@ -323,6 +544,7 @@ export function WorkflowEditor({
         ? await client.updateWorkflowDefinition(workflow.id, request)
         : await client.createWorkflowDefinition(request);
       setWorkflow(saved);
+      setSavedVersion(JSON.stringify(saved));
       onSaved?.(saved);
       const next = await client.getWorkflowRevisions(saved.id, 30);
       setRevisions(next.revisions);
@@ -337,36 +559,67 @@ export function WorkflowEditor({
     }
   }, [onSaved, workflow]);
 
-  const run = useCallback(async () => {
-    setRunning(true);
-    setError(null);
-    try {
-      const workflowId = workflow.id || (await save())?.id;
-      if (!workflowId) return;
-      const execution = await client.runWorkflowDefinition(workflowId);
-      setExecutions((current) => [
-        execution,
-        ...current.filter((run) => run.id !== execution.id),
-      ]);
-      setSelectedRunId(execution.id);
-      setTab("runs");
-    } catch (cause) {
-      setError(
-        cause instanceof Error ? cause.message : "Unable to start workflow.",
-      );
-    } finally {
-      setRunning(false);
+  const run = useCallback(
+    async (input: Record<string, unknown> = {}) => {
+      setRunning(true);
+      setError(null);
+      try {
+        const workflowId =
+          !workflow.id || dirty ? (await save())?.id : workflow.id;
+        if (!workflowId) return;
+        const execution = await client.runWorkflowDefinition(workflowId, input);
+        setExecutions((current) => [
+          execution,
+          ...current.filter((run) => run.id !== execution.id),
+        ]);
+        setSelectedRunId(execution.id);
+        setTab("runs");
+      } catch (cause) {
+        setError(
+          cause instanceof Error ? cause.message : "Unable to start workflow.",
+        );
+      } finally {
+        setRunning(false);
+      }
+    },
+    [dirty, save, workflow.id],
+  );
+
+  const requestRun = useCallback(() => {
+    if (inputFields.length === 0) {
+      void run();
+      return;
     }
-  }, [save, workflow.id]);
+    setRunInput(
+      Object.fromEntries(
+        inputFields.flatMap((field) =>
+          field.defaultValue === undefined
+            ? []
+            : [[field.key, field.defaultValue]],
+        ),
+      ),
+    );
+    setRunInputOpen(true);
+  }, [inputFields, run]);
 
   const toggleActive = useCallback(async () => {
-    if (!workflow.id) return;
-    const updated = workflow.active
-      ? await client.deactivateWorkflowDefinition(workflow.id)
-      : await client.activateWorkflowDefinition(workflow.id);
-    setWorkflow(updated);
-    onSaved?.(updated);
-  }, [onSaved, workflow.active, workflow.id]);
+    setError(null);
+    try {
+      const current = dirty ? await save() : workflow;
+      if (!current?.id) return;
+      const updated = current.active
+        ? await client.deactivateWorkflowDefinition(current.id)
+        : await client.activateWorkflowDefinition(current.id);
+      setWorkflow(updated);
+      setSavedVersion(JSON.stringify(updated));
+      onSaved?.(updated);
+    } catch (cause) {
+      // error-policy:J4 activation failures preserve the saved workflow and surface the error.
+      setError(
+        cause instanceof Error ? cause.message : "Unable to update workflow.",
+      );
+    }
+  }, [dirty, onSaved, save, workflow]);
 
   const openInChat = useCallback(() => {
     dispatchChatPrefill({
@@ -379,9 +632,9 @@ export function WorkflowEditor({
   return (
     <PagePanel
       data-testid="workflow-studio"
-      className="flex min-h-0 flex-1 flex-col overflow-hidden p-0 pb-20"
+      className="relative flex min-h-0 flex-1 flex-col overflow-hidden p-0 pb-20"
     >
-      <div className="flex items-center gap-1 border-b border-transparent bg-card/70 px-3 py-2 backdrop-blur-sm lg:border-border/70 lg:px-4">
+      <div className="flex flex-wrap items-center gap-1 border-b border-transparent bg-card/90 px-3 py-2 lg:border-border/70 lg:px-4">
         <Input
           value={workflow.name}
           onChange={(event) =>
@@ -390,20 +643,15 @@ export function WorkflowEditor({
               name: event.target.value,
             }))
           }
-          className="h-8 min-w-20 flex-1 border-0 bg-transparent px-0 text-sm font-semibold shadow-none focus-visible:ring-0 sm:text-base"
+          className="h-8 min-w-20 flex-1 border-0 bg-transparent px-0 text-sm font-semibold shadow-none sm:text-base"
           aria-label="Workflow name"
           title={workflow.description || undefined}
         />
-        <nav className="flex items-center gap-0.5" aria-label="Workflow views">
-          {(
-            [
-              ["build", "Build", WorkflowIcon],
-              ["source", "Source", Braces],
-              ["runs", "Runs", Activity],
-              ["widgets", "Widgets", LayoutDashboard],
-              ["history", "History", History],
-            ] as const
-          ).map(([value, label, Icon]) => (
+        <nav
+          className="order-last flex basis-full items-center justify-center gap-2 pt-1 sm:order-none sm:basis-auto sm:gap-0.5 sm:pt-0"
+          aria-label="Workflow views"
+        >
+          {STUDIO_TABS.map(([value, label, Icon]) => (
             <button
               key={value}
               type="button"
@@ -432,7 +680,16 @@ export function WorkflowEditor({
             />
           </button>
         ) : null}
+        {dirty ? (
+          <span
+            className="h-2 w-2 shrink-0 rounded-full bg-primary"
+            title="Unsaved changes"
+          >
+            <span className="sr-only">Unsaved changes</span>
+          </span>
+        ) : null}
         <Button
+          className="hidden sm:inline-flex"
           variant="ghost"
           size="icon-sm"
           onClick={openInChat}
@@ -458,7 +715,7 @@ export function WorkflowEditor({
         </Button>
         <Button
           size="icon-sm"
-          onClick={() => void run()}
+          onClick={requestRun}
           disabled={running}
           aria-label="Run"
           title="Run"
@@ -480,6 +737,14 @@ export function WorkflowEditor({
           </Button>
         ) : null}
       </div>
+
+      <WorkflowTriggerPanel
+        workflowId={workflow.id}
+        workflowName={workflow.name}
+        onNeedsSave={async () =>
+          !workflow.id || dirty ? ((await save())?.id ?? null) : workflow.id
+        }
+      />
 
       {error ? (
         <div className="mx-4 mt-3 rounded-lg border border-destructive/25 bg-destructive/10 px-3 py-2 text-xs text-destructive">
@@ -511,86 +776,6 @@ export function WorkflowEditor({
             aria-label="Smithers workflow source"
             className="min-h-[420px] flex-1 resize-none rounded-xl border-0 bg-zinc-950 p-4 font-mono text-[12px] leading-5 text-zinc-100"
           />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            className="absolute bottom-4 right-4 text-muted-foreground"
-            onClick={() => setScheduleOpen((current) => !current)}
-            aria-expanded={scheduleOpen}
-            aria-label="Schedule"
-            title={workflow.schedule?.enabled ? "Scheduled" : "Schedule"}
-          >
-            <Clock3
-              className={`h-4 w-4 ${workflow.schedule?.enabled ? "text-primary" : ""}`}
-            />
-          </Button>
-          {scheduleOpen ? (
-            <div className="absolute inset-x-3 bottom-14 grid gap-2 rounded-xl bg-card/95 p-2 shadow-lg backdrop-blur sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
-              <Input
-                value={workflow.schedule?.cron ?? ""}
-                onChange={(event) =>
-                  setWorkflow((current) => ({
-                    ...current,
-                    schedule: {
-                      cron: event.target.value,
-                      timezone:
-                        current.schedule?.timezone ??
-                        Intl.DateTimeFormat().resolvedOptions().timeZone,
-                      enabled: current.schedule?.enabled ?? false,
-                    },
-                  }))
-                }
-                placeholder="Cron schedule (optional)"
-                aria-label="Workflow cron schedule"
-              />
-              <Input
-                value={workflow.schedule?.timezone ?? ""}
-                onChange={(event) =>
-                  setWorkflow((current) => ({
-                    ...current,
-                    schedule: {
-                      cron: current.schedule?.cron ?? "",
-                      timezone: event.target.value,
-                      enabled: current.schedule?.enabled ?? false,
-                    },
-                  }))
-                }
-                placeholder="Timezone"
-                aria-label="Workflow schedule timezone"
-              />
-              <Button
-                type="button"
-                variant={workflow.schedule?.enabled ? "default" : "outline"}
-                size="icon"
-                disabled={!workflow.schedule?.cron}
-                aria-label={
-                  workflow.schedule?.enabled
-                    ? "Disable schedule"
-                    : "Enable schedule"
-                }
-                title={
-                  workflow.schedule?.enabled
-                    ? "Disable schedule"
-                    : "Enable schedule"
-                }
-                onClick={() =>
-                  setWorkflow((current) => ({
-                    ...current,
-                    schedule: {
-                      cron: current.schedule?.cron ?? "",
-                      timezone:
-                        current.schedule?.timezone ??
-                        Intl.DateTimeFormat().resolvedOptions().timeZone,
-                      enabled: !current.schedule?.enabled,
-                    },
-                  }))
-                }
-              >
-                <Clock3 className="h-4 w-4" />
-              </Button>
-            </div>
-          ) : null}
         </section>
       ) : null}
 
@@ -660,15 +845,30 @@ export function WorkflowEditor({
                   <div className="flex-1" />
                   {!terminal(selectedRun.status) ? (
                     <Button
-                      variant="ghost"
+                      variant={
+                        cancelArmedId === selectedRun.id
+                          ? "destructive"
+                          : "ghost"
+                      }
                       size="icon-sm"
-                      aria-label="Cancel run"
-                      title="Cancel"
-                      onClick={() =>
+                      aria-label={
+                        cancelArmedId === selectedRun.id
+                          ? "Confirm cancel run"
+                          : "Cancel run"
+                      }
+                      title={
+                        cancelArmedId === selectedRun.id ? "Confirm" : "Cancel"
+                      }
+                      onClick={() => {
+                        if (cancelArmedId !== selectedRun.id) {
+                          setCancelArmedId(selectedRun.id);
+                          return;
+                        }
+                        setCancelArmedId(null);
                         void client
                           .cancelWorkflowExecution(selectedRun.id)
-                          .then(refreshRuns)
-                      }
+                          .then(refreshRuns);
+                      }}
                     >
                       <CircleStop className="h-4 w-4" />
                     </Button>
@@ -853,18 +1053,28 @@ export function WorkflowEditor({
                   </p>
                 </div>
                 <Button
-                  variant="ghost"
+                  variant={restoreArmedId === revision.id ? "default" : "ghost"}
                   size="icon-sm"
-                  aria-label="Restore revision"
-                  title="Restore"
-                  onClick={() =>
+                  aria-label={
+                    restoreArmedId === revision.id
+                      ? "Confirm restore revision"
+                      : "Restore revision"
+                  }
+                  title={restoreArmedId === revision.id ? "Confirm" : "Restore"}
+                  onClick={() => {
+                    if (restoreArmedId !== revision.id) {
+                      setRestoreArmedId(revision.id);
+                      return;
+                    }
+                    setRestoreArmedId(null);
                     void client
                       .restoreWorkflowRevision(workflow.id, revision.versionId)
                       .then((restored) => {
                         setWorkflow(restored);
+                        setSavedVersion(JSON.stringify(restored));
                         void refreshRevisions();
-                      })
-                  }
+                      });
+                  }}
                 >
                   <ArchiveRestore className="h-4 w-4" />
                 </Button>
@@ -880,6 +1090,89 @@ export function WorkflowEditor({
               </div>
             ) : null}
           </div>
+        </div>
+      ) : null}
+
+      {runInputOpen ? (
+        <div className="absolute inset-0 z-30 grid place-items-center bg-background/80 p-4">
+          <form
+            aria-label="Workflow input"
+            className="w-full max-w-md rounded-2xl border border-border/60 bg-card p-4 shadow-xl"
+            onSubmit={(event) => {
+              event.preventDefault();
+              setRunInputOpen(false);
+              void run(runInput);
+            }}
+          >
+            <div className="mb-3 flex items-center gap-2">
+              <FileInput className="h-4 w-4 text-primary" />
+              <span className="text-sm font-semibold">Input</span>
+              <div className="flex-1" />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Close input"
+                onClick={() => setRunInputOpen(false)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+            <div className="space-y-2.5">
+              {inputFields.map((field) => (
+                <label
+                  key={field.key}
+                  htmlFor={`workflow-input-${field.key}`}
+                  className="block"
+                >
+                  <span className="sr-only">{field.title}</span>
+                  {field.type === "boolean" ? (
+                    <span className="flex items-center justify-between rounded-lg bg-muted/35 px-3 py-2 text-sm">
+                      {field.title}
+                      <input
+                        id={`workflow-input-${field.key}`}
+                        type="checkbox"
+                        checked={Boolean(runInput[field.key])}
+                        onChange={(event) =>
+                          setRunInput((current) => ({
+                            ...current,
+                            [field.key]: event.target.checked,
+                          }))
+                        }
+                      />
+                    </span>
+                  ) : (
+                    <Input
+                      id={`workflow-input-${field.key}`}
+                      aria-label={field.title}
+                      required={field.required}
+                      type={field.type === "string" ? "text" : "number"}
+                      step={field.type === "integer" ? 1 : undefined}
+                      placeholder={field.title}
+                      value={String(runInput[field.key] ?? "")}
+                      onChange={(event) =>
+                        setRunInput((current) => ({
+                          ...current,
+                          [field.key]:
+                            field.type === "string"
+                              ? event.target.value
+                              : Number(event.target.value),
+                        }))
+                      }
+                    />
+                  )}
+                </label>
+              ))}
+            </div>
+            <Button type="submit" className="mt-4 w-full" disabled={running}>
+              {running ? (
+                <Spinner className="h-4 w-4" />
+              ) : (
+                <Play className="h-4 w-4" />
+              )}
+              <span className="sr-only">Run workflow</span>
+            </Button>
+          </form>
         </div>
       ) : null}
     </PagePanel>

--- a/packages/ui/src/components/pages/WorkflowTriggerPanel.test.tsx
+++ b/packages/ui/src/components/pages/WorkflowTriggerPanel.test.tsx
@@ -1,0 +1,120 @@
+/** Exercises native workflow trigger creation, deletion, and unavailable states with mocked elizaOS APIs. */
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { client } from "../../api";
+import { WorkflowTriggerPanel } from "./WorkflowTriggerPanel";
+
+vi.mock("../../api", () => ({
+  client: {
+    createTrigger: vi.fn(),
+    deleteTrigger: vi.fn(),
+    getTriggers: vi.fn(),
+  },
+}));
+
+const api = client as unknown as Record<string, ReturnType<typeof vi.fn>>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getTriggers.mockResolvedValue({ triggers: [] });
+  api.createTrigger.mockResolvedValue({ trigger: { id: "trigger-new" } });
+  api.deleteTrigger.mockResolvedValue({});
+});
+
+afterEach(cleanup);
+
+describe("WorkflowTriggerPanel", () => {
+  it("creates a cron trigger against the saved workflow", async () => {
+    const onNeedsSave = vi.fn().mockResolvedValue("workflow-1");
+    render(
+      <WorkflowTriggerPanel
+        workflowId="workflow-1"
+        workflowName="Digest"
+        onNeedsSave={onNeedsSave}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add workflow trigger" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cron" }));
+    fireEvent.change(screen.getByLabelText("Cron expression"), {
+      target: { value: "0 9 * * 1-5" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save trigger" }));
+
+    await waitFor(() => expect(onNeedsSave).toHaveBeenCalledTimes(1));
+    expect(api.createTrigger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "workflow",
+        workflowId: "workflow-1",
+        triggerType: "cron",
+        cronExpression: "0 9 * * 1-5",
+        enabled: true,
+      }),
+    );
+  });
+
+  it("deletes an existing trigger and refreshes the visual strip", async () => {
+    api.getTriggers
+      .mockResolvedValueOnce({
+        triggers: [
+          {
+            id: "trigger-1",
+            kind: "workflow",
+            workflowId: "workflow-1",
+            workflowName: "Digest",
+            displayName: "Cron: Digest",
+            instructions: "Run workflow Digest",
+            triggerType: "cron",
+            cronExpression: "0 9 * * 1-5",
+            enabled: true,
+            wakeMode: "inject_now",
+            createdBy: "workflow.studio",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ triggers: [] });
+    render(
+      <WorkflowTriggerPanel
+        workflowId="workflow-1"
+        workflowName="Digest"
+        onNeedsSave={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Delete Cron trigger" }),
+    );
+    await waitFor(() =>
+      expect(api.deleteTrigger).toHaveBeenCalledWith("trigger-1"),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Delete Cron trigger" }),
+      ).toBeNull(),
+    );
+  });
+
+  it("keeps manual runs visible when trigger loading is unavailable", async () => {
+    api.getTriggers.mockRejectedValue(new Error("Trigger service offline"));
+    render(
+      <WorkflowTriggerPanel
+        workflowId="workflow-1"
+        workflowName="Digest"
+        onNeedsSave={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTitle("Manual")).toBeTruthy();
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Trigger service offline",
+    );
+  });
+});

--- a/packages/ui/src/components/pages/WorkflowTriggerPanel.test.tsx
+++ b/packages/ui/src/components/pages/WorkflowTriggerPanel.test.tsx
@@ -16,6 +16,7 @@ vi.mock("../../api", () => ({
     createTrigger: vi.fn(),
     deleteTrigger: vi.fn(),
     getTriggers: vi.fn(),
+    listWorkflowDefinitions: vi.fn(),
   },
 }));
 
@@ -26,6 +27,19 @@ beforeEach(() => {
   api.getTriggers.mockResolvedValue({ triggers: [] });
   api.createTrigger.mockResolvedValue({ trigger: { id: "trigger-new" } });
   api.deleteTrigger.mockResolvedValue({});
+  api.listWorkflowDefinitions.mockResolvedValue([
+    {
+      id: "source-workflow",
+      name: "Research",
+      active: true,
+      versionId: "v1",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      source: "",
+      language: "tsx",
+      steps: [{ id: "collect", label: "Collect", kind: "task" }],
+    },
+  ]);
 });
 
 afterEach(cleanup);
@@ -99,6 +113,42 @@ describe("WorkflowTriggerPanel", () => {
       expect(
         screen.queryByRole("button", { name: "Delete Cron trigger" }),
       ).toBeNull(),
+    );
+  });
+
+  it("targets an exact Smithers step with a native filtered event", async () => {
+    render(
+      <WorkflowTriggerPanel
+        workflowId="workflow-1"
+        workflowName="Digest"
+        onNeedsSave={vi.fn().mockResolvedValue("workflow-1")}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add workflow trigger" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Event" }));
+    await waitFor(() =>
+      expect(api.listWorkflowDefinitions).toHaveBeenCalledTimes(1),
+    );
+    fireEvent.change(screen.getByLabelText("Event source"), {
+      target: { value: "step" },
+    });
+    await screen.findByRole("option", { name: "Collect" });
+    fireEvent.click(screen.getByRole("button", { name: "Save trigger" }));
+
+    await waitFor(() => expect(api.createTrigger).toHaveBeenCalledTimes(1));
+    expect(api.createTrigger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventKind: "workflow_run_event",
+        eventFilter: {
+          event: {
+            type: "NodeFinished",
+            workflowId: "source-workflow",
+            nodeId: "collect",
+          },
+        },
+      }),
     );
   });
 

--- a/packages/ui/src/components/pages/WorkflowTriggerPanel.tsx
+++ b/packages/ui/src/components/pages/WorkflowTriggerPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { client } from "../../api";
+import type { WorkflowDefinition } from "../../api/client-types-chat";
 import type {
   CreateTriggerRequest,
   TriggerSummary,
@@ -20,12 +21,17 @@ import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Spinner } from "../ui/spinner";
 
-const EVENT_OPTIONS = [
-  ["message.received", "Message"],
-  ["workflow.finished", "Workflow done"],
-  ["task.completed", "Task done"],
-  ["calendar.event.ended", "Calendar"],
-] as const;
+const WORKFLOW_RUN_EVENT = "workflow_run_event";
+type EventMode = "message" | "workflow" | "step";
+
+const EVENT_OPTIONS: ReadonlyArray<{
+  value: EventMode;
+  label: string;
+}> = [
+  { value: "message", label: "Message" },
+  { value: "workflow", label: "Workflow" },
+  { value: "step", label: "Step" },
+];
 
 const TYPE_META: Record<TriggerType, { label: string; icon: typeof Clock3 }> = {
   once: { label: "Once", icon: CalendarClock },
@@ -43,6 +49,7 @@ function triggerSummary(trigger: TriggerSummary): string {
     return minutes % 60 === 0 ? `${minutes / 60}h` : `${Math.round(minutes)}m`;
   }
   if (trigger.triggerType === "cron") return trigger.cronExpression ?? "—";
+  if (trigger.triggerType === "event") return trigger.displayName;
   return trigger.eventKind ?? "—";
 }
 
@@ -58,6 +65,10 @@ export function WorkflowTriggerPanel({
   const [triggers, setTriggers] = useState<TriggerSummary[]>([]);
   const [type, setType] = useState<TriggerType | null>(null);
   const [value, setValue] = useState("");
+  const [eventMode, setEventMode] = useState<EventMode>("message");
+  const [sources, setSources] = useState<WorkflowDefinition[]>([]);
+  const [sourceWorkflowId, setSourceWorkflowId] = useState("");
+  const [sourceStepId, setSourceStepId] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -79,6 +90,34 @@ export function WorkflowTriggerPanel({
       setError(cause instanceof Error ? cause.message : "Triggers unavailable");
     });
   }, [refresh]);
+
+  const loadEventSources = useCallback(async () => {
+    const definitions = (await client.listWorkflowDefinitions()).filter(
+      (definition) => definition.id !== workflowId,
+    );
+    setSources(definitions);
+    setSourceWorkflowId((current) =>
+      definitions.some((definition) => definition.id === current)
+        ? current
+        : (definitions[0]?.id ?? ""),
+    );
+  }, [workflowId]);
+
+  const sourceWorkflow = sources.find(
+    (definition) => definition.id === sourceWorkflowId,
+  );
+  const sourceStep = sourceWorkflow?.steps?.find(
+    (step) => step.id === sourceStepId,
+  );
+
+  useEffect(() => {
+    const steps = sourceWorkflow?.steps ?? [];
+    setSourceStepId((current) =>
+      steps.some((step) => step.id === current)
+        ? current
+        : (steps[0]?.id ?? ""),
+    );
+  }, [sourceWorkflow]);
 
   const create = useCallback(async () => {
     if (!type) return;
@@ -103,7 +142,25 @@ export function WorkflowTriggerPanel({
         request.scheduledAtIso = new Date(value).toISOString();
       if (type === "interval") request.intervalMs = Number(value) * 60_000;
       if (type === "cron") request.cronExpression = value;
-      if (type === "event") request.eventKind = value;
+      if (type === "event") {
+        if (eventMode === "message") {
+          request.eventKind = "MESSAGE_RECEIVED";
+          request.displayName = "Message";
+        } else {
+          request.eventKind = WORKFLOW_RUN_EVENT;
+          request.eventFilter = {
+            event: {
+              type: eventMode === "workflow" ? "RunFinished" : "NodeFinished",
+              workflowId: sourceWorkflowId,
+              ...(eventMode === "step" ? { nodeId: sourceStepId } : {}),
+            },
+          };
+          request.displayName =
+            eventMode === "workflow"
+              ? `After ${sourceWorkflow?.name ?? sourceWorkflowId}`
+              : `After ${sourceStep?.label ?? sourceStepId}`;
+        }
+      }
       await client.createTrigger(request);
       setType(null);
       setValue("");
@@ -116,7 +173,24 @@ export function WorkflowTriggerPanel({
     } finally {
       setBusy(false);
     }
-  }, [onNeedsSave, refresh, type, value, workflowName]);
+  }, [
+    eventMode,
+    onNeedsSave,
+    refresh,
+    sourceStepId,
+    sourceStep?.label,
+    sourceWorkflowId,
+    sourceWorkflow?.name,
+    type,
+    value,
+    workflowName,
+  ]);
+
+  const eventReady =
+    eventMode === "message" ||
+    (Boolean(sourceWorkflowId) &&
+      (eventMode === "workflow" || Boolean(sourceStepId)));
+  const canCreate = type === "event" ? eventReady : Boolean(value);
 
   return (
     <section
@@ -198,7 +272,18 @@ export function WorkflowTriggerPanel({
                 title={TYPE_META[option].label}
                 onClick={() => {
                   setType(option);
-                  setValue(option === "event" ? EVENT_OPTIONS[0][0] : "");
+                  setValue("");
+                  if (option === "event") {
+                    setEventMode("message");
+                    void loadEventSources().catch((cause) => {
+                      // error-policy:J4 source loading failures leave message events available.
+                      setError(
+                        cause instanceof Error
+                          ? cause.message
+                          : "Workflows unavailable",
+                      );
+                    });
+                  }
                 }}
               >
                 <Icon className="h-4 w-4" />
@@ -206,18 +291,56 @@ export function WorkflowTriggerPanel({
             );
           })}
           {type === "event" ? (
-            <select
-              aria-label="Event"
-              value={value}
-              onChange={(event) => setValue(event.target.value)}
-              className="h-8 min-w-40 flex-1 rounded-md border border-input bg-background px-2 text-xs"
-            >
-              {EVENT_OPTIONS.map(([eventKind, label]) => (
-                <option key={eventKind} value={eventKind}>
-                  {label}
-                </option>
-              ))}
-            </select>
+            <>
+              <select
+                aria-label="Event source"
+                value={eventMode}
+                onChange={(event) =>
+                  setEventMode(event.target.value as EventMode)
+                }
+                className="h-8 min-w-28 rounded-md border border-input bg-background px-2 text-xs"
+              >
+                {EVENT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              {eventMode !== "message" ? (
+                <select
+                  aria-label="Source workflow"
+                  value={sourceWorkflowId}
+                  onChange={(event) => setSourceWorkflowId(event.target.value)}
+                  className="h-8 min-w-32 flex-1 rounded-md border border-input bg-background px-2 text-xs"
+                >
+                  {sources.length === 0 ? (
+                    <option value="">No source</option>
+                  ) : null}
+                  {sources.map((definition) => (
+                    <option key={definition.id} value={definition.id}>
+                      {definition.name}
+                    </option>
+                  ))}
+                </select>
+              ) : null}
+              {eventMode === "step" ? (
+                <select
+                  aria-label="Source step"
+                  value={sourceStepId}
+                  onChange={(event) => setSourceStepId(event.target.value)}
+                  className="h-8 min-w-28 flex-1 rounded-md border border-input bg-background px-2 text-xs"
+                >
+                  {(sourceWorkflow?.steps ?? []).length === 0 ? (
+                    <option value="">No steps</option>
+                  ) : null}
+                  {(sourceWorkflow?.steps ?? []).map((step) => (
+                    <option key={step.id} value={step.id}>
+                      {step.label}
+                    </option>
+                  ))}
+                </select>
+              ) : null}
+            </>
           ) : (
             <Input
               type={
@@ -250,7 +373,7 @@ export function WorkflowTriggerPanel({
           <Button
             size="icon-sm"
             aria-label="Save trigger"
-            disabled={busy || !value}
+            disabled={busy || !canCreate}
             onClick={() => void create()}
           >
             {busy ? (

--- a/packages/ui/src/components/pages/WorkflowTriggerPanel.tsx
+++ b/packages/ui/src/components/pages/WorkflowTriggerPanel.tsx
@@ -1,0 +1,279 @@
+/** Presents native elizaOS workflow triggers as a compact visual start surface. */
+import {
+  Bell,
+  CalendarClock,
+  Clock3,
+  Plus,
+  Radio,
+  Repeat2,
+  Trash2,
+  X,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { client } from "../../api";
+import type {
+  CreateTriggerRequest,
+  TriggerSummary,
+  TriggerType,
+} from "../../api/client-types-core";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Spinner } from "../ui/spinner";
+
+const EVENT_OPTIONS = [
+  ["message.received", "Message"],
+  ["workflow.finished", "Workflow done"],
+  ["task.completed", "Task done"],
+  ["calendar.event.ended", "Calendar"],
+] as const;
+
+const TYPE_META: Record<TriggerType, { label: string; icon: typeof Clock3 }> = {
+  once: { label: "Once", icon: CalendarClock },
+  interval: { label: "Repeat", icon: Repeat2 },
+  cron: { label: "Cron", icon: Clock3 },
+  event: { label: "Event", icon: Radio },
+};
+
+function triggerSummary(trigger: TriggerSummary): string {
+  if (trigger.triggerType === "once" && trigger.scheduledAtIso) {
+    return new Date(trigger.scheduledAtIso).toLocaleString();
+  }
+  if (trigger.triggerType === "interval" && trigger.intervalMs) {
+    const minutes = trigger.intervalMs / 60_000;
+    return minutes % 60 === 0 ? `${minutes / 60}h` : `${Math.round(minutes)}m`;
+  }
+  if (trigger.triggerType === "cron") return trigger.cronExpression ?? "—";
+  return trigger.eventKind ?? "—";
+}
+
+export function WorkflowTriggerPanel({
+  workflowId,
+  workflowName,
+  onNeedsSave,
+}: {
+  workflowId: string;
+  workflowName: string;
+  onNeedsSave: () => Promise<string | null>;
+}) {
+  const [triggers, setTriggers] = useState<TriggerSummary[]>([]);
+  const [type, setType] = useState<TriggerType | null>(null);
+  const [value, setValue] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    const id = workflowId;
+    if (!id) return;
+    const result = await client.getTriggers();
+    setTriggers(
+      result.triggers.filter(
+        (trigger) => trigger.kind === "workflow" && trigger.workflowId === id,
+      ),
+    );
+  }, [workflowId]);
+
+  useEffect(() => {
+    void refresh().catch((cause) => {
+      // error-policy:J4 the trigger strip remains usable for manual runs while
+      // an unavailable trigger service is shown as an explicit error state.
+      setError(cause instanceof Error ? cause.message : "Triggers unavailable");
+    });
+  }, [refresh]);
+
+  const create = useCallback(async () => {
+    if (!type) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const id = await onNeedsSave();
+      if (!id) return;
+      const request: CreateTriggerRequest = {
+        kind: "workflow",
+        workflowId: id,
+        workflowName,
+        displayName: `${TYPE_META[type].label}: ${workflowName}`,
+        instructions: `Run workflow ${workflowName}`,
+        triggerType: type,
+        wakeMode: "inject_now",
+        enabled: true,
+        createdBy: "workflow.studio",
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      };
+      if (type === "once")
+        request.scheduledAtIso = new Date(value).toISOString();
+      if (type === "interval") request.intervalMs = Number(value) * 60_000;
+      if (type === "cron") request.cronExpression = value;
+      if (type === "event") request.eventKind = value;
+      await client.createTrigger(request);
+      setType(null);
+      setValue("");
+      await refresh();
+    } catch (cause) {
+      // error-policy:J4 create failures remain visible beside the attempted trigger.
+      setError(
+        cause instanceof Error ? cause.message : "Unable to add trigger",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, [onNeedsSave, refresh, type, value, workflowName]);
+
+  return (
+    <section
+      aria-label="Workflow triggers"
+      className="border-b border-border/50 bg-card/40 px-3 py-2"
+    >
+      <div className="flex min-w-0 items-center gap-2 overflow-x-auto">
+        <span
+          className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-primary/10 text-primary"
+          title="Start"
+        >
+          <Bell className="h-3.5 w-3.5" />
+          <span className="sr-only">Start</span>
+        </span>
+        <span
+          className="h-2 w-2 shrink-0 rounded-full bg-emerald-500"
+          title="Manual"
+        />
+        {triggers.map((trigger) => {
+          const meta = TYPE_META[trigger.triggerType];
+          const Icon = meta.icon;
+          return (
+            <span
+              key={trigger.id}
+              className="group flex shrink-0 items-center gap-1 rounded-full bg-muted/60 px-2 py-1 text-xs"
+              title={`${meta.label} · ${triggerSummary(trigger)}`}
+            >
+              <Icon className="h-3.5 w-3.5 text-primary" />
+              <span>{triggerSummary(trigger)}</span>
+              <button
+                type="button"
+                className="ml-0.5 text-muted-foreground opacity-40 hover:text-destructive group-hover:opacity-100"
+                aria-label={`Delete ${meta.label} trigger`}
+                onClick={() =>
+                  void client
+                    .deleteTrigger(trigger.id)
+                    .then(refresh)
+                    .catch((cause) => {
+                      // error-policy:J4 deletion failures preserve the trigger and surface the error.
+                      setError(
+                        cause instanceof Error
+                          ? cause.message
+                          : "Unable to delete trigger",
+                      );
+                    })
+                }
+              >
+                <Trash2 className="h-3 w-3" />
+              </button>
+            </span>
+          );
+        })}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="shrink-0 rounded-full"
+          aria-label="Add workflow trigger"
+          onClick={() => setType((current) => current ?? "once")}
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+
+      {type ? (
+        <div
+          className="mt-2 flex flex-wrap items-center gap-1.5"
+          data-testid="workflow-trigger-form"
+        >
+          {(Object.keys(TYPE_META) as TriggerType[]).map((option) => {
+            const Icon = TYPE_META[option].icon;
+            return (
+              <button
+                key={option}
+                type="button"
+                className={`grid h-8 w-8 place-items-center rounded-md ${type === option ? "bg-primary/10 text-primary" : "text-muted-foreground hover:bg-muted"}`}
+                aria-label={TYPE_META[option].label}
+                aria-pressed={type === option}
+                title={TYPE_META[option].label}
+                onClick={() => {
+                  setType(option);
+                  setValue(option === "event" ? EVENT_OPTIONS[0][0] : "");
+                }}
+              >
+                <Icon className="h-4 w-4" />
+              </button>
+            );
+          })}
+          {type === "event" ? (
+            <select
+              aria-label="Event"
+              value={value}
+              onChange={(event) => setValue(event.target.value)}
+              className="h-8 min-w-40 flex-1 rounded-md border border-input bg-background px-2 text-xs"
+            >
+              {EVENT_OPTIONS.map(([eventKind, label]) => (
+                <option key={eventKind} value={eventKind}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <Input
+              type={
+                type === "once"
+                  ? "datetime-local"
+                  : type === "interval"
+                    ? "number"
+                    : "text"
+              }
+              min={type === "interval" ? 1 : undefined}
+              value={value}
+              onChange={(event) => setValue(event.target.value)}
+              placeholder={
+                type === "interval"
+                  ? "Minutes"
+                  : type === "cron"
+                    ? "0 9 * * 1-5"
+                    : undefined
+              }
+              aria-label={
+                type === "interval"
+                  ? "Interval minutes"
+                  : type === "cron"
+                    ? "Cron expression"
+                    : "Start time"
+              }
+              className="h-8 min-w-40 flex-1 text-xs"
+            />
+          )}
+          <Button
+            size="icon-sm"
+            aria-label="Save trigger"
+            disabled={busy || !value}
+            onClick={() => void create()}
+          >
+            {busy ? (
+              <Spinner className="h-3.5 w-3.5" />
+            ) : (
+              <Plus className="h-3.5 w-3.5" />
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Cancel trigger"
+            onClick={() => setType(null)}
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ) : null}
+      {error ? (
+        <p role="alert" className="mt-1 text-xs text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/packages/ui/src/testing/builtin-view-action-ratchet.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.ts
@@ -258,9 +258,10 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
       "packages/ui/src/components/pages/TaskEditor.tsx",
       "packages/ui/src/components/pages/ScheduledTaskEditor.tsx",
       "packages/ui/src/components/pages/WorkflowEditor.tsx",
+      "packages/ui/src/components/pages/WorkflowTriggerPanel.tsx",
     ],
     semanticActions: ["SCHEDULED_TASKS", "TRIGGER"],
-    maxMutationSites: 71,
+    maxMutationSites: 65,
     notes:
       "Automations feed plus its task/workflow editors all write ScheduledTask records through the one scheduler; SCHEDULED_TASKS is the umbrella twin and TRIGGER pairs the trigger steps inside workflow editing.",
   },

--- a/plugins/plugin-workflow/__tests__/unit/embedded-workflow-lifecycle.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/embedded-workflow-lifecycle.test.ts
@@ -6,7 +6,11 @@ import type { IAgentRuntime, Task, UUID } from '@elizaos/core';
 import { drizzle } from 'drizzle-orm/pglite';
 import * as schema from '../../src/db/schema';
 import { EmbeddedWorkflowService } from '../../src/services/embedded-workflow-service';
-import type { WorkflowDefinition } from '../../src/types/index';
+import type {
+  WorkflowDefinition,
+  WorkflowDefinitionResponse,
+  WorkflowExecution,
+} from '../../src/types/index';
 
 const clients: PGlite[] = [];
 
@@ -55,6 +59,19 @@ async function harness() {
       PRIMARY KEY (agent_id, id),
       UNIQUE (agent_id, workflow_id, version_id)
     );
+    CREATE TABLE workflow.embedded_executions (
+      agent_id text NOT NULL,
+      id text NOT NULL,
+      workflow_id text NOT NULL,
+      status text NOT NULL,
+      mode text NOT NULL,
+      finished boolean NOT NULL DEFAULT false,
+      started_at text NOT NULL,
+      stopped_at text,
+      execution jsonb NOT NULL,
+      idempotency_key text,
+      PRIMARY KEY (agent_id, id)
+    );
   `);
   const tasks: Task[] = [];
   const runtime = {
@@ -73,7 +90,12 @@ async function harness() {
       if (index >= 0) tasks.splice(index, 1);
     },
   } as unknown as IAgentRuntime;
-  return { service: await EmbeddedWorkflowService.start(runtime), tasks };
+  return {
+    service: await EmbeddedWorkflowService.start(runtime),
+    tasks,
+    client,
+    runtime,
+  };
 }
 
 afterEach(async () => {
@@ -111,5 +133,59 @@ describe('embedded native workflow lifecycle', () => {
     expect((await service.listWorkflows()).data).toHaveLength(0);
     expect(tasks).toHaveLength(0);
     expect((await service.listWorkflowRevisions('review')).data[0].operation).toBe('delete');
+  });
+
+  test('resumes an unfinished persisted run with its exact workflow version', async () => {
+    const { service, client, runtime } = await harness();
+    const workflow = await service.createWorkflow({
+      ...definition('Recovery'),
+      id: 'recovery',
+      schedule: undefined,
+    });
+    const execution: WorkflowExecution = {
+      id: 'persisted-run',
+      workflowId: workflow.id,
+      workflowVersionId: workflow.versionId,
+      workflowName: workflow.name,
+      mode: 'manual',
+      status: 'running',
+      finished: false,
+      startedAt: '2026-08-13T00:00:00.000Z',
+      input: { topic: 'resume' },
+      events: [],
+    };
+    await client.query(
+      `INSERT INTO workflow.embedded_executions
+       (agent_id, id, workflow_id, status, mode, finished, started_at, execution)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)`,
+      [
+        runtime.agentId,
+        execution.id,
+        execution.workflowId,
+        execution.status,
+        execution.mode,
+        execution.finished,
+        execution.startedAt,
+        JSON.stringify(execution),
+      ]
+    );
+
+    const resumedVersions: string[] = [];
+    const restarted = new EmbeddedWorkflowService(runtime);
+    const internals = restarted as unknown as {
+      runInBackground: (
+        workflow: WorkflowDefinitionResponse,
+        pending: WorkflowExecution
+      ) => Promise<WorkflowExecution>;
+      resumeInterruptedExecutions: () => Promise<void>;
+    };
+    internals.runInBackground = async (definition, pending) => {
+      resumedVersions.push(definition.versionId);
+      return { ...pending, status: 'finished', finished: true };
+    };
+    await internals.resumeInterruptedExecutions();
+    await Bun.sleep(0);
+
+    expect(resumedVersions).toEqual([workflow.versionId]);
   });
 });

--- a/plugins/plugin-workflow/__tests__/unit/workflow-owner-isolation.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-owner-isolation.test.ts
@@ -1,0 +1,169 @@
+/** Proves the workflow facade enforces owner isolation before every embedded Smithers operation. */
+
+import { describe, expect, test } from 'bun:test';
+import type { IAgentRuntime, UUID } from '@elizaos/core';
+import {
+  EMBEDDED_WORKFLOW_SERVICE_TYPE,
+  type ExecuteWorkflowOptions,
+} from '../../src/services/embedded-workflow-service';
+import { WorkflowService } from '../../src/services/workflow-service';
+import type {
+  WorkflowDefinition,
+  WorkflowDefinitionResponse,
+  WorkflowExecution,
+} from '../../src/types/index';
+import { WorkflowApiError } from '../../src/types/index';
+
+function definition(name: string): WorkflowDefinition {
+  return {
+    name,
+    language: 'tsx',
+    source: `import { createSmithers } from 'smthrs/create';
+const api = createSmithers({}, { dbPath: process.env.ELIZA_SMTHRS_DB_PATH });
+export default api.smithers(() => api.Workflow({ name: '${name}' }));`,
+  };
+}
+
+function harness() {
+  const workflows = new Map<string, WorkflowDefinitionResponse>();
+  const executions = new Map<string, WorkflowExecution>();
+  let sequence = 0;
+  const embedded = {
+    async createWorkflow(workflow: WorkflowDefinition) {
+      sequence += 1;
+      const id = workflow.id ?? `workflow-${sequence}`;
+      const stored = {
+        ...workflow,
+        id,
+        createdAt: '2026-08-13T00:00:00.000Z',
+        updatedAt: '2026-08-13T00:00:00.000Z',
+        versionId: `version-${sequence}`,
+      } satisfies WorkflowDefinitionResponse;
+      workflows.set(id, stored);
+      return stored;
+    },
+    async updateWorkflow(id: string, workflow: WorkflowDefinition) {
+      const current = await this.getWorkflow(id);
+      const stored = {
+        ...workflow,
+        id,
+        createdAt: current.createdAt,
+        updatedAt: '2026-08-13T00:01:00.000Z',
+        versionId: `version-${++sequence}`,
+      } satisfies WorkflowDefinitionResponse;
+      workflows.set(id, stored);
+      return stored;
+    },
+    async listWorkflows() {
+      return { data: [...workflows.values()] };
+    },
+    async getWorkflow(id: string) {
+      const workflow = workflows.get(id);
+      if (!workflow) throw new WorkflowApiError(`Workflow not found: ${id}`, 404);
+      return workflow;
+    },
+    async deleteWorkflow(id: string) {
+      workflows.delete(id);
+    },
+    async activateWorkflow(id: string) {
+      return this.updateWorkflow(id, { ...(await this.getWorkflow(id)), active: true });
+    },
+    async deactivateWorkflow(id: string) {
+      return this.updateWorkflow(id, { ...(await this.getWorkflow(id)), active: false });
+    },
+    async startWorkflow(id: string, options: ExecuteWorkflowOptions = {}) {
+      const workflow = await this.getWorkflow(id);
+      const execution: WorkflowExecution = {
+        id: `execution-${++sequence}`,
+        workflowId: id,
+        workflowVersionId: workflow.versionId,
+        workflowName: workflow.name,
+        mode: options.mode ?? 'manual',
+        status: 'queued',
+        finished: false,
+        startedAt: '2026-08-13T00:02:00.000Z',
+        input: options.input ?? {},
+      };
+      executions.set(execution.id, execution);
+      return execution;
+    },
+    async executeWorkflow(id: string, options: ExecuteWorkflowOptions = {}) {
+      return this.startWorkflow(id, options);
+    },
+    async listExecutions(params: { workflowId?: string; limit?: number } = {}) {
+      const data = [...executions.values()].filter(
+        (execution) => !params.workflowId || execution.workflowId === params.workflowId
+      );
+      return { data: params.limit ? data.slice(0, params.limit) : data };
+    },
+    async getExecution(id: string) {
+      const execution = executions.get(id);
+      if (!execution) throw new WorkflowApiError(`Workflow execution not found: ${id}`, 404);
+      return execution;
+    },
+    async cancelExecution(id: string) {
+      return this.getExecution(id);
+    },
+    async listWorkflowRevisions() {
+      return { data: [] };
+    },
+    async restoreWorkflowRevision(id: string) {
+      return this.getWorkflow(id);
+    },
+  };
+  const runtime = {
+    agentId: '00000000-0000-4000-8000-000000000001' as UUID,
+    character: { name: 'Owner isolation test' },
+    getService: (type: string) => (type === EMBEDDED_WORKFLOW_SERVICE_TYPE ? embedded : null),
+  } as unknown as IAgentRuntime;
+  return { service: new WorkflowService(runtime), embedded, workflows };
+}
+
+async function expectNotFound(operation: () => Promise<unknown>): Promise<void> {
+  try {
+    await operation();
+    throw new Error('Expected owner isolation to reject the operation');
+  } catch (error) {
+    expect(error).toBeInstanceOf(WorkflowApiError);
+    expect((error as WorkflowApiError).statusCode).toBe(404);
+  }
+}
+
+describe('workflow owner isolation', () => {
+  test('scopes CRUD, execution, and revision access to the creating principal', async () => {
+    const { service } = harness();
+    const created = await service.deployWorkflow(definition('Private'), 'owner-a');
+
+    const visible = await service.listWorkflows('owner-a');
+    expect(visible).toHaveLength(1);
+    expect(visible[0]?.metadata).not.toHaveProperty('elizaOwnerEntityId');
+    expect(await service.listWorkflows('owner-b')).toHaveLength(0);
+    await expectNotFound(() => service.getWorkflow(created.id, 'owner-b'));
+    await expectNotFound(() =>
+      service.updateWorkflow(created.id, definition('Hijacked'), 'owner-b')
+    );
+    await expectNotFound(() => service.activateWorkflow(created.id, 'owner-b'));
+    await expectNotFound(() => service.deleteWorkflow(created.id, 'owner-b'));
+    await expectNotFound(() => service.startWorkflow(created.id, {}, 'owner-b'));
+    await expectNotFound(() => service.getWorkflowRevisions(created.id, 20, 'owner-b'));
+
+    const execution = await service.startWorkflow(created.id, { input: { ok: true } }, 'owner-a');
+    await expectNotFound(() => service.getExecutionDetail(execution.id, 'owner-b'));
+    await expectNotFound(() => service.cancelExecution(execution.id, 'owner-b'));
+    expect((await service.listExecutions({}, 'owner-b')).data).toHaveLength(0);
+    expect((await service.listExecutions({}, 'owner-a')).data).toHaveLength(1);
+  });
+
+  test('does not let a caller replace persisted ownership metadata', async () => {
+    const { service } = harness();
+    const created = await service.deployWorkflow(definition('Owned'), 'owner-a');
+    await service.updateWorkflow(
+      created.id,
+      { ...definition('Still owned'), metadata: { elizaOwnerEntityId: 'owner-b' } },
+      'owner-a'
+    );
+
+    expect((await service.getWorkflow(created.id, 'owner-a')).name).toBe('Still owned');
+    await expectNotFound(() => service.getWorkflow(created.id, 'owner-b'));
+  });
+});

--- a/plugins/plugin-workflow/__tests__/unit/workflow-schema-registration.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-schema-registration.test.ts
@@ -1,0 +1,9 @@
+/** Verifies every persisted workflow table is exposed to the runtime migrator. */
+import { describe, expect, it } from 'vitest';
+import { workflowPlugin } from '../../src/index';
+
+describe('workflow schema registration', () => {
+  it('registers the revision table used by workflow history', () => {
+    expect(workflowPlugin.schema).toHaveProperty('workflowRevisions');
+  });
+});

--- a/plugins/plugin-workflow/src/actions/workflow.ts
+++ b/plugins/plugin-workflow/src/actions/workflow.ts
@@ -244,10 +244,14 @@ export const workflowAction: Action = {
       }
       if (op === 'run') {
         const workflow = await service.getWorkflow(workflowId as string, ownerId);
-        const execution = await service.startWorkflow(workflowId as string, {
-          mode: 'chat',
-          input: record(params.input),
-        });
+        const execution = await service.startWorkflow(
+          workflowId as string,
+          {
+            mode: 'chat',
+            input: record(params.input),
+          },
+          ownerId
+        );
         const marker = JSON.stringify({
           id: execution.id,
           workflowId,

--- a/plugins/plugin-workflow/src/db/index.ts
+++ b/plugins/plugin-workflow/src/db/index.ts
@@ -5,5 +5,6 @@ export {
   embeddedExecutions,
   embeddedTags,
   embeddedWorkflows,
+  workflowRevisions,
   workflowSchema,
 } from './schema';

--- a/plugins/plugin-workflow/src/lib/automations-types.ts
+++ b/plugins/plugin-workflow/src/lib/automations-types.ts
@@ -79,6 +79,7 @@ export interface TriggerSummary {
   scheduledAtIso?: string;
   cronExpression?: string;
   eventKind?: string;
+  eventFilter?: Record<string, unknown>;
   maxRuns?: number;
   runCount: number;
   nextRunAtMs?: number;
@@ -106,6 +107,7 @@ interface TriggerConfigShape {
   scheduledAtIso?: string;
   cronExpression?: string;
   eventKind?: string;
+  eventFilter?: Record<string, unknown>;
   maxRuns?: number;
   runCount?: number;
   nextRunAtMs?: number;
@@ -214,6 +216,7 @@ export function taskToTriggerSummary(task: Task): TriggerSummary | null {
       ...(trigger.scheduledAtIso !== undefined ? { scheduledAtIso: trigger.scheduledAtIso } : {}),
       ...(trigger.cronExpression !== undefined ? { cronExpression: trigger.cronExpression } : {}),
       ...(trigger.eventKind !== undefined ? { eventKind: trigger.eventKind } : {}),
+      ...(trigger.eventFilter !== undefined ? { eventFilter: trigger.eventFilter } : {}),
       ...(trigger.maxRuns !== undefined ? { maxRuns: trigger.maxRuns } : {}),
       runCount: typeof trigger.runCount === 'number' ? trigger.runCount : 0,
       ...(trigger.nextRunAtMs !== undefined ? { nextRunAtMs: trigger.nextRunAtMs } : {}),

--- a/plugins/plugin-workflow/src/routes/workflow-routes.ts
+++ b/plugins/plugin-workflow/src/routes/workflow-routes.ts
@@ -103,9 +103,13 @@ function idMatch(path: string): { id: string; suffix: string } | null {
   return match ? { id: decodeURIComponent(match[1]), suffix: match[2] || '' } : null;
 }
 
-async function streamEvents(ctx: WorkflowRouteContext, runId: string): Promise<void> {
+async function streamEvents(
+  ctx: WorkflowRouteContext,
+  runId: string,
+  ownerEntityId: string
+): Promise<void> {
   const service = embeddedFor(ctx);
-  const execution = await service.getExecution(runId);
+  const execution = await serviceFor(ctx).getExecutionDetail(runId, ownerEntityId);
   ctx.res.statusCode = 200;
   ctx.res.setHeader('content-type', 'text/event-stream; charset=utf-8');
   ctx.res.setHeader('cache-control', 'no-cache, no-transform');
@@ -166,7 +170,7 @@ export async function handleWorkflowRoutes(ctx: WorkflowRouteContext): Promise<v
     if (executionMatch) {
       const runId = decodeURIComponent(executionMatch[1]);
       const operation = executionMatch[2];
-      if (ctx.method === 'GET' && operation === 'events') return streamEvents(ctx, runId);
+      if (ctx.method === 'GET' && operation === 'events') return streamEvents(ctx, runId, owner);
       if (ctx.method === 'POST' && operation === 'cancel') {
         ctx.json(ctx.res, { execution: await service.cancelExecution(runId, owner) }, 202);
         return;
@@ -244,10 +248,14 @@ export async function handleWorkflowRoutes(ctx: WorkflowRouteContext): Promise<v
     }
     if (ctx.method === 'POST' && match.suffix === '/run') {
       const body = await readBody(ctx.req);
-      const execution = await service.startWorkflow(match.id, {
-        mode: 'manual',
-        input: isRecord(body.input) ? body.input : body,
-      });
+      const execution = await service.startWorkflow(
+        match.id,
+        {
+          mode: 'manual',
+          input: isRecord(body.input) ? body.input : body,
+        },
+        owner
+      );
       ctx.json(ctx.res, { execution }, 202);
       return;
     }

--- a/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
+++ b/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
@@ -118,6 +118,7 @@ export class EmbeddedWorkflowService extends Service {
 
   static async start(runtime: IAgentRuntime): Promise<EmbeddedWorkflowService> {
     const service = new EmbeddedWorkflowService(runtime);
+    await service.resumeInterruptedExecutions();
     logger.info({ src: 'plugin:workflow:embedded' }, 'Native Smithers workflow service ready');
     return service;
   }
@@ -163,6 +164,98 @@ export class EmbeddedWorkflowService extends Service {
       updatedAt: row.updatedAt,
       versionId: row.versionId,
     };
+  }
+
+  private async workflowVersionForExecution(
+    execution: WorkflowExecution
+  ): Promise<WorkflowDefinitionResponse> {
+    const currentRows = await this.getDb()
+      .select()
+      .from(embeddedWorkflows)
+      .where(
+        and(
+          eq(embeddedWorkflows.agentId, this.tenantId),
+          eq(embeddedWorkflows.id, execution.workflowId),
+          eq(embeddedWorkflows.versionId, execution.workflowVersionId)
+        )
+      )
+      .limit(1);
+    const current = currentRows[0];
+    if (current) {
+      return responseFromStored({
+        workflow: current.workflow,
+        createdAt: current.createdAt,
+        updatedAt: current.updatedAt,
+        versionId: current.versionId,
+      });
+    }
+    const revisionRows = await this.getDb()
+      .select()
+      .from(workflowRevisions)
+      .where(
+        and(
+          eq(workflowRevisions.agentId, this.tenantId),
+          eq(workflowRevisions.workflowId, execution.workflowId),
+          eq(workflowRevisions.versionId, execution.workflowVersionId)
+        )
+      )
+      .limit(1);
+    const revision = revisionRows[0];
+    if (!revision) {
+      throw new WorkflowApiError(
+        `Workflow version not found: ${execution.workflowId}/${execution.workflowVersionId}`,
+        404
+      );
+    }
+    return responseFromStored({
+      workflow: revision.workflow,
+      createdAt: revision.createdAt,
+      updatedAt: revision.updatedAt,
+      versionId: revision.versionId,
+    });
+  }
+
+  private async resumeExecution(execution: WorkflowExecution): Promise<void> {
+    if (execution.finished || this.running.has(execution.id)) return;
+    const workflow = await this.workflowVersionForExecution(execution);
+    const controller = new AbortController();
+    this.controllers.set(execution.id, controller);
+    const executionPromise = this.runInBackground(workflow, execution, controller).finally(() => {
+      this.controllers.delete(execution.id);
+      this.running.delete(execution.id);
+    });
+    this.running.set(execution.id, executionPromise);
+  }
+
+  private async resumeInterruptedExecutions(): Promise<void> {
+    const interrupted = (await this.listExecutions()).data.filter(
+      (execution) => !execution.finished
+    );
+    for (const execution of interrupted) {
+      try {
+        await this.resumeExecution(execution);
+      } catch (error) {
+        // error-policy:J4 an unrecoverable persisted run becomes an explicit
+        // failed execution instead of remaining in a healthy-looking wait state.
+        const failed: WorkflowExecution = {
+          ...execution,
+          status: 'failed',
+          finished: true,
+          stoppedAt: nowIso(),
+          error: { message: error instanceof Error ? error.message : String(error) },
+        };
+        await this.saveExecution(failed);
+        logger.error(
+          {
+            src: 'plugin:workflow:embedded',
+            runId: execution.id,
+            workflowId: execution.workflowId,
+            error: failed.error?.message,
+          },
+          'Unable to resume persisted Smithers workflow run'
+        );
+      }
+    }
   }
 
   private async captureRevision(
@@ -544,6 +637,7 @@ export class EmbeddedWorkflowService extends Service {
       },
     ];
     await this.saveExecution(execution);
+    await this.resumeExecution(execution);
     return execution;
   }
 
@@ -562,6 +656,7 @@ export class EmbeddedWorkflowService extends Service {
       payload,
       ...(receivedBy ? { receivedBy } : {}),
     });
+    await this.resumeExecution(execution);
     return execution;
   }
 

--- a/plugins/plugin-workflow/src/services/workflow-service.ts
+++ b/plugins/plugin-workflow/src/services/workflow-service.ts
@@ -14,6 +14,7 @@ import type {
   WorkflowRevision,
 } from '../types/index';
 import { WorkflowApiError } from '../types/index';
+import { getLocalOwnerEntityId } from '../utils/context';
 import {
   EMBEDDED_WORKFLOW_SERVICE_TYPE,
   type EmbeddedWorkflowService,
@@ -33,6 +34,8 @@ export interface WorkflowGenerationOptions {
   triggerContext?: TriggerContext;
   existingWorkflow?: WorkflowDefinitionResponse;
 }
+
+const OWNER_METADATA_KEY = 'elizaOwnerEntityId';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -133,6 +136,51 @@ export class WorkflowService extends Service {
     return service;
   }
 
+  private ownerOf(workflow: WorkflowDefinition): string | null {
+    const value = workflow.metadata?.[OWNER_METADATA_KEY];
+    return typeof value === 'string' && value.trim() ? value.trim() : null;
+  }
+
+  private isOwnedBy(workflow: WorkflowDefinition, ownerEntityId: string): boolean {
+    const owner = this.ownerOf(workflow);
+    if (owner) return owner === ownerEntityId;
+    return ownerEntityId === getLocalOwnerEntityId(this.runtime);
+  }
+
+  private publicWorkflow(workflow: WorkflowDefinitionResponse): WorkflowDefinitionResponse {
+    if (!workflow.metadata || !(OWNER_METADATA_KEY in workflow.metadata)) return workflow;
+    const { [OWNER_METADATA_KEY]: _owner, ...metadata } = workflow.metadata;
+    return {
+      ...workflow,
+      metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+    };
+  }
+
+  private requireOwned(
+    workflow: WorkflowDefinitionResponse,
+    ownerEntityId?: string
+  ): WorkflowDefinitionResponse {
+    if (!ownerEntityId || this.isOwnedBy(workflow, ownerEntityId)) {
+      return this.publicWorkflow(workflow);
+    }
+    throw new WorkflowApiError(`Workflow not found: ${workflow.id}`, 404);
+  }
+
+  private ownedDefinition(workflow: WorkflowDefinition, ownerEntityId: string): WorkflowDefinition {
+    return {
+      ...workflow,
+      metadata: { ...(workflow.metadata ?? {}), [OWNER_METADATA_KEY]: ownerEntityId },
+    };
+  }
+
+  private async requireExecutionOwner(
+    execution: WorkflowExecution,
+    ownerEntityId?: string
+  ): Promise<WorkflowExecution> {
+    if (ownerEntityId) await this.getWorkflow(execution.workflowId, ownerEntityId);
+    return execution;
+  }
+
   async generateWorkflowDraft(
     instruction: string,
     options: { userId: string; triggerContext?: TriggerContext }
@@ -161,15 +209,20 @@ export class WorkflowService extends Service {
 
   async deployWorkflow(
     workflow: WorkflowDefinition,
-    _ownerEntityId: string,
+    ownerEntityId: string,
     options: { activate?: boolean } = {}
   ): Promise<WorkflowCreationResult> {
-    const deployed = workflow.id
-      ? await this.embedded().updateWorkflow(workflow.id, workflow)
-      : await this.embedded().createWorkflow({
-          ...workflow,
-          active: options.activate ?? workflow.active ?? false,
-        });
+    const owned = this.ownedDefinition(workflow, ownerEntityId);
+    let deployed: WorkflowDefinitionResponse;
+    if (workflow.id) {
+      await this.getWorkflow(workflow.id, ownerEntityId);
+      deployed = await this.embedded().updateWorkflow(workflow.id, owned);
+    } else {
+      deployed = await this.embedded().createWorkflow({
+        ...owned,
+        active: options.activate ?? workflow.active ?? false,
+      });
+    }
     if (options.activate === true && !deployed.active)
       await this.embedded().activateWorkflow(deployed.id);
     if (options.activate === false && deployed.active)
@@ -182,8 +235,12 @@ export class WorkflowService extends Service {
     };
   }
 
-  async listWorkflows(_ownerEntityId?: string): Promise<WorkflowDefinitionResponse[]> {
-    return (await this.embedded().listWorkflows()).data;
+  async listWorkflows(ownerEntityId?: string): Promise<WorkflowDefinitionResponse[]> {
+    const workflows = (await this.embedded().listWorkflows()).data;
+    const owned = ownerEntityId
+      ? workflows.filter((workflow) => this.isOwnedBy(workflow, ownerEntityId))
+      : workflows;
+    return owned.map((workflow) => this.publicWorkflow(workflow));
   }
 
   async searchWorkflows(
@@ -206,67 +263,90 @@ export class WorkflowService extends Service {
       .map(({ workflow }) => workflow);
   }
 
-  async getWorkflow(id: string, _ownerEntityId?: string): Promise<WorkflowDefinitionResponse> {
-    return this.embedded().getWorkflow(id);
+  async getWorkflow(id: string, ownerEntityId?: string): Promise<WorkflowDefinitionResponse> {
+    return this.requireOwned(await this.embedded().getWorkflow(id), ownerEntityId);
   }
 
   async updateWorkflow(
     id: string,
     workflow: WorkflowDefinition,
-    _ownerEntityId?: string
+    ownerEntityId?: string
   ): Promise<WorkflowDefinitionResponse> {
-    return this.embedded().updateWorkflow(id, workflow);
+    const current = await this.embedded().getWorkflow(id);
+    this.requireOwned(current, ownerEntityId);
+    const owner = ownerEntityId ?? this.ownerOf(current);
+    return this.publicWorkflow(
+      await this.embedded().updateWorkflow(
+        id,
+        owner ? this.ownedDefinition(workflow, owner) : workflow
+      )
+    );
   }
 
-  async deleteWorkflow(id: string, _ownerEntityId?: string): Promise<void> {
+  async deleteWorkflow(id: string, ownerEntityId?: string): Promise<void> {
+    await this.getWorkflow(id, ownerEntityId);
     return this.embedded().deleteWorkflow(id);
   }
 
-  async activateWorkflow(id: string, _ownerEntityId?: string): Promise<WorkflowDefinitionResponse> {
-    return this.embedded().activateWorkflow(id);
+  async activateWorkflow(id: string, ownerEntityId?: string): Promise<WorkflowDefinitionResponse> {
+    await this.getWorkflow(id, ownerEntityId);
+    return this.publicWorkflow(await this.embedded().activateWorkflow(id));
   }
 
   async deactivateWorkflow(
     id: string,
-    _ownerEntityId?: string
+    ownerEntityId?: string
   ): Promise<WorkflowDefinitionResponse> {
-    return this.embedded().deactivateWorkflow(id);
+    await this.getWorkflow(id, ownerEntityId);
+    return this.publicWorkflow(await this.embedded().deactivateWorkflow(id));
   }
 
   async startWorkflow(
     id: string,
-    options: ExecuteWorkflowOptions = {}
+    options: ExecuteWorkflowOptions = {},
+    ownerEntityId?: string
   ): Promise<WorkflowExecution> {
+    await this.getWorkflow(id, ownerEntityId);
     return this.embedded().startWorkflow(id, options);
   }
 
   async executeWorkflow(
     id: string,
-    options: ExecuteWorkflowOptions = {}
+    options: ExecuteWorkflowOptions = {},
+    ownerEntityId?: string
   ): Promise<WorkflowExecution> {
+    await this.getWorkflow(id, ownerEntityId);
     return this.embedded().executeWorkflow(id, options);
   }
 
   async getWorkflowExecutions(
     id: string,
     limit = 20,
-    _ownerEntityId?: string
+    ownerEntityId?: string
   ): Promise<WorkflowExecution[]> {
+    await this.getWorkflow(id, ownerEntityId);
     return (await this.embedded().listExecutions({ workflowId: id, limit })).data;
   }
 
   async listExecutions(
     params: { workflowId?: string; limit?: number } = {},
-    _ownerEntityId?: string
+    ownerEntityId?: string
   ): Promise<{ data: WorkflowExecution[] }> {
-    return this.embedded().listExecutions(params);
+    if (params.workflowId) await this.getWorkflow(params.workflowId, ownerEntityId);
+    const result = await this.embedded().listExecutions(params);
+    if (!ownerEntityId || params.workflowId) return result;
+    const workflowIds = new Set(
+      (await this.listWorkflows(ownerEntityId)).map((workflow) => workflow.id)
+    );
+    return { data: result.data.filter((execution) => workflowIds.has(execution.workflowId)) };
   }
 
-  async getExecutionDetail(id: string, _ownerEntityId?: string): Promise<WorkflowExecution> {
-    return this.embedded().getExecution(id);
+  async getExecutionDetail(id: string, ownerEntityId?: string): Promise<WorkflowExecution> {
+    return this.requireExecutionOwner(await this.embedded().getExecution(id), ownerEntityId);
   }
 
-  async cancelExecution(id: string, _ownerEntityId?: string): Promise<WorkflowExecution> {
+  async cancelExecution(id: string, ownerEntityId?: string): Promise<WorkflowExecution> {
+    await this.getExecutionDetail(id, ownerEntityId);
     return this.embedded().cancelExecution(id);
   }
 
@@ -277,6 +357,7 @@ export class WorkflowService extends Service {
     approved: boolean,
     options: { note?: string; decidedBy?: string; decision?: unknown } = {}
   ): Promise<WorkflowExecution> {
+    if (options.decidedBy) await this.getExecutionDetail(runId, options.decidedBy);
     return this.embedded().decideApproval(runId, nodeId, iteration, approved, options);
   }
 
@@ -286,23 +367,26 @@ export class WorkflowService extends Service {
     payload: unknown,
     receivedBy?: string
   ): Promise<WorkflowExecution> {
+    if (receivedBy) await this.getExecutionDetail(runId, receivedBy);
     return this.embedded().signalExecution(runId, signal, payload, receivedBy);
   }
 
   async getWorkflowRevisions(
     id: string,
     limit = 20,
-    _ownerEntityId?: string
+    ownerEntityId?: string
   ): Promise<WorkflowRevision[]> {
+    await this.getWorkflow(id, ownerEntityId);
     return (await this.embedded().listWorkflowRevisions(id, limit)).data;
   }
 
   async restoreWorkflowRevision(
     id: string,
     versionId: string,
-    _ownerEntityId?: string
+    ownerEntityId?: string
   ): Promise<WorkflowDefinitionResponse> {
-    return this.embedded().restoreWorkflowRevision(id, versionId);
+    await this.getWorkflow(id, ownerEntityId);
+    return this.publicWorkflow(await this.embedded().restoreWorkflowRevision(id, versionId));
   }
 
   async getWorkflowEvaluationSuite(

--- a/plugins/plugin-workflow/src/trigger-routes.ts
+++ b/plugins/plugin-workflow/src/trigger-routes.ts
@@ -54,6 +54,7 @@ export interface TriggerSummary {
   scheduledAtIso?: string;
   cronExpression?: string;
   eventKind?: string;
+  eventFilter?: Record<string, unknown>;
   maxRuns?: number;
   runCount: number;
   nextRunAtMs?: number;
@@ -89,6 +90,7 @@ export interface NormalizedTriggerDraft {
   scheduledAtIso?: string;
   cronExpression?: string;
   eventKind?: string;
+  eventFilter?: Record<string, unknown>;
   maxRuns?: number;
   kind: TriggerKind;
   // Present only for `kind === "workflow"`.
@@ -126,6 +128,7 @@ interface TriggerDraftInput {
   scheduledAtIso?: string;
   cronExpression?: string;
   eventKind?: string;
+  eventFilter?: Record<string, unknown>;
   maxRuns?: number;
   kind?: TriggerKind;
   workflowId?: string;
@@ -195,6 +198,10 @@ function parseNonEmptyString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function parseEventPayload(value: unknown): Record<string, unknown> {
@@ -299,6 +306,10 @@ export async function handleTriggerRoutes(ctx: TriggerRouteContext): Promise<boo
       error(res, "instructions is required when kind is 'prompt'", 400);
       return true;
     }
+    if (body.eventFilter != null && !isRecord(body.eventFilter)) {
+      error(res, 'eventFilter must be a JSON object', 400);
+      return true;
+    }
 
     const inputDraft: TriggerDraftInput = {
       displayName: typeof body.displayName === 'string' ? body.displayName : undefined,
@@ -313,6 +324,7 @@ export async function handleTriggerRoutes(ctx: TriggerRouteContext): Promise<boo
       scheduledAtIso: typeof body.scheduledAtIso === 'string' ? body.scheduledAtIso : undefined,
       cronExpression: typeof body.cronExpression === 'string' ? body.cronExpression : undefined,
       eventKind: typeof body.eventKind === 'string' ? body.eventKind : undefined,
+      eventFilter: isRecord(body.eventFilter) ? body.eventFilter : undefined,
       maxRuns: typeof body.maxRuns === 'number' ? body.maxRuns : undefined,
       kind: requestedKind,
       workflowId,
@@ -530,6 +542,10 @@ export async function handleTriggerRoutes(ctx: TriggerRouteContext): Promise<boo
 
     const body = await readJsonBody<Record<string, unknown>>(req, res);
     if (!body) return true;
+    if (body.eventFilter != null && !isRecord(body.eventFilter)) {
+      error(res, 'eventFilter must be a JSON object', 400);
+      return true;
+    }
 
     const kindParsed = parseTriggerKindStrict(body.kind);
     if (kindParsed !== undefined && kindParsed.ok === false) {
@@ -580,6 +596,11 @@ export async function handleTriggerRoutes(ctx: TriggerRouteContext): Promise<boo
       cronExpression:
         typeof body.cronExpression === 'string' ? body.cronExpression : current.cronExpression,
       eventKind: typeof body.eventKind === 'string' ? body.eventKind : current.eventKind,
+      eventFilter: Object.hasOwn(body, 'eventFilter')
+        ? isRecord(body.eventFilter)
+          ? body.eventFilter
+          : undefined
+        : current.eventFilter,
       maxRuns: typeof body.maxRuns === 'number' ? body.maxRuns : current.maxRuns,
       kind: nextKind,
       workflowId: nextWorkflowId,


### PR DESCRIPTION
# Relates to

- Relates to #16580.
- Follows the native `smthrs` foundation merged in #19000.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Summary

- Replaces the text-heavy workflow surface with a sparse, visual Smithers studio.
- Uses native `smthrs` execution through the elizaOS backend; no Smithers gateway, n8n compatibility layer, or legacy orchestrator runtime.
- Adds visual build/source/runs/widgets/history modes, revisions, activation, approvals, typed inputs, execution events, and Smithers widgets.
- Adds native once, interval, cron, message, workflow-complete, and exact-step triggers.
- Enforces owner isolation across definitions, revisions, executions, approvals, signals, Cloud routes, and chat actions.
- Resumes interrupted persisted runs with the exact workflow version after restart.
- Fixes fresh-database provisioning of `workflow.workflow_revisions`.

# Reviewer journey

Open Automations, create a workflow, edit Smithers source, save twice and inspect History, activate it, attach a Message/Workflow/Step trigger, run it, inspect the event timeline, close it, reload the library, and reopen it.

# Validation

- `bun install` after rebase onto current `origin/develop`.
- `RUN_TURBO_CONCURRENCY=4 bun run verify` — 350/350 tasks passed; all repository audits passed.
- Workflow E2E — 6/6 passed on Chromium, WebKit, desktop landscape, phone portrait/landscape, and iPad.
- Trigger runtime/normalization Vitest — 26/26 passed.
- Workflow persistence/ownership/schema tests — 5/5 passed.
- Full app visual audit — 219/219 passed; broken=0, needs-work=0, minimalism/hover/density failures=0.
- Packaged OCR — 216 views, broken=0.
- Manual in-app browser walkthrough against a newly created PGlite database: create → source edit → save → revision → activate → Message trigger → execute → `RunFinished` → close → reload → reopen. The run persisted and the backend migrated 19 workflow schema statements, including revisions.
- macOS Computer Use was attempted but the host session remained locked; the signed-in in-app Browser was used for the hands-on walkthrough instead.

# Evidence Gate

<!-- evidence-head:fe1f65ca692198eff10c9ac1695dfe56c81e3e8c -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19000-workflow-before-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19052-workflow-after-desktop.png https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19052-workflow-after-mobile.png https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19052-automations-after-desktop.png https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19052-automations-after-mobile.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19052-workflow-walkthrough-19052.mp4
<!-- evidence-row:backend-logs -->
- [x] [19052-workflow-backend-v2.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19052-workflow-backend-v2.log)
<!-- evidence-row:frontend-logs -->
- [x] [19052-workflow-frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19052-workflow-frontend.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-provider or prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] ![domain-artifacts](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19052-workflow-execution-artifact-19052.png)
<!-- evidence-row:ocr-review -->
- [x] [19052-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19052-ocr-triage.json)

# Risk

Medium. This changes creation, editing, scheduling, execution recovery, ownership, and responsive workflow UI. Typed route tests, persistence tests, cross-browser E2E, a real fresh-database walkthrough, and the strict visual audit cover those boundaries.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-workflows]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no repository contribution skill used","attribution_status":"self-reported","lane":"codex-workflows"} -->



