### PR TITLE
fix(core): honor the metadata filter in InMemoryDatabaseAdapter.countMemories

### DIFF
--- a/packages/core/src/database/inMemoryAdapter.count-memories-metadata.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.count-memories-metadata.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Deterministic in-memory adapter coverage: countMemories must honor the same
+ * `metadata` matcher getMemories applies, so a metadata-filtered count equals
+ * getMemories({ metadata }).length for both the room-scoped and unscoped paths.
+ */
+import { describe, expect, it } from "vitest";
+import type { Memory, MemoryMetadata, UUID } from "../types";
+import { stringToUuid } from "../utils.ts";
+import { InMemoryDatabaseAdapter } from "./inMemoryAdapter.ts";
+
+const TABLE = "messages";
+const ROOM = stringToUuid("room-count-metadata") as UUID;
+
+async function seed(): Promise<InMemoryDatabaseAdapter> {
+	const adapter = new InMemoryDatabaseAdapter();
+	await adapter.init?.();
+	const make = (
+		i: number,
+		source: string,
+	): { memory: Memory; tableName: string } => ({
+		memory: {
+			entityId: stringToUuid(`e-${i}`) as UUID,
+			roomId: ROOM,
+			content: { text: `m${i}` },
+			metadata: { source } as MemoryMetadata,
+		},
+		tableName: TABLE,
+	});
+	await adapter.createMemories([
+		make(1, "alpha"),
+		make(2, "alpha"),
+		make(3, "alpha"),
+		make(4, "beta"),
+		make(5, "beta"),
+	]);
+	return adapter;
+}
+
+describe("InMemoryDatabaseAdapter.countMemories metadata filter", () => {
+	it("counts only memories matching the metadata filter (no room filter)", async () => {
+		const adapter = await seed();
+		const filter = { source: "alpha" };
+		const count = await adapter.countMemories({
+			tableName: TABLE,
+			metadata: filter,
+		});
+		const got = await adapter.getMemories({
+			tableName: TABLE,
+			metadata: filter,
+		});
+		expect(count).toBe(3);
+		expect(count).toBe(got.length);
+	});
+
+	it("counts only matching memories within a room filter", async () => {
+		const adapter = await seed();
+		const filter = { source: "beta" };
+		const count = await adapter.countMemories({
+			roomIds: [ROOM],
+			tableName: TABLE,
+			metadata: filter,
+		});
+		const got = await adapter.getMemories({
+			roomId: ROOM,
+			tableName: TABLE,
+			metadata: filter,
+		});
+		expect(count).toBe(2);
+		expect(count).toBe(got.length);
+	});
+
+	it("counts every memory when no metadata filter is given", async () => {
+		const adapter = await seed();
+		expect(await adapter.countMemories({ tableName: TABLE })).toBe(5);
+	});
+
+	it("counts zero when the metadata filter matches nothing", async () => {
+		const adapter = await seed();
+		const filter = { source: "gamma" };
+		const count = await adapter.countMemories({
+			tableName: TABLE,
+			metadata: filter,
+		});
+		const got = await adapter.getMemories({
+			tableName: TABLE,
+			metadata: filter,
+		});
+		expect(count).toBe(0);
+		expect(count).toBe(got.length);
+	});
+});

--- a/packages/core/src/database/inMemoryAdapter.count-memories-metadata.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.count-memories-metadata.test.ts
@@ -50,12 +50,6 @@ describe("InMemoryDatabaseAdapter.countMemories metadata filter", () => {
 		});
 		expect(count).toBe(3);
 		expect(count).toBe(got.length);
