### PR TITLE
fix(plugins): repair the Tests (plugins) lane after the Cloud consolidation

### DIFF
--- a/plugins/plugin-app-control/vitest.config.ts
+++ b/plugins/plugin-app-control/vitest.config.ts
@@ -131,6 +131,13 @@ export default defineConfig({
 				replacement: path.join(sharedSrc, "steward-session-client/index.ts"),
 			},
 			{
+				// Directory subpath: the generic rules below map a subpath to a
+				// sibling `.ts` FILE, which misses barrel directories. Anchor it
+				// like steward-session-client above.
+				find: "@elizaos/shared/elizacloud",
+				replacement: path.join(sharedSrc, "elizacloud/index.ts"),
+			},
+			{
 				find: /^@elizaos\/shared\/(.*)\.js$/,
 				replacement: path.join(sharedSrc, "$1.ts"),
 			},

--- a/plugins/plugin-elizacloud/__tests__/cloud-billing-routes.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-billing-routes.test.ts
@@ -103,7 +103,7 @@ describe("handleCloudBillingRoute money proxies", () => {
       expect(response.headers.get("PAYMENT-REQUIRED")).toBe("encoded-payment-required");
       expect(upstreamRequest).toEqual({
         method: "POST",
-        url: "https://elizacloud.ai/api/v1/x402/requests",
+        url: "https://cloud.eliza.app/api/v1/x402/requests",
         authorization: "Bearer eliza_test_key",
         body: {
           amountUsd: 5,

--- a/plugins/plugin-elizacloud/__tests__/cloud-setup-failures.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-setup-failures.test.ts
@@ -299,7 +299,7 @@ describe("C1 — availability=true happy path", () => {
     expect(result?.apiKey).toBe("eliza_test_key_C1");
     expect(result?.agentId).toBe("agent-id-c1");
     expect(result?.bridgeUrl).toBe("https://bridge.example/agent-c1");
-    expect(result?.baseUrl).toMatch(/^https:\/\/elizacloud\.ai/);
+    expect(result?.baseUrl).toMatch(/^https:\/\/cloud\.eliza\.app/);
 
     // Availability success surfaced via observer event.
     expect(observer.onAvailabilityChecked).toHaveBeenCalledWith({ ok: true });

--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-account-actions.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-account-actions.test.ts
@@ -82,7 +82,7 @@ describe("CLOUD_ACCOUNT_STATUS", () => {
     );
     expect(result.success).toBe(true);
     expect(replies[0]?.text).toContain("critically low");
-    expect(replies[0]?.text).toContain("dashboard/settings?tab=billing");
+    expect(replies[0]?.text).toContain("cloud.eliza.app/cloud/billing");
   });
 
   it("re-guards in the handler when signed out (validate is advisory)", async () => {
@@ -244,7 +244,7 @@ describe("CLOUD_CREATE_API_KEY", () => {
     expect(result.success).toBe(false);
     expect(result.data).toMatchObject({ reason: "session_required" });
     expect(replies[0]?.text).toContain("signed-in session");
-    expect(replies[0]?.text).toContain("Cloud app");
+    expect(replies[0]?.text).toContain("cloud.eliza.app/cloud/api-keys");
   });
 
   it("refuses the reserved agent-sandbox: prefix without any network call", async () => {


### PR DESCRIPTION
# Relates to

Restores CI's `Tests (plugins)` lane, red on `develop`. Both failures are
fallout from `0468c1850a3` (#18996, "consolidate Eliza Cloud into eliza.app").

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop`.
- [x] `bun install` was run after sync; both failures reproduced red and verified
      green locally.
- [x] A reviewer can confirm the change works without reading the code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` @ `0e98b198f3d`; zero conflicts.
- [x] Full `bun run verify` was not run — see **Known gaps / failures**.

# Risks

Low. Test-only: four spec assertions and one vitest alias entry. No product
code, no public surface, no workflow behavior.

# Background

## What does this PR do?

Two independent causes in the same lane.

### 1. `plugin-elizacloud` — stale specs after a deliberate product change

#18996 made `cloud.eliza.app` the canonical managed host. `packages/shared`
already pins that contract (`elizacloud/base-url.test.ts` asserts
`normalizeCloudSiteUrl("https://www.elizacloud.ai") === "https://cloud.eliza.app"`),
and those tests pass. Four `plugin-elizacloud` specs still asserted the retired
origin and the old billing/API-key copy:

| Spec | Was | Now |
| --- | --- | --- |
| `cloud-billing-routes` x402 proxy | `https://elizacloud.ai/api/v1/x402/requests` | `https://cloud.eliza.app/api/v1/x402/requests` |
| `cloud-setup-failures` C1 happy path | `/^https:\/\/elizacloud\.ai/` | `/^https:\/\/cloud\.eliza\.app/` |
| `CLOUD_ACCOUNT_STATUS` critical balance | `dashboard/settings?tab=billing` | `cloud.eliza.app/cloud/billing` |
| `CLOUD_CREATE_API_KEY` session required | `Cloud app` | `cloud.eliza.app/cloud/api-keys` |

The product change is intentional, so the specs are ported rather than the
product reverted.

**Scope note:** `elizacloud.ai` appears 31 times in this test directory. Most are
legacy hosts passed in as **inputs**, which the resolver is *supposed* to accept
and normalize — those are deliberately left alone. Only the four
**resolved-output** assertions move. The `CLOUD_CREATE_API_KEY` assertion was
also tightened from the vague `"Cloud app"` to the actual destination URL, so it
now pins something specific.

### 2. `plugin-app-control` — directory subpath missed by the vitest aliases

#18996 added `@elizaos/shared/elizacloud` to
`packages/ui/src/api/native-cloud-http-transport.ts`. The alias list in
`plugins/plugin-app-control/vitest.config.ts` maps a bare subpath to a sibling
**file**:

```js
{ find: /^@elizaos\/shared\/(.*)$/, replacement: path.join(sharedSrc, "$1.ts") },
```

`elizacloud` is a barrel **directory**, so that rewrite misses, the import falls
through to the package `exports` map, and resolves at
`./dist/elizacloud/index.js` — which does not exist without a built
`@elizaos/shared`. Three suites then fail to collect:

```
Error: Cannot find package '@elizaos/shared/elizacloud' imported from
  packages/ui/src/api/native-cloud-http-transport.ts
```

The entry directly above it — `@elizaos/shared/steward-session-client` — is
special-cased for exactly this reason (it is also a directory). This adds the
parallel entry, placed before the generic rules because Vite string `find`
matches by prefix and first match wins.

This is the same family as #19166: a workspace package resolving to `dist` that
nothing guarantees is built.

## What kind of change is this?

Bug fixes (restores a red develop lane; test-only).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-app-control/vitest.config.ts` — the added alias entry.

## Detailed testing steps

```bash
node packages/app-core/scripts/ensure-shared-i18n-data.mjs
bun run --cwd plugins/plugin-elizacloud test
bun run --cwd plugins/plugin-app-control test
```

# Evidence Gate

<!-- evidence-head:e47f5a7aeeaab1b239f4d9c11352fb8511714c03 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - test-only change with no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - test-only change with no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing flow; this repairs a CI test lane.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no backend code path is touched.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend code path is touched; the app-control
      suites are jsdom unit tests whose output is attached below.`
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: `N/A - no agent, action, provider, prompt, or model path
      is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: attached — the test-run output below is the artifact
      this change is judged by.
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - the diff renders no visual text.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model path is touched.`

## Backend + frontend logs

<details>
<summary>RED — <code>develop</code> @ <code>0e98b198f3d</code>, unmodified</summary>

```
$ bun run --cwd plugins/plugin-elizacloud test
 FAIL  __tests__/cloud-billing-routes.test.ts > handleCloudBillingRoute money proxies > forwards x402 payment requests and preserves payment headers
 FAIL  __tests__/cloud-setup-failures.test.ts > C1 — availability=true happy path > advances availability → auth → provisioning → running and returns the result
 FAIL  __tests__/unit/cloud-account-actions.test.ts > CLOUD_ACCOUNT_STATUS > warns and links the top-up page on a critical balance
 FAIL  __tests__/unit/cloud-account-actions.test.ts > CLOUD_CREATE_API_KEY > redirects to a signed-in session when the route rejects the agent key
 Test Files  3 failed | 48 passed | 2 skipped (53)
      Tests  4 failed | 460 passed | 5 skipped (469)

$ bun run --cwd plugins/plugin-app-control test
 FAIL  src/views/ViewManagerView.render.test.tsx
Error: Failed to resolve import "@elizaos/shared/elizacloud" from "../../packages/ui/src/api/native-cloud-http-transport.ts". Does the file exist?
 FAIL  src/views/viewManagerData.contract.test.ts
 FAIL  src/views/viewManagerData.interact.test.ts
Error: Cannot find package '@elizaos/shared/elizacloud' imported from .../native-cloud-http-transport.ts
 Test Files  3 failed | 47 passed (50)
      Tests  1770 passed (1770)
```

This reproduces CI run 31731055079, job `Tests (plugins)`, exactly.
</details>

<details>
<summary>GREEN — same tree with this commit applied</summary>

```
$ bun run --cwd plugins/plugin-elizacloud test
 Test Files  51 passed | 2 skipped (53)
      Tests  464 passed | 5 skipped (469)

$ bun run --cwd plugins/plugin-app-control test
 Test Files  50 passed (50)
      Tests  1794 passed (1794)
```

Note `1770 → 1794`: the alias fix does not silence three suites, it makes them
**collect and run**, adding 24 previously-unexecuted tests. `plugin-elizacloud`
likewise goes 460 → 464 passing with zero failures.
</details>

<details>
<summary>Lint</summary>

```
$ bunx @biomejs/biome check <the 4 changed files>
Checked 4 files in 75ms. No fixes applied.
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only change with no rendered surface.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

- Full `bun run verify` was not captured for this test-only diff. It was run
  against `dd7190c50f4` earlier in the same investigation and passed (350/350
  turbo tasks, exit 0; `format:check` 134/134), and CI's `Quality` job is green
  at develop's tip.
- `Tests (plugins)` also requires the generated shared i18n data locally
  (`node packages/app-core/scripts/ensure-shared-i18n-data.mjs`); without it 47
  suites fail to resolve `./generated/validation-keyword-data.ts`. CI generates
  it as its own step, so this is a local-setup note, not a lane defect.
- CI's `Tests (client)`, `Tests (server)`, `Tests (scripts)` and the `Smoke`
  shards are independently red at this tip and are **not** addressed here. The
  Smoke breakage is also #18996 fallout (green on every branch through 09:06Z,
  red on every branch from 10:34Z; #18996 merged ~10:15Z) and is being tracked
  separately.
