### PR TITLE
fix(cloud): verify public router after local readiness

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -629,9 +629,32 @@ jobs:
             report_public_route_failure() {
               sudo nginx -t || true
               sudo systemctl status nginx --no-pager || true
-              sudo journalctl -u nginx --since "$HEALTH_SINCE_TS" --no-pager || true
+              sudo journalctl -u nginx --since "$HEALTH_SINCE_TS" -n 200 --no-pager || true
               sudo systemctl status eliza-agent-router.service --no-pager || true
-              sudo journalctl -u eliza-agent-router.service --since "$HEALTH_SINCE_TS" --no-pager || true
+              sudo journalctl -u eliza-agent-router.service --since "$HEALTH_SINCE_TS" -n 200 --no-pager || true
+            }
+            # The router's health contract is a JSON object with boolean
+            # ok === true. A substring grep would also accept HTML error
+            # pages that merely contain the text, so parse for real.
+            validate_public_health_payload() {
+              node -e '
+                let raw = "";
+                process.stdin.on("data", (chunk) => { raw += chunk; });
+                process.stdin.on("end", () => {
+                  let parsed;
+                  try {
+                    parsed = JSON.parse(raw);
+                  } catch {
+                    process.exit(1);
+                  }
+                  const healthy =
+                    typeof parsed === "object" &&
+                    parsed !== null &&
+                    !Array.isArray(parsed) &&
+                    parsed.ok === true;
+                  process.exit(healthy ? 0 : 1);
+                });
+              '
             }
             for attempt in $(seq 1 18); do
               if sudo systemctl is-active --quiet "$SYSTEMD_UNIT"; then
@@ -669,12 +692,22 @@ jobs:
                   ROUTER_PORT=$(systemctl show eliza-agent-router.service --property=Environment --value | tr ' ' '\n' | awk -F= '$1=="AGENT_ROUTER_PORT" {print $2}')
                   : "${ROUTER_PORT:=3458}"
                   if curl -sf -m 3 "http://127.0.0.1:${ROUTER_PORT}/healthz" >/dev/null 2>&1; then
-                    if ! PUBLIC_HEALTH=$(curl -fsS -m 5 "https://${AGENT_ROUTER_PUBLIC_HOST}/healthz"); then
+                    PUBLIC_HEALTH=""
+                    public_route_ok=false
+                    for public_attempt in 1 2 3; do
+                      if PUBLIC_HEALTH=$(curl -fsS -m 5 "https://${AGENT_ROUTER_PUBLIC_HOST}/healthz"); then
+                        public_route_ok=true
+                        break
+                      fi
+                      echo "Canonical /healthz attempt ${public_attempt}/3 failed for ${AGENT_ROUTER_PUBLIC_HOST}; retrying in 2s."
+                      sleep 2
+                    done
+                    if [ "$public_route_ok" != "true" ]; then
                       echo "::error::Canonical agent-router host failed after local readiness: ${AGENT_ROUTER_PUBLIC_HOST}"
                       report_public_route_failure
                       exit 1
                     fi
-                    if ! grep -Eq '"ok"[[:space:]]*:[[:space:]]*true' <<<"$PUBLIC_HEALTH"; then
+                    if ! printf '%s' "$PUBLIC_HEALTH" | validate_public_health_payload; then
                       echo "::error::Canonical agent-router host returned an unexpected health payload: ${AGENT_ROUTER_PUBLIC_HOST}"
                       report_public_route_failure
                       exit 1

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -601,21 +601,6 @@ jobs:
             done
             sudo nginx -t
             sudo systemctl reload nginx
-            canonical_router_ready=false
-            for attempt in $(seq 1 30); do
-              if curl -fsS "https://${AGENT_ROUTER_PUBLIC_HOST}/healthz" \
-                | grep -Eq '"ok"[[:space:]]*:[[:space:]]*true'; then
-                canonical_router_ready=true
-                break
-              fi
-              echo "Canonical agent-router health not ready (attempt ${attempt}/30)"
-              sleep 2
-            done
-            if [ "$canonical_router_ready" != "true" ]; then
-              echo "::error::Canonical agent-router did not return JSON health after 30 attempts"
-              exit 1
-            fi
-            echo "Verified canonical agent-router nginx host alias: ${AGENT_ROUTER_PUBLIC_HOST}"
 
       - name: Health check
         if: steps.deploy_config.outputs.configured == 'true'
