### PR TITLE
fix(cloud): surface typed wake/provision failures instead of a six-minute join spinner (#18463)

### DIFF
--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -39,7 +39,7 @@ function expectNoLocalPersistOrStatusProbe(): void {
   for (const url of calledNativeUrls()) {
     expect(url).not.toContain("localhost");
     expect(url).not.toContain("/api/cloud/login/persist");
-    expect(url).not.toBe("https://api.elizacloud.ai/api/status");
+    expect(url).not.toBe("https://api.eliza.app/api/status");
   }
 }
 
@@ -67,7 +67,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
 
     expect(capacitorMocks.post).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/auth/cli-session",
+        url: "https://api.eliza.app/api/auth/cli-session",
         data: expect.objectContaining({ sessionId: expect.any(String) }),
       }),
     );
@@ -77,9 +77,9 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expect(result).toEqual(
       expect.objectContaining({
         ok: true,
-        apiBase: "https://api.elizacloud.ai",
+        apiBase: "https://api.eliza.app",
         browserUrl: expect.stringMatching(
-          /^https:\/\/elizacloud\.ai\/auth\/cli-login\?session=/,
+          /^https:\/\/eliza\.app\/auth\/cli-login\?session=/,
         ),
       }),
     );
@@ -96,16 +96,16 @@ describe("ElizaClient direct Cloud auth on native", () => {
 
     expect(capacitorMocks.post).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api-staging.elizacloud.ai/api/auth/cli-session",
+        url: "https://api-staging.eliza.app/api/auth/cli-session",
         data: expect.objectContaining({ sessionId: expect.any(String) }),
       }),
     );
     expect(result).toEqual(
       expect.objectContaining({
         ok: true,
-        apiBase: "https://api-staging.elizacloud.ai",
+        apiBase: "https://api-staging.eliza.app",
         browserUrl: expect.stringMatching(
-          /^https:\/\/staging\.elizacloud\.ai\/auth\/cli-login\?session=/,
+          /^https:\/\/staging\.eliza\.app\/auth\/cli-login\?session=/,
         ),
       }),
     );
@@ -121,15 +121,15 @@ describe("ElizaClient direct Cloud auth on native", () => {
 
     expect(capacitorMocks.post).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api-staging.elizacloud.ai/api/auth/cli-session",
+        url: "https://api-staging.eliza.app/api/auth/cli-session",
       }),
     );
     expect(result).toEqual(
       expect.objectContaining({
         ok: true,
-        apiBase: "https://api-staging.elizacloud.ai",
+        apiBase: "https://api-staging.eliza.app",
         browserUrl: expect.stringMatching(
-          /^https:\/\/staging\.elizacloud\.ai\/auth\/cli-login\?session=/,
+          /^https:\/\/staging\.eliza\.app\/auth\/cli-login\?session=/,
         ),
       }),
     );
@@ -152,15 +152,15 @@ describe("ElizaClient direct Cloud auth on native", () => {
 
     expect(capacitorMocks.post).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api-staging.elizacloud.ai/api/auth/cli-session",
+        url: "https://api-staging.eliza.app/api/auth/cli-session",
       }),
     );
     expect(result).toEqual(
       expect.objectContaining({
         ok: true,
-        apiBase: "https://api-staging.elizacloud.ai",
+        apiBase: "https://api-staging.eliza.app",
         browserUrl: expect.stringMatching(
-          /^https:\/\/staging\.elizacloud\.ai\/auth\/cli-login\?session=/,
+          /^https:\/\/staging\.eliza\.app\/auth\/cli-login\?session=/,
         ),
       }),
     );
@@ -187,7 +187,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
 
     expect(capacitorMocks.get).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/auth/cli-session/mobile-session",
+        url: "https://api.eliza.app/api/auth/cli-session/mobile-session",
       }),
     );
     expect(result).toEqual({
@@ -213,7 +213,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
 
     expect(capacitorMocks.request).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/user",
+        url: "https://api.eliza.app/api/v1/user",
         headers: expect.objectContaining({
           Authorization: "Bearer cloud-api-key",
         }),
@@ -240,7 +240,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
 
     expect(capacitorMocks.request).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/credits/balance",
+        url: "https://api.eliza.app/api/v1/credits/balance",
         headers: expect.objectContaining({
           Authorization: "Bearer cloud-api-key",
         }),
@@ -277,7 +277,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
 
     expect(capacitorMocks.request).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/eliza/agents",
+        url: "https://api.eliza.app/api/v1/eliza/agents",
         method: "GET",
         headers: expect.objectContaining({
           Authorization: "Bearer cloud-api-key",
@@ -298,7 +298,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     });
     if (!result.success) throw new Error("Expected the agent list to load");
     const selected = await client.selectOrProvisionCloudAgent({
-      cloudApiBase: "https://api.elizacloud.ai/api/v1",
+      cloudApiBase: "https://api.eliza.app/api/v1",
       authToken: "cloud-api-key",
       name: "My Agent",
       knownAgents: result.data,
@@ -342,7 +342,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expect(capacitorMocks.request).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/eliza/agents",
+        url: "https://api.eliza.app/api/v1/eliza/agents",
         method: "POST",
         data: expect.objectContaining({ agentName: "My Agent" }),
       }),
@@ -350,7 +350,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expect(capacitorMocks.request).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1/provision",
+        url: "https://api.eliza.app/api/v1/eliza/agents/agent-1/provision",
         method: "POST",
       }),
     );
@@ -388,7 +388,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expect(capacitorMocks.request).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/eliza/agents",
+        url: "https://api.eliza.app/api/v1/eliza/agents",
         method: "POST",
         data: expect.objectContaining({
           agentName: "My Agent",
@@ -468,7 +468,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
 
     expect(capacitorMocks.request).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1",
+        url: "https://api.eliza.app/api/v1/eliza/agents/agent-1",
         method: "DELETE",
       }),
     );
@@ -503,7 +503,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
 
     expect(capacitorMocks.request).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1/suspend",
+        url: "https://api.eliza.app/api/v1/eliza/agents/agent-1/suspend",
         method: "POST",
         headers: expect.objectContaining({
           Authorization: "Bearer cloud-api-key",
@@ -541,7 +541,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
 
     expect(capacitorMocks.request).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1/resume",
+        url: "https://api.eliza.app/api/v1/eliza/agents/agent-1/resume",
         method: "POST",
         headers: expect.objectContaining({
           Authorization: "Bearer cloud-api-key",
@@ -576,7 +576,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     );
     expect(capacitorMocks.request).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1/suspend",
+        url: "https://api.eliza.app/api/v1/eliza/agents/agent-1/suspend",
         method: "POST",
       }),
     );
@@ -655,7 +655,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
 
     expect(capacitorMocks.request).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/compat/agents/agent-1/launch",
+        url: "https://api.eliza.app/api/compat/agents/agent-1/launch",
         method: "POST",
         headers: expect.objectContaining({
           Authorization: "Bearer cloud-api-key",
@@ -693,7 +693,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     await expectation;
     expect(capacitorMocks.request).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1/provision",
+        url: "https://api.eliza.app/api/v1/eliza/agents/agent-1/provision",
         method: "POST",
       }),
     );
@@ -717,7 +717,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     );
     expect(capacitorMocks.request).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1/provision",
+        url: "https://api.eliza.app/api/v1/eliza/agents/agent-1/provision",
         method: "POST",
       }),
     );
@@ -750,7 +750,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     );
     expect(capacitorMocks.request).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1/provision",
+        url: "https://api.eliza.app/api/v1/eliza/agents/agent-1/provision",
         method: "POST",
       }),
     );
@@ -829,7 +829,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
 
     expect(capacitorMocks.request).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/jobs/job-1",
+        url: "https://api.eliza.app/api/v1/jobs/job-1",
         method: "GET",
       }),
     );
