### PR TITLE
fix(agent): promote streaming snapshot response to main

### DIFF
--- a/packages/agent/src/api/backup-json-response.test.ts
+++ b/packages/agent/src/api/backup-json-response.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Exercises the real HTTP transport used to stream large agent backup JSON
+ * without substituting a response mock for Node's buffering behavior.
+ */
+
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentBackupStateData } from "../services/agent-backup.ts";
+import { writeAgentBackupJsonResponse } from "./backup-json-response.ts";
+
+const servers: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      ),
+  );
+});
+
+async function serveSnapshot(
+  snapshot: AgentBackupStateData,
+): Promise<Response> {
+  const server = http.createServer((_req, res) => {
+    void writeAgentBackupJsonResponse(res, snapshot);
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("No test port");
+  return fetch(`http://127.0.0.1:${address.port}`);
+}
+
+function snapshotWithConfig(
+  config: Record<string, unknown>,
+): AgentBackupStateData {
+  return {
+    memories: [],
+    config,
+    workspaceFiles: {},
+    manifest: {
+      schemaVersion: 1,
+      format: "elizaos.agent-backup",
+      createdAt: "2026-08-13T00:00:00.000Z",
+      agentId: "00000000-0000-4000-8000-000000000000",
+      components: {
+        database: { kind: "none", reason: "test", sha256: "db" },
+        media: {
+          kind: "file-set",
+          rootLabel: "state-dir",
+          files: [],
+          sha256: "media",
+        },
+        vault: {
+          kind: "file-set",
+          rootLabel: "state-dir",
+          files: [],
+          sha256: "vault",
+        },
+        character: { runtimeCharacter: {}, sha256: "character" },
+        stateFiles: {
+          kind: "file-set",
+          rootLabel: "state-dir",
+          files: [],
+          sha256: "state",
+        },
+      },
+      integrity: { componentHashes: {} },
+    },
+  };
+}
+
+describe("writeAgentBackupJsonResponse", () => {
+  it("round-trips a multi-chunk backup response through a real HTTP server", async () => {
+    const largeValue = "backup-data-".repeat(300_000);
+    const snapshot = snapshotWithConfig({ largeValue });
+
+    const response = await serveSnapshot(snapshot);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    await expect(response.json()).resolves.toEqual(snapshot);
+  });
+
+  it("preserves escaping, surrogate pairs, arrays, and JSON omission rules", async () => {
+    const boundaryPrefix = "x".repeat(256 * 1024 - 1);
+    const snapshot = snapshotWithConfig({
+      text: `${boundaryPrefix}😀\n"done`,
+      array: [undefined, Number.NaN, true],
+      omitted: undefined,
+      date: new Date("2026-08-13T00:00:00.000Z"),
+    });
+
+    const response = await serveSnapshot(snapshot);
+    const parsed = (await response.json()) as AgentBackupStateData;
+
+    expect(parsed.config).toEqual({
+      text: `${boundaryPrefix}😀\n"done`,
+      array: [null, null, true],
+      date: "2026-08-13T00:00:00.000Z",
+    });
+  });
+});

--- a/packages/agent/src/api/backup-json-response.ts
+++ b/packages/agent/src/api/backup-json-response.ts
@@ -1,0 +1,120 @@
+/**
+ * Streams full-agent backup manifests across the HTTP boundary without asking
+ * Node's response writer to materialize one giant outgoing buffer.
+ */
+
+import { once } from "node:events";
+import type http from "node:http";
+import type { AgentBackupStateData } from "../services/agent-backup.ts";
+
+const STRING_CHUNK_CODE_UNITS = 256 * 1024;
+
+function isUnsupportedJsonValue(value: unknown): boolean {
+  return (
+    value === undefined ||
+    typeof value === "function" ||
+    typeof value === "symbol"
+  );
+}
+
+async function* encodeJsonString(value: string): AsyncGenerator<string> {
+  yield '"';
+  for (
+    let offset = 0;
+    offset < value.length;
+    offset += STRING_CHUNK_CODE_UNITS
+  ) {
+    const encoded = JSON.stringify(
+      value.slice(offset, offset + STRING_CHUNK_CODE_UNITS),
+    );
+    yield encoded.slice(1, -1);
+  }
+  yield '"';
+}
+
+async function* encodeJsonValue(
+  input: unknown,
+  ancestors: Set<object>,
+): AsyncGenerator<string> {
+  let value = input;
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    "toJSON" in value &&
+    typeof value.toJSON === "function"
+  ) {
+    value = value.toJSON();
+  }
+
+  if (value === null) {
+    yield "null";
+    return;
+  }
+  if (typeof value === "string") {
+    yield* encodeJsonString(value);
+    return;
+  }
+  if (typeof value === "number") {
+    yield Number.isFinite(value) ? String(value) : "null";
+    return;
+  }
+  if (typeof value === "boolean") {
+    yield value ? "true" : "false";
+    return;
+  }
+  if (typeof value === "bigint") {
+    throw new TypeError("Do not know how to serialize a BigInt");
+  }
+  if (isUnsupportedJsonValue(value)) {
+    yield "null";
+    return;
+  }
+  if (typeof value !== "object") {
+    yield "null";
+    return;
+  }
+  if (ancestors.has(value)) {
+    throw new TypeError("Converting circular structure to JSON");
+  }
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      yield "[";
+      for (let index = 0; index < value.length; index += 1) {
+        if (index > 0) yield ",";
+        yield* encodeJsonValue(value[index], ancestors);
+      }
+      yield "]";
+      return;
+    }
+
+    yield "{";
+    let wroteProperty = false;
+    for (const key of Object.keys(value)) {
+      const propertyValue = (value as Record<string, unknown>)[key];
+      if (isUnsupportedJsonValue(propertyValue)) continue;
+      if (wroteProperty) yield ",";
+      yield JSON.stringify(key);
+      yield ":";
+      yield* encodeJsonValue(propertyValue, ancestors);
+      wroteProperty = true;
+    }
+    yield "}";
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+/** Writes a restorable snapshot as chunked JSON while honoring backpressure. */
+export async function writeAgentBackupJsonResponse(
+  res: http.ServerResponse,
+  snapshot: AgentBackupStateData,
+): Promise<void> {
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "application/json");
+  for await (const chunk of encodeJsonValue(snapshot, new Set())) {
+    if (!res.write(chunk)) await once(res, "drain");
+  }
+  res.end();
+}

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -67,6 +67,7 @@ import {
 import { parseClampedInteger } from "@elizaos/shared/utils/number-parsing";
 import { type WebSocket, WebSocketServer } from "ws";
 import { installPlugin as installPluginDirect } from "../services/plugin-installer.ts";
+import { writeAgentBackupJsonResponse } from "./backup-json-response.ts";
 import { handleStandaloneCloudPairRoute } from "./cloud-pair-route.ts";
 import { handlePluginDirectoryRoutes } from "./plugin-directory-routes.ts";
 
@@ -1836,7 +1837,7 @@ async function handleRequest(
     }
     try {
       const snapshot = await createAgentSnapshot(state.runtime, state.config);
-      json(res, snapshot);
+      await writeAgentBackupJsonResponse(res, snapshot);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (message === PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT) {
@@ -1858,6 +1859,12 @@ async function handleRequest(
         return;
       }
       logger.error({ err: message }, "[agent-backup] Snapshot failed");
+      if (res.headersSent) {
+        // error-policy:J1 Streaming may fail after the response is committed;
+        // terminate that transport instead of appending a false JSON error.
+        res.destroy(err instanceof Error ? err : new Error(message));
+        return;
+      }
       error(res, message, 500);
     }
     return;


### PR DESCRIPTION
## Production promotion

Promotes the already-merged snapshot streaming fix from `develop` PR #19080 to `main` without bringing unrelated develop-only changes.

Production agent lifecycle operations currently fail closed after snapshot manifest creation because the old response writer throws `RangeError: Invalid string length`. This commit streams the unchanged backup schema with backpressure.

## Verification

- #19080 merged into `develop`
- focused real-HTTP transport tests: 4 passed
- agent typecheck: passed
- agent lint: passed
- root `bun run verify`: passed (350/350 build/typecheck tasks and all repository audits)
