### PR TITLE
fix(ui): use fresh steward token for tier repair after refresh

### DIFF
--- a/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
@@ -127,7 +127,7 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     localStorage.setItem(STEWARD_TOKEN_KEY, nearExpiry);
     const fresh = makeJwt(3600);
     // …and a MISSING apiBase forces the backfill, which derives the dedicated
-    // `<agentId>.elizacloud.ai` base purely from the persisted id.
+    // `<agentId>.cloud.eliza.app` base purely from the persisted id.
     const restored: PersistedActiveServer = {
       id: `cloud:${AGENT_ID}`,
       kind: "cloud",
@@ -156,7 +156,7 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     expect(clientRef.setToken).toHaveBeenNthCalledWith(1, null);
     expect(clientRef.setToken).toHaveBeenLastCalledWith(nearExpiry);
     expect(clientRef.setBaseUrl).toHaveBeenLastCalledWith(
-      `https://${AGENT_ID}.elizacloud.ai`,
+      `https://${AGENT_ID}.cloud.eliza.app`,
     );
     expect(clientRef.setToken.mock.invocationCallOrder[0]).toBeLessThan(
       clientRef.setBaseUrl.mock.invocationCallOrder[0] as number,
@@ -181,8 +181,10 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     expect(clientRef.setToken).toHaveBeenLastCalledWith(fresh);
   });
 
-  it("preserves a shared adapter regardless of the dedicated-create default", async () => {
-    const sharedApiBase = `https://api.elizacloud.ai/api/v1/eliza/agents/${SHARED_AGENT_ID}`;
+  it("preserves a shared adapter with account authority regardless of the create default", async () => {
+    const stewardToken = makeJwt(3600);
+    localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken);
+    const sharedApiBase = `https://api.eliza.app/api/v1/eliza/agents/${SHARED_AGENT_ID}`;
     const restored: PersistedActiveServer = {
       id: `cloud:${SHARED_AGENT_ID}`,
       kind: "cloud",
@@ -197,7 +199,7 @@ describe("cloud restore routes the client without waiting on the Steward refresh
       clientRef: dedicatedClient,
     });
     expect(dedicatedClient.setBaseUrl).toHaveBeenCalledWith(sharedApiBase);
-    expect(dedicatedClient.setToken).toHaveBeenCalledWith("paired-token");
+    expect(dedicatedClient.setToken).toHaveBeenLastCalledWith(stewardToken);
 
     setBootConfig({ ...DEFAULT_BOOT_CONFIG, preferSharedCloudTier: true });
     const sharedClient = { setBaseUrl: vi.fn(), setToken: vi.fn() };
@@ -206,14 +208,16 @@ describe("cloud restore routes the client without waiting on the Steward refresh
       clientRef: sharedClient,
     });
     expect(sharedClient.setBaseUrl).toHaveBeenCalledWith(sharedApiBase);
-    expect(sharedClient.setToken).toHaveBeenCalledWith("paired-token");
+    expect(sharedClient.setToken).toHaveBeenLastCalledWith(stewardToken);
   });
 
