### PR TITLE
fix(discord): report configured and connected state accurately

### DIFF
--- a/plugins/plugin-registry/src/api/plugin-routes.test.ts
+++ b/plugins/plugin-registry/src/api/plugin-routes.test.ts
@@ -352,4 +352,87 @@ describe("handlePluginRoutes config persistence", () => {
       vi.useRealTimers();
     }
   });
+
+  it("uses runtime settings instead of a poisoned process env in the plugin catalog", async () => {
+    process.env.DISCORD_API_TOKEN = "host-token-must-not-count";
+    const config = {
+      env: {},
+      plugins: { entries: { discord: { enabled: true } } },
+    };
+    const ctx = makeContext({}, config, {
+      method: "GET",
+      pathname: "/api/plugins",
+      url: new URL("http://localhost/api/plugins"),
+    });
+    ctx.state.plugins[0].parameters[0].required = true;
+    ctx.buildPluginEvmDiagnosticEntry = vi.fn(() => ({
+      ...makePlugin(),
+      id: "evm",
+      name: "EVM",
+      npmName: "@elizaos/plugin-evm",
+    })) as never;
+    ctx.state.runtime = {
+      plugins: [{ name: "discord" }],
+      getSetting: vi.fn(() => null),
+      getService: vi.fn(() => null),
+    } as never;
+
+    await handlePluginRoutes(ctx);
+
+    const response = vi.mocked(ctx.json).mock.calls.at(-1)?.[1] as {
+      plugins: ReturnType<typeof makePlugin>[];
+    };
+    const discord = response.plugins.find((plugin) => plugin.id === "discord");
+    expect(discord).toEqual(
+      expect.objectContaining({ configured: false, isActive: false }),
+    );
+    expect(discord?.parameters[0]).toEqual(
+      expect.objectContaining({ isSet: false, currentValue: null }),
+    );
+  });
+
+  it.each([
+    [false, false],
+    [true, true],
+  ])(
+    "reports loaded Discord active=%s only when its gateway is healthy",
+    async (healthy, expectedActive) => {
+      const config = {
+        env: {},
+        plugins: { entries: { discord: { enabled: true } } },
+      };
+      const ctx = makeContext({}, config, {
+        method: "GET",
+        pathname: "/api/plugins",
+        url: new URL("http://localhost/api/plugins"),
+      });
+      ctx.state.plugins[0].parameters[0].required = true;
+      ctx.buildPluginEvmDiagnosticEntry = vi.fn(() => ({
+        ...makePlugin(),
+        id: "evm",
+        name: "EVM",
+        npmName: "@elizaos/plugin-evm",
+      })) as never;
+      ctx.state.runtime = {
+        plugins: [{ name: "discord" }],
+        getSetting: vi.fn(() => "runtime-discord-token"),
+        getService: vi.fn(() => ({ isHealthy: () => healthy })),
+      } as never;
+
+      await handlePluginRoutes(ctx);
+
+      const response = vi.mocked(ctx.json).mock.calls.at(-1)?.[1] as {
+        plugins: ReturnType<typeof makePlugin>[];
+      };
+      const discord = response.plugins.find(
+        (plugin) => plugin.id === "discord",
+      );
+      expect(discord).toEqual(
+        expect.objectContaining({ configured: true, isActive: expectedActive }),
+      );
+      expect(discord?.parameters[0]).toEqual(
+        expect.objectContaining({ isSet: true, currentValue: "***21" }),
+      );
+    },
+  );
 });

--- a/plugins/plugin-registry/src/api/plugin-routes.ts
+++ b/plugins/plugin-registry/src/api/plugin-routes.ts
@@ -63,6 +63,34 @@ const ADVANCED_CAPABILITY_SERVICE_BY_PLUGIN_ID: Partial<
   personality: "CHARACTER_MANAGEMENT",
 };
 
