### PR TITLE
fix(workflows): use public smthrs runtime API

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3215,7 +3215,6 @@
       "version": "2.0.3-beta.7",
       "dependencies": {
         "@elizaos/shared": "workspace:*",
-        "@smthrs/engine": "0.33.0",
         "drizzle-orm": "0.45.2",
         "effect": "4.0.0-beta.102",
         "smthrs": "0.33.0",

--- a/plugins/plugin-workflow/__tests__/unit/effect-peer-coherence.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/effect-peer-coherence.test.ts
@@ -1,7 +1,7 @@
 /**
  * Deterministic peer-coherence gate for the spawned-worker Effect prerelease
  * family (#18810). Walks the real module-resolution chain the Smithers worker
- * uses — this plugin → @smthrs/engine → @effect/platform-bun →
+ * uses — this plugin → smthrs → @smthrs/engine → @effect/platform-bun →
  * @effect/platform-node-shared — through Bun's isolated store, and fails when
  * any link's declared dependency or peer range on `effect` (or on another
  * family member) is not satisfied by the version that link actually resolves,
@@ -74,7 +74,7 @@ function declaredEdges(manifest: FamilyManifest): Array<[string, string]> {
 describe('spawned-worker Effect family peer coherence (#18810)', () => {
   // The worker resolves from the plugin root (smithers-runtime spawns with
   // cwd=pluginRoot and imports `effect` directly), so the chain is seeded
-  // with the plugin's own manifest — plugin→effect and plugin→engine are
+  // with the plugin's own manifest — plugin→effect and plugin→smthrs are
   // asserted edges, not assumptions.
   const pluginManifestPath = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),

--- a/plugins/plugin-workflow/__tests__/unit/worker-script.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/worker-script.test.ts
@@ -1,16 +1,28 @@
 /** Pins the isolated worker's smthrs import, progress protocol, and elizaOS AgentLike bridge. */
 import { describe, expect, test } from 'bun:test';
-import { createSmithersWorkerScript } from '../../src/services/smithers-runtime';
+import {
+  createSmithersControlScript,
+  createSmithersWorkerScript,
+} from '../../src/services/smithers-runtime';
 
 describe('Smithers worker script', () => {
   test('uses smthrs directly and routes agent generation to its parent', () => {
     const source = createSmithersWorkerScript();
-    expect(source).toContain("from '@smthrs/engine'");
+    expect(source).toContain("from 'smthrs'");
     expect(source).toContain('__elizaSmithers');
     expect(source).toContain("kind: 'agent-request'");
     expect(source).toContain('onProgress');
     expect(source).toContain('Invalid elizaOS model response');
     expect(source).not.toContain('catch {}');
+    expect(source).not.toContain('@smithers-orchestrator');
+    expect(source).not.toContain('Gateway');
+  });
+
+  test('uses the public smthrs API for durable controls', () => {
+    const source = createSmithersControlScript();
+    expect(source).toContain("from 'smthrs'");
+    expect(source).toContain("from 'smthrs/openSmithersStore'");
+    expect(source).not.toContain('@smthrs/engine');
     expect(source).not.toContain('@smithers-orchestrator');
     expect(source).not.toContain('Gateway');
   });

--- a/plugins/plugin-workflow/package.json
+++ b/plugins/plugin-workflow/package.json
@@ -101,7 +101,6 @@
   },
   "dependencies": {
     "@elizaos/shared": "workspace:*",
-    "@smthrs/engine": "0.33.0",
     "smthrs": "0.33.0",
     "zod": "^4.4.3",
     "drizzle-orm": "0.45.2",

--- a/plugins/plugin-workflow/src/services/smithers-runtime.ts
+++ b/plugins/plugin-workflow/src/services/smithers-runtime.ts
@@ -171,7 +171,7 @@ export function createSmithersWorkerScript(): string {
     import { readFileSync } from 'node:fs';
     import { pathToFileURL } from 'node:url';
     import { Effect } from 'effect';
-    import { runWorkflow } from '@smthrs/engine';
+    import { runWorkflow } from 'smthrs';
     import { createInterface } from 'node:readline';
 
     const PREFIX = ${JSON.stringify(PROTOCOL_PREFIX)};
@@ -264,7 +264,7 @@ export function createSmithersControlScript(): string {
   return `
     import { readFileSync } from 'node:fs';
     import { Effect } from 'effect';
-    import { approveNode, denyNode, signalRun } from '@smthrs/engine';
+    import { approveNode, denyNode, signalRun } from 'smthrs';
     import { openSmithersStore } from 'smthrs/openSmithersStore';
 
     const payload = JSON.parse(readFileSync(process.env.ELIZA_SMTHRS_PAYLOAD_PATH, 'utf8'));

--- a/plugins/plugin-workflow/src/services/workflow-service.ts
+++ b/plugins/plugin-workflow/src/services/workflow-service.ts
@@ -110,7 +110,7 @@ Source contract:
 - Use Smithers Workflow, Task, Sequence, Parallel, Branch, Loop, Approval, Signal, Timer, UI, and TUI primitives as appropriate.
 - Make Task ids stable and identical to ids in steps.
 - Include a UI component and widget manifest when the workflow has useful interactive output.
-- Do not use Smithers Gateway, gateway-react, gateway-ui, HTTP calls to a Smithers server, n8n concepts, node catalogs, or legacy Smithers package names.
+- Do not use Smithers Gateway, gateway-react, gateway-ui, HTTP calls to a Smithers server, foreign workflow concepts, node catalogs, or legacy Smithers package names.
 - Do not use placeholders for the workflow logic. The module must run.
 
 Return JSON only.`;


### PR DESCRIPTION
Closes #19087

## Summary

- import run execution and durable approve/deny/signal controls from the public `smthrs` package
- remove the redundant direct `@smthrs/engine` dependency
- remove the final legacy workflow-system reference from maintained generation guidance
- pin the public API boundary with generated-worker regression coverage

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Verification

- Exact current head `0f255ee530da9e603e26175e7d254edc4d9738d7` is one commit directly over `origin/develop@8adfe6254abce7ecd8e2ba4c77f35c6716059845`.
- `bun install --frozen-lockfile --ignore-scripts` — passed without lockfile drift.
- `bun run build:core` — 56/56 prerequisite workspace builds passed.\n- `bun run --cwd plugins/plugin-workflow test` — 11/11 isolated files passed, including real Smithers TSX execution and Effect-family coherence.
- `bun run --cwd plugins/plugin-workflow typecheck` — passed.
- `bun run --cwd plugins/plugin-workflow lint:check` and `git diff --check` — passed.
- The identical pre-rebase semantic patch completed `RUN_TURBO_CONCURRENCY=4 bun run verify` — 350/350 tasks and all repository audits passed. The current-base rebase contains only unrelated upstream app/gateway changes and no workflow-path overlap; hosted exact-head gates remain required before merge.

## Evidence Gate

<!-- evidence-head:0f255ee530da9e603e26175e7d254edc4d9738d7 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI behavior or pixels changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI behavior or pixels changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI behavior changed; the real isolated Smithers runner test exercises the changed boundary.
<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic package and repository verification are recorded in this PR.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-provider or prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the changed output is child-process execution behavior covered by the real runner integration test.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no UI behavior or pixels changed.

## Risk

Low. This replaces internal imports with equivalent public re-exports from the already-pinned `smthrs@0.33.0` package. Real execution and the full repository verify gate pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-workflows]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no repository contribution skill used","attribution_status":"self-reported","lane":"codex-workflows"} -->
