### PR TITLE
fix(app): make consolidated web build self-preparing

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -137,6 +137,7 @@
     "cap:sync:android": "node scripts/ensure-capacitor-platform.mjs android && capacitor sync android",
     "cap:open:ios": "node scripts/ensure-capacitor-platform.mjs ios && capacitor open ios",
     "cap:open:android": "node scripts/ensure-capacitor-platform.mjs android && capacitor open android",
+    "prebuild:web": "bun run prebuild",
     "build:web": "ELIZA_WEB_ABSOLUTE_BASE=1 node ../../node_modules/@elizaos/vitest-vite/bin/vite.js build && node scripts/verify-chunk-safety.mjs && node scripts/verify-viewport-meta.mjs",
     "verify:chunks": "node scripts/verify-chunk-safety.mjs",
     "predev": "node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --concepts --banners --background --background-videos && node ../app-core/scripts/write-homepage-release-data.mjs && node scripts/sync-homepage-assets.mjs",

--- a/packages/app/scripts/sync-homepage-assets.mjs
+++ b/packages/app/scripts/sync-homepage-assets.mjs
@@ -25,7 +25,6 @@ export const HOMEPAGE_PUBLIC_ASSETS = [
   "grain.webp",
   "install.ps1",
   "install.sh",
-  "product/elizaos-usb-key-concept.png",
   "tbg.webp",
 ];
 

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -20,6 +20,9 @@ describe("homepage deployment workflow", () => {
       "utf8",
     ),
   ) as { name?: string; scripts?: Record<string, string> };
+  const appPackage = JSON.parse(
+    readFileSync(path.join(repositoryRoot, "packages/app/package.json"), "utf8"),
+  ) as { scripts?: Record<string, string> };
   const devAll = readFileSync(
     path.join(repositoryRoot, "packages/scripts/dev-all.mjs"),
     "utf8",
@@ -48,6 +51,7 @@ describe("homepage deployment workflow", () => {
   });
 
   it("builds homepage changes into the single eliza-app artifact", () => {
+    expect(appPackage.scripts?.["prebuild:web"]).toBe("bun run prebuild");
     expect(workflow).toContain('      - "packages/homepage/**"');
     expect(workflow).toContain("Build consolidated frontend artifact");
     expect(workflow).toContain("Upload consolidated frontend artifact");


### PR DESCRIPTION
Fixes part of #18806

## Outcome

- makes every packages/app build:web invocation run the canonical prebuild lifecycle first
- regenerates embedded homepage release data and synchronizes approved public assets before Vite starts
- removes the deleted USB concept image from the approved homepage asset manifest
- adds a contract test so Cloudflare and quality workflows cannot silently return to a non-self-preparing build

## Root cause

The consolidated Cloudflare workflow invokes build:web directly. That script did not have a matching prebuild:web lifecycle, so a clean checkout could not resolve the gitignored homepage release-data module. Running prebuild manually then failed because the asset manifest referenced a file that no longer exists.

## Verification

- bun run verify: pass across 141 workspaces; focused-test audit scanned 7,962 files
- bun run --cwd packages/app build:web: pass from a clean checkout and visibly invokes prebuild:web first; 608 assets emitted
- bun run --cwd packages/app typecheck: pass after building the declared native bridge dependency
- bun run --cwd packages/app lint:check: pass
- focused asset/workflow tests: 5 pass
- bun run --cwd packages/app audit:app: 219/219 pass; broken=0; needs-work=0; OCR broken=0
- git diff --check and guide parity: pass

## Evidence

- Before/after screenshots: N/A - no rendered source or styling changed.
- Walkthrough video: N/A - this is a deterministic build-lifecycle correction.
- Console/network/backend logs: N/A - no runtime request path changed.
- Domain artifact: a clean build now creates eliza-renderer-build.json and 608 assets without manual preparation.

## Contribution provenance

- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Codex desktop
- Contribution skill revision: elizaOS/eliza@16529e19614c0d7d245b787fc4dd3b919a6d0476:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@16529e19614c0d7d245b787fc4dd3b919a6d0476:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-cloud-consolidation]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@16529e19614c0d7d245b787fc4dd3b919a6d0476:packages/skills/skills/contribute-to-eliza"} -->