+function createRuntimeSettingReader(
+  runtime: AgentRuntime | null,
+): ((key: string) => string | undefined) | undefined {
+  if (!runtime || typeof (runtime as unknown as { getSetting?: unknown }).getSetting !== "function") {
+    return undefined;
+  }
+  return (key: string) => {
+    const value = (runtime as AgentRuntime).getSetting(key);
+    return typeof value === "string" && value.trim() ? value.trim() : undefined;
+  };
+}
+
+function resolvePluginServiceHealth(
+  runtime: AgentRuntime | null,
+  pluginId: string,
+): boolean | null {
+  if (!runtime || typeof (runtime as unknown as { getService?: unknown }).getService !== "function") {
+    return null;
+  }
+  const service = (runtime as AgentRuntime).getService(pluginId) as
+    | { isHealthy?: () => boolean }
+    | null;
+  if (!service || typeof service.isHealthy !== "function") {
+    return null;
+  }
+  return Boolean(service.isHealthy());
+}
+
 // ---------------------------------------------------------------------------
 // Types — kept lean to avoid circular deps with server.ts
 // ---------------------------------------------------------------------------
@@ -600,34 +628,57 @@ export async function handlePluginRoutes(
       }
     }
 
+    const readRuntimeSetting = createRuntimeSettingReader(state.runtime);
     for (const plugin of allPlugins) {
       for (const param of plugin.parameters) {
-        const envValue = process.env[param.key];
-        param.isSet = Boolean(envValue?.trim());
-        param.currentValue = param.isSet
+        const envValue = process.env[param.key]?.trim() || undefined;
+        const runtimeValue = readRuntimeSetting?.(param.key);
+        const effectiveValue = runtimeValue ?? envValue;
+        // When runtime exists, getSetting is authoritative — connectors never fall through to process.env
+        const isSet = readRuntimeSetting ? Boolean(runtimeValue) : Boolean(envValue);
+        param.isSet = isSet;
+        const displayValue = effectiveValue ?? "";
+        param.currentValue = isSet
           ? param.sensitive
-            ? maskValue(envValue ?? "")
-            : (envValue ?? "")
+            ? maskValue(displayValue)
+            : displayValue
           : null;
       }
-      const paramInfos: PluginParamInfo[] = plugin.parameters.map((p) => ({
-        key: p.key,
-        required: p.required,
-        sensitive: p.sensitive,
-        type: p.type,
-        description: p.description,
-        default: p.default,
-      }));
+      // Validate against effective isSet, not stale process.env. This keeps
+      // `configured` honest when getSetting is empty but process.env is set (#18713).
+      const validationErrors = plugin.parameters
+        .filter((p) => p.required && !p.isSet)
+        .map((p) => ({ field: p.key, message: `${p.key} is required but not set` }));
       const validation = validatePluginConfig(
         plugin.id,
         plugin.category,
         plugin.envKey,
         plugin.configKeys,
         undefined,
-        paramInfos,
+        plugin.parameters.map((p) => ({
+          key: p.key,
+          required: p.required,
+          sensitive: p.sensitive,
+          type: p.type,
+          description: p.description,
+          default: p.default,
+        })),
       );
-      plugin.validationErrors = validation.errors;
+      // Merge format warnings from validatePluginConfig, but replace required errors with authoritative ones
+      plugin.validationErrors = validationErrors;
       plugin.validationWarnings = validation.warnings;
+      plugin.configured = validationErrors.length === 0;
+    }
+    // Health gate: demote isActive when service reports unhealthy (Discord gateway never connected)
+    for (const plugin of allPlugins) {
+      if (!plugin.isActive) continue;
+      if (resolvePluginServiceHealth(state.runtime, plugin.id) === false) {
+        plugin.isActive = false;
+        plugin.validationWarnings = [
+          ...(plugin.validationWarnings ?? []),
+          { message: "Service is loaded but reports unhealthy: the connection is not established. Check credentials and connectivity." },
+        ];
+      }
     }
 
     applyWhatsAppQrOverride(allPlugins, resolveDefaultAgentWorkspaceDir());
@@ -917,8 +968,34 @@ export async function handlePluginRoutes(
           bridgedValues,
           { isBlockedKey: isBlockedEnvKey },
         );
