### PR TITLE
fix(ui): route labelled settings fields through SettingsInputRow

### DIFF
--- a/packages/ui/src/components/settings/IdentitySettingsSection.tsx
+++ b/packages/ui/src/components/settings/IdentitySettingsSection.tsx
@@ -9,7 +9,6 @@
 
 import { Volume2, VolumeX } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAgentElement } from "../../agent-surface";
 import { client, type VoiceConfig } from "../../api";
 import { dispatchWindowEvent, VOICE_CONFIG_UPDATED_EVENT } from "../../events";
 import { useAppSelectorShallow } from "../../state";
@@ -25,121 +24,9 @@ import {
   ELEVENLABS_VOICE_GROUPS,
 } from "../character/character-voice-config";
 import { SaveFooter } from "../ui/save-footer";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectValue,
-} from "../ui/select";
-import { SettingsSelectTrigger } from "../ui/settings-controls";
-import { SettingsActionButton } from "./settings-agent-rows";
+import { SettingsActionButton, SettingsSelectRow } from "./settings-agent-rows";
 import { useSettingsSave } from "./settings-control-primitives.hooks";
-import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
-
-interface VoiceSelectRowProps {
-  label: string;
-  placeholder: string;
-  value: string | null;
-  options: readonly string[];
-  groups: Array<{
-    label: string;
-    items: Array<{ id: string; text: string; hint?: string }>;
-  }>;
-  onValueChange: (value: string) => void;
-  previewLabel: string;
-  stopLabel: string;
-  previewing: boolean;
-  previewDisabled: boolean;
-  onPreviewToggle: () => void;
-}
-
-function VoiceSelectRow({
-  label,
-  placeholder,
-  value,
-  options,
-  groups,
-  onValueChange,
-  previewLabel,
-  stopLabel,
-  previewing,
-  previewDisabled,
-  onPreviewToggle,
-}: VoiceSelectRowProps) {
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: "identity-voice",
-    role: "select",
-    label,
-    group: "settings",
-    status: value || undefined,
-    options,
-    getValue: () => value ?? "",
-    onFill: (next: string) => onValueChange(next),
-  });
-
-  return (
-    <SettingsRow
-      label={<span id="settings-identity-voice-label">{label}</span>}
-      stacked
-    >
-      <div className="flex items-center gap-2">
-        <Select value={value ?? undefined} onValueChange={onValueChange}>
-          <SettingsSelectTrigger
-            ref={ref}
-            variant="touch"
-            aria-labelledby="settings-identity-voice-label"
-            className="min-w-0 flex-1"
-            {...agentProps}
-          >
-            <SelectValue placeholder={placeholder} />
-          </SettingsSelectTrigger>
-          <SelectContent className="border-border/60 bg-bg/92">
-            {groups.map((group) => (
-              <SelectGroup key={group.label}>
-                <SelectLabel className="px-2.5 py-1 text-2xs font-semibold text-muted">
-                  {group.label}
-                </SelectLabel>
-                {group.items.map((item) => (
-                  <SelectItem
-                    key={item.id}
-                    value={item.id}
-                    textValue={item.text}
-                  >
-                    <div className="flex w-full items-center justify-between gap-2">
-                      <span className="font-semibold">{item.text}</span>
-                      {item.hint ? (
-                        <span className="text-muted text-xs">{item.hint}</span>
-                      ) : null}
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-            ))}
-          </SelectContent>
-        </Select>
-        <SettingsActionButton
-          agentId="identity-voice-preview"
-          agentLabel={previewing ? stopLabel : previewLabel}
-          type="button"
-          variant={previewing ? "destructive" : "ghost"}
-          size="icon"
-          className="h-11 w-11 shrink-0 rounded-md"
-          onClick={onPreviewToggle}
-          aria-label={previewing ? stopLabel : previewLabel}
-          disabled={previewDisabled}
-        >
-          {previewing ? (
-            <VolumeX className="h-4 w-4" />
-          ) : (
-            <Volume2 className="h-4 w-4" />
-          )}
-        </SettingsActionButton>
-      </div>
-    </SettingsRow>
-  );
-}
+import { SettingsGroup, SettingsStack } from "./settings-layout";
 
 function resolveEditableVoiceSelectionKey(config: VoiceConfig | null): string {
   const elevenLabsVoiceId =
@@ -342,11 +229,6 @@ export function IdentitySettingsSection() {
     }));
   }, [t, useElevenLabs]);
 
-  const voiceOptions = useMemo(
-    () => voiceGroups.flatMap((group) => group.items.map((item) => item.id)),
-    [voiceGroups],
-  );
-
   const voiceDirty =
     resolveEditableVoiceSelectionKey(voiceConfig) !==
     resolveEditableVoiceSelectionKey(savedVoiceConfig);
@@ -440,24 +322,49 @@ export function IdentitySettingsSection() {
       <SettingsGroup
         title={t("settings.identity.groupTitle", { defaultValue: "Identity" })}
       >
-        <VoiceSelectRow
+        <SettingsSelectRow
+          agentId="identity-voice"
           label={t("common.voice", { defaultValue: "Voice" })}
           placeholder={t("charactereditor.SelectAVoice", {
             defaultValue: "Select a voice",
           })}
-          value={visibleVoicePresetId}
-          options={voiceOptions}
-          groups={voiceGroups}
+          value={visibleVoicePresetId ?? ""}
+          groups={voiceGroups.map((group) => ({
+            label: group.label,
+            items: group.items.map((item) => ({
+              value: item.id,
+              label: item.text,
+              hint: item.hint,
+            })),
+          }))}
           onValueChange={handleVoiceSelect}
-          previewLabel={t("settings.identity.previewVoice", {
-            defaultValue: "Preview voice",
-          })}
-          stopLabel={t("settings.identity.stopVoicePreview", {
-            defaultValue: "Stop voice preview",
-          })}
-          previewing={voiceTesting}
-          previewDisabled={!activeVoicePreset?.previewUrl || voiceLoading}
-          onPreviewToggle={voiceTesting ? stopVoicePreview : handlePreviewVoice}
+          contentClassName="border-border/60 bg-bg/92"
+          trailing={
+            <SettingsActionButton
+              agentId="identity-voice-preview"
+              agentLabel={
+                voiceTesting
+                  ? t("settings.identity.stopVoicePreview", {
+                      defaultValue: "Stop voice preview",
+                    })
+                  : t("settings.identity.previewVoice", {
+                      defaultValue: "Preview voice",
+                    })
+              }
+              type="button"
+              variant={voiceTesting ? "destructive" : "ghost"}
+              size="icon"
+              className="h-11 w-11 shrink-0 rounded-md"
+              onClick={voiceTesting ? stopVoicePreview : handlePreviewVoice}
+              disabled={!activeVoicePreset?.previewUrl || voiceLoading}
+            >
+              {voiceTesting ? (
+                <VolumeX className="h-4 w-4" />
+              ) : (
+                <Volume2 className="h-4 w-4" />
+              )}
+            </SettingsActionButton>
+          }
         />
       </SettingsGroup>
 

--- a/packages/ui/src/components/settings/SecuritySettingsSection.tsx
+++ b/packages/ui/src/components/settings/SecuritySettingsSection.tsx
@@ -21,7 +21,6 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
-  useId,
   useState,
 } from "react";
 import { useAgentElement } from "../../agent-surface";
@@ -36,18 +35,16 @@ import {
   authSetup,
 } from "../../api/auth-client";
 import { useBootConfig } from "../../config/boot-config-react.hooks";
-import { cn } from "../../lib/utils";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { OwnerOnlyNotice, RoleGate } from "../RoleGate";
 import { Button } from "../ui/button";
-import { Input } from "../ui/input";
-import { Label } from "../ui/label";
 import {
   StatusBadge as SharedStatusBadge,
   type StatusVariant,
 } from "../ui/status-badge";
 import { AdvancedToggle } from "./AdvancedToggle";
 import { useAdvancedSettingsEnabled } from "./AdvancedToggle.hooks";