-  it("keeps a staging shared adapter on the staging control plane", async () => {
+  it("canonicalizes a legacy staging shared adapter on the staging control plane", async () => {
     setBootConfig({
       ...DEFAULT_BOOT_CONFIG,
       cloudApiBase: "https://staging.elizacloud.ai",
     });
+    const stewardToken = makeJwt(3600);
+    localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken);
     const restored: PersistedActiveServer = {
       id: `cloud:${STAGING_AGENT_ID}`,
       kind: "cloud",
@@ -229,9 +233,9 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     });
 
     expect(clientRef.setBaseUrl).toHaveBeenCalledWith(
-      `https://api-staging.elizacloud.ai/api/v1/eliza/agents/${STAGING_AGENT_ID}`,
+      `https://api-staging.eliza.app/api/v1/eliza/agents/${STAGING_AGENT_ID}`,
     );
-    expect(clientRef.setToken).toHaveBeenCalledWith("paired-token");
+    expect(clientRef.setToken).toHaveBeenLastCalledWith(stewardToken);
   });
 
   it("repairs a legacy dedicated-looking staging base when the owner record is shared", async () => {
@@ -262,7 +266,7 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api-staging.elizacloud.ai/api/v1/eliza/agents/${SHARED_AGENT_ID}`,
+      `https://api-staging.eliza.app/api/v1/eliza/agents/${SHARED_AGENT_ID}`,
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: `Bearer ${stewardToken}`,
@@ -271,11 +275,136 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     );
     await vi.waitFor(() => {
       expect(clientRef.setBaseUrl).toHaveBeenLastCalledWith(
-        `https://api-staging.elizacloud.ai/api/v1/eliza/agents/${SHARED_AGENT_ID}`,
+        `https://api-staging.eliza.app/api/v1/eliza/agents/${SHARED_AGENT_ID}`,
       );
       expect(clientRef.setToken).toHaveBeenLastCalledWith(stewardToken);
     });
     expect(clientRef.setToken).toHaveBeenCalledWith(stewardToken);
+  });
+
+  it("uses the refreshed Steward token for legacy tier repair", async () => {
+    bridgeMock.isElectrobunRuntime.mockReturnValue(false);
+    const expired = makeJwt(-60);
+    const fresh = makeJwt(3600);
+    localStorage.setItem(STEWARD_TOKEN_KEY, expired);
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      if (url.includes("steward-refresh")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ token: fresh }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          data: { executionTier: "shared" },
+        }),
+      } as Response;
+    });
+    const clientRef = { setBaseUrl: vi.fn(), setToken: vi.fn() };
+
+    await applyRestoredConnection({
+      restoredActiveServer: {
+        id: `cloud:${SHARED_AGENT_ID}`,
+        kind: "cloud",
+        label: "Eliza Cloud",
+        apiBase: `https://${SHARED_AGENT_ID}.elizacloud.ai`,
+      },
+      clientRef,
+    });
+
+    await vi.waitFor(() => {
+      expect(clientRef.setBaseUrl).toHaveBeenLastCalledWith(
+        `https://api.eliza.app/api/v1/eliza/agents/${SHARED_AGENT_ID}`,
+      );
+    });
+    const tierLookup = fetchMock.mock.calls.find(([input]) =>
+      String(input).includes(`/api/v1/eliza/agents/${SHARED_AGENT_ID}`),
+    );
+    expect(tierLookup?.[1]).toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Bearer ${fresh}`,
+        }),
+      }),
+    );
+    expect(tierLookup?.[1]).not.toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Bearer ${expired}`,
+        }),
+      }),
+    );
+    expect(clientRef.setToken).toHaveBeenLastCalledWith(fresh);
+  });
+
+  it("keeps the native owner key through tier repair when Steward refresh fails", async () => {
+    bridgeMock.isElectrobunRuntime.mockReturnValue(true);
+    const nearExpiry = makeJwt(30);
+    const nativeOwnerKey = "eliza_native-owner-key";
+    localStorage.setItem(STEWARD_TOKEN_KEY, nearExpiry);
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      if (url.includes("steward-refresh")) {
+        return {
+          ok: false,
+          status: 401,
+          json: async () => ({}),
+        } as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          data: { executionTier: "shared" },
+        }),
+      } as Response;
+    });
+    const clientRef = { setBaseUrl: vi.fn(), setToken: vi.fn() };
+
+    await applyRestoredConnection({
+      restoredActiveServer: {
+        id: `cloud:${SHARED_AGENT_ID}`,
+        kind: "cloud",
+        label: "Eliza Cloud",
+        apiBase: `https://${SHARED_AGENT_ID}.elizacloud.ai`,
+        accessToken: nativeOwnerKey,
+      },
+      clientRef,
+    });
+
+    await vi.waitFor(() => {
+      expect(clientRef.setBaseUrl).toHaveBeenLastCalledWith(
+        `https://api.eliza.app/api/v1/eliza/agents/${SHARED_AGENT_ID}`,
+      );
+    });
+    const tierLookup = fetchMock.mock.calls.find(([input]) =>
+      String(input).includes(`/api/v1/eliza/agents/${SHARED_AGENT_ID}`),
+    );
+    expect(tierLookup?.[1]).toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Bearer ${nativeOwnerKey}`,
+        }),
+      }),
+    );
+    expect(clientRef.setToken).toHaveBeenLastCalledWith(nativeOwnerKey);
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
   });
 
   it("repairs a previously persisted production ingress in the staging app", async () => {
@@ -298,7 +427,7 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     });
 
     expect(clientRef.setBaseUrl).toHaveBeenCalledWith(
-      `https://${STAGING_AGENT_ID}.staging.elizacloud.ai`,
+      `https://${STAGING_AGENT_ID}.cloud-staging.eliza.app`,
     );
     expect(clientRef.setToken).toHaveBeenCalledWith("paired-token");
   });
