### PR TITLE
fix(cloud): inject Telegram bot config into Pages build

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -1250,10 +1250,71 @@ jobs:
   # ---------------------------------------------------------------------------
   # Pages build — one prepared workspace emits the host-aware frontend.
   # ---------------------------------------------------------------------------
+  resolve-pages-environment-config:
+    name: Resolve Pages environment configuration
+    needs: migrate-db
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.migrate-db.result == 'success' }}
+    runs-on: ubuntu-latest
+    environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
+    outputs:
+      telegram_bot_id: ${{ steps.telegram.outputs.bot_id }}
+      telegram_bot_username: ${{ steps.telegram.outputs.bot_username }}
+    steps:
+      - name: Validate Telegram configuration
+        id: telegram
+        env:
+          TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
+          TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$TELEGRAM_BOT_ID" && -z "$TELEGRAM_BOT_USERNAME" ]]; then
+            TELEGRAM_BOT_ID=7684336618
+            TELEGRAM_BOT_USERNAME=Elizav2_Bot
+          elif [[ -z "$TELEGRAM_BOT_ID" || -z "$TELEGRAM_BOT_USERNAME" ]]; then
+            echo "::error::VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME must be configured together"
+            exit 1
+          fi
+          [[ "$TELEGRAM_BOT_ID" =~ ^[0-9]+$ ]] || { echo "::error::VITE_TELEGRAM_BOT_ID must be numeric"; exit 1; }
+          [[ "$TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]+$ ]] || { echo "::error::VITE_TELEGRAM_BOT_USERNAME must be a Telegram username without @"; exit 1; }
+          echo "bot_id=$TELEGRAM_BOT_ID" >> "$GITHUB_OUTPUT"
+          echo "bot_username=$TELEGRAM_BOT_USERNAME" >> "$GITHUB_OUTPUT"
+
+  resolve-pages-preview-config:
+    name: Resolve Pages preview configuration
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      telegram_bot_id: ${{ steps.telegram.outputs.bot_id }}
+      telegram_bot_username: ${{ steps.telegram.outputs.bot_username }}
+    steps:
+      - name: Resolve public preview defaults
+        id: telegram
+        env:
+          TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
+          TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$TELEGRAM_BOT_ID" && -z "$TELEGRAM_BOT_USERNAME" ]]; then
+            TELEGRAM_BOT_ID=7684336618
+            TELEGRAM_BOT_USERNAME=Elizav2_Bot
+          elif [[ -z "$TELEGRAM_BOT_ID" || -z "$TELEGRAM_BOT_USERNAME" ]]; then
+            echo "::error::VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME must be configured together"
+            exit 1
+          fi
+          [[ "$TELEGRAM_BOT_ID" =~ ^[0-9]+$ ]] || { echo "::error::VITE_TELEGRAM_BOT_ID must be numeric"; exit 1; }
+          [[ "$TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]+$ ]] || { echo "::error::VITE_TELEGRAM_BOT_USERNAME must be a Telegram username without @"; exit 1; }
+          echo "bot_id=$TELEGRAM_BOT_ID" >> "$GITHUB_OUTPUT"
+          echo "bot_username=$TELEGRAM_BOT_USERNAME" >> "$GITHUB_OUTPUT"
+
   build-pages:
     name: Build Pages artifacts
-    needs: migrate-db
-    if: ${{ !cancelled() && (needs.migrate-db.result == 'success' || (github.event_name == 'pull_request' && needs.migrate-db.result == 'skipped')) }}
+    needs:
+      [
+        migrate-db,
+        resolve-pages-environment-config,
+        resolve-pages-preview-config,
+      ]
+    if: ${{ !cancelled() && (needs.migrate-db.result == 'success' || (github.event_name == 'pull_request' && needs.migrate-db.result == 'skipped')) && ((github.event_name == 'pull_request' && needs.resolve-pages-preview-config.result == 'success') || (github.event_name != 'pull_request' && needs.resolve-pages-environment-config.result == 'success')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # GitHub preserves outputs from successful jobs when only failed jobs are
@@ -1264,6 +1325,8 @@ jobs:
       artifact_run_id: ${{ steps.pages-artifact.outputs.run_id }}
       artifact_run_attempt: ${{ steps.pages-artifact.outputs.run_attempt }}
       artifact_source_sha: ${{ steps.pages-artifact.outputs.source_sha }}
+      telegram_bot_id: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_id || needs.resolve-pages-preview-config.outputs.telegram_bot_id }}
+      telegram_bot_username: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username || needs.resolve-pages-preview-config.outputs.telegram_bot_username }}
     steps:
       - name: Validate PR preview identity
         if: github.event_name == 'pull_request'
@@ -1315,6 +1378,8 @@ jobs:
       - name: Build consolidated frontend artifact
         run: bun run --cwd packages/app build:web
         env:
+          VITE_TELEGRAM_BOT_ID: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_id || needs.resolve-pages-preview-config.outputs.telegram_bot_id }}
+          VITE_TELEGRAM_BOT_USERNAME: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username || needs.resolve-pages-preview-config.outputs.telegram_bot_username }}
           VITE_API_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
           NEXT_PUBLIC_API_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
           VITE_OIDC_ISSUER_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