@@ -625,7 +610,7 @@ jobs:
           username: deploy
           key: ${{ env.DEPLOY_SSH_KEY }}
           command_timeout: 5m
-          envs: SYSTEMD_UNIT,ELIZA_CLOUD_AGENT_BASE_DOMAIN
+          envs: SYSTEMD_UNIT,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST
           script: |
             set -euo pipefail
             ENV_FILE=/opt/eliza/cloud/.env.local
@@ -641,6 +626,13 @@ jobs:
             HEALTH_SINCE_TS="$(date -u '+%Y-%m-%d %H:%M:%S')"
             STABLE_THRESHOLD_SEC=20
             FATAL_LOG_PATTERN="\[(provisioning-worker|agent-router)\] (fatal|unhandled rejection)|node:internal/.*Error:|Error \[ERR_|^[A-Za-z]+Error:"
+            report_public_route_failure() {
+              sudo nginx -t || true
+              sudo systemctl status nginx --no-pager || true
+              sudo journalctl -u nginx --since "$HEALTH_SINCE_TS" --no-pager || true
+              sudo systemctl status eliza-agent-router.service --no-pager || true
+              sudo journalctl -u eliza-agent-router.service --since "$HEALTH_SINCE_TS" --no-pager || true
+            }
             for attempt in $(seq 1 18); do
               if sudo systemctl is-active --quiet "$SYSTEMD_UNIT"; then
                 JOURNAL=$(sudo journalctl -u "$SYSTEMD_UNIT" --since "$HEALTH_SINCE_TS" --no-pager 2>/dev/null || true)
@@ -677,7 +669,17 @@ jobs:
                   ROUTER_PORT=$(systemctl show eliza-agent-router.service --property=Environment --value | tr ' ' '\n' | awk -F= '$1=="AGENT_ROUTER_PORT" {print $2}')
                   : "${ROUTER_PORT:=3458}"
                   if curl -sf -m 3 "http://127.0.0.1:${ROUTER_PORT}/healthz" >/dev/null 2>&1; then
