### PR TITLE
fix(cloud): route gateway through canonical agent origin

### DIFF
--- a/packages/cloud/services/gateway-webhook/AGENTS.md
+++ b/packages/cloud/services/gateway-webhook/AGENTS.md
@@ -105,6 +105,11 @@ Other:
   unset, every internal-event request is rejected (logged as a warning at boot).
 - `AGENT_SERVER_SHARED_SECRET` — sent as `X-Server-Token` on forwards to
   agent-server pods.
+- `AGENT_ROUTER_ORIGIN_HOST` — canonical dedicated-agent router origin used
+  after a direct transport failure. The gateway sends the validated
+  `<agent-id>.<ELIZA_CLOUD_AGENT_BASE_DOMAIN>` value as `X-Forwarded-Host`.
+- `ELIZA_CLOUD_AGENT_BASE_DOMAIN` — dedicated-agent hostname suffix used with
+  the router origin (default `cloud.eliza.app`).
 - `PORT` (default 3000; `dev`/`start` scripts set 3002), `POD_NAME` /
   `HOSTNAME`.
 - `KEDA_COOLDOWN_SECONDS` (default 900) — TTL on the KEDA activity key.

--- a/packages/cloud/services/gateway-webhook/CLAUDE.md
+++ b/packages/cloud/services/gateway-webhook/CLAUDE.md
@@ -105,6 +105,11 @@ Other:
   unset, every internal-event request is rejected (logged as a warning at boot).
 - `AGENT_SERVER_SHARED_SECRET` — sent as `X-Server-Token` on forwards to
   agent-server pods.
+- `AGENT_ROUTER_ORIGIN_HOST` — canonical dedicated-agent router origin used
+  after a direct transport failure. The gateway sends the validated
+  `<agent-id>.<ELIZA_CLOUD_AGENT_BASE_DOMAIN>` value as `X-Forwarded-Host`.
+- `ELIZA_CLOUD_AGENT_BASE_DOMAIN` — dedicated-agent hostname suffix used with
+  the router origin (default `cloud.eliza.app`).
 - `PORT` (default 3000; `dev`/`start` scripts set 3002), `POD_NAME` /
   `HOSTNAME`.
 - `KEDA_COOLDOWN_SECONDS` (default 900) — TTL on the KEDA activity key.

--- a/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
   forwardToServer,
   getCanonicalAgentFallbackBase,
+  getCanonicalAgentFallbackTarget,
 } from "../src/server-router";
 
 const AGENT_ID = "4602b3be-2c01-4e7e-9cdc-849604e1bef7";
