### PR TITLE
fix(ui): route labelled settings toggles through SettingsSwitchRow

### DIFF
--- a/packages/ui/src/components/settings/AppPermissionsSection.tsx
+++ b/packages/ui/src/components/settings/AppPermissionsSection.tsx
@@ -15,12 +15,10 @@ import {
 } from "@elizaos/shared";
 import { Loader2, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAgentElement } from "../../agent-surface";
 import { client } from "../../api/client";
 import { useAppSelector } from "../../state";
-import { Switch } from "../ui/switch";
-import { SettingsActionButton } from "./settings-agent-rows";
-import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
+import { SettingsActionButton, SettingsSwitchRow } from "./settings-agent-rows";
+import { SettingsGroup, SettingsStack } from "./settings-layout";
 
 const NAMESPACE_LABELS: Record<RecognisedPermissionNamespace, string> = {
   fs: "Filesystem",
@@ -296,20 +294,12 @@ function AppPermissionToggle({
   ) => void;
 }) {
   const toggleId = `appperm-${slug}-${ns}`;
-  const label = `Toggle ${NAMESPACE_LABELS[ns]} for ${slug}`;
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: toggleId,
-    role: "toggle",
-    label,
-    group: "app-permissions",
-    status: granted ? "on" : "off",
-    getValue: () => granted,
-    onActivate: disabled ? undefined : () => onToggle(slug, ns, !granted),
-  });
   return (
-    <SettingsRow
-      htmlFor={toggleId}
+    <SettingsSwitchRow
+      agentId={toggleId}
+      group="app-permissions"
       label={NAMESPACE_LABELS[ns]}
+      agentLabel={`Toggle ${NAMESPACE_LABELS[ns]} for ${slug}`}
       description={
         summary ? (
           <span className="block truncate font-mono text-xs text-txt">
@@ -317,17 +307,9 @@ function AppPermissionToggle({
           </span>
         ) : undefined
       }
-      control={
-        <Switch
-          ref={ref}
-          id={toggleId}
-          checked={granted}
-          disabled={disabled}
-          onCheckedChange={(checked) => onToggle(slug, ns, checked)}
-          aria-label={label}
-          {...agentProps}
-        />
-      }
+      checked={granted}
+      disabled={disabled}
+      onCheckedChange={(checked) => onToggle(slug, ns, checked)}
     />
   );
 }

--- a/packages/ui/src/components/settings/AppearanceSettingsSection.tsx
+++ b/packages/ui/src/components/settings/AppearanceSettingsSection.tsx
@@ -13,11 +13,11 @@ import { ACCENT_PRESETS, useAppSelector, useContentPack } from "../../state";
 import type { AccentPreset } from "../../state/ui-preferences";
 import { LANGUAGES } from "../shared/LanguageDropdown.helpers";
 import { Button } from "../ui/button";
-import { Switch } from "../ui/switch";
 import { selectableTileClass } from "./appearance-primitives.helpers";
 import { BackgroundSettingsControls } from "./BackgroundSettingsControls";
 import { LoadedPacksList } from "./LoadedPacksList";
-import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
+import { SettingsSwitchRow } from "./settings-agent-rows";
+import { SettingsGroup, SettingsStack } from "./settings-layout";
 
 function LanguageTileButton({
   languageId,
@@ -57,30 +57,6 @@ function LanguageTileButton({
         <Check className="absolute right-1.5 top-1.5 h-3 w-3 text-accent" />
       ) : null}
     </Button>
-  );
-}
-
-function HomeTimeWidgetSwitch({
-  hidden,
-  onHiddenChange,
-}: {
-  hidden: boolean;
-  onHiddenChange: (hidden: boolean) => void;
-}) {
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: "appearance-show-time-widget",
-    role: "toggle",
-    label: "Show time & date",
-    status: hidden ? "off" : "on",
-    onActivate: () => onHiddenChange(!hidden),
-  });
-  return (
-    <Switch
-      ref={ref}
-      checked={!hidden}
-      onCheckedChange={(checked) => onHiddenChange(!checked)}
-      {...agentProps}
-    />
   );
 }
 
