### PR TITLE
fix(cloud): restore canonical Steward sign-in

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -698,15 +698,25 @@ jobs:
           # publish or mutate the pre-existing service bridge credential.
           ELIZA_SERVICE_JWT_SECRET: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_SERVICE_JWT_SECRET || '' }}
           STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID: ${{ steps.env.outputs.deploy_environment == 'staging' && vars.STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID || '' }}
-          STAGING_SESSION_EXCHANGE_ALLOWED_API_KEY_IDS: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.STAGING_SESSION_EXCHANGE_ALLOWED_API_KEY_IDS || '' }}
-          STAGING_SESSION_EXCHANGE_ALLOWED_USER_IDS: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.STAGING_SESSION_EXCHANGE_ALLOWED_USER_IDS || '' }}
-          STAGING_SESSION_EXCHANGE_ALLOWED_ORGANIZATION_IDS: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.STAGING_SESSION_EXCHANGE_ALLOWED_ORGANIZATION_IDS || '' }}
+          STAGING_SESSION_EXCHANGE_ALLOWED_API_KEY_IDS: ${{ steps.env.outputs.deploy_environment == 'staging' && vars.STAGING_SESSION_EXCHANGE_ALLOWED_API_KEY_IDS || '' }}
+          STAGING_SESSION_EXCHANGE_ALLOWED_USER_IDS: ${{ steps.env.outputs.deploy_environment == 'staging' && vars.STAGING_SESSION_EXCHANGE_ALLOWED_USER_IDS || '' }}
+          STAGING_SESSION_EXCHANGE_ALLOWED_ORGANIZATION_IDS: ${{ steps.env.outputs.deploy_environment == 'staging' && vars.STAGING_SESSION_EXCHANGE_ALLOWED_ORGANIZATION_IDS || '' }}
+          # Core Steward/OIDC bindings are preserved when their protected
+          # GitHub source is not yet backfilled, then names-only verified after
+          # deploy. Once configured, this step converges them on every release.
+          STEWARD_API_URL: ${{ secrets.STEWARD_API_URL }}
+          STEWARD_JWT_SECRET: ${{ secrets.STEWARD_JWT_SECRET }}
+          STEWARD_SESSION_SECRET: ${{ secrets.STEWARD_SESSION_SECRET }}
+          STEWARD_REQUEST_SIGNING_SECRET: ${{ secrets.STEWARD_REQUEST_SIGNING_SECRET }}
           # Platform key the Worker forwards as X-Steward-Platform-Key so per-org
           # sandbox Steward tenants provision instead of collapsing onto the
           # shared default tenant (#11461). publish_secret no-ops with a notice
           # while unset, so this is safe before ops adds the GH env secret and
           # keeps it published on every redeploy once they do.
           STEWARD_PLATFORM_KEYS: ${{ secrets.STEWARD_PLATFORM_KEYS }}
+          STEWARD_TENANT_API_KEY: ${{ secrets.STEWARD_TENANT_API_KEY }}
+          OIDC_SIGNING_JWKS: ${{ secrets.OIDC_SIGNING_JWKS }}
+          OIDC_CLIENTS: ${{ secrets.OIDC_CLIENTS }}
           ELIZA_APP_WEBHOOK_GATEWAY_URL: ${{ vars.ELIZA_APP_WEBHOOK_GATEWAY_URL }}
           ELIZA_APP_WEBHOOK_GATEWAY_SECRET: ${{ secrets.ELIZA_APP_WEBHOOK_GATEWAY_SECRET }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -958,7 +968,14 @@ jobs:
             FISH_AUDIO_API_KEY \
             FISH_AUDIO_REFERENCE_ID \
             VOICE_REALTIME_ELIZA_AUTHORIZATION \
+            STEWARD_API_URL \
+            STEWARD_JWT_SECRET \
+            STEWARD_SESSION_SECRET \
+            STEWARD_REQUEST_SIGNING_SECRET \
             STEWARD_PLATFORM_KEYS \
+            STEWARD_TENANT_API_KEY \
+            OIDC_SIGNING_JWKS \
+            OIDC_CLIENTS \
             ELIZA_APP_WEBHOOK_GATEWAY_SECRET
           do
             publish_secret "$name"
@@ -1065,6 +1082,14 @@ jobs:
               "CONTAINERS_SSH_KEY",
               "SECRETS_MASTER_KEY",
               "TUNNEL_HOSTNAME_SIGNING_SECRET",
+              "OIDC_CLIENTS",
+              "OIDC_SIGNING_JWKS",
+              "STEWARD_API_URL",
+              "STEWARD_JWT_SECRET",
+              "STEWARD_SESSION_SECRET",
+              "STEWARD_REQUEST_SIGNING_SECRET",
+              "STEWARD_PLATFORM_KEYS",
+              "STEWARD_TENANT_API_KEY",
             ];
             const missing = required.filter((name) => !present.has(name));
             if (missing.length > 0) {
@@ -1759,6 +1784,14 @@ jobs:
             verify_exact_api_route "$served_url/api"
             verify_json_endpoint "$served_url/.well-known/openid-configuration" discovery
             verify_json_endpoint "$served_url/.well-known/oidc/jwks.json" jwks
+            tenant_id="elizacloud"
+            if [ "$DEPLOY_ENVIRONMENT" = "staging" ]; then
+              tenant_id="elizacloud-staging"
+            fi
+            node packages/cloud/scripts/verify-steward-oauth-callbacks.mjs \
+              --base-url "$served_url" \
+              --callback-url "$served_url/login" \
+              --tenant-id "$tenant_id"
           done
 
       - name: Clean temp checkout

--- a/packages/app/public/sw.js
+++ b/packages/app/public/sw.js
@@ -83,11 +83,28 @@ const HERO_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 h
 const ASSETS_CACHE_MAX_ENTRIES = 220;
 const KNOWN_CACHES = [VIEWS_CACHE_NAME, SHELL_CACHE_NAME, ASSETS_CACHE_NAME];
 
+// Snapshot this while the new worker is still installing. On an update the
+// registration points at the previous active worker; on a first install it is
+// null. Reading it later during `activate` would see this worker instead and
+// could not distinguish the two cases.
+const IS_SERVICE_WORKER_UPDATE = Boolean(self.registration.active);
+
 const VIEW_BUNDLE_RE = /^\/api\/views\/[^/]+\/bundle\.js$/;
 const VIEW_HERO_RE = /^\/api\/views\/[^/]+\/hero$/;
+const AUTH_NAVIGATION_PATH_RE =
+  /^\/(?:login(?:\/|$)|auth(?:\/|$)|oidc\/continue(?:\/|$))/;
 // Vite emits content-hashed static build output under /assets/. The hash makes
 // these safe to treat as immutable (cache-first, never revalidate).
 const IMMUTABLE_ASSET_RE = /^\/assets\/[^/]+\.(?:js|mjs|css|woff2?|json|wasm)$/;
+
+function isAuthNavigationUrl(rawUrl) {
+  try {
+    return AUTH_NAVIGATION_PATH_RE.test(new URL(rawUrl).pathname);
+  } catch {
+    // An unparseable client URL is not safe to replay during activation.
+    return true;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Lifecycle
@@ -123,21 +140,26 @@ self.addEventListener("activate", (event) => {
 
       await self.clients.claim();
 
-      // A newly activated worker means a new renderer was deployed. Existing
-      // tabs still execute their old JS indefinitely (notably across an OAuth
-      // app-pause/resume), so navigate same-origin windows once to load the
-      // current content-hashed renderer.
-      const windows = await self.clients.matchAll({
-        type: "window",
-        includeUncontrolled: true,
-      });
-      await Promise.all(
-        windows.map((client) =>
-          typeof client.navigate === "function"
-            ? client.navigate(client.url).catch(() => undefined)
-            : undefined,
-        ),
-      );
+      if (IS_SERVICE_WORKER_UPDATE) {
+        // A replacement worker means a new renderer was deployed. Existing
+        // tabs still execute their old JS indefinitely (notably across an OAuth
+        // app-pause/resume), so navigate same-origin windows once to load the
+        // current content-hashed renderer. Never navigate on first install:
+        // replaying an in-flight cross-origin auth bridge erases its referrer
+        // and makes the bridge correctly reject the now-unverifiable request.
+        const windows = await self.clients.matchAll({
+          type: "window",
+          includeUncontrolled: true,
+        });
+        await Promise.all(
+          windows.map((client) =>
+            typeof client.navigate === "function" &&
+            !isAuthNavigationUrl(client.url)
+              ? client.navigate(client.url).catch(() => undefined)
+              : undefined,
+          ),
+        );
+      }
     })(),
   );
 });

