### PR TITLE
fix(cloud): onboard unknown Telegram senders without preempting app automation

### DIFF
--- a/packages/cloud/api/v1/telegram/webhook/[orgId]/onboarding-precedence.test.ts
+++ b/packages/cloud/api/v1/telegram/webhook/[orgId]/onboarding-precedence.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Exercises unknown-sender onboarding and app-automation precedence through
+ * the real per-organization Telegram webhook handler with a deterministic bot
+ * transport harness.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const replies: string[] = [];
+interface TestMessage {
+  message_id: number;
+  text: string;
+  chat: { id: number; type: "private" };
+  from: { id: number; first_name: string; username: string };
+}
+
+interface TestContext {
+  message: TestMessage;
+  chat: TestMessage["chat"];
+  from: TestMessage["from"];
+  reply(text: string): Promise<void>;
+}
+
+interface TestApp {
+  id: string;
+  name: string;
+  telegram_automation: { channelId: string; autoReply: boolean };
+}
+
+let textHandler: ((context: TestContext) => Promise<void>) | undefined;
+
+class FakeTelegraf {
+  telegram = {
+    getMe: mock(async () => ({ id: 42 })),
+    getChatMember: mock(async () => ({ status: "member" })),
+  };
+
+  start() {}
+  help() {}
+  command() {}
+  on(event: string, handler: (context: TestContext) => Promise<void>) {
+    if (event === "text") textHandler = handler;
+  }
+
+  async handleUpdate(update: { message?: TestMessage }) {
+    const message = update.message;
+    if (!message || !textHandler) return;
+    await textHandler({
+      message,
+      chat: message.chat,
+      from: message.from,
+      reply: async (text: string) => {
+        replies.push(text);
+      },
+    });
+  }
+}
+
+mock.module("telegraf", () => ({ Telegraf: FakeTelegraf }));
+
+const activeApps = mock(async () => [] as TestApp[]);
+const handleIncomingMessage = mock(async () => undefined);
+mock.module("@/lib/services/telegram-automation/app-automation", () => ({
+  telegramAppAutomationService: {
+    getAppsWithActiveAutomation: activeApps,
+    handleIncomingMessage,
+  },
+}));
+
+mock.module("@/lib/services/telegram-automation", () => ({
+  telegramAutomationService: {
+    getWebhookSecret: mock(async () => "webhook-secret"),
+    getBotToken: mock(async () => "bot-token"),
+  },
+}));
+
+interface TestRouteResult {
+  handled: boolean;
+  reason: "unknown_owner";
+  replyText?: string;
+}
+
+const routeTelegramMessage = mock(
+  async (): Promise<TestRouteResult> => ({
+    handled: true,
+    reason: "unknown_owner",
+    replyText: "Connect your Eliza account",
+  }),
+);
+mock.module("@/lib/services/agent-gateway-router", () => ({
+  agentGatewayRouterService: { routeTelegramMessage },
+}));
+
+mock.module("@/db/repositories/telegram-chats", () => ({
+  telegramChatsRepository: {
+    findByChatId: mock(async () => undefined),
+    upsert: mock(async () => undefined),
+    delete: mock(async () => undefined),
+  },
+}));
+
+mock.module("@/db/repositories/webhook-events", () => ({
+  webhookEventsRepository: {
+    tryCreate: mock(async () => ({ created: true, event: { id: "event" } })),
+    deleteByEventId: mock(async () => undefined),
+  },
+}));
+
+mock.module("@/lib/auth/cron", () => ({
+  timingSafeEqualSecret: (left: string, right: string) => left === right,
+}));
+mock.module("@/lib/api/hono-next-style-params", () => ({
+  nextStyleParams: (context: {
+    req: { param: (name: string) => string | undefined };
+  }) => ({
+    params: Promise.resolve({ orgId: context.req.param("orgId") ?? "" }),
+  }),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (context: {
+    json: (body: unknown, status: number) => Response;
+  }) => context.json({ error: "internal" }, 500),
+}));
+mock.module("@/lib/utils/telegram-helpers", () => ({
+  isCommand: (text: string) => text.startsWith("/"),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { debug() {}, info() {}, warn() {}, error() {} },
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { AGGRESSIVE: "aggressive" },
+  rateLimit: () => async (_context: unknown, next: () => Promise<void>) =>
+    await next(),
+}));
+
+const { default: telegramRoute } = await import("./route");
+
+function appAutomation(autoReply: boolean) {
+  return {
+    id: "app-1",
+    name: "Configured app",
+    telegram_automation: { channelId: "555", autoReply },
+  };
+}
+
+async function deliver(): Promise<Response> {
+  const app = new Hono();
+  app.route("/:orgId", telegramRoute);
+  return await app.fetch(
+    new Request("https://api.example.test/org-1", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-telegram-bot-api-secret-token": "webhook-secret",
+      },
+      body: JSON.stringify({
+        update_id: 1001,
+        message: {
+          message_id: 7,
+          date: 0,
+          chat: { id: 555, type: "private" },
+          from: { id: 555, first_name: "Shaw", username: "shaw" },
+          text: "hello",
+        },
+      }),
+    }),
+  );
+}
+
+describe("per-organization Telegram first-contact precedence", () => {
+  beforeEach(() => {
+    replies.length = 0;
+    textHandler = undefined;
+    activeApps.mockReset();
+    activeApps.mockResolvedValue([]);
+    handleIncomingMessage.mockClear();
+    routeTelegramMessage.mockClear();
+    routeTelegramMessage.mockResolvedValue({
+      handled: true,
+      reason: "unknown_owner",
+      replyText: "Connect your Eliza account",
+    });
+  });
+
+  test("a matching active autoReply app retains precedence", async () => {
+    activeApps.mockResolvedValue([appAutomation(true)]);
+    routeTelegramMessage.mockResolvedValue({
+      handled: false,
+      reason: "unknown_owner",
+      replyText: undefined,
+    });
+
+    expect((await deliver()).status).toBe(200);
+
+    expect(routeTelegramMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ onboardUnknownOwner: false }),
+    );
+    expect(handleIncomingMessage).toHaveBeenCalledTimes(1);
+    expect(replies).toEqual([]);
+  });
+
+  test("an unknown sender with no matching app receives onboarding", async () => {
+    expect((await deliver()).status).toBe(200);
+
+    expect(routeTelegramMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ onboardUnknownOwner: true }),
+    );
+    expect(handleIncomingMessage).not.toHaveBeenCalled();
+    expect(replies).toEqual(["Connect your Eliza account"]);
+  });
+
+  test("a matching app without autoReply no longer leaves first contact silent", async () => {
+    activeApps.mockResolvedValue([appAutomation(false)]);
+
+    expect((await deliver()).status).toBe(200);
+
+    expect(routeTelegramMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ onboardUnknownOwner: true }),
+    );
+    expect(handleIncomingMessage).not.toHaveBeenCalled();
+    expect(replies).toEqual(["Connect your Eliza account"]);
+  });
+});

