### PR TITLE
fix(ci): build the core workspace before quality.yml's frontend build

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -119,6 +119,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # The install above uses --ignore-scripts, so no workspace dist exists.
+      # packages/app/vite.config.ts imports ../shared/src/runtime-env.ts, whose
+      # barrels re-export from @elizaos/core, and Vite bundles the config with
+      # esbuild under default export conditions -- it cannot see core's
+      # eliza-source condition, so it needs core's real dist. cloud-cf-deploy.yml
+      # builds core the same way before the same build:web.
+      - name: Build linked elizaOS core workspace once
+        if: steps.frontend-scope.outputs.run == 'true'
+        run: bun run build:core
+
       - name: Build the only deployable frontend
         if: steps.frontend-scope.outputs.run == 'true'
         working-directory: packages/app

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -113,4 +113,17 @@ describe("homepage deployment workflow", () => {
       "PLAYWRIGHT_INSTALL_CWD=packages/homepage",
     );
   });
+
+  it("builds the core workspace before the quality frontend build", () => {
+    // packages/app/vite.config.ts reaches @elizaos/core through the
+    // packages/shared barrels, and Vite bundles the config with esbuild under
+    // default export conditions, so core's dist must exist first. Both
+    // workflows install with --ignore-scripts and therefore need the step.
+    expect(workflow).toContain("run: bun run build:core");
+    expect(qualityWorkflow).toContain("run: bun run build:core");
+    const coreBuildIndex = qualityWorkflow.indexOf("run: bun run build:core");
+    const webBuildIndex = qualityWorkflow.indexOf("run: bun run build:web");
+    expect(coreBuildIndex).toBeGreaterThan(-1);
+    expect(webBuildIndex).toBeGreaterThan(coreBuildIndex);
+  });
 });


### PR DESCRIPTION
# Relates to