@@ -178,16 +154,14 @@ export function AppearanceSettingsSection() {
         bare
         title={t("settings.homeDashboard", { defaultValue: "Home" })}
       >
-        <SettingsRow
+        <SettingsSwitchRow
+          agentId="appearance-show-time-widget"
+          group="appearance"
           label={t("settings.showTimeWidget", {
             defaultValue: "Show time & date",
           })}
-          control={
-            <HomeTimeWidgetSwitch
-              hidden={homeTimeWidgetHidden}
-              onHiddenChange={setHomeTimeWidgetHidden}
-            />
-          }
+          checked={!homeTimeWidgetHidden}
+          onCheckedChange={(checked) => setHomeTimeWidgetHidden(!checked)}
         />
       </SettingsGroup>
 

--- a/packages/ui/src/components/settings/ChatHotkeySettingsGroup.test.tsx
+++ b/packages/ui/src/components/settings/ChatHotkeySettingsGroup.test.tsx
@@ -76,6 +76,8 @@ describe("ChatHotkeySettingsGroup", () => {
     expect(screen.getByText("CommandOrControl+Shift+C")).toBeTruthy();
     const sw = screen.getByRole("switch") as HTMLButtonElement;
     expect(sw.getAttribute("data-state")).toBe("checked");
+    expect(sw.getAttribute("data-agent-id")).toBe("desktop-chat-summon-hotkey");
+    expect(sw.getAttribute("data-agent-role")).toBe("toggle");
   });
 
   it("disabling the toggle persists disabled and unregisters the shortcut", async () => {

--- a/packages/ui/src/components/settings/ChatHotkeySettingsGroup.tsx
+++ b/packages/ui/src/components/settings/ChatHotkeySettingsGroup.tsx
@@ -16,7 +16,7 @@ import {
   useChatOverlayHotkey,
 } from "../../state/useChatOverlayHotkey";
 import { Button } from "../ui/button";
-import { Switch } from "../ui/switch";
+import { SettingsSwitchRow } from "./settings-agent-rows";
 import { SettingsGroup, SettingsRow } from "./settings-layout";
 
 /**
@@ -99,7 +99,9 @@ export function ChatHotkeySettingsGroup() {
           "A global keyboard shortcut that brings the floating chat surface to the foreground.",
       })}
     >
-      <SettingsRow
+      <SettingsSwitchRow
+        agentId="desktop-chat-summon-hotkey"
+        group="desktop-workspace"
         icon={Keyboard}
         label={t("desktopworkspacesection.chatHotkey.enableLabel", {
           defaultValue: "Enable chat summon hotkey",
@@ -108,17 +110,8 @@ export function ChatHotkeySettingsGroup() {
           defaultValue:
             "The command palette keeps ⌘/Ctrl+K; this is a separate shortcut.",
         })}
-        control={
-          <Switch
-            checked={hotkey.enabled}
-            onCheckedChange={(checked) =>
-              void apply(hotkey.accelerator, checked)
-            }
-            aria-label={t("desktopworkspacesection.chatHotkey.enableLabel", {
-              defaultValue: "Enable chat summon hotkey",
-            })}
-          />
-        }
+        checked={hotkey.enabled}
+        onCheckedChange={(checked) => void apply(hotkey.accelerator, checked)}
       />
       <SettingsRow
         label={t("desktopworkspacesection.chatHotkey.shortcutLabel", {

--- a/packages/ui/src/components/settings/WebPushSettingsSection.tsx
+++ b/packages/ui/src/components/settings/WebPushSettingsSection.tsx
@@ -1,18 +1,18 @@
 /**
  * Notifications settings section — minimal, tasteful web-push toggle for the
- * installed iOS PWA (16.4+). Follows the existing SettingsGroup/SettingsRow
- * pattern; the whole behavior lives in `useWebPush`. This is intentionally a
- * single toggle + status copy, not new elaborate UX: it lets the user turn on
- * push and reflects the coarse state, degrading gracefully everywhere push
- * isn't available (unsupported browser, non-standalone, unconfigured VAPID).
+ * installed iOS PWA (16.4+). Uses the shared SettingsSwitchRow so the toggle
+ * stays agent-addressable; the whole behavior lives in `useWebPush`. This is
+ * intentionally a single toggle + status copy, not new elaborate UX: it lets
+ * the user turn on push and reflects the coarse state, degrading gracefully
+ * everywhere push isn't available (unsupported browser, non-standalone,
+ * unconfigured VAPID).
  */
 
 import { BellRing } from "lucide-react";
 import { useCallback } from "react";
-import { useAgentElement } from "../../agent-surface";
 import { useWebPush } from "../../state/notifications/useWebPush";
-import { Switch } from "../ui/switch";
-import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
+import { SettingsSwitchRow } from "./settings-agent-rows";
+import { SettingsGroup, SettingsStack } from "./settings-layout";
 
 /** Human copy for each coarse state. */
 function describeState(state: ReturnType<typeof useWebPush>["state"]): {
@@ -77,36 +77,21 @@ export function WebPushSettingsSection() {
     [subscribe, unsubscribe],
   );
 
-  // Agent-addressable so "turn on notifications" reaches the toggle from chat +
-  // voice, like every other settings control.
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: "notifications-push-toggle",
-    role: "toggle",
-    label: view.label,
-    group: "settings",
-    status: view.canToggle ? (view.on ? "on" : "off") : "unavailable",
-    onActivate: () => {
-      if (view.canToggle && !busy && ready) onToggle(!view.on);
-    },
-  });
-
   return (
     <SettingsStack>
       <SettingsGroup title="Notifications">
-        <SettingsRow
+        <SettingsSwitchRow
+          agentId="notifications-push-toggle"
+          agentLabel="Toggle push notifications"
           icon={BellRing}
           label={view.label}
           description={error ?? view.description}
-          control={
-            <Switch
-              ref={ref}
-              checked={view.on}
-              disabled={!view.canToggle || busy || !ready}
-              onCheckedChange={onToggle}
-              aria-label="Toggle push notifications"
-              {...agentProps}
-            />
+          checked={view.on}
+          disabled={!view.canToggle || busy || !ready}
+          agentStatus={
+            view.canToggle ? (view.on ? "on" : "off") : "unavailable"
           }
+          onCheckedChange={onToggle}
         />
       </SettingsGroup>
     </SettingsStack>

--- a/packages/ui/src/components/settings/no-raw-switch.test.ts
+++ b/packages/ui/src/components/settings/no-raw-switch.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Static source-scan guard: boolean settings rows must use SettingsSwitchRow
+ * instead of a hand-rolled SettingsRow + Switch. Reads files off disk — no
+ * render. Remaining raw Switch sites are an explicit, documented allowlist.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const settingsRoot = resolve(import.meta.dirname);
+
+/**
+ * Files that still own a raw `<Switch` because they are not a 1:1 labelled
+ * settings row. Adding a new file here is a product decision; the default is
+ * `SettingsSwitchRow` so the toggle is themed, 44px-touch, and agent-addressable.
+ */
+const RAW_SWITCH_ALLOWLIST = new Map<string, string>([
+  [
+    "settings-agent-rows.tsx",
+    "canonical SettingsSwitchRow primitive; it is the one allowed Switch owner",
+  ],
+  [
+    "AdvancedToggle.tsx",
+    "compact inline disclosure control, not a labelled settings row",
+  ],
+  [
+    "ConnectorsSection.tsx",
+    "standalone enable switch on a custom connector card, not a SettingsRow",
+  ],
+  [
+    "VoiceConfigView.tsx",
+    "compact enable switch inside a custom status chip, not a SettingsRow",
+  ],
+  [
+    "permission-controls.tsx",
+    "compound permission rows mix badges with Switch or Button trailing controls",
+  ],
+]);
+
+function listTsxFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      out.push(...listTsxFiles(full));
+    } else if (
+      name.endsWith(".tsx") &&
+      !name.endsWith(".test.tsx") &&
+      !name.endsWith(".stories.tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("settings controls: no raw <Switch outside the allowlist", () => {
+  const files = listTsxFiles(settingsRoot);
+
+  it.each(files.map((file) => relative(settingsRoot, file)))(
+    "%s uses SettingsSwitchRow instead of a raw <Switch, or is allowlisted",
+    (relPath) => {
+      const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
+      const hasRawSwitch = source.includes("<Switch");
+      if (!hasRawSwitch) {
+        expect(RAW_SWITCH_ALLOWLIST.has(relPath)).toBe(false);
+        return;
+      }
+      expect(
+        RAW_SWITCH_ALLOWLIST.has(relPath),
+        `${relPath} hand-rolls a raw <Switch. Use SettingsSwitchRow from ` +
+          `./settings-agent-rows for labelled boolean settings. If this file is ` +
+          `not a settings row, add it to RAW_SWITCH_ALLOWLIST with a reason.`,
+      ).toBe(true);
+    },
+  );
+
+  it("documents a reason for every allowlisted raw Switch file", () => {
+    for (const [relPath, reason] of RAW_SWITCH_ALLOWLIST) {
+      expect(reason.trim().length).toBeGreaterThan(8);
+      const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
+      expect(
+        source.includes("<Switch"),
+        `${relPath} is allowlisted but no longer contains <Switch; remove it from the allowlist`,
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/ui/src/components/settings/settings-agent-rows.tsx
+++ b/packages/ui/src/components/settings/settings-agent-rows.tsx
@@ -45,6 +45,8 @@ export interface SettingsSwitchRowProps {
   disabled?: boolean;
   /** Agent-surface grouping key. */
   group?: string;
+  /** Override the agent-surface status token (defaults to on/off). */
+  agentStatus?: string;
   className?: string;
 }
 
@@ -59,6 +61,7 @@ export function SettingsSwitchRow({
   onCheckedChange,
   disabled = false,
   group = "settings",
+  agentStatus,
   className,
 }: SettingsSwitchRowProps) {
   const resolvedLabel = agentLabel ?? labelToString(label, agentId);
@@ -68,7 +71,7 @@ export function SettingsSwitchRow({
     label: resolvedLabel,
     group,
     description: typeof description === "string" ? description : undefined,
-    status: checked ? "on" : "off",
+    status: agentStatus ?? (checked ? "on" : "off"),
     getValue: () => checked,
     onActivate: disabled ? undefined : () => onCheckedChange(!checked),
   });
@@ -80,9 +83,11 @@ export function SettingsSwitchRow({
       label={label}
       description={description}
       className={className}
+      htmlFor={agentId}
       control={
         <Switch
           ref={ref}
+          id={agentId}
           checked={checked}
           onCheckedChange={onCheckedChange}
           disabled={disabled}

--- a/packages/ui/src/components/settings/settings-layout.test.tsx
+++ b/packages/ui/src/components/settings/settings-layout.test.tsx
@@ -79,8 +79,34 @@ describe("agent-addressable rows", () => {
     const sw = screen.getByRole("switch");
     expect(sw.getAttribute("data-agent-id")).toBe("toggle-dark");
     expect(sw.getAttribute("data-agent-role")).toBe("toggle");
+    expect(sw.getAttribute("data-agent-label")).toBe("Dark mode");
+    expect(sw.getAttribute("id")).toBe("toggle-dark");
+    expect(screen.getByText("Dark mode").tagName).toBe("LABEL");
+    expect(screen.getByText("Dark mode").getAttribute("for")).toBe(
+      "toggle-dark",
+    );
     fireEvent.click(sw);
     expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it("SettingsSwitchRow stays disabled when the agent status is unavailable", () => {
+    render(
+      <SettingsSwitchRow
+        agentId="notifications-push-toggle"
+        label="Push notifications"
+        agentLabel="Toggle push notifications"
+        checked={false}
+        agentStatus="unavailable"
+        disabled
+        onCheckedChange={() => {}}
+      />,
+    );
+    const sw = screen.getByRole("switch");
+    expect(sw.getAttribute("data-agent-id")).toBe("notifications-push-toggle");
+    expect(sw.getAttribute("data-agent-label")).toBe(
+      "Toggle push notifications",
+    );
+    expect(sw).toHaveProperty("disabled", true);
   });
 
   it("SettingsSelectRow registers as an agent-addressable select", () => {


### PR DESCRIPTION
# Relates to

Closes #19142

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Behaviour-preserving reuse of the existing `SettingsSwitchRow` primitive.
The remaining compact/custom Switch owners stay on an explicit allowlist. A
false-positive source-scan failure is the main regression risk if a new
non-row Switch is added without updating that allowlist.

# Background

## What does this PR do?

A static scan of the settings dashboard found four labelled boolean rows that
reimplemented `SettingsRow + Switch` instead of using the shared
`SettingsSwitchRow`. This PR routes those sites through the primitive, keeps
the label/`htmlFor` association, accepts an explicit agent status for
unavailable toggles, and adds a disk source-scan gate so new labelled settings
toggles cannot re-hand-roll `<Switch`.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

No.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:2faf292b62c487eba7cb7760ea37100ab683a93a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19146-before-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19146-after-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19146-walkthrough-long.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or API path is changed; this is a renderer reuse of SettingsSwitchRow.
<!-- evidence-row:frontend-logs -->
- [x] [19146-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19146-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows, memories, schedules, wallet records, audio, or generated domain artifacts are changed.
<!-- evidence-row:ocr-review -->
- [x] [19146-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19146-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Backend + frontend logs

N/A - no backend path is changed. Focused UI tests are the source-of-truth
measurement for this reuse change; settings e2e capture is being attached after
open.

## Screenshots (before / after) + video walkthrough

Source-structure reuse of an existing primitive. Settings e2e capture is being
attached after open so the rows are code-produced rather than eyeballed.

### Before

Pending settings e2e capture.

### After

Pending settings e2e capture.

### Walkthrough video

Pending settings e2e capture.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT path is changed.

## Known gaps / failures

- Full-repo `bun run verify` was not run in this worktree. Focused package
  checks after rebase:
  - `bun run --cwd packages/ui test` on
    `no-raw-switch.test.ts`, `no-native-select.test.ts`,
    `settings-layout.test.tsx`, `ChatHotkeySettingsGroup.test.tsx`,
    `AppearanceSettingsSection.background.test.tsx` — 5 files, 130 tests passed.
  - `bunx biome check` on the touched settings files — clean.
  - `bun run --cwd packages/ui typecheck` — passed after building
    `@elizaos/cloud-routing` from the light install.
- Settings e2e / OCR artifacts are being captured and attached after this PR
  opens.

— [pi-grok]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza"} -->