+import { SettingsInputRow } from "./settings-agent-rows";
 import { SettingsGroup, SettingsStack } from "./settings-layout";
 
 function formatRelativeTime(ms: number | null): string {
@@ -783,53 +780,12 @@ function RemotePasswordSection({
   onAccessChanged: () => Promise<void>;
 }) {
   const { t } = useTranslation();
-  const displayNameId = useId().replace(/:/g, "");
-  const currentPasswordId = useId().replace(/:/g, "");
-  const newPasswordId = useId().replace(/:/g, "");
-  const confirmPasswordId = useId().replace(/:/g, "");
-
   const [displayName, setDisplayName] = useState("Owner");
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [state, setState] = useState<PasswordState>({ phase: "idle" });
 
-  const { ref: displayNameRef, agentProps: displayNameAgentProps } =
-    useAgentElement<HTMLInputElement>({
-      id: "security-password-display-name",
-      role: "text-input",
-      label: "Owner display name",
-      group: "security-password",
-      getValue: () => displayName,
-      onFill: (v) => setDisplayName(v),
-    });
-  const { ref: currentPasswordRef, agentProps: currentPasswordAgentProps } =
-    useAgentElement<HTMLInputElement>({
-      id: "security-password-current",
-      role: "text-input",
-      label: "Current password",
-      group: "security-password",
-      getValue: () => currentPassword,
-      onFill: (v) => setCurrentPassword(v),
-    });
-  const { ref: newPasswordRef, agentProps: newPasswordAgentProps } =
-    useAgentElement<HTMLInputElement>({
-      id: "security-password-new",
-      role: "text-input",
-      label: "New remote password",
-      group: "security-password",
-      getValue: () => newPassword,
-      onFill: (v) => setNewPassword(v),
-    });
-  const { ref: confirmPasswordRef, agentProps: confirmPasswordAgentProps } =
-    useAgentElement<HTMLInputElement>({
-      id: "security-password-confirm",
-      role: "text-input",
-      label: "Confirm new remote password",
-      group: "security-password",
-      getValue: () => confirmPassword,
-      onFill: (v) => setConfirmPassword(v),
-    });
   const { ref: passwordSubmitRef, agentProps: passwordSubmitAgentProps } =
     useAgentElement<HTMLButtonElement>({
       id: "security-password-submit",
@@ -970,107 +926,87 @@ function RemotePasswordSection({
     >
       <form onSubmit={handleSubmit} className="flex flex-col gap-3" noValidate>
         {setupMode && (
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor={displayNameId} className="text-xs text-muted">
-              {t("security.password.field.displayName", {
-                defaultValue: "Display name",
-              })}
-            </Label>
-            <Input
-              ref={displayNameRef}
-              {...displayNameAgentProps}
-              id={displayNameId}
-              type="text"
-              autoComplete="username"
-              value={displayName}
-              onChange={(event) => {
-                setDisplayName(event.target.value);
-                if (state.phase === "error") setState({ phase: "idle" });
-              }}
-              disabled={isSubmitting}
-              className="h-11"
-            />
-          </div>
+          <SettingsInputRow
+            agentId="security-password-display-name"
+            agentLabel="Owner display name"
+            group="security-password"
+            label={t("security.password.field.displayName", {
+              defaultValue: "Display name",
+            })}
+            type="text"
+            autoComplete="username"
+            value={displayName}
+            onValueChange={(next) => {
+              setDisplayName(next);
+              if (state.phase === "error") setState({ phase: "idle" });
+            }}
+            disabled={isSubmitting}
+          />
         )}
 
         {currentPasswordRequired && (
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor={currentPasswordId} className="text-xs text-muted">
-              {t("security.password.field.current", {
-                defaultValue: "Current password",
-              })}
-            </Label>
-            <Input
-              ref={currentPasswordRef}
-              {...currentPasswordAgentProps}
-              id={currentPasswordId}
-              type="password"
-              autoComplete="current-password"
-              value={currentPassword}
-              onChange={(event) => {
-                setCurrentPassword(event.target.value);
-                if (state.phase === "error") setState({ phase: "idle" });
-              }}
-              disabled={isSubmitting}
-              className="h-11"
-            />
-          </div>
+          <SettingsInputRow
+            agentId="security-password-current"
+            agentLabel="Current password"
+            group="security-password"
+            label={t("security.password.field.current", {
+              defaultValue: "Current password",
+            })}
+            type="password"
+            autoComplete="current-password"
+            value={currentPassword}
+            onValueChange={(next) => {
+              setCurrentPassword(next);
+              if (state.phase === "error") setState({ phase: "idle" });
+            }}
+            disabled={isSubmitting}
+          />
         )}
 
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor={newPasswordId} className="text-xs text-muted">
-            {t("security.password.field.new", {
-              defaultValue: "New password",
-            })}
-          </Label>
-          <Input
-            ref={newPasswordRef}
-            {...newPasswordAgentProps}
-            id={newPasswordId}
-            type="password"
-            autoComplete="new-password"
-            placeholder={t("security.password.field.newPlaceholder", {
-              defaultValue: "At least 12 characters",
-            })}
-            value={newPassword}
-            onChange={(event) => {
-              setNewPassword(event.target.value);
-              if (state.phase === "error") setState({ phase: "idle" });
-            }}
-            disabled={isSubmitting}
-            className="h-11"
-          />
-        </div>
+        <SettingsInputRow
+          agentId="security-password-new"
+          agentLabel="New remote password"
+          group="security-password"
+          label={t("security.password.field.new", {
+            defaultValue: "New password",
+          })}
+          type="password"
+          autoComplete="new-password"
+          placeholder={t("security.password.field.newPlaceholder", {
+            defaultValue: "At least 12 characters",
+          })}
+          value={newPassword}
+          onValueChange={(next) => {
+            setNewPassword(next);
+            if (state.phase === "error") setState({ phase: "idle" });
+          }}
+          disabled={isSubmitting}
+        />
 
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor={confirmPasswordId} className="text-xs text-muted">
-            {t("security.password.field.confirm", {
-              defaultValue: "Confirm new password",
-            })}
-          </Label>
-          <Input
-            ref={confirmPasswordRef}
-            {...confirmPasswordAgentProps}
-            id={confirmPasswordId}
-            type="password"
-            autoComplete="new-password"
-            value={confirmPassword}
-            onChange={(event) => {
-              setConfirmPassword(event.target.value);
-              if (state.phase === "error") setState({ phase: "idle" });
-            }}
-            disabled={isSubmitting}
-            aria-invalid={confirmMismatch}
-            className={cn("h-11", confirmMismatch && "border-danger ")}
-          />
-          {confirmMismatch && (
-            <p className="text-xs text-danger">
-              {t("security.password.error.mismatchShort", {
-                defaultValue: "Passwords do not match.",
-              })}
-            </p>
-          )}
-        </div>
+        <SettingsInputRow
+          agentId="security-password-confirm"
+          agentLabel="Confirm new remote password"
+          group="security-password"
+          label={t("security.password.field.confirm", {
+            defaultValue: "Confirm new password",
+          })}
+          type="password"
+          autoComplete="new-password"
+          value={confirmPassword}
+          onValueChange={(next) => {
+            setConfirmPassword(next);
+            if (state.phase === "error") setState({ phase: "idle" });
+          }}
+          disabled={isSubmitting}
+          invalid={confirmMismatch}
+          description={
+            confirmMismatch
+              ? t("security.password.error.mismatchShort", {
+                  defaultValue: "Passwords do not match.",
+                })
+              : undefined
+          }
+        />
 
         {state.phase === "error" && (
           <p role="alert" className="text-sm text-danger">

--- a/packages/ui/src/components/settings/SecuritySettingsSection.tsx
+++ b/packages/ui/src/components/settings/SecuritySettingsSection.tsx
@@ -998,8 +998,7 @@ function RemotePasswordSection({
             if (state.phase === "error") setState({ phase: "idle" });
           }}
           disabled={isSubmitting}
-          invalid={confirmMismatch}
-          description={
+          error={
             confirmMismatch
               ? t("security.password.error.mismatchShort", {
                   defaultValue: "Passwords do not match.",

--- a/packages/ui/src/components/settings/VoiceProfileSection.test.tsx
+++ b/packages/ui/src/components/settings/VoiceProfileSection.test.tsx
@@ -214,10 +214,16 @@ describe("VoiceProfileSection", () => {
     );
 
     await user.click(screen.getByTestId("voice-profile-manage-g1"));
-    await user.type(
-      screen.getByTestId("voice-profile-bind-entity-g1"),
-      "entity-alex",
+    const entity = screen.getByTestId("voice-profile-bind-entity-g1");
+    const bindLabel = screen.getByTestId("voice-profile-bind-label-g1");
+    expect(entity.getAttribute("data-agent-id")).toBe(
+      "voice-profile-entity-g1",
     );
+    expect(bindLabel.getAttribute("data-agent-id")).toBe(
+      "voice-profile-entity-label-g1",
+    );
+    expect(entity.getAttribute("aria-label")).toBeNull();
+    await user.type(entity, "entity-alex");
     await user.type(screen.getByTestId("voice-profile-bind-label-g1"), "Alex");
     await user.click(screen.getByTestId("voice-profile-bind-g1"));
 

--- a/packages/ui/src/components/settings/VoiceProfileSection.tsx
+++ b/packages/ui/src/components/settings/VoiceProfileSection.tsx
@@ -31,7 +31,7 @@ import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import { Select, SelectContent, SelectItem, SelectValue } from "../ui/select";
 import { SettingsSelectTrigger } from "../ui/settings-controls";
-import { SettingsInputRow } from "./settings-agent-rows";
+import { SettingsInputRow, SettingsSelectRow } from "./settings-agent-rows";
 
 export interface VoiceProfileSectionProps {
   /** Adapter supplied by the parent that holds the `ElizaClient`. */
@@ -156,52 +156,45 @@ function VoiceProfileLifecycleEditor({
       </div>
 
       {!profile.isOwner && mergeTargets.length > 0 ? (
-        <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
-          <div className="grid gap-1.5">
-            <Label htmlFor={`voice-profile-merge-${profile.id}`}>
-              {t("voiceprofile.merge.target", {
-                defaultValue: "Merge into",
+        <SettingsSelectRow
+          agentId={`voice-profile-merge-${profile.id}`}
+          group="voice-profiles"
+          label={t("voiceprofile.merge.target", {
+            defaultValue: "Merge into",
+          })}
+          value={mergeIntoId}
+          onValueChange={setMergeIntoId}
+          placeholder={t("voiceprofile.merge.choose", {
+            defaultValue: "Choose destination profile",
+          })}
+          testId={`voice-profile-merge-target-${profile.id}`}
+          trailingStackUntilSm
+          options={mergeTargets.map((candidate) => ({
+            value: candidate.id,
+            label: candidate.displayName,
+          }))}
+          trailing={
+            <Button
+              type="button"
+              variant="secondary"
+              className="min-h-11"
+              disabled={!mergeIntoId || pending}
+              onClick={() =>
+                void dispatch({
+                  type: "merge",
+                  id: profile.id,
+                  intoId: mergeIntoId,
+                })
+              }
+              data-testid={`voice-profile-merge-${profile.id}`}
+            >
+              <GitMerge className="mr-1.5 h-4 w-4" />
+              {t("voiceprofile.merge.action", {
+                defaultValue: "Merge profile",
               })}
-            </Label>
-            <Select value={mergeIntoId} onValueChange={setMergeIntoId}>
-              <SettingsSelectTrigger
-                id={`voice-profile-merge-${profile.id}`}
-                className="min-h-11"
-                data-testid={`voice-profile-merge-target-${profile.id}`}
-              >
-                <SelectValue
-                  placeholder={t("voiceprofile.merge.choose", {
-                    defaultValue: "Choose destination profile",
-                  })}
-                />
-              </SettingsSelectTrigger>
-              <SelectContent>
-                {mergeTargets.map((candidate) => (
-                  <SelectItem key={candidate.id} value={candidate.id}>
-                    {candidate.displayName}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <Button
-            type="button"
-            variant="secondary"
-            className="min-h-11"
-            disabled={!mergeIntoId || pending}
-            onClick={() =>
-              void dispatch({
-                type: "merge",
-                id: profile.id,
-                intoId: mergeIntoId,
-              })
-            }
-            data-testid={`voice-profile-merge-${profile.id}`}
-          >
-            <GitMerge className="mr-1.5 h-4 w-4" />
-            {t("voiceprofile.merge.action", { defaultValue: "Merge profile" })}
-          </Button>
-        </div>
+            </Button>
+          }
+        />
       ) : null}
 
       {profile.samples.length >= 2 ? (

--- a/packages/ui/src/components/settings/VoiceProfileSection.tsx
+++ b/packages/ui/src/components/settings/VoiceProfileSection.tsx
@@ -31,6 +31,7 @@ import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import { Select, SelectContent, SelectItem, SelectValue } from "../ui/select";
 import { SettingsSelectTrigger } from "../ui/settings-controls";
+import { SettingsInputRow } from "./settings-agent-rows";
 
 export interface VoiceProfileSectionProps {
   /** Adapter supplied by the parent that holds the `ElizaClient`. */
@@ -268,32 +269,28 @@ function VoiceProfileLifecycleEditor({
       {!profile.entityId ? (
         <div className="grid gap-2">
           <div className="grid gap-2 sm:grid-cols-2">
-            <div className="grid gap-1.5">
-              <Label htmlFor={`voice-profile-entity-${profile.id}`}>
-                {t("voiceprofile.bind.entity", { defaultValue: "Entity ID" })}
-              </Label>
-              <Input
-                id={`voice-profile-entity-${profile.id}`}
-                value={entityId}
-                onChange={(event) => setEntityId(event.target.value)}
-                className="h-11"
-                data-testid={`voice-profile-bind-entity-${profile.id}`}
-              />
-            </div>
-            <div className="grid gap-1.5">
-              <Label htmlFor={`voice-profile-entity-label-${profile.id}`}>
-                {t("voiceprofile.bind.label", {
-                  defaultValue: "Binding label (optional)",
-                })}
-              </Label>
-              <Input
-                id={`voice-profile-entity-label-${profile.id}`}
-                value={entityLabel}
-                onChange={(event) => setEntityLabel(event.target.value)}
-                className="h-11"
-                data-testid={`voice-profile-bind-label-${profile.id}`}
-              />
-            </div>
+            <SettingsInputRow
+              agentId={`voice-profile-entity-${profile.id}`}
+              group="voice-profiles"
+              label={t("voiceprofile.bind.entity", {
+                defaultValue: "Entity ID",
+              })}
+              value={entityId}
+              onValueChange={setEntityId}
+              testId={`voice-profile-bind-entity-${profile.id}`}
+              inputClassName="h-11"
+            />
+            <SettingsInputRow
+              agentId={`voice-profile-entity-label-${profile.id}`}
+              group="voice-profiles"
+              label={t("voiceprofile.bind.label", {
+                defaultValue: "Binding label (optional)",
+              })}
+              value={entityLabel}
+              onValueChange={setEntityLabel}
+              testId={`voice-profile-bind-label-${profile.id}`}
+              inputClassName="h-11"
+            />
           </div>
           <Button
             type="button"

--- a/packages/ui/src/components/settings/no-raw-labelled-input.test.ts
+++ b/packages/ui/src/components/settings/no-raw-labelled-input.test.ts
@@ -62,6 +62,10 @@ const RAW_INPUT_ALLOWLIST = new Map<string, string>([
   ],
 ]);
 
+function posixRelative(from: string, to: string): string {
+  return relative(from, to).replaceAll("\\", "/");
+}
+
 function listTsxFiles(dir: string): string[] {
   const out: string[] = [];
   for (const name of readdirSync(dir)) {
@@ -82,7 +86,7 @@ function listTsxFiles(dir: string): string[] {
 describe("settings controls: no raw labelled <Input outside the allowlist", () => {
   const files = listTsxFiles(settingsRoot);
 
-  it.each(files.map((file) => relative(settingsRoot, file)))(
+  it.each(files.map((file) => posixRelative(settingsRoot, file)))(
     "%s uses SettingsInputRow instead of a raw <Input, or is allowlisted",
     (relPath) => {
       const source = readFileSync(resolve(settingsRoot, relPath), "utf8");

--- a/packages/ui/src/components/settings/no-raw-labelled-input.test.ts
+++ b/packages/ui/src/components/settings/no-raw-labelled-input.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Static source-scan guard: labelled text/password settings fields must use
+ * SettingsInputRow instead of a hand-rolled Label + Input pair. Reads files
+ * off disk — no render. Remaining raw Input sites are an explicit allowlist.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const settingsRoot = resolve(import.meta.dirname);
+
+/**
+ * Files that still own a raw `<Input` because they are not a 1:1 labelled
+ * text/password settings field. Adding a new file here is a product decision;
+ * the default is `SettingsInputRow`.
+ */
+const RAW_INPUT_ALLOWLIST = new Map<string, string>([
+  [
+    "AdvancedSection.tsx",
+    "radio list of backup files, not a labelled text field",
+  ],
+  [
+    "BackgroundSettingsControls.tsx",
+    "hidden file picker for wallpaper upload, not a labelled text field",
+  ],
+  [
+    "CloudAgentsSection.tsx",
+    "inline rename and create-name fields sit beside action buttons",
+  ],
+  [
+    "SubscriptionStatus.tsx",
+    "billing/checkout form fields live in a custom card, not a settings row",
+  ],
+  [
+    "VaultInventoryPanel.tsx",
+    "vault credential editor is a custom multi-field form, not a settings row",
+  ],
+  [
+    "VoiceConfigView.tsx",
+    "compact wake-word and device fields inside a custom status chip",
+  ],
+  [
+    "VoiceProfileSection.tsx",
+    "inline rename field; remaining Label usages are merge/sample checkboxes",
+  ],
+  [
+    "VoiceSection.tsx",
+    "checkbox consent controls, not labelled text/password fields",
+  ],
+  [
+    "vault-tabs/LoginsTab.tsx",
+    "vault login editor is a custom multi-field form, not a settings row",
+  ],
+  [
+    "vault-tabs/OverviewTab.tsx",
+    "vault overview editor is a custom multi-field form, not a settings row",
+  ],
+  [
+    "vault-tabs/RoutingTab.tsx",
+    "vault routing editor is a custom multi-field form, not a settings row",
+  ],
+]);
+
+function listTsxFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      out.push(...listTsxFiles(full));
+    } else if (
+      name.endsWith(".tsx") &&
+      !name.endsWith(".test.tsx") &&
+      !name.endsWith(".stories.tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("settings controls: no raw labelled <Input outside the allowlist", () => {
+  const files = listTsxFiles(settingsRoot);
+
+  it.each(files.map((file) => relative(settingsRoot, file)))(
+    "%s uses SettingsInputRow instead of a raw <Input, or is allowlisted",
+    (relPath) => {
+      const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
+      const hasRawInput = source.includes("<Input");
+      if (!hasRawInput) {
+        expect(RAW_INPUT_ALLOWLIST.has(relPath)).toBe(false);
+        return;
+      }
+      expect(
+        RAW_INPUT_ALLOWLIST.has(relPath),
+        `${relPath} hand-rolls a raw <Input. Use SettingsInputRow from ` +
+          `./settings-agent-rows for labelled text/password settings. If this ` +
+          `file is not a settings text field, add it to RAW_INPUT_ALLOWLIST ` +
+          `with a reason.`,
+      ).toBe(true);
+    },
+  );
+
+  it("documents a reason for every allowlisted raw Input file", () => {
+    for (const [relPath, reason] of RAW_INPUT_ALLOWLIST) {
+      expect(reason.trim().length).toBeGreaterThan(8);
+      const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
+      expect(
+        source.includes("<Input"),
+        `${relPath} is allowlisted but no longer contains <Input; remove it from the allowlist`,
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/ui/src/components/settings/no-raw-labelled-input.test.ts
+++ b/packages/ui/src/components/settings/no-raw-labelled-input.test.ts
@@ -1,7 +1,8 @@
 /**
- * Static source-scan guard: labelled text/password settings fields must use
- * SettingsInputRow instead of a hand-rolled Label + Input pair. Reads files
- * off disk — no render. Remaining raw Input sites are an explicit allowlist.
+ * Occurrence ratchet for raw `<Input` in the settings surface. A labelled
+ * text/password field must use SettingsInputRow. Remaining raw Input sites
+ * are recorded by exact count so an extra occurrence in an already-known
+ * file fails. Reads files off disk — no render.
  */
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
@@ -11,54 +12,97 @@ import { describe, expect, it } from "vitest";
 const settingsRoot = resolve(import.meta.dirname);
 
 /**
- * Files that still own a raw `<Input` because they are not a 1:1 labelled
- * text/password settings field. Adding a new file here is a product decision;
- * the default is `SettingsInputRow`.
+ * Exact remaining raw `<Input` counts. Raising a count is a product decision;
+ * the default is SettingsInputRow. A new occurrence in any of these files
+ * fails until the count is deliberately updated.
  */
-const RAW_INPUT_ALLOWLIST = new Map<string, string>([
+const RAW_INPUT_OCCURRENCES = new Map<
+  string,
+  { count: number; reason: string }
+>([
   [
     "AdvancedSection.tsx",
-    "radio list of backup files, not a labelled text field",
+    {
+      count: 1,
+      reason: "radio list of backup files, not a labelled text field",
+    },
   ],
   [
     "BackgroundSettingsControls.tsx",
-    "hidden file picker for wallpaper upload, not a labelled text field",
+    {
+      count: 1,
+      reason:
+        "hidden file picker for wallpaper upload, not a labelled text field",
+    },
   ],
   [
     "CloudAgentsSection.tsx",
-    "inline rename and create-name fields sit beside action buttons",
+    {
+      count: 2,
+      reason: "inline rename and create-name fields sit beside action buttons",
+    },
   ],
   [
     "SubscriptionStatus.tsx",
-    "billing/checkout form fields live in a custom card, not a settings row",
+    {
+      count: 2,
+      reason:
+        "billing/checkout form fields live in a custom card, not a settings row",
+    },
   ],
   [
     "VaultInventoryPanel.tsx",
-    "vault credential editor is a custom multi-field form, not a settings row",
+    {
+      count: 8,
+      reason:
+        "vault credential editor is a custom multi-field form, not a settings row",
+    },
   ],
   [
     "VoiceConfigView.tsx",
-    "compact wake-word and device fields inside a custom status chip",
+    {
+      count: 3,
+      reason: "compact wake-word and device fields inside a custom status chip",
+    },
   ],
   [
     "VoiceProfileSection.tsx",
-    "inline rename field; remaining Label usages are merge/sample checkboxes",
+    {
+      count: 1,
+      reason:
+        "inline rename field; remaining Label usages are merge/sample checkboxes",
+    },
   ],
   [
     "VoiceSection.tsx",
-    "checkbox consent controls, not labelled text/password fields",
+    {
+      count: 4,
+      reason: "checkbox consent controls, not labelled text/password fields",
+    },
   ],
   [
     "vault-tabs/LoginsTab.tsx",
-    "vault login editor is a custom multi-field form, not a settings row",
+    {
+      count: 4,
+      reason:
+        "vault login editor is a custom multi-field form, not a settings row",
+    },
   ],
   [
     "vault-tabs/OverviewTab.tsx",
-    "vault overview editor is a custom multi-field form, not a settings row",
+    {
+      count: 7,
+      reason:
+        "vault overview editor is a custom multi-field form, not a settings row",
+    },
   ],
   [
     "vault-tabs/RoutingTab.tsx",
-    "vault routing editor is a custom multi-field form, not a settings row",
+    {
+      count: 2,
+      reason:
+        "vault routing editor is a custom multi-field form, not a settings row",
+    },
   ],
 ]);
 
@@ -83,36 +127,79 @@ function listTsxFiles(dir: string): string[] {
   return out;
 }
 
-describe("settings controls: no raw labelled <Input outside the allowlist", () => {
+function countRawInputs(source: string): number {
+  return source.split("<Input").length - 1;
+}
+
+function rawInputVerdict(
+  relPath: string,
+  source: string,
+): { ok: true } | { ok: false; message: string } {
+  const count = countRawInputs(source);
+  const allowed = RAW_INPUT_OCCURRENCES.get(relPath);
+  if (!allowed) {
+    if (count === 0) return { ok: true };
+    return {
+      ok: false,
+      message:
+        `${relPath} has ${count} raw <Input occurrence(s). Use SettingsInputRow ` +
+        `from ./settings-agent-rows, or record the exact remaining count in ` +
+        `RAW_INPUT_OCCURRENCES with a reason.`,
+    };
+  }
+  if (count !== allowed.count) {
+    return {
+      ok: false,
+      message:
+        `${relPath} has ${count} raw <Input occurrence(s); the ratchet allows ` +
+        `${allowed.count} (${allowed.reason}).`,
+    };
+  }
+  return { ok: true };
+}
+
+describe("settings controls: raw <Input occurrences are ratcheted", () => {
   const files = listTsxFiles(settingsRoot);
 
   it.each(files.map((file) => posixRelative(settingsRoot, file)))(
-    "%s uses SettingsInputRow instead of a raw <Input, or is allowlisted",
+    "%s stays at its recorded raw <Input count",
     (relPath) => {
       const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
-      const hasRawInput = source.includes("<Input");
-      if (!hasRawInput) {
-        expect(RAW_INPUT_ALLOWLIST.has(relPath)).toBe(false);
-        return;
-      }
-      expect(
-        RAW_INPUT_ALLOWLIST.has(relPath),
-        `${relPath} hand-rolls a raw <Input. Use SettingsInputRow from ` +
-          `./settings-agent-rows for labelled text/password settings. If this ` +
-          `file is not a settings text field, add it to RAW_INPUT_ALLOWLIST ` +
-          `with a reason.`,
-      ).toBe(true);
+      const verdict = rawInputVerdict(relPath, source);
+      expect(verdict.ok, !verdict.ok ? verdict.message : undefined).toBe(true);
     },
   );
 
-  it("documents a reason for every allowlisted raw Input file", () => {
-    for (const [relPath, reason] of RAW_INPUT_ALLOWLIST) {
-      expect(reason.trim().length).toBeGreaterThan(8);
+  it("documents a reason and exact count for every recorded file", () => {
+    for (const [relPath, entry] of RAW_INPUT_OCCURRENCES) {
+      expect(entry.reason.trim().length).toBeGreaterThan(8);
+      expect(entry.count).toBeGreaterThan(0);
       const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
-      expect(
-        source.includes("<Input"),
-        `${relPath} is allowlisted but no longer contains <Input; remove it from the allowlist`,
-      ).toBe(true);
+      expect(countRawInputs(source)).toBe(entry.count);
     }
+  });
+
+  it("fails when an already-recorded file gains another raw <Input", () => {
+    const source = readFileSync(
+      resolve(settingsRoot, "VoiceProfileSection.tsx"),
+      "utf8",
+    );
+    const extra = `${source}\n<Input value="" onChange={() => {}} />\n`;
+    const verdict = rawInputVerdict("VoiceProfileSection.tsx", extra);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.ok ? "" : verdict.message).toContain(
+      "has 2 raw <Input occurrence(s); the ratchet allows 1",
+    );
+  });
+
+  it("fails when a new settings file introduces a raw <Input", () => {
+    const verdict = rawInputVerdict(
+      "NewSettingsSection.tsx",
+      '<Input value="" onChange={() => {}} />',
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.ok ? "" : verdict.message).toContain(
+      "has 1 raw <Input occurrence(s)",
+    );
   });
 });

--- a/packages/ui/src/components/settings/no-raw-select.test.ts
+++ b/packages/ui/src/components/settings/no-raw-select.test.ts
@@ -1,8 +1,8 @@
 /**
- * Static source-scan guard: labelled settings selects must use
- * SettingsSelectRow instead of a hand-rolled SettingsRow/Label + Select.
- * Reads files off disk — no render. Remaining raw Select sites are an
- * explicit allowlist for compact/custom forms.
+ * Occurrence ratchet for raw `<Select` in the settings surface. A labelled
+ * settings select must use SettingsSelectRow. Remaining raw Select sites are
+ * recorded by exact count so an extra occurrence in an already-known file
+ * fails. Reads files off disk — no render.
  */
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
@@ -12,26 +12,44 @@ import { describe, expect, it } from "vitest";
 const settingsRoot = resolve(import.meta.dirname);
 
 /**
- * Files that still own a raw `<Select` because they are not a 1:1 labelled
- * settings row. Adding a new file here is a product decision; the default is
- * `SettingsSelectRow`.
+ * Exact remaining raw `<Select` counts (`<Select` followed by space or `>`).
+ * Raising a count is a product decision; the default is SettingsSelectRow.
  */
-const RAW_SELECT_ALLOWLIST = new Map<string, string>([
+const RAW_SELECT_OCCURRENCES = new Map<
+  string,
+  { count: number; reason: string }
+>([
   [
     "settings-agent-rows.tsx",
-    "canonical SettingsSelectRow primitive; it is the one allowed Select owner",
+    {
+      count: 1,
+      reason:
+        "canonical SettingsSelectRow primitive; it is the one allowed Select owner",
+    },
   ],
   [
     "VaultInventoryPanel.tsx",
-    "vault add-form category picker lives in a compact custom form, not a settings row",
+    {
+      count: 1,
+      reason:
+        "vault add-form category picker lives in a compact custom form, not a settings row",
+    },
   ],
   [
     "VoiceProfileSection.tsx",
-    "inline relationship chip on the profile row, not a labelled settings select",
+    {
+      count: 1,
+      reason:
+        "inline relationship chip on the profile row, not a labelled settings select",
+    },
   ],
   [
     "vault-tabs/RoutingTab.tsx",
-    "routing table cells and default-profile compact picker, not labelled settings rows",
+    {
+      count: 5,
+      reason:
+        "routing table cells and default-profile compact picker, not labelled settings rows",
+    },
   ],
 ]);
 
@@ -56,35 +74,79 @@ function listTsxFiles(dir: string): string[] {
   return out;
 }
 
-describe("settings controls: no raw <Select outside the allowlist", () => {
+function countRawSelects(source: string): number {
+  return (source.match(/<Select[\s>]/g) ?? []).length;
+}
+
+function rawSelectVerdict(
+  relPath: string,
+  source: string,
+): { ok: true } | { ok: false; message: string } {
+  const count = countRawSelects(source);
+  const allowed = RAW_SELECT_OCCURRENCES.get(relPath);
+  if (!allowed) {
+    if (count === 0) return { ok: true };
+    return {
+      ok: false,
+      message:
+        `${relPath} has ${count} raw <Select occurrence(s). Use SettingsSelectRow ` +
+        `from ./settings-agent-rows, or record the exact remaining count in ` +
+        `RAW_SELECT_OCCURRENCES with a reason.`,
+    };
+  }
+  if (count !== allowed.count) {
+    return {
+      ok: false,
+      message:
+        `${relPath} has ${count} raw <Select occurrence(s); the ratchet allows ` +
+        `${allowed.count} (${allowed.reason}).`,
+    };
+  }
+  return { ok: true };
+}
+
+describe("settings controls: raw <Select occurrences are ratcheted", () => {
   const files = listTsxFiles(settingsRoot);
 
   it.each(files.map((file) => posixRelative(settingsRoot, file)))(
-    "%s uses SettingsSelectRow instead of a raw <Select, or is allowlisted",
+    "%s stays at its recorded raw <Select count",
     (relPath) => {
       const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
-      const hasRawSelect = source.includes("<Select");
-      if (!hasRawSelect) {
-        expect(RAW_SELECT_ALLOWLIST.has(relPath)).toBe(false);
-        return;
-      }
-      expect(
-        RAW_SELECT_ALLOWLIST.has(relPath),
-        `${relPath} hand-rolls a raw <Select. Use SettingsSelectRow from ` +
-          `./settings-agent-rows for labelled settings selects. If this file ` +
-          `is not a settings select row, add it to RAW_SELECT_ALLOWLIST with a reason.`,
-      ).toBe(true);
+      const verdict = rawSelectVerdict(relPath, source);
+      expect(verdict.ok, !verdict.ok ? verdict.message : undefined).toBe(true);
     },
   );
 
-  it("documents a reason for every allowlisted raw Select file", () => {
-    for (const [relPath, reason] of RAW_SELECT_ALLOWLIST) {
-      expect(reason.trim().length).toBeGreaterThan(8);
+  it("documents a reason and exact count for every recorded file", () => {
+    for (const [relPath, entry] of RAW_SELECT_OCCURRENCES) {
+      expect(entry.reason.trim().length).toBeGreaterThan(8);
+      expect(entry.count).toBeGreaterThan(0);
       const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
-      expect(
-        source.includes("<Select"),
-        `${relPath} is allowlisted but no longer contains <Select; remove it from the allowlist`,
-      ).toBe(true);
+      expect(countRawSelects(source)).toBe(entry.count);
     }
+  });
+
+  it("fails when an already-recorded file gains another raw <Select", () => {
+    const source = readFileSync(
+      resolve(settingsRoot, "VoiceProfileSection.tsx"),
+      "utf8",
+    );
+    const extra = `${source}\n<Select value="" onValueChange={() => {}} />\n`;
+    const verdict = rawSelectVerdict("VoiceProfileSection.tsx", extra);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.ok ? "" : verdict.message).toContain(
+      "has 2 raw <Select occurrence(s); the ratchet allows 1",
+    );
+  });
+
+  it("fails when a new settings file introduces a raw <Select", () => {
+    const verdict = rawSelectVerdict(
+      "NewSettingsSection.tsx",
+      '<Select value="" onValueChange={() => {}} />',
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.ok ? "" : verdict.message).toContain(
+      "has 1 raw <Select occurrence(s)",
+    );
   });
 });

--- a/packages/ui/src/components/settings/no-raw-select.test.ts
+++ b/packages/ui/src/components/settings/no-raw-select.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Static source-scan guard: labelled settings selects must use
+ * SettingsSelectRow instead of a hand-rolled SettingsRow/Label + Select.
+ * Reads files off disk — no render. Remaining raw Select sites are an
+ * explicit allowlist for compact/custom forms.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const settingsRoot = resolve(import.meta.dirname);
+
+/**
+ * Files that still own a raw `<Select` because they are not a 1:1 labelled
+ * settings row. Adding a new file here is a product decision; the default is
+ * `SettingsSelectRow`.
+ */
+const RAW_SELECT_ALLOWLIST = new Map<string, string>([
+  [
+    "settings-agent-rows.tsx",
+    "canonical SettingsSelectRow primitive; it is the one allowed Select owner",
+  ],
+  [
+    "VaultInventoryPanel.tsx",
+    "vault add-form category picker lives in a compact custom form, not a settings row",
+  ],
+  [
+    "VoiceProfileSection.tsx",
+    "inline relationship chip on the profile row, not a labelled settings select",
+  ],
+  [
+    "vault-tabs/RoutingTab.tsx",
+    "routing table cells and default-profile compact picker, not labelled settings rows",
+  ],
+]);
+
+function posixRelative(from: string, to: string): string {
+  return relative(from, to).replaceAll("\\", "/");
+}
+
+function listTsxFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      out.push(...listTsxFiles(full));
+    } else if (
+      name.endsWith(".tsx") &&
+      !name.endsWith(".test.tsx") &&
+      !name.endsWith(".stories.tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("settings controls: no raw <Select outside the allowlist", () => {
+  const files = listTsxFiles(settingsRoot);
+
+  it.each(files.map((file) => posixRelative(settingsRoot, file)))(
+    "%s uses SettingsSelectRow instead of a raw <Select, or is allowlisted",
+    (relPath) => {
+      const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
+      const hasRawSelect = source.includes("<Select");
+      if (!hasRawSelect) {
+        expect(RAW_SELECT_ALLOWLIST.has(relPath)).toBe(false);
+        return;
+      }
+      expect(
+        RAW_SELECT_ALLOWLIST.has(relPath),
+        `${relPath} hand-rolls a raw <Select. Use SettingsSelectRow from ` +
+          `./settings-agent-rows for labelled settings selects. If this file ` +
+          `is not a settings select row, add it to RAW_SELECT_ALLOWLIST with a reason.`,
+      ).toBe(true);
+    },
+  );
+
+  it("documents a reason for every allowlisted raw Select file", () => {
+    for (const [relPath, reason] of RAW_SELECT_ALLOWLIST) {
+      expect(reason.trim().length).toBeGreaterThan(8);
+      const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
+      expect(
+        source.includes("<Select"),
+        `${relPath} is allowlisted but no longer contains <Select; remove it from the allowlist`,
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/ui/src/components/settings/no-raw-switch.test.ts
+++ b/packages/ui/src/components/settings/no-raw-switch.test.ts
@@ -1,7 +1,8 @@
 /**
- * Static source-scan guard: boolean settings rows must use SettingsSwitchRow
- * instead of a hand-rolled SettingsRow + Switch. Reads files off disk — no
- * render. Remaining raw Switch sites are an explicit, documented allowlist.
+ * Occurrence ratchet for raw `<Switch` in the settings surface. A labelled
+ * boolean settings row must use SettingsSwitchRow. Remaining raw Switch sites
+ * are recorded by exact count so an extra occurrence in an already-known file
+ * fails. Reads files off disk — no render.
  */
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
@@ -11,30 +12,51 @@ import { describe, expect, it } from "vitest";
 const settingsRoot = resolve(import.meta.dirname);
 
 /**
- * Files that still own a raw `<Switch` because they are not a 1:1 labelled
- * settings row. Adding a new file here is a product decision; the default is
- * `SettingsSwitchRow` so the toggle is themed, 44px-touch, and agent-addressable.
+ * Exact remaining raw `<Switch` counts. Raising a count is a product decision;
+ * the default is SettingsSwitchRow.
  */
-const RAW_SWITCH_ALLOWLIST = new Map<string, string>([
+const RAW_SWITCH_OCCURRENCES = new Map<
+  string,
+  { count: number; reason: string }
+>([
   [
     "settings-agent-rows.tsx",
-    "canonical SettingsSwitchRow primitive; it is the one allowed Switch owner",
+    {
+      count: 1,
+      reason:
+        "canonical SettingsSwitchRow primitive; it is the one allowed Switch owner",
+    },
   ],
   [
     "AdvancedToggle.tsx",
-    "compact inline disclosure control, not a labelled settings row",
+    {
+      count: 1,
+      reason: "compact inline disclosure control, not a labelled settings row",
+    },
   ],
   [
     "ConnectorsSection.tsx",
-    "standalone enable switch on a custom connector card, not a SettingsRow",
+    {
+      count: 1,
+      reason:
+        "standalone enable switch on a custom connector card, not a SettingsRow",
+    },
   ],
   [
     "VoiceConfigView.tsx",
-    "compact enable switch inside a custom status chip, not a SettingsRow",
+    {
+      count: 1,
+      reason:
+        "compact enable switch inside a custom status chip, not a SettingsRow",
+    },
   ],
   [
     "permission-controls.tsx",
-    "compound permission rows mix badges with Switch or Button trailing controls",
+    {
+      count: 2,
+      reason:
+        "compound permission rows mix badges with Switch or Button trailing controls",
+    },
   ],
 ]);
 
@@ -59,35 +81,79 @@ function listTsxFiles(dir: string): string[] {
   return out;
 }
 
-describe("settings controls: no raw <Switch outside the allowlist", () => {
+function countRawSwitches(source: string): number {
+  return (source.match(/<Switch[\s>]/g) ?? []).length;
+}
+
+function rawSwitchVerdict(
+  relPath: string,
+  source: string,
+): { ok: true } | { ok: false; message: string } {
+  const count = countRawSwitches(source);
+  const allowed = RAW_SWITCH_OCCURRENCES.get(relPath);
+  if (!allowed) {
+    if (count === 0) return { ok: true };
+    return {
+      ok: false,
+      message:
+        `${relPath} has ${count} raw <Switch occurrence(s). Use SettingsSwitchRow ` +
+        `from ./settings-agent-rows, or record the exact remaining count in ` +
+        `RAW_SWITCH_OCCURRENCES with a reason.`,
+    };
+  }
+  if (count !== allowed.count) {
+    return {
+      ok: false,
+      message:
+        `${relPath} has ${count} raw <Switch occurrence(s); the ratchet allows ` +
+        `${allowed.count} (${allowed.reason}).`,
+    };
+  }
+  return { ok: true };
+}
+
+describe("settings controls: raw <Switch occurrences are ratcheted", () => {
   const files = listTsxFiles(settingsRoot);
 
   it.each(files.map((file) => posixRelative(settingsRoot, file)))(
-    "%s uses SettingsSwitchRow instead of a raw <Switch, or is allowlisted",
+    "%s stays at its recorded raw <Switch count",
     (relPath) => {
       const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
-      const hasRawSwitch = source.includes("<Switch");
-      if (!hasRawSwitch) {
-        expect(RAW_SWITCH_ALLOWLIST.has(relPath)).toBe(false);
-        return;
-      }
-      expect(
-        RAW_SWITCH_ALLOWLIST.has(relPath),
-        `${relPath} hand-rolls a raw <Switch. Use SettingsSwitchRow from ` +
-          `./settings-agent-rows for labelled boolean settings. If this file is ` +
-          `not a settings row, add it to RAW_SWITCH_ALLOWLIST with a reason.`,
-      ).toBe(true);
+      const verdict = rawSwitchVerdict(relPath, source);
+      expect(verdict.ok, !verdict.ok ? verdict.message : undefined).toBe(true);
     },
   );
 
-  it("documents a reason for every allowlisted raw Switch file", () => {
-    for (const [relPath, reason] of RAW_SWITCH_ALLOWLIST) {
-      expect(reason.trim().length).toBeGreaterThan(8);
+  it("documents a reason and exact count for every recorded file", () => {
+    for (const [relPath, entry] of RAW_SWITCH_OCCURRENCES) {
+      expect(entry.reason.trim().length).toBeGreaterThan(8);
+      expect(entry.count).toBeGreaterThan(0);
       const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
-      expect(
-        source.includes("<Switch"),
-        `${relPath} is allowlisted but no longer contains <Switch; remove it from the allowlist`,
-      ).toBe(true);
+      expect(countRawSwitches(source)).toBe(entry.count);
     }
+  });
+
+  it("fails when an already-recorded file gains another raw <Switch", () => {
+    const source = readFileSync(
+      resolve(settingsRoot, "AdvancedToggle.tsx"),
+      "utf8",
+    );
+    const extra = `${source}\n<Switch checked={false} onCheckedChange={() => {}} />\n`;
+    const verdict = rawSwitchVerdict("AdvancedToggle.tsx", extra);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.ok ? "" : verdict.message).toContain(
+      "has 2 raw <Switch occurrence(s); the ratchet allows 1",
+    );
+  });
+
+  it("fails when a new settings file introduces a raw <Switch", () => {
+    const verdict = rawSwitchVerdict(
+      "NewSettingsSection.tsx",
+      "<Switch checked={false} onCheckedChange={() => {}} />",
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.ok ? "" : verdict.message).toContain(
+      "has 1 raw <Switch occurrence(s)",
+    );
   });
 });

--- a/packages/ui/src/components/settings/no-raw-switch.test.ts
+++ b/packages/ui/src/components/settings/no-raw-switch.test.ts
@@ -38,6 +38,10 @@ const RAW_SWITCH_ALLOWLIST = new Map<string, string>([
   ],
 ]);
 
+function posixRelative(from: string, to: string): string {
+  return relative(from, to).replaceAll("\\", "/");
+}
+
 function listTsxFiles(dir: string): string[] {
   const out: string[] = [];
   for (const name of readdirSync(dir)) {
@@ -58,7 +62,7 @@ function listTsxFiles(dir: string): string[] {
 describe("settings controls: no raw <Switch outside the allowlist", () => {
   const files = listTsxFiles(settingsRoot);
 
-  it.each(files.map((file) => relative(settingsRoot, file)))(
+  it.each(files.map((file) => posixRelative(settingsRoot, file)))(
     "%s uses SettingsSwitchRow instead of a raw <Switch, or is allowlisted",
     (relPath) => {
       const source = readFileSync(resolve(settingsRoot, relPath), "utf8");

--- a/packages/ui/src/components/settings/settings-agent-rows.tsx
+++ b/packages/ui/src/components/settings/settings-agent-rows.tsx
@@ -375,6 +375,8 @@ export interface SettingsInputRowProps {
   group?: string;
   /** Marks the field invalid for assistive tech and danger styling. */
   invalid?: boolean;
+  /** Validation error announced below the field. Implies invalid. */
+  error?: React.ReactNode;
   /** Optional stable test id applied to the input. */
   testId?: string;
   className?: string;
@@ -399,20 +401,30 @@ export function SettingsInputRow({
   disabled = false,
   group = "settings",
   invalid = false,
+  error,
   testId,
   className,
   inputClassName,
 }: SettingsInputRowProps) {
   const resolvedLabel = agentLabel ?? labelToString(label, agentId);
+  const showError = Boolean(error);
+  const isInvalid = invalid || showError;
+  const errorId = `${agentId}-error`;
   const { ref, agentProps } = useAgentElement<HTMLInputElement>({
     id: agentId,
     role: type === "number" ? "number-input" : "text-input",
     label: resolvedLabel,
     group,
-    description: typeof description === "string" ? description : undefined,
+    description:
+      typeof error === "string"
+        ? error
+        : typeof description === "string"
+          ? description
+          : undefined,
     getValue: () => value,
     onFill: disabled ? undefined : (next: string) => onValueChange(next),
   });
+  const { "aria-label": _ignoredAccessibleName, ...rowAgentProps } = agentProps;
 
   return (
     <SettingsRow
@@ -435,12 +447,17 @@ export function SettingsInputRow({
         inputMode={inputMode}
         autoComplete={autoComplete}
         disabled={disabled}
-        aria-invalid={invalid || undefined}
-        aria-label={resolvedLabel}
+        aria-invalid={isInvalid || undefined}
+        aria-describedby={showError ? errorId : undefined}
         data-testid={testId}
-        className={cn(invalid && "border-danger", inputClassName)}
-        {...agentProps}
+        className={cn(isInvalid && "border-danger", inputClassName)}
+        {...rowAgentProps}
       />
+      {showError ? (
+        <p id={errorId} role="alert" className="mt-1 text-xs text-danger">
+          {error}
+        </p>
+      ) : null}
     </SettingsRow>
   );
 }

--- a/packages/ui/src/components/settings/settings-agent-rows.tsx
+++ b/packages/ui/src/components/settings/settings-agent-rows.tsx
@@ -16,7 +16,14 @@ import * as React from "react";
 import { useAgentElement } from "../../agent-surface";
 import { cn } from "../../lib/utils";
 import { Button, type ButtonProps } from "../ui/button";
-import { Select, SelectContent, SelectItem, SelectValue } from "../ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectValue,
+} from "../ui/select";
 import {
   SettingsInput,
   type SettingsInputVariant,
@@ -103,6 +110,14 @@ export function SettingsSwitchRow({
 export interface SettingsSelectRowOption {
   value: string;
   label: React.ReactNode;
+  hint?: string;
+  /** Plain-text typeahead value. Defaults to a string label; omitted for JSX. */
+  textValue?: string;
+}
+
+export interface SettingsSelectRowGroup {
+  label: string;
+  items: SettingsSelectRowOption[];
 }
 
 export interface SettingsSelectRowProps {
@@ -114,11 +129,46 @@ export interface SettingsSelectRowProps {
   iconClassName?: string;
   value: string;
   onValueChange: (value: string) => void;
-  options: SettingsSelectRowOption[];
+  options?: SettingsSelectRowOption[];
+  groups?: SettingsSelectRowGroup[];
   placeholder?: string;
   disabled?: boolean;
   group?: string;
   triggerClassName?: string;
+  contentClassName?: string;
+  /** Trailing control kept with the select (preview, merge, etc.). */
+  trailing?: React.ReactNode;
+  /** Stack the trailing control under the select until `sm`. */
+  trailingStackUntilSm?: boolean;
+  testId?: string;
+}
+
+function flattenSelectOptions(
+  options: SettingsSelectRowOption[] | undefined,
+  groups: SettingsSelectRowGroup[] | undefined,
+): SettingsSelectRowOption[] {
+  if (groups && groups.length > 0) {
+    return groups.flatMap((group) => group.items);
+  }
+  return options ?? [];
+}
+
+function renderSelectOption(option: SettingsSelectRowOption) {
+  const textValue =
+    option.textValue ??
+    (typeof option.label === "string" ? option.label : undefined);
+  return (
+    <SelectItem key={option.value} value={option.value} textValue={textValue}>
+      {option.hint ? (
+        <div className="flex w-full items-center justify-between gap-2">
+          <span className="font-semibold">{option.label}</span>
+          <span className="text-muted text-xs">{option.hint}</span>
+        </div>
+      ) : (
+        option.label
+      )}
+    </SelectItem>
+  );
 }
 
 export function SettingsSelectRow({
@@ -131,12 +181,18 @@ export function SettingsSelectRow({
   value,
   onValueChange,
   options,
+  groups,
   placeholder,
   disabled = false,
   group = "settings",
   triggerClassName,
+  contentClassName,
+  trailing,
+  trailingStackUntilSm = false,
+  testId,
 }: SettingsSelectRowProps) {
   const resolvedLabel = agentLabel ?? labelToString(label, agentId);
+  const flattened = flattenSelectOptions(options, groups);
   const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
     id: agentId,
     role: "select",
@@ -144,10 +200,38 @@ export function SettingsSelectRow({
     group,
     description: typeof description === "string" ? description : undefined,
     status: value || undefined,
-    options: options.map((option) => option.value),
+    options: flattened.map((option) => option.value),
     getValue: () => value,
     onFill: disabled ? undefined : (next: string) => onValueChange(next),
   });
+
+  const select = (
+    <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+      <SettingsSelectTrigger
+        ref={ref}
+        id={agentId}
+        variant="touch"
+        className={cn(trailing && "min-w-0 flex-1", triggerClassName)}
+        aria-label={resolvedLabel}
+        data-testid={testId}
+        {...agentProps}
+      >
+        <SelectValue placeholder={placeholder} />
+      </SettingsSelectTrigger>
+      <SelectContent className={contentClassName}>
+        {groups && groups.length > 0
+          ? groups.map((optionGroup) => (
+              <SelectGroup key={optionGroup.label}>
+                <SelectLabel className="px-2.5 py-1 text-2xs font-semibold text-muted">
+                  {optionGroup.label}
+                </SelectLabel>
+                {optionGroup.items.map(renderSelectOption)}
+              </SelectGroup>
+            ))
+          : flattened.map(renderSelectOption)}
+      </SelectContent>
+    </Select>
+  );
 
   return (
     <SettingsRow
@@ -155,26 +239,23 @@ export function SettingsSelectRow({
       iconClassName={iconClassName}
       label={label}
       description={description}
+      htmlFor={agentId}
       stacked
     >
-      <Select value={value} onValueChange={onValueChange} disabled={disabled}>
-        <SettingsSelectTrigger
-          ref={ref}
-          variant="touch"
-          className={triggerClassName}
-          aria-label={resolvedLabel}
-          {...agentProps}
+      {trailing ? (
+        <div
+          className={
+            trailingStackUntilSm
+              ? "grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end"
+              : "flex items-center gap-2"
+          }
         >
-          <SelectValue placeholder={placeholder} />
-        </SettingsSelectTrigger>
-        <SelectContent>
-          {options.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+          {select}
+          {trailing}
+        </div>
+      ) : (
+        select
+      )}
     </SettingsRow>
   );
 }

--- a/packages/ui/src/components/settings/settings-agent-rows.tsx
+++ b/packages/ui/src/components/settings/settings-agent-rows.tsx
@@ -204,6 +204,8 @@ export function SettingsSelectRow({
     getValue: () => value,
     onFill: disabled ? undefined : (next: string) => onValueChange(next),
   });
+  const { "aria-label": _ignoredSelectAccessibleName, ...selectAgentProps } =
+    agentProps;
 
   const select = (
     <Select value={value} onValueChange={onValueChange} disabled={disabled}>
@@ -212,9 +214,8 @@ export function SettingsSelectRow({
         id={agentId}
         variant="touch"
         className={cn(trailing && "min-w-0 flex-1", triggerClassName)}
-        aria-label={resolvedLabel}
         data-testid={testId}
-        {...agentProps}
+        {...selectAgentProps}
       >
         <SelectValue placeholder={placeholder} />
       </SettingsSelectTrigger>

--- a/packages/ui/src/components/settings/settings-agent-rows.tsx
+++ b/packages/ui/src/components/settings/settings-agent-rows.tsx
@@ -292,6 +292,10 @@ export interface SettingsInputRowProps {
   variant?: SettingsInputVariant;
   disabled?: boolean;
   group?: string;
+  /** Marks the field invalid for assistive tech and danger styling. */
+  invalid?: boolean;
+  /** Optional stable test id applied to the input. */
+  testId?: string;
   className?: string;
   inputClassName?: string;
 }
@@ -313,6 +317,8 @@ export function SettingsInputRow({
   variant = "touch",
   disabled = false,
   group = "settings",
+  invalid = false,
+  testId,
   className,
   inputClassName,
 }: SettingsInputRowProps) {
@@ -334,10 +340,12 @@ export function SettingsInputRow({
       label={label}
       description={description}
       className={className}
+      htmlFor={agentId}
       stacked
     >
       <SettingsInput
         ref={ref}
+        id={agentId}
         variant={variant}
         type={type}
         value={value}
@@ -346,8 +354,10 @@ export function SettingsInputRow({
         inputMode={inputMode}
         autoComplete={autoComplete}
         disabled={disabled}
+        aria-invalid={invalid || undefined}
         aria-label={resolvedLabel}
-        className={inputClassName}
+        data-testid={testId}
+        className={cn(invalid && "border-danger", inputClassName)}
         {...agentProps}
       />
     </SettingsRow>

--- a/packages/ui/src/components/settings/settings-layout.test.tsx
+++ b/packages/ui/src/components/settings/settings-layout.test.tsx
@@ -122,17 +122,44 @@ describe("agent-addressable rows", () => {
         type="password"
         value=""
         onValueChange={onValueChange}
-        invalid
+        testId="security-password-new-input"
       />,
     );
     const input = screen.getByLabelText("New password");
     expect(input.getAttribute("data-agent-id")).toBe("security-password-new");
     expect(input.getAttribute("data-agent-role")).toBe("text-input");
     expect(input.getAttribute("id")).toBe("security-password-new");
-    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(input.getAttribute("data-testid")).toBe(
+      "security-password-new-input",
+    );
+    expect(input.getAttribute("aria-label")).toBeNull();
     expect(screen.getByText("New password").tagName).toBe("LABEL");
+    expect(screen.getByText("New password").getAttribute("for")).toBe(
+      "security-password-new",
+    );
     fireEvent.change(input, { target: { value: "abcdefghijkl" } });
     expect(onValueChange).toHaveBeenCalledWith("abcdefghijkl");
+  });
+
+  it("SettingsInputRow announces a validation error below the field", () => {
+    render(
+      <SettingsInputRow
+        agentId="security-password-confirm"
+        label="Confirm new password"
+        type="password"
+        value="nope"
+        onValueChange={() => {}}
+        error="Passwords do not match."
+      />,
+    );
+    const input = screen.getByLabelText("Confirm new password");
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toBe("Passwords do not match.");
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(input.getAttribute("aria-describedby")).toBe(
+      "security-password-confirm-error",
+    );
+    expect(alert.className).toContain("text-danger");
   });
 
   it("SettingsSelectRow registers as an agent-addressable select", () => {

--- a/packages/ui/src/components/settings/settings-layout.test.tsx
+++ b/packages/ui/src/components/settings/settings-layout.test.tsx
@@ -179,7 +179,26 @@ describe("agent-addressable rows", () => {
     expect(trigger.getAttribute("data-agent-id")).toBe("pick-theme");
     expect(trigger.getAttribute("data-agent-role")).toBe("select");
     expect(trigger.getAttribute("id")).toBe("pick-theme");
+    expect(trigger.getAttribute("aria-label")).toBeNull();
     expect(screen.getByText("Theme").tagName).toBe("LABEL");
+    expect(screen.getByText("Theme").getAttribute("for")).toBe("pick-theme");
+  });
+
+  it("SettingsSelectRow keeps the visible label as the accessible name", () => {
+    render(
+      <SettingsSelectRow
+        agentId="identity-voice"
+        label="Voice"
+        agentLabel="Agent voice preset"
+        value="alloy"
+        onValueChange={() => {}}
+        options={[{ value: "alloy", label: "Alloy" }]}
+      />,
+    );
+    const trigger = screen.getByLabelText("Voice");
+    expect(trigger.getAttribute("data-agent-label")).toBe("Agent voice preset");
+    expect(trigger.getAttribute("aria-label")).toBeNull();
+    expect(screen.queryByLabelText("Agent voice preset")).toBeNull();
   });
 
   it("SettingsSelectRow renders grouped options and a trailing control", () => {

--- a/packages/ui/src/components/settings/settings-layout.test.tsx
+++ b/packages/ui/src/components/settings/settings-layout.test.tsx
@@ -9,7 +9,11 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { Bell } from "lucide-react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { SettingsSelectRow, SettingsSwitchRow } from "./settings-agent-rows";
+import {
+  SettingsInputRow,
+  SettingsSelectRow,
+  SettingsSwitchRow,
+} from "./settings-agent-rows";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
 
 afterEach(() => cleanup());
@@ -107,6 +111,28 @@ describe("agent-addressable rows", () => {
       "Toggle push notifications",
     );
     expect(sw).toHaveProperty("disabled", true);
+  });
+
+  it("SettingsInputRow labels the field and exposes agent data attributes", () => {
+    const onValueChange = vi.fn();
+    render(
+      <SettingsInputRow
+        agentId="security-password-new"
+        label="New password"
+        type="password"
+        value=""
+        onValueChange={onValueChange}
+        invalid
+      />,
+    );
+    const input = screen.getByLabelText("New password");
+    expect(input.getAttribute("data-agent-id")).toBe("security-password-new");
+    expect(input.getAttribute("data-agent-role")).toBe("text-input");
+    expect(input.getAttribute("id")).toBe("security-password-new");
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(screen.getByText("New password").tagName).toBe("LABEL");
+    fireEvent.change(input, { target: { value: "abcdefghijkl" } });
+    expect(onValueChange).toHaveBeenCalledWith("abcdefghijkl");
   });
 
   it("SettingsSelectRow registers as an agent-addressable select", () => {

--- a/packages/ui/src/components/settings/settings-layout.test.tsx
+++ b/packages/ui/src/components/settings/settings-layout.test.tsx
@@ -151,5 +151,32 @@ describe("agent-addressable rows", () => {
     const trigger = screen.getByLabelText("Theme");
     expect(trigger.getAttribute("data-agent-id")).toBe("pick-theme");
     expect(trigger.getAttribute("data-agent-role")).toBe("select");
+    expect(trigger.getAttribute("id")).toBe("pick-theme");
+    expect(screen.getByText("Theme").tagName).toBe("LABEL");
+  });
+
+  it("SettingsSelectRow renders grouped options and a trailing control", () => {
+    render(
+      <SettingsSelectRow
+        agentId="identity-voice"
+        label="Voice"
+        value="alloy"
+        onValueChange={() => {}}
+        groups={[
+          {
+            label: "Premade",
+            items: [
+              { value: "alloy", label: "Alloy", hint: "fast" },
+              { value: "verse", label: "Verse" },
+            ],
+          },
+        ]}
+        trailing={<button type="button">Preview</button>}
+        testId="identity-voice-trigger"
+      />,
+    );
+    const trigger = screen.getByTestId("identity-voice-trigger");
+    expect(trigger.getAttribute("data-agent-id")).toBe("identity-voice");
+    expect(screen.getByText("Preview")).toBeTruthy();
   });
 });


### PR DESCRIPTION
# Relates to

Closes #19149
Closes #19154

Follow-up to #19146.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Behaviour-preserving reuse of the existing `SettingsInputRow` primitive.
Remaining custom Input owners stay on an explicit allowlist. A false-positive
source-scan failure is the main regression risk if a new non-row Input is added
without updating that allowlist.

# Background

## What does this PR do?

A static scan of the settings dashboard found 1:1 labelled `Label + Input`
fields that reimplemented `SettingsInputRow`. This PR routes the Security
remote-password fields and Voice Profile bind fields through the primitive,
keeps the label/`htmlFor` association, adds `invalid` / `testId` support, and
adds a disk source-scan gate so new labelled text fields cannot re-hand-roll
`<Input`.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

No.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:4a44f1be0886526351941ec568de72c2a23e4c0c -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19150-before-fullpage.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19150-after-fullpage.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19150-fullpage-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or API path is changed; auth/session calls are unchanged.
<!-- evidence-row:frontend-logs -->
- [x] [19150-fullpage-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19150-fullpage-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows, memories, schedules, wallet records, audio, or generated domain artifacts are changed.
<!-- evidence-row:ocr-review -->
- [x] [19150-fullpage-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19150-fullpage-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Backend + frontend logs

N/A - no backend path is changed. Focused UI tests are the source-of-truth
measurement for this reuse change; isolated capture is being attached after
open.

## Screenshots (before / after) + video walkthrough

Matching full-page Settings captures from the packaged app smoke harness:

- Before (`origin/develop@0e98b198f3`): Security rest/error + Voice bind editor, desktop 1440x1000 and mobile 390x844.
- After (`5b049a05cb`): same surfaces, same viewports, same fixture data.
- Walkthrough: rest → password mismatch → Voice bind editor on desktop then mobile.

`bun run --cwd packages/app audit:app:capture` completed on this branch (219 passed; `broken=0`, `needs-work=0`). The all-views audit records the Settings hub; the section-level Security/Voice frames above are the exact-head application evidence for the changed rows.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT path is changed.

## Known gaps / failures

- Full-repo `bun run verify` was not run in this worktree. Focused package
  checks after rebase onto `origin/develop@0e98b198f3`:
  - `bun run --cwd packages/ui test` on
    `settings-layout.test.tsx`, `no-raw-select.test.ts`,
    `no-raw-labelled-input.test.ts`, `VoiceProfileSection.test.tsx` — 4 files,
    123 tests passed.
  - `bunx biome check` on the touched settings files — clean.
  - `ELIZA_NODE_PATH=/opt/homebrew/opt/node@24/bin/node bun run --cwd packages/app audit:app:capture` — 219 passed.

— [pi-grok]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza"} -->





















