### PR TITLE
fix(cloud): paginate steward pending approvals per agent, not globally (#19099)

### DIFF
--- a/packages/cloud/api/__tests__/wallet-proxy-steward-agent-id.test.ts
+++ b/packages/cloud/api/__tests__/wallet-proxy-steward-agent-id.test.ts
@@ -269,3 +269,139 @@ describe("wallet proxy steward agent id resolution", () => {
     expect(createStewardClient).not.toHaveBeenCalled();
   });
 });
+
+describe("steward-pending-approvals agent-scoped pagination (#19099)", () => {
+  type ApprovalRow = { agentId?: string } & Record<string, unknown>;
+
+  /** A global pending list interleaving this agent's rows with others'. */
+  function globalList(mineCount: number, othersPerMine: number): ApprovalRow[] {
+    const rows: ApprovalRow[] = [];
+    for (let i = 0; i < mineCount; i++) {
+      for (let o = 0; o < othersPerMine; o++) {
+        rows.push({ agentId: "other-agent", txId: `other-${i}-${o}` });
+      }
+      rows.push({
+        agentId: "cloud-client-address",
+        txId: `mine-${String(i).padStart(3, "0")}`,
+      });
+    }
+    return rows;
+  }
+
+  /** callWallet embeds the path only; approvals params ride on the req URL. */
+  async function callApprovals(query: string) {
+    requireUserOrApiKeyWithOrg.mockResolvedValue({
+      id: "user-1",
+      organization_id: "org-1",
+    });
+    getAgent.mockResolvedValue({ id: "sandbox-agent-1" });
+    createStewardClient.mockResolvedValue(stewardClient);
+    const context = {
+      req: {
+        url: `http://test.local/api/wallet/steward-pending-approvals${query}`,
+        header: () => undefined,
+        text: async () => "",
+      },
+    } as never;
+    return routeModule.handleDirectWalletRequest(
+      context,
+      Promise.resolve({
+        agentId: "sandbox-agent-1",
+        path: ["steward-pending-approvals"],
+      }),
+      "GET",
+    );
+  }
+
+  function serveGlobalList(rows: ApprovalRow[]) {
+    stewardClient.listApprovals.mockImplementation(async (opts?: unknown) => {
+      const { limit = 50, offset = 0 } = (opts ?? {}) as {
+        limit?: number;
+        offset?: number;
+      };
+      return rows.slice(offset, offset + limit);
+    });
+  }
+
+  test("a page filled with other agents' rows still returns this agent's approvals", async () => {
+    dbRows.push({ stewardAgentId: "cloud-client-address" });
+    // 5 of ours, each preceded by 30 others: ours all sit beyond the first
+    // source window, where the old slice-then-filter returned [].
+    serveGlobalList(globalList(5, 30));
+
+    const res = await callApprovals("?limit=5&offset=0");
+    const body = (await res.json()) as {
+      approvals: Array<{ txId: string }>;
+      total: number;
+    };
+
+    expect(body.approvals.map((a) => a.txId)).toEqual([
+      "mine-000",
+      "mine-001",
+      "mine-002",
+      "mine-003",
+      "mine-004",
+    ]);
+    expect(body.total).toBe(5);
+  });
+
+  test("offset pages through this agent's list, not the global list", async () => {
+    dbRows.push({ stewardAgentId: "cloud-client-address" });
+    serveGlobalList(globalList(12, 4));
+
+    const first = (await (await callApprovals("?limit=5&offset=0")).json()) as {
+      approvals: Array<{ txId: string }>;
+      total: number;
+    };
+    const second = (await (
+      await callApprovals("?limit=5&offset=5")
+    ).json()) as { approvals: Array<{ txId: string }>; total: number };
+
+    expect(first.approvals.map((a) => a.txId)).toEqual([
+      "mine-000",
+      "mine-001",
+      "mine-002",
+      "mine-003",
+      "mine-004",
+    ]);
+    expect(second.approvals.map((a) => a.txId)).toEqual([
+      "mine-005",
+      "mine-006",
+      "mine-007",
+      "mine-008",
+      "mine-009",
+    ]);
+    // total advances past the requested page so clients keep paging.
+    expect(second.total).toBeGreaterThan(10);
+  });
+
+  test("total is the agent's full pending count when the source is exhausted", async () => {
+    dbRows.push({ stewardAgentId: "cloud-client-address" });
+    serveGlobalList(globalList(7, 2));
+
+    const res = await callApprovals("?limit=50&offset=0");
+    const body = (await res.json()) as {
+      approvals: Array<{ txId: string }>;
+      total: number;
+    };
+
+    expect(body.approvals).toHaveLength(7);
+    expect(body.total).toBe(7);
+  });
+
+  test("an agent with no pending approvals gets an empty page, not others' rows", async () => {
+    dbRows.push({ stewardAgentId: "cloud-client-address" });
+    serveGlobalList(
+      Array.from({ length: 40 }, (_, i) => ({
+        agentId: "other-agent",
+        txId: `other-${i}`,
+      })),
+    );
+
+    const res = await callApprovals("?limit=5&offset=0");
+    const body = (await res.json()) as { approvals: unknown[]; total: number };
+
+    expect(body.approvals).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+});

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
@@ -486,10 +486,36 @@ export async function handleDirectWalletRequest(
       0,
       Number.MAX_SAFE_INTEGER,
     );
-    const approvals = (
-      await client.listApprovals({ status: "pending", limit, offset })
-    ).filter((entry) => entry.agentId === stewardAgentId);
-    return json({ approvals, total: approvals.length, offset, limit });
+    // Collect THIS agent's pending approvals before paginating: the Steward
+    // list API is global across agents with no agent scoping, so slicing it
+    // first paginates the wrong list — pages under-fill, other agents' rows
+    // push this agent's approvals off the page, and total describes one
+    // already-sliced page (#19099). Walk the global list in fixed windows
+    // until the requested page is satisfiable (plus one row so paging
+    // continues past it) or the source / scan ceiling is exhausted.
+    const SOURCE_WINDOW = 100;
+    const MAX_SCANNED_ROWS = 2_000;
+    const agentApprovals: Array<{ agentId?: string } & JsonObject> = [];
+    let scanned = 0;
+    for (
+      let sourceOffset = 0;
+      scanned < MAX_SCANNED_ROWS;
+      sourceOffset += SOURCE_WINDOW
+    ) {
+      const page = await client.listApprovals({
+        status: "pending",
+        limit: SOURCE_WINDOW,
+        offset: sourceOffset,
+      });
+      scanned += page.length;
+      agentApprovals.push(
+        ...page.filter((entry) => entry.agentId === stewardAgentId),
+      );
+      if (page.length < SOURCE_WINDOW) break;
+      if (agentApprovals.length >= offset + limit + 1) break;
+    }
+    const approvals = agentApprovals.slice(offset, offset + limit);
+    return json({ approvals, total: agentApprovals.length, offset, limit });
   }
 
   if (method === "POST" && walletPath === "steward-approve-tx") {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #19099

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run; **verify passes green on this head**.
- [x] A reviewer can confirm the behavior without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop` (`f2d016e0ab`); zero conflicts.
- [x] `bun run verify` passes on this head.

# Risks

Low. One read-only listing branch of the wallet route; approval state and the approve/deny paths are untouched. Remote load per request is bounded by the fixed window walk (100-row windows, 2000-row scan ceiling) and stops as soon as the requested page is satisfiable, so a typical request costs the same one source call as before.

# Background

## What does this PR do?

The `steward-pending-approvals` wallet endpoint passed the caller's `limit`/`offset` straight to `client.listApprovals` — which lists pending approvals globally across every agent with no agent scoping — and only afterwards filtered to the current agent. Pages under-filled, other agents' rows could push this agent's approvals off the page entirely, `offset` skipped rows in the wrong list, and `total` reported the filtered size of one already-sliced page. The handler now collects this agent's rows first by walking the global list in fixed windows, then applies pagination exactly once to the agent-scoped list.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The windowed-collection comment block in the `steward-pending-approvals` branch of `packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts`, then the `#19099` describe in `__tests__/wallet-proxy-steward-agent-id.test.ts`.

## Detailed testing steps

```bash
cd packages/cloud/api && bun test __tests__/wallet-proxy-steward-agent-id.test.ts
```

# Evidence Gate

<!-- evidence-head:7e0c953d29c63cfc349e6cdf111c1d00a1912fd3 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend JSON endpoint; no rendered UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend JSON endpoint; no rendered UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - pagination contract shown in the transcripts below`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — the suite on this head and against the previous handler:

  <details><summary>test transcripts (recorded steward-client double serving a windowed global list)</summary>

  ```
  this head:
    wallet-proxy-steward-agent-id.test.ts — 10 pass, 0 fail
    #19099 cases:
      first source window all other agents' rows -> this agent's page still
        returned in full (was: empty)
      offset=5 pages through the AGENT's list (mine-005..mine-009), not the
        global list; total advances past the page so clients keep paging
      exhausted source -> total is the agent's exact pending count
      agent with nothing pending -> empty page, never other agents' rows

  previous handler (route change stashed, tests kept):
    the two core cases fail (page filled by other agents' rows comes back
    empty; offset paging returns the wrong rows); 8 pass
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no browser surface involved`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - deterministic pagination logic; no model, prompt, provider, or action behavior involved`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the page contract with a global list interleaving 30 other-agent rows before each of this agent's 5:

  <details><summary>request/response contract</summary>

  ```
  ?limit=5&offset=0 -> approvals mine-000..mine-004, total=5
                       (was: services=[] — all of ours sat beyond the first
                        global window)
  ?limit=5&offset=5 (12 mine, 4 others each) -> mine-005..mine-009
                       (was: offset skipped rows of the GLOBAL list)
  pagination applied exactly once, to the agent-scoped list; source walked
  in 100-row windows with a 2000-row scan ceiling, stopping when the page
  is satisfiable plus one row
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Evidence Details

All evidence is inline above.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZXP663XR8XRCPF2NXXCMNB4","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T13:50:03.389Z","completed_at":"2026-08-13T14:03:23.312Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"4nvQh_o01UuNMgsUZVMXNV39emIxHOG5KtcdLDZfKjhJ9rrwb_0MGe8Wmjn7e_zgqSytJDXtK1i4MSu3oIyJCg"}} -->

