### PR TITLE
fix(ui): boot the settings e2e fixture as a managed Cloud runtime

### DIFF
--- a/packages/ui/src/components/pages/__e2e__/settings-fixture-state-stub.ts
+++ b/packages/ui/src/components/pages/__e2e__/settings-fixture-state-stub.ts
@@ -23,6 +23,10 @@ const fixtureState: Record<string, unknown> = {
   uiLanguage: "en",
   loadPlugins: async () => {},
   walletEnabled: false,
+  // SettingsView gates `cloudOnly` sections on the resolved runtime target.
+  // The fixture covers the managed-Cloud surface (the Cloud group and its
+  // "Connect Eliza Cloud" handoff), so it must boot as a managed target.
+  startupCoordinator: { target: "cloud-managed" },
   plugins: [],
   pluginsLoaded: true,
   elizaCloudConnected: false,


### PR DESCRIPTION
# Relates to

Restores the `UI Extended Fixture E2E` lane, red on every `develop` push since
`4e62753a760` (merge of #18996).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] `bun install` was run after sync; the failing lane was reproduced red and
      verified green locally (see **Evidence Details**).
- [x] A reviewer can confirm the change works without reading the code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` @ `dd7190c50f4`; zero conflicts.
- [x] The affected lane passes post-sync. Full `bun run verify` was not run:
      the diff is a single e2e fixture constant, and `develop` is under a
      continuous push storm that cancels every push-triggered run.

# Risks

Low. Test-fixture-only change; no product code, no public surface.

# Background

## What does this PR do?

#18996 added a `cloudOnly` settings-section gate driven by
`useAppSelector((s) => s.startupCoordinator.target)` in `SettingsView`. The
settings e2e fixture's state stub (`settings-fixture-state-stub.ts`) never
supplied `startupCoordinator`, so the selector dereferenced `undefined`,
`SettingsView` threw during render, and the page stayed blank. Every run since
has died on `waitForSelector('[data-testid="desktop-settings-navigation"]')`
after 30s.

This PR ports the stale fixture to the new contract: the settings e2e asserts
the `Cloud` rail group, the `cloud-overview` row, and the "Connect Eliza Cloud"
popup handoff, so the fixture declares `cloud-managed` as its runtime target —
the value under which those assertions are the real product behavior. The
`cloudOnly` product gate itself is deliberate and unchanged.

## What kind of change is this?

Bug fixes (restores a broken CI lane; no behavior change to shipped code).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/pages/__e2e__/settings-fixture-state-stub.ts` — one
added fixture field.

## Detailed testing steps

```bash
node packages/app-core/scripts/ensure-shared-i18n-data.mjs
bun run --cwd packages/ui test:settings-e2e
```

# Evidence Gate

<!-- evidence-head:4efe62e2f1aac3067fe0f9d9b296440467c1342b -->

<!-- evidence-row:before-screenshots -->
- [x] Before: `N/A - no rendered surface changed. The pre-fix state is a blank
      page (SettingsView throws); the failure is captured as the CI timeout log
      below.`
<!-- evidence-row:after-screenshots -->
- [x] After: `N/A - no rendered surface changed. The e2e itself captures the
      desktop (1280x900) and mobile (390x844) settings screenshots on every run;
      all of them are produced again by the green run below.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - fixture-only diff with no shipped-UI change. The
      e2e records walkthrough.webm as part of the green run.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - the settings e2e runs against an esbuild bundle with
      no app server.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: attached — the run asserts
      `no uncaught page errors (0)`, which is exactly the assertion that was
      failing.
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: `N/A - no agent, action, provider, prompt, or model path
      is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no database, memory, task, wallet, or generated
      artifact is involved.`
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - the diff adds one constant to a TypeScript test stub
      and renders no visual text.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model path is touched.`

## Backend + frontend logs

<details>
<summary>RED — <code>develop</code> @ <code>dd7190c50f4</code>, unmodified (reproduces CI run 31727737572)</summary>

```
$ bun run --cwd packages/ui test:settings-e2e
TimeoutError: waitForSelector: Timeout 30000ms exceeded.
Call log:
  - waiting for locator('[data-testid="desktop-settings-navigation"]') to be visible
error: script "test:settings-e2e" exited with code 1
```
</details>

<details>
<summary>GREEN — same tree with this commit applied</summary>

```
✓ rail shows the "Agent" group label
✓ rail shows the "App" group label
✓ rail shows the "Privacy & Security" group label
✓ rail shows the "Cloud" group label
✓ rail lists the "identity" item
✓ rail lists the "ai-model" item
✓ rail lists the "voice" item
✓ rail lists the "connectors" item
✓ rail lists the "appearance" item
✓ rail lists the "advanced" item
✓ rail lists the "permissions" item
✓ rail lists the "cloud-overview" item
✓ rail hides the "capabilities" item (Developer Mode off)
✓ rail hides the "apps" item (Developer Mode off)
✓ rail hides the "background" item (Developer Mode off)
✓ rail hides the "runtime" item (Developer Mode off)
✓ rail hides the "wallet-rpc" item (Developer Mode off)
✓ rail hides the "secrets" item (Developer Mode off)
✓ rail hides the "app-permissions" item (Developer Mode off)
✓ desktop replaces the mobile hub with the persistent rail
✓ rail item "identity" opens its section content
✓ rail item "ai-model" opens its section content
✓ rail item "voice" opens its section content
✓ Voice renders both shortcut microphone consent controls
✓ rail item "connectors" opens its section content
✓ rail item "appearance" opens its section content
✓ rail item "advanced" opens its section content
✓ rail item "permissions" opens its section content
✓ rail item "cloud-overview" opens its section content
✓ walked every visible desktop section with the rail retained
✓ desktop Cloud login keeps Settings mounted instead of navigating its document
✓ Settings passes the live pre-opened auth window into handleCloudLogin
✓ the auth handoff uses the shared named Cloud popup
✓ #appearance deep-link activates Appearance in the persistent rail
✓ mobile Voice settings default both shortcut microphone permissions off
✓ mobile Voice settings can grant voice-shortcut microphone permission
✓ mobile Voice settings can revoke voice-shortcut microphone permission
✓ no uncaught page errors (0):
✅ settings hub e2e passed
```
(assertion list trimmed of per-section "retains the active state" / "rail remains
mounted" duplicates; every assertion passed, zero failures)
</details>

## Screenshots (before / after) + video walkthrough

`N/A - the diff changes no rendered component. The e2e's own desktop and mobile
captures plus walkthrough.webm are regenerated by the green run above; before
this fix the run produced none because the page never mounted.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

- Full `bun run verify` was not run for this one-line fixture change. `develop`
  is currently under a continuous push storm in which nearly every
  push-triggered workflow run is cancelled by `cancel-in-progress` concurrency,
  so a repository-wide gate cannot be captured against a stable tip. The lane
  this PR repairs was reproduced red and verified green directly.
