### PR TITLE
fix(agent): reject invalid deferred plugin watchdog timeouts

### DIFF
--- a/packages/agent/src/runtime/deferred-plugin-timeout.test.ts
+++ b/packages/agent/src/runtime/deferred-plugin-timeout.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit coverage for deferred-plugin watchdog configuration validation.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseDeferredPluginRegistrationTimeoutMs } from "./deferred-plugin-timeout.ts";
+
+describe("parseDeferredPluginRegistrationTimeoutMs", () => {
+  it("uses the default only when the setting is absent or blank", () => {
+    expect(parseDeferredPluginRegistrationTimeoutMs(undefined)).toBe(30_000);
+    expect(parseDeferredPluginRegistrationTimeoutMs("   ")).toBe(30_000);
+  });
+
+  it("accepts positive decimal integers through the maximum timer delay", () => {
+    expect(parseDeferredPluginRegistrationTimeoutMs(" 45000 ")).toBe(45_000);
+    expect(parseDeferredPluginRegistrationTimeoutMs("00045")).toBe(45);
+    expect(parseDeferredPluginRegistrationTimeoutMs("2147483647")).toBe(
+      2_147_483_647,
+    );
+  });
+
+  it.each(["0", "-1", "45.5", "1e3", "45ms", "NaN", "Infinity"])(
+    "rejects malformed or non-positive explicit value %s",
+    (value) => {
+      expect(() => parseDeferredPluginRegistrationTimeoutMs(value)).toThrow(
+        /must be a positive decimal integer/,
+      );
+    },
+  );
+
+  it.each(["2147483648", "9007199254740992"])(
+    "rejects explicit value %s that Node cannot schedule as requested",
+    (value) => {
+      expect(() => parseDeferredPluginRegistrationTimeoutMs(value)).toThrow(
+        /no greater than 2147483647/,
+      );
+    },
+  );
+});

--- a/packages/agent/src/runtime/deferred-plugin-timeout.test.ts
+++ b/packages/agent/src/runtime/deferred-plugin-timeout.test.ts
@@ -2,8 +2,21 @@
  * Unit coverage for deferred-plugin watchdog configuration validation.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { parseDeferredPluginRegistrationTimeoutMs } from "./deferred-plugin-timeout.ts";
