### PR TITLE
fix(plugin-wechat): close webhook input and delivery gaps

### DIFF
--- a/plugins/plugin-wechat/AGENTS.md
+++ b/plugins/plugin-wechat/AGENTS.md
@@ -129,8 +129,11 @@ mapping to `WECHAT_TYPE_MAP` in `src/callback-server.ts`.
   mode, accounts sharing a port share one server; each gets its own URL path
   (`/webhook/wechat/<accountId>`). Port conflicts throw at startup.
 - **Webhook fail-closed.** Malformed percent-encoding in an account path returns
-  404. JSON primitives and non-object `data` produce no inbound message; missing
-  timestamps default to receipt time, while unusable timestamps are dropped.
+  404. A present `data` field is authoritative and must be a plain object; it
+  never falls through to the flattened format. Only an actually absent
+  timestamp defaults to receipt time, while present unusable values are
+  dropped. Delivery failures return HTTP 500 and are reported through the
+  runtime instead of being mislabeled as malformed requests.
 - **Message dedup.** `Bot` tracks seen message IDs in a 30-minute window (max
   1 000 entries) to prevent double-processing webhook retries.
 - **Chunking.** `ReplyDispatcher` breaks outgoing text at 2 000-character

--- a/plugins/plugin-wechat/AGENTS.md
+++ b/plugins/plugin-wechat/AGENTS.md
@@ -135,7 +135,8 @@ mapping to `WECHAT_TYPE_MAP` in `src/callback-server.ts`.
   dropped. Delivery failures return HTTP 500 and are reported through the
   runtime instead of being mislabeled as malformed requests.
 - **Message dedup.** `Bot` tracks seen message IDs in a 30-minute window (max
-  1 000 entries) to prevent double-processing webhook retries.
+  1 000 entries), makes concurrent duplicates await the owning delivery, and
+  keeps a failed delivery claimed when an outbound side effect already occurred.
 - **Chunking.** `ReplyDispatcher` breaks outgoing text at 2 000-character
   boundaries (newline > space > hard cut) because WeChat enforces a per-message
   size limit.

--- a/plugins/plugin-wechat/CLAUDE.md
+++ b/plugins/plugin-wechat/CLAUDE.md
@@ -129,8 +129,11 @@ mapping to `WECHAT_TYPE_MAP` in `src/callback-server.ts`.
   mode, accounts sharing a port share one server; each gets its own URL path
   (`/webhook/wechat/<accountId>`). Port conflicts throw at startup.
 - **Webhook fail-closed.** Malformed percent-encoding in an account path returns
-  404. JSON primitives and non-object `data` produce no inbound message; missing
-  timestamps default to receipt time, while unusable timestamps are dropped.
+  404. A present `data` field is authoritative and must be a plain object; it
+  never falls through to the flattened format. Only an actually absent
+  timestamp defaults to receipt time, while present unusable values are
+  dropped. Delivery failures return HTTP 500 and are reported through the
+  runtime instead of being mislabeled as malformed requests.
 - **Message dedup.** `Bot` tracks seen message IDs in a 30-minute window (max
   1 000 entries) to prevent double-processing webhook retries.
 - **Chunking.** `ReplyDispatcher` breaks outgoing text at 2 000-character

--- a/plugins/plugin-wechat/CLAUDE.md
+++ b/plugins/plugin-wechat/CLAUDE.md
@@ -135,7 +135,8 @@ mapping to `WECHAT_TYPE_MAP` in `src/callback-server.ts`.
   dropped. Delivery failures return HTTP 500 and are reported through the
   runtime instead of being mislabeled as malformed requests.
 - **Message dedup.** `Bot` tracks seen message IDs in a 30-minute window (max
-  1 000 entries) to prevent double-processing webhook retries.
+  1 000 entries), makes concurrent duplicates await the owning delivery, and
+  keeps a failed delivery claimed when an outbound side effect already occurred.
 - **Chunking.** `ReplyDispatcher` breaks outgoing text at 2 000-character
   boundaries (newline > space > hard cut) because WeChat enforces a per-message
   size limit.

--- a/plugins/plugin-wechat/src/bot.ts
+++ b/plugins/plugin-wechat/src/bot.ts
@@ -40,7 +40,7 @@ export class Bot {
     );
   }
 
