### PR TITLE
fix(netlify): strip body for 204 responses in adapter (fixes #18915)

### DIFF
--- a/packages/app/functions/_middleware.ts
+++ b/packages/app/functions/_middleware.ts
@@ -111,10 +111,21 @@ const SERVICE_WORKER_PATH = "/sw.js";
 const ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable";
 const SERVICE_WORKER_CACHE_CONTROL = "no-store";
 
+const NULL_BODY_STATUS_CODES = new Set([204, 205, 304]);
+
+const getNullBodySafeBody = (response: Response): BodyInit | null =>
+  NULL_BODY_STATUS_CODES.has(response.status) ? null : response.body;
+
 const withCacheControl = (response: Response, value: string): Response => {
   const headers = new Headers(response.headers);
   headers.set("Cache-Control", value);
-  return new Response(response.body, {
+  // Per Fetch spec, 204/205/304 MUST have null body — Response constructor throws otherwise.
+  // Preserve original status but strip body for null-body statuses (fixes #18915).
+  if (NULL_BODY_STATUS_CODES.has(response.status)) {
+    headers.delete("Content-Length");
+    headers.delete("Content-Type");
+  }
+  return new Response(getNullBodySafeBody(response), {
     status: response.status,
     statusText: response.statusText,
     headers,
@@ -224,7 +235,14 @@ export const onRequest = async (
   );
   headers.delete("X-Frame-Options");
 
-  return new Response(response.body, {
+  // 204/205/304 must have null body per Fetch spec — constructing Response with body throws
+  // TypeError: Invalid response status code 204 (fixes #18915).
+  const body = getNullBodySafeBody(response);
+  if (body === null) {
+    headers.delete("Content-Length");
+    headers.delete("Content-Type");
+  }
+  return new Response(body, {
     status: response.status,
     statusText: response.statusText,
     headers,


### PR DESCRIPTION
Fixes #18915

## Bug
Netlify `___netlify-server-handler` crashed with `TypeError: Response constructor: Invalid response status code 204` at `.next/server/chunks`. Per Fetch spec, 204/205/304 MUST have null body — constructing `new Response(body, {status:204})` throws.

## Root cause
- `packages/app/functions/_middleware.ts` rewrapped responses via `new Response(response.body, {status, headers})` for cache-control (`/assets/*` immutable, `/sw.js` no-store) and `/embed` CSP hardening.
- When upstream returned 204 with a body (or empty body), the rewrapping preserved the body and threw.

## Fix (1 file)
- Add `NULL_BODY_STATUS_CODES = Set([204,205,304])` + `getNullBodySafeBody(response)` helper.
- Both `withCacheControl()` and `onRequest()` embed branch now pass null body + strip `Content-Length`/`Content-Type` for 204/205/304, preserving original status/statusText.
- Verified with Node repro: direct 204+body throws, wrapped null does not. `pages-middleware` tests unaffected.

## Testing
- Manual repro script confirms fix. Existing middleware unit tests pass.

Closes #18915
