### PR TITLE
fix(shared): guard formatDateTime/formatShortDate against invalid ISO calendar dates

### DIFF
--- a/packages/shared/src/utils/format.test.ts
+++ b/packages/shared/src/utils/format.test.ts
@@ -5,11 +5,19 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   formatByteSize,
+  formatDateTime,
   formatDurationMs,
+  formatShortDate,
   formatTime,
   formatUptime,
   formatUsd,
 } from "./format";
+
+const DATE_FORMATTERS = [
+  ["date and time", formatDateTime],
+  ["time", formatTime],
+  ["short date", formatShortDate],
+] as const;
 
 describe("formatUptime", () => {
   it("renders compact units and handles invalid input", () => {
@@ -144,6 +152,65 @@ describe("formatTime", () => {
     expect(formatTime("June 5, 2026 10:00:00", { locale: "en-US" })).toBe(
       "12:34:56 PM",
     );
+    expect(localeSpy).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe.each(DATE_FORMATTERS)("formatting %s", (_label, formatter) => {
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+    ["malformed", "not-a-date"],
+    ["numeric NaN", Number.NaN],
+    ["invalid Date", new Date(Number.NaN)],
+    ["outside TimeClip", 8.64e15 + 1],
+    ["calendar-invalid ISO timestamp", "2026-02-31T00:00:00Z"],
+    ["non-leap February 29", "2026-02-29"],
+    ["month zero", "2026-00-01"],
+    ["month thirteen", "2026-13-01"],
+    ["day zero", "2026-01-00"],
+    ["thirty-first day in April", "2026-04-31"],
+  ])("returns the configured fallback for %s input", (_case, value) => {
+    expect(formatter(value, { fallback: "Unavailable", locale: "en-US" })).toBe(
+      "Unavailable",
+    );
+  });
+});
+
+describe("date display formatter compatibility", () => {
+  it("preserves supported date-and-time input shapes", () => {
+    const localeSpy = vi
+      .spyOn(Date.prototype, "toLocaleString")
+      .mockReturnValue("June 5, 2026 at 10:00 AM");
+
+    for (const value of [
+      0,
+      new Date(0),
+      "2026-06-05T10:00:00Z",
+      "2024-02-29T00:00:00Z",
+      "June 5, 2026 10:00:00",
+    ]) {
+      expect(formatDateTime(value, { locale: "en-US" })).toBe(
+        "June 5, 2026 at 10:00 AM",
+      );
+    }
+    expect(localeSpy).toHaveBeenCalledTimes(5);
+  });
+
+  it("preserves supported short-date input shapes", () => {
+    const localeSpy = vi
+      .spyOn(Date.prototype, "toLocaleDateString")
+      .mockReturnValue("Jun 5, 2026");
+
+    for (const value of [
+      0,
+      new Date(0),
+      "2026-06-05T10:00:00Z",
+      "2024-02-29",
+      "June 5, 2026 10:00:00",
+    ]) {
+      expect(formatShortDate(value, { locale: "en-US" })).toBe("Jun 5, 2026");
+    }
     expect(localeSpy).toHaveBeenCalledTimes(5);
   });
 });

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -101,6 +101,17 @@ function hasValidIsoCalendarDate(value: string): boolean {
   return day <= daysInMonth[month - 1];
 }
 
+function parseDisplayDate(
+  value: number | string | Date | null | undefined,
+): Date | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "string" && !hasValidIsoCalendarDate(value)) {
+    return null;
+  }
+  const parsed = value instanceof Date ? value : new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed : null;
+}
+
 /**
  * Format a byte count in human-readable units.
  */
@@ -179,12 +190,8 @@ export function formatDateTime(
   options: DateFormatOptions = {},
 ): string {
   const { fallback = "—", locale } = options;
-  if (value == null || value === "") return fallback;
-  if (typeof value === "string" && !hasValidIsoCalendarDate(value)) {
-    return fallback;
-  }
-  const parsed = value instanceof Date ? value : new Date(value);
-  if (!Number.isFinite(parsed.getTime())) return fallback;
+  const parsed = parseDisplayDate(value);
+  if (!parsed) return fallback;
   return parsed.toLocaleString(locale);
 }
 
@@ -196,12 +203,8 @@ export function formatTime(
   options: DateFormatOptions = {},
 ): string {
   const { fallback = "—", locale } = options;
-  if (value == null || value === "") return fallback;
-  if (typeof value === "string" && !hasValidIsoCalendarDate(value)) {
-    return fallback;
-  }
-  const parsed = value instanceof Date ? value : new Date(value);
-  if (!Number.isFinite(parsed.getTime())) return fallback;
+  const parsed = parseDisplayDate(value);
+  if (!parsed) return fallback;
   return parsed.toLocaleTimeString(locale);
 }
 
@@ -213,12 +216,8 @@ export function formatShortDate(
   options: DateFormatOptions = {},
 ): string {
   const { fallback = "—", locale } = options;
-  if (value == null || value === "") return fallback;
-  if (typeof value === "string" && !hasValidIsoCalendarDate(value)) {
-    return fallback;
-  }
-  const parsed = value instanceof Date ? value : new Date(value);
-  if (!Number.isFinite(parsed.getTime())) return fallback;
+  const parsed = parseDisplayDate(value);
+  if (!parsed) return fallback;
   return parsed.toLocaleDateString(locale, {
     year: "numeric",
     month: "short",

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -180,6 +180,9 @@ export function formatDateTime(
 ): string {
   const { fallback = "—", locale } = options;
   if (value == null || value === "") return fallback;
+  if (typeof value === "string" && !hasValidIsoCalendarDate(value)) {
+    return fallback;
+  }
   const parsed = value instanceof Date ? value : new Date(value);
   if (!Number.isFinite(parsed.getTime())) return fallback;
   return parsed.toLocaleString(locale);
@@ -211,6 +214,9 @@ export function formatShortDate(
 ): string {
   const { fallback = "—", locale } = options;
   if (value == null || value === "") return fallback;
+  if (typeof value === "string" && !hasValidIsoCalendarDate(value)) {
+    return fallback;
+  }
   const parsed = value instanceof Date ? value : new Date(value);
   if (!Number.isFinite(parsed.getTime())) return fallback;
   return parsed.toLocaleDateString(locale, {


### PR DESCRIPTION
# Relates to

- Fixes #19144.
- Original issue was self-reported by the contributor in this PR.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and the full root `bun run verify` were not run outside isolation; focused package validation and the exact unrelated package-suite blocker are recorded below, with current-head CI as the final repository gate.
- [x] A reviewer can confirm the changed contract from the automated tests and validation record below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes - maintainer repair; original contributor assistance was not declared`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` for the maintainer repair; original contributor provenance was not supplied
<!-- attribution-row:client -->
- Agent tooling: `codex` for the maintainer repair; original contributor provenance was not supplied
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a99005229f89004940177a4fafb5a026c20601c6:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

Original contributor provenance remains undeclared; this structured status applies to the attributed maintainer repair.

# Sync with develop

- [x] Rebased onto `a99005229f89004940177a4fafb5a026c20601c6`; zero conflicts.
- [ ] Current-head CI must pass before merge. Focused package gates pass; the exact unrelated base failure is documented below.

# Risks

Low. This centralizes validation already used by `formatTime` and applies it consistently to all three shared display-date formatters. The principal compatibility risk is rejecting strings that begin with an ISO-looking but impossible calendar date; tests retain numeric epochs, `Date` objects, valid ISO strings, leap days, and existing human-readable date strings.

# Background

## What does this PR do?

JavaScript normalizes impossible ISO calendar dates such as `2026-02-31` instead of rejecting them. The original patch copied the existing `formatTime` guard into two siblings, but left three parsing paths and added no regression tests. The repaired implementation introduces one internal `parseDisplayDate` path for `formatDateTime`, `formatTime`, and `formatShortDate`, then exercises invalid, adversarial, and compatibility inputs across the shared contract.

## What kind of change is this?

Bug fix (non-breaking validation correction).

# Documentation changes needed?

No. This corrects an internal shared formatter contract and is covered by source-level regression tests.

# Testing

## Where should a reviewer start?

- `packages/shared/src/utils/format.ts`
- `packages/shared/src/utils/format.test.ts`

## Detailed testing steps

Validation was run in a disposable Lima VM using `oven/bun:1.3.14`. Dependencies were built separately from trusted `develop` with lifecycle scripts disabled; the repaired files were mounted read-only into a network-disabled, capability-dropped container.

- `bun run --cwd packages/shared test -- src/utils/format.test.ts` — PASS, 61/61.
- `bun run --cwd packages/shared typecheck` — PASS after building the trusted `@elizaos/cloud-routing` workspace prerequisite.
- `bun run --cwd packages/shared lint:check` — PASS, 382 files.
- `bun run --cwd packages/shared format:check` — PASS, 382 files.
- `bun run --cwd packages/shared build` — PASS.
- Full shared test lane — 1,487 passed, 2 failed in `src/local-inference/hf-proxy.test.ts`. The same two URL-expectation failures reproduce on pristine `develop` without the PR overlay (`https://elizacloud.ai/...` expected versus `https://api.eliza.app/...` received), so they are unrelated to this date-format change.

# Evidence Gate

<!-- evidence-head:e36376d56a0ba212ce05c849d996600f79b7ab1b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Shared formatter code has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Shared formatter code has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - This is a deterministic utility contract with no user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - No backend process, transport, or service path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - No frontend runtime, request, or state transition changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - No agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No mutable domain state or generated runtime artifact; verification is the automated unit, type, lint, format, and build gates recorded above.
<!-- evidence-row:ocr-review -->
- [x] N/A - The change has no rendered visual or text surface.

# Evidence Details

## Real LLM-call trajectory

N/A - No model invocation or agent behavior is involved.

## Backend + frontend logs

N/A - The changed path is a synchronous, deterministic shared formatter with no runtime logging boundary.

## Screenshots (before / after) + video walkthrough

N/A - No UI files or rendered surfaces are touched.

## Audio / voice walkthrough

N/A - No voice, transcript, TTS, or STT path is touched.

## Known gaps / failures

- The current-head GitHub checks remain required before merge.
- The full shared suite's two `hf-proxy.test.ts` failures reproduce identically on pristine `develop` and are unrelated to the two-file date-format diff.
- `bun run check:agents-claude` could not execute in the minimal sandbox because its image intentionally contains no `git` binary; this PR does not modify any guide file, and current-head CI remains authoritative.
- The original contributor did not supply contribution-assistance provenance. The maintainer-authored repair and review are attributed below; an independent reviewer is still required because the repairing reviewer cannot self-approve.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@a99005229f89004940177a4fafb5a026c20601c6:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@a99005229f89004940177a4fafb5a026c20601c6:packages/skills/skills/contribute-to-eliza"} -->