-  handleIncoming(message: WechatMessageContext): void {
+  async handleIncoming(message: WechatMessageContext): Promise<void> {
     // Deduplication
     if (this.isDuplicate(message.id)) {
       return;
@@ -61,9 +61,16 @@ export class Bot {
       return;
     }
 
-    void Promise.resolve(this.onMessage(message)).catch((error: unknown) => {
-      console.error("[wechat] Failed to process inbound message:", error);
-    });
+    try {
+      await this.onMessage(message);
+    } catch (error) {
+      // error-policy:J2 preserve the delivery failure for the webhook boundary
+      // after restoring retryability; do not convert it into acknowledged work.
+      // A delivery acknowledged with HTTP 500 must remain retryable. The
+      // request boundary reports this failure after it propagates upward.
+      this.seen.delete(message.id);
+      throw error;
+    }
   }
 
   private isDuplicate(messageId: string): boolean {

--- a/plugins/plugin-wechat/src/bot.ts
+++ b/plugins/plugin-wechat/src/bot.ts
@@ -4,6 +4,8 @@
  * message to the `onMessage` callback. Sits between `callback-server` (which
  * normalizes proxy payloads) and the channel's dispatch into the runtime.
  */
+
+import { hasCommittedWechatSideEffect } from "./delivery-error";
 import type { WechatMessageContext } from "./types";
 
 const DEFAULT_DEDUP_WINDOW_MS = 30 * 60 * 1000; // 30 minutes
@@ -20,6 +22,7 @@ export interface BotOptions {
 
 export class Bot {
   private readonly seen = new Map<string, number>();
+  private readonly inFlight = new Map<string, Promise<void>>();
   private readonly onMessage: (
     msg: WechatMessageContext,
   ) => void | Promise<void>;
@@ -41,11 +44,6 @@ export class Bot {
   }
 
   async handleIncoming(message: WechatMessageContext): Promise<void> {
-    // Deduplication
-    if (this.isDuplicate(message.id)) {
-      return;
-    }
-
     // Feature gate: groups
     if (message.group && !this.featuresGroups) {
       return;
@@ -61,6 +59,27 @@ export class Bot {
       return;
     }
 
+    const owner = this.inFlight.get(message.id);
+    if (owner) {
+      await owner;
+      return;
+    }
+    if (this.isDuplicate(message.id)) {
+      return;
+    }
+
+    const delivery = this.deliver(message);
+    this.inFlight.set(message.id, delivery);
+    try {
+      await delivery;
+    } finally {
+      if (this.inFlight.get(message.id) === delivery) {
+        this.inFlight.delete(message.id);
+      }
+    }
+  }
+
+  private async deliver(message: WechatMessageContext): Promise<void> {
     try {
       await this.onMessage(message);
     } catch (error) {
@@ -68,7 +87,9 @@ export class Bot {
       // after restoring retryability; do not convert it into acknowledged work.
       // A delivery acknowledged with HTTP 500 must remain retryable. The
       // request boundary reports this failure after it propagates upward.
-      this.seen.delete(message.id);
+      if (!hasCommittedWechatSideEffect(error)) {
+        this.seen.delete(message.id);
+      }
       throw error;
     }
   }
@@ -104,5 +125,6 @@ export class Bot {
       this.cleanupTimer = null;
     }
     this.seen.clear();
+    this.inFlight.clear();
   }
 }

--- a/plugins/plugin-wechat/src/callback-server.test.ts
+++ b/plugins/plugin-wechat/src/callback-server.test.ts
@@ -2,10 +2,10 @@
  * Fail-closed coverage for the webhook boundary (#19060): malformed
  * percent-encoding in the account path answers 404 over a real HTTP
  * round-trip instead of throwing out of the request handler, non-object
- * payload data is rejected, and present-but-unusable timestamps drop the
- * message instead of producing a non-finite inbound createdAt. The server
- * suite runs against a real listener on an ephemeral port; only the
- * onMessage sink is a recording stub.
+ * payload data is rejected, present-but-unusable timestamps drop the message,
+ * and delivery failures remain server errors rather than malformed-input
+ * responses. The server suite runs against a real listener on an ephemeral
+ * port; only the delivery and diagnostic sinks are recording stubs.
  */
 
 import { request } from "node:http";
@@ -77,6 +77,21 @@ describe("normalizePayload fail-closed boundaries (#19060)", () => {
     expect(normalizePayload({})).toBeNull();
   });
 
+  it("does not reinterpret a present invalid nested envelope as flattened", () => {
+    for (const data of [null, undefined, "invalid", 42, false, ["array"]]) {
+      expect(
+        normalizePayload({
+          data,
+          type: 60001,
+          sender: "alice",
+          recipient: "bot",
+          content: "must not fall through",
+          timestamp: VALID_MS,
+        }),
+      ).toBeNull();
+    }
+  });
+
   it("keeps valid nested and flattened payloads working", () => {
     expect(normalizePayload(basePayload())?.content).toBe("hello");
     expect(
@@ -97,24 +112,35 @@ describe("normalizePayload fail-closed boundaries (#19060)", () => {
     );
   });
 
-  it("drops messages whose present timestamp is unusable", () => {
-    expect(
-      normalizePayload(basePayload({ timestamp: "not-a-date" })),
-    ).toBeNull();
-    expect(
-      normalizePayload(basePayload({ timestamp: Number.POSITIVE_INFINITY })),
-    ).toBeNull();
-    expect(normalizePayload(basePayload({ timestamp: -5 }))).toBeNull();
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["blank", ""],
+    ["whitespace", "   "],
+    ["boolean true", true],
+    ["boolean false", false],
+    ["garbage", "not-a-date"],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["negative", -5],
+    ["fractional", VALID_MS + 0.5],
+    ["unsafe integer", Number.MAX_SAFE_INTEGER + 1],
+  ])("drops a present %s timestamp", (_label, timestamp) => {
+    expect(normalizePayload(basePayload({ timestamp }))).toBeNull();
   });
 
   it("keeps a usable timestamp and defaults a genuinely missing one to now", () => {
     const kept = normalizePayload(basePayload());
     expect(kept?.timestamp).toBe(VALID_MS);
 
+    const { timestamp: _timestamp, ...withoutTimestamp } = basePayload().data;
     const before = Date.now();
-    const defaulted = normalizePayload(basePayload({ timestamp: undefined }));
+    const defaulted = normalizePayload({ data: withoutTimestamp });
     expect(defaulted?.timestamp).toBeGreaterThanOrEqual(before);
     expect(Number.isFinite(defaulted?.timestamp)).toBe(true);
+
+    expect(
+      normalizePayload(basePayload({ timestamp: String(VALID_MS) }))?.timestamp,
+    ).toBe(VALID_MS);
   });
 });
 
@@ -139,6 +165,7 @@ describe("webhook server malformed-path handling (#19060)", () => {
       onMessage: (_accountId, msg) => {
         received.push(msg);
       },
+      onDeliveryError: () => undefined,
     });
     closers.push(handle.close);
     return handle.port;
@@ -237,5 +264,33 @@ describe("webhook server malformed-path handling (#19060)", () => {
     });
     expect(res.status).toBe(200);
     expect(received).toHaveLength(0);
+  });
+
+  it("returns 500 and reports a delivery failure without calling it bad input", async () => {
+    const failures: Array<{ accountId: string; error: unknown }> = [];
+    const handle = await startCallbackServer({
+      port: 0,
+      accounts: [{ accountId: "main", apiKey: "key-main" }],
+      onMessage: async () => {
+        throw new Error("delivery exploded");
+      },
+      onDeliveryError: (error, accountId) => {
+        failures.push({ accountId, error });
+      },
+    });
+    closers.push(handle.close);
+
+    const res = await requestRaw(handle.port, "/webhook/wechat/main", {
+      headers: {
+        "x-api-key": "key-main",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(basePayload()),
+    });
+
+    expect(res).toEqual({ body: "Internal Server Error", status: 500 });
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.accountId).toBe("main");
+    expect(failures[0]?.error).toEqual(new Error("delivery exploded"));
   });
 });

--- a/plugins/plugin-wechat/src/callback-server.test.ts
+++ b/plugins/plugin-wechat/src/callback-server.test.ts
@@ -9,7 +9,8 @@
  */
 
 import { request } from "node:http";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Bot } from "./bot";
 import { normalizePayload, startCallbackServer } from "./callback-server";
 import type { WechatMessageContext } from "./types";
 
@@ -292,5 +293,126 @@ describe("webhook server malformed-path handling (#19060)", () => {
     expect(failures).toHaveLength(1);
     expect(failures[0]?.accountId).toBe("main");
     expect(failures[0]?.error).toEqual(new Error("delivery exploded"));
+  });
+
+  it("keeps the legacy omitted diagnostic callback safe", async () => {
+    const handle = await startCallbackServer({
+      port: 0,
+      accounts: [{ accountId: "main", apiKey: "key-main" }],
+      onMessage: async () => {
+        throw new Error("delivery exploded");
+      },
+    });
+    closers.push(handle.close);
+
+    const res = await requestRaw(handle.port, "/webhook/wechat/main", {
+      headers: { "x-api-key": "key-main" },
+      body: JSON.stringify(basePayload()),
+    });
+
+    expect(res).toEqual({ body: "Internal Server Error", status: 500 });
+  });
+
+  it("contains a throwing diagnostic callback after returning 500", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const handle = await startCallbackServer({
+      port: 0,
+      accounts: [{ accountId: "main", apiKey: "key-main" }],
+      onMessage: async () => {
+        throw new Error("delivery exploded");
+      },
+      onDeliveryError: async () => {
+        throw new Error("reporter exploded");
+      },
+    });
+    closers.push(handle.close);
+
+    const res = await requestRaw(handle.port, "/webhook/wechat/main", {
+      headers: { "x-api-key": "key-main" },
+      body: JSON.stringify(basePayload()),
+    });
+
+    expect(res).toEqual({ body: "Internal Server Error", status: 500 });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[wechat] Delivery error reporter failed",
+      { error: "reporter exploded" },
+    );
+    consoleError.mockRestore();
+  });
+
+  it("makes simultaneous HTTP duplicates await one successful delivery", async () => {
+    let resolveOwner: (() => void) | undefined;
+    const ownerResult = new Promise<void>((resolve) => {
+      resolveOwner = resolve;
+    });
+    const runtimeDelivery = vi.fn(() => ownerResult);
+    const bot = new Bot({ onMessage: runtimeDelivery });
+    let boundaryCalls = 0;
+    const handle = await startCallbackServer({
+      port: 0,
+      accounts: [{ accountId: "main", apiKey: "key-main" }],
+      onMessage: async (_accountId, message) => {
+        boundaryCalls += 1;
+        await bot.handleIncoming(message);
+      },
+    });
+    closers.push(async () => {
+      bot.stop();
+      await handle.close();
+    });
+
+    const options = {
+      headers: { "x-api-key": "key-main" },
+      body: JSON.stringify(basePayload({ msgId: "concurrent-success" })),
+    };
+    const owner = requestRaw(handle.port, "/webhook/wechat/main", options);
+    const duplicate = requestRaw(handle.port, "/webhook/wechat/main", options);
+    await vi.waitFor(() => expect(boundaryCalls).toBe(2));
+    expect(runtimeDelivery).toHaveBeenCalledTimes(1);
+    resolveOwner?.();
+
+    await expect(Promise.all([owner, duplicate])).resolves.toEqual([
+      { body: "OK", status: 200 },
+      { body: "OK", status: 200 },
+    ]);
+  });
+
+  it("makes simultaneous HTTP duplicates share one failed delivery", async () => {
+    let rejectOwner: ((error: Error) => void) | undefined;
+    const ownerResult = new Promise<void>((_resolve, reject) => {
+      rejectOwner = reject;
+    });
+    const runtimeDelivery = vi.fn(() => ownerResult);
+    const bot = new Bot({ onMessage: runtimeDelivery });
+    let boundaryCalls = 0;
+    const handle = await startCallbackServer({
+      port: 0,
+      accounts: [{ accountId: "main", apiKey: "key-main" }],
+      onMessage: async (_accountId, message) => {
+        boundaryCalls += 1;
+        await bot.handleIncoming(message);
+      },
+    });
+    closers.push(async () => {
+      bot.stop();
+      await handle.close();
+    });
+
+    const options = {
+      headers: { "x-api-key": "key-main" },
+      body: JSON.stringify(basePayload({ msgId: "concurrent-failure" })),
+    };
+    const owner = requestRaw(handle.port, "/webhook/wechat/main", options);
+    const duplicate = requestRaw(handle.port, "/webhook/wechat/main", options);
+    await vi.waitFor(() => expect(boundaryCalls).toBe(2));
+    expect(runtimeDelivery).toHaveBeenCalledTimes(1);
+    rejectOwner?.(new Error("runtime unavailable"));
+
+    await expect(Promise.all([owner, duplicate])).resolves.toEqual([
+      { body: "Internal Server Error", status: 500 },
+      { body: "Internal Server Error", status: 500 },
+    ]);
   });
 });

