### PR TITLE
fix(core): redact terminal secrets across all surfaces (re-land of #19115)

### DIFF
--- a/packages/agent/src/actions/terminal-effect-receipt.test.ts
+++ b/packages/agent/src/actions/terminal-effect-receipt.test.ts
@@ -13,6 +13,7 @@ function runtime(): IAgentRuntime {
   return {
     agentId: "00000000-0000-0000-0000-000000000001",
     createMemory: vi.fn(async () => "00000000-0000-0000-0000-000000000004"),
+    redactSecrets: vi.fn((text: string) => text),
   } as unknown as IAgentRuntime;
 }
 
@@ -182,6 +183,108 @@ describe("terminal action effect proof", () => {
     });
   });
 
+  it("summarizes multiline stdout without marking it canonical", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => terminalResponse({ stdout: "first\nsecond\n" })),
+    );
+
+    const result = await terminalAction.handler(
+      runtime(),
+      message(),
+      undefined,
+      options("printf 'first\\nsecond\\n'"),
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      userFacingText:
+        "The command finished (exit 0) with 2 lines of output; ask me about specifics instead of dumping it into chat.",
+      verifiedUserFacing: false,
+    });
+    expect(result?.text).toContain("first\nsecond");
+  });
+
+  it("summarizes single-line stdout over the relay limit", async () => {
+    const stdout = "x".repeat(201);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => terminalResponse({ stdout })),
+    );
+
+    const result = await terminalAction.handler(
+      runtime(),
+      message(),
+      undefined,
+      options("generate-long-output"),
+    );
+
+    expect(result).toMatchObject({
+      userFacingText:
+        "The command finished (exit 0) with 1 line of output; ask me about specifics instead of dumping it into chat.",
+      verifiedUserFacing: false,
+    });
+    expect(result?.text).toContain(stdout);
+  });
+
+  it("relays a single line at the exact size limit without marking it canonical", async () => {
+    const stdout = "x".repeat(200);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => terminalResponse({ stdout })),
+    );
+
+    const result = await terminalAction.handler(
+      runtime(),
+      message(),
+      undefined,
+      options("generate-bounded-output"),
+    );
+
+    expect(result).toMatchObject({
+      userFacingText: stdout,
+      verifiedUserFacing: false,
+    });
+  });
+
+  it("keeps action-owned empty, stderr, truncated, and timeout statuses canonical", async () => {
+    const cases = [
+      {
+        override: { stdout: "" },
+        text: "The command finished successfully with exit code 0.",
+      },
+      {
+        override: { stdout: "partial", stderr: "warning" },
+        text: "The command finished successfully with exit code 0.",
+      },
+      {
+        override: { stdout: "partial", truncated: true },
+        text: "The command finished successfully with exit code 0.",
+      },
+      {
+        override: { stdout: "partial", timedOut: true, maxDurationMs: 30_000 },
+        text: "The command timed out after 30000 ms; I can't verify that it completed.",
+      },
+    ];
+
+    for (const testCase of cases) {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => terminalResponse(testCase.override)),
+      );
+      const result = await terminalAction.handler(
+        runtime(),
+        message(),
+        undefined,
+        options(),
+      );
+      expect(result).toMatchObject({
+        userFacingText: testCase.text,
+        verifiedUserFacing: true,
+      });
+    }
+  });
+
   it("rejects a response that omits its exit code instead of fabricating zero", async () => {
     const response = terminalResponse();
     const payload = (await response.json()) as Record<string, unknown>;
@@ -219,7 +322,7 @@ describe("terminal action effect proof", () => {
   });
 });
 
