### PR TITLE
test(workflow): deepen route dispatcher coverage

### DIFF
--- a/plugins/plugin-workflow/__tests__/integration/routes-e2e.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/routes-e2e.test.ts
@@ -51,6 +51,7 @@ function workflowResponse(overrides: Record<string, unknown> = {}) {
     active: true,
     language: 'typescript',
     source: 'export default async function main() { return 1; }',
+    versionId: 'version-current',
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
     ...overrides,
@@ -108,6 +109,13 @@ function makeWorkflowService(state: FakeServiceState) {
     getWorkflowExecutions: record('getWorkflowExecutions', [
       { id: 'exec-001', workflowId: 'wf-001', status: 'success' },
     ]),
+    getWorkflowRevisions: record('getWorkflowRevisions', [
+      { id: 'revision-001', versionId: 'version-old' },
+    ]),
+    restoreWorkflowRevision: record(
+      'restoreWorkflowRevision',
+      workflowResponse({ versionId: 'version-old' })
+    ),
   };
 }
 
@@ -226,16 +234,31 @@ describe('plugin-workflow rawPath routes through real dispatch (#19044)', () => 
     expect(state.calls.find((c) => c.method === 'deployWorkflow')).toBeUndefined();
   });
 
+  test('the dispatcher rejects malformed JSON before the workflow handler runs', async () => {
+    const state: FakeServiceState = { calls: [] };
+    const base = await startServer(makeRuntime({ state }));
+
+    const res = await fetch(`${base}/api/workflow/workflows`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: 'Invalid JSON body' });
+    expect(state.calls).toEqual([]);
+  });
+
   test('GET /api/workflow/workflows/:id dispatches the decoded id parameter', async () => {
     const state: FakeServiceState = { calls: [] };
     const base = await startServer(makeRuntime({ state }));
 
-    const res = await fetch(`${base}/api/workflow/workflows/wf-001`);
+    const res = await fetch(`${base}/api/workflow/workflows/wf%20one`);
 
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ id: 'wf-001' });
     const call = state.calls.find((c) => c.method === 'getWorkflow');
-    expect(call?.args[0]).toBe('wf-001');
+    expect(call?.args[0]).toBe('wf one');
   });
 
   test('POST /api/workflow/workflows/:id/run starts a manual execution and answers 202', async () => {
@@ -270,6 +293,39 @@ describe('plugin-workflow rawPath routes through real dispatch (#19044)', () => 
     });
     const call = state.calls.find((c) => c.method === 'cancelExecution');
     expect(call?.args[0]).toBe('exec-001');
+  });
+
+  test('GET /api/workflow/executions/:id returns execution detail for the owner', async () => {
+    const state: FakeServiceState = { calls: [] };
+    const base = await startServer(makeRuntime({ state }));
+
+    const res = await fetch(`${base}/api/workflow/executions/exec-001`);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      execution: { id: 'exec-001', status: 'success' },
+    });
+    const call = state.calls.find((candidate) => candidate.method === 'getExecutionDetail');
+    expect(call?.args[0]).toBe('exec-001');
+    expect(typeof call?.args[1]).toBe('string');
+  });
+
+  test('POST /api/workflow/workflows/:id/revisions/:versionId/restore decodes both ids', async () => {
+    const state: FakeServiceState = { calls: [] };
+    const base = await startServer(makeRuntime({ state }));
+
+    const res = await postJson(
+      base,
+      '/api/workflow/workflows/wf%20one/revisions/version%20old/restore',
+      {}
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ id: 'wf-001', versionId: 'version-old' });
+    const call = state.calls.find((candidate) => candidate.method === 'restoreWorkflowRevision');
+    expect(call?.args[0]).toBe('wf one');
+    expect(call?.args[1]).toBe('version old');
+    expect(typeof call?.args[2]).toBe('string');
   });
 
   test('the dispatcher auth gate rejects unauthenticated calls before any handler runs', async () => {


### PR DESCRIPTION
# Relates to

Closes #19070
Follow-up to contributor PR #19050.

# Summary

Extends the real loopback HTTP suite contributed in #19050 rather than introducing another harness. The added cases prove:

- malformed JSON returns 400 before any `WorkflowService` call;
- execution detail traverses `tryHandleRuntimePluginRoute` with an owner;
- revision restore decodes both workflow and version identifiers;
- the existing get-by-id claim now uses a genuinely encoded identifier.

This is test-only: no runtime behavior, manifest, timeout, skip, or production fallback changes.

# Verification

All gates ran on exact tree `ad6b6969c3b17434e1b1fd183305fb8bfde75d8d` / head `17d082a31fb04e5d3942316a6de8c2d42e93990f`:

```text
route suite: 13 pass, 0 fail, 42 assertions
plugin-workflow: 9/9 isolated files pass
test:scripts: complete 143-file lane exits 0
verify: 350 successful, 350 total workspace tasks
anti-larp: 7,953 test files; 0 focused; 0 orphaned skips
```

# Evidence Gate

<!-- evidence-head:17d082a31fb04e5d3942316a6de8c2d42e93990f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only, no UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only, no UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic HTTP contract exercised in the suite.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no deployed backend changed; verification transcript summarized above.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain artifact changed.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [codex]