### PR TITLE
fix(core): make document contextualization respect runtime settings for custom LLM

### DIFF
--- a/packages/core/src/features/documents/document-processor-custom-llm.test.ts
+++ b/packages/core/src/features/documents/document-processor-custom-llm.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Covers the custom-LLM gate that decides how document contextualization
+ * generates a chunk's context: through the documents pipeline's direct provider
+ * client, or through the agent's registered TEXT_LARGE model. The direct-provider
+ * branch runs against a local OpenAI-compatible HTTP server, so each assertion
+ * observes which real transport handled the request rather than a stubbed
+ * predicate. Settings resolution is the behavior under test: runtime settings
+ * must drive the branch when the environment is unset, and a blank runtime
+ * setting must fall through to the environment instead of reading as "present".
+ */
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { createMockRuntime, MOCK_AGENT_ID } from "../../testing/mock-runtime";
+import type { IAgentRuntime, Memory, UUID } from "../../types";
+import { ModelType } from "../../types";
+import { processFragmentsSynchronously } from "./document-processor.ts";
+
+const DOCUMENT_ID = "11111111-1111-1111-1111-111111111111" as UUID;
+const DOCUMENT_TEXT =
+	"Refund requests are processed within five business days of approval.";
+const PROVIDER_CONTEXT = "context-from-direct-provider";
+const RUNTIME_MODEL_CONTEXT = "context-from-runtime-model";
+
+const SETTING_KEYS = [
+	"CTX_DOCUMENTS_ENABLED",
+	"TEXT_PROVIDER",
+	"TEXT_MODEL",
+	"OPENAI_API_KEY",
+	"OPENAI_BASE_URL",
+	"OPENAI_EMBEDDING_MODEL",
+	"TEXT_EMBEDDING_MODEL",
+	"EMBEDDING_PROVIDER",
+	"RATE_LIMIT_ENABLED",
+	"BATCH_EMBEDDINGS",
+	"ELIZA_MODEL_GATEWAY_URL",
+] as const;
+
+interface ProviderStub {
+	baseUrl: string;
+	requestCount: () => number;
+	close: () => Promise<void>;
+}
+
+async function startOpenAiCompatibleServer(): Promise<ProviderStub> {
+	let requests = 0;
+	const server: Server = createServer((req, res) => {
+		requests += 1;
+		req.resume();
+		req.on("end", () => {
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				JSON.stringify({
+					id: "chatcmpl-test",
+					object: "chat.completion",
+					created: 0,
+					model: "gpt-test",
+					choices: [
+						{
+							index: 0,
+							message: { role: "assistant", content: PROVIDER_CONTEXT },
+							finish_reason: "stop",
+						},
+					],
+					usage: {
+						prompt_tokens: 1,
+						completion_tokens: 1,
+						total_tokens: 2,
+					},
+				}),
+			);
+		});
+	});
+	await new Promise<void>((resolve) => {
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const address = server.address() as AddressInfo;
+	return {
+		baseUrl: `http://127.0.0.1:${address.port}/v1`,
+		requestCount: () => requests,
+		close: () =>
+			new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()));
+			}),
+	};
+}
+
+interface Harness {
+	runtime: IAgentRuntime;
+	savedFragments: Memory[];
+	runtimeModelCalls: () => number;
+}
+
+function makeHarness(settings: Record<string, string>): Harness {
+	const savedFragments: Memory[] = [];
+	let runtimeModelCalls = 0;
+	const runtime = createMockRuntime({
+		getSetting: (key: string) => settings[key] ?? null,
+		redactSecrets: (text: string) => text,
+		// The direct-provider path wraps generation in a standalone trajectory,
+		// which looks for optional recorder services.
+		getService: () => null,
+		getServicesByType: () => [],
+		getModel: (type: string) =>
+			type === ModelType.TEXT_EMBEDDING
+				? async () => [0.1, 0.2, 0.3]
+				: undefined,
+		useModel: (async (type: string) => {
+			if (type === ModelType.TEXT_EMBEDDING) {
+				return [0.1, 0.2, 0.3];
+			}
+			if (type === ModelType.TEXT_LARGE) {
+				runtimeModelCalls += 1;
+				return RUNTIME_MODEL_CONTEXT;
+			}
+			throw new Error(`Unexpected model request: ${type}`);
+		}) as IAgentRuntime["useModel"],
+		createMemory: async (memory: Memory): Promise<UUID> => {
+			savedFragments.push(memory);
+			return memory.id as UUID;
+		},
+	});
+	return {
+		runtime,
+		savedFragments,
+		runtimeModelCalls: () => runtimeModelCalls,
+	};
+}
+
+async function ingest(runtime: IAgentRuntime): Promise<number> {
+	return processFragmentsSynchronously({
+		runtime,
+		documentId: DOCUMENT_ID,
+		fullDocumentText: DOCUMENT_TEXT,
+		agentId: MOCK_AGENT_ID,
+	});
+}
+
+function fragmentText(fragments: Memory[]): string {
+	const text = fragments[0]?.content?.text;
+	if (typeof text !== "string") {
+		throw new Error("Expected a persisted fragment with text content");
+	}
+	return text;
+}
+
+describe("document contextualization custom-LLM gate", () => {
+	let provider: ProviderStub;
+	const savedEnv = new Map<string, string | undefined>();
+
+	beforeEach(async () => {
+		provider = await startOpenAiCompatibleServer();
+		for (const key of SETTING_KEYS) {
+			savedEnv.set(key, process.env[key]);
+			delete process.env[key];
+		}
+		// The pipeline's rate limiter would otherwise pace a single-chunk ingest.
+		process.env.RATE_LIMIT_ENABLED = "false";
+	});
+
+	afterEach(async () => {
+		for (const [key, value] of savedEnv) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+		savedEnv.clear();
+		await provider.close();
+	});
+
+	test("runtime settings alone select the direct provider when the environment is unset", async () => {
+		const harness = makeHarness({
+			CTX_DOCUMENTS_ENABLED: "true",
+			TEXT_PROVIDER: "openai",
+			TEXT_MODEL: "gpt-test",
+			OPENAI_API_KEY: "runtime-openai-key",
+			OPENAI_BASE_URL: provider.baseUrl,
+		});
+
+		const saved = await ingest(harness.runtime);
+
+		expect(saved).toBe(1);
+		expect(provider.requestCount()).toBe(1);
+		expect(harness.runtimeModelCalls()).toBe(0);
+		expect(fragmentText(harness.savedFragments)).toContain(PROVIDER_CONTEXT);
+	});
+
+	test("a blank runtime setting falls through to the environment value", async () => {
+		process.env.TEXT_PROVIDER = "openai";
+		process.env.TEXT_MODEL = "gpt-test";
+		process.env.OPENAI_API_KEY = "env-openai-key";
+		process.env.OPENAI_BASE_URL = provider.baseUrl;
+
+		const harness = makeHarness({
+			CTX_DOCUMENTS_ENABLED: "true",
+			// A blank runtime alias is unset, not a value that masks the environment.
+			TEXT_PROVIDER: "",
+			TEXT_MODEL: "   ",
+			OPENAI_API_KEY: "",
+		});
+
+		const saved = await ingest(harness.runtime);
+
+		expect(saved).toBe(1);
+		expect(provider.requestCount()).toBe(1);
+		expect(harness.runtimeModelCalls()).toBe(0);
+		expect(fragmentText(harness.savedFragments)).toContain(PROVIDER_CONTEXT);
+	});
+
+	test("a missing provider key keeps contextualization on the runtime TEXT_LARGE model", async () => {
+		const harness = makeHarness({
+			CTX_DOCUMENTS_ENABLED: "true",
+			TEXT_EMBEDDING_MODEL: "test-embedding",
+		});
+
+		const saved = await ingest(harness.runtime);
+
+		expect(saved).toBe(1);
+		expect(provider.requestCount()).toBe(0);
+		expect(harness.runtimeModelCalls()).toBe(1);
+		expect(fragmentText(harness.savedFragments)).toContain(
+			RUNTIME_MODEL_CONTEXT,
+		);
+	});
+});