-describe("terminal command-line secret hygiene", () => {
+describe("terminal secret hygiene", () => {
   beforeEach(() => {
     vi.stubEnv("ELIZA_BUILD_VARIANT", "direct");
   });
@@ -229,13 +332,22 @@ describe("terminal command-line secret hygiene", () => {
     vi.unstubAllGlobals();
   });
 
-  it("redacts secrets embedded in the command line before any consumer sees it", async () => {
-    const secret = "sk-proj-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-    const leakyCommand = `curl -H "Authorization: Bearer ${secret}" https://api.example.com`;
+  it("removes configured, argument, output, and URI secrets from every returned and persisted surface", async () => {
+    const configuredSecret = "plain-character-secret-123456789";
+    const bearerSecret = "sk-proj-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const flagSecret = "flag-secret-value-123456789";
+    const urlPassword = "url-password-value-123456789";
+    const leakyCommand =
+      `curl --token=${flagSecret} -H "Authorization: Bearer ${bearerSecret}" ` +
+      `https://operator:${urlPassword}@api.example.com/${configuredSecret}`;
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
-        terminalResponse({ command: leakyCommand, stdout: "ok\n" }),
+        terminalResponse({
+          command: leakyCommand,
+          stdout: `result ${configuredSecret} ${bearerSecret}\n`,
+          stderr: `postgres://service:${urlPassword}@db.example.com/app`,
+        }),
       ),
     );
 
@@ -245,21 +357,32 @@ describe("terminal command-line secret hygiene", () => {
     const rt = {
       agentId: "00000000-0000-0000-0000-000000000001",
       createMemory,
+      redactSecrets: vi.fn((text: string) =>
+        text.replaceAll(configuredSecret, "[REDACTED:CONFIGURED_SECRET]"),
+      ),
     } as unknown as IAgentRuntime;
 
-    const result = (await terminalAction.handler(
+    const result = await terminalAction.handler(
       rt,
       message(),
       undefined,
       options(leakyCommand),
-    )) as { text?: string; data?: unknown };
+    );
+    const surfaces = JSON.stringify({
+      result,
+      memory: createMemory.mock.calls,
+    });
 
-    const surfaces = [
-      result.text ?? "",
-      JSON.stringify(result.data ?? {}),
-      JSON.stringify(createMemory.mock.calls),
-    ].join("\n");
-    expect(surfaces).not.toContain(secret);
-    expect(surfaces).toContain("curl");
+    for (const secret of [
+      configuredSecret,
+      bearerSecret,
+      flagSecret,
+      urlPassword,
+    ]) {
+      expect(surfaces).not.toContain(secret);
+    }
+    expect(surfaces).toContain("api.example.com");
+    expect(surfaces).toContain("db.example.com");
+    expect(surfaces).toContain("[REDACTED:CONFIGURED_SECRET]");
   });
 });

--- a/packages/agent/src/actions/terminal-effect-receipt.test.ts
+++ b/packages/agent/src/actions/terminal-effect-receipt.test.ts
@@ -205,6 +205,27 @@ describe("terminal action effect proof", () => {
     expect(result?.text).toContain("first\nsecond");
   });
 
+  it("summarizes carriage-return-delimited stdout", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => terminalResponse({ stdout: "first\rsecond" })),
+    );
+
+    const result = await terminalAction.handler(
+      runtime(),
+      message(),
+      undefined,
+      options("printf 'first\\rsecond'"),
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      userFacingText:
+        "The command finished (exit 0) with 2 lines of output; ask me about specifics instead of dumping it into chat.",
+      verifiedUserFacing: false,
+    });
+  });
+
   it("summarizes single-line stdout over the relay limit", async () => {
     const stdout = "x".repeat(201);
     vi.stubGlobal(

--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -35,6 +35,11 @@ import { normalizeTerminalCommand } from "../utils/terminal-command.ts";
 
 const TERMINAL_ACTION_NAME = "TERMINAL_SHELL";
 const MAX_TERMINAL_DATA_CHARS = 16000;
+// Max raw stdout, in chars, that may be relayed verbatim as the user-facing
+// message. Small single-line results (a SHA, a count, a path) are useful to
+// echo for "run X and tell me the value" turns; anything larger — or with
+// multiple lines — must NOT be dumped to the (possibly shared) channel.
+const TERMINAL_RELAY_MAX_CHARS = 200;
 
 type TerminalActionParameters = {
   arguments?: JsonValue;
@@ -303,15 +308,6 @@ function terminalEffectReceipt(
   };
 }
 
-// Max raw stdout, in chars, that may be relayed verbatim as the user-facing
-// message. Small single-line results (a SHA, a count, a path) are useful to
-// echo for "run X and tell me the value" turns; anything larger — or with
-// multiple lines — must NOT be dumped to the (possibly shared) channel, or a
-// `cat`/`grep` of a config or secrets file leaks its contents. Larger output
-// stays available to the model through the action's diagnostic `text`, so it
-// can still answer specifics from context without the raw dump.
-const TERMINAL_RELAY_MAX_CHARS = 200;
-
 function terminalUserFacingText(
   result: CapturedTerminalRun,
   cleanStdout: string,
@@ -326,10 +322,23 @@ function terminalUserFacingText(
     return "The command finished successfully with exit code 0.";
   }
   const lineCount = cleanStdout.split("\n").length;
-  if (cleanStdout.length <= TERMINAL_RELAY_MAX_CHARS && lineCount <= 1) {
+  if (cleanStdout.length <= TERMINAL_RELAY_MAX_CHARS && lineCount === 1) {
     return cleanStdout;
   }
   return `The command finished (exit 0) with ${lineCount} line${lineCount === 1 ? "" : "s"} of output; ask me about specifics instead of dumping it into chat.`;
+}
+
+/**
+ * One projection boundary for every terminal consumer: runtime-known secrets
+ * first (character-configured values), then shape-based tools redaction
+ * (Bearer, CLI flags, URI userinfo, token prefixes). Lightweight/test runtimes
+ * may stub `redactSecrets` as identity, so the pattern pass remains required.
+ */
+function redactCapturedTerminalText(
+  runtime: IAgentRuntime,
+  text: string,
+): string {
+  return redactSensitiveText(runtime.redactSecrets(text), { mode: "tools" });
 }
 
 function buildCapturedResponseText(
@@ -464,20 +473,13 @@ export const terminalAction: Action = {
       });
     }
     const rawRun = normalizeCapturedRun(command, responseBody);
-    // Secret hygiene: scrub known secret shapes (API keys, tokens, Bearer
-    // headers, PEM private keys, credential env/JSON fields) out of stdout and
-    // stderr at the source, so no downstream path — the model-facing diagnostic
-    // preview, the user-facing chat relay, or the stored output attachment —
-    // can echo a plaintext secret that happened to appear in command output.
-    // The command LINE itself is a leak vector too (curl -H "Authorization:
-    // Bearer <token>", psql postgres://user:pass@host): scrub it once here so
-    // every consumer — "Command:" artifact header, attachment title and
-    // description, and the model-facing action text — sees the redacted form.
+    // Sanitize once before constructing model text, bounded action data, the
+    // user-facing relay, attachments, or persisted attachment memory.
     const capturedRun: CapturedTerminalRun = {
       ...rawRun,
-      command: redactSensitiveText(rawRun.command, { mode: "tools" }),
-      stdout: redactSensitiveText(rawRun.stdout, { mode: "tools" }),
-      stderr: redactSensitiveText(rawRun.stderr, { mode: "tools" }),
+      command: redactCapturedTerminalText(runtime, rawRun.command),
+      stdout: redactCapturedTerminalText(runtime, rawRun.stdout),
+      stderr: redactCapturedTerminalText(runtime, rawRun.stderr),
     };
     const boundedRun = {
       ...capturedRun,

--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -35,7 +35,7 @@ import { normalizeTerminalCommand } from "../utils/terminal-command.ts";
 
 const TERMINAL_ACTION_NAME = "TERMINAL_SHELL";
 const MAX_TERMINAL_DATA_CHARS = 16000;
-// Max raw stdout, in chars, that may be relayed verbatim as the user-facing
+// Max sanitized stdout, in chars, that may be relayed verbatim as the user-facing
 // message. Small single-line results (a SHA, a count, a path) are useful to
 // echo for "run X and tell me the value" turns; anything larger — or with
 // multiple lines — must NOT be dumped to the (possibly shared) channel.
@@ -321,7 +321,10 @@ function terminalUserFacingText(
   if (!cleanStdout) {
     return "The command finished successfully with exit code 0.";
   }
-  const lineCount = cleanStdout.split("\n").length;
+  // Treat every JavaScript line terminator as a channel-visible line break.
+  // In particular, terminal programs commonly emit bare carriage returns;
+  // counting only `\n` would let a short multi-line payload bypass the relay cap.
+  const lineCount = cleanStdout.split(/\r\n|[\n\r\u2028\u2029]/u).length;
   if (cleanStdout.length <= TERMINAL_RELAY_MAX_CHARS && lineCount === 1) {
     return cleanStdout;
   }

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -45,6 +45,46 @@ describe("redactSecrets (known values)", () => {
 });
 
 describe("redactSensitiveText (pattern detection)", () => {
+	it("redacts credentials embedded in URI userinfo", () => {
+		const httpsUrl = "https://admin:hunter2hunter2@host.example.com/private";
+		const postgresUrl =
+			"postgres://service:database-password-123@db.example.com:5432/app";
+		const tokenUrl =
+			"https://github-token-value-123456789@github.com/org/repo.git";
+		const passwordOnlyUrl =
+			"https://:password-only-value-123456789@host.example/db";
+
+		const redactedHttps = redactSensitiveText(httpsUrl);
+		const redactedPostgres = redactSensitiveText(postgresUrl);
+		const redactedToken = redactSensitiveText(tokenUrl);
+		const redactedPasswordOnly = redactSensitiveText(passwordOnlyUrl);
+
+		expect(redactedHttps).toContain("https://");
+		expect(redactedHttps).toContain("@host.example.com/private");
+		expect(redactedHttps).not.toContain("admin");
+		expect(redactedHttps).not.toContain("hunter2hunter2");
+		expect(redactedPostgres).toContain("postgres://");
+		expect(redactedPostgres).toContain("@db.example.com:5432/app");
+		expect(redactedPostgres).not.toContain("service");
+		expect(redactedPostgres).not.toContain("database-password-123");
+		expect(redactedToken).toContain("@github.com/org/repo.git");
+		expect(redactedToken).not.toContain("github-token-value-123456789");
+		expect(redactedPasswordOnly).toContain("@host.example/db");
+		expect(redactedPasswordOnly).not.toContain("password-only-value-123456789");
+	});
+
+	it("redacts both spaced and equals-form credential flags", () => {
+		const spaced = "run --token flag-secret-value-123456789";
+		const equals = "run --password=flag-password-value-123456789";
+
+		expect(redactSensitiveText(spaced)).not.toContain(
+			"flag-secret-value-123456789",
+		);
+		expect(redactSensitiveText(equals)).not.toContain(
+			"flag-password-value-123456789",
+		);
+	});
+
 	it("masks an openai-style key without leaking it", () => {
 		const key = "sk-0123456789abcdefghij";
 		const out = redactSensitiveText(`my key ${key} end`);

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -73,6 +73,29 @@ describe("redactSensitiveText (pattern detection)", () => {
 		expect(redactedPasswordOnly).not.toContain("password-only-value-123456789");
 	});
 
+	it("rewrites the userinfo span, never the scheme, for short user names", () => {
+		// A first-occurrence `replace(userinfo, "***")` matches inside the scheme
+		// whenever the userinfo is a substring of it: "https://s@host/x" became
+		// "http***://s@host/x", leaving the credential fully intact.
+		const shortUser = redactSensitiveText("https://s@host/x");
+		expect(shortUser).toBe("https://***@host/x");
+		expect(shortUser).toContain("https://");
+
+		const postgres = redactSensitiveText("postgres://p@db");
+		expect(postgres).toBe("postgres://***@db");
+		expect(postgres).toContain("postgres://");
+	});
+
+	it("masks the leading userinfo of a password containing a literal @", () => {
+		// Documented residual: the userinfo class cannot cross an `@`, so only the
+		// span up to the first `@` is masked. The scheme must still survive intact
+		// and the leading credential must be gone.
+		const out = redactSensitiveText("https://user:p@ss@host/db");
+		expect(out).toContain("https://");
+		expect(out).not.toContain("user:p");
+		expect(out.startsWith("https://***@")).toBe(true);
+	});
+
 	it("redacts both spaced and equals-form credential flags", () => {
 		const spaced = "run --token flag-secret-value-123456789";
 		const equals = "run --password=flag-password-value-123456789";

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -25,11 +25,15 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	String.raw`\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|MNEMONIC|SEED|CREDENTIAL)\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1`,
 	// JSON fields.
 	String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|refreshToken|mnemonic|seedPhrase|passphrase|privateKey|credential)"\s*:\s*"([^"]+)"`,
-	// CLI flags.
-	String.raw`--(?:api[-_]?key|token|secret|password|passwd)\s+(["']?)([^\s"']+)\1`,
+	// CLI flags (space-separated and --flag=value forms).
+	String.raw`--(?:api[-_]?key|token|secret|password|passwd)(?:\s+|=)(["']?)([^\s"']+)\1`,
 	// Authorization headers.
 	String.raw`Authorization\s*[:=]\s*Bearer\s+([A-Za-z0-9._\-+=]+)`,
 	String.raw`\bBearer\s+([A-Za-z0-9._\-+=]{18,})\b`,
+	// URI userinfo. Mask the complete userinfo component (user:password,
+	// token-only, or password-only) so credentials in database URLs, curl
+	// arguments, and remote URLs never survive as output.
+	String.raw`\b[a-z][a-z0-9+.-]*:\/\/([^\s/@]+)@`,
 	// PEM blocks.
 	String.raw`-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----`,
 	// Common token prefixes.
@@ -189,6 +193,11 @@ function redactMatch(match: string, groups: string[]): string {
 		(value) => typeof value === "string" && value.length > 0,
 	);
 	const token = filteredGroups[filteredGroups.length - 1] ?? match;
+	// Unlike provider tokens, URI userinfo includes an account identifier; do
+	// not preserve its usual six-character prefix in diagnostics.
+	if (/^[a-z][a-z0-9+.-]*:\/\//i.test(match) && match.endsWith("@")) {
+		return match.replace(token, () => "***");
+	}
 	const masked = maskToken(token);
 	if (token === match) {
 		return masked;

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -195,8 +195,18 @@ function redactMatch(match: string, groups: string[]): string {
 	const token = filteredGroups[filteredGroups.length - 1] ?? match;
 	// Unlike provider tokens, URI userinfo includes an account identifier; do
 	// not preserve its usual six-character prefix in diagnostics.
+	// Anchor the rewrite to the userinfo span. A plain `replace(token, …)` hits
+	// the FIRST occurrence of the userinfo substring, which for a short user
+	// name is usually inside the scheme itself ("https://s@h" would become
+	// "http***://s@h" and leak the credential verbatim).
+	//
+	// Known residual: `[^\s/@]+` cannot cross an `@`, so a password containing a
+	// literal `@` ("https://user:p@ss@host") only masks up to the first `@` and
+	// leaves the tail ("ss@host") in the output. Widening the userinfo class
+	// would make the pattern swallow unrelated text after a bare scheme, so the
+	// partial mask is deliberate.
 	if (/^[a-z][a-z0-9+.-]*:\/\//i.test(match) && match.endsWith("@")) {
-		return match.replace(token, () => "***");
+		return match.replace(/^([a-z][a-z0-9+.-]*:\/\/)[^\s/@]+@$/i, "$1***@");
 	}
 	const masked = maskToken(token);
 	if (token === match) {


### PR DESCRIPTION
## Summary

Re-land of #19115, closed by base-branch deletion when #18943 merged — **not on merits**. #19115 targeted `fix/terminal-user-facing-hygiene` (the #18943 branch); when #18943 merged and GitHub deleted that branch, #19115 was auto-closed. It had already been reviewed, its one blocking defect fixed, and the fix verified.

Original author: **@hermesagent270-commits** (TrapLord). All three original commits are cherry-picked verbatim onto `develop` — the changed-line diff is byte-identical to #19115's final head `b52ce678a0d132139e073151077e02402c98c87d`.

## What #18943 already landed vs. what was still missing

`develop` already carries #18943's work: `redactSensitiveText(..., { mode: "tools" })` over the terminal `command`/`stdout`/`stderr`, and the `TERMINAL_RELAY_MAX_CHARS` relay cap. Nothing from #19115 was on `develop`.

Still missing, and restored here:

- **URI userinfo is not redacted at all.** `postgres://user:pass@host`, `curl https://tok@host`, and `https://operator:pw@api.example.com` survived every terminal surface verbatim. Adds a userinfo pattern that masks the complete component (`user:password`, token-only, password-only).
- **Anchored userinfo rewrite.** The blocking defect found in review: an unanchored first-occurrence `replace(token, …)` matches inside the *scheme* whenever the userinfo is a substring of it — `https://s@host/x` became `http***://s@host/x`, rewriting the scheme and leaving the credential fully intact. Fixed with `match.replace(/^([a-z][a-z0-9+.-]*:\/\/)[^\s/@]+@$/i, "$1***@")`.
- **Runtime-known character secrets were never applied at the terminal boundary.** A value configured as a character secret was redacted in logs but echoed verbatim in the action's model text, action data, attachment title/description, and the persisted attachment memory. A single `redactCapturedTerminalText` projection now runs `runtime.redactSecrets` first, then the shape-based pattern pass.
- **Relay-cap bypass via bare `\r`.** Line counting split only on `\n`, so `printf 'first\rsecond'` counted as one line and was relayed verbatim into the (possibly shared) channel. Now splits on every JS line terminator (`\r\n | \n | \r |   |  `), and the single-line check is `=== 1`.
- **`--flag=value` credential form** made explicit in the CLI-flag pattern (`(?:\s+|=)`). Note: on current `develop` this specific form already happens to be caught by the case-insensitive ENV-assignment pattern, so this line is defense-in-depth/explicitness rather than a live hole — called out here so reviewers don't over-credit it.

### Documented residual

`[^\s/@]+` cannot cross an `@`, so a password containing a literal `@` (`https://user:p@ss@host/db`) only masks up to the first `@` and leaves the tail. Widening the class would make the pattern swallow unrelated text after a bare scheme, so the partial mask is deliberate; it is documented in `redactMatch` and pinned by a test.

## Verification

Red-then-green against `develop`'s source. With the new tests applied but `packages/core/src/security/redact.ts` and `packages/agent/src/actions/terminal.ts` reverted to `origin/develop`:

**RED — 3 core + 2 agent tests fail**

```
packages/core/src/security/redact.test.ts  (28 tests | 3 failed)
  x redacts credentials embedded in URI userinfo
      expected 'https://admin:hunter2hunter2@host.exa...' not to contain 'admin'
  x rewrites the userinfo span, never the scheme, for short user names
      expected 'https://s@host/x' to be 'https://***@host/x'
  x masks the leading userinfo of a password containing a literal @
      expected 'https://user:p@ss@host/db' not to contain 'user:p'

packages/agent/src/actions/terminal-effect-receipt.test.ts  (12 tests | 2 failed)
  x summarizes carriage-return-delimited stdout
      userFacingText: expected the 2-line summary, received "firstsecond" (raw relay)
  x removes configured, argument, output, and URI secrets from every returned and persisted surface
      expected surfaces not to contain 'plain-character-secret-123456789'
      (leaked in result.text, data.stdout, attachment title/description/text, and createMemory payload;
       'url-password-value-123456789' leaked in both the command line and the postgres:// stderr URL)
```

**GREEN — with the fix**

| Check | Result |
| --- | --- |
| `bun run --cwd packages/core vitest run src/security/redact.test.ts` | 28/28 pass |
| `bun run --cwd packages/core vitest run src/security/` | 30 files, 438/438 pass |
| `bun run --cwd packages/agent vitest run src/actions/terminal-effect-receipt.test.ts` | 12/12 pass |
| `bun run --cwd packages/core typecheck` | pass |
| `bunx biome check` (4 changed files) | pass, no fixes applied |
| `git diff --check` | pass |

`bun run --cwd packages/agent typecheck` reports only pre-existing unbuilt-workspace-dependency errors (`@elizaos/cloud-routing`, optional plugin imports) that reproduce on unmodified `develop`; none are in the changed files.

<!-- contribution-attribution:v1
original-pr: 19115
original-author: hermesagent270-commits
original-head: b52ce678a0d132139e073151077e02402c98c87d
closure-reason: base-branch-deleted-on-18943-merge
closure-on-merits: false
relanded-commits: 12c8b45743bf3f6ea5a7cf0a9117f116b010a11f, f0cba63cce0b339572772738fde6974c50c02614, b52ce678a0d132139e073151077e02402c98c87d
-->

<!-- evidence-head:a38564ceede74eba7133a540f7d63faa2cce16d0 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only terminal action and core redaction change; no rendered UI surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only terminal action and core redaction change; no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI flow changes.

<!-- evidence-row:backend-logs -->
- [x] The red-then-green Vitest output above is the backend evidence: the RED run is the real action handler on `develop`'s source leaking the configured secret and the `postgres://` credential into `result.text`, `data.stdout`, the attachment title/description/text, and the `createMemory` payload; the GREEN run is the same handler after the fix.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser execution path changes.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no planner, prompt, model, or trajectory behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] Returned action data, attachment content, and persisted memory are asserted directly by the regression suite, which stringifies the full result plus `createMemory` calls and rejects every secret; no standalone artifact is produced.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or rendered text artifacts.