+
+function captureConfigError(value: string): ElizaError {
+  try {
+    parseDeferredPluginRegistrationTimeoutMs(value);
+  } catch (error) {
+    // error-policy:J3 the test captures the explicit invalid-config result so
+    // it can assert the typed classification and structured boundary context.
+    expect(error).toBeInstanceOf(ElizaError);
+    return error as ElizaError;
+  }
+  throw new Error(`Expected ${JSON.stringify(value)} to be rejected`);
+}
 
 describe("parseDeferredPluginRegistrationTimeoutMs", () => {
   it("uses the default only when the setting is absent or blank", () => {
@@ -36,4 +49,17 @@ describe("parseDeferredPluginRegistrationTimeoutMs", () => {
       );
     },
   );
+
+  it("classifies invalid operator configuration as a typed fatal error", () => {
+    expect(captureConfigError("45ms")).toMatchObject({
+      code: "DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_INVALID",
+      context: {
+        setting: "ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS",
+        received: "45ms",
+        minimum: 1,
+        maximum: 2_147_483_647,
+      },
+      severity: "fatal",
+    });
+  });
 });

--- a/packages/agent/src/runtime/deferred-plugin-timeout.ts
+++ b/packages/agent/src/runtime/deferred-plugin-timeout.ts
@@ -2,9 +2,28 @@
  * Validates the operator-configured watchdog for deferred plugin registration.
  */
 
+import { ElizaError } from "@elizaos/core";
+
 const DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS = 30_000;
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
 const DECIMAL_INTEGER = /^\d+$/;
+const SETTING_NAME = "ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS";
+
+function invalidDeferredPluginRegistrationTimeout(raw: string): ElizaError {
+  return new ElizaError(
+    `${SETTING_NAME} must be a positive decimal integer no greater than ${MAX_TIMER_DELAY_MS}`,
+    {
+      code: "DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_INVALID",
+      context: {
+        setting: SETTING_NAME,
+        received: raw,
+        minimum: 1,
+        maximum: MAX_TIMER_DELAY_MS,
+      },
+      severity: "fatal",
+    },
+  );
+}
 
 export function parseDeferredPluginRegistrationTimeoutMs(
   raw: string | undefined,
@@ -13,9 +32,7 @@ export function parseDeferredPluginRegistrationTimeoutMs(
   if (!value) return DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS;
 
   if (!DECIMAL_INTEGER.test(value)) {
-    throw new Error(
-      `ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS must be a positive decimal integer no greater than ${MAX_TIMER_DELAY_MS}; received ${JSON.stringify(raw)}`,
-    );
+    throw invalidDeferredPluginRegistrationTimeout(raw ?? value);
   }
 
   const parsed = Number(value);
@@ -24,9 +41,7 @@ export function parseDeferredPluginRegistrationTimeoutMs(
     parsed <= 0 ||
     parsed > MAX_TIMER_DELAY_MS
   ) {
-    throw new Error(
-      `ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS must be a positive decimal integer no greater than ${MAX_TIMER_DELAY_MS}; received ${JSON.stringify(raw)}`,
-    );
+    throw invalidDeferredPluginRegistrationTimeout(raw ?? value);
   }
 
   return parsed;

--- a/packages/agent/src/runtime/deferred-plugin-timeout.ts
+++ b/packages/agent/src/runtime/deferred-plugin-timeout.ts
@@ -1,0 +1,33 @@
+/**
+ * Validates the operator-configured watchdog for deferred plugin registration.
+ */
+
+const DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS = 30_000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+const DECIMAL_INTEGER = /^\d+$/;
+
+export function parseDeferredPluginRegistrationTimeoutMs(
+  raw: string | undefined,
+): number {
+  const value = raw?.trim();
+  if (!value) return DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS;
+
+  if (!DECIMAL_INTEGER.test(value)) {
+    throw new Error(
+      `ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS must be a positive decimal integer no greater than ${MAX_TIMER_DELAY_MS}; received ${JSON.stringify(raw)}`,
+    );
+  }
+
+  const parsed = Number(value);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed <= 0 ||
+    parsed > MAX_TIMER_DELAY_MS
+  ) {
+    throw new Error(
+      `ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS must be a positive decimal integer no greater than ${MAX_TIMER_DELAY_MS}; received ${JSON.stringify(raw)}`,
+    );
+  }
+
+  return parsed;
+}

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -42,6 +42,7 @@ import { BootTimer } from "./boot-timer.ts";
 // Dev/test-only crash/hang injection (#10203). No-op unless ELIZA_CRASH_INJECT
 // is armed, and it refuses to arm in production — see crash-injection.ts.
 import { maybeInjectFault } from "./crash-injection.ts";
+import { parseDeferredPluginRegistrationTimeoutMs } from "./deferred-plugin-timeout.ts";
 import { runFirstTimeSetup } from "./first-time-setup.ts";
 import { startMemoryWatchdog } from "./memory-watchdog.ts";
 import {
@@ -5515,13 +5516,9 @@ export async function startEliza(
       ...deferredPluginsForRuntime,
     ]);
 
-    const timeoutMs = (() => {
-      const raw =
-        process.env.ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS?.trim();
-      if (!raw) return 30_000;
-      const parsed = Number.parseInt(raw, 10);
-      return Number.isFinite(parsed) && parsed > 0 ? parsed : 30_000;
-    })();
+    const timeoutMs = parseDeferredPluginRegistrationTimeoutMs(
+      process.env.ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+    );
     const registerDeferredPlugin = async (
       plugin: (typeof deferredPluginsForRuntime)[number],
     ): Promise<void> => {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -3935,6 +3935,14 @@ export async function startEliza(
   opts?: StartElizaOptions,
 ): Promise<AgentRuntime | undefined> {
   opts?.abortSignal?.throwIfAborted();
+  // Validate operator configuration before creating boot state or runtime
+  // resources. The deferred-task boundary intentionally catches later
+  // failures, so parsing inside that task would leave a ready-looking runtime
+  // with every deferred capability absent instead of failing startup.
+  const deferredPluginRegistrationTimeoutMs =
+    parseDeferredPluginRegistrationTimeoutMs(
+      process.env.ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+    );
   const bootContext =
     opts?.bootContext ?? createBootContext({ observePhase: opts?.onBootPhase });
   const bootTimer = new BootTimer("[eliza-boot]");
@@ -5516,9 +5524,6 @@ export async function startEliza(
       ...deferredPluginsForRuntime,
     ]);
 
-    const timeoutMs = parseDeferredPluginRegistrationTimeoutMs(
-      process.env.ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
-    );
     const registerDeferredPlugin = async (
       plugin: (typeof deferredPluginsForRuntime)[number],
     ): Promise<void> => {
@@ -5535,10 +5540,10 @@ export async function startEliza(
         registrationWatchdog = setTimeout(() => {
           exceededWatchdog = true;
           const error = new Error(
-            `Registration exceeded ${timeoutMs / 1000}s watchdog`,
+            `Registration exceeded ${deferredPluginRegistrationTimeoutMs / 1000}s watchdog`,
           );
           logger.warn(
-            `[eliza] deferred: Plugin ${plugin.name} registration exceeded the ${timeoutMs / 1000}s watchdog; still waiting for a definitive result`,
+            `[eliza] deferred: Plugin ${plugin.name} registration exceeded the ${deferredPluginRegistrationTimeoutMs / 1000}s watchdog; still waiting for a definitive result`,
           );
           // error-policy:J7 the watchdog reports a diagnostic without killing
           // the deferred loop; the same registration promise remains awaited.
@@ -5548,10 +5553,10 @@ export async function startEliza(
             {
               plugin: plugin.name,
               phase: "deferred-boot",
-              timeoutMs,
+              timeoutMs: deferredPluginRegistrationTimeoutMs,
             },
           );
-        }, timeoutMs);
+        }, deferredPluginRegistrationTimeoutMs);
         registrationWatchdog.unref?.();
         await runtime.registerPlugin(plugin);
         logger.info(


### PR DESCRIPTION
# Relates to

Fixes #19167.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto `origin/develop@574498511731d0bbb3a2ac0e9d8b03505a241526` with zero conflicts.
- [ ] Root `bun run verify` was not run; exact focused gates and the full agent dependency-build/typecheck proof are recorded below.
- [x] A reviewer can confirm the invalid-input and timer-overflow behavior from deterministic tests and the real Node timer reproduction.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: contributor `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`; maintainer review `elizaOS/eliza@574498511731d0bbb3a2ac0e9d8b03505a241526:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact head `97acf44c4e9f787926b0a3d0264b2baad9e5e463` is two commits over `origin/develop@574498511731d0bbb3a2ac0e9d8b03505a241526`; zero conflicts.
- [x] The final base-only rebase added #19108's Cloud deletion repair and did not overlap `packages/agent`.

# Risks

Low and bounded to the operator-only `ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS` setting. Unset/blank keeps the 30-second default; complete positive decimal integers through Node's real timer ceiling remain valid. Malformed, partial, non-positive, unsafe, and overflowing values now fail startup with a typed fatal configuration error instead of truncating, falling back silently, or reporting readiness with every deferred capability absent.

# Background

## What does this PR do?

The old implementation used `Number.parseInt`, so values such as `45.5`, `45ms`, and `1e3` were partially accepted. Values above `2^31-1` reached Node's timer API, which emits `TimeoutOverflowWarning` and schedules a one-millisecond timer.

The contributor correctly added complete-decimal and timer-bound validation. Review found a deeper lifecycle issue: parsing at the original consumer site occurs inside the post-readiness deferred task. Throwing there is caught and reported by the deferred-task boundary, so startup remains alive while all deferred capabilities are absent.

The repaired implementation therefore:

- validates the setting at the start of `startEliza()`, before boot state or runtime resources are created;
- throws a fatal `ElizaError` with code `DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_INVALID` and structured setting/range/value context;
- captures the validated value once and passes it to the deferred registration watchdog, avoiding a later read of mutable process state;
- covers defaults, exact boundaries, malformed values, overflow, and typed error metadata.

## What kind of change is this?

Bug fix for operator configuration validation and startup failure semantics.

# Documentation changes needed?

N/A - the setting remains a millisecond timeout; this enforces the domain its existing Node timer consumer already requires.

# Testing

## Where should a reviewer start?

1. `packages/agent/src/runtime/deferred-plugin-timeout.ts`
2. `packages/agent/src/runtime/deferred-plugin-timeout.test.ts`
3. The pre-boot validation and captured-value consumer in `packages/agent/src/runtime/eliza.ts`

## Detailed testing steps

PR code was run in a disposable Linux arm64 container with networking disabled, all capabilities dropped, and `no-new-privileges`, using pinned Bun 1.3.14 and trusted preinstalled dependencies.

- Full `@elizaos/agent...` dependency build: **84/84 workspaces passed**.
- Focused parser suite: **12/12 passed**.
- Strict `bun run --cwd packages/agent typecheck`: **passed** after the full dependency build.
- Exact-head agent package build: **passed**; package boundary audit and 193 import rewrites completed.
- Exact-head Biome on all three changed files: **passed**.
- `git diff --check origin/develop...HEAD`: **passed**.
- Agent guide parity remains unchanged.

The strict typecheck ran on the source-identical repair immediately before the final base-only rebase; the only intervening `develop` commit changed the separate Cloud deletion surface. Exact-head focused tests, build, Biome, and diff checks were rerun after that rebase.

# Evidence Gate

Evidence matches exact head `97acf44c4e9f787926b0a3d0264b2baad9e5e463`.
<!-- evidence-head:97acf44c4e9f787926b0a3d0264b2baad9e5e463 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side runtime configuration only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side runtime configuration only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual user flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - the invalid setting is rejected before runtime logging starts; the real timer output and exact tests are captured below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent decision, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Real Node timer reproduction and exact regression output:
  ```text
  Pre-fix real Node timer API:
  (node) TimeoutOverflowWarning: 9007199254740992 does not fit into a 32-bit signed integer.
  Timeout duration was set to 1.
  {"raw":"9007199254740992","parsed":9007199254740992,"elapsedMs":4}

  Exact-head focused suite:
  Test Files  1 passed (1)
       Tests  12 passed (12)
  ```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changes.

## Backend + frontend logs

N/A - invalid configuration fails before backend startup; no frontend path changes.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI files, layout, copy, or interaction changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- `bun install` and root `bun run verify` were not rerun. Validation used pinned Bun 1.3.14, a trusted dependency image, a full 84-workspace agent dependency build, strict agent typecheck, exact focused tests, exact package build, and Biome.
- No live invalid-config process boot was run because that path would initialize broad real agent dependencies; the parser's real consumer boundary and Node's timer overflow were inspected directly, and the parser contract is deterministic.
- Independent current-head review and hosted CI remain required because the maintainer repair author is not self-approving or self-merging.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@574498511731d0bbb3a2ac0e9d8b03505a241526:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@574498511731d0bbb3a2ac0e9d8b03505a241526:packages/skills/skills/contribute-to-eliza"} -->