### PR TITLE
fix(app): align core-view coverage contract with the consolidated workflow spec

### DIFF
--- a/packages/app/test/core-view-interaction-coverage.test.ts
+++ b/packages/app/test/core-view-interaction-coverage.test.ts
@@ -147,11 +147,11 @@ const CORE_VIEW_INTERACTIONS: Readonly<Record<string, CoreViewInteraction>> = {
       {
         spec: "packages/app/test/ui-smoke/workflow-editor.spec.ts",
         proves:
-          "Opens the Automations WorkflowEditor, saves a connected graph, and reloads the persisted definition.",
+          "Authors, persists, executes, inspects, and reloads a native Smithers workflow.",
         signals: [
-          "workflow editor saves a connected graph",
-          "workflow save should receive a 2xx POST",
-          "matrix smoke digest",
+          "workflow studio creates, executes, inspects, and reloads a Smithers workflow",
+          "smithers-source-editor",
+          "workflow.finished",
         ],
       },
     ],

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -32,6 +32,13 @@ export default defineConfig({
     ...baseConfig.resolve,
     alias: [
       {
+        // The renderer imports the public marketing entrypoints through the
+        // same source boundary as the Vite build. Keep unit entrypoint tests
+        // independent of a separately built homepage package.
+        find: /^@homepage\//,
+        replacement: `${path.resolve(here, "../homepage/src")}/`,
+      },
+      {
         // Entrypoint tests exercise the shipped iOS bridge import in source mode;
         // the changed-test lane intentionally builds core only, so they cannot
         // depend on a pre-existing app-core dist directory.


### PR DESCRIPTION
# Relates to

Unblocks every open PR whose `Tests (client)` lane inherits a develop-side failure in `packages/app/test/core-view-interaction-coverage.test.ts` (observed on #18895 and others).

## Root cause

The workflow-studio consolidation landed the new `packages/app/test/ui-smoke/workflow-editor.spec.ts` but not the matching coverage-contract entry. The coverage matrix still demanded the **old** spec's signals (`workflow editor saves a connected graph`, `workflow save should receive a 2xx POST`, `matrix smoke digest`), none of which exist in the consolidated spec — so the gate fails on `develop` itself and on every branch that merges it.

This **realigns the declared signals to the consolidated spec's real assertions** (`workflow studio creates, executes, inspects, and reloads a Smithers workflow`, `smithers-source-editor`, `workflow.finished`). The gate is **not** weakened: the same number of required signals is asserted, now against strings the spec actually contains.

Also adds a `@homepage/*` → source alias in `packages/app/vitest.config.ts`, matching how the Vite build resolves the marketing entrypoints, so renderer entrypoint unit tests do not depend on a separately built homepage package.

Cherry-picked from `fix/develop-workflows-20260812@adc81d115c6` so it can land independently of that branch's other 31 commits.

## Red/green proof (run locally on this branch, develop tree)

```
# with the fix
$ bunx vitest run test/core-view-interaction-coverage.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)

# same tree, fix reverted
$ git revert --no-commit HEAD && bunx vitest run test/core-view-interaction-coverage.test.ts
 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
```

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

# Evidence Gate

<!-- evidence-head:006f49fab82b71c49af24545699e5770ecc82df5 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-contract and vitest-alias change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow.
<!-- evidence-row:backend-logs -->
- [x] Red/green transcript from the real suite on this branch:

```
$ bunx vitest run test/core-view-interaction-coverage.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
   Duration  322ms

$ git revert --no-commit HEAD; bunx vitest run test/core-view-interaction-coverage.test.ts
 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser session; this is a node-side contract test.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model path touched.
<!-- evidence-row:domain-artifacts -->
- [x] The realigned signal set is the artifact; it is asserted against the consolidated spec's real strings (`smithers-source-editor`, `workflow.finished`), verified by the passing run above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no pixels.