### PR TITLE
fix(ci): inject Telegram bot ID into the Pages build (#19121)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -1254,6 +1254,10 @@ jobs:
     name: Build Pages artifacts
     needs: migrate-db
     if: ${{ !cancelled() && (needs.migrate-db.result == 'success' || (github.event_name == 'pull_request' && needs.migrate-db.result == 'skipped')) }}
+    # Bound to the selected environment so environment-scoped vars (e.g.
+    # VITE_TELEGRAM_BOT_ID) are visible to the Vite build (#19121). PR runs
+    # bind to staging; the staging environment must allow PR branches.
+    environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # GitHub preserves outputs from successful jobs when only failed jobs are
@@ -1327,6 +1331,7 @@ jobs:
           VITE_ENVIRONMENT: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
           VITE_VOICE_REALTIME_WS: ${{ !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED) && '1' || '0' }}
           VITE_VOICE_REALTIME_FORCE: "0"
+          VITE_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
 
       - name: Verify frontend chunk safety
@@ -1356,6 +1361,9 @@ jobs:
       group: cloud-cf-deploy-app-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging') }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     # Hosted unconditionally to preserve CI/placement workload separation.
+    # Bound to the selected environment so the legacy inline fallback build
+    # sees the same environment-scoped vars as build-pages (#19121).
+    environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
     runs-on: ubuntu-latest
     timeout-minutes: 75
     # Release gate (#11208/#18088): canonical Pages aliases wait for the matching
@@ -1583,6 +1591,7 @@ jobs:
           VITE_ENVIRONMENT: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
           VITE_VOICE_REALTIME_WS: ${{ !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED) && '1' || '0' }}
           VITE_VOICE_REALTIME_FORCE: "0"
+          VITE_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
 
       # Refuse to deploy a bundle where the bn.js/crypto graph folded into an


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #19121

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run; **verify passes green on this head**.
- [x] A reviewer can confirm the change from the evidence below, except the final post-deploy staging check, which requires protected-environment deploy access and is explicitly deferred to a maintainer-triggered deploy.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop` (`643bd7e419`); zero conflicts.
- [x] `bun run verify` passes on this head.

# Risks

Workflow-only, two additions per acceptance: the `environment:` binding on the two Pages producer jobs (same production/staging conditional the deploy jobs already use) and `VITE_TELEGRAM_BOT_ID` in both Vite env blocks. **One consequence for reviewer attention:** binding `build-pages` means pull-request runs now target the `staging` environment, so its deployment branch policy must allow PR branches (or PR preview builds will be blocked at admission). If that policy is not already permissive, the binding can be made conditional instead — happy to adjust.

# Background

## What does this PR do?

The protected environments define `VITE_TELEGRAM_BOT_ID`, but the consolidated Pages producer neither bound the GitHub environment (so environment-scoped vars were invisible) nor passed the variable to Vite. The deployed bundle therefore never contained the configured bot ID. This PR binds `build-pages` and `deploy-app` (which hosts the legacy inline fallback build) to the selected environment and passes `vars.VITE_TELEGRAM_BOT_ID` through both build env blocks.

## What kind of change is this?

Bug fix (CI workflow change; no application code touched).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The two `environment:` additions and the two `VITE_TELEGRAM_BOT_ID` lines in `.github/workflows/cloud-cf-deploy.yml` (the diff is four hunks).

## Detailed testing steps

```bash
VITE_TELEGRAM_BOT_ID=987654321099 bun run --cwd packages/app build:web && grep -rl 987654321099 packages/app/dist
```

# Evidence Gate

<!-- evidence-head:e94a2bbec264dfb390ebe37777bada90af5cb2de -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - CI workflow variable plumbing; no rendered UI change`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - CI workflow variable plumbing; no rendered UI change`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - build-artifact contract shown in the transcripts below`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — local production-build proof that the variable reaches the emitted bundle:

  <details><summary>sentinel build transcript</summary>

  ```
  VITE_TELEGRAM_BOT_ID=987654321099 bun run --cwd packages/app build:web
    build exit 0; sentinel present in the emitted assets:
      packages/app/dist/assets/App-D9GdWA1_.js
      packages/app/dist/assets/index-CB4Sx1E0.js
      packages/app/dist/assets/useVoiceConfig-BJNAy82W.js

  clean rebuild without the variable:
    build exit 0; sentinel absent from all 527 emitted js files —
    the env var is the only source of the ID in the artifact

  workflow: YAML lint successful; root bun run verify green on this head
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no runtime surface exercised; the change is build-time variable injection`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - CI workflow configuration; no model, prompt, provider, or action behavior involved`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the deployed-bundle contract, with the deploy-gated row stated as deferred:

  <details><summary>artifact contract</summary>

  ```
  env var set at build      -> configured bot ID present in Pages artifact
  env var absent            -> ID absent (reproduces the reported staging state)
  build-pages / deploy-app  -> now bound to the selected environment, so the
                               environment-scoped var is visible to both the
                               canonical and legacy inline builds
  post-deploy staging check -> DEFERRED: requires protected-environment deploy
                               access; verifiable by a maintainer on the first
                               staging deploy after merge
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Evidence Details

All evidence is inline above.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZXVP257N65Z3EWZZFEWHXYE","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T15:26:06.504Z","completed_at":"2026-08-13T15:37:02.863Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"o2fdquZjoVlsw6yXJVgZUsRIJ2F18AW5nA5RAuD5z20lRSRpmWU8SgcMe4dgYPGU5mZXIR9GjWcwgxzuViwRCg"}} -->

