### PR TITLE
fix(plugin-slack): handle invalid dates and permalink timestamps

### DIFF
--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -1,8 +1,9 @@
 /**
  * Slack mrkdwn formatting helpers. Escaping &, <, > is required so user text
  * can't forge Slack control sequences (mentions/links); the mention/link
- * builders and their extractors must round-trip; and markdown→mrkdwn must use
- * Slack's *bold* / _italic_ syntax rather than the markdown originals.
+ * builders and their extractors must round-trip; date and permalink helpers
+ * must reject malformed boundary values; and markdown→mrkdwn must use Slack's
+ * *bold* / _italic_ syntax rather than the markdown originals.
  */
 import { describe, expect, it } from "vitest";
 import {
@@ -13,6 +14,7 @@ import {
   extractUrlFromSlackLink,
   extractUserIdFromMention,
   formatSlackChannelMention,
+  formatSlackDate,
   formatSlackLink,
   formatSlackSpecialMention,
   formatSlackUserGroupMention,
@@ -22,6 +24,7 @@ import {
   stripSlackFormatting,
   truncateText,
 } from "./formatting.ts";
+import { isValidMessageTs, parseSlackMessageLink } from "./types.ts";
 
 describe("escapeSlackMrkdwn", () => {
   it("escapes the three Slack control chars, leaves clean text untouched", () => {
@@ -154,32 +157,119 @@ describe("permalink build/parse round-trip", () => {
   });
 
   it("parses user DM channel permalinks and non-fractional 10-digit timestamps", () => {
-    expect(
-      parseSlackMessagePermalink(
-        "https://acme.slack.com/archives/U1234567/p1700000000123456",
-      ),
-    ).toEqual({
+    const parsed16 = parseSlackMessagePermalink(
+      "https://acme.slack.com/archives/U1234567/p1700000000123456",
+    );
+    expect(parsed16).toEqual({
       workspaceDomain: "acme",
       channelId: "U1234567",
       messageTs: "1700000000.123456",
     });
+    expect(isValidMessageTs(parsed16?.messageTs ?? "")).toBe(true);
 
-    expect(
-      parseSlackMessagePermalink(
-        "https://acme.slack.com/archives/C0ABCDE/p1700000000",
-      ),
-    ).toEqual({
+    const parsed10 = parseSlackMessagePermalink(
+      "https://acme.slack.com/archives/C0ABCDE/p1700000000",
+    );
+    expect(parsed10).toEqual({
       workspaceDomain: "acme",
       channelId: "C0ABCDE",
-      messageTs: "1700000000",
+      messageTs: "1700000000.000000",
     });
+    expect(isValidMessageTs(parsed10?.messageTs ?? "")).toBe(true);
   });
 
-  it("returns null for malformed short timestamps", () => {
+  it("returns null for malformed timestamps, wrong lengths, or trailing garbage", () => {
     expect(
       parseSlackMessagePermalink(
         "https://acme.slack.com/archives/C0ABCDE/p12345",
       ),
     ).toBeNull();
+    expect(
+      parseSlackMessagePermalink(
+        "https://acme.slack.com/archives/C0ABCDE/p17000000001",
+      ),
+    ).toBeNull(); // 11 digits
+    expect(
+      parseSlackMessagePermalink(
+        "https://acme.slack.com/archives/C0ABCDE/p170000000012345",
+      ),
+    ).toBeNull(); // 15 digits
+    expect(
+      parseSlackMessagePermalink(
+        "https://acme.slack.com/archives/C0ABCDE/p17000000001234567",
+      ),
+    ).toBeNull(); // 17 digits
+    expect(
+      parseSlackMessagePermalink(
+        "https://acme.slack.com/archives/C0ABCDE/p1700000000123456evil",
+      ),
+    ).toBeNull(); // trailing garbage
+  });
+});
+
+describe("formatSlackDate", () => {
+  it("formats valid Date or timestamp into Slack <!date...>", () => {
+    const d = new Date(1700000000000);
+    expect(formatSlackDate(d)).toBe(
+      "<!date^1700000000^{date_short_pretty} at {time}|2023-11-14T22:13:20.000Z>",
+    );
+  });
+
+  it("degrades instead of throwing on unrepresentable timestamps", () => {
+    // Previously `new Date(NaN).toISOString()` threw RangeError out of a
+    // formatting helper; out-of-range epoch millis are the same failure.
+    expect(formatSlackDate(new Date("invalid"))).toBe("Invalid date");
+    expect(formatSlackDate(Infinity)).toBe("Invalid date");
+    expect(formatSlackDate(8_640_000_000_000_001, "{date}", "Fallback")).toBe(
+      "Fallback",
+    );
+  });
+});
+
+describe("parseSlackMessageLink", () => {
+  it("parses valid archives links and normalizes messageTs to satisfy isValidMessageTs", () => {
+    const res16 = parseSlackMessageLink(
+      "https://acme.slack.com/archives/C12345678/p1700000000123456",
+    );
+    expect(res16).toEqual({
+      channelId: "C12345678",
+      messageTs: "1700000000.123456",
+    });
+    expect(isValidMessageTs(res16?.messageTs ?? "")).toBe(true);
+
+    const res10 = parseSlackMessageLink(
+      "https://acme.slack.com/archives/C12345678/p1700000000",
+    );
+    expect(res10).toEqual({
+      channelId: "C12345678",
+      messageTs: "1700000000.000000",
+    });
+    expect(isValidMessageTs(res10?.messageTs ?? "")).toBe(true);
+  });
+
+  it("returns null for malformed lengths, invalid digits, or trailing garbage", () => {
+    expect(
+      parseSlackMessageLink("https://acme.slack.com/archives/C12345678/p123"),
+    ).toBeNull();
+    expect(
+      parseSlackMessageLink(
+        "https://acme.slack.com/archives/C12345678/p17000000001",
+      ),
+    ).toBeNull(); // 11 digits
+    expect(
+      parseSlackMessageLink(
+        "https://acme.slack.com/archives/C12345678/p170000000012345",
+      ),
+    ).toBeNull(); // 15 digits
+    expect(
+      parseSlackMessageLink(
+        "https://acme.slack.com/archives/C12345678/p17000000001234567",
+      ),
+    ).toBeNull(); // 17 digits
+    expect(
+      parseSlackMessageLink(
+        "https://acme.slack.com/archives/C12345678/p1700000000123456evil",
+      ),
+    ).toBeNull(); // trailing garbage
   });
 });

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -287,6 +287,23 @@ describe("parseSlackMessageLink", () => {
     expect(isValidMessageTs(threaded?.messageTs ?? "")).toBe(true);
   });
 
+  it("requires a bare permalink, and round-trips the mrkdwn-wrapped form via extractUrlFromSlackLink", () => {
+    const bare = "https://acme.slack.com/archives/C12345678/p1700000000123456";
+    // parseSlackMessageLink substring-matched before anchoring, so these three
+    // used to parse; parseSlackMessagePermalink was already start-anchored and
+    // is pinned here so both helpers now agree on rejecting a non-bare link.
+    expect(parseSlackMessageLink(`<${bare}|jump to message>`)).toBeNull();
+    expect(parseSlackMessageLink(`see ${bare} for context`)).toBeNull();
+    expect(parseSlackMessagePermalink(`<${bare}>`)).toBeNull();
+
+    const extracted = extractUrlFromSlackLink(`<${bare}|jump to message>`);
+    expect(extracted).toBe(bare);
+    expect(parseSlackMessageLink(extracted ?? "")).toEqual({
+      channelId: "C12345678",
+      messageTs: "1700000000.123456",
+    });
+  });
+
   it("returns null for malformed lengths, invalid digits, or trailing garbage", () => {
     expect(
       parseSlackMessageLink("https://acme.slack.com/archives/C12345678/p123"),

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -178,6 +178,28 @@ describe("permalink build/parse round-trip", () => {
     expect(isValidMessageTs(parsed10?.messageTs ?? "")).toBe(true);
   });
 
+  it("normalizes Slack's documented 15-digit chat.getPermalink examples", () => {
+    const documented = parseSlackMessagePermalink(
+      "https://ghostbusters.slack.com/archives/C1H9RESGA/p135854651500008",
+    );
+    expect(documented).toEqual({
+      workspaceDomain: "ghostbusters",
+      channelId: "C1H9RESGA",
+      messageTs: "1358546515.000080",
+    });
+    expect(isValidMessageTs(documented?.messageTs ?? "")).toBe(true);
+
+    const threaded = parseSlackMessagePermalink(
+      "https://ghostbusters.slack.com/archives/C1H9RESGL/p135854651700023?thread_ts=1358546515.000008&cid=C1H9RESGL",
+    );
+    expect(threaded).toEqual({
+      workspaceDomain: "ghostbusters",
+      channelId: "C1H9RESGL",
+      messageTs: "1358546517.000230",
+    });
+    expect(isValidMessageTs(threaded?.messageTs ?? "")).toBe(true);
+  });
+
   it("returns null for malformed timestamps, wrong lengths, or trailing garbage", () => {
     expect(
       parseSlackMessagePermalink(
@@ -191,9 +213,9 @@ describe("permalink build/parse round-trip", () => {
     ).toBeNull(); // 11 digits
     expect(
       parseSlackMessagePermalink(
-        "https://acme.slack.com/archives/C0ABCDE/p170000000012345",
+        "https://acme.slack.com/archives/C0ABCDE/p17000000001234",
       ),
-    ).toBeNull(); // 15 digits
+    ).toBeNull(); // 14 digits
     expect(
       parseSlackMessagePermalink(
         "https://acme.slack.com/archives/C0ABCDE/p17000000001234567",
@@ -245,6 +267,24 @@ describe("parseSlackMessageLink", () => {
       messageTs: "1700000000.000000",
     });
     expect(isValidMessageTs(res10?.messageTs ?? "")).toBe(true);
+
+    const documented = parseSlackMessageLink(
+      "https://ghostbusters.slack.com/archives/C1H9RESGA/p135854651500008",
+    );
+    expect(documented).toEqual({
+      channelId: "C1H9RESGA",
+      messageTs: "1358546515.000080",
+    });
+    expect(isValidMessageTs(documented?.messageTs ?? "")).toBe(true);
+
+    const threaded = parseSlackMessageLink(
+      "https://ghostbusters.slack.com/archives/C1H9RESGL/p135854651700023?thread_ts=1358546515.000008&cid=C1H9RESGL",
+    );
+    expect(threaded).toEqual({
+      channelId: "C1H9RESGL",
+      messageTs: "1358546517.000230",
+    });
+    expect(isValidMessageTs(threaded?.messageTs ?? "")).toBe(true);
   });
 
   it("returns null for malformed lengths, invalid digits, or trailing garbage", () => {
@@ -258,9 +298,9 @@ describe("parseSlackMessageLink", () => {
     ).toBeNull(); // 11 digits
     expect(
       parseSlackMessageLink(
-        "https://acme.slack.com/archives/C12345678/p170000000012345",
+        "https://acme.slack.com/archives/C12345678/p17000000001234",
       ),
-    ).toBeNull(); // 15 digits
+    ).toBeNull(); // 14 digits
     expect(
       parseSlackMessageLink(
         "https://acme.slack.com/archives/C12345678/p17000000001234567",

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -479,7 +479,10 @@ export function buildSlackMessagePermalink(
 }
 
 /**
- * Parses a Slack message permalink
+ * Parses a Slack message permalink.
+ *
+ * The match is anchored at both ends, so prose-embedded or mrkdwn-wrapped
+ * links must be extracted before they are passed in.
  */
 export function parseSlackMessagePermalink(
   link: string,

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -317,10 +317,21 @@ export function formatSlackDate(
   format: string = "{date_short_pretty} at {time}",
   fallbackText?: string,
 ): string {
-  const unix = Math.floor(
-    (typeof timestamp === "number" ? timestamp : timestamp.getTime()) / 1000,
-  );
-  const fallback = fallbackText || new Date(unix * 1000).toISOString();
+  const timeMs =
+    typeof timestamp === "number" ? timestamp : timestamp.getTime();
+  const date = new Date(timeMs);
+  if (!Number.isFinite(date.getTime())) {
+    return fallbackText || "Invalid date";
+  }
+  const unix = Math.floor(timeMs / 1000);
+  let fallback = fallbackText;
+  if (!fallback) {
+    try {
+      fallback = date.toISOString();
+    } catch {
+      return fallbackText || "Invalid date";
+    }
+  }
   return `<!date^${unix}^${format}|${fallback}>`;
 }
 
@@ -477,21 +488,15 @@ export function parseSlackMessagePermalink(
   link: string,
 ): { workspaceDomain: string; channelId: string; messageTs: string } | null {
   const match = link.match(
-    /^https?:\/\/([^.]+)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d+)/i,
+    /^https?:\/\/([^.]+)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d{10}|\d{16})(?:[/?#].*)?$/i,
   );
   if (!match) {
     return null;
   }
 
   const ts = match[3];
-  if (ts.length < 10) {
-    return null;
-  }
-
-  const fractional = ts.slice(10);
-  const messageTs = fractional
-    ? `${ts.slice(0, 10)}.${fractional}`
-    : ts.slice(0, 10);
+  const messageTs =
+    ts.length === 16 ? `${ts.slice(0, 10)}.${ts.slice(10)}` : `${ts}.000000`;
 
   return {
     workspaceDomain: match[1],

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -8,7 +8,11 @@
  * channel-type / display-name helpers. Used by `service.ts` on the send/receive
  * paths and re-exported from `index.ts`.
  */
-import type { SlackChannel, SlackUser } from "./types";
+import {
+  normalizeSlackPermalinkTimestamp,
+  type SlackChannel,
+  type SlackUser,
+} from "./types";
 
 /**
  * Escape special characters for Slack mrkdwn format
@@ -488,15 +492,16 @@ export function parseSlackMessagePermalink(
   link: string,
 ): { workspaceDomain: string; channelId: string; messageTs: string } | null {
   const match = link.match(
-    /^https?:\/\/([^.]+)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d{10}|\d{16})(?:[/?#].*)?$/i,
+    /^https?:\/\/([^.]+)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d{16}|\d{15}|\d{10})(?:[/?#].*)?$/i,
   );
   if (!match) {
     return null;
   }
 
-  const ts = match[3];
-  const messageTs =
-    ts.length === 16 ? `${ts.slice(0, 10)}.${ts.slice(10)}` : `${ts}.000000`;
+  const messageTs = normalizeSlackPermalinkTimestamp(match[3]);
+  if (!messageTs) {
+    return null;
+  }
 
   return {
     workspaceDomain: match[1],

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -328,14 +328,7 @@ export function formatSlackDate(
     return fallbackText || "Invalid date";
   }
   const unix = Math.floor(timeMs / 1000);
-  let fallback = fallbackText;
-  if (!fallback) {
-    try {
-      fallback = date.toISOString();
-    } catch {
-      return fallbackText || "Invalid date";
-    }
-  }
+  const fallback = fallbackText || date.toISOString();
   return `<!date^${unix}^${format}|${fallback}>`;
 }
 

--- a/plugins/plugin-slack/src/types.ts
+++ b/plugins/plugin-slack/src/types.ts
@@ -384,8 +384,16 @@ export function isValidMessageTs(ts: string): boolean {
 /**
  * Normalizes a Slack permalink path timestamp (`p` digits with the decimal
  * removed) to the `seconds.microseconds` form `isValidMessageTs` accepts.
- * Official `chat.getPermalink` examples use 15 digits; current links use 16;
- * seconds-only links use 10. Other widths stay rejected.
+ * Current links use 16 digits, seconds-only links use 10, and the documented
+ * `chat.getPermalink` examples use 15. Other widths stay rejected.
+ *
+ * The 15-digit width is padded on the right (`00008` -> `000080`), which is an
+ * assumption the published documentation cannot settle: that page's own
+ * `message_ts` argument example is the dot-less `135854651500008`, so its
+ * 15-digit permalink may equally be a truncated 16-digit value needing a left
+ * pad (`000008`). Both decodings satisfy `isValidMessageTs`, and the previous
+ * code emitted a value this package's own contract rejected, so the ambiguity
+ * is confined here: an API-verified correction changes only this function.
  */
 export function normalizeSlackPermalinkTimestamp(
   digits: string,
@@ -397,7 +405,12 @@ export function normalizeSlackPermalinkTimestamp(
 }
 
 /**
- * Parses a Slack message link to extract channel and message IDs
+ * Parses a Slack message link to extract channel and message IDs.
+ *
+ * The match is anchored, so the argument must be a bare permalink: a link
+ * embedded in surrounding prose or wrapped in mrkdwn (`<https://…|label>`)
+ * returns `null`. Callers holding message text extract the URL first, with
+ * `extractUrlFromSlackLink` for the mrkdwn form.
  */
 export function parseSlackMessageLink(
   link: string,

--- a/plugins/plugin-slack/src/types.ts
+++ b/plugins/plugin-slack/src/types.ts
@@ -388,13 +388,15 @@ export function parseSlackMessageLink(
   link: string,
 ): { channelId: string; messageTs: string } | null {
   // Format: https://workspace.slack.com/archives/C12345678/p1234567890123456
-  const match = link.match(/\/archives\/([CGD][A-Z0-9]+)\/p(\d+)/i);
+  const match = link.match(
+    /^https?:\/\/[^/]+\/archives\/([CGD][A-Z0-9]+)\/p(\d{10}|\d{16})(?:[/?#].*)?$/i,
+  );
   if (!match) return null;
 
   const channelId = match[1];
   const ts = match[2];
-  // Convert the timestamp: p1234567890123456 -> 1234567890.123456
-  const messageTs = `${ts.slice(0, 10)}.${ts.slice(10)}`;
+  const messageTs =
+    ts.length === 16 ? `${ts.slice(0, 10)}.${ts.slice(10)}` : `${ts}.000000`;
 
   return { channelId, messageTs };
 }

--- a/plugins/plugin-slack/src/types.ts
+++ b/plugins/plugin-slack/src/types.ts
@@ -382,6 +382,21 @@ export function isValidMessageTs(ts: string): boolean {
 }
 
 /**
+ * Normalizes a Slack permalink path timestamp (`p` digits with the decimal
+ * removed) to the `seconds.microseconds` form `isValidMessageTs` accepts.
+ * Official `chat.getPermalink` examples use 15 digits; current links use 16;
+ * seconds-only links use 10. Other widths stay rejected.
+ */
+export function normalizeSlackPermalinkTimestamp(
+  digits: string,
+): string | null {
+  if (!/^(?:\d{16}|\d{15}|\d{10})$/.test(digits)) {
+    return null;
+  }
+  return `${digits.slice(0, 10)}.${digits.slice(10).padEnd(6, "0")}`;
+}
+
+/**
  * Parses a Slack message link to extract channel and message IDs
  */
 export function parseSlackMessageLink(
@@ -389,16 +404,14 @@ export function parseSlackMessageLink(
 ): { channelId: string; messageTs: string } | null {
   // Format: https://workspace.slack.com/archives/C12345678/p1234567890123456
   const match = link.match(
-    /^https?:\/\/[^/]+\/archives\/([CGD][A-Z0-9]+)\/p(\d{10}|\d{16})(?:[/?#].*)?$/i,
+    /^https?:\/\/[^/]+\/archives\/([CGD][A-Z0-9]+)\/p(\d{16}|\d{15}|\d{10})(?:[/?#].*)?$/i,
   );
   if (!match) return null;
 
-  const channelId = match[1];
-  const ts = match[2];
-  const messageTs =
-    ts.length === 16 ? `${ts.slice(0, 10)}.${ts.slice(10)}` : `${ts}.000000`;
+  const messageTs = normalizeSlackPermalinkTimestamp(match[2]);
+  if (!messageTs) return null;
 
-  return { channelId, messageTs };
+  return { channelId: match[1], messageTs };
 }
 
 /**


### PR DESCRIPTION
# Relates to

Fixes date formatting and permalink timestamp parsing defects in `plugin-slack`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop` at `499af898993342817ae603b8bd9be36e66df6c7a` with zero conflicts.
- [x] Focused/package gates were run on exact head `f9518c5dc105c74869a1a15d48ea904b0bd277c8`.
- [x] The deterministic formatter and parser artifacts below let a reviewer verify the behavior without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.6-flash, xai/grok-4.6, anthropic/claude-fable-5, anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI, Grok, Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6c033a6d10e6af64e773bc715d96efac06be396f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

The latest commit `f9518c5dc1` was authored with `anthropic/claude-opus-5` via Claude Code; the earlier rows remain applicable to the commits that precede it.

# Sync with develop

- [x] Rebased onto current `origin/develop` at `499af898993342817ae603b8bd9be36e66df6c7a`; zero conflicts. No develop commit since the previous base touches `plugins/plugin-slack`.
- [x] Package suite, typecheck, and changed-file Biome pass on exact head `f9518c5dc105c74869a1a15d48ea904b0bd277c8`.

# Risks

Low overall; the changes are Slack formatting and link-parsing helpers. Two contract notes a downstream consumer should read, both now recorded in the source doc comments:

1. **Anchoring narrows `parseSlackMessageLink` for non-bare links.** Its old regex substring-matched, so a permalink embedded in prose or wrapped in mrkdwn (`<https://…|label>`) parsed; it is now `^…$`-anchored and returns `null` for those. I replayed develop's exact old expression to confirm the scope rather than assume it: the mrkdwn-wrapped, prose-embedded, and angle-wrapped forms all parsed under `parseSlackMessageLink` and all already returned `null` under `parseSlackMessagePermalink`, which was start-anchored before this PR. So the behavior change is confined to that one helper, and the two now agree. This is the fail-closed behavior earlier review rounds asked for and there are no in-repo consumers beyond the barrel re-export, but out-of-repo callers holding message text must extract the bare URL first — `extractUrlFromSlackLink` covers the mrkdwn form. A regression pins both the rejection and that recovery path.
2. **The 15-digit pad direction is an assumption, not a verified decode.** `00008` is right-padded to `000080`. The published `chat.getPermalink` page cannot settle the direction: its own `message_ts` argument example is the dot-less `135854651500008`, so the 15-digit permalink is equally readable as a truncated 16-digit value that should be left-padded to `000008`. Both decodings satisfy `isValidMessageTs`, and `develop` currently emits `1358546515.00008`, which the package's own contract rejects — so either choice is an improvement. The ambiguity is documented at `normalizeSlackPermalinkTimestamp`, which is the single place an API-verified correction would change.

# Background

## What does this PR do?

1. Makes `formatSlackDate` return its explicit fallback or `Invalid date` for invalid, non-finite, and finite-but-out-of-range timestamps instead of throwing `RangeError`. The unreachable `toISOString` catch after the TimeClip guard is removed.
2. Parses Slack permalink timestamps of 10, 15, and 16 digits in `parseSlackMessageLink` and `parseSlackMessagePermalink`, including Slack's documented `chat.getPermalink` 15-digit examples. Each width is normalized to a 6-decimal microsecond timestamp that satisfies `isValidMessageTs`. Malformed lengths, invalid digits, and trailing garbage still return `null`.
3. Records the two caller-facing contracts above in the exported helpers' doc comments and pins the anchoring behavior with a regression.

## What kind of change is this?

Bug fix (formatter/parser hardening). See the Risks section for the parser-narrowing note affecting out-of-repo callers.

# Documentation changes needed?

No. This restores the existing public helper contracts and does not add configuration or a user-facing workflow.

# Testing

## Where should a reviewer start?

- `plugins/plugin-slack/src/formatting.ts`: `formatSlackDate` and `parseSlackMessagePermalink`.
- `plugins/plugin-slack/src/types.ts`: `normalizeSlackPermalinkTimestamp` and `parseSlackMessageLink`.
- `plugins/plugin-slack/src/formatting.test.ts`: invalid date, 10/15/16-digit permalink, documented `chat.getPermalink`, trailing-garbage, and mrkdwn-wrapped/embedded regressions.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-slack test        # 5 files / 46 tests passed
bun run --cwd plugins/plugin-slack typecheck   # passed
bunx biome check plugins/plugin-slack/src/formatting.ts \
  plugins/plugin-slack/src/types.ts plugins/plugin-slack/src/formatting.test.ts
git diff --check origin/develop
```

# Evidence Gate

Evidence matches the exact commit reviewed.
<!-- evidence-head:f9518c5dc105c74869a1a15d48ea904b0bd277c8 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface is changed.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface is changed.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no interactive visual flow is changed.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure formatter/parser helpers run without a backend process.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend request or state transition is changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no prompt, provider, model, action, or planner behavior is changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: exact-head deterministic test transcript and parser probe.

  ```text
  $ bun run --cwd plugins/plugin-slack test   # exact head f9518c5dc105c74869a1a15d48ea904b0bd277c8
  Test Files  5 passed (5)
       Tests  46 passed (46)

  $ bun run --cwd plugins/plugin-slack typecheck
  $ tsc --noEmit -p tsconfig.json            # exit 0

  $ bunx biome check <the three changed files>
  Checked 3 files in 29ms. No fixes applied.

  $ git diff --check origin/develop          # clean

  before (origin/develop@499af89899):
    formatSlackDate(new Date("nope"))            -> RangeError: Invalid Date
    parseSlackMessageLink(".../p1700000000")     -> messageTs "1700000000." (invalid messageTs)
    documented 15-digit chat.getPermalink example
                                                 -> messageTs "1358546515.00008" (invalid messageTs)
    old-expression replay, scope of the anchoring change:
      mrkdwn-wrapped   link={"channelId":"C12345678","messageTs":"1700000000.123456"} permalink=null
      prose-embedded   link={"channelId":"C12345678","messageTs":"1700000000.123456"} permalink=null
      angle-wrapped    link={"channelId":"C12345678","messageTs":"1700000000.123456"} permalink=null
  after (this head f9518c5dc1):
    formatSlackDate(new Date("nope"))            -> "Invalid date"
    formatSlackDate(8_640_000_000_000_001, "{date}", "Fallback") -> "Fallback"
    parseSlackMessageLink(".../p1700000000")     -> messageTs "1700000000.000000" (valid messageTs)
    parseSlackMessagePermalink("https://ghostbusters.slack.com/archives/C1H9RESGA/p135854651500008")
                                                 -> messageTs "1358546515.000080" (valid messageTs)
    parseSlackMessagePermalink("https://ghostbusters.slack.com/archives/C1H9RESGL/p135854651700023?thread_ts=1358546515.000008&cid=C1H9RESGL")
                                                 -> messageTs "1358546517.000230" (valid messageTs)
    parseSlackMessageLink(".../p17000000001")    -> null
    parseSlackMessageLink(".../p1700000000123456evil") -> null
    parseSlackMessageLink("<https://acme.slack.com/archives/C12345678/p1700000000123456|jump to message>")
                                                 -> null   (anchored; extract the URL first)
    extractUrlFromSlackLink(same wrapped link) then parseSlackMessageLink
                                                 -> messageTs "1700000000.123456" (valid messageTs)
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no UI or image rendering is changed.`

# Evidence Details

The full plugin test suite (5 files / 46 tests) passes on the exact head, up from 45 with the added anchoring regression. Package typecheck and changed-file Biome pass.

## Known gaps / failures

Root `bun run verify` is still running on this head at edit time; I will post its exact result as a comment rather than claim it here. Focused package gates (46/46 suite, typecheck, changed-file Biome, `git diff --check`) all passed on `f9518c5dc1`.

The previous hosted run failed `Smoke (1/3/4/5/6)` on the pre-rebase base. Those failures are in `packages/app` UI smoke specs (`agent-detail-invalid-date-capture.spec.ts`, `all-views-interaction.spec.ts` automations) with no path intersection with this three-file `plugins/plugin-slack` diff; this rebase onto current `develop` is so those trunk lanes are re-evaluated on an up-to-date base.

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [rama0x1-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"N/A - no repository contribution skill used"} -->
