### PR TITLE
fix(ui): clear stale Cloud sessions and agent bindings

### DIFF
--- a/packages/ui/src/api/auth-client.ts
+++ b/packages/ui/src/api/auth-client.ts
@@ -10,7 +10,11 @@
 
 import type { RoleGateRole } from "@elizaos/core";
 import { getElizaApiToken } from "@elizaos/shared";
-import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
+import {
+  clearStoredStewardToken,
+  readStoredStewardToken,
+  writeStoredStewardToken,
+} from "@elizaos/shared/steward-session-client";
 import { invokeDesktopBridgeRequest } from "../bridge/electrobun-rpc";
 import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
 import { normalizeCloudApiKeyToken } from "../cloud/lib/cloud-api-key-token";
@@ -18,7 +22,10 @@ import { getBootConfig } from "../config/boot-config";
 import { isNative } from "../platform";
 import { clearSharedCloudAccountBinding } from "../state/shared-cloud-account-binding";
 import { isManagedCloudSharedAgentBase } from "../utils/cloud-agent-base";
-import { cloudTokenSecsRemaining } from "./client-cloud";
+import {
+  cloudTokenSecsRemaining,
+  refreshCloudStewardSession,
+} from "./client-cloud";
 import { fetchWithCsrf } from "./csrf-client";
 import { isDesktopExternalApiBaseUrl } from "./desktop-external-api-base";
 
