### PR TITLE
fix(cloud): inject Telegram bot ID into Pages Vite builds

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -1256,6 +1256,9 @@ jobs:
     if: ${{ !cancelled() && (needs.migrate-db.result == 'success' || (github.event_name == 'pull_request' && needs.migrate-db.result == 'skipped')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Staging now stores VITE_TELEGRAM_BOT_ID on the GitHub environment.
+    # Bind this producer so vars.VITE_TELEGRAM_BOT_ID resolves during Vite.
+    environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
     # GitHub preserves outputs from successful jobs when only failed jobs are
     # rerun. Consumers must therefore use the producer's attempt, not their own
     # newer github.run_attempt. A full rerun executes this job again and emits
@@ -1328,6 +1331,7 @@ jobs:
           VITE_VOICE_REALTIME_WS: ${{ !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED) && '1' || '0' }}
           VITE_VOICE_REALTIME_FORCE: "0"
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
+          VITE_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
 
       - name: Verify frontend chunk safety
         run: bun run --cwd packages/app verify:chunks
@@ -1584,6 +1588,7 @@ jobs:
           VITE_VOICE_REALTIME_WS: ${{ !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED) && '1' || '0' }}
           VITE_VOICE_REALTIME_FORCE: "0"
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
+          VITE_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
 
       # Refuse to deploy a bundle where the bn.js/crypto graph folded into an
       # eager chunk (the "Class constructor cannot be invoked without 'new'"

--- a/packages/scripts/__tests__/cloud-cf-telegram-bot-id-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-telegram-bot-id-workflow.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Pages producer must bind the selected GitHub environment and pass
+ * vars.VITE_TELEGRAM_BOT_ID into both Vite builds (#19121).
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const workflowSource = readFileSync(
+  new URL(".github/workflows/cloud-cf-deploy.yml", repoRoot),
+  "utf8",
+);
+
+interface WorkflowStep {
+  env?: Record<string, string>;
+  name?: string;
+}
+
+interface WorkflowJob {
+  environment?: string;
+  steps?: WorkflowStep[];
+}
+
+const workflow = Bun.YAML.parse(workflowSource) as {
+  jobs?: Record<string, WorkflowJob>;
+};
+
+const ENV_EXPR =
+  "${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}";
+const BOT_ID_EXPR = "${{ vars.VITE_TELEGRAM_BOT_ID }}";
+
+function namedStep(jobId: string, name: string): WorkflowStep {
+  const step = workflow.jobs?.[jobId]?.steps?.find(
+    (candidate) => candidate.name === name,
+  );
+  if (!step) {
+    throw new Error(`Missing ${name} step for ${jobId}`);
+  }
+  return step;
+}
+
+describe("cloud-cf-deploy Pages Telegram bot ID (#19121)", () => {
+  test("binds build-pages to the selected GitHub environment", () => {
+    expect(workflow.jobs?.["build-pages"]?.environment).toBe(ENV_EXPR);
+  });
+
+  test("canonical Pages Vite build receives vars.VITE_TELEGRAM_BOT_ID", () => {
+    const step = namedStep("build-pages", "Build consolidated frontend artifact");
+    expect(step.env?.VITE_TELEGRAM_BOT_ID).toBe(BOT_ID_EXPR);
+  });
+
+  test("legacy inline Vite build receives vars.VITE_TELEGRAM_BOT_ID", () => {
+    const matches = Object.entries(workflow.jobs ?? {}).flatMap(([jobId, job]) =>
+      (job.steps ?? [])
+        .filter((step) => step.name === "Legacy inline fallback - build app")
+        .map((step) => ({ jobId, step })),
+    );
+    expect(matches.length).toBeGreaterThan(0);
+    for (const { step } of matches) {
+      expect(step.env?.VITE_TELEGRAM_BOT_ID).toBe(BOT_ID_EXPR);
+    }
+  });
+
+  test("does not leak a hardcoded Telegram bot ID into the workflow", () => {
+    expect(workflowSource).not.toMatch(/VITE_TELEGRAM_BOT_ID:\s*["']?\d+/);
+  });
+});


### PR DESCRIPTION
Closing per CR review from `lalalune` and the issue thread: the patch binds the shared PR producer to the protected `staging` env (breaking PR previews) and the variable is tree-shaken from the deployed `packages/app` artifact, so it cannot prove #19121. The issue needs a product/architecture decision; I'm not pushing that decision into this PR.