### PR TITLE
test(workflows): execute durable controls through smthrs

### DIFF
--- a/plugins/plugin-workflow/__tests__/integration/smithers-controls.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/smithers-controls.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Executes elizaOS durable controls through the real one-shot Bun child and
+ * verifies the public smthrs API mutates the shared SQLite store.
+ */
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdir, rm } from 'node:fs/promises';
+import { Effect } from 'effect';
+import { openSmithersStore } from 'smthrs';
+import {
+  controlSmithersRun,
+  resolveSmithersWorkflowDir,
+  type SmithersControlRequest,
+} from '../../src/services/smithers-runtime';
+
+const tenantId = `smithers-controls-test-${process.pid}`;
+const workflowId = 'durable-controls';
+const rootDir = resolveSmithersWorkflowDir(tenantId, workflowId);
+const dbPath = `${rootDir}/runs.sqlite`;
+
+function runRow(runId: string, status: string): Record<string, unknown> {
+  const now = Date.now();
+  return {
+    runId,
+    parentRunId: null,
+    workflowName: 'controls-test',
+    workflowPath: null,
+    workflowHash: null,
+    status,
+    createdAtMs: now,
+    startedAtMs: now,
+    finishedAtMs: null,
+    heartbeatAtMs: null,
+    runtimeOwnerId: null,
+    cancelRequestedAtMs: null,
+    hijackRequestedAtMs: null,
+    hijackTarget: null,
+    vcsType: null,
+    vcsRoot: null,
+    vcsRevision: null,
+    errorJson: null,
+    configJson: null,
+  };
+}
+
+async function withStore<T>(
+  mode: 'read' | 'write',
+  fn: (adapter: Awaited<ReturnType<typeof openSmithersStore>>['adapter']) => Promise<T>
+): Promise<T> {
+  if (mode === 'write') await mkdir(rootDir, { recursive: true });
+  const store = await openSmithersStore({ mode, backend: 'sqlite', dbPath });
+  try {
+    return await fn(store.adapter);
+  } finally {
+    await store.cleanup();
+  }
+}
+
+async function seedApproval(runId: string, nodeId: string): Promise<void> {
+  await withStore('write', async (adapter) => {
+    await Effect.runPromise(adapter.insertRun(runRow(runId, 'waiting-approval')));
+    await Effect.runPromise(
+      adapter.insertNode({
+        runId,
+        nodeId,
+        iteration: 0,
+        state: 'waiting-approval',
+        lastAttempt: 0,
+        updatedAtMs: Date.now(),
+        outputTable: '',
+        label: nodeId,
+      })
+    );
+    await Effect.runPromise(
+      adapter.insertOrUpdateApproval({
+        runId,
+        nodeId,
+        iteration: 0,
+        status: 'requested',
+        requestedAtMs: Date.now(),
+        decidedAtMs: null,
+        note: null,
+        decidedBy: null,
+        requestJson: null,
+        decisionJson: null,
+        autoApproved: false,
+      })
+    );
+  });
+}
+
+async function apply(request: SmithersControlRequest): Promise<void> {
+  await controlSmithersRun(tenantId, workflowId, request);
+}
+
+afterAll(async () => {
+  await rm(rootDir, { recursive: true, force: true });
+});
+
+describe('real Smithers durable controls', () => {
+  test('approve executes and persists through the public smthrs API', async () => {
+    const runId = 'approve-run';
+    const nodeId = 'approval';
+    await seedApproval(runId, nodeId);
+
+    await apply({
+      kind: 'approve',
+      runId,
+      nodeId,
+      iteration: 0,
+      note: 'ship it',
+      decidedBy: 'reviewer',
+      decision: { accepted: true },
+    });
+
+    await withStore('read', async (adapter) => {
+      const approval = await Effect.runPromise(adapter.getApproval(runId, nodeId, 0));
+      const node = await Effect.runPromise(adapter.getNode(runId, nodeId, 0));
+      expect(approval).toMatchObject({
+        status: 'approved',
+        note: 'ship it',
+        decidedBy: 'reviewer',
+        decisionJson: JSON.stringify({ accepted: true }),
+      });
+      expect(node?.state).toBe('pending');
+    });
+  });
+
+  test('deny executes and persists through the public smthrs API', async () => {
+    const runId = 'deny-run';
+    const nodeId = 'approval';
+    await seedApproval(runId, nodeId);
+
+    await apply({
+      kind: 'deny',
+      runId,
+      nodeId,
+      iteration: 0,
+      note: 'not safe',
+      decidedBy: 'reviewer',
+    });
+
+    await withStore('read', async (adapter) => {
+      const approval = await Effect.runPromise(adapter.getApproval(runId, nodeId, 0));
+      const node = await Effect.runPromise(adapter.getNode(runId, nodeId, 0));
+      expect(approval).toMatchObject({
+        status: 'denied',
+        note: 'not safe',
+        decidedBy: 'reviewer',
+      });
+      expect(node?.state).toBe('failed');
+    });
+  });
+
+  test('signal executes and persists payload and attribution', async () => {
+    const runId = 'signal-run';
+    await withStore('write', async (adapter) => {
+      await Effect.runPromise(adapter.insertRun(runRow(runId, 'waiting-event')));
+    });
+
+    await apply({
+      kind: 'signal',
+      runId,
+      signal: 'customer-replied',
+      payload: { ticket: 42 },
+      receivedBy: 'webhook',
+    });
+
+    await withStore('read', async (adapter) => {
+      const signals = await Effect.runPromise(adapter.listSignals(runId));
+      expect(signals).toHaveLength(1);
+      expect(signals[0]).toMatchObject({
+        signalName: 'customer-replied',
+        payloadJson: JSON.stringify({ ticket: 42 }),
+        receivedBy: 'webhook',
+      });
+    });
+  });
+});

