### PR TITLE
fix(homepage): keep staging sign-in in staging

### DIFF
--- a/packages/homepage/package.json
+++ b/packages/homepage/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "check:release-data": "node ../app-core/scripts/check-homepage-release-data.mjs",
     "check:snapshot-inventory": "bun scripts/check-snapshot-inventory.ts",
-    "test": "bun test tests/smoke.node.test.mjs tests/screenshot-stability.node.test.mjs tests/e2e-port.node.test.mjs tests/contact.test.ts tests/snapshot-inventory.test.ts tests/auth-return.test.ts tests/wallet-linking.test.ts tests/release-availability.test.ts edge/apple-app-site-association.test.ts tests/provisioning-poll-body.test.ts tests/onboarding-continuation.test.ts tests/get-started-continuation-render.test.tsx tests/legacy-onboarding-redirect.test.ts && bun test tests/provisioning-poll-hook.test.ts",
+    "test": "bun --conditions=eliza-source test tests/smoke.node.test.mjs tests/screenshot-stability.node.test.mjs tests/e2e-port.node.test.mjs tests/contact.test.ts tests/snapshot-inventory.test.ts tests/auth-return.test.ts tests/wallet-linking.test.ts tests/release-availability.test.ts edge/apple-app-site-association.test.ts tests/provisioning-poll-body.test.ts tests/onboarding-continuation.test.ts tests/get-started-continuation-render.test.tsx tests/legacy-onboarding-redirect.test.ts tests/product-navigation.test.ts && bun --conditions=eliza-source test tests/provisioning-poll-hook.test.ts",
     "test:aasa-edge": "bun run typecheck:aasa-edge && bun test edge/apple-app-site-association.test.ts",
     "typecheck:aasa-edge": "bunx --package typescript@6.0.3 tsc --noEmit -p edge/tsconfig.json",
     "deploy:aasa-edge": "bunx wrangler@4.100.0 deploy --config wrangler-aasa.toml --strict",

--- a/packages/homepage/src/lib/product-navigation.ts
+++ b/packages/homepage/src/lib/product-navigation.ts
@@ -1,0 +1,27 @@
+/**
+ * Resolves homepage authentication and managed-Cloud destinations from the
+ * canonical environment contract for the browser's current hostname.
+ */
+
+import {
+  ELIZA_DOMAIN_CONTRACTS,
+  elizaCloudEnvironmentForHostname,
+} from "@elizaos/shared/elizacloud/domain-contract";
+
+export interface HomepageProductNavigation {
+  signInUrl: string;
+  dashboardUrl: string;
+}
+
+export function resolveHomepageProductNavigation(
+  hostname: string,
+): HomepageProductNavigation {
+  const environment =
+    elizaCloudEnvironmentForHostname(hostname) ?? "production";
+  const cloudAppOrigin = ELIZA_DOMAIN_CONTRACTS[environment].cloudAppOrigin;
+
+  return {
+    signInUrl: `${cloudAppOrigin}/login?intent=launch`,
+    dashboardUrl: `${cloudAppOrigin}/cloud-apps`,
+  };
+}

--- a/packages/homepage/src/pages/landing.tsx
+++ b/packages/homepage/src/pages/landing.tsx
@@ -12,7 +12,6 @@
  * tests deterministic.
  */
 
