### PR TITLE
fix(cloud): preserve onboarding coordinator errors

### DIFF
--- a/packages/cloud/api/__tests__/onboarding-coordinator-errors.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-coordinator-errors.miniflare.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Dispatches the production public onboarding route through a declared
+ * Miniflare Durable Object namespace and verifies typed authorization mapping.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { Miniflare } from "miniflare";
+
+const ROUTE_BOUNDARIES = {
+  users:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]db[\\/]repositories[\\/]users\.ts$/,
+  auth: /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]auth[\\/]workers-hono-auth\.ts$/,
+  session:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]eliza-app[\\/]index\.ts$/,
+  internalAuth: /packages[\\/]cloud[\\/]api[\\/]internal[\\/]_auth\.ts$/,
+  provisioning:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]eliza-app[\\/]provisioning\.ts$/,
+  cache:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]cache[\\/]client\.ts$/,
+  userService:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]eliza-app[\\/]user-service\.ts$/,
+  managedLaunch:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]eliza-managed-launch\.ts$/,
+  proactiveGreeting:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]eliza-app[\\/]onboarding-proactive-greeting\.ts$/,
+  logger:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]utils[\\/]logger\.ts$/,
+  cloudBindings:
+    /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]runtime[\\/]cloud-bindings\.ts$/,
+} as const;
+
+describe("onboarding coordinator error integration", () => {
+  let miniflare: Miniflare;
+
+  beforeAll(async () => {
+    const build = await Bun.build({
+      entrypoints: [
+        fileURLToPath(
+          new URL(
+            "../test/fixtures/onboarding-route-worker.ts",
+            import.meta.url,
+          ),
+        ),
+      ],
+      format: "esm",
+      target: "browser",
+      conditions: ["worker", "browser"],
+      plugins: [
+        {
+          name: "onboarding-route-boundaries",
+          setup(build) {
+            build.onResolve({ filter: /^@elizaos\/core$/ }, () => ({
+              path: fileURLToPath(
+                new URL("../src/stubs/elizaos-core.ts", import.meta.url),
+              ),
+            }));
+            build.onLoad({ filter: ROUTE_BOUNDARIES.users }, () => ({
+              loader: "ts",
+              contents: `
+                export function providerForPlatform() { return undefined; }
+                export const usersRepository = { async resolveIdentity() { return null; } };
+              `,
+            }));
+            build.onLoad({ filter: ROUTE_BOUNDARIES.auth }, () => ({
+              loader: "ts",
+              contents:
+                "export async function getCurrentUser() { return null; }",
+            }));
+            build.onLoad({ filter: ROUTE_BOUNDARIES.session }, () => ({
+              loader: "ts",
+              contents: `export const elizaAppSessionService = {
+                async validateAuthHeader() { return null; }
+              };`,
+            }));
+            build.onLoad({ filter: ROUTE_BOUNDARIES.internalAuth }, () => ({
+              loader: "ts",
+              contents: `export async function requireInternalAuth() {
+                return new Response("Unauthorized", { status: 401 });
+              }`,
+            }));
+            build.onLoad({ filter: ROUTE_BOUNDARIES.provisioning }, () => ({
+              loader: "ts",
+              contents: `
+                const none = { status: "none", agentId: null, bridgeUrl: null, sandbox: null };
+                export async function ensureElizaAppProvisioning() { return none; }
+                export async function getElizaAppProvisioningStatus() { return none; }
+                export function publicElizaAppProvisioningPayload(value) { return value; }
+              `,
+            }));
+            build.onLoad({ filter: ROUTE_BOUNDARIES.cache }, () => ({
+              loader: "ts",
+              contents: `export const cache = {
+                async get() { return null; },
+                async set() {}
+              };`,
+            }));
+            build.onLoad({ filter: ROUTE_BOUNDARIES.userService }, () => ({
+              loader: "ts",
+              contents: `export const elizaAppUserService = {
+                async findOrCreateByPhone() { return { success: true }; },
+                async linkPhoneToUser() { return { success: true }; },
+                async linkDiscordToUser() { return { success: true }; },
+                async linkTelegramToUser() { return { success: true }; }
+              };`,
+            }));
+            build.onLoad({ filter: ROUTE_BOUNDARIES.managedLaunch }, () => ({
+              loader: "ts",
+              contents: `export async function launchManagedElizaAgent() {
+                throw new Error("launch is outside this authorization test");
+              }`,
+            }));
+            build.onLoad(
+              { filter: ROUTE_BOUNDARIES.proactiveGreeting },
+              () => ({
+                loader: "ts",
+                contents: `
+                  export const PROACTIVE_GREETING_QUEUE_PREFIX = "proactive-greetings:";
+                  export async function enqueueDiscordProactiveGreeting() {}
+                `,
+              }),
+            );
+            build.onLoad({ filter: ROUTE_BOUNDARIES.logger }, () => ({
+              loader: "ts",
+              contents: `export const logger = {
+                debug() {}, info() {}, warn() {}, error() {}
+              };`,
+            }));
+            build.onLoad({ filter: ROUTE_BOUNDARIES.cloudBindings }, () => ({
+              loader: "ts",
+              contents: `
+                let bindings;
+                export async function runWithCloudBindingsAsync(next, operation) {
+                  const previous = bindings;
+                  bindings = next;
+                  try { return await operation(); }
+                  finally { bindings = previous; }
+                }
+                export function getCloudBinding(name) { return bindings?.[name]; }
+                export function hasCloudBindingsContext() { return bindings !== undefined; }
+                export function getCloudAwareEnv() { return {}; }
+              `,
+            }));
+          },
+        },
+      ],
+    });
+    if (!build.success) {
+      throw new AggregateError(
+        build.logs,
+        "Failed to bundle onboarding Worker",
+      );
+    }
+    const output = build.outputs[0];
+    if (!output) throw new Error("Onboarding Worker bundle was not emitted");
+
+    miniflare = new Miniflare({
+      compatibilityDate: "2026-06-01",
+      compatibilityFlags: ["nodejs_compat"],
+      modules: true,
+      script: await output.text(),
+      durableObjects: {
+        ONBOARDING_SESSIONS: {
+          className: "OnboardingSessionCoordinator",
+          useSQLite: true,
+        },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await miniflare?.dispose();
+  });
+
+  test("public route maps a typed coordinator rejection to fail-closed 403", async () => {
+    const response = await miniflare.dispatchFetch(
+      "https://cloud.test/api/eliza-app/onboarding/chat",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sessionId: "forged-continuation",
+          confirmPlatformLink: true,
+        }),
+      },
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      error:
+        "Authenticate with the same messaging account that started this onboarding session",
+      code: "access_denied",
+    });
+  }, 120_000);
+});