@@ -20,6 +21,81 @@ describe("canonical agent forwarding fallback", () => {
     );
     expect(getCanonicalAgentFallbackBase("../../attacker.example")).toBeNull();
     expect(getCanonicalAgentFallbackBase("not-an-agent-id")).toBeNull();
+  });
+
+  test("routes through the configured canonical origin with a validated forwarded host", () => {
+    expect(
+      getCanonicalAgentFallbackTarget(AGENT_ID, {
+        AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.eliza.app",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
+      }),
+    ).toEqual({
+      baseUrl: "https://eliza-production-1.eliza.app/api",
+      forwardedHost: `${AGENT_ID}.cloud.eliza.app`,
+    });
+    expect(
+      getCanonicalAgentFallbackTarget(AGENT_ID, {
+        AGENT_ROUTER_ORIGIN_HOST: "https://attacker.example/path",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
+      }),
+    ).toBeNull();
+  });
+
+  test("sends the canonical agent hostname to the router origin", async () => {
+    const requests: Array<{ url: string; forwardedHost: string | null }> = [];
+    const previousOrigin = process.env.AGENT_ROUTER_ORIGIN_HOST;
+    const previousDomain = process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN;
+    process.env.AGENT_ROUTER_ORIGIN_HOST = "eliza-production-1.eliza.app";
+    process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN = "cloud.eliza.app";
+    globalThis.fetch = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = input instanceof Request ? input.url : String(input);
+        requests.push({
+          url,
+          forwardedHost: new Headers(init?.headers).get("x-forwarded-host"),
+        });
+        if (url.startsWith("http://stale-sandbox.example")) {
+          throw new TypeError("connection timed out");
+        }
+        return new Response(JSON.stringify({ response: "agent is live" }), {
+          status: 200,
+        });
+      },
+    ) as typeof fetch;
+
+    try {
+      await expect(
+        forwardToServer(
+          "http://stale-sandbox.example/api",
+          "sandbox-stale",
+          AGENT_ID,
+          "user-1",
+          "hello",
+        ),
+      ).resolves.toBe("agent is live");
+    } finally {
+      if (previousOrigin === undefined) {
+        delete process.env.AGENT_ROUTER_ORIGIN_HOST;
+      } else {
+        process.env.AGENT_ROUTER_ORIGIN_HOST = previousOrigin;
+      }
+      if (previousDomain === undefined) {
+        delete process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN;
+      } else {
+        process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN = previousDomain;
+      }
+    }
+
+    expect(requests).toEqual([
+      {
+        url: `http://stale-sandbox.example/api/agents/${AGENT_ID}/message`,
+        forwardedHost: null,
+      },
+      {
+        url: `https://eliza-production-1.eliza.app/api/agents/${AGENT_ID}/message`,
+        forwardedHost: `${AGENT_ID}.cloud.eliza.app`,
+      },
+    ]);
   });
 
   test("uses the canonical agent route after a primary transport failure", async () => {

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -13,6 +13,15 @@ const RETRY_INCREMENT_MS = 1_000;
 const IDENTITY_CACHE_TTL_SECONDS = 300;
 const AGENT_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const DNS_HOSTNAME_PATTERN =
+  /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
+
+interface CanonicalAgentFallbackTarget {
+  baseUrl: string;
+  forwardedHost?: string;
+}
+
+type CanonicalAgentFallbackEnv = Record<string, string | undefined>;
 
 interface ServerRoute {
   serverName: string;
@@ -33,10 +42,36 @@ export interface ResolvedIdentity {
   agentId: string | null;
 }
 
-/** Returns the fixed-domain public route for a validated cloud agent id. */
-export function getCanonicalAgentFallbackBase(agentId: string): string | null {
+/** Resolves a validated public or router-origin fallback for a cloud agent. */
+export function getCanonicalAgentFallbackTarget(
+  agentId: string,
+  env: CanonicalAgentFallbackEnv = process.env,
+): CanonicalAgentFallbackTarget | null {
   if (!AGENT_ID_PATTERN.test(agentId)) return null;
-  return `https://${agentId.toLowerCase()}.elizacloud.ai/api`;
+  const normalizedAgentId = agentId.toLowerCase();
+  const routerOriginHost = env.AGENT_ROUTER_ORIGIN_HOST?.trim();
+  if (!routerOriginHost) {
+    return {
+      baseUrl: `https://${normalizedAgentId}.elizacloud.ai/api`,
+    };
+  }
+  const agentBaseDomain =
+    env.ELIZA_CLOUD_AGENT_BASE_DOMAIN?.trim() || "cloud.eliza.app";
+  if (
+    !DNS_HOSTNAME_PATTERN.test(routerOriginHost) ||
+    !DNS_HOSTNAME_PATTERN.test(agentBaseDomain)
+  ) {
+    return null;
+  }
+  return {
+    baseUrl: `https://${routerOriginHost}/api`,
+    forwardedHost: `${normalizedAgentId}.${agentBaseDomain.toLowerCase()}`,
+  };
+}
+
+/** Returns the selected fallback base URL for compatibility callers. */
+export function getCanonicalAgentFallbackBase(agentId: string): string | null {
+  return getCanonicalAgentFallbackTarget(agentId)?.baseUrl ?? null;
 }
 
 export async function resolveIdentity(
@@ -351,7 +386,7 @@ export async function forwardToServer(
     userId,
     `/agents/${agentId}/message`,
     JSON.stringify(body),
-    getCanonicalAgentFallbackBase(agentId),
+    getCanonicalAgentFallbackTarget(agentId),
   );
   return parseAgentResponse(raw, agentId);
 }
@@ -410,7 +445,7 @@ export async function forwardEventToServer(
     userId,
     `/agents/${agentId}/event`,
     JSON.stringify({ userId, type, payload }),
-    getCanonicalAgentFallbackBase(agentId),
+    getCanonicalAgentFallbackTarget(agentId),
   );
 }
 
@@ -432,19 +467,25 @@ const RUNTIME_AGENT_ID_PATTERN =
  * canonical host, and only when exactly one running runtime is present.
  */
 async function discoverCanonicalRuntimeAgentId(
-  canonicalBaseUrl: string,
+  canonicalTarget: CanonicalAgentFallbackTarget,
 ): Promise<string | null> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), FORWARD_TIMEOUT_MS);
   const headers: Record<string, string> = {};
   const sharedSecret = process.env.AGENT_SERVER_SHARED_SECRET;
   if (sharedSecret) headers["X-Server-Token"] = sharedSecret;
+  if (canonicalTarget.forwardedHost) {
+    headers["X-Forwarded-Host"] = canonicalTarget.forwardedHost;
+  }
 
   try {
-    const res = await fetch(`${canonicalBaseUrl.replace(/\/$/, "")}/agents`, {
-      headers,
-      signal: controller.signal,
-    });
+    const res = await fetch(
+      `${canonicalTarget.baseUrl.replace(/\/$/, "")}/agents`,
+      {
+        headers,
+        signal: controller.signal,
+      },
+    );
     if (!res.ok) return null;
 
     const data = (await res.json()) as {
@@ -467,24 +508,29 @@ async function discoverCanonicalRuntimeAgentId(
 }
 
 async function tryCanonicalTarget(
-  canonicalBaseUrl: string,
+  canonicalTarget: CanonicalAgentFallbackTarget,
   endpointPath: string,
   body: string,
 ): Promise<TargetResult> {
-  const direct = await tryTarget(canonicalBaseUrl, endpointPath, body);
+  const direct = await tryTarget(
+    canonicalTarget.baseUrl,
+    endpointPath,
+    body,
+    canonicalTarget.forwardedHost,
+  );
   if (direct.ok || direct.status !== 404) return direct;
 
   const match = endpointPath.match(/^\/agents\/[^/]+\/(message|event)$/);
   if (!match) return direct;
 
-  const runtimeAgentId =
-    await discoverCanonicalRuntimeAgentId(canonicalBaseUrl);
+  const runtimeAgentId = await discoverCanonicalRuntimeAgentId(canonicalTarget);
   if (!runtimeAgentId) return direct;
 
   return tryTarget(
-    canonicalBaseUrl,
+    canonicalTarget.baseUrl,
     `/agents/${encodeURIComponent(runtimeAgentId)}/${match[1]}`,
     body,
+    canonicalTarget.forwardedHost,
   );
 }
 
@@ -500,7 +546,7 @@ async function forwardWithRetry(
   hashKey: string,
   endpointPath: string,
   body: string,
-  connectionFallbackBaseUrl?: string | null,
+  connectionFallback?: CanonicalAgentFallbackTarget | null,
 ): Promise<string> {
   let lastError: Error | null = null;
   let woken = false;
@@ -534,12 +580,12 @@ async function forwardWithRetry(
     // authoritative and must not be bypassed through a second ingress.
     if (
       result.isConnectionError &&
-      connectionFallbackBaseUrl &&
+      connectionFallback &&
       targets[0].replace(/\/$/, "") !==
-        connectionFallbackBaseUrl.replace(/\/$/, "")
+        connectionFallback.baseUrl.replace(/\/$/, "")
     ) {
       const canonical = await tryCanonicalTarget(
-        connectionFallbackBaseUrl,
+        connectionFallback,
         endpointPath,
         body,
       );
@@ -574,6 +620,7 @@ async function tryTarget(
   target: string,
   endpointPath: string,
   body: string,
+  forwardedHost?: string,
 ): Promise<TargetResult> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), FORWARD_TIMEOUT_MS);
@@ -584,6 +631,9 @@ async function tryTarget(
   const sharedSecret = process.env.AGENT_SERVER_SHARED_SECRET;
   if (sharedSecret) {
     headers["X-Server-Token"] = sharedSecret;
+  }
+  if (forwardedHost) {
+    headers["X-Forwarded-Host"] = forwardedHost;
   }
 
   try {


### PR DESCRIPTION
## What

Adds a validated router-origin target for dedicated-agent webhook forwarding. When `AGENT_ROUTER_ORIGIN_HOST` is configured, the gateway sends the validated `<agent-id>.<ELIZA_CLOUD_AGENT_BASE_DOMAIN>` value as `X-Forwarded-Host`; without it, the legacy UUID fallback remains unchanged.

Closes #19085

## Production evidence

A real iMessage test proved:

- Blooio `message.received` delivery to `https://api.eliza.app/api/eliza-app/webhook/blooio`: HTTP 200
- gateway dedupe key and linked identity resolve to agent `4602b3be-2c01-4e7e-9cdc-849604e1bef7`
- registered direct target `http://136.243.47.243:18799/api`: connection timeout
- legacy fallback `https://<agent>.elizacloud.ai/api/health`: HTTP 404
- router origin `https://eliza-production-1.eliza.app/api/health` with canonical `X-Forwarded-Host`: HTTP 200, runtime ready
- router origin `/api/agents`: HTTP 200 with the sole running runtime

## Verification

- gateway package tests: 103 passed, 0 failed
- focused fallback tests: 5 passed
- gateway typecheck: passed
- gateway lint: passed
- gateway build: passed
- `bun run check:agents-claude`: passed
- `git diff --check`: passed
