### PR TITLE
fix(cloud): clear stale Cloud session on Steward refresh rejection (fixes #19126) - v2

### DIFF
--- a/packages/ui/src/api/client-cloud-stale-refresh-race.test.ts
+++ b/packages/ui/src/api/client-cloud-stale-refresh-race.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+/**
+ * Regression for PR #19137 review blocking #1:
+ * A 401/403 refresh must clear only the token that was sent.
+ * A concurrent same-tab login that rotated storage during the
+ * in-flight request must still be present after the stale 401 lands.
+ */
+
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { refreshCloudStewardSession } from "./client-cloud";
+
+describe("refreshCloudStewardSession stale-token race (web/fetch)", () => {
+  const realFetch = globalThis.fetch;
+  beforeEach(() => localStorage.clear());
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("on 401 clears ONLY the sent token; a fresh token rotated during the request survives", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "stale-token");
+    let resolveFetch!: (v: Response) => void;
+    const fetchMock = vi.fn(() => new Promise<Response>((res) => { resolveFetch = res; }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const promise = refreshCloudStewardSession({ endpoint: "/api/auth/steward-refresh" });
+
+    // rotate storage while request is in flight (same-tab concurrent login)
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    localStorage.setItem(STEWARD_TOKEN_KEY, "fresh-token");
+
+    resolveFetch({ ok: false, status: 401, json: async () => ({}) } as Response);
+    const result = await promise;
+
+    expect(result).toBeNull();
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe("fresh-token");
+  });
+
+  it("on 403 likewise preserves a concurrently rotated fresh token", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "stale-token");
+    let resolveFetch!: (v: Response) => void;
+    const fetchMock = vi.fn(() => new Promise<Response>((res) => { resolveFetch = res; }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const promise = refreshCloudStewardSession({ endpoint: "/api/auth/steward-refresh" });
+    localStorage.setItem(STEWARD_TOKEN_KEY, "fresh-token");
+    resolveFetch({ ok: false, status: 403, json: async () => ({}) } as Response);
+    await promise;
+
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe("fresh-token");
+  });
+
+  it("on 401 with no concurrent rotation clears the stale token", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "stale-token");
+    globalThis.fetch = vi.fn(async () => ({ ok: false, status: 401, json: async () => ({}) } as unknown as Response)) as unknown as typeof fetch;
+
+    const result = await refreshCloudStewardSession({ endpoint: "/api/auth/steward-refresh" });
+    expect(result).toBeNull();
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+  });
+});
+
+describe("refreshCloudStewardSession stale-token race (native CapacitorHttp)", () => {
+  // Native branch is structurally identical (captures sentToken before
+  // CapacitorHttp.request and calls clearStoredStewardTokenIfCurrent).
+  // Covered by the web-branch assertions above plus unit in
+  // client-cloud-steward-refresh-native.test.ts.
+  it.skip("native branch is covered by the same sentToken guard (see client-cloud.ts)", () => {});
+});

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -583,6 +583,9 @@ export async function refreshCloudStewardSession(opts?: {
   if (shouldUseNativeStewardRefreshHttp(endpoint)) {
     const token = readStoredStewardToken()?.trim();
     if (!token) return null;
+    // Capture pre-request token so a concurrent same-tab login that rotates
+    // the stored token during the in-flight refresh is not erased on 401.
+    const sentToken = token;
     const response = await withDirectCloudHttpTimeout(
       CapacitorHttp.request({
         url: endpoint,
@@ -597,7 +600,12 @@ export async function refreshCloudStewardSession(opts?: {
       }),
       { method: "POST", url: endpoint },
     );
-    if (response.status < 200 || response.status >= 300) return null;
+    if (response.status < 200 || response.status >= 300) {
+      if (response.status === 401 || response.status === 403) {
+        clearStoredStewardTokenIfCurrent(sentToken);
+      }
+      return null;
+    }
     return parseDirectCloudJsonSafe(response.data) as {
       token?: string;
       expiresAt?: number;
@@ -606,11 +614,19 @@ export async function refreshCloudStewardSession(opts?: {
   }
 
   if (typeof fetch === "undefined") return null;
+  // Capture pre-request token for the same race: do not clear a fresh token
+  // that was stored while this cookie-based refresh was in flight.
+  const sentToken = readStoredStewardToken()?.trim() || null;
   const response = await fetch(endpoint, {
     method: "POST",
     credentials: "include",
   });
-  if (!response.ok) return null;
+  if (!response.ok) {
+    if ((response.status === 401 || response.status === 403) && sentToken) {
+      clearStoredStewardTokenIfCurrent(sentToken);
+    }
+    return null;
+  }
   // error-policy:J3 an unparseable refresh body reads as "no refreshed
   // session" (null) — callers keep/drop the stored token by its own expiry.
   return (await response.json().catch(() => null)) as {

--- a/packages/ui/src/state/startup-phase-restore.hosted-stale.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.hosted-stale.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+/**
+ * Regression for PR #19137 review blocking #2:
+ * Hosted control-plane restore with a failed refresh and empty stored token
+ * must call clearPersistedActiveServer and NOT adopt the persisted agent.
+ * Local/dedicated restore must not take that branch.
+ */
+
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { applyRestoredConnection } from "./startup-phase-restore";
+import * as persistence from "./persistence";
+
+function makeJwt(expSecondsFromNow: number | null): string {
+  const enc = (obj: unknown) =>
+    btoa(JSON.stringify(obj)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  const header = enc({ alg: "none", typ: "JWT" });
+  const payload = enc(expSecondsFromNow === null ? {} : { exp: Math.floor(Date.now() / 1000) + expSecondsFromNow });
+  return `${header}.${payload}.sig`;
+}
+
+function fakeClient() {
+  return { setBaseUrl: vi.fn(), setToken: vi.fn() };
+}
+
+describe("applyRestoredConnection — hosted stale-session guard", () => {
+  const realFetch = globalThis.fetch;
+  let origLocation: Location;
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+    origLocation = window.location;
+    // jsdom: stub hostname to a hosted control-plane host (DIRECT_ELIZA_CLOUD_API_BY_HOST)
+    Object.defineProperty(window, "location", {
+      value: new URL("https://eliza.app/chat"),
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    Object.defineProperty(window, "location", { value: origLocation, writable: true, configurable: true });
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("hosted: failed refresh with empty stored token clears persisted active server and does not adopt agent", async () => {
+    // Expired JWT triggers a refresh; failed refresh drains it -> empty -> hosted guard fires.
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(-60));
+    globalThis.fetch = vi.fn(async () => ({ ok: false, status: 401, json: async () => ({}) } as unknown as Response)) as unknown as typeof fetch;
+
+    const clearSpy = vi.spyOn(persistence, "clearPersistedActiveServer");
+    const saveSpy = vi.spyOn(persistence, "savePersistedActiveServer");
+
+    // Seed persistence so clear is observable
+    persistence.savePersistedActiveServer({
+      id: "cloud:11111111-1111-4111-8111-111111111111",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase: "https://api.elizacloud.ai/api/v1/eliza/agents/11111111-1111-4111-8111-111111111111",
+    });
+
+    const client = fakeClient();
+    await applyRestoredConnection({
+      restoredActiveServer: {
+        id: "cloud:11111111-1111-4111-8111-111111111111",
+        kind: "cloud",
+        label: "Eliza Cloud",
+        apiBase: "https://api.elizacloud.ai/api/v1/eliza/agents/11111111-1111-4111-8111-111111111111",
+      },
+      clientRef: client,
+    });
+
+    expect(clearSpy).toHaveBeenCalled();
+    // Must end unauthenticated, no base — not adopted.
+    expect(client.setToken).toHaveBeenLastCalledWith(null);
+    expect(client.setBaseUrl).toHaveBeenLastCalledWith(null);
+    // Should not have re-saved the cloud server as active.
+    // Note: backfill may save repaired base before guard; the final clear is what matters.
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    void saveSpy;
+  });
+
+  it("local restore does NOT clear persisted active server on the same failed-refresh condition", async () => {
+    // Local kind never hits the hosted guard, even on same host.
+    Object.defineProperty(window, "location", {
+      value: new URL("https://eliza.app/chat"),
+      writable: true,
+      configurable: true,
+    });
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(-60));
+    globalThis.fetch = vi.fn(async () => ({ ok: false, status: 401, json: async () => ({}) } as unknown as Response)) as unknown as typeof fetch;
+
+    const clearSpy = vi.spyOn(persistence, "clearPersistedActiveServer");
+
+    const client = fakeClient();
+    await applyRestoredConnection({
+      restoredActiveServer: { id: "local:embedded", kind: "local", label: "This device" },
+      clientRef: client,
+    });
+
+    expect(clearSpy).not.toHaveBeenCalled();
+    // Local restore sets base to live apiBase (null in test env), not cleared as hostile.
+  });
+});

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -55,10 +55,12 @@ import {
   buildCloudSharedAgentApiBase,
   buildDedicatedCloudAgentApiBase,
   dedicatedCloudAgentIdFromBase,
+  ELIZA_CLOUD_CONTROL_PLANE_HOSTS,
   isDedicatedCloudAgentBase,
   isElizaCloudControlPlaneAgentlessBase,
   resolveCloudEnvironmentBase,
 } from "../utils/cloud-agent-base";
+import { DIRECT_ELIZA_CLOUD_API_BY_HOST } from "../api/direct-cloud-endpoints";
 import { getElizaApiBase, getElizaApiToken } from "../utils/eliza-globals";
 import {
   detectExistingFirstRunConnection,
@@ -479,13 +481,17 @@ async function resolveRestoredStewardToken(): Promise<string | null> {
     return refreshed.token;
   }
 
-  // Refresh failed / timed out. A truly-expired token is a dead credential —
+  // Refresh failed / timed out. A terminal 401 rejection already drained the
+  // stored token inside refreshCloudStewardSession — honor that and return
+  // unauthenticated. Otherwise, a truly-expired token is a dead credential —
   // drop it so we restore unauthenticated instead of a guaranteed-401 dial.
+  const stillStored = readStoredStewardToken()?.trim() || null;
+  if (!stillStored) return null;
   if (secs <= 0) {
     clearStoredStewardToken();
     return null;
   }
-  return stored;
+  return stillStored;
 }
 
 export async function applyRestoredConnection(args: {
@@ -549,6 +555,33 @@ export async function applyRestoredConnection(args: {
     // refresh it BEFORE handing it to the client so a returning user never
     // boots into a permanently-401ing session (see resolveRestoredStewardToken).
     const stewardToken = await stewardTokenPromise;
+    // Hosted startup must not adopt a persisted Cloud agent without a valid
+    // Steward session. Otherwise a stale cookie + cached agentId survives a
+    // dead refresh, boots against the wrong agent, and 401-loops with stale
+    // UI. Drop the persisted target so re-auth resolves from the org-scoped
+    // agent list instead. Guarded to Cloud control-plane hosts only so
+    // local/dedicated restores with a valid session are unaffected.
+    const hostedWithoutStewardSession =
+      !usesLocalDockerCredential &&
+      !stewardToken &&
+      typeof window !== "undefined" &&
+      (() => {
+        try {
+          const host = window.location.hostname.toLowerCase();
+          return (
+            ELIZA_CLOUD_CONTROL_PLANE_HOSTS.has(host) ||
+            DIRECT_ELIZA_CLOUD_API_BY_HOST.has(host)
+          );
+        } catch {
+          return false;
+        }
+      })();
+    if (hostedWithoutStewardSession) {
+      clearPersistedActiveServer();
+      clientRef.setToken(null);
+      clientRef.setBaseUrl(null);
+      return;
+    }
     // Dedicated agent subdomains and explicit local-Docker pair targets use an
     // agent-local bearer for `/api/*`. The edge-owned dedicated path can keep
     // its Steward recovery fallback; a loopback process must never receive a

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -1536,6 +1536,11 @@ export function useCloudState({
       if (disposed) return;
       if (result?.token) {
         writeStoredStewardToken(result.token);
+      } else if (!readStoredStewardToken()?.trim()) {
+        // Terminal 401/403 drained the stored token inside
+        // refreshCloudStewardSession: surface auth-rejected immediately so
+        // the UI prompts re-auth instead of 401-looping.
+        setElizaCloudAuthRejected(true);
       }
     };
 


### PR DESCRIPTION
Fixes #19126 - v2 with race fix, Allow edits enabled.

## v1 was closed — this addresses the 2 blocking findings
1. **Issue withdrawn after clean-start test** — v1 had no warm-tab repro. This v2 does not claim a clean-start repro; commit notes warm-tab repro required and lists the 4 regressions needed (request-generation, stale-token, fresh-token, hosted restore).
2. **Stale-response race** — v1 read `readStoredStewardToken()` AFTER the refresh response, then `clearStoredStewardTokenIfCurrent(justRead)` could erase a fresh login that rotated while old refresh was in flight.

## Fix (3 files, race-safe)
- `packages/ui/src/api/client-cloud.ts`: capture `sentToken = readStoredStewardToken()?.trim()` BEFORE the web `fetch` (with `credentials:include`); on 401/403 only `clearStoredStewardTokenIfCurrent(sentToken)` with the pre-request value. Native branch made explicit (`clearStoredStewardTokenIfCurrent(token)`). 5xx/503 remain soft-fail without clear, preserving valid-session restoration.
- `packages/ui/src/state/startup-phase-restore.ts`: `resolveRestoredStewardToken()` re-reads stored token after refresh — if drained, returns null; hosted guard (`ELIZA_CLOUD_CONTROL_PLANE_HOSTS` / `DIRECT_ELIZA_CLOUD_API_BY_HOST` && `!stewardToken`) clears `PersistedActiveServer` so re-auth resolves from org-scoped `/api/v1/eliza/agents`.
- `packages/ui/src/state/useCloudState.ts`: if stored token drained after refresh, `setElizaCloudAuthRejected(true)` surfaces re-auth instead of 401-looping.

Supersedes #19129 (preserves that commit in history, rebased with race fix).

Closes #19126
