### PR TITLE
fix(cloud): route canonical agent origin through nginx

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -175,6 +175,12 @@ jobs:
       # Keep the daemon's parser on the same environment-specific suffix or a
       # staging host (`<uuid>.cloud-staging.eliza.app`) is rejected as malformed.
       ELIZA_CLOUD_AGENT_BASE_DOMAIN: ${{ needs.determine-env.outputs.environment == 'production' && 'cloud.eliza.app' || 'cloud-staging.eliza.app' }}
+      # Public hostname the edge Worker uses to reach this agent-router. The
+      # host's nginx config predates the eliza.app consolidation and must accept
+      # both this canonical name and the legacy elizacloud.ai name during the
+      # compatibility window.
+      AGENT_ROUTER_PUBLIC_HOST: ${{ needs.determine-env.outputs.environment == 'production' && 'eliza-production-1.eliza.app' || 'eliza-staging-1.eliza.app' }}
+      LEGACY_AGENT_ROUTER_PUBLIC_HOST: ${{ needs.determine-env.outputs.environment == 'production' && 'eliza-production-1.elizacloud.ai' || 'eliza-staging-1.elizacloud.ai' }}
     steps:
       - name: Validate canonical deploy configuration and shared secrets
         id: deploy_config
@@ -290,7 +296,7 @@ jobs:
           # Preserve setup/build headroom without weakening the preflight's own
           # eight-minute fail-closed fence near the end of this remote script.
           command_timeout: 20m
-          envs: DEPLOY_BRANCH,DEPLOY_SHA,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,CONTAINERS_SSH_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE,ELIZA_CLOUD_AGENT_BASE_DOMAIN
+          envs: DEPLOY_BRANCH,DEPLOY_SHA,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,CONTAINERS_SSH_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST,LEGACY_AGENT_ROUTER_PUBLIC_HOST
           script: |
             set -euo pipefail
             echo "=== Deploying eliza-provisioning-worker (branch: $DEPLOY_BRANCH sha: $DEPLOY_SHA) ==="
@@ -539,6 +545,35 @@ jobs:
             sudo systemctl restart "$SYSTEMD_UNIT"
             sudo systemctl restart eliza-agent-router.service
             echo "=== Restart issued for both daemons ==="
+
+            # The canonical edge origin must terminate in the same nginx vhost
+            # as the legacy control-plane hostname. Without this alias, nginx
+            # serves its default blank web shell with HTTP 200; lifecycle calls
+            # then parse HTML as a snapshot and safe restarts wedge. Amend the
+            # existing, operator-reviewed router vhost rather than creating a
+            # second listener or certificate configuration.
+            mapfile -t router_vhosts < <(
+              sudo grep -RIl \
+                "server_name.*${LEGACY_AGENT_ROUTER_PUBLIC_HOST}" \
+                /etc/nginx 2>/dev/null || true
+            )
+            if [ "${#router_vhosts[@]}" -eq 0 ]; then
+              echo "::error::No nginx vhost owns legacy agent-router host ${LEGACY_AGENT_ROUTER_PUBLIC_HOST}"
+              exit 1
+            fi
+            for vhost in "${router_vhosts[@]}"; do
+              if sudo grep -Eq "server_name[^;]*${AGENT_ROUTER_PUBLIC_HOST}([[:space:]]|;)" "$vhost"; then
+                continue
+              fi
+              sudo sed -Ei \
+                "/server_name[^;]*${LEGACY_AGENT_ROUTER_PUBLIC_HOST}/ s/[[:space:]]*;/ ${AGENT_ROUTER_PUBLIC_HOST};/" \
+                "$vhost"
+            done
+            sudo nginx -t
+            sudo systemctl reload nginx
+            curl -fsS "https://${AGENT_ROUTER_PUBLIC_HOST}/healthz" \
+              | grep -Eq '"ok"[[:space:]]*:[[:space:]]*true'
+            echo "Verified canonical agent-router nginx host alias: ${AGENT_ROUTER_PUBLIC_HOST}"
 
       - name: Health check
         if: steps.deploy_config.outputs.configured == 'true'


### PR DESCRIPTION
# Relates to

Follow-up required to complete #19047.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the failure and deployment assertion from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@32c5b76026e`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Medium, deployment-only. The workflow edits the existing nginx vhost that already owns the reviewed legacy agent-router hostname, validates nginx before reload, and requires the public canonical `/healthz` response to contain `{"ok":true}`. It fails closed if the legacy vhost cannot be found.

# Background

## What does this PR do?

It makes every provisioning-host deploy reconcile `eliza-production-1.eliza.app` (or staging equivalent) into the existing agent-router nginx `server_name` list, validates the nginx configuration, reloads it, and probes the canonical public health route.

Root cause: the canonical DNS name reached the correct production machine but nginx selected its default web vhost. Dedicated-agent bridge calls therefore received a 123-byte blank HTML shell instead of the router API. Snapshot generation then timed out at the caller and fail-closed restarts could not proceed.

## What kind of change is this?

Bug fix and deployment hardening.

# Documentation changes needed?

No user-facing documentation change. The workflow comments document the compatibility invariant and failure mode.

# Testing

## Where should a reviewer start?

Review the new canonical/legacy host variables and the reconciliation block in `.github/workflows/deploy-eliza-provisioning-worker.yml`.

## Detailed testing steps

- `actionlint .github/workflows/deploy-eliza-provisioning-worker.yml`
- `bun install --frozen-lockfile`
- `bun run --cwd packages/homepage typecheck` (generates the required ignored release-data input)
- `bun run verify`
- Production before-fix probes:
  - `https://eliza-production-1.eliza.app/healthz` returned HTTP 200 `text/html`, 123 bytes.
  - direct legacy origin routing returned `{"ok":true}`.
  - the UUID agent `/api/snapshot` returned the same 123-byte HTML shell through the canonical origin path.

# Evidence Gate

<!-- evidence-head:69c38bdd7bacb737a239b16fa6d2f13cf5eda688 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - deployment workflow only; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - deployment workflow only; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deployment workflow only; no rendered UI changes.
<!-- evidence-row:backend-logs -->
- [x] The production probes above capture the real pre-fix routing failure; the workflow requires a real canonical health response after deployment.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] The production HTTP status/content-type/body-size probes above are the applicable routing artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

Before the fix, the canonical public control-plane health request returned a blank HTML document instead of the agent-router JSON health contract. The post-deploy workflow now fails unless the same public URL contains `"ok":true`.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio or voice change.

## Known gaps / failures

The first `bun run verify` invocation found the ignored homepage release-data file absent after a fresh worktree install. Running the owning homepage typecheck generated it; the full verify then passed, and passed again after the required rebase.

## Deployment instructions

Merge to `develop`, promote to `main`, then run the production `Deploy Eliza Provisioning Worker` workflow. Confirm the workflow's canonical `/healthz` assertion and retry the state-preserving agent restart.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-production-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no repository contribution skill used","attribution_status":"self-reported","lane":"codex-production-repair"} -->
