### PR TITLE
fix(google-workspace): fail-closed OAuth callback validation and readiness ordering

### DIFF
--- a/packages/agent/src/api/cloud-pair-route.ts
+++ b/packages/agent/src/api/cloud-pair-route.ts
@@ -12,6 +12,8 @@ import {
   renderCloudPairHandoffHtml,
   resolveCloudPairAgentIdFromEnv,
 } from "@elizaos/shared/contracts";
+import { isLoopbackBindHost } from "@elizaos/shared/runtime-env";
+import { resolveRequestOrigin } from "./request-origin.js";
 
 const RELAY_TIMEOUT_MS = 15_000;
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -56,32 +58,9 @@ function resolveCloudAuthRoot(): string {
   return resolveCloudApiBaseUrl().replace(/\/api\/v1\/?$/, "");
 }
 
-/**
- * Externally served origin of a request: proxy metadata (X-Forwarded-Proto /
- * X-Forwarded-Host) first, then the TLS state and Host header. Empty string
- * when the request carries no host at all.
- */
-export function resolveRequestOrigin(req: http.IncomingMessage): string {
-  const proto =
-    (req.headers["x-forwarded-proto"] as string | undefined) ||
-    (req.socket && "encrypted" in req.socket && req.socket.encrypted
-      ? "https"
-      : "http");
-  const host =
-    (req.headers["x-forwarded-host"] as string | undefined) || req.headers.host;
-  return host ? `${proto}://${host}` : "";
-}
-
 function isLoopbackOrigin(origin: string): boolean {
   try {
-    const hostname = new URL(origin).hostname
-      .toLowerCase()
-      .replace(/^\[|\]$/g, "");
-    return (
-      hostname === "localhost" ||
-      hostname === "::1" ||
-      /^127(?:\.\d{1,3}){3}$/.test(hostname)
-    );
+    return isLoopbackBindHost(new URL(origin).hostname);
   } catch {
     // error-policy:J3 malformed request origins are never trusted as loopback.
     return false;

--- a/packages/agent/src/api/cloud-pair-route.ts
+++ b/packages/agent/src/api/cloud-pair-route.ts
@@ -56,7 +56,12 @@ function resolveCloudAuthRoot(): string {
   return resolveCloudApiBaseUrl().replace(/\/api\/v1\/?$/, "");
 }
 
-function resolveRequestOrigin(req: http.IncomingMessage): string {
+/**
+ * Externally served origin of a request: proxy metadata (X-Forwarded-Proto /
+ * X-Forwarded-Host) first, then the TLS state and Host header. Empty string
+ * when the request carries no host at all.
+ */
+export function resolveRequestOrigin(req: http.IncomingMessage): string {
   const proto =
     (req.headers["x-forwarded-proto"] as string | undefined) ||
     (req.socket && "encrypted" in req.socket && req.socket.encrypted

--- a/packages/agent/src/api/connector-account-routes.test.ts
+++ b/packages/agent/src/api/connector-account-routes.test.ts
@@ -42,7 +42,10 @@ const coreMocks = vi.hoisted(() => {
   };
   type TestProvider = {
     provider: string;
-    startOAuth?: (request: { flow: TestFlow }) => Promise<{ authUrl: string }>;
+    startOAuth?: (request: {
+      flow: TestFlow;
+      servedOrigin?: string;
+    }) => Promise<{ authUrl: string }>;
     completeOAuth?: (request: {
       flow: TestFlow;
       code?: string;
@@ -184,7 +187,7 @@ const coreMocks = vi.hoisted(() => {
 
     async startOAuth(
       provider: string,
-      input?: { metadata?: Record<string, unknown> },
+      input?: { servedOrigin?: string; metadata?: Record<string, unknown> },
     ) {
       const normalized = provider.toLowerCase();
       const registered = this.providers.get(normalized);
@@ -200,7 +203,12 @@ const coreMocks = vi.hoisted(() => {
         metadata: input?.metadata,
       };
       await this.storage.createOAuthFlow(flow);
-      const started = await registered.startOAuth({ flow });
+      // Mirror the real manager: the served origin captured at the HTTP
+      // boundary is forwarded to the provider's start handler.
+      const started = await registered.startOAuth({
+        flow,
+        servedOrigin: input?.servedOrigin,
+      });
       return (
         (await this.storage.updateOAuthFlow(normalized, flow.id, {
           authUrl: started.authUrl,
@@ -344,6 +352,7 @@ function createConnectorAccountHarness(options: {
   method: string;
   pathname: string;
   body?: Record<string, unknown>;
+  headers?: Record<string, string>;
   storage?: TestStorage;
   adapter?: unknown;
   authorize?: ConnectorAccountRouteContext["authorize"] | null;
@@ -354,6 +363,7 @@ function createConnectorAccountHarness(options: {
   runtime.adapter = options.adapter;
   const req = {
     url: options.pathname,
+    headers: options.headers ?? {},
     on: vi.fn(),
   } as unknown as IncomingMessage;
   const res = {
@@ -535,6 +545,58 @@ describe("connector account routes", () => {
       ok: true,
       accountId: "acct_callback",
     });
+  });
+
+  it("forwards the externally served origin, proxy metadata first, into OAuth start", async () => {
+    const { ctx, captured, runtime, storage } = createConnectorAccountHarness({
+      method: "POST",
+      pathname: "/api/connectors/google/oauth/start",
+      body: {},
+      headers: {
+        host: "127.0.0.1:2138",
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "eliza.example",
+      },
+    });
+    const manager = getConnectorAccountManager(runtime as never, storage);
+    const seen: Array<string | undefined> = [];
+    manager.registerProvider({
+      provider: "google",
+      startOAuth: async ({ flow, servedOrigin }) => {
+        seen.push(servedOrigin);
+        return {
+          authUrl: `https://accounts.google.example/?state=${flow.state}`,
+        };
+      },
+    });
+
+    await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
+    expect(captured.status).toBe(201);
+    expect(seen).toEqual(["https://eliza.example"]);
+  });
+
+  it("derives the served origin from the Host header when no proxy metadata exists", async () => {
+    const { ctx, captured, runtime, storage } = createConnectorAccountHarness({
+      method: "POST",
+      pathname: "/api/connectors/google/oauth/start",
+      body: {},
+      headers: { host: "127.0.0.1:2138" },
+    });
+    const manager = getConnectorAccountManager(runtime as never, storage);
+    const seen: Array<string | undefined> = [];
+    manager.registerProvider({
+      provider: "google",
+      startOAuth: async ({ flow, servedOrigin }) => {
+        seen.push(servedOrigin);
+        return {
+          authUrl: `https://accounts.google.example/?state=${flow.state}`,
+        };
+      },
+    });
+
+    await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
+    expect(captured.status).toBe(201);
+    expect(seen).toEqual(["http://127.0.0.1:2138"]);
   });
 
   it("persists OAuth start state through the connector account storage contract", async () => {

--- a/packages/agent/src/api/connector-account-routes.test.ts
+++ b/packages/agent/src/api/connector-account-routes.test.ts
@@ -329,10 +329,14 @@ type Captured = {
 
 type TestStorage = InstanceType<typeof InMemoryConnectorAccountStorage>;
 
-function createRuntime(storage: TestStorage) {
+function createRuntime(
+  storage: TestStorage,
+  settings: Record<string, string> = {},
+) {
   return {
     agentId: "00000000-0000-0000-0000-000000000001",
     adapter: undefined as unknown,
+    getSetting: vi.fn((key: string) => settings[key]),
     getService: vi.fn((type: string) =>
       type === "connector_account_storage" ? storage : null,
     ),
@@ -353,13 +357,14 @@ function createConnectorAccountHarness(options: {
   pathname: string;
   body?: Record<string, unknown>;
   headers?: Record<string, string>;
+  settings?: Record<string, string>;
   storage?: TestStorage;
   adapter?: unknown;
   authorize?: ConnectorAccountRouteContext["authorize"] | null;
 }) {
   const captured: Captured = { status: 200, body: null };
   const storage = options.storage ?? new InMemoryConnectorAccountStorage();
-  const runtime = createRuntime(storage);
+  const runtime = createRuntime(storage, options.settings);
   runtime.adapter = options.adapter;
   const req = {
     url: options.pathname,
@@ -547,7 +552,7 @@ describe("connector account routes", () => {
     });
   });
 
-  it("forwards the externally served origin, proxy metadata first, into OAuth start", async () => {
+  it("uses the configured external base as the trusted proxy origin", async () => {
     const { ctx, captured, runtime, storage } = createConnectorAccountHarness({
       method: "POST",
       pathname: "/api/connectors/google/oauth/start",
@@ -555,7 +560,36 @@ describe("connector account routes", () => {
       headers: {
         host: "127.0.0.1:2138",
         "x-forwarded-proto": "https",
-        "x-forwarded-host": "eliza.example",
+        "x-forwarded-host": "attacker.example",
+      },
+      settings: { ELIZA_EXTERNAL_BASE_URL: "https://eliza.example" },
+    });
+    const manager = getConnectorAccountManager(runtime as never, storage);
+    const seen: Array<string | undefined> = [];
+    manager.registerProvider({
+      provider: "google",
+      startOAuth: async ({ flow, servedOrigin }) => {
+        seen.push(servedOrigin);
+        return {
+          authUrl: `https://accounts.google.example/?state=${flow.state}`,
+        };
+      },
+    });
+
+    await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
+    expect(captured.status, JSON.stringify(captured.body)).toBe(201);
+    expect(seen).toEqual(["https://eliza.example"]);
+  });
+
+  it("ignores untrusted forwarded origins when no external base is configured", async () => {
+    const { ctx, captured, runtime, storage } = createConnectorAccountHarness({
+      method: "POST",
+      pathname: "/api/connectors/google/oauth/start",
+      body: {},
+      headers: {
+        host: "127.0.0.1:2138",
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "attacker.example",
       },
     });
     const manager = getConnectorAccountManager(runtime as never, storage);
@@ -571,8 +605,8 @@ describe("connector account routes", () => {
     });
 
     await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
-    expect(captured.status).toBe(201);
-    expect(seen).toEqual(["https://eliza.example"]);
+    expect(captured.status, JSON.stringify(captured.body)).toBe(201);
+    expect(seen).toEqual(["http://127.0.0.1:2138"]);
   });
 
   it("derives the served origin from the Host header when no proxy metadata exists", async () => {
@@ -595,7 +629,7 @@ describe("connector account routes", () => {
     });
 
     await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
-    expect(captured.status).toBe(201);
+    expect(captured.status, JSON.stringify(captured.body)).toBe(201);
     expect(seen).toEqual(["http://127.0.0.1:2138"]);
   });
 
@@ -621,7 +655,7 @@ describe("connector account routes", () => {
     });
 
     await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
-    expect(captured.status).toBe(201);
+    expect(captured.status, JSON.stringify(captured.body)).toBe(201);
     const startBody = captured.body as {
       flow: {
         id: string;

--- a/packages/agent/src/api/connector-account-routes.ts
+++ b/packages/agent/src/api/connector-account-routes.ts
@@ -26,7 +26,7 @@ import {
 import type { ReadJsonBodyOptions } from "@elizaos/shared";
 import type { infer as ZodInfer } from "zod";
 import * as zod from "zod";
-import { resolveRequestOrigin } from "./cloud-pair-route.ts";
+import { resolveDirectRequestOrigin } from "./request-origin.ts";
 import { isBlockedObjectKey } from "./server-helpers-config.ts";
 
 const z = (zod as typeof zod & { z?: typeof zod }).z ?? zod;
@@ -918,10 +918,19 @@ export async function handleConnectorAccountRoutes(
         return true;
       }
       try {
-        // Served origin is derived from the request (proxy metadata included),
-        // never from the client body: providers validate that their OAuth
-        // callback can actually reach the origin serving this API.
-        const servedOrigin = resolveRequestOrigin(req);
+        // A configured external base is the authority behind a reverse proxy.
+        // Otherwise use the direct TLS/Host request that passed the server Host
+        // gate; arbitrary X-Forwarded-* headers must not bless a callback.
+        const configuredExternalBase = ctx.state.runtime?.getSetting?.(
+          "ELIZA_EXTERNAL_BASE_URL",
+        );
+        const normalizedExternalBase =
+          typeof configuredExternalBase === "string" &&
+          configuredExternalBase.trim()
+            ? configuredExternalBase.trim()
+            : undefined;
+        const servedOrigin =
+          normalizedExternalBase ?? resolveDirectRequestOrigin(req);
         const flow = await manager.startOAuth(provider, {
           ...parsed.data,
           ...(servedOrigin ? { servedOrigin } : {}),

--- a/packages/agent/src/api/connector-account-routes.ts
+++ b/packages/agent/src/api/connector-account-routes.ts
@@ -26,6 +26,7 @@ import {
 import type { ReadJsonBodyOptions } from "@elizaos/shared";
 import type { infer as ZodInfer } from "zod";
 import * as zod from "zod";
+import { resolveRequestOrigin } from "./cloud-pair-route.ts";
 import { isBlockedObjectKey } from "./server-helpers-config.ts";
 
 const z = (zod as typeof zod & { z?: typeof zod }).z ?? zod;
@@ -917,8 +918,13 @@ export async function handleConnectorAccountRoutes(
         return true;
       }
       try {
+        // Served origin is derived from the request (proxy metadata included),
+        // never from the client body: providers validate that their OAuth
+        // callback can actually reach the origin serving this API.
+        const servedOrigin = resolveRequestOrigin(req);
         const flow = await manager.startOAuth(provider, {
           ...parsed.data,
+          ...(servedOrigin ? { servedOrigin } : {}),
           metadata: cleanMetadata(parsed.data.metadata),
         });
         json(res, { provider, flow: serializeFlow(flow) }, 201);

--- a/packages/agent/src/api/request-origin.test.ts
+++ b/packages/agent/src/api/request-origin.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Deterministically verifies external request-origin reconstruction from proxy
+ * chains, direct Host headers, TLS socket state, and missing host metadata.
+ */
+
+import type http from "node:http";
+import { describe, expect, it } from "vitest";
+import {
+  resolveDirectRequestOrigin,
+  resolveRequestOrigin,
+} from "./request-origin.js";
+
+function request(
+  headers: http.IncomingHttpHeaders,
+  encrypted = false,
+): http.IncomingMessage {
+  return {
+    headers,
+    socket: { encrypted },
+  } as unknown as http.IncomingMessage;
+}
+
+describe("resolveRequestOrigin", () => {
+  it("uses the client-facing first proxy values", () => {
+    expect(
+      resolveRequestOrigin(
+        request({
+          host: "127.0.0.1:2138",
+          "x-forwarded-proto": "https, http",
+          "x-forwarded-host": "eliza.example, proxy.internal",
+        }),
+      ),
+    ).toBe("https://eliza.example");
+  });
+
+  it("uses TLS state and Host for a direct request", () => {
+    expect(resolveRequestOrigin(request({ host: "eliza.example" }, true))).toBe(
+      "https://eliza.example",
+    );
+  });
+
+  it("uses http for a direct cleartext request", () => {
+    expect(resolveRequestOrigin(request({ host: "127.0.0.1:2138" }))).toBe(
+      "http://127.0.0.1:2138",
+    );
+  });
+
+  it("ignores spoofable forwarding headers at a direct-request boundary", () => {
+    expect(
+      resolveDirectRequestOrigin(
+        request({
+          host: "127.0.0.1:2138",
+          "x-forwarded-proto": "https",
+          "x-forwarded-host": "attacker.example",
+        }),
+      ),
+    ).toBe("http://127.0.0.1:2138");
+  });
+
+  it("returns empty when no host metadata exists", () => {
+    expect(resolveRequestOrigin(request({}))).toBe("");
+  });
+});

--- a/packages/agent/src/api/request-origin.ts
+++ b/packages/agent/src/api/request-origin.ts
@@ -1,0 +1,43 @@
+/**
+ * Reconstructs direct and proxy-aware HTTP origins at API request boundaries.
+ * Forwarded metadata is opt-in because it is only authoritative behind a
+ * configured proxy; comma-separated chains use the client-facing first value.
+ */
+
+import type http from "node:http";
+
+function firstHeaderValue(
+  value: string | string[] | undefined,
+): string | undefined {
+  const first = Array.isArray(value) ? value[0] : value;
+  if (typeof first !== "string") return undefined;
+  const normalized = first.split(",", 1)[0]?.trim();
+  return normalized || undefined;
+}
+
+/** Empty when the request carries no usable host metadata. */
+export function resolveDirectRequestOrigin(req: http.IncomingMessage): string {
+  const proto =
+    req.socket && "encrypted" in req.socket && req.socket.encrypted
+      ? "https"
+      : "http";
+  const host = firstHeaderValue(req.headers.host);
+  return host ? `${proto}://${host}` : "";
+}
+
+/**
+ * Proxy-aware origin for boundaries that already permit forwarded metadata.
+ * Security-sensitive callers should use `resolveDirectRequestOrigin` unless a
+ * configured external origin establishes proxy authority.
+ */
+export function resolveRequestOrigin(req: http.IncomingMessage): string {
+  const proto =
+    firstHeaderValue(req.headers["x-forwarded-proto"]) ??
+    (req.socket && "encrypted" in req.socket && req.socket.encrypted
+      ? "https"
+      : "http");
+  const host =
+    firstHeaderValue(req.headers["x-forwarded-host"]) ??
+    firstHeaderValue(req.headers.host);
+  return host ? `${proto}://${host}` : "";
+}

--- a/packages/core/src/connectors/account-manager.ts
+++ b/packages/core/src/connectors/account-manager.ts
@@ -108,6 +108,13 @@ export interface ConnectorOAuthStartRequest {
 	accountId?: string;
 	label?: string;
 	scopes?: string[];
+	/**
+	 * Externally served origin of the request that started the flow (derived
+	 * server-side from proxy metadata / the Host header, never from the client
+	 * body). Providers whose callback must reach this origin validate against
+	 * it; callers with no HTTP request (chat actions, snapshots) omit it.
+	 */
+	servedOrigin?: string;
 	metadata?: Metadata;
 }
 
@@ -1575,6 +1582,7 @@ export class ConnectorAccountManager extends Service {
 			accountId?: string;
 			label?: string;
 			scopes?: string[];
+			servedOrigin?: string;
 			metadata?: Metadata;
 		} = {},
 	): Promise<ConnectorOAuthFlow> {
@@ -1610,6 +1618,7 @@ export class ConnectorAccountManager extends Service {
 					accountId: input.accountId,
 					label: input.label,
 					scopes: input.scopes,
+					servedOrigin: input.servedOrigin,
 					metadata: input.metadata,
 				},
 				this,

--- a/packages/core/src/connectors/account-manager.ts
+++ b/packages/core/src/connectors/account-manager.ts
@@ -109,10 +109,10 @@ export interface ConnectorOAuthStartRequest {
 	label?: string;
 	scopes?: string[];
 	/**
-	 * Externally served origin of the request that started the flow (derived
-	 * server-side from proxy metadata / the Host header, never from the client
-	 * body). Providers whose callback must reach this origin validate against
-	 * it; callers with no HTTP request (chat actions, snapshots) omit it.
+	 * Externally served origin selected at a trusted server boundary (configured
+	 * external base or direct TLS/Host request, never the client body). Providers
+	 * whose callback must reach this origin validate against it; callers without
+	 * an authoritative origin may omit it.
 	 */
 	servedOrigin?: string;
 	metadata?: Metadata;

--- a/packages/core/src/runtime-env.test.ts
+++ b/packages/core/src/runtime-env.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Verifies the public runtime host classifier against valid loopback spellings
+ * and deceptive or malformed `127.*` names. The cases mirror the shared host
+ * contract because core and shared expose the same security decision.
+ */
+
+import { describe, expect, it } from "vitest";
+import { isLoopbackBindHost } from "./runtime-env";
+
+describe("runtime environment loopback classification", () => {
+	it.each([
+		"127.0.0.1",
+		"127.255.255.255",
+		"localhost",
+		"::1",
+		"[::1]:31337",
+		"http://127.0.0.1:31337",
+		"::ffff:127.0.0.1",
+	])("accepts a valid loopback host: %s", (host) => {
+		expect(isLoopbackBindHost(host)).toBe(true);
+	});
+
+	it.each([
+		"127.evil",
+		"127.999.999.999",
+		"127.0.0.256",
+		"127.0.0.1.evil.example",
+		"http://127.999.999.999:31337",
+		"http://[::1",
+		"192.168.1.1",
+		"example.com",
+	])("rejects a malformed or remote host: %s", (host) => {
+		expect(isLoopbackBindHost(host)).toBe(false);
+	});
+});

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -225,7 +225,12 @@ export function stripOptionalHostPort(value: string): string {
 
 	const lower = trimmed.toLowerCase();
 	if (lower.startsWith("http://") || lower.startsWith("https://")) {
-		return new URL(lower).hostname.toLowerCase();
+		try {
+			return new URL(lower).hostname.toLowerCase();
+		} catch {
+			// error-policy:J3 malformed host input remains untrusted and is rejected.
+			return lower;
+		}
 	}
 
 	if (lower.startsWith("[")) {
@@ -243,8 +248,18 @@ export function stripOptionalHostPort(value: string): string {
 export function isLoopbackBindHost(host: string): boolean {
 	const normalized = stripOptionalHostPort(host);
 	if (!normalized) return true;
-	if (LOOPBACK_BIND_RE.test(normalized)) return true;
-	return normalized.startsWith("127.");
+	if (!LOOPBACK_BIND_RE.test(normalized)) return false;
+	const ipv4 = normalized.startsWith("::ffff:")
+		? normalized.slice("::ffff:".length)
+		: normalized;
+	if (/^127(?:\.\d{1,3}){3}$/.test(ipv4)) {
+		return ipv4
+			.split(".")
+			.every(
+				(octet) => Number.isInteger(Number(octet)) && Number(octet) <= 255,
+			);
+	}
+	return true;
 }
 
 export function isWildcardBindHost(host: string): boolean {

--- a/plugins/plugin-google-workspace/src/connector-account-provider.oauth-start.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.oauth-start.test.ts
@@ -65,7 +65,7 @@ describe("google provider startOAuth served-origin boundary", () => {
     {
       name: "production behind a TLS-terminating proxy",
       redirect: "https://eliza.example/api/connectors/google/oauth/callback",
-      servedOrigin: "http://eliza.example",
+      servedOrigin: "https://eliza.example",
     },
   ];
 
@@ -100,5 +100,21 @@ describe("google provider startOAuth served-origin boundary", () => {
         "http://127.0.0.1:2138"
       )
     ).rejects.toThrow(/served on port 2138/);
+  });
+
+  it("fails closed when proxy metadata reports a different served scheme", async () => {
+    await expect(
+      startWith(
+        "https://eliza.example/api/connectors/google/oauth/callback",
+        "http://eliza.example"
+      )
+    ).rejects.toThrow(/served over http/);
+  });
+
+  it("fails closed on a malformed served origin without echoing it", async () => {
+    const secret = "origin-secret-must-not-leak";
+    await expect(startWith(CASES[0].redirect, `not a URL ${secret}`)).rejects.toThrow(
+      /^The configured external connector origin is not a valid URL\.$/
+    );
   });
 });

--- a/plugins/plugin-google-workspace/src/connector-account-provider.oauth-start.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.oauth-start.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The real connector OAuth start boundary: createGoogleConnectorAccountProvider
+ * startOAuth must validate GOOGLE_REDIRECT_URI against the served origin the
+ * manager forwards from the HTTP request (Settings route / LifeOps), accept
+ * local, staging, and production deployments whose callback matches, and fail
+ * closed when the callback cannot reach the served origin. Deterministic: no
+ * network is touched before the authorization redirect, the manager is stubbed.
+ */
+import type { ConnectorAccountManager, ConnectorOAuthFlow } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { createGoogleConnectorAccountProvider } from "./connector-account-provider.js";
+
+function runtimeWith(redirectUri: string) {
+  return {
+    getSetting: (key: string) =>
+      ({
+        GOOGLE_CLIENT_ID: "client-id",
+        GOOGLE_CLIENT_SECRET: "client-secret",
+        GOOGLE_REDIRECT_URI: redirectUri,
+      })[key],
+    getService: () => null,
+  } as never;
+}
+
+function flow(): ConnectorOAuthFlow {
+  const now = Date.now();
+  return {
+    id: "oauth_test",
+    provider: "google",
+    state: "state_test",
+    status: "pending",
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+const managerStub = {} as ConnectorAccountManager;
+
+async function startWith(redirectUri: string, servedOrigin?: string) {
+  const provider = createGoogleConnectorAccountProvider(runtimeWith(redirectUri));
+  if (!provider.startOAuth) throw new Error("google provider must support startOAuth");
+  return provider.startOAuth(
+    {
+      provider: "google",
+      flow: flow(),
+      scopes: ["gmail.read"],
+      servedOrigin,
+    },
+    managerStub
+  );
+}
+
+describe("google provider startOAuth served-origin boundary", () => {
+  const CASES = [
+    {
+      name: "local",
+      redirect: "http://127.0.0.1:31437/api/connectors/google/oauth/callback",
+      servedOrigin: "http://127.0.0.1:31437",
+    },
+    {
+      name: "staging",
+      redirect: "https://staging.eliza.example/api/connectors/google/oauth/callback",
+      servedOrigin: "https://staging.eliza.example",
+    },
+    {
+      name: "production behind a TLS-terminating proxy",
+      redirect: "https://eliza.example/api/connectors/google/oauth/callback",
+      servedOrigin: "http://eliza.example",
+    },
+  ];
+
+  for (const { name, redirect, servedOrigin } of CASES) {
+    it(`starts OAuth for a ${name} deployment whose callback matches the served origin`, async () => {
+      const result = await startWith(redirect, servedOrigin);
+      expect(result.redirectUri).toBe(redirect);
+      expect(result.authUrl).toContain(encodeURIComponent(redirect));
+    });
+  }
+
+  it("starts OAuth when the caller has no request origin (chat action)", async () => {
+    const result = await startWith("https://eliza.example/api/connectors/google/oauth/callback");
+    expect(result.authUrl).toContain(
+      encodeURIComponent("https://eliza.example/api/connectors/google/oauth/callback")
+    );
+  });
+
+  it("fails closed when the callback targets a different host than the served origin", async () => {
+    await expect(
+      startWith(
+        "https://other.example/api/connectors/google/oauth/callback",
+        "https://eliza.example"
+      )
+    ).rejects.toThrow(/targets other\.example/);
+  });
+
+  it("fails closed when a loopback callback misses the served API port", async () => {
+    await expect(
+      startWith(
+        "http://127.0.0.1:31437/api/connectors/google/oauth/callback",
+        "http://127.0.0.1:2138"
+      )
+    ).rejects.toThrow(/served on port 2138/);
+  });
+});

--- a/plugins/plugin-google-workspace/src/connector-account-provider.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.ts
@@ -109,14 +109,20 @@ function readSetting(runtime: IAgentRuntime, key: string): string | undefined {
   return nonEmptyString(runtime.getSetting?.(key));
 }
 
-function readClientConfig(runtime: IAgentRuntime): {
+function readClientConfig(
+  runtime: IAgentRuntime,
+  servedOrigin?: string
+): {
   clientId: string;
   clientSecret: string;
   redirectUri: string;
 } {
   const clientId = readSetting(runtime, "GOOGLE_CLIENT_ID");
   const clientSecret = readSetting(runtime, "GOOGLE_CLIENT_SECRET");
-  const redirectUri = resolveGoogleConnectorOAuthCallbackUrl(runtime);
+  const redirectUri = resolveGoogleConnectorOAuthCallbackUrl(
+    runtime,
+    servedOrigin ? { servedOrigin } : undefined
+  );
   if (!clientId || !clientSecret) {
     throw new Error(
       "Google OAuth requires GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and GOOGLE_REDIRECT_URI to be configured."
@@ -454,7 +460,10 @@ export function createGoogleConnectorAccountProvider(
       request: ConnectorOAuthStartRequest,
       manager: ConnectorAccountManager
     ): Promise<ConnectorOAuthStartResult> => {
-      const config = readClientConfig(runtime);
+      // The manager forwards the served origin captured at the HTTP boundary
+      // (Settings route) or by LifeOps; callback validation runs against it so
+      // an unreachable callback fails here instead of stranding the grant.
+      const config = readClientConfig(runtime, request.servedOrigin);
       const redirectUri = config.redirectUri;
       const capabilities = normalizeRequestedCapabilities(
         await resolveRequestedScopes(request, manager)

--- a/plugins/plugin-google-workspace/src/google-oauth-callback.test.ts
+++ b/plugins/plugin-google-workspace/src/google-oauth-callback.test.ts
@@ -60,4 +60,104 @@ describe("google oauth callback contract", () => {
     expect(assessment.configured).toBe(true);
     expect(isPortlessLoopbackRedirectUrl(new URL(production))).toBe(false);
   });
+
+  it("rejects non-http(s) schemes", () => {
+    for (const uri of [
+      "ftp://127.0.0.1:31437/api/connectors/google/oauth/callback",
+      "javascript:alert(1)",
+    ]) {
+      const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(uri));
+      expect(assessment.configured).toBe(false);
+      expect(assessment.issues.some((issue) => issue.code === "wrong_scheme")).toBe(true);
+    }
+  });
+
+  it("rejects plain http on a non-loopback host", () => {
+    const assessment = assessGoogleOAuthCallbackConfig(
+      runtimeWithRedirect("http://eliza.example/api/connectors/google/oauth/callback")
+    );
+    expect(assessment.configured).toBe(false);
+    expect(assessment.issues.some((issue) => issue.code === "wrong_scheme")).toBe(true);
+  });
+
+  it("rejects credential-bearing callbacks", () => {
+    const assessment = assessGoogleOAuthCallbackConfig(
+      runtimeWithRedirect("http://user:pass@127.0.0.1:31437/api/connectors/google/oauth/callback")
+    );
+    expect(assessment.configured).toBe(false);
+    expect(assessment.issues.some((issue) => issue.code === "credentials")).toBe(true);
+  });
+
+  it("rejects query-bearing callbacks", () => {
+    const assessment = assessGoogleOAuthCallbackConfig(
+      runtimeWithRedirect(`${CANONICAL}?next=https://evil.example`)
+    );
+    expect(assessment.configured).toBe(false);
+    expect(assessment.issues.some((issue) => issue.code === "query")).toBe(true);
+  });
+
+  it("rejects fragment-bearing callbacks", () => {
+    const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(`${CANONICAL}#frag`));
+    expect(assessment.configured).toBe(false);
+    expect(assessment.issues.some((issue) => issue.code === "fragment")).toBe(true);
+  });
+
+  it("treats a portless bracketed ::1 loopback as portless loopback", () => {
+    const assessment = assessGoogleOAuthCallbackConfig(
+      runtimeWithRedirect("http://[::1]/api/connectors/google/oauth/callback")
+    );
+    expect(assessment.configured).toBe(false);
+    expect(assessment.issues.some((issue) => issue.code === "portless_loopback")).toBe(true);
+  });
+
+  describe("served-origin comparison", () => {
+    it("rejects a callback on a different host than the served origin", () => {
+      const assessment = assessGoogleOAuthCallbackConfig(
+        runtimeWithRedirect("https://other.example/api/connectors/google/oauth/callback"),
+        { servedOrigin: new URL("http://eliza.example/api/lifeops/connectors/google") }
+      );
+      expect(assessment.configured).toBe(false);
+      expect(assessment.issues.some((issue) => issue.code === "wrong_host")).toBe(true);
+    });
+
+    it("rejects a loopback callback on a different port than the served origin", () => {
+      const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(CANONICAL), {
+        servedOrigin: new URL("http://127.0.0.1:2138/api/lifeops/connectors/google"),
+      });
+      expect(assessment.configured).toBe(false);
+      expect(assessment.issues.some((issue) => issue.code === "wrong_port")).toBe(true);
+    });
+
+    it("rejects a loopback callback when the API is served on a public host", () => {
+      const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(CANONICAL), {
+        servedOrigin: new URL("http://eliza.example/api/lifeops/connectors/google"),
+      });
+      expect(assessment.configured).toBe(false);
+      expect(assessment.issues.some((issue) => issue.code === "wrong_host")).toBe(true);
+    });
+
+    it("accepts a matching loopback callback across loopback host spellings", () => {
+      const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(CANONICAL), {
+        servedOrigin: new URL("http://localhost:31437/api/lifeops/connectors/google"),
+      });
+      expect(assessment.configured).toBe(true);
+    });
+
+    it("accepts a production https callback served behind a default-port proxy", () => {
+      // Request URLs are reconstructed from the Host header behind an http
+      // base, so the served origin reads http://eliza.example with no port.
+      const assessment = assessGoogleOAuthCallbackConfig(
+        runtimeWithRedirect("https://eliza.example/api/connectors/google/oauth/callback"),
+        { servedOrigin: new URL("http://eliza.example/api/lifeops/connectors/google") }
+      );
+      expect(assessment.configured).toBe(true);
+    });
+
+    it("skips the port assertion when a loopback served origin names no port", () => {
+      const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(CANONICAL), {
+        servedOrigin: new URL("http://127.0.0.1/"),
+      });
+      expect(assessment.configured).toBe(true);
+    });
+  });
 });

--- a/plugins/plugin-google-workspace/src/google-oauth-callback.test.ts
+++ b/plugins/plugin-google-workspace/src/google-oauth-callback.test.ts
@@ -81,10 +81,15 @@ describe("google oauth callback contract", () => {
   });
 
   it("rejects credential-bearing callbacks", () => {
+    const secret = "callback-password-must-not-leak";
     const assessment = assessGoogleOAuthCallbackConfig(
-      runtimeWithRedirect("http://user:pass@127.0.0.1:31437/api/connectors/google/oauth/callback")
+      runtimeWithRedirect(
+        `http://user:${secret}@127.0.0.1:31437/api/connectors/google/oauth/callback`
+      )
     );
     expect(assessment.configured).toBe(false);
+    expect(assessment.redirectUri).toBeNull();
+    expect(JSON.stringify(assessment)).not.toContain(secret);
     expect(assessment.issues.some((issue) => issue.code === "credentials")).toBe(true);
   });
 
@@ -100,6 +105,20 @@ describe("google oauth callback contract", () => {
     const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(`${CANONICAL}#frag`));
     expect(assessment.configured).toBe(false);
     expect(assessment.issues.some((issue) => issue.code === "fragment")).toBe(true);
+  });
+
+  it("rejects callbacks carrying an explicitly empty query or fragment", () => {
+    for (const uri of [`${CANONICAL}?`, `${CANONICAL}#`]) {
+      const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(uri));
+      expect(assessment.configured).toBe(false);
+      expect(assessment.redirectUri).toBeNull();
+    }
+  });
+
+  it("rejects a trailing slash instead of normalizing a different callback path", () => {
+    const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(`${CANONICAL}/`));
+    expect(assessment.configured).toBe(false);
+    expect(assessment.issues.some((issue) => issue.code === "wrong_path")).toBe(true);
   });
 
   it("treats a portless bracketed ::1 loopback as portless loopback", () => {
@@ -136,28 +155,68 @@ describe("google oauth callback contract", () => {
       expect(assessment.issues.some((issue) => issue.code === "wrong_host")).toBe(true);
     });
 
-    it("accepts a matching loopback callback across loopback host spellings", () => {
+    it("rejects distinct loopback spellings without proof that one listener covers both", () => {
       const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(CANONICAL), {
         servedOrigin: new URL("http://localhost:31437/api/lifeops/connectors/google"),
       });
-      expect(assessment.configured).toBe(true);
+      expect(assessment.configured).toBe(false);
+      expect(assessment.issues.some((issue) => issue.code === "wrong_host")).toBe(true);
     });
 
     it("accepts a production https callback served behind a default-port proxy", () => {
-      // Request URLs are reconstructed from the Host header behind an http
-      // base, so the served origin reads http://eliza.example with no port.
       const assessment = assessGoogleOAuthCallbackConfig(
         runtimeWithRedirect("https://eliza.example/api/connectors/google/oauth/callback"),
-        { servedOrigin: new URL("http://eliza.example/api/lifeops/connectors/google") }
+        { servedOrigin: new URL("https://eliza.example/api/lifeops/connectors/google") }
       );
       expect(assessment.configured).toBe(true);
     });
 
-    it("skips the port assertion when a loopback served origin names no port", () => {
+    it("rejects a loopback callback when a portless origin says the API is on port 80", () => {
       const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(CANONICAL), {
         servedOrigin: new URL("http://127.0.0.1/"),
       });
-      expect(assessment.configured).toBe(true);
+      expect(assessment.configured).toBe(false);
+      expect(assessment.issues.some((issue) => issue.code === "wrong_port")).toBe(true);
+    });
+
+    it("rejects a callback whose scheme differs from the served origin", () => {
+      const assessment = assessGoogleOAuthCallbackConfig(
+        runtimeWithRedirect("https://eliza.example/api/connectors/google/oauth/callback"),
+        { servedOrigin: "http://eliza.example" }
+      );
+      expect(assessment.configured).toBe(false);
+      expect(assessment.issues.some((issue) => issue.code === "wrong_scheme")).toBe(true);
+    });
+
+    it("rejects a custom callback port for a default-port public origin", () => {
+      const assessment = assessGoogleOAuthCallbackConfig(
+        runtimeWithRedirect("https://eliza.example:8443/api/connectors/google/oauth/callback"),
+        { servedOrigin: "https://eliza.example" }
+      );
+      expect(assessment.configured).toBe(false);
+      expect(assessment.issues.some((issue) => issue.code === "wrong_port")).toBe(true);
+    });
+
+    it("rejects a default-port callback for a custom-port public origin", () => {
+      const assessment = assessGoogleOAuthCallbackConfig(
+        runtimeWithRedirect("https://eliza.example/api/connectors/google/oauth/callback"),
+        { servedOrigin: "https://eliza.example:8443" }
+      );
+      expect(assessment.configured).toBe(false);
+      expect(assessment.issues.some((issue) => issue.code === "wrong_port")).toBe(true);
+    });
+
+    it("rejects a malformed served origin without echoing it", () => {
+      const secret = "external-origin-secret";
+      const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(CANONICAL), {
+        servedOrigin: `not a URL ${secret}`,
+      });
+      expect(assessment.configured).toBe(false);
+      expect(assessment.redirectUri).toBeNull();
+      expect(assessment.issues.some((issue) => issue.code === "served_origin_malformed")).toBe(
+        true
+      );
+      expect(JSON.stringify(assessment)).not.toContain(secret);
     });
   });
 
@@ -165,6 +224,14 @@ describe("google oauth callback contract", () => {
     it("rejects a DNS name beginning with 127. as a plain-http callback host", () => {
       const probe = "http://127.0.0.1.attacker.example:31437/api/connectors/google/oauth/callback";
       const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(probe));
+      expect(assessment.configured).toBe(false);
+      expect(assessment.issues.some((issue) => issue.code === "wrong_scheme")).toBe(true);
+    });
+
+    it("rejects a short 127.-prefixed DNS name as a plain-http callback host", () => {
+      const assessment = assessGoogleOAuthCallbackConfig(
+        runtimeWithRedirect("http://127.evil:31437/api/connectors/google/oauth/callback")
+      );
       expect(assessment.configured).toBe(false);
       expect(assessment.issues.some((issue) => issue.code === "wrong_scheme")).toBe(true);
     });
@@ -180,12 +247,30 @@ describe("google oauth callback contract", () => {
       expect(assessment.issues.some((issue) => issue.code === "wrong_host")).toBe(true);
     });
 
-    it("keeps genuinely numeric 127.0.0.0/8 addresses loopback", () => {
+    it("accepts the same genuinely numeric 127.0.0.0/8 address", () => {
+      const assessment = assessGoogleOAuthCallbackConfig(
+        runtimeWithRedirect("http://127.0.0.2:31437/api/connectors/google/oauth/callback"),
+        { servedOrigin: new URL("http://127.0.0.2:31437/") }
+      );
+      expect(assessment.configured).toBe(true);
+    });
+
+    it("rejects a callback on another numeric 127/8 address", () => {
       const assessment = assessGoogleOAuthCallbackConfig(
         runtimeWithRedirect("http://127.0.0.2:31437/api/connectors/google/oauth/callback"),
         { servedOrigin: new URL("http://127.0.0.1:31437/") }
       );
-      expect(assessment.configured).toBe(true);
+      expect(assessment.configured).toBe(false);
+      expect(assessment.issues.some((issue) => issue.code === "wrong_host")).toBe(true);
+    });
+
+    it("rejects an IPv6 callback for an IPv4-only served listener", () => {
+      const assessment = assessGoogleOAuthCallbackConfig(
+        runtimeWithRedirect("http://[::1]:31437/api/connectors/google/oauth/callback"),
+        { servedOrigin: new URL("http://127.0.0.1:31437/") }
+      );
+      expect(assessment.configured).toBe(false);
+      expect(assessment.issues.some((issue) => issue.code === "wrong_host")).toBe(true);
     });
   });
 });

--- a/plugins/plugin-google-workspace/src/google-oauth-callback.test.ts
+++ b/plugins/plugin-google-workspace/src/google-oauth-callback.test.ts
@@ -160,4 +160,32 @@ describe("google oauth callback contract", () => {
       expect(assessment.configured).toBe(true);
     });
   });
+
+  describe("loopback host classification", () => {
+    it("rejects a DNS name beginning with 127. as a plain-http callback host", () => {
+      const probe = "http://127.0.0.1.attacker.example:31437/api/connectors/google/oauth/callback";
+      const assessment = assessGoogleOAuthCallbackConfig(runtimeWithRedirect(probe));
+      expect(assessment.configured).toBe(false);
+      expect(assessment.issues.some((issue) => issue.code === "wrong_scheme")).toBe(true);
+    });
+
+    it("does not treat a 127.-prefixed DNS name as host-equivalent to a served loopback origin", () => {
+      const assessment = assessGoogleOAuthCallbackConfig(
+        runtimeWithRedirect(
+          "https://127.0.0.1.attacker.example:31437/api/connectors/google/oauth/callback"
+        ),
+        { servedOrigin: new URL("http://127.0.0.1:31437/api/lifeops/connectors/google") }
+      );
+      expect(assessment.configured).toBe(false);
+      expect(assessment.issues.some((issue) => issue.code === "wrong_host")).toBe(true);
+    });
+
+    it("keeps genuinely numeric 127.0.0.0/8 addresses loopback", () => {
+      const assessment = assessGoogleOAuthCallbackConfig(
+        runtimeWithRedirect("http://127.0.0.2:31437/api/connectors/google/oauth/callback"),
+        { servedOrigin: new URL("http://127.0.0.1:31437/") }
+      );
+      expect(assessment.configured).toBe(true);
+    });
+  });
 });

--- a/plugins/plugin-google-workspace/src/google-oauth-callback.ts
+++ b/plugins/plugin-google-workspace/src/google-oauth-callback.ts
@@ -8,7 +8,7 @@
  * and — when the caller knows the origin actually serving the connector API —
  * a callback targeting a different host or port is rejected as unreachable.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { type IAgentRuntime, isLoopbackBindHost } from "@elizaos/core";
 
 export const GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH = "/api/connectors/google/oauth/callback";
 
@@ -21,6 +21,7 @@ export type GoogleOAuthCallbackConfigIssueCode =
   | "fragment"
   | "portless_loopback"
   | "wrong_path"
+  | "served_origin_malformed"
   | "wrong_host"
   | "wrong_port";
 
@@ -31,6 +32,7 @@ export interface GoogleOAuthCallbackConfigIssue {
 
 export interface GoogleOAuthCallbackConfigAssessment {
   configured: boolean;
+  /** Present only when the callback passed every validation check. */
   redirectUri: string | null;
   issues: GoogleOAuthCallbackConfigIssue[];
 }
@@ -39,10 +41,9 @@ export interface GoogleOAuthCallbackConfigOptions {
   /**
    * Origin actually serving the connector API, typically the URL of the
    * request being handled. When provided, the callback must target the same
-   * host (loopback names are one equivalence class) and, when the served
-   * origin names an explicit port, the same port. The served scheme is never
-   * compared: request URLs are built from the Host header behind an http base,
-   * so a TLS-terminating proxy would make scheme comparison lie.
+   * concrete host, scheme, and effective port. Distinct loopback addresses are
+   * not assumed to share a listener. Proxied HTTP routes use the configured
+   * external base as their authority.
    */
   servedOrigin?: URL | string;
 }
@@ -59,17 +60,11 @@ function readRedirectUriSetting(runtime: RuntimeWithSettings): string | undefine
   return nonEmptyString(runtime.getSetting?.("GOOGLE_REDIRECT_URI"));
 }
 
-function isLoopbackHost(hostname: string): boolean {
-  const normalized = hostname
+function normalizedHostname(url: URL): string {
+  return url.hostname
     .trim()
     .toLowerCase()
     .replace(/^\[|\]$/g, "");
-  // Loopback IPv4 must be a genuinely numeric dotted quad in 127.0.0.0/8: a DNS
-  // name like 127.0.0.1.attacker.example is an external host, never loopback.
-  // The URL parser already canonicalizes IPv4 shorthand (127.1 → 127.0.0.1).
-  return (
-    normalized === "localhost" || normalized === "::1" || /^127(?:\.\d{1,3}){3}$/.test(normalized)
-  );
 }
 
 /**
@@ -78,7 +73,7 @@ function isLoopbackHost(hostname: string): boolean {
  * served local API.
  */
 export function isPortlessLoopbackRedirectUrl(url: URL): boolean {
-  if (!isLoopbackHost(url.hostname)) return false;
+  if (!isLoopbackBindHost(url.hostname)) return false;
   return url.port === "";
 }
 
@@ -130,7 +125,7 @@ export function assessGoogleOAuthCallbackConfig(
       code: "wrong_scheme",
       message: `GOOGLE_REDIRECT_URI must use http or https, not ${parsed.protocol.replace(/:$/, "")}.`,
     });
-  } else if (parsed.protocol === "http:" && !isLoopbackHost(parsed.hostname)) {
+  } else if (parsed.protocol === "http:" && !isLoopbackBindHost(parsed.hostname)) {
     issues.push({
       code: "wrong_scheme",
       message: "GOOGLE_REDIRECT_URI may use plain http only for loopback callbacks; use https.",
@@ -142,26 +137,22 @@ export function assessGoogleOAuthCallbackConfig(
       message: "GOOGLE_REDIRECT_URI must not embed credentials.",
     });
   }
-  if (parsed.search !== "") {
+  if (parsed.href.includes("?")) {
     issues.push({
       code: "query",
       message: "GOOGLE_REDIRECT_URI must not carry a query string.",
     });
   }
-  if (parsed.hash !== "") {
+  if (parsed.href.includes("#")) {
     issues.push({
       code: "fragment",
       message: "GOOGLE_REDIRECT_URI must not carry a fragment.",
     });
   }
-  const normalizedPath =
-    parsed.pathname.endsWith("/") && parsed.pathname.length > 1
-      ? parsed.pathname.slice(0, -1)
-      : parsed.pathname;
-  if (normalizedPath !== GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH) {
+  if (parsed.pathname !== GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH) {
     issues.push({
       code: "wrong_path",
-      message: `GOOGLE_REDIRECT_URI must end with ${GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH}.`,
+      message: `GOOGLE_REDIRECT_URI path must equal ${GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH}.`,
     });
   }
   if (isPortlessLoopbackRedirectUrl(parsed)) {
@@ -173,26 +164,48 @@ export function assessGoogleOAuthCallbackConfig(
   }
 
   if (options?.servedOrigin !== undefined) {
-    const served =
-      options.servedOrigin instanceof URL ? options.servedOrigin : new URL(options.servedOrigin);
-    const sameHost = isLoopbackHost(parsed.hostname)
-      ? isLoopbackHost(served.hostname)
-      : parsed.hostname.toLowerCase() === served.hostname.toLowerCase();
+    let served: URL;
+    try {
+      served =
+        options.servedOrigin instanceof URL ? options.servedOrigin : new URL(options.servedOrigin);
+    } catch {
+      issues.push({
+        code: "served_origin_malformed",
+        message: "The configured external connector origin is not a valid URL.",
+      });
+      return { configured: false, redirectUri: null, issues };
+    }
+    if (
+      (served.protocol !== "http:" && served.protocol !== "https:") ||
+      served.username !== "" ||
+      served.password !== ""
+    ) {
+      issues.push({
+        code: "served_origin_malformed",
+        message: "The configured external connector origin must be an http or https origin.",
+      });
+      return { configured: false, redirectUri: null, issues };
+    }
+    if (parsed.protocol !== served.protocol) {
+      issues.push({
+        code: "wrong_scheme",
+        message: `GOOGLE_REDIRECT_URI uses ${parsed.protocol.replace(/:$/, "")}, but the connector API is served over ${served.protocol.replace(/:$/, "")}.`,
+      });
+    }
+    const sameHost = normalizedHostname(parsed) === normalizedHostname(served);
     if (!sameHost) {
       issues.push({
         code: "wrong_host",
         message: `GOOGLE_REDIRECT_URI targets ${parsed.hostname}, but the connector API is served on ${served.hostname}.`,
       });
     } else {
-      // Assert the port only when the served origin names one explicitly. A
-      // portless served origin (default-port deployment behind a proxy) tells
-      // us nothing to fail closed on; portless loopback callbacks are already
-      // rejected above.
       const servedPort = explicitPort(served);
-      if (servedPort !== "" && explicitPort(parsed) !== servedPort) {
+      if (explicitPort(parsed) !== servedPort) {
+        const callbackPort = explicitPort(parsed) || (parsed.protocol === "https:" ? "443" : "80");
+        const connectorPort = servedPort || (served.protocol === "https:" ? "443" : "80");
         issues.push({
           code: "wrong_port",
-          message: `GOOGLE_REDIRECT_URI targets port ${explicitPort(parsed) || "(default)"}, but the connector API is served on port ${servedPort}.`,
+          message: `GOOGLE_REDIRECT_URI targets port ${callbackPort}, but the connector API is served on port ${connectorPort}.`,
         });
       }
     }
@@ -201,7 +214,7 @@ export function assessGoogleOAuthCallbackConfig(
   if (issues.length > 0) {
     return {
       configured: false,
-      redirectUri: parsed.toString(),
+      redirectUri: null,
       issues,
     };
   }

--- a/plugins/plugin-google-workspace/src/google-oauth-callback.ts
+++ b/plugins/plugin-google-workspace/src/google-oauth-callback.ts
@@ -64,7 +64,12 @@ function isLoopbackHost(hostname: string): boolean {
     .trim()
     .toLowerCase()
     .replace(/^\[|\]$/g, "");
-  return normalized === "localhost" || normalized === "::1" || normalized.startsWith("127.");
+  // Loopback IPv4 must be a genuinely numeric dotted quad in 127.0.0.0/8: a DNS
+  // name like 127.0.0.1.attacker.example is an external host, never loopback.
+  // The URL parser already canonicalizes IPv4 shorthand (127.1 → 127.0.0.1).
+  return (
+    normalized === "localhost" || normalized === "::1" || /^127(?:\.\d{1,3}){3}$/.test(normalized)
+  );
 }
 
 /**

--- a/plugins/plugin-google-workspace/src/google-oauth-callback.ts
+++ b/plugins/plugin-google-workspace/src/google-oauth-callback.ts
@@ -1,8 +1,12 @@
 /**
  * Canonical Google connector OAuth callback resolution. Chat, Settings, and the
  * connector-account provider must agree on `GOOGLE_REDIRECT_URI` for
- * `/api/connectors/google/oauth/callback`; portless loopback origins are
- * rejected because they cannot reach the served local API port.
+ * `/api/connectors/google/oauth/callback`. Validation fails closed: only
+ * http/https callbacks are accepted (plain http only on loopback), URLs
+ * carrying credentials, a query, or a fragment are rejected, portless loopback
+ * origins are rejected because they cannot reach the served local API port,
+ * and — when the caller knows the origin actually serving the connector API —
+ * a callback targeting a different host or port is rejected as unreachable.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 
@@ -11,8 +15,14 @@ export const GOOGLE_CONNECTOR_OAUTH_CALLBACK_PATH = "/api/connectors/google/oaut
 export type GoogleOAuthCallbackConfigIssueCode =
   | "missing"
   | "malformed"
+  | "wrong_scheme"
+  | "credentials"
+  | "query"
+  | "fragment"
   | "portless_loopback"
-  | "wrong_path";
+  | "wrong_path"
+  | "wrong_host"
+  | "wrong_port";
 
 export interface GoogleOAuthCallbackConfigIssue {
   code: GoogleOAuthCallbackConfigIssueCode;
@@ -23,6 +33,18 @@ export interface GoogleOAuthCallbackConfigAssessment {
   configured: boolean;
   redirectUri: string | null;
   issues: GoogleOAuthCallbackConfigIssue[];
+}
+
+export interface GoogleOAuthCallbackConfigOptions {
+  /**
+   * Origin actually serving the connector API, typically the URL of the
+   * request being handled. When provided, the callback must target the same
+   * host (loopback names are one equivalence class) and, when the served
+   * origin names an explicit port, the same port. The served scheme is never
+   * compared: request URLs are built from the Host header behind an http base,
+   * so a TLS-terminating proxy would make scheme comparison lie.
+   */
+  servedOrigin?: URL | string;
 }
 
 type RuntimeWithSettings = Pick<IAgentRuntime, "getSetting">;
@@ -38,8 +60,11 @@ function readRedirectUriSetting(runtime: RuntimeWithSettings): string | undefine
 }
 
 function isLoopbackHost(hostname: string): boolean {
-  const normalized = hostname.trim().toLowerCase();
-  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
+  const normalized = hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
+  return normalized === "localhost" || normalized === "::1" || normalized.startsWith("127.");
 }
 
 /**
@@ -52,8 +77,16 @@ export function isPortlessLoopbackRedirectUrl(url: URL): boolean {
   return url.port === "";
 }
 
+/** URL.port with scheme-default ports ("80" for http, "443" for https) normalized to "". */
+function explicitPort(url: URL): string {
+  if (url.protocol === "http:" && url.port === "80") return "";
+  if (url.protocol === "https:" && url.port === "443") return "";
+  return url.port;
+}
+
 export function assessGoogleOAuthCallbackConfig(
-  runtime: RuntimeWithSettings
+  runtime: RuntimeWithSettings,
+  options?: GoogleOAuthCallbackConfigOptions
 ): GoogleOAuthCallbackConfigAssessment {
   const raw = readRedirectUriSetting(runtime);
   if (!raw) {
@@ -87,6 +120,35 @@ export function assessGoogleOAuthCallbackConfig(
   }
 
   const issues: GoogleOAuthCallbackConfigIssue[] = [];
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    issues.push({
+      code: "wrong_scheme",
+      message: `GOOGLE_REDIRECT_URI must use http or https, not ${parsed.protocol.replace(/:$/, "")}.`,
+    });
+  } else if (parsed.protocol === "http:" && !isLoopbackHost(parsed.hostname)) {
+    issues.push({
+      code: "wrong_scheme",
+      message: "GOOGLE_REDIRECT_URI may use plain http only for loopback callbacks; use https.",
+    });
+  }
+  if (parsed.username !== "" || parsed.password !== "") {
+    issues.push({
+      code: "credentials",
+      message: "GOOGLE_REDIRECT_URI must not embed credentials.",
+    });
+  }
+  if (parsed.search !== "") {
+    issues.push({
+      code: "query",
+      message: "GOOGLE_REDIRECT_URI must not carry a query string.",
+    });
+  }
+  if (parsed.hash !== "") {
+    issues.push({
+      code: "fragment",
+      message: "GOOGLE_REDIRECT_URI must not carry a fragment.",
+    });
+  }
   const normalizedPath =
     parsed.pathname.endsWith("/") && parsed.pathname.length > 1
       ? parsed.pathname.slice(0, -1)
@@ -105,6 +167,32 @@ export function assessGoogleOAuthCallbackConfig(
     });
   }
 
+  if (options?.servedOrigin !== undefined) {
+    const served =
+      options.servedOrigin instanceof URL ? options.servedOrigin : new URL(options.servedOrigin);
+    const sameHost = isLoopbackHost(parsed.hostname)
+      ? isLoopbackHost(served.hostname)
+      : parsed.hostname.toLowerCase() === served.hostname.toLowerCase();
+    if (!sameHost) {
+      issues.push({
+        code: "wrong_host",
+        message: `GOOGLE_REDIRECT_URI targets ${parsed.hostname}, but the connector API is served on ${served.hostname}.`,
+      });
+    } else {
+      // Assert the port only when the served origin names one explicitly. A
+      // portless served origin (default-port deployment behind a proxy) tells
+      // us nothing to fail closed on; portless loopback callbacks are already
+      // rejected above.
+      const servedPort = explicitPort(served);
+      if (servedPort !== "" && explicitPort(parsed) !== servedPort) {
+        issues.push({
+          code: "wrong_port",
+          message: `GOOGLE_REDIRECT_URI targets port ${explicitPort(parsed) || "(default)"}, but the connector API is served on port ${servedPort}.`,
+        });
+      }
+    }
+  }
+
   if (issues.length > 0) {
     return {
       configured: false,
@@ -120,8 +208,11 @@ export function assessGoogleOAuthCallbackConfig(
   };
 }
 
-export function resolveGoogleConnectorOAuthCallbackUrl(runtime: RuntimeWithSettings): string {
-  const assessment = assessGoogleOAuthCallbackConfig(runtime);
+export function resolveGoogleConnectorOAuthCallbackUrl(
+  runtime: RuntimeWithSettings,
+  options?: GoogleOAuthCallbackConfigOptions
+): string {
+  const assessment = assessGoogleOAuthCallbackConfig(runtime, options);
   if (!assessment.configured || !assessment.redirectUri) {
     const detail = assessment.issues.map((issue) => issue.message).join(" ");
     throw new Error(

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.oauth-callback.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.oauth-callback.test.ts
@@ -1,11 +1,55 @@
 /**
  * LifeOps Google OAuth start must use the canonical GOOGLE_REDIRECT_URI instead
- * of deriving a portless callback from INTERNAL_URL.
+ * of deriving a portless callback from INTERNAL_URL, must fail closed before
+ * redirecting to Google when the callback cannot reach the served origin, and
+ * must never report a persisted grant as disconnected because of a callback
+ * config mistake. Deterministic: manager and repository are stubbed.
  */
 import { describe, expect, it, vi } from "vitest";
 import { GoogleDomain } from "./google-service.js";
 
 const CANONICAL = "http://127.0.0.1:31437/api/connectors/google/oauth/callback";
+
+function connectedAccount() {
+  const now = Date.now();
+  return {
+    id: "acct-1",
+    provider: "google",
+    role: "OWNER",
+    purpose: ["messaging"],
+    accessGate: "open",
+    status: "connected",
+    externalId: "sub-1",
+    displayHandle: "owner@example.com",
+    createdAt: now,
+    updatedAt: now,
+    metadata: {
+      email: "owner@example.com",
+      grantedCapabilities: ["gmail.triage"],
+      grantedScopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      hasRefreshToken: true,
+    },
+  };
+}
+
+function fakeManager(accounts: unknown[]) {
+  return {
+    registerProvider: () => undefined,
+    evaluatePolicy: () => undefined,
+    getProvider: () => ({ provider: "google" }),
+    listAccounts: async () => accounts,
+  };
+}
+
+function domainWith(accounts: unknown[], settings: Record<string, string>) {
+  const manager = fakeManager(accounts);
+  const runtime = {
+    getSetting: (key: string) => settings[key],
+    getService: () => manager,
+  };
+  const ctx = { runtime, agentId: () => "agent-1" };
+  return new GoogleDomain(ctx as never);
+}
 
 describe("GoogleDomain OAuth callback parity", () => {
   it("starts OAuth with GOOGLE_REDIRECT_URI, not a portless INTERNAL_URL origin", async () => {
@@ -51,5 +95,93 @@ describe("GoogleDomain OAuth callback parity", () => {
       expect.not.objectContaining({ redirectUri: expect.anything() }),
     );
     expect(response.redirectUri).toBe(CANONICAL);
+  });
+
+  it("fails OAuth start closed when the callback cannot reach the served origin", async () => {
+    const domain = domainWith([], {
+      GOOGLE_CLIENT_ID: "client-id",
+      GOOGLE_CLIENT_SECRET: "client-secret",
+      GOOGLE_REDIRECT_URI: CANONICAL,
+    });
+    await expect(
+      domain.startGoogleConnector(
+        { side: "owner" },
+        new URL("http://127.0.0.1:2138/api/lifeops/connectors/google/start"),
+      ),
+    ).rejects.toThrow(/served on port 2138/);
+  });
+
+  it("fails OAuth start closed on a credential/query/fragment-bearing callback", async () => {
+    for (const redirect of [
+      "http://user:pass@127.0.0.1:31437/api/connectors/google/oauth/callback",
+      `${CANONICAL}?next=https://evil.example`,
+      `${CANONICAL}#frag`,
+    ]) {
+      const domain = domainWith([], {
+        GOOGLE_CLIENT_ID: "client-id",
+        GOOGLE_CLIENT_SECRET: "client-secret",
+        GOOGLE_REDIRECT_URI: redirect,
+      });
+      await expect(
+        domain.startGoogleConnector(
+          { side: "owner" },
+          new URL("http://127.0.0.1:31437/api/lifeops/connectors/google/start"),
+        ),
+      ).rejects.toThrow(/callback is not usable/);
+    }
+  });
+
+  it("keeps a persisted grant connected when the callback config is broken", async () => {
+    const domain = domainWith([connectedAccount()], {
+      // Portless loopback: the misconfiguration Shaw's leftover names.
+      GOOGLE_REDIRECT_URI:
+        "http://127.0.0.1/api/connectors/google/oauth/callback",
+    });
+    const status = await domain.getGoogleConnectorStatus(
+      new URL("http://127.0.0.1:2138/api/lifeops/connectors/google"),
+      "local",
+      "owner",
+    );
+    expect(status.connected).toBe(true);
+    expect(status.configured).toBe(true);
+    expect(status.reason).toBe("connected");
+    expect(status.grant).not.toBeNull();
+  });
+
+  it("reports callback misconfiguration only when no account is persisted", async () => {
+    const domain = domainWith([], {
+      GOOGLE_REDIRECT_URI:
+        "http://127.0.0.1/api/connectors/google/oauth/callback",
+    });
+    const status = await domain.getGoogleConnectorStatus(
+      new URL("http://127.0.0.1:2138/api/lifeops/connectors/google"),
+      "local",
+      "owner",
+    );
+    expect(status.connected).toBe(false);
+    expect(status.configured).toBe(false);
+    expect(status.reason).toBe("config_missing");
+    expect(
+      status.degradations?.some(
+        (degradation) =>
+          degradation.code === "google_oauth_callback_portless_loopback",
+      ),
+    ).toBe(true);
+  });
+
+  it("reports a served-origin port mismatch in the disconnected status", async () => {
+    const domain = domainWith([], { GOOGLE_REDIRECT_URI: CANONICAL });
+    const status = await domain.getGoogleConnectorStatus(
+      new URL("http://127.0.0.1:2138/api/lifeops/connectors/google"),
+      "local",
+      "owner",
+    );
+    expect(status.configured).toBe(false);
+    expect(
+      status.degradations?.some(
+        (degradation) =>
+          degradation.code === "google_oauth_callback_wrong_port",
+      ),
+    ).toBe(true);
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.oauth-callback.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.oauth-callback.test.ts
@@ -52,7 +52,10 @@ function domainWith(accounts: unknown[], settings: Record<string, string>) {
 }
 
 /** Domain wired for OAuth start: a manager whose startOAuth echoes the callback. */
-function startDomainWith(redirectUri: string) {
+function startDomainWith(
+  redirectUri: string,
+  settings: Record<string, string> = {},
+) {
   const startOAuth = vi.fn(async () => ({
     redirectUri,
     authUrl: "https://accounts.google.com/o/oauth2/v2/auth?client_id=test",
@@ -63,6 +66,7 @@ function startDomainWith(redirectUri: string) {
         GOOGLE_CLIENT_ID: "client-id",
         GOOGLE_CLIENT_SECRET: "client-secret",
         GOOGLE_REDIRECT_URI: redirectUri,
+        ...settings,
       })[key],
   };
   const domain = new GoogleDomain({
@@ -88,6 +92,7 @@ describe("GoogleDomain OAuth callback parity", () => {
           GOOGLE_CLIENT_ID: "client-id",
           GOOGLE_CLIENT_SECRET: "client-secret",
           GOOGLE_REDIRECT_URI: CANONICAL,
+          ELIZA_API_PORT: "31437",
         })[key],
     };
     const manager = {
@@ -214,12 +219,58 @@ describe("GoogleDomain OAuth callback parity", () => {
   });
 
   it("starts OAuth from chat against a local loopback callback", async () => {
-    const { domain } = startDomainWith(CANONICAL);
+    const { domain, startOAuth } = startDomainWith(CANONICAL, {
+      ELIZA_API_PORT: "31437",
+    });
     const response = await domain.startGoogleConnector(
       { side: "owner" },
       new URL("http://127.0.0.1/"),
     );
     expect(response.redirectUri).toBe(CANONICAL);
+    expect(startOAuth).toHaveBeenCalledWith(
+      "google",
+      expect.objectContaining({ servedOrigin: "http://127.0.0.1:31437" }),
+    );
+  });
+
+  it("fails chat OAuth start when the configured loopback callback misses the API port", async () => {
+    const { domain } = startDomainWith(CANONICAL, {
+      ELIZA_API_PORT: "2138",
+    });
+    await expect(
+      domain.startGoogleConnector(
+        { side: "owner" },
+        new URL("http://127.0.0.1/"),
+      ),
+    ).rejects.toThrow(/served on port 2138/);
+  });
+
+  it("uses the configured concrete API bind host for chat reachability", async () => {
+    const { domain } = startDomainWith(CANONICAL, {
+      ELIZA_API_BIND: "localhost",
+      ELIZA_API_PORT: "31437",
+    });
+    await expect(
+      domain.startGoogleConnector(
+        { side: "owner" },
+        new URL("http://127.0.0.1/"),
+      ),
+    ).rejects.toThrow(/served on localhost/);
+  });
+
+  it("accepts a loopback callback proven reachable through a wildcard bind", async () => {
+    const { domain, startOAuth } = startDomainWith(CANONICAL, {
+      ELIZA_API_BIND: "0.0.0.0",
+      ELIZA_API_PORT: "31437",
+    });
+    await domain.startGoogleConnector(
+      { side: "owner" },
+      new URL("http://127.0.0.1/"),
+    );
+    expect(startOAuth).toHaveBeenCalledWith(
+      "google",
+      expect.objectContaining({ servedOrigin: "http://127.0.0.1:31437" }),
+    );
   });
 
   it("forwards the real served origin to the connector start boundary", async () => {
@@ -232,7 +283,56 @@ describe("GoogleDomain OAuth callback parity", () => {
     await domain.startGoogleConnector({ side: "owner" }, requestUrl);
     expect(startOAuth).toHaveBeenCalledWith(
       "google",
-      expect.objectContaining({ servedOrigin: requestUrl.href }),
+      expect.objectContaining({ servedOrigin: requestUrl.origin }),
+    );
+  });
+
+  it("uses the configured external origin for chat OAuth callback validation", async () => {
+    const callback =
+      "https://eliza.example/api/connectors/google/oauth/callback";
+    const { domain, startOAuth } = startDomainWith(callback, {
+      ELIZA_EXTERNAL_BASE_URL: "https://eliza.example/app",
+    });
+    await domain.startGoogleConnector(
+      { side: "owner" },
+      new URL("http://127.0.0.1/"),
+    );
+    expect(startOAuth).toHaveBeenCalledWith(
+      "google",
+      expect.objectContaining({
+        servedOrigin: "https://eliza.example",
+      }),
+    );
+  });
+
+  it("rejects a configured external origin that does not match the callback", async () => {
+    const callback =
+      "https://eliza.example/api/connectors/google/oauth/callback";
+    const { domain } = startDomainWith(callback, {
+      ELIZA_EXTERNAL_BASE_URL: "https://other.example",
+    });
+    await expect(
+      domain.startGoogleConnector(
+        { side: "owner" },
+        new URL("http://127.0.0.1/"),
+      ),
+    ).rejects.toThrow(/served on other\.example/);
+  });
+
+  it("rejects a malformed external origin without echoing its secret", async () => {
+    const secret = "external-origin-secret";
+    const callback =
+      "https://eliza.example/api/connectors/google/oauth/callback";
+    const { domain } = startDomainWith(callback, {
+      ELIZA_EXTERNAL_BASE_URL: `not a URL ${secret}`,
+    });
+    await expect(
+      domain.startGoogleConnector(
+        { side: "owner" },
+        new URL("http://127.0.0.1/"),
+      ),
+    ).rejects.toThrow(
+      "Google OAuth callback is not usable: The configured external connector origin is not a valid URL.",
     );
   });
 

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.oauth-callback.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.oauth-callback.test.ts
@@ -51,6 +51,31 @@ function domainWith(accounts: unknown[], settings: Record<string, string>) {
   return new GoogleDomain(ctx as never);
 }
 
+/** Domain wired for OAuth start: a manager whose startOAuth echoes the callback. */
+function startDomainWith(redirectUri: string) {
+  const startOAuth = vi.fn(async () => ({
+    redirectUri,
+    authUrl: "https://accounts.google.com/o/oauth2/v2/auth?client_id=test",
+  }));
+  const runtime = {
+    getSetting: (key: string) =>
+      ({
+        GOOGLE_CLIENT_ID: "client-id",
+        GOOGLE_CLIENT_SECRET: "client-secret",
+        GOOGLE_REDIRECT_URI: redirectUri,
+      })[key],
+  };
+  const domain = new GoogleDomain({
+    runtime,
+    agentId: () => "agent-1",
+  } as never);
+  vi.spyOn(domain as never, "googleConnectorManager").mockReturnValue({
+    getProvider: () => ({ provider: "google" }),
+    startOAuth,
+  } as never);
+  return { domain, startOAuth };
+}
+
 describe("GoogleDomain OAuth callback parity", () => {
   it("starts OAuth with GOOGLE_REDIRECT_URI, not a portless INTERNAL_URL origin", async () => {
     const startOAuth = vi.fn(async () => ({
@@ -161,6 +186,83 @@ describe("GoogleDomain OAuth callback parity", () => {
     expect(status.connected).toBe(false);
     expect(status.configured).toBe(false);
     expect(status.reason).toBe("config_missing");
+    expect(
+      status.degradations?.some(
+        (degradation) =>
+          degradation.code === "google_oauth_callback_portless_loopback",
+      ),
+    ).toBe(true);
+  });
+
+  it("starts OAuth from chat (INTERNAL_URL sentinel) against a production callback", async () => {
+    // Shaw's production probe: chat has no HTTP request, so the synthetic
+    // INTERNAL_URL must not masquerade as the served origin and reject a
+    // valid https callback as wrong_host.
+    const production =
+      "https://eliza.example/api/connectors/google/oauth/callback";
+    const { domain, startOAuth } = startDomainWith(production);
+    const response = await domain.startGoogleConnector(
+      { side: "owner" },
+      new URL("http://127.0.0.1/"),
+    );
+    expect(response.redirectUri).toBe(production);
+    expect(response.authUrl).not.toBe("");
+    expect(startOAuth).toHaveBeenCalledWith(
+      "google",
+      expect.objectContaining({ servedOrigin: undefined }),
+    );
+  });
+
+  it("starts OAuth from chat against a local loopback callback", async () => {
+    const { domain } = startDomainWith(CANONICAL);
+    const response = await domain.startGoogleConnector(
+      { side: "owner" },
+      new URL("http://127.0.0.1/"),
+    );
+    expect(response.redirectUri).toBe(CANONICAL);
+  });
+
+  it("forwards the real served origin to the connector start boundary", async () => {
+    const staging =
+      "https://staging.eliza.example/api/connectors/google/oauth/callback";
+    const { domain, startOAuth } = startDomainWith(staging);
+    const requestUrl = new URL(
+      "https://staging.eliza.example/api/lifeops/connectors/google/start",
+    );
+    await domain.startGoogleConnector({ side: "owner" }, requestUrl);
+    expect(startOAuth).toHaveBeenCalledWith(
+      "google",
+      expect.objectContaining({ servedOrigin: requestUrl.href }),
+    );
+  });
+
+  it("still fails closed when a real served origin does not match the callback", async () => {
+    const { domain } = startDomainWith(
+      "https://eliza.example/api/connectors/google/oauth/callback",
+    );
+    await expect(
+      domain.startGoogleConnector(
+        { side: "owner" },
+        new URL("https://other.example/api/lifeops/connectors/google/start"),
+      ),
+    ).rejects.toThrow(/callback is not usable/);
+  });
+
+  it("keeps callback diagnostics for an errored account that needs a new flow", async () => {
+    // Shaw's readiness probe: an errored persisted account plus a broken
+    // portless callback must report needs_reauth AND the callback degradation,
+    // so the operator can fix the callback before retrying reauth.
+    const domain = domainWith([{ ...connectedAccount(), status: "error" }], {
+      GOOGLE_REDIRECT_URI:
+        "http://127.0.0.1/api/connectors/google/oauth/callback",
+    });
+    const status = await domain.getGoogleConnectorStatus(
+      new URL("http://127.0.0.1:2138/api/lifeops/connectors/google"),
+      "local",
+      "owner",
+    );
+    expect(status.connected).toBe(false);
+    expect(status.reason).toBe("needs_reauth");
     expect(
       status.degradations?.some(
         (degradation) =>

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts
@@ -356,7 +356,7 @@ export class GoogleDomain {
   }
 
   async getGoogleConnectorStatus(
-    _requestUrl: URL,
+    requestUrl: URL,
     requestedMode?: LifeOpsConnectorMode,
     requestedSide?: LifeOpsConnectorSide,
     grantId?: string,
@@ -369,20 +369,26 @@ export class GoogleDomain {
     if (!manager?.getProvider?.("google")) {
       return googlePluginUnavailableStatus(side);
     }
-    const callbackAssessment = assessGoogleOAuthCallbackConfig(
-      this.ctx.runtime,
-    );
-    if (!callbackAssessment.configured) {
-      return googleOAuthCallbackMisconfigStatus(side, callbackAssessment);
-    }
+    // Resolve the persisted account BEFORE assessing callback readiness: an
+    // existing grant works through its stored/refresh tokens regardless of the
+    // callback config, so a config mistake must not make it look disconnected
+    // (#18455). Callback readiness only gates starting a new OAuth flow.
     const account = await resolveGoogleConnectorAccount({
       runtime: this.ctx.runtime,
       requestedSide: side,
       grantId,
     });
-    return account
-      ? this.googleAccountStatus(account)
-      : disconnectedGoogleStatus(side);
+    if (account) {
+      return this.googleAccountStatus(account);
+    }
+    const callbackAssessment = assessGoogleOAuthCallbackConfig(
+      this.ctx.runtime,
+      { servedOrigin: requestUrl },
+    );
+    if (!callbackAssessment.configured) {
+      return googleOAuthCallbackMisconfigStatus(side, callbackAssessment);
+    }
+    return disconnectedGoogleStatus(side);
   }
 
   async getGoogleConnectorAccounts(
@@ -424,7 +430,7 @@ export class GoogleDomain {
 
   async startGoogleConnector(
     request: StartLifeOpsGoogleConnectorRequest,
-    _requestUrl: URL,
+    requestUrl: URL,
   ): Promise<StartLifeOpsGoogleConnectorResponse> {
     const mode = normalizeOptionalConnectorMode(request.mode, "mode");
     assertLocalMode(mode);
@@ -438,6 +444,20 @@ export class GoogleDomain {
       fail(
         503,
         "@elizaos/plugin-google-workspace is required before starting Google OAuth.",
+      );
+    }
+    // Fail closed before redirecting the user to Google: a callback that
+    // cannot reach the origin serving this request would strand the grant.
+    const callbackAssessment = assessGoogleOAuthCallbackConfig(
+      this.ctx.runtime,
+      { servedOrigin: requestUrl },
+    );
+    if (!callbackAssessment.configured) {
+      fail(
+        503,
+        `Google OAuth callback is not usable: ${callbackAssessment.issues
+          .map((issue) => issue.message)
+          .join(" ")}`,
       );
     }
 

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts
@@ -17,6 +17,7 @@ import type {
   StartLifeOpsGoogleConnectorRequest,
   StartLifeOpsGoogleConnectorResponse,
 } from "../../contracts/index.js";
+import { INTERNAL_URL } from "../access.js";
 import {
   disconnectedGoogleStatus,
   googleAccountIdFromGrantId,
@@ -35,6 +36,16 @@ import {
   normalizeOptionalConnectorMode,
   normalizeOptionalConnectorSide,
 } from "../service-normalize-connector.js";
+
+/**
+ * Chat actions and provider snapshots have no HTTP request; they pass the
+ * synthetic INTERNAL_URL sentinel (`http://127.0.0.1/`). That is not a served
+ * origin, so host/port callback comparison only runs for real request URLs —
+ * a production callback must not be rejected against the sentinel.
+ */
+function servedOriginFromRequestUrl(requestUrl: URL): URL | undefined {
+  return requestUrl.href === INTERNAL_URL.href ? undefined : requestUrl;
+}
 
 function roleForSide(side: LifeOpsConnectorSide): "OWNER" | "AGENT" {
   return side === "agent" ? "AGENT" : "OWNER";
@@ -75,6 +86,17 @@ function assertLocalMode(mode?: LifeOpsConnectorMode): void {
   }
 }
 
+function googleOAuthCallbackDegradations(
+  assessment: ReturnType<typeof assessGoogleOAuthCallbackConfig>,
+): NonNullable<LifeOpsGoogleConnectorStatus["degradations"]> {
+  return assessment.issues.map((issue) => ({
+    axis: "disconnected" as const,
+    code: `google_oauth_callback_${issue.code}`,
+    message: issue.message,
+    retryable: true,
+  }));
+}
+
 function googleOAuthCallbackMisconfigStatus(
   side: LifeOpsConnectorSide,
   assessment: ReturnType<typeof assessGoogleOAuthCallbackConfig>,
@@ -98,12 +120,7 @@ function googleOAuthCallbackMisconfigStatus(
     expiresAt: null,
     hasRefreshToken: false,
     grant: null,
-    degradations: assessment.issues.map((issue) => ({
-      axis: "disconnected",
-      code: `google_oauth_callback_${issue.code}`,
-      message: issue.message,
-      retryable: true,
-    })),
+    degradations: googleOAuthCallbackDegradations(assessment),
   };
 }
 
@@ -369,22 +386,36 @@ export class GoogleDomain {
     if (!manager?.getProvider?.("google")) {
       return googlePluginUnavailableStatus(side);
     }
-    // Resolve the persisted account BEFORE assessing callback readiness: an
-    // existing grant works through its stored/refresh tokens regardless of the
-    // callback config, so a config mistake must not make it look disconnected
-    // (#18455). Callback readiness only gates starting a new OAuth flow.
+    // Resolve the persisted account BEFORE assessing callback readiness: a
+    // CONNECTED grant works through its stored/refresh tokens regardless of
+    // the callback config, so a config mistake must not make it look
+    // disconnected (#18455). Pending/error accounts need a fresh OAuth flow,
+    // which the callback gates — those keep the callback diagnostics.
     const account = await resolveGoogleConnectorAccount({
       runtime: this.ctx.runtime,
       requestedSide: side,
       grantId,
     });
-    if (account) {
+    if (account?.status === "connected") {
       return this.googleAccountStatus(account);
     }
+    const servedOrigin = servedOriginFromRequestUrl(requestUrl);
     const callbackAssessment = assessGoogleOAuthCallbackConfig(
       this.ctx.runtime,
-      { servedOrigin: requestUrl },
+      servedOrigin ? { servedOrigin } : undefined,
     );
+    if (account) {
+      const status = this.googleAccountStatus(account);
+      return callbackAssessment.configured
+        ? status
+        : {
+            ...status,
+            degradations: [
+              ...(status.degradations ?? []),
+              ...googleOAuthCallbackDegradations(callbackAssessment),
+            ],
+          };
+    }
     if (!callbackAssessment.configured) {
       return googleOAuthCallbackMisconfigStatus(side, callbackAssessment);
     }
@@ -448,9 +479,12 @@ export class GoogleDomain {
     }
     // Fail closed before redirecting the user to Google: a callback that
     // cannot reach the origin serving this request would strand the grant.
+    // Chat has no request origin (INTERNAL_URL sentinel); scheme/path/port
+    // shape is still validated, host/port comparison is skipped.
+    const servedOrigin = servedOriginFromRequestUrl(requestUrl);
     const callbackAssessment = assessGoogleOAuthCallbackConfig(
       this.ctx.runtime,
-      { servedOrigin: requestUrl },
+      servedOrigin ? { servedOrigin } : undefined,
     );
     if (!callbackAssessment.configured) {
       fail(
@@ -465,6 +499,7 @@ export class GoogleDomain {
     const flow = await manager.startOAuth("google", {
       accountId: requestedAccountId ?? undefined,
       scopes: requestedScopesForCapabilities(requestedCapabilities),
+      servedOrigin: servedOrigin?.href,
       metadata: {
         lifeops: true,
         side: requestedSide,

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts
@@ -5,7 +5,10 @@
  */
 import {
   type ConnectorAccount,
+  DEFAULT_SERVER_ONLY_PORT,
   getConnectorAccountManager,
+  isLoopbackBindHost,
+  isWildcardBindHost,
 } from "@elizaos/core";
 import { assessGoogleOAuthCallbackConfig } from "@elizaos/plugin-google-workspace";
 import type {
@@ -38,13 +41,68 @@ import {
 } from "../service-normalize-connector.js";
 
 /**
- * Chat actions and provider snapshots have no HTTP request; they pass the
- * synthetic INTERNAL_URL sentinel (`http://127.0.0.1/`). That is not a served
- * origin, so host/port callback comparison only runs for real request URLs —
- * a production callback must not be rejected against the sentinel.
+ * Resolve the externally served connector origin. HTTP requests carry it
+ * directly. Chat and provider snapshots use the synthetic INTERNAL_URL, so
+ * public callbacks rely on ELIZA_EXTERNAL_BASE_URL while loopback callbacks
+ * infer the same API-port precedence as the agent host.
  */
-function servedOriginFromRequestUrl(requestUrl: URL): URL | undefined {
-  return requestUrl.href === INTERNAL_URL.href ? undefined : requestUrl;
+function servedOriginFromRequestUrl(
+  runtime: LifeOpsContext["runtime"],
+  requestUrl: URL,
+): string | undefined {
+  if (requestUrl.href !== INTERNAL_URL.href) return requestUrl.origin;
+
+  const externalBase = nonEmptySetting(runtime, "ELIZA_EXTERNAL_BASE_URL");
+  if (externalBase) return externalBase;
+
+  const redirect = nonEmptySetting(runtime, "GOOGLE_REDIRECT_URI");
+  if (!redirect) return undefined;
+  let callback: URL;
+  try {
+    callback = new URL(redirect);
+  } catch {
+    // error-policy:J3 callback assessment reports the malformed setting.
+    return undefined;
+  }
+  if (!isLoopbackBindHost(callback.hostname)) return undefined;
+
+  const configuredBind =
+    nonEmptySetting(runtime, "ELIZA_API_BIND") ?? "127.0.0.1";
+  const callbackHost = callback.hostname.replace(/^\[|\]$/g, "");
+  const servedHost = isWildcardBindHost(configuredBind)
+    ? callbackHost
+    : configuredBind;
+  const originHost = servedHost.includes(":")
+    ? `[${servedHost.replace(/^\[|\]$/g, "")}]`
+    : servedHost;
+  const apiPort =
+    positivePortSetting(runtime, "ELIZA_API_PORT") ??
+    positivePortSetting(runtime, "ELIZA_PORT") ??
+    positivePortSetting(runtime, "ELIZA_UI_PORT") ??
+    DEFAULT_SERVER_ONLY_PORT;
+  return `http://${originHost}:${apiPort}`;
+}
+
+function nonEmptySetting(
+  runtime: LifeOpsContext["runtime"],
+  key: string,
+): string | undefined {
+  const value = runtime.getSetting?.(key);
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function positivePortSetting(
+  runtime: LifeOpsContext["runtime"],
+  key: string,
+): number | undefined {
+  const value = nonEmptySetting(runtime, key);
+  if (!value || !/^\d+$/.test(value)) return undefined;
+  const port = Number(value);
+  return Number.isInteger(port) && port >= 1 && port <= 65_535
+    ? port
+    : undefined;
 }
 
 function roleForSide(side: LifeOpsConnectorSide): "OWNER" | "AGENT" {
@@ -399,7 +457,10 @@ export class GoogleDomain {
     if (account?.status === "connected") {
       return this.googleAccountStatus(account);
     }
-    const servedOrigin = servedOriginFromRequestUrl(requestUrl);
+    const servedOrigin = servedOriginFromRequestUrl(
+      this.ctx.runtime,
+      requestUrl,
+    );
     const callbackAssessment = assessGoogleOAuthCallbackConfig(
       this.ctx.runtime,
       servedOrigin ? { servedOrigin } : undefined,
@@ -479,9 +540,12 @@ export class GoogleDomain {
     }
     // Fail closed before redirecting the user to Google: a callback that
     // cannot reach the origin serving this request would strand the grant.
-    // Chat has no request origin (INTERNAL_URL sentinel); scheme/path/port
-    // shape is still validated, host/port comparison is skipped.
-    const servedOrigin = servedOriginFromRequestUrl(requestUrl);
+    // Chat has no request URL (INTERNAL_URL sentinel), so it uses an explicit
+    // external base when configured or infers the local agent API port.
+    const servedOrigin = servedOriginFromRequestUrl(
+      this.ctx.runtime,
+      requestUrl,
+    );
     const callbackAssessment = assessGoogleOAuthCallbackConfig(
       this.ctx.runtime,
       servedOrigin ? { servedOrigin } : undefined,
@@ -494,12 +558,15 @@ export class GoogleDomain {
           .join(" ")}`,
       );
     }
+    const providerServedOrigin = servedOrigin
+      ? new URL(servedOrigin).origin
+      : undefined;
 
     const requestedAccountId = googleAccountIdFromGrantId(request.grantId);
     const flow = await manager.startOAuth("google", {
       accountId: requestedAccountId ?? undefined,
       scopes: requestedScopesForCapabilities(requestedCapabilities),
-      servedOrigin: servedOrigin?.href,
+      servedOrigin: providerServedOrigin,
       metadata: {
         lifeops: true,
         side: requestedSide,


### PR DESCRIPTION
# Relates to

Relates to #18455 (non-closing). This patch hardens callback validation and readiness ordering, but it does not deliver the live Google authorization/callback, restart-persistence, revoke, read-only Gmail/Calendar, and browser evidence still required by that issue.

# Summary

- Validate `GOOGLE_REDIRECT_URI` at the real connector `startOAuth` boundary and return no redirect URI for malformed or unreachable configurations.
- Carry the actual served origin through `ConnectorOAuthStartRequest`; the Settings route ignores spoofable forwarding headers and uses `ELIZA_EXTERNAL_BASE_URL` as the only reverse-proxy authority.
- Require exact scheme, canonical host, effective port, and callback path. Reject credentials, query strings, fragments, malformed hosts, fake `127.*` DNS names, and distinct loopback listeners.
- Share strict loopback classification between core, agent, Google Workspace, and LifeOps.
- Keep a persisted connected grant usable when callback configuration later breaks, while pending/error accounts retain actionable callback diagnostics.
- Infer chat/internal callback reachability only from configured external origin or the API bind/port; wildcard binds prove local reachability without pretending distinct loopback addresses are equivalent.

This is the narrowest deep implementation because the trust decision is enforced at both ingress and provider boundaries: the agent establishes an authoritative origin, and the Google provider independently refuses to create an OAuth URL when that origin cannot receive the callback.

# Risk

Existing invalid callback values that were previously accepted now fail early. Valid public HTTPS and exact loopback deployments remain supported. No UI, prompt, model, or database schema changes are included.

# Sync and verification

- [x] Rebased without conflicts onto `origin/develop@8adfe6254abce7ecd8e2ba4c77f35c6716059845`.
- [x] Final reviewed head: `46a60c31eb4d1207211c8183d47e8096930573c9`.
- [x] Exact-head focused tests: core 15, agent 35, Google Workspace 37, Personal Assistant 17 — 104/104 passing.
- [x] Exact-head build, typecheck, and lint pass for all four affected workspaces.
- [x] Exact-head `bun run verify`: 350/350 tasks passing; anti-larp scanned 7,965 test files with 0 focused tests and 0 orphaned skips.
- [x] Full Google Workspace suite: 154/154 passing.
- [x] Full Personal Assistant suite: 1,765 passing, 6 skipped across 214 files.

The full Agent suite reported three failures in untouched cloud/routing tests. Each reproduces independently, and its test plus direct implementation files are byte-identical to `origin/develop`: cloud plugin injection, the existing `api.eliza.app` versus `api.elizacloud.ai` expectation, and an existing workflow score expectation. They are not on the runtime-env, account-manager, request-origin, or connector OAuth paths changed here.

# Reviewer entry points

- `packages/core/src/runtime-env.ts`
- `packages/agent/src/api/request-origin.ts`
- `packages/agent/src/api/connector-account-routes.ts`
- `plugins/plugin-google-workspace/src/google-oauth-callback.ts`
- `plugins/plugin-google-workspace/src/connector-account-provider.ts`
- `plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts`

# Evidence Gate

<!-- evidence-head:46a60c31eb4d1207211c8183d47e8096930573c9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only change; no rendered UI files are touched`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only change; no rendered UI files are touched`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - backend-only validation and connector orchestration change`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: exact-head focused runs passed 104/104; repository verification passed 350/350 tasks and the 7,965-file anti-larp audit.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no prompt, model, planner, action, or provider behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: adversarial tests cover malformed origins, spoofed forwarding headers, exact host/port/scheme/path matching, wildcard binds, chat-origin inference, and connected/pending/error account states.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Known evidence gap

Live Google OAuth proof is `N/A` for this PR because project Google credentials were unavailable to the contributor/reviewer. That evidence remains required by, and deliberately leaves open, #18455.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [claude-18455]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZX8ZDV0XKM8C37980CYJM7G","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T09:59:10.432Z","completed_at":"2026-08-13T12:15:27.626Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA1wup-TpOQbidV6XOR-nWj5-01vmuc1Uuv5emKqsM8iA","device_key_id":"dbd0806ed31cfab14a18eeb4990c66497a5ce64fdb0d37d3c878b8f5e6227484","device_signature":"FHwDaUeKUMXl8-6cfDETg62dWcXlHPIjs2LARyKGuCtQp5eERIwei3AvA7DbMgwVKLynNI3UVb8awOO-os97DA"}} -->