-		expect(
-			await adapter.countMemories({
-				tableName: TABLE,
-				metadata: { source: "gamma" },
-			}),
-		).toBe(0);
 	});
 
 	it("counts only matching memories within a room filter", async () => {

--- a/packages/core/src/database/inMemoryAdapter.count-memories-metadata.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.count-memories-metadata.test.ts
@@ -50,6 +50,12 @@ describe("InMemoryDatabaseAdapter.countMemories metadata filter", () => {
 		});
 		expect(count).toBe(3);
 		expect(count).toBe(got.length);
+		expect(
+			await adapter.countMemories({
+				tableName: TABLE,
+				metadata: { source: "gamma" },
+			}),
+		).toBe(0);
 	});
 
 	it("counts only matching memories within a room filter", async () => {

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -101,6 +101,19 @@ function roomTableKey(tableName: string, roomId: UUID): string {
 	return `${tableName}:${String(roomId)}`;
 }
 
+function memoryMatchesMetadata(
+	memory: Memory,
+	filter: Record<string, unknown>,
+): boolean {
+	if (!memory.metadata) return false;
+	const metadata = memory.metadata as Record<string, unknown>;
+	for (const [key, value] of Object.entries(filter)) {
+		if (!(key in metadata)) return false;
+		if (JSON.stringify(metadata[key]) !== JSON.stringify(value)) return false;
+	}
+	return true;
+}
+
 function connectorAccountKey(params: {
 	agentId: UUID;
 	provider: string;
@@ -963,24 +976,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			});
 		}
 
-		// WHY: In-memory metadata filtering uses deep equality check for each
-		// filter key. This is less efficient than SQL containment operators but
-		// correct for nested objects/arrays. Matches PG @> and MySQL JSON_CONTAINS semantics.
+		// In-memory metadata filtering compares each requested top-level value by
+		// JSON representation. Keep get/count on this shared matcher so their
+		// pagination totals cannot drift apart.
 		if (params.metadata) {
 			const filterMeta = params.metadata as Record<string, unknown>;
-			all = all.filter((memory) => {
-				if (!memory.metadata) return false;
-				const memMeta = memory.metadata as Record<string, unknown>;
-				// Check if memory.metadata contains all key-value pairs from params.metadata
-				for (const [key, value] of Object.entries(filterMeta)) {
-					if (!(key in memMeta)) return false;
-					// Deep equality check for nested objects/arrays
-					if (JSON.stringify(memMeta[key]) !== JSON.stringify(value)) {
-						return false;
-					}
-				}
-				return true;
-			});
+			all = all.filter((memory) => memoryMatchesMetadata(memory, filterMeta));
 		}
 
 		// Keyword filter — same case-insensitive `includes` semantics the SQL
@@ -1326,21 +1327,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		const roomIds = params.roomIds ?? [];
 		const tbl = params.tableName ?? "messages";
 		const u = params.unique;
-		// Mirror the metadata matcher getMemories applies (per-key JSON.stringify
-		// equality) so a metadata-filtered count matches the number of memories
-		// getMemories would return.
 		const filterMeta = params.metadata as Record<string, unknown> | undefined;
-		const matchesMetadata = (m: Memory): boolean => {
-			if (!filterMeta) return true;
-			if (!m.metadata) return false;
-			const memMeta = m.metadata as Record<string, unknown>;
-			for (const [key, value] of Object.entries(filterMeta)) {
-				if (!(key in memMeta)) return false;
-				if (JSON.stringify(memMeta[key]) !== JSON.stringify(value))
-					return false;
-			}
-			return true;
-		};
 		let total = 0;
 		if (roomIds.length === 0) {
 			// No room filter: count all memories matching tableName and other filters (consistent with SQL/store behavior)
@@ -1352,7 +1339,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 					list = list.filter((m) => m.entityId === params.entityId);
 				if (params.agentId)
 					list = list.filter((m) => m.agentId === params.agentId);
-				if (filterMeta) list = list.filter(matchesMetadata);
+				if (filterMeta)
+					list = list.filter((memory) =>
+						memoryMatchesMetadata(memory, filterMeta),
+					);
 				total += u ? list.filter((m) => m.unique).length : list.length;
 			}
 			return total;
@@ -1365,7 +1355,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				list = list.filter((m) => m.entityId === params.entityId);
 			if (params.agentId)
 				list = list.filter((m) => m.agentId === params.agentId);
-			if (filterMeta) list = list.filter(matchesMetadata);
+			if (filterMeta)
+				list = list.filter((memory) =>
+					memoryMatchesMetadata(memory, filterMeta),
+				);
 			total += u ? list.filter((m) => m.unique).length : list.length;
 		}
 		return total;

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -1326,6 +1326,21 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		const roomIds = params.roomIds ?? [];
 		const tbl = params.tableName ?? "messages";
 		const u = params.unique;