--- a/packages/app/scripts/sync-homepage-assets.mjs
+++ b/packages/app/scripts/sync-homepage-assets.mjs
@@ -14,7 +14,7 @@ const appRoot = path.resolve(
 const homepagePublic = path.resolve(appRoot, "../homepage/public");
 const appPublic = path.join(appRoot, "public");
 
-const ASSETS = [
+export const HOMEPAGE_PUBLIC_ASSETS = [
   ".well-known/apple-app-site-association",
   ".well-known/assetlinks.json",
   "eliza-logo.webp",
@@ -25,16 +25,27 @@ const ASSETS = [
   "grain.webp",
   "install.ps1",
   "install.sh",
-  "models/iphone-meshopt.glb",
   "product/elizaos-usb-key-concept.png",
   "tbg.webp",
 ];
 
-await Promise.all(
-  ASSETS.map(async (relativePath) => {
-    const source = path.join(homepagePublic, relativePath);
-    const destination = path.join(appPublic, relativePath);
-    await mkdir(path.dirname(destination), { recursive: true });
-    await copyFile(source, destination);
-  }),
-);
+export async function syncHomepageAssets({
+  sourceRoot = homepagePublic,
+  destinationRoot = appPublic,
+} = {}) {
+  await Promise.all(
+    HOMEPAGE_PUBLIC_ASSETS.map(async (relativePath) => {
+      const source = path.join(sourceRoot, relativePath);
+      const destination = path.join(destinationRoot, relativePath);
+      await mkdir(path.dirname(destination), { recursive: true });
+      await copyFile(source, destination);
+    }),
+  );
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  await syncHomepageAssets();
+}

--- a/packages/app/scripts/sync-homepage-assets.test.mjs
+++ b/packages/app/scripts/sync-homepage-assets.test.mjs
@@ -1,0 +1,68 @@
+/**
+ * Verifies the unified app's homepage asset manifest against real source files
+ * and exercises its nested-directory copy boundary in an isolated directory.
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { after, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  HOMEPAGE_PUBLIC_ASSETS,
+  syncHomepageAssets,
+} from "./sync-homepage-assets.mjs";
+
+const homepagePublic = fileURLToPath(
+  new URL("../../homepage/public/", import.meta.url),
+);
+const temporaryRoots = [];
+
+after(async () => {
+  await Promise.all(
+    temporaryRoots.map((temporaryRoot) =>
+      rm(temporaryRoot, { recursive: true, force: true }),
+    ),
+  );
+});
+
+test("every approved homepage asset exists in the source module", async () => {
+  assert.equal(
+    new Set(HOMEPAGE_PUBLIC_ASSETS).size,
+    HOMEPAGE_PUBLIC_ASSETS.length,
+    "homepage asset manifest must not contain duplicate paths",
+  );
+
+  await Promise.all(
+    HOMEPAGE_PUBLIC_ASSETS.map(async (relativePath) => {
+      const source = path.join(homepagePublic, relativePath);
+      assert.equal(
+        (await stat(source)).isFile(),
+        true,
+        `homepage asset manifest source is not a file: ${relativePath}`,
+      );
+    }),
+  );
+});
+
+test("asset sync preserves bytes and nested relative paths", async () => {
+  const destinationRoot = await mkdtemp(
+    path.join(os.tmpdir(), "eliza-homepage-assets-"),
+  );
+  temporaryRoots.push(destinationRoot);
+
+  await syncHomepageAssets({
+    sourceRoot: homepagePublic,
+    destinationRoot,
+  });
+
+  await Promise.all(
+    HOMEPAGE_PUBLIC_ASSETS.map(async (relativePath) => {
+      const [source, destination] = await Promise.all([
+        readFile(path.join(homepagePublic, relativePath)),
+        readFile(path.join(destinationRoot, relativePath)),
+      ]);
+      assert.deepEqual(destination, source, relativePath);
+    }),
+  );
+});

--- a/packages/app/src/sw-registration.test.ts
+++ b/packages/app/src/sw-registration.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Service-worker update reload wiring through deterministic registration and
+ * container fakes. First installation must not replay an auth navigation;
+ * replacement workers reload the stale renderer exactly once.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  isAuthNavigationUrl,
+  wireServiceWorkerUpdateReload,
+} from "./sw-registration";
+
+interface ListenerStore {
+  registration: Map<string, EventListener>;
+  container: Map<string, EventListener>;
+}
+
+function makeHarness(
+  hasController: boolean,
+  currentUrl = "https://staging.eliza.app/chat",
+) {
+  const listeners: ListenerStore = {
+    registration: new Map(),
+    container: new Map(),
+  };
+  const registration = {
+    waiting: null,
+    installing: null,
+    addEventListener(type: string, listener: EventListener) {
+      listeners.registration.set(type, listener);
+    },
+  } as unknown as ServiceWorkerRegistration;
+  const serviceWorkers = {
+    controller: hasController ? ({} as ServiceWorker) : null,
+    addEventListener(type: string, listener: EventListener) {
+      listeners.container.set(type, listener);
+    },
+  } as unknown as ServiceWorkerContainer;
+  const reload = vi.fn();
+
+  wireServiceWorkerUpdateReload(
+    registration,
+    serviceWorkers,
+    reload,
+    () => currentUrl,
+  );
+
+  return { listeners, reload };
+}
+
+describe("service-worker controller-change reload", () => {
+  it("does not reload when the first worker claims an uncontrolled page", () => {
+    const { listeners, reload } = makeHarness(false);
+
+    listeners.container.get("controllerchange")?.(
+      new Event("controllerchange"),
+    );
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("reloads exactly once when a replacement worker takes control", () => {
+    const { listeners, reload } = makeHarness(true);
+    const controllerChange = listeners.container.get("controllerchange");
+
+    controllerChange?.(new Event("controllerchange"));
+    controllerChange?.(new Event("controllerchange"));
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    "https://staging.eliza.app/auth/bridge?state=state",
+    "https://staging.eliza.app/login?code=one-time-code",
+    "https://staging.eliza.app/oidc/continue?rid=eoq_request",
+  ])("does not replay an auth-sensitive update navigation: %s", (url) => {
+    const { listeners, reload } = makeHarness(true, url);
+
+    listeners.container.get("controllerchange")?.(
+      new Event("controllerchange"),
+    );
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+describe("service-worker auth navigation classification", () => {
+  it("matches exact auth route families without blocking ordinary app pages", () => {
+    expect(isAuthNavigationUrl("https://eliza.app/login")).toBe(true);
+    expect(isAuthNavigationUrl("https://eliza.app/auth/email-callback")).toBe(
+      true,
+    );
+    expect(isAuthNavigationUrl("https://eliza.app/oidc/continue")).toBe(true);
+    expect(isAuthNavigationUrl("https://eliza.app/chat")).toBe(false);
+    expect(isAuthNavigationUrl("https://eliza.app/login-history")).toBe(false);
+  });
+});

--- a/packages/app/src/sw-registration.ts
+++ b/packages/app/src/sw-registration.ts
@@ -36,6 +36,20 @@ function isElectrobunHost(): boolean {
   );
 }
 
+const AUTH_NAVIGATION_PATH_RE =
+  /^\/(?:login(?:\/|$)|auth(?:\/|$)|oidc\/continue(?:\/|$))/;
+
+/** Auth callbacks and bridges are one-time navigations that updates must not replay. */
+export function isAuthNavigationUrl(rawUrl: string): boolean {
+  try {
+    return AUTH_NAVIGATION_PATH_RE.test(new URL(rawUrl).pathname);
+  } catch {
+    // error-policy:J3 an unparseable current URL is treated as auth-sensitive;
+    // skipping an update reload is safer than replaying an unknown navigation.
+    return true;
+  }
+}
+
 /**
  * When a NEW service worker reaches `installed` while an existing controller is
  * present, a fresh renderer was just deployed. The new SW's own `activate`
@@ -45,15 +59,22 @@ function isElectrobunHost(): boolean {
  * Guarded so the FIRST install (no prior controller) does NOT reload — that is a
  * normal first paint, not an update (CONVERSATIONS-500-2026-07-22 fix #1).
  */
-function wireServiceWorkerUpdateReload(
+export function wireServiceWorkerUpdateReload(
   registration: ServiceWorkerRegistration,
+  serviceWorkers: ServiceWorkerContainer = navigator.serviceWorker,
+  reload: () => void = () => globalThis.location.reload(),
+  currentUrl: () => string = () => globalThis.location.href,
 ): void {
+  // Snapshot before `controllerchange`: first-install claim changes this from
+  // null to the new worker, while an update already has the previous worker.
+  // Only the latter represents a stale renderer that needs a reload.
+  const isUpdate = Boolean(serviceWorkers.controller);
   let reloading = false;
   const reloadOnControllerChange = () => {
-    if (reloading) return;
+    if (!isUpdate || reloading || isAuthNavigationUrl(currentUrl())) return;
     reloading = true;
     // The new worker is now controlling this page → load the new renderer.
-    globalThis.location.reload();
+    reload();
   };
 
   const trackInstalling = (worker: ServiceWorker | null) => {
@@ -61,7 +82,7 @@ function wireServiceWorkerUpdateReload(
     worker.addEventListener("statechange", () => {
       // A worker reaching `installed` with an existing controller = an UPDATE
       // (not the first install). Ask it to activate immediately.
-      if (worker.state === "installed" && navigator.serviceWorker.controller) {
+      if (worker.state === "installed" && serviceWorkers.controller) {
         try {
           worker.postMessage({ type: "SKIP_WAITING" });
         } catch {
@@ -72,7 +93,7 @@ function wireServiceWorkerUpdateReload(
   };
 
   // A worker already waiting at registration time (installed between sessions).
-  if (registration.waiting && navigator.serviceWorker.controller) {
+  if (registration.waiting && serviceWorkers.controller) {
     try {
       registration.waiting.postMessage({ type: "SKIP_WAITING" });
     } catch {
@@ -84,11 +105,8 @@ function wireServiceWorkerUpdateReload(
     trackInstalling(registration.installing);
   });
 
-  // Reload exactly once when control passes to the new worker.
-  navigator.serviceWorker.addEventListener(
-    "controllerchange",
-    reloadOnControllerChange,
-  );
+  // On an update, reload exactly once when control passes to the new worker.
+  serviceWorkers.addEventListener("controllerchange", reloadOnControllerChange);
 }
 
 /**

--- a/packages/app/test/service-worker-cache-strategies.test.ts
+++ b/packages/app/test/service-worker-cache-strategies.test.ts
@@ -6,6 +6,8 @@
  *
  * Covers the cold-start wins added for the installed iOS PWA:
  *  - navigation preload is enabled on activate (feature-detected)
+ *  - first install claims but never navigates an in-flight auth bridge
+ *  - replacement workers navigate existing windows to the fresh renderer
  *  - a navigation consumes event.preloadResponse instead of a second fetch
  *  - immutable /assets/<hash>.{js,css,...} are served cache-first and cached
  *  - the immutable asset cache is bounded (oldest entries evicted past the cap)
@@ -67,17 +69,23 @@ type Harness = {
   dispatch: (type: string, event: unknown) => void;
   caches: Map<string, FakeCache>;
   navPreloadEnabled: () => boolean;
+  clientClaims: () => number;
+  clientNavigations: () => string[];
   fetchCalls: () => string[];
 };
 
 function loadServiceWorker(options?: {
   navigationPreload?: boolean;
+  previousActiveWorker?: boolean;
   preexistingCaches?: string[];
+  clientUrls?: string[];
   fetchImpl?: (url: string) => Response;
 }): Harness {
   const {
     navigationPreload = true,
+    previousActiveWorker = false,
     preexistingCaches = [],
+    clientUrls = [],
     fetchImpl,
   } = options ?? {};
 
@@ -88,13 +96,17 @@ function loadServiceWorker(options?: {
   let navPreloadOn = false;
   const registration = navigationPreload
     ? {
+        active: previousActiveWorker ? {} : null,
         navigationPreload: {
           enable: async () => {
             navPreloadOn = true;
           },
         },
       }
-    : {};
+    : { active: previousActiveWorker ? {} : null };
+
+  let clientClaims = 0;
+  const clientNavigations: string[] = [];
 
   const self = {
     location: { origin: "https://app.example.test" },
@@ -104,8 +116,19 @@ function loadServiceWorker(options?: {
     },
     skipWaiting: () => Promise.resolve(),
     clients: {
-      claim: () => Promise.resolve(),
-      matchAll: () => Promise.resolve([]),
+      claim: () => {
+        clientClaims += 1;
+        return Promise.resolve();
+      },
+      matchAll: () =>
+        Promise.resolve(
+          clientUrls.map((url) => ({
+            url,
+            navigate: async (target: string) => {
+              clientNavigations.push(target);
+            },
+          })),
+        ),
     },
   };
 
@@ -145,6 +168,8 @@ function loadServiceWorker(options?: {
     },
     caches: cacheStore,
     navPreloadEnabled: () => navPreloadOn,
+    clientClaims: () => clientClaims,
+    clientNavigations: () => clientNavigations,
     fetchCalls: () => fetchCalls,
   };
 }
@@ -213,6 +238,41 @@ describe("service worker navigation preload", () => {
     expect(worker.caches.has("stale-cache-v0")).toBe(false);
     expect(worker.caches.has("elizaos-shell-v5")).toBe(false);
     expect(worker.caches.has(SHELL_CACHE_NAME)).toBe(true);
+  });
+
+  it("claims clients without navigating an in-flight auth bridge on first install", async () => {
+    const bridgeUrl =
+      "https://app.example.test/auth/bridge?state=state&challenge=challenge";
+    const worker = loadServiceWorker({ clientUrls: [bridgeUrl] });
+    const event = makeActivateEvent();
+
+    worker.dispatch("activate", event);
+    await Promise.all(event._work);
+
+    expect(worker.clientClaims()).toBe(1);
+    expect(worker.clientNavigations()).toEqual([]);
+  });
+
+  it("refreshes ordinary windows but preserves auth flows during an update", async () => {
+    const urls = [
+      "https://app.example.test/chat",
+      "https://app.example.test/login?code=oauth-code",
+      "https://app.example.test/auth/bridge?state=state",
+      "https://app.example.test/oidc/continue?rid=eoq_request",
+    ];
+    const worker = loadServiceWorker({
+      previousActiveWorker: true,
+      clientUrls: urls,
+    });
+    const event = makeActivateEvent();
+
+    worker.dispatch("activate", event);
+    await Promise.all(event._work);
+
+    expect(worker.clientClaims()).toBe(1);
+    expect(worker.clientNavigations()).toEqual([
+      "https://app.example.test/chat",
+    ]);
   });
 
   it("consumes the navigation preload response instead of issuing a second fetch", async () => {

--- a/packages/cloud/api/auth/logout/route.test.ts
+++ b/packages/cloud/api/auth/logout/route.test.ts
@@ -1,7 +1,7 @@
 /**
- * Logout cookie clearing keeps production and staging sessions isolated on the
- * shared elizacloud.ai parent domain. Non-production must clear its suffixed
- * Steward cookies without deleting production's historical unsuffixed names.
+ * Logout enforces the Steward mutation origin policy while keeping production
+ * and staging cookie names isolated. The harness mocks teardown collaborators
+ * but exercises the real route and cookie headers.
  */
 
 import { describe, expect, mock, test } from "bun:test";
@@ -61,6 +61,7 @@ describe("POST /api/auth/logout cookie clearing", () => {
         method: "POST",
         headers: {
           host: "api-staging.elizacloud.ai",
+          origin: "https://staging.eliza.app",
           cookie:
             "steward-token=prod-token; steward-refresh-token=prod-refresh",
         },
@@ -90,6 +91,7 @@ describe("POST /api/auth/logout cookie clearing", () => {
         method: "POST",
         headers: {
           host: "api-staging.elizacloud.ai",
+          origin: "https://staging.eliza.app",
           cookie:
             "steward-token=prod-token; steward-refresh-token=prod-refresh; steward-token-staging=staging-token; steward-refresh-token-staging=staging-refresh",
         },
@@ -114,6 +116,7 @@ describe("POST /api/auth/logout cookie clearing", () => {
         method: "POST",
         headers: {
           host: "api.elizacloud.ai",
+          origin: "https://eliza.app",
           cookie:
             "steward-token=prod-token; steward-refresh-token=prod-refresh",
         },
@@ -126,5 +129,56 @@ describe("POST /api/auth/logout cookie clearing", () => {
     expect(cleared).toContain("steward-token");
     expect(cleared).toContain("steward-refresh-token");
     expect(cleared).toContain("steward-authed");
+  });
+
+  test("same-site user-content origin cannot force a production logout", async () => {
+    getCurrentUserMock.mockClear();
+    endAllUserSessionsMock.mockClear();
+
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api.eliza.app",
+          origin: "https://attacker.cloud.eliza.app",
+          cookie:
+            "steward-token=prod-token; steward-refresh-token=prod-refresh",
+        },
+      },
+      { ENVIRONMENT: "production", NODE_ENV: "production" },
+    );
+
+    expect(res.status).toBe(403);
+    expect((await res.json()) as unknown).toEqual({
+      error: "Forbidden",
+      code: "forbidden_origin",
+    });
+    expect(res.headers.getSetCookie()).toEqual([]);
+    expect(getCurrentUserMock).not.toHaveBeenCalled();
+    expect(endAllUserSessionsMock).not.toHaveBeenCalled();
+  });
+
+  test("missing browser origin cannot mutate the session", async () => {
+    getCurrentUserMock.mockClear();
+    endAllUserSessionsMock.mockClear();
+
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api.eliza.app",
+          cookie:
+            "steward-token=prod-token; steward-refresh-token=prod-refresh",
+        },
+      },
+      { ENVIRONMENT: "production", NODE_ENV: "production" },
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.headers.getSetCookie()).toEqual([]);
+    expect(getCurrentUserMock).not.toHaveBeenCalled();
+    expect(endAllUserSessionsMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/auth/logout/route.ts
+++ b/packages/cloud/api/auth/logout/route.ts
@@ -8,6 +8,7 @@ import { Hono } from "hono";
 import { deleteCookie, getCookie } from "hono/cookie";
 import { getAuditDispatcher } from "@/api-app/services/audit-dispatcher-singleton";
 import { invalidateSessionCaches } from "@/lib/auth";
+import { checkElizaMutatingRequestOrigin } from "@/lib/auth/browser-origin-policy";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
 import { verifyStewardTokenCached } from "@/lib/auth/steward-client";
 import { stewardCookieNames } from "@/lib/auth/steward-cookies";
@@ -26,6 +27,20 @@ const app = new Hono<AppEnv>();
 app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
+  const originCheck = checkElizaMutatingRequestOrigin(
+    c.req,
+    c.env.NODE_ENV === "production",
+  );
+  if (!originCheck.ok) {
+    logger.warn("[Logout] Rejected cross-origin POST", {
+      detail: originCheck.reason,
+    });
+    return c.json(
+      { error: "Forbidden", code: "forbidden_origin" as const },
+      403,
+    );
+  }
+
   const cookieNames = stewardCookieNames(c.env.ENVIRONMENT);
   // Each environment reads only its own scoped cookie. The bounded read-only
   // migration window that let non-production fall back to the historical

--- a/packages/cloud/api/test/e2e/group-a-auth.test.ts
+++ b/packages/cloud/api/test/e2e/group-a-auth.test.ts
@@ -728,7 +728,12 @@ describeE2E("Group A: auth + sessions", () => {
       const res = await api.post(
         "/api/auth/logout",
         {},
-        { headers: bearerHeaders() },
+        {
+          headers: {
+            ...bearerHeaders(),
+            Origin: new URL(getBaseUrl()).origin,
+          },
+        },
       );
       expect(res.status).toBe(200);
       const body = (await res.json()) as { success?: boolean };

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -260,7 +260,8 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 #   REDIS_URL                          Railway TCP Redis (primary cache/queue/rate-limit; rediss://...)
 #   STEWARD_API_URL                    Optional Steward base URL override;
 #       defaults to NEXT_PUBLIC_STEWARD_API_URL or NEXT_PUBLIC_API_URL + /steward
-#   STEWARD_SESSION_SECRET             HS256 secret for Steward JWT verify (jose); MUST match Steward host
+#   STEWARD_JWT_SECRET                 Canonical HS256 secret for Steward JWT verify (jose); MUST match Steward host
+#   STEWARD_SESSION_SECRET             Deprecated compatibility alias for STEWARD_JWT_SECRET
 #   STEWARD_MASTER_PASSWORD            Steward vault encryption master password; required for wallet/key ops
 #   STEWARD_TENANT_ID                  Default tenant scope; verifier rejects other tenants
 #   STEWARD_DEFAULT_TENANT_ID          Embedded Steward default tenant id (optional; defaults to elizacloud)

--- a/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Steward canonical-callback deploy probe tests use deterministic fetch fakes;
+ * no provider request or tenant mutation leaves the process.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  parseStewardCallbackProbeArgs,
+  verifyStewardOAuthCallbacks,
+} from "../verify-steward-oauth-callbacks.mjs";
+
+const CONFIG = {
+  baseUrl: "https://staging.eliza.app",
+  callbackUrl: "https://staging.eliza.app/login",
+  tenantId: "elizacloud-staging",
+};
+
+describe("Steward OAuth callback deployment probe", () => {
+  test("proves both provider handoffs use the exact canonical callback", async () => {
+    const requested: URL[] = [];
+    const results = await verifyStewardOAuthCallbacks(CONFIG, {
+      fetchImpl: async (input: string | URL | Request) => {
+        const url = new URL(String(input));
+        requested.push(url);
+        const provider = url.pathname.includes("/discord/")
+          ? "discord"
+          : "google";
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location:
+              provider === "discord"
+                ? "https://discord.com/oauth2/authorize?client_id=public"
+                : "https://accounts.google.com/o/oauth2/v2/auth?client_id=public",
+          },
+        });
+      },
+    });
+
+    expect(results).toEqual([
+      { provider: "discord", destinationHostname: "discord.com" },
+      { provider: "google", destinationHostname: "accounts.google.com" },
+    ]);
+    expect(requested).toHaveLength(2);
+    for (const url of requested) {
+      expect(url.origin).toBe(CONFIG.baseUrl);
+      expect(url.searchParams.get("tenant_id")).toBe(CONFIG.tenantId);
+      expect(url.searchParams.get("redirect_uri")).toBe(CONFIG.callbackUrl);
+      expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    }
+  });
+
+  test("fails closed on the tenant's disallowed-redirect response", async () => {
+    await expect(
+      verifyStewardOAuthCallbacks(CONFIG, {
+        fetchImpl: async () =>
+          Response.json(
+            { ok: false, error: "redirect_uri is not allowed for this tenant" },
+            { status: 400 },
+          ),
+      }),
+    ).rejects.toThrow("HTTP 400");
+  });
+
+  test("rejects a redirect to a non-provider host", async () => {
+    await expect(
+      verifyStewardOAuthCallbacks(CONFIG, {
+        fetchImpl: async () =>
+          new Response(null, {
+            status: 302,
+            headers: { Location: "https://attacker.example/collect" },
+          }),
+      }),
+    ).rejects.toThrow("unexpected provider host");
+  });
+
+  test("requires HTTPS and all three deployment-owned inputs", () => {
+    expect(() =>
+      parseStewardCallbackProbeArgs([
+        "--base-url",
+        "http://staging.eliza.app",
+        "--callback-url",
+        CONFIG.callbackUrl,
+        "--tenant-id",
+        CONFIG.tenantId,
+      ]),
+    ).toThrow("--base-url must use https");
+    expect(() => parseStewardCallbackProbeArgs([])).toThrow(
+      "--base-url is required",
+    );
+  });
+});

--- a/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
+++ b/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Verify that a deployed Eliza browser host can begin every supported Steward
+ * OAuth flow with its exact canonical callback. The probe stops at the first
+ * provider redirect, so it validates Pages routing, tenant allowlists, and
+ * provider configuration without authenticating a user or mutating a session.
+ */
+
+import { createHash } from "node:crypto";
+import { pathToFileURL } from "node:url";
+
+const PROVIDER_DESTINATIONS = Object.freeze({
+  discord: "discord.com",
+  google: "accounts.google.com",
+});
+
+function requiredUrl(value, flag) {
+  if (!value) throw new Error(`${flag} is required`);
+  const url = new URL(value);
+  if (url.protocol !== "https:") {
+    throw new Error(`${flag} must use https`);
+  }
+  return url;
+}
+
+export function parseStewardCallbackProbeArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith("--") || !value) {
+      throw new Error(`Invalid argument near ${flag ?? "<end>"}`);
+    }
+    values.set(flag, value);
+  }
+
+  const baseUrl = requiredUrl(values.get("--base-url"), "--base-url");
+  const callbackUrl = requiredUrl(
+    values.get("--callback-url"),
+    "--callback-url",
+  );
+  const tenantId = values.get("--tenant-id")?.trim();
+  if (!tenantId) throw new Error("--tenant-id is required");
+
+  return {
+    baseUrl: baseUrl.origin,
+    callbackUrl: callbackUrl.toString(),
+    tenantId,
+  };
+}
+
+function pkceChallenge() {
+  return createHash("sha256")
+    .update("eliza-canonical-callback-deploy-probe")
+    .digest("base64url");
+}
+
+export async function verifyStewardOAuthCallbacks(
+  { baseUrl, callbackUrl, tenantId },
+  { fetchImpl = fetch } = {},
+) {
+  const results = [];
+  for (const [provider, expectedHostname] of Object.entries(
+    PROVIDER_DESTINATIONS,
+  )) {
+    const query = new URLSearchParams({
+      tenant_id: tenantId,
+      redirect_uri: callbackUrl,
+      code_challenge: pkceChallenge(),
+      code_challenge_method: "S256",
+      state: "canonical-callback-deploy-probe",
+    });
+    const endpoint = `${baseUrl}/steward/auth/oauth/${provider}/authorize?${query}`;
+    const response = await fetchImpl(endpoint, { redirect: "manual" });
+    const location = response.headers.get("location");
+
+    if (response.status !== 302 || !location) {
+      throw new Error(
+        `${provider} callback probe returned HTTP ${response.status}; expected a provider redirect`,
+      );
+    }
+
+    const destination = new URL(location);
+    if (
+      destination.protocol !== "https:" ||
+      destination.hostname !== expectedHostname
+    ) {
+      throw new Error(
+        `${provider} callback probe reached unexpected provider host ${destination.hostname}`,
+      );
+    }
+    results.push({ provider, destinationHostname: destination.hostname });
+  }
+  return results;
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const config = parseStewardCallbackProbeArgs(argv);
+  const results = await verifyStewardOAuthCallbacks(config);
+  for (const result of results) {
+    console.log(
+      `Verified ${result.provider} canonical callback via ${result.destinationHostname}.`,
+    );
+  }
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href
+  : undefined;
+if (invokedPath === import.meta.url) {
+  main().catch((error) => {
+    console.error(
+      `verify-steward-oauth-callbacks: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/packages/cloud/shared/.env.example
+++ b/packages/cloud/shared/.env.example
@@ -72,9 +72,9 @@ DATABASE_URL=postgresql://user:password@host:5432/eliza_platform?sslmode=require
 # Steward is the sole user-session provider for eliza-cloud.
 # The Cloud API Worker mounts Steward at /steward; override only for non-default dev.
 #
-# IMPORTANT: STEWARD_SESSION_SECRET MUST match the value Steward signs JWTs
-# with (Steward reads `STEWARD_SESSION_SECRET` with a fallback to
-# `STEWARD_MASTER_PASSWORD`). If they diverge, every JWT signature check fails.
+# IMPORTANT: STEWARD_JWT_SECRET MUST match the value Steward signs JWTs with.
+# STEWARD_SESSION_SECRET remains a deprecated compatibility alias during the
+# credential migration. If the verifier and Steward diverge, every JWT check fails.
 
 # Server + client base URL for the Steward API.
 NEXT_PUBLIC_STEWARD_API_URL=http://localhost:8787/steward
@@ -82,7 +82,8 @@ STEWARD_API_URL=http://localhost:8787/steward
 
 # HS256 secret used to verify Steward access JWTs locally (jose).
 # Generate with: openssl rand -base64 48
-STEWARD_SESSION_SECRET=replace_with_strong_random_secret
+STEWARD_JWT_SECRET=replace_with_strong_random_secret
+# STEWARD_SESSION_SECRET=replace_with_the_same_secret_during_migration
 
 # Default tenant scope. The verifier rejects JWTs whose `tenantId` claim does
 # not match this value (defence against tenant-mixing).

--- a/packages/cloud/shared/src/lib/config/env-validator.test.ts
+++ b/packages/cloud/shared/src/lib/config/env-validator.test.ts
@@ -13,7 +13,8 @@ function withBaseEnv(stripeSecretKey: string) {
   process.env = {
     ...ORIGINAL_ENV,
     DATABASE_URL: "postgresql://user:pass@localhost:5432/eliza",
-    STEWARD_SESSION_SECRET: "x".repeat(32),
+    STEWARD_JWT_SECRET: "x".repeat(32),
+    STEWARD_SESSION_SECRET: undefined,
     CRON_SECRET: "y".repeat(32),
     STRIPE_SECRET_KEY: stripeSecretKey,
   };
@@ -47,6 +48,31 @@ describe("validateEnvironment", () => {
       message:
         "STRIPE_SECRET_KEY: Must start with 'sk_test_', 'sk_live_', 'rk_test_', or 'rk_live_'. Feature may not work correctly.",
       required: false,
+    });
+  });
+
+  it("accepts the deprecated Steward session-secret alias during migration", () => {
+    withBaseEnv("sk_test_123");
+    process.env.STEWARD_JWT_SECRET = undefined;
+    process.env.STEWARD_SESSION_SECRET = "s".repeat(32);
+
+    const result = validateEnvironment();
+
+    expect(result.errors.filter((error) => error.variable === "STEWARD_JWT_SECRET")).toEqual([]);
+  });
+
+  it("requires either canonical or deprecated Steward JWT verifier secret", () => {
+    withBaseEnv("sk_test_123");
+    process.env.STEWARD_JWT_SECRET = undefined;
+    process.env.STEWARD_SESSION_SECRET = undefined;
+
+    const result = validateEnvironment();
+
+    expect(result.errors).toContainEqual({
+      variable: "STEWARD_JWT_SECRET",
+      message:
+        "STEWARD_JWT_SECRET is required but not set (STEWARD_SESSION_SECRET is accepted as a deprecated fallback).",
+      required: true,
     });
   });
 });

--- a/packages/cloud/shared/src/lib/config/env-validator.ts
+++ b/packages/cloud/shared/src/lib/config/env-validator.ts
@@ -52,9 +52,18 @@ const ENV_VARS = {
     },
     errorMessage: "Must be an http(s) URL or same-origin /steward path",
   },
+  STEWARD_JWT_SECRET: {
+    required: false,
+    failOnInvalid: true,
+    description:
+      "Canonical HS256 secret used to verify Steward session JWTs (must match Steward host)",
+    validate: (value: string) => value.trim().length >= 32,
+    errorMessage: "Must be at least 32 characters",
+  },
   STEWARD_SESSION_SECRET: {
-    required: true,
-    description: "HS256 secret used to verify Steward session JWTs (must match Steward host)",
+    required: false,
+    failOnInvalid: true,
+    description: "Deprecated alias for STEWARD_JWT_SECRET used during credential migration",
     validate: (value: string) => value.trim().length >= 32,
     errorMessage: "Must be at least 32 characters",
   },
@@ -231,6 +240,15 @@ const ENV_VARS = {
 export function validateEnvironment(): EnvValidationResult {
   const errors: EnvValidationError[] = [];
   const warnings: EnvValidationError[] = [];
+
+  if (!process.env.STEWARD_JWT_SECRET && !process.env.STEWARD_SESSION_SECRET) {
+    errors.push({
+      variable: "STEWARD_JWT_SECRET",
+      message:
+        "STEWARD_JWT_SECRET is required but not set (STEWARD_SESSION_SECRET is accepted as a deprecated fallback).",
+      required: true,
+    });
+  }
 
   for (const [variable, config] of Object.entries(ENV_VARS)) {
     const value = process.env[variable];

--- a/packages/scripts/__tests__/cloud-cf-staging-session-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-staging-session-deploy-workflow.test.ts
@@ -127,6 +127,22 @@ describe("Cloud CF staging session cutover", () => {
     expect(validateStagingSessionCutoverConfig(VALID)).toEqual([]);
     expect(workflowSource).toContain("ELIZA_SERVICE_JWT_SECRET:");
     expect(workflowSource).toContain("secrets.ELIZA_SERVICE_JWT_SECRET");
+    expect(workflowSource).toContain(
+      `STAGING_SESSION_EXCHANGE_SIGNING_SECRET: \${{ steps.env.outputs.deploy_environment == 'staging' && secrets.STAGING_SESSION_EXCHANGE_SIGNING_SECRET || '' }}`,
+    );
+    expect(workflowSource).toContain(
+      `STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID: \${{ steps.env.outputs.deploy_environment == 'staging' && vars.STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID || '' }}`,
+    );
+    for (const name of [
+      "STAGING_SESSION_EXCHANGE_ALLOWED_API_KEY_IDS",
+      "STAGING_SESSION_EXCHANGE_ALLOWED_USER_IDS",
+      "STAGING_SESSION_EXCHANGE_ALLOWED_ORGANIZATION_IDS",
+    ]) {
+      expect(workflowSource).toContain(
+        `${name}: \${{ steps.env.outputs.deploy_environment == 'staging' && vars.${name} || '' }}`,
+      );
+      expect(workflowSource).not.toContain(`secrets.${name}`);
+    }
     expect(
       validateStagingSessionCutoverConfig({
         ...VALID,

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -61,6 +61,17 @@ const cloudWorkerSecretNames = [
   "TUNNEL_HOSTNAME_SIGNING_SECRET",
 ] as const;
 
+const requiredAuthWorkerSecretNames = [
+  "OIDC_CLIENTS",
+  "OIDC_SIGNING_JWKS",
+  "STEWARD_API_URL",
+  "STEWARD_JWT_SECRET",
+  "STEWARD_SESSION_SECRET",
+  "STEWARD_REQUEST_SIGNING_SECRET",
+  "STEWARD_PLATFORM_KEYS",
+  "STEWARD_TENANT_API_KEY",
+] as const;
+
 describe("canonical cloud deployment environment contract", () => {
   test("derives Terraform deploy branches from the selected environment", () => {
     const deployBranch = infra.jobs?.terraform?.env?.TF_VAR_deploy_branch;
@@ -235,6 +246,19 @@ describe("canonical cloud deployment environment contract", () => {
       'echo "::notice::$name is not configured; skipping"',
     );
     expect(publish.run).not.toContain("required_worker_provisioning_secrets=(");
+    for (const name of requiredAuthWorkerSecretNames) {
+      expect(publish.env?.[name]).toContain("secrets.");
+      expect(publish.run).toContain(`\n  ${name} \\\n`);
+    }
+    expect(publish.env?.STAGING_SESSION_EXCHANGE_ALLOWED_API_KEY_IDS).toContain(
+      "vars.STAGING_SESSION_EXCHANGE_ALLOWED_API_KEY_IDS",
+    );
+    expect(publish.env?.STAGING_SESSION_EXCHANGE_ALLOWED_USER_IDS).toContain(
+      "vars.STAGING_SESSION_EXCHANGE_ALLOWED_USER_IDS",
+    );
+    expect(
+      publish.env?.STAGING_SESSION_EXCHANGE_ALLOWED_ORGANIZATION_IDS,
+    ).toContain("vars.STAGING_SESSION_EXCHANGE_ALLOWED_ORGANIZATION_IDS");
   });
 
   test("verifies required Worker binding names after deploy without reading values", () => {
@@ -257,6 +281,9 @@ describe("canonical cloud deployment environment contract", () => {
     expect(inventory?.run).toContain("wrangler@4.100.0 secret list");
     expect(inventory?.run).toContain("--format json");
     for (const name of cloudWorkerSecretNames) {
+      expect(inventory?.run).toContain(`\n    "${name}",\n`);
+    }
+    for (const name of requiredAuthWorkerSecretNames) {
       expect(inventory?.run).toContain(`\n    "${name}",\n`);
     }
     expect(inventory?.run).toContain(
@@ -299,6 +326,11 @@ describe("canonical cloud deployment environment contract", () => {
     expect(verify.run).toContain(
       'verify_json_endpoint "$served_url/.well-known/oidc/jwks.json" jwks',
     );
+    expect(verify.run).toContain(
+      "node packages/cloud/scripts/verify-steward-oauth-callbacks.mjs",
+    );
+    expect(verify.run).toContain('--callback-url "$served_url/login"');
+    expect(verify.run).toContain('tenant_id="elizacloud-staging"');
     expect(verify.run).toContain("OIDC issuer mismatch");
     expect(cloudSource).not.toContain(
       "pages project create eliza-app --production-branch=main 2>/dev/null || true",

--- a/packages/ui/src/cloud/public-pages/lib/oidc-continue.test.ts
+++ b/packages/ui/src/cloud/public-pages/lib/oidc-continue.test.ts
@@ -17,6 +17,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildOidcResumeTarget,
   configuredOidcIssuerUrl,
+  prepareOidcResumeTarget,
   resolveOidcIssuerOrigin,
 } from "./oidc-continue";
 
@@ -98,6 +99,17 @@ describe("resolveOidcIssuerOrigin", () => {
     ).toBeNull();
   });
 
+  it.each(["javascript:alert(1)", "data:text/plain,issuer", "file:///api"])(
+    "rejects a non-HTTP issuer scheme: %s",
+    (issuer) => {
+      withIssuer(issuer);
+      expect(resolveOidcIssuerOrigin("staging.eliza.app")).toBeNull();
+      expect(buildOidcResumeTarget(RID, "staging.eliza.app")).toEqual({
+        status: "issuer_unconfigured",
+      });
+    },
+  );
+
   it("reads only the VITE_ name Vite actually exposes to the bundle", () => {
     // The Next-era name was accepted here as a fallback, but Vite only inlines
     // `VITE_`-prefixed members, so that branch could never fire in a real build
@@ -171,5 +183,69 @@ describe("buildOidcResumeTarget", () => {
     expect(buildOidcResumeTarget("nope", "console.example").status).toBe(
       "invalid_request_id",
     );
+  });
+});
+
+describe("prepareOidcResumeTarget", () => {
+  it("syncs the stored session to the configured staging issuer before resume", async () => {
+    withIssuer("https://api-staging.eliza.app");
+    const events: string[] = [];
+
+    const target = await prepareOidcResumeTarget(
+      RID,
+      "staging.eliza.app",
+      "https://staging.eliza.app",
+      {
+        readToken: () => "  steward-access-token  ",
+        syncSession: async (token, endpoint) => {
+          events.push(`${token} ${endpoint}`);
+        },
+      },
+    );
+
+    expect(events).toEqual([
+      "steward-access-token https://api-staging.eliza.app/api/auth/steward-session",
+    ]);
+    expect(target).toEqual({
+      status: "ok",
+      url: `https://api-staging.eliza.app/api/oidc/authorize/resume?rid=${RID}`,
+    });
+  });
+
+  it("does not sync an invalid request id", async () => {
+    withIssuer("https://api-staging.eliza.app");
+    const syncSession = vi.fn(() => Promise.resolve());
+
+    await expect(
+      prepareOidcResumeTarget("invalid", "staging.eliza.app", undefined, {
+        readToken: () => "token",
+        syncSession,
+      }),
+    ).resolves.toEqual({ status: "invalid_request_id" });
+    expect(syncSession).not.toHaveBeenCalled();
+  });
+
+  it("does not consume the request without a stored Steward session", async () => {
+    withIssuer("https://api-staging.eliza.app");
+    const syncSession = vi.fn(() => Promise.resolve());
+
+    await expect(
+      prepareOidcResumeTarget(RID, "staging.eliza.app", undefined, {
+        readToken: () => "  ",
+        syncSession,
+      }),
+    ).resolves.toEqual({ status: "session_missing" });
+    expect(syncSession).not.toHaveBeenCalled();
+  });
+
+  it("keeps the parked request unconsumed when issuer session sync fails", async () => {
+    withIssuer("https://api-staging.eliza.app");
+
+    await expect(
+      prepareOidcResumeTarget(RID, "staging.eliza.app", undefined, {
+        readToken: () => "token",
+        syncSession: () => Promise.reject(new Error("network unavailable")),
+      }),
+    ).resolves.toEqual({ status: "session_sync_failed" });
   });
 });

--- a/packages/ui/src/cloud/public-pages/lib/oidc-continue.ts
+++ b/packages/ui/src/cloud/public-pages/lib/oidc-continue.ts
@@ -1,5 +1,6 @@
 /**
- * Destination resolution for the OIDC sign-in bounce (`/oidc/continue`).
+ * Destination resolution and issuer-session preparation for the OIDC sign-in
+ * bounce (`/oidc/continue`).
  *
  * The Eliza Cloud OpenID Provider lives on the API origin, but its `/authorize`
  * endpoint can only send a signed-out browser to the console's `/login`, whose
@@ -19,15 +20,21 @@
  * its issuer names, so a guess that misses lands on a host where the parked
  * request does not exist and the user is told their sign-in expired. Nor is it
  * the console's own origin: the resume leg is authenticated by a per-request
- * binding cookie that `/authorize` set as a HOST-ONLY cookie on the issuer host,
- * so a hop through the console origin's `/api` proxy arrives without it and every
- * sign-in reads as expired.
+ * binding cookie that `/authorize` set as a HOST-ONLY cookie on the issuer host.
+ * Steward's session cookie is also host-only, so this module explicitly syncs
+ * the browser's stored Steward token to that issuer origin before resuming.
  *
  * When the issuer is unset, only LOOPBACK development resolves — to the current
  * origin, where the dev server proxies `/api` and the binding cookie therefore
  * belongs to that origin — and every other host resolves to nothing so the page
  * can say which variable is missing.
  */
+
+import {
+  readStoredStewardToken,
+  STEWARD_SESSION_ENDPOINT,
+  syncStewardSession,
+} from "@elizaos/shared/steward-session-client";
 
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
@@ -48,6 +55,21 @@ export type OidcResumeTarget =
   | { status: "ok"; url: string }
   | { status: "invalid_request_id" }
   | { status: "issuer_unconfigured" };
+
+/**
+ * Result after both destination validation and issuer-origin session sync.
+ * Session failures are deliberately distinct from invalid request ids because
+ * retrying the application request cannot repair a missing browser login.
+ */
+export type PreparedOidcResumeTarget =
+  | OidcResumeTarget
+  | { status: "session_missing" }
+  | { status: "session_sync_failed" };
+
+export interface OidcIssuerSessionDependencies {
+  readToken?: () => string | null;
+  syncSession?: (token: string, endpoint: string) => Promise<unknown>;
+}
 
 /**
  * The configured issuer. `import.meta.env.VITE_OIDC_ISSUER_URL` is written as a
@@ -77,7 +99,9 @@ export function resolveOidcIssuerOrigin(
   const configured = configuredOidcIssuerUrl();
   if (configured) {
     try {
-      return new URL(configured).origin;
+      const url = new URL(configured);
+      if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+      return url.origin;
     } catch {
       // error-policy:J3 untrusted-input sanitizing — an unusable build-time
       // value is reported as "no issuer", never silently replaced by a guess at
@@ -108,4 +132,49 @@ export function buildOidcResumeTarget(
   const url = new URL(OIDC_RESUME_PATH, `${origin}/`);
   url.searchParams.set("rid", requestId);
   return { status: "ok", url: url.toString() };
+}
+
+/**
+ * Validate the parked request destination and establish a Steward cookie on
+ * the issuer host before `/resume` consumes the request. The sync endpoint is
+ * derived from the already issuer-pinned resume target, never from caller
+ * input, preserving the open-redirect and cross-tenant boundaries above.
+ */
+export async function prepareOidcResumeTarget(
+  requestId: string | null | undefined,
+  hostname: string | null | undefined,
+  currentOrigin?: string | null,
+  dependencies: OidcIssuerSessionDependencies = {},
+): Promise<PreparedOidcResumeTarget> {
+  const target = buildOidcResumeTarget(requestId, hostname, currentOrigin);
+  if (target.status !== "ok") return target;
+
+  const readToken = dependencies.readToken ?? readStoredStewardToken;
+  const token = readToken()?.trim();
+  if (!token) return { status: "session_missing" };
+
+  let endpoint: string;
+  try {
+    endpoint = new URL(STEWARD_SESSION_ENDPOINT, target.url).toString();
+  } catch {
+    // error-policy:J3 the already validated issuer unexpectedly failed URL
+    // construction; report deployment configuration instead of rejecting the
+    // continuation promise and leaving the page in a permanent loading state.
+    return { status: "issuer_unconfigured" };
+  }
+  const syncSession =
+    dependencies.syncSession ??
+    ((stewardToken: string, sessionEndpoint: string) =>
+      syncStewardSession(stewardToken, null, { endpoint: sessionEndpoint }));
+
+  try {
+    await syncSession(token, endpoint);
+  } catch {
+    // error-policy:J4 user-facing degrade — a failed cross-origin session sync
+    // is shown as an authentication error and the one-time OIDC request is not
+    // consumed without the issuer-host session required to authorize it.
+    return { status: "session_sync_failed" };
+  }
+
+  return target;
 }

--- a/packages/ui/src/cloud/public-pages/pages/oidc/oidc-continue-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/oidc/oidc-continue-page.test.tsx
@@ -1,4 +1,4 @@
-/** Verifies invalid OIDC continuation recovery through the public page. */
+/** Verifies OIDC continuation recovery through the real public page state. */
 // @vitest-environment jsdom
 
 import { cleanup, render, screen } from "@testing-library/react";
@@ -12,14 +12,32 @@ vi.mock("../../../shell/CloudI18nProvider", () => ({
 }));
 vi.mock("../../lib/use-page-title", () => ({ usePageTitle: () => {} }));
 
+const { prepareOidcResumeTargetMock } = vi.hoisted(() => ({
+  prepareOidcResumeTargetMock: vi.fn(),
+}));
+vi.mock("../../lib/oidc-continue", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("../../lib/oidc-continue")>();
+  return {
+    ...original,
+    prepareOidcResumeTarget: prepareOidcResumeTargetMock,
+  };
+});
+
 import OidcContinuePage from "./oidc-continue-page";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  prepareOidcResumeTargetMock.mockReset();
+});
 
 describe("OidcContinuePage", () => {
   it.each(["/oidc/continue", "/oidc/continue?rid=%20"])(
     "offers a safe keyboard-reachable recovery action for %s",
     async (path) => {
+      prepareOidcResumeTargetMock.mockResolvedValue({
+        status: "invalid_request_id",
+      });
       const user = userEvent.setup();
 
       render(
@@ -41,4 +59,50 @@ describe("OidcContinuePage", () => {
       expect(document.activeElement).toBe(recovery);
     },
   );
+
+  it.each(["session_missing", "session_sync_failed"] as const)(
+    "offers sign-in recovery when issuer session preparation returns %s",
+    async (status) => {
+      prepareOidcResumeTargetMock.mockResolvedValue({ status });
+
+      render(
+        <MemoryRouter
+          initialEntries={[`/oidc/continue?rid=eoq_${"a".repeat(64)}`]}
+        >
+          <OidcContinuePage />
+        </MemoryRouter>,
+      );
+
+      expect(
+        await screen.findByText(
+          "Your Eliza session could not be securely transferred to the identity provider. Sign in again to continue.",
+        ),
+      ).toBeTruthy();
+      expect(
+        screen
+          .getByRole("link", { name: "Sign In Again" })
+          .getAttribute("href"),
+      ).toBe(
+        `/login?returnTo=${encodeURIComponent(`/oidc/continue?rid=eoq_${"a".repeat(64)}`)}`,
+      );
+    },
+  );
+
+  it("turns an unexpected preparation rejection into recoverable UI", async () => {
+    prepareOidcResumeTargetMock.mockRejectedValue(
+      new Error("unexpected browser failure"),
+    );
+
+    render(
+      <MemoryRouter
+        initialEntries={[`/oidc/continue?rid=eoq_${"a".repeat(64)}`]}
+      >
+        <OidcContinuePage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByRole("link", { name: "Sign In Again" }),
+    ).toBeTruthy();
+  });
 });

--- a/packages/ui/src/cloud/public-pages/pages/oidc/oidc-continue-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/oidc/oidc-continue-page.tsx
@@ -5,8 +5,8 @@
  * The provider cannot send a signed-out browser back to itself directly: the
  * login page sanitizes `returnTo` to a same-origin path, so the round trip
  * carries only an opaque request id. This page turns that id back into the
- * absolute resume URL and hard-navigates, which is also what makes the Steward
- * session cookie present on arrival.
+ * absolute resume URL, establishes the host-only Steward session on the API
+ * issuer origin, and only then hard-navigates to consume the parked request.
  *
  * The destination origin comes from the configured issuer, never from the URL,
  * so this route cannot be used as an open redirect. An expired link and a
@@ -20,18 +20,18 @@ import { useSearchParams } from "react-router-dom";
 import { Button } from "../../../../components/primitives";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
 import {
-  buildOidcResumeTarget,
   OIDC_ISSUER_ENV_VAR,
-  type OidcResumeTarget,
+  type PreparedOidcResumeTarget,
+  prepareOidcResumeTarget,
 } from "../../lib/oidc-continue";
 import { usePageTitle } from "../../lib/use-page-title";
 
 export default function OidcContinuePage() {
   const t = useCloudT();
   const [searchParams] = useSearchParams();
-  const [failure, setFailure] = useState<OidcResumeTarget["status"] | null>(
-    null,
-  );
+  const [failure, setFailure] = useState<
+    PreparedOidcResumeTarget["status"] | null
+  >(null);
 
   usePageTitle(
     t("cloud.oidcContinue.metaTitle", {
@@ -40,21 +40,38 @@ export default function OidcContinuePage() {
   );
 
   const requestId = searchParams.get("rid");
+  const retryContinuationHref = requestId
+    ? `/login?returnTo=${encodeURIComponent(`/oidc/continue?rid=${requestId}`)}`
+    : "/login";
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const target = buildOidcResumeTarget(
+    let cancelled = false;
+
+    void prepareOidcResumeTarget(
       requestId,
       window.location.hostname,
       window.location.origin,
-    );
-    if (target.status !== "ok") {
-      setFailure(target.status);
-      return;
-    }
-    // `replace` keeps the bounce out of history, so Back returns to the
-    // application the user came from rather than re-triggering the resume.
-    window.location.replace(target.url);
+    )
+      .then((target) => {
+        if (cancelled) return;
+        if (target.status !== "ok") {
+          setFailure(target.status);
+          return;
+        }
+        // `replace` keeps the bounce out of history, so Back returns to the
+        // application the user came from rather than re-triggering the resume.
+        window.location.replace(target.url);
+      })
+      .catch(() => {
+        // error-policy:J4 user-facing degrade — unexpected preparation errors
+        // become a recoverable authentication screen, never an endless spinner.
+        if (!cancelled) setFailure("session_sync_failed");
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [requestId]);
 
   return (
@@ -70,6 +87,17 @@ export default function OidcContinuePage() {
               })}
             </p>
             <RecoveryAction />
+          </RecoveryPanel>
+        ) : failure === "session_missing" ||
+          failure === "session_sync_failed" ? (
+          <RecoveryPanel>
+            <p className="text-fg">
+              {t("cloud.oidcContinue.sessionUnavailable", {
+                defaultValue:
+                  "Your Eliza session could not be securely transferred to the identity provider. Sign in again to continue.",
+              })}
+            </p>
+            <RecoveryAction href={retryContinuationHref} />
           </RecoveryPanel>
         ) : failure ? (
           <RecoveryPanel>
@@ -105,13 +133,13 @@ export default function OidcContinuePage() {
     );
   }
 
-  function RecoveryAction() {
+  function RecoveryAction({ href = "/login" }: { href?: string }) {
     return (
       <Button
         asChild
         className="hosted-signin-focus-emphasis border border-transparent"
       >
-        <a href="/login">
+        <a href={href}>
           {t("cloud.cliLogin.signInAgain", {
             defaultValue: "Sign In Again",
           })}


### PR DESCRIPTION
Fixes #18806

## Outcome

- restores Steward OAuth callbacks for `staging.eliza.app` and `cloud-staging.eliza.app`
- prevents first-install and replacement service workers from replaying one-time auth bridges and callbacks
- synchronizes the host-only Steward session onto `api-staging.eliza.app` before OIDC resume, preserving the parked request on recovery
- adds the missing logout origin guard so user-controlled sibling hosts cannot force session mutation
- makes canonical/deprecated Steward verifier bindings explicit and adds protected deployment inventory for Steward/OIDC
- probes exact Google and Discord callbacks on both deployed browser hosts before a Cloudflare release can pass
- removes the retired homepage model from the unified app asset manifest so the release build is reproducible

## Operations already completed

- Steward tenant `elizacloud-staging` now allows both canonical staging `/login` callbacks and uses `https://staging.eliza.app` for magic links
- Steward tenant `elizacloud` now allows `eliza.app` and `cloud.eliza.app` callbacks and uses `https://eliza.app` for magic links
- legacy callback origins remain temporarily allowed during migration
- exact existing Steward secrets were backfilled from the authoritative Steward Railway service into both protected GitHub environments without rotation
- staging QA session exchange was disabled because its dedicated signer/key id are not provisioned; normal Steward/OIDC sign-in remains enabled

## Verification

- `bun run verify`: 350/350 workspace tasks plus all repository audits passed; 7,955 test files scanned with no focused or orphaned skips
- `bun run build`: 123/123 tasks passed; 19/19 view bundles verified
- `bun run --cwd packages/app audit:app`: 219/219 captures passed, broken=0, needs-work=0; OCR broken=0
- affected app/UI/cloud API/shared typechecks passed
- focused browser/OIDC/service-worker/API/config/workflow tests passed
- Cloud Worker bundle dry-run passed
- `actionlint`, Biome, guide parity, and `git diff --check` passed
- live canonical Google/Discord callback probes return provider redirects on both staging hosts

## Rollout

Merge to `develop`, dispatch the protected staging Cloudflare deployment for the exact merge SHA, then run credentialed Google/Discord/email/passkey, bridge, OIDC, refresh, and logout acceptance before production promotion.

### Agent Attribution

- Generated by: Codex
- Model: gpt-5.6-sol
- Provider: OpenAI
- Skills: Cloudflare, browser control, GitHub publish workflow
- Human edits: 0%
- Prompt: Restore all sign-in on staging.eliza.app, ensure Steward owns staging.eliza.app and eliza.app, deploy and verify staging completely.
