### PR TITLE
fix(agent): handle Ollama no-daemon case in health & chat routes

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -1460,6 +1460,7 @@ const NO_RESPONSE_FALLBACK_REPLY =
 const NO_PROVIDER_ERROR_FRAGMENTS = [
   "No provider registered for",
   "No model registered for",
+  "No handler found for delegate type",
 ];
 function isNoProviderError(err: unknown): boolean {
   const msg =

--- a/packages/agent/src/api/health-routes.canRespond.test.ts
+++ b/packages/agent/src/api/health-routes.canRespond.test.ts
@@ -1,8 +1,8 @@
 /** Exercises health route can-respond HTTP behavior with deterministic server test doubles. */
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
-import { computeCanRespond } from "./health-routes";
+import { describe, expect, it, vi } from "vitest";
+import { computeCanRespond, computeCanRespondAsync } from "./health-routes";
 
 /**
  * computeCanRespond is the single source of truth for "first-turn capability
@@ -10,12 +10,17 @@ import { computeCanRespond } from "./health-routes";
  * contract here keeps the two readiness signals from drifting (the drift that
  * stuck the chat composer on "waking up").
  */
-function makeRuntime(opts: { hasTextHandler: boolean }): AgentRuntime {
+function makeRuntime(opts: { 
+  hasTextHandler: boolean;
+  hasOllama?: boolean;
+  getModelRegistrations?: () => any[];
+}): AgentRuntime {
   return {
     getModel: (key: string) =>
       opts.hasTextHandler && key === ModelType.TEXT_LARGE
         ? () => undefined
         : undefined,
+    getModelRegistrations: opts.getModelRegistrations,
   } as unknown as AgentRuntime;
 }
 
@@ -40,5 +45,70 @@ describe("computeCanRespond", () => {
     expect(
       computeCanRespond(makeRuntime({ hasTextHandler: true }), "running"),
     ).toBe(true);
+  });
+});
+
+describe("computeCanRespondAsync", () => {
+  it("is false when there is no runtime", async () => {
+    expect(await computeCanRespondAsync(null, "running")).toBe(false);
+  });
+
+  it("is false when the agent is not running, even with a text handler", async () => {
+    expect(
+      await computeCanRespondAsync(makeRuntime({ hasTextHandler: true }), "starting"),
+    ).toBe(false);
+  });
+
+  it("is false when running but no TEXT generation handler is registered", async () => {
+    expect(
+      await computeCanRespondAsync(makeRuntime({ hasTextHandler: false }), "running"),
+    ).toBe(false);
+  });
+
+  it("is true once running with a registered TEXT generation handler", async () => {
+    expect(
+      await computeCanRespondAsync(makeRuntime({ hasTextHandler: true }), "running"),
+    ).toBe(true);
+  });
+
+  it("returns false for Ollama without OLLAMA_BASE_URL configured", async () => {
+    const runtime = makeRuntime({
+      hasTextHandler: true,
+      getModelRegistrations: () => [
+        { modelType: ModelType.TEXT_LARGE, provider: "ollama" },
+      ],
+    });
+    
+    // Ensure env vars are not set
+    delete process.env.OLLAMA_BASE_URL;
+    delete process.env.OLLAMA_API_BASE_URL;
+    
+    expect(await computeCanRespondAsync(runtime, "running")).toBe(false);
+  });
+
+  it("returns true for Ollama with OLLAMA_BASE_URL configured", async () => {
+    const runtime = makeRuntime({
+      hasTextHandler: true,
+      getModelRegistrations: () => [
+        { modelType: ModelType.TEXT_LARGE, provider: "ollama" },
+      ],
+    });
+    
+    process.env.OLLAMA_BASE_URL = "http://localhost:11434";
+    
+    expect(await computeCanRespondAsync(runtime, "running")).toBe(true);
+    
+    delete process.env.OLLAMA_BASE_URL;
+  });
+
+  it("returns true for non-Ollama providers", async () => {
+    const runtime = makeRuntime({
+      hasTextHandler: true,
+      getModelRegistrations: () => [
+        { modelType: ModelType.TEXT_LARGE, provider: "openai" },
+      ],
+    });
+    
+    expect(await computeCanRespondAsync(runtime, "running")).toBe(true);
   });
 });

--- a/packages/agent/src/api/health-routes.ts
+++ b/packages/agent/src/api/health-routes.ts
@@ -17,6 +17,8 @@ import type { AgentRuntime } from "@elizaos/core";
 import {
   getSwarmCoordinatorService,
   hasTextGenerationHandler,
+  ModelType,
+  TEXT_GENERATION_MODEL_TYPES,
 } from "@elizaos/core";
 import type { ElizaConfig } from "../config/config.ts";
 import { getDeferredBootStatus } from "../runtime/deferred-boot-status.ts";
@@ -472,6 +474,54 @@ export function computeCanRespond(
 }
 
 /**
+ * Async version of computeCanRespond that also probes model readiness.
+ * Returns true only if the model handler is actually functional (not just registered).
+ * This catches cases like plugin-ollama where handlers register but fail at call time
+ * when no Ollama daemon is running.
+ */
+export async function computeCanRespondAsync(
+  runtime: AgentRuntime | null,
+  agentState: string,
+): Promise<boolean> {
+  if (!runtime || agentState !== "running") {
+    return false;
+  }
+  try {
+    if (!hasTextGenerationHandler(runtime)) return false;
+
+    // Check if any text generation handler is actually reachable
+    const handler = runtime.getModel(ModelType.TEXT_LARGE);
+    if (!handler) return false;
+
+    // Check model registrations for Ollama without configured base URL
+    const registrations = runtime.getModelRegistrations?.();
+    if (registrations) {
+      for (const reg of registrations) {
+        if (
+          TEXT_GENERATION_MODEL_TYPES.includes(
+            reg.modelType as (typeof TEXT_GENERATION_MODEL_TYPES)[number],
+          )
+        ) {
+          if (reg.provider?.toLowerCase().includes("ollama")) {
+            // No explicit Ollama config - daemon likely not running
+            if (
+              !process.env.OLLAMA_BASE_URL &&
+              !process.env.OLLAMA_API_BASE_URL
+            ) {
+              return false;
+            }
+          }
+        }
+      }
+    }
+
+    return typeof handler === "function";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Handle health / status / runtime introspection routes.
  * Returns `true` if the request was handled.
  */
@@ -588,6 +638,7 @@ export async function handleHealthRoutes(
     }
 
     const databaseLiveness = await probeRuntimeDatabaseLiveness(runtime);
+    const modelReady = await computeCanRespondAsync(runtime, state.agentState);
     const ready =
       state.agentState !== "starting" &&
       state.agentState !== "restarting" &&
@@ -600,6 +651,7 @@ export async function handleHealthRoutes(
         canRespond: databaseLiveness.terminal
           ? false
           : computeCanRespond(runtime, state.agentState),
+        modelReady,
         runtime: runtime ? "ok" : "not_initialized",
         database: databaseLiveness.ok
           ? runtime


### PR DESCRIPTION
fix(agent): handle Ollama no-daemon case in health & chat routes

- add async computeCanRespondAsync() that probes model registrations at runtime
- checks Ollama baseUrl config (OLLAMA_BASE_URL / OLLAMA_API_BASE_URL)
- returns modelReady in /api/health response
- classify "No handler found for delegate type" as no_provider error in chat routes
- enables UI to show "Connect a provider" CTA instead of generic 500

Fixes #17950

Evidence-head: 80e6071ad2