### PR TITLE
fix(agent): reject invalid deferred watchdog configuration before readiness (#19167)

### DIFF
--- a/packages/agent/src/runtime/deferred-watchdog-config.test.ts
+++ b/packages/agent/src/runtime/deferred-watchdog-config.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS validation.
+ */
+import { isElizaError } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+  MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+  resolveDeferredPluginRegistrationTimeoutMs,
+  startEliza,
+} from "./eliza.ts";
+
+describe("resolveDeferredPluginRegistrationTimeoutMs", () => {
+  it("returns default 30,000 ms for unset or blank values", () => {
+    expect(resolveDeferredPluginRegistrationTimeoutMs(undefined)).toBe(
+      DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+    );
+    expect(resolveDeferredPluginRegistrationTimeoutMs(null)).toBe(
+      DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+    );
+    expect(resolveDeferredPluginRegistrationTimeoutMs("")).toBe(
+      DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+    );
+    expect(resolveDeferredPluginRegistrationTimeoutMs("   \t\n  ")).toBe(
+      DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+    );
+  });
+
+  it("accepts valid positive decimal integers in range 1..2147483647", () => {
+    expect(resolveDeferredPluginRegistrationTimeoutMs("1")).toBe(1);
+    expect(resolveDeferredPluginRegistrationTimeoutMs("30000")).toBe(30_000);
+    expect(resolveDeferredPluginRegistrationTimeoutMs("  5000  ")).toBe(5_000);
+    expect(resolveDeferredPluginRegistrationTimeoutMs("2147483647")).toBe(
+      MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+    );
+  });
+
+  it("rejects non-positive integer values with a typed fatal ElizaError", () => {
+    for (const invalidValue of ["0", "-1", "-30000"]) {
+      try {
+        resolveDeferredPluginRegistrationTimeoutMs(invalidValue);
+        expect.unreachable(`Should have thrown for input: ${invalidValue}`);
+      } catch (err: unknown) {
+        expect(isElizaError(err)).toBe(true);
+        if (isElizaError(err)) {
+          expect(err.code).toBe("INVALID_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT");
+          expect(err.severity).toBe("fatal");
+          expect(err.context).toMatchObject({
+            raw: invalidValue,
+            min: 1,
+            max: MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+          });
+        }
+      }
+    }
+  });
+
+  it("rejects malformed or partial decimal inputs with a typed fatal ElizaError", () => {
+    const malformedInputs = [
+      "30000ms",
+      "30_000",
+      "10.5",
+      "abc",
+      "+1000",
+      "0x10",
+      "1e5",
+      "Infinity",
+      "NaN",
+    ];
+
+    for (const input of malformedInputs) {
+      try {
+        resolveDeferredPluginRegistrationTimeoutMs(input);
+        expect.unreachable(`Should have thrown for input: ${input}`);
+      } catch (err: unknown) {
+        expect(isElizaError(err)).toBe(true);
+        if (isElizaError(err)) {
+          expect(err.code).toBe("INVALID_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT");
+          expect(err.severity).toBe("fatal");
+          expect(err.context).toMatchObject({
+            raw: input,
+            min: 1,
+            max: MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+          });
+        }
+      }
+    }
+  });
+
+  it("rejects values exceeding Node timer range 2147483647", () => {
+    const overflowInputs = ["2147483648", "99999999999999999999999"];
+
+    for (const input of overflowInputs) {
+      try {
+        resolveDeferredPluginRegistrationTimeoutMs(input);
+        expect.unreachable(`Should have thrown for input: ${input}`);
+      } catch (err: unknown) {
+        expect(isElizaError(err)).toBe(true);
+        if (isElizaError(err)) {
+          expect(err.code).toBe("INVALID_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT");
+          expect(err.severity).toBe("fatal");
+          expect(err.context).toMatchObject({
+            raw: input,
+            min: 1,
+            max: MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+          });
+        }
+      }
+    }
+  });
+});
+
+describe("startEliza pre-readiness watchdog validation", () => {
+  const originalEnv = process.env.ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS = originalEnv;
+    } else {
+      delete process.env.ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS;
+    }
+  });
+
+  it("validates watchdog configuration up front before creating runtime resources", async () => {
+    process.env.ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS =
+      "invalid_timeout";
+
+    try {
+      await startEliza();
+      expect.unreachable(
+        "startEliza should have rejected invalid watchdog env var",
+      );
+    } catch (err: unknown) {
+      expect(isElizaError(err)).toBe(true);
+      if (isElizaError(err)) {
+        expect(err.code).toBe("INVALID_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT");
+        expect(err.severity).toBe("fatal");
+      }
+    }
+  });
+});

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -3655,6 +3655,65 @@ export function resolveEmbeddingProviderPluginName(
   return backend ? getFirstRunProviderOption(backend)?.pluginName : undefined;
 }
 
