### PR TITLE
fix(cloud): promote router readiness retry to main

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -573,8 +573,20 @@ jobs:
             done
             sudo nginx -t
             sudo systemctl reload nginx
-            curl -fsS "https://${AGENT_ROUTER_PUBLIC_HOST}/healthz" \
-              | grep -Eq '"ok"[[:space:]]*:[[:space:]]*true'
+            canonical_router_ready=false
+            for attempt in $(seq 1 30); do
+              if curl -fsS "https://${AGENT_ROUTER_PUBLIC_HOST}/healthz" \
+                | grep -Eq '"ok"[[:space:]]*:[[:space:]]*true'; then
+                canonical_router_ready=true
+                break
+              fi
+              echo "Canonical agent-router health not ready (attempt ${attempt}/30)"
+              sleep 2
+            done
+            if [ "$canonical_router_ready" != "true" ]; then
+              echo "::error::Canonical agent-router did not return JSON health after 30 attempts"
+              exit 1
+            fi
             echo "Verified canonical agent-router nginx host alias: ${AGENT_ROUTER_PUBLIC_HOST}"
 
       - name: Health check


### PR DESCRIPTION
## Summary
Promotes only #19073 to main so the production router deploy retries its public JSON readiness proof after daemon restart. Unrelated develop-only changes remain out of this urgent production promotion.

## Validation
- actionlint passed
- production run 31699069266 proved nginx config/reload and exposed a single-probe transient 502 during router startup

Refs #19047

---
Created by Codex for @ShawWalters