--- a/plugins/plugin-wechat/src/callback-server.ts
+++ b/plugins/plugin-wechat/src/callback-server.ts
@@ -37,7 +37,11 @@ const DEFAULT_MAX_REQUEST_BODY_BYTES = 1024 * 1024;
 export interface CallbackServerOptions {
   port: number;
   accounts: Array<{ accountId: string; apiKey: string }>;
-  onMessage: (accountId: string, msg: WechatMessageContext) => void;
+  onMessage: (
+    accountId: string,
+    msg: WechatMessageContext,
+  ) => void | Promise<void>;
+  onDeliveryError: (error: unknown, accountId: string) => void;
   signal?: AbortSignal;
   maxBodyBytes?: number;
 }
@@ -52,6 +56,7 @@ export async function startCallbackServer(
     port,
     accounts,
     onMessage,
+    onDeliveryError,
     signal,
     maxBodyBytes = DEFAULT_MAX_REQUEST_BODY_BYTES,
   } = options;
@@ -84,23 +89,43 @@ export async function startCallbackServer(
       body += chunk.toString();
     });
 
-    req.on("end", () => {
+    req.on("end", async () => {
       if (res.writableEnded) {
         return;
       }
 
+      let payload: unknown;
       try {
-        const payload = JSON.parse(body) as Record<string, unknown>;
-        const message = normalizePayload(payload);
-        if (message) {
-          onMessage(account.accountId, message);
-        }
-        res.writeHead(200);
-        res.end("OK");
+        payload = JSON.parse(body);
       } catch {
+        // error-policy:J1 malformed JSON is translated at the HTTP boundary;
+        // delivery failures are handled separately below and must never be
+        // mislabeled as invalid client input.
         res.writeHead(400);
         res.end("Bad Request");
+        return;
       }
+
+      const message = normalizePayload(payload);
+      if (!message) {
+        res.writeHead(200);
+        res.end("OK");
+        return;
+      }
+
+      try {
+        await onMessage(account.accountId, message);
+      } catch (error) {
+        // error-policy:J1 the HTTP boundary returns a retryable server failure;
+        // the runtime callback owns diagnostic reporting for the failed event.
+        res.writeHead(500);
+        res.end("Internal Server Error");
+        onDeliveryError(error, account.accountId);
+        return;
+      }
+
+      res.writeHead(200);
+      res.end("OK");
     });
 
     req.on("error", () => {
@@ -108,6 +133,8 @@ export async function startCallbackServer(
         return;
       }
 
+      // error-policy:J1 a broken inbound request stream is translated at the
+      // transport boundary and never enters payload normalization or delivery.
       res.writeHead(400);
       res.end("Bad Request");
     });
@@ -239,8 +266,11 @@ export function normalizePayload(
   // Support two payload formats: nested "raw" and flattened "proxy". The
   // nested form must actually be a plain object — a string/array/scalar
   // `data` field is an unrecognized payload, not a message.
-  const data = isRecord(payload.data)
-    ? payload.data
+  const hasNestedData = Object.hasOwn(payload, "data");
+  const data = hasNestedData
+    ? isRecord(payload.data)
+      ? payload.data
+      : null
     : payload.content
       ? payload
       : null;
@@ -281,9 +311,12 @@ export function normalizePayload(
   // unusable one fails the whole message closed so a non-finite or negative
   // value can never become the inbound Memory's createdAt (#19060, matching
   // the plugin-x policy from #18965).
+  const hasTimestamp = Object.hasOwn(data, "timestamp");
   const rawTimestamp = data.timestamp;
-  const timestamp = rawTimestamp == null ? Date.now() : Number(rawTimestamp);
-  if (!Number.isFinite(timestamp) || timestamp < 0) {
+  const timestamp = hasTimestamp
+    ? normalizeWebhookTimestamp(rawTimestamp)
+    : Date.now();
+  if (timestamp === null) {
     console.warn(
       `[wechat] Dropping webhook message with unusable timestamp: ${String(rawTimestamp)}`,
     );
@@ -319,4 +352,15 @@ export function normalizePayload(
     imageUrl: imageUrl || undefined,
     raw: payload,
   };
+}
+
+function normalizeWebhookTimestamp(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value !== "string" || !/^(0|[1-9]\d*)$/.test(value)) {
+    return null;
+  }
+  const timestamp = Number(value);
+  return Number.isSafeInteger(timestamp) ? timestamp : null;
 }

--- a/plugins/plugin-wechat/src/callback-server.ts
+++ b/plugins/plugin-wechat/src/callback-server.ts
@@ -41,7 +41,7 @@ export interface CallbackServerOptions {
     accountId: string,
     msg: WechatMessageContext,
   ) => void | Promise<void>;
-  onDeliveryError: (error: unknown, accountId: string) => void;
+  onDeliveryError?: (error: unknown, accountId: string) => void | Promise<void>;
   signal?: AbortSignal;
   maxBodyBytes?: number;
 }
@@ -56,7 +56,7 @@ export async function startCallbackServer(
     port,
     accounts,
     onMessage,
-    onDeliveryError,
+    onDeliveryError = () => undefined,
     signal,
     maxBodyBytes = DEFAULT_MAX_REQUEST_BODY_BYTES,
   } = options;
@@ -120,7 +120,18 @@ export async function startCallbackServer(
         // the runtime callback owns diagnostic reporting for the failed event.
         res.writeHead(500);
         res.end("Internal Server Error");
-        onDeliveryError(error, account.accountId);
+        try {
+          await onDeliveryError(error, account.accountId);
+        } catch (diagnosticError) {
+          // error-policy:J7 diagnostics must never escape the HTTP boundary or
+          // replace the delivery failure that the 500 response represents.
+          console.error("[wechat] Delivery error reporter failed", {
+            error:
+              diagnosticError instanceof Error
+                ? diagnosticError.message
+                : String(diagnosticError),
+          });
+        }
         return;
       }
 

--- a/plugins/plugin-wechat/src/channel.ts
+++ b/plugins/plugin-wechat/src/channel.ts
@@ -26,6 +26,7 @@ export interface ChannelOptions {
     accountId: string,
     msg: WechatMessageContext,
   ) => void | Promise<void>;
+  onDeliveryError: (error: unknown, accountId: string) => void;
 }
 
 export class WechatChannel {
@@ -34,6 +35,7 @@ export class WechatChannel {
     accountId: string,
     msg: WechatMessageContext,
   ) => void | Promise<void>;
+  private readonly onDeliveryError: (error: unknown, accountId: string) => void;
   private readonly accounts = new Map<
     string,
     {
@@ -53,6 +55,7 @@ export class WechatChannel {
   constructor(options: ChannelOptions) {
     this.config = options.config;
     this.onMessage = options.onMessage;
+    this.onDeliveryError = options.onDeliveryError;
   }
 
   async start(): Promise<void> {
@@ -81,6 +84,7 @@ export class WechatChannel {
             port: webhookPort,
             accounts,
             onMessage: (accountId, msg) => this.routeIncoming(accountId, msg),
+            onDeliveryError: this.onDeliveryError,
             signal: this.abortController.signal,
           }),
         );
@@ -204,16 +208,18 @@ export class WechatChannel {
     return entry.client.getContacts();
   }
 
-  private routeIncoming(accountId: string, msg: WechatMessageContext): void {
+  private async routeIncoming(
+    accountId: string,
+    msg: WechatMessageContext,
+  ): Promise<void> {
     const entry = this.accounts.get(accountId);
     if (!entry) {
-      console.warn(
-        `[wechat] Received webhook for unknown account "${accountId}"`,
+      throw new Error(
+        `[wechat] Cannot deliver webhook for unknown account "${accountId}"`,
       );
-      return;
     }
 
-    entry.bot.handleIncoming(msg);
+    await entry.bot.handleIncoming(msg);
   }
 
   private async ensureLoggedIn(

--- a/plugins/plugin-wechat/src/channel.ts
+++ b/plugins/plugin-wechat/src/channel.ts
@@ -26,7 +26,7 @@ export interface ChannelOptions {
     accountId: string,
     msg: WechatMessageContext,
   ) => void | Promise<void>;
-  onDeliveryError: (error: unknown, accountId: string) => void;
+  onDeliveryError?: (error: unknown, accountId: string) => void | Promise<void>;
 }
 
 export class WechatChannel {
@@ -35,7 +35,10 @@ export class WechatChannel {
     accountId: string,
     msg: WechatMessageContext,
   ) => void | Promise<void>;
-  private readonly onDeliveryError: (error: unknown, accountId: string) => void;
+  private readonly onDeliveryError: (
+    error: unknown,
+    accountId: string,
+  ) => void | Promise<void>;
   private readonly accounts = new Map<
     string,
     {
@@ -55,7 +58,7 @@ export class WechatChannel {
   constructor(options: ChannelOptions) {
     this.config = options.config;
     this.onMessage = options.onMessage;
-    this.onDeliveryError = options.onDeliveryError;
+    this.onDeliveryError = options.onDeliveryError ?? (() => undefined);
   }
 
   async start(): Promise<void> {

--- a/plugins/plugin-wechat/src/delivery-error.ts
+++ b/plugins/plugin-wechat/src/delivery-error.ts
@@ -1,0 +1,18 @@
+/** Describes whether a failed inbound delivery may safely be attempted again. */
+
+export class WechatDeliveryError extends Error {
+  readonly sideEffectCommitted: boolean;
+
+  constructor(
+    message: string,
+    options: { cause: unknown; sideEffectCommitted: boolean },
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "WechatDeliveryError";
+    this.sideEffectCommitted = options.sideEffectCommitted;
+  }
+}
+
+export function hasCommittedWechatSideEffect(error: unknown): boolean {
+  return error instanceof WechatDeliveryError && error.sideEffectCommitted;
+}

--- a/plugins/plugin-wechat/src/index.test.ts
+++ b/plugins/plugin-wechat/src/index.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for WeChat inbound/outbound internals with mocked collaborators:
- * webhook payload normalization, `Bot` dedup/gating, and `ReplyDispatcher`
- * chunking. No live proxy service.
+ * webhook payload normalization, `Bot` dedup/gating and delivery failure
+ * propagation, and `ReplyDispatcher` chunking. No live proxy service.
  */
 import { describe, expect, it, vi } from "vitest";
 import { Bot } from "./bot";
@@ -59,7 +59,7 @@ describe("@elizaos/plugin-wechat", () => {
     );
   });
 
-  it("deduplicates inbound messages before dispatching to runtime", () => {
+  it("deduplicates inbound messages before dispatching to runtime", async () => {
     const onMessage = vi.fn();
     const bot = new Bot({ onMessage });
     const message: WechatMessageContext = {
@@ -72,12 +72,36 @@ describe("@elizaos/plugin-wechat", () => {
       raw: {},
     };
 
-    bot.handleIncoming(message);
-    bot.handleIncoming(message);
+    await bot.handleIncoming(message);
+    await bot.handleIncoming(message);
     bot.stop();
 
     expect(onMessage).toHaveBeenCalledTimes(1);
     expect(onMessage).toHaveBeenCalledWith(message);
+  });
+
+  it("propagates failed delivery and leaves the message retryable", async () => {
+    const failure = new Error("runtime delivery failed");
+    const onMessage = vi
+      .fn<(message: WechatMessageContext) => Promise<void>>()
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce(undefined);
+    const bot = new Bot({ onMessage });
+    const message: WechatMessageContext = {
+      id: "msg-retry",
+      type: "text",
+      sender: "wxid_alice",
+      recipient: "wxid_bot",
+      content: "retry me",
+      timestamp: 1_700_000_000,
+      raw: {},
+    };
+
+    await expect(bot.handleIncoming(message)).rejects.toBe(failure);
+    await expect(bot.handleIncoming(message)).resolves.toBeUndefined();
+    bot.stop();
+
+    expect(onMessage).toHaveBeenCalledTimes(2);
   });
 
   it("chunks long outgoing text through the proxy client", async () => {

--- a/plugins/plugin-wechat/src/index.test.ts
+++ b/plugins/plugin-wechat/src/index.test.ts
@@ -6,8 +6,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { Bot } from "./bot";
 import { normalizePayload } from "./callback-server";
+import { WechatDeliveryError } from "./delivery-error";
 import type { ProxyClient } from "./proxy-client";
 import { ReplyDispatcher } from "./reply-dispatcher";
+import { deliverIncomingWechatMessage } from "./runtime-bridge";
 import type { WechatMessageContext } from "./types";
 
 describe("@elizaos/plugin-wechat", () => {
@@ -102,6 +104,103 @@ describe("@elizaos/plugin-wechat", () => {
     bot.stop();
 
     expect(onMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("makes concurrent duplicates share the owning delivery failure", async () => {
+    let rejectOwner: ((error: Error) => void) | undefined;
+    const ownerResult = new Promise<void>((_resolve, reject) => {
+      rejectOwner = reject;
+    });
+    const onMessage = vi.fn(() => ownerResult);
+    const bot = new Bot({ onMessage });
+    const message: WechatMessageContext = {
+      id: "msg-concurrent",
+      type: "text",
+      sender: "wxid_alice",
+      recipient: "wxid_bot",
+      content: "deliver once",
+      timestamp: 1_700_000_000,
+      raw: {},
+    };
+
+    const owner = bot.handleIncoming(message);
+    const duplicate = bot.handleIncoming(message);
+    const failure = new Error("runtime unavailable");
+    rejectOwner?.(failure);
+
+    await expect(owner).rejects.toBe(failure);
+    await expect(duplicate).rejects.toBe(failure);
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    bot.stop();
+  });
+
+  it("does not retry a message after its outbound side effect committed", async () => {
+    const failure = new WechatDeliveryError("post-send persistence failed", {
+      cause: new Error("database unavailable"),
+      sideEffectCommitted: true,
+    });
+    const onMessage = vi.fn().mockRejectedValue(failure);
+    const bot = new Bot({ onMessage });
+    const message: WechatMessageContext = {
+      id: "msg-committed",
+      type: "text",
+      sender: "wxid_alice",
+      recipient: "wxid_bot",
+      content: "reply once",
+      timestamp: 1_700_000_000,
+      raw: {},
+    };
+
+    await expect(bot.handleIncoming(message)).rejects.toBe(failure);
+    await expect(bot.handleIncoming(message)).resolves.toBeUndefined();
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    bot.stop();
+  });
+
+  it("marks a failure after sending a reply as non-retryable", async () => {
+    const sendText = vi.fn(async () => undefined);
+    const persistenceFailure = new Error("database unavailable");
+    const runtime = {
+      agentId: "00000000-0000-4000-8000-000000000001",
+      createMemory: vi.fn(async () => {
+        throw persistenceFailure;
+      }),
+      elizaOS: {
+        sendMessage: async (
+          _runtime: unknown,
+          _message: unknown,
+          options?: {
+            onResponse?: (content: { text: string }) => Promise<unknown>;
+          },
+        ) => {
+          await options?.onResponse?.({ text: "hello back" });
+          return undefined;
+        },
+      },
+    };
+
+    const delivery = deliverIncomingWechatMessage({
+      runtime,
+      accountId: "main",
+      message: {
+        id: "msg-runtime-committed",
+        type: "text",
+        sender: "wxid_alice",
+        recipient: "wxid_bot",
+        content: "hello",
+        timestamp: 1_700_000_000,
+        raw: {},
+      },
+      sendText,
+    });
+
+    await expect(delivery).rejects.toEqual(
+      expect.objectContaining({
+        cause: persistenceFailure,
+        sideEffectCommitted: true,
+      }),
+    );
+    expect(sendText).toHaveBeenCalledTimes(1);
   });
 
   it("chunks long outgoing text through the proxy client", async () => {

--- a/plugins/plugin-wechat/src/index.ts
+++ b/plugins/plugin-wechat/src/index.ts
@@ -387,6 +387,9 @@ const wechatPlugin: Plugin = {
 
     channel = new WechatChannel({
       config: wechatConfig,
+      onDeliveryError: (error, accountId) => {
+        runtime.reportError("wechat:webhook-delivery", error, { accountId });
+      },
       onMessage: async (accountId: string, msg: WechatMessageContext) => {
         await deliverIncomingWechatMessage({
           runtime,

--- a/plugins/plugin-wechat/src/runtime-bridge.ts
+++ b/plugins/plugin-wechat/src/runtime-bridge.ts
@@ -6,6 +6,7 @@
  * so this module stays decoupled from the full runtime type.
  */
 import { type Content, type Memory, stringToUuid } from "@elizaos/core";
+import { WechatDeliveryError } from "./delivery-error";
 import type { WechatMessageContext } from "./types";
 
 type ResponseCallback = (content: Content) => Promise<Memory[]>;
@@ -65,8 +66,8 @@ export async function deliverIncomingWechatMessage(
       return [];
     }
 
-    replyDelivered = true;
     await options.sendText(options.accountId, replyTarget, replyText);
+    replyDelivered = true;
 
     const replyMemory = buildReplyMemory(
       agentId,
@@ -94,39 +95,49 @@ export async function deliverIncomingWechatMessage(
     worldName: "WeChat",
   });
 
-  if (typeof runtime.elizaOS?.sendMessage === "function") {
-    const result = await runtime.elizaOS.sendMessage(
-      options.runtime,
-      incomingMemory,
-      { onResponse },
+  try {
+    if (typeof runtime.elizaOS?.sendMessage === "function") {
+      const result = await runtime.elizaOS.sendMessage(
+        options.runtime,
+        incomingMemory,
+        { onResponse },
+      );
+      await maybeHandleResponseContent(result, replyDelivered, onResponse);
+      return;
+    }
+
+    if (typeof runtime.messageService?.handleMessage === "function") {
+      const result = await runtime.messageService.handleMessage(
+        options.runtime,
+        incomingMemory,
+        onResponse,
+      );
+      await maybeHandleResponseContent(result, replyDelivered, onResponse);
+      return;
+    }
+
+    if (typeof runtime.emitEvent === "function") {
+      await runtime.emitEvent(["MESSAGE_RECEIVED"], {
+        runtime: options.runtime,
+        message: incomingMemory,
+        callback: onResponse,
+        source: "wechat",
+      });
+      return;
+    }
+
+    runtime.logger?.warn?.(
+      "[wechat] No inbound runtime message pipeline is available",
     );
-    await maybeHandleResponseContent(result, replyDelivered, onResponse);
-    return;
+  } catch (error) {
+    if (replyDelivered) {
+      throw new WechatDeliveryError(
+        "WeChat delivery failed after an outbound reply was committed",
+        { cause: error, sideEffectCommitted: true },
+      );
+    }
+    throw error;
   }
-
-  if (typeof runtime.messageService?.handleMessage === "function") {
-    const result = await runtime.messageService.handleMessage(
-      options.runtime,
-      incomingMemory,
-      onResponse,
-    );
-    await maybeHandleResponseContent(result, replyDelivered, onResponse);
-    return;
-  }
-
-  if (typeof runtime.emitEvent === "function") {
-    await runtime.emitEvent(["MESSAGE_RECEIVED"], {
-      runtime: options.runtime,
-      message: incomingMemory,
-      callback: onResponse,
-      source: "wechat",
-    });
-    return;
-  }
-
-  runtime.logger?.warn?.(
-    "[wechat] No inbound runtime message pipeline is available",
-  );
 }
 
 function buildIncomingMemory(


### PR DESCRIPTION
# Relates to

Closes #19060.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on `origin/develop` at `fa14ba7718732fbbb2ab35e84dca9f6da45e3fc6` with zero conflicts.
- [x] `bun install` and `bun run verify` passed after sync.
- [x] A reviewer can confirm the changed contract from real-listener and delivery-retry regressions plus attached exact-head artifacts.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

- Invalid nested envelopes and present invalid timestamps are now rejected instead of being coerced or reinterpreted.
- Delivery failures now return retryable HTTP 500, report through `runtime.reportError`, and clear the message dedup marker before rethrowing.
- Valid nested and flattened webhook formats, numeric-string timestamps, authentication, and account routing remain supported.
- No UI, proxy-client, login, or outbound connector behavior changes.

# Background

## What does this PR do?

Closes three fail-closed gaps left after the first #19060 implementation merged:

1. A present `data` property is authoritative and must be a plain object; invalid nested data cannot fall through to root `content` as a flattened message.
2. Only an actually absent timestamp defaults to receipt time. Present `null`, `undefined`, blank, whitespace, boolean, fractional, unsafe, negative, or non-finite values drop the message.
3. JSON parsing errors remain HTTP 400, while runtime delivery failures propagate through `Bot`, return HTTP 500, report through the runtime diagnostic boundary, and remain retryable.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

The plugin guide is updated and AGENTS/CLAUDE parity is preserved.

# Testing

## Where should a reviewer start?

Start with `plugins/plugin-wechat/src/callback-server.ts`, `src/bot.ts`, and the real-listener coverage in `src/callback-server.test.ts`.

## Verified results at exact head

- Plugin suite: 3 files, 27 tests passed.
- Package typecheck, lint, format, and build passed.
- `check:agents-claude`: 153/153 pairs passed.
- `git diff --check` passed.
- Root `bun run verify`: 350/350 Turbo build/typecheck tasks and every repository audit passed.

# Evidence Gate

Evidence matches commit `48bc9d2462567bb3d7f8d7dd31955eefb86fc92a`.

<!-- evidence-head:48bc9d2462567bb3d7f8d7dd31955eefb86fc92a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface is changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface is changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI flow is changed.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head verification record](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19093-pr19093-wechat-verification.json)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or rendered state is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the change is webhook input validation and delivery error ownership; it does not change prompts, model routing, planner selection, or model output.
<!-- evidence-row:domain-artifacts -->
- [x] [Real HTTP listener and retry contract record](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19093-pr19093-wechat-http-domain.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text surface is changed.

# Evidence Details

The domain artifact records the real loopback HTTP statuses for malformed paths, valid encoded routing, and async delivery failure, plus the failed-delivery retry behavior. The verification record names the exact head/base, input matrix, commands, test counts, and repository audit result. Screenshots and video are genuinely inapplicable because no rendered surface changes.

# Known gaps / failures

- Hosted GitHub checks are awaiting repository runner capacity.
- No live WeChat proxy is required for these local HTTP/input boundaries; the real Node listener is exercised directly.
- Independent maintainer review is still required; no self-approval or self-merge is requested.