### PR TITLE
fix(plugin-inmemorydb): align cached embedding lookup

### DIFF
--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -864,9 +864,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     const results: { embedding: number[]; levenshtein_score: number }[] = [];
     for (const memory of memories) {
       if (!memory.embedding) continue;
-      const record = memory as StoredMemory & Record<string, unknown>;
-      const fieldValue = record[params.query_field_name];
-      const text = String(fieldValue ?? "");
+      const content = memory.content as Record<string, unknown> | undefined;
+      const fieldValue = content?.[params.query_field_sub_name];
+      if (typeof fieldValue !== "string") continue;
+      const text = fieldValue;
       const score = levenshtein(params.query_input, text);
       if (score <= params.query_threshold) {
         results.push({ embedding: memory.embedding, levenshtein_score: score });

--- a/plugins/plugin-inmemorydb/cached-embeddings.test.ts
+++ b/plugins/plugin-inmemorydb/cached-embeddings.test.ts
@@ -1,0 +1,76 @@
+import { randomUUID } from "node:crypto";
+import type { Memory, UUID } from "@elizaos/core";
+import { beforeEach, describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "./adapter";
+import { MemoryStorage } from "./storage-memory";
+
+describe("InMemoryDatabaseAdapter.getCachedEmbeddings", () => {
+  const agentId = randomUUID() as UUID;
+  const entityId = randomUUID() as UUID;
+  const roomId = randomUUID() as UUID;
+  let adapter: InMemoryDatabaseAdapter;
+
+  beforeEach(async () => {
+    adapter = new InMemoryDatabaseAdapter(new MemoryStorage(), agentId);
+    await adapter.initialize();
+  });
+
+  it("matches the nested content subfield used by the SQL adapter", async () => {
+    const embedding = Array.from({ length: 384 }, (_, index) => (index === 0 ? 1 : 0));
+    const memory: Memory = {
+      id: randomUUID() as UUID,
+      agentId,
+      entityId,
+      roomId,
+      content: { text: "cached phrase" },
+      embedding,
+    };
+    await adapter.createMemories([{ memory, tableName: "memories" }]);
+
+    await expect(
+      adapter.getCachedEmbeddings({
+        query_table_name: "memories",
+        query_threshold: 0,
+        query_input: "cached phrase",
+        query_field_name: "body",
+        query_field_sub_name: "text",
+        query_match_count: 10,
+      })
+    ).resolves.toEqual([{ embedding, levenshtein_score: 0 }]);
+  });
+
+  it("excludes memories without a string content subfield", async () => {
+    const embedding = Array.from({ length: 384 }, (_, index) => (index === 1 ? 1 : 0));
+    const missing: Memory = {
+      id: randomUUID() as UUID,
+      agentId,
+      entityId,
+      roomId,
+      content: {},
+      embedding,
+    };
+    const nonString: Memory = {
+      id: randomUUID() as UUID,
+      agentId,
+      entityId,
+      roomId,
+      content: { text: "placeholder" },
+      embedding,
+    };
+    (nonString.content as { text?: unknown }).text = 42;
+    await adapter.createMemories(
+      [missing, nonString].map((memory) => ({ memory, tableName: "memories" }))
+    );
+
+    await expect(
+      adapter.getCachedEmbeddings({
+        query_table_name: "memories",
+        query_threshold: 0,
+        query_input: "",
+        query_field_name: "body",
+        query_field_sub_name: "text",
+        query_match_count: 10,
+      })
+    ).resolves.toEqual([]);
+  });
+});

--- a/plugins/plugin-inmemorydb/cached-embeddings.test.ts
+++ b/plugins/plugin-inmemorydb/cached-embeddings.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Contract for the in-memory adapter's fuzzy embedding cache: it must key off
+ * the same nested `content` subfield the SQL adapter matches on
+ * (`content->>query_field_sub_name`), or a runtime swapping storage backends
+ * silently loses every cache hit. Real adapter over real MemoryStorage.
+ */
 import { randomUUID } from "node:crypto";
 import type { Memory, UUID } from "@elizaos/core";
 import { beforeEach, describe, expect, it } from "vitest";


### PR DESCRIPTION
## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (self-reported); `Anthropic / Claude Fable 5` is proven by Git author/committer metadata on commits `5c8d4c57b1999294d5ab9e97d2ec7cd4e1589f2d` and `96f7c79d8803831967a96ed5cd9a67764a18fa86` (no narrower runtime model identifier is inferred)
<!-- attribution-row:client -->
- Agent tooling: `codex` (self-reported for the OpenAI-assisted work); Git metadata proves the Claude Fable 5 author identity but does not establish a narrower client/runtime, so none is asserted
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Relates to

Closes #19203.

## Summary

`InMemoryDatabaseAdapter.getCachedEmbeddings()` now reads the nested content subfield named by `query_field_sub_name`, matching the SQL adapter contract. Missing or non-string fields are excluded instead of being coerced to an empty string. Table filtering, threshold, ordering, and match-count behavior remain unchanged.

## Scope

- `plugins/plugin-inmemorydb/adapter.ts`
- `plugins/plugin-inmemorydb/cached-embeddings.test.ts`

No SQL, UI, cloud, credentials, or unrelated adapter paths changed.

## Evidence gate

<!-- evidence-head:29cc387c78ec5c27109baa5efbaf1aaaa27f1d4b -->
<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - deterministic in-memory adapter behavior; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - deterministic in-memory adapter behavior; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - deterministic in-memory adapter behavior; no user-facing flow.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - no running service or backend deployment is changed.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs: N/A - no frontend surface is changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no model/provider call is involved.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: red/green on the real adapter over real `MemoryStorage`, in a worktree pinned to historical `origin/develop@a91e1d3` (the exact validation base recorded at review time).

  ```text
  # this PR's test against develop's adapter.ts (RED)
  AssertionError: expected [] to deeply equal [ { embedding: [...], levenshtein_score: 0 } ]
   ❯ cached-embeddings.test.ts:74:5
   Test Files  1 failed (1)
        Tests  2 failed (2)

  # same test with this PR's adapter.ts (GREEN)
   Test Files  1 passed (1)
        Tests  2 passed (2)

  # whole plugin suite on this head
   Test Files  7 passed (7)
        Tests  17 passed (17)
  ```
<!-- evidence-row:ocr-review -->
- [ ] OCR review: N/A - no rendered UI or image artifact.

## Verification

- `bun run --cwd plugins/plugin-inmemorydb test -- cached-embeddings.test.ts` — 2/2 passed.
- `bun run --cwd plugins/plugin-inmemorydb test` — 7 files, 17 tests passed.
- `bun run --cwd plugins/plugin-inmemorydb typecheck` — passed.
- `bun run --cwd plugins/plugin-inmemorydb lint:check` — passed.
- `bun run --cwd plugins/plugin-inmemorydb build` — Node + browser + declarations passed.
- `git diff --check` — passed.
- `bun run --cwd packages/core typecheck` — passed (required generated keyword files).
- `bun run --cwd packages/core build:node` — passed after building `packages/logger` and `packages/cloud/routing`; initial attempt was blocked by absent generated/dependency build artifacts, then rerun passed.

## Maintainer review (@lalalune)

Confirmed deep, not cosmetic. `plugin-sql`'s reference implementation matches on `m.content->>${query_field_sub_name}`; this adapter read the top-level `StoredMemory[query_field_name]`, so `content` stringified to `[object Object]` and every cache lookup missed. The fix is four lines and aligns the two adapters on one contract. Only edit: added the required file header to the new test.

## Known limitations

Branch synchronization: current head `29cc387c78ec5c27109baa5efbaf1aaaa27f1d4b` is rebased onto latest `origin/develop` at `3e88b13c13dc9390410df3476df19eaa5067529`; source changes remain limited to the adapter fix and regression test.

Root `bun run verify` was not run because this bounded change was verified at package level and the full monorepo gate is disproportionate to this adapter-only contract. No live credentials or external services were used.

AI provider/model: OpenAI / gpt-5.6-sol (self-reported); Anthropic / Claude Fable 5 is proven by Git author/committer metadata for the two follow-up commits above, with no narrower runtime model inferred
Client / agent tooling: Codex for the OpenAI-assisted work (self-reported); no narrower client is inferred for the Claude-authored commits
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
Compute receipt: 34122029 project-attributed tokens (bounded; device-signed, locally reported)
— [inmemorydb-cached-embeddings]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZYFK12GC2FDQHGWJ3G8WCHH","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T21:13:58.608Z","completed_at":"2026-08-13T21:19:18.478Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":983502,"output_tokens":42335,"cache_creation_tokens":0,"cache_read_tokens":33096192,"total_tokens":34122029,"cost_micro_usd":"22735656","session_count":7},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"71TlWbVippDK7WOysd5gv6UfElNSIYuGMI2Pk0szCfleH4nJ3-22TY3fF4DosuNR8Awlj_N2LCWwQkjsUxE_Cw"}} -->