--- a/packages/cloud/api/v1/telegram/webhook/[orgId]/route.ts
+++ b/packages/cloud/api/v1/telegram/webhook/[orgId]/route.ts
@@ -376,6 +376,11 @@ ${matchingApp.website_url ? `🌐 Website: ${matchingApp.website_url}` : ""}`;
     const telegramUserId = String(ctx.from?.id ?? chatId);
     const telegramUsername = ctx.from?.username ?? `telegram-${telegramUserId}`;
     const isPrivateChat = ctx.chat?.type === "private";
+    const matchingApp = activeApps.find(
+      (app) =>
+        app.telegram_automation?.channelId === String(chatId) ||
+        app.telegram_automation?.groupId === String(chatId),
+    );
 
     if (isPrivateChat) {
       const routed = await agentGatewayRouterService.routeTelegramMessage({
@@ -388,6 +393,10 @@ ${matchingApp.website_url ? `🌐 Website: ${matchingApp.website_url}` : ""}`;
           username: telegramUsername,
           ...(userName ? { displayName: userName } : {}),
         },
+        // An explicitly configured app automation owns unknown first-contact
+        // traffic. Known users still route to their agent because the router
+        // consults this flag only after identity resolution returns no owner.
+        onboardUnknownOwner: !matchingApp?.telegram_automation?.autoReply,
       });
 
       if (routed.handled) {
@@ -400,12 +409,6 @@ ${matchingApp.website_url ? `🌐 Website: ${matchingApp.website_url}` : ""}`;
     }
 
     // Route to app automation
-    const matchingApp = activeApps.find(
-      (app) =>
-        app.telegram_automation?.channelId === String(chatId) ||
-        app.telegram_automation?.groupId === String(chatId),
-    );
-
     if (matchingApp?.telegram_automation?.autoReply) {
       try {
         await telegramAppAutomationService.handleIncomingMessage(

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
@@ -13,6 +13,7 @@ const routeToSession = mock();
 const bridge = mock();
 const runOnboardingChat = mock();
 const findByDiscordIdWithOrganization = mock();
+const findByTelegramIdWithOrganization = mock();
 const readManagedAgentDiscordBinding = mock(() => null as unknown);
 const readManagedAgentDiscordGateway = mock(() => null as unknown);
 
@@ -67,7 +68,7 @@ mock.module("../../db/repositories/users", () => ({
     findByPhoneNumberWithOrganization,
     findByEmailWithOrganization: mock(),
     findByDiscordIdWithOrganization,
-    findByTelegramIdWithOrganization: mock(),
+    findByTelegramIdWithOrganization,
     findByPrivyDidWithOrganization: mock(),
   },
 }));
@@ -182,6 +183,7 @@ function routeArgs(overrides: Record<string, unknown> = {}) {
 // either suite valid when test ordering or filtering changes.
 beforeEach(() => {
   findByDiscordIdWithOrganization.mockReset();
+  findByTelegramIdWithOrganization.mockReset();
   findByManagedDiscordGuildId.mockReset();
   readManagedAgentDiscordBinding.mockReset();
   readManagedAgentDiscordBinding.mockReturnValue(null);
@@ -863,6 +865,91 @@ describe("AgentGatewayRouterService discord DM onboarding (#17341)", () => {
     expect(result.handled).toBe(false);
     expect(result.reason).toBe("owner_agent_not_running");
     expect(result.agentId).toBe("sb-stopped");
+    expect(runOnboardingChat).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentGatewayRouterService telegram onboarding", () => {
+  beforeEach(() => {
+    listOwnerSessions.mockReset();
+    listByOrganization.mockReset();
+    runOnboardingChat.mockReset();
+  });
+
+  function telegramArgs(overrides: Record<string, unknown> = {}) {
+    return {
+      organizationId: "org-1",
+      chatId: "chat-1",
+      messageId: "tg-msg-1",
+      content: "hi eliza",
+      sender: { id: "telegram-user-1", username: "newuser", displayName: "New User" },
+      ...overrides,
+    };
+  }
+
+  test("an unknown telegram_id onboards instead of silence", async () => {
+    findByTelegramIdWithOrganization.mockResolvedValue(null);
+    runOnboardingChat.mockResolvedValue({
+      reply: "Welcome! Here is your login link.",
+      cta: null,
+      session: { userId: undefined, organizationId: undefined },
+      provisioning: { agentId: null },
+    });
+
+    const result = await newRouter().routeTelegramMessage(telegramArgs());
+
+    // handled:true is load-bearing: the webhook route only delivers replyText
+    // when the router claims the message, otherwise it falls through to the
+    // app-automation canned response.
+    expect(result.handled).toBe(true);
+    expect(result.reason).toBe("unknown_owner");
+    expect(result.replyText).toBe("Welcome! Here is your login link.");
+    expect(runOnboardingChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "hi eliza",
+        platform: "telegram",
+        platformUserId: "telegram-user-1",
+        platformDisplayName: "New User",
+        // Same key the gateway webhook uses, so both Telegram entry points
+        // append to one transcript instead of restarting the greeting.
+        sessionId: "platform:telegram:telegram-user-1",
+        trustedPlatformIdentity: true,
+        idempotencyKey: "telegram:tg-msg-1",
+      }),
+    );
+  });
+
+  test("the onboarding identity is carried back on the result", async () => {
+    findByTelegramIdWithOrganization.mockResolvedValue(null);
+    runOnboardingChat.mockResolvedValue({
+      reply: "Your agent is provisioning.",
+      cta: null,
+      session: { userId: "user-9", organizationId: "org-9" },
+      provisioning: { agentId: "sb-new" },
+    });
+
+    const result = await newRouter().routeTelegramMessage(telegramArgs());
+
+    expect(result).toMatchObject({
+      handled: true,
+      reason: "unknown_owner",
+      userId: "user-9",
+      organizationId: "org-9",
+      agentId: "sb-new",
+    });
+  });
+
+  test("a sender known under another organization keeps today's silence", async () => {
+    // Onboarding here would run a personal setup flow on somebody else's bot.
+    findByTelegramIdWithOrganization.mockResolvedValue({
+      id: "user-1",
+      organization_id: "other-org",
+    });
+
+    const result = await newRouter().routeTelegramMessage(telegramArgs());
+
+    expect(result.handled).toBe(false);
+    expect(result.reason).toBe("owner_org_mismatch");
     expect(runOnboardingChat).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
@@ -883,6 +883,7 @@ describe("AgentGatewayRouterService telegram onboarding", () => {
       messageId: "tg-msg-1",
       content: "hi eliza",
       sender: { id: "telegram-user-1", username: "newuser", displayName: "New User" },
+      onboardUnknownOwner: true,
       ...overrides,
     };
   }
@@ -914,9 +915,48 @@ describe("AgentGatewayRouterService telegram onboarding", () => {
         // append to one transcript instead of restarting the greeting.
         sessionId: "platform:telegram:telegram-user-1",
         trustedPlatformIdentity: true,
-        idempotencyKey: "telegram:tg-msg-1",
+        idempotencyKey: "telegram:org-1:chat-1:tg-msg-1",
       }),
     );
+  });
+
+  test("overlapping message ids stay isolated across organization bot chats", async () => {
+    findByTelegramIdWithOrganization.mockResolvedValue(null);
+    runOnboardingChat.mockResolvedValue({
+      reply: "Connect",
+      cta: null,
+      session: { userId: undefined, organizationId: undefined },
+      provisioning: { agentId: null },
+    });
+
+    await newRouter().routeTelegramMessage(telegramArgs());
+    await newRouter().routeTelegramMessage(
+      telegramArgs({ organizationId: "org-2", chatId: "chat-2" }),
+    );
+
+    expect(runOnboardingChat).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        idempotencyKey: "telegram:org-1:chat-1:tg-msg-1",
+      }),
+    );
+    expect(runOnboardingChat).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        idempotencyKey: "telegram:org-2:chat-2:tg-msg-1",
+      }),
+    );
+  });
+
+  test("an active app automation can retain unknown-owner precedence", async () => {
+    findByTelegramIdWithOrganization.mockResolvedValue(null);
+
+    const result = await newRouter().routeTelegramMessage(
+      telegramArgs({ onboardUnknownOwner: false }),
+    );
+
+    expect(result).toEqual({ handled: false, reason: "unknown_owner" });
+    expect(runOnboardingChat).not.toHaveBeenCalled();
   });
 
   test("the onboarding identity is carried back on the result", async () => {

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
@@ -1136,9 +1136,29 @@ export class AgentGatewayRouterService {
     const owner = await usersRepository.findByTelegramIdWithOrganization(senderTelegramId);
 
     if (!owner) {
+      // Parity with the Discord DM and phone first-contact paths: an unlinked
+      // sender is an onboarding candidate, not silence. This route only ever
+      // sees private chats (the webhook and the gateway adapter both drop group
+      // traffic), so the Discord public-channel guard has nothing to protect
+      // here. The session key matches the one the gateway webhook already uses
+      // so both Telegram entry points share a single onboarding transcript.
+      const onboarding = await this.runOnboardingChat({
+        message: args.content,
+        platform: "telegram",
+        platformUserId: senderTelegramId,
+        platformDisplayName: args.sender.displayName ?? args.sender.username,
+        sessionId: `platform:telegram:${senderTelegramId}`,
+        trustedPlatformIdentity: true,
+        idempotencyKey: `telegram:${args.messageId}`,
+      });
+
       return {
-        handled: false,
+        handled: true,
+        replyText: onboarding.reply,
         reason: "unknown_owner",
+        userId: onboarding.session.userId,
+        organizationId: onboarding.session.organizationId,
+        agentId: onboarding.provisioning.agentId ?? undefined,
       };
     }
 

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
@@ -1131,11 +1131,19 @@ export class AgentGatewayRouterService {
     messageId: string;
     content: string;
     sender: AgentGatewaySender;
+    /** Allows the owning webhook to preserve an active app automation. */
+    onboardUnknownOwner: boolean;
   }): Promise<AgentGatewayRouteResult> {
     const senderTelegramId = args.sender.id.trim();
     const owner = await usersRepository.findByTelegramIdWithOrganization(senderTelegramId);
 
     if (!owner) {
+      if (!args.onboardUnknownOwner) {
+        return {
+          handled: false,
+          reason: "unknown_owner",
+        };
+      }
       // Parity with the Discord DM and phone first-contact paths: an unlinked
       // sender is an onboarding candidate, not silence. This route only ever
       // sees private chats (the webhook and the gateway adapter both drop group
@@ -1149,7 +1157,10 @@ export class AgentGatewayRouterService {
         platformDisplayName: args.sender.displayName ?? args.sender.username,
         sessionId: `platform:telegram:${senderTelegramId}`,
         trustedPlatformIdentity: true,
-        idempotencyKey: `telegram:${args.messageId}`,
+        // Telegram message ids are only unique inside one chat. The same sender
+        // can DM multiple per-organization bots whose counters overlap, while
+        // the onboarding transcript intentionally remains sender-scoped.
+        idempotencyKey: `telegram:${args.organizationId}:${args.chatId}:${args.messageId}`,
       });
 
       return {


### PR DESCRIPTION
# Relates to

Closes #19107. Supersedes #19020 after its fork ref repeatedly returned a GitHub server-side error during the maintainer update.

- [x] Targets `develop` and is rebased onto the latest `origin/develop`.
- [x] `bun install` and `bun run verify` passed on the exact head.
- [x] The backend behavior is independently reviewable from attached logs.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Full root `bun run verify` passes, including the 7,966-file focused/skip audit.

# Risks

Medium. This changes unknown-user Telegram routing, while preserving known-user routing, organization isolation, replay identity, and explicitly configured `autoReply` app precedence.

# Background

## What does this PR do?

The signed per-organization Telegram webhook now onboards an unknown private sender when no active app automation owns the message, while preserving existing known-user agent routing and an explicitly configured `autoReply` app. The previously silent matching-app/autoReply-off configuration receives onboarding.

Replay identity is `telegram:<organization>:<chat>:<message>` because Telegram message IDs are only unique within one chat; two organization bots can otherwise collide inside the intentionally sender-scoped onboarding session.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is required.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/telegram/webhook/[orgId]/onboarding-precedence.test.ts`

## Detailed testing steps

- Router suite: 24/24.
- Real per-org webhook precedence: 3/3.
- Existing webhook authentication and replay-dedupe suites: 13/13.
- Cloud API and shared typechecks pass.
- Wrangler production Worker dry-run passes with canonical `eliza.app` bindings.
- Biome and `git diff --check` pass.
- Full root `bun run verify` passes.

# Evidence Gate

<!-- evidence-head:d04736cb6edd43463578c1017a643b14938873fc -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this backend-only routing change has no rendered visual surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this backend-only routing change has no rendered visual surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the observable contract is a signed webhook response covered by backend tests, not a rendered UI flow.
<!-- evidence-row:backend-logs -->
- [x] [19110-eliza-pr19110-backend-summary.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19110-eliza-pr19110-backend-summary.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or renderer files are changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database rows, memories, schedules, wallet records, audio, or generated domain artifacts are changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface exists in this diff.

# Evidence Details

No provider credential or production configuration changes are included.

— [codex-desktop]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->



