### PR TITLE
fix(ui): route labelled settings selects through SettingsSelectRow

### DIFF
--- a/packages/ui/src/components/settings/IdentitySettingsSection.tsx
+++ b/packages/ui/src/components/settings/IdentitySettingsSection.tsx
@@ -9,7 +9,6 @@
 
 import { Volume2, VolumeX } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAgentElement } from "../../agent-surface";
 import { client, type VoiceConfig } from "../../api";
 import { dispatchWindowEvent, VOICE_CONFIG_UPDATED_EVENT } from "../../events";
 import { useAppSelectorShallow } from "../../state";
@@ -25,121 +24,9 @@ import {
   ELEVENLABS_VOICE_GROUPS,
 } from "../character/character-voice-config";
 import { SaveFooter } from "../ui/save-footer";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectValue,
-} from "../ui/select";
-import { SettingsSelectTrigger } from "../ui/settings-controls";
-import { SettingsActionButton } from "./settings-agent-rows";
+import { SettingsActionButton, SettingsSelectRow } from "./settings-agent-rows";
 import { useSettingsSave } from "./settings-control-primitives.hooks";
-import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
-
-interface VoiceSelectRowProps {
-  label: string;
-  placeholder: string;
-  value: string | null;
-  options: readonly string[];
-  groups: Array<{
-    label: string;
-    items: Array<{ id: string; text: string; hint?: string }>;
-  }>;
-  onValueChange: (value: string) => void;
-  previewLabel: string;
-  stopLabel: string;
-  previewing: boolean;
-  previewDisabled: boolean;
-  onPreviewToggle: () => void;
-}
-
-function VoiceSelectRow({
-  label,
-  placeholder,
-  value,
-  options,
-  groups,
-  onValueChange,
-  previewLabel,
-  stopLabel,
-  previewing,
-  previewDisabled,
-  onPreviewToggle,
-}: VoiceSelectRowProps) {
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: "identity-voice",
-    role: "select",
-    label,
-    group: "settings",
-    status: value || undefined,
-    options,
-    getValue: () => value ?? "",
-    onFill: (next: string) => onValueChange(next),
-  });
-
-  return (
-    <SettingsRow
-      label={<span id="settings-identity-voice-label">{label}</span>}
-      stacked
-    >
-      <div className="flex items-center gap-2">
-        <Select value={value ?? undefined} onValueChange={onValueChange}>
-          <SettingsSelectTrigger
-            ref={ref}
-            variant="touch"
-            aria-labelledby="settings-identity-voice-label"
-            className="min-w-0 flex-1"
-            {...agentProps}
-          >
-            <SelectValue placeholder={placeholder} />
-          </SettingsSelectTrigger>
-          <SelectContent className="border-border/60 bg-bg/92">
-            {groups.map((group) => (
-              <SelectGroup key={group.label}>
-                <SelectLabel className="px-2.5 py-1 text-2xs font-semibold text-muted">
-                  {group.label}
-                </SelectLabel>
-                {group.items.map((item) => (
-                  <SelectItem
-                    key={item.id}
-                    value={item.id}
-                    textValue={item.text}
-                  >
-                    <div className="flex w-full items-center justify-between gap-2">
-                      <span className="font-semibold">{item.text}</span>
-                      {item.hint ? (
-                        <span className="text-muted text-xs">{item.hint}</span>
-                      ) : null}
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-            ))}
-          </SelectContent>
-        </Select>
-        <SettingsActionButton
-          agentId="identity-voice-preview"
-          agentLabel={previewing ? stopLabel : previewLabel}
-          type="button"
-          variant={previewing ? "destructive" : "ghost"}
-          size="icon"
-          className="h-11 w-11 shrink-0 rounded-md"
-          onClick={onPreviewToggle}
-          aria-label={previewing ? stopLabel : previewLabel}
-          disabled={previewDisabled}
-        >
-          {previewing ? (
-            <VolumeX className="h-4 w-4" />
-          ) : (
-            <Volume2 className="h-4 w-4" />
-          )}
-        </SettingsActionButton>
-      </div>
-    </SettingsRow>
-  );
-}
+import { SettingsGroup, SettingsStack } from "./settings-layout";
 
 function resolveEditableVoiceSelectionKey(config: VoiceConfig | null): string {
   const elevenLabsVoiceId =
@@ -342,11 +229,6 @@ export function IdentitySettingsSection() {
     }));
   }, [t, useElevenLabs]);
 
