### PR TITLE
fix(app-core): map capacitor-bun-runtime to source in the electrobun tsconfig

### DIFF
--- a/packages/app-core/platforms/electrobun/tsconfig.json
+++ b/packages/app-core/platforms/electrobun/tsconfig.json
@@ -31,6 +31,12 @@
       "@elizaos/app-core/*": ["../../src/*"],
       "@elizaos/agent": ["../../../agent/src/index.ts"],
       "@elizaos/agent/*": ["../../../agent/src/*"],
+      "@elizaos/capacitor-bun-runtime": [
+        "../../../../plugins/plugin-native-bun-runtime/src/index.ts"
+      ],
+      "@elizaos/capacitor-bun-runtime/*": [
+        "../../../../plugins/plugin-native-bun-runtime/src/*"
+      ],
       "@elizaos/core": ["../../../core/src/index.node.ts"],
       "@elizaos/core/atomic-json": ["../../../core/src/utils/atomic-json.ts"],
       "@elizaos/core/*": ["../../../core/src/*"],


### PR DESCRIPTION
# Relates to

Fourth develop-wide CI regression found in this sweep: `@elizaos/electrobun#typecheck` fails on `develop` itself and therefore on **every** PR branch, regardless of what that branch touches.

## Root cause

`packages/app-core/platforms/electrobun/tsconfig.json` maps every other `@elizaos/*` workspace package to its **source** entry (`@elizaos/core`, `@elizaos/agent`, `@elizaos/shared`, `@elizaos/ui`, …) but has **no mapping for `@elizaos/capacitor-bun-runtime`** (which lives in `plugins/plugin-native-bun-runtime`). That package resolves through its `types` field to `dist/esm/index.d.ts`, which the typecheck lane never builds — so `tsc` reports `Cannot find module '@elizaos/capacitor-bun-runtime'` and cascades ~14 `TS18046` `'unknown'` errors out of the guarded dynamic `import()` that consumes it.

Evidence it is inherited, not branch-specific:
- Two PRs sharing **zero files** (#19081 — workflow YAML + scripts test; #19104 — Terraform + scripts) fail with the identical error, both already containing current `origin/develop`.
- **#19173 was merged into `develop` with `typecheck` red**, same signature.

## Fix

One mapping, consistent with every sibling entry in the same `paths` block — point the module at its source entry instead of an unbuilt `dist`.

## Red/green proof (same worktree, deps installed)

```
# without the fix
$ bunx tsc --noEmit    # packages/app-core/platforms/electrobun
98 errors   (16 of them capacitor-bun-runtime / TS18046)

# with the fix
$ bunx tsc --noEmit
82 errors   (0 capacitor-bun-runtime / TS18046)
```

All 16 target errors eliminated, **no new errors introduced**. The remaining 82 are pre-existing `develop` debt in this package and are deliberately out of scope for this targeted unblock.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

# Evidence Gate

<!-- evidence-head:1ee374702881e68551d4aab92cf3d7f936d33abf -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - tsconfig path mapping; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow.
<!-- evidence-row:backend-logs -->
- [x] Red/green typecheck transcript from the real package:

```
# baseline (fix stashed)
BASELINE (no fix): 98 errors; capacitor/TS18046: 16

# with the fix applied
82 errors; capacitor-bun-runtime|TS18046 matches: 0
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser session; this is a compiler configuration change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model path touched.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - tsconfig path-mapping only. Red/green is the typecheck itself: 98 errors before, 82 after; all 16 capacitor-bun-runtime / TS18046 errors eliminated, none introduced. Captured inline in the evidence rows above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no pixels.
