### PR TITLE
fix(cloud): align cloud unit expectations with the eliza.app consolidation

### DIFF
--- a/packages/cloud/shared/src/lib/api/compat-envelope.test.ts
+++ b/packages/cloud/shared/src/lib/api/compat-envelope.test.ts
@@ -68,7 +68,7 @@ describe("toCompatStatus", () => {
       containerId: "container-1",
       containerUrl: "https://runtime.example",
       bridgeUrl: "https://runtime.example",
-      webUiUrl: "https://123e4567-e89b-12d3-a456-426614174000.elizacloud.ai",
+      webUiUrl: "https://123e4567-e89b-12d3-a456-426614174000.cloud.eliza.app",
       status: "running",
       databaseStatus: "ready",
       account: {

--- a/packages/cloud/shared/src/lib/services/pairing-token.test.ts
+++ b/packages/cloud/shared/src/lib/services/pairing-token.test.ts
@@ -2,15 +2,28 @@
 import { describe, expect, it } from "bun:test";
 import { DOMAIN_ALIAS_GROUPS, getAlternateDomainOrigins } from "./pairing-token-domains";
 
+const [CANONICAL_GROUP] = DOMAIN_ALIAS_GROUPS;
+
+/**
+ * Hostnames the canonical group should alias `prefix` to, excluding the suffix
+ * the caller matched on. Derived rather than hardcoded so adding a suffix to
+ * the group cannot silently rot these expectations, as the eliza.app
+ * consolidation did.
+ */
+const aliasHostnames = (prefix: string, matched: string): string[] =>
+  CANONICAL_GROUP.filter((suffix) => suffix !== matched)
+    .map((suffix) => `${prefix}${suffix}`)
+    .sort();
+
 describe("getAlternateDomainOrigins", () => {
   it("returns every other suffix in the same alias group", () => {
     // The canonical group is the first entry. Verify each domain produces
     // (group.length - 1) alternates — the matched suffix is excluded.
-    const inputs = ["https://abc.waifu.fun", "https://abc.eliza.ai", "https://abc.elizacloud.ai"];
+    const inputs = CANONICAL_GROUP.map((suffix) => `https://abc${suffix}`);
 
     for (const origin of inputs) {
       const alts = getAlternateDomainOrigins(origin);
-      expect(alts).toHaveLength(2);
+      expect(alts).toHaveLength(CANONICAL_GROUP.length - 1);
       expect(alts).not.toContain(origin);
       const hostnames = alts.map((url) => new URL(url).hostname);
       for (const hostname of hostnames) {
@@ -25,10 +38,7 @@ describe("getAlternateDomainOrigins", () => {
     );
     const hostnames = alts.map((u) => new URL(u).hostname).sort();
     expect(hostnames).toEqual(
-      [
-        "9d77d8b5-1d63-4b4c-9bd1-ec1b5deb4dc8.eliza.ai",
-        "9d77d8b5-1d63-4b4c-9bd1-ec1b5deb4dc8.elizacloud.ai",
-      ].sort(),
+      aliasHostnames("9d77d8b5-1d63-4b4c-9bd1-ec1b5deb4dc8", ".waifu.fun"),
     );
   });
 
@@ -44,7 +54,7 @@ describe("getAlternateDomainOrigins", () => {
     // `URL.origin` keeps non-default ports — the alternate origins must
     // round-trip them so a sandbox served on :8443 still matches its alias.
     const alts = getAlternateDomainOrigins("https://abc.waifu.fun:8443");
-    expect(alts).toHaveLength(2);
+    expect(alts).toHaveLength(CANONICAL_GROUP.length - 1);
     for (const alt of alts) {
       const url = new URL(alt);
       expect(url.port).toBe("8443");
@@ -58,7 +68,7 @@ describe("getAlternateDomainOrigins", () => {
     // `a.b.c.eliza.ai` without touching the inner labels.
     const alts = getAlternateDomainOrigins("https://a.b.c.waifu.fun");
     const hostnames = alts.map((u) => new URL(u).hostname).sort();
-    expect(hostnames).toEqual(["a.b.c.eliza.ai", "a.b.c.elizacloud.ai"].sort());
+    expect(hostnames).toEqual(aliasHostnames("a.b.c", ".waifu.fun"));
   });
 
   it("returns an empty array when no aliased suffix matches", () => {
@@ -78,7 +88,7 @@ describe("getAlternateDomainOrigins", () => {
     // so an Origin header arriving as `https://ABC.WAIFU.FUN` still aliases.
     const alts = getAlternateDomainOrigins("https://ABC.WAIFU.FUN");
     const hostnames = alts.map((u) => new URL(u).hostname).sort();
-    expect(hostnames).toEqual(["abc.eliza.ai", "abc.elizacloud.ai"].sort());
+    expect(hostnames).toEqual(aliasHostnames("abc", ".waifu.fun"));
   });
 
   it("matches the suffix on the right boundary (no partial-domain false positive)", () => {
@@ -98,6 +108,9 @@ describe("DOMAIN_ALIAS_GROUPS", () => {
     const allDomains = DOMAIN_ALIAS_GROUPS.flat();
     expect(allDomains).toContain(".elizacloud.ai");
     expect(allDomains).toContain(".waifu.fun");
+    // Post-consolidation canonical host: dropping it would strand tokens
+    // issued against either retired brand.
+    expect(allDomains).toContain(".cloud.eliza.app");
   });
 
   it("uses leading-dot suffixes so subdomain matching is anchored", () => {


### PR DESCRIPTION
<!-- evidence-head:8436b22939a87b1d03a88bdd54fd5742779132a2 -->
## Summary

Two cloud unit suites have been failing on **clean develop** since the Eliza Cloud domain consolidation. Neither is caused by any PR — together they fail every PR that runs the cloud unit lane.

Commit `0468c1850a3` ("feat: consolidate Eliza Cloud into eliza.app") moved the agent web-UI base domain to `cloud.eliza.app` and added `.cloud.eliza.app` to `DOMAIN_ALIAS_GROUPS`, but updated neither test file. The producer is authoritative in both cases; the tests were stale. **No production code is touched.**

<!-- evidence-row:repro -->
### Reproduction (clean develop, no PR code in tree)

`compat-envelope.test.ts` — the web UI host:

```
-   "webUiUrl": "https://....elizacloud.ai",
+   "webUiUrl": "https://....cloud.eliza.app",
(fail) toCompatStatus > includes service status aliases and wallet account metadata
 0 pass / 1 fail
```

`pairing-token.test.ts` — five `getAlternateDomainOrigins` cases hardcoded **two** alternates and two literal hostnames against a group that now has **four** members:

```
(fail) returns every other suffix in the same alias group        Received length: 3
(fail) rewrites the suffix while keeping the agent UUID prefix intact
(fail) preserves the URL port when an origin includes one
(fail) rewrites only the suffix when the prefix is itself a multi-level subdomain
(fail) matches uppercase hostnames (URL parser lowercases per WHATWG spec)
 6 pass / 5 fail
```

The `currentNode`/`lastHeartbeat`/`suspendedReason` lines in the raw compat-envelope diff are `toMatchObject` display noise — extra received fields are permitted by that matcher. The domain mismatch is the sole real failure there.

<!-- evidence-row:fix -->
### Fix, and why it is not just a find-and-replace

For `compat-envelope`, one literal host corrected.

For `pairing-token`, replacing `2` with `3` would rot again on the next suffix change — the test's own comment already claimed it verified "(group.length - 1) alternates" while hardcoding the number, and it **already imported `DOMAIN_ALIAS_GROUPS`**. So the count and the expected hostnames are now derived from the group through one shared helper:

```ts
const [CANONICAL_GROUP] = DOMAIN_ALIAS_GROUPS;
const aliasHostnames = (prefix: string, matched: string): string[] =>
  CANONICAL_GROUP.filter((suffix) => suffix !== matched)
    .map((suffix) => `${prefix}${suffix}`)
    .sort();
```

This removes five hardcoded literal lists rather than updating them. The load-bearing `DOMAIN_ALIAS_GROUPS` guarantee now also asserts `.cloud.eliza.app`, so dropping the new canonical host fails loudly the way removing the retired brands already did.

Every negative-path case (retired 0xSolace domains, unparseable input, right-boundary false positives) is untouched and still asserted.

<!-- evidence-row:fix-green -->
### After the fix

```
$ bun test packages/cloud/shared/src/lib/services/pairing-token.test.ts \
           packages/cloud/shared/src/lib/api/compat-envelope.test.ts
 12 pass
 0 fail
```

<!-- evidence-row:scope -->
### Scope

```
packages/cloud/shared/src/lib/api/compat-envelope.test.ts
packages/cloud/shared/src/lib/services/pairing-token.test.ts
```

Test files only. No production behavior change.

<!-- evidence-row:ui -->
N/A — no user-facing surface is touched; these are unit expectations correcting to match already-shipped producer behavior.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - unit test expectations only; no user-facing surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - unit test expectations only; no user-facing surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - unit test expectations only; no user-facing surface

<!-- evidence-row:backend-logs -->
- [ ] N/A - see inline bun test output above: 6 pass/5 fail (pairing-token) and 0 pass/1 fail (compat-envelope) before; 12 pass/0 fail after

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface touched

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - test-only change; no production code modified
