### PR TITLE
fix(google): require complete compound grants

### DIFF
--- a/plugins/plugin-google-workspace/src/connector-account-provider.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.ts
@@ -218,6 +218,7 @@ function normalizeGrantedCapabilities(scopes: readonly string[]): {
   ignoredScopes: string[];
 } {
   const capabilities = new Set<GoogleCapability>();
+  const grantedScopeSet = new Set<string>();
   const ignoredScopes: string[] = [];
   const identityScopes = new Set(GOOGLE_IDENTITY_SCOPES.map((scope) => scope.toLowerCase()));
 
@@ -231,13 +232,24 @@ function normalizeGrantedCapabilities(scopes: readonly string[]): {
       capabilities.add(normalized);
       continue;
     }
-    const matched = matchCapabilityFromScope(normalized);
-    if (matched) {
-      capabilities.add(matched);
+    const normalizedScope = normalized.toLowerCase();
+    if (identityScopes.has(normalizedScope)) {
       continue;
     }
-    if (!identityScopes.has(normalized.toLowerCase())) {
-      ignoredScopes.push(normalized);
+    if (matchCapabilityFromScope(normalized)) {
+      grantedScopeSet.add(normalizedScope);
+      continue;
+    }
+    ignoredScopes.push(normalized);
+  }
+
+  for (const capability of GOOGLE_CAPABILITIES) {
+    if (capabilities.has(capability)) continue;
+    const capabilityScopes = scopesForGoogleCapabilities([capability], {
+      includeIdentityScopes: false,
+    });
+    if (capabilityScopes.every((scope) => grantedScopeSet.has(scope.toLowerCase()))) {
+      capabilities.add(capability);
     }
   }
 

--- a/plugins/plugin-google-workspace/src/index.test.ts
+++ b/plugins/plugin-google-workspace/src/index.test.ts
@@ -858,6 +858,114 @@ describe("google plugin", () => {
     ).toContain(providerAddedScope);
   });
 
+  it("does not record or re-request a compound capability from a partial provider grant", async () => {
+    const vault = new Map<string, string>();
+    const runtime = {
+      agentId: "agent-1",
+      getSetting: (key: string) =>
+        ({
+          GOOGLE_CLIENT_ID: "google-client",
+          GOOGLE_CLIENT_SECRET: "google-secret",
+          GOOGLE_REDIRECT_URI: "http://localhost:31437/api/connectors/google/oauth/callback",
+        })[key],
+      getService: (serviceType: string) =>
+        serviceType === "vault"
+          ? {
+              set: async (key: string, value: string) => {
+                vault.set(key, value);
+              },
+            }
+          : null,
+    } as never;
+    const manager = createOAuthCallbackManager(
+      "google",
+      "acct_google_partial_compound",
+      vi.fn(async () => undefined)
+    );
+    const provider = createGoogleConnectorAccountProvider(runtime);
+    const returnedScopes = [
+      GOOGLE_OAUTH_SCOPES.profile.openid,
+      GOOGLE_OAUTH_SCOPES.profile.email,
+      GOOGLE_OAUTH_SCOPES.gmail.read,
+      GOOGLE_OAUTH_SCOPES.gmail.manage,
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request) => {
+        const href = String(url);
+        if (href.includes("oauth2.googleapis.com/token")) {
+          return new Response(
+            JSON.stringify({
+              access_token: "google-access-token",
+              refresh_token: "google-refresh-token",
+              expires_in: 3600,
+              scope: returnedScopes.join(" "),
+              token_type: "Bearer",
+              id_token: createUnsignedJwt({
+                sub: "google-subject",
+                email: "ada@example.com",
+              }),
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        throw new Error(`Unexpected fetch ${href}`);
+      })
+    );
+
+    const result = await provider.completeOAuth?.(
+      {
+        provider: "google",
+        code: "oauth-code",
+        query: {},
+        flow: {
+          id: "flow-partial-compound",
+          provider: "google",
+          state: "state-partial-compound",
+          status: "pending",
+          codeVerifier: "verifier",
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          metadata: {
+            requestedCapabilities: ["gmail.read", "gmail.manage"],
+            requestedScopes: scopesForGoogleCapabilities(["gmail.read", "gmail.manage"]),
+          },
+        },
+      },
+      manager as never
+    );
+
+    const account = result?.account as ConnectorAccount;
+    const metadata = account.metadata as Record<string, unknown>;
+    expect(metadata.grantedCapabilities).toEqual(["gmail.read"]);
+    expect(metadata.grantedCapabilities).not.toContain("gmail.manage");
+    expect(metadata.grantedScopes).toEqual(returnedScopes);
+
+    const reauthResult = await provider.startOAuth?.(
+      {
+        provider: "google",
+        accountId: account.id,
+        flow: {
+          id: "flow-partial-compound-reauth",
+          provider: "google",
+          state: "state-partial-compound-reauth",
+          status: "pending",
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      },
+      {
+        getAccount: vi.fn(async () => account),
+      } as never
+    );
+    const requestedScopes = new Set(
+      new URL(reauthResult?.authUrl ?? "").searchParams.get("scope")?.split(" ") ?? []
+    );
+    expect(requestedScopes).toContain(GOOGLE_OAUTH_SCOPES.gmail.read);
+    expect(requestedScopes).not.toContain(GOOGLE_OAUTH_SCOPES.gmail.manage);
+    expect(requestedScopes).not.toContain(GOOGLE_OAUTH_SCOPES.gmail.settings);
+  });
+
   it("fails an OAuth callback that grants identity but no connector capability", async () => {
     const runtime = {
       agentId: "agent-1",


### PR DESCRIPTION
﻿# Relates to

Fixes #19158.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@afdaf57f46ff77b79c02c6d9b34d22608d07c3bd:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. This changes only Google Workspace OAuth grant normalization and adds deterministic tests. The main behavior change is stricter: a compound capability is not stored unless every required Google scope is present.

# Background

## What does this PR do?

Google can return a subset of requested scopes when a user denies part of a compound permission. Before this PR, any one scope belonging to `gmail.manage` could mark the whole `gmail.manage` capability as granted. That could make a later omitted-scope re-auth expand back to both `gmail.modify` and `gmail.settings.basic`, re-requesting a scope the user did not grant.

This PR treats provider-returned raw scopes as one complete grant set. Single-scope capabilities still work normally. Compound capabilities, including `gmail.manage`, are recorded only when all required scopes are present.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Start with `plugins/plugin-google-workspace/src/connector-account-provider.ts`, then the regression in `plugins/plugin-google-workspace/src/index.test.ts` named `does not record or re-request a compound capability from a partial provider grant`.

## Detailed testing steps

Passed on PR head `afdaf57f46ff77b79c02c6d9b34d22608d07c3bd`:

```bash
bun run --cwd packages/core build
bun run --cwd plugins/plugin-google-workspace test -- src/index.test.ts
bun run --cwd plugins/plugin-google-workspace typecheck
bun run --cwd plugins/plugin-google-workspace lint:check
bun run --cwd plugins/plugin-google-workspace test
bun run --cwd plugins/plugin-google-workspace build
git diff --check
```

Observed results:

- Focused Google Workspace test file: 1 file passed, 33 tests passed.
- Full Google Workspace plugin suite: 15 files passed, 155 tests passed.
- Google Workspace typecheck: passed.
- Google Workspace lint: checked 39 files, no fixes applied.
- Google Workspace build: finished successfully.
- Whitespace check: passed.

`bun install` was also run after sync and exited 0, but printed many Windows symlink `EPERM` warnings. `bun run verify` was attempted and failed outside this PR; details are in **Known gaps / failures**.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:95d9f14c10703e52a0a50bc9aa2af2f149a9a9c1 -->

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changed; this PR only touches Google Workspace OAuth normalization and tests.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface changed; this PR only touches Google Workspace OAuth normalization and tests.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no rendered UI or browser flow changed in this PR.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no deployed backend or live Google OAuth credential was used; the callback and re-auth behavior is covered by deterministic provider-boundary tests with stubbed Google token exchange.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/prompt/model behavior changed; this is connector OAuth grant normalization.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no database rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, or external artifacts are produced by this change.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface changed.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/prompt/model behavior changed.

## Backend + frontend logs

N/A - no deployed backend or frontend path changed. The deterministic test exercises the real `createGoogleConnectorAccountProvider(...).completeOAuth` and `startOAuth` boundaries with a stubbed Google token response, proving that a partial `gmail.manage` grant stores only `gmail.read` and does not re-request the missing `gmail.settings.basic` scope on omitted-scope re-auth.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changed.

### Before

N/A - no rendered UI surface changed.

### After

N/A - no rendered UI surface changed.

### Walkthrough video

N/A - no rendered UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice changes.

## Known gaps / failures

- `bun install` exited 0 after sync, but this Windows host printed many workspace symlink warnings such as `EPERM: operation not permitted, symlink ...`. The package-local Google Workspace checks above still passed after install.
- This host is using `bun 1.3.13` and `node v26.3.0`; the repository currently pins Bun `1.3.14` and Node `24.15.0`.
- `bun run verify` was attempted and failed outside this PR at `@elizaos/logger#lint:check`. The failing process was `node packages/scripts/run-biome-typescript.mjs src check`, which threw `Error: spawnSync bun.exe ENOENT`. This is an environment/toolchain failure in `packages/logger`, not a failure in the touched `plugins/plugin-google-workspace` files.
- Live Google OAuth evidence was not captured because no live OAuth credential/staging account was used for this scoped regression. The linked issue asks for deterministic prevention of partial compound grant re-expansion, which is covered at the provider callback and re-auth boundary.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@afdaf57f46ff77b79c02c6d9b34d22608d07c3bd:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [OxBenji-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@afdaf57f46ff77b79c02c6d9b34d22608d07c3bd:packages/skills/skills/contribute-to-eliza"} -->


