### PR TITLE
fix(ui): pin the workflow revision timestamp to an explicit locale

### DIFF
--- a/packages/ui/src/components/pages/WorkflowEditor.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.tsx
@@ -1049,7 +1049,7 @@ export function WorkflowEditor({
                 </div>
                 <div className="min-w-0 flex-1">
                   <p className="text-[11px] text-muted-foreground">
-                    {new Date(revision.capturedAt).toLocaleString()}
+                    {new Date(revision.capturedAt).toLocaleString("en-US")}
                   </p>
                 </div>
                 <Button


### PR DESCRIPTION
# Relates to

Restores the `audit:ui-determinism` step of the `Quality (Extended)` →
`Develop Gate (secret scan + UI determinism)` job, red on every `develop` push
since `56401c2ee48` (#19000).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop`.
- [x] `bun install` was run after sync; the failing gate was reproduced red and
      verified green locally.
- [x] A reviewer can confirm the change works without reading the code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` @ `dd7190c50f4`; zero conflicts.
- [x] Full `bun run verify` was not run — see **Known gaps / failures**.

# Risks

Low. One argument added to one `toLocaleString` call in a revision-history
timestamp. It pins the rendered format to `en-US` instead of the host default,
which is the intent of the determinism gate and matches the surrounding file.

# Background

## What does this PR do?

`packages/ui/src/components/pages/WorkflowEditor.tsx` rendered the revision
timestamp as `new Date(revision.capturedAt).toLocaleString()` with no locale
argument, so the output depended on the host environment at render time.
`packages/scripts/audit-ui-determinism.mjs` flags exactly this:

```
FAIL audit-ui-determinism - 1 NEW render-time nondeterminism occurrence(s):
  packages/ui/src/components/pages/WorkflowEditor.tsx
      L1052 toLocaleString() [no locale]
```

Attribution: introduced by `56401c2ee48` — `feat(workflows): integrate native
smthrs studio (#19000)`, found with
`git log -S "toLocaleString()" -- packages/ui/src/components/pages/WorkflowEditor.tsx`.

This PR passes the explicit locale the audit asks for. `"en-US"` is chosen over
the bare `[]` default because it is the established form in this package —
34 call sites under `packages/ui/src` use an explicit `"en-US"`, versus 3 using
`[]` (two of which are the sibling timestamps added to this same file by the
same commit). `WorkflowEditor` consumes no app state or translator, so there is
no in-scope UI language to plumb through; a wider locale refactor would exceed a
CI-health fix.

The gate itself is not weakened and the baseline is **not** regenerated — the
occurrence is removed, so the count drops from 37 to 36.

## What kind of change is this?

Bug fixes (restores a red develop gate).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/pages/WorkflowEditor.tsx` L1052.

## Detailed testing steps

```bash
node packages/scripts/audit-ui-determinism.mjs
bun run --cwd packages/ui test -- src/components/pages/WorkflowEditor.test.tsx
```

# Evidence Gate

<!-- evidence-head:914774daa527c7f29165dab9c637d1575d9c8b44 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - the rendered output is a timestamp string whose
      only change is locale pinning; on an en-US CI/dev host the before and after
      pixels are identical, so a screenshot pair would show no difference and
      prove nothing.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - same reason as the before row.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user flow changes; the revision list behaves
      identically.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no backend code path is touched.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: attached — the `WorkflowEditor` component test suite output
      below exercises the rendered component.
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: `N/A - no agent, action, provider, prompt, or model path
      is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: attached — the determinism audit output below is the
      artifact this change is judged by.
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - no visual text layout changes; the string content and
      position are unchanged on an en-US host.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model path is touched.`

## Backend + frontend logs

<details>
<summary>RED — <code>develop</code> @ <code>dd7190c50f4</code>, unmodified</summary>

```
$ node packages/scripts/audit-ui-determinism.mjs
audit-ui-determinism: render-time=37 deferred=270 module=210 (baseline 29 files)

FAIL audit-ui-determinism - 1 NEW render-time nondeterminism occurrence(s):
  packages/ui/src/components/pages/WorkflowEditor.tsx
      L1052 toLocaleString() [no locale]

Move the value out of render (into useEffect / a handler / props), pass an explicit 'en-US' locale,
or - if intentional - run `node packages/scripts/audit-ui-determinism.mjs --update-baseline` and commit the baseline.
```

This reproduces CI runs 31719100155, 31712535908, 31705571905 and 31688457714
(all `push` to `develop`) exactly.
</details>

<details>
<summary>GREEN — same tree with this commit applied</summary>

```
$ node packages/scripts/audit-ui-determinism.mjs
audit-ui-determinism: render-time=36 deferred=270 module=210 (baseline 29 files)
OK audit-ui-determinism PASSED (no new render-time nondeterminism)
```

Note `render-time=37` → `36`: the occurrence is removed, not baselined.
</details>

<details>
<summary>Component tests + lint</summary>

```
$ bun run --cwd packages/ui test -- src/components/pages/WorkflowEditor.test.tsx
 Test Files  1 passed (1)
      Tests  7 passed (7)

$ npx biome check packages/ui/src/components/pages/WorkflowEditor.tsx
Checked 1 file in 119ms. No fixes applied.
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - see the evidence rows above; the change is locale pinning with no visual
delta on an en-US host.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

- Full `bun run verify` was not captured. `develop` is under a continuous push
  storm in which nearly every push-triggered workflow run is cancelled by
  `cancel-in-progress` before finishing, so a repository-wide gate cannot be
  captured against a stable tip. The gate this PR repairs was reproduced red and
  verified green directly, and the owning component's tests and lint pass.
- The `Quality (Extended)` job that runs this gate has a **second, independent**
  failure in its `Consolidated Frontend Build` job (`build:web` cannot resolve
  the `@elizaos/core` entry). That is a separate root cause and is not addressed
  here; this PR fixes only the `audit:ui-determinism` step.