+        // Refresh plugin param isSet from authoritative getSetting so
+        // configured/isSet matches what gateway will see
+        const rtReader = createRuntimeSettingReader(state.runtime);
+        for (const param of plugin.parameters) {
+          const rtVal = rtReader?.(param.key);
+          const envVal = process.env[param.key]?.trim() || undefined;
+          const isSet = rtReader ? Boolean(rtVal) : Boolean(envVal);
+          param.isSet = isSet;
+          const eff = rtVal ?? envVal ?? "";
+          param.currentValue = isSet
+            ? param.sensitive
+              ? maskValue(eff)
+              : eff
+            : null;
+        }
+        const errs = plugin.parameters
+          .filter((p) => p.required && !p.isSet)
+          .map((p) => ({ field: p.key, message: `${p.key} is required but not set` }));
+        plugin.validationErrors = errs;
+        plugin.configured = errs.length === 0;
+      } else {
+        // No config touched, but still recompute configured from current isSet
+        const errs = plugin.parameters
+          .filter((p) => p.required && !p.isSet)
+          .map((p) => ({ field: p.key, message: `${p.key} is required but not set` }));
+        if (errs.length > 0) plugin.validationErrors = errs;
+        plugin.configured = (plugin.validationErrors?.length ?? 0) === 0;
       }
-      plugin.configured = true;
 
       // Save config even when only config values changed (no enable toggle)
       if (body.enabled === undefined) {
@@ -932,7 +1009,23 @@ export async function handlePluginRoutes(
       }
     }
 