@@ -903,7 +903,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
       },
     });
     capacitorMocks.request.mockImplementation(async ({ url, method }) => {
-      if (url === "https://api.elizacloud.ai/api/v1/user") {
+      if (url === "https://api.eliza.app/api/v1/user") {
         return {
           status: 200,
           data: {
@@ -913,13 +913,13 @@ describe("ElizaClient direct Cloud auth on native", () => {
         };
       }
       if (
-        url === "https://api.elizacloud.ai/api/v1/eliza/agents" &&
+        url === "https://api.eliza.app/api/v1/eliza/agents" &&
         method === "GET"
       ) {
         return { status: 200, data: { success: true, data: [] } };
       }
       if (
-        url === "https://api.elizacloud.ai/api/v1/eliza/agents" &&
+        url === "https://api.eliza.app/api/v1/eliza/agents" &&
         method === "POST"
       ) {
         return {
@@ -936,7 +936,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
       }
       if (
         url ===
-          "https://api.elizacloud.ai/api/v1/eliza/agents/agent-dev/provision" &&
+          "https://api.eliza.app/api/v1/eliza/agents/agent-dev/provision" &&
         method === "POST"
       ) {
         return {
@@ -947,7 +947,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
           },
         };
       }
-      if (url === "https://api.elizacloud.ai/api/v1/jobs/job-dev") {
+      if (url === "https://api.eliza.app/api/v1/jobs/job-dev") {
         return {
           status: 200,
           data: {
@@ -971,7 +971,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     const client = new ElizaClient("");
     const login = await client.cloudLoginDirect("https://www.elizacloud.ai");
     const poll = await client.cloudLoginPollDirect(
-      login.apiBase ?? "https://api.elizacloud.ai",
+      login.apiBase ?? "https://api.eliza.app",
       login.sessionId ?? "missing-session",
     );
     client.setToken(poll.token ?? null);
@@ -1010,14 +1010,14 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(calledNativeUrls()).toEqual(
       expect.arrayContaining([
-        "https://api.elizacloud.ai/api/auth/cli-session",
+        "https://api.eliza.app/api/auth/cli-session",
         expect.stringMatching(
-          /^https:\/\/api\.elizacloud\.ai\/api\/auth\/cli-session\//,
+          /^https:\/\/api\.eliza\.app\/api\/auth\/cli-session\//,
         ),
-        "https://api.elizacloud.ai/api/v1/user",
-        "https://api.elizacloud.ai/api/v1/eliza/agents",
-        "https://api.elizacloud.ai/api/v1/eliza/agents/agent-dev/provision",
-        "https://api.elizacloud.ai/api/v1/jobs/job-dev",
+        "https://api.eliza.app/api/v1/user",
+        "https://api.eliza.app/api/v1/eliza/agents",
+        "https://api.eliza.app/api/v1/eliza/agents/agent-dev/provision",
+        "https://api.eliza.app/api/v1/jobs/job-dev",
       ]),
     );
     expectNoLocalPersistOrStatusProbe();
@@ -1032,7 +1032,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
       );
     capacitorMocks.request.mockImplementation(async ({ url, method }) => {
       if (
-        url === "https://api.elizacloud.ai/api/v1/eliza/agents" &&
+        url === "https://api.eliza.app/api/v1/eliza/agents" &&
         method === "POST"
       ) {
         return {
@@ -1042,7 +1042,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
       }
       if (
         url ===
-          "https://api.elizacloud.ai/api/v1/eliza/agents/sandbox-agent/provision" &&
+          "https://api.eliza.app/api/v1/eliza/agents/sandbox-agent/provision" &&
         method === "POST"
       ) {
         return {
@@ -1054,7 +1054,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
           },
         };
       }
-      if (url === "https://api.elizacloud.ai/api/v1/jobs/sandbox-job") {
+      if (url === "https://api.eliza.app/api/v1/jobs/sandbox-job") {
         return {
           status: 200,
           data: {
@@ -1094,7 +1094,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expect(capacitorMocks.request).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/eliza/agents",
+        url: "https://api.eliza.app/api/v1/eliza/agents",
         method: "POST",
         headers: expect.objectContaining({
           authorization: "Bearer dev-js-bearer",
@@ -1110,7 +1110,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expect(capacitorMocks.request).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/eliza/agents/sandbox-agent/provision",
+        url: "https://api.eliza.app/api/v1/eliza/agents/sandbox-agent/provision",
         method: "POST",
         headers: expect.objectContaining({
           authorization: "Bearer dev-js-bearer",
@@ -1120,7 +1120,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expect(capacitorMocks.request).toHaveBeenNthCalledWith(
       3,
       expect.objectContaining({
-        url: "https://api.elizacloud.ai/api/v1/jobs/sandbox-job",
+        url: "https://api.eliza.app/api/v1/jobs/sandbox-job",
         method: "GET",
         headers: expect.objectContaining({
           authorization: "Bearer dev-js-bearer",
@@ -1134,7 +1134,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
   it("rejects shared-runtime Cloud agents by default", async () => {
     capacitorMocks.request.mockImplementation(async ({ url, method }) => {
       if (
-        url === "https://api.elizacloud.ai/api/v1/eliza/agents" &&
+        url === "https://api.eliza.app/api/v1/eliza/agents" &&
         method === "POST"
       ) {
         return {
@@ -1151,7 +1151,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
       }
       if (
         url ===
-          "https://api.elizacloud.ai/api/v1/eliza/agents/shared-agent/provision" &&
+          "https://api.eliza.app/api/v1/eliza/agents/shared-agent/provision" &&
         method === "POST"
       ) {
         return {
@@ -1190,7 +1190,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
       );
     capacitorMocks.request.mockImplementation(async ({ url, method }) => {
       if (
-        url === "https://api.elizacloud.ai/api/v1/eliza/agents" &&
+        url === "https://api.eliza.app/api/v1/eliza/agents" &&
         method === "POST"
       ) {
         return {
@@ -1207,7 +1207,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
       }
       if (
         url ===
-          "https://api.elizacloud.ai/api/v1/eliza/agents/shared-agent/provision" &&
+          "https://api.eliza.app/api/v1/eliza/agents/shared-agent/provision" &&
         method === "POST"
       ) {
         return {
@@ -1237,8 +1237,8 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expect(result).toEqual({
       agentId: "shared-agent",
       bridgeUrl:
-        "https://api.elizacloud.ai/api/v1/eliza/agents/shared-agent/bridge",
-      webUiUrl: "https://api.elizacloud.ai/api/v1/eliza/agents/shared-agent",
+        "https://api.eliza.app/api/v1/eliza/agents/shared-agent/bridge",
+      webUiUrl: "https://api.eliza.app/api/v1/eliza/agents/shared-agent",
       executionTier: "shared",
     });
     expect(result.bridgeUrl).toContain("/api/v1/eliza/agents/shared-agent/");

--- a/packages/ui/src/api/client-cloud-provision-sandbox.test.ts
+++ b/packages/ui/src/api/client-cloud-provision-sandbox.test.ts
@@ -23,7 +23,7 @@ import { ElizaClient } from "./client-base";
 // Side-effect import: patches provisionCloudSandbox onto the prototype.
 import "./client-cloud";
 
-const CLOUD_API_BASE = "https://api.elizacloud.ai";
+const CLOUD_API_BASE = "https://api.eliza.app";
 
 function jsonResponse(status: number, body: unknown) {
   return {
@@ -177,7 +177,7 @@ describe("provisionCloudSandbox", () => {
     });
     expect(result.executionTier).toBe("shared");
     expect(result.webUiUrl).toBe(
-      "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1",
+      "https://api.eliza.app/api/v1/eliza/agents/agent-1",
     );
   });
 });

--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -55,12 +55,19 @@ function fakeClient() {
   const createCloudCompatAgent = vi.fn();
   const getCloudCompatAgent = vi.fn();
   const resumeCloudCompatAgent = vi.fn(async () => ({ success: true }));
+  // Fresh creates that answer with a jobId now follow the job to terminal;
+  // default it to an already-completed job so reuse-focused cases pass through.
+  const getCloudCompatJobStatus = vi.fn(async (jobId: string) => ({
+    success: true,
+    data: { jobId, id: jobId, status: "completed", state: "completed" },
+  }));
   const client = Object.create(ElizaClient.prototype) as ElizaClient;
   Object.assign(client, {
     getCloudCompatAgents,
     createCloudCompatAgent,
     getCloudCompatAgent,
     resumeCloudCompatAgent,
+    getCloudCompatJobStatus,
   });
   return {
     client,
@@ -68,6 +75,7 @@ function fakeClient() {
     createCloudCompatAgent,
     getCloudCompatAgent,
     resumeCloudCompatAgent,
+    getCloudCompatJobStatus,
   };
 }
 

--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -214,7 +214,7 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
 
     expect(result.created).toBe(false);
     expect(result.agentId).toBe("agent-no-urls");
-    expect(result.apiBase).toBe("https://agent-no-urls.elizacloud.ai");
+    expect(result.apiBase).toBe("https://agent-no-urls.cloud.eliza.app");
     expect(result.apiBase).not.toContain("/api/v1/eliza/agents/");
     expect(createCloudCompatAgent).not.toHaveBeenCalled();
   });
@@ -242,7 +242,9 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     });
 
     expect(result.created).toBe(false);
-    expect(result.apiBase).toBe("https://agent-staging.staging.elizacloud.ai");
+    expect(result.apiBase).toBe(
+      "https://agent-staging.cloud-staging.eliza.app",
+    );
     expect(createCloudCompatAgent).not.toHaveBeenCalled();
   });
 
@@ -272,7 +274,7 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(result.created).toBe(false);
     expect(result.executionTier).toBe("shared");
     expect(result.apiBase).toBe(
-      "https://api-staging.elizacloud.ai/api/v1/eliza/agents/agent-shared",
+      "https://api-staging.eliza.app/api/v1/eliza/agents/agent-shared",
     );
     expect(createCloudCompatAgent).not.toHaveBeenCalled();
   });

--- a/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
+++ b/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
@@ -14,6 +14,7 @@ vi.mock("@capacitor/core", () => ({
   CapacitorHttp: { get: vi.fn(), post: vi.fn(), request: vi.fn() },
 }));
 
+import { CloudAgentWakeError as PublicCloudAgentWakeError } from "./client";
 import { ElizaClient } from "./client-base";
 import {
   CloudAgentWakeError,
@@ -21,6 +22,7 @@ import {
   waitForCloudProvisionJob,
 } from "./client-cloud";
 import type { CloudCompatAgent } from "./client-types-cloud";
+import { isCloudAgentGoneError } from "./client-types-core";
 
 function makeAgent(
   overrides: Partial<CloudCompatAgent> = {},
@@ -67,6 +69,31 @@ function fakeClient(mocks: Record<string, unknown>): ElizaClient {
 const FAST = { pollIntervalMs: 1, timeoutMs: 60 };
 
 describe("waitForCloudAgentRunning — typed non-transient failures", () => {
+  it("exports the typed error through the public API barrel", () => {
+    expect(PublicCloudAgentWakeError).toBe(CloudAgentWakeError);
+  });
+
+  it("surfaces a resolved resume rejection instead of entering the status poll", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({
+        success: false,
+        error: "Eliza Cloud login session is missing. Sign in again.",
+        data: { status: "auth-missing" },
+      })),
+      getCloudCompatAgent: vi.fn(),
+    });
+    const error = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      ...FAST,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    expect((error as CloudAgentWakeError).phase).toBe("resume");
+    expect((error as CloudAgentWakeError).code).toBe(
+      "CLOUD_AGENT_RESUME_REJECTED",
+    );
+    expect(client.getCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
   it("surfaces a 402 resume rejection immediately with status and Retry-After", async () => {
     const client = fakeClient({
       resumeCloudCompatAgent: vi
@@ -107,6 +134,62 @@ describe("waitForCloudAgentRunning — typed non-transient failures", () => {
     expect(client.getCloudCompatAgent).toHaveBeenCalledTimes(1);
   });
 
+  it("surfaces a resolved detail-read rejection instead of timing out", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({ success: true })),
+      getCloudCompatAgent: vi.fn(async () => ({
+        success: false,
+        error: "Cloud session expired",
+        data: makeAgent({ status: "auth-missing" }),
+      })),
+    });
+    const error = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      ...FAST,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    expect((error as CloudAgentWakeError).phase).toBe("status-poll");
+    expect((error as CloudAgentWakeError).message).toBe(
+      "Cloud session expired",
+    );
+    expect(client.getCloudCompatAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry an unclassified client HTTP rejection", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi
+        .fn()
+        .mockRejectedValue(httpError(400, { code: "invalid_request" })),
+      getCloudCompatAgent: vi.fn(),
+    });
+    const error = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      ...FAST,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    expect((error as CloudAgentWakeError).status).toBe(400);
+    expect((error as CloudAgentWakeError).code).toBe("invalid_request");
+    expect(client.getCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
+  it("preserves agent_not_found through the typed wrapper for stale-binding recovery", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({ success: true })),
+      getCloudCompatAgent: vi.fn().mockRejectedValue(
+        httpError(404, {
+          data: { code: "agent_not_found", error: "Agent not found" },
+        }),
+      ),
+    });
+    const error = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      ...FAST,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    expect((error as CloudAgentWakeError).code).toBe("agent_not_found");
+    expect(isCloudAgentGoneError(error)).toBe(true);
+  });
+
   it("reads Retry-After out of a direct-cloud 503 error body", async () => {
     const client = fakeClient({
       resumeCloudCompatAgent: vi.fn(async () => ({ success: true })),
@@ -121,6 +204,43 @@ describe("waitForCloudAgentRunning — typed non-transient failures", () => {
     expect(error).toBeInstanceOf(CloudAgentWakeError);
     expect((error as CloudAgentWakeError).status).toBe(503);
     expect((error as CloudAgentWakeError).retryAfter).toBe(45);
+  });
+
+  it("preserves a direct-cloud Retry-After header and structured code", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: false,
+          code: "provisioning_capacity_unavailable",
+          error: "No provisioning worker is currently available",
+        }),
+        {
+          status: 503,
+          headers: {
+            "Content-Type": "application/json",
+            "Retry-After": "17",
+          },
+        },
+      ),
+    );
+    try {
+      const client = new ElizaClient("https://api.eliza.app", "test-token");
+      const error = await waitForCloudAgentRunning(client, {
+        agentId: "agent-1",
+        ...FAST,
+      }).catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(CloudAgentWakeError);
+      const wake = error as CloudAgentWakeError;
+      expect(wake.status).toBe(503);
+      expect(wake.retryAfter).toBe(17);
+      expect(wake.code).toBe("provisioning_capacity_unavailable");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(String(fetchSpy.mock.calls[0]?.[0])).toContain(
+        "/api/v1/eliza/agents/agent-1/resume",
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("keeps polling through transient failures (network / other 5xx) and resolves", async () => {
@@ -163,6 +283,26 @@ describe("waitForCloudAgentRunning — typed non-transient failures", () => {
 });
 
 describe("waitForCloudProvisionJob — canonical job followed to terminal", () => {
+  it("surfaces a resolved job-read rejection instead of treating it as progress", async () => {
+    const client = fakeClient({
+      getCloudCompatJobStatus: vi.fn(async () => ({
+        success: false,
+        error: "Eliza Cloud login session is missing. Sign in again.",
+        data: { status: "failed", state: "failed" },
+      })),
+    });
+    const error = await waitForCloudProvisionJob(client, {
+      agentId: "agent-1",
+      jobId: "job-1",
+      ...FAST,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    expect((error as CloudAgentWakeError).code).toBe(
+      "CLOUD_PROVISION_JOB_STATUS_REJECTED",
+    );
+    expect(client.getCloudCompatJobStatus).toHaveBeenCalledTimes(1);
+  });
+
   it("resolves when the job completes", async () => {
     const client = fakeClient({
       getCloudCompatJobStatus: vi

--- a/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
+++ b/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
@@ -7,6 +7,7 @@
  * job to terminal instead of discarding its jobId. Mocked client, no live
  * cloud.
  */
+import { ElizaError } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@capacitor/core", () => ({
@@ -424,5 +425,154 @@ describe("selectOrProvisionCloudAgent — fresh create follows its job", () => {
     expect((error as CloudAgentWakeError).jobId).toBe("job-9");
     expect((error as CloudAgentWakeError).message).toMatch(/image pull failed/);
     expect(getCloudCompatAgent).not.toHaveBeenCalled();
+  });
+});
+
+describe("CloudAgentWakeError — real typed-error identity", () => {
+  it("is an ElizaError carrying the wake code and context", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi
+        .fn()
+        .mockRejectedValue(httpError(402, { retryAfter: 30 })),
+      getCloudCompatAgent: vi.fn(),
+    });
+    const error = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      ...FAST,
+    }).catch((e: unknown) => e);
+    // The class must extend the real ElizaError, not a degraded plain-Error
+    // base: `code`/`context` are what `isCloudAgentGoneError` and the error
+    // reporters read, and a fixture bundle that swapped the base would
+    // exercise a different class than production.
+    expect(error).toBeInstanceOf(ElizaError);
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    const wake = error as CloudAgentWakeError;
+    expect(wake.code).toBe("CLOUD_AGENT_WAKE_FAILED");
+    expect(wake.context).toMatchObject({
+      phase: "resume",
+      agentId: "agent-1",
+      status: 402,
+      retryAfter: 30,
+    });
+  });
+});
+
+describe("throttled wake polls stay transient and honor Retry-After", () => {
+  it("keeps polling through a 429 status read instead of aborting the join", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({ success: true })),
+      getCloudCompatAgent: vi
+        .fn()
+        .mockRejectedValueOnce(httpError(429, { retryAfter: 0 }))
+        .mockRejectedValueOnce(httpError(408))
+        .mockResolvedValue({ success: true, data: makeAgent() }),
+    });
+    const agent = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      pollIntervalMs: 1,
+      timeoutMs: 1_000,
+    });
+    expect(agent.status).toBe("running");
+    expect(client.getCloudCompatAgent).toHaveBeenCalledTimes(3);
+  });
+
+  it("waits the Retry-After the control plane asked for before the next tick", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({ success: true })),
+      getCloudCompatAgent: vi
+        .fn()
+        .mockRejectedValueOnce(httpError(429, { retryAfter: 0.12 }))
+        .mockResolvedValue({ success: true, data: makeAgent() }),
+    });
+    const startedAt = Date.now();
+    const agent = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      pollIntervalMs: 1,
+      timeoutMs: 5_000,
+    });
+    // Re-polling on the 1ms tick would earn another 429; the loop must back off
+    // for the 120ms the backend named.
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(100);
+    expect(agent.status).toBe("running");
+  });
+
+  it("keeps polling through a 429 job read and honors its Retry-After", async () => {
+    const client = fakeClient({
+      getCloudCompatJobStatus: vi
+        .fn()
+        .mockRejectedValueOnce(httpError(429, { data: { retry_after: 0.12 } }))
+        .mockResolvedValue({
+          success: true,
+          data: { status: "completed", state: "completed" },
+        }),
+    });
+    const startedAt = Date.now();
+    await waitForCloudProvisionJob(client, {
+      agentId: "agent-1",
+      jobId: "job-1",
+      pollIntervalMs: 1,
+      timeoutMs: 5_000,
+    });
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(100);
+    expect(client.getCloudCompatJobStatus).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("selectOrProvisionCloudAgent — one wake budget for the whole join", () => {
+  it("spends the provisioning wait out of the same deadline as the running wait", async () => {
+    const WAKE_TIMEOUT_MS = 300;
+    const JOB_LATENCY_MS = 240;
+    const getCloudCompatAgent = vi.fn(async () => ({
+      success: true,
+      data: makeAgent({
+        agent_id: "agent-new",
+        status: "starting",
+        web_ui_url: "https://agent-new.elizacloud.ai",
+        webUiUrl: "https://agent-new.elizacloud.ai",
+      }),
+    }));
+    const client = fakeClient({
+      getCloudCompatAgents: vi.fn(async () => ({ success: true, data: [] })),
+      createCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: {
+          agentId: "agent-new",
+          agentName: "Eliza",
+          jobId: "job-9",
+          status: "provisioning",
+          nodeId: null,
+          message: "",
+        },
+      })),
+      getCloudCompatJobStatus: vi.fn(async () => {
+        await new Promise((r) => setTimeout(r, JOB_LATENCY_MS));
+        return {
+          success: true,
+          data: { status: "completed", state: "completed" },
+        };
+      }),
+      getCloudCompatAgent,
+      resumeCloudCompatAgent: vi.fn(async () => ({ success: true })),
+    });
+
+    const startedAt = Date.now();
+    const error = await client
+      .selectOrProvisionCloudAgent({
+        cloudApiBase: "https://api.elizacloud.ai/api/v1",
+        authToken: "test-token",
+        name: "Eliza",
+        wakePollIntervalMs: 1,
+        wakeTimeoutMs: WAKE_TIMEOUT_MS,
+      })
+      .catch((e: unknown) => e);
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    expect((error as CloudAgentWakeError).phase).toBe("timeout");
+    // Before the shared deadline each wait got the full budget, so a job that
+    // finished just under the wire handed a fresh full timeout to the status
+    // poll — the doubled spinner of #18463.
+    expect(elapsedMs).toBeLessThan(JOB_LATENCY_MS + WAKE_TIMEOUT_MS);
+    expect(elapsedMs).toBeGreaterThanOrEqual(JOB_LATENCY_MS);
   });
 });

--- a/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
+++ b/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Unit coverage for the typed wake/provision failure surface (#18463): the
+ * dedicated-agent wait must surface non-transient control-plane failures
+ * (auth expiry, credits, missing row, conflict, worker outage) immediately as
+ * `CloudAgentWakeError` with status + Retry-After + correlation ids, keep
+ * retrying only transient errors, and follow a fresh create's provisioning
+ * job to terminal instead of discarding its jobId. Mocked client, no live
+ * cloud.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => false },
+  CapacitorHttp: { get: vi.fn(), post: vi.fn(), request: vi.fn() },
+}));
+
+import { ElizaClient } from "./client-base";
+import {
+  CloudAgentWakeError,
+  waitForCloudAgentRunning,
+  waitForCloudProvisionJob,
+} from "./client-cloud";
+import type { CloudCompatAgent } from "./client-types-cloud";
+
+function makeAgent(
+  overrides: Partial<CloudCompatAgent> = {},
+): CloudCompatAgent {
+  return {
+    agent_id: "agent-1",
+    agent_name: "Eliza",
+    node_id: null,
+    container_id: null,
+    headscale_ip: null,
+    bridge_url: null,
+    web_ui_url: "https://agent-1.example.test",
+    status: "running",
+    agent_config: {},
+    created_at: "2026-08-01T00:00:00.000Z",
+    updated_at: "2026-08-01T00:00:00.000Z",
+    containerUrl: "",
+    webUiUrl: "https://agent-1.example.test",
+    database_status: "ok",
+    error_message: null,
+    last_heartbeat_at: null,
+    execution_tier: "dedicated-always",
+    ...overrides,
+  };
+}
+
+/** Transport-shaped rejection: both ApiError and the direct-cloud throw carry `status`. */
+function httpError(
+  status: number,
+  extras: Record<string, unknown> = {},
+): Error {
+  return Object.assign(new Error(`HTTP ${status} from cloud`), {
+    status,
+    ...extras,
+  });
+}
+
+function fakeClient(mocks: Record<string, unknown>): ElizaClient {
+  const client = Object.create(ElizaClient.prototype) as ElizaClient;
+  Object.assign(client, mocks);
+  return client;
+}
+
+const FAST = { pollIntervalMs: 1, timeoutMs: 60 };
+
+describe("waitForCloudAgentRunning — typed non-transient failures", () => {
+  it("surfaces a 402 resume rejection immediately with status and Retry-After", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi
+        .fn()
+        .mockRejectedValue(httpError(402, { retryAfter: 30 })),
+      getCloudCompatAgent: vi.fn(),
+    });
+    const error = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      ...FAST,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    const wake = error as CloudAgentWakeError;
+    expect(wake.phase).toBe("resume");
+    expect(wake.status).toBe(402);
+    expect(wake.retryAfter).toBe(30);
+    expect(wake.agentId).toBe("agent-1");
+    expect(wake.message).toMatch(/HTTP 402/);
+    expect(wake.message).toMatch(/about 30s/);
+    // Never fell through to the six-minute poll.
+    expect(client.getCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 401 detail-poll rejection immediately instead of masking it until timeout", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({ success: true })),
+      getCloudCompatAgent: vi.fn().mockRejectedValue(httpError(401)),
+    });
+    const error = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      ...FAST,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    const wake = error as CloudAgentWakeError;
+    expect(wake.phase).toBe("status-poll");
+    expect(wake.status).toBe(401);
+    expect((wake.cause as Error).message).toMatch(/HTTP 401/);
+    expect(client.getCloudCompatAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads Retry-After out of a direct-cloud 503 error body", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({ success: true })),
+      getCloudCompatAgent: vi
+        .fn()
+        .mockRejectedValue(httpError(503, { data: { retry_after: 45 } })),
+    });
+    const error = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      ...FAST,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    expect((error as CloudAgentWakeError).status).toBe(503);
+    expect((error as CloudAgentWakeError).retryAfter).toBe(45);
+  });
+
+  it("keeps polling through transient failures (network / other 5xx) and resolves", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn().mockRejectedValue(new Error("offline")),
+      getCloudCompatAgent: vi
+        .fn()
+        .mockRejectedValueOnce(httpError(500))
+        .mockRejectedValueOnce(new Error("socket hang up"))
+        .mockResolvedValue({ success: true, data: makeAgent() }),
+    });
+    const agent = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      pollIntervalMs: 1,
+      timeoutMs: 1_000,
+    });
+    expect(agent.status).toBe("running");
+    expect(client.getCloudCompatAgent).toHaveBeenCalledTimes(3);
+  });
+
+  it("times out with phase, last observed status, and the agent correlation id", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({ success: true })),
+      getCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: makeAgent({ status: "starting" }),
+      })),
+    });
+    const error = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      ...FAST,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    const wake = error as CloudAgentWakeError;
+    expect(wake.phase).toBe("timeout");
+    expect(wake.lastObservedStatus).toBe("starting");
+    expect(wake.message).toMatch(/still "starting" after \d+s/);
+    expect(wake.message).toContain("agent-1");
+  });
+});
+
+describe("waitForCloudProvisionJob — canonical job followed to terminal", () => {
+  it("resolves when the job completes", async () => {
+    const client = fakeClient({
+      getCloudCompatJobStatus: vi
+        .fn()
+        .mockResolvedValueOnce({
+          success: true,
+          data: { status: "processing", state: "in_progress" },
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          data: { status: "completed", state: "completed" },
+        }),
+    });
+    await expect(
+      waitForCloudProvisionJob(client, {
+        agentId: "agent-1",
+        jobId: "job-1",
+        pollIntervalMs: 1,
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toBeUndefined();
+    expect(client.getCloudCompatJobStatus).toHaveBeenCalledWith("job-1");
+  });
+
+  it("surfaces a failed job with its real reason and both correlation ids", async () => {
+    const client = fakeClient({
+      getCloudCompatJobStatus: vi.fn(async () => ({
+        success: true,
+        data: {
+          status: "failed",
+          state: "failed",
+          error: "no provisioning worker available",
+        },
+      })),
+    });
+    const error = await waitForCloudProvisionJob(client, {
+      agentId: "agent-1",
+      jobId: "job-1",
+      ...FAST,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    const wake = error as CloudAgentWakeError;
+    expect(wake.phase).toBe("provision-job");
+    expect(wake.agentId).toBe("agent-1");
+    expect(wake.jobId).toBe("job-1");
+    expect(wake.message).toMatch(/failed to start.*no provisioning worker/i);
+  });
+
+  it("surfaces a non-transient job read (503 + Retry-After) immediately", async () => {
+    const client = fakeClient({
+      getCloudCompatJobStatus: vi
+        .fn()
+        .mockRejectedValue(httpError(503, { retryAfter: 20 })),
+    });
+    const error = await waitForCloudProvisionJob(client, {
+      agentId: "agent-1",
+      jobId: "job-1",
+      ...FAST,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    expect((error as CloudAgentWakeError).status).toBe(503);
+    expect((error as CloudAgentWakeError).retryAfter).toBe(20);
+    expect(client.getCloudCompatJobStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps polling through a transient job read, then times out truthfully", async () => {
+    const client = fakeClient({
+      getCloudCompatJobStatus: vi.fn().mockRejectedValue(new Error("blip")),
+    });
+    const error = await waitForCloudProvisionJob(client, {
+      agentId: "agent-1",
+      jobId: "job-1",
+      ...FAST,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    const wake = error as CloudAgentWakeError;
+    expect(wake.phase).toBe("timeout");
+    expect(wake.message).toContain("job-1");
+    expect(
+      (client.getCloudCompatJobStatus as ReturnType<typeof vi.fn>).mock.calls
+        .length,
+    ).toBeGreaterThan(1);
+  });
+});
+
+describe("selectOrProvisionCloudAgent — fresh create follows its job", () => {
+  it("rejects with the job's failure instead of polling agent detail for six minutes", async () => {
+    const getCloudCompatAgent = vi.fn();
+    const client = fakeClient({
+      getCloudCompatAgents: vi.fn(async () => ({ success: true, data: [] })),
+      createCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: {
+          agentId: "agent-new",
+          agentName: "Eliza",
+          jobId: "job-9",
+          status: "provisioning",
+          nodeId: null,
+          message: "",
+        },
+      })),
+      getCloudCompatJobStatus: vi.fn(async () => ({
+        success: true,
+        data: { status: "failed", state: "failed", error: "image pull failed" },
+      })),
+      getCloudCompatAgent,
+      resumeCloudCompatAgent: vi.fn(async () => ({ success: true })),
+    });
+    const error = await client
+      .selectOrProvisionCloudAgent({
+        cloudApiBase: "https://api.elizacloud.ai/api/v1",
+        authToken: "test-token",
+        name: "Eliza",
+        wakePollIntervalMs: 1,
+        wakeTimeoutMs: 60,
+      })
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(CloudAgentWakeError);
+    expect((error as CloudAgentWakeError).jobId).toBe("job-9");
+    expect((error as CloudAgentWakeError).message).toMatch(/image pull failed/);
+    expect(getCloudCompatAgent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -142,6 +142,7 @@ type DirectCloudAgentCreateData = {
   id: string;
   agentName: string;
   status: string;
+  jobId: string | null;
 };
 
 function requireConfirmedFreshCloudAgentCreate(
@@ -947,6 +948,7 @@ function parseDirectCloudAgentCreateData(
 ): DirectCloudAgentCreateData {
   const data = recordOrNull(value);
   if (!data) throw new Error("Eliza Cloud response missing data");
+  const job = recordOrNull(data.job);
   return {
     // The cloud create response carries the new agent's id under `id` in most
     // branches but only `agentId` in the async-provisioning (202) branch.
@@ -955,6 +957,12 @@ function parseDirectCloudAgentCreateData(
     id: requireString(data.id ?? data.agentId, "data.id"),
     agentName: stringOrNull(data.agentName) ?? fallbackAgentName,
     status: stringOrNull(data.status) ?? "pending",
+    // The async-provisioning branch also answers with the canonical job id.
+    // It must survive normalization so the caller can follow the job to a
+    // terminal state instead of inferring progress from agent-detail polling.
+    jobId:
+      firstString(data.jobId, data.job_id, job?.jobId, job?.job_id, job?.id) ??
+      null,
   };
 }
 
@@ -2111,7 +2119,7 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
       data: {
         agentId: data.id,
         agentName: data.agentName,
-        jobId: "",
+        jobId: data.jobId ?? "",
         status: data.status,
         nodeId: null,
         message: direct.success ? "Agent created" : (direct.error ?? ""),
@@ -2169,7 +2177,7 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
       data: {
         agentId: data.id,
         agentName: data.agentName,
-        jobId: "",
+        jobId: data.jobId ?? "",
         status: data.status,
         nodeId: null,
         message: response.success ? "Agent created" : (response.error ?? ""),
@@ -3413,6 +3421,114 @@ const CLOUD_AGENT_FAILED_STATUSES = new Set([
   "deletion_failed",
 ]);
 
+/**
+ * Control-plane answers a wake/provision wait must surface immediately: auth
+ * expiry (401/403), credit exhaustion (402), a deleted agent row (404), a
+ * conflicting lifecycle operation (409), and a worker/capacity outage (503).
+ * Continuing to poll cannot cure any of them — it only hides the real failure
+ * behind the six-minute timeout (#18463). Everything else (network blips,
+ * other 5xx churn) stays transient: the bounded poll is the authority.
+ */
+const CLOUD_WAKE_NON_TRANSIENT_STATUSES = new Set([
+  401, 402, 403, 404, 409, 503,
+]);
+
+/** Where in the wake/provision state machine a typed failure was observed. */
+export type CloudAgentWakePhase =
+  | "resume"
+  | "status-poll"
+  | "provision-job"
+  | "failed"
+  | "timeout";
+
+/**
+ * Typed failure from the dedicated wake/provision wait. The pre-#18463 loop
+ * swallowed every resume/detail error, collapsing auth expiry, missing rows,
+ * credit exhaustion, and worker outages into one indistinguishable spinner
+ * and a generic timeout string. Callers render `message` as-is; programmatic
+ * consumers branch on `phase`/`status` and honor `retryAfter` (seconds, from
+ * the backend's Retry-After) when present. `agentId`/`jobId` are the
+ * operator-safe correlation ids for the attempt.
+ */
+export class CloudAgentWakeError extends Error {
+  readonly phase: CloudAgentWakePhase;
+  readonly agentId: string;
+  readonly jobId?: string;
+  /** HTTP status of the underlying non-transient control-plane failure. */
+  readonly status?: number;
+  /** Seconds until retry is worthwhile, when the backend sent Retry-After. */
+  readonly retryAfter?: number;
+  /** Last agent/job status observed before the failure. */
+  readonly lastObservedStatus?: string;
+
+  constructor(options: {
+    message: string;
+    phase: CloudAgentWakePhase;
+    agentId: string;
+    jobId?: string;
+    status?: number;
+    retryAfter?: number;
+    lastObservedStatus?: string;
+    cause?: unknown;
+  }) {
+    super(options.message);
+    this.name = "CloudAgentWakeError";
+    this.phase = options.phase;
+    this.agentId = options.agentId;
+    if (options.jobId !== undefined) this.jobId = options.jobId;
+    if (options.status !== undefined) this.status = options.status;
+    if (options.retryAfter !== undefined) this.retryAfter = options.retryAfter;
+    if (options.lastObservedStatus !== undefined) {
+      this.lastObservedStatus = options.lastObservedStatus;
+    }
+    if (options.cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+/**
+ * Classify a wake-path request rejection. Returns the HTTP status (+
+ * Retry-After when the transport preserved one) for the statuses in
+ * `CLOUD_WAKE_NON_TRANSIENT_STATUSES`; `null` means transient — keep polling.
+ * Reads both transport error shapes: `ApiError` (`status`/`retryAfter`) and
+ * the direct-cloud `Object.assign(new Error(), { status, data })` throw.
+ */
+function nonTransientWakeFailure(
+  cause: unknown,
+): { status: number; retryAfter?: number } | null {
+  if (typeof cause !== "object" || cause === null) return null;
+  const { status } = cause as { status?: unknown };
+  if (
+    typeof status !== "number" ||
+    !CLOUD_WAKE_NON_TRANSIENT_STATUSES.has(status)
+  ) {
+    return null;
+  }
+  const body = recordOrNull((cause as { data?: unknown }).data);
+  const retryAfter = firstNumber(
+    (cause as { retryAfter?: unknown }).retryAfter,
+    body?.retryAfter,
+    body?.retry_after,
+  );
+  return { status, ...(retryAfter !== null ? { retryAfter } : {}) };
+}
+
+function wakeFailureMessage(
+  what: string,
+  status: number,
+  retryAfter: number | undefined,
+  cause: unknown,
+): string {
+  const causeMessage =
+    cause instanceof Error && cause.message ? ` ${cause.message}` : "";
+  const retryHint =
+    typeof retryAfter === "number" && retryAfter > 0
+      ? ` Try again in about ${Math.ceil(retryAfter)}s.`
+      : "";
+  return `${what} (HTTP ${status}).${causeMessage}${retryHint}`;
+}
+
 function isTerminalFailedCloudAgent(agent: CloudCompatAgent): boolean {
   return CLOUD_AGENT_FAILED_STATUSES.has(
     String(agent.status ?? "").toLowerCase(),
@@ -3456,34 +3572,79 @@ export async function waitForCloudAgentRunning(
     "starting",
     "Starting your agent — a cold boot can take a few minutes...",
   );
-  // error-policy:J4 resume is an idempotent wake nudge — the status poll
-  // below is the authority and surfaces failed/timed-out boots as errors.
-  await client.resumeCloudCompatAgent(agentId).catch(() => null);
+  await client.resumeCloudCompatAgent(agentId).catch((cause: unknown) => {
+    const hard = nonTransientWakeFailure(cause);
+    if (hard) {
+      throw new CloudAgentWakeError({
+        message: wakeFailureMessage(
+          "Starting your cloud agent failed",
+          hard.status,
+          hard.retryAfter,
+          cause,
+        ),
+        phase: "resume",
+        agentId,
+        ...hard,
+        cause,
+      });
+    }
+    // error-policy:J4 a transient resume rejection is an idempotent wake
+    // nudge lost in transit — the status poll below is the authority and
+    // surfaces failed/timed-out boots as errors.
+    return null;
+  });
 
   let lastStatus = "unknown";
   for (;;) {
-    // error-policy:J4 a failed status read counts as an unknown tick inside
-    // this bounded poll; the deadline below throws with the last status.
-    const detail = await client.getCloudCompatAgent(agentId).catch(() => null);
+    const detail = await client
+      .getCloudCompatAgent(agentId)
+      .catch((cause: unknown) => {
+        const hard = nonTransientWakeFailure(cause);
+        if (hard) {
+          throw new CloudAgentWakeError({
+            message: wakeFailureMessage(
+              "Checking your cloud agent failed",
+              hard.status,
+              hard.retryAfter,
+              cause,
+            ),
+            phase: "status-poll",
+            agentId,
+            lastObservedStatus: lastStatus,
+            ...hard,
+            cause,
+          });
+        }
+        // error-policy:J4 a transient status read counts as an unknown tick
+        // inside this bounded poll; the deadline below throws with the last
+        // status.
+        return null;
+      });
     const agent = detail?.success ? detail.data : null;
     if (agent) {
       lastStatus = agent.status || "unknown";
       if (lastStatus === "running") return agent;
       if (CLOUD_AGENT_FAILED_STATUSES.has(lastStatus)) {
-        throw new Error(
-          agent.error_message
+        throw new CloudAgentWakeError({
+          message: agent.error_message
             ? `Your cloud agent failed to start: ${agent.error_message}`
             : "Your cloud agent failed to start. Check its status in Eliza Cloud and try again.",
-        );
+          phase: "failed",
+          agentId,
+          lastObservedStatus: lastStatus,
+        });
       }
     }
     const elapsedMs = Date.now() - startedAt;
     if (elapsedMs + pollIntervalMs > timeoutMs) {
-      throw new Error(
-        `Your cloud agent is still "${lastStatus}" after ${Math.round(
+      throw new CloudAgentWakeError({
+        message: `Your cloud agent is still "${lastStatus}" after ${Math.round(
           elapsedMs / 1000,
-        )}s. It may still be booting — try again in a minute.`,
-      );
+        )}s (agent ${agentId}). It may still be booting — try again in a minute.`,
+        phase: "timeout",
+        agentId,
+        lastObservedStatus: lastStatus,
+      });
     }
     onProgress?.("starting", describeAgentWakeWait(elapsedMs));
     await new Promise((r) => setTimeout(r, pollIntervalMs));
@@ -3504,6 +3665,98 @@ export function describeAgentWakeWait(elapsedMs: number): string {
   }
   const minutes = Math.floor(elapsedMs / 60_000);
   return `Still starting your agent — about ${minutes} minute${minutes === 1 ? "" : "s"} in. Cold boots can take a few minutes…`;
+}
+
+/**
+ * Follow the canonical provisioning job for a fresh dedicated create to a
+ * terminal state. The 202 create path answers with a `jobId` the old flow
+ * discarded, reducing a failed provision to an opaque agent-detail timeout;
+ * the job row carries the real failure reason (worker unavailable, image
+ * pull, capacity) as soon as the worker records it. Resolves on `completed`,
+ * throws typed on `failed`, on a non-transient job read, and on timeout.
+ * Exported for unit tests.
+ */
+export async function waitForCloudProvisionJob(
+  client: ElizaClient,
+  options: {
+    agentId: string;
+    jobId: string;
+    pollIntervalMs?: number;
+    timeoutMs?: number;
+    onProgress?: (status: string, detail?: string) => void;
+  },
+): Promise<void> {
+  const { agentId, jobId, onProgress } = options;
+  const pollIntervalMs = Math.max(
+    50,
+    options.pollIntervalMs ?? CLOUD_AGENT_WAKE_POLL_INTERVAL_MS,
+  );
+  const timeoutMs = Math.max(
+    pollIntervalMs,
+    options.timeoutMs ?? CLOUD_AGENT_WAKE_TIMEOUT_MS,
+  );
+  const startedAt = Date.now();
+  let lastStatus = "queued";
+  for (;;) {
+    const res = await client
+      .getCloudCompatJobStatus(jobId)
+      .catch((cause: unknown) => {
+        const hard = nonTransientWakeFailure(cause);
+        if (hard) {
+          throw new CloudAgentWakeError({
+            message: wakeFailureMessage(
+              "Provisioning your cloud agent failed",
+              hard.status,
+              hard.retryAfter,
+              cause,
+            ),
+            phase: "provision-job",
+            agentId,
+            jobId,
+            lastObservedStatus: lastStatus,
+            ...hard,
+            cause,
+          });
+        }
+        // error-policy:J4 a transient job read counts as an unknown tick
+        // inside this bounded poll; the deadline below throws with the last
+        // status.
+        return null;
+      });
+    const job = res?.data ?? null;
+    if (job) {
+      lastStatus = job.state || job.status;
+      if (job.status === "completed") return;
+      if (job.status === "failed") {
+        throw new CloudAgentWakeError({
+          message: job.error
+            ? `Your cloud agent failed to start: ${job.error}`
+            : "Your cloud agent failed to start. Check its status in Eliza Cloud and try again.",
+          phase: "provision-job",
+          agentId,
+          jobId,
+          lastObservedStatus: lastStatus,
+        });
+      }
+    }
+    const elapsedMs = Date.now() - startedAt;
+    if (elapsedMs + pollIntervalMs > timeoutMs) {
+      throw new CloudAgentWakeError({
+        message: `Your cloud agent's provisioning job is still "${lastStatus}" after ${Math.round(
+          elapsedMs / 1000,
+        )}s (agent ${agentId}, job ${jobId}). It may still be working — try again in a minute.`,
+        phase: "timeout",
+        agentId,
+        jobId,
+        lastObservedStatus: lastStatus,
+      });
+    }
+    onProgress?.(
+      "provisioning",
+      describeProvisioningWait(lastStatus, elapsedMs),
+    );
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
 }
 
 /**
@@ -3703,6 +3956,22 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   }
   requireConfirmedFreshCloudAgentCreate(mustForceCreate, created.created);
   const agentId = created.data.agentId;
+  // A 202 async create names its canonical provisioning job. Follow THAT job
+  // to terminal — its row carries the real failure reason long before the
+  // agent-detail poll below would time out — instead of discarding the id.
+  if (created.data.jobId) {
+    await waitForCloudProvisionJob(this, {
+      agentId,
+      jobId: created.data.jobId,
+      ...(typeof options.wakePollIntervalMs === "number"
+        ? { pollIntervalMs: options.wakePollIntervalMs }
+        : {}),
+      ...(typeof options.wakeTimeoutMs === "number"
+        ? { timeoutMs: options.wakeTimeoutMs }
+        : {}),
+      ...(onProgress ? { onProgress } : {}),
+    });
+  }
   // error-policy:J4 detail is an optimization probe (warm-pool fast path);
   // on failure the standard dedicated subdomain is still the desired default.
   const detail = await this.getCloudCompatAgent(agentId).catch(() => null);

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -4,6 +4,7 @@
  */
 
 import { Capacitor, CapacitorHttp } from "@capacitor/core";
+import { ElizaError } from "@elizaos/core";
 import {
   clearStoredStewardToken,
   readStoredStewardToken,
@@ -268,6 +269,40 @@ function firstNumber(...values: unknown[]): number | null {
     if (numberValue !== null) return numberValue;
   }
   return null;
+}
+
+function headerNumber(
+  headers: Headers | Record<string, string> | undefined,
+  name: string,
+): number | null {
+  if (!headers) return null;
+  const raw =
+    headers instanceof Headers
+      ? headers.get(name)
+      : Object.entries(headers).find(
+          ([key]) => key.toLowerCase() === name.toLowerCase(),
+        )?.[1];
+  return numberOrNull(raw);
+}
+
+function directCloudErrorMetadata(
+  body: unknown,
+  headers?: Headers | Record<string, string>,
+): { code?: string; retryAfter?: number } {
+  const root = recordOrNull(body);
+  const nestedError = recordOrNull(root?.error);
+  const code = firstString(root?.code, nestedError?.code);
+  const retryAfter = firstNumber(
+    root?.retryAfter,
+    root?.retry_after,
+    nestedError?.retryAfter,
+    nestedError?.retry_after,
+    headerNumber(headers, "Retry-After"),
+  );
+  return {
+    ...(code ? { code } : {}),
+    ...(retryAfter !== null && retryAfter >= 0 ? { retryAfter } : {}),
+  };
 }
 
 function directCloudLoginToken(data: unknown): string | null {
@@ -862,6 +897,7 @@ async function directCloudRequest<T>(
           status: res.status,
           data: res.data,
           url,
+          ...directCloudErrorMetadata(parsed, res.headers),
         },
       );
     }
@@ -887,6 +923,7 @@ async function directCloudRequest<T>(
         status: res.status,
         data,
         url,
+        ...directCloudErrorMetadata(data, res.headers),
       },
     );
   }
@@ -1347,6 +1384,7 @@ declare module "./client-base" {
     getCloudCompatAgent(agentId: string): Promise<{
       success: boolean;
       data: CloudCompatAgent;
+      error?: string;
     }>;
     getCloudCompatAgentManagedDiscord(agentId: string): Promise<{
       success: boolean;
@@ -1492,6 +1530,7 @@ declare module "./client-base" {
     getCloudCompatJobStatus(jobId: string): Promise<{
       success: boolean;
       data: CloudCompatJob;
+      error?: string;
     }>;
     exportAgent(password: string, includeLogs?: boolean): Promise<Response>;
     getExportEstimate(): Promise<{
@@ -2262,6 +2301,7 @@ ElizaClient.prototype.getCloudCompatAgent = async function (
     return {
       success: direct.success,
       data: toCloudCompatAgent(direct.data ?? { id: agentId }),
+      ...(direct.error ? { error: direct.error } : {}),
     };
   }
 
@@ -2282,6 +2322,7 @@ ElizaClient.prototype.getCloudCompatAgent = async function (
     return {
       success: response.success,
       data: toCloudCompatAgent(response.data ?? { id: agentId }),
+      ...(response.error ? { error: response.error } : {}),
     };
   }
 
@@ -2843,6 +2884,7 @@ ElizaClient.prototype.getCloudCompatJobStatus = async function (
     return {
       success: direct.success,
       data: toCloudCompatJob(direct.data ?? { id: jobId }),
+      ...(direct.error ? { error: direct.error } : {}),
     };
   }
 
@@ -2867,6 +2909,7 @@ ElizaClient.prototype.getCloudCompatJobStatus = async function (
     return {
       success: response.success,
       data: toCloudCompatJob(response.data ?? { id: jobId }),
+      ...(response.error ? { error: response.error } : {}),
     };
   }
 
@@ -3426,12 +3469,11 @@ const CLOUD_AGENT_FAILED_STATUSES = new Set([
  * expiry (401/403), credit exhaustion (402), a deleted agent row (404), a
  * conflicting lifecycle operation (409), and a worker/capacity outage (503).
  * Continuing to poll cannot cure any of them — it only hides the real failure
- * behind the six-minute timeout (#18463). Everything else (network blips,
- * other 5xx churn) stays transient: the bounded poll is the authority.
+ * behind the six-minute timeout (#18463). Transport failures without an HTTP
+ * status and explicit 500/502/504 infrastructure churn stay transient: the
+ * bounded poll remains the authority for those cases.
  */
-const CLOUD_WAKE_NON_TRANSIENT_STATUSES = new Set([
-  401, 402, 403, 404, 409, 503,
-]);
+const CLOUD_WAKE_TRANSIENT_STATUSES = new Set([500, 502, 504]);
 
 /** Where in the wake/provision state machine a typed failure was observed. */
 export type CloudAgentWakePhase =
@@ -3450,7 +3492,8 @@ export type CloudAgentWakePhase =
  * the backend's Retry-After) when present. `agentId`/`jobId` are the
  * operator-safe correlation ids for the attempt.
  */
-export class CloudAgentWakeError extends Error {
+export class CloudAgentWakeError extends ElizaError {
+  override readonly name = "CloudAgentWakeError";
   readonly phase: CloudAgentWakePhase;
   readonly agentId: string;
   readonly jobId?: string;
@@ -3469,10 +3512,26 @@ export class CloudAgentWakeError extends Error {
     status?: number;
     retryAfter?: number;
     lastObservedStatus?: string;
+    controlPlaneCode?: string;
     cause?: unknown;
   }) {
-    super(options.message);
-    this.name = "CloudAgentWakeError";
+    super(options.message, {
+      code: options.controlPlaneCode ?? "CLOUD_AGENT_WAKE_FAILED",
+      ...(options.cause !== undefined ? { cause: options.cause } : {}),
+      context: {
+        phase: options.phase,
+        agentId: options.agentId,
+        ...(options.jobId !== undefined ? { jobId: options.jobId } : {}),
+        ...(options.status !== undefined ? { status: options.status } : {}),
+        ...(options.retryAfter !== undefined
+          ? { retryAfter: options.retryAfter }
+          : {}),
+        ...(options.lastObservedStatus !== undefined
+          ? { lastObservedStatus: options.lastObservedStatus }
+          : {}),
+      },
+      severity: "ephemeral",
+    });
     this.phase = options.phase;
     this.agentId = options.agentId;
     if (options.jobId !== undefined) this.jobId = options.jobId;
@@ -3481,37 +3540,75 @@ export class CloudAgentWakeError extends Error {
     if (options.lastObservedStatus !== undefined) {
       this.lastObservedStatus = options.lastObservedStatus;
     }
-    if (options.cause !== undefined) {
-      (this as Error & { cause?: unknown }).cause = options.cause;
-    }
   }
 }
 
 /**
- * Classify a wake-path request rejection. Returns the HTTP status (+
- * Retry-After when the transport preserved one) for the statuses in
- * `CLOUD_WAKE_NON_TRANSIENT_STATUSES`; `null` means transient — keep polling.
- * Reads both transport error shapes: `ApiError` (`status`/`retryAfter`) and
- * the direct-cloud `Object.assign(new Error(), { status, data })` throw.
+ * Classify a wake-path request rejection. Returns any terminal HTTP status (+
+ * Retry-After when the transport preserved one); status-less network errors
+ * and explicit 500/502/504 infrastructure churn return `null` and keep
+ * polling. Reads both transport error shapes: `ApiError`
+ * (`status`/`retryAfter`) and the direct-cloud
+ * `Object.assign(new Error(), { status, data })` throw.
  */
-function nonTransientWakeFailure(
-  cause: unknown,
-): { status: number; retryAfter?: number } | null {
+function nonTransientWakeFailure(cause: unknown): {
+  status: number;
+  retryAfter?: number;
+  controlPlaneCode?: string;
+} | null {
   if (typeof cause !== "object" || cause === null) return null;
   const { status } = cause as { status?: unknown };
   if (
     typeof status !== "number" ||
-    !CLOUD_WAKE_NON_TRANSIENT_STATUSES.has(status)
+    !Number.isInteger(status) ||
+    CLOUD_WAKE_TRANSIENT_STATUSES.has(status)
   ) {
     return null;
   }
   const body = recordOrNull((cause as { data?: unknown }).data);
+  const nestedError = recordOrNull(body?.error);
   const retryAfter = firstNumber(
     (cause as { retryAfter?: unknown }).retryAfter,
     body?.retryAfter,
     body?.retry_after,
+    nestedError?.retryAfter,
+    nestedError?.retry_after,
   );
-  return { status, ...(retryAfter !== null ? { retryAfter } : {}) };
+  const controlPlaneCode = firstString(
+    (cause as { code?: unknown }).code,
+    body?.code,
+    nestedError?.code,
+  );
+  return {
+    status,
+    ...(retryAfter !== null && retryAfter >= 0 ? { retryAfter } : {}),
+    ...(controlPlaneCode ? { controlPlaneCode } : {}),
+  };
+}
+
+function envelopeFailure(value: unknown): {
+  message: string | null;
+  controlPlaneCode?: string;
+} {
+  const root = recordOrNull(value);
+  const data = recordOrNull(root?.data);
+  const nestedError = recordOrNull(root?.error);
+  const message = firstString(
+    root?.error,
+    root?.message,
+    data?.error,
+    data?.message,
+    nestedError?.message,
+  );
+  const controlPlaneCode = firstString(
+    root?.code,
+    data?.code,
+    nestedError?.code,
+  );
+  return {
+    message,
+    ...(controlPlaneCode ? { controlPlaneCode } : {}),
+  };
 }
 
 function wakeFailureMessage(
@@ -3572,27 +3669,41 @@ export async function waitForCloudAgentRunning(
     "starting",
     "Starting your agent — a cold boot can take a few minutes...",
   );
-  await client.resumeCloudCompatAgent(agentId).catch((cause: unknown) => {
-    const hard = nonTransientWakeFailure(cause);
-    if (hard) {
-      throw new CloudAgentWakeError({
-        message: wakeFailureMessage(
-          "Starting your cloud agent failed",
-          hard.status,
-          hard.retryAfter,
+  const resume = await client
+    .resumeCloudCompatAgent(agentId)
+    .catch((cause: unknown) => {
+      const hard = nonTransientWakeFailure(cause);
+      if (hard) {
+        throw new CloudAgentWakeError({
+          message: wakeFailureMessage(
+            "Starting your cloud agent failed",
+            hard.status,
+            hard.retryAfter,
+            cause,
+          ),
+          phase: "resume",
+          agentId,
+          ...hard,
           cause,
-        ),
-        phase: "resume",
-        agentId,
-        ...hard,
-        cause,
-      });
-    }
-    // error-policy:J4 a transient resume rejection is an idempotent wake
-    // nudge lost in transit — the status poll below is the authority and
-    // surfaces failed/timed-out boots as errors.
-    return null;
-  });
+        });
+      }
+      // error-policy:J4 a transport failure without a terminal HTTP status is
+      // an idempotent wake nudge lost in transit; the bounded status poll is
+      // the authority and can still observe the agent becoming ready.
+      return null;
+    });
+  if (resume && !resume.success) {
+    const failure = envelopeFailure(resume);
+    throw new CloudAgentWakeError({
+      message:
+        failure.message ??
+        "Starting your cloud agent was rejected. Sign in again and retry.",
+      phase: "resume",
+      agentId,
+      controlPlaneCode:
+        failure.controlPlaneCode ?? "CLOUD_AGENT_RESUME_REJECTED",
+    });
+  }
 
   let lastStatus = "unknown";
   for (;;) {
@@ -3620,11 +3731,24 @@ export async function waitForCloudAgentRunning(
         // status.
         return null;
       });
-    const agent = detail?.success ? detail.data : null;
+    if (detail && !detail.success) {
+      const failure = envelopeFailure(detail);
+      throw new CloudAgentWakeError({
+        message:
+          failure.message ??
+          "Eliza Cloud could not read your agent status. Sign in again and retry.",
+        phase: "status-poll",
+        agentId,
+        lastObservedStatus: lastStatus,
+        controlPlaneCode:
+          failure.controlPlaneCode ?? "CLOUD_AGENT_STATUS_REJECTED",
+      });
+    }
+    const agent = detail?.data ?? null;
     if (agent) {
       lastStatus = agent.status || "unknown";
       if (lastStatus === "running") return agent;
-      if (CLOUD_AGENT_FAILED_STATUSES.has(lastStatus)) {
+      if (CLOUD_AGENT_FAILED_STATUSES.has(lastStatus.toLowerCase())) {
         throw new CloudAgentWakeError({
           message: agent.error_message
             ? `Your cloud agent failed to start: ${agent.error_message}`
@@ -3636,7 +3760,7 @@ export async function waitForCloudAgentRunning(
       }
     }
     const elapsedMs = Date.now() - startedAt;
-    if (elapsedMs + pollIntervalMs > timeoutMs) {
+    if (elapsedMs >= timeoutMs) {
       throw new CloudAgentWakeError({
         message: `Your cloud agent is still "${lastStatus}" after ${Math.round(
           elapsedMs / 1000,
@@ -3647,7 +3771,9 @@ export async function waitForCloudAgentRunning(
       });
     }
     onProgress?.("starting", describeAgentWakeWait(elapsedMs));
-    await new Promise((r) => setTimeout(r, pollIntervalMs));
+    await new Promise((r) =>
+      setTimeout(r, Math.min(pollIntervalMs, timeoutMs - elapsedMs)),
+    );
   }
 }
 
@@ -3723,6 +3849,20 @@ export async function waitForCloudProvisionJob(
         // status.
         return null;
       });
+    if (res && !res.success) {
+      const failure = envelopeFailure(res);
+      throw new CloudAgentWakeError({
+        message:
+          failure.message ??
+          "Eliza Cloud could not read the provisioning job. Sign in again and retry.",
+        phase: "provision-job",
+        agentId,
+        jobId,
+        lastObservedStatus: lastStatus,
+        controlPlaneCode:
+          failure.controlPlaneCode ?? "CLOUD_PROVISION_JOB_STATUS_REJECTED",
+      });
+    }
     const job = res?.data ?? null;
     if (job) {
       lastStatus = job.state || job.status;
@@ -3740,7 +3880,7 @@ export async function waitForCloudProvisionJob(
       }
     }
     const elapsedMs = Date.now() - startedAt;
-    if (elapsedMs + pollIntervalMs > timeoutMs) {
+    if (elapsedMs >= timeoutMs) {
       throw new CloudAgentWakeError({
         message: `Your cloud agent's provisioning job is still "${lastStatus}" after ${Math.round(
           elapsedMs / 1000,
@@ -3755,7 +3895,9 @@ export async function waitForCloudProvisionJob(
       "provisioning",
       describeProvisioningWait(lastStatus, elapsedMs),
     );
-    await new Promise((r) => setTimeout(r, pollIntervalMs));
+    await new Promise((r) =>
+      setTimeout(r, Math.min(pollIntervalMs, timeoutMs - elapsedMs)),
+    );
   }
 }
 

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -3470,10 +3470,12 @@ const CLOUD_AGENT_FAILED_STATUSES = new Set([
  * conflicting lifecycle operation (409), and a worker/capacity outage (503).
  * Continuing to poll cannot cure any of them — it only hides the real failure
  * behind the six-minute timeout (#18463). Transport failures without an HTTP
- * status and explicit 500/502/504 infrastructure churn stay transient: the
- * bounded poll remains the authority for those cases.
+ * status and explicit 408/429/500/502/504 churn stay transient: those are the
+ * control plane asking for another attempt (a rate-limited or timed-out poll
+ * tick says nothing about the wake itself), so the bounded poll remains the
+ * authority and honors any Retry-After it carried.
  */
-const CLOUD_WAKE_TRANSIENT_STATUSES = new Set([500, 502, 504]);
+const CLOUD_WAKE_TRANSIENT_STATUSES = new Set([408, 429, 500, 502, 504]);
 
 /** Where in the wake/provision state machine a typed failure was observed. */
 export type CloudAgentWakePhase =
@@ -3492,14 +3494,7 @@ export type CloudAgentWakePhase =
  * the backend's Retry-After) when present. `agentId`/`jobId` are the
  * operator-safe correlation ids for the attempt.
  */
-// The isolated-browser fixture harnesses (src/**/__e2e__/run-*-e2e.mjs) stub
-// `@elizaos/core` with a CJS Proxy whose named exports arrive as `undefined`
-// through esbuild's ESM interop. A `class … extends undefined` crashes the
-// fixture bundle at evaluation time, so guard the base: real builds always see
-// the real ElizaError; only stubbed fixture bundles degrade to plain Error.
-const WakeErrorBase = (ElizaError ?? Error) as typeof ElizaError;
-
-export class CloudAgentWakeError extends WakeErrorBase {
+export class CloudAgentWakeError extends ElizaError {
   override readonly name = "CloudAgentWakeError";
   readonly phase: CloudAgentWakePhase;
   readonly agentId: string;
@@ -3553,23 +3548,54 @@ export class CloudAgentWakeError extends WakeErrorBase {
 /**
  * Classify a wake-path request rejection. Returns any terminal HTTP status (+
  * Retry-After when the transport preserved one); status-less network errors
- * and explicit 500/502/504 infrastructure churn return `null` and keep
- * polling. Reads both transport error shapes: `ApiError`
- * (`status`/`retryAfter`) and the direct-cloud
- * `Object.assign(new Error(), { status, data })` throw.
+ * and the transient statuses return `null` and keep polling.
  */
 function nonTransientWakeFailure(cause: unknown): {
   status: number;
   retryAfter?: number;
   controlPlaneCode?: string;
 } | null {
+  const details = wakeFailureDetails(cause);
+  if (details === null || CLOUD_WAKE_TRANSIENT_STATUSES.has(details.status)) {
+    return null;
+  }
+  return details;
+}
+
+/**
+ * Milliseconds a transient wake-path rejection asked the caller to back off,
+ * or `null` when it carried no Retry-After. A 429/503-style throttle is the
+ * control plane naming its own pace; polling it again on the fixed 5s tick
+ * only earns another rejection, so the loop sleeps for what it was told.
+ */
+function transientWakeRetryDelayMs(cause: unknown): number | null {
+  const details = wakeFailureDetails(cause);
+  if (
+    details === null ||
+    !CLOUD_WAKE_TRANSIENT_STATUSES.has(details.status) ||
+    details.retryAfter === undefined ||
+    details.retryAfter <= 0
+  ) {
+    return null;
+  }
+  return Math.ceil(details.retryAfter * 1000);
+}
+
+/**
+ * Parse the HTTP status, Retry-After, and control-plane code out of a
+ * wake-path rejection, reading both transport error shapes: `ApiError`
+ * (`status`/`retryAfter`) and the direct-cloud
+ * `Object.assign(new Error(), { status, data })` throw. Returns `null` for a
+ * status-less transport failure, which no classification can act on.
+ */
+function wakeFailureDetails(cause: unknown): {
+  status: number;
+  retryAfter?: number;
+  controlPlaneCode?: string;
+} | null {
   if (typeof cause !== "object" || cause === null) return null;
   const { status } = cause as { status?: unknown };
-  if (
-    typeof status !== "number" ||
-    !Number.isInteger(status) ||
-    CLOUD_WAKE_TRANSIENT_STATUSES.has(status)
-  ) {
+  if (typeof status !== "number" || !Number.isInteger(status)) {
     return null;
   }
   const body = recordOrNull((cause as { data?: unknown }).data);
@@ -3713,7 +3739,9 @@ export async function waitForCloudAgentRunning(
   }
 
   let lastStatus = "unknown";
+  let backoffMs: number | null = null;
   for (;;) {
+    backoffMs = null;
     const detail = await client
       .getCloudCompatAgent(agentId)
       .catch((cause: unknown) => {
@@ -3735,7 +3763,8 @@ export async function waitForCloudAgentRunning(
         }
         // error-policy:J4 a transient status read counts as an unknown tick
         // inside this bounded poll; the deadline below throws with the last
-        // status.
+        // status. A Retry-After on that rejection sets the next tick's pace.
+        backoffMs = transientWakeRetryDelayMs(cause);
         return null;
       });
     if (detail && !detail.success) {
@@ -3779,7 +3808,13 @@ export async function waitForCloudAgentRunning(
     }
     onProgress?.("starting", describeAgentWakeWait(elapsedMs));
     await new Promise((r) =>
-      setTimeout(r, Math.min(pollIntervalMs, timeoutMs - elapsedMs)),
+      setTimeout(
+        r,
+        Math.min(
+          Math.max(pollIntervalMs, backoffMs ?? 0),
+          timeoutMs - elapsedMs,
+        ),
+      ),
     );
   }
 }
@@ -3830,7 +3865,9 @@ export async function waitForCloudProvisionJob(
   );
   const startedAt = Date.now();
   let lastStatus = "queued";
+  let backoffMs: number | null = null;
   for (;;) {
+    backoffMs = null;
     const res = await client
       .getCloudCompatJobStatus(jobId)
       .catch((cause: unknown) => {
@@ -3853,7 +3890,8 @@ export async function waitForCloudProvisionJob(
         }
         // error-policy:J4 a transient job read counts as an unknown tick
         // inside this bounded poll; the deadline below throws with the last
-        // status.
+        // status. A Retry-After on that rejection sets the next tick's pace.
+        backoffMs = transientWakeRetryDelayMs(cause);
         return null;
       });
     if (res && !res.success) {
@@ -3903,7 +3941,13 @@ export async function waitForCloudProvisionJob(
       describeProvisioningWait(lastStatus, elapsedMs),
     );
     await new Promise((r) =>
-      setTimeout(r, Math.min(pollIntervalMs, timeoutMs - elapsedMs)),
+      setTimeout(
+        r,
+        Math.min(
+          Math.max(pollIntervalMs, backoffMs ?? 0),
+          timeoutMs - elapsedMs,
+        ),
+      ),
     );
   }
 }
@@ -4105,6 +4149,16 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   }
   requireConfirmedFreshCloudAgentCreate(mustForceCreate, created.created);
   const agentId = created.data.agentId;
+  // The provisioning-job wait and the running wait below are two halves of ONE
+  // join, so they share ONE budget. Giving each the full wake timeout let a job
+  // that finished at 5:59 hand a fresh six minutes to the status poll — the
+  // twelve-minute spinner of #18463. Each wait gets whatever is left.
+  const wakeBudgetMs =
+    typeof options.wakeTimeoutMs === "number"
+      ? options.wakeTimeoutMs
+      : CLOUD_AGENT_WAKE_TIMEOUT_MS;
+  const wakeDeadlineAt = Date.now() + wakeBudgetMs;
+  const remainingWakeMs = () => Math.max(0, wakeDeadlineAt - Date.now());
   // A 202 async create names its canonical provisioning job. Follow THAT job
   // to terminal — its row carries the real failure reason long before the
   // agent-detail poll below would time out — instead of discarding the id.
@@ -4115,9 +4169,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
       ...(typeof options.wakePollIntervalMs === "number"
         ? { pollIntervalMs: options.wakePollIntervalMs }
         : {}),
-      ...(typeof options.wakeTimeoutMs === "number"
-        ? { timeoutMs: options.wakeTimeoutMs }
-        : {}),
+      timeoutMs: remainingWakeMs(),
       ...(onProgress ? { onProgress } : {}),
     });
   }
@@ -4154,9 +4206,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
       ...(typeof options.wakePollIntervalMs === "number"
         ? { pollIntervalMs: options.wakePollIntervalMs }
         : {}),
-      ...(typeof options.wakeTimeoutMs === "number"
-        ? { timeoutMs: options.wakeTimeoutMs }
-        : {}),
+      timeoutMs: remainingWakeMs(),
       ...(onProgress ? { onProgress } : {}),
     });
   }

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -3492,7 +3492,14 @@ export type CloudAgentWakePhase =
  * the backend's Retry-After) when present. `agentId`/`jobId` are the
  * operator-safe correlation ids for the attempt.
  */
-export class CloudAgentWakeError extends ElizaError {
+// The isolated-browser fixture harnesses (src/**/__e2e__/run-*-e2e.mjs) stub
+// `@elizaos/core` with a CJS Proxy whose named exports arrive as `undefined`
+// through esbuild's ESM interop. A `class … extends undefined` crashes the
+// fixture bundle at evaluation time, so guard the base: real builds always see
+// the real ElizaError; only stubbed fixture bundles degrade to plain Error.
+const WakeErrorBase = (ElizaError ?? Error) as typeof ElizaError;
+
+export class CloudAgentWakeError extends WakeErrorBase {
   override readonly name = "CloudAgentWakeError";
   readonly phase: CloudAgentWakePhase;
   readonly agentId: string;

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -109,6 +109,12 @@ export type {
 } from "./android-native-agent-transport";
 // Re-export the class from client-base (no circular dependency issues)
 export { ElizaClient } from "./client-base";
+export {
+  CloudAgentWakeError,
+  type CloudAgentWakePhase,
+  waitForCloudAgentRunning,
+  waitForCloudProvisionJob,
+} from "./client-cloud";
 export type {
   ComputerUseApprovalMode,
   ComputerUseApprovalResolution,

--- a/packages/ui/src/components/composites/__e2e__/resize-handles.e2e.test.ts
+++ b/packages/ui/src/components/composites/__e2e__/resize-handles.e2e.test.ts
@@ -72,8 +72,28 @@ const stubElizaCore: EsbuildPlugin = {
       // everything else falls through to the inert proxy.
       contents: `
         const noop = new Proxy(() => noop, { get: () => noop });
+        // The wake/provision path (client-cloud.ts) subclasses the real
+        // ElizaError; esbuild's ESM interop copies only this object's own keys,
+        // so a Proxy fallback would surface undefined here and break the
+        // subclass at evaluation time. Export a real class with core's shape so
+        // the fixture bundle exercises the same error type production does.
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+            this.severity = options.severity;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
         module.exports = new Proxy(
           {
+            ElizaError,
+            isElizaError: (v) => v instanceof ElizaError,
             isViewVisible: () => true,
             dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
             findInteractionRegions: () => [],

--- a/packages/ui/src/components/pages/__e2e__/run-chat-infinite-scroll-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-chat-infinite-scroll-e2e.mjs
@@ -75,7 +75,28 @@ const stubElizaCore = {
     b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
       contents: `
         const noop = new Proxy(() => noop, { get: () => noop });
-        module.exports = new Proxy({}, { get: (t, p) => (p in t ? t[p] : noop) });
+        // The wake/provision path (client-cloud.ts) subclasses the real
+        // ElizaError; esbuild's ESM interop copies only this object's own keys,
+        // so a Proxy fallback would surface undefined here and break the
+        // subclass at evaluation time. Export a real class with core's shape so
+        // the fixture bundle exercises the same error type production does.
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+            this.severity = options.severity;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
+        module.exports = new Proxy(
+          { ElizaError, isElizaError: (v) => v instanceof ElizaError },
+          { get: (t, p) => (p in t ? t[p] : noop) },
+        );
       `,
       loader: "js",
     }));

--- a/packages/ui/src/components/pages/__e2e__/run-connectors-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-connectors-e2e.mjs
@@ -58,7 +58,28 @@ const stubElizaCore = {
     b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
       contents: `
         const noop = new Proxy(() => noop, { get: () => noop });
-        module.exports = new Proxy({}, { get: () => noop });
+        // The wake/provision path (client-cloud.ts) subclasses the real
+        // ElizaError; esbuild's ESM interop copies only this object's own keys,
+        // so a Proxy fallback would surface undefined here and break the
+        // subclass at evaluation time. Export a real class with core's shape so
+        // the fixture bundle exercises the same error type production does.
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+            this.severity = options.severity;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
+        module.exports = new Proxy(
+          { ElizaError, isElizaError: (v) => v instanceof ElizaError },
+          { get: (t, p) => (p in t ? t[p] : noop) },
+        );
       `,
       loader: "js",
     }));

--- a/packages/ui/src/components/pages/__e2e__/run-launcher-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-launcher-e2e.mjs
@@ -56,8 +56,26 @@ const stubElizaCore = {
     b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
       contents: `
         const noop = new Proxy(() => noop, { get: () => noop });
+        // The wake/provision path (client-cloud.ts) subclasses the real
+        // ElizaError; esbuild's ESM interop copies only this object's own keys,
+        // so a Proxy fallback would surface undefined here and break the
+        // subclass at evaluation time. Export a real class with core's shape so
+        // the fixture bundle exercises the same error type production does.
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+            this.severity = options.severity;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
         module.exports = new Proxy(
-          { isViewVisible: () => true, dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])) },
+          { ElizaError, isElizaError: (v) => v instanceof ElizaError, isViewVisible: () => true, dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])) },
           { get: (t, p) => (p in t ? t[p] : noop) },
         );
       `,

--- a/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
@@ -53,13 +53,31 @@ const stubElizaCore = {
     b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
       contents: `
         const noop = new Proxy(() => noop, { get: () => noop });
+        // The wake/provision path (client-cloud.ts) subclasses the real
+        // ElizaError; esbuild's ESM interop copies only this object's own keys,
+        // so a Proxy fallback would surface undefined here and break the
+        // subclass at evaluation time. Export a real class with core's shape so
+        // the fixture bundle exercises the same error type production does.
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+            this.severity = options.severity;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
         const isElizaSettingsDebugEnabled = () => false;
         const isViewVisible = (view, kinds) => {
           if (view && view.developerOnly) return Boolean(kinds && kinds.developer);
           if (view && view.viewKind === "developer") return Boolean(kinds && kinds.developer);
           return true;
         };
-        module.exports = new Proxy({ isElizaSettingsDebugEnabled, isViewVisible }, {
+        module.exports = new Proxy({ ElizaError, isElizaError: (v) => v instanceof ElizaError, isElizaSettingsDebugEnabled, isViewVisible }, {
           get: (t, p) => (p in t ? t[p] : noop),
         });
       `,

--- a/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
+++ b/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
@@ -34,8 +34,28 @@ const stubElizaCore = {
       // would blank the rested state and fake a regression.
       contents: `
         const noop = new Proxy(() => noop, { get: () => noop });
+        // The wake/provision path (client-cloud.ts) subclasses the real
+        // ElizaError; esbuild's ESM interop copies only this object's own keys,
+        // so a Proxy fallback would surface undefined here and break the
+        // subclass at evaluation time. Export a real class with core's shape so
+        // the fixture bundle exercises the same error type production does.
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+            this.severity = options.severity;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
         module.exports = new Proxy(
           {
+            ElizaError,
+            isElizaError: (v) => v instanceof ElizaError,
             DEFAULT_NOTIFICATION_CATEGORY: "general",
             DEFAULT_NOTIFICATION_PRIORITY: "normal",
             tierForPriority: (priority) =>

--- a/packages/ui/src/components/shell/__e2e__/capture-no-provider-evidence.mjs
+++ b/packages/ui/src/components/shell/__e2e__/capture-no-provider-evidence.mjs
@@ -38,8 +38,28 @@ const stubElizaCore = {
     b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
       contents: `
         const noop = new Proxy(() => noop, { get: () => noop });
+        // The wake/provision path (client-cloud.ts) subclasses the real
+        // ElizaError; esbuild's ESM interop copies only this object's own keys,
+        // so a Proxy fallback would surface undefined here and break the
+        // subclass at evaluation time. Export a real class with core's shape so
+        // the fixture bundle exercises the same error type production does.
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+            this.severity = options.severity;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
         module.exports = new Proxy(
           {
+            ElizaError,
+            isElizaError: (v) => v instanceof ElizaError,
             isViewVisible: () => true,
             dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
             findInteractionRegions: () => [],

--- a/packages/ui/src/components/shell/__e2e__/record-voice-trajectories.mjs
+++ b/packages/ui/src/components/shell/__e2e__/record-voice-trajectories.mjs
@@ -50,8 +50,28 @@ const stubElizaCore = {
     b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
       contents: `
         const noop = new Proxy(() => noop, { get: () => noop });
+        // The wake/provision path (client-cloud.ts) subclasses the real
+        // ElizaError; esbuild's ESM interop copies only this object's own keys,
+        // so a Proxy fallback would surface undefined here and break the
+        // subclass at evaluation time. Export a real class with core's shape so
+        // the fixture bundle exercises the same error type production does.
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+            this.severity = options.severity;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
         module.exports = new Proxy(
           {
+            ElizaError,
+            isElizaError: (v) => v instanceof ElizaError,
             isViewVisible: () => true,
             dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
             findInteractionRegions: () => [],

--- a/packages/ui/src/components/shell/__e2e__/run-chat-scroll-axis-lock-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-scroll-axis-lock-e2e.mjs
@@ -58,8 +58,28 @@ const stubElizaCore = {
     b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
       contents: `
         const noop = new Proxy(() => noop, { get: () => noop });
+        // The wake/provision path (client-cloud.ts) subclasses the real
+        // ElizaError; esbuild's ESM interop copies only this object's own keys,
+        // so a Proxy fallback would surface undefined here and break the
+        // subclass at evaluation time. Export a real class with core's shape so
+        // the fixture bundle exercises the same error type production does.
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+            this.severity = options.severity;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
         module.exports = new Proxy(
           {
+            ElizaError,
+            isElizaError: (v) => v instanceof ElizaError,
             isViewVisible: () => true,
             dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
             findInteractionRegions: () => [],

--- a/packages/ui/src/components/shell/__e2e__/run-chat-scroll-web-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-scroll-web-e2e.mjs
@@ -54,8 +54,28 @@ const stubElizaCore = {
     b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
       contents: `
         const noop = new Proxy(() => noop, { get: () => noop });
+        // The wake/provision path (client-cloud.ts) subclasses the real
+        // ElizaError; esbuild's ESM interop copies only this object's own keys,
+        // so a Proxy fallback would surface undefined here and break the
+        // subclass at evaluation time. Export a real class with core's shape so
+        // the fixture bundle exercises the same error type production does.
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+            this.severity = options.severity;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
         module.exports = new Proxy(
           {
+            ElizaError,
+            isElizaError: (v) => v instanceof ElizaError,
             isViewVisible: () => true,
             dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
             findInteractionRegions: () => [],

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -161,6 +161,24 @@ const stubElizaCore = {
     b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
       contents: `
         const noop = new Proxy(() => noop, { get: () => noop });
+        // The wake/provision path (client-cloud.ts) subclasses the real
+        // ElizaError; esbuild's ESM interop copies only this object's own keys,
+        // so a Proxy fallback would surface undefined here and break the
+        // subclass at evaluation time. Export a real class with core's shape so
+        // the fixture bundle exercises the same error type production does.
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+            this.severity = options.severity;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
         const resolveViewKind = (d) =>
           (d && d.viewKind) || (d && d.developerOnly ? "developer" : "release");
         const isViewKindEnabled = (kind, enabled) =>
@@ -173,6 +191,8 @@ const stubElizaCore = {
                 : false;
         module.exports = new Proxy(
           {
+            ElizaError,
+            isElizaError: (v) => v instanceof ElizaError,
             resolveViewKind,
             isViewKindEnabled,
             isViewVisible: (d, enabled) =>

--- a/packages/ui/src/components/shell/__e2e__/run-launcher-loop-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-launcher-loop-e2e.mjs
@@ -180,6 +180,24 @@ const stubElizaCore = {
     b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
       contents: `
         const noop = new Proxy(() => noop, { get: () => noop });
+        // The wake/provision path (client-cloud.ts) subclasses the real
+        // ElizaError; esbuild's ESM interop copies only this object's own keys,
+        // so a Proxy fallback would surface undefined here and break the
+        // subclass at evaluation time. Export a real class with core's shape so
+        // the fixture bundle exercises the same error type production does.
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+            this.severity = options.severity;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
         const resolveViewKind = (d) =>
           (d && d.viewKind) || (d && d.developerOnly ? "developer" : "release");
         const isViewKindEnabled = (kind, enabled) =>
@@ -192,6 +210,8 @@ const stubElizaCore = {
                 : false;
         module.exports = new Proxy(
           {
+            ElizaError,
+            isElizaError: (v) => v instanceof ElizaError,
             resolveViewKind,
             isViewKindEnabled,
             isViewVisible: (d, enabled) =>

--- a/packages/ui/src/components/views/__e2e__/run-view-lifecycle-e2e.mjs
+++ b/packages/ui/src/components/views/__e2e__/run-view-lifecycle-e2e.mjs
@@ -55,7 +55,28 @@ const stubElizaCore = {
     }));
     b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
       contents: `const noop = new Proxy(() => noop, { get: () => noop });
-        module.exports = new Proxy({}, { get: (t, p) => (p in t ? t[p] : noop) });`,
+// The wake/provision path (client-cloud.ts) subclasses the real
+// ElizaError; esbuild's ESM interop copies only this object's own keys,
+// so a Proxy fallback would surface undefined here and break the
+// subclass at evaluation time. Export a real class with core's shape so
+// the fixture bundle exercises the same error type production does.
+class ElizaError extends Error {
+  constructor(message, options = {}) {
+    super(
+      message,
+      options.cause !== undefined ? { cause: options.cause } : undefined,
+    );
+    this.name = "ElizaError";
+    this.code = options.code;
+    this.context = options.context;
+    this.severity = options.severity;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+        module.exports = new Proxy(
+          { ElizaError, isElizaError: (v) => v instanceof ElizaError },
+          { get: (t, p) => (p in t ? t[p] : noop) },
+        );`,
       loader: "js",
     }));
   },

--- a/packages/ui/src/testing/e2e-runner/esbuild-stubs.test.ts
+++ b/packages/ui/src/testing/e2e-runner/esbuild-stubs.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Contract test for the `@elizaos/core` fixture stub: bundles a module that
+ * subclasses `ElizaError` through real esbuild with `stubElizaCore()`, then
+ * evaluates the output. The stub replaces core's Node graph, but any symbol a
+ * fixture actually *uses at evaluation time* must be a working implementation —
+ * a Proxy fallback surfaces `undefined` through esbuild's ESM interop, and
+ * `class … extends undefined` crashes the whole bundle at load. `client-cloud.ts`
+ * subclasses `ElizaError`, so the stub must export a real one rather than force
+ * production code to guard its own base class.
+ */
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { build } from "esbuild";
+import { describe, expect, it } from "vitest";
+import { stubElizaCore } from "./esbuild-stubs";
+
+async function bundleWithCoreStub(source: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "eliza-core-stub-"));
+  const entry = join(root, "entry.mjs");
+  await writeFile(entry, source);
+  const result = await build({
+    entryPoints: [entry],
+    bundle: true,
+    write: false,
+    format: "iife",
+    globalName: "fixture",
+    platform: "browser",
+    plugins: [stubElizaCore()],
+  });
+  const output = result.outputFiles?.[0]?.text;
+  if (!output)
+    throw new Error("esbuild produced no output for the stub bundle");
+  return output;
+}
+
+describe("stubElizaCore", () => {
+  it("exports a real ElizaError a fixture bundle can subclass", async () => {
+    const bundle = await bundleWithCoreStub(`
+      import { ElizaError } from "@elizaos/core";
+      class WakeError extends ElizaError {}
+      const thrown = new WakeError("wake failed", {
+        code: "CLOUD_AGENT_WAKE_FAILED",
+        context: { phase: "resume", agentId: "agent-1" },
+        cause: new Error("HTTP 402"),
+      });
+      export const observed = {
+        isElizaError: thrown instanceof ElizaError,
+        isWakeError: thrown instanceof WakeError,
+        message: thrown.message,
+        code: thrown.code,
+        context: thrown.context,
+        causeMessage: thrown.cause instanceof Error ? thrown.cause.message : null,
+      };
+    `);
+
+    const evaluated = new Function(`${bundle}; return fixture.observed;`)() as {
+      isElizaError: boolean;
+      isWakeError: boolean;
+      message: string;
+      code: string;
+      context: Record<string, unknown>;
+      causeMessage: string | null;
+    };
+
+    expect(evaluated.isElizaError).toBe(true);
+    expect(evaluated.isWakeError).toBe(true);
+    expect(evaluated.message).toBe("wake failed");
+    expect(evaluated.code).toBe("CLOUD_AGENT_WAKE_FAILED");
+    expect(evaluated.context).toEqual({ phase: "resume", agentId: "agent-1" });
+    expect(evaluated.causeMessage).toBe("HTTP 402");
+  });
+
+  it("still proxies unnamed core symbols and never bundles core's Node graph", async () => {
+    // Property reads go through the Proxy, so anything a fixture only touches
+    // dynamically keeps its no-op answer. A NAMED import cannot: esbuild's
+    // interop copies own keys, which is exactly why ElizaError has to be a
+    // concrete export above.
+    const bundle = await bundleWithCoreStub(`
+      import core from "@elizaos/core";
+      export const observed = typeof core.someSymbolThatDoesNotExist;
+    `);
+
+    const evaluated = new Function(
+      `${bundle}; return fixture.observed;`,
+    )() as string;
+
+    expect(evaluated).toBe("function");
+    expect(bundle).not.toContain("node:crypto");
+  });
+});

--- a/packages/ui/src/testing/e2e-runner/esbuild-stubs.ts
+++ b/packages/ui/src/testing/e2e-runner/esbuild-stubs.ts
@@ -29,8 +29,28 @@ export function stubElizaCore(): Plugin {
       build.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
         contents: `
         const noop = new Proxy(() => noop, { get: () => noop });
+        // The wake/provision path (client-cloud.ts) subclasses the real
+        // ElizaError; esbuild's ESM interop copies only this object's own keys,
+        // so a Proxy fallback would surface undefined here and break the
+        // subclass at evaluation time. Export a real class with core's shape so
+        // the fixture bundle exercises the same error type production does.
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+            this.severity = options.severity;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
         module.exports = new Proxy(
           {
+            ElizaError,
+            isElizaError: (v) => v instanceof ElizaError,
             isViewVisible: () => true,
             dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
             findInteractionRegions: () => [],


### PR DESCRIPTION
# Relates to

#18463 — Cloud join masks dedicated wake and provisioning failures behind a six-minute spinner.

Scope of this PR is the **join client state machine** in the typed API client (`packages/ui/src/api/client-cloud.ts`). The real-browser staging acceptance QA on this issue is owned by gauss (Project 18 draft) and is intentionally **not** claimed here.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker. → focused package gates were run instead; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `4165571a` (including #19078 and #9090); zero conflicts.
- [ ] `bun run verify` passes post-sync → not run in this worktree; the exact substitute gates and the pre-existing unrelated failures are documented in **Known gaps / failures**.

# Risks

**Low–medium.** All changes are inside the cloud wake/provision wait in the typed client.

- Failures that previously polled silently until the six-minute timeout now throw immediately as `CloudAgentWakeError`, including HTTP failures and resolved `{ success: false }` envelopes from resume, agent-detail reads, and job reads. Only status-less transport failures and explicit 500/502/504 infrastructure churn remain transient inside the bounded poll. Control-plane codes and `Retry-After` metadata survive both browser and native transports.
- A fresh 202 create that reports a `jobId` now polls `/api/v1/jobs/:jobId` to terminal before the agent-detail wait. A backend that answers with a jobId but no job read endpoint would previously have been ignored; a transient job-read failure only ticks, and a create with no `jobId` (warm pool / sync create) is byte-identical to before.
- `cause` is preserved on every typed error, so the join flow's `isCloudAgentGoneError` stale-binding recovery (404 + `agent_not_found`) continues to classify through the wrapper.

# Background

## What does this PR do?

The dedicated-agent wake wait (`waitForCloudAgentRunning`) swallowed every resume and status-read failure (`.catch(() => null)`), so auth expiry (401), credit exhaustion (402), a deleted agent row (404), lifecycle conflicts (409), and worker/capacity outages (503) all rendered as the same "Starting your agent…" spinner until a generic six-minute timeout. The fresh-create path also received the backend's provisioning `jobId` on the 202 response and hardcoded it away (`jobId: ""`), reducing a failed provision to that same opaque timeout instead of the job row's recorded failure reason.

This PR repairs the state machine at the API-client layer:

- **`CloudAgentWakeError`** — typed error with `phase` (`resume` / `status-poll` / `provision-job` / `failed` / `timeout`), the HTTP `status` of the underlying control-plane failure, `retryAfter` (seconds, from the backend's Retry-After header or error body) when sent, `lastObservedStatus`, and the `agentId`/`jobId` operator-safe correlation ids. Timeout messages now name the last truthful status, elapsed time, and the agent id — never a fabricated healthy state.
- **Terminal failures surface immediately** from resume, detail, and job operations, whether the adapter rejects or resolves a `{ success: false }` envelope. Status-less network errors and explicit 500/502/504 responses remain transient; every other HTTP status is returned to the join boundary with preserved control-plane code and `Retry-After` metadata.
- **The fresh-create `jobId` is preserved** through `parseDirectCloudAgentCreateData` and `createCloudCompatAgent`, and `selectOrProvisionCloudAgent` follows the canonical job (`getCloudCompatJobStatus`, `/api/v1/jobs/:jobId`) to a terminal state via the new exported `waitForCloudProvisionJob` before binding — a failed provision surfaces the job's real reason (e.g. "no provisioning worker available") within one poll interval instead of six minutes of agent-detail polling.

Issue acceptance coverage (client-state-machine items): typed phase/source exposure → public `CloudAgentWakeError.phase` + preserved `onProgress` vocabulary; jobId preserved and polled to terminal → `waitForCloudProvisionJob`; no swallowed rejected or resolved-failure resume/detail/job operations, with retry only for explicitly transient states → classifier + tests; truthful timeout with correlation id → timeout message carries last status, elapsed seconds, agent/job ids. The rendered-UI phase display, elapsed-time UI, safe sign-out escape, and real-staging E2E rows belong to the join page surface and gauss's acceptance lane and are **not** claimed here (see Known gaps).

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/ui/src/api/client-cloud-wake-typed-errors.test.ts` — the new contract, both directions: each non-transient status throws typed immediately (with Retry-After carried from both transport error shapes), transient errors keep polling, a failed job surfaces its real reason with both correlation ids, and timeouts stay truthful.
- `packages/ui/src/api/client-cloud.ts` — `CLOUD_WAKE_NON_TRANSIENT_STATUSES`, `CloudAgentWakeError`, `nonTransientWakeFailure`, `waitForCloudAgentRunning`, `waitForCloudProvisionJob`, and the create-branch hookup.

## Detailed testing steps

Automated tests, all run at head `6699e53a656cd197e714b56b118f488cd6d84f19` after rebasing onto `4165571a`:

```
$ cd packages/ui && bunx vitest run \
+    src/api/client-cloud-wake-typed-errors.test.ts \
+    src/api/client-cloud-select-or-provision.test.ts \
+    src/api/client-cloud-connect-mock-cloud.test.ts \
+    src/api/client-cloud-web-join-base.test.ts \
+    src/api/client-cloud-direct-auth.test.ts \
+    src/api/client-cloud-provision-sandbox.test.ts \
+    src/cloud/join/lib/run-join-flow.test.ts --coverage.enabled=false
 Test Files  7 passed (7)
      Tests  110 passed (110)
```

The contract suite now covers rejected and resolved-failure envelopes, public barrel exposure, arbitrary terminal HTTP statuses, preservation of `agent_not_found`, real browser `Retry-After` header propagation, job failure correlation, transient polling, and truthful timeouts. Directly adjacent stale hostname fixtures introduced by the `eliza.app` domain consolidation were updated to the canonical origins.

```
$ bun run --cwd packages/ui typecheck
# exit 0
$ bun run --cwd packages/ui lint
Checked 2946 files. No fixes applied.
```

A full `packages/ui` test run completed with 9,907 passing, 7 skipped, and 46 failures across 21 files. Those failures are current-base issues outside this change, predominantly stale `elizacloud.ai` expectations after #19078 plus unrelated view/action baselines; none are in the seven wake/join suites above.

Not verified here: live staging `/join` runs (real Magic-Link auth is gated; gauss owns the real-browser acceptance on #18463), and the root `bun run verify` aggregate (see Known gaps).

## Review follow-ups (second pass)

Three defects found in review of the first pass are fixed here:

1. **One deadline for the whole join.** `waitForCloudProvisionJob` and the `waitForCloudAgentRunning` that follows it each received the full `CLOUD_AGENT_WAKE_TIMEOUT_MS`, so a job completing at 5:59 handed a fresh six minutes to the status poll — up to twelve minutes, which is the literal complaint in #18463. `selectOrProvisionCloudAgent` now computes one deadline and passes the remaining budget to each wait.
2. **408/429 are transient, and Retry-After is slept, not thrown.** `CLOUD_WAKE_TRANSIENT_STATUSES` treated every status outside 500/502/504 as terminal, so a single rate-limited or timed-out poll tick aborted an otherwise healthy join. 408 and 429 are now transient, and the `Retry-After` the classifier already extracted paces the next tick instead of decorating a thrown error.
3. **The real `ElizaError`, not a guarded base.** `const WakeErrorBase = (ElizaError ?? Error)` was production code bending around a broken test stub: in the degraded mode `code`/`context` are dropped, so `isCloudAgentGoneError` returned false in fixture-e2e and true in production — the fixtures exercised a different class than users get. The `@elizaos/core` esbuild stub the `__e2e__` runners share now exports a real `ElizaError`, and `CloudAgentWakeError extends ElizaError` directly.

New coverage:

- `client-cloud-wake-typed-errors.test.ts` — `CloudAgentWakeError` is an `ElizaError` carrying `code` + `context`; a 429 and a 408 status read keep polling to a running agent; the loop waits the ~120ms `Retry-After` the control plane named (agent poll and job poll); and the provisioning wait plus the running wait finish inside ONE `wakeTimeoutMs` rather than two.
- `packages/ui/src/testing/e2e-runner/esbuild-stubs.test.ts` — bundles a module that subclasses `ElizaError` through real esbuild with `stubElizaCore()` and evaluates the output, asserting `instanceof`, `code`, `context`, and `cause` survive, while unnamed core symbols still resolve to the no-op proxy and core's Node graph is never bundled.

```
$ cd packages/core && node ../shared/scripts/generate-keywords.mjs
$ cd packages/ui && bunx vitest run src/api/client-cloud
  Test Files  4 failed | 14 passed (18)
       Tests  8 failed | 223 passed (231)
$ bunx vitest run src/testing/e2e-runner/esbuild-stubs.test.ts
  Test Files  1 passed (1)
       Tests  2 passed (2)
$ bun run --cwd packages/ui typecheck
  exit 0
```

The 8 failures are byte-identical with this second pass stashed (baseline: `8 failed | 218 passed`), i.e. the same current-base stale-hostname/domain-migration failures already recorded below. All wake/provision assertions pass, and the pass count rises by the 5 new tests.

# Evidence Gate

Evidence matches exact head `f5b0ddee050dc27397ed757a5a5896bd25f2b084`.
<!-- evidence-head:f5b0ddee050dc27397ed757a5a5896bd25f2b084 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no rendered surface changed: the diff is typed API-client .ts logic, the shared esbuild fixture stub, and unit tests; no .tsx/.css/rendered file touched.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no rendered surface changed (same as above).`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-visible flow changed to walk through; behavior change is typed errors from the API client, proven by unit tests above.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no backend code changed; this is the client half of the contract. The client-side path firing end to end is shown in the vitest transcripts above, including the wall-clock assertions on the shared join budget and the Retry-After backoff.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - non-rendered client-library diff; the request/response state transitions are exercised against a mock control plane in client-cloud-connect-mock-cloud.test.ts and the new unit suite (transcript above).`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB rows, memories, scheduled tasks, or generated files are produced by this change.`
<!-- evidence-row:ocr-review -->
- [x] `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model/action/prompt behavior is changed.`

## Backend + frontend logs

`N/A - client API library change with no rendered surface; see the vitest transcripts in Testing (real state-machine transitions against a mocked control plane, both success and failure directions).`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered surface changed; the CI evidence gate's rendered-UI file check does not trigger on this diff (typed .ts client + tests only).`

## Audio / voice walkthrough

`N/A - no voice/audio path touched.`

## Known gaps / failures

- `bun run verify` (root aggregate) was not run in this worktree: this measured run uses a light install (`bun run install:light`) without the full artifact sync the aggregate gates need. Substitutes run instead, all at the PR head: `packages/ui` typecheck (pass), biome on the changed files (pass), and the focused + adjacent cloud-client vitest suites (transcripts above).
- The directly adjacent hostname fixtures were repaired and all seven focused wake/join suites pass (110/110). The full UI package still has 46 current-base failures outside this PR, predominantly stale domain-migration expectations and unrelated view/action baselines; their exact aggregate is recorded above.
- The issue's rendered-UI acceptance rows (phase display, elapsed-time UI, safe escape/sign-out, real staging E2E across stopped-resume / warm hit / warm miss / worker-unavailable / credits / auth-expiry / timeout, MP4+network evidence) are the join-page surface and gauss's real-browser acceptance lane on #18463 and remain open there — this PR supplies the typed client contract those rows consume.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [claude-18463]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZXZVTC1A2BCRMAYZTE5RJ5S","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T16:39:09.441Z","completed_at":"2026-08-13T16:52:44.023Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA1wup-TpOQbidV6XOR-nWj5-01vmuc1Uuv5emKqsM8iA","device_key_id":"dbd0806ed31cfab14a18eeb4990c66497a5ce64fdb0d37d3c878b8f5e6227484","device_signature":"y9hKEL3qlBWPcFJbtgIJAsYBFUNytlHxWhy1zJHwnjfkNNycspM9Rhxh1oDlZqDuNNuxwZ23cWcQ8kAO0pFbDA"}} -->