### PR TITLE
fix(ui): route passkey sign-in errors safely

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3317,6 +3317,7 @@
     "bigint-buffer",
   ],
   "patchedDependencies": {
+    "@stwd/sdk@0.11.0": "patches/@stwd%2Fsdk@0.11.0.patch",
     "@solana/rpc-subscriptions-spec@5.5.1": "patches/@solana%2Frpc-subscriptions-spec@5.5.1.patch",
     "@solana/rpc-transformers@5.5.1": "patches/@solana%2Frpc-transformers@5.5.1.patch",
     "@solana/fast-stable-stringify@5.5.1": "patches/@solana%2Ffast-stable-stringify@5.5.1.patch",

--- a/package.json
+++ b/package.json
@@ -367,6 +367,7 @@
     "pdfjs-dist": "6.2.108"
   },
   "patchedDependencies": {
+    "@stwd/sdk@0.11.0": "patches/@stwd%2Fsdk@0.11.0.patch",
     "@orca-so/common-sdk@0.7.0": "patches/@orca-so%2Fcommon-sdk@0.7.0.patch",
     "@pixiv/three-vrm@3.5.2": "packages/app-core/patches/@pixiv%2Fthree-vrm@3.5.2.patch",
     "@vitest/mocker@4.1.5": "patches/@vitest%2Fmocker@4.1.5.patch",

--- a/packages/app/test/ui-smoke/passkey-signin-error-routing.spec.ts
+++ b/packages/app/test/ui-smoke/passkey-signin-error-routing.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Rendered browser evidence for the passkey sign-in error routing contract
+ * (#19088). The real `/login` route runs against a Chromium CDP virtual
+ * platform authenticator, so the capability probe resolves `usable` through the
+ * production WebAuthn path rather than a stub; only the Steward
+ * `/auth/passkey/login/options` response is fixed at the network boundary, the
+ * established ui-smoke pattern.
+ *
+ * Two rendered outcomes are pinned. A `500` from the login-options probe must
+ * surface the failure in place and must NOT send a "Set up your passkey" OTP
+ * email — the defect this PR fixes, where every sign-in failure was read as
+ * "this user has no credential". A `404` — the only response that actually
+ * means "no account or no passkeys" — must still enter enrollment.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { expect, type Page, type TestInfo, test } from "@playwright/test";
+import { saveBrowserVideoArtifact } from "./helpers/video-artifacts";
+
+test.use({ video: "on" });
+
+const VIEWPORTS = [
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "mobile", width: 390, height: 844 },
+] as const;
+
+const PROVIDERS = {
+  passkey: true,
+  email: true,
+  siwe: false,
+  siws: false,
+  google: true,
+  discord: true,
+  github: false,
+  twitter: false,
+  oauth: [],
+};
+
+const EMAIL = "person@example.com";
+
+async function enableVirtualAuthenticator(page: Page): Promise<void> {
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("WebAuthn.enable");
+  await cdp.send("WebAuthn.addVirtualAuthenticator", {
+    options: {
+      protocol: "ctap2",
+      transport: "internal",
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true,
+      automaticPresenceSimulation: true,
+    },
+  });
+}
+
+async function screenshot(
+  page: Page,
+  testInfo: TestInfo,
+  name: string,
+): Promise<void> {
+  const path = testInfo.outputPath(`${name}.png`);
+  await mkdir(testInfo.outputDir, { recursive: true });
+  await page.screenshot({ path, fullPage: true });
+  await testInfo.attach(name, { path, contentType: "image/png" });
+}
+
+for (const viewport of VIEWPORTS) {
+  test(`passkey login-options failure never starts OTP enrollment at ${viewport.name}`, async ({
+    page,
+  }, testInfo) => {
+    await page.setViewportSize(viewport);
+    await enableVirtualAuthenticator(page);
+
+    const frontendEvents: string[] = [];
+    page.on("console", (message) =>
+      frontendEvents.push(`console:${message.type()}:${message.text()}`),
+    );
+    page.on("requestfailed", (request) =>
+      frontendEvents.push(
+        `requestfailed:${request.method()}:${request.url()}:${request.failure()?.errorText ?? "unknown"}`,
+      ),
+    );
+    page.on("response", (response) =>
+      frontendEvents.push(
+        `response:${response.request().method()}:${response.status()}:${response.url()}`,
+      ),
+    );
+
+    await page.route("**/auth/providers", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(PROVIDERS),
+      }),
+    );
+    // Any OTP send is a contract violation for the 500 case; fail loudly rather
+    // than letting a real request escape the fixture.
+    let otpSendCount = 0;
+    await page.route("**/auth/email/otp**", (route) => {
+      otpSendCount += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      });
+    });
+
+    let loginOptionsStatus = 500;
+    await page.route("**/auth/passkey/login/options", (route) =>
+      route.fulfill({
+        status: loginOptionsStatus,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: false,
+          error:
+            loginOptionsStatus === 404
+              ? "No passkey registered"
+              : "Passkey service unavailable",
+        }),
+      }),
+    );
+
+    await page.goto("/login");
+    const emailInput = page.getByPlaceholder("you@example.com");
+    await expect(emailInput).toBeVisible();
+    const passkeyButton = page.getByRole("button", { name: /Passkey/i });
+    await expect(passkeyButton).toBeVisible();
+    await screenshot(page, testInfo, `${viewport.name}-1-rest`);
+
+    await emailInput.fill(EMAIL);
+    await passkeyButton.click();
+
+    // Server failure: the error is surfaced in place, enrollment is not entered.
+    await expect(page.getByText("Passkey service unavailable")).toBeVisible();
+    await expect(page.getByText("Set up your passkey")).toHaveCount(0);
+    expect(otpSendCount, "a 500 must not send a passkey-setup OTP").toBe(0);
+    await expect(passkeyButton).toBeEnabled();
+    await expect(passkeyButton).toContainText("Passkey");
+    await passkeyButton.hover();
+    await expect(passkeyButton).toHaveCSS("color", "rgb(0, 0, 0)");
+    await screenshot(page, testInfo, `${viewport.name}-2-server-failure`);
+
+    // The one response that genuinely means "no credential" still enrolls.
+    loginOptionsStatus = 404;
+    await page.reload();
+    const emailAfterReload = page.getByPlaceholder("you@example.com");
+    await expect(emailAfterReload).toBeVisible();
+    await emailAfterReload.fill(EMAIL);
+    await page.getByRole("button", { name: /Passkey/i }).click();
+    await expect(page.getByText("Set up your passkey")).toBeVisible();
+    expect(otpSendCount, "a 404 must send exactly one setup OTP").toBe(1);
+    await screenshot(
+      page,
+      testInfo,
+      `${viewport.name}-3-no-credential-enrolls`,
+    );
+
+    const logPath = testInfo.outputPath(`${viewport.name}-frontend.log`);
+    await writeFile(logPath, `${frontendEvents.join("\n")}\n`, "utf8");
+    await testInfo.attach(`${viewport.name}-frontend-log`, {
+      path: logPath,
+      contentType: "text/plain",
+    });
+
+    const video = page.video();
+    if (video) {
+      await page.close();
+      const artifact = await saveBrowserVideoArtifact({
+        video,
+        testInfo,
+        basename: `${viewport.name}-walkthrough`,
+      });
+      await testInfo.attach(`${viewport.name}-walkthrough`, artifact);
+    }
+  });
+}

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-auth-passkey-fallback.test.ts
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-auth-passkey-fallback.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { type StewardApiError, StewardAuth } from "@stwd/sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function jsonResponse(status: number, error: string): Response {
+  return new Response(JSON.stringify({ ok: false, error }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function recordFetch(responses: Response[]) {
+  let calls = 0;
+  const fetch = async (): Promise<Response> => {
+    const response = responses[calls];
+    calls += 1;
+    if (!response) throw new Error("Unexpected fetch call");
+    return response;
+  };
+  return { fetch, callCount: () => calls };
+}
+
+describe("StewardAuth passkey registration fallback", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves the default smart registration fallback", async () => {
+    const recorder = recordFetch([
+      jsonResponse(404, "No passkey registered"),
+      jsonResponse(401, "Authentication required"),
+    ]);
+    vi.stubGlobal("fetch", recorder.fetch);
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+
+    await expect(
+      auth.signInWithPasskey("person@example.com"),
+    ).rejects.toMatchObject({
+      status: 401,
+      message: "Authentication required",
+    });
+    expect(recorder.callCount()).toBe(2);
+  });
+
+  it("can expose the typed no-credential result without starting registration", async () => {
+    const recorder = recordFetch([jsonResponse(404, "No passkey registered")]);
+    vi.stubGlobal("fetch", recorder.fetch);
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+
+    const error = await auth
+      .signInWithPasskey("person@example.com", {
+        fallbackToRegistration: false,
+      })
+      .catch((cause: unknown) => cause);
+
+    expect(recorder.callCount()).toBe(1);
+    expect(error).toEqual(
+      expect.objectContaining<Partial<StewardApiError>>({
+        status: 404,
+        message: "No passkey registered",
+      }),
+    );
+  });
+
+  it("does not reinterpret non-404 login failures", async () => {
+    const recorder = recordFetch([
+      jsonResponse(500, "Passkey service unavailable"),
+    ]);
+    vi.stubGlobal("fetch", recorder.fetch);
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+
+    await expect(
+      auth.signInWithPasskey("person@example.com", {
+        fallbackToRegistration: false,
+      }),
+    ).rejects.toMatchObject({
+      status: 500,
+      message: "Passkey service unavailable",
+    });
+    expect(recorder.callCount()).toBe(1);
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-auth-passkey-fallback.test.ts
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-auth-passkey-fallback.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies the patched Steward SDK's opt-out from implicit passkey enrollment
+ * using its real client implementation with only the HTTP boundary replaced.
+ */
 // @vitest-environment jsdom
 
 import { type StewardApiError, StewardAuth } from "@stwd/sdk";

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
@@ -59,6 +59,14 @@ vi.mock("@elizaos/shared/steward-session-client", async (importOriginal) => {
 });
 
 vi.mock("@stwd/sdk", () => ({
+  StewardApiError: class StewardApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = "StewardApiError";
+      this.status = status;
+    }
+  },
   StewardAuth: class {
     getProviders = stewardAuthSpies.getProviders;
     getSession = stewardAuthSpies.getSession;
@@ -116,6 +124,7 @@ vi.mock("../../lib/login-return-to", () => ({
   storePendingOAuthReturnTo: () => undefined,
 }));
 
+import { StewardApiError } from "@stwd/sdk";
 import StewardLoginSection from "./steward-login-section";
 
 function renderSection() {
@@ -222,6 +231,7 @@ describe("StewardLoginSection passkey capability gating", () => {
     await waitFor(() =>
       expect(stewardAuthSpies.signInWithPasskey).toHaveBeenCalledWith(
         "person@example.com",
+        { fallbackToRegistration: false },
       ),
     );
     expect(emailLoginSpies.start).not.toHaveBeenCalled();
@@ -242,11 +252,11 @@ describe("StewardLoginSection passkey capability gating", () => {
     expect(stewardAuthSpies.signInWithPasskey).not.toHaveBeenCalled();
   });
 
-  it("falls back to email-OTP passkey signup when passkey sign-in fails, then completes registration", async () => {
+  it("falls back to email-OTP passkey signup only when the login probe reports no credential", async () => {
     capabilityRef.usable = true;
     capabilityRef.reason = "available";
     stewardAuthSpies.signInWithPasskey.mockRejectedValue(
-      new Error("no credential for this email"),
+      new StewardApiError("No passkey registered", 404),
     );
     stewardAuthSpies.sendEmailOtp.mockResolvedValue(undefined);
     stewardAuthSpies.verifyEmailOtp.mockResolvedValue({
@@ -263,12 +273,16 @@ describe("StewardLoginSection passkey capability gating", () => {
     fireEvent.change(input, { target: { value: "person@example.com" } });
     fireEvent.click(screen.getByRole("button", { name: /Passkey/i }));
 
-    // Sign-in failure routes into the OTP signup step, not an error dead-end.
+    // A typed 404 from the login-options probe alone routes into OTP signup.
     expect(await screen.findByText("Set up your passkey")).toBeTruthy();
     await waitFor(() =>
-      expect(stewardAuthSpies.sendEmailOtp).toHaveBeenCalledWith(
+      expect(stewardAuthSpies.signInWithPasskey).toHaveBeenCalledWith(
         "person@example.com",
+        { fallbackToRegistration: false },
       ),
+    );
+    expect(stewardAuthSpies.sendEmailOtp).toHaveBeenCalledWith(
+      "person@example.com",
     );
 
     const codeInput = screen.getByPlaceholderText("123456");
@@ -308,22 +322,76 @@ describe("StewardLoginSection passkey capability gating", () => {
     fireEvent.change(input, { target: { value: "person@example.com" } });
     fireEvent.click(screen.getByRole("button", { name: /Passkey/i }));
 
-    // Error is surfaced; no OTP email is sent, no signup flow is entered.
+    // Designed recovery guidance is reachable; raw server diagnostics stay hidden.
     await waitFor(() =>
       expect(stewardAuthSpies.signInWithPasskey).toHaveBeenCalledWith(
         "person@example.com",
+        { fallbackToRegistration: false },
       ),
     );
-    expect(await screen.findByText(/user could not be verified/i)).toBeTruthy();
+    expect(
+      await screen.findByText(
+        "Passkey sign-in requires device verification (PIN or biometric). Your device may not support this — try Magic Link instead.",
+      ),
+    ).toBeTruthy();
     expect(stewardAuthSpies.sendEmailOtp).not.toHaveBeenCalled();
     expect(screen.queryByText("Set up your passkey")).toBeNull();
   });
+
+  it.each([
+    {
+      label: "browser cancellation",
+      error: new StewardApiError(
+        "WebAuthn authentication cancelled or failed: NotAllowedError",
+        0,
+      ),
+      expectedMessage: "Passkey sign-in was cancelled. Try again when ready.",
+    },
+    {
+      label: "network failure",
+      error: new StewardApiError("Network request failed", 0),
+      expectedMessage: "Network request failed",
+    },
+    {
+      label: "server failure",
+      error: new StewardApiError("Request failed with status 500", 500),
+      expectedMessage: "Request failed with status 500",
+    },
+    {
+      label: "additional-authentication requirement",
+      error: new StewardApiError("MFA verification required", 401),
+      expectedMessage: "MFA verification required",
+    },
+  ])(
+    "surfaces $label without entering passkey signup",
+    async ({ error, expectedMessage }) => {
+      capabilityRef.usable = true;
+      capabilityRef.reason = "available";
+      stewardAuthSpies.signInWithPasskey.mockRejectedValue(error);
+
+      renderSection();
+
+      const input = await screen.findByPlaceholderText("you@example.com");
+      fireEvent.change(input, { target: { value: "person@example.com" } });
+      fireEvent.click(screen.getByRole("button", { name: /Passkey/i }));
+
+      await waitFor(() =>
+        expect(stewardAuthSpies.signInWithPasskey).toHaveBeenCalledWith(
+          "person@example.com",
+          { fallbackToRegistration: false },
+        ),
+      );
+      expect(stewardAuthSpies.sendEmailOtp).not.toHaveBeenCalled();
+      expect(screen.queryByText("Set up your passkey")).toBeNull();
+      expect(await screen.findByText(expectedMessage)).toBeTruthy();
+    },
+  );
 
   it("rejects a too-short OTP code without calling the API and reports a cancelled passkey setup", async () => {
     capabilityRef.usable = true;
     capabilityRef.reason = "available";
     stewardAuthSpies.signInWithPasskey.mockRejectedValue(
-      new Error("no credential"),
+      new StewardApiError("No passkey registered", 404),
     );
     stewardAuthSpies.sendEmailOtp.mockResolvedValue(undefined);
     stewardAuthSpies.verifyEmailOtp.mockResolvedValue({

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -24,7 +24,7 @@ import type {
   StewardMfaRequiredResult,
   StewardProviders,
 } from "@stwd/sdk";
-import { StewardAuth } from "@stwd/sdk";
+import { StewardApiError, StewardAuth } from "@stwd/sdk";
 import { AlertCircle } from "lucide-react";
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -681,20 +681,25 @@ export default function StewardLoginSection() {
     setError(null);
     try {
       const result = requireCompletedAuth(
-        await auth.signInWithPasskey(email.trim()),
+        await auth.signInWithPasskey(email.trim(), {
+          fallbackToRegistration: false,
+        }),
       );
       await handleSuccess(result.token, result.refreshToken);
     } catch (e: unknown) {
-      if (isUserVerificationError(e)) {
+      if (e instanceof StewardApiError && e.status === 404) {
+        await startPasskeySignup();
+      } else if (isUserVerificationError(e)) {
         setError(
-          getErrorMessage(
-            e,
-            "Passkey sign-in requires device verification (PIN or biometric). Your device may not support this — try Magic Link instead.",
-          ),
+          "Passkey sign-in requires device verification (PIN or biometric). Your device may not support this — try Magic Link instead.",
         );
         setLoading(null);
+      } else if (isUserCancelled(e)) {
+        setError("Passkey sign-in was cancelled. Try again when ready.");
+        setLoading(null);
       } else {
-        await startPasskeySignup();
+        setError(getErrorMessage(e, "Passkey sign-in failed. Try again."));
+        setLoading(null);
       }
     }
   }
@@ -1216,7 +1221,7 @@ export default function StewardLoginSection() {
             type="button"
             onClick={handlePasskey}
             disabled={isLoading}
-            className="flex min-h-touch flex-1 items-center justify-center gap-2 rounded-md border border-transparent bg-accent px-4 py-3 font-semibold text-accent-foreground transition-[background-color,border-color,transform] hover:bg-accent-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+            className="flex min-h-touch flex-1 items-center justify-center gap-2 rounded-md border border-transparent bg-accent px-4 py-3 font-semibold text-accent-foreground transition-[background-color,border-color,transform] hover:bg-accent-hover hover:text-accent-foreground active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
           >
             {loading === "passkey" ? <Spinner /> : <PasskeyIcon />}{" "}
             {t("cloud.login.button.passkey", { defaultValue: "Passkey" })}

--- a/patches/@stwd%2Fsdk@0.11.0.patch
+++ b/patches/@stwd%2Fsdk@0.11.0.patch
@@ -1,0 +1,36 @@
+--- a/dist/auth.d.ts
++++ b/dist/auth.d.ts
+@@ -109,7 +109,9 @@
+      * Requires a browser environment and `@simplewebauthn/browser` installed.
+      * Throws `StewardApiError` in Node or when the dependency is missing.
+      */
+-    signInWithPasskey(email: string): Promise<StewardAuthResult | StewardMfaRequiredResult>;
++    signInWithPasskey(email: string, options?: {
++        fallbackToRegistration?: boolean;
++    }): Promise<StewardAuthResult | StewardMfaRequiredResult>;
+     /**
+      * Register a new passkey for the given email, regardless of whether the
+      * user already has other passkeys on other relying parties (RPs).
+--- a/dist/auth.js
++++ b/dist/auth.js
+@@ -540,7 +540,7 @@
+      * Requires a browser environment and `@simplewebauthn/browser` installed.
+      * Throws `StewardApiError` in Node or when the dependency is missing.
+      */
+-    async signInWithPasskey(email) {
++    async signInWithPasskey(email, options = {}) {
+         if (!isBrowser()) {
+             throw new StewardApiError("Passkeys require a browser environment. Use signInWithEmail or signInWithSIWE in Node.", 0);
+         }
+@@ -564,8 +564,9 @@
+             // User exists with passkeys — run authentication flow
+             return this.completePasskeyLogin(email, loginOptsRes.data, browserLib);
+         }
+-        if (loginOptsRes.status === 404) {
+-            // No account or no passkeys — run registration flow
++        if (loginOptsRes.status === 404 && options.fallbackToRegistration !== false) {
++            // No account or no passkeys — run registration flow unless the caller
++            // needs to distinguish login from first-passkey enrollment.
+             return this.completePasskeyRegister(email, browserLib);
+         }
+         throw new StewardApiError(loginOptsRes.error, loginOptsRes.status);


### PR DESCRIPTION
# Relates to

Closes #19088.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`; cleanly rebased onto `origin/develop@15c8bc849f219712a084ebf225a777d7d9909e42` with no merge commit (`0` behind / `2` ahead).
- [x] Exact-head focused behavior, type, format, production-renderer, desktop/mobile pixel, video, and OCR evidence is supplied below.
- [ ] Hosted repository gates and an independent approval must finish before merge. A maintainer authored part of the repair and is not self-approving it.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`, `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`, `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@15c8bc849f219712a084ebf225a777d7d9909e42:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

The original change was contributed with `openai-codex/gpt-5.6-sol` via Hermes Agent
at `elizaOS/eliza@44541c32bb306798e27e6869ebcbe08054a8f665`. The browser-evidence
commit (`test(app): pin passkey sign-in error routing in the browser`) and the
maintainer review were produced with `anthropic/claude-opus-5` via Claude Code.

# What this fixes

The login UI previously treated every passkey sign-in failure as evidence that the user had no credential and started OTP enrollment. Network failures, 5xx responses, cancellation, user-verification failures, and MFA/auth-required responses could therefore be misrouted into “Set up your passkey.” The Steward SDK also swallowed its login-options `404` into an implicit registration fallback before the UI could classify the response.

This PR fixes the boundary at its source:

- `@stwd/sdk@0.11.0` gains a backward-compatible `fallbackToRegistration` option. Existing callers retain the former default; this login page opts out.
- The UI enters enrollment only for a typed `StewardApiError` with status `404`.
- Cancellation, user-verification, network, 5xx, MFA/auth-required, unknown errors, and untyped status-shaped objects remain error states and never send the setup OTP.
- The review repair added the missing real-vs-mocked test responsibility header, corrected the issue reference, removed 48 lines of old-base `bun.lock` serialization churn, and replaced the branch's merge-up with the required clean rebase.
- Pixel review found and fixed a real hover contrast defect exposed by this flow: the shared `ghost` variant changed the primary Passkey label to white on a light hover fill. The caller now pins `hover:text-accent-foreground`, and the browser test locks the computed black label color.

# Risk and design assessment

Risk is medium and localized to the passkey login boundary and a patched browser-auth seam. The approach is preferable to substring classification because it branches on a typed transport result, keeps enrollment explicit, and preserves the SDK's public default for other consumers. The final diff is seven files, with only one semantic `bun.lock` addition.

# Exact-head verification

Head: `8a0128e0124a2ae9371f3625d09a79f9d94df1bd`

Executed in an isolated Linux ARM64 VM/container with Bun `1.3.14`, Node `24.15.0`, no repository credentials, and network disabled for PR execution:

- Focused Vitest: `2` files, `16/16` tests passed.
- UI TypeScript: `bun run --cwd packages/ui typecheck` passed.
- Changed-file Biome: `5` maintained files passed.
- Production renderer + Chromium/CDP virtual platform authenticator: `2/2` desktop/mobile tests passed.
- The browser contract proves a `500` remains on sign-in with zero setup OTP sends; a typed `404` enters enrollment with exactly one intercepted OTP send.
- Hover proof waits for the control to recover, hovers it, and asserts computed `color: rgb(0, 0, 0)` before capture.
- `git diff --check origin/develop...HEAD` passed; branch is `0` behind / `2` ahead.
- Manual review of all six exact-head screenshots found no clipping, overlap, blue accent, broken layout, or unreadable touched control.

Repository app audit accounting:

- `bun run --cwd packages/app audit:app` completed `218/219` capture tests with `broken=0`, `undebted-needs-work=0`, and no hover-probe failures.
- Its terminal failure is outside this PR: the untouched `builtin-background` view exceeded two already-baselined whitespace-ratio ratchets on mobile portrait/landscape.
- Packaged OCR triage over that full repository matrix separately flagged three untouched phone/relationships views. Exact-head OCR for this PR's four changed outcomes is attached and reads the expected error/enrollment copy on desktop and mobile.

Hosted root gates remain authoritative and are running on the pushed exact head.

# Evidence Gate

<!-- evidence-head:8a0128e0124a2ae9371f3625d09a79f9d94df1bd -->

<!-- evidence-row:before-screenshots -->
- [x] Current-develop behavior is unchanged in the affected branch: a `500` incorrectly enters enrollment. Existing controlled base captures: [desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19077-desktop-server-failure-BEFORE.png), [mobile before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19077-mobile-server-failure-BEFORE.png).

<!-- evidence-row:after-screenshots -->
- [x] Exact-head desktop: [rest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19077-8a0128e-desktop-rest.png), [500 remains on sign-in](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19077-8a0128e-desktop-server-failure.png), [404 enrolls](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19077-8a0128e-desktop-no-credential-enrolls.png). Exact-head mobile: [rest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19077-8a0128e-mobile-rest.png), [500 remains on sign-in](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19077-8a0128e-mobile-server-failure.png), [404 enrolls](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19077-8a0128e-mobile-no-credential-enrolls.png).

<!-- evidence-row:walkthrough-video -->
- [x] Exact-head [desktop MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19077-8a0128e-desktop-walkthrough.mp4) and [mobile MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19077-8a0128e-mobile-walkthrough.mp4).

<!-- evidence-row:backend-logs -->
- [x] N/A — the controlled browser proof intercepts every write-capable request at the HTTP boundary; no authentic bounded backend export exists, and no empty or fabricated log is substituted.

<!-- evidence-row:frontend-logs -->
- [x] Exact-head controlled console/network transcripts: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19077-8a0128e-desktop-frontend.log), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19077-8a0128e-mobile-frontend.log). They record `POST .../login/options` as `500` with no OTP request, then `404` followed by one intercepted `POST .../email/otp/send`.

<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent, action, provider, prompt, planner, or model behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] N/A — no database row, memory, scheduled item, wallet output, or generated domain artifact changes.

<!-- evidence-row:ocr-review -->
- [x] [Exact-head OCR and manual pixel review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19077-8a0128e-ocr-review.txt).

# Reviewer starting points

1. `packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx`
2. `patches/@stwd%2Fsdk@0.11.0.patch`
3. `packages/ui/src/cloud/public-pages/pages/login/steward-auth-passkey-fallback.test.ts`
4. `packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx`
5. `packages/app/test/ui-smoke/passkey-signin-error-routing.spec.ts`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@15c8bc849f219712a084ebf225a777d7d9909e42:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@15c8bc849f219712a084ebf225a777d7d9909e42:packages/skills/skills/contribute-to-eliza"} -->