@@ -313,7 +320,7 @@ export async function authMe(): Promise<AuthMeResult> {
   // shell "authenticated", allowing protected pollers and chat sends to loop
   // on 401 while stale agent content remained visible.
   if (isManagedCloudSharedAgentBase(authBase())) {
-    const token = readStoredStewardToken()?.trim();
+    let token = readStoredStewardToken()?.trim();
     const hasNativeOwnerApiKey =
       (isNative || isElectrobunRuntime()) &&
       Boolean(
@@ -327,12 +334,19 @@ export async function authMe(): Promise<AuthMeResult> {
       secondsRemaining <= 0 &&
       !hasNativeOwnerApiKey
     ) {
-      // Expiry alone is not terminal: a backgrounded browser may still have a
-      // valid HttpOnly refresh cookie, and native owns a separate absolute-URL
-      // refresh transport. Keep the shell fail-closed while the existing
-      // single-owner refresh lifecycle rotates or clears the token; its
-      // canonical session-change event then re-probes or invalidates us.
-      return { ok: false, status: 503 };
+      try {
+        const refreshed = await refreshCloudStewardSession();
+        token = refreshed?.token?.trim() || undefined;
+        if (token) writeStoredStewardToken(token);
+      } catch {
+        // error-policy:J1 this auth boundary translates a failed terminal
+        // refresh into the same explicit signed-out state as a rejected one.
+        token = undefined;
+      }
+      if (!token) {
+        clearStoredStewardToken();
+        clearSharedCloudAccountBinding();
+      }
     }
     if (!token && !hasNativeOwnerApiKey) {
       clearSharedCloudAccountBinding();

--- a/packages/ui/src/api/auth-client.ts
+++ b/packages/ui/src/api/auth-client.ts
@@ -9,9 +9,16 @@
  */
 
 import type { RoleGateRole } from "@elizaos/core";
+import { getElizaApiToken } from "@elizaos/shared";
+import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
 import { invokeDesktopBridgeRequest } from "../bridge/electrobun-rpc";
+import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
+import { normalizeCloudApiKeyToken } from "../cloud/lib/cloud-api-key-token";
 import { getBootConfig } from "../config/boot-config";
-import { isDirectCloudSharedAgentBase } from "./client-cloud";
+import { isNative } from "../platform";
+import { clearSharedCloudAccountBinding } from "../state/shared-cloud-account-binding";
+import { isManagedCloudSharedAgentBase } from "../utils/cloud-agent-base";
+import { cloudTokenSecsRemaining } from "./client-cloud";
 import { fetchWithCsrf } from "./csrf-client";
 import { isDesktopExternalApiBaseUrl } from "./desktop-external-api-base";
 
@@ -299,12 +306,47 @@ export async function authLogout(): Promise<AuthLogoutResult> {
  * show a backend failure instead of a misleading credential prompt.
  */
 export async function authMe(): Promise<AuthMeResult> {
-  // A serverless shared-runtime cloud agent has no agent server, so /api/auth/me
-  // 404s and the startup auth probe fails "Backend Unreachable". The cloud API
-  // key (validated per-request by the cloud API) IS the auth here — there's no
-  // per-agent password/session gate to satisfy. Report authenticated (machine
-  // identity = the API-key-authed cloud caller) so auth-checking passes.
-  if (isDirectCloudSharedAgentBase(authBase())) {
+  // A serverless shared-runtime agent has no independent password/session
+  // service, so this gate reflects the canonical Steward account credential.
+  // It must not report synthetic success merely because the selected base has
+  // a shared-agent URL: after terminal refresh expiry that kept the mounted
+  // shell "authenticated", allowing protected pollers and chat sends to loop
+  // on 401 while stale agent content remained visible.
+  if (isManagedCloudSharedAgentBase(authBase())) {
+    const token = readStoredStewardToken()?.trim();
+    const hasNativeOwnerApiKey =
+      (isNative || isElectrobunRuntime()) &&
+      Boolean(
+        normalizeCloudApiKeyToken(getBootConfig().apiToken) ??
+          normalizeCloudApiKeyToken(getElizaApiToken()),
+      );
+    const secondsRemaining = token ? cloudTokenSecsRemaining(token) : null;
+    if (
+      token &&
+      secondsRemaining !== null &&
+      secondsRemaining <= 0 &&
+      !hasNativeOwnerApiKey
+    ) {
+      // Expiry alone is not terminal: a backgrounded browser may still have a
+      // valid HttpOnly refresh cookie, and native owns a separate absolute-URL
+      // refresh transport. Keep the shell fail-closed while the existing
+      // single-owner refresh lifecycle rotates or clears the token; its
+      // canonical session-change event then re-probes or invalidates us.
+      return { ok: false, status: 503 };
+    }
+    if (!token && !hasNativeOwnerApiKey) {
+      clearSharedCloudAccountBinding();
+      return {
+        ok: false,
+        status: 401,
+        reason: "remote_auth_required",
+        access: {
+          mode: "remote",
+          passwordConfigured: false,
+          ownerConfigured: true,
+        },
+      };
+    }
     return {
       ok: true,
       identity: { id: "cloud", displayName: "Eliza Cloud", kind: "machine" },

--- a/packages/ui/src/api/client-cloud-agent-base.test.ts
+++ b/packages/ui/src/api/client-cloud-agent-base.test.ts
@@ -16,6 +16,7 @@ import {
   directCloudSharedAgentIdFromBase,
   isCloudAgentsCollectionBase,
   isElizaCloudControlPlaneAgentlessBase,
+  isManagedCloudSharedAgentBase,
   resolveCloudEnvironmentBase,
 } from "../utils/cloud-agent-base";
 import { resolveCloudAgentApiBase } from "./client-cloud";
@@ -137,6 +138,19 @@ describe("resolveCloudAgentApiBase", () => {
 });
 
 describe("cloud-agent-base helpers", () => {
+  it("restricts account-scoped shared-agent classification to managed Cloud hosts", () => {
+    expect(
+      isManagedCloudSharedAgentBase(
+        "https://api.eliza.app/api/v1/eliza/agents/agent-123",
+      ),
+    ).toBe(true);
+    expect(
+      isManagedCloudSharedAgentBase(
+        "https://vps.example/api/v1/eliza/agents/agent-123",
+      ),
+    ).toBe(false);
+  });
+
   it("buildCloudSharedAgentApiBase appends the per-agent REST path", () => {
     expect(
       buildCloudSharedAgentApiBase("https://api.elizacloud.ai/", "abc"),

--- a/packages/ui/src/cloud/lib/api-client.test.ts
+++ b/packages/ui/src/cloud/lib/api-client.test.ts
@@ -85,9 +85,7 @@ describe("cloud api-client transport bridge", () => {
     it("STILL throws CROSS_ORIGIN_API_URL on a cross-origin Cloud API URL", async () => {
       const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-      await expectCrossOriginThrow(
-        api("https://api.elizacloud.ai/api/v1/apps"),
-      );
+      await expectCrossOriginThrow(api("https://api.eliza.app/api/v1/apps"));
 
       // The throw fires before any transport is touched.
       expect(fetchSpy).not.toHaveBeenCalled();
@@ -149,7 +147,7 @@ describe("cloud api-client transport bridge", () => {
       expect(capacitorMocks.request).toHaveBeenCalledWith(
         expect.objectContaining({
           // www.elizacloud.ai (boot config) normalized to the API host.
-          url: "https://api.elizacloud.ai/api/v1/apps",
+          url: "https://api.eliza.app/api/v1/apps",
           method: "GET",
           // WHATWG Headers lowercases keys; HTTP header names are
           // case-insensitive, so the server reads this identically.
@@ -168,13 +166,13 @@ describe("cloud api-client transport bridge", () => {
       });
 
       const result = await api<{ ok: boolean }>(
-        "https://api.elizacloud.ai/api/v1/apps/app-1",
+        "https://api.eliza.app/api/v1/apps/app-1",
       );
 
       expect(result).toEqual({ ok: true });
       expect(capacitorMocks.request).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: "https://api.elizacloud.ai/api/v1/apps/app-1",
+          url: "https://api.eliza.app/api/v1/apps/app-1",
         }),
       );
     });
@@ -193,7 +191,7 @@ describe("cloud api-client transport bridge", () => {
 
       expect(capacitorMocks.request).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: "https://api.elizacloud.ai/api/v1/apps",
+          url: "https://api.eliza.app/api/v1/apps",
           method: "POST",
           data: { name: "My App" },
           headers: expect.objectContaining({
@@ -253,7 +251,7 @@ describe("cloud api-client transport bridge", () => {
       expect(fetchSpy).not.toHaveBeenCalled();
       expect(capacitorMocks.request).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: "https://api.elizacloud.ai/api/v1/apps",
+          url: "https://api.eliza.app/api/v1/apps",
         }),
       );
     });
@@ -292,7 +290,7 @@ describe("cloud api-client transport bridge", () => {
 
       expect(capacitorMocks.request).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: "https://api.elizacloud.ai/api/v1/apps",
+          url: "https://api.eliza.app/api/v1/apps",
           headers: expect.objectContaining({
             authorization: `Bearer ${CLOUD_API_KEY}`,
           }),
@@ -313,7 +311,7 @@ describe("cloud api-client transport bridge", () => {
       await api("/api/v1/apps");
 
       const call = capacitorMocks.request.mock.calls[0]?.[0];
-      expect(call?.url).toBe("https://api.elizacloud.ai/api/v1/apps");
+      expect(call?.url).toBe("https://api.eliza.app/api/v1/apps");
       expect(call?.headers.authorization).toBeUndefined();
     });
 

--- a/packages/ui/src/cloud/lib/api-client.ts
+++ b/packages/ui/src/cloud/lib/api-client.ts
@@ -184,17 +184,22 @@ function readLiveNativeStewardToken(token: string): string | null {
  * fallback never applies — it resolves to the steward token or nothing.
  */
 export function readCloudBearerToken(): string | null {
+  const nativeRuntime = isNativeCloudRuntime();
+  // Resolve the supported owner-key fallback before expiry cleanup dispatches
+  // the canonical session-clear event. That event may synchronously remove the
+  // rejected account target from boot config; the already-validated fallback
+  // must remain usable for this request on native/Electrobun (#11930).
+  const nativeCloudApiKey = nativeRuntime
+    ? (normalizeCloudApiKeyToken(getBootConfig().apiToken) ??
+      normalizeCloudApiKeyToken(getElizaApiToken()))
+    : null;
   const stewardToken = readStewardToken()?.trim();
   if (stewardToken) {
-    if (!isNativeCloudRuntime()) return stewardToken;
+    if (!nativeRuntime) return stewardToken;
     const liveToken = readLiveNativeStewardToken(stewardToken);
     if (liveToken) return liveToken;
   }
-  if (!isNativeCloudRuntime()) return null;
-  return (
-    normalizeCloudApiKeyToken(getBootConfig().apiToken) ??
-    normalizeCloudApiKeyToken(getElizaApiToken())
-  );
+  return nativeCloudApiKey;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
@@ -8,9 +8,16 @@
  * JWT `exp` claim.
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  loadPersistedActiveServer,
+  savePersistedActiveServer,
+} from "../../state/persistence";
 
-import { tokenIsExpired } from "./StewardProviderShared";
+import {
+  clearStaleStewardSession,
+  tokenIsExpired,
+} from "./StewardProviderShared";
 
 // The Steward auth endpoints are resolved per browser host: co-hosted cloud
 // surfaces use their same-origin Pages/Worker proxy. The invariant under guard:
@@ -112,6 +119,45 @@ function makeJwt(payload: Record<string, unknown>): string {
       .replace(/=+$/, "");
   return `${b64url({ alg: "HS256", typ: "JWT" })}.${b64url(payload)}.sig`;
 }
+
+describe("clearStaleStewardSession", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("drops a shared Cloud agent selection so the next account resolves its own agent", () => {
+    savePersistedActiveServer({
+      id: "cloud:old-agent",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase: "https://api.eliza.app/api/v1/eliza/agents/old-agent",
+      accessToken: "expired-steward-token",
+    });
+
+    clearStaleStewardSession();
+
+    expect(loadPersistedActiveServer()).toBeNull();
+  });
+
+  it("preserves a dedicated target selection while scrubbing its rejected bearer", () => {
+    savePersistedActiveServer({
+      id: "cloud:dedicated-agent",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase: "https://dedicated-agent.eliza.app",
+      accessToken: "rejected-agent-token",
+    });
+
+    clearStaleStewardSession();
+
+    expect(loadPersistedActiveServer()).toEqual({
+      id: "cloud:dedicated-agent",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase: "https://dedicated-agent.eliza.app",
+    });
+  });
+});
 
 describe("tokenIsExpired", () => {
   it("keeps a token with a future exp", () => {

--- a/packages/ui/src/cloud/shell/StewardProviderShared.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.ts
@@ -9,8 +9,12 @@ import {
   STEWARD_TOKEN_KEY,
 } from "@elizaos/shared/steward-session-client";
 import { createContext } from "react";
-import { scrubPersistedAgentProfileTokens } from "../../state/agent-profiles";
+import {
+  removeManagedSharedCloudAgentProfiles,
+  scrubPersistedAgentProfileTokens,
+} from "../../state/agent-profiles";
 import { scrubPersistedActiveServerToken } from "../../state/persistence";
+import { clearSharedCloudAccountBinding } from "../../state/shared-cloud-account-binding";
 import { decodeJwtPayload } from "../lib/jwt";
 import { ELIZA_CLOUD_DIRECT_API_BY_HOST } from "./steward-url";
 
@@ -157,11 +161,24 @@ export function tokenSecsRemaining(token: string): number | null {
 export function clearStaleStewardSession(): void {
   if (typeof window === "undefined") return;
   clearStoredStewardToken();
+  // Every shared-agent profile belongs to the ending Steward account, even
+  // when a dedicated or self-hosted target happens to be active at sign-out.
+  removeManagedSharedCloudAgentProfiles();
   // SECURITY: also scrub the persisted accessToken mirrors so the secondary
   // sign-out / 401-self-heal paths that route through here (native apps-studio
   // signOut, the authorize-content edge, StewardProviderRuntime 401 clears) don't
   // leave a usable cloud bearer/API-key at rest in localStorage.
-  scrubPersistedActiveServerToken();
+  if (clearSharedCloudAccountBinding()) {
+    // Shared runtime authorization is the Steward account itself. Once that
+    // account session ends, retaining its selected agent id can bind the next
+    // login to an agent outside the newly authenticated organization. Remove
+    // the selection so the normal post-login flow resolves the current
+    // account's organization-scoped agent list before mounting chat.
+  } else {
+    // Dedicated/self-hosted targets have an independent agent-local recovery
+    // path, so preserve their selection while removing the rejected bearer.
+    scrubPersistedActiveServerToken();
+  }
   scrubPersistedAgentProfileTokens();
   clearServerStewardSessionCookies();
   try {

--- a/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
+++ b/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
@@ -8,9 +8,14 @@
 // test; only global fetch (the network boundary) is stubbed. The shared
 // module snapshot is reset per test via the __resetAuthStatusForTests seam.
 
+import {
+  clearStoredStewardToken,
+  writeStoredStewardToken,
+} from "@elizaos/shared/steward-session-client";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { setBootConfig } from "../config/boot-config-store";
+import { clearStaleStewardSession } from "../cloud/shell/StewardProviderShared";
+import { getBootConfig, setBootConfig } from "../config/boot-config-store";
 import {
   createPersistedActiveServer,
   loadPersistedActiveServer,
@@ -31,6 +36,17 @@ const AUTH_ME_BODY = {
   access: { mode: "session", passwordConfigured: true, ownerConfigured: true },
 };
 
+function makeJwt(expSecondsFromNow: number): string {
+  const encode = (value: unknown) =>
+    btoa(JSON.stringify(value))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${encode({ alg: "none" })}.${encode({
+    exp: Math.floor(Date.now() / 1000) + expSecondsFromNow,
+  })}.sig`;
+}
+
 function jsonResponse(status: number, body: unknown): Response {
   return {
     ok: status >= 200 && status < 300,
@@ -44,6 +60,8 @@ describe("primeAuthStatusProbe + activation reuse", () => {
   const realFetch = globalThis.fetch;
 
   beforeEach(() => {
+    delete (window as Window & { __electrobunWindowId?: number })
+      .__electrobunWindowId;
     localStorage.clear();
     setBootConfig({ branding: {} });
     __resetAuthStatusForTests();
@@ -64,8 +82,140 @@ describe("primeAuthStatusProbe + activation reuse", () => {
       await new Promise((resolve) => setImmediate(resolve));
     });
     globalThis.fetch = realFetch;
+    delete (window as Window & { __electrobunWindowId?: number })
+      .__electrobunWindowId;
     vi.restoreAllMocks();
     __resetAuthStatusForTests();
+  });
+
+  it("fails the shared Cloud auth gate when no Steward account session exists", async () => {
+    setBootConfig({
+      branding: {},
+      apiBase: "https://api.eliza.app/api/v1/eliza/agents/shared-agent",
+    });
+    clearStoredStewardToken();
+
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+
+    await waitFor(() =>
+      expect(result.current.state).toMatchObject({
+        phase: "unauthenticated",
+        reason: "remote_auth_required",
+      }),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves a native owner API-key session without a Steward JWT", async () => {
+    const apiBase = "https://api.eliza.app/api/v1/eliza/agents/shared-agent";
+    (
+      window as Window & { __electrobunWindowId?: number }
+    ).__electrobunWindowId = 1;
+    setBootConfig({
+      branding: {},
+      apiBase,
+      apiToken: "eliza_native_owner_key",
+    });
+    savePersistedActiveServer({
+      id: "cloud:shared-agent",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase,
+      accessToken: "eliza_native_owner_key",
+    });
+    clearStoredStewardToken();
+
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+
+    await waitFor(() =>
+      expect(result.current.state.phase).toBe("authenticated"),
+    );
+    expect(loadPersistedActiveServer()).not.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("probes self-hosted targets whose route resembles the shared adapter", async () => {
+    setBootConfig({
+      branding: {},
+      apiBase: "https://vps.example/api/v1/eliza/agents/agent-1",
+    });
+    fetchMock.mockResolvedValue(jsonResponse(200, AUTH_ME_BODY));
+
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+
+    await waitFor(() =>
+      expect(result.current.state.phase).toBe("authenticated"),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/api/auth/me");
+  });
+
+  it("invalidates a mounted shared Cloud shell immediately when Steward expires", async () => {
+    const apiBase = "https://api.eliza.app/api/v1/eliza/agents/shared-agent";
+    setBootConfig({ branding: {}, apiBase });
+    writeStoredStewardToken(makeJwt(3600));
+    savePersistedActiveServer({
+      id: "cloud:shared-agent",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase,
+      accessToken: "stale-token-mirror",
+    });
+
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+    await waitFor(() =>
+      expect(result.current.state.phase).toBe("authenticated"),
+    );
+    fetchMock.mockResolvedValue(jsonResponse(200, {}));
+
+    act(() => {
+      clearStaleStewardSession();
+    });
+
+    await waitFor(() =>
+      expect(result.current.state).toMatchObject({
+        phase: "unauthenticated",
+        reason: "remote_auth_required",
+      }),
+    );
+    expect(loadPersistedActiveServer()).toBeNull();
+    expect(getBootConfig().apiBase).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalled();
+    expect(
+      fetchMock.mock.calls.every(([, init]) => init?.method === "DELETE"),
+    ).toBe(true);
+  });
+
+  it("invalidates a peer tab when the canonical Steward token is removed", async () => {
+    const apiBase = "https://api.eliza.app/api/v1/eliza/agents/shared-agent";
+    setBootConfig({ branding: {}, apiBase });
+    writeStoredStewardToken(makeJwt(3600));
+    savePersistedActiveServer({
+      id: "cloud:shared-agent",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase,
+    });
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+    await waitFor(() =>
+      expect(result.current.state.phase).toBe("authenticated"),
+    );
+
+    act(() => {
+      localStorage.removeItem("steward_session_token");
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "steward_session_token",
+          oldValue: makeJwt(3600),
+          newValue: null,
+        }),
+      );
+    });
+
+    await waitFor(() =>
+      expect(result.current.state.phase).toBe("unauthenticated"),
+    );
+    expect(loadPersistedActiveServer()).toBeNull();
   });
 
   it("publishes an authenticated prime and the activating hook reuses it without a second probe", async () => {

--- a/packages/ui/src/hooks/useAuthStatus.ts
+++ b/packages/ui/src/hooks/useAuthStatus.ts
@@ -16,6 +16,10 @@
  * fresh result instead of serializing a new probe after first paint.
  */
 
+import {
+  STEWARD_SESSION_CHANGE_EVENT,
+  STEWARD_TOKEN_KEY,
+} from "@elizaos/shared/steward-session-client";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   type AuthAccessInfo,
@@ -25,7 +29,10 @@ import {
 } from "../api/auth-client";
 import { getBootConfig, setBootConfig } from "../config/boot-config-store";
 import { scrubRejectedActiveServerCredential } from "../state/active-server-credential";
+import { scrubPersistedAgentProfileTokens } from "../state/agent-profiles";
 import { loadPersistedActiveServer } from "../state/persistence";
+import { clearSharedCloudAccountBinding } from "../state/shared-cloud-account-binding";
+import { isManagedCloudSharedAgentBase } from "../utils/cloud-agent-base";
 
 export type AuthStatusState =
   | { phase: "loading" }
@@ -74,6 +81,7 @@ let authStatusSnapshot: AuthStatusState = { phase: "loading" };
 let authStatusFetch: Promise<void> | null = null;
 let authStatusPrime: Promise<void> | null = null;
 let authStatusPrimeSettledAt = 0;
+let authStatusEpoch = 0;
 // A primed result is only trusted by the activation path for a boot-scale
 // window; a hook that (re)activates later re-probes exactly as before, so a
 // stale prime can never stand in for the session's current auth state.
@@ -113,9 +121,11 @@ async function fetchAuthStatus(): Promise<void> {
   // backend still enforces auth while the UI retains its mounted shell until an
   // authoritative authenticated/unauthenticated/unavailable result arrives.
 
+  const probeEpoch = authStatusEpoch;
   authStatusFetch = (async () => {
     for (let attempt = 0; ; attempt += 1) {
       const result = await authMeWithRejectedBearerRecovery();
+      if (probeEpoch !== authStatusEpoch) return;
       if (result.ok === true) {
         publishAuthStatus({
           phase: "authenticated",
@@ -130,6 +140,7 @@ async function fetchAuthStatus(): Promise<void> {
           await new Promise((resolve) =>
             setTimeout(resolve, SERVER_UNAVAILABLE_RETRY_MS),
           );
+          if (probeEpoch !== authStatusEpoch) return;
           continue;
         }
         publishAuthStatus({ phase: "server_unavailable" });
@@ -173,8 +184,10 @@ async function fetchAuthStatus(): Promise<void> {
 export function primeAuthStatusProbe(): void {
   if (authStatusPrime || authStatusFetch) return;
   if (authStatusSnapshot.phase !== "loading") return;
+  const probeEpoch = authStatusEpoch;
   authStatusPrime = (async () => {
     const result = await authMeWithRejectedBearerRecovery();
+    if (probeEpoch !== authStatusEpoch) return;
     // A real fetch started (or a state was published) while the prime was in
     // flight — that path owns the snapshot; drop the primed result.
     if (authStatusFetch || authStatusSnapshot.phase !== "loading") return;
@@ -303,6 +316,7 @@ export function __resetAuthStatusForTests(): void {
   authStatusFetch = null;
   authStatusPrime = null;
   authStatusPrimeSettledAt = 0;
+  authStatusEpoch += 1;
   publishAuthStatus({ phase: "loading" });
 }
 
@@ -343,19 +357,81 @@ export function useAuthStatus(options: UseAuthStatusOptions = {}): {
   }, [skip, observeOnly, activate]);
 
   useEffect(() => {
-    if (skip || observeOnly || pollIntervalMs === 0) return;
-    const id = setInterval(() => {
-      if (
-        typeof document !== "undefined" &&
-        document.visibilityState === "hidden"
-      ) {
+    if (skip || observeOnly) return;
+
+    const stewardSessionHandler = (event: Event) => {
+      const detail = (event as CustomEvent<{ state?: string }>).detail;
+      if (detail?.state === "cleared") {
+        if (isManagedCloudSharedAgentBase(getBootConfig().apiBase)) {
+          // Any auth request started under the ending account is no longer
+          // authoritative and must not overwrite the terminal state below.
+          authStatusEpoch += 1;
+          clearSharedCloudAccountBinding();
+          scrubPersistedAgentProfileTokens();
+          // The shared runtime has no independent agent session: terminal
+          // Steward expiry is authoritative immediately. Publishing here
+          // unmounts every useIsAuthenticated-gated poller and moves the shell
+          // to Cloud reauthentication instead of waiting for the five-minute
+          // auth poll while protected requests loop on 401.
+          const {
+            apiBase: _apiBase,
+            apiToken: _apiToken,
+            ...accountConfig
+          } = getBootConfig();
+          setBootConfig(accountConfig);
+          publishAuthStatus({
+            phase: "unauthenticated",
+            reason: "remote_auth_required",
+            access: {
+              mode: "remote",
+              passwordConfigured: false,
+              ownerConfigured: true,
+            },
+          });
+        }
         return;
       }
-      void fetch();
-    }, pollIntervalMs);
+      // A new Steward session may have landed after reauthentication. Only
+      // re-probe when an account-scoped target is already bound; terminal
+      // shared-session cleanup deliberately removed the old account's target,
+      // and authenticating against its in-memory base before agent selection
+      // would remount stale chat. Full-page SSO reload or onboarding owns the
+      // targetless account-resolution path.
+      if (loadPersistedActiveServer()) void fetch();
+    };
+    window.addEventListener(
+      STEWARD_SESSION_CHANGE_EVENT,
+      stewardSessionHandler,
+    );
+    const stewardStorageHandler = (event: StorageEvent) => {
+      if (event.key !== STEWARD_TOKEN_KEY) return;
+      stewardSessionHandler(
+        new CustomEvent(STEWARD_SESSION_CHANGE_EVENT, {
+          detail: { state: event.newValue ? "present" : "cleared" },
+        }),
+      );
+    };
+    window.addEventListener("storage", stewardStorageHandler);
+    const stewardTokenSyncHandler = () => {
+      if (isManagedCloudSharedAgentBase(getBootConfig().apiBase)) void fetch();
+    };
+    window.addEventListener("steward-token-sync", stewardTokenSyncHandler);
+
+    const id =
+      pollIntervalMs === 0
+        ? null
+        : setInterval(() => {
+            if (
+              typeof document !== "undefined" &&
+              document.visibilityState === "hidden"
+            ) {
+              return;
+            }
+            void fetch();
+          }, pollIntervalMs);
 
     const visibilityHandler =
-      typeof document !== "undefined"
+      pollIntervalMs !== 0 && typeof document !== "undefined"
         ? () => {
             if (document.visibilityState === "visible") void fetch();
           }
@@ -365,7 +441,13 @@ export function useAuthStatus(options: UseAuthStatusOptions = {}): {
     }
 
     return () => {
-      clearInterval(id);
+      window.removeEventListener(
+        STEWARD_SESSION_CHANGE_EVENT,
+        stewardSessionHandler,
+      );
+      window.removeEventListener("storage", stewardStorageHandler);
+      window.removeEventListener("steward-token-sync", stewardTokenSyncHandler);
+      if (id !== null) clearInterval(id);
       if (visibilityHandler && typeof document !== "undefined") {
         document.removeEventListener("visibilitychange", visibilityHandler);
       }

--- a/packages/ui/src/state/agent-profiles.ts
+++ b/packages/ui/src/state/agent-profiles.ts
@@ -7,6 +7,7 @@
 
 import { logger } from "@elizaos/logger";
 import { shellLocalStorage } from "../surface-realm-channel";
+import { isManagedCloudSharedAgentBase } from "../utils/cloud-agent-base";
 import type { AgentProfile, AgentProfileRegistry } from "./agent-profile-types";
 import {
   type PersistedActiveServer,
@@ -272,6 +273,23 @@ export function activeServerIdForAgentProfile(profile: AgentProfile): string {
   return profile.kind === "cloud" && profile.cloudAgentId
     ? `cloud:${profile.cloudAgentId}`
     : profile.id;
+}
+
+/** Remove every profile owned by the ending shared Cloud account session. */
+export function removeManagedSharedCloudAgentProfiles(): void {
+  const registry = loadAgentProfileRegistry();
+  const profiles = registry.profiles.filter(
+    (profile) => !isManagedCloudSharedAgentBase(profile.apiBase),
+  );
+  if (profiles.length === registry.profiles.length) return;
+  const activeStillPresent = profiles.some(
+    (profile) => profile.id === registry.activeProfileId,
+  );
+  saveAgentProfileRegistry({
+    version: 1,
+    activeProfileId: activeStillPresent ? registry.activeProfileId : null,
+    profiles,
+  });
 }
 
 export function removeAgentProfile(id: string): void {

--- a/packages/ui/src/state/agent-session-recovery.test.ts
+++ b/packages/ui/src/state/agent-session-recovery.test.ts
@@ -298,6 +298,16 @@ describe("shouldShowCloudAgentReauthNotice", () => {
     ).toBe(true);
   });
 
+  it("routes managed desktop Cloud targets to Cloud instead of the password wall", () => {
+    expect(
+      shouldShowCloudAgentReauthNotice({
+        isHostedLocation: false,
+        isNative: false,
+        activeServer: cloudServer("23766030-0000-0000-0000-000000000000"),
+      }),
+    ).toBe(true);
+  });
+
   it("preserves the password wall for native self-hosted targets", () => {
     expect(
       shouldShowCloudAgentReauthNotice({

--- a/packages/ui/src/state/agent-session-recovery.ts
+++ b/packages/ui/src/state/agent-session-recovery.ts
@@ -123,7 +123,7 @@ export function shouldShowCloudAgentReauthNotice(input: {
   return (
     input.isHostedLocation ||
     Boolean(input.recoveryStatus) ||
-    (input.isNative && isManagedCloudAgentServer(input.activeServer))
+    isManagedCloudAgentServer(input.activeServer)
   );
 }
 

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -28,6 +28,7 @@ import type { Tab } from "../navigation";
 import { shellLocalStorage } from "../surface-realm-channel";
 import {
   ELIZA_CLOUD_CONTROL_PLANE_HOSTS,
+  isManagedCloudSharedAgentBase,
   normalizeDirectCloudSharedAgentApiBase,
 } from "../utils/cloud-agent-base";
 import { DEFAULT_LOCAL_ASR_AUTO_STOP } from "../voice/local-asr-capture";
@@ -1402,6 +1403,21 @@ export function clearPersistedActiveServer(): void {
   tryLocalStorage(() => {
     shellLocalStorage.removeItem(ACTIVE_SERVER_STORAGE_KEY);
   }, undefined);
+}
+
+/**
+ * Clear an account-scoped shared Cloud selection after the Steward account
+ * session ends. Shared runtimes have no independent agent credential, so the
+ * selected agent id is valid only within the account that selected it; the next
+ * login must resolve that account's organization-scoped agent list again.
+ */
+export function clearPersistedSharedCloudActiveServer(): boolean {
+  const current = loadPersistedActiveServer();
+  if (!isManagedCloudSharedAgentBase(current?.apiBase)) {
+    return false;
+  }
+  clearPersistedActiveServer();
+  return true;
 }
 
 /**

--- a/packages/ui/src/state/shared-cloud-account-binding.test.ts
+++ b/packages/ui/src/state/shared-cloud-account-binding.test.ts
@@ -1,0 +1,93 @@
+/** Verifies complete browser teardown of an account-scoped shared Cloud binding under jsdom. */
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { getBootConfig, setBootConfig } from "../config/boot-config";
+import {
+  loadAgentProfileRegistry,
+  saveAgentProfileRegistry,
+} from "./agent-profiles";
+import {
+  loadPersistedActiveServer,
+  savePersistedActiveServer,
+} from "./persistence";
+import { clearSharedCloudAccountBinding } from "./shared-cloud-account-binding";
+
+const SHARED_BASE =
+  "https://api.eliza.app/api/v1/eliza/agents/previous-account-agent";
+
+describe("clearSharedCloudAccountBinding", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    setBootConfig({
+      branding: {},
+      apiBase: SHARED_BASE,
+      apiToken: "previous-account-token",
+    });
+  });
+
+  it("clears active-server, profile, boot, and legacy base mirrors", () => {
+    savePersistedActiveServer({
+      id: "cloud:previous-account-agent",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase: SHARED_BASE,
+    });
+    saveAgentProfileRegistry({
+      version: 1,
+      activeProfileId: "old-profile",
+      profiles: [
+        {
+          id: "old-profile",
+          kind: "cloud",
+          label: "Eliza Cloud",
+          apiBase: SHARED_BASE,
+          createdAt: new Date().toISOString(),
+        },
+        {
+          id: "inactive-old-profile",
+          kind: "cloud",
+          label: "Other old shared agent",
+          apiBase: "https://api.eliza.app/api/v1/eliza/agents/other-old-agent",
+          createdAt: new Date().toISOString(),
+        },
+        {
+          id: "legacy-shared-profile",
+          kind: "cloud",
+          label: "Legacy shared agent",
+          apiBase:
+            "https://api.eliza.app/api/v1/eliza/agents/legacy-agent/bridge",
+          createdAt: new Date().toISOString(),
+        },
+        {
+          id: "self-hosted-profile",
+          kind: "remote",
+          label: "Self hosted",
+          apiBase: "https://box.example/api/v1/eliza/agents/local-agent",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+    localStorage.setItem("elizaos_api_base", SHARED_BASE);
+    sessionStorage.setItem("elizaos_api_base", SHARED_BASE);
+
+    expect(clearSharedCloudAccountBinding()).toBe(true);
+
+    expect(loadPersistedActiveServer()).toBeNull();
+    expect(loadAgentProfileRegistry()).toEqual({
+      version: 1,
+      activeProfileId: null,
+      profiles: [
+        expect.objectContaining({
+          id: "self-hosted-profile",
+          apiBase: "https://box.example/api/v1/eliza/agents/local-agent",
+        }),
+      ],
+    });
+    expect(getBootConfig().apiBase).toBeUndefined();
+    expect(getBootConfig().apiToken).toBeUndefined();
+    expect(localStorage.getItem("elizaos_api_base")).toBeNull();
+    expect(sessionStorage.getItem("elizaos_api_base")).toBeNull();
+  });
+});

--- a/packages/ui/src/state/shared-cloud-account-binding.ts
+++ b/packages/ui/src/state/shared-cloud-account-binding.ts
@@ -1,0 +1,40 @@
+/**
+ * Atomically releases browser-persisted mirrors of an account-scoped shared
+ * Cloud agent when its Steward account session ends.
+ */
+
+import { client } from "../api";
+import { clearElizaApiBase } from "../utils/eliza-globals";
+import { removeManagedSharedCloudAgentProfiles } from "./agent-profiles";
+import {
+  clearPersistedSharedCloudActiveServer,
+  loadPersistedActiveServer,
+} from "./persistence";
+
+const STORED_API_BASE_KEY = "elizaos_api_base";
+
+/**
+ * Clear the active server, matching profile, boot/global base, and legacy
+ * client-base storage mirror. Returns false for dedicated or self-hosted
+ * selections, whose independent agent credentials remain recoverable.
+ */
+export function clearSharedCloudAccountBinding(): boolean {
+  const activeServer = loadPersistedActiveServer();
+  const apiBase = activeServer?.apiBase;
+  if (!apiBase || !clearPersistedSharedCloudActiveServer()) return false;
+
+  removeManagedSharedCloudAgentProfiles();
+  client.setToken(null);
+  client.setBaseUrl(null);
+  clearElizaApiBase();
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.removeItem(STORED_API_BASE_KEY);
+      window.sessionStorage.removeItem(STORED_API_BASE_KEY);
+    } catch {
+      // error-policy:J6 best-effort stale account-binding teardown; canonical
+      // active-server and boot-config state has already been cleared.
+    }
+  }
+  return true;
+}

--- a/packages/ui/src/state/startup-phase-restore.steward-refresh.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.steward-refresh.test.ts
@@ -6,13 +6,17 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { PersistedActiveServer } from "./persistence";
+import {
+  loadPersistedActiveServer,
+  type PersistedActiveServer,
+  savePersistedActiveServer,
+} from "./persistence";
 import { applyRestoredConnection } from "./startup-phase-restore";
 
 const STEWARD_TOKEN_KEY = "steward_session_token";
 const STEWARD_REFRESH_PATH = "/api/auth/steward-refresh";
 const CLOUD_AGENT_ID = "11111111-1111-4111-8111-111111111111";
-const CLOUD_AGENT_API_BASE = `https://api.elizacloud.ai/api/v1/eliza/agents/${CLOUD_AGENT_ID}`;
+const CLOUD_AGENT_API_BASE = `https://api.eliza.app/api/v1/eliza/agents/${CLOUD_AGENT_ID}`;
 
 /** Build a minimal (unsigned) JWT whose payload carries the given `exp`. */
 function makeJwt(expSecondsFromNow: number | null): string {
@@ -174,22 +178,32 @@ describe("applyRestoredConnection — cloud Steward token refresh at restore", (
     expect(client.setToken).not.toHaveBeenCalledWith(steward);
   });
 
-  it("leaves the session UNAUTHENTICATED (and clears the token) when refresh fails, without looping", async () => {
+  it("leaves the session UNAUTHENTICATED and drops the shared selection when refresh fails", async () => {
     localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(-60));
+    savePersistedActiveServer(
+      cloudServer({ accessToken: "expired-steward-token" }),
+    );
     fetchMock.mockResolvedValue({ ok: false, json: async () => ({}) });
 
     const client = fakeClient();
     await applyRestoredConnection({
-      // No provision-time accessToken to fall back to.
-      restoredActiveServer: cloudServer({ accessToken: undefined }),
+      // A normal persisted record mirrors the now-expired Steward bearer.
+      restoredActiveServer: cloudServer({
+        accessToken: "expired-steward-token",
+      }),
       clientRef: client,
     });
 
     // Exactly one refresh attempt — no retry loop.
     expect(fetchMock).toHaveBeenCalledTimes(1);
     // The dead credential is dropped and the client is left unauthenticated.
-    expect(client.setToken).toHaveBeenCalledWith(null);
+    expect(client.setToken).toHaveBeenLastCalledWith(null);
+    expect(client.setBaseUrl).toHaveBeenLastCalledWith(null);
+    expect(client.setToken).not.toHaveBeenLastCalledWith(
+      "expired-steward-token",
+    );
     expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    expect(loadPersistedActiveServer()).toBeNull();
   });
 
   it("falls back to the provision-time token when refresh fails but the JWT is still (barely) alive", async () => {

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -528,6 +528,14 @@ export async function applyRestoredConnection(args: {
       return;
     }
     const restoreProbeToken = readStoredStewardToken()?.trim() || null;
+    // Capture the host-injected owner key before clientRef.setToken(null)
+    // mutates boot config. Native/Electrobun device-code sessions may have no
+    // persisted active-server token and rely exclusively on this credential.
+    const nativeOwnerApiKey =
+      isNative || isElectrobunRuntime()
+        ? (normalizeCloudApiKeyToken(resolved.accessToken) ??
+          normalizeCloudApiKeyToken(getElizaApiToken()))
+        : null;
     const usesLocalDockerCredential = isCloudPairLoopbackOrigin(
       resolved.apiBase,
     );
@@ -547,24 +555,36 @@ export async function applyRestoredConnection(args: {
     )
       ? reconcileLegacyDedicatedCloudApiBase(resolved, restoreProbeToken)
       : Promise.resolve(null);
-    const nativeOwnerApiKey =
-      isNative || isElectrobunRuntime()
-        ? (normalizeCloudApiKeyToken(resolved.accessToken) ??
-          normalizeCloudApiKeyToken(getElizaApiToken()))
-        : null;
+    let stewardTokenPromise: Promise<string | null>;
     if (nativeOwnerApiKey && restoreProbeToken) {
       const secs = cloudTokenSecsRemaining(restoreProbeToken);
-      if (secs !== null && secs <= 0 && typeof window !== "undefined") {
-        // The owner key remains a valid native transport credential, but the
-        // canonical getter prefers any stored Steward token. Drain the dead JWT
-        // without publishing terminal logout so subsequent requests reach the
-        // supported owner-key fallback.
-        window.localStorage.removeItem(STEWARD_TOKEN_KEY);
+      if (secs !== null && secs < STEWARD_RESTORE_REFRESH_AHEAD_SECS) {
+        // A near-expiry Steward JWT would shadow the valid owner-key fallback.
+        // Try rotation once; on failure remove only that JWT so native Cloud
+        // requests continue with the independently valid owner key.
+        stewardTokenPromise = refreshCloudStewardSession()
+          .then((refreshed) => {
+            const fresh = refreshed?.token?.trim() || null;
+            if (fresh) writeStoredStewardToken(fresh);
+            else if (typeof window !== "undefined")
+              window.localStorage.removeItem(STEWARD_TOKEN_KEY);
+            return fresh;
+          })
+          .catch(() => {
+            // error-policy:J4 the valid native owner key remains available;
+            // remove the shadowing near-expiry JWT and visibly continue with it.
+            if (typeof window !== "undefined")
+              window.localStorage.removeItem(STEWARD_TOKEN_KEY);
+            return null;
+          });
+      } else {
+        stewardTokenPromise = Promise.resolve(restoreProbeToken);
       }
+    } else {
+      stewardTokenPromise = nativeOwnerApiKey
+        ? Promise.resolve(null)
+        : resolveRestoredStewardToken();
     }
-    const stewardTokenPromise = nativeOwnerApiKey
-      ? Promise.resolve(null)
-      : resolveRestoredStewardToken();
     // Cloud = Steward everywhere (DECISIONS.md D3): prefer the live Steward
     // session token over the token captured at provision time (which may have
     // rotated since). If that stored JWT expired while the app was closed,

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -13,6 +13,7 @@ import {
   clearStoredStewardToken,
   hasStewardAuthedCookie,
   readStoredStewardToken,
+  STEWARD_TOKEN_KEY,
   writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
 import { client, type FirstRunOptions } from "../api";
@@ -27,6 +28,7 @@ import {
   invokeDesktopBridgeRequestWithTimeout,
   isElectrobunRuntime,
 } from "../bridge";
+import { normalizeCloudApiKeyToken } from "../cloud/lib/cloud-api-key-token";
 import { getBootConfig } from "../config/boot-config";
 import {
   ANDROID_LOCAL_AGENT_IPC_BASE,
@@ -57,6 +59,7 @@ import {
   dedicatedCloudAgentIdFromBase,
   isDedicatedCloudAgentBase,
   isElizaCloudControlPlaneAgentlessBase,
+  isManagedCloudSharedAgentBase,
   resolveCloudEnvironmentBase,
 } from "../utils/cloud-agent-base";
 import { getElizaApiBase, getElizaApiToken } from "../utils/eliza-globals";
@@ -77,6 +80,7 @@ import {
   isTrustedCloudApiBaseUrl,
   isTrustedRestoreApiBaseUrl,
 } from "./runtime-url-trust";
+import { clearSharedCloudAccountBinding } from "./shared-cloud-account-binding";
 import type { StartupEvent } from "./startup-coordinator";
 import { buildStaticFirstRunOptions } from "./startup-first-run-options";
 import { runStartupProbeWithTimeout } from "./startup-probe";
@@ -483,6 +487,7 @@ async function resolveRestoredStewardToken(): Promise<string | null> {
   // drop it so we restore unauthenticated instead of a guaranteed-401 dial.
   if (secs <= 0) {
     clearStoredStewardToken();
+    clearSharedCloudAccountBinding();
     return null;
   }
   return stored;
@@ -542,13 +547,43 @@ export async function applyRestoredConnection(args: {
     )
       ? reconcileLegacyDedicatedCloudApiBase(resolved, restoreProbeToken)
       : Promise.resolve(null);
-    const stewardTokenPromise = resolveRestoredStewardToken();
+    const nativeOwnerApiKey =
+      isNative || isElectrobunRuntime()
+        ? (normalizeCloudApiKeyToken(resolved.accessToken) ??
+          normalizeCloudApiKeyToken(getElizaApiToken()))
+        : null;
+    if (nativeOwnerApiKey && restoreProbeToken) {
+      const secs = cloudTokenSecsRemaining(restoreProbeToken);
+      if (secs !== null && secs <= 0 && typeof window !== "undefined") {
+        // The owner key remains a valid native transport credential, but the
+        // canonical getter prefers any stored Steward token. Drain the dead JWT
+        // without publishing terminal logout so subsequent requests reach the
+        // supported owner-key fallback.
+        window.localStorage.removeItem(STEWARD_TOKEN_KEY);
+      }
+    }
+    const stewardTokenPromise = nativeOwnerApiKey
+      ? Promise.resolve(null)
+      : resolveRestoredStewardToken();
     // Cloud = Steward everywhere (DECISIONS.md D3): prefer the live Steward
     // session token over the token captured at provision time (which may have
     // rotated since). If that stored JWT expired while the app was closed,
     // refresh it BEFORE handing it to the client so a returning user never
     // boots into a permanently-401ing session (see resolveRestoredStewardToken).
     const stewardToken = await stewardTokenPromise;
+    if (
+      isManagedCloudSharedAgentBase(resolved.apiBase) &&
+      !stewardToken &&
+      !nativeOwnerApiKey
+    ) {
+      // Terminal refresh failure or a missing account session makes the saved
+      // shared target unsafe. Clear every account-scoped mirror before startup
+      // can reinstall the provision-time token or poll the previous agent.
+      clearSharedCloudAccountBinding();
+      clientRef.setToken(null);
+      clientRef.setBaseUrl(null);
+      return;
+    }
     // Dedicated agent subdomains and explicit local-Docker pair targets use an
     // agent-local bearer for `/api/*`. The edge-owned dedicated path can keep
     // its Steward recovery fallback; a loopback process must never receive a
@@ -559,8 +594,8 @@ export async function applyRestoredConnection(args: {
         : isDedicatedCloudAgentBase(resolved.apiBase)
           ? resolved.accessToken || stewardToken || null
           : isAgentlessControlPlane
-            ? stewardToken || null
-            : stewardToken || resolved.accessToken || null,
+            ? stewardToken || nativeOwnerApiKey || null
+            : stewardToken || nativeOwnerApiKey || resolved.accessToken || null,
     );
     void tierRepairPromise.then((repaired) => {
       if (!repaired || repaired.apiBase === resolved.apiBase) return;
@@ -904,6 +939,17 @@ export async function runRestoringSession(
       }
     },
   });
+
+  if (
+    isManagedCloudSharedAgentBase(restoredActiveServer.apiBase) &&
+    !loadPersistedActiveServer()
+  ) {
+    deps.setFirstRunOptions(buildStaticFirstRunOptions(deps.uiLanguage));
+    deps.setFirstRunComplete(false);
+    deps.setFirstRunLoading(false);
+    dispatch({ type: "NO_SESSION", hadPriorFirstRun: hadPrior });
+    return;
+  }
 
   // The connection is applied (base URL + token are what the post-paint auth
   // gate will use), so start the /api/auth/me probe now — it overlaps the

--- a/packages/ui/src/utils/cloud-agent-base.ts
+++ b/packages/ui/src/utils/cloud-agent-base.ts
@@ -82,6 +82,20 @@ export function directCloudSharedAgentIdFromBase(
   }
 }
 
+/**
+ * True only for shared-runtime adapter paths on a trusted Eliza Cloud
+ * control-plane host. Path-only classification is intentionally broader for
+ * protocol routing, but account-session ownership must not capture a
+ * self-hosted server that happens to expose the same path shape.
+ */
+export function isManagedCloudSharedAgentBase(
+  value: string | null | undefined,
+): boolean {
+  if (directCloudSharedAgentIdFromBase(value) === null || !value) return false;
+  const url = normalizeHttpUrl(value.trim());
+  return Boolean(url && isElizaCloudControlPlaneHostname(url.hostname));
+}
+
 function hostnameOf(origin: string): string {
   return new URL(origin).hostname;
 }


### PR DESCRIPTION
## Summary
- invalidate stale shared Cloud authentication when the Steward account session expires
- stop protected warm-tab pollers from repeatedly issuing unauthorized requests
- clear account-scoped shared-agent bindings and persisted selections before another account/session restores
- refresh expired browser credentials at the auth boundary instead of leaving the UI permanently unavailable
- preserve dedicated/self-hosted credentials and native/Electrobun owner-key fallback, including when a stale Steward JWT would otherwise shadow it

## Root cause
The shared-runtime auth gate inferred authenticated state from the selected Cloud URL even after the Steward session became terminal. The mounted shell therefore remained authenticated and continued protected polling. Account teardown also retained the shared-agent selection, allowing a later login to restore the previous account's agent ID and fail with `Agent not found`.

A related native edge case allowed a stale stored Steward JWT to take precedence over a still-valid owner API key. The restore boundary now rotates or removes that shadowing JWT while retaining the owner-key fallback.

Closes #19127.

## Verification
- reproduced twice on staging using fresh authentication state and a warm Cloud tab
- 7 focused Vitest suites: 100 tests passed
- `bun run --cwd packages/ui typecheck`
- targeted Biome checks and `git diff --check`
- `bun run check:agents-claude` (153 tracked pairs)
- app visual audit executed with pinned Node 24
- adversarial review findings were addressed in follow-up commit `50c0df1881`

## Post-deployment verification
After this PR is deployed to staging, repeat the original fresh-login and warm-tab journeys and verify:
1. the selected agent belongs to the current account;
2. chat no longer fails with `Agent not found`;
3. refresh/session expiry clears stale authenticated shell state;
4. native owner-key authentication still works without a Steward JWT.

## Scope note
PR #19030 is already in the base and addresses onboarding Durable Object scope migration. It does not change renderer session invalidation or active-agent persistence.