--- a/packages/core/src/features/documents/document-processor.ts
+++ b/packages/core/src/features/documents/document-processor.ts
@@ -26,6 +26,7 @@ import {
 import { splitChunks } from "../../utils";
 import { BatchProcessor } from "../../utils/batch-queue";
 import { getProviderRateLimits, validateModelConfig } from "./config.ts";
+import type { ModelConfig } from "./types.ts";
 import {
 	DEFAULT_CHUNK_OVERLAP_TOKENS,
 	DEFAULT_CHUNK_TOKEN_SIZE,
@@ -72,25 +73,29 @@ function getCtxDocumentsEnabled(runtime?: IAgentRuntime): boolean {
 	return result;
 }
 
-function shouldUseCustomLLM(runtime?: IAgentRuntime): boolean {
-	const get = (key: string) =>
-		(runtime?.getSetting(key) as string | undefined) ?? process.env[key];
-	const textProvider = get("TEXT_PROVIDER");
-	const textModel = get("TEXT_MODEL");
+function shouldUseCustomLLM(config: ModelConfig): boolean {
+	const textProvider = config.TEXT_PROVIDER;
+	const textModel = config.TEXT_MODEL;
 
 	if (!textProvider || !textModel) {
 		return false;
 	}
 
-	switch (textProvider.toLowerCase()) {
+	// config values are validated strings; guard toLowerCase to string-only
+	// so non-string can never throw (see #19147 P1). Blank/whitespace and
+	// model-gateway transformations are already resolved by validateModelConfig.
+	const normalizedProvider =
+		typeof textProvider === "string" ? textProvider.toLowerCase() : "";
+
+	switch (normalizedProvider) {
 		case "openrouter":
-			return !!get("OPENROUTER_API_KEY");
+			return !!config.OPENROUTER_API_KEY;
 		case "openai":
-			return !!get("OPENAI_API_KEY");
+			return !!config.OPENAI_API_KEY;
 		case "anthropic":
-			return !!get("ANTHROPIC_API_KEY");
+			return !!config.ANTHROPIC_API_KEY;
 		case "google":
-			return !!get("GOOGLE_API_KEY");
+			return !!config.GOOGLE_API_KEY;
 		default:
 			return false;
 	}
@@ -995,7 +1000,7 @@ async function generateContextsInBatch(
 
 			try {
 				const generateTextOperation = async () => {
-					if (shouldUseCustomLLM(runtime)) {
+					if (shouldUseCustomLLM(config)) {
 						if (item.usesCaching && item.promptText) {
 							return generateText(runtime, item.promptText, item.systemPrompt, {
 								cacheDocument: item.fullDocumentTextForContext,

--- a/packages/core/src/features/documents/document-processor.ts
+++ b/packages/core/src/features/documents/document-processor.ts
@@ -72,9 +72,11 @@ function getCtxDocumentsEnabled(runtime?: IAgentRuntime): boolean {
 	return result;
 }
 
-function shouldUseCustomLLM(): boolean {
-	const textProvider = process.env.TEXT_PROVIDER;
-	const textModel = process.env.TEXT_MODEL;
+function shouldUseCustomLLM(runtime?: IAgentRuntime): boolean {
+	const get = (key: string) =>
+		(runtime?.getSetting(key) as string | undefined) ?? process.env[key];
+	const textProvider = get("TEXT_PROVIDER");
+	const textModel = get("TEXT_MODEL");
 
 	if (!textProvider || !textModel) {
 		return false;
@@ -82,19 +84,17 @@ function shouldUseCustomLLM(): boolean {
 
 	switch (textProvider.toLowerCase()) {
 		case "openrouter":
-			return !!process.env.OPENROUTER_API_KEY;
+			return !!get("OPENROUTER_API_KEY");
 		case "openai":
-			return !!process.env.OPENAI_API_KEY;
+			return !!get("OPENAI_API_KEY");
 		case "anthropic":
-			return !!process.env.ANTHROPIC_API_KEY;
+			return !!get("ANTHROPIC_API_KEY");
 		case "google":
-			return !!process.env.GOOGLE_API_KEY;
+			return !!get("GOOGLE_API_KEY");
 		default:
 			return false;
 	}
 }
-
-const useCustomLLM = shouldUseCustomLLM();
 
 /** Whether vector enrichment is available for newly ingested documents. */
 export function hasDocumentEmbeddingModel(runtime: IAgentRuntime): boolean {
@@ -995,7 +995,7 @@ async function generateContextsInBatch(
 
 			try {
 				const generateTextOperation = async () => {
-					if (useCustomLLM) {
+					if (shouldUseCustomLLM(runtime)) {
 						if (item.usesCaching && item.promptText) {
 							return generateText(runtime, item.promptText, item.systemPrompt, {
 								cacheDocument: item.fullDocumentTextForContext,

--- a/packages/core/src/features/documents/document-processor.ts
+++ b/packages/core/src/features/documents/document-processor.ts
@@ -26,7 +26,6 @@ import {
 import { splitChunks } from "../../utils";
 import { BatchProcessor } from "../../utils/batch-queue";
 import { getProviderRateLimits, validateModelConfig } from "./config.ts";
-import type { ModelConfig } from "./types.ts";
 import {
 	DEFAULT_CHUNK_OVERLAP_TOKENS,
 	DEFAULT_CHUNK_TOKEN_SIZE,
@@ -40,6 +39,7 @@ import { generateText } from "./llm.ts";
 import type {
 	DocumentFragmentMemoryMetadata,
 	DocumentMemoryMetadata,
+	ModelConfig,
 	PreChunkedFragmentInput,
 } from "./types.ts";
 import {
@@ -966,6 +966,10 @@ async function generateContextsInBatch(
 	);
 
 	const config = validateModelConfig(runtime);
+	// Resolved once per batch: the gate is configuration, not per-chunk state, so
+	// deriving it inside generateTextOperation below re-ran it for every chunk
+	// AND every rate-limit retry.
+	const useCustomLLM = shouldUseCustomLLM(config);
 	const isUsingOpenRouter = config.TEXT_PROVIDER === "openrouter";
 	const isUsingCacheCapableModel =
 		isUsingOpenRouter &&
@@ -1000,7 +1004,7 @@ async function generateContextsInBatch(
 
 			try {
 				const generateTextOperation = async () => {
-					if (shouldUseCustomLLM(config)) {
+					if (useCustomLLM) {
 						if (item.usesCaching && item.promptText) {
 							return generateText(runtime, item.promptText, item.systemPrompt, {
 								cacheDocument: item.fullDocumentTextForContext,


### PR DESCRIPTION
# Relates to — Self-found — document contextualization env poison (runtime vs process.env)

Scope of this PR is the document ingestion pipeline (packages/core/src/features/documents/document-processor.ts). No staging QA claimed. Parallels the Discord isSet poison (fixes #18713 pattern) but for LLM contextualization.

Definition of Done: full standard in [CONTRIBUTING.md](../CONTRIBUTING.md).

- [x] This PR targets develop and is rebased onto the latest origin/develop with zero conflicts (git fetch origin && git rebase origin/develop).
- [ ] bun install and bun run verify were run after sync, or any failure is recorded below with the exact unrelated blocker. → focused package gates were run instead; see Known gaps / failures.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto origin/develop at 69f44283; zero conflicts.
- [ ] bun run verify passes post-sync → not run in this worktree; the exact substitute gates and the pre-existing unrelated failures are documented in Known gaps / failures.

# Risks

Low. Only `shouldUseCustomLLM()` in `document-processor.ts` is touched. It now reads the SAME `validateModelConfig(runtime)` result that `generateText` resolves, so the gate and the executor cannot disagree about provider, model, key, blank-is-unset normalization, or model-gateway substitution. The frozen import-time `const useCustomLLM` is gone; the gate is evaluated once per `generateContextsInBatch` call. `validateModelConfig` already ran on this path (via `getProviderRateLimits`), so no new configuration failure is introduced. Other providers and the batch-embeddings path are unaffected. No `.tsx`/rendered surface.

# Background

## What does this PR do?

`shouldUseCustomLLM()` read `TEXT_PROVIDER`/`TEXT_MODEL`/API keys only from `process.env` at import time via frozen `const useCustomLLM = shouldUseCustomLLM()`. Runtime DB settings (hosted) were ignored and stale after hot-reload, so contextual retrieval silently fell back to `runtime.useModel(TEXT_LARGE)` instead of the custom LLM path (`generateText`).

This PR makes the gate runtime-aware by deriving it from `validateModelConfig(runtime)` — the same resolution `generateText` performs on the branch the gate selects.

Two review follow-ups are folded in:

- A hand-rolled `runtime.getSetting(key) ?? process.env[key]` would have diverged from `validateModelConfig`'s blank-is-unset `normalizeEnvValue` handling (a runtime setting of `""` is falsy but present, so the gate would report "no custom LLM" while `validateModelConfig` fell through to a valid `process.env` value) and would have called `.toLowerCase()` on a `string | boolean | number | null` read. Reading the validated config removes both by construction.
- The gate is resolved once at the top of `generateContextsInBatch` instead of inside `generateTextOperation`, which re-derived it for every chunk AND every rate-limit retry.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/core/src/features/documents/document-processor.ts` — `shouldUseCustomLLM(runtime?)` + call site at line 998

## Detailed testing steps

New test: `packages/core/src/features/documents/document-processor-custom-llm.test.ts`. It runs a real ingestion through `processFragmentsSynchronously` against a local OpenAI-compatible HTTP server, so each assertion observes which transport actually handled the request rather than a stubbed predicate:

1. `runtime.getSetting` alone supplies `TEXT_PROVIDER` / `TEXT_MODEL` / `OPENAI_API_KEY` / `OPENAI_BASE_URL` while `process.env` is unset → the direct provider is called once, `TEXT_LARGE` is never used, and the persisted fragment carries the provider's context.
2. Blank runtime settings (`""` and `"   "`) with the values present in `process.env` → still the direct provider. This case FAILS against the pre-fix `getSetting(key) ?? process.env[key]` gate (verified by reverting the gate locally).
3. No provider configured → contextualization stays on `runtime.useModel(TEXT_LARGE)`.

```
$ cd packages/core && node ../shared/scripts/generate-keywords.mjs
$ bunx vitest run src/features/documents --root packages/core
  Test Files  2 failed | 10 passed (12)
       Tests  2 failed | 213 passed (215)

$ cd packages/core && bunx tsc --noEmit -p ./tsconfig.json
  (clean)
```

The two failures are `service-character-ingest.test.ts` / `service-regression-lane.test.ts` → "does not write the parent when any pre-chunked embedding fails" (an `ElizaError` shape mismatch on `DOCUMENT_FRAGMENT_EMBED_FAILED`). Both reproduce identically on this PR's base commit with the diff stashed, so they are pre-existing and unrelated.

# Evidence Gate

Evidence matches exact head `d0e2c8c6c1c3368c37589d9cef810371beadbb6a`.
<!-- evidence-head:d0e2c8c6c1c3368c37589d9cef810371beadbb6a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes; the diff is `packages/core` document-ingestion logic plus one new test file.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered interaction or visual flow changes.
<!-- evidence-row:backend-logs -->
- [x] Ingestion-path run at this head. The direct-provider branch is proven by the local OpenAI-compatible server receiving exactly one chat-completion request per ingest; the fallback branch by that server receiving zero.

```
$ cd packages/core && bunx vitest run src/features/documents/document-processor-custom-llm.test.ts --reporter=verbose
 ✓ src/features/documents/document-processor-custom-llm.test.ts > document contextualization custom-LLM gate > runtime settings alone select the direct provider when the environment is unset 155ms
 ✓ src/features/documents/document-processor-custom-llm.test.ts > document contextualization custom-LLM gate > a blank runtime setting falls through to the environment value 19ms
 ✓ src/features/documents/document-processor-custom-llm.test.ts > document contextualization custom-LLM gate > a missing provider key keeps contextualization on the runtime TEXT_LARGE model 2ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  1.89s (transform 913ms, setup 0ms, import 1.48s, tests 206ms, environment 0ms)
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code path is reachable from this change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, agent, action, or model behavior changes. Which CLIENT carries an unchanged prompt is the entire change, and that is asserted deterministically against a local provider endpoint rather than a billed live model.
<!-- evidence-row:domain-artifacts -->
- [x] The persisted FRAGMENT memory is the artifact, and it is asserted directly rather than inferred from a call count: its stored text carries the direct provider's context in cases 1-2 and the runtime TEXT_LARGE context in case 3.

```
expect(saved).toBe(1);                                        // one FRAGMENT memory persisted
expect(provider.requestCount()).toBe(1);                      // direct provider handled it
expect(harness.runtimeModelCalls()).toBe(0);                  // TEXT_LARGE never used
expect(fragmentText(harness.savedFragments)).toContain(PROVIDER_CONTEXT);
// ...and the unconfigured case, same ingest, opposite artifact:
expect(provider.requestCount()).toBe(0);
expect(harness.runtimeModelCalls()).toBe(1);
expect(fragmentText(harness.savedFragments)).toContain(RUNTIME_MODEL_CONTEXT);
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changes.

# Known gaps / failures

- `bun run verify` was not run in this worktree; the owning package's document suites, the new test, and `packages/core` typecheck were run instead (output above).
- Pre-existing, unrelated: the two `DOCUMENT_FRAGMENT_EMBED_FAILED` assertions described above fail identically without this diff.