+		// Mirror the metadata matcher getMemories applies (per-key JSON.stringify
+		// equality) so a metadata-filtered count matches the number of memories
+		// getMemories would return.
+		const filterMeta = params.metadata as Record<string, unknown> | undefined;
+		const matchesMetadata = (m: Memory): boolean => {
+			if (!filterMeta) return true;
+			if (!m.metadata) return false;
+			const memMeta = m.metadata as Record<string, unknown>;
+			for (const [key, value] of Object.entries(filterMeta)) {
+				if (!(key in memMeta)) return false;
+				if (JSON.stringify(memMeta[key]) !== JSON.stringify(value))
+					return false;
+			}
+			return true;
+		};
 		let total = 0;
 		if (roomIds.length === 0) {
 			// No room filter: count all memories matching tableName and other filters (consistent with SQL/store behavior)
@@ -1337,6 +1352,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 					list = list.filter((m) => m.entityId === params.entityId);
 				if (params.agentId)
 					list = list.filter((m) => m.agentId === params.agentId);
+				if (filterMeta) list = list.filter(matchesMetadata);
 				total += u ? list.filter((m) => m.unique).length : list.length;
 			}
 			return total;
@@ -1349,6 +1365,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				list = list.filter((m) => m.entityId === params.entityId);
 			if (params.agentId)
 				list = list.filter((m) => m.agentId === params.agentId);
+			if (filterMeta) list = list.filter(matchesMetadata);
 			total += u ? list.filter((m) => m.unique).length : list.length;
 		}
 		return total;


### PR DESCRIPTION
# Relates to

Fixes #19089

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto `origin/develop@0c1593ad5fc8d52288d04626fb0f46d14743d1f7` with zero conflicts.
- [x] `bun install --frozen-lockfile` completed with Bun 1.3.14 and Node 24.15.0.
- [x] A reviewer can verify the behavior from the evidence below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`, `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used, direct repository fix and maintainer repair`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What changed

`InMemoryDatabaseAdapter.countMemories` declared a `metadata` filter but ignored it, so filtered counts were inflated relative to `getMemories`. The implementation now applies the same metadata matcher in both room-scoped and unscoped count paths.

The final repair extracts that existing matcher into one shared function used by both `getMemories` and `countMemories`. This preserves the adapter's current top-level JSON-representation comparison exactly while preventing count/get behavior from drifting again. It does not claim SQL containment equivalence and does not add fallback or error suppression.

# Verification

Exact head: `17112d0721d5dafbe7a121e9a1c5e8073fca3cc9`

- Focused deterministic contract: 4/4 passed, covering unscoped match, room-scoped match, no filter, and zero matches.
- `packages/core`: Biome check passed; typecheck passed; Node/browser/edge/testing build passed.
- Root `bun run verify`: 350/350 tasks passed, followed by all repository audits.
- Full core lane: 5,826 passed, 1 skipped, 4 failed on baseline-only expectations documented below. No failing test touches `InMemoryDatabaseAdapter` or the changed contract.

# Evidence Gate

<!-- evidence-head:17112d0721d5dafbe7a121e9a1c5e8073fca3cc9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - core in-memory adapter logic has no rendered UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - core in-memory adapter logic has no rendered UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - deterministic backend adapter contract has no user-facing flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs [exact-head root verify (350/350)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19090-root-verify-final3.log) and [exact-head full core lane](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19090-core-full-test-final3.log).
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - no frontend code or route is changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - no agent, action, provider, prompt, planner, or model path is changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts [exact-head deterministic memory-count contract (4/4)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19090-focused-contract-final3.log).
<!-- evidence-row:ocr-review -->
- [x] OCR review `N/A - backend-only change has no rendered visual surface`.

# Known gaps / failures

The exact-head full core lane is 5,826/5,831 passed with one skip and four failures unrelated to this two-file adapter change:

- `src/cloud-routing.test.ts` and `src/testing/live-provider.alias.test.ts` still expect obsolete `elizacloud.ai` URLs, while current source returns `api.eliza.app`; this same baseline mismatch is documented on #19101.
- `src/features/documents/service-character-ingest.test.ts` and its regression-lane inclusion expect `DOCUMENT_FRAGMENT_EMBED_FAILED`, while current source returns the typed inner `EMBEDDING_MODEL_OUTPUT_INVALID` cause.

The raw full-lane log above records the assertions and stack traces verbatim. The focused changed contract, package type/build/style gates, and root verification are green.

---

Original contribution: latent-9 using Anthropic Claude Opus 4.8 / Claude Code. Maintainer repair and exact-head verification: OpenAI GPT-5.6-sol / Codex desktop.

AI provider/model: OpenAI / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: N/A - no contribution skill used  
Attribution status: self-reported  
— [codex-pr-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->