--- a/plugins/plugin-workflow/__tests__/unit/worker-script.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/worker-script.test.ts
@@ -1,14 +1,20 @@
-/** Pins the isolated worker's smthrs import, progress protocol, and elizaOS AgentLike bridge. */
+/** Pins public smthrs imports, the worker protocol, and dependency ownership. */
+
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   createSmithersControlScript,
   createSmithersWorkerScript,
 } from '../../src/services/smithers-runtime';
 
+const pluginRoot = join(import.meta.dir, '../..');
+
 describe('Smithers worker script', () => {
-  test('uses smthrs directly and routes agent generation to its parent', () => {
+  test('uses the public smthrs facade and routes generation to its parent', () => {
     const source = createSmithersWorkerScript();
-    expect(source).toContain("from 'smthrs'");
+    expect(source).toContain("import { runWorkflow } from 'smthrs'");
+    expect(source).not.toContain("runWorkflow } from '@smthrs/engine'");
     expect(source).toContain('__elizaSmithers');
     expect(source).toContain("kind: 'agent-request'");
     expect(source).toContain('onProgress');
@@ -18,12 +24,22 @@ describe('Smithers worker script', () => {
     expect(source).not.toContain('Gateway');
   });
 
-  test('uses the public smthrs API for durable controls', () => {
+  test('uses only public smthrs entry points for durable controls', () => {
     const source = createSmithersControlScript();
     expect(source).toContain("from 'smthrs'");
     expect(source).toContain("from 'smthrs/openSmithersStore'");
     expect(source).not.toContain('@smthrs/engine');
     expect(source).not.toContain('@smithers-orchestrator');
     expect(source).not.toContain('Gateway');
+  });
+
+  test('declares smthrs, not @smthrs/engine, as the owned runtime dependency', () => {
+    const manifest = JSON.parse(readFileSync(join(pluginRoot, 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    expect(manifest.dependencies?.smthrs).toBe('0.33.0');
+    expect(manifest.dependencies?.['@smthrs/engine']).toBeUndefined();
+    expect(manifest.devDependencies?.['@smthrs/engine']).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up for #19091 that closes the requested runtime-proof and dependency-boundary gaps:

- execute approve, deny, and signal through the real `controlSmithersRun()` one-shot Bun child
- verify each operation mutates the shared durable SQLite store
- assert the plugin owns `smthrs@0.33.0` and does not directly declare `@smthrs/engine`
- pin generated worker `runWorkflow` to the public `smthrs` facade and reject internal engine imports

## Scope

Targets `fix/workflow-public-smthrs-api`. The original author can merge this follow-up or cherry-pick `81f7a64cb2e291ca6a52bc2097fb131b3bf73922`.

## Verification

- targeted suite: **6 tests passed**, including real approve/deny/signal child-process execution
- plugin typecheck: pass
- Biome: pass
- `git diff --check`: pass

<!-- pr-source-ref: contribution=follow-up-to-19091; base=0f255ee530da9e603e26175e7d254edc4d9738d7; patch=81f7a64cb2e291ca6a52bc2097fb131b3bf73922 -->

<!-- evidence-head:81f7a64cb2e291ca6a52bc2097fb131b3bf73922 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - tests-only workflow runtime proof; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - tests-only workflow runtime proof; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive user flow changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - exact-head child-process test output is recorded in Verification

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - controls do not invoke a model

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - ephemeral SQLite rows are asserted by the approve, deny, and signal integration tests and removed during teardown
