### PR TITLE
test(homepage): port the AASA contract to the merged publish job

### DIFF
--- a/packages/homepage/edge/apple-app-site-association.test.ts
+++ b/packages/homepage/edge/apple-app-site-association.test.ts
@@ -186,8 +186,8 @@ describe("eliza.app AASA edge Worker", () => {
     );
     expect(workflow).toContain("branches: [main]");
     expect(workflow).toContain("environment: production");
-    expect(workflow.match(/runs-on: ubuntu-24\.04/g)).toHaveLength(3);
-    expect(workflow.match(/persist-credentials: false/g)).toHaveLength(3);
+    expect(workflow.match(/runs-on: ubuntu-24\.04/g)).toHaveLength(2);
+    expect(workflow.match(/persist-credentials: false/g)).toHaveLength(2);
     expect(workflow).not.toContain("workflow_call:");
     expect(workflow).not.toContain("bun install");
     expect(workflow).toContain(
@@ -208,12 +208,35 @@ describe("eliza.app AASA edge Worker", () => {
     expect(workflow).toContain(
       "bunx wrangler@4.100.0 delete --config wrangler-aasa.toml --force",
     );
-    expect(workflow).toContain("verify-apple-cdn:");
+    // The CDN proof used to be a third `verify-apple-cdn:` job. It now runs as
+    // the closing step of the publish job so one post-approval lock covers
+    // mutate + proof. The property that mattered is unchanged and asserted
+    // structurally below: observing Apple's cache can never itself mutate.
+    expect(workflow).not.toContain("verify-apple-cdn:");
     expect(workflow).toContain("--apple-cdn-live");
-    const cdnJob = workflow.split("  verify-apple-cdn:")[1];
-    expect(cdnJob).toBeDefined();
-    expect(cdnJob).not.toContain("rollback");
-    expect(cdnJob).not.toContain("CLOUDFLARE_API_TOKEN");
+
+    const cdnWait = workflow.indexOf("Wait for Apple's unmodified CDN cache");
+    const rollback = workflow.indexOf(
+      "Restore the previous safe origin on verification failure",
+    );
+    expect(cdnWait).toBeGreaterThan(-1);
+    expect(rollback).toBeGreaterThan(-1);
+
+    // Rollback reacts only to the origin verification, never to the CDN wait,
+    // and precedes it — so nothing downstream of the CDN observation can roll
+    // back or delete the Worker.
+    expect(workflow).toContain(
+      "always() && steps.deploy.outcome == 'success' && steps.origin.outcome != 'success'",
+    );
+    expect(rollback).toBeLessThan(cdnWait);
+    const afterCdnWait = workflow.slice(cdnWait);
+    expect(afterCdnWait).not.toContain("rollback");
+    expect(afterCdnWait).not.toContain("CLOUDFLARE_API_TOKEN");
+
+    // The CDN wait runs only after a published and verified origin.
+    expect(workflow).toContain(
+      "steps.deploy.outcome == 'success' && steps.origin.outcome == 'success'",
+    );
   });
 
   test("validates a captured production response and rejects stale hosting", () => {


### PR DESCRIPTION
# Relates to

Restores `Quality (Extended)` → `Consolidated Frontend Build` → **Validate
homepage source contracts**, red on `develop` since the AASA deploy jobs were
consolidated.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop`.
- [x] The failing gate was reproduced red and verified green locally.
- [x] A reviewer can confirm the change works without reading the code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` @ `dd7190c50f4`; zero conflicts.
- [x] Full `bun run verify` was not run — see **Known gaps / failures**. `bun run
      verify` was separately confirmed green on this base commit.

# Risks

Low. Test-only change. No workflow, product, or deployment behavior is modified.

# Background

## What does this PR do?

`.github/workflows/deploy-aasa.yml` used to have three jobs. The `verify-apple-cdn`
job was **deliberately** folded into `deploy-and-verify-origin` so that one
post-approval concurrency lock covers mutate + proof (the same #18092 line of
work as the Cloud CF release lock); the workflow now says so directly:

```yaml
# Per-run admission so two dispatches of the same SHA both reach
# validate-ref (#18092). The publish job owns mutate+CDN proof.
```

`packages/homepage/edge/apple-app-site-association.test.ts` still asserted the
old three-job shape, so it fails on the current tree:

```
189 |     expect(workflow.match(/runs-on: ubuntu-24\.04/g)).toHaveLength(3);
error: expect(received).toHaveLength(expected)
Expected length: 3
Received length: 2
```

The product change is intentional, so this ports the stale test rather than
reverting the workflow.

**The safety property is preserved, not dropped.** The old test asserted that
the isolated `verify-apple-cdn` job contained neither `rollback` nor
`CLOUDFLARE_API_TOKEN` — i.e. *observing Apple's CDN can never mutate*. With the
step inlined, that is now pinned structurally:

- the rollback step's condition keys on the **origin** verification alone
  (`always() && steps.deploy.outcome == 'success' && steps.origin.outcome != 'success'`),
  never on the CDN wait;
- the rollback step **precedes** the CDN wait (`rollback < cdnWait` by index);
- **nothing after** the CDN wait contains `rollback` or `CLOUDFLARE_API_TOKEN`;
- the CDN wait itself runs only after a published and verified origin.

Net effect: the gate gets **stronger**, 86 → 108 assertions.

Attribution: the workflow change arrived in the range
`6f84242c118..dd7190c50f4` (`aceac54fcc1` / `12b833896b8` / `84013778f6a`,
"admit production deploys before the mutation lock" / "hold one post-approval
lock for the Cloud CF release" / "queue approved releases with GitHub queue:
max"). `deploy-aasa.yml` had 3 × `runs-on: ubuntu-24.04` at `6f84242c118` and 2
at `dd7190c50f4`; the test file itself has not changed since #16618.

## What kind of change is this?

Bug fixes (restores a red develop gate; test-only).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/homepage/edge/apple-app-site-association.test.ts`, the
`keeps production routing exact and deployment fail closed` case.

## Detailed testing steps

```bash
bun run --cwd packages/homepage test:aasa-edge
```

# Evidence Gate

<!-- evidence-head:a92017b70ffd939c1ded2741321e2b10af029d3c -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - test-only change with no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - test-only change with no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing flow; the change is a workflow
      contract assertion.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no backend code path is touched.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend code path is touched.`
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: `N/A - no agent, action, provider, prompt, or model path
      is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: attached — the test-run output below is the artifact
      this change is judged by.
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - the diff renders no visual text.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model path is touched.`

## Backend + frontend logs

<details>
<summary>RED — <code>develop</code> @ <code>dd7190c50f4</code>, unmodified</summary>

```
$ bun test edge/apple-app-site-association.test.ts
189 |     expect(workflow.match(/runs-on: ubuntu-24\.04/g)).toHaveLength(3);
                                                            ^
error: expect(received).toHaveLength(expected)

Expected length: 3
Received length: 2

(fail) eliza.app AASA edge Worker > keeps production routing exact and deployment fail closed
 16 pass
 1 fail
 86 expect() calls
```

This reproduces CI run 31731047596 (`Quality (Extended)` dispatched on
develop's tip), job `Consolidated Frontend Build`, step
`Validate homepage source contracts`.
</details>

<details>
<summary>GREEN — same tree with this commit applied (full gate, typecheck + tests)</summary>

```
$ bun run --cwd packages/homepage test:aasa-edge
$ bun run typecheck:aasa-edge && bun test edge/apple-app-site-association.test.ts
$ bunx --package typescript@6.0.3 tsc --noEmit -p edge/tsconfig.json
bun test v1.3.14 (0d9b296a)

 17 pass
 0 fail
 108 expect() calls
```
</details>

<details>
<summary>Anti-vacuity check — the ported test still REJECTS the old three-job workflow</summary>

`deploy-aasa.yml` was temporarily restored from `6f84242c118` (the last develop
SHA where this step passed) and the **ported** test re-run:

```
 16 pass
 1 fail
 86 expect() calls
```

So the new assertions are load-bearing in both directions — they are not a
rubber stamp on whatever the workflow currently says.
</details>

<details>
<summary>Lint</summary>

```
$ bunx @biomejs/biome check packages/homepage/edge/apple-app-site-association.test.ts
Checked 1 file in 33ms. No fixes applied.
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only change with no rendered surface.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

- Full `bun run verify` was not re-run for this test-only diff. It was run
  separately against this exact base commit (`dd7190c50f4`) during the same
  investigation and passed: 350/350 turbo tasks, exit 0, plus
  `bun run format:check` 134/134.
- `Quality (Extended)` has two further independent failures at this tip that
  are **not** addressed here — `audit:ui-determinism` and the `build:web`
  `@elizaos/core` resolution — handled in separate PRs.