--- a/packages/cloud/api/__tests__/onboarding-coordinator-errors.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-coordinator-errors.miniflare.test.ts
@@ -30,6 +30,14 @@ const ROUTE_BOUNDARIES = {
     /packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]runtime[\\/]cloud-bindings\.ts$/,
 } as const;
 
+const NESTED_BUILD_DEPENDENCIES: Record<string, string> = {
+  "libphonenumber-js": "../../shared/node_modules/libphonenumber-js/index.js",
+  "@noble/ciphers/aes.js": "../../../core/node_modules/@noble/ciphers/aes.js",
+  "@noble/hashes/legacy.js":
+    "../../../core/node_modules/@noble/hashes/legacy.js",
+  "@noble/hashes/sha2.js": "../../../core/node_modules/@noble/hashes/sha2.js",
+};
+
 describe("onboarding coordinator error integration", () => {
   let miniflare: Miniflare;
 
@@ -50,6 +58,22 @@ describe("onboarding coordinator error integration", () => {
         {
           name: "onboarding-route-boundaries",
           setup(build) {
+            // Bun's nested build does not inherit the test runner's workspace
+            // package search roots. Resolve the production shim's direct
+            // dependencies from each importing workspace, preserving pins.
+            build.onResolve(
+              {
+                filter:
+                  /^(?:libphonenumber-js|@noble\/ciphers\/aes\.js|@noble\/hashes\/(?:legacy|sha2)\.js)$/,
+              },
+              (args) => {
+                const relativePath = NESTED_BUILD_DEPENDENCIES[args.path];
+                if (!relativePath) return undefined;
+                return {
+                  path: fileURLToPath(new URL(relativePath, import.meta.url)),
+                };
+              },
+            );
             build.onResolve({ filter: /^@elizaos\/core$/ }, () => ({
               path: fileURLToPath(
                 new URL("../src/stubs/elizaos-core.ts", import.meta.url),

--- a/packages/cloud/api/__tests__/onboarding-coordinator-transport.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-coordinator-transport.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Exercises strict serialization and parsing at the onboarding Durable Object
+ * boundary with real Response bodies and adversarial payload shapes.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ElizaError, isElizaError } from "@elizaos/core";
+import {
+  onboardingCoordinatorErrorResponse,
+  readOnboardingCoordinatorResult,
+} from "@/lib/services/eliza-app/onboarding-coordinator-transport";
+
+describe("onboarding coordinator transport", () => {
+  test("preserves an ElizaError code and context at HTTP 500", async () => {
+    const response = onboardingCoordinatorErrorResponse(
+      new ElizaError("Continuation rejected", {
+        code: "ONBOARDING_TRUSTED_CONTINUATION_INVALID",
+        context: { platform: "telegram", sessionFound: false },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect((await response.json()) as unknown).toEqual({
+      error: "Continuation rejected",
+      code: "ONBOARDING_TRUSTED_CONTINUATION_INVALID",
+      context: { platform: "telegram", sessionFound: false },
+    });
+  });
+
+  test("reconstructs a typed error only from message plus non-empty code", async () => {
+    const response = Response.json(
+      {
+        error: "Continuation rejected",
+        code: "ONBOARDING_TRUSTED_CONTINUATION_INVALID",
+        context: { sessionFound: false },
+      },
+      { status: 500 },
+    );
+
+    try {
+      await readOnboardingCoordinatorResult(response);
+      throw new Error("expected coordinator failure");
+    } catch (error) {
+      expect(isElizaError(error)).toBe(true);
+      if (!isElizaError(error)) throw error;
+      expect(error.code).toBe("ONBOARDING_TRUSTED_CONTINUATION_INVALID");
+      expect(error.context).toEqual({ sessionFound: false });
+    }
+  });
+
+  for (const [name, body] of [
+    ["null", "null"],
+    ["array", "[]"],
+    ["missing error", JSON.stringify({ code: "AUTH" })],
+    ["non-string error", JSON.stringify({ error: 42, code: "AUTH" })],
+    ["missing code", JSON.stringify({ error: "no code" })],
+    ["non-string code", JSON.stringify({ error: "bad code", code: 42 })],
+    ["empty code", JSON.stringify({ error: "empty code", code: "  " })],
+  ] as const) {
+    test(`keeps ${name} payload generic`, async () => {
+      const error = await readOnboardingCoordinatorResult(
+        new Response(body, { status: 500 }),
+      ).catch((caught: unknown) => caught);
+      expect(error).toBeInstanceOf(Error);
+      expect(isElizaError(error)).toBe(false);
+      expect((error as Error).message).toBe(
+        "onboarding session coordinator failed (500)",
+      );
+    });
+  }
+
+  test("keeps unreadable JSON generic", async () => {
+    const error = await readOnboardingCoordinatorResult(
+      new Response("not-json", { status: 500 }),
+    ).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(Error);
+    expect(isElizaError(error)).toBe(false);
+  });
+});

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -11,6 +11,7 @@ import type {
   OnboardingChatResult,
   OnboardingSession,
 } from "@/lib/services/eliza-app/onboarding-chat";
+import { onboardingCoordinatorErrorResponse } from "@/lib/services/eliza-app/onboarding-coordinator-transport";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -965,10 +966,7 @@ export class OnboardingSessionCoordinator {
         // error-policy:J1 Durable Object transport boundary; inner onboarding
         // failures remain observable as a failed request and are never replaced
         // with an empty or successful-looking result.
-        return Response.json(
-          { error: error instanceof Error ? error.message : String(error) },
-          { status: 500 },
-        );
+        return onboardingCoordinatorErrorResponse(error);
       }
     });
   }

--- a/packages/cloud/api/test/fixtures/onboarding-route-worker.ts
+++ b/packages/cloud/api/test/fixtures/onboarding-route-worker.ts
@@ -1,0 +1,27 @@
+/**
+ * Mounts the production onboarding route and coordinator in one Worker so
+ * Miniflare can exercise the real public-to-Durable-Object transport path.
+ */
+
+import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import onboardingRoute from "../../eliza-app/onboarding/chat/route";
+import { OnboardingSessionCoordinator } from "../../src/onboarding-session-coordinator";
+
+export { OnboardingSessionCoordinator };
+
+export default {
+  async fetch(
+    request: Request,
+    env: Record<string, unknown>,
+  ): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname !== "/api/eliza-app/onboarding/chat") {
+      return Response.json({ error: "Not found" }, { status: 404 });
+    }
+    const routeRequest = new Request("https://onboarding.test/", request);
+    return runWithCloudBindingsAsync(
+      env,
+      async () => await onboardingRoute.fetch(routeRequest, env as never),
+    );
+  },
+};

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -18,6 +18,7 @@ import {
 import { logger } from "../../utils/logger";
 import { normalizePhoneNumber } from "../../utils/phone-normalization";
 import { launchManagedElizaAgent } from "../eliza-managed-launch";
+import { readOnboardingCoordinatorResult } from "./onboarding-coordinator-transport";
 import {
   enqueueDiscordProactiveGreeting,
   PROACTIVE_GREETING_QUEUE_PREFIX,
@@ -1534,19 +1535,12 @@ function onboardingCoordinator(): RuntimeDurableObjectNamespace | undefined {
   return getCloudBinding<RuntimeDurableObjectNamespace>("ONBOARDING_SESSIONS");
 }
 
-async function readCoordinatorResult(response: Response): Promise<OnboardingChatResult> {
-  if (!response.ok) {
-    throw new Error(`onboarding session coordinator failed (${response.status})`);
-  }
-  return (await response.json()) as OnboardingChatResult;
-}
-
 async function runViaCoordinator(
   stub: RuntimeDurableObjectStub,
   input: OnboardingChatInput,
   sessionId: string,
 ): Promise<OnboardingChatResult> {
-  return readCoordinatorResult(
+  return readOnboardingCoordinatorResult<OnboardingChatResult>(
     await stub.fetch("https://onboarding.internal/turn", {
       method: "POST",
       headers: { "content-type": "application/json" },

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-coordinator-transport.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-coordinator-transport.ts
@@ -1,0 +1,47 @@
+/**
+ * Preserves typed onboarding failures across the Durable Object HTTP boundary
+ * while treating every response body as untrusted transport input.
+ */
+
+import { ElizaError, isElizaError } from "@elizaos/core";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Serializes an onboarding failure without changing the boundary's status. */
+export function onboardingCoordinatorErrorResponse(error: unknown): Response {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!isElizaError(error)) {
+    return Response.json({ error: message }, { status: 500 });
+  }
+  return Response.json(
+    { error: message, code: error.code, context: error.context },
+    { status: 500 },
+  );
+}
+
+/** Reads a coordinator result and reconstructs only a fully identified error. */
+export async function readOnboardingCoordinatorResult<T>(response: Response): Promise<T> {
+  if (response.ok) return (await response.json()) as T;
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    // error-policy:J3 An unreadable boundary body is explicitly invalid and
+    // must not acquire a trusted application error code.
+    throw new Error(`onboarding session coordinator failed (${response.status})`);
+  }
+
+  if (isRecord(payload)) {
+    const message = payload.error;
+    const code = payload.code;
+    if (typeof message === "string" && typeof code === "string" && code.trim().length > 0) {
+      const context = isRecord(payload.context) ? payload.context : undefined;
+      throw new ElizaError(message, { code, context });
+    }
+  }
+
+  throw new Error(`onboarding session coordinator failed (${response.status})`);
+}


### PR DESCRIPTION
Fixes #19105

## Summary

- serialize typed `ElizaError` message, code, and plain-object context across the onboarding Durable Object boundary without changing the transport status
- reconstruct a typed error only when an untrusted failed response contains both a string message and a non-empty string code; malformed, unreadable, null, array, and incomplete bodies remain generic failures
- prove the production public onboarding route crosses a declared Miniflare Durable Object namespace and maps a forged continuation to the intended fail-closed 403

## Verification

Exact source head: `6354d1e026b7ff145a0e0ab5f107fb15649a4210`
Base: `origin/develop` at `55b3b1e34f3e0d0054b6d440731f41741dc2ec34`

- `bun run verify` — PASS on functional predecessor `f5510e162114b18c7da1b0fbf46c3e31c438689c` (350/350 Turbo tasks plus repository audits); exact head only adds deterministic nested-build dependency resolution to the Miniflare harness.
- `bun run verify:cloud` — PASS (78/78 tasks; includes Cloud lint, typecheck, and production Worker dry-run)
- transport boundary suite — 10/10 PASS
- coordinator state-machine suite — current-base run has one unrelated account-adoption expectation failure; changed error transport is covered by the green 10/10 boundary suite and real Miniflare route
- Miniflare public-route/Durable-Object integration — 1/1 PASS after an exact-head clean-install rerun; the harness resolves the production shim dependencies from their owning workspaces rather than relying on Bun test-runner hoisting
- onboarding public route suite — 20/20 PASS
- Telegram continuation integration — 3/3 PASS
- Telegram continuation route suite — 11/11 PASS
- `bun run test:cloud` — changed-surface suites PASS; the aggregate remains red on current-base configuration/default-contract clusters outside this patch (`toCompatStatus`, onboarding host origins, alternate-domain origins, Steward API/VAPID defaults, blob/registry hosts, and default cloud route). The filtered rerun reproduced only those unrelated failures.

## Real Worker evidence

The Miniflare test bundles the production public onboarding route and `OnboardingSessionCoordinator`, declares `ONBOARDING_SESSIONS` with SQLite-backed Durable Object storage, and dispatches:

```text
POST /api/eliza-app/onboarding/chat
{"sessionId":"forged-continuation","confirmPlatformLink":true}
```

Observed final public response:

```json
{
  "status": 403,
  "body": {
    "success": false,
    "error": "Authenticate with the same messaging account that started this onboarding session",
    "code": "access_denied"
  }
}
```

The transport suite separately proves the coordinator still emits HTTP 500 internally while preserving the typed code/context, and that null, array, unreadable JSON, missing/non-string error, and missing/non-string/empty code never become trusted typed errors.

## Evidence matrix

- Desktop/mobile screenshots: N/A — backend Worker error transport only; no rendered UI changed.
- MP4 walkthrough: N/A — no interactive UI flow changed; the real path is an automated Worker request.
- Backend logs/artifacts: included above as the exact Miniflare request/response contract.
- Frontend console/network logs: N/A — no frontend code or browser transport changed.
- Live-model trajectory: N/A — deterministic authorization/error mapping; no model invocation.

<!-- evidence-head:6354d1e026b7ff145a0e0ab5f107fb15649a4210 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend Worker transport only; no visual surface changed

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend Worker transport only; no visual surface changed

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changed; Miniflare exercises the real request path

<!-- evidence-row:backend-logs -->
- [x] N/A - exact Miniflare request and observed 403 response are pasted in the PR description

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser transport changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic authorization and error transport do not invoke a model

<!-- evidence-row:domain-artifacts -->
- [x] N/A - the public HTTP 403 response is pasted in the PR description

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - repository contribution skill is not available in this session
Attribution status: self-reported
— [codex-19105]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - repository contribution skill is not available in this session"} -->