@@ -333,7 +462,7 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     expect(clientRef.setToken).toHaveBeenCalledWith("paired-token");
   });
 
-  it("does not demote a persisted staging dedicated base under the prod boot default", async () => {
+  it("canonicalizes a legacy staging dedicated base under the prod boot default", async () => {
     setBootConfig({
       ...DEFAULT_BOOT_CONFIG,
       cloudApiBase: "https://elizacloud.ai",
@@ -353,7 +482,9 @@ describe("cloud restore routes the client without waiting on the Steward refresh
       clientRef,
     });
 
-    expect(clientRef.setBaseUrl).toHaveBeenCalledWith(stagingOrigin);
+    expect(clientRef.setBaseUrl).toHaveBeenCalledWith(
+      `https://${STAGING_AGENT_ID}.cloud-staging.eliza.app`,
+    );
     expect(clientRef.setToken).toHaveBeenCalledWith("paired-token");
   });
 });

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -129,9 +129,9 @@ function recoverCloudAgentId(active: PersistedActiveServer): string | null {
  */
 async function reconcileLegacyDedicatedCloudApiBase(
   active: PersistedActiveServer,
-  stewardToken: string | null,
+  ownerToken: string | null,
 ): Promise<PersistedActiveServer | null> {
-  if (!stewardToken || !isDedicatedCloudAgentBase(active.apiBase)) return null;
+  if (!ownerToken || !isDedicatedCloudAgentBase(active.apiBase)) return null;
   const agentId = recoverCloudAgentId(active);
   if (!agentId) return null;
   const pageHostname =
@@ -150,7 +150,7 @@ async function reconcileLegacyDedicatedCloudApiBase(
       {
         headers: {
           Accept: "application/json",
-          Authorization: `Bearer ${stewardToken}`,
+          Authorization: `Bearer ${ownerToken}`,
         },
         signal: AbortSignal.timeout(CLOUD_AGENT_TIER_PROBE_TIMEOUT_MS),
       },
@@ -514,8 +514,9 @@ export async function applyRestoredConnection(args: {
     // Environment reconciliation is synchronous. The selected target's known
     // credential is cleared before the base changes, then the selected record's
     // known credential is installed. A slower Steward refresh may replace it.
-    // Never send an agent-local paired token to the Cloud control plane. The
-    // Steward session store is the only valid credential for this owner lookup.
+    // Never send an agent-local paired token to the Cloud control plane. A
+    // refreshed Steward session, or the native host's Cloud owner key, is the
+    // valid authority for this owner lookup.
     const resolved = backfillCloudApiBase(restoredActiveServer);
     const agentId = recoverCloudAgentId(resolved);
     if (!isTrustedCloudApiBaseUrl(resolved.apiBase, agentId)) {
@@ -550,11 +551,6 @@ export async function applyRestoredConnection(args: {
     clientRef.setToken(null);
     clientRef.setBaseUrl(resolved.apiBase ?? null);
     clientRef.setToken(initialToken);
-    const tierRepairPromise = isDedicatedCloudAgentBase(
-      restoredActiveServer.apiBase,
-    )
-      ? reconcileLegacyDedicatedCloudApiBase(resolved, restoreProbeToken)
-      : Promise.resolve(null);
     let stewardTokenPromise: Promise<string | null>;
     if (nativeOwnerApiKey && restoreProbeToken) {
       const secs = cloudTokenSecsRemaining(restoreProbeToken);
@@ -604,6 +600,15 @@ export async function applyRestoredConnection(args: {
       clientRef.setBaseUrl(null);
       return;
     }
+    // The compatibility lookup must use the post-refresh authority. The stored
+    // pre-refresh JWT can be expired, while native/Electrobun restores may
+    // intentionally rely on a host-injected Cloud owner key instead.
+    const controlPlaneOwnerToken = stewardToken ?? nativeOwnerApiKey;
+    const tierRepairPromise = isDedicatedCloudAgentBase(
+      restoredActiveServer.apiBase,
+    )
+      ? reconcileLegacyDedicatedCloudApiBase(resolved, controlPlaneOwnerToken)
+      : Promise.resolve(null);
     // Dedicated agent subdomains and explicit local-Docker pair targets use an
     // agent-local bearer for `/api/*`. The edge-owned dedicated path can keep
     // its Steward recovery fallback; a loopback process must never receive a
@@ -633,7 +638,9 @@ export async function applyRestoredConnection(args: {
       savePersistedActiveServer(repaired);
       clientRef.setToken(null);
       clientRef.setBaseUrl(repaired.apiBase ?? null);
-      clientRef.setToken(stewardToken || repaired.accessToken || null);
+      // A shared adapter is a Cloud control-plane target. The same owner
+      // authority that proved the tier must remain installed after rerouting.
+      clientRef.setToken(controlPlaneOwnerToken);
     });
     return;
   }


### PR DESCRIPTION
# Relates to

Fixes #19156. This is the bounded stale-authority race in legacy dedicated-to-shared restore repair; it does not reopen the separate wrong-agent claim from #19126.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is synced with `origin/develop@e68a5744f5446d9258f665b1474edadfdb473d6c`; the one conflict in `startup-phase-restore.ts` (develop's `nativeOwnerApiKey` branch) is resolved in the merge commit.
- [ ] Root `bun run verify` was not run; exact focused gates and unrelated package-lane limitations are recorded below.
- [x] A reviewer can confirm the token-ordering and fallback behavior from deterministic network/state regressions.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`, `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@cc3df4096d33b16990590d0842e5a5fa74a12157:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact head `0819f0df82a437abd92b8993b199d5f7871d8b99` merges `origin/develop@e68a5744f5446d9258f665b1474edadfdb473d6c` into the fix commit `0819f0df82a437abd92b8993b199d5f7871d8b99`.
- The earlier "zero conflicts" note was stale: develop grew the `nativeOwnerApiKey` branch in `applyRestoredConnection`, which collides with this change's relocation of `tierRepairPromise`. Resolution keeps develop's Steward-token-promise construction intact and places `tierRepairPromise` BELOW the `isManagedCloudSharedAgentBase && !stewardToken && !nativeOwnerApiKey` early return — above it, that `return` would orphan an in-flight probe against a connection the same function just tore down.
- [x] The contributor fix was replayed over the current native/Electrobun owner-key and fail-closed restore behavior without dropping either contract.
- [ ] Root `bun run verify` was not run; see **Known gaps / failures**.

# Risks

Medium and bounded to Cloud startup restore. The change delays only the compatibility tier lookup until Steward refresh settles. It does not delay initial safe base routing, alter token issuance, change backend authorization, touch local-Docker routing, or change rendered UI. Failed/no Steward refresh retains the existing native/Electrobun owner-key fallback instead of reviving the stale JWT.

# Background

## What does this PR do?

`applyRestoredConnection` previously started `reconcileLegacyDedicatedCloudApiBase` with the pre-refresh stored JWT. An expired JWT could therefore receive a 401 even when refresh immediately produced a valid Steward token, leaving a legacy dedicated-looking base unrepaired.

The lookup now starts after refresh and receives the resolved owner authority:

- the refreshed Steward token when refresh succeeds;
- the native/Electrobun `eliza_` Cloud owner key when that is the valid fallback;
- no lookup when no valid owner authority exists.

After a shared-tier repair, the same authority that proved ownership remains installed on the rerouted client. Two regressions cover the fresh-token and failed-refresh/native-key paths. Six pre-existing assertions in the touched restore harness were updated from retired `elizacloud.ai`/provision-token expectations to the current `eliza.app` and fail-closed account-authority contracts.

## What kind of change is this?

Bug fix with deterministic regression coverage.

# Documentation changes needed?

N/A - this corrects internal restore ordering and preserves existing public contracts.

# Testing

## Where should a reviewer start?

- `packages/ui/src/state/startup-phase-restore.ts`
- `packages/ui/src/state/startup-phase-restore.concurrency.test.ts`

## Detailed testing steps

All executable PR code was run in a disposable Linux arm64 container with networking disabled, all capabilities dropped, and `no-new-privileges`, using pinned Bun 1.3.14 and trusted preinstalled dependencies.

- `vitest` restore concurrency + Steward refresh suites: **17/17 passed**.
- `bun run --cwd packages/ui typecheck`: **passed**.
- Biome on both changed files: **passed**.
- `bun run --cwd packages/ui build`: **passed**; runtime export verifier checked **46/46** exports.
- `git diff --check origin/develop...HEAD`: **passed**.

Re-run at the merge head against current `origin/develop`:

```
$ cd packages/core && node ../shared/scripts/generate-keywords.mjs
$ cd packages/ui && bunx vitest run src/state/startup-phase-restore
  Test Files  5 passed (5)
       Tests  46 passed (46)
$ bun run --cwd packages/ui typecheck
  exit 0
```

The refreshed-token regression was also confirmed to fail closed: reverting the tier-repair bearer to the pre-refresh `restoreProbeToken` reproduces the `Bearer <expired>` assertion failure.
- UI/app guide parity: `CLAUDE.md` and `AGENTS.md` hashes match in both packages.

# Evidence Gate

Evidence matches exact head `0819f0df82a437abd92b8993b199d5f7871d8b99`.
<!-- evidence-head:0819f0df82a437abd92b8993b199d5f7871d8b99 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes; the diff is startup state/network logic and tests only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered interaction or visual flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code or deployed backend path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no exact-head staging session was available; deterministic regressions record the refresh request, owner Authorization header, rerouted base, and terminal client token.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduled task, wallet, on-chain, audio, or generated domain artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changes.

## Backend + frontend logs

N/A - no deployed backend or staging browser trace was available. The two deterministic regressions fail closed and assert the exact bearer used by the owner lookup plus the final base/token state.

## Screenshots (before / after) + video walkthrough

N/A - no rendered `.tsx`, CSS, SVG, layout, copy, or interaction changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- `bun install` was not rerun; validation used the repository's pinned Bun 1.3.14 with a trusted preinstalled dependency image and rebuilt package prerequisites from exact source.
- Root `bun run verify` was not run.
- The exact-head full UI package lane was not used as a pass claim. A wider run on the behaviorally equivalent repair kept the touched restore suite green (13/13) while exposing numerous unrelated current-`develop` failures, particularly stale Cloud-host migration expectations and unrelated fixture/import debt. Exact-head focused suites, typecheck, format, and build are green.
- No exact-head staging deployment was available for a real expired-session browser trace.
- Independent current-head review and hosted CI remain required because the maintainer repair author is not self-approving or self-merging.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@cc3df4096d33b16990590d0842e5a5fa74a12157:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@cc3df4096d33b16990590d0842e5a5fa74a12157:packages/skills/skills/contribute-to-eliza"} -->