-    // Refresh validation
+    // Refresh validation — authoritative via getSetting when runtime exists
+    const rtReader2 = createRuntimeSettingReader(state.runtime);
+    for (const param of plugin.parameters) {
+      const rtVal = rtReader2?.(param.key);
+      const envVal = process.env[param.key]?.trim() || undefined;
+      param.isSet = rtReader2 ? Boolean(rtVal) : Boolean(envVal);
+      const eff = rtVal ?? envVal ?? "";
+      param.currentValue = param.isSet
+        ? param.sensitive
+          ? maskValue(eff)
+          : eff
+        : null;
+    }
+    const requiredErrs = plugin.parameters
+      .filter((p) => p.required && !p.isSet)
+      .map((p) => ({ field: p.key, message: `${p.key} is required but not set` }));
+    // Preserve format warnings from validatePluginConfig but use authoritative required errors
     const refreshParamInfos: PluginParamInfo[] = plugin.parameters.map((p) => ({
       key: p.key,
       required: p.required,
@@ -949,8 +1042,9 @@ export async function handlePluginRoutes(
       undefined,
       refreshParamInfos,
     );
-    plugin.validationErrors = updated.errors;
+    plugin.validationErrors = requiredErrs;
     plugin.validationWarnings = updated.warnings;
+    plugin.configured = requiredErrs.length === 0;
 
     // Update config.plugins.entries so the runtime loads/skips this plugin
     if (body.enabled !== undefined) {

--- a/plugins/plugin-registry/src/api/plugin-routes.ts
+++ b/plugins/plugin-registry/src/api/plugin-routes.ts
@@ -65,30 +65,42 @@ const ADVANCED_CAPABILITY_SERVICE_BY_PLUGIN_ID: Partial<
 
 function createRuntimeSettingReader(
   runtime: AgentRuntime | null,
-): ((key: string) => string | undefined) | undefined {
-  if (!runtime || typeof (runtime as unknown as { getSetting?: unknown }).getSetting !== "function") {
+): ((key: string) => string | boolean | number | undefined) | undefined {
+  if (
+    !runtime ||
+    typeof (runtime as unknown as { getSetting?: unknown }).getSetting !==
+      "function"
+  ) {
     return undefined;
   }
   return (key: string) => {
     const value = (runtime as AgentRuntime).getSetting(key);
-    return typeof value === "string" && value.trim() ? value.trim() : undefined;
+    if (typeof value === "string") {
+      return value.trim() || undefined;
+    }
+    return typeof value === "boolean" || typeof value === "number"
+      ? value
+      : undefined;
   };
 }
 
-function resolvePluginServiceHealth(
+function resolveDiscordServiceHealth(
   runtime: AgentRuntime | null,
-  pluginId: string,
 ): boolean | null {
-  if (!runtime || typeof (runtime as unknown as { getService?: unknown }).getService !== "function") {
+  if (
+    !runtime ||
+    typeof (runtime as unknown as { getService?: unknown }).getService !==
+      "function"
+  ) {
     return null;
   }
-  const service = (runtime as AgentRuntime).getService(pluginId) as
-    | { isHealthy?: () => boolean }
-    | null;
+  const service = (runtime as AgentRuntime).getService("discord") as {
+    isHealthy?: () => boolean;
+  } | null;
   if (!service || typeof service.isHealthy !== "function") {
-    return null;
+    return false;
   }
-  return Boolean(service.isHealthy());
+  return service.isHealthy();
 }
 
 // ---------------------------------------------------------------------------
@@ -633,11 +645,15 @@ export async function handlePluginRoutes(
       for (const param of plugin.parameters) {
         const envValue = process.env[param.key]?.trim() || undefined;
         const runtimeValue = readRuntimeSetting?.(param.key);
-        const effectiveValue = runtimeValue ?? envValue;
-        // When runtime exists, getSetting is authoritative — connectors never fall through to process.env
-        const isSet = readRuntimeSetting ? Boolean(runtimeValue) : Boolean(envValue);
+        // When a runtime exists, getSetting is authoritative: connector
+        // services do not fall through to the process-wide environment.
+        const isSet = readRuntimeSetting
+          ? runtimeValue !== undefined
+          : Boolean(envValue);
         param.isSet = isSet;
-        const displayValue = effectiveValue ?? "";
+        const displayValue = String(
+          (readRuntimeSetting ? runtimeValue : envValue) ?? "",
+        );
         param.currentValue = isSet
           ? param.sensitive
             ? maskValue(displayValue)
@@ -647,8 +663,11 @@ export async function handlePluginRoutes(
       // Validate against effective isSet, not stale process.env. This keeps
       // `configured` honest when getSetting is empty but process.env is set (#18713).
       const validationErrors = plugin.parameters
-        .filter((p) => p.required && !p.isSet)
-        .map((p) => ({ field: p.key, message: `${p.key} is required but not set` }));
+        .filter((p) => p.required && !p.default && !p.isSet)
+        .map((p) => ({
+          field: p.key,
+          message: `${p.key} is required but not set`,
+        }));
       const validation = validatePluginConfig(
         plugin.id,
         plugin.category,
@@ -664,19 +683,26 @@ export async function handlePluginRoutes(
           default: p.default,
         })),
       );
-      // Merge format warnings from validatePluginConfig, but replace required errors with authoritative ones
+      // Format/default diagnostics remain warnings. Required-field errors use
+      // the authoritative runtime-backed presence calculated above.
       plugin.validationErrors = validationErrors;
       plugin.validationWarnings = validation.warnings;
       plugin.configured = validationErrors.length === 0;
     }
-    // Health gate: demote isActive when service reports unhealthy (Discord gateway never connected)
+    // A loaded Discord package is not an active connector until its service
+    // exists and the Discord client reports ready. Other plugins retain their
+    // existing loaded-package semantics; they do not share this health API.
     for (const plugin of allPlugins) {
-      if (!plugin.isActive) continue;
-      if (resolvePluginServiceHealth(state.runtime, plugin.id) === false) {
+      if (plugin.id !== "discord" || !plugin.isActive) continue;
+      if (resolveDiscordServiceHealth(state.runtime) === false) {
         plugin.isActive = false;
         plugin.validationWarnings = [
           ...(plugin.validationWarnings ?? []),
-          { message: "Service is loaded but reports unhealthy: the connection is not established. Check credentials and connectivity." },
+          {
+            field: "DISCORD_API_TOKEN",
+            message:
+              "Discord is loaded but not connected. Check credentials and connectivity.",
+          },
         ];
       }
     }
@@ -974,9 +1000,9 @@ export async function handlePluginRoutes(
         for (const param of plugin.parameters) {
           const rtVal = rtReader?.(param.key);
           const envVal = process.env[param.key]?.trim() || undefined;
-          const isSet = rtReader ? Boolean(rtVal) : Boolean(envVal);
+          const isSet = rtReader ? rtVal !== undefined : Boolean(envVal);
           param.isSet = isSet;
-          const eff = rtVal ?? envVal ?? "";
+          const eff = String((rtReader ? rtVal : envVal) ?? "");
           param.currentValue = isSet
             ? param.sensitive
               ? maskValue(eff)
@@ -984,15 +1010,21 @@ export async function handlePluginRoutes(
             : null;
         }
         const errs = plugin.parameters
-          .filter((p) => p.required && !p.isSet)
-          .map((p) => ({ field: p.key, message: `${p.key} is required but not set` }));
+          .filter((p) => p.required && !p.default && !p.isSet)
+          .map((p) => ({
+            field: p.key,
+            message: `${p.key} is required but not set`,
+          }));
         plugin.validationErrors = errs;
         plugin.configured = errs.length === 0;
       } else {
         // No config touched, but still recompute configured from current isSet
         const errs = plugin.parameters
-          .filter((p) => p.required && !p.isSet)
-          .map((p) => ({ field: p.key, message: `${p.key} is required but not set` }));
+          .filter((p) => p.required && !p.default && !p.isSet)
+          .map((p) => ({
+            field: p.key,
+            message: `${p.key} is required but not set`,
+          }));
         if (errs.length > 0) plugin.validationErrors = errs;
         plugin.configured = (plugin.validationErrors?.length ?? 0) === 0;
       }
@@ -1014,8 +1046,8 @@ export async function handlePluginRoutes(
     for (const param of plugin.parameters) {
       const rtVal = rtReader2?.(param.key);
       const envVal = process.env[param.key]?.trim() || undefined;
-      param.isSet = rtReader2 ? Boolean(rtVal) : Boolean(envVal);
-      const eff = rtVal ?? envVal ?? "";
+      param.isSet = rtReader2 ? rtVal !== undefined : Boolean(envVal);
+      const eff = String((rtReader2 ? rtVal : envVal) ?? "");
       param.currentValue = param.isSet
         ? param.sensitive
           ? maskValue(eff)
@@ -1023,8 +1055,11 @@ export async function handlePluginRoutes(
         : null;
     }
     const requiredErrs = plugin.parameters
-      .filter((p) => p.required && !p.isSet)
-      .map((p) => ({ field: p.key, message: `${p.key} is required but not set` }));
+      .filter((p) => p.required && !p.default && !p.isSet)
+      .map((p) => ({
+        field: p.key,
+        message: `${p.key} is required but not set`,
+      }));
     // Preserve format warnings from validatePluginConfig but use authoritative required errors
     const refreshParamInfos: PluginParamInfo[] = plugin.parameters.map((p) => ({
       key: p.key,


### PR DESCRIPTION
Closes #18713.

Supersedes #19131 while retaining its contributor implementation and authorship in git history. The contributor PR lives on a fork that maintainers cannot update; this branch rebases it onto current `develop` and fixes the review blockers before publication.

## What changed

- keeps `runtime.getSetting()` authoritative instead of allowing process environment values to poison live plugin status
- treats defined `false` and `0` settings as configured values
- respects parameter defaults when computing missing required settings
- reports Discord active only when its live gateway service exists and is healthy
- preserves existing semantics for other plugins

## Verification

Exact head: `03357c0fd0f91c530bfc0855a178b7cca7619a7e`
Base: `799db3bdb77586f9d86ae5563a5d926250a1a719`

- plugin-registry catalog and bridge-settings tests: 18/18 pass
- Biome: pass
- root `bun run verify`: 350/350 pass

Co-authored-by: byt61 <byt61@users.noreply.github.com>