-                    echo "Both daemons active and stable (worker ${AGE}s, router ${ROUTER_AGE}s, router /healthz OK) on attempt $attempt."
+                    if ! PUBLIC_HEALTH=$(curl -fsS -m 5 "https://${AGENT_ROUTER_PUBLIC_HOST}/healthz"); then
+                      echo "::error::Canonical agent-router host failed after local readiness: ${AGENT_ROUTER_PUBLIC_HOST}"
+                      report_public_route_failure
+                      exit 1
+                    fi
+                    if ! grep -Eq '"ok"[[:space:]]*:[[:space:]]*true' <<<"$PUBLIC_HEALTH"; then
+                      echo "::error::Canonical agent-router host returned an unexpected health payload: ${AGENT_ROUTER_PUBLIC_HOST}"
+                      report_public_route_failure
+                      exit 1
+                    fi
+                    echo "Both daemons active and stable (worker ${AGE}s, router ${ROUTER_AGE}s, local and canonical /healthz OK) on attempt $attempt."
                     exit 0
                   fi
                   echo "Health check attempt $attempt/18: worker stable (${AGE}s), router ${ROUTER_AGE}s but /healthz not ready on port ${ROUTER_PORT}."

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -147,10 +147,55 @@ describe("provisioning worker deployment contract", () => {
     expect(workflow).toContain(
       "Canonical agent-router host failed after local readiness",
     );
-    expect(workflow).toContain("report_public_route_failure");
+    expect(workflow).toContain(
+      "Canonical agent-router host returned an unexpected health payload",
+    );
     expect(workflow).toContain(
       "sudo systemctl status eliza-agent-router.service --no-pager || true",
     );
+  });
+
+  it("settles both public-route failure branches with diagnostics then exit 1", () => {
+    // Both the transport-failure branch and the unexpected-payload branch
+    // must run diagnostics and then terminate the deployment immediately;
+    // a mutation that logs diagnostics and continues must fail here.
+    const failFast = [
+      ...workflow.matchAll(/report_public_route_failure\n\s*exit 1\b/g),
+    ];
+    expect(failFast).toHaveLength(2);
+    // The transport probe is bounded: a short retry absorbs one-off blips
+    // without reintroducing the blind 30-attempt loop this PR removed.
+    expect(workflow).toContain("for public_attempt in 1 2 3; do");
+    expect(workflow).not.toContain("for attempt in $(seq 1 30)");
+  });
+
+  it("rejects non-JSON and malformed public health payloads", () => {
+    // Execute the actual validator embedded in the workflow rather than
+    // asserting on its text, so a regression to substring matching fails.
+    const validator = workflow.match(
+      /validate_public_health_payload\(\) \{\n\s*node -e '([\s\S]*?)'\n\s*\}/,
+    );
+    expect(validator).not.toBeNull();
+    const script = (validator as RegExpMatchArray)[1];
+
+    const runValidator = (payload: string): number => {
+      const proc = Bun.spawnSync(["node", "-e", script], {
+        stdin: Buffer.from(payload),
+      });
+      return proc.exitCode;
+    };
+
+    expect(runValidator('{"ok":true}')).toBe(0);
+    expect(runValidator('{ "ok" : true, "uptime": 12 }')).toBe(0);
+    // HTTP-200 HTML error page containing the healthy substring must fail.
+    expect(
+      runValidator('<html><body>router says "ok": true</body></html>'),
+    ).not.toBe(0);
+    expect(runValidator('{"ok":false}')).not.toBe(0);
+    expect(runValidator('{"ok":"true"}')).not.toBe(0);
+    expect(runValidator('[{"ok":true}]')).not.toBe(0);
+    expect(runValidator("null")).not.toBe(0);
+    expect(runValidator("")).not.toBe(0);
   });
 
   it("keeps replacement workload memory inside the control-plane service fence", () => {

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -127,6 +127,32 @@ describe("provisioning worker deployment contract", () => {
     expect((occurrences ?? []).length).toBe(3);
   });
 
+  it("checks the canonical router only after local readiness and fails with diagnostics", () => {
+    const routerPort = "$" + "{ROUTER_PORT}";
+    const publicHost = "$" + "{AGENT_ROUTER_PUBLIC_HOST}";
+    const healthStep = workflow.indexOf("- name: Health check");
+    const localHealth = workflow.indexOf(
+      `curl -sf -m 3 "http://127.0.0.1:${routerPort}/healthz"`,
+    );
+    const canonicalHealth = workflow.indexOf(
+      `curl -fsS -m 5 "https://${publicHost}/healthz"`,
+    );
+
+    expect(healthStep).toBeGreaterThan(-1);
+    expect(localHealth).toBeGreaterThan(healthStep);
+    expect(canonicalHealth).toBeGreaterThan(localHealth);
+    expect(workflow.slice(0, healthStep)).not.toContain(
+      `"https://${publicHost}/healthz"`,
+    );
+    expect(workflow).toContain(
+      "Canonical agent-router host failed after local readiness",
+    );
+    expect(workflow).toContain("report_public_route_failure");
+    expect(workflow).toContain(
+      "sudo systemctl status eliza-agent-router.service --no-pager || true",
+    );
+  });
+
   it("keeps replacement workload memory inside the control-plane service fence", () => {
     const oldSpaceMatches = [
       ...provisioningService.matchAll(


### PR DESCRIPTION
# Relates to

Closes #19072. Follow-up evidence for #19047.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the ordering and failure behavior from the production failure, focused contract test, and verification output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `f6d8f8ee7f3006693113bbc313979724e603b355`; zero conflicts.
- [x] `bun run verify` passed after the substantive change. Subsequent rebases added only path-disjoint WeChat, snapshot-streaming, and UI merges; the focused deployment contract, formatting, and diff checks were rerun at exact head `da000ea9203323b33422accda96693f3df21b095`.

# Risks

Low. This changes only deployment health-check ordering and failure diagnostics. A deployment now reaches the public canonical check only after the router is active, stable, and locally healthy; a real public-route failure still terminates the deployment immediately.

# Background

## What does this PR do?

- Removes the blind 30-attempt public-host retry from the restart step introduced by #19073.
- Verifies the canonical public host once, only after both daemons are stable and the router's localhost `/healthz` succeeds.
- Fails immediately on transport failure or an unexpected JSON health payload.
- Prints nginx and agent-router status/journal diagnostics on that failure, without converting it into success.
- Locks the ordering, absence of the pre-readiness probe, and diagnostic contract in the workflow test.

Production run [31699069266](https://github.com/elizaOS/eliza/actions/runs/31699069266) showed why ordering matters: both daemons were restarted and `nginx -t` succeeded, but the immediate public curl returned HTTP 502 before the workflow's actual readiness step ran. Retrying the same public request for an arbitrary duration hides whether the router, nginx, or route is broken. This change first establishes local readiness, then treats a canonical-route failure as a distinct, diagnostic failure.

## What kind of change is this?

Bug fix (non-breaking deployment workflow correction).

# Documentation changes needed?

No project documentation change is needed; the operator behavior and its static contract remain together in the workflow and test.

# Testing

## Where should a reviewer start?

Review the `Health check` step in `.github/workflows/deploy-eliza-provisioning-worker.yml`, then the focused contract in `packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts`.

## Detailed testing steps

```text
bun test packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
7 pass, 0 fail, 40 expect() calls

bunx biome check .github/workflows/deploy-eliza-provisioning-worker.yml packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
Checked 1 file. No fixes applied. (YAML is not a Biome target.)

git diff --check origin/develop...HEAD
PASS

YAML.parse(workflow)
PASS

bun run test:scripts
PASS after repository bootstrap artifacts were generated

bun run verify
350 successful / 350 workspace tasks
build/typecheck audit PASS
script audits PASS
view inventory audit PASS
anti-larp: 7,956 test files, 0 focused, 0 orphaned skips
```

# Evidence Gate

<!-- evidence-head:b523849755f4efc381aa4946d41f5b6a27d6162c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - deployment workflow has no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - deployment workflow has no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - SSH deployment workflow has no interactive user flow
<!-- evidence-row:backend-logs -->
- [x] [19081-backend.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19081-backend.txt)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain artifact changed
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual surface changed

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changed.

## Backend + frontend logs

The existing production run is the before evidence. On canonical-route failure, the new path emits the exact failed host and gathers:

```text
nginx -t
systemctl status nginx
journalctl -u nginx --since <health-start>
systemctl status eliza-agent-router.service
journalctl -u eliza-agent-router.service --since <health-start>
```

These commands are best-effort diagnostics after the primary failure; the workflow then exits nonzero. A new production run after merge is the required after evidence and is intentionally not fabricated here.

## Screenshots (before / after) + video walkthrough

N/A - workflow-only change with no rendered UI.

## Audio / voice walkthrough

N/A - no audio or voice behavior changed.

## Known gaps / failures

- The first cold `bun run test:scripts` attempt exposed missing installed/generated repository bootstrap artifacts (`saxes`, then the generated shared keyword artifact). After `bun install --frozen-lockfile --ignore-scripts` and `bun run --cwd packages/shared build:i18n`, the complete script suite passed. These were checkout bootstrap preconditions, not failures in this diff.
- Live after evidence requires merging and running the production deployment. Keep #19047 open until the canonical and legacy UUID hosts are probed against the deployed revision.

# Deploy Notes

After merge, run the normal provisioning-worker production deployment. Confirm the health step reports local and canonical `/healthz` success, then probe the legacy UUID hostname required by #19047.

— [codex]





## Final landing verification

Reviewed head `b523849755f4` is rebased onto `origin/develop@48d1ed88add5`. The rebase preserved develop's warm-pool workflow contracts alongside this PR's router-health contracts. Exact reviewed-head results: deployment workflow suite 13/13 (63 assertions); embedded JSON validator exercised against valid, malformed, HTML, string, array, null, and empty payloads; YAML parse passed; `git diff --check` passed; root `bun run verify` passed all 350 workspace tasks plus all repository audits. `actionlint` reports only the existing `concurrency.queue` key identically present on develop.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Attribution status: self-reported
— [codex]