`develop` branch health: the **Quality (Extended)** workflow's `consolidated-frontend-build`
job ("Consolidated Frontend Build") has failed on **every** develop push since
PR #18996 merged. Example failing runs:
[31719100155](https://github.com/elizaOS/eliza/actions/runs/31719100155),
[31712535908](https://github.com/elizaOS/eliza/actions/runs/31712535908),
[31705571905](https://github.com/elizaOS/eliza/actions/runs/31705571905).

No pre-existing issue was found for this; opening the fix directly since develop is red.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker. (See **Known gaps / failures** —
      `bun run verify` is not run for this CI-config-only diff; the exact CI command
      this PR fixes was run instead, red and green.)
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** The diff adds one CI step to one job in `.github/workflows/quality.yml`
and one assertion block to an existing workflow contract test. No runtime,
product, or published-package code is touched. The added step is byte-identical
in name and command to the step `cloud-cf-deploy.yml` already runs before the
same `build:web`, so it introduces no new tooling. Worst case is ~100 s of extra
job time (`build:core` measured at 1m41s locally). No gate is weakened or
skipped: the step is guarded by the same `steps.frontend-scope.outputs.run ==
'true'` condition as the build it precedes, so scope-skipped runs are unaffected.

# Background

## What does this PR do?

Restores the missing `bun run build:core` prerequisite to the
`consolidated-frontend-build` job in `.github/workflows/quality.yml`, and pins
the ordering in the existing workflow contract test.

### Root cause

`0468c1850a3` (PR #18996, *feat: consolidate Eliza Cloud into eliza.app*,
merged 2026-08-13T10:15:44Z) repurposed this job. It previously built
`packages/homepage`:

```yaml
-      - name: Build homepage
-        working-directory: packages/homepage
-        run: bun run build
```

and now builds `packages/app`:

```yaml
+      - name: Build the only deployable frontend
+        working-directory: packages/app
+        run: bun run build:web
```

The `packages/homepage` build had no `@elizaos/core` dependency. The
`packages/app` build does, **at Vite-config-bundling time**:

```
packages/app/vite.config.ts
  -> ../shared/src/runtime-env.ts
       -> ./env-utils.js                  -> export { isTruthyEnvValue }      from "@elizaos/core"
  -> ../shared/src/config/app-config.ts
       -> ./config/boot-config-store.ts   -> export { resolveAliasedEnvValue } from "@elizaos/core"
```

The job installs with `bun install --frozen-lockfile --ignore-scripts`, so no
workspace `dist` is produced. Vite bundles `vite.config.ts` with esbuild
(`bundleConfigFile`) under **default** export conditions, which cannot see the
`eliza-source` condition that `packages/core/package.json` exposes for in-repo
source consumers. Resolution therefore falls through to
`./dist/node/index.node.js`, which does not exist, and the config load fails
with two errors before app bundling ever begins.

The job simply never had the build step. `.github/workflows/cloud-cf-deploy.yml`
runs the identical `build:web` after the identical `--ignore-scripts` install and
**does** have it:

```yaml
      - name: Install frontend dependencies
        run: bun install --frozen-lockfile --ignore-scripts

      - name: Build linked elizaOS core workspace once
        run: bun run build:core

      - name: Build consolidated frontend artifact
        run: bun run --cwd packages/app build:web
```

`.github/workflows/ci.yml` carries the same prerequisite in three places, with
the rationale in a comment: *"build:core runs first so package typechecks resolve
workspace dist output…"*.

### Why this fix and not the alternatives

Two other fixes were considered and rejected:

1. **Break the config-time dependency on `@elizaos/core`** (stop
   `packages/shared/src/env-utils.ts` / `config/boot-config-store.ts` re-exporting
   from core). Rejected: those barrels exist *deliberately*. `env-utils.ts`'s own
   header states core owns `isTruthyEnvValue` and shared re-exports it so existing
   `@elizaos/shared` consumers keep their import path, and commit `89522a60ae2`
   (*refactor(core,shared,app-core): unify isTruthyEnvValue + collapse env-bool
   dupes*) established that ownership. Undoing it to appease a CI job would
   re-duplicate a symbol core owns and contradict the repository's
   single-ownership convention.
2. **Change `packages/core`'s `exports`.** Rejected: the entry is not
   misdeclared. `main`/`module`/`exports` point at real build outputs, and the
   `eliza-source` condition already exists for source consumers. The contract is
   "build core before consuming its package entry" — which the production deploy
   workflow honors and this job did not.

Adding the step is the minimal change that satisfies the existing, documented
build-order contract rather than papering over it. Nothing is weakened: the
`build:web` gate still runs and still has to pass.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue) — CI configuration.

# Documentation changes needed?

My changes do not require a change to the project documentation. The rationale is
captured as an inline comment on the workflow step and in the contract test.

# Testing

## Where should a reviewer start?

`.github/workflows/quality.yml`, the `consolidated-frontend-build` job — compare
it to the `build-pages` job in `.github/workflows/cloud-cf-deploy.yml`, which
already runs the identical step before the identical build.

## Detailed testing steps

Reproduced in a clean worktree at `dd7190c50f4` under CI conditions
(`--ignore-scripts` install, therefore no `packages/core/dist`):

```bash
git worktree add <wt> dd7190c50f4 --detach
cd <wt> && ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile --ignore-scripts
ls packages/core/dist   # -> No such file or directory  (matches CI)

# RED  — what develop does today
cd packages/app && bun run build:web        # exits 1

# GREEN — what this PR makes CI do
cd <wt> && bun run build:core
cd packages/app && bun run build:web        # exits 0
```

Contract tests:

```bash
bunx vitest run packages/scripts/__tests__/homepage-deploy-workflow.test.ts
bun test packages/scripts/__tests__/quality-workflow-concurrency.test.ts \
         packages/scripts/__tests__/github-action-pinning.test.ts
```

# Evidence Gate

<!-- evidence-head:fb0f96323c21f42b45366b1681953ce4b401e490 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - CI workflow YAML and a workflow contract test only; this diff renders no UI surface. The app build output is byte-identical before and after; the change is only whether the build runs at all.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - same reason as the before-screenshots row: no rendered surface is added, removed, or restyled by this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - the user-facing flow here is a CI job. Its complete before/after console output is pasted verbatim below, which is the reviewable artifact for a build step.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — see the RED and GREEN build transcripts below. There is no server process in this change; the build tool output is the end-to-end path.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs — `N/A - no browser is involved. The failure and the fix both occur in Vite's config-bundling phase in Node, before any bundle is emitted or served; that output is pasted below.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent, action, provider, prompt, or model code is touched. The diff is one CI step and one test assertion.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — `N/A - no DB rows, memories, scheduled tasks, wallet/on-chain output, or generated product files. The only artifact is the frontend bundle, whose successful emission is shown in the GREEN transcript below.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - the change has no rendered visual surface (workflow YAML + a Vitest assertion).`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model surface is touched by this diff.`

## Backend + frontend logs

### RED — `bun run build:web` at `dd7190c50f4` with no `packages/core/dist` (current develop behavior)

<details>
<summary>RED: <code>cd packages/app &amp;&amp; bun run build:web</code> → exit 1</summary>

```
$ bun run prebuild
$ node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --concepts --banners --background --background-videos && node ../app-core/scripts/write-homepage-release-data.mjs && node scripts/sync-homepage-assets.mjs
[shared-brand] synced into .../packages/app/public: logos, favicons, banners, concepts, background+videos
homepage release data: stable=no published release, canary=v2.0.3-beta.7, osArtifacts=10
$ ELIZA_WEB_ABSOLUTE_BASE=1 node ../../node_modules/@elizaos/vitest-vite/bin/vite.js build && node scripts/verify-chunk-safety.mjs && node scripts/verify-viewport-meta.mjs
✘ [ERROR] Failed to resolve entry for package "@elizaos/core". The package may have incorrect main/module/exports specified in its package.json. [plugin externalize-deps]

    ../../node_modules/.bun/esbuild@0.27.7/node_modules/esbuild/lib/main.js:1498:27:
      1498 │         let result = await callback({
           ╵                            ^

    at packageEntryFailure (.../vite/dist/node/chunks/config.js:32836:32)
    at resolvePackageEntry (.../vite/dist/node/chunks/config.js:32833:2)
    at tryNodeResolve (.../vite/dist/node/chunks/config.js:32736:70)
    at nodeResolveWithVite (.../vite/dist/node/chunks/config.js:32966:9)
    at bundleConfigFile (.../vite/dist/node/chunks/config.js:35835:23)

  The plugin "externalize-deps" was triggered by this import

    ../shared/src/env-utils.ts:10:33:
      10 │ export { isTruthyEnvValue } from "@elizaos/core";
         ╵                                  ~~~~~~~~~~~~~~~

✘ [ERROR] Failed to resolve entry for package "@elizaos/core". The package may have incorrect main/module/exports specified in its package.json. [plugin externalize-deps]

    at bundleConfigFile (.../vite/dist/node/chunks/config.js:35835:23)

  The plugin "externalize-deps" was triggered by this import

    ../shared/src/config/boot-config-store.ts:11:39:
      11 │ export { resolveAliasedEnvValue } from "@elizaos/core";
         ╵                                        ~~~~~~~~~~~~~~~

failed to load config from .../packages/app/vite.config.ts
error during build:
Error: Build failed with 2 errors:
.../esbuild/lib/main.js:1498:27: ERROR: [plugin: externalize-deps] Failed to resolve entry for package "@elizaos/core". The package may have incorrect main/module/exports specified in its package.json.
.../esbuild/lib/main.js:1498:27: ERROR: [plugin: externalize-deps] Failed to resolve entry for package "@elizaos/core". The package may have incorrect main/module/exports specified in its package.json.
    at failureErrorWithLog (.../esbuild/lib/main.js:1748:15)
error: script "build:web" exited with code 1

EXIT=1
```

This is character-for-character the failure in CI job
[94514910012](https://github.com/elizaOS/eliza/actions/runs/31719100155) —
same two errors, same two importing files, same `bundleConfigFile` frame.

</details>

### GREEN — with this PR's step (`bun run build:core` first)

<details>
<summary>GREEN: <code>bun run build:core</code> → exit 0</summary>

```
$ node packages/scripts/build-core.mjs

 Tasks:    56 successful, 56 total
Cached:    0 cached, 56 total
  Time:    1m41.427s

CORE_EXIT=0
```

</details>

<details>
<summary>GREEN: <code>cd packages/app &amp;&amp; bun run build:web</code> → exit 0</summary>

```
$ ELIZA_WEB_ABSOLUTE_BASE=1 node ../../node_modules/@elizaos/vitest-vite/bin/vite.js build && node scripts/verify-chunk-safety.mjs && node scripts/verify-viewport-meta.mjs
vite v7.3.3 building client environment for production...
transforming...
✓ 8927 modules transformed.
rendering chunks...
computing gzip size...
dist/assets/verify-filled-Cpl8OaQA.js                          0.89 kB │ gzip:   0.53 kB
dist/assets/verify-2WMunUm1.js                                 1.59 kB │ gzip:   0.78 kB
dist/assets/chunk-62JRHF6Z-BjxlIROp.js                        39.61 kB │ gzip:  14.22 kB
dist/assets/webhook-verify-KRctZ4cy.js                        95.37 kB │ gzip:  15.43 kB
✓ built in 2m 14s
[plugin renderer-build-manifest] wrote eliza-renderer-build.json buildId=78bfb9ab261e (643 assets)
[plugin sw-build-rev] stamped dist/sw.js build rev=fb0f96323c21
[verify-chunk-safety] OK: bn.js/crypto graph is confined to lazy vendor chunks (554 current chunks scanned).
[verify-chunk-safety] OK: entry static closure (3 chunks from index-BgTQ-umO.js) contains no lazy-by-design vendor chunk.
[verify-viewport-meta] web policy verified: width=device-width, initial-scale=1.0, viewport-fit=cover

WEB_EXIT=0
```

</details>

### Workflow contract tests

<details>
<summary><code>bunx vitest run packages/scripts/__tests__/homepage-deploy-workflow.test.ts</code></summary>

```
❯ packages/scripts/__tests__/homepage-deploy-workflow.test.ts (5 tests | 2 failed) 70ms
     × builds homepage changes into the single eliza-app artifact 39ms
     × resolves matched Telegram configuration for canonical and preview builds 24ms

 Test Files  1 failed (1)
      Tests  2 failed | 3 passed (5)
```

The new `builds the core workspace before the quality frontend build` case
passes. The two failing cases (`builds homepage changes into the single
eliza-app artifact`, `resolves matched Telegram configuration…`) are
**pre-existing on `dd7190c50f4`** and unrelated to this diff — verified by
stashing this PR's test change and re-running the identical command:

```
--- BASELINE (this PR's test removed) ---
     × builds homepage changes into the single eliza-app artifact 18ms
     × resolves matched Telegram configuration for canonical and preview builds 8ms
      Tests  2 failed | 2 passed (4)
```

Identical two failures, so this PR adds one passing case and changes nothing else.

</details>

<details>
<summary><code>bun test .../quality-workflow-concurrency.test.ts .../github-action-pinning.test.ts</code></summary>

```
 13 pass
 1 fail
 38 expect() calls
Ran 14 tests across 2 files. [314.00ms]
```

The single failure is `github-action-pinning > routes homepage deploys through
the consolidated Cloudflare workflow`, asserting `PAGES_PROJECT: eliza-app` is
present in `cloud-cf-deploy.yml`. That string is absent on `dd7190c50f4`
independently of this PR (this diff does not touch `cloud-cf-deploy.yml`) — it
is the same pre-existing PR #18996 drift as the two Vitest failures above.

</details>

### YAML validity and step ordering

<details>
<summary>Parsed <code>quality.yml</code> after the change</summary>

```
'Build linked elizaOS core workspace once' | bun run build:core | wd= None
'Build the only deployable frontend' | bun run build:web | wd= packages/app
YAML OK
```

Order and working directories are correct, and both steps carry the same
`if: steps.frontend-scope.outputs.run == 'true'` guard.

</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface is touched. The diff is .github/workflows/quality.yml plus packages/scripts/__tests__/homepage-deploy-workflow.test.ts; no .tsx, .css, or .svg is modified, so the CI evidence gate's UI-diff rule does not apply.`

### After

`N/A - same reason as Before.`

### Walkthrough video

`N/A - the reviewable flow is a CI build step; its full before/after transcripts are inline above.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice code is touched.`

## Known gaps / failures

- **`bun run verify` was not run for this PR.** This diff is CI workflow YAML
  plus one test assertion; the full repository verify fan-out does not exercise
  the failing path. Instead the exact command the broken CI step runs
  (`bun run build:web` in `packages/app`, under CI's `--ignore-scripts` install
  with no `packages/core/dist`) was executed red and green, plus every contract
  test that reads `quality.yml`. Transcripts are inline above.
- **Two Vitest cases and one Bun test case fail on the base commit.** They assert
  `PAGES_PROJECT: eliza-app`, `resolve-pages-environment-config:`, and related
  strings in `.github/workflows/cloud-cf-deploy.yml`, which are absent at
  `dd7190c50f4`. Shown above to be present with this PR's changes stashed, so
  they are pre-existing PR #18996 drift, out of scope here, and not a blocker
  for restoring the frontend build. Worth a separate follow-up.
- **Screenshot / video / OCR / LLM-trajectory rows are `N/A`** with the concrete
  reasons stated on each row: this change has no rendered surface and no
  agent-behavior surface.