@@ -1567,6 +1632,8 @@ jobs:
         working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun run --cwd packages/app build:web
         env:
+          VITE_TELEGRAM_BOT_ID: ${{ needs.build-pages.outputs.telegram_bot_id }}
+          VITE_TELEGRAM_BOT_USERNAME: ${{ needs.build-pages.outputs.telegram_bot_username }}
           VITE_API_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
           NEXT_PUBLIC_API_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
           VITE_OIDC_ISSUER_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}

--- a/packages/scripts/__tests__/cloud-cf-pages-artifact-rerun-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-pages-artifact-rerun-workflow.test.ts
@@ -110,6 +110,12 @@ describe("Cloud CF Pages artifact metadata", () => {
         "$" + "{{ steps.pages-artifact.outputs.run_attempt }}",
       artifact_source_sha:
         "$" + "{{ steps.pages-artifact.outputs.source_sha }}",
+      telegram_bot_id:
+        "$" +
+        "{{ needs.resolve-pages-environment-config.outputs.telegram_bot_id || needs.resolve-pages-preview-config.outputs.telegram_bot_id }}",
+      telegram_bot_username:
+        "$" +
+        "{{ needs.resolve-pages-environment-config.outputs.telegram_bot_username || needs.resolve-pages-preview-config.outputs.telegram_bot_username }}",
     });
 
     const metadata = namedStep(

--- a/packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
@@ -159,7 +159,11 @@ describe("Cloud CF PR preview workflow contract", () => {
 
   test("keeps PR builds reachable and gates canonical Pages on the API", () => {
     const buildJob = producer.jobs?.["build-pages"];
-    expect(buildJob?.needs).toBe("migrate-db");
+    expect(buildJob?.needs).toEqual([
+      "migrate-db",
+      "resolve-pages-environment-config",
+      "resolve-pages-preview-config",
+    ]);
     expect(buildJob?.if).toContain(
       "github.event_name == 'pull_request' && needs.migrate-db.result == 'skipped'",
     );

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -21,7 +21,10 @@ describe("homepage deployment workflow", () => {
     ),
   ) as { name?: string; scripts?: Record<string, string> };
   const appPackage = JSON.parse(
-    readFileSync(path.join(repositoryRoot, "packages/app/package.json"), "utf8"),
+    readFileSync(
+      path.join(repositoryRoot, "packages/app/package.json"),
+      "utf8",
+    ),
   ) as { scripts?: Record<string, string> };
   const devAll = readFileSync(
     path.join(repositoryRoot, "packages/scripts/dev-all.mjs"),
@@ -60,6 +63,37 @@ describe("homepage deployment workflow", () => {
     expect(workflow).toContain("https://cloud.eliza.app");
     expect(workflow).toContain("https://staging.eliza.app");
     expect(workflow).toContain("https://cloud-staging.eliza.app");
+  });
+
+  it("resolves matched Telegram configuration for canonical and preview builds", () => {
+    expect(workflow).toContain("resolve-pages-environment-config:");
+    expect(workflow).toContain("resolve-pages-preview-config:");
+    expect(workflow).toContain("VITE_TELEGRAM_BOT_ID must be numeric");
+    expect(workflow.match(/TELEGRAM_BOT_ID=7684336618/g)).toHaveLength(2);
+    expect(workflow.match(/TELEGRAM_BOT_USERNAME=Elizav2_Bot/g)).toHaveLength(
+      2,
+    );
+    expect(
+      workflow.match(
+        /VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME must be configured together/g,
+      ),
+    ).toHaveLength(2);
+    expect(workflow).toContain(
+      "VITE_TELEGRAM_BOT_ID: $" +
+        "{{ needs.resolve-pages-environment-config.outputs.telegram_bot_id || needs.resolve-pages-preview-config.outputs.telegram_bot_id }}",
+    );
+    expect(workflow).toContain(
+      "VITE_TELEGRAM_BOT_USERNAME: $" +
+        "{{ needs.resolve-pages-environment-config.outputs.telegram_bot_username || needs.resolve-pages-preview-config.outputs.telegram_bot_username }}",
+    );
+    expect(workflow).toContain(
+      "VITE_TELEGRAM_BOT_ID: $" +
+        "{{ needs.build-pages.outputs.telegram_bot_id }}",
+    );
+    expect(workflow).toContain(
+      "VITE_TELEGRAM_BOT_USERNAME: $" +
+        "{{ needs.build-pages.outputs.telegram_bot_username }}",
+    );
   });
 
   it("validates homepage source while building only packages/app in quality CI", () => {


### PR DESCRIPTION
# Relates to

Fixes #19121.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Pi`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@43a0e3d82c96829d2f833be579975e17e08cada4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [ ] Full `bun run verify` deferred to CI; focused workflow contract tests passed locally.

# Risks

Low-to-medium workflow risk. Canonical builds fail closed on malformed or partially configured bot identity pairs; PR previews remain unprivileged and use repository variables/defaults.

# Background

## What does this PR do?

- Resolves Telegram bot ID and username together from the selected protected environment after deployment admission.
- Validates both values and rejects partial/malformed overrides.
- Uses documented defaults when neither override exists.
- Injects both values into canonical and legacy inline Vite build paths.
- Preserves unprivileged PR preview builds through a separate repository-variable resolver.
- Propagates configuration through build outputs for artifact reruns and fallback builds.

## What kind of change is this?

Bug fix (deployment configuration).

# Documentation changes needed?

No. The variables and defaults are already documented under `packages/homepage`.

# Testing

## Where should a reviewer start?

- `.github/workflows/cloud-cf-deploy.yml`
- `packages/scripts/__tests__/homepage-deploy-workflow.test.ts`

## Detailed testing steps

- Focused workflow tests: 12 passed, 7 platform-skipped, 0 failed.
- Biome check passed for all changed TypeScript tests.
- Prettier and `git diff --check` passed.
- `codex review --base origin/develop` completed with no blocking correctness issues.

# Evidence Gate

<!-- evidence-head:ae671fa2cfa4a71d5361d5c24c1050aa465bc6ab -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow-only change with no rendered UI or visual styling change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow-only change with no rendered UI or visual styling change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - workflow-only configuration plumbing; deployment is exercised after merge.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime code changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime code changed; workflow contract tests inspect exact Vite inputs.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - staging bundle verification requires the canonical post-merge deployment.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Known gaps / failures

The deployed staging bundle remains unchanged until merge and canonical deployment. Post-deployment verification should confirm bot ID `7684336618` appears in the served bundle.

AI provider/model: openai-codex / gpt-5.6-sol
Client / agent tooling: Pi
Contribution skill revision: elizaOS/eliza@43a0e3d82c96829d2f833be579975e17e08cada4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [pi-telegram-build]
<!-- eliza-computer-attribution:v1 {"provider":"openai-codex","model":"gpt-5.6-sol","client":"Pi","skill_revision":"elizaOS/eliza@43a0e3d82c96829d2f833be579975e17e08cada4:packages/skills/skills/contribute-to-eliza"} -->

