### PR TITLE
test(app): drop cloudOnly sections from the local-runtime settings sweep

### DIFF
--- a/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
+++ b/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
@@ -425,7 +425,6 @@ const SETTING_SECTIONS_TO_CLICK: readonly {
   { label: /^Capabilities$/, expectedHash: "capabilities" },
   { label: /^Apps$/, expectedHash: "apps" },
   { label: /^Connectors$/, expectedHash: "connectors" },
-  { label: /^Cloud Connectors$/, expectedHash: "cloud-connectors" },
   { label: /^My Runtimes$/, expectedHash: "my-runtimes" },
   { label: /^Runtime$/, expectedHash: "runtime" },
   { label: /^Appearance$/, expectedHash: "appearance" },
@@ -433,8 +432,6 @@ const SETTING_SECTIONS_TO_CLICK: readonly {
   { label: /^Wallet & RPC\b/, expectedHash: "wallet-rpc" },
   { label: /^Updates$/, expectedHash: "updates" },
   { label: /^Backups$/, expectedHash: "advanced" },
-  { label: /^Overview$/, expectedHash: "cloud-overview" },
-  { label: /^Agents$/, expectedHash: "cloud-agents" },
 ];
 const SETTING_DEEP_LINKS: readonly {
   hash: string;


### PR DESCRIPTION
# Relates to

Restores CI's `Smoke (1)` shard, red on `develop` since `4e62753a760`
(#18996). Fixes one of four independent smoke failures; the other three are
tracked separately.

> **Evidence split — please read.** The **product-side correctness** of this
> change IS verified browser-free (`SettingsView.test.tsx`, 17/17). The
> **spec edit itself is browser-UNVERIFIED**: no Playwright run was possible,
> because the build host is at 100% disk (15G free of 1.9T) and a smoke repro
> needs ~10G plus browsers. Details in **Known gaps / failures**.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop`.
- [ ] The edited spec was NOT executed — see the evidence-split note above.
- [x] A reviewer can confirm the reasoning without reading the code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` @ `8e33056ad05`; zero conflicts.
- [x] Full `bun run verify` was not run — see **Known gaps / failures**.

# Risks

Low. Test-only: three entries removed from one Playwright spec's section list.
No product code, no public surface. The residual risk is that the spec fails
*later* in the same sweep for an unrelated reason, which execution would reveal.

# Background

## What does this PR do?

`Smoke (1)` fails at `all-pages-clicksafe.spec.ts:998`:

```
TimeoutError: locator.scrollIntoViewIfNeeded: Timeout 15000ms exceeded.
  - waiting for getByTestId('settings-shell').getByText(/^Cloud Connectors$/)
  at openSettingsSection (packages/app/test/ui-smoke/helpers.ts:579:6)
```

**The product behavior changed deliberately.** #18996 marked the Cloud sections
`cloudOnly`:

```
$ git log --oneline -1 -S "cloudOnly: true" -- packages/ui/src/cloud/connectors/index.ts
0468c1850a3 feat: consolidate Eliza Cloud into eliza.app
```

`SettingsView` hides `cloudOnly` sections unless the active runtime target is a
managed Eliza Cloud agent, and the registry states why
(`packages/ui/src/components/settings/settings-section-registry.ts`):

> Show only while the active runtime target is a managed Eliza Cloud agent.
> This is independent from role/view-kind authorization: local and VPS
> runtimes must not expose management controls they cannot fulfill.

**The spec does not establish a managed-cloud runtime.** Its `beforeEach`
(`all-pages-clicksafe.spec.ts:962`) seeds only:

```js
await seedAppStorage(page, {
  "eliza:permissions-primed": "1",
  "eliza:developerMode": "1",
});
```

No `seedStewardSession`, no `injectCloudAuthToken`, no `installCloudRoutes`. So
the three Cloud rows are **correctly** absent, and the spec is stale. Developer
Mode does not compensate: `SettingsView` evaluates `section.cloudOnly &&
!managedCloudRuntime` **before** `isViewVisible`, so `cloudOnly` sections stay
hidden regardless.

Three entries are dropped from `SETTING_SECTIONS_TO_CLICK`: `Cloud Connectors`,
`Overview` (`cloud-overview`), and `Agents` (`cloud-agents`) — all three are
`cloudOnly`. Only `Cloud Connectors` had failed yet, because the sweep aborts at
the first miss; the other two would fail next.

**Why drop rather than seed a managed-cloud runtime:** this sweep is a
local-runtime pass everywhere else. Seeding a Cloud session would change what it
covers and silently reduce local-runtime coverage. Managed-cloud settings
coverage belongs in a cloud-seeded spec.

**`SETTING_DEEP_LINKS` is deliberately left alone.** It still contains
`cloud-agents`, and that is correct: hidden sections stay registered, and
`activeSectionDef` falls back to `getAllSettingsSections()`
(`SettingsView.tsx:378-384`), so deep links to hidden sections still resolve —
the documented mvp-hidden contract. The rail listing and the deep-link table are
intentionally different surfaces.

## What kind of change is this?

Bug fixes (restores a red develop shard; test-only).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts`, the
`SETTING_SECTIONS_TO_CLICK` list.

## Detailed testing steps

Product side (runs anywhere):

```bash
bun run --cwd packages/ui test -- src/components/pages/SettingsView.test.tsx
```

Spec side (needs a host with disk + Playwright browsers) — **not run here**:

```bash
bun run --cwd packages/app test:e2e -- all-pages-clicksafe.spec.ts
```

# Evidence Gate

<!-- evidence-head:56ec3770d1823e321926ef459f9cf3340f16f49a -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - test-only change with no rendered UI surface;
      the product rendering is unchanged by this PR.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - same reason.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing flow; this repairs a CI spec.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no backend code path is touched.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: attached — the jsdom `SettingsView` suite below exercises
      the gate this PR relies on.
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: `N/A - no agent, action, provider, prompt, or model path
      is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: attached — `git log -S` attribution and the registry
      docstring below are the artifacts this change rests on.
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - the diff renders no visual text.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model path is touched.`

## Backend + frontend logs

<details>
<summary>Attribution — the gate arrived in #18996</summary>

```
$ git log --oneline -1 -S "cloudOnly: true" -- packages/ui/src/cloud/connectors/index.ts
0468c1850a3 feat: consolidate Eliza Cloud into eliza.app
```
</details>

<details>
<summary>Intent — the registry docstring</summary>

`packages/ui/src/components/settings/settings-section-registry.ts`:

```
 * Show only while the active runtime target is a managed Eliza Cloud agent.
 * This is independent from role/view-kind authorization: local and VPS
 * runtimes must not expose management controls they cannot fulfill.
 */
```
</details>

<details>
<summary>VERIFIED (browser-free) — the product hides these rows off managed Cloud</summary>

```
$ bun run --cwd packages/ui test -- src/components/pages/SettingsView.test.tsx
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

That suite includes explicit cases asserting the Cloud row is `null` for
`embedded-local` and `remote-backend` targets and present only for
`cloud-managed` — i.e. the behavior this spec edit assumes is already pinned by
executing tests.
</details>

<details>
<summary>CI failure being fixed (run 31731055079, job Smoke (1))</summary>

```
2) [chromium] › test/ui-smoke/all-pages-clicksafe.spec.ts:998:1 › visible safe app tiles and allowlisted buttons are click-safe
TimeoutError: locator.scrollIntoViewIfNeeded: Timeout 15000ms exceeded.
Call log:
  - waiting for getByTestId('settings-shell').getByText(/^Cloud Connectors$/).filter({ visible: true }).first()
   at helpers.ts:579
    at openSettingsSection (packages/app/test/ui-smoke/helpers.ts:579:6)
    at clickSafeAllowlist (packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts:928:5)
```
</details>

<details>
<summary>Lint</summary>

```
$ bunx @biomejs/biome check packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
Checked 1 file in 50ms. No fixes applied.
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only change; no rendered surface is modified.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

- **The edited spec was not executed.** The build host is at 100% disk (15G free
  of 1.9T, ~291 worktrees); a smoke repro needs roughly 10G plus Playwright
  browsers, and freeing that space would mean deleting other contributors'
  worktrees. The product-side claim this edit rests on IS verified by the jsdom
  suite above. A reviewer with disk should run the spec command in **Testing**.
- Full `bun run verify` was not captured for this test-only diff. It passed
  against `dd7190c50f4` earlier in this investigation (350/350 turbo tasks, exit
  0; `format:check` 134/134), and CI's `Quality` job is green at develop's tip.
- **Three other smoke failures at this tip are NOT addressed here** and are
  tracked separately: `onboarding-cloud-only.spec.ts:90` (chat-sheet settles
  `collapsed`, expected `half`), `agent-detail-invalid-date-capture.spec.ts:17`
  (`Smoke Agent` never visible), and `all-views-interaction.spec.ts:675`
  (`http 501: /api/workflow/workflows`, likely unimplemented workflow-studio
  route). The first two need a browser to root-cause; several structural
  hypotheses for them were investigated and eliminated.
