### PR TITLE
perf(app): defer full bootstrap on public routes

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -466,7 +466,7 @@
       };
     }
   </script>
-  <script type="module" src="/src/main.tsx"></script>
+  <script type="module" src="/src/entry.ts"></script>
 </body>
 
 </html>

--- a/packages/app/login-transfer-budgets.json
+++ b/packages/app/login-transfer-budgets.json
@@ -1,5 +1,5 @@
 {
-  "description": "Cold anonymous /login transfer budgets for issue #18056. Measured with scripts/measure-anonymous-login-transfer.mjs (SW blocked, empty context, settle ~6s, no interaction). Budgets are calibrated after a develop baseline capture — null means not yet set (gate reports missing-budget until filled).",
+  "description": "Cold anonymous /login transfer budgets for issue #18056. Measured with scripts/measure-anonymous-login-transfer.mjs (SW blocked, empty context, settle ~6s, no interaction). The calibrated baseline is the dedicated hosted-public entry; ceilings include 10% transfer tolerance and a small request-count allowance.",
   "settleMs": 6000,
   "conditions": {
     "serviceWorkers": "block",
@@ -8,19 +8,19 @@
   },
   "tolerancePct": 10,
   "desktop": {
-    "maxTotalTransferBytes": 2114147,
-    "maxScriptTransferBytes": 2033595,
-    "maxScriptCount": 272,
-    "baselineTotalTransferBytes": 1921951,
-    "baselineScriptTransferBytes": 1848722,
-    "baselineScriptCount": 247
+    "maxTotalTransferBytes": 1691036,
+    "maxScriptTransferBytes": 1573531,
+    "maxScriptCount": 58,
+    "baselineTotalTransferBytes": 1537305,
+    "baselineScriptTransferBytes": 1430482,
+    "baselineScriptCount": 52
   },
   "mobile": {
-    "maxTotalTransferBytes": 2114147,
-    "maxScriptTransferBytes": 2033595,
-    "maxScriptCount": 272,
-    "baselineTotalTransferBytes": 1921951,
-    "baselineScriptTransferBytes": 1848722,
-    "baselineScriptCount": 247
+    "maxTotalTransferBytes": 1691036,
+    "maxScriptTransferBytes": 1573531,
+    "maxScriptCount": 58,
+    "baselineTotalTransferBytes": 1537305,
+    "baselineScriptTransferBytes": 1430482,
+    "baselineScriptCount": 52
   }
 }

--- a/packages/app/scripts/measure-anonymous-login-transfer.mjs
+++ b/packages/app/scripts/measure-anonymous-login-transfer.mjs
@@ -40,7 +40,9 @@ import { createServer } from "node:http";
 import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gzipSync } from "node:zlib";
-import { chromium } from "@playwright/test";
+
+// Playwright is loaded lazily in main() so CLI-boundary unit tests can import
+// pure helpers without requiring a browser install in the script test lane.
 
 const here = dirname(fileURLToPath(import.meta.url));
 const appDir = resolve(here, "..");
@@ -323,6 +325,164 @@ export function assertNoRuntimeErrors(runtimeErrors, viewportId) {
   );
 }
 
