### PR TITLE
fix(documents): normalize MIME essence before upload routing

### DIFF
--- a/packages/core/src/features/documents/index.ts
+++ b/packages/core/src/features/documents/index.ts
@@ -75,3 +75,4 @@ export {
 	fetchDocumentFromUrl,
 	isYouTubeUrl,
 } from "./url-ingest";
+export { normalizeDocumentContentType } from "./utils";

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -74,6 +74,7 @@ import {
 	isBinaryContentType,
 	isTextBackedDocumentContent,
 	looksLikeBase64,
+	normalizeDocumentContentType,
 	stripDocumentFilenameExtension,
 } from "./utils.ts";
 
@@ -964,8 +965,9 @@ export class DocumentService extends Service {
 			let fileBuffer: Buffer | null = null;
 			let extractedText: string;
 			let documentContentToStore: string;
+			const normalizedContentType = normalizeDocumentContentType(contentType);
 			const isPdfFile =
-				contentType === "application/pdf" ||
+				normalizedContentType === "application/pdf" ||
 				originalFilename.toLowerCase().endsWith(".pdf");
 
 			if (isPdfFile) {
@@ -989,11 +991,11 @@ export class DocumentService extends Service {
 				}
 				extractedText = await extractTextFromDocument(
 					fileBuffer,
-					contentType,
+					normalizedContentType,
 					originalFilename,
 				);
 				documentContentToStore = content;
-			} else if (isBinaryContentType(contentType, originalFilename)) {
+			} else if (isBinaryContentType(normalizedContentType, originalFilename)) {
 				try {
 					fileBuffer = Buffer.from(content, "base64");
 				} catch (e) {
@@ -1014,7 +1016,7 @@ export class DocumentService extends Service {
 				}
 				extractedText = await extractTextFromDocument(
 					fileBuffer,
-					contentType,
+					normalizedContentType,
 					originalFilename,
 				);
 				documentContentToStore = extractedText;

--- a/packages/core/src/features/documents/utils.test.ts
+++ b/packages/core/src/features/documents/utils.test.ts
@@ -9,7 +9,10 @@ import {
 	deriveDocumentTitle,
 	extractFirstLines,
 	generateContentBasedId,
+	isBinaryContentType,
+	isTextBackedDocumentContent,
 	looksLikeBase64,
+	normalizeDocumentContentType,
 	normalizeDocumentSourceValue,
 	normalizeS3Url,
 	stripDocumentFilenameExtension,
@@ -49,6 +52,31 @@ describe("filename + title derivation", () => {
 });
 
 describe("classification", () => {
+	it.each([
+		["application/pdf", "application/pdf"],
+		[" APPLICATION/PDF ; charset=UTF-8 ", "application/pdf"],
+		["TEXT/PLAIN; charset=utf-8", "text/plain"],
+	])("normalizes MIME essence %#", (input, expected) => {
+		expect(normalizeDocumentContentType(input)).toBe(expected);
+	});
+
+	it.each([
+		"application/pdf",
+		"APPLICATION/PDF",
+		"application/pdf; charset=UTF-8",
+	])("classifies PDF MIME variants as binary: %s", (contentType) => {
+		expect(isBinaryContentType(contentType, "upload.blob")).toBe(true);
+	});
+
+	it.each(["text/plain", "TEXT/PLAIN; charset=UTF-8"])(
+		"classifies text MIME variants as text-backed: %s",
+		(contentType) => {
+			expect(isTextBackedDocumentContent(contentType, "upload.blob")).toBe(
+				true,
+			);
+		},
+	);
+
 	it("normalizeDocumentSourceValue maps known sources, else 'unknown'", () => {
 		expect(normalizeDocumentSourceValue("upload")).toBe("upload");
 		expect(normalizeDocumentSourceValue("rag-service-main-upload")).toBe(

--- a/packages/core/src/features/documents/utils.ts
+++ b/packages/core/src/features/documents/utils.ts
@@ -28,6 +28,14 @@ const PLAIN_TEXT_CONTENT_TYPES = [
 const MAX_FALLBACK_SIZE_BYTES = 5 * 1024 * 1024;
 const BINARY_CHECK_BYTES = 1024;
 
+/**
+ * Return the case-insensitive MIME essence used for routing document content.
+ * Parameters belong to the media type but do not change its routing identity.
+ */
+export function normalizeDocumentContentType(contentType: string): string {
+	return contentType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+}
+
 export async function extractTextFromFileBuffer(
 	fileBuffer: Buffer,
 	contentType: string,
@@ -139,6 +147,7 @@ export function isBinaryContentType(
 	contentType: string,
 	filename: string,
 ): boolean {
+	const normalizedContentType = normalizeDocumentContentType(contentType);
 	const textContentTypes = [
 		"text/",
 		"application/json",
@@ -150,7 +159,7 @@ export function isBinaryContentType(
 	];
 
 	const isTextMimeType = textContentTypes.some((type) =>
-		contentType.includes(type),
+		normalizedContentType.includes(type),
 	);
 	if (isTextMimeType) {
 		return false;
@@ -171,7 +180,7 @@ export function isBinaryContentType(
 	];
 
 	const isBinaryMimeType = binaryContentTypes.some((type) =>
-		contentType.includes(type),
+		normalizedContentType.includes(type),
 	);
 
 	if (isBinaryMimeType) {

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -57,6 +57,7 @@ export {
 	type FetchedDocumentUrlKind,
 	fetchDocumentFromUrl,
 	isYouTubeUrl,
+	normalizeDocumentContentType,
 } from "./features/documents/index";
 export type {
 	DeferredMessageScheduleCommit,

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -39,6 +39,7 @@ import {
   actorFromAccessContext,
   fetchDocumentFromUrl,
   isYouTubeUrl,
+  normalizeDocumentContentType,
   ServiceType,
 } from "@elizaos/core";
 import { parseClampedFloat, parsePositiveInteger } from "@elizaos/shared";
@@ -132,12 +133,13 @@ function isTextBackedContentType(
   contentType: string,
   filename: string,
 ): boolean {
-  if (contentType.startsWith("text/")) return true;
+  const normalizedContentType = normalizeDocumentContentType(contentType);
+  if (normalizedContentType.startsWith("text/")) return true;
   if (
-    contentType === "application/json" ||
-    contentType === "application/xml" ||
-    contentType === "application/javascript" ||
-    contentType === "text/markdown"
+    normalizedContentType === "application/json" ||
+    normalizedContentType === "application/xml" ||
+    normalizedContentType === "application/javascript" ||
+    normalizedContentType === "text/markdown"
   ) {
     return true;
   }
@@ -1106,7 +1108,8 @@ export async function handleDocumentsRoutes(
     // image → description text), so the linked original-bytes file is faithful.
     const originalContent = document.content;
     const originalContentType = document.contentType || "text/plain";
-    let contentType = originalContentType;
+    let contentType =
+      normalizeDocumentContentType(originalContentType) || "text/plain";
     const warnings: string[] = [];
     const textBacked = isTextBackedContentType(
       originalContentType,

--- a/plugins/plugin-documents/test/routes.test.ts
+++ b/plugins/plugin-documents/test/routes.test.ts
@@ -209,6 +209,80 @@ describe("document routes", () => {
     });
   });
 
+  it.each([
+    {
+      content: "hello world",
+      filename: "notes.txt",
+      contentType: "TEXT/PLAIN; charset=UTF-8",
+      expectedContentType: "text/plain",
+      expectedTextBacked: true,
+      expectedBytes: "hello world",
+    },
+    {
+      content: Buffer.from("pdf bytes").toString("base64"),
+      filename: "report.bin",
+      contentType: "APPLICATION/PDF",
+      expectedContentType: "application/pdf",
+      expectedTextBacked: false,
+      expectedBytes: "pdf bytes",
+    },
+    {
+      content: Buffer.from("pdf bytes").toString("base64"),
+      filename: "report.bin",
+      contentType: "application/pdf; charset=UTF-8",
+      expectedContentType: "application/pdf",
+      expectedTextBacked: false,
+      expectedBytes: "pdf bytes",
+    },
+  ])(
+    "canonicalizes case and parameters before document service routing %#",
+    async ({
+      content,
+      filename,
+      contentType,
+      expectedContentType,
+      expectedTextBacked,
+      expectedBytes,
+    }) => {
+      const store = vi.fn(async () => ({
+        url: "/api/media/deadbeef.bin",
+        hash: "deadbeef",
+        fileName: "deadbeef.bin",
+        mimeType: contentType,
+        size: expectedBytes.length,
+      }));
+      addDocument.mockResolvedValueOnce({
+        clientDocumentId: "doc-id",
+        fragmentCount: 1,
+      });
+      const { ctx, res } = buildCtx({
+        method: "POST",
+        pathname: "/api/documents",
+        runtime: {
+          getService: vi.fn(() => ({ store })),
+        } as Partial<NonNullable<DocumentRouteContext["runtime"]>>,
+        body: { content, filename, contentType },
+      });
+
+      await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+      expect(res.statusCode).toBe(200);
+      expect(store.mock.calls).toHaveLength(1);
+      const storedContent = store.mock.calls[0][0] as Buffer;
+      expect(storedContent.toString("utf8")).toBe(expectedBytes);
+      expect(addDocument).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contentType: expectedContentType,
+          metadata: expect.objectContaining({
+            contentType: expectedContentType,
+            fileType: contentType,
+            textBacked: expectedTextBacked,
+          }),
+        }),
+      );
+    },
+  );
+
   it("rejects image uploads when the image description model fails", async () => {
     const useModel = vi.fn(async () => {
       throw new Error("vision unavailable");


### PR DESCRIPTION
# Relates to

Closes #19153

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop` at `dd7190c50f4f8eb11700fc596368271b929d474f` with zero conflicts.
- [x] Frozen-lockfile install, focused tests, owning package typechecks/builds, and root `bun run verify` were run after sync. Focused/package gates and root verification pass on exact head `bfa4570c7ae2ca81c393c4641004cae9b307581c`.
- [x] The evidence below lets a reviewer confirm the behavior without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@34953f555be973d5d9c1e71e02f756bd597291fe:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` at `dd7190c50f4f8eb11700fc596368271b929d474f`; zero conflicts.
- [x] `bun run verify` passes post-sync on exact head `bfa4570c7ae2ca81c393c4641004cae9b307581c` (350/350 tasks; all audits clean).

# Risks

Low. This is a routing-only normalization: MIME essence is trimmed, lowercased, and separated from parameters before classification. Original upload bytes and the caller's original `fileType` metadata remain unchanged; no storage provider, parser, UI, or live model behavior changes.

# Background

## What does this PR do?

It canonicalizes MIME essence at the document upload boundary and in the shared document classifier. Mixed-case and parameterized values now take the same text/PDF/binary paths as their canonical MIME tokens. The public core export is kept in the browser barrel for package parity.

## What kind of change is this?

Bug fix (non-breaking correction of valid MIME routing).

# Documentation changes needed?

No documentation change is needed; this restores RFC-compatible handling of equivalent MIME representations.

# Testing

## Where should a reviewer start?

Start with the parameterized route table in `plugins/plugin-documents/test/routes.test.ts`, then the shared classifier matrix in `packages/core/src/features/documents/utils.test.ts`.

## Detailed testing steps

- `ELIZA_SKIP_LOCAL_UPSTREAMS=1 node packages/scripts/run-vitest.mjs run --config ./vitest.config.ts src/features/documents/utils.test.ts` from `packages/core`: 16/16 passed.
- `ELIZA_SKIP_LOCAL_UPSTREAMS=1 node packages/scripts/run-vitest.mjs run --config ./vitest.config.ts test/routes.test.ts` from `plugins/plugin-documents`: 25/25 passed.
- `bun run --cwd packages/core typecheck`: passed.
- `bun run --cwd packages/core build`: passed.
- `bun run --cwd plugins/plugin-documents typecheck`: passed.
- `bun run --cwd plugins/plugin-documents build`: passed.
- Focused Biome check and `git diff --check`: passed.
- Root `bun run verify` on rebased exact head `bfa4570c7ae2ca81c393c4641004cae9b307581c`: 350/350 tasks passed; build/typecheck, script inventory, and anti-focused-test audits passed.

Post-fix checked-in PDF artifact (exact Bun 1.3.14, `2025-10-v5.5.pdf`):

```text
application/pdf                    -> canonical application/pdf, binary=true, 7812 chars
APPLICATION/PDF                    -> canonical application/pdf, binary=true, 7812 chars
application/pdf; charset=UTF-8     -> canonical application/pdf, binary=true, 7812 chars
```

# Evidence Gate

Evidence matches the exact commit reviewed.
<!-- evidence-head:bfa4570c7ae2ca81c393c4641004cae9b307581c -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface is changed.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface is changed.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no rendered UI surface or interactive visual flow is changed.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - deterministic unit/service routing is fully exercised without a live service.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend request or state change is included.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior is changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: checked-in PDF extraction transcript above; original-byte persistence is asserted by the route regression.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no UI or image rendering is changed.`

# Evidence Details

The regression covers `application/pdf`, uppercase PDF, PDF with parameters, uppercase/parameterized `text/plain`, and preserves the original upload bytes while passing canonical `contentType` to document persistence/service routing.

## Known gaps / failures

None for the changed scope. The native Vitest wrapper was used instead of Bun's bare test runner so the existing Vitest `vi.mocked` APIs execute under the repository's supported runner.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@34953f555be973d5d9c1e71e02f756bd597291fe:skills/contribute-to-eliza
Compute receipt: 72772279 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [symbiex-sol-xhigh-candidate-scout-20260813]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@34953f555be973d5d9c1e71e02f756bd597291fe:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZY4JY28MQ9E2C2TH5PMTZVN","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T18:01:41.192Z","completed_at":"2026-08-13T18:18:45.769Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":2485425,"output_tokens":151558,"cache_creation_tokens":0,"cache_read_tokens":70135296,"total_tokens":72772279,"cost_micro_usd":"43875674","session_count":17},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"mEmHTTK9xj0n2mri0IVb6T2_0L3RBtUmuouiJiEaasfY_wDbOIpwTSKYzY0CP5UyZGcKCwmi67U1knNFwqwSAA"}} -->
