### PR TITLE
fix(plugin-coding-tools): fail fast on invalid shell timeout settings

### DIFF
--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -912,9 +912,10 @@
           "required": false,
           "sensitive": false,
           "label": "Shell timeout",
-          "help": "Default SHELL timeout in milliseconds.",
+          "help": "Default SHELL timeout in milliseconds. Must be a canonical decimal integer from 100 through 600000; invalid values fail before execution.",
           "advanced": false,
-          "min": 0,
+          "min": 100,
+          "max": 600000,
           "unit": "ms"
         },
         "CODING_TOOLS_SHELL_BG_BUDGET_MS": {

--- a/plugins/plugin-coding-tools/AGENTS.md
+++ b/plugins/plugin-coding-tools/AGENTS.md
@@ -99,7 +99,7 @@ All settings are read via `runtime.getSetting(key)` or `process.env`. None are r
 | `CODING_TOOLS_BLOCKED_PATHS` | (built-in list) | Comma-separated absolute paths — **replaces** the default blocklist. |
 | `CODING_TOOLS_BLOCKED_PATHS_ADD` | — | Comma-separated paths to **add** to the default blocklist. |
 | `CODING_TOOLS_SHELL` | (auto-detected) | Override the shell binary used by SHELL action. Takes priority over `SHELL`. Useful on Android/AOSP where the default shell path may not be executable. |
-| `CODING_TOOLS_SHELL_TIMEOUT_MS` | `120000` | Default SHELL timeout (ms); per-call `timeout` clamps to `[100, 600000]`. |
+| `CODING_TOOLS_SHELL_TIMEOUT_MS` | `120000` | Optional canonical decimal integer from `100` through `600000` used as the default SHELL timeout (ms); invalid values fail before execution and per-call `timeout` takes precedence within the same range. |
 | `CODING_TOOLS_BACKGROUND_SHELL_BUFFER_CHARS` | `64000` | Per-stream retained stdout/stderr ring size for background shell polling. |
 | `CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS` | `1500` | Grace period between SIGTERM and SIGKILL for background shell termination. |
 | `CODING_TOOLS_MAX_READ_LINES` | `2000` | Max lines returned by FILE action=read before truncation. |

--- a/plugins/plugin-coding-tools/CLAUDE.md
+++ b/plugins/plugin-coding-tools/CLAUDE.md
@@ -99,7 +99,7 @@ All settings are read via `runtime.getSetting(key)` or `process.env`. None are r
 | `CODING_TOOLS_BLOCKED_PATHS` | (built-in list) | Comma-separated absolute paths — **replaces** the default blocklist. |
 | `CODING_TOOLS_BLOCKED_PATHS_ADD` | — | Comma-separated paths to **add** to the default blocklist. |
 | `CODING_TOOLS_SHELL` | (auto-detected) | Override the shell binary used by SHELL action. Takes priority over `SHELL`. Useful on Android/AOSP where the default shell path may not be executable. |
-| `CODING_TOOLS_SHELL_TIMEOUT_MS` | `120000` | Default SHELL timeout (ms); per-call `timeout` clamps to `[100, 600000]`. |
+| `CODING_TOOLS_SHELL_TIMEOUT_MS` | `120000` | Optional canonical decimal integer from `100` through `600000` used as the default SHELL timeout (ms); invalid values fail before execution and per-call `timeout` takes precedence within the same range. |
 | `CODING_TOOLS_BACKGROUND_SHELL_BUFFER_CHARS` | `64000` | Per-stream retained stdout/stderr ring size for background shell polling. |
 | `CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS` | `1500` | Grace period between SIGTERM and SIGKILL for background shell termination. |
 | `CODING_TOOLS_MAX_READ_LINES` | `2000` | Max lines returned by FILE action=read before truncation. |

--- a/plugins/plugin-coding-tools/README.md
+++ b/plugins/plugin-coding-tools/README.md
@@ -49,7 +49,7 @@ All settings are optional. Configure via environment variables or agent settings
 | `CODING_TOOLS_WORKSPACE_ROOTS` | `process.cwd()` | Comma-separated absolute paths the tools may access. Files outside these roots are rejected. |
 | `CODING_TOOLS_BLOCKED_PATHS` | (built-in) | Comma-separated absolute paths to block — replaces the default blocklist. |
 | `CODING_TOOLS_BLOCKED_PATHS_ADD` | — | Paths to add to the default blocklist. |
-| `CODING_TOOLS_SHELL_TIMEOUT_MS` | `120000` | Default SHELL timeout (ms); per-call `timeout` clamps to `[100, 600000]`. |
+| `CODING_TOOLS_SHELL_TIMEOUT_MS` | `120000` | Optional canonical decimal integer from `100` through `600000` used as the default SHELL timeout (ms); invalid values fail before execution and per-call `timeout` takes precedence within the same range. |
 | `CODING_TOOLS_BACKGROUND_SHELL_BUFFER_CHARS` | `64000` | Per-stream retained stdout/stderr ring size for background shell polling. |
 | `CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS` | `1500` | Grace period between SIGTERM and SIGKILL for background shell termination. |
 | `CODING_TOOLS_MAX_READ_LINES` | `2000` | Max lines returned by FILE action=read. |

--- a/plugins/plugin-coding-tools/package.json
+++ b/plugins/plugin-coding-tools/package.json
@@ -110,9 +110,11 @@
       },
       "CODING_TOOLS_SHELL_TIMEOUT_MS": {
         "type": "number",
-        "description": "Default SHELL timeout in milliseconds. Hard ceiling enforced before backgrounding kicks in.",
+        "description": "Default SHELL timeout in milliseconds. Must be a canonical decimal integer from 100 through 600000; invalid values fail before execution.",
         "required": false,
         "default": 120000,
+        "min": 100,
+        "max": 600000,
         "sensitive": false
       },
       "CODING_TOOLS_SHELL_BG_BUDGET_MS": {

--- a/plugins/plugin-coding-tools/registry-entry.json
+++ b/plugins/plugin-coding-tools/registry-entry.json
@@ -29,9 +29,10 @@
       "required": false,
       "sensitive": false,
       "label": "Shell timeout",
-      "help": "Default SHELL timeout in milliseconds.",
+      "help": "Default SHELL timeout in milliseconds. Must be a canonical decimal integer from 100 through 600000; invalid values fail before execution.",
       "advanced": false,
-      "min": 0,
+      "min": 100,
+      "max": 600000,
       "unit": "ms"
     },
     "CODING_TOOLS_SHELL_BG_BUDGET_MS": {

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -89,7 +89,7 @@ async function pathExists(target: string): Promise<boolean> {
 
 interface RuntimeOptions {
   blockedPaths?: string;
-  shellTimeoutMs?: number;
+  shellTimeoutMs?: unknown;
   shellHistoryCommands?: string[];
   withShellHistoryService?: boolean;
   capabilityRouter?: ElizaCapabilityRouter;
@@ -1815,6 +1815,129 @@ describeIfPosix("shellAction", () => {
     );
     const data = result.data as Record<string, unknown> | undefined;
     expect(data?.action).toBe("view_history");
+  });
+});
+
+describe("shell timeout operator setting", () => {
+  it.each(["0", "-1", "45.5", "9007199254740992", "600001", "1e3", " 200"])(
+    "rejects malformed timeout setting %j before starting the shell",
+    async (shellTimeoutMs) => {
+      const markerRoot = await fs.mkdtemp(
+        path.join(os.tmpdir(), "coding-tools-timeout-setting-"),
+      );
+      const marker = path.join(markerRoot, "started");
+      const script = path.join(markerRoot, "write-marker.mjs");
+      await fs.writeFile(
+        script,
+        `import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(marker)}, "started");\n`,
+      );
+
+      try {
+        const { runtime } = await makeRuntime({ shellTimeoutMs });
+        const result = await shellAction.handler?.(
+          runtime,
+          makeMessage(),
+          undefined,
+          {
+            command: `${JSON.stringify(process.execPath)} ${JSON.stringify(script)}`,
+          },
+        );
+
+        expect(result?.success).toBe(false);
+        expect(result?.text).toContain("invalid_param");
+        expect(result?.text).toContain("CODING_TOOLS_SHELL_TIMEOUT_MS");
+        await expect(fs.access(marker)).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      } finally {
+        await fs.rm(markerRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each([
+    [undefined, 120_000],
+    ["200", 200],
+    [100, 100],
+    [600_000, 600_000],
+  ] as const)(
+    "passes the omitted or valid setting %j to foreground execution as %j ms",
+    async (shellTimeoutMs, expectedTimeoutMs) => {
+      const calls: Array<{ timeoutMs?: number }> = [];
+      const router = makeShellRouter(async (params) => {
+        calls.push(params);
+        return { output: "ok\n", exitCode: 0, timedOut: false };
+      });
+      const { runtime } = await makeRuntime({
+        shellTimeoutMs,
+        capabilityRouter: router,
+      });
+
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(),
+        undefined,
+        { command: "echo ok" },
+      );
+
+      expect(result?.success).toBe(true);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.timeoutMs).toBe(expectedTimeoutMs);
+    },
+  );
+
+  it("prefers the per-call timeout over the operator default", async () => {
+    const calls: Array<{ timeoutMs?: number }> = [];
+    const router = makeShellRouter(async (params) => {
+      calls.push(params);
+      return { output: "ok\n", exitCode: 0, timedOut: false };
+    });
+    const { runtime } = await makeRuntime({
+      shellTimeoutMs: "600000",
+      capabilityRouter: router,
+    });
+
+    const result = await shellAction.handler?.(
+      runtime,
+      makeMessage(),
+      undefined,
+      { command: "echo ok", timeout: 250 },
+    );
+
+    expect(result?.success).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.timeoutMs).toBe(250);
+  });
+
+  it("rejects invalid background settings without starting a child", async () => {
+    const markerRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "coding-tools-background-timeout-setting-"),
+    );
+    const marker = path.join(markerRoot, "started");
+    const script = path.join(markerRoot, "write-marker.mjs");
+    await fs.writeFile(
+      script,
+      `import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(marker)}, "started");\n`,
+    );
+
+    try {
+      const { runtime } = await makeRuntime({ shellTimeoutMs: "0" });
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(),
+        undefined,
+        {
+          action: "start_background",
+          command: `${JSON.stringify(process.execPath)} ${JSON.stringify(script)}`,
+        },
+      );
+
+      expect(result?.success).toBe(false);
+      expect(result?.text).toContain("CODING_TOOLS_SHELL_TIMEOUT_MS");
+      await expect(fs.access(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await fs.rm(markerRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -1819,7 +1819,7 @@ describeIfPosix("shellAction", () => {
 });
 
 describe("shell timeout operator setting", () => {
-  it.each(["0", "-1", "45.5", "9007199254740992", "600001", "1e3", " 200"])(
+  it.each(["", "0", "-1", "45.5", "9007199254740992", "600001", "1e3", " 200"])(
     "rejects malformed timeout setting %j before starting the shell",
     async (shellTimeoutMs) => {
       const markerRoot = await fs.mkdtemp(
@@ -1857,6 +1857,7 @@ describe("shell timeout operator setting", () => {
 
   it.each([
     [undefined, 120_000],
+    [null, 120_000],
     ["200", 200],
     [100, 100],
     [600_000, 600_000],

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -87,6 +87,22 @@ async function pathExists(target: string): Promise<boolean> {
   }
 }
 
+async function withShellTimeoutEnv<T>(
+  value: string | undefined,
+  run: () => Promise<T>,
+): Promise<T> {
+  const key = "CODING_TOOLS_SHELL_TIMEOUT_MS";
+  const previousValue = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  try {
+    return await run();
+  } finally {
+    if (previousValue === undefined) delete process.env[key];
+    else process.env[key] = previousValue;
+  }
+}
+
 interface RuntimeOptions {
   blockedPaths?: string;
   shellTimeoutMs?: unknown;
@@ -1908,6 +1924,81 @@ describe("shell timeout operator setting", () => {
     expect(result?.success).toBe(true);
     expect(calls).toHaveLength(1);
     expect(calls[0]?.timeoutMs).toBe(250);
+  });
+
+  it("uses the environment timeout when the runtime setting is omitted", async () => {
+    await withShellTimeoutEnv("200", async () => {
+      const calls: Array<{ timeoutMs?: number }> = [];
+      const router = makeShellRouter(async (params) => {
+        calls.push(params);
+        return { output: "ok\n", exitCode: 0, timedOut: false };
+      });
+      const { runtime } = await makeRuntime({
+        shellTimeoutMs: null,
+        capabilityRouter: router,
+      });
+
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(),
+        undefined,
+        { command: "echo ok" },
+      );
+
+      expect(result?.success).toBe(true);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.timeoutMs).toBe(200);
+    });
+  });
+
+  it("rejects a malformed environment timeout before dispatch", async () => {
+    await withShellTimeoutEnv("45.5", async () => {
+      const calls: Array<{ timeoutMs?: number }> = [];
+      const router = makeShellRouter(async (params) => {
+        calls.push(params);
+        return { output: "unexpected\n", exitCode: 0, timedOut: false };
+      });
+      const { runtime } = await makeRuntime({
+        shellTimeoutMs: null,
+        capabilityRouter: router,
+      });
+
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(),
+        undefined,
+        { command: "echo must-not-run" },
+      );
+
+      expect(result?.success).toBe(false);
+      expect(result?.text).toContain("CODING_TOOLS_SHELL_TIMEOUT_MS");
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  it("prefers the explicit runtime setting over the environment", async () => {
+    await withShellTimeoutEnv("200", async () => {
+      const calls: Array<{ timeoutMs?: number }> = [];
+      const router = makeShellRouter(async (params) => {
+        calls.push(params);
+        return { output: "ok\n", exitCode: 0, timedOut: false };
+      });
+      const { runtime } = await makeRuntime({
+        shellTimeoutMs: "300",
+        capabilityRouter: router,
+      });
+
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(),
+        undefined,
+        { command: "echo ok" },
+      );
+
+      expect(result?.success).toBe(true);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.timeoutMs).toBe(300);
+    });
   });
 
   it("rejects invalid background settings without starting a child", async () => {

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -26,8 +26,8 @@ import {
   failureToActionResult,
   fencePreformatted,
   readBoolParam,
+  readBoundedIntSetting,
   readNumberParam,
-  readPositiveIntSetting,
   readStringParam,
   successActionResult,
   truncate,
@@ -334,7 +334,10 @@ function getBackgroundShellService(
 }
 
 function clampTimeout(value: number | undefined, fallback: number): number {
-  if (value === undefined || !Number.isFinite(value)) return fallback;
+  const boundedFallback = Number.isFinite(fallback)
+    ? Math.max(TIMEOUT_MIN_MS, Math.min(TIMEOUT_MAX_MS, Math.floor(fallback)))
+    : DEFAULT_TIMEOUT_MS;
+  if (value === undefined || !Number.isFinite(value)) return boundedFallback;
   return Math.max(TIMEOUT_MIN_MS, Math.min(TIMEOUT_MAX_MS, Math.floor(value)));
 }
 
@@ -1686,6 +1689,20 @@ export const shellAction: Action = {
       }
     }
 
+    // Validate the operator timeout before any action can create a child.
+    const timeoutSetting = readBoundedIntSetting(
+      runtime,
+      "CODING_TOOLS_SHELL_TIMEOUT_MS",
+      TIMEOUT_MIN_MS,
+      TIMEOUT_MAX_MS,
+    );
+    if (timeoutSetting && "error" in timeoutSetting) {
+      return failureToActionResult({
+        reason: "invalid_param",
+        message: timeoutSetting.error,
+      });
+    }
+
     if (subaction === "start_background") {
       const backgroundShell = getBackgroundShellService(runtime);
       if (!backgroundShell) {
@@ -1733,11 +1750,7 @@ export const shellAction: Action = {
       }
     }
 
-    const defaultTimeout = readPositiveIntSetting(
-      runtime,
-      "CODING_TOOLS_SHELL_TIMEOUT_MS",
-      DEFAULT_TIMEOUT_MS,
-    );
+    const defaultTimeout = timeoutSetting?.value ?? DEFAULT_TIMEOUT_MS;
     const timeout = clampTimeout(
       readNumberParam(options, "timeout"),
       defaultTimeout,

--- a/plugins/plugin-coding-tools/src/lib/format.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.test.ts
@@ -8,6 +8,7 @@ import {
   fencePreformatted,
   readArrayParam,
   readBoolParam,
+  readBoundedIntSetting,
   readNumberParam,
   readParam,
   readPositiveIntSetting,
@@ -120,6 +121,51 @@ describe("readPositiveIntSetting", () => {
     expect(readPositiveIntSetting(rt(0), "k", 3)).toBe(3);
     expect(readPositiveIntSetting(rt(-2), "k", 3)).toBe(3);
     expect(readPositiveIntSetting(rt("nope"), "k", 3)).toBe(3);
+  });
+});
+
+describe("readBoundedIntSetting", () => {
+  const rt = (value: unknown): IAgentRuntime =>
+    ({ getSetting: () => value }) as unknown as IAgentRuntime;
+
+  it("accepts omitted, canonical integer, and numeric settings in range", () => {
+    expect(
+      readBoundedIntSetting(rt(undefined), "k", 100, 600_000),
+    ).toBeUndefined();
+    expect(readBoundedIntSetting(rt("200"), "k", 100, 600_000)).toEqual({
+      value: 200,
+    });
+    expect(readBoundedIntSetting(rt(600_000), "k", 100, 600_000)).toEqual({
+      value: 600_000,
+    });
+  });
+
+  it.each([
+    "45.5",
+    "1e3",
+    " 200",
+    "0200",
+    "9007199254740992",
+    "oops",
+    45.5,
+    0,
+    600_001,
+    null,
+    false,
+    {},
+    Symbol("timeout"),
+  ])("rejects invalid operator settings: %j", (value) => {
+    expect(
+      readBoundedIntSetting(
+        rt(value),
+        "CODING_TOOLS_SHELL_TIMEOUT_MS",
+        100,
+        600_000,
+      ),
+    ).toEqual({
+      error:
+        "CODING_TOOLS_SHELL_TIMEOUT_MS must be a canonical decimal integer between 100 and 600000.",
+    });
   });
 });
 

--- a/plugins/plugin-coding-tools/src/lib/format.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.test.ts
@@ -132,6 +132,7 @@ describe("readBoundedIntSetting", () => {
     expect(
       readBoundedIntSetting(rt(undefined), "k", 100, 600_000),
     ).toBeUndefined();
+    expect(readBoundedIntSetting(rt(null), "k", 100, 600_000)).toBeUndefined();
     expect(readBoundedIntSetting(rt("200"), "k", 100, 600_000)).toEqual({
       value: 200,
     });
@@ -141,6 +142,7 @@ describe("readBoundedIntSetting", () => {
   });
 
   it.each([
+    "",
     "45.5",
     "1e3",
     " 200",
@@ -150,7 +152,6 @@ describe("readBoundedIntSetting", () => {
     45.5,
     0,
     600_001,
-    null,
     false,
     {},
     Symbol("timeout"),

--- a/plugins/plugin-coding-tools/src/lib/format.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.test.ts
@@ -130,14 +130,30 @@ describe("readBoundedIntSetting", () => {
 
   it("accepts omitted, canonical integer, and numeric settings in range", () => {
     expect(
-      readBoundedIntSetting(rt(undefined), "k", 100, 600_000),
+      readBoundedIntSetting(rt(undefined), "k", 100, 600_000, {}),
     ).toBeUndefined();
-    expect(readBoundedIntSetting(rt(null), "k", 100, 600_000)).toBeUndefined();
-    expect(readBoundedIntSetting(rt("200"), "k", 100, 600_000)).toEqual({
+    expect(
+      readBoundedIntSetting(rt(null), "k", 100, 600_000, {}),
+    ).toBeUndefined();
+    expect(readBoundedIntSetting(rt("200"), "k", 100, 600_000, {})).toEqual({
       value: 200,
     });
-    expect(readBoundedIntSetting(rt(600_000), "k", 100, 600_000)).toEqual({
+    expect(readBoundedIntSetting(rt(600_000), "k", 100, 600_000, {})).toEqual({
       value: 600_000,
+    });
+  });
+
+  it("reads the environment only on runtime omission", () => {
+    expect(
+      readBoundedIntSetting(rt(null), "k", 100, 600_000, { k: "200" }),
+    ).toEqual({ value: 200 });
+    expect(
+      readBoundedIntSetting(rt("300"), "k", 100, 600_000, { k: "200" }),
+    ).toEqual({ value: 300 });
+    expect(
+      readBoundedIntSetting(rt(""), "k", 100, 600_000, { k: "200" }),
+    ).toEqual({
+      error: "k must be a canonical decimal integer between 100 and 600000.",
     });
   });
 
@@ -162,12 +178,24 @@ describe("readBoundedIntSetting", () => {
         "CODING_TOOLS_SHELL_TIMEOUT_MS",
         100,
         600_000,
+        {},
       ),
     ).toEqual({
       error:
         "CODING_TOOLS_SHELL_TIMEOUT_MS must be a canonical decimal integer between 100 and 600000.",
     });
   });
+
+  it.each(["", "45.5", " 200", "600001"])(
+    "rejects invalid environment settings: %j",
+    (value) => {
+      expect(
+        readBoundedIntSetting(rt(null), "k", 100, 600_000, { k: value }),
+      ).toEqual({
+        error: "k must be a canonical decimal integer between 100 and 600000.",
+      });
+    },
+  );
 });
 
 describe("fencePreformatted", () => {

--- a/plugins/plugin-coding-tools/src/lib/format.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.ts
@@ -173,3 +173,27 @@ export function readPositiveIntSetting(
   }
   return fallback;
 }
+
+/** Reads an operator setting that must be a bounded, canonical integer. */
+export function readBoundedIntSetting(
+  runtime: IAgentRuntime,
+  key: string,
+  min: number,
+  max: number,
+): { value: number } | { error: string } | undefined {
+  const raw = runtime.getSetting(key);
+  if (raw === undefined) return undefined;
+
+  const valid =
+    (typeof raw === "number" && Number.isSafeInteger(raw)) ||
+    (typeof raw === "string" && /^(?:0|[1-9]\d*)$/.test(raw));
+  const value =
+    typeof raw === "number" || typeof raw === "string" ? Number(raw) : NaN;
+  if (!valid || !Number.isSafeInteger(value) || value < min || value > max) {
+    return {
+      error: `${key} must be a canonical decimal integer between ${min} and ${max}.`,
+    };
+  }
+
+  return { value };
+}

--- a/plugins/plugin-coding-tools/src/lib/format.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.ts
@@ -182,7 +182,9 @@ export function readBoundedIntSetting(
   max: number,
 ): { value: number } | { error: string } | undefined {
   const raw = runtime.getSetting(key);
-  if (raw === undefined) return undefined;
+  // AgentRuntime normalizes a missing setting to null. Only that absence
+  // signal defaults; explicit strings (including "") still validate below.
+  if (raw == null) return undefined;
 
   const valid =
     (typeof raw === "number" && Number.isSafeInteger(raw)) ||

--- a/plugins/plugin-coding-tools/src/lib/format.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.ts
@@ -180,10 +180,13 @@ export function readBoundedIntSetting(
   key: string,
   min: number,
   max: number,
+  env: Readonly<Record<string, string | undefined>> = process.env,
 ): { value: number } | { error: string } | undefined {
-  const raw = runtime.getSetting(key);
-  // AgentRuntime normalizes a missing setting to null. Only that absence
-  // signal defaults; explicit strings (including "") still validate below.
+  const runtimeValue = runtime.getSetting(key);
+  // AgentRuntime normalizes a missing setting to null. A runtime value wins;
+  // only a runtime miss consults the documented raw environment fallback.
+  // Explicit strings (including "") from either source validate below.
+  const raw = runtimeValue ?? env[key];
   if (raw == null) return undefined;
 
   const valid =


### PR DESCRIPTION
# Relates to

Closes #19003.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased on `origin/develop` at `0c1593ad5fc8d52288d04626fb0f46d14743d1f7` with zero conflicts.
- [x] Pinned Bun 1.3.14 and Node 24.15.0 validation passed at the exact head.
- [x] A reviewer can confirm the changed contract from real-handler regressions, raw command output, and a live-model SHELL trajectory.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

- Low: malformed operator timeout settings now fail before shell execution or background spawn instead of being silently converted into apparent success.
- Omitted runtime settings consult the documented raw environment variable and otherwise retain the 120000 ms default.
- An explicit runtime setting takes precedence over the raw environment value; explicit empty or malformed values remain invalid.
- Existing per-call timeout clamping remains unchanged.
- No wallet, payment, credential, external-service, or rendered UI behavior is touched.

# Background

## What does this PR do?

Adds strict fail-fast validation for `CODING_TOOLS_SHELL_TIMEOUT_MS` before the SHELL action's background-process branch. Runtime values take precedence; when the runtime returns its real omission signal (`null`), the action consults `process.env`. If both are omitted, the documented 120000 ms default remains. Explicit values must be canonical decimal safe integers in the inclusive 100–600000 ms range.

Registry metadata, generated first-party metadata, README, and package guides advertise the same contract. Real-handler tests cover omitted/default, environment fallback, invalid environment/no dispatch, runtime precedence, explicit-empty failure, and background no-child behavior.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

Documentation is updated in `plugins/plugin-coding-tools/README.md`, `AGENTS.md`, and `CLAUDE.md`; package and generated registry metadata are updated as well.

# Testing

## Where should a reviewer start?

Start with `plugins/plugin-coding-tools/src/lib/format.ts`, `src/actions/bash.ts`, and the timeout regressions in `src/lib/format.test.ts` and `src/actions/bash.test.ts`.

## Verified results at exact head

- Exact head: `b6e96dc43b700f4e2408b04c56bbae5a6096d51c`; base: `0c1593ad5fc8d52288d04626fb0f46d14743d1f7`.
- Toolchain: Bun 1.3.14 and Node 24.15.0.
- Focused handler/parser suite: 2 files, 133 tests passed.
- Prior semantic-equivalent head: full `plugin-coding-tools` suite passed 506/506 tests.
- Prior semantic-equivalent head: package typecheck, lint (100 files), format, and build passed; current rebased head changed-file Biome and diff hygiene pass.
- First-party registry generation check passed.
- `check:agents-claude` passed for 153 pairs.
- `git diff --check origin/develop...HEAD` passed.
- Prior semantic-equivalent head: root `bun run verify` passed 350/350 Turbo tasks plus all repository audits.
- Prior semantic-equivalent head live authenticated Codex scenario passed: one SHELL call, exit 0, expected stdout, final `FINISH`, 0 tool failures.

# Evidence Gate

Evidence matches commit `b6e96dc43b700f4e2408b04c56bbae5a6096d51c`.

<!-- evidence-head:b6e96dc43b700f4e2408b04c56bbae5a6096d51c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface is changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface is changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI flow is changed.
<!-- evidence-row:backend-logs -->
- [x] [Prior semantic-patch verification transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19079-exact-head-verification.log), [live scenario raw log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19079-live-valid-raw.log), and [scenario report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19079-live-model-report.json).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or rendered state is changed.
<!-- evidence-row:llm-trajectory -->
- [x] [Live-model SHELL trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19079-live-model-trajectory.json).
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, on-chain, audio, or other domain artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text surface is changed.

# Evidence Details

The prior verification transcript contains the earlier semantic-equivalent head/base, pinned tool versions, raw command output, timings, test counts, and final exit status. The live trajectory records the user input, model routing, SHELL tool call, arguments, exit-0 result, stdout marker, evaluator decision, and final model output. The scenario report records `passed` in 60743 ms.

The live runner emitted a post-pass `runtime.stop()` cleanup deadline warning and a Bun directory-mismatch diagnostic after it had persisted the passing report and finished trajectory. Those diagnostics are visible in the raw log and are not represented as success. A separate malformed-setting diagnostic run also showed the expected action rejection but was not used as passing evidence because the model kept retrying until the scenario deadline.

# Known gaps / failures

- Current rebased head preserves stable patch-id `eeb7199a749f535cd6990ccfff77105dc2637fc1`; focused handler/parser tests pass 133/133, changed-file Biome and guide parity pass. Package typecheck is locally non-admissible because the shared dependency tree lacks the unchanged `fast-redact` declaration; hosted typecheck remains required.\n- Hosted GitHub checks are awaiting repository runner capacity.
- Independent maintainer review is still required; the maintainer who authored repair commits is not self-approving or self-merging.
