### PR TITLE
fix(plugin-imessage): validate heartbeat interval configuration

### DIFF
--- a/plugins/plugin-imessage/README.md
+++ b/plugins/plugin-imessage/README.md
@@ -37,6 +37,7 @@ bun add @elizaos/plugin-imessage
 | `IMESSAGE_CLI_PATH` | Path to iMessage CLI tool | No |
 | `IMESSAGE_DB_PATH` | Path to iMessage database | No |
 | `IMESSAGE_POLL_INTERVAL_MS` | Polling interval in ms | No |
+| `IMESSAGE_HEARTBEAT_INTERVAL_MS` | Heartbeat health-check interval in ms (default `60000`) | No |
 | `IMESSAGE_DM_POLICY` | DM policy: open, pairing, allowlist, disabled | No |
 | `IMESSAGE_GROUP_POLICY` | Group policy: open, allowlist, disabled | No |
 | `IMESSAGE_ALLOW_FROM` | Comma-separated handles for allowlist | No |
@@ -176,4 +177,3 @@ bun run --cwd plugins/plugin-imessage test
 1. Check that iMessage is signed in and working
 2. Verify the recipient has iMessage enabled
 3. Check for rate limiting (try again later)
-

--- a/plugins/plugin-imessage/package.json
+++ b/plugins/plugin-imessage/package.json
@@ -93,6 +93,12 @@
         "required": false,
         "sensitive": false
       },
+      "IMESSAGE_HEARTBEAT_INTERVAL_MS": {
+        "type": "number",
+        "description": "Heartbeat health-check interval in milliseconds",
+        "required": false,
+        "sensitive": false
+      },
       "IMESSAGE_DM_POLICY": {
         "type": "string",
         "description": "DM policy (e.g. allow, deny, allowlist)",
@@ -140,19 +146,25 @@
         "order": 10,
         "group": "behavior"
       },
+      "IMESSAGE_HEARTBEAT_INTERVAL_MS": {
+        "label": "Heartbeat interval",
+        "unit": "ms",
+        "order": 11,
+        "group": "behavior"
+      },
       "IMESSAGE_DM_POLICY": {
         "label": "DM policy",
-        "order": 11,
+        "order": 12,
         "group": "behavior"
       },
       "IMESSAGE_GROUP_POLICY": {
         "label": "Group policy",
-        "order": 12,
+        "order": 13,
         "group": "behavior"
       },
       "IMESSAGE_ALLOW_FROM": {
         "label": "Allow from",
-        "order": 13,
+        "order": 14,
         "group": "behavior"
       }
     }

--- a/plugins/plugin-imessage/src/heartbeat-config.test.ts
+++ b/plugins/plugin-imessage/src/heartbeat-config.test.ts
@@ -2,8 +2,21 @@
  * Verifies operator heartbeat configuration before it reaches recurring task scheduling.
  */
 