-  const voiceOptions = useMemo(
-    () => voiceGroups.flatMap((group) => group.items.map((item) => item.id)),
-    [voiceGroups],
-  );
-
   const voiceDirty =
     resolveEditableVoiceSelectionKey(voiceConfig) !==
     resolveEditableVoiceSelectionKey(savedVoiceConfig);
@@ -440,24 +322,49 @@ export function IdentitySettingsSection() {
       <SettingsGroup
         title={t("settings.identity.groupTitle", { defaultValue: "Identity" })}
       >
-        <VoiceSelectRow
+        <SettingsSelectRow
+          agentId="identity-voice"
           label={t("common.voice", { defaultValue: "Voice" })}
           placeholder={t("charactereditor.SelectAVoice", {
             defaultValue: "Select a voice",
           })}
-          value={visibleVoicePresetId}
-          options={voiceOptions}
-          groups={voiceGroups}
+          value={visibleVoicePresetId ?? ""}
+          groups={voiceGroups.map((group) => ({
+            label: group.label,
+            items: group.items.map((item) => ({
+              value: item.id,
+              label: item.text,
+              hint: item.hint,
+            })),
+          }))}
           onValueChange={handleVoiceSelect}
-          previewLabel={t("settings.identity.previewVoice", {
-            defaultValue: "Preview voice",
-          })}
-          stopLabel={t("settings.identity.stopVoicePreview", {
-            defaultValue: "Stop voice preview",
-          })}
-          previewing={voiceTesting}
-          previewDisabled={!activeVoicePreset?.previewUrl || voiceLoading}
-          onPreviewToggle={voiceTesting ? stopVoicePreview : handlePreviewVoice}
+          contentClassName="border-border/60 bg-bg/92"
+          trailing={
+            <SettingsActionButton
+              agentId="identity-voice-preview"
+              agentLabel={
+                voiceTesting
+                  ? t("settings.identity.stopVoicePreview", {
+                      defaultValue: "Stop voice preview",
+                    })
+                  : t("settings.identity.previewVoice", {
+                      defaultValue: "Preview voice",
+                    })
+              }
+              type="button"
+              variant={voiceTesting ? "destructive" : "ghost"}
+              size="icon"
+              className="h-11 w-11 shrink-0 rounded-md"
+              onClick={voiceTesting ? stopVoicePreview : handlePreviewVoice}
+              disabled={!activeVoicePreset?.previewUrl || voiceLoading}
+            >
+              {voiceTesting ? (
+                <VolumeX className="h-4 w-4" />
+              ) : (
+                <Volume2 className="h-4 w-4" />
+              )}
+            </SettingsActionButton>
+          }
         />
       </SettingsGroup>
 

--- a/packages/ui/src/components/settings/VoiceProfileSection.tsx
+++ b/packages/ui/src/components/settings/VoiceProfileSection.tsx
@@ -31,7 +31,7 @@ import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import { Select, SelectContent, SelectItem, SelectValue } from "../ui/select";
 import { SettingsSelectTrigger } from "../ui/settings-controls";
-import { SettingsInputRow } from "./settings-agent-rows";
+import { SettingsInputRow, SettingsSelectRow } from "./settings-agent-rows";
 
 export interface VoiceProfileSectionProps {
   /** Adapter supplied by the parent that holds the `ElizaClient`. */
@@ -156,52 +156,45 @@ function VoiceProfileLifecycleEditor({
       </div>
 
       {!profile.isOwner && mergeTargets.length > 0 ? (
-        <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
-          <div className="grid gap-1.5">
-            <Label htmlFor={`voice-profile-merge-${profile.id}`}>
-              {t("voiceprofile.merge.target", {
-                defaultValue: "Merge into",
+        <SettingsSelectRow
+          agentId={`voice-profile-merge-${profile.id}`}
+          group="voice-profiles"
+          label={t("voiceprofile.merge.target", {
+            defaultValue: "Merge into",
+          })}
+          value={mergeIntoId}
+          onValueChange={setMergeIntoId}
+          placeholder={t("voiceprofile.merge.choose", {
+            defaultValue: "Choose destination profile",
+          })}
+          testId={`voice-profile-merge-target-${profile.id}`}
+          trailingStackUntilSm
+          options={mergeTargets.map((candidate) => ({
+            value: candidate.id,
+            label: candidate.displayName,
+          }))}
+          trailing={
+            <Button
+              type="button"
+              variant="secondary"
+              className="min-h-11"
+              disabled={!mergeIntoId || pending}
+              onClick={() =>
+                void dispatch({
+                  type: "merge",
+                  id: profile.id,
+                  intoId: mergeIntoId,
+                })
+              }
+              data-testid={`voice-profile-merge-${profile.id}`}
+            >
+              <GitMerge className="mr-1.5 h-4 w-4" />
+              {t("voiceprofile.merge.action", {
+                defaultValue: "Merge profile",
               })}
-            </Label>
-            <Select value={mergeIntoId} onValueChange={setMergeIntoId}>
-              <SettingsSelectTrigger
-                id={`voice-profile-merge-${profile.id}`}
-                className="min-h-11"
-                data-testid={`voice-profile-merge-target-${profile.id}`}
-              >
-                <SelectValue
-                  placeholder={t("voiceprofile.merge.choose", {
-                    defaultValue: "Choose destination profile",
-                  })}
-                />
-              </SettingsSelectTrigger>
-              <SelectContent>
-                {mergeTargets.map((candidate) => (
-                  <SelectItem key={candidate.id} value={candidate.id}>
-                    {candidate.displayName}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <Button
-            type="button"
-            variant="secondary"
-            className="min-h-11"
-            disabled={!mergeIntoId || pending}
-            onClick={() =>
-              void dispatch({
-                type: "merge",
-                id: profile.id,
-                intoId: mergeIntoId,
-              })
-            }
-            data-testid={`voice-profile-merge-${profile.id}`}
-          >
-            <GitMerge className="mr-1.5 h-4 w-4" />
-            {t("voiceprofile.merge.action", { defaultValue: "Merge profile" })}
-          </Button>
-        </div>
+            </Button>
+          }
+        />
       ) : null}
 
       {profile.samples.length >= 2 ? (

--- a/packages/ui/src/components/settings/no-raw-labelled-input.test.ts
+++ b/packages/ui/src/components/settings/no-raw-labelled-input.test.ts
@@ -62,6 +62,10 @@ const RAW_INPUT_ALLOWLIST = new Map<string, string>([
   ],
 ]);
 
+function posixRelative(from: string, to: string): string {
+  return relative(from, to).replaceAll("\\", "/");
+}
+
 function listTsxFiles(dir: string): string[] {
   const out: string[] = [];
   for (const name of readdirSync(dir)) {
@@ -82,7 +86,7 @@ function listTsxFiles(dir: string): string[] {
 describe("settings controls: no raw labelled <Input outside the allowlist", () => {
   const files = listTsxFiles(settingsRoot);
 
-  it.each(files.map((file) => relative(settingsRoot, file)))(
+  it.each(files.map((file) => posixRelative(settingsRoot, file)))(
     "%s uses SettingsInputRow instead of a raw <Input, or is allowlisted",
     (relPath) => {
       const source = readFileSync(resolve(settingsRoot, relPath), "utf8");

--- a/packages/ui/src/components/settings/no-raw-select.test.ts
+++ b/packages/ui/src/components/settings/no-raw-select.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Static source-scan guard: labelled settings selects must use
+ * SettingsSelectRow instead of a hand-rolled SettingsRow/Label + Select.
+ * Reads files off disk — no render. Remaining raw Select sites are an
+ * explicit allowlist for compact/custom forms.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const settingsRoot = resolve(import.meta.dirname);
+
+/**
+ * Files that still own a raw `<Select` because they are not a 1:1 labelled
+ * settings row. Adding a new file here is a product decision; the default is
+ * `SettingsSelectRow`.
+ */
+const RAW_SELECT_ALLOWLIST = new Map<string, string>([
+  [
+    "settings-agent-rows.tsx",
+    "canonical SettingsSelectRow primitive; it is the one allowed Select owner",
+  ],
+  [
+    "VaultInventoryPanel.tsx",
+    "vault add-form category picker lives in a compact custom form, not a settings row",
+  ],
+  [
+    "VoiceProfileSection.tsx",
+    "inline relationship chip on the profile row, not a labelled settings select",
+  ],
+  [
+    "vault-tabs/RoutingTab.tsx",
+    "routing table cells and default-profile compact picker, not labelled settings rows",
+  ],
+]);
+
+function posixRelative(from: string, to: string): string {
+  return relative(from, to).replaceAll("\\", "/");
+}
+
+function listTsxFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      out.push(...listTsxFiles(full));
+    } else if (
+      name.endsWith(".tsx") &&
+      !name.endsWith(".test.tsx") &&
+      !name.endsWith(".stories.tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("settings controls: no raw <Select outside the allowlist", () => {
+  const files = listTsxFiles(settingsRoot);
+
+  it.each(files.map((file) => posixRelative(settingsRoot, file)))(
+    "%s uses SettingsSelectRow instead of a raw <Select, or is allowlisted",
+    (relPath) => {
+      const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
+      const hasRawSelect = source.includes("<Select");
+      if (!hasRawSelect) {
+        expect(RAW_SELECT_ALLOWLIST.has(relPath)).toBe(false);
+        return;
+      }
+      expect(
+        RAW_SELECT_ALLOWLIST.has(relPath),
+        `${relPath} hand-rolls a raw <Select. Use SettingsSelectRow from ` +
+          `./settings-agent-rows for labelled settings selects. If this file ` +
+          `is not a settings select row, add it to RAW_SELECT_ALLOWLIST with a reason.`,
+      ).toBe(true);
+    },
+  );
+
+  it("documents a reason for every allowlisted raw Select file", () => {
+    for (const [relPath, reason] of RAW_SELECT_ALLOWLIST) {
+      expect(reason.trim().length).toBeGreaterThan(8);
+      const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
+      expect(
+        source.includes("<Select"),
+        `${relPath} is allowlisted but no longer contains <Select; remove it from the allowlist`,
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/ui/src/components/settings/no-raw-switch.test.ts
+++ b/packages/ui/src/components/settings/no-raw-switch.test.ts
@@ -38,6 +38,10 @@ const RAW_SWITCH_ALLOWLIST = new Map<string, string>([
   ],
 ]);
 
+function posixRelative(from: string, to: string): string {
+  return relative(from, to).replaceAll("\\", "/");
+}
+
 function listTsxFiles(dir: string): string[] {
   const out: string[] = [];
   for (const name of readdirSync(dir)) {
@@ -58,7 +62,7 @@ function listTsxFiles(dir: string): string[] {
 describe("settings controls: no raw <Switch outside the allowlist", () => {
   const files = listTsxFiles(settingsRoot);
 
-  it.each(files.map((file) => relative(settingsRoot, file)))(
+  it.each(files.map((file) => posixRelative(settingsRoot, file)))(
     "%s uses SettingsSwitchRow instead of a raw <Switch, or is allowlisted",
     (relPath) => {
       const source = readFileSync(resolve(settingsRoot, relPath), "utf8");

--- a/packages/ui/src/components/settings/settings-agent-rows.tsx
+++ b/packages/ui/src/components/settings/settings-agent-rows.tsx
@@ -16,7 +16,14 @@ import * as React from "react";
 import { useAgentElement } from "../../agent-surface";
 import { cn } from "../../lib/utils";
 import { Button, type ButtonProps } from "../ui/button";
-import { Select, SelectContent, SelectItem, SelectValue } from "../ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectValue,
+} from "../ui/select";
 import {
   SettingsInput,
   type SettingsInputVariant,
@@ -103,6 +110,14 @@ export function SettingsSwitchRow({
 export interface SettingsSelectRowOption {
   value: string;
   label: React.ReactNode;
+  hint?: string;
+  /** Plain-text typeahead value. Defaults to a string label; omitted for JSX. */
+  textValue?: string;
+}
+
+export interface SettingsSelectRowGroup {
+  label: string;
+  items: SettingsSelectRowOption[];
 }
 
 export interface SettingsSelectRowProps {
@@ -114,11 +129,46 @@ export interface SettingsSelectRowProps {
   iconClassName?: string;
   value: string;
   onValueChange: (value: string) => void;
-  options: SettingsSelectRowOption[];
+  options?: SettingsSelectRowOption[];
+  groups?: SettingsSelectRowGroup[];
   placeholder?: string;
   disabled?: boolean;
   group?: string;
   triggerClassName?: string;
+  contentClassName?: string;
+  /** Trailing control kept with the select (preview, merge, etc.). */
+  trailing?: React.ReactNode;
+  /** Stack the trailing control under the select until `sm`. */
+  trailingStackUntilSm?: boolean;
+  testId?: string;
+}
+
+function flattenSelectOptions(
+  options: SettingsSelectRowOption[] | undefined,
+  groups: SettingsSelectRowGroup[] | undefined,
+): SettingsSelectRowOption[] {
+  if (groups && groups.length > 0) {
+    return groups.flatMap((group) => group.items);
+  }
+  return options ?? [];
+}
+
+function renderSelectOption(option: SettingsSelectRowOption) {
+  const textValue =
+    option.textValue ??
+    (typeof option.label === "string" ? option.label : undefined);
+  return (
+    <SelectItem key={option.value} value={option.value} textValue={textValue}>
+      {option.hint ? (
+        <div className="flex w-full items-center justify-between gap-2">
+          <span className="font-semibold">{option.label}</span>
+          <span className="text-muted text-xs">{option.hint}</span>
+        </div>
+      ) : (
+        option.label
+      )}
+    </SelectItem>
+  );
 }
 
 export function SettingsSelectRow({
@@ -131,12 +181,18 @@ export function SettingsSelectRow({
   value,
   onValueChange,
   options,
+  groups,
   placeholder,
   disabled = false,
   group = "settings",
   triggerClassName,
+  contentClassName,
+  trailing,
+  trailingStackUntilSm = false,
+  testId,
 }: SettingsSelectRowProps) {
   const resolvedLabel = agentLabel ?? labelToString(label, agentId);
+  const flattened = flattenSelectOptions(options, groups);
   const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
     id: agentId,
     role: "select",
@@ -144,10 +200,38 @@ export function SettingsSelectRow({
     group,
     description: typeof description === "string" ? description : undefined,
     status: value || undefined,
-    options: options.map((option) => option.value),
+    options: flattened.map((option) => option.value),
     getValue: () => value,
     onFill: disabled ? undefined : (next: string) => onValueChange(next),
   });
+
+  const select = (
+    <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+      <SettingsSelectTrigger
+        ref={ref}
+        id={agentId}
+        variant="touch"
+        className={cn(trailing && "min-w-0 flex-1", triggerClassName)}
+        aria-label={resolvedLabel}
+        data-testid={testId}
+        {...agentProps}
+      >
+        <SelectValue placeholder={placeholder} />
+      </SettingsSelectTrigger>
+      <SelectContent className={contentClassName}>
+        {groups && groups.length > 0
+          ? groups.map((optionGroup) => (
+              <SelectGroup key={optionGroup.label}>
+                <SelectLabel className="px-2.5 py-1 text-2xs font-semibold text-muted">
+                  {optionGroup.label}
+                </SelectLabel>
+                {optionGroup.items.map(renderSelectOption)}
+              </SelectGroup>
+            ))
+          : flattened.map(renderSelectOption)}
+      </SelectContent>
+    </Select>
+  );
 
   return (
     <SettingsRow
@@ -155,26 +239,23 @@ export function SettingsSelectRow({
       iconClassName={iconClassName}
       label={label}
       description={description}
+      htmlFor={agentId}
       stacked
     >
-      <Select value={value} onValueChange={onValueChange} disabled={disabled}>
-        <SettingsSelectTrigger
-          ref={ref}
-          variant="touch"
-          className={triggerClassName}
-          aria-label={resolvedLabel}
-          {...agentProps}
+      {trailing ? (
+        <div
+          className={
+            trailingStackUntilSm
+              ? "grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end"
+              : "flex items-center gap-2"
+          }
         >
-          <SelectValue placeholder={placeholder} />
-        </SettingsSelectTrigger>
-        <SelectContent>
-          {options.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+          {select}
+          {trailing}
+        </div>
+      ) : (
+        select
+      )}
     </SettingsRow>
   );
 }

--- a/packages/ui/src/components/settings/settings-layout.test.tsx
+++ b/packages/ui/src/components/settings/settings-layout.test.tsx
@@ -151,5 +151,32 @@ describe("agent-addressable rows", () => {
     const trigger = screen.getByLabelText("Theme");
     expect(trigger.getAttribute("data-agent-id")).toBe("pick-theme");
     expect(trigger.getAttribute("data-agent-role")).toBe("select");
+    expect(trigger.getAttribute("id")).toBe("pick-theme");
+    expect(screen.getByText("Theme").tagName).toBe("LABEL");
+  });
+
+  it("SettingsSelectRow renders grouped options and a trailing control", () => {
+    render(
+      <SettingsSelectRow
+        agentId="identity-voice"
+        label="Voice"
+        value="alloy"
+        onValueChange={() => {}}
+        groups={[
+          {
+            label: "Premade",
+            items: [
+              { value: "alloy", label: "Alloy", hint: "fast" },
+              { value: "verse", label: "Verse" },
+            ],
+          },
+        ]}
+        trailing={<button type="button">Preview</button>}
+        testId="identity-voice-trigger"
+      />,
+    );
+    const trigger = screen.getByTestId("identity-voice-trigger");
+    expect(trigger.getAttribute("data-agent-id")).toBe("identity-voice");
+    expect(screen.getByText("Preview")).toBeTruthy();
   });
 });


### PR DESCRIPTION
# Relates to

Closes #19154

Stacked on #19150.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets the previous settings-pattern branch and is stacked on
      #19150 (`fix/settings-input-row-pattern`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Stacked on #19150, which is rebased onto `origin/develop`.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Behaviour-preserving reuse of the existing `SettingsSelectRow` primitive.
Remaining compact/custom Select owners stay on an explicit allowlist. A
false-positive source-scan failure is the main regression risk if a new non-row
Select is added without updating that allowlist.

# Background

## What does this PR do?

A static scan of the settings dashboard found 1:1 labelled Select fields that
reimplemented `SettingsSelectRow`. This PR routes the Identity voice picker
and Voice Profile merge target through the primitive, adds grouped options
plus a trailing action, preserves mobile stacking for text trailing controls,
and adds a disk source-scan gate so new labelled selects cannot re-hand-roll
`<Select`.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

No.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:5ae8e45e2c04d54c892868de7cb2ae0a59854905 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19157-before-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19157-after-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19157-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or API path is changed; this is a renderer reuse of SettingsSelectRow.
<!-- evidence-row:frontend-logs -->
- [x] [19157-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19157-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows, memories, schedules, wallet records, audio, or generated domain artifacts are changed.
<!-- evidence-row:ocr-review -->
- [x] [19157-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19157-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Backend + frontend logs

N/A - no backend path is changed. Focused UI tests are the source-of-truth
measurement for this reuse change; isolated capture is being attached after
open.

## Screenshots (before / after) + video walkthrough

Source-structure reuse of an existing primitive. Isolated SettingsSelectRow
capture is being attached after open so the rows are code-produced rather than
eyeballed.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT path is changed.

## Known gaps / failures

- Full-repo `bun run verify` was not run in this worktree. Focused package
  checks after rebase:
  - `bun run --cwd packages/ui test` on
    `no-raw-select.test.ts`, `settings-layout.test.tsx`,
    `VoiceProfileSection.test.tsx` — 3 files, 68 tests passed.
  - `bunx biome check` on the touched settings files — clean.

— [pi-grok]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza"} -->
