### PR TITLE
chore: promote provisioning runner fix to main

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -56,7 +56,7 @@ permissions:
 jobs:
   determine-env:
     name: Determine environment
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, Linux, X64]
     outputs:
       environment: ${{ steps.env.outputs.environment }}
       branch: ${{ steps.env.outputs.branch }}
@@ -113,7 +113,7 @@ jobs:
 
   deploy:
     name: Deploy worker to Hetzner host (${{ needs.determine-env.outputs.environment }} @ ${{ needs.determine-env.outputs.deployment_sha }})
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, Linux, X64]
     needs: determine-env
     environment: ${{ needs.determine-env.outputs.environment }}
     # The three bounded remote phases (5m prerequisites, 20m deploy, 5m health)


### PR DESCRIPTION
## Summary
Promotes the exact current `develop` commit `7ef78dce4c8` to `main` so the protected production provisioning deployment can use the repository runner pool while GitHub-hosted capacity is stalled.

## Included
- #19057

## Validation
- actionlint passed on the workflow
- self-hosted dispatch environment-resolution job succeeded on `eliza-robot-12` and resolved the exact main deployment SHA
- production environment protection correctly rejected the test dispatch branch, proving protected production remains main-only

Refs #19047

---
Created by Codex for @ShawWalters