+/**
+ * @typedef {{
+ *   ok: boolean,
+ *   failure: string,
+ *   rootChildren: number,
+ *   emailVisible: boolean,
+ *   headingVisible: boolean,
+ *   formVisible: boolean,
+ *   appMarker: string,
+ *   bodySample: string,
+ * }} LoginSurfaceProbe
+ */
+
+/**
+ * Inspect the settled `/login` DOM for a stable visible auth surface.
+ * Prefer a visible email field plus login heading/form; also accept the
+ * app-owned login marker together with a visible email field so a future
+ * marker-only pin remains possible without treating an empty shell as healthy.
+ *
+ * Runs inside the page (Playwright `evaluate`) and under unit fixtures.
+ *
+ * @returns {LoginSurfaceProbe}
+ */
+export function collectLoginSurfaceProbe() {
+  const isVisible = (element) => {
+    if (!element) return false;
+    const style =
+      typeof globalThis.getComputedStyle === "function"
+        ? globalThis.getComputedStyle(element)
+        : element.style || {};
+    if (
+      style.display === "none" ||
+      style.visibility === "hidden" ||
+      style.opacity === "0"
+    ) {
+      return false;
+    }
+    const rect =
+      typeof element.getBoundingClientRect === "function"
+        ? element.getBoundingClientRect()
+        : null;
+    if (!rect) return true;
+    return rect.width > 0 && rect.height > 0;
+  };
+
+  const root = document.getElementById("root");
+  const rootChildren = root ? root.children.length : 0;
+  const email =
+    document.getElementById("steward-login-email") ||
+    document.querySelector('input[type="email"]') ||
+    document.querySelector('input[name="email"]');
+  const emailVisible = isVisible(email);
+
+  const headings = Array.from(document.querySelectorAll("h1"));
+  const headingVisible = headings.some((heading) => {
+    if (!isVisible(heading)) return false;
+    const text = String(heading.textContent || "")
+      .trim()
+      .toLowerCase();
+    return (
+      text.includes("sign in") || text.includes("log in") || text.length > 0
+    );
+  });
+
+  const formVisible = Array.from(document.querySelectorAll("form")).some(
+    (form) => isVisible(form),
+  );
+  const mainVisible = Array.from(document.querySelectorAll("main")).some(
+    (main) => isVisible(main),
+  );
+
+  const markerEl =
+    document.querySelector('[data-testid="login-safe-area-fill"]') ||
+    document.querySelector('[data-login-surface="ready"]');
+  const appMarker = markerEl
+    ? markerEl.getAttribute("data-testid") ||
+      markerEl.getAttribute("data-login-surface") ||
+      "present"
+    : "";
+  const markerVisible = isVisible(markerEl);
+
+  const bodySample = String(document.body?.textContent || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 120);
+
+  // Primary contract: visible email + (heading or form). This matches the
+  // shipped Steward login card and rejects empty/black #root shells.
+  if (emailVisible && (headingVisible || formVisible)) {
+    return {
+      ok: true,
+      failure: "",
+      rootChildren,
+      emailVisible,
+      headingVisible,
+      formVisible,
+      appMarker,
+      bodySample,
+    };
+  }
+
+  // Secondary contract: app-owned marker + visible email + main landmark.
+  // Keeps an explicit product marker usable without accepting blank shells.
+  if (markerVisible && emailVisible && mainVisible) {
+    return {
+      ok: true,
+      failure: "",
+      rootChildren,
+      emailVisible,
+      headingVisible,
+      formVisible,
+      appMarker,
+      bodySample,
+    };
+  }
+
+  let failure = "missing-login-surface";
+  if (!root) failure = "missing-root";
+  else if (rootChildren === 0) failure = "empty-root";
+  else if (!emailVisible && !headingVisible && !formVisible) {
+    failure = "blank-or-invalid-login-dom";
+  } else if (!emailVisible) failure = "missing-email";
+  else failure = "missing-login-chrome";
+
+  return {
+    ok: false,
+    failure,
+    rootChildren,
+    emailVisible,
+    headingVisible,
+    formVisible,
+    appMarker,
+    bodySample,
+  };
+}
+
+/**
+ * Fail closed when the settled page is not a usable login surface — even if
+ * zero console/page errors were emitted.
+ *
+ * @param {LoginSurfaceProbe} probe
+ * @param {string} viewportId
+ */
+export function assertLoginSurfaceReady(probe, viewportId) {
+  if (probe?.ok) return;
+  const diagnostic = [
+    `failure=${probe?.failure || "unknown"}`,
+    `rootChildren=${probe?.rootChildren ?? "?"}`,
+    `emailVisible=${Boolean(probe?.emailVisible)}`,
+    `headingVisible=${Boolean(probe?.headingVisible)}`,
+    `formVisible=${Boolean(probe?.formVisible)}`,
+    `appMarker=${probe?.appMarker || "none"}`,
+    `bodySample=${JSON.stringify(String(probe?.bodySample || "").slice(0, 80))}`,
+  ].join(" ");
+  const message = `${viewportId} /login failed visible login contract after settle: ${diagnostic}`;
+  throw new Error(message.slice(0, 480));
+}
+
 async function measureViewport(browser, { url, settleMs, timeout, viewport }) {
   const context = await browser.newContext({
     viewport: { width: viewport.width, height: viewport.height },
@@ -346,11 +506,19 @@ async function measureViewport(browser, { url, settleMs, timeout, viewport }) {
     await new Promise((r) => setTimeout(r, settleMs));
     const sample = await page.evaluate(sampleTransferInPage);
     assertNoRuntimeErrors(runtimeErrors, viewport.id);
+    const loginProbe = await page.evaluate(collectLoginSurfaceProbe);
+    assertLoginSurfaceReady(loginProbe, viewport.id);
     return {
       viewport: viewport.id,
       width: viewport.width,
       height: viewport.height,
       wallMs: Date.now() - started,
+      loginSurface: {
+        emailVisible: loginProbe.emailVisible,
+        headingVisible: loginProbe.headingVisible,
+        formVisible: loginProbe.formVisible,
+        appMarker: loginProbe.appMarker,
+      },
       ...sample,
     };
   } finally {
@@ -404,6 +572,7 @@ async function main(argv = process.argv) {
     `Measuring cold /login: url=${loginUrl} settleMs=${args.settleMs} sw=blocked cache=empty head=${head ?? "unknown"}`,
   );
 
+  const { chromium } = await import("@playwright/test");
   const browser = await chromium.launch({ headless: !args.headed });
   const samples = [];
   try {

--- a/packages/app/scripts/measure-anonymous-login-transfer.mjs
+++ b/packages/app/scripts/measure-anonymous-login-transfer.mjs
@@ -308,6 +308,21 @@ function sampleTransferInPage() {
   };
 }
 
+/**
+ * Reject a sample whose renderer crashed or logged an error. A smaller broken
+ * page is not a valid performance improvement.
+ *
+ * @param {string[]} runtimeErrors
+ * @param {string} viewportId
+ */
+export function assertNoRuntimeErrors(runtimeErrors, viewportId) {
+  if (runtimeErrors.length === 0) return;
+  const details = runtimeErrors.slice(0, 5).join(" | ");
+  throw new Error(
+    `${viewportId} /login emitted ${runtimeErrors.length} runtime error(s): ${details}`,
+  );
+}
+
 async function measureViewport(browser, { url, settleMs, timeout, viewport }) {
   const context = await browser.newContext({
     viewport: { width: viewport.width, height: viewport.height },
@@ -316,11 +331,21 @@ async function measureViewport(browser, { url, settleMs, timeout, viewport }) {
     ignoreHTTPSErrors: true,
   });
   const page = await context.newPage();
+  const runtimeErrors = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      runtimeErrors.push(`console: ${message.text()}`);
+    }
+  });
+  page.on("pageerror", (error) => {
+    runtimeErrors.push(`page: ${error.message}`);
+  });
   const started = Date.now();
   try {
     await page.goto(url, { waitUntil: "domcontentloaded", timeout });
     await new Promise((r) => setTimeout(r, settleMs));
     const sample = await page.evaluate(sampleTransferInPage);
+    assertNoRuntimeErrors(runtimeErrors, viewport.id);
     return {
       viewport: viewport.id,
       width: viewport.width,

--- a/packages/app/scripts/measure-anonymous-login-transfer.test.ts
+++ b/packages/app/scripts/measure-anonymous-login-transfer.test.ts
@@ -1,8 +1,7 @@
 /**
- * Unit and CLI-boundary tests for the login-transfer measurement argument
- * parser. The harness is deterministic here: invalid flags must fail closed
- * before Chromium launches, so subprocess cases never need a renderer or
- * browser.
+ * Unit and CLI-boundary tests for the login-transfer measurement harness. The
+ * deterministic cases verify invalid flags fail before Chromium launches and
+ * broken renderers cannot qualify as performance improvements.
  */
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
@@ -10,6 +9,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  assertNoRuntimeErrors,
   MAX_TIMER_DELAY_MS,
   parseArgs,
   parseDecimalInt,
@@ -178,6 +178,23 @@ describe("parseArgs --settle-ms / --timeout", () => {
     ]);
     expect(args.settleMs).toBe(MAX_TIMER_DELAY_MS);
     expect(args.timeout).toBe(MAX_TIMER_DELAY_MS);
+  });
+});
+
+describe("assertNoRuntimeErrors", () => {
+  it("accepts a clean renderer", () => {
+    expect(() => assertNoRuntimeErrors([], "desktop")).not.toThrow();
+  });
+
+  it("rejects a crashed renderer with bounded diagnostics", () => {
+    expect(() =>
+      assertNoRuntimeErrors(
+        ["console: React is not defined", "page: mount failed"],
+        "mobile",
+      ),
+    ).toThrow(
+      "mobile /login emitted 2 runtime error(s): console: React is not defined | page: mount failed",
+    );
   });
 });
 

--- a/packages/app/scripts/measure-anonymous-login-transfer.test.ts
+++ b/packages/app/scripts/measure-anonymous-login-transfer.test.ts
@@ -9,7 +9,9 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  assertLoginSurfaceReady,
   assertNoRuntimeErrors,
+  collectLoginSurfaceProbe,
   MAX_TIMER_DELAY_MS,
   parseArgs,
   parseDecimalInt,
@@ -195,6 +197,207 @@ describe("assertNoRuntimeErrors", () => {
     ).toThrow(
       "mobile /login emitted 2 runtime error(s): console: React is not defined | page: mount failed",
     );
+  });
+});
+
+/** @param {"blank" | "valid"} fixture */
+function installLoginProbeDom(fixture) {
+  const previousDocument = globalThis.document;
+  const previousGetComputedStyle = globalThis.getComputedStyle;
+
+  /** @param {any} node @param {string} selector */
+  function matches(node, selector) {
+    if (selector.startsWith("#")) return node.id === selector.slice(1);
+    if (selector.startsWith("[") && selector.endsWith("]")) {
+      const body = selector.slice(1, -1);
+      const eq = body.indexOf("=");
+      if (eq === -1) return node.getAttribute(body) != null;
+      const key = body.slice(0, eq);
+      let value = body.slice(eq + 1);
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      return node.getAttribute(key) === value;
+    }
+    if (selector.includes("[")) {
+      const tag = selector.slice(0, selector.indexOf("["));
+      const attrPart = selector.slice(selector.indexOf("["));
+      return node.tagName === tag.toUpperCase() && matches(node, attrPart);
+    }
+    return node.tagName === selector.toUpperCase();
+  }
+
+  /** @param {string} tagName @param {Record<string, unknown>} [attrs] @param {any[]} [children] */
+  function el(tagName, attrs = {}, children = []) {
+    /** @type {any} */
+    const node = {
+      tagName: tagName.toUpperCase(),
+      attrs: { ...attrs },
+      children,
+      ownerDocument: null,
+      parentElement: null,
+      getAttribute(name) {
+        const value = node.attrs[name];
+        return value == null ? null : String(value);
+      },
+      get id() {
+        return node.attrs.id == null ? "" : String(node.attrs.id);
+      },
+      get textContent() {
+        if (typeof node.attrs.text === "string") return node.attrs.text;
+        return node.children.map((child) => child.textContent).join("");
+      },
+      get style() {
+        return {
+          display: node.attrs.display ?? "",
+          visibility: node.attrs.visibility ?? "",
+          opacity: node.attrs.opacity ?? "",
+        };
+      },
+      getBoundingClientRect() {
+        if (node.attrs.hidden === true) {
+          return { width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 };
+        }
+        const width = Number(node.attrs.width ?? 120);
+        const height = Number(node.attrs.height ?? 24);
+        return { width, height, top: 0, left: 0, right: width, bottom: height };
+      },
+      querySelector(selector) {
+        return node.querySelectorAll(selector)[0] ?? null;
+      },
+      querySelectorAll(selector) {
+        const out = [];
+        const visit = (current) => {
+          if (matches(current, selector)) out.push(current);
+          for (const child of current.children) visit(child);
+        };
+        for (const child of node.children) visit(child);
+        return out;
+      },
+    };
+    for (const child of children) child.parentElement = node;
+    return node;
+  }
+
+  /** @type {Record<string, any>} */
+  let byId = {};
+  /** @type {any} */
+  let body = null;
+
+  if (fixture === "blank") {
+    const root = el("div", { id: "root" });
+    body = el("body", {}, [root]);
+    byId = { root };
+  } else {
+    const email = el("input", {
+      id: "steward-login-email",
+      type: "email",
+      name: "email",
+      width: 280,
+      height: 44,
+    });
+    const heading = el("h1", {
+      text: "Sign in to Eliza",
+      width: 200,
+      height: 32,
+    });
+    const form = el("form", { width: 320, height: 200 }, [email]);
+    const marker = el("div", {
+      "data-testid": "login-safe-area-fill",
+      width: 390,
+      height: 844,
+    });
+    const main = el("main", { width: 360, height: 480 }, [heading, form]);
+    const root = el("div", { id: "root" }, [marker, main]);
+    body = el("body", { text: "Sign in to Eliza" }, [root]);
+    byId = { root, "steward-login-email": email };
+  }
+
+  const doc = {
+    body,
+    documentElement: body,
+    getElementById(id) {
+      return byId[id] ?? null;
+    },
+    querySelector(selector) {
+      if (selector.startsWith("#"))
+        return this.getElementById(selector.slice(1));
+      return body.querySelector(selector);
+    },
+    querySelectorAll(selector) {
+      return body.querySelectorAll(selector);
+    },
+  };
+  body.ownerDocument = doc;
+  for (const node of Object.values(byId)) node.ownerDocument = doc;
+
+  globalThis.document = doc;
+  globalThis.getComputedStyle = (element) => ({
+    display: element?.style?.display || "block",
+    visibility: element?.style?.visibility || "visible",
+    opacity: element?.style?.opacity || "1",
+  });
+
+  return () => {
+    globalThis.document = previousDocument;
+    globalThis.getComputedStyle = previousGetComputedStyle;
+  };
+}
+
+describe("login surface contract", () => {
+  it("rejects a silent blank renderer with bounded diagnostics", () => {
+    const restore = installLoginProbeDom("blank");
+    try {
+      const probe = collectLoginSurfaceProbe();
+      expect(probe.ok).toBe(false);
+      expect(() => assertLoginSurfaceReady(probe, "desktop")).toThrow(
+        /desktop \/login failed visible login contract/,
+      );
+      try {
+        assertLoginSurfaceReady(probe, "desktop");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        expect(message.length).toBeLessThan(500);
+        expect(message).toMatch(/rootChildren=0|emailVisible=false/);
+        expect(message).not.toMatch(/console\.error|pageerror/);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it("accepts a stable visible login surface (email + heading/form)", () => {
+    const restore = installLoginProbeDom("valid");
+    try {
+      const probe = collectLoginSurfaceProbe();
+      expect(probe.ok).toBe(true);
+      expect(probe.emailVisible).toBe(true);
+      expect(probe.headingVisible || probe.formVisible).toBe(true);
+      expect(() => assertLoginSurfaceReady(probe, "mobile")).not.toThrow();
+    } finally {
+      restore();
+    }
+  });
+
+  it("assertLoginSurfaceReady rejects incomplete probes without requiring runtime errors", () => {
+    expect(() =>
+      assertLoginSurfaceReady(
+        {
+          ok: false,
+          failure: "missing-email",
+          rootChildren: 1,
+          emailVisible: false,
+          headingVisible: true,
+          formVisible: false,
+          appMarker: "login-safe-area-fill",
+          bodySample: "",
+        },
+        "desktop",
+      ),
+    ).toThrow(/missing-email/);
   });
 });
 

--- a/packages/app/src/entry.ts
+++ b/packages/app/src/entry.ts
@@ -1,0 +1,47 @@
+/**
+ * Chooses the renderer boot boundary before the full application module graph
+ * evaluates. Hosted public routes load their dedicated shell; every native,
+ * desktop, harness, and agent-app route retains the established main entry.
+ */
+
+import { shouldUsePublicWebEntry } from "./web-entry-policy";
+
+declare const __ELIZA_WEB_SHELL__: boolean | undefined;
+declare const __ELIZA_CHAT_UI_HARNESS__: boolean | undefined;
+
+type ShellWindow = Window & {
+  __electrobunWindowId?: number;
+  __electrobunWebviewId?: number;
+  __ELIZA_ELECTROBUN_RPC__?: unknown;
+};
+
+function hasDesktopShellMarker(): boolean {
+  const runtimeWindow = window as ShellWindow;
+  return (
+    typeof runtimeWindow.__electrobunWindowId === "number" ||
+    typeof runtimeWindow.__electrobunWebviewId === "number" ||
+    runtimeWindow.__ELIZA_ELECTROBUN_RPC__ !== undefined
+  );
+}
+
+const usePublicEntry = shouldUsePublicWebEntry({
+  pathname: window.location.pathname,
+  hostname: window.location.hostname,
+  webShellEnabled: __ELIZA_WEB_SHELL__ === true,
+  chatHarnessEnabled: __ELIZA_CHAT_UI_HARNESS__ === true,
+  desktopShell: hasDesktopShellMarker(),
+  forceApexConsole:
+    import.meta.env?.DEV === true &&
+    import.meta.env?.VITE_FORCE_APEX_CONSOLE === "true",
+});
+
+const rendererEntry = usePublicEntry
+  ? import("./public-web-entry")
+  : import("./main");
+
+// error-policy:J1 renderer-entry boundary — import failures render the same
+// actionable reload card as failures inside the established main boot.
+void rendererEntry.catch(async (error) => {
+  const { renderBootFailure } = await import("./boot-failure");
+  renderBootFailure(error);
+});

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -143,7 +143,7 @@ import {
   shouldInstallMainWindowFirstRunPatches,
   syncDetachedShellLocation,
 } from "@elizaos/ui/platform/window-shell";
-import { AppProvider } from "@elizaos/ui/state";
+import { AppProvider } from "@elizaos/ui/state/AppContext";
 import { upsertAndActivateAgentProfile } from "@elizaos/ui/state/agent-profiles";
 import { resolveDedicatedAgentId } from "@elizaos/ui/state/agent-session-recovery";
 import { initOcrBridge } from "@elizaos/ui/state/ocr-bridge";

--- a/packages/app/src/public-web-boot-config.test.ts
+++ b/packages/app/src/public-web-boot-config.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Ensures the lightweight public entry seeds environment-derived Cloud API
+ * config before join/auth routes read it.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  config: { cloudApiBase: "https://eliza.app", marker: "preserved" },
+  setCalls: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@elizaos/ui/config", () => ({
+  getBootConfig: () => state.config,
+  setBootConfig: (next: Record<string, unknown>) => {
+    state.config = next as typeof state.config;
+    state.setCalls.push(next);
+  },
+}));
+
+vi.mock("./ios-runtime", () => ({
+  resolveIosRuntimeConfig: (
+    env: Record<string, string | boolean | undefined>,
+  ) => ({
+    cloudApiBase:
+      typeof env.VITE_ELIZA_CLOUD_BASE === "string"
+        ? env.VITE_ELIZA_CLOUD_BASE.replace(/\/+$/, "")
+        : "https://eliza.app",
+  }),
+}));
+
+import { seedPublicWebBootConfig } from "./public-web-boot-config.js";
+
+describe("seedPublicWebBootConfig", () => {
+  beforeEach(() => {
+    state.config = {
+      cloudApiBase: "https://eliza.app",
+      marker: "preserved",
+    };
+    state.setCalls.length = 0;
+  });
+
+  it("applies the staging Cloud base while preserving existing boot fields", () => {
+    seedPublicWebBootConfig({
+      VITE_ELIZA_CLOUD_BASE: "https://cloud-staging.eliza.app/",
+    });
+
+    expect(state.config).toEqual({
+      cloudApiBase: "https://cloud-staging.eliza.app",
+      marker: "preserved",
+    });
+    expect(state.setCalls).toHaveLength(1);
+  });
+
+  it("is idempotent when the environment-derived base already matches", () => {
+    state.config.cloudApiBase = "https://cloud-staging.eliza.app";
+
+    seedPublicWebBootConfig({
+      VITE_ELIZA_CLOUD_BASE: "https://cloud-staging.eliza.app",
+    });
+
+    expect(state.setCalls).toHaveLength(0);
+    expect(state.config.marker).toBe("preserved");
+  });
+});

--- a/packages/app/src/public-web-boot-config.ts
+++ b/packages/app/src/public-web-boot-config.ts
@@ -1,0 +1,31 @@
+/**
+ * Lightweight environment boot seed for the hosted public renderer.
+ *
+ * The public entry must not import `main.tsx`, but `/join` still reads
+ * `getBootConfig().cloudApiBase` through `resolveJoinCloudApiBase()`. Without
+ * this seed, staging builds that supply `VITE_ELIZA_CLOUD_BASE` keep the
+ * production default and can provision against the wrong Cloud API origin.
+ */
+
+import { getBootConfig, setBootConfig } from "@elizaos/ui/config";
+import { resolveIosRuntimeConfig } from "./ios-runtime";
+
+type RuntimeEnv = Record<string, string | boolean | undefined>;
+
+/**
+ * Apply environment-derived Cloud API (and related) boot fields before public
+ * routes mount. Safe to call more than once; only writes when values change.
+ */
+export function seedPublicWebBootConfig(
+  env: RuntimeEnv = import.meta.env as RuntimeEnv,
+): void {
+  const runtime = resolveIosRuntimeConfig(env);
+  const current = getBootConfig();
+  if (current.cloudApiBase === runtime.cloudApiBase) {
+    return;
+  }
+  setBootConfig({
+    ...current,
+    cloudApiBase: runtime.cloudApiBase,
+  });
+}

--- a/packages/app/src/public-web-entry.tsx
+++ b/packages/app/src/public-web-entry.tsx
@@ -1,0 +1,81 @@
+/**
+ * Mounts only the Cloud public/auth/marketing route shell for a cold hosted
+ * public URL. The full application entry remains behind a document reload when
+ * client-side navigation leaves that route table, so none of its native,
+ * bridge, plugin, or agent-dashboard imports enter anonymous `/login`.
+ */
+
+import "@elizaos/ui/styles";
+import "./renderer-build-stamp";
+
+import { registerPublicCloudSurfaces } from "@elizaos/ui/cloud/register-public";
+import { CloudRouterShell } from "@elizaos/ui/cloud/shell/CloudRouterShell";
+import { ErrorBoundary } from "@elizaos/ui/components/ui/error-boundary";
+import * as React from "react";
+import { lazy, Suspense, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { renderBootFailure } from "./boot-failure";
+import { registerViewServiceWorker } from "./sw-registration";
+
+const MarketingHomePage = lazy(() => import("@homepage/embedded-home"));
+const MarketingDownloadsPage = lazy(
+  () => import("@homepage/embedded-downloads"),
+);
+
+/**
+ * A public-route link can navigate into the application without reloading the
+ * document. Reload once at that catch-all so `entry.ts` selects the full boot
+ * for the new, non-public pathname.
+ */
+function FullAppHandoff(): React.JSX.Element {
+  useEffect(() => {
+    window.location.reload();
+  }, []);
+  return (
+    <main
+      aria-busy="true"
+      aria-live="polite"
+      className="flex min-h-dvh items-center justify-center bg-black text-sm text-white/60"
+    >
+      Loading Eliza…
+    </main>
+  );
+}
+
+function mountPublicWebEntry(): void {
+  const rootElement = document.getElementById("root");
+  if (!rootElement) throw new Error("Root element #root not found");
+  registerViewServiceWorker();
+  registerPublicCloudSurfaces();
+  createRoot(rootElement).render(
+    <ErrorBoundary>
+      <React.StrictMode>
+        <Suspense fallback={null}>
+          <CloudRouterShell
+            marketingHomeElement={<MarketingHomePage />}
+            downloadsElement={<MarketingDownloadsPage />}
+            appElement={<FullAppHandoff />}
+          />
+        </Suspense>
+      </React.StrictMode>
+    </ErrorBoundary>,
+  );
+}
+
+function bootPublicWebEntry(): void {
+  try {
+    mountPublicWebEntry();
+  } catch (error) {
+    // error-policy:J1 public renderer boundary — preserve the established
+    // reload recovery when registration or the initial mount fails.
+    renderBootFailure(error);
+  }
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", bootPublicWebEntry, {
+    once: true,
+  });
+} else {
+  bootPublicWebEntry();
+}

