### PR TITLE
fix(core): serialize channel topic persistence

### DIFF
--- a/packages/core/src/services/__tests__/channel-topics.test.ts
+++ b/packages/core/src/services/__tests__/channel-topics.test.ts
@@ -9,6 +9,7 @@ import { createCharacter } from "../../character.ts";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter.ts";
 import { AgentRuntime } from "../../runtime.ts";
 import type { Room, UUID } from "../../types/index";
+import type { IAgentRuntime } from "../../types/runtime";
 import {
 	CHANNEL_TOPICS_LRU_CAPACITY,
 	CHANNEL_TOPICS_METADATA_KEY,
@@ -127,6 +128,307 @@ describe("ChannelTopicsService", () => {
 			"billing",
 			"auth",
 		]);
+	});
+
+	it("serializes concurrent persistence and preserves the newest topic list", async () => {
+		let storedRoom = makeRoom(ROOM_A);
+		const updates: Room[] = [];
+		const releaseUpdates: Array<() => void> = [];
+		const controlledRuntime = {
+			getRoom: async (_roomId: UUID) => ({
+				...storedRoom,
+				metadata: storedRoom.metadata ? { ...storedRoom.metadata } : undefined,
+			}),
+			updateRoom: async (updated: Room) => {
+				updates.push(updated);
+				await new Promise<void>((resolve) => releaseUpdates.push(resolve));
+				storedRoom = {
+					...updated,
+					metadata: updated.metadata ? { ...updated.metadata } : undefined,
+				};
+				return undefined;
+			},
+			reportError: (
+				_scope: string,
+				_error: unknown,
+				_context?: Record<string, unknown>,
+			) => undefined,
+		} satisfies Pick<IAgentRuntime, "getRoom" | "updateRoom" | "reportError">;
+		const controlledService =
+			await ChannelTopicsService.start(controlledRuntime);
+
+		const waitForUpdateCount = async (count: number) => {
+			for (
+				let attempt = 0;
+				attempt < 100 && updates.length < count;
+				attempt++
+			) {
+				await Promise.resolve();
+			}
+			expect(updates).toHaveLength(count);
+		};
+		const settle = async () => {
+			for (let attempt = 0; attempt < 20; attempt++) {
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+			}
+		};
+
+		const first = controlledService.recordTopics(ROOM_A, ["a"]);
+		await waitForUpdateCount(1);
+		const second = controlledService.recordTopics(ROOM_A, ["b"]);
+		await settle();
+		expect(updates).toHaveLength(1);
+
+		const releaseFirst = releaseUpdates.shift();
+		if (!releaseFirst) throw new Error("first update was not released");
+		releaseFirst();
+		await waitForUpdateCount(2);
+		const releaseSecond = releaseUpdates.shift();
+		if (!releaseSecond) throw new Error("second update was not released");
+		releaseSecond();
+		await Promise.all([first, second]);
+
+		expect(storedRoom.metadata?.[CHANNEL_TOPICS_METADATA_KEY]).toEqual([
+			"a",
+			"b",
+		]);
+		expect(controlledService.getTopicsForRoom(ROOM_A)).toEqual(["a", "b"]);
+	});
+
+	it("never allows an older same-room snapshot to complete last", async () => {
+		let storedRoom = makeRoom(ROOM_A);
+		const inFlight: Room[] = [];
+		let maxConcurrentWrites = 0;
+		const releaseUpdates: Array<() => void> = [];
+		const controlledRuntime = {
+			getRoom: async (_roomId: UUID) => ({
+				...storedRoom,
+				metadata: storedRoom.metadata ? { ...storedRoom.metadata } : undefined,
+			}),
+			updateRoom: async (updated: Room) => {
+				inFlight.push(updated);
+				maxConcurrentWrites = Math.max(maxConcurrentWrites, inFlight.length);
+				await new Promise<void>((resolve) => releaseUpdates.push(resolve));
+				inFlight.splice(inFlight.indexOf(updated), 1);
+				storedRoom = {
+					...updated,
+					metadata: updated.metadata ? { ...updated.metadata } : undefined,
+				};
+				return undefined;
+			},
+			reportError: (
+				_scope: string,
+				_error: unknown,
+				_context?: Record<string, unknown>,
+			) => undefined,
+		} satisfies Pick<IAgentRuntime, "getRoom" | "updateRoom" | "reportError">;
+		const controlledService =
+			await ChannelTopicsService.start(controlledRuntime);
+		const settle = async () => {
+			for (let attempt = 0; attempt < 20; attempt++) {
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+			}
+		};
+
+		const first = controlledService.recordTopics(ROOM_A, ["a"]);
+		const second = controlledService.recordTopics(ROOM_A, ["b"]);
+		await settle();
+		expect(maxConcurrentWrites).toBe(1);
+
+		while (releaseUpdates.length > 0 || inFlight.length > 0) {
+			const release = releaseUpdates.pop();
+			if (release) release();
+			await settle();
+		}
+		await Promise.all([first, second]);
+
+		expect(maxConcurrentWrites).toBe(1);
+		expect(storedRoom.metadata?.[CHANNEL_TOPICS_METADATA_KEY]).toEqual([
+			"a",
+			"b",
+		]);
+	});
+
+	it("serializes cold hydration with writes without rolling back the cache", async () => {
+		let storedRoom = makeRoom(ROOM_A, ["seed"]);
+		const reads: Array<Promise<Room | null>> = [];
+		const resolveReads: Array<(room: Room | null) => void> = [];
+		const updates: Room[] = [];
+		const releaseUpdates: Array<() => void> = [];
+		const controlledRuntime = {
+			getRoom: async (_roomId: UUID) => {
+				const read = new Promise<Room | null>((resolve) =>
+					resolveReads.push(resolve),
+				);
+				reads.push(read);
+				return read;
+			},
+			updateRoom: async (updated: Room) => {
+				updates.push(updated);
+				await new Promise<void>((resolve) => releaseUpdates.push(resolve));
+				storedRoom = {
+					...updated,
+					metadata: updated.metadata ? { ...updated.metadata } : undefined,
+				};
+				return undefined;
+			},
+			reportError: (
+				_scope: string,
+				_error: unknown,
+				_context?: Record<string, unknown>,
+			) => undefined,
+		} satisfies Pick<IAgentRuntime, "getRoom" | "updateRoom" | "reportError">;
+		const controlledService =
+			await ChannelTopicsService.start(controlledRuntime);
+
+		const waitForUpdateCount = async (count: number) => {
+			for (
+				let attempt = 0;
+				attempt < 100 && updates.length < count;
+				attempt++
+			) {
+				await Promise.resolve();
+			}
+			expect(updates).toHaveLength(count);
+		};
+
+		const waitForReadCount = async (count: number) => {
+			for (let attempt = 0; attempt < 100 && reads.length < count; attempt++) {
+				await Promise.resolve();
+			}
+			expect(reads).toHaveLength(count);
+		};
+
+		const reader = controlledService.ensureHydrated(ROOM_A);
+		await waitForReadCount(1);
+		const writer = controlledService.recordTopics(ROOM_A, ["b"]);
+		await Promise.resolve();
+		// The writer waits for the cold reader instead of starting a competing
+		// hydration read that could restore the stale seed snapshot later.
+		expect(reads).toHaveLength(1);
+
+		const resolveInitialRead = resolveReads.shift();
+		if (!resolveInitialRead) throw new Error("initial read was not released");
+		resolveInitialRead({
+			...storedRoom,
+			metadata: storedRoom.metadata ? { ...storedRoom.metadata } : undefined,
+		});
+		await reader;
+
+		await waitForReadCount(2);
+		const resolvePersistRead = resolveReads.shift();
+		if (!resolvePersistRead) throw new Error("persist read was not released");
+		resolvePersistRead({
+			...storedRoom,
+			metadata: storedRoom.metadata ? { ...storedRoom.metadata } : undefined,
+		});
+		await waitForUpdateCount(1);
+		const releaseUpdate = releaseUpdates.shift();
+		if (!releaseUpdate) throw new Error("update was not released");
+		releaseUpdate();
+		await writer;
+
+		expect(storedRoom.metadata?.[CHANNEL_TOPICS_METADATA_KEY]).toEqual([
+			"seed",
+			"b",
+		]);
+		expect(controlledService.getTopicsForRoom(ROOM_A)).toEqual(["seed", "b"]);
+	});
+
+	it("waits for pending room operations before clearing on stop", async () => {
+		const updates: Room[] = [];
+		const releaseUpdates: Array<() => void> = [];
+		const controlledRuntime = {
+			getRoom: async (_roomId: UUID) => makeRoom(ROOM_A),
+			updateRoom: async (updated: Room) => {
+				updates.push(updated);
+				await new Promise<void>((resolve) => releaseUpdates.push(resolve));
+				return undefined;
+			},
+			reportError: (
+				_scope: string,
+				_error: unknown,
+				_context?: Record<string, unknown>,
+			) => undefined,
+		} satisfies Pick<IAgentRuntime, "getRoom" | "updateRoom" | "reportError">;
+		const controlledService =
+			await ChannelTopicsService.start(controlledRuntime);
+		const write = controlledService.recordTopics(ROOM_A, ["pending"]);
+
+		for (let attempt = 0; attempt < 100 && updates.length < 1; attempt++) {
+			await Promise.resolve();
+		}
+		expect(updates).toHaveLength(1);
+		const stopping = controlledService.stop();
+		await Promise.resolve();
+		expect(controlledService.getTopicsForRoom(ROOM_A)).toEqual(["pending"]);
+		await expect(
+			controlledService.recordTopics(ROOM_A, ["rejected-while-stopping"]),
+		).rejects.toMatchObject({ code: "CHANNEL_TOPICS_STOPPING" });
+
+		const releaseUpdate = releaseUpdates.shift();
+		if (!releaseUpdate) throw new Error("pending update was not released");
+		releaseUpdate();
+		await write;
+		await stopping;
+		expect(controlledService.getTopicsForAllRooms()).toEqual({});
+	});
+
+	it("allows different-room writes to proceed independently", async () => {
+		const inFlight = new Set<UUID>();
+		const releaseUpdates = new Map<UUID, () => void>();
+		let maxConcurrentWrites = 0;
+		const controlledRuntime = {
+			getRoom: async (roomId: UUID) => makeRoom(roomId),
+			updateRoom: async (updated: Room) => {
+				if (!updated.id) throw new Error("updated room is missing an id");
+				inFlight.add(updated.id);
+				maxConcurrentWrites = Math.max(maxConcurrentWrites, inFlight.size);
+				await new Promise<void>((resolve) =>
+					releaseUpdates.set(updated.id as UUID, resolve),
+				);
+				inFlight.delete(updated.id);
+			},
+			reportError: (
+				_scope: string,
+				_error: unknown,
+				_context?: Record<string, unknown>,
+			) => undefined,
+		} satisfies Pick<IAgentRuntime, "getRoom" | "updateRoom" | "reportError">;
+		const controlledService =
+			await ChannelTopicsService.start(controlledRuntime);
+
+		const roomAWrite = controlledService.recordTopics(ROOM_A, ["alpha"]);
+		const roomBWrite = controlledService.recordTopics(ROOM_B, ["beta"]);
+		for (let attempt = 0; attempt < 100 && releaseUpdates.size < 2; attempt++) {
+			await Promise.resolve();
+		}
+		expect(releaseUpdates.size).toBe(2);
+		expect(maxConcurrentWrites).toBe(2);
+
+		releaseUpdates.get(ROOM_A)?.();
+		releaseUpdates.get(ROOM_B)?.();
+		await Promise.all([roomAWrite, roomBWrite]);
+		expect(inFlight.size).toBe(0);
+	});
+
+	it("recovers the room queue after a failed write", async () => {
+		const adapter = new FailingRoomAdapter();
+		const failingRuntime = await makeRuntime([makeRoom(ROOM_A)], adapter);
+		const svc = await ChannelTopicsService.start(failingRuntime);
+		adapter.failWrites = true;
+
+		await expect(svc.recordTopics(ROOM_A, ["first"])).rejects.toMatchObject({
+			code: "CHANNEL_TOPICS_PERSIST_FAILED",
+		});
+
+		adapter.failWrites = false;
+		await expect(svc.recordTopics(ROOM_A, ["second"])).resolves.toBeUndefined();
+		expect(
+			(await failingRuntime.getRoom(ROOM_A))?.metadata?.[
+				CHANNEL_TOPICS_METADATA_KEY
+			],
+		).toEqual(["first", "second"]);
 	});
 
 	it("hydrates from room metadata on first access (survives restart)", async () => {

--- a/packages/core/src/services/channel-topics.ts
+++ b/packages/core/src/services/channel-topics.ts
@@ -77,6 +77,13 @@ export class ChannelTopicsService extends Service {
 	private readonly topicsByRoom = new Map<UUID, string[]>();
 	/** Rooms whose metadata has already been hydrated into the cache. */
 	private readonly hydrated = new Set<UUID>();
+	/**
+	 * Serializes every room state transition, including cold hydration and
+	 * read-modify-write persistence. Without this, a concurrent cold read can
+	 * replace a newer cache generation even when writes themselves are ordered.
+	 */
+	private readonly roomQueues = new Map<UUID, Promise<unknown>>();
+	private stopping = false;
 
 	private reportDatabaseFailure(
 		operation: "hydrate" | "persist",
@@ -103,8 +110,42 @@ export class ChannelTopicsService extends Service {
 	}
 
 	override async stop(): Promise<void> {
+		this.stopping = true;
+		while (this.roomQueues.size > 0) {
+			await Promise.allSettled(this.roomQueues.values());
+		}
 		this.topicsByRoom.clear();
 		this.hydrated.clear();
+		this.roomQueues.clear();
+		this.stopping = false;
+	}
+
+	private enqueueRoomOperation<T>(
+		roomId: UUID,
+		operation: () => Promise<T>,
+	): Promise<T> {
+		if (this.stopping) {
+			return Promise.reject(
+				new ElizaError("Channel topic service is stopping", {
+					code: "CHANNEL_TOPICS_STOPPING",
+					context: { roomId },
+					severity: "ephemeral",
+				}),
+			);
+		}
+		const previous = this.roomQueues.get(roomId) ?? Promise.resolve();
+		const current = previous
+			// error-policy:J5 The failed prior writer already rejects its own caller;
+			// continue this room's queue so later enrichment can retry durability.
+			.catch(() => undefined)
+			.then(operation);
+		this.roomQueues.set(roomId, current);
+
+		return current.finally(() => {
+			if (this.roomQueues.get(roomId) === current) {
+				this.roomQueues.delete(roomId);
+			}
+		});
 	}
 
 	/**
@@ -204,9 +245,12 @@ export class ChannelTopicsService extends Service {
 		if (!roomId || !Array.isArray(topics) || topics.length === 0) {
 			return;
 		}
-		await this.hydrateRoom(roomId);
-		const next = this.applyTopics(roomId, topics);
-		await this.persistRoom(roomId, next);
+
+		return this.enqueueRoomOperation(roomId, async () => {
+			await this.hydrateRoom(roomId);
+			const next = this.applyTopics(roomId, topics);
+			await this.persistRoom(roomId, next);
+		});
 	}
 
 	/**
@@ -226,8 +270,10 @@ export class ChannelTopicsService extends Service {
 	 * persisted state on a cold cache (after restart).
 	 */
 	async ensureHydrated(roomId: UUID): Promise<string[]> {
-		await this.hydrateRoom(roomId);
-		return this.getTopicsForRoom(roomId);
+		return this.enqueueRoomOperation(roomId, async () => {
+			await this.hydrateRoom(roomId);
+			return this.getTopicsForRoom(roomId);
+		});
 	}
 
 	/**


### PR DESCRIPTION
# Relates to

Closes #19165

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`; merge parent is `develop@75b83886e585a80ab8a47b2024673832a4d3941e`.
- [x] Exact head: `f615abfa368156827753268291948fc2e78c844d`.
- [x] Controlled persistence regression is included for reviewer verification.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branch merge parent is `develop@75b83886e585a80ab8a47b2024673832a4d3941e`; zero conflicts were present.
- [x] Replayed directly onto `origin/develop@75b83886e585a80ab8a47b2024673832a4d3941e`; live `develop` then advanced one non-overlapping elizaresearch HTML commit to `1c65e80f05520256c48a775ab9cc1d8a35c84a35` after exact-head proof.
- [ ] Root `bun run verify` reached 197/204 Turbo tasks before an unrelated `plugin-elizacloud` build crashed Bun 1.3.14 while creating a temporary executable; no changed-path failure was observed.

# Risks

Low. Same-room hydration, mutation, and persistence are serialized; different rooms remain independent. Failed writers reject their own caller while later queued work continues, and stop waits for in-flight room operations.

# What does this PR do?

It adds a per-room promise queue around channel-topic hydration, application, and persistence. `ensureHydrated` and `recordTopics` share the queue so cold reads cannot roll the cache back after a writer, reverse completion cannot overwrite newer data, failed writes do not poison later writes, and stop drains in-flight work.

# Testing

Start with `serializes concurrent persistence and preserves the newest topic list` in `packages/core/src/services/__tests__/channel-topics.test.ts`, then inspect `ChannelTopicsService.recordTopics`.

- Available Bun `1.3.14` and Node `24.15.0` in a disposable sandbox.
- `bun test packages/core/src/services/__tests__/channel-topics.test.ts`: 19 passed, 0 failed, 52 assertions.
- `bun run --cwd packages/core typecheck`: passed.
- `bun run --cwd packages/core build:node`: passed.
- Biome check on the two changed files: passed.
- `git diff --check`: passed.

Controlled persistence result:

```text
before release: updateRoom calls = 1; second same-room write remains queued
after release:  persisted channelTopics = ["a", "b"]
after release:  cached channelTopics    = ["a", "b"]
focused suite:  19 pass, 0 fail, 52 assertions
```

# Evidence Gate

Evidence matches the exact commit reviewed.
<!-- evidence-head:f615abfa368156827753268291948fc2e78c844d -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface is changed.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface is changed.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no rendered UI surface or interactive visual flow is changed.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - deterministic service-level path; no HTTP backend changed.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: controlled persisted-room and cache transcript from the focused regression.

  <details><summary>Channel-topic persistence artifact</summary>

  ```text
  cold read/write: one room operation at a time; cache remains ["seed", "b"]
  reverse completion: max concurrent writes = 1; persisted channelTopics = ["a", "b"]
  failure recovery: first caller rejects; next write persists ["first", "second"]
  focused service suite: 19 pass, 0 fail, 52 assertions on exact head f615abfa368156827753268291948fc2e78c844d
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no UI or image rendering is changed.`

# Evidence Details

The regressions exercise real `ChannelTopicsService.start`, `ensureHydrated`, `recordTopics`, and `stop` paths through controlled `getRoom` and `updateRoom` boundaries. Existing hydration, persistence-failure, LRU, and different-room tests remain green.

## Contribution authorship clarification

The replayed head is `f615abfa368156827753268291948fc2e78c844d`, directly based on `develop@75b83886e585a80ab8a47b2024673832a4d3941e`. Its single commit is authored and committed by `SYMBaiEX <solsymbaiex@gmail.com>`; no other authorship is present on this exact head.

## Known gaps / failures

Root verification reached 197/204 Turbo tasks before the unrelated sandboxed plugin-elizacloud Bun temporary-executable crash; the changed core package gates passed. Focused tests, core typecheck/build, Biome, and diff-check passed on this exact head.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza"} -->