### PR TITLE
fix(ci): accept the force-hosted fleet routing selector

### DIFF
--- a/packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts
+++ b/packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts
@@ -23,6 +23,11 @@ jobs:
   test:
     runs-on: \${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-24.04"]' || vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
 `;
+const FORCE_HOSTED_WORKFLOW = `name: Test
+jobs:
+  test:
+    runs-on: \${{ fromJSON((inputs.force_hosted || github.event_name == 'pull_request' || vars.HETZNER_FLEET_ONLINE != 'true') && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+`;
 const MANUAL_FLEET_WORKFLOW = `name: Test
 jobs:
   test:
@@ -93,6 +98,34 @@ describe("Hetzner fleet routing contract", () => {
         files: 1,
         selectors: 1,
       });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("accepts a force-hosted override that retains the repository opt-in", () => {
+    const root = buildRepo(FORCE_HOSTED_WORKFLOW);
+    try {
+      expect(validateHetznerFleetRouting(root)).toEqual({
+        files: 1,
+        selectors: 1,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a force-hosted override without the repository opt-in", () => {
+    const root = buildRepo(
+      FORCE_HOSTED_WORKFLOW.replace(
+        " || vars.HETZNER_FLEET_ONLINE != 'true'",
+        "",
+      ),
+    );
+    try {
+      expect(() => validateHetznerFleetRouting(root)).toThrow(
+        /must require explicit HETZNER_FLEET_ONLINE opt-in/,
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/scripts/hetzner-fleet-routing-contract.mjs
+++ b/packages/scripts/hetzner-fleet-routing-contract.mjs
@@ -19,6 +19,9 @@ const CANONICAL_SELECTOR =
 const PULL_REQUEST_HOSTED_SELECTOR =
   EXPRESSION_OPEN +
   " fromJSON(github.event_name == 'pull_request' && '[\"ubuntu-24.04\"]' || vars.HETZNER_FLEET_ONLINE != 'true' && '[\"ubuntu-24.04\"]' || '[\"self-hosted\",\"hetzner-robot\"]') }}";
+const FORCE_HOSTED_SELECTOR =
+  EXPRESSION_OPEN +
+  " fromJSON((inputs.force_hosted || github.event_name == 'pull_request' || vars.HETZNER_FLEET_ONLINE != 'true') && '[\"ubuntu-24.04\"]' || '[\"self-hosted\",\"hetzner-robot\"]') }}";
 const JANITOR_ROBOT_SELECTOR =
   EXPRESSION_OPEN +
   ' vars.HETZNER_FLEET_ONLINE != \'true\' && \'["ubuntu-latest"]\' || vars.ACTIONS_JANITOR_ROBOT_LANE_DISABLED == \'true\' && \'["ubuntu-latest"]\' || vars.ACTIONS_JANITOR_ROBOT_RUNNER_JSON || \'["self-hosted","Linux","X64","hetzner-robot"]\' }}';
@@ -32,6 +35,7 @@ const CERTIFICATION_DISPATCH_SELECTOR =
 const DIRECT_RUNNER_SELECTORS = new Set([
   CANONICAL_SELECTOR,
   PULL_REQUEST_HOSTED_SELECTOR,
+  FORCE_HOSTED_SELECTOR,
   CERTIFICATION_DISPATCH_SELECTOR,
 ]);
 const JANITOR_WORKFLOW = "actions-zombie-janitor.yml";


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #19197.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Dependency setup was completed with the repository's pinned Bun toolchain before the final sync; `bun run verify` was rerun after sync and passed. No dependency files changed during the sync.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@64105d7b2636478b39f7a5677999adc963d30863:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `a91e1d328762f7e523ca8a9170377d672f4b7912`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. The change only extends the CI audit's exact allowlist with the fail-safe selector already used by `classify-paths.yml`. An adversarial regression test proves that removing the repository opt-in guard remains rejected.

# Background

## What does this PR do?

Accepts the reusable path-classifier workflow's `force_hosted` runner selector in the Hetzner fleet routing audit, while preserving the audit's requirement that self-hosted routing occurs only when `HETZNER_FLEET_ONLINE == 'true'`.

It also adds deterministic acceptance and guard-removal regression coverage.

## What kind of change is this?

Bug fix (non-breaking CI contract correction).

# Documentation changes needed?

No documentation change is needed. This aligns the checked audit contract with an existing reviewed workflow selector.

# Testing

## Where should a reviewer start?

Start with `packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts`, then inspect the added selector in `packages/scripts/hetzner-fleet-routing-contract.mjs`.

## Detailed testing steps

```text
bun test packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts packages/scripts/__tests__/ci-classifier-dedup-contract.test.ts packages/scripts/__tests__/github-action-pinning.test.ts
32 pass, 0 fail

bun run audit:hetzner-fleet-routing
[hetzner-fleet-routing] verified 61 selectors across 16 workflows

bunx @biomejs/biome check packages/scripts/hetzner-fleet-routing-contract.mjs packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts
Checked 2 files. No fixes applied.

bun run verify
Tasks: 350 successful, 350 total
[hetzner-fleet-routing] verified 61 selectors across 16 workflows
[anti-larp] clean - no focused tests, no untracked skips.
```

# Evidence Gate

Evidence matches commit `2b1df8d55e39591490f6e6660aba4ef7f148d0b6`.
<!-- evidence-head:2b1df8d55e39591490f6e6660aba4ef7f148d0b6 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-visual CI audit contract; no UI surface is affected.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-visual CI audit contract; no UI surface is affected.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic command-line contract change with no user flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime path is changed; deterministic audit output is included below.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, request, response, or state is changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, scheduled task, wallet, on-chain, audio, or generated domain output is changed.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text is changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior is changed.

## Backend + frontend logs

N/A - this is a CI audit contract. The end-to-end checked-in workflow audit output is:

```text
$ bun run audit:hetzner-fleet-routing
[hetzner-fleet-routing] verified 61 selectors across 16 workflows
```

## Screenshots (before / after) + video walkthrough

N/A - no UI surface or interactive user flow is affected.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path is affected.

## Known gaps / failures

`npm test` was also run with Node 24.15.0 and Bun 1.3.14. It stopped in `@elizaos/agent` after four unrelated failures across 402 isolated batches:

- `src/api/remote-capability-routes.test.ts`: expected a cloud plugin to remain in runtime state; reproduced on direct rerun.
- `src/api/snapshot-route-transient.test.ts`: temporary-directory cleanup reported `ENOTEMPTY`; passed on direct rerun.
- `src/services/e2b-capability-router.test.ts`: expected the legacy `api.elizacloud.ai` URL while current code returned `api.eliza.app`; reproduced on direct rerun.
- `test/runtime/workflow-action-routing.test.ts`: expected an `exact` stage score that current retrieval omitted; reproduced on direct rerun.

These failures are outside the two changed CI audit files. The repository's required `bun run verify` completed successfully after the final rebase, including all 350 typecheck/lint tasks and every script audit.

<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@64105d7b2636478b39f7a5677999adc963d30863:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZYDWHNHA75N4ZZFSGBRBPM7","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T20:44:13.361Z","completed_at":"2026-08-13T21:15:04.717Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEASLwS0eshLeA4cpT_vbS3lnzrnGRmGrX8f03fEtMmqdA","device_key_id":"3d2067bc23a0d32e00b5dcb579c70fa9f982894b17fdb1dfe2497057f9d99324","device_signature":"S9eKXGCzRKS3JvWXveKZk1f5W8jpeRzt4bYo4siuFRAee9cnyKvgYVI33bZsJrWxGNaShi4r6z2hlgEHaMpFBg"}} -->

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@64105d7b2636478b39f7a5677999adc963d30863:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [mysteryjax-codex-sol]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@64105d7b2636478b39f7a5677999adc963d30863:skills/contribute-to-eliza"} -->
