### PR TITLE
fix(ui): give the priming e2e core stub a real ElizaError base

### DIFF
--- a/packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs
+++ b/packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs
@@ -80,8 +80,26 @@ const stubClient = {
 // CJS stub (`.cjs` so esbuild wraps it and `module` is defined): arbitrary
 // named imports of core resolve to `undefined` via CJS interop, since the modal
 // never executes any core code path.
+//
+// `ElizaError` is the one exception and must be a real constructor. The graph
+// reaches `api/client-cloud.ts`, which evaluates `class CloudAgentWakeError
+// extends ElizaError` at module scope — a class heritage clause runs on load
+// even though the modal never constructs it. With core stubbed to `{}` that
+// threw `Class extends value undefined`, killing the bundle before React
+// mounted and leaving the runner to time out on the first card's selector.
 const coreStub = join(outDir, "core-stub.cjs");
-await writeFile(coreStub, "module.exports = {};\n");
+await writeFile(
+  coreStub,
+  `class ElizaError extends Error {
+  constructor(message, options) {
+    super(message);
+    this.name = "ElizaError";
+    if (options && options.code) this.code = options.code;
+  }
+}
+module.exports = { ElizaError };
+`,
+);
 const stubCore = {
   name: "stub-core",
   setup(b) {


### PR DESCRIPTION
# Relates to

Self-found while reviewing #19042. The `fixture-e2e` lane was red there and on
every other `packages/ui` PR; it is a harness defect, not any PR's regression.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is linearly rebased onto current `origin/develop@63f235b6dfeac6a8803d1f051883542b1bc24136` with zero conflicts.
- [x] The affected lane is reproduced red before and green after on this exact
      head; full root `verify` not run for this one-file, test-harness-only fix.
- [x] A reviewer can confirm the change without reading the code, from the
      runner output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Linearly rebased onto current `origin/develop@63f235b6dfeac6a8803d1f051883542b1bc24136`; the one implementation patch is range-diff identical.

# Risks

Very low. Test-harness only — one esbuild stub inside
`run-permission-priming-e2e.mjs`. No production code, no assertions changed.

# Background

## What does this PR do?

`fixture-e2e` runs exactly one command, `bun run --cwd packages/ui
test:permission-priming-e2e`, and it has been failing with:

```
TimeoutError: waitForSelector: Timeout 30000ms exceeded.
  - waiting for locator('[data-testid="priming-card-microphone"]') to be visible
```

That reads like a UI regression. It is not — the modal never mounts. Attaching
`page.on("pageerror")` to the runner gives the real cause:

```
TypeError: Class extends value undefined is not a constructor or null
```

The runner bundles the fixture with esbuild and stubs `@elizaos/core` to
`module.exports = {}`, with the comment that "the modal never executes any core
code path". That premise is true for *calls* but not for *class heritage*. The
bundle graph reaches `packages/ui/src/api/client-cloud.ts` (via
`api/client-agent.ts` — note the runner's `onResolve` stub only intercepts
`api/client`), and that module evaluates at load:

```ts
import { ElizaError } from "@elizaos/core";
export class CloudAgentWakeError extends ElizaError { ... }   // line 3497
```

A heritage clause is evaluated when the module loads, whether or not the class
is ever constructed. With core stubbed to `{}`, `ElizaError` is `undefined`, the
bundle throws before React mounts, nothing renders, and the runner times out on
the first card.

**Fix:** the core stub now exports a real minimal `ElizaError` constructor.
Every other core export stays `undefined` via CJS interop, so the stub keeps its
original purpose and blast radius.

## What was ruled out

- **Any product PR.** Reproduced on unmodified `origin/develop` with no PR code
  in the tree.
- **`format: "esm"`.** The `import.meta`-under-`iife` warnings in the build log
  are a red herring — esbuild compiles `import.meta` to empty and continues.
  Switching the bundle to `esm` does **not** work anyway: the fixture is loaded
  from a `file://` URL and browsers block ES module scripts on `file://`
  origins under CORS. That route would also require moving the runner to an
  http server; widening the stub is far smaller.
- **Reshaping the fixture's assertions.** Not touched — all ten original
  assertions run and pass.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs`,
the `coreStub` definition.

## Detailed testing steps

```bash
# one-time, or the build dies on ./generated/validation-keyword-data.js
node packages/shared/scripts/generate-keywords.mjs

bun run --cwd packages/ui test:permission-priming-e2e
```

**Before (clean `origin/develop`):**

```
TimeoutError: waitForSelector: Timeout 30000ms exceeded.
  - waiting for locator('[data-testid="priming-card-microphone"]') to be visible
error: script "test:permission-priming-e2e" exited with code 1
```

**After (this head):**

```
✓ [desktop] first card (microphone) shows Enable
✓ [desktop] granting microphone advances to the next card
✓ [desktop] a denied permission surfaces the recovery callout
✓ [desktop] Continue advances past the denied card
✓ [desktop] granting the last card completes the sequence
✓ [mobile] first card (microphone) shows Enable
✓ [mobile] granting microphone advances to the next card
✓ [mobile] a denied permission surfaces the recovery callout
✓ [mobile] Continue advances past the denied card
✓ [mobile] granting the last card completes the sequence
✓ no page errors (0)
```

All ten assertions pass on desktop and mobile, and the runner captures its eight
screenshots and mobile video again.

# Evidence Gate

<!-- evidence-head:ddd46f45e7018c8fc12c71093106c5c22a60a443 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - the "before" state renders nothing at all (blank page, bundle throws
  on load); the before/after artifact is the runner transcript above, and the
  eight desktop/mobile screenshots the runner emits only exist in the "after"
  state.
<!-- evidence-row:after-screenshots -->
- [x] N/A - after-state screenshots are produced by the runner itself
  (`01-desktop-01-microphone.png` … `08-mobile-04-complete.png`) into its
  gitignored output dir; the assertion transcript above is the reviewable proof.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changed; the runner's own mobile video is
  regenerated by the steps above.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend process involved; the runner is a self-contained esbuild
  bundle in headless chromium.
<!-- evidence-row:frontend-logs -->
- [x] Browser-side `pageerror` / console capture, before and after this commit:

```
# BEFORE (clean origin/develop) - page.on("pageerror") added to the runner
PAGEERROR: Class extends value undefined is not a constructor or null
  (bundle throws at module scope; React never mounts; #root stays empty)
TimeoutError: waitForSelector: Timeout 30000ms exceeded.
  - waiting for locator('[data-testid="priming-card-microphone"]') to be visible
error: script "test:permission-priming-e2e" exited with code 1

# AFTER (this head)
(no pageerror events emitted)
[desktop] no console errors
[mobile]  no console errors
+ no page errors (0)
```
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - test-harness change; the exact-head runner transcript is the
  delivered artifact.
