### PR TITLE
fix(ci): realign Cloud CF workflow contracts with the release split

### DIFF
--- a/packages/scripts/__tests__/cloud-cf-onboarding-login-url-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-onboarding-login-url-workflow.test.ts
@@ -5,7 +5,9 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, test } from "vitest";
 
-const workflow = readFileSync(".github/workflows/cloud-cf-deploy.yml", "utf8");
+// Worker secret migration runs inside the reusable release workflow invoked by
+// `cloud-cf-deploy.yml`, so the legacy-alias contract is read from there.
+const workflow = readFileSync(".github/workflows/cloud-cf-release.yml", "utf8");
 const wrangler = readFileSync("packages/cloud/api/wrangler.toml", "utf8");
 
 describe("staging onboarding login URL deployment", () => {

--- a/packages/scripts/__tests__/cloud-cf-pages-artifact-rerun-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-pages-artifact-rerun-workflow.test.ts
@@ -13,8 +13,17 @@ import { join } from "node:path";
 import { resolveGnuBash } from "../lib/gnu-shell.mjs";
 import { spawnSync } from "../lib/spawn-sync-captured.mjs";
 
+// The canonical producer/consumer pair (build-pages -> deploy-app) lives in the
+// reusable release workflow invoked by `cloud-cf-deploy.yml`; the entry
+// workflow keeps only the credential-free pull-request producer, whose artifact
+// is consumed by `cloud-cf-pr-preview-deploy.yml`. Both producers are asserted
+// so neither can drift away from the immutable-identity contract.
 const repoRoot = new URL("../../../", import.meta.url);
 const workflowSource = readFileSync(
+  new URL(".github/workflows/cloud-cf-release.yml", repoRoot),
+  "utf8",
+);
+const entrySource = readFileSync(
   new URL(".github/workflows/cloud-cf-deploy.yml", repoRoot),
   "utf8",
 );
@@ -40,7 +49,9 @@ interface Workflow {
 }
 
 const workflow = Bun.YAML.parse(workflowSource) as Workflow;
+const entryWorkflow = Bun.YAML.parse(entrySource) as Workflow;
 const buildJob = workflow.jobs?.["build-pages"];
+const entryBuildJob = entryWorkflow.jobs?.["build-pages"];
 const deployJobs = [
   {
     artifactPrefix: "pages-app",
@@ -112,32 +123,47 @@ describe("Cloud CF Pages artifact metadata", () => {
         "$" + "{{ steps.pages-artifact.outputs.source_sha }}",
       telegram_bot_id:
         "$" +
-        "{{ needs.resolve-pages-environment-config.outputs.telegram_bot_id || needs.resolve-pages-preview-config.outputs.telegram_bot_id }}",
+        "{{ needs.resolve-pages-environment-config.outputs.telegram_bot_id }}",
       telegram_bot_username:
         "$" +
-        "{{ needs.resolve-pages-environment-config.outputs.telegram_bot_username || needs.resolve-pages-preview-config.outputs.telegram_bot_username }}",
+        "{{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}",
+    });
+    expect(entryBuildJob?.outputs).toEqual({
+      artifact_run_id: "$" + "{{ steps.pages-artifact.outputs.run_id }}",
+      artifact_run_attempt:
+        "$" + "{{ steps.pages-artifact.outputs.run_attempt }}",
+      artifact_source_sha:
+        "$" + "{{ steps.pages-artifact.outputs.source_sha }}",
+      telegram_bot_id:
+        "$" +
+        "{{ needs.resolve-pages-preview-config.outputs.telegram_bot_id }}",
+      telegram_bot_username:
+        "$" +
+        "{{ needs.resolve-pages-preview-config.outputs.telegram_bot_username }}",
     });
 
-    const metadata = namedStep(
-      buildJob,
-      "Bind Pages artifacts to this producer attempt",
-    );
-    expect(metadata.id).toBe("pages-artifact");
-    expect(metadata.env).toEqual({
-      PRODUCER_RUN_ID: "$" + "{{ github.run_id }}",
-      PRODUCER_RUN_ATTEMPT: "$" + "{{ github.run_attempt }}",
-      PRODUCER_SOURCE_SHA: "$" + "{{ github.sha }}",
-    });
-
-    for (const { artifactPrefix, upload: uploadName } of deployJobs) {
-      const upload = namedStep(buildJob, uploadName);
-      expect(upload.with?.name).toBe(
-        `${artifactPrefix}-` +
-          "$" +
-          "{{ steps.pages-artifact.outputs.run_id }}-" +
-          "$" +
-          "{{ steps.pages-artifact.outputs.run_attempt }}",
+    for (const producer of [buildJob, entryBuildJob]) {
+      const metadata = namedStep(
+        producer,
+        "Bind Pages artifacts to this producer attempt",
       );
+      expect(metadata.id).toBe("pages-artifact");
+      expect(metadata.env).toEqual({
+        PRODUCER_RUN_ID: "$" + "{{ github.run_id }}",
+        PRODUCER_RUN_ATTEMPT: "$" + "{{ github.run_attempt }}",
+        PRODUCER_SOURCE_SHA: "$" + "{{ github.sha }}",
+      });
+
+      for (const { artifactPrefix, upload: uploadName } of deployJobs) {
+        const upload = namedStep(producer, uploadName);
+        expect(upload.with?.name).toBe(
+          `${artifactPrefix}-` +
+            "$" +
+            "{{ steps.pages-artifact.outputs.run_id }}-" +
+            "$" +
+            "{{ steps.pages-artifact.outputs.run_attempt }}",
+        );
+      }
     }
   });
 

--- a/packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
@@ -21,6 +21,13 @@ const consumerSource = readFileSync(
   new URL(".github/workflows/cloud-cf-pr-preview-deploy.yml", repoRoot),
   "utf8",
 );
+// The unprivileged pull-request producer stays in the entry workflow. Canonical
+// Pages deployment moved into the reusable release workflow the entry calls
+// after admission, so its API gate is asserted there.
+const releaseSource = readFileSync(
+  new URL(".github/workflows/cloud-cf-release.yml", repoRoot),
+  "utf8",
+);
 
 interface WorkflowStep {
   env?: Record<string, string>;
@@ -37,6 +44,7 @@ interface WorkflowJob {
   if?: string;
   needs?: string | string[];
   steps?: WorkflowStep[];
+  uses?: string;
   strategy?: {
     matrix?: {
       include?: Array<Record<string, string>>;
@@ -64,6 +72,7 @@ interface Workflow {
 
 const producer = Bun.YAML.parse(producerSource) as Workflow;
 const consumer = Bun.YAML.parse(consumerSource) as Workflow;
+const release = Bun.YAML.parse(releaseSource) as Workflow;
 const deployJobs = ["deploy-app"] as const;
 const GNU_BASH = resolveGnuBash();
 const executedDescribe = GNU_BASH ? describe : describe.skip;
@@ -160,20 +169,30 @@ describe("Cloud CF PR preview workflow contract", () => {
   test("keeps PR builds reachable and gates canonical Pages on the API", () => {
     const buildJob = producer.jobs?.["build-pages"];
     expect(buildJob?.needs).toEqual([
-      "migrate-db",
-      "resolve-pages-environment-config",
+      "validate-deploy-source",
       "resolve-pages-preview-config",
     ]);
-    expect(buildJob?.if).toContain(
-      "github.event_name == 'pull_request' && needs.migrate-db.result == 'skipped'",
+    expect(buildJob?.if).toBe(
+      "$" +
+        "{{ github.event_name == 'pull_request' && needs.resolve-pages-preview-config.result == 'success' }}",
     );
     expect(
       namedStep(producer, "build-pages", "Validate PR preview identity").if,
     ).toBe("github.event_name == 'pull_request'");
     expect(JSON.stringify(buildJob)).not.toContain("secrets.");
 
+    // The entry workflow owns no Cloudflare mutation of its own: every deploy
+    // job lives behind the approved release call, which pull requests can
+    // never reach.
+    for (const jobId of [...deployJobs, "deploy-api", "migrate-db"] as const) {
+      expect(producer.jobs?.[jobId]).toBeUndefined();
+    }
+    const releaseCall = producer.jobs?.release;
+    expect(releaseCall?.uses).toBe("./.github/workflows/cloud-cf-release.yml");
+    expect(releaseCall?.if).toContain("github.event_name != 'pull_request'");
+
     for (const jobId of deployJobs) {
-      const job = producer.jobs?.[jobId];
+      const job = release.jobs?.[jobId];
       expect(job?.needs).toEqual(["deploy-api", "build-pages"]);
       expect(job?.if).toBe(
         "$" +

--- a/packages/scripts/__tests__/cloud-cf-staging-session-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-staging-session-deploy-workflow.test.ts
@@ -4,9 +4,12 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { validateStagingSessionCutoverConfig } from "../../cloud/scripts/validate-staging-session-cutover.mjs";
 
+// The mutating `deploy-api` job lives in the reusable release workflow that
+// `cloud-cf-deploy.yml` calls once admission and approval have passed; the
+// cutover contract is asserted where the mutation actually runs.
 const repoRoot = new URL("../../../", import.meta.url);
 const workflowSource = readFileSync(
-  new URL(".github/workflows/cloud-cf-deploy.yml", repoRoot),
+  new URL(".github/workflows/cloud-cf-release.yml", repoRoot),
   "utf8",
 );
 

--- a/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
@@ -24,11 +24,17 @@ interface WorkflowStep {
 }
 
 interface Workflow {
-  jobs?: Record<string, { steps?: WorkflowStep[] }>;
+  jobs?: Record<string, { if?: string; steps?: WorkflowStep[] }>;
 }
 
-const workflowSource = read(".github/workflows/cloud-cf-deploy.yml");
+// The Worker `deploy-api` job lives in the reusable release workflow that
+// `cloud-cf-deploy.yml` calls after admission; the pull-request entry workflow
+// still owns the credential-free preview frontend build. Both files are read so
+// no expression in either escapes the balance and realtime-flag contracts.
+const entrySource = read(".github/workflows/cloud-cf-deploy.yml");
+const workflowSource = read(".github/workflows/cloud-cf-release.yml");
 const workflow = Bun.YAML.parse(workflowSource) as Workflow;
+const entryWorkflow = Bun.YAML.parse(entrySource) as Workflow;
 const publishStep = workflow.jobs?.["deploy-api"]?.steps?.find(
   (step) => step.name === "Publish Worker AI secrets",
 );
@@ -101,6 +107,7 @@ describe("Cloud CF realtime voice deploy contract", () => {
         "{{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZACLOUD_API_KEY || '' }}",
     );
     expect(workflowSource).not.toContain("format('Bearer {0}'");
+    expect(entrySource).not.toContain("format('Bearer {0}'");
   });
 
   test("gates realtime secret publication behind explicit opt-in", () => {
@@ -207,15 +214,39 @@ describe("Cloud CF realtime voice deploy contract", () => {
       "&& 'true' || 'false'",
     );
 
-    const frontendRealtimeFlags = workflowSource.match(
-      /VITE_VOICE_REALTIME_WS: \$\{\{[^}]*vars\.VOICE_REALTIME_WS_ENABLED[^}]*&& '1' \|\| '0' \}\}/g,
-    );
-    expect(frontendRealtimeFlags?.length).toBeGreaterThanOrEqual(2);
-    for (const flag of frontendRealtimeFlags ?? []) {
-      expect(flag).toContain("inputs.environment == 'production'");
-      expect(flag).toContain("github.ref == 'refs/heads/main'");
+    // Every frontend build in either workflow must resolve the realtime flag
+    // from the repository variable and must not be able to reach production
+    // with it on. The canonical release build carries the production guard in
+    // the expression itself; the pull-request preview build has no production
+    // path at all because its whole environment is pinned to staging.
+    const flagPattern =
+      /VITE_VOICE_REALTIME_WS: \$\{\{[^}]*vars\.VOICE_REALTIME_WS_ENABLED[^}]*&& '1' \|\| '0' \}\}/g;
+    const releaseRealtimeFlags = workflowSource.match(flagPattern) ?? [];
+    expect(releaseRealtimeFlags.length).toBeGreaterThanOrEqual(1);
+    for (const flag of releaseRealtimeFlags) {
+      expect(flag).toContain("!(inputs.target_environment == 'production')");
       expect(flag).toContain("vars.VOICE_REALTIME_WS_ENABLED");
     }
+
+    const entryRealtimeFlags = entrySource.match(flagPattern) ?? [];
+    expect(entryRealtimeFlags.length).toBeGreaterThanOrEqual(1);
+    for (const flag of entryRealtimeFlags) {
+      expect(flag).toContain("vars.VOICE_REALTIME_WS_ENABLED");
+    }
+    const previewBuild = entryWorkflow.jobs?.["build-pages"]?.steps?.find(
+      (step) => step.name === "Build consolidated frontend artifact",
+    );
+    expect(previewBuild?.env?.VITE_VOICE_REALTIME_WS).toBe(
+      entryRealtimeFlags[0]?.replace("VITE_VOICE_REALTIME_WS: ", ""),
+    );
+    expect(previewBuild?.env?.VITE_ENVIRONMENT).toBe("staging");
+    expect(previewBuild?.env?.VITE_API_URL).toBe(
+      "https://api-staging.eliza.app",
+    );
+    expect(previewBuild?.env?.VITE_APP_URL).toBe("https://staging.eliza.app");
+    expect(entryWorkflow.jobs?.["build-pages"]?.if).toContain(
+      "github.event_name == 'pull_request'",
+    );
   });
 
   test("every GitHub expression in the deploy workflow has balanced parentheses", () => {
@@ -223,7 +254,10 @@ describe("Cloud CF realtime voice deploy contract", () => {
     // the GitHub layer (instant run failure with zero jobs) while remaining
     // invisible to the substring/regex assertions above. Balance-check every
     // expression so the parse error fails HERE, in a reviewable unit test.
-    const expressions = workflowSource.match(/\$\{\{[\s\S]*?\}\}/g) ?? [];
+    const expressions = [
+      ...(workflowSource.match(/\$\{\{[\s\S]*?\}\}/g) ?? []),
+      ...(entrySource.match(/\$\{\{[\s\S]*?\}\}/g) ?? []),
+    ];
     expect(expressions.length).toBeGreaterThan(0);
     for (const expression of expressions) {
       let depth = 0;

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -40,8 +40,11 @@ function step(workflow: Workflow, jobId: string, name: string): WorkflowStep {
   return found;
 }
 
-const cloudSource = read(".github/workflows/cloud-cf-deploy.yml");
-const cloud = parse(".github/workflows/cloud-cf-deploy.yml");
+// `cloud-cf-deploy.yml` is the trigger/admission/approval entry point; every
+// Cloudflare mutation (deploy-api, deploy-app) runs in the reusable
+// `cloud-cf-release.yml` it calls, so the mutation contracts are read there.
+const cloudSource = read(".github/workflows/cloud-cf-release.yml");
+const cloud = parse(".github/workflows/cloud-cf-release.yml");
 const infraSource = read(".github/workflows/infra.yml");
 const infra = parse(".github/workflows/infra.yml");
 const provisioning = parse(

--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -306,15 +306,25 @@ describe("GitHub action supply-chain references", () => {
   });
 
   test("routes homepage deploys through the consolidated Cloudflare workflow", () => {
+    // The entry workflow owns the homepage trigger paths and the unprivileged
+    // preview build; the Pages project it deploys into is bound in the reusable
+    // release workflow it calls.
     const source = readFileSync(
       join(githubRoot, "workflows", "cloud-cf-deploy.yml"),
       "utf8",
     );
+    const releaseSource = readFileSync(
+      join(githubRoot, "workflows", "cloud-cf-release.yml"),
+      "utf8",
+    );
     expect(source).toContain('      - "packages/homepage/**"');
     expect(source).toContain("Build consolidated frontend artifact");
-    expect(source).toContain("PAGES_PROJECT: eliza-app");
-    expect(source).not.toContain("PAGES_PROJECT: eliza-app-home");
-    expect(source).not.toContain("git push");
+    expect(releaseSource).toContain("Build consolidated frontend artifact");
+    expect(releaseSource).toContain("PAGES_PROJECT: eliza-app");
+    for (const workflowSource of [source, releaseSource]) {
+      expect(workflowSource).not.toContain("PAGES_PROJECT: eliza-app-home");
+      expect(workflowSource).not.toContain("git push");
+    }
   });
 
   test("keeps the Docker smoke on a runner with a Docker daemon", () => {

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -8,11 +8,20 @@ import { describe, expect, it } from "vitest";
 
 const repositoryRoot = path.resolve(import.meta.dirname, "../../..");
 const workflowsDirectory = path.join(repositoryRoot, ".github/workflows");
+// Homepage deployment authority spans the entry workflow (triggers and the
+// unprivileged pull-request preview build) and the reusable release workflow it
+// calls (canonical build and Pages deploy). Both are asserted explicitly so a
+// guarantee cannot silently satisfy itself from the wrong file.
 const workflowPath = path.join(workflowsDirectory, "cloud-cf-deploy.yml");
+const releaseWorkflowPath = path.join(
+  workflowsDirectory,
+  "cloud-cf-release.yml",
+);
 const qualityWorkflowPath = path.join(workflowsDirectory, "quality.yml");
 
 describe("homepage deployment workflow", () => {
   const workflow = readFileSync(workflowPath, "utf8");
+  const releaseWorkflow = readFileSync(releaseWorkflowPath, "utf8");
   const qualityWorkflow = readFileSync(qualityWorkflowPath, "utf8");
   const homepagePackage = JSON.parse(
     readFileSync(
@@ -49,6 +58,7 @@ describe("homepage deployment workflow", () => {
       expect(homepagePackage.scripts?.[script]).toBeUndefined();
     }
     expect(workflow).not.toContain("eliza-app-home");
+    expect(releaseWorkflow).not.toContain("eliza-app-home");
     expect(devAll).not.toContain("packages/homepage");
     expect(devAll).not.toContain("DEV_ALL_HOMEPAGE_PORT");
   });
@@ -58,39 +68,53 @@ describe("homepage deployment workflow", () => {
     expect(workflow).toContain('      - "packages/homepage/**"');
     expect(workflow).toContain("Build consolidated frontend artifact");
     expect(workflow).toContain("Upload consolidated frontend artifact");
-    expect(workflow).toContain("PAGES_PROJECT: eliza-app");
-    expect(workflow).toContain("https://eliza.app");
-    expect(workflow).toContain("https://cloud.eliza.app");
-    expect(workflow).toContain("https://staging.eliza.app");
-    expect(workflow).toContain("https://cloud-staging.eliza.app");
+    expect(releaseWorkflow).toContain("Build consolidated frontend artifact");
+    expect(releaseWorkflow).toContain("Upload consolidated frontend artifact");
+    expect(releaseWorkflow).toContain("PAGES_PROJECT: eliza-app");
+    expect(releaseWorkflow).toContain("https://eliza.app");
+    expect(releaseWorkflow).toContain("https://cloud.eliza.app");
+    expect(releaseWorkflow).toContain("https://staging.eliza.app");
+    expect(releaseWorkflow).toContain("https://cloud-staging.eliza.app");
   });
 
   it("resolves matched Telegram configuration for canonical and preview builds", () => {
-    expect(workflow).toContain("resolve-pages-environment-config:");
+    expect(releaseWorkflow).toContain("resolve-pages-environment-config:");
     expect(workflow).toContain("resolve-pages-preview-config:");
-    expect(workflow).toContain("VITE_TELEGRAM_BOT_ID must be numeric");
-    expect(workflow.match(/TELEGRAM_BOT_ID=7684336618/g)).toHaveLength(2);
-    expect(workflow.match(/TELEGRAM_BOT_USERNAME=Elizav2_Bot/g)).toHaveLength(
-      2,
+    // Each workflow owns exactly one resolver, and each resolver still refuses a
+    // half-configured pair and supplies the matched public default.
+    for (const source of [workflow, releaseWorkflow]) {
+      expect(source).toContain("VITE_TELEGRAM_BOT_ID must be numeric");
+      expect(source.match(/TELEGRAM_BOT_ID=7684336618/g)).toHaveLength(1);
+      expect(source.match(/TELEGRAM_BOT_USERNAME=Elizav2_Bot/g)).toHaveLength(
+        1,
+      );
+      expect(
+        source.match(
+          /VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME must be configured together/g,
+        ),
+      ).toHaveLength(1);
+    }
+    expect(releaseWorkflow).toContain(
+      "VITE_TELEGRAM_BOT_ID: $" +
+        "{{ needs.resolve-pages-environment-config.outputs.telegram_bot_id }}",
     );
-    expect(
-      workflow.match(
-        /VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME must be configured together/g,
-      ),
-    ).toHaveLength(2);
+    expect(releaseWorkflow).toContain(
+      "VITE_TELEGRAM_BOT_USERNAME: $" +
+        "{{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}",
+    );
     expect(workflow).toContain(
       "VITE_TELEGRAM_BOT_ID: $" +
-        "{{ needs.resolve-pages-environment-config.outputs.telegram_bot_id || needs.resolve-pages-preview-config.outputs.telegram_bot_id }}",
+        "{{ needs.resolve-pages-preview-config.outputs.telegram_bot_id }}",
     );
     expect(workflow).toContain(
       "VITE_TELEGRAM_BOT_USERNAME: $" +
-        "{{ needs.resolve-pages-environment-config.outputs.telegram_bot_username || needs.resolve-pages-preview-config.outputs.telegram_bot_username }}",
+        "{{ needs.resolve-pages-preview-config.outputs.telegram_bot_username }}",
     );
-    expect(workflow).toContain(
+    expect(releaseWorkflow).toContain(
       "VITE_TELEGRAM_BOT_ID: $" +
         "{{ needs.build-pages.outputs.telegram_bot_id }}",
     );
-    expect(workflow).toContain(
+    expect(releaseWorkflow).toContain(
       "VITE_TELEGRAM_BOT_USERNAME: $" +
         "{{ needs.build-pages.outputs.telegram_bot_username }}",
     );

--- a/packages/scripts/__tests__/release-workflow-authority.test.ts
+++ b/packages/scripts/__tests__/release-workflow-authority.test.ts
@@ -20,7 +20,32 @@ describe("release workflow authority", () => {
         name,
       ),
     );
-    expect(releaseEntries).toEqual(["release.yaml"]);
+    expect(releaseEntries).toEqual(["cloud-cf-release.yml", "release.yaml"]);
+
+    // `cloud-cf-release.yml` shares the name but not the authority: it is the
+    // reusable Cloudflare deployment leg of `cloud-cf-deploy.yml`. It must stay
+    // callable only by that workflow and must never publish packages, or the
+    // repository would have a second release entry point.
+    const cloudRelease = readFileSync(
+      join(workflowDirectory, "cloud-cf-release.yml"),
+      "utf8",
+    );
+    const cloudReleaseWorkflow = Bun.YAML.parse(cloudRelease) as {
+      on?: Record<string, unknown>;
+    };
+    expect(Object.keys(cloudReleaseWorkflow.on ?? {})).toEqual([
+      "workflow_call",
+    ]);
+    for (const publication of [
+      "npm publish",
+      "bun publish",
+      "npm dist-tag",
+      "registry.npmjs.org",
+      "release-candidate",
+      "NPM_TOKEN",
+    ]) {
+      expect(cloudRelease).not.toContain(publication);
+    }
 
     const source = readFileSync(
       join(workflowDirectory, "release.yaml"),


### PR DESCRIPTION
# Relates to

Repairs the last known-red canonical lane on `develop`: `Tests (scripts)`
(`E2E_COVERAGE_GATE_ENFORCE=1 bun run test:scripts`), red since the Eliza Cloud
consolidation (#18996) and only partially repaired by #18987.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and branches from `origin/develop` at `48971a06818` with zero conflicts.
- [x] `bun install` was run after sync.
- [x] A reviewer can confirm the change from the per-test old-assertion/new-home table below without reading the diff.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no packaged skill was used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `48971a06818`; zero conflicts.
- [x] Full `E2E_COVERAGE_GATE_ENFORCE=1 bun run test:scripts` passes at this head (exit 0, zero `(fail)` lines).
- [x] `bun run --cwd packages/scripts typecheck` passes (218/218 Turbo tasks).
- [x] `biome check` clean on all nine touched files.

# Risks

Low, and confined to test files. **No workflow YAML is modified by this PR.** Nine
contract-test files are re-pointed at the workflow that now owns each guarantee.
No assertion was weakened to make a test pass: every `toEqual`/`toBe` stayed a
`toEqual`/`toBe`, no `toContain` replaced a structural check, and no assertion
was deleted. Where a guarantee is now split across the two workflows, **both**
files are asserted separately rather than concatenated, so a check cannot
silently satisfy itself from the wrong file.

# Background

## What does this PR do?

#18996 split the Cloudflare deploy into two workflows:

- `.github/workflows/cloud-cf-deploy.yml` — the **entry** workflow. Owns the
  triggers, `validate-deploy-source`, `admit-staging`, `authorize-production`,
  the credential-free pull-request `build-pages` producer, and the `release`
  caller job that holds the single post-approval mutation lock.
- `.github/workflows/cloud-cf-release.yml` — the reusable (`workflow_call`)
  **release** workflow. Owns every Cloudflare mutation: `migrate-db`,
  `deploy-api`, `resolve-pages-environment-config`, the canonical `build-pages`,
  `deploy-app`, and `verify-routing`.

Ten contract-test files still read the mutation steps from the entry workflow.
23 tests failed on a **file location**, not on a behavior change.

## What kind of change is this?

Bug fix (CI contract-test realignment). Non-breaking; no runtime or workflow behavior changes.

# Per-test resolution

Every guarantee below was traced to its new home before the test was moved.

| Test file | Assertion that broke | New home (file:line) | Verdict |
| --- | --- | --- | --- |
| `cloud-deploy-environment-contract.test.ts` | `deploy-api` step `Validate canonical routing contract` precedes the first cutover mutation | `cloud-cf-release.yml:350` (job `deploy-api`, L93) | **Preserved** — same job id, same step names, same order |
| `cloud-deploy-environment-contract.test.ts` | `Publish Worker AI secrets` publishes configured shared secrets, never deletes absent ones | `cloud-cf-release.yml:412` | **Preserved** verbatim |
| `cloud-deploy-environment-contract.test.ts` | `Verify required Worker secret binding names` runs after deploy, before health, names-only | `cloud-cf-release.yml:861` | **Preserved** verbatim |
| `cloud-deploy-environment-contract.test.ts` | `Ensure eliza-app Pages project exists` handles only `already exists`, no `|| true` | `cloud-cf-release.yml:1489` | **Preserved** verbatim |
| `cloud-deploy-environment-contract.test.ts` | `Verify Pages frontend freshness` checks both browser hosts + exact API/OIDC routes | `cloud-cf-release.yml:1550` | **Preserved** verbatim |
| `cloud-cf-staging-session-deploy-workflow.test.ts` | off-first / deploy / proof / activate ordering; `Activate and verify staging session exchange after deploy proof` | `cloud-cf-release.yml:936` | **Preserved** verbatim (pure file redirect; all 4 tests, 45 assertions unchanged) |
| `cloud-cf-onboarding-login-url-workflow.test.ts` | `delete_legacy_onboarding_secret` ordering and `trap restore_legacy_onboarding_secrets ERR` rollback | `cloud-cf-release.yml:855` | **Preserved** verbatim (pure file redirect) |
| `cloud-cf-voice-deploy-workflow.test.ts` | entire `deploy-api` realtime-voice preflight, executed verbatim in bash | `cloud-cf-release.yml:412` / `:798` | **Preserved** verbatim |
| `cloud-cf-voice-deploy-workflow.test.ts` | `VITE_VOICE_REALTIME_WS` appears >=2x, each gated `inputs.environment == 'production'` **and** `github.ref == 'refs/heads/main'` | canonical: `cloud-cf-release.yml:1160`; preview: `cloud-cf-deploy.yml:331` | **Preserved, expressed differently** — see note below |
| `cloud-cf-pages-artifact-rerun-workflow.test.ts` | `build-pages` producer identity outputs; `Resolve immutable app artifact` fail-closed resolver (executed) | `cloud-cf-release.yml:1082` / `:1311` | **Preserved**; test now additionally asserts the PR producer in `cloud-cf-deploy.yml:252` |
| `cloud-cf-pages-branch-workflow.test.ts` | `build-pages.needs == [migrate-db, resolve-pages-environment-config, resolve-pages-preview-config]`; `deploy-app.needs == [deploy-api, build-pages]` | PR producer: `cloud-cf-deploy.yml:252`; canonical gate: `cloud-cf-release.yml:1184` | **Preserved and strengthened** — see note below |
| `homepage-deploy-workflow.test.ts` | one `||`-merged Telegram expression; `TELEGRAM_BOT_ID=7684336618` x2 in one file | `cloud-cf-release.yml:1053` (canonical) + `cloud-cf-deploy.yml:225` (preview) | **Preserved** — 2 resolvers total, now 1 per file; each still rejects a half-configured pair |
| `homepage-deploy-workflow.test.ts` | `PAGES_PROJECT: eliza-app` and canonical host URLs | `cloud-cf-release.yml:1533` | **Preserved** |
| `github-action-pinning.test.ts` | `PAGES_PROJECT: eliza-app` in the homepage deploy route | `cloud-cf-release.yml:1533` | **Preserved**; the negative checks (`eliza-app-home`, `git push`) now run against **both** files |
| `release-workflow.test.ts` | (no change needed) | — | Passed once the i18n keyword codegen prerequisite existed |
| `release-workflow-authority.test.ts` | `releaseEntries == ["release.yaml"]` — `cloud-cf-release.yml` matches the `*-release.yml` pattern | `.github/workflows/cloud-cf-release.yml` | **Preserved and strengthened** — see note below |

## Three assertions whose shape changed (and why that is not a weakening)

**1. Frontend realtime flag (`cloud-cf-voice-deploy-workflow.test.ts`).**
The old assertion required both frontend builds to carry a production guard in
the expression. The canonical build still does, as
`!(inputs.target_environment == 'production')` — the reusable workflow's
equivalent of `inputs.environment`/`github.ref`. The pull-request preview build
no longer carries a production guard because **it has no production path at
all**: its whole environment is hard-pinned to staging. The test now asserts
that pinning explicitly (`VITE_ENVIRONMENT: staging`,
`VITE_API_URL: https://api-staging.eliza.app`,
`VITE_APP_URL: https://staging.eliza.app`, job `if` requires
`github.event_name == 'pull_request'`), so the *outcome* — a preview build can
never serve production with realtime on — is asserted rather than assumed.

**2. PR-vs-canonical Pages gating (`cloud-cf-pages-branch-workflow.test.ts`).**
The old assertion proved a pull request could not reach a mutation by requiring
`needs.migrate-db.result == 'skipped'` inside one workflow. That same property
is now structural: the entry workflow contains **no** `migrate-db`,
`deploy-api`, or `deploy-app` job, and the only route to them is the
`release` caller job gated on `github.event_name != 'pull_request'`. The test
asserts all of that (job absence, `uses: ./.github/workflows/cloud-cf-release.yml`,
the PR gate) **plus** the unchanged `deploy-app.needs == ["deploy-api", "build-pages"]`
and its exact `if` string in the release workflow. Strictly more is proven.

**3. Release authority (`release-workflow-authority.test.ts`).**
`cloud-cf-release.yml` genuinely matches the `*-release.(yml|yaml)` scan, so the
expected list now includes it. The guarantee — *one* package-publication release
authority — is preserved by proving `cloud-cf-release.yml` is not one: its
triggers are exactly `["workflow_call"]` (not dispatchable), and it contains
none of `npm publish`, `bun publish`, `npm dist-tag`, `registry.npmjs.org`,
`release-candidate`, `NPM_TOKEN`. `release.yaml` keeps its existing
dispatch-only assertions untouched.

# LOST guarantee found (not papered over)

**One real coverage gap survives the consolidation, and this PR deliberately
does not hide it.**

`packages/scripts/ci-bun-version-contract.mjs:143` declares:

```js
const GATE_WORKFLOWS = ["test.yml", "develop-pr.yml", "cloud-cf-deploy.yml"];
```

with the comment *"the canonical cloud deploy [is one of] the load-bearing
paths"*. After #18996, the canonical cloud deploy's installs run in
`cloud-cf-release.yml` — four `oven-sh/setup-bun` steps across `migrate-db`,
`deploy-api`, `build-pages`, and `deploy-app` — and **none of them are covered
by the concrete-pin gate**. `cloud-cf-deploy.yml` retains only the
pull-request preview build's setup-bun, so the gate still passes while guarding
a workflow that no longer performs the deploy it was written to protect.

This is latent, not currently broken: every `bun-version` in
`cloud-cf-release.yml` is pinned to `"1.3.14"` today. But a future change could
float the release workflow to `canary`/`latest` and the gate would stay green.

It is **not** fixed here because the fix is a behavior change to a passing gate
(adding `cloud-cf-release.yml` to `GATE_WORKFLOWS` in both
`ci-bun-version-contract.mjs` and its fixture-driven test), which does not
belong in a red-lane repair. Flagging it for a follow-up issue so it stays
visible rather than being absorbed into this PR.

# Documentation changes needed?

No. No public surface, runtime behavior, or workflow YAML changed.

# Testing

## Where should a reviewer start?

Start with `packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts`
— its diff is a five-line comment plus two path constants, which is the whole
shape of this PR. Then read
`packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts`, the one
file where assertions were added rather than moved.

## Detailed testing steps

```bash
git checkout fix/cloud-cf-contract-realignment
bun install
bun packages/shared/scripts/generate-keywords.mjs   # i18n codegen prerequisite
E2E_COVERAGE_GATE_ENFORCE=1 bun run test:scripts
```

To confirm nothing was weakened, revert any single test file and observe it fail
against the workflow it now reads:

```bash
git checkout origin/develop -- packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
bun test packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts   # 5 fail
```

# Evidence Gate

<!-- evidence-head:e20d4409893bb7105b0adab9121b7544249725ab -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed; this PR touches only `packages/scripts/__tests__/*.test.ts`.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow exists for a workflow-contract test lane.
<!-- evidence-row:backend-logs -->
- [x] Lane output included below; no backend runtime path changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, scheduled-task, wallet, or generated domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Lane result: before (`develop` @ `48971a06818`)

```
EXIT=1

23 failing contract tests across 10 files:
  cloud-cf-pages-artifact-rerun-workflow.test.ts        5
  cloud-deploy-environment-contract.test.ts             5
  cloud-cf-staging-session-deploy-workflow.test.ts      4
  cloud-cf-onboarding-login-url-workflow.test.ts        2
  homepage-deploy-workflow.test.ts                      2
  cloud-cf-pages-branch-workflow.test.ts                1
  github-action-pinning.test.ts                         1
  release-workflow-authority.test.ts                    1
  cloud-cf-voice-deploy-workflow.test.ts                whole file (module-load throw)

Representative diffs:
  (fail) canonical cloud deployment environment contract > validates canonical
         Worker routes before any cutover mutation
    error: Missing deploy-api workflow step: Publish Worker AI secrets

  (fail) release workflow authority > has one manually dispatched release workflow
    @@ -1,3 +1,3 @@
      [
    +   "cloud-cf-release.yml",
        "release.yaml",

  (fail) Cloud CF PR preview workflow contract > keeps PR builds reachable and
         gates canonical Pages on the API
    @@ -1,4 +1,3 @@
      [
    -   "migrate-db",
    -   "resolve-pages-environment-config",
    +   "validate-deploy-source",
        "resolve-pages-preview-config",
```

## Lane result: after (this head)

```
$ E2E_COVERAGE_GATE_ENFORCE=1 bun run test:scripts
EXIT=0
(zero "(fail)" lines across the entire lane)
```

Per-file confirmation:

```
cloud-cf-staging-session-deploy-workflow.test.ts     4 pass  0 fail   45 expect()
cloud-cf-onboarding-login-url-workflow.test.ts       3 pass  0 fail
cloud-cf-voice-deploy-workflow.test.ts              13 pass  0 fail
cloud-cf-pages-artifact-rerun-workflow.test.ts       6 pass  0 fail
cloud-deploy-environment-contract.test.ts            9 pass  0 fail  147 expect()
cloud-cf-pages-branch-workflow.test.ts               9 pass  0 fail  113 expect()
homepage-deploy-workflow.test.ts                     5 pass  0 fail
release-workflow-authority.test.ts + pinning        14 pass  0 fail   55 expect()
```

## Static gates

```
bun run --cwd packages/scripts typecheck   ->  218 successful, 218 total
biome check (9 touched files)              ->  clean (1 pre-existing warning,
                                               noTemplateCurlyInString, untouched)
```

## Note on lane prerequisites

Two failures observed in the first local reproduction
(`check-e2e-coverage.test.ts` and `provisioning-worker` one-shot daemon) were
`Cannot find module './generated/validation-keyword-data.ts'` cascades from a
clean `--ignore-scripts` install, not regressions. Running the documented
prerequisite (`packages/shared/scripts/generate-keywords.mjs`, which
`packages/scripts/test-cloud-run.mjs` already codifies as
`PREFLIGHT_STEPS.keywordCodegen`) cleared both. No repository change was needed.