--- a/packages/app/src/public-web-entry.tsx
+++ b/packages/app/src/public-web-entry.tsx
@@ -15,6 +15,7 @@ import * as React from "react";
 import { lazy, Suspense, useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { renderBootFailure } from "./boot-failure";
+import { seedPublicWebBootConfig } from "./public-web-boot-config";
 import { registerViewServiceWorker } from "./sw-registration";
 
 const MarketingHomePage = lazy(() => import("@homepage/embedded-home"));
@@ -45,6 +46,8 @@ function FullAppHandoff(): React.JSX.Element {
 function mountPublicWebEntry(): void {
   const rootElement = document.getElementById("root");
   if (!rootElement) throw new Error("Root element #root not found");
+  // Seed env-derived Cloud API base before join/auth routes read boot config.
+  seedPublicWebBootConfig();
   registerViewServiceWorker();
   registerPublicCloudSurfaces();
   createRoot(rootElement).render(

--- a/packages/app/src/web-entry-policy.test.ts
+++ b/packages/app/src/web-entry-policy.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Deterministically verifies that only exact hosted public routes bypass the
+ * full renderer entry, while desktop/native-style and near-miss paths retain
+ * the established application boot.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  isHostedPublicPath,
+  shouldUsePublicWebEntry,
+} from "./web-entry-policy";
+
+const PUBLIC_PATHS = [
+  "/login",
+  "/login/",
+  "/auth/success",
+  "/auth/callback/email",
+  "/payment/request-1",
+  "/payment/app-charge/app-1/charge-1",
+  "/approve/approval-1",
+  "/ballot/ballot-1",
+  "/sensitive-requests/request-1",
+  "/chat/character-1",
+  "/join",
+  "/get-started",
+  "/terms-of-service",
+] as const;
+
+describe("hosted public renderer entry policy", () => {
+  it("ships the selector as the HTML entry and keeps both renderers dynamic", () => {
+    const appRoot = resolve(import.meta.dirname, "..");
+    const indexHtml = readFileSync(resolve(appRoot, "index.html"), "utf8");
+    const entrySource = readFileSync(resolve(appRoot, "src/entry.ts"), "utf8");
+    const publicEntrySource = readFileSync(
+      resolve(appRoot, "src/public-web-entry.tsx"),
+      "utf8",
+    );
+
+    expect(indexHtml).toContain('src="/src/entry.ts"');
+    expect(entrySource).toContain('import("./public-web-entry")');
+    expect(entrySource).toContain('import("./main")');
+    expect(publicEntrySource).not.toMatch(/from\s+["']\.\/main["']/);
+  });
+
+  it.each(PUBLIC_PATHS)("recognizes registered public path %s", (pathname) => {
+    expect(isHostedPublicPath(pathname)).toBe(true);
+  });
+
+  it.each([
+    "/cloud",
+    "/settings",
+    "/chat",
+    "/payment",
+    "/payment/app-charge/app-only",
+    "/approve/id/extra",
+    "/unknown",
+  ])("rejects non-public or near-miss path %s", (pathname) => {
+    expect(isHostedPublicPath(pathname)).toBe(false);
+  });
+
+  it("uses the public entry for marketing home but not app-host home", () => {
+    const common = {
+      pathname: "/",
+      webShellEnabled: true,
+      chatHarnessEnabled: false,
+      desktopShell: false,
+      forceApexConsole: false,
+    };
+    expect(shouldUsePublicWebEntry({ ...common, hostname: "eliza.app" })).toBe(
+      true,
+    );
+    expect(
+      shouldUsePublicWebEntry({ ...common, hostname: "cloud.eliza.app" }),
+    ).toBe(false);
+  });
+
+  it("never bypasses the established desktop, disabled-shell, or harness boot", () => {
+    const common = {
+      pathname: "/login",
+      hostname: "eliza.app",
+      webShellEnabled: true,
+      chatHarnessEnabled: false,
+      desktopShell: false,
+      forceApexConsole: false,
+    };
+    expect(shouldUsePublicWebEntry({ ...common, desktopShell: true })).toBe(
+      false,
+    );
+    expect(shouldUsePublicWebEntry({ ...common, webShellEnabled: false })).toBe(
+      false,
+    );
+    expect(
+      shouldUsePublicWebEntry({ ...common, chatHarnessEnabled: true }),
+    ).toBe(false);
+  });
+});

--- a/packages/app/src/web-entry-policy.test.ts
+++ b/packages/app/src/web-entry-policy.test.ts
@@ -28,9 +28,71 @@ const PUBLIC_PATHS = [
   "/terms-of-service",
 ] as const;
 
+const appRoot = resolve(import.meta.dirname, "..");
+const uiRoot = resolve(appRoot, "../ui");
+
+/** Paths owned by the public Cloud shell but not registered as cloud routes. */
+const MARKETING_SHELL_PATHS = new Set(["/downloads"]);
+
+/**
+ * Extract `path: "..."` registrations from cloud domain register modules.
+ * Source-level on purpose: avoids coupling the app policy test to registry
+ * runtime internals while still failing when either side mutates alone.
+ */
+function extractRegisteredCloudPaths(source: string): string[] {
+  const paths: string[] = [];
+  const pathLiteral = /path:\s*["']([^"']+)["']/g;
+  for (const match of source.matchAll(pathLiteral)) {
+    paths.push(match[1]);
+  }
+  // join/register exports path constants referenced by registerCloudRoute.
+  const constPath = /export const \w+_ROUTE_PATH = ["']([^"']+)["']/g;
+  for (const match of source.matchAll(constPath)) {
+    paths.push(match[1]);
+  }
+  return [...new Set(paths)];
+}
+
+/** Convert a cloud-route path template into sample URL pathnames. */
+function samplePathnamesForRoute(routePath: string): string[] {
+  const segments = routePath.split("/").filter(Boolean);
+  const concrete = segments.map((segment) =>
+    segment.startsWith(":") ? "sample" : segment,
+  );
+  return [`/${concrete.join("/")}`];
+}
+
+function extractPolicyExactPaths(policySource: string): string[] {
+  const block = policySource.match(
+    /const EXACT_PUBLIC_PATHS = new Set\(\[([\s\S]*?)\]\)/,
+  );
+  if (!block) return [];
+  return [...block[1].matchAll(/["']([^"']+)["']/g)].map((match) => match[1]);
+}
+
+function extractPolicyParamPatterns(policySource: string): RegExp[] {
+  const block = policySource.match(
+    /const PARAMETRIC_PUBLIC_PATHS = \[([\s\S]*?)\] as const/,
+  );
+  if (!block) return [];
+  const patterns: RegExp[] = [];
+  for (const line of block[1].split("\n")) {
+    const literal = line.trim().replace(/,$/, "");
+    if (!literal.startsWith("/")) continue;
+    const closingSlash = literal.lastIndexOf("/");
+    if (closingSlash <= 0) continue;
+    patterns.push(
+      new RegExp(
+        literal.slice(1, closingSlash),
+        literal.slice(closingSlash + 1),
+      ),
+    );
+  }
+  return patterns;
+}
+
 describe("hosted public renderer entry policy", () => {
   it("ships the selector as the HTML entry and keeps both renderers dynamic", () => {
-    const appRoot = resolve(import.meta.dirname, "..");
     const indexHtml = readFileSync(resolve(appRoot, "index.html"), "utf8");
     const entrySource = readFileSync(resolve(appRoot, "src/entry.ts"), "utf8");
     const publicEntrySource = readFileSync(
@@ -42,6 +104,7 @@ describe("hosted public renderer entry policy", () => {
     expect(entrySource).toContain('import("./public-web-entry")');
     expect(entrySource).toContain('import("./main")');
     expect(publicEntrySource).not.toMatch(/from\s+["']\.\/main["']/);
+    expect(publicEntrySource).toContain("seedPublicWebBootConfig");
   });
 
   it.each(PUBLIC_PATHS)("recognizes registered public path %s", (pathname) => {
@@ -94,5 +157,75 @@ describe("hosted public renderer entry policy", () => {
     expect(
       shouldUsePublicWebEntry({ ...common, chatHarnessEnabled: true }),
     ).toBe(false);
+  });
+
+  it("keeps web-entry policy paths synchronized with public/join route registration", () => {
+    const policySource = readFileSync(
+      resolve(appRoot, "src/web-entry-policy.ts"),
+      "utf8",
+    );
+    const publicPagesSource = readFileSync(
+      resolve(uiRoot, "src/cloud/public-pages/register.ts"),
+      "utf8",
+    );
+    const joinSource = readFileSync(
+      resolve(uiRoot, "src/cloud/join/register.ts"),
+      "utf8",
+    );
+
+    const registeredRoutes = [
+      ...extractRegisteredCloudPaths(publicPagesSource),
+      ...extractRegisteredCloudPaths(joinSource),
+    ];
+    expect(registeredRoutes.length).toBeGreaterThan(10);
+
+    // Every registered public/join route must be owned by the lightweight
+    // entry policy; otherwise navigation stays on the public shell and
+    // FullAppHandoff reload-loops or never reaches the full app.
+    for (const routePath of registeredRoutes) {
+      for (const sample of samplePathnamesForRoute(routePath)) {
+        expect(
+          isHostedPublicPath(sample),
+          `registered route "${routePath}" sample "${sample}" missing from web-entry policy`,
+        ).toBe(true);
+      }
+    }
+
+    const exactPolicyPaths = extractPolicyExactPaths(policySource).filter(
+      (path) => !MARKETING_SHELL_PATHS.has(path),
+    );
+
+    // Every exact policy path (except marketing shell props) must appear in a
+    // register module so policy-only additions cannot silently diverge.
+    const registeredPathSet = new Set(
+      registeredRoutes.map((route) => route.replace(/^\/+/, "")),
+    );
+    for (const policyPath of exactPolicyPaths) {
+      const normalized = policyPath.replace(/^\/+/, "");
+      expect(
+        registeredPathSet.has(normalized),
+        `policy exact path "${policyPath}" has no matching cloud route registration`,
+      ).toBe(true);
+    }
+
+    const parametricPatterns = extractPolicyParamPatterns(policySource);
+    // Parametric policy patterns must each match at least one registered
+    // template sample (mutation-sensitive: adding only one side fails).
+    for (const pattern of parametricPatterns) {
+      const matched = registeredRoutes.some((routePath) =>
+        samplePathnamesForRoute(routePath).some((sample) =>
+          pattern.test(sample),
+        ),
+      );
+      expect(
+        matched,
+        `parametric policy ${pattern} matches no registered cloud route sample`,
+      ).toBe(true);
+    }
+
+    // Sabotage-style pin: a synthetic policy-only path must not be considered
+    // registered, proving the assertions above are not vacuously true.
+    expect(registeredPathSet.has("policy-only-sabotage-path")).toBe(false);
+    expect(isHostedPublicPath("/policy-only-sabotage-path")).toBe(false);
   });
 });

--- a/packages/app/src/web-entry-policy.ts
+++ b/packages/app/src/web-entry-policy.ts
@@ -1,0 +1,78 @@
+/**
+ * Selects the lightweight hosted-public renderer entry without changing the
+ * native, desktop, chat-harness, or agent-application boot paths.
+ *
+ * Keep these exact pathname patterns aligned with the routes registered by
+ * `@elizaos/ui/cloud/register-public`. Near misses deliberately fall through
+ * to the full application so an unknown URL cannot reload-loop at the public
+ * shell catch-all.
+ */
+
+import { classifyElizaHostname } from "@elizaos/shared/elizacloud/domain-contract";
+
+export interface WebEntryDecisionInput {
+  pathname: string;
+  hostname: string;
+  webShellEnabled: boolean;
+  chatHarnessEnabled: boolean;
+  desktopShell: boolean;
+  forceApexConsole: boolean;
+}
+
+const EXACT_PUBLIC_PATHS = new Set([
+  "/accept-invitation",
+  "/app-auth/authorize",
+  "/auth/bridge",
+  "/auth/callback/email",
+  "/auth/cli-login",
+  "/auth/error",
+  "/auth/success",
+  "/bsc",
+  "/downloads",
+  "/get-started",
+  "/invite/accept",
+  "/join",
+  "/login",
+  "/oidc/continue",
+  "/privacy-policy",
+  "/terms-of-service",
+]);
+
+const PARAMETRIC_PUBLIC_PATHS = [
+  /^\/approve\/[^/]+$/,
+  /^\/ballot\/[^/]+$/,
+  /^\/chat\/[^/]+$/,
+  /^\/payment\/[^/]+$/,
+  /^\/payment\/app-charge\/[^/]+\/[^/]+$/,
+  /^\/sensitive-requests\/[^/]+$/,
+] as const;
+
+function normalizePathname(pathname: string): string {
+  if (pathname === "/") return pathname;
+  return pathname.replace(/\/+$/, "") || "/";
+}
+
+/** Whether the path is owned completely by the hosted public route table. */
+export function isHostedPublicPath(pathname: string): boolean {
+  const normalized = normalizePathname(pathname);
+  return (
+    EXACT_PUBLIC_PATHS.has(normalized) ||
+    PARAMETRIC_PUBLIC_PATHS.some((pattern) => pattern.test(normalized))
+  );
+}
+
+/** Decide which renderer entry may execute before any application modules load. */
+export function shouldUsePublicWebEntry(input: WebEntryDecisionInput): boolean {
+  if (
+    !input.webShellEnabled ||
+    input.chatHarnessEnabled ||
+    input.desktopShell
+  ) {
+    return false;
+  }
+  if (isHostedPublicPath(input.pathname)) return true;
+  if (normalizePathname(input.pathname) !== "/") return false;
+  if (input.forceApexConsole) return true;
+  const role = classifyElizaHostname(input.hostname).role;
+  return role === "marketing" || role === "legacy-marketing";
+}


### PR DESCRIPTION
Closes #18056.

## Root cause

The document entry imported `src/main.tsx` before route selection. Anonymous hosted routes therefore evaluated the complete cross-platform application composition root—including native bridges, plugin/runtime surfaces, and agent-dashboard dependencies—even though `/login` only renders the public Cloud shell. The earlier #18441 work added measurement and chunking but left that dominant eager edge intact.

## What changed

- add a tiny entry selector that chooses a dedicated hosted public/auth renderer before importing the full application
- preserve the existing full boot for desktop, native, disabled-web-shell, chat-harness, app-host `/`, and every non-public route
- reload once when public-shell navigation crosses into a full-app route so the selector reevaluates the new path
- directly import `AppProvider` from its owning module to avoid a cross-chunk re-export cycle
- calibrate an enforced cold `/login` budget from the working renderer
- make the transfer harness fail closed on console/page errors so a crashed, smaller page cannot pass the performance gate

## Exact-head evidence

Validated at `206af6ad8aac6797dcd78f3a14dc0ccc5e6a53d9`, rebased on `develop@fa14ba7718732fbbb2ab35e84dca9f6da45e3fc6`.

Cold fresh Chromium context, service workers blocked, 6 s settle, no interaction:

| Viewport | Graph | Resources | Total transfer | Scripts | Script transfer |
| --- | --- | ---: | ---: | ---: | ---: |
| desktop | current develop baseline | 119 | 2,434,113 B | 111 | 2,327,260 B |
| desktop | this PR | 60 | 1,537,426 B | 52 | 1,430,526 B |
| mobile | current develop baseline | 119 | 2,434,113 B | 111 | 2,327,260 B |
| mobile | this PR | 60 | 1,537,426 B | 52 | 1,430,526 B |

That is **896,734 fewer script bytes (38.53%)** and **59 fewer script requests (53.15%)**, identically on desktop and mobile. The exact-head budget gate passes with a 10% transfer tolerance and small request allowance.

## Validation

- `bun install --frozen-lockfile` — pass
- focused entry policy + transfer harness: 49 passed
- public/private Cloud registration and shell: 40 passed
- `bun run --cwd packages/app build:web` — pass; entry static closure is 3 chunks and contains no lazy vendor chunk
- `bun run --cwd packages/app measure:login-transfer --serve-dist` — pass, exact results above
- `bun run --cwd packages/app perf:login-transfer-budget --report ...` — pass desktop + mobile
- `bun run --cwd packages/app lint:check` — pass
- `bun run --cwd packages/app audit:app` — 219/219 passed; broken=0, needs-work=0; OCR broken=0
- desktop 1280×720 and mobile 390×844 real-browser review — login rendered correctly; console warnings/errors: 0
- `bun run verify` — 350/350 tasks passed at the exact PR head

Visual appearance is intentionally unchanged; screenshots are attached below as proof of the exact-head desktop/mobile render. MP4 is N/A because this changes the initial module graph only and introduces no new visual or interactive behavior. Backend/live-model/native evidence is N/A because the affected path is a pre-auth browser document bootstrap.

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Before screenshots | [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19094-login-desktop-chromium-linux.png), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19094-login-mobile-chromium-linux.png) |
| After screenshots | [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19094-exact-head-desktop.png), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19094-exact-head-mobile.png) |
| Walkthrough video | N/A - initial module-graph change only; no new visual or interactive behavior |
| Backend logs | N/A - pre-auth static browser bootstrap; no backend behavior changed |
| Frontend logs | [exact-head production measurement JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19094-exact-head.json); browser console warnings/errors: 0 |
| Live-model trajectory | N/A - no agent or model behavior changed |
| Domain artifacts | [exact-head root verify log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19094-exact-head-root-verify.log) |
| OCR review | `audit:app`: 216 views, verified=200, broken=0, needs-work=0 |

### Exact-head desktop

![Exact-head desktop login](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19094-exact-head-desktop.png)

### Exact-head mobile

![Exact-head mobile login](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19094-exact-head-mobile.png)

<!-- evidence-head:7123ef5420310aed9ae370f518be676b658c1ce2 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19094-login-desktop-chromium-linux.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19094-exact-head-desktop.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19094-exact-head-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - pre-auth static browser bootstrap; no backend change

<!-- evidence-row:frontend-logs -->
- [x] [19094-frontend-console-network-v2.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19094-frontend-console-network-v2.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [19094-exact-head-root-verify.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19094-exact-head-root-verify.log)

<!-- evidence-row:ocr-review -->
- [x] [19094-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19094-ocr-triage.json)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-18056]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->


