### PR TITLE
fix(cloud): promote complete gateway host validation

### DIFF
--- a/packages/cloud/services/gateway-webhook/AGENTS.md
+++ b/packages/cloud/services/gateway-webhook/AGENTS.md
@@ -108,6 +108,8 @@ Other:
 - `AGENT_ROUTER_ORIGIN_HOST` — canonical dedicated-agent router origin used
   after a direct transport failure. The gateway sends the validated
   `<agent-id>.<ELIZA_CLOUD_AGENT_BASE_DOMAIN>` value as `X-Forwarded-Host`.
+  Validation applies to the complete generated hostname, including the
+  253-character total and 63-character per-label DNS limits.
 - `ELIZA_CLOUD_AGENT_BASE_DOMAIN` — dedicated-agent hostname suffix used with
   the router origin (default `cloud.eliza.app`).
 - `PORT` (default 3000; `dev`/`start` scripts set 3002), `POD_NAME` /

--- a/packages/cloud/services/gateway-webhook/CLAUDE.md
+++ b/packages/cloud/services/gateway-webhook/CLAUDE.md
@@ -108,6 +108,8 @@ Other:
 - `AGENT_ROUTER_ORIGIN_HOST` — canonical dedicated-agent router origin used
   after a direct transport failure. The gateway sends the validated
   `<agent-id>.<ELIZA_CLOUD_AGENT_BASE_DOMAIN>` value as `X-Forwarded-Host`.
+  Validation applies to the complete generated hostname, including the
+  253-character total and 63-character per-label DNS limits.
 - `ELIZA_CLOUD_AGENT_BASE_DOMAIN` — dedicated-agent hostname suffix used with
   the router origin (default `cloud.eliza.app`).
 - `PORT` (default 3000; `dev`/`start` scripts set 3002), `POD_NAME` /

--- a/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
@@ -10,6 +10,18 @@ const AGENT_ID = "4602b3be-2c01-4e7e-9cdc-849604e1bef7";
 const RUNTIME_AGENT_ID = "b850bc30-45f8-0041-a00a-83df46d8555d";
 const originalFetch = globalThis.fetch;
 
+function domainWithLength(length: number): string {
+  const labels: string[] = [];
+  let remaining = length;
+  while (remaining > 0) {
+    const labelLength = Math.min(63, remaining);
+    labels.push("a".repeat(labelLength));
+    remaining -= labelLength;
+    if (remaining > 0) remaining -= 1;
+  }
+  return labels.join(".");
+}
+
 afterEach(() => {
   globalThis.fetch = originalFetch;
 });
@@ -37,6 +49,39 @@ describe("canonical agent forwarding fallback", () => {
       getCanonicalAgentFallbackTarget(AGENT_ID, {
         AGENT_ROUTER_ORIGIN_HOST: "https://attacker.example/path",
         ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
+      }),
+    ).toBeNull();
+  });
+
+  test("validates the complete forwarded hostname at the DNS length boundary", () => {
+    const maxBaseDomain = domainWithLength(216);
+    const overlongBaseDomain = domainWithLength(217);
+
+    expect(
+      getCanonicalAgentFallbackTarget(AGENT_ID, {
+        AGENT_ROUTER_ORIGIN_HOST: "router.eliza.app",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: maxBaseDomain,
+      })?.forwardedHost,
+    ).toHaveLength(253);
+    expect(
+      getCanonicalAgentFallbackTarget(AGENT_ID, {
+        AGENT_ROUTER_ORIGIN_HOST: "router.eliza.app",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: overlongBaseDomain,
+      }),
+    ).toBeNull();
+  });
+
+  test("accepts a 63-character base-domain label and rejects 64", () => {
+    expect(
+      getCanonicalAgentFallbackTarget(AGENT_ID, {
+        AGENT_ROUTER_ORIGIN_HOST: "router.eliza.app",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: `${"a".repeat(63)}.app`,
+      }),
+    ).not.toBeNull();
+    expect(
+      getCanonicalAgentFallbackTarget(AGENT_ID, {
+        AGENT_ROUTER_ORIGIN_HOST: "router.eliza.app",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: `${"a".repeat(64)}.app`,
       }),
     ).toBeNull();
   });

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -57,15 +57,16 @@ export function getCanonicalAgentFallbackTarget(
   }
   const agentBaseDomain =
     env.ELIZA_CLOUD_AGENT_BASE_DOMAIN?.trim() || "cloud.eliza.app";
+  const forwardedHost = `${normalizedAgentId}.${agentBaseDomain.toLowerCase()}`;
   if (
     !DNS_HOSTNAME_PATTERN.test(routerOriginHost) ||
-    !DNS_HOSTNAME_PATTERN.test(agentBaseDomain)
+    !DNS_HOSTNAME_PATTERN.test(forwardedHost)
   ) {
     return null;
   }
   return {
     baseUrl: `https://${routerOriginHost}/api`,
-    forwardedHost: `${normalizedAgentId}.${agentBaseDomain.toLowerCase()}`,
+    forwardedHost,
   };
 }
 


### PR DESCRIPTION
Production promotion of the isolated, reviewed DNS-boundary correction from #19095.

Validation on this exact promotion commit:
- canonical fallback tests: 7/7
- gateway package typecheck: pass
- diff check: pass
- source PR full verification: 105/105 gateway tests and 350/350 root verify tasks
- live production iMessage provider → gateway → canonical router → runtime → reply delivery proved on 2026-08-13

No unrelated develop commits are included.