-import { EXTERNAL_URLS } from "@elizaos/shared/brand";
 import {
   DiscordIcon,
   IMessageIcon,
@@ -27,6 +26,7 @@ import {
   buildElizaWhatsAppHref,
   ELIZA_PHONE_NUMBER,
 } from "@/lib/contact";
+import { resolveHomepageProductNavigation } from "@/lib/product-navigation";
 import { useT } from "@/providers/I18nProvider";
 
 // The ambient gradient wave stays lazy so the static hero is interactive
@@ -526,14 +526,16 @@ function DemoKeyboard({ composerText }: { composerText: string }) {
 }
 
 const SESSION_STORAGE_KEY = "eliza_app_session";
-const CLOUD_SIGN_IN_URL = `${EXTERNAL_URLS.cloud}/login?intent=launch`;
-const CLOUD_DASHBOARD_URL = `${EXTERNAL_URLS.app}/cloud-apps`;
 
 export default function LandingPage() {
   const t = useT();
+  const browserWindow = typeof window === "undefined" ? null : window;
   const signedIn =
-    typeof window !== "undefined" &&
-    window.localStorage.getItem(SESSION_STORAGE_KEY) !== null;
+    browserWindow !== null &&
+    browserWindow.localStorage.getItem(SESSION_STORAGE_KEY) !== null;
+  const productNavigation = resolveHomepageProductNavigation(
+    browserWindow?.location.hostname ?? "",
+  );
   const channels = [
     {
       key: "telegram",
@@ -585,7 +587,11 @@ export default function LandingPage() {
         </a>
         <a
           className="landing-cta landing-cta--white landing-header-cta"
-          href={signedIn ? CLOUD_DASHBOARD_URL : CLOUD_SIGN_IN_URL}
+          href={
+            signedIn
+              ? productNavigation.dashboardUrl
+              : productNavigation.signInUrl
+          }
         >
           {signedIn
             ? t("homepage_eliza.landing.dashboard", {

--- a/packages/homepage/tests/product-navigation.test.ts
+++ b/packages/homepage/tests/product-navigation.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Deterministically verifies that public homepage navigation stays within the
+ * environment selected by canonical and legacy browser hostnames.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { resolveHomepageProductNavigation } from "../src/lib/product-navigation";
+
+describe("homepage product navigation", () => {
+  test("routes the production homepage to the production Cloud app", () => {
+    expect(resolveHomepageProductNavigation("eliza.app")).toEqual({
+      signInUrl: "https://cloud.eliza.app/login?intent=launch",
+      dashboardUrl: "https://cloud.eliza.app/cloud-apps",
+    });
+  });
+
+  test("routes the staging homepage to the staging Cloud app", () => {
+    expect(resolveHomepageProductNavigation("staging.eliza.app")).toEqual({
+      signInUrl: "https://cloud-staging.eliza.app/login?intent=launch",
+      dashboardUrl: "https://cloud-staging.eliza.app/cloud-apps",
+    });
+  });
+
+  test("preserves staging for the legacy staging hostname", () => {
+    expect(resolveHomepageProductNavigation("staging.elizacloud.ai")).toEqual({
+      signInUrl: "https://cloud-staging.eliza.app/login?intent=launch",
+      dashboardUrl: "https://cloud-staging.eliza.app/cloud-apps",
+    });
+  });
+
+  test("defaults unknown and local hosts to production rather than trusting them", () => {
+    for (const hostname of ["localhost", "preview.example.com", ""]) {
+      expect(resolveHomepageProductNavigation(hostname)).toEqual({
+        signInUrl: "https://cloud.eliza.app/login?intent=launch",
+        dashboardUrl: "https://cloud.eliza.app/cloud-apps",
+      });
+    }
+  });
+});

--- a/packages/homepage/tsconfig.app.json
+++ b/packages/homepage/tsconfig.app.json
@@ -21,6 +21,9 @@
       "@/*": ["./src/*"],
       "@elizaos/shared": ["../shared/src/i18n/language.ts"],
       "@elizaos/shared/brand": ["../shared/src/brand/index.ts"],
+      "@elizaos/shared/elizacloud/domain-contract": [
+        "../shared/src/elizacloud/domain-contract.ts"
+      ],
       "@elizaos/ui/cloud-ui/components/icons": [
         "../ui/src/cloud-ui/components/icons.tsx"
       ],

--- a/packages/homepage/vite.config.ts
+++ b/packages/homepage/vite.config.ts
@@ -45,7 +45,14 @@ export default defineConfig({
         find: "@elizaos/shared/brand",
         replacement: path.resolve(__dirname, "../shared/src/brand/index.ts"),
       },
-      // Keep this bare-package alias after the brand subpath: Vite string
+      {
+        find: "@elizaos/shared/elizacloud/domain-contract",
+        replacement: path.resolve(
+          __dirname,
+          "../shared/src/elizacloud/domain-contract.ts",
+        ),
+      },
+      // Keep this bare-package alias after the exact subpaths: Vite string
       // aliases also match slash-prefixed subpaths. The source-aliased UI
       // region helper imports only these dependency-free language primitives,
       // so clean source-harness builds neither require shared/dist nor bundle the


### PR DESCRIPTION
# Relates to

Fixes #19106. Related to #18197 and #18806.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change from the hostname-contract tests, staging-host build probe, screenshots, walkthrough, and frontend log below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Pi`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0c1593ad5fc8d52288d04626fb0f46d14743d1f7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `643bd7e4195e1b052b6d4c0c222a437d5d349708`; zero conflicts.
- [x] `bun run verify` passed post-sync.

# Risks

Low. The landing page now uses the existing canonical hostname contract instead of production-only brand constants. Unknown/local hosts continue to fail closed to the production contract rather than trusting arbitrary hosts.

# Background

## What does this PR do?

- Derives homepage sign-in and dashboard destinations from the current canonical/legacy hostname.
- Routes `staging.eliza.app` and legacy staging hosts to `cloud-staging.eliza.app`.
- Keeps production hosts on `cloud.eliza.app`.
- Adds deterministic production, staging, legacy staging, and unknown-host tests.
- Adds exact source aliases so both the unified app and optional homepage harness resolve the shared contract.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. Existing domain documentation already declares `cloud-staging.eliza.app`; this repairs the implementation to match it.

# Testing

## Where should a reviewer start?

- `packages/homepage/src/lib/product-navigation.ts`
- `packages/homepage/tests/product-navigation.test.ts`
- `packages/homepage/src/pages/landing.tsx`

## Detailed testing steps

1. Build the unified artifact with staging environment values.
2. Serve it under a browser hostname of `staging.eliza.app`.
3. Inspect the header's **Sign in** link.
4. Verify it is exactly `https://cloud-staging.eliza.app/login?intent=launch`.

Commands run:

- `bun install`
- `bun run --cwd packages/homepage test`
- `bun run --cwd packages/homepage typecheck`
- `bun run --cwd packages/homepage lint:check`
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/app lint`
- `ELIZA_NODE_PATH=/tmp/node-v24.15.0-darwin-arm64/bin/node bun run --cwd packages/app test`
- staging-configured `bun run --cwd packages/app build:web`
- `ELIZA_NODE_PATH=/opt/homebrew/opt/node@24/bin/node bun run --cwd packages/app audit:app` — 219/219 captures passed; broken=0, needs-work=0
- `ELIZA_NODE_PATH=/tmp/node-v24.15.0-darwin-arm64/bin/node bun run verify`
- `codex review --base origin/develop` — no actionable defects

# Evidence Gate

<!-- evidence-head:673cb2afdb85d9d4a861174e00a09e5df39d8471 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19106-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19106-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19106-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure browser hostname resolution; no backend path fires before navigation
<!-- evidence-row:frontend-logs -->
- [x] [19119-frontend-log.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19119-frontend-log.json)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [19119-domain-artifacts.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19119-domain-artifacts.txt)
<!-- evidence-row:ocr-review -->
- [x] [19119-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19119-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model surface changed.

## Backend + frontend logs

Backend: N/A - pure browser navigation resolution.

Frontend assertion:

```json
{
  "page": "http://staging.eliza.app:4179/",
  "signInHref": "https://cloud-staging.eliza.app/login?intent=launch"
}
```

## Screenshots (before / after) + video walkthrough

Artifacts are inline in the evidence rows above. The visual surface is intentionally unchanged; the corrected behavior is the anchor destination.

## Audio / voice walkthrough

N/A - no voice/audio behavior changed.

## Known gaps / failures

- The currently deployed staging page remains broken until this PR merges and the normal staging deployment publishes it; no deployment or DNS mutation was performed from this branch.
- The first app test attempt used the shell's Node 22 and exposed the pinned-runtime requirement. The suite was rerun using a verified Node 24.15.0 binary and passed its Bun lane; the later Vitest lane exposed pre-existing unrelated unified-app test issues (unresolved `@homepage/embedded-home` in entrypoint tests, stale workflow interaction signal, and service-worker fixture shape). Root `bun run verify`, package typecheck/lint/build, homepage tests, and visual audit passed.

AI provider/model: openai-codex / gpt-5.6-sol
Client / agent tooling: Pi
Contribution skill revision: elizaOS/eliza@0c1593ad5fc8d52288d04626fb0f46d14743d1f7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [pi-staging-signin]
<!-- eliza-computer-attribution:v1 {"provider":"openai-codex","model":"gpt-5.6-sol","client":"Pi","skill_revision":"elizaOS/eliza@0c1593ad5fc8d52288d04626fb0f46d14743d1f7:packages/skills/skills/contribute-to-eliza"} -->

