### PR TITLE
fix(ci): give dispatched runs their own concurrency identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,12 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# A manual run is a diagnostic: it must not share the push ref group, or a
+# develop push storm parks it `pending` forever and then supersedes it, so
+# branch health can never be read on demand. Give workflow_dispatch its own
+# run-scoped identity — the same shape test.yml already uses.
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ci-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -43,8 +43,11 @@ on:
 # pending, which cannot starve the fleet. merge_group and schedule events are
 # also not in the cancel set, so the merge queue and nightly runs always
 # complete.
+# workflow_dispatch is excluded from the shared ref group: a manual run is an
+# on-demand health read, and parking it behind the push queue means it is
+# superseded before it ever starts.
 concurrency:
-  group: quality-${{ github.event.pull_request.number || github.ref }}
+  group: quality-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -28,8 +28,10 @@ on:
 
 # A reusable caller's scope separates it from the standalone ref domain. PRs
 # still supersede obsolete work; scheduled and exhaustive work always completes.
+# A manual run also gets a run-scoped identity so an on-demand health read is
+# not parked behind — and then superseded by — the develop push queue.
 concurrency:
-  group: scenario-pr-e2e-${{ inputs.concurrency_scope || 'standalone' }}-${{ github.event.pull_request.number || github.ref }}
+  group: scenario-pr-e2e-${{ inputs.concurrency_scope || 'standalone' }}-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/packages/scripts/__tests__/quality-workflow-concurrency.test.ts
+++ b/packages/scripts/__tests__/quality-workflow-concurrency.test.ts
@@ -25,9 +25,14 @@ describe("quality.yml concurrency contract", () => {
     const group = workflow.concurrency?.group;
     expect(group).toStartWith("quality-");
     expect(group).toContain("github.event.pull_request.number || github.ref");
-    // A run_id fallback would give every push a unique group and re-open the
-    // unbounded queue from #14069.
-    expect(group).not.toContain("run_id");
+    // An unconditional run_id fallback would give every push a unique group
+    // and re-open the unbounded queue from #14069. run_id may appear only
+    // behind an explicit workflow_dispatch guard, so a manual health read is
+    // not parked behind — and then superseded by — the develop push queue.
+    const dispatchGuard =
+      "github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id)";
+    const withoutDispatchGuard = String(group).replace(dispatchGuard, "");
+    expect(withoutDispatchGuard).not.toContain("run_id");
   });
 
   test("cancels in progress only for pull_request events, never push", () => {


### PR DESCRIPTION
# Relates to

Branch-health observability on `develop`: under the current merge wave a manual
run of `CI`, `Quality (Extended)`, or `Scenario PR E2E` can never start, so
there is no way to get a decisive read on whether `develop` is green.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop`.
- [x] `bun install` was run after sync; the affected contract test was verified
      red-then-green (see **Evidence Details**).
- [x] A reviewer can confirm the change works without reading the code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` @ `dd7190c50f4`; zero conflicts.
- [x] Full `bun run verify` was not run — see **Known gaps / failures**. This is
      precisely the condition this PR fixes.

# Risks

Low, and scoped to CI scheduling. No product code. `push`, `pull_request`,
`merge_group`, and `workflow_call` grouping is byte-identical; every
`cancel-in-progress` rule is unchanged. Only `workflow_dispatch` moves to a
run-scoped group, which can add at most one extra concurrent run per manual
invocation — bounded by how often a human presses the button.

# Background

## What does this PR do?

`ci.yml`, `quality.yml`, and `scenario-pr.yml` place `workflow_dispatch` runs in
the same `github.ref` concurrency group as `develop` pushes:

```
ci-${{ github.event.pull_request.number || github.ref || github.run_id }}
```

During a merge wave that group is permanently occupied. GitHub keeps at most one
*pending* run per group, so a manual run sits `pending` and is then superseded by
the next push — it never starts. The lanes that are hardest to read are exactly
the ones that cannot be read on demand.

`test.yml` already solved this and documents why:

```
group: test-${{ github.event_name == 'push' && github.ref || format('{0}-{1}', github.event_name, github.run_id) }}
```

> Develop pushes share a stable group so an obsolete tip is superseded before it
> can starve the fleet. Scheduled and manual runs use per-run groups: an incoming
> push therefore cannot cancel their independent diagnostic work.

This PR applies the same shape to the three remaining workflows, as a minimal
prefix on the existing expression so all other event grouping is untouched.

## What kind of change is this?

Bug fixes (restores on-demand branch-health observability).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The three `concurrency.group` expressions, then
`packages/scripts/__tests__/quality-workflow-concurrency.test.ts`.

That test previously banned `run_id` outright, to keep #14069's unbounded push
queue closed. The intent is "**push** runs must not get unique groups" — so the
assertion is ported to ban an *unguarded* `run_id` and pin the
`workflow_dispatch` guard. Push runs still share exactly one ref group; the
#14069 regression remains locked out.

## Detailed testing steps

```bash
bun test packages/scripts/__tests__/quality-workflow-concurrency.test.ts
```

# Evidence Gate

<!-- evidence-head:7bb3f07480fc59825bb228d62ef3a9b4f55fce62 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - CI workflow configuration change; there is no
      rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - CI workflow configuration change; there is no
      rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing flow. The behavior is proven by
      the live GitHub Actions run states below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: attached — live run-state observation from the GitHub
      Actions API (below).
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend code path is touched.`
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: `N/A - no agent, action, provider, prompt, or model path
      is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: attached — the workflow-contract test output below is
      the domain artifact for a CI-config change.
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - the diff renders no visual text.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model path is touched.`

## Backend + frontend logs

### The bug, measured live on `develop` @ `dd7190c50f4`

Four identical `gh workflow run ... --ref develop` dispatches of the same tree.
`Tests` is the one workflow that already carves manual runs out of the push
group; it is also the only one that got scheduled:

```
$ gh run list --branch develop --event workflow_dispatch --limit 4
CI:                pending   created 2026-08-13T18:23:14Z
Scenario PR E2E:   pending   created 2026-08-13T18:23:12Z
Quality (Extended):pending   created 2026-08-13T18:23:10Z
Tests:             queued    created 2026-08-13T18:23:08Z   <- already fixed
```

The three `pending` runs were still `pending` — never started — long after
dispatch, while push runs in the same groups cycled through
`cancelled`/`queued`.

### The control: same four workflows, same tree, uncontended ref

`dd7190c50f4` pushed verbatim to `ci/develop-health-snapshot-dd7190c` and
dispatched there. With no push traffic contending for the group, all four are
schedulable:

```
$ gh run list --branch ci/develop-health-snapshot-dd7190c --limit 4
CI:                 queued
Scenario PR E2E:    queued
Quality (Extended): queued
Tests:              queued
```

Same commit, same workflows, same runner fleet — the only variable is
concurrency-group contention.

## Screenshots (before / after) + video walkthrough

`N/A - CI configuration change with no rendered surface.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

<details>
<summary>Workflow contract test — RED with the old assertion, GREEN with the ported one</summary>

RED (pre-existing test against the new workflow — proves the assertion really
gates this expression, not a tautology):

```
26 |     expect(group).toStartWith("quality-");
27 |     expect(group).toContain("github.event.pull_request.number || github.ref");
30 |     expect(group).not.toContain("run_id");
error: expect(received).not.toContain(expected)
(fail) quality.yml concurrency contract > shares one concurrency group per ref so pushes supersede, not queue
 1 pass, 1 fail
```

GREEN (ported assertion):

```
$ bun test packages/scripts/__tests__/quality-workflow-concurrency.test.ts
 2 pass
 0 fail
 5 expect() calls
```
</details>

All three edited workflows were confirmed to parse and to expand to the intended
group expression via `Bun.YAML.parse`:

```
ci.yml          -> ci-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.event.pull_request.number || github.ref || github.run_id }}
quality.yml     -> quality-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.event.pull_request.number || github.ref }}
scenario-pr.yml -> scenario-pr-e2e-${{ inputs.concurrency_scope || 'standalone' }}-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.event.pull_request.number || github.ref }}
```

- Full `bun run verify` was not captured. `develop` is under a continuous push
  storm in which nearly every push-triggered run is cancelled by
  `cancel-in-progress` before finishing, and manual runs cannot be scheduled at
  all — which is the defect this PR fixes. The affected contract test was
  verified directly, red and green.
