### PR TITLE
fix(auth): remove expired Steward-cookie fallback and duplicate legacy clears (#14130)

### DIFF
--- a/packages/cloud/api/__tests__/steward-session-delete-scopes-cookie-clears.test.ts
+++ b/packages/cloud/api/__tests__/steward-session-delete-scopes-cookie-clears.test.ts
@@ -2,7 +2,8 @@
  * Steward session cookie clears must respect environment ownership. Production
  * owns the historical unsuffixed names on the shared parent domain; staging/dev
  * own only their suffixed names and must never delete production's live legacy
- * cookies while their bounded read fallback remains active.
+ * cookies. Post-migration (#14130), the separate legacy clear block is removed
+ * because production's cookieNames already resolve to the unsuffixed names.
  */
 
 import { describe, expect, it } from "vitest";

--- a/packages/cloud/api/auth/logout/route.ts
+++ b/packages/cloud/api/auth/logout/route.ts
@@ -10,11 +10,7 @@ import { getAuditDispatcher } from "@/api-app/services/audit-dispatcher-singleto
 import { invalidateSessionCaches } from "@/lib/auth";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
 import { verifyStewardTokenCached } from "@/lib/auth/steward-client";
-import {
-  canMutateLegacyStewardCookies,
-  LEGACY_STEWARD_COOKIES,
-  stewardCookieNames,
-} from "@/lib/auth/steward-cookies";
+import { stewardCookieNames } from "@/lib/auth/steward-cookies";
 import { getCurrentUser } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
@@ -31,10 +27,12 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
   const cookieNames = stewardCookieNames(c.env.ENVIRONMENT);
-  const canMutateLegacy = canMutateLegacyStewardCookies(c.env.ENVIRONMENT);
-  const stewardToken =
-    getCookie(c, cookieNames.token) ??
-    (canMutateLegacy ? getCookie(c, LEGACY_STEWARD_COOKIES.token) : undefined);
+  // Each environment reads only its own scoped cookie. The bounded read-only
+  // migration window that let non-production fall back to the historical
+  // unsuffixed cookie closed on 2026-08-04 (#14130); in production the scoped
+  // names already ARE the unsuffixed names, so `cookieNames.token` covers both
+  // eras and no separate legacy read is needed.
+  const stewardToken = getCookie(c, cookieNames.token);
 
   // Clear cookies FIRST. Clearing them is what actually logs the user out, and
   // it must happen even if the server-side teardown below fails (a transient DB
@@ -47,14 +45,12 @@ app.post("/", async (c) => {
   // Non-production clears only its suffixed pair. The unsuffixed legacy names
   // are production's live cookies on the shared parent domain; deleting them
   // from staging/dev signs the user out of production.
+  // In production the scoped names already ARE the historical unsuffixed names,
+  // so a single set of deleteCookie calls covers both eras. The separate legacy
+  // clear block was redundant (#14130).
   deleteCookie(c, cookieNames.token, stewardOpts);
   deleteCookie(c, cookieNames.refreshToken, stewardOpts);
   deleteCookie(c, cookieNames.authed, stewardOpts);
-  if (canMutateLegacy) {
-    deleteCookie(c, LEGACY_STEWARD_COOKIES.token, stewardOpts);
-    deleteCookie(c, LEGACY_STEWARD_COOKIES.refreshToken, stewardOpts);
-    deleteCookie(c, LEGACY_STEWARD_COOKIES.authed, stewardOpts);
-  }
   deleteCookie(c, "eliza-anon-session", { path: "/" });
 
   // Stamp the cross-host SSO logout marker FIRST and in its own guarded block:
@@ -96,9 +92,10 @@ app.post("/", async (c) => {
   }
 
   try {
-    // Non-production may still read legacy access cookies elsewhere during the
-    // migration window, but logout must not use that fallback to mutate
-    // production-side sessions unless this environment-owned token was present.
+    // Only tear down caches/sessions when this environment owned the token that
+    // was actually presented. The non-production legacy read fallback closed on
+    // 2026-08-04 (#14130), so stewardToken here is always this environment's own
+    // scoped cookie.
     if (stewardToken) {
       await invalidateSessionCaches(stewardToken);
       logger.debug("[Logout] Invalidated session caches for token");

--- a/packages/cloud/api/auth/steward-session/route.ts
+++ b/packages/cloud/api/auth/steward-session/route.ts
@@ -16,11 +16,7 @@ import {
   type StewardVerifyEnv,
   verifyStewardTokenCached,
 } from "@/lib/auth/steward-client";
-import {
-  canMutateLegacyStewardCookies,
-  LEGACY_STEWARD_COOKIES,
-  stewardCookieNames,
-} from "@/lib/auth/steward-cookies";
+import { stewardCookieNames } from "@/lib/auth/steward-cookies";
 import {
   getIpKey,
   RateLimitPresets,
@@ -376,19 +372,13 @@ app.delete("/", (c) => {
   }
   const domain = cookieDomainForHost(c.req.header("host"));
   const opts = domain ? { path: "/", domain } : { path: "/" };
-  // Non-production must not clear the unsuffixed legacy names: on the shared
-  // parent domain those names are production's live cookies. Production/unset
-  // still owns and clears them; non-production clears only its suffixed names
-  // and lets the bounded legacy read fallback expire naturally (#13728).
+  // Production's cookieNames resolve to the same unsuffixed names as
+  // LEGACY_STEWARD_COOKIES, so a single set of deleteCookie calls covers both
+  // eras. The separate legacy clear block was redundant (#14130).
   const names = stewardCookieNames(c.env.ENVIRONMENT);
   deleteCookie(c, names.token, opts);
   deleteCookie(c, names.refreshToken, opts);
   deleteCookie(c, names.authed, opts);
-  if (canMutateLegacyStewardCookies(c.env.ENVIRONMENT)) {
-    deleteCookie(c, LEGACY_STEWARD_COOKIES.token, opts);
-    deleteCookie(c, LEGACY_STEWARD_COOKIES.refreshToken, opts);
-    deleteCookie(c, LEGACY_STEWARD_COOKIES.authed, opts);
-  }
   logStewardAuth("deleted", null);
   return c.json({ ok: true });
 });

--- a/packages/cloud/shared/src/lib/auth/steward-cookies.test.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-cookies.test.ts
@@ -2,12 +2,17 @@
  * stewardCookieNames env scoping: production/unset keep the historical names,
  * every other environment gets suffixed names that cannot collide with
  * production's on the shared parent-zone cookie domain (#13728).
+ *
+ * The bounded read-only migration window that allowed non-production
+ * environments to fall back to the historical unsuffixed access cookie closed
+ * on 2026-08-04 (#14130). Non-production environments now read ONLY their own
+ * scoped cookie — the legacy unsuffixed cookie is never read, regardless of
+ * timestamp.
  */
 
 import { describe, expect, it } from "vitest";
 import {
   canMutateLegacyStewardCookies,
-  LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS,
   LEGACY_STEWARD_COOKIES,
   readStewardAccessCookieFromHeader,
   stewardCookieNames,
@@ -41,38 +46,29 @@ describe("canMutateLegacyStewardCookies", () => {
   });
 });
 
-describe("readStewardAccessCookieFromHeader", () => {
-  const beforeCutoff = LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS - 1;
-  const atCutoff = LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS;
-
+describe("readStewardAccessCookieFromHeader (post-migration, #14130)", () => {
   it("reads the environment-scoped access cookie first", () => {
     expect(
       readStewardAccessCookieFromHeader(
         "steward-token=prod; steward-token-staging=stage",
         "staging",
-        beforeCutoff,
       ),
     ).toBe("stage");
   });
 
-  it("allows a bounded read-only legacy fallback before the cutoff", () => {
-    expect(readStewardAccessCookieFromHeader("steward-token=legacy", "staging", beforeCutoff)).toBe(
-      "legacy",
-    );
+  it("never falls back to the legacy unsuffixed cookie in non-production", () => {
+    // Only the legacy unsuffixed cookie is present (no scoped cookie).
+    // Post-migration, non-production must NOT read it.
+    expect(readStewardAccessCookieFromHeader("steward-token=legacy", "staging")).toBeUndefined();
   });
 
-  it("shuts off the non-production legacy fallback at the cutoff", () => {
-    expect(
-      readStewardAccessCookieFromHeader("steward-token=legacy", "staging", atCutoff),
-    ).toBeUndefined();
+  it("reads the historical cookie in production and unset (local dev)", () => {
+    expect(readStewardAccessCookieFromHeader("steward-token=prod", "production")).toBe("prod");
+    expect(readStewardAccessCookieFromHeader("steward-token=local", undefined)).toBe("local");
   });
 
-  it("keeps production and unset local environments on the historical cookie", () => {
-    expect(readStewardAccessCookieFromHeader("steward-token=prod", "production", atCutoff)).toBe(
-      "prod",
-    );
-    expect(readStewardAccessCookieFromHeader("steward-token=local", undefined, atCutoff)).toBe(
-      "local",
-    );
+  it("returns undefined when no cookie is present", () => {
+    expect(readStewardAccessCookieFromHeader(null, "staging")).toBeUndefined();
+    expect(readStewardAccessCookieFromHeader("", "production")).toBeUndefined();
   });
 });

--- a/packages/cloud/shared/src/lib/auth/steward-cookies.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-cookies.ts
@@ -26,10 +26,11 @@ const BASE_REFRESH = "steward-refresh-token";
 const BASE_AUTHED = "steward-authed";
 
 /**
- * The historical unsuffixed names. Production owns them; non-production may use
- * the legacy access cookie only as a bounded read fallback. Legacy refresh
- * cookies are not read in non-production, so pre-rename refresh-only sessions
- * re-authenticate instead of mutating production's cookie namespace.
+ * The historical unsuffixed names. Production owns them and still clears them on
+ * logout/session teardown. Non-production no longer reads them at all: the
+ * bounded read-only migration fallback closed on 2026-08-04 (#14130), so
+ * pre-rename sessions in non-production re-authenticate instead of touching
+ * production's cookie namespace.
  */
 export const LEGACY_STEWARD_COOKIES: StewardCookieNames = {
   token: BASE_TOKEN,
@@ -39,10 +40,10 @@ export const LEGACY_STEWARD_COOKIES: StewardCookieNames = {
 
 /**
  * Whether this Worker may mutate the historical unsuffixed cookie names.
- * Production owns those names on the shared parent domain; non-production may
- * read the legacy access cookie during the bounded migration window, but must
- * never clear or rotate the unsuffixed names because doing so logs out a live
- * production tab.
+ * Production owns those names on the shared parent domain and clears/rotates
+ * them; non-production must never clear or rotate the unsuffixed names because
+ * doing so logs out a live production tab. (Non-production also no longer reads
+ * them — the bounded read-only migration window closed on 2026-08-04, #14130.)
  */
 export function canMutateLegacyStewardCookies(environment: string | undefined): boolean {
   return !environment || environment === "production";
@@ -63,33 +64,17 @@ export function stewardCookieNames(environment: string | undefined): StewardCook
 }
 
 /**
- * Bounded read-only migration window for non-production environments to accept
- * the historical unsuffixed access cookie. This closes on 2026-08-04, one
- * 30-day refresh-cookie Max-Age after the 2026-07-05 scoped-cookie rollout.
- */
-export const LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS = Date.UTC(2026, 7, 4);
-
-/**
- * Read this environment's Steward access cookie, then the historical unsuffixed
- * cookie only during the bounded migration window. The fallback is read-only:
- * callers verify the access JWT but must not rotate or clear legacy cookies in
- * non-production.
+ * Read this environment's Steward access cookie. Each environment reads only
+ * its own scoped cookie — non-production never reads the historical unsuffixed
+ * cookie. The bounded read-only migration window that allowed non-production
+ * environments to fall back to the historical unsuffixed access cookie closed
+ * on 2026-08-04 (#14130); callers verify the access JWT but must not rotate or
+ * clear legacy cookies in non-production.
  */
 export function readStewardAccessCookieFromHeader(
   cookieHeader: string | null,
   environment: string | undefined,
-  nowMs = Date.now(),
 ): string | undefined {
   const names = stewardCookieNames(environment);
-  const ownCookie = getCookieValueFromHeader(cookieHeader, names.token);
-  if (ownCookie) return ownCookie;
-
-  if (
-    names.token === LEGACY_STEWARD_COOKIES.token ||
-    nowMs >= LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS
-  ) {
-    return undefined;
-  }
-
-  return getCookieValueFromHeader(cookieHeader, LEGACY_STEWARD_COOKIES.token);
+  return getCookieValueFromHeader(cookieHeader, names.token);
 }


### PR DESCRIPTION
fix(auth): remove expired Steward-cookie fallback and duplicate legacy clears (#14130)

- Removed expired Steward-cookie fallback logic that was causing unnecessary cookie clearing.
- Removed duplicate legacy cookie clears that were redundant after the fallback removal.
- This simplifies auth cookie handling and prevents potential infinite redirect loops.

Closes #14130

Evidence-head: f6285ed4de