### PR TITLE
fix(cloud): clear stale Cloud session on Steward refresh rejection (fixes #19126)

### DIFF
--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -597,7 +597,12 @@ export async function refreshCloudStewardSession(opts?: {
       }),
       { method: "POST", url: endpoint },
     );
-    if (response.status < 200 || response.status >= 300) return null;
+    if (response.status < 200 || response.status >= 300) {
+      if (response.status === 401 || response.status === 403) {
+        clearStoredStewardTokenIfCurrent(token);
+      }
+      return null;
+    }
     return parseDirectCloudJsonSafe(response.data) as {
       token?: string;
       expiresAt?: number;
@@ -610,7 +615,13 @@ export async function refreshCloudStewardSession(opts?: {
     method: "POST",
     credentials: "include",
   });
-  if (!response.ok) return null;
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      const rejected = readStoredStewardToken()?.trim();
+      if (rejected) clearStoredStewardTokenIfCurrent(rejected);
+    }
+    return null;
+  }
   // error-policy:J3 an unparseable refresh body reads as "no refreshed
   // session" (null) — callers keep/drop the stored token by its own expiry.
   return (await response.json().catch(() => null)) as {

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -55,10 +55,12 @@ import {
   buildCloudSharedAgentApiBase,
   buildDedicatedCloudAgentApiBase,
   dedicatedCloudAgentIdFromBase,
+  ELIZA_CLOUD_CONTROL_PLANE_HOSTS,
   isDedicatedCloudAgentBase,
   isElizaCloudControlPlaneAgentlessBase,
   resolveCloudEnvironmentBase,
 } from "../utils/cloud-agent-base";
+import { DIRECT_ELIZA_CLOUD_API_BY_HOST } from "../api/direct-cloud-endpoints";
 import { getElizaApiBase, getElizaApiToken } from "../utils/eliza-globals";
 import {
   detectExistingFirstRunConnection,
@@ -479,13 +481,17 @@ async function resolveRestoredStewardToken(): Promise<string | null> {
     return refreshed.token;
   }
 
-  // Refresh failed / timed out. A truly-expired token is a dead credential —
+  // Refresh failed / timed out. A terminal 401 rejection already drained the
+  // stored token inside refreshCloudStewardSession — honor that and return
+  // unauthenticated. Otherwise, a truly-expired token is a dead credential —
   // drop it so we restore unauthenticated instead of a guaranteed-401 dial.
+  const stillStored = readStoredStewardToken()?.trim() || null;
+  if (!stillStored) return null;
   if (secs <= 0) {
     clearStoredStewardToken();
     return null;
   }
-  return stored;
+  return stillStored;
 }
 
 export async function applyRestoredConnection(args: {
@@ -549,6 +555,32 @@ export async function applyRestoredConnection(args: {
     // refresh it BEFORE handing it to the client so a returning user never
     // boots into a permanently-401ing session (see resolveRestoredStewardToken).
     const stewardToken = await stewardTokenPromise;
+    // Hosted startup must not adopt a persisted Cloud agent without a valid
+    // Steward session. Otherwise a stale cookie + cached agentId survives a
+    // dead refresh, boots against the wrong agent, and 401-loops with stale
+    // UI. Drop the persisted target so re-auth resolves from the org-scoped
+    // agent list instead.
+    const hostedWithoutStewardSession =
+      !usesLocalDockerCredential &&
+      !stewardToken &&
+      typeof window !== "undefined" &&
+      (() => {
+        try {
+          const host = window.location.hostname.toLowerCase();
+          return (
+            ELIZA_CLOUD_CONTROL_PLANE_HOSTS.has(host) ||
+            DIRECT_ELIZA_CLOUD_API_BY_HOST.has(host)
+          );
+        } catch {
+          return false;
+        }
+      })();
+    if (hostedWithoutStewardSession) {
+      clearPersistedActiveServer();
+      clientRef.setToken(null);
+      clientRef.setBaseUrl(null);
+      return;
+    }
     // Dedicated agent subdomains and explicit local-Docker pair targets use an
     // agent-local bearer for `/api/*`. The edge-owned dedicated path can keep
     // its Steward recovery fallback; a loopback process must never receive a

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -1527,6 +1527,9 @@ export function useCloudState({
       // error-policy:J4 pre-emptive token refresh; a failed refresh keeps the
       // still-valid stored token until it actually expires (the next authed
       // call then surfaces the re-auth path). No token rotation on failure.
+      // A terminal 401/403 rejection (invalid/expired refresh) clears the
+      // rejected Cloud session state inside refreshCloudStewardSession so a
+      // stale token never loops against a dead agent target.
       const result = await refreshCloudStewardSession({
         endpoint: resolveStewardRefreshEndpoint(),
       }).catch((err: unknown) => {
@@ -1536,6 +1539,10 @@ export function useCloudState({
       if (disposed) return;
       if (result?.token) {
         writeStoredStewardToken(result.token);
+      } else if (!readStoredStewardToken()?.trim()) {
+        // Terminal rejection drained the stored token: surface auth-rejected
+        // immediately so the UI prompts re-auth instead of 401-looping.
+        setElizaCloudAuthRejected(true);
       }
     };
 


### PR DESCRIPTION
Fixes #19126

## Bug
Hosted Cloud app could restore a persisted agent target (`PersistedActiveServer` → `apiBase` / `cloud:<agentId>`) after Steward access + refresh sessions were both invalid. Startup continued against the cached agent ID, 401-looped, and left stale agent UI visible instead of requiring sign-in.

## Root cause
- `refreshCloudStewardSession()` (`packages/ui/src/api/client-cloud.ts`) returned `null` on any non-2xx without clearing the rejected token. A terminal 401/403 drained in the refresh left the dead JWT in `localStorage.steward_session_token`, so subsequent `getCloudAuthToken()` keeps returning it and hosted chat loops.
- `applyRestoredConnection()` (`packages/ui/src/state/startup-phase-restore.ts`) adopted the persisted Cloud agent unconditionally, even with no valid Steward session — on hosted control-plane hosts that survives a dead refresh.

## Fix
- `api/client-cloud.ts`: on 401/403 in both web (`fetch` + `credentials:include`) and native (`CapacitorHttp` Bearer) paths, `clearStoredStewardTokenIfCurrent(rejected)` + dispatch `steward-token-sync` before returning `null`. 5xx/503 stay soft-fail (no clear) so valid-session restore is untouched.
- `state/startup-phase-restore.ts`: `resolveRestoredStewardToken()` re-reads stored token after refresh — if drained, returns `null` immediately. Cloud branch in `applyRestoredConnection()`: if hosted (`ELIZA_CLOUD_CONTROL_PLANE_HOSTS` or `DIRECT_ELIZA_CLOUD_API_BY_HOST`) and `!stewardToken` → `clearPersistedActiveServer(); client.setToken(null); setBaseUrl(null); return;`. Local-Docker/loopback exempt, so after reauth `selectOrProvisionCloudAgent` resolves from `GET /api/v1/eliza/agents` (org-scoped).
- `state/useCloudState.ts`: after refresh, if stored token drained → `setElizaCloudAuthRejected(true)` to surface re-auth instead of 401-looping.

## Acceptance
- [x] Terminal Steward refresh rejection clears rejected Cloud session state
- [x] Hosted startup does not adopt persisted Cloud agent without valid Steward session
- [x] After reauthentication, selection resolves from authenticated org-scoped agent list
- [x] Valid-session fast-path (`secs >= 120s`) and opaque-token no-refresh untouched

## Testing
- Unit/state tests for restore paths (stale-cookie/stale-token vs valid-session) — follow-up if requested
- Manual: hosted stale session (expired/invalid refresh) boots unauthenticated, no stale agent UI; reauth populates agent list from `/api/v1/eliza/agents`

Closes #19126
