### PR TITLE
fix(cloud): validate complete gateway forwarded host

### DIFF
--- a/packages/cloud/services/gateway-webhook/AGENTS.md
+++ b/packages/cloud/services/gateway-webhook/AGENTS.md
@@ -108,6 +108,8 @@ Other:
 - `AGENT_ROUTER_ORIGIN_HOST` — canonical dedicated-agent router origin used
   after a direct transport failure. The gateway sends the validated
   `<agent-id>.<ELIZA_CLOUD_AGENT_BASE_DOMAIN>` value as `X-Forwarded-Host`.
+  Validation applies to the complete generated hostname, including the
+  253-character total and 63-character per-label DNS limits.
 - `ELIZA_CLOUD_AGENT_BASE_DOMAIN` — dedicated-agent hostname suffix used with
   the router origin (default `cloud.eliza.app`).
 - `PORT` (default 3000; `dev`/`start` scripts set 3002), `POD_NAME` /

--- a/packages/cloud/services/gateway-webhook/CLAUDE.md
+++ b/packages/cloud/services/gateway-webhook/CLAUDE.md
@@ -108,6 +108,8 @@ Other:
 - `AGENT_ROUTER_ORIGIN_HOST` — canonical dedicated-agent router origin used
   after a direct transport failure. The gateway sends the validated
   `<agent-id>.<ELIZA_CLOUD_AGENT_BASE_DOMAIN>` value as `X-Forwarded-Host`.
+  Validation applies to the complete generated hostname, including the
+  253-character total and 63-character per-label DNS limits.
 - `ELIZA_CLOUD_AGENT_BASE_DOMAIN` — dedicated-agent hostname suffix used with
   the router origin (default `cloud.eliza.app`).
 - `PORT` (default 3000; `dev`/`start` scripts set 3002), `POD_NAME` /

--- a/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
@@ -10,6 +10,18 @@ const AGENT_ID = "4602b3be-2c01-4e7e-9cdc-849604e1bef7";
 const RUNTIME_AGENT_ID = "b850bc30-45f8-0041-a00a-83df46d8555d";
 const originalFetch = globalThis.fetch;
 
+function domainWithLength(length: number): string {
+  const labels: string[] = [];
+  let remaining = length;
+  while (remaining > 0) {
+    const labelLength = Math.min(63, remaining);
+    labels.push("a".repeat(labelLength));
+    remaining -= labelLength;
+    if (remaining > 0) remaining -= 1;
+  }
+  return labels.join(".");
+}
+
 afterEach(() => {
   globalThis.fetch = originalFetch;
 });
@@ -37,6 +49,39 @@ describe("canonical agent forwarding fallback", () => {
       getCanonicalAgentFallbackTarget(AGENT_ID, {
         AGENT_ROUTER_ORIGIN_HOST: "https://attacker.example/path",
         ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
+      }),
+    ).toBeNull();
+  });
+
+  test("validates the complete forwarded hostname at the DNS length boundary", () => {
+    const maxBaseDomain = domainWithLength(216);
+    const overlongBaseDomain = domainWithLength(217);
+
+    expect(
+      getCanonicalAgentFallbackTarget(AGENT_ID, {
+        AGENT_ROUTER_ORIGIN_HOST: "router.eliza.app",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: maxBaseDomain,
+      })?.forwardedHost,
+    ).toHaveLength(253);
+    expect(
+      getCanonicalAgentFallbackTarget(AGENT_ID, {
+        AGENT_ROUTER_ORIGIN_HOST: "router.eliza.app",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: overlongBaseDomain,
+      }),
+    ).toBeNull();
+  });
+
+  test("accepts a 63-character base-domain label and rejects 64", () => {
+    expect(
+      getCanonicalAgentFallbackTarget(AGENT_ID, {
+        AGENT_ROUTER_ORIGIN_HOST: "router.eliza.app",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: `${"a".repeat(63)}.app`,
+      }),
+    ).not.toBeNull();
+    expect(
+      getCanonicalAgentFallbackTarget(AGENT_ID, {
+        AGENT_ROUTER_ORIGIN_HOST: "router.eliza.app",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: `${"a".repeat(64)}.app`,
       }),
     ).toBeNull();
   });

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -57,15 +57,16 @@ export function getCanonicalAgentFallbackTarget(
   }
   const agentBaseDomain =
     env.ELIZA_CLOUD_AGENT_BASE_DOMAIN?.trim() || "cloud.eliza.app";
+  const forwardedHost = `${normalizedAgentId}.${agentBaseDomain.toLowerCase()}`;
   if (
     !DNS_HOSTNAME_PATTERN.test(routerOriginHost) ||
-    !DNS_HOSTNAME_PATTERN.test(agentBaseDomain)
+    !DNS_HOSTNAME_PATTERN.test(forwardedHost)
   ) {
     return null;
   }
   return {
     baseUrl: `https://${routerOriginHost}/api`,
-    forwardedHost: `${normalizedAgentId}.${agentBaseDomain.toLowerCase()}`,
+    forwardedHost,
   };
 }
 


### PR DESCRIPTION
# Relates to

Follow-up for #19085 after #19086 merged before the complete-hostname validation review blocker was resolved. This PR deliberately does not close the issue; its required deployed iMessage round trip remains outstanding.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on `origin/develop` at `fa14ba7718732fbbb2ab35e84dca9f6da45e3fc6` with zero conflicts.
- [x] `bun install` and `bun run verify` passed after sync.
- [x] A reviewer can confirm the hostname contract from exact total-length and per-label boundary tests.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

- Low and fail-closed: the gateway now validates the complete `<agent-id>.<base-domain>` value before sending it as `X-Forwarded-Host`.
- A final hostname above 253 characters or any label above 63 characters produces no canonical fallback target.
- Valid configured hosts and the configuration-absent legacy fallback remain unchanged.

# Background

## What does this PR do?

#19086 validated `ELIZA_CLOUD_AGENT_BASE_DOMAIN` alone, then prefixed the 36-character agent UUID. A valid 217-character base domain therefore produced an invalid 254-character forwarded hostname. This follow-up constructs the final hostname first and validates the exact value sent on the wire.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

The gateway guide now states the complete-hostname and per-label bounds; AGENTS/CLAUDE parity is preserved.

# Testing

- Focused canonical-fallback suite: 7/7 passed.
- Full gateway suite: 105/105 passed.
- Gateway typecheck, lint, format, and build passed.
- `check:agents-claude`: 153/153 pairs passed.
- `git diff --check` passed.
- Root `bun run verify`: 350/350 Turbo build/typecheck tasks and every repository audit passed.

# Evidence Gate

Evidence matches commit `9f9b5bf938643f8dbf09e5c7d963ab5f042c9bc3`.

<!-- evidence-head:9f9b5bf938643f8dbf09e5c7d963ab5f042c9bc3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface is changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface is changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI flow is changed.
<!-- evidence-row:backend-logs -->
- [x] [19095-pr19095-gateway-verification.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19095-pr19095-gateway-verification.json)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or rendered state is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - hostname validation does not change prompts, model routing, planner selection, or model output.
<!-- evidence-row:domain-artifacts -->
- [x] [19095-pr19095-gateway-dns-boundary.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19095-pr19095-gateway-dns-boundary.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text surface is changed.

# Known gaps / failures

- #19085 still requires a deployed real iMessage round trip through provider → gateway fallback → router → runtime → reply. The earlier manual router probe is not mislabeled as this proof.
- Production deployment and external-message mutation are outside this code-only follow-up's authority; the issue must remain open until an authorized operator supplies that evidence.