-import { describe, expect, it } from "vitest";
-import { resolveHeartbeatIntervalMs } from "./service";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { IMessageService, resolveHeartbeatIntervalMs } from "./service";
+import { IMessageConfigurationError, type IMessageSettings } from "./types";
+
+const originalHeartbeatEnv = process.env.IMESSAGE_HEARTBEAT_INTERVAL_MS;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalHeartbeatEnv === undefined) {
+    delete process.env.IMESSAGE_HEARTBEAT_INTERVAL_MS;
+  } else {
+    process.env.IMESSAGE_HEARTBEAT_INTERVAL_MS = originalHeartbeatEnv;
+  }
+});
 
 describe("resolveHeartbeatIntervalMs", () => {
   it("uses the default when the setting is absent or blank", () => {
@@ -16,10 +29,46 @@ describe("resolveHeartbeatIntervalMs", () => {
     expect(resolveHeartbeatIntervalMs("2147483647")).toBe(2_147_483_647);
   });
 
+  it("loads the per-runtime setting before the process environment", () => {
+    process.env.IMESSAGE_HEARTBEAT_INTERVAL_MS = "9000";
+    const runtime = {
+      getSetting: vi.fn((key: string) =>
+        key === "IMESSAGE_HEARTBEAT_INTERVAL_MS" ? "7000" : undefined
+      ),
+    } as unknown as IAgentRuntime;
+    const service = new IMessageService(runtime);
+    const settings = (service as unknown as { loadSettings(): IMessageSettings }).loadSettings();
+
+    expect(settings.heartbeatIntervalMs).toBe(7000);
+  });
+
+  it("rejects a bad runtime setting during settings load", () => {
+    const runtime = {
+      getSetting: vi.fn((key: string) =>
+        key === "IMESSAGE_HEARTBEAT_INTERVAL_MS" ? "Infinity" : undefined
+      ),
+    } as unknown as IAgentRuntime;
+    const service = new IMessageService(runtime);
+
+    expect(() =>
+      (service as unknown as { loadSettings(): IMessageSettings }).loadSettings()
+    ).toThrow(IMessageConfigurationError);
+  });
+
   it.each(["0", "-1", "1.5", "1e3", "5000oops", "Infinity", "2147483648"])(
     "rejects invalid operator input %s",
     (raw) => {
-      expect(() => resolveHeartbeatIntervalMs(raw)).toThrow(/IMESSAGE_HEARTBEAT_INTERVAL_MS/);
+      try {
+        resolveHeartbeatIntervalMs(raw);
+        throw new Error("expected heartbeat configuration to be rejected");
+      } catch (error) {
+        expect(error).toBeInstanceOf(IMessageConfigurationError);
+        expect(error).toMatchObject({
+          code: "CONFIGURATION_ERROR",
+          details: { setting: "IMESSAGE_HEARTBEAT_INTERVAL_MS" },
+        });
+        expect((error as Error).message).toMatch(/IMESSAGE_HEARTBEAT_INTERVAL_MS/);
+      }
     }
   );
 });

--- a/plugins/plugin-imessage/src/heartbeat-config.test.ts
+++ b/plugins/plugin-imessage/src/heartbeat-config.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Verifies operator heartbeat configuration before it reaches recurring task scheduling.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveHeartbeatIntervalMs } from "./service";
+
+describe("resolveHeartbeatIntervalMs", () => {
+  it("uses the default when the setting is absent or blank", () => {
+    expect(resolveHeartbeatIntervalMs(undefined)).toBe(60_000);
+    expect(resolveHeartbeatIntervalMs("  ")).toBe(60_000);
+  });
+
+  it("accepts positive integer millisecond intervals", () => {
+    expect(resolveHeartbeatIntervalMs(" 5000 ")).toBe(5_000);
+    expect(resolveHeartbeatIntervalMs("2147483647")).toBe(2_147_483_647);
+  });
+
+  it.each(["0", "-1", "1.5", "1e3", "5000oops", "Infinity", "2147483648"])(
+    "rejects invalid operator input %s",
+    (raw) => {
+      expect(() => resolveHeartbeatIntervalMs(raw)).toThrow(/IMESSAGE_HEARTBEAT_INTERVAL_MS/);
+    }
+  );
+});

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -81,18 +81,28 @@ import {
 const execFileAsync = promisify(execFile);
 
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 60_000;
-const MAX_TIMER_INTERVAL_MS = 2_147_483_647;
+// Keep the recurring-task value portable to runtimes that ultimately schedule
+// with a JavaScript timer, even though current TaskService compares timestamps.
+const MAX_HEARTBEAT_INTERVAL_MS = 2_147_483_647;
 
 export function resolveHeartbeatIntervalMs(raw: string | undefined): number {
   if (raw === undefined || raw.trim() === "") return DEFAULT_HEARTBEAT_INTERVAL_MS;
   const normalized = raw.trim();
   if (!/^\d+$/.test(normalized)) {
-    throw new Error("IMESSAGE_HEARTBEAT_INTERVAL_MS must be a positive integer");
+    throw new IMessageConfigurationError(
+      "IMESSAGE_HEARTBEAT_INTERVAL_MS must be a positive integer",
+      "IMESSAGE_HEARTBEAT_INTERVAL_MS"
+    );
   }
   const intervalMs = Number(normalized);
-  if (!Number.isSafeInteger(intervalMs) || intervalMs <= 0 || intervalMs > MAX_TIMER_INTERVAL_MS) {
-    throw new Error(
-      `IMESSAGE_HEARTBEAT_INTERVAL_MS must be between 1 and ${MAX_TIMER_INTERVAL_MS}`
+  if (
+    !Number.isSafeInteger(intervalMs) ||
+    intervalMs <= 0 ||
+    intervalMs > MAX_HEARTBEAT_INTERVAL_MS
+  ) {
+    throw new IMessageConfigurationError(
+      `IMESSAGE_HEARTBEAT_INTERVAL_MS must be between 1 and ${MAX_HEARTBEAT_INTERVAL_MS}`,
+      "IMESSAGE_HEARTBEAT_INTERVAL_MS"
     );
   }
   return intervalMs;
@@ -1159,6 +1169,13 @@ export class IMessageService extends Service implements IIMessageService {
         ? DEFAULT_POLL_INTERVAL_MS
         : Math.max(0, parsedPollIntervalMs);
 
+    // Resolve all startup configuration before opening chat.db or arming the
+    // polling interval. A rejected setting must not leave a partial service
+    // running after Service.start() rejects.
+    const heartbeatIntervalMs = resolveHeartbeatIntervalMs(
+      getStringSetting("IMESSAGE_HEARTBEAT_INTERVAL_MS", "IMESSAGE_HEARTBEAT_INTERVAL_MS")
+    );
+
     const dmPolicy = getStringSetting(
       "IMESSAGE_DM_POLICY",
       "IMESSAGE_DM_POLICY",
@@ -1186,6 +1203,7 @@ export class IMessageService extends Service implements IIMessageService {
       cliPath,
       dbPath,
       pollIntervalMs,
+      heartbeatIntervalMs,
       dmPolicy,
       groupPolicy,
       allowFrom,
@@ -1903,9 +1921,10 @@ export class IMessageService extends Service implements IIMessageService {
       return;
     }
 
-    const heartbeatIntervalMs = resolveHeartbeatIntervalMs(
-      process.env.IMESSAGE_HEARTBEAT_INTERVAL_MS
-    );
+    if (!this.settings) {
+      throw new IMessageConfigurationError("Settings not loaded");
+    }
+    const { heartbeatIntervalMs } = this.settings;
 
     this.runtime.registerTaskWorker({
       name: "IMESSAGE_HEARTBEAT",

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -80,6 +80,24 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 60_000;
+const MAX_TIMER_INTERVAL_MS = 2_147_483_647;
+
+export function resolveHeartbeatIntervalMs(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === "") return DEFAULT_HEARTBEAT_INTERVAL_MS;
+  const normalized = raw.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error("IMESSAGE_HEARTBEAT_INTERVAL_MS must be a positive integer");
+  }
+  const intervalMs = Number(normalized);
+  if (!Number.isSafeInteger(intervalMs) || intervalMs <= 0 || intervalMs > MAX_TIMER_INTERVAL_MS) {
+    throw new Error(
+      `IMESSAGE_HEARTBEAT_INTERVAL_MS must be between 1 and ${MAX_TIMER_INTERVAL_MS}`
+    );
+  }
+  return intervalMs;
+}
+
 function resolveInteractionAppBaseUrl(runtime: IAgentRuntime): string | undefined {
   const rawAppUrl =
     runtime.getSetting?.("ELIZA_APP_URL") || runtime.getSetting?.("ELIZA_CLOUD_URL");
@@ -1885,7 +1903,9 @@ export class IMessageService extends Service implements IIMessageService {
       return;
     }
 
-    const heartbeatIntervalMs = Number(process.env.IMESSAGE_HEARTBEAT_INTERVAL_MS) || 60_000;
+    const heartbeatIntervalMs = resolveHeartbeatIntervalMs(
+      process.env.IMESSAGE_HEARTBEAT_INTERVAL_MS
+    );
 
     this.runtime.registerTaskWorker({
       name: "IMESSAGE_HEARTBEAT",

--- a/plugins/plugin-imessage/src/types.ts
+++ b/plugins/plugin-imessage/src/types.ts
@@ -42,6 +42,8 @@ export interface IMessageSettings {
   dbPath?: string;
   /** Polling interval in ms */
   pollIntervalMs: number;
+  /** Heartbeat health-check interval in ms */
+  heartbeatIntervalMs: number;
   /** DM policy */
   dmPolicy: "open" | "pairing" | "allowlist" | "disabled";
   /** Group policy */


### PR DESCRIPTION
# Relates to

self-found bug, no numbered issue exists.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused package checks (tests, typecheck, Biome) were run after sync; full
      `bun run verify` not run for this narrow, five-file, non-UI fix.
- [x] A reviewer can confirm the change works without reading the code, from the
      focused regression tests and traced core behavior below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] rebased onto latest `origin/develop` (`265d6381751baf3b3bbde6953e495056236cfd8b`), zero conflicts (`git log --oneline HEAD..origin/develop` comes back empty)
- [x] focused package gates (tests, typecheck, biome) all pass on the exact rebased head

# Risks

low, `IMESSAGE_HEARTBEAT_INTERVAL_MS` is the only input touched. unset/blank keeps the existing 60s default, ordinary positive integers unchanged. only malformed, non-positive, or absurdly-huge values now fail loudly at startup instead of degrading in three different silent ways at runtime, traced below.

# Background

## What does this PR do?

`registerHeartbeat` parsed the interval with `Number(raw) || 60_000`. that fallback only catches falsy results (`NaN`, `0`, empty string), so a negative value or `"Infinity"` sails through as a truthy number and reaches `runtime.createTask` inside `metadata.updateInterval` unchanged.

traced what actually happens to that value once it's in core, rather than assuming it matched the setTimeout-overflow pattern from earlier fixes this session, it doesn't:

- `TaskService`'s per-tick loop calls `invalidScheduleField(task)` (`packages/core/src/services/task.ts:498`), which correctly flags a non-finite or non-positive `updateInterval`. but it does this check on every single tick, not once, and when it fires it throws a `TASK_TICK_FAILED` error that same tick. this repo already has a comment describing and fixing the identical pattern for orphaned tasks ("re-erroring every 1s tick... narrated into chat 9x", see the `quarantinedOrphans` handling right above it), the same anti-pattern is reachable here too, just via a different validation path that never got the same treatment. a negative or `Infinity` heartbeat interval means this fatal error repeats forever, every tick, until the operator notices, fixes the env var, and restarts.
- a huge-but-finite value (bigger than node's real setTimeout range but still a normal js number) passes `invalidScheduleField` clean, since that check only tests `isFinite` and positivity, no upper bound. the scheduler never calls `setTimeout(ms)` with this value directly though, it computes `idealNextRun = lastRan + updateIntervalMs` as plain arithmetic (`packages/core/src/services/task.ts:633-637`) and compares that against `now` on each tick. so the practical effect of an absurdly large value here is a heartbeat that silently stops firing again (the "next run" timestamp lands so far in the future it's effectively never), not a timer crash.

live chain:
- `resolveHeartbeatIntervalMs`, `plugins/plugin-imessage/src/service.ts:83-96` (this fix)
- `registerHeartbeat`, `plugins/plugin-imessage/src/service.ts:1898-1993`, calls the parser then `runtime.createTask` with the result in `metadata.updateInterval`
- `TaskService`'s tick loop, `packages/core/src/services/task.ts:299,479-501,633-637`, the two real downstream behaviors traced above

fix adds `resolveHeartbeatIntervalMs`, requiring a clean positive decimal integer within `[1, 2147483647]` and throwing once at service startup for anything else, instead of letting a bad value slide into one of the two silent-degradation paths above.

## What kind of change is this?

bug fix, non-breaking for valid values.

# Documentation changes needed?

no, the setting stays the same, this just fails clearly instead of degrading silently for bad input.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-imessage/src/service.ts:83-96` (`resolveHeartbeatIntervalMs`)
2. `plugins/plugin-imessage/src/heartbeat-config.test.ts` (new regression suite)

## Detailed testing steps

```text
bun run --cwd plugins/plugin-imessage test -- --run src/heartbeat-config.test.ts
Test Files  1 passed (1)
     Tests  11 passed (11)

bunx @biomejs/biome check plugins/plugin-imessage/src/service.ts plugins/plugin-imessage/src/heartbeat-config.test.ts
Checked 2 files. No fixes applied.

bun run --cwd plugins/plugin-imessage typecheck
exit 0, no output
```

The contributor verification was rerun after the maintainer repair; exact-head results are recorded in the latest review comment.

manual old vs new sweep, beyond the automated suite:

```text
interval(undefined)              old=60000     new=60000
interval("")                     old=60000     new=60000
interval("60000")                old=60000     new=60000
interval(" 5000 ")               old=5000      new=5000
interval("007")                  old=7         new=7
interval("0")                    old=60000     new=REJECTED
interval("-1")                   old=-1        new=REJECTED
interval("Infinity")             old=Infinity  new=REJECTED
interval("1.5")                  old=1.5       new=REJECTED
interval("1e3")                  old=1000      new=REJECTED
interval("5000oops")             old=60000     new=REJECTED
interval("2147483648")           old=2147483648  new=REJECTED
interval("9007199254740992")     old=<huge>    new=REJECTED
interval("+5000")                old=5000      new=REJECTED
```

`"0"` and malformed strings were already harmless before (the `||` fallback silently chose the default), those are now explicit rejections instead, same as every other changed row. `"-1"` and `"Infinity"` are the two that were genuinely reaching core unguarded and causing the repeated-tick-failure pattern described above.

# Evidence Gate

<!-- evidence-head:4e2823baac113313359e077ec313c93c36a9a65f -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend service startup logic, no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend service startup logic, no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no visual user flow changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - invalid input now throws at service startup, before any task gets registered; the real core scheduler behavior it used to reach is traced above with file:line, not just asserted.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or request path touched.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent decision or model behavior changed, this is an operator runtime setting, never model-supplied.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real regression run plus the edge-case sweep, captured directly:
  ```text
  bun run --cwd plugins/plugin-imessage test -- --run src/heartbeat-config.test.ts
  Test Files  1 passed (1)
       Tests  11 passed (11)

  new tests cover: default/blank preservation, ordinary positive integers,
  and rejection of 0, -1, 1.5, 1e3, malformed strings, Infinity, and the
  overflow boundary.

  manual old vs new sweep (14 inputs), see Testing above.
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface.

# Known gaps / failures

didn't run the full root `bun run verify` locally, the focused package's own test/typecheck/biome gates plus the edge-case sweep on the changed files all pass, see Testing above. the `packages/core/src/services/task.ts` per-tick repeated-error pattern this PR routes around is a real, separate, pre-existing gap in core's own scheduler (it already fixed the identical pattern for orphaned tasks but not for `invalidScheduleField`), out of scope for this plugin-level fix, flagging it here in case it's worth its own issue.





AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@265d6381751baf3b3bbde6953e495056236cfd8b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@265d6381751baf3b3bbde6953e495056236cfd8b:packages/skills/skills/contribute-to-eliza"} -->