+export const DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS = 30_000;
+export const MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS = 2_147_483_647;
+
+/**
+ * Validates and resolves `ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS`.
+ *
+ * Acceptance criteria:
+ * - Accept only blank/unset or a complete positive decimal integer in Node's schedulable timer range 1..2147483647.
+ * - Reject malformed, partial, non-positive, unsafe, and overflowing values with a typed fatal `ElizaError` carrying actionable code/context.
+ */
+export function resolveDeferredPluginRegistrationTimeoutMs(
+  rawEnv?: string | null,
+): number {
+  if (rawEnv === undefined || rawEnv === null) {
+    return DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS;
+  }
+  const trimmed = rawEnv.trim();
+  if (trimmed === "") {
+    return DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS;
+  }
+  if (!/^\d+$/.test(trimmed)) {
+    throw new ElizaError(
+      `Invalid ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS: "${rawEnv}". Expected a positive decimal integer between 1 and ${MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS}.`,
+      {
+        code: "INVALID_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT",
+        severity: "fatal",
+        context: {
+          raw: rawEnv,
+          trimmed,
+          min: 1,
+          max: MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+        },
+      },
+    );
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < 1 ||
+    parsed > MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS
+  ) {
+    throw new ElizaError(
+      `Invalid ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS: "${rawEnv}". Value ${parsed} is out of schedulable timer range 1..${MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS}.`,
+      {
+        code: "INVALID_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT",
+        severity: "fatal",
+        context: {
+          raw: rawEnv,
+          trimmed,
+          parsed,
+          min: 1,
+          max: MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+        },
+      },
+    );
+  }
+  return parsed;
+}
+
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
@@ -3934,6 +3993,9 @@ export async function startEliza(
   opts?: StartElizaOptions,
 ): Promise<AgentRuntime | undefined> {
   opts?.abortSignal?.throwIfAborted();
+  const deferredWatchdogTimeoutMs = resolveDeferredPluginRegistrationTimeoutMs(
+    process.env.ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
+  );
   const bootContext =
     opts?.bootContext ?? createBootContext({ observePhase: opts?.onBootPhase });
   const bootTimer = new BootTimer("[eliza-boot]");
@@ -5476,6 +5538,7 @@ export async function startEliza(
   const registerDeferredRuntimePlugins = async (
     deferredResolvedPlugins: RuntimeResolvedPlugin[],
     abortSignal: AbortSignal,
+    watchdogTimeoutMs: number = deferredWatchdogTimeoutMs,
   ): Promise<void> => {
     if (blockDeferredPluginImports) {
       return;
@@ -5515,13 +5578,7 @@ export async function startEliza(
       ...deferredPluginsForRuntime,
     ]);
 
-    const timeoutMs = (() => {
-      const raw =
-        process.env.ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS?.trim();
-      if (!raw) return 30_000;
-      const parsed = Number.parseInt(raw, 10);
-      return Number.isFinite(parsed) && parsed > 0 ? parsed : 30_000;
-    })();
+    const timeoutMs = watchdogTimeoutMs;
     const registerDeferredPlugin = async (
       plugin: (typeof deferredPluginsForRuntime)[number],
     ): Promise<void> => {
@@ -5699,6 +5756,7 @@ export async function startEliza(
       await registerDeferredRuntimePlugins(
         deferredResolvedPlugins,
         abortSignal,
+        deferredWatchdogTimeoutMs,
       );
       bootTimer.lap("deferred:runtime-plugins");
     }

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -3659,52 +3659,32 @@ export const DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS = 30_000;
 export const MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS = 2_147_483_647;
 
 /**
- * Validates and resolves `ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS`.
+ * Resolves `ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS` for the deferred
+ * registration watchdog.
  *
- * Acceptance criteria:
- * - Accept only blank/unset or a complete positive decimal integer in Node's schedulable timer range 1..2147483647.
- * - Reject malformed, partial, non-positive, unsafe, and overflowing values with a typed fatal `ElizaError` carrying actionable code/context.
+ * Blank/unset keeps the default. Anything else must be a complete decimal
+ * integer inside Node's schedulable timer range: `Number.parseInt` alone
+ * silently truncates `"10.5"` to a 10 ms watchdog and lets `"2147483648"`
+ * through to a `setTimeout` that Node clamps to 1 ms, either of which aborts
+ * deferred plugin registration instantly instead of waiting.
  */
 export function resolveDeferredPluginRegistrationTimeoutMs(
   rawEnv?: string | null,
 ): number {
-  if (rawEnv === undefined || rawEnv === null) {
-    return DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS;
-  }
-  const trimmed = rawEnv.trim();
+  const trimmed = rawEnv?.trim() ?? "";
   if (trimmed === "") {
     return DEFAULT_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS;
   }
-  if (!/^\d+$/.test(trimmed)) {
+  const parsed = /^\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
+  if (!(parsed >= 1 && parsed <= MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS)) {
     throw new ElizaError(
-      `Invalid ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS: "${rawEnv}". Expected a positive decimal integer between 1 and ${MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS}.`,
+      `Invalid ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS: "${rawEnv}". Expected a decimal integer between 1 and ${MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS}.`,
       {
         code: "INVALID_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT",
         severity: "fatal",
         context: {
           raw: rawEnv,
           trimmed,
-          min: 1,
-          max: MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
-        },
-      },
-    );
-  }
-  const parsed = Number.parseInt(trimmed, 10);
-  if (
-    !Number.isSafeInteger(parsed) ||
-    parsed < 1 ||
-    parsed > MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS
-  ) {
-    throw new ElizaError(
-      `Invalid ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS: "${rawEnv}". Value ${parsed} is out of schedulable timer range 1..${MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS}.`,
-      {
-        code: "INVALID_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT",
-        severity: "fatal",
-        context: {
-          raw: rawEnv,
-          trimmed,
-          parsed,
           min: 1,
           max: MAX_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS,
         },
@@ -5538,7 +5518,6 @@ export async function startEliza(
   const registerDeferredRuntimePlugins = async (
     deferredResolvedPlugins: RuntimeResolvedPlugin[],
     abortSignal: AbortSignal,
-    watchdogTimeoutMs: number = deferredWatchdogTimeoutMs,
   ): Promise<void> => {
     if (blockDeferredPluginImports) {
       return;
@@ -5578,7 +5557,6 @@ export async function startEliza(
       ...deferredPluginsForRuntime,
     ]);
 
-    const timeoutMs = watchdogTimeoutMs;
     const registerDeferredPlugin = async (
       plugin: (typeof deferredPluginsForRuntime)[number],
     ): Promise<void> => {
@@ -5595,10 +5573,10 @@ export async function startEliza(
         registrationWatchdog = setTimeout(() => {
           exceededWatchdog = true;
           const error = new Error(
-            `Registration exceeded ${timeoutMs / 1000}s watchdog`,
+            `Registration exceeded ${deferredWatchdogTimeoutMs / 1000}s watchdog`,
           );
           logger.warn(
-            `[eliza] deferred: Plugin ${plugin.name} registration exceeded the ${timeoutMs / 1000}s watchdog; still waiting for a definitive result`,
+            `[eliza] deferred: Plugin ${plugin.name} registration exceeded the ${deferredWatchdogTimeoutMs / 1000}s watchdog; still waiting for a definitive result`,
           );
           // error-policy:J7 the watchdog reports a diagnostic without killing
           // the deferred loop; the same registration promise remains awaited.
@@ -5608,10 +5586,10 @@ export async function startEliza(
             {
               plugin: plugin.name,
               phase: "deferred-boot",
-              timeoutMs,
+              timeoutMs: deferredWatchdogTimeoutMs,
             },
           );
-        }, timeoutMs);
+        }, deferredWatchdogTimeoutMs);
         registrationWatchdog.unref?.();
         await runtime.registerPlugin(plugin);
         logger.info(
@@ -5756,7 +5734,6 @@ export async function startEliza(
       await registerDeferredRuntimePlugins(
         deferredResolvedPlugins,
         abortSignal,
-        deferredWatchdogTimeoutMs,
       );
       bootTimer.lap("deferred:runtime-plugins");
     }


### PR DESCRIPTION
# Relates to

Fixes #19167

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.6-flash, anthropic/claude-fable-5, anthropic/claude-opus-5, openai/gpt-5.6-sol, xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `antigravity, Claude Code, Codex, Grok`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d1463e90a5ec617e2d2eb49655b074655b5e4672:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Per-commit provenance

Requested by the `CHANGES_REQUESTED` review on `c5c67d7e2b`. Commit authorship
is stated exactly as it appears in `git log`, so the ledger and the commit
metadata agree.

| Commit (current head) | Git author | Provider / model | Client |
| --- | --- | --- | --- |
| `05881b0627` original implementation | `Rama <rama0x1@users.noreply.github.com>` | `google/gemini-3.6-flash` | `antigravity` |
| `81bdddf09e` reviewer simplification | `Claude Fable 5 <noreply@anthropic.com>` | `anthropic/claude-fable-5` | `Claude Code` |

The simplification commit that the review flagged is the rebased continuation of
`c5c67d7e2b`; it is still authored and `Co-Authored-By` the Anthropic identity,
and the `anthropic/claude-fable-5` entry above is the requested correction. The
pre-existing `google/gemini-3.6-flash` entry remains applicable to the original
implementation commit and has been kept.

This rebase, the exact-head revalidation, and this body update were performed by
`anthropic/claude-opus-5` via `Claude Code`; that entry is recorded above and
introduces no source change.

# Sync with develop

- [x] Rebased onto current `origin/develop` at `d1463e90a5ec617e2d2eb49655b074655b5e4672`; zero conflicts.
- [x] `git range-diff` confirms both commits are patch-identical to the reviewed head `82c8b56900`; only the base moved.
- [x] Focused package gates re-run and pass on exact head `81bdddf09efecfa010b53de3d1c98f038298df94`.

# Risks

Low. The change validates `ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS` environment variable up front before runtime boot or resource creation. Blank or unset configuration continues to default to 30,000 ms.

# Background

## What does this PR do?

1. Validates `ELIZA_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT_MS` at the start of `startEliza()` before creating runtime resources or reporting readiness.
2. Accepts blank/unset or complete decimal positive integers in Node's schedulable timer range (`1..2147483647`).
3. Rejects malformed (`"30000ms"`, `"10.5"`, `"abc"`), non-positive (`"0"`, `"-100"`), unsafe integer, or overflowing (`"2147483648"`) inputs with a typed fatal `ElizaError` (`code: "INVALID_DEFERRED_PLUGIN_REGISTRATION_TIMEOUT"`, `severity: "fatal"`, `context`).
4. Passes the validated number into `registerDeferredRuntimePlugins` and `runDeferredBoot` rather than re-reading or re-parsing `process.env` later.
5. Adds unit tests covering defaults, valid values, boundaries, malformed inputs, and pre-readiness boot rejection.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/agent/src/runtime/eliza.ts`: `resolveDeferredPluginRegistrationTimeoutMs` function and validation call in `startEliza`.
- `packages/agent/src/runtime/deferred-watchdog-config.test.ts`: test suite.

## Detailed testing steps

```bash
bunx vitest run --config packages/agent/vitest.config.ts --coverage.enabled=false packages/agent/src/runtime/deferred-watchdog-config.test.ts
bun run --cwd packages/agent typecheck
bunx biome check packages/agent/src/runtime/eliza.ts packages/agent/src/runtime/deferred-watchdog-config.test.ts
```

# Evidence Gate

<!-- evidence-head:81bdddf09efecfa010b53de3d1c98f038298df94 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend runtime configuration validation only
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend runtime configuration validation only
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend runtime configuration validation only
<!-- evidence-row:backend-logs -->
- [ ] N/A - unit test suite demonstrates pre-boot fatal ElizaError on invalid watchdog configuration
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend UI surface involved
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - non-LLM agent runtime startup configuration
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - non-persistence runtime watchdog validation
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - non-LLM agent runtime startup configuration

## Backend + frontend logs

Exact head `81bdddf09efecfa010b53de3d1c98f038298df94` after rebase onto `origin/develop@d1463e90a5ec617e2d2eb49655b074655b5e4672`:

```text
$ git range-diff abdfe57e094..82c8b569007 origin/develop..HEAD
1:  f324481be4 = 1:  05881b0627 fix(agent): reject invalid deferred watchdog configuration before readiness (#19167)
2:  82c8b56900 = 2:  81bdddf09e refactor(agent): fold the watchdog timeout validation into one guard

$ git diff --stat abdfe57e094 origin/develop -- \
    packages/agent/src/runtime/eliza.ts \
    packages/agent/src/runtime/deferred-watchdog-config.test.ts
# empty: develop did not touch either file since the previous base

$ bunx vitest run --config packages/agent/vitest.config.ts --coverage.enabled=false \
    packages/agent/src/runtime/deferred-watchdog-config.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  11.81s

$ bun run --cwd packages/agent typecheck
$ tsc --noEmit -p tsconfig.json
# exit 0

$ bunx biome check packages/agent/src/runtime/eliza.ts \
    packages/agent/src/runtime/deferred-watchdog-config.test.ts
Checked 2 files in 115ms. No fixes applied.

$ git diff --check origin/develop
# clean
```

## Screenshots (before / after) + video walkthrough

N/A - no rendered visual surface

## Audio / voice walkthrough

N/A - no audio/voice component

## Known gaps / failures

- No source change was made in this update. The only substantive edit is the
  per-commit provenance correction the review required; the two code commits are
  byte-identical to the reviewed head.
- Hosted CI remains the full-lane proof. The previous hosted run on `06e1d21d10`
  failed Smoke / Tests (client) / Tests (server) on unrelated trunk defects
  (`/api/workflow/workflows` 501, `workflow-action-routing.test.ts`, ui-smoke)
  whose paths are not in this diff; this rebase onto current `develop` picks up
  those trunk fixes.
- I did not re-run root `bun run verify` for this provenance-only update; the
  focused package gates above are re-run at the exact head and hosted CI covers
  the remainder.

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@d1463e90a5ec617e2d2eb49655b074655b5e4672:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [rama0x1-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"elizaOS/eliza@d1463e90a5ec617e2d2eb49655b074655b5e4672:packages/skills/skills/contribute-to-eliza"} -->
