### PR TITLE
fix(cloud): enforce honest discovery types

### DIFF
--- a/packages/cloud/api/__tests__/discovery-supported-types.test.ts
+++ b/packages/cloud/api/__tests__/discovery-supported-types.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The public discovery route advertises and executes only its real agent and
+ * MCP catalog sources. The Hono handler is real; catalog and cache boundaries
+ * are deterministic stubs so unsupported type tokens fail before any lookup.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const listPublicAgents = mock(async () => []);
+const listPublicMcps = mock(async () => []);
+const cacheGet = mock(async () => null);
+const cacheSet = mock(async () => undefined);
+
+mock.module("@/lib/services/characters/characters", () => ({
+  charactersService: { listPublic: listPublicAgents },
+}));
+
+mock.module("@/lib/services/user-mcps", () => ({
+  userMcpsService: {
+    listPublic: listPublicMcps,
+    getPublicProxyUrl: mock(() => "https://app.example.test/mcp"),
+  },
+}));
+
+mock.module("@/lib/cache/client", () => ({
+  cache: { get: cacheGet, set: cacheSet },
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_context: unknown, next: () => Promise<void>) =>
+    next(),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: mock(),
+    error: mock(),
+    info: mock(),
+    warn: mock(),
+  },
+}));
+
+const discoveryRoute = (await import("../v1/discovery/route")).default;
+const app = new Hono<AppEnv>();
+app.route("/api/v1/discovery", discoveryRoute);
+
+const ENV = {
+  NODE_ENV: "test",
+  NEXT_PUBLIC_APP_URL: "https://app.example.test",
+} as unknown as AppEnv["Bindings"];
+
+async function discover(query = ""): Promise<Response> {
+  return app.request(`/api/v1/discovery${query}`, {}, ENV);
+}
+
+beforeEach(() => {
+  listPublicAgents.mockClear();
+  listPublicMcps.mockClear();
+  cacheGet.mockClear();
+  cacheSet.mockClear();
+});
+
+describe("GET /api/v1/discovery supported type contract", () => {
+  test("the default request fetches both supported catalogs", async () => {
+    const response = await discover();
+
+    expect(response.status).toBe(200);
+    expect(listPublicAgents).toHaveBeenCalledTimes(1);
+    expect(listPublicMcps).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    ["agent", 1, 0],
+    ["mcp", 0, 1],
+  ] as const)(
+    "an explicit %s request fetches only that catalog",
+    async (type, agentCalls, mcpCalls) => {
+      const response = await discover(`?types=${type}`);
+
+      expect(response.status).toBe(200);
+      expect(listPublicAgents).toHaveBeenCalledTimes(agentCalls);
+      expect(listPublicMcps).toHaveBeenCalledTimes(mcpCalls);
+    },
+  );
+
+  test.each(["app", "a2a", "unknown", "", "agent,app"])(
+    "rejects unsupported type list %j before catalog lookup",
+    async (types) => {
+      const response = await discover(`?types=${types}`);
+
+      expect(response.status).toBe(400);
+      expect(listPublicAgents).not.toHaveBeenCalled();
+      expect(listPublicMcps).not.toHaveBeenCalled();
+      expect(cacheGet).not.toHaveBeenCalled();
+
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Invalid parameters");
+    },
+  );
+
+  test("trims supported comma-separated type tokens", async () => {
+    const response = await discover("?types=agent%2C%20mcp");
+
+    expect(response.status).toBe(200);
+    expect(listPublicAgents).toHaveBeenCalledTimes(1);
+    expect(listPublicMcps).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/api/v1/discovery/route.ts
+++ b/packages/cloud/api/v1/discovery/route.ts
@@ -21,7 +21,8 @@ import { userMcpsService } from "@/lib/services/user-mcps";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
-type ServiceType = "agent" | "mcp" | "a2a" | "app";
+const serviceTypeSchema = z.enum(["agent", "mcp"]);
+type ServiceType = z.infer<typeof serviceTypeSchema>;
 type ServiceSource = "cloud" | "local";
 
 interface ServicePricing {
@@ -124,7 +125,8 @@ const querySchema = z.object({
   query: z.string().optional(),
   types: z
     .string()
-    .transform((s) => s.split(",") as ServiceType[])
+    .transform((value) => value.split(",").map((type) => type.trim()))
+    .pipe(z.array(serviceTypeSchema).min(1))
     .optional(),
   categories: z
     .string()
@@ -188,7 +190,7 @@ app.get("/", async (c) => {
     logger.debug("[Discovery] Cache miss, fetching fresh data", { params });
 
     const services: DiscoveredService[] = [];
-    const types = params.types ?? ["agent", "mcp", "app"];
+    const types: ServiceType[] = params.types ?? ["agent", "mcp"];
 
     if (types.includes("agent")) {
       const localAgents = await fetchLocalAgents(


### PR DESCRIPTION
Closes #19098.

## Root cause

The public discovery route declared `agent | mcp | a2a | app` as valid service types and defaulted to `agent,mcp,app`, but its implementation only fetched agent and MCP catalogs. Requests for `app` therefore returned a successful, silently incomplete result. The existing apps service is organization-owned rather than a public catalog, so wiring it into this unauthenticated route would expose the wrong data boundary.

## Fix

- make `agent` and `mcp` the route's explicit supported-type schema
- default discovery to those two real catalog sources only
- trim comma-separated tokens and reject empty, unsupported, or mixed unsupported lists with the route's structured `400 Invalid parameters` response
- cover the real Hono handler, including default, source-selective, whitespace, and fail-before-lookup behavior

Pagination work in #19083 is intentionally untouched.

## Contribution provenance

- AI assistance: yes
- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Codex desktop
- Contribution skill revision: N/A - no repository contribution skill used
- Attribution status: self-reported

## Exact-head validation

Validated commit: `59178fa2e4c2d68d2bd8b473043aa52815bfeadd`, rebased onto `0c1593ad5fc8d52288d04626fb0f46d14743d1f7`.

- rebase integrity — pass: `git range-diff` reports the sole patch as unchanged and the stable patch ID remains `e4bf73b5256211ab4f7b04315ebb2ba26092e780`
- `bun test packages/cloud/api/__tests__/discovery-supported-types.test.ts` — pass, 9/9 tests and 37 assertions
- `bunx @biomejs/biome check packages/cloud/api/v1/discovery/route.ts packages/cloud/api/__tests__/discovery-supported-types.test.ts` — pass, 2/2 files
- `bun run --cwd packages/cloud/api typecheck` — pass, including the production Worker dry-run (17,367.22 KiB / gzip 3,863.58 KiB)
- `git diff --check` — pass

### Prior-head validation retained for history

The following broader commands passed at `7ca8c58a29bed28d621d8039c1db532da0d44e2d` before the develop-only OAuth merge. They are historical results, not exact-head reruns:

- `bun install --frozen-lockfile` — pass (3,831 installs; no changes)
- `bun run --cwd packages/cloud/api lint` — pass, 1,025 files
- related PGlite shape-guard suite — pass, 9/9
- `bun run verify` — pass, 350/350 tasks; all repository audits green

## Evidence matrix

- Backend behavior/log: exact-head focused real-handler test log demonstrates default agent+MCP execution and structured rejection for `app`, `a2a`, unknown, empty, and mixed unsupported lists.
- Build artifact: exact-head package typecheck and production Cloudflare Worker dry-run succeed.
- Full repository proof: root verify passed at the prior head `7ca8c58a`; it was not represented as rerun after the patch-identical rebase.
- Screenshots / MP4 / frontend console / network / OCR: N/A — backend-only query validation; no UI or frontend path changed.
- Live-model trajectory: N/A — deterministic HTTP contract; no model behavior changed.

### Known prior-head develop baseline outside this patch

At `7ca8c58a`, the complete cloud API unit lane reported only `src/blob-host.test.ts` and `src/registry-host.test.ts` failing because their fixtures still used retired `*.elizacloud.ai` hostnames while current production bindings used `blob.eliza.app` / `plugins.eliza.app`. Both failures reproduced independently and returned `null` at the hostname guard; this discovery patch does not touch those handlers or tests. All other 245/247 files, including the new discovery contract suite, passed. This lane was not rerun after the patch-identical rebase.

<!-- evidence-head:9252bad975caca9addace499012699db3972478f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Backend-only query validation; no UI existed in scope.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Backend-only query validation; no UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Deterministic HTTP query contract; no user-facing interaction changed.

<!-- evidence-row:backend-logs -->
- [x] [19101-rebased-discovery-supported-types.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19101-rebased-discovery-supported-types.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend files or browser execution path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model invocation or agent behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [19101-rebased-cloud-api-typecheck-59178fa2-exact.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19101-rebased-cloud-api-typecheck-59178fa2-exact.log)

<!-- evidence-row:ocr-review -->
- [ ] N/A - No screenshots or visual text changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-19098]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->
