### PR TITLE
fix(app): promote reproducible consolidated frontend build

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -137,6 +137,7 @@
     "cap:sync:android": "node scripts/ensure-capacitor-platform.mjs android && capacitor sync android",
     "cap:open:ios": "node scripts/ensure-capacitor-platform.mjs ios && capacitor open ios",
     "cap:open:android": "node scripts/ensure-capacitor-platform.mjs android && capacitor open android",
+    "prebuild:web": "bun run prebuild",
     "build:web": "ELIZA_WEB_ABSOLUTE_BASE=1 node ../../node_modules/@elizaos/vitest-vite/bin/vite.js build && node scripts/verify-chunk-safety.mjs && node scripts/verify-viewport-meta.mjs",
     "verify:chunks": "node scripts/verify-chunk-safety.mjs",
     "predev": "node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --concepts --banners --background --background-videos && node ../app-core/scripts/write-homepage-release-data.mjs && node scripts/sync-homepage-assets.mjs",

--- a/packages/app/scripts/sync-homepage-assets.mjs
+++ b/packages/app/scripts/sync-homepage-assets.mjs
@@ -25,7 +25,6 @@ export const HOMEPAGE_PUBLIC_ASSETS = [
   "grain.webp",
   "install.ps1",
   "install.sh",
-  "product/elizaos-usb-key-concept.png",
   "tbg.webp",
 ];
 

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -20,6 +20,9 @@ describe("homepage deployment workflow", () => {
       "utf8",
     ),
   ) as { name?: string; scripts?: Record<string, string> };
+  const appPackage = JSON.parse(
+    readFileSync(path.join(repositoryRoot, "packages/app/package.json"), "utf8"),
+  ) as { scripts?: Record<string, string> };
   const devAll = readFileSync(
     path.join(repositoryRoot, "packages/scripts/dev-all.mjs"),
     "utf8",
@@ -48,6 +51,7 @@ describe("homepage deployment workflow", () => {
   });
 
   it("builds homepage changes into the single eliza-app artifact", () => {
+    expect(appPackage.scripts?.["prebuild:web"]).toBe("bun run prebuild");
     expect(workflow).toContain('      - "packages/homepage/**"');
     expect(workflow).toContain("Build consolidated frontend artifact");
     expect(workflow).toContain("Upload consolidated frontend artifact");


### PR DESCRIPTION
## Outcome

Promotes the exact three-file consolidated frontend build repair from develop PR #19096 to production main.

The release commit is byte-identical to source commit 16529e19614913e9d17aa0a6b445500e0856987e for every touched file. It makes build:web invoke the canonical prebuild lifecycle and removes one deleted source asset from the approved sync manifest.

## Why production needs this

The current production Cloudflare Pages job invokes build:web from a clean checkout. Without this patch it cannot generate the gitignored homepage release-data module, and a manual prebuild fails on the deleted USB concept image. This blocks the single-artifact eliza.app cutover.

## Verification inherited from #19096

- bun run verify: pass across 141 workspaces; 7,962 test files scanned
- clean build:web: pass; prebuild:web visibly runs first; 608 assets emitted
- app typecheck and lint: pass
- focused asset/workflow tests: 5 pass
- app audit: 219/219 pass; broken=0; needs-work=0; OCR broken=0
- complete touched-file set is byte-identical to the verified develop commit

## Evidence

- Visual evidence: N/A - no rendered source or styling changed.
- Runtime logs: N/A - no request path changed.
- Release artifact: production build will emit the renderer manifest from a clean checkout without manual preparation.

## Contribution provenance

- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Codex desktop
- Contribution skill revision: elizaOS/eliza@9801580ffedbb82f8e874136277987bfe8b0ec5a:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@9801580ffedbb82f8e874136277987bfe8b0ec5a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-cloud-consolidation]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/eliza@9801580ffedbb82f8e874136277987bfe8b0ec5a:packages/skills/skills/contribute-to-eliza"} -->