### PR TITLE
feat(core): add duplicate-safe @elizaos/core/client-public surface

### DIFF
--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -1157,11 +1157,6 @@ export async function generateTypeScriptDeclarations() {
 		"dist/roles.js",
 		`// Roles subpath entry point (explicit)\nexport * from './node/roles.js';\n`,
 	);
-	await fs.writeFile(
-		"dist/client-public.js",
-		`// Client-public subpath entry point (explicit)\nexport * from './node/client-public.js';\n`,
-	);
-
 	// Create main index.d.ts to re-export all types from node build
 	// This ensures TypeScript resolves all exports when using moduleResolution: bundler
 	// Note: Use .js extension for NodeNext module resolution compatibility

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -763,6 +763,7 @@ export async function buildNode(
 			entrypoints: [
 				`${TS_SRC}/index.node.ts`,
 				`${TS_SRC}/roles.ts`,
+				`${TS_SRC}/client-public.ts`,
 				`${TS_SRC}/security/kms/index.ts`,
 				`${TS_SRC}/security/mcp-server-config.ts`,
 				`${TS_SRC}/utils/atomic-json.ts`,
@@ -797,7 +798,11 @@ export async function buildBrowser(
 	const runBrowser = runnerFactory({
 		...sharedConfig,
 		buildOptions: {
-			entrypoints: [`${TS_SRC}/index.browser.ts`, `${TS_SRC}/roles.ts`],
+			entrypoints: [
+				`${TS_SRC}/index.browser.ts`,
+				`${TS_SRC}/roles.ts`,
+				`${TS_SRC}/client-public.ts`,
+			],
 			outdir: "dist/browser",
 			// Use the Node target so `node:*` imports bundle without broken browser polyfills.
 			// The dashboard/Vite shell still aliases `node:*` where the bundle runs in the browser.
@@ -1151,6 +1156,10 @@ export async function generateTypeScriptDeclarations() {
 	await fs.writeFile(
 		"dist/roles.js",
 		`// Roles subpath entry point (explicit)\nexport * from './node/roles.js';\n`,
+	);
+	await fs.writeFile(
+		"dist/client-public.js",
+		`// Client-public subpath entry point (explicit)\nexport * from './node/client-public.js';\n`,
 	);
 
 	// Create main index.d.ts to re-export all types from node build

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -83,8 +83,22 @@
 				"import": "./src/client-public.ts",
 				"default": "./src/client-public.ts"
 			},
-			"import": "./dist/client-public.js",
-			"default": "./dist/client-public.js"
+			"browser": {
+				"types": "./dist/client-public.d.ts",
+				"import": "./dist/browser/client-public.js",
+				"default": "./dist/browser/client-public.js"
+			},
+			"node": {
+				"types": "./dist/client-public.d.ts",
+				"import": "./dist/node/client-public.js",
+				"default": "./dist/node/client-public.js"
+			},
+			"bun": {
+				"types": "./dist/client-public.d.ts",
+				"import": "./dist/node/client-public.js",
+				"default": "./dist/node/client-public.js"
+			},
+			"default": "./dist/node/client-public.js"
 		},
 		"./testing": {
 			"types": "./dist/testing/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,6 +76,16 @@
 			"import": "./dist/roles.js",
 			"default": "./dist/roles.js"
 		},
+		"./client-public": {
+			"types": "./dist/client-public.d.ts",
+			"eliza-source": {
+				"types": "./src/client-public.ts",
+				"import": "./src/client-public.ts",
+				"default": "./src/client-public.ts"
+			},
+			"import": "./dist/client-public.js",
+			"default": "./dist/client-public.js"
+		},
 		"./testing": {
 			"types": "./dist/testing/index.d.ts",
 			"import": "./dist/testing/index.js",

--- a/packages/core/src/client-public.duplicate-safe.test.ts
+++ b/packages/core/src/client-public.duplicate-safe.test.ts
@@ -1,37 +1,57 @@
 /**
- * The client-public surface is stateless only: types, constants, and pure
- * functions. Identity-bearing classes and mutable registries belong elsewhere.
+ * The client-public surface is safe to bundle separately from the core root:
+ * identity-bearing classes and private mutable registries stay elsewhere,
+ * while boot configuration uses the established cross-bundle ambient slot.
  */
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { setAmbientSingleton } from "./ambient-context.ts";
 import * as clientPublic from "./client-public.ts";
 
 const src = readFileSync(
 	path.join(path.dirname(fileURLToPath(import.meta.url)), "client-public.ts"),
 	"utf8",
 );
+const packageJson = JSON.parse(
+	readFileSync(
+		path.join(path.dirname(fileURLToPath(import.meta.url)), "../package.json"),
+		"utf8",
+	),
+);
 
-describe("@elizaos/core/client-public is a stateless surface", () => {
-	it("does not export ElizaError or connector registration", () => {
+describe("@elizaos/core/client-public is duplicate-safe", () => {
+	it("exports only the reviewed helper allowlist", () => {
 		expect(src).not.toMatch(/^export[\s\S]*\bElizaError\b/m);
 		expect(src).not.toMatch(/^export[\s\S]*registerConnectorSource/m);
-		expect(src).not.toMatch(/^export[\s\S]*normalizeConnectorSource/m);
-		expect(Object.keys(clientPublic)).not.toContain("ElizaError");
-		expect(Object.keys(clientPublic)).not.toContain(
-			"registerConnectorSourceAliases",
-		);
-		expect(Object.keys(clientPublic)).not.toContain("normalizeConnectorSource");
+		expect(src).not.toMatch(/^export\s+\*/m);
+		expect(Object.keys(clientPublic).sort()).toEqual([
+			"formatError",
+			"isElizaSettingsDebugEnabled",
+			"isTruthyEnvValue",
+			"resolveAliasedEnvValue",
+			"sanitizeForSettingsDebug",
+			"settingsDebugCloudSummary",
+		]);
 	});
 
-	it("exports the shared-needed pure helpers", () => {
+	it("exports the helpers required by shared", () => {
 		expect(typeof clientPublic.formatError).toBe("function");
 		expect(typeof clientPublic.isTruthyEnvValue).toBe("function");
 		expect(typeof clientPublic.resolveAliasedEnvValue).toBe("function");
 		expect(typeof clientPublic.isElizaSettingsDebugEnabled).toBe("function");
 		expect(typeof clientPublic.sanitizeForSettingsDebug).toBe("function");
 		expect(typeof clientPublic.settingsDebugCloudSummary).toBe("function");
+	});
+
+	it("publishes the browser and server builds through matching conditions", () => {
+		const subpath = packageJson.exports["./client-public"];
+		expect(subpath.browser.import).toBe("./dist/browser/client-public.js");
+		expect(subpath.browser.default).toBe("./dist/browser/client-public.js");
+		expect(subpath.node.import).toBe("./dist/node/client-public.js");
+		expect(subpath.bun.import).toBe("./dist/node/client-public.js");
+		expect(subpath.default).toBe("./dist/node/client-public.js");
 	});
 
 	it("formatError survives hostile primitives", () => {
@@ -73,5 +93,27 @@ describe("@elizaos/core/client-public is a stateless surface", () => {
 		expect(
 			clientPublic.resolveAliasedEnvValue("UNRELATED_KEY", aliases, env),
 		).toBeUndefined();
+	});
+
+	it("reads default aliases from the shared ambient boot-config slot", () => {
+		const key = Symbol.for("elizaos.app.boot-config");
+		const slot = globalThis as Record<PropertyKey, unknown>;
+		const hadOriginal = Object.hasOwn(slot, key);
+		const original = slot[key];
+		try {
+			setAmbientSingleton(key, {
+				current: {
+					envAliases: [["MILADY_API_TOKEN", "ELIZA_API_TOKEN"]],
+				},
+			});
+			expect(
+				clientPublic.resolveAliasedEnvValue("ELIZA_API_TOKEN", undefined, {
+					MILADY_API_TOKEN: "ambient-secret",
+				}),
+			).toBe("ambient-secret");
+		} finally {
+			if (hadOriginal) slot[key] = original;
+			else Reflect.deleteProperty(slot, key);
+		}
 	});
 });

--- a/packages/core/src/client-public.stateless.test.ts
+++ b/packages/core/src/client-public.stateless.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The client-public surface is stateless only: types, constants, and pure
+ * functions. Identity-bearing classes and mutable registries belong elsewhere.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import * as clientPublic from "./client-public.ts";
+
+const src = readFileSync(
+	path.join(path.dirname(fileURLToPath(import.meta.url)), "client-public.ts"),
+	"utf8",
+);
+
+describe("@elizaos/core/client-public is a stateless surface", () => {
+	it("does not export ElizaError or connector registration", () => {
+		expect(src).not.toMatch(/^export[\s\S]*\bElizaError\b/m);
+		expect(src).not.toMatch(/^export[\s\S]*registerConnectorSource/m);
+		expect(src).not.toMatch(/^export[\s\S]*normalizeConnectorSource/m);
+		expect(Object.keys(clientPublic)).not.toContain("ElizaError");
+		expect(Object.keys(clientPublic)).not.toContain(
+			"registerConnectorSourceAliases",
+		);
+		expect(Object.keys(clientPublic)).not.toContain("normalizeConnectorSource");
+	});
+
+	it("exports the shared-needed pure helpers", () => {
+		expect(typeof clientPublic.formatError).toBe("function");
+		expect(typeof clientPublic.isTruthyEnvValue).toBe("function");
+		expect(typeof clientPublic.resolveAliasedEnvValue).toBe("function");
+		expect(typeof clientPublic.isElizaSettingsDebugEnabled).toBe("function");
+		expect(typeof clientPublic.sanitizeForSettingsDebug).toBe("function");
+		expect(typeof clientPublic.settingsDebugCloudSummary).toBe("function");
+	});
+
+	it("formatError survives hostile primitives", () => {
+		const hostile = Object.create(null);
+		Object.defineProperty(hostile, Symbol.toPrimitive, {
+			get() {
+				throw new Error("poisoned");
+			},
+		});
+		expect(clientPublic.formatError(hostile)).toMatch(/^\[object /);
+
+		const throwingMessage = new Error("visible");
+		Object.defineProperty(throwingMessage, "message", {
+			get() {
+				throw new Error("poisoned-message");
+			},
+		});
+		expect(clientPublic.formatError(throwingMessage)).toMatch(/^\[object /);
+	});
+
+	it("isTruthyEnvValue rejects non-strings and unknown tokens", () => {
+		expect(clientPublic.isTruthyEnvValue("true")).toBe(true);
+		expect(clientPublic.isTruthyEnvValue("  YES  ")).toBe(true);
+		expect(clientPublic.isTruthyEnvValue("false")).toBe(false);
+		expect(clientPublic.isTruthyEnvValue("maybe")).toBe(false);
+		expect(clientPublic.isTruthyEnvValue(undefined)).toBe(false);
+		expect(clientPublic.isTruthyEnvValue(null)).toBe(false);
+	});
+
+	it("blank ELIZA_ values do not shadow a present brand alias", () => {
+		const aliases = [["MILADY_API_TOKEN", "ELIZA_API_TOKEN"]] as const;
+		const env = {
+			ELIZA_API_TOKEN: "   ",
+			MILADY_API_TOKEN: "brand-secret",
+		};
+		expect(
+			clientPublic.resolveAliasedEnvValue("ELIZA_API_TOKEN", aliases, env),
+		).toBe("brand-secret");
+		expect(
+			clientPublic.resolveAliasedEnvValue("UNRELATED_KEY", aliases, env),
+		).toBeUndefined();
+	});
+});

--- a/packages/core/src/client-public.ts
+++ b/packages/core/src/client-public.ts
@@ -1,13 +1,14 @@
 /**
- * Stateless client/public surface of `@elizaos/core` (#18056 / #18704).
+ * Duplicate-safe client/public surface of `@elizaos/core` (#18056 / #18704).
  *
  * The app Vite config aliases bare `@elizaos/core` to the prebuilt browser
  * blob. Callers that must stay off that blob import this subpath instead.
  *
- * This file may export types, constants, and pure functions only. Do not
- * re-export `ElizaError`, connector-source registration, or any other
- * identity-bearing / module-level mutable registry. Those need a design
- * where the root barrel and this subpath share one module instance.
+ * Core entrypoints are bundled separately, so values exported here must remain
+ * coherent when both the root barrel and this subpath are loaded. Functions
+ * may read cross-bundle state only through the existing `Symbol.for` ambient
+ * slots. Do not export classes, private mutable registries, or other values
+ * whose correctness depends on one module instance.
  */
 
 export { resolveAliasedEnvValue } from "./boot-env.ts";

--- a/packages/core/src/client-public.ts
+++ b/packages/core/src/client-public.ts
@@ -1,0 +1,20 @@
+/**
+ * Stateless client/public surface of `@elizaos/core` (#18056 / #18704).
+ *
+ * The app Vite config aliases bare `@elizaos/core` to the prebuilt browser
+ * blob. Callers that must stay off that blob import this subpath instead.
+ *
+ * This file may export types, constants, and pure functions only. Do not
+ * re-export `ElizaError`, connector-source registration, or any other
+ * identity-bearing / module-level mutable registry. Those need a design
+ * where the root barrel and this subpath share one module instance.
+ */
+
+export { resolveAliasedEnvValue } from "./boot-env.ts";
+export { isTruthyEnvValue } from "./env-utils.ts";
+export {
+	isElizaSettingsDebugEnabled,
+	sanitizeForSettingsDebug,
+	settingsDebugCloudSummary,
+} from "./settings-debug.ts";
+export { formatError } from "./utils/format-error.ts";

--- a/packages/core/tsconfig.declarations.json
+++ b/packages/core/tsconfig.declarations.json
@@ -32,6 +32,7 @@
 		"src/index.ts",
 		"src/index.node.ts",
 		"src/index.browser.ts",
+		"src/client-public.ts",
 		"src/security/kms/index.ts",
 		"src/security/mcp-server-config.ts",
 		"src/utils/atomic-json.ts",

--- a/packages/scripts/__tests__/vitest-integration-config-core-subpath-alias.test.ts
+++ b/packages/scripts/__tests__/vitest-integration-config-core-subpath-alias.test.ts
@@ -6,9 +6,10 @@
  * (`importee === find || importee.startsWith(find + "/")`), so a string
  * "@elizaos/core" alias rewrote "@elizaos/core/node" (imported by plugin
  * dists), "@elizaos/core/testing" (imported by real-runtime tests), and
- * "@elizaos/core/connectors" (imported by connector plugins) into
+ * "@elizaos/core/connectors" (imported by connector plugins), and
+ * "@elizaos/core/client-public" (imported by shared browser-safe facades) into
  * "<core entry file>/<subpath>" — a path nested under a *file*, which fails
- * with ENOTDIR and killed every plugins/*\/test integration test in the lane.
+ * with ENOTDIR and kills the importing test suite.
  *
  * This test replays rollup's documented alias-matching semantics against the
  * config's actual alias list and asserts each core specifier lands on a real
@@ -67,6 +68,7 @@ describe("integration.config.ts @elizaos/core alias (#11047)", () => {
     "@elizaos/core/node",
     "@elizaos/core/testing",
     "@elizaos/core/connectors",
+    "@elizaos/core/client-public",
   ] as const;
 
   it.each(coreSpecifiers)("resolves %s to a real file", (specifier) => {

--- a/packages/scripts/vitest/default.config.ts
+++ b/packages/scripts/vitest/default.config.ts
@@ -418,6 +418,18 @@ const vitestResolveAlias: ModuleAlias[] = [
           ),
         },
         {
+          // The client-public entry is bundled separately from the core root.
+          // Resolve it before the prefix-matching bare-core alias below so
+          // package tests do not produce index.node.ts/client-public (ENOTDIR).
+          find: /^@elizaos\/core\/client-public$/,
+          replacement: path.join(
+            path.dirname(elizaCoreEntry),
+            elizaCoreEntry.endsWith(".ts")
+              ? "client-public.ts"
+              : "client-public.js",
+          ),
+        },
+        {
           find: /^@elizaos\/core\/security\/kms$/,
           replacement: path.join(
             path.dirname(elizaCoreEntry),

--- a/packages/scripts/vitest/integration.config.ts
+++ b/packages/scripts/vitest/integration.config.ts
@@ -43,6 +43,10 @@ const elizaCoreSubpathAliases: ModuleAlias[] = elizaCoreEntryDir
         subpath: "connectors",
         candidates: ["connectors.ts", "../connectors.js"],
       },
+      {
+        subpath: "client-public",
+        candidates: ["client-public.ts", "client-public.js"],
+      },
     ].flatMap(({ subpath, candidates }) => {
       const replacement = candidates
         .map((candidate) => path.join(elizaCoreEntryDir, candidate))

--- a/packages/scripts/vitest/real.config.ts
+++ b/packages/scripts/vitest/real.config.ts
@@ -137,6 +137,10 @@ const elizaCoreSubpathAliases: ModuleAlias[] = elizaCoreEntryDir
         subpath: "connectors",
         candidates: ["connectors.ts", "../connectors.js"],
       },
+      {
+        subpath: "client-public",
+        candidates: ["client-public.ts", "client-public.js"],
+      },
     ].flatMap(({ subpath, candidates }) => {
       const replacement = candidates
         .map((candidate) => path.join(elizaCoreEntryDir, candidate))

--- a/packages/scripts/vitest/unit.config.ts
+++ b/packages/scripts/vitest/unit.config.ts
@@ -48,6 +48,17 @@ const unitAliasEntries: ModuleAlias[] = [
     localElizaCoreReplacement
       ? [
           {
+            // Keep the separately bundled public client entry ahead of the
+            // prefix-matching bare-core alias below.
+            find: /^@elizaos\/core\/client-public$/,
+            replacement: path.join(
+              path.dirname(localElizaCoreReplacement),
+              localElizaCoreReplacement.endsWith(".ts")
+                ? "client-public.ts"
+                : "client-public.js",
+            ),
+          },
+          {
             // Published-only CI disables the repo-local eliza checkout, so unit tests must fall back to the installed package entry in that mode.
             find: "@elizaos/core",
             replacement: localElizaCoreReplacement,

--- a/packages/shared/src/client-public-reexport.test.ts
+++ b/packages/shared/src/client-public-reexport.test.ts
@@ -1,9 +1,8 @@
 /**
- * Shared must import the published `@elizaos/core/client-public` subpath, never
- * a sibling `packages/core/src` file. Built dist must stay resolvable for
- * installed consumers (#18704).
+ * Shared imports the published `@elizaos/core/client-public` subpath rather
+ * than a sibling source tree, and preserves the exact helper implementations.
  */
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -52,23 +51,5 @@ describe("shared re-exports @elizaos/core/client-public, not core source files",
     expect(resolveAliasedEnvValue).toBe(publicResolveAlias);
     expect(sanitizeForSettingsDebug).toBe(publicSanitize);
     expect(isElizaSettingsDebugEnabled).toBe(publicSettingsDebugEnabled);
-  });
-
-  it("built shared dist does not import the unshipped core source tree", () => {
-    const distRoot = path.join(here, "../dist");
-    const files = [
-      "format-error.js",
-      "env-utils.js",
-      path.join("config", "boot-config-store.js"),
-      "settings-debug.js",
-    ];
-    for (const rel of files) {
-      const dest = path.join(distRoot, rel);
-      if (!existsSync(dest)) continue;
-      const js = readFileSync(dest, "utf8");
-      expect(js, dest).not.toMatch(/\.\.\/\.\.\/core\/src\//);
-      expect(js, dest).not.toMatch(/\.\.\/\.\.\/\.\.\/core\/src\//);
-      expect(js, dest).toMatch(/@elizaos\/core\/client-public/);
-    }
   });
 });

--- a/packages/shared/src/client-public-reexport.test.ts
+++ b/packages/shared/src/client-public-reexport.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared must import the published `@elizaos/core/client-public` subpath, never
+ * a sibling `packages/core/src` file. Built dist must stay resolvable for
+ * installed consumers (#18704).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  formatError as publicFormatError,
+  isTruthyEnvValue as publicIsTruthy,
+  resolveAliasedEnvValue as publicResolveAlias,
+  sanitizeForSettingsDebug as publicSanitize,
+  isElizaSettingsDebugEnabled as publicSettingsDebugEnabled,
+} from "@elizaos/core/client-public";
+import { describe, expect, it } from "vitest";
+import { resolveAliasedEnvValue } from "./config/boot-config-store.ts";
+import { isTruthyEnvValue } from "./env-utils.ts";
+import { formatError } from "./format-error.ts";
+import {
+  isElizaSettingsDebugEnabled,
+  sanitizeForSettingsDebug,
+} from "./settings-debug.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+function readSrc(...parts: string[]): string {
+  return readFileSync(path.join(here, ...parts), "utf8");
+}
+
+describe("shared re-exports @elizaos/core/client-public, not core source files", () => {
+  it("source files import the package subpath only", () => {
+    const files = [
+      readSrc("format-error.ts"),
+      readSrc("env-utils.ts"),
+      readSrc("config", "boot-config-store.ts"),
+      readSrc("settings-debug.ts"),
+    ];
+    for (const src of files) {
+      expect(src).toMatch(/from ["']@elizaos\/core\/client-public["']/);
+      expect(src).not.toMatch(/\.\.\/.*core\/src\//);
+      expect(src).not.toMatch(/export function formatError\(/);
+      expect(src).not.toMatch(/export function isTruthyEnvValue/);
+      expect(src).not.toMatch(/export function resolveAliasedEnvValue/);
+      expect(src).not.toMatch(/export function sanitizeForSettingsDebug/);
+    }
+  });
+
+  it("shared symbols are the client-public implementations", () => {
+    expect(formatError).toBe(publicFormatError);
+    expect(isTruthyEnvValue).toBe(publicIsTruthy);
+    expect(resolveAliasedEnvValue).toBe(publicResolveAlias);
+    expect(sanitizeForSettingsDebug).toBe(publicSanitize);
+    expect(isElizaSettingsDebugEnabled).toBe(publicSettingsDebugEnabled);
+  });
+
+  it("built shared dist does not import the unshipped core source tree", () => {
+    const distRoot = path.join(here, "../dist");
+    const files = [
+      "format-error.js",
+      "env-utils.js",
+      path.join("config", "boot-config-store.js"),
+      "settings-debug.js",
+    ];
+    for (const rel of files) {
+      const dest = path.join(distRoot, rel);
+      if (!existsSync(dest)) continue;
+      const js = readFileSync(dest, "utf8");
+      expect(js, dest).not.toMatch(/\.\.\/\.\.\/core\/src\//);
+      expect(js, dest).not.toMatch(/\.\.\/\.\.\/\.\.\/core\/src\//);
+      expect(js, dest).toMatch(/@elizaos\/core\/client-public/);
+    }
+  });
+});

--- a/packages/shared/src/config/boot-config-store.ts
+++ b/packages/shared/src/config/boot-config-store.ts
@@ -8,7 +8,7 @@
 
 import type { BrandingConfig } from "./branding.js";
 
-export { resolveAliasedEnvValue } from "@elizaos/core";
+export { resolveAliasedEnvValue } from "@elizaos/core/client-public";
 
 export interface BundledVrmAsset {
   title: string;

--- a/packages/shared/src/env-utils.ts
+++ b/packages/shared/src/env-utils.ts
@@ -2,9 +2,9 @@
  * Shared environment variable utilities.
  *
  * `isTruthyEnvValue` is owned by `@elizaos/core` (canonical truthy set
- * `1/true/yes/y/on/enabled`) and re-exported here so existing
- * `@elizaos/shared` consumers keep their import path. The core symbol is
- * exported from both the node and browser barrels, so this re-export resolves
- * in browser bundles too.
+ * `1/true/yes/y/on/enabled`) and re-exported from
+ * `@elizaos/core/client-public` so existing `@elizaos/shared` consumers keep
+ * their import path without pulling the prebuilt core browser blob. Do not
+ * reach into `packages/core/src`.
  */
-export { isTruthyEnvValue } from "@elizaos/core";
+export { isTruthyEnvValue } from "@elizaos/core/client-public";

--- a/packages/shared/src/format-error.ts
+++ b/packages/shared/src/format-error.ts
@@ -1,17 +1,17 @@
 /**
  * Browser-safe error formatting helpers.
  *
- * `formatError` is the canonical message extractor and lives in `@elizaos/core`;
- * it is re-exported here so existing `@elizaos/shared` importers keep resolving.
- * It returns the human-readable message for `Error` instances and
- * `String(value)` for everything else — the dominant idiom across the codebase.
+ * `formatError` is the canonical `@elizaos/core` implementation, published on
+ * `@elizaos/core/client-public` so the app renderer does not pull the prebuilt
+ * core browser blob. Do not import the bare `@elizaos/core` barrel here, and
+ * do not reach into `packages/core/src`.
  *
  * `formatErrorWithStack` returns the stack when available, falling back to
  * the message. Use this only where the stack is genuinely useful (debug
  * logs, plugin crash diagnostics).
  */
 
-export { formatError } from "@elizaos/core";
+export { formatError } from "@elizaos/core/client-public";
 
 export function formatErrorWithStack(err: unknown): string {
   return err instanceof Error ? (err.stack ?? err.message) : String(err);

--- a/packages/shared/src/settings-debug.ts
+++ b/packages/shared/src/settings-debug.ts
@@ -1,13 +1,14 @@
 /**
  * Opt-in verbose logging for settings load / change / save flows.
  *
- * The canonical implementation lives in `@elizaos/core`. This module re-exports
- * it so existing `@elizaos/shared` (and `@elizaos/shared/settings-debug`)
- * importers keep resolving without maintaining a duplicate copy.
+ * The canonical implementation lives in `@elizaos/core` and is published on
+ * `@elizaos/core/client-public`. This module re-exports that leaf so existing
+ * `@elizaos/shared` (and `@elizaos/shared/settings-debug`) importers keep
+ * resolving without a second sanitizer body or the prebuilt core browser blob.
  */
 
 export {
   isElizaSettingsDebugEnabled,
   sanitizeForSettingsDebug,
   settingsDebugCloudSummary,
-} from "@elizaos/core";
+} from "@elizaos/core/client-public";


### PR DESCRIPTION
# Relates to

Follow-up to closed #18704 / still-open #18056. This is **step 1 only** of the close note: a duplicate-safe published helper surface. It does **not** migrate `packages/ui`, remeasure `/login`, or add `ElizaError` / connector-registry exports.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `elizaOS/develop` with zero conflicts.
- [x] Focused tests, touched-package builds/typechecks, and changed-file lint were run against the exact head in an offline isolated environment.
- [x] The packed packages were installed into a clean consumer and both Node and browser export conditions were exercised.
- [x] A reviewer can verify the changed contract from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `Grok`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b757d83a84ed426e6a293eae7525bdc659655fbc:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `elizaOS/develop` `2fe1f8782ee393e572435402747d699952a45e5c`; zero conflicts.
- [x] Exact-head validation was rerun after the final rebase.

# Risks

Low and bounded. `@elizaos/shared` already depends on core and already re-exported these helpers from the bare package. The change moves those re-exports onto an explicit leaf surface and gives installed consumers correct conditional artifacts. The surface remains duplicate-safe rather than globally stateless: its only cross-bundle state is the intentional ambient boot-config slot.

# Background

## What does this PR do?

Adds `@elizaos/core/client-public` as a small, duplicate-safe published surface and points the existing `@elizaos/shared` helper re-exports at that subpath:

- `formatError`
- `isTruthyEnvValue`
- `resolveAliasedEnvValue`
- `isElizaSettingsDebugEnabled`
- `sanitizeForSettingsDebug`
- `settingsDebugCloudSummary`

The repair also:

- routes `browser` consumers to `dist/browser/client-public.js` and Node/Bun/default consumers to `dist/node/client-public.js`;
- removes the Node-only top-level shim that made the browser build unreachable;
- adds exact export, duplicate-safety, ambient boot-alias, and package-condition coverage;
- gives all repository Vitest configurations an exact `@elizaos/core/client-public` alias so the shared package's real test configuration resolves the leaf correctly.

Explicitly **not** in this PR:

- UI value-import migration;
- `/login` remeasurement, `audit:app`, or authenticated-shell smoke;
- `ElizaError` or connector-registry exports.

## What kind of change is this?

Improvement: publish the narrow helper boundary needed for a later UI import-graph migration without exposing core registries or identity-sensitive classes.

# Documentation changes needed?

No project-documentation change. The source header states the duplicate-safety boundary and its intentional ambient boot-config dependency.

# Testing

## Where should a reviewer start?

1. `packages/core/package.json` — conditional `./client-public` export.
2. `packages/core/src/client-public.ts` — exact six-symbol surface.
3. `packages/core/src/client-public.duplicate-safe.test.ts` — duplicate-bundle and ambient boot-config contract.
4. The shared re-export files and `packages/shared/src/client-public-reexport.test.ts`.
5. The exact leaf aliases in `packages/scripts/vitest/*.config.ts`.

## Detailed testing steps

```bash
bun run --cwd packages/core build
bun run --cwd packages/shared build
bunx vitest run --config packages/core/vitest.config.ts \
  packages/core/src/client-public.duplicate-safe.test.ts \
  packages/core/src/boot-env.test.ts \
  packages/core/src/boot-alias-read-migration.test.ts
bunx vitest run --config packages/shared/vitest.config.ts \
  packages/shared/src/client-public-reexport.test.ts \
  packages/shared/src/config/brand-env-resolution.test.ts
bun test packages/scripts/__tests__/vitest-integration-config-core-subpath-alias.test.ts
bun run --cwd packages/core typecheck
bun run --cwd packages/shared typecheck
```

# Evidence Gate

<!-- evidence-head:2e51d36ce78fc21edd95aaa22f0918cc71c7a06b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered surface change
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered surface change
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow; UI migration belongs to a later PR
<!-- evidence-row:backend-logs -->
- [ ] N/A - no server behavior change
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no renderer import migration in this PR
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, or model behavior change
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, wallet, or generated-domain artifact change
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual output

# Evidence Details

Head: `ac66a9fe278de36623599b3e7535c61d8b93c65f` on `elizaOS/develop` `2fe1f8782ee393e572435402747d699952a45e5c`.

- Focused tests: **43 pass / 0 fail** across core, shared, and Vitest-alias regression suites.
- `packages/core` and `packages/shared`: build and typecheck pass.
- Changed-file Biome check passes; only three pre-existing undeclared-environment warnings remain in the full Vitest config files.
- Packed-consumer proof passes: default resolution selects `dist/node/client-public.js`, `--conditions=browser` selects `dist/browser/client-public.js`, the surface exposes exactly six named exports, and shared's built `env-utils` imports successfully.
- Repository `typecheck lint:check --concurrency=1`: **350/350 tasks pass**. Build-model, Turbo-dependency, and secret-leak audits pass. The aggregate gate then stops on the existing Hetzner runner-routing audit in `.github/workflows/classify-paths.yml`, outside this PR's diff; CI remains required.

# Test plan

- [x] Publish exactly the six helper exports; no `ElizaError`, connector registry, class, or private registry.
- [x] Preserve the intentional ambient boot-config alias across duplicate bundles.
- [x] Route installed Node and browser consumers to their corresponding artifacts.
- [x] Resolve the leaf under core, shared, and repository Vitest configurations.
- [x] Exercise hostile `formatError` values and branded environment aliases.
- [x] Build and typecheck core and shared.
- [ ] UI `/login` remeasurement, `audit:app`, and auth/connector smoke — not in this PR.

# Known gaps / failures

The repository-wide Hetzner fleet-routing audit currently fails on untouched `.github/workflows/classify-paths.yml`. This PR does not change workflow routing. Independent exact-head review and green required checks are still required before merge.

AI provider/model: xai / grok-4.6
Client / agent tooling: Grok
Contribution skill revision: elizaOS/eliza@b757d83a84ed426e6a293eae7525bdc659655fbc:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [raynord22]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok","skill_revision":"elizaOS/eliza@b757d83a84ed426e6a293eae7525bdc659655fbc:packages/skills/skills/contribute-to-eliza"} -->

