### PR TITLE
fix(cloud): align domain contracts and isolate pairing aliases

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-host-contract.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-host-contract.test.ts
@@ -16,6 +16,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { ELIZA_DOMAIN_CONTRACTS, LEGACY_ELIZA_DOMAIN_CONTRACTS } from "@elizaos/shared/elizacloud";
 import { runWithCloudBindingsAsync } from "../../runtime/cloud-bindings";
 import {
   type OnboardingSession,
@@ -95,11 +96,7 @@ async function resolveOnboardingOrigins(
 }
 
 /**
- * `appOrigin` is the Eliza *app* host, never the homepage apex: production pins
- * cloud.eliza.app while its public homepage is eliza.app, and staging's peer
- * of that app host is cloud-staging.eliza.app (the `eliza-app` Pages domain,
- * following the same environment-peer rule as STAGING_ELIZA_APP_ORIGIN in
- * packages/ui/src/utils/cloud-agent-base.ts).
+ * `appOrigin` is the canonical Cloud app host, never the marketing origin.
  *
  * `loginOrigin` is the messaging-continuation Connect CTA target. It now equals
  * the Cloud *app* host: the CTA points at the app's authenticated
@@ -116,22 +113,31 @@ const ONBOARDING_HOST_CONTRACT: ReadonlyArray<{
 }> = [
   {
     section: "vars",
-    loginOrigin: "https://cloud.eliza.app",
-    appOrigin: "https://cloud.eliza.app",
+    loginOrigin: ELIZA_DOMAIN_CONTRACTS.production.cloudAppOrigin,
+    appOrigin: ELIZA_DOMAIN_CONTRACTS.production.cloudAppOrigin,
   },
   {
     section: "env.production.vars",
-    loginOrigin: "https://cloud.eliza.app",
-    appOrigin: "https://cloud.eliza.app",
+    loginOrigin: ELIZA_DOMAIN_CONTRACTS.production.cloudAppOrigin,
+    appOrigin: ELIZA_DOMAIN_CONTRACTS.production.cloudAppOrigin,
   },
   {
     section: "env.staging.vars",
-    loginOrigin: "https://cloud-staging.eliza.app",
-    appOrigin: "https://cloud-staging.eliza.app",
+    loginOrigin: ELIZA_DOMAIN_CONTRACTS.staging.cloudAppOrigin,
+    appOrigin: ELIZA_DOMAIN_CONTRACTS.staging.cloudAppOrigin,
   },
 ];
 
-const PRODUCTION_APP_ORIGINS = ["https://cloud.eliza.app", "https://eliza.app"];
+const PRODUCTION_APP_ORIGINS = [
+  ELIZA_DOMAIN_CONTRACTS.production.cloudAppOrigin,
+  ELIZA_DOMAIN_CONTRACTS.production.marketingOrigin,
+  ...LEGACY_ELIZA_DOMAIN_CONTRACTS.production.cloudAppHostnames.map(
+    (hostname) => `https://${hostname}`,
+  ),
+  ...LEGACY_ELIZA_DOMAIN_CONTRACTS.production.marketingHostnames.map(
+    (hostname) => `https://${hostname}`,
+  ),
+];
 
 describe("onboarding host deployment contract", () => {
   test.each(ONBOARDING_HOST_CONTRACT)(
@@ -150,8 +156,8 @@ describe("onboarding host deployment contract", () => {
       // The Steward-login handoff lives on the Cloud app, so login and app
       // origins coincide by design; neither is the homepage (eliza.app).
       expect(resolved.loginOrigin).toBe(appOrigin);
-      expect(resolved.loginOrigin).not.toBe("https://eliza.app");
-      expect(resolved.loginOrigin).not.toBe("https://staging.eliza.app");
+      expect(resolved.loginOrigin).not.toBe(ELIZA_DOMAIN_CONTRACTS.production.marketingOrigin);
+      expect(resolved.loginOrigin).not.toBe(ELIZA_DOMAIN_CONTRACTS.staging.marketingOrigin);
     },
   );
 
@@ -167,10 +173,11 @@ describe("onboarding host deployment contract", () => {
 
   test("the staging section pins the app origin instead of inheriting one", () => {
     const staging = environmentBindings("env.staging.vars");
-    // Resolution alone cannot tell a pin from a fallback: NEXT_PUBLIC_APP_URL
-    // would answer for ELIZA_ONBOARDING_APP_URL and quietly hand back the
-    // console apex the moment the explicit key is dropped.
-    expect(staging.ELIZA_ONBOARDING_APP_URL).toBe("https://cloud-staging.eliza.app");
-    expect(staging.NEXT_PUBLIC_APP_URL).toBe("https://cloud-staging.eliza.app");
+    // Both bindings intentionally resolve to the Cloud app now, so value
+    // equality cannot prove that the onboarding-specific deployment key is
+    // present. Keep the own-property assertion as the pinning contract.
+    expect(Object.hasOwn(staging, "ELIZA_ONBOARDING_APP_URL")).toBe(true);
+    expect(staging.ELIZA_ONBOARDING_APP_URL).toBe(ELIZA_DOMAIN_CONTRACTS.staging.cloudAppOrigin);
+    expect(staging.NEXT_PUBLIC_APP_URL).toBe(ELIZA_DOMAIN_CONTRACTS.staging.cloudAppOrigin);
   });
 });

--- a/packages/cloud/shared/src/lib/services/pairing-token-domains.ts
+++ b/packages/cloud/shared/src/lib/services/pairing-token-domains.ts
@@ -1,27 +1,30 @@
-// Domain alias groups — all domains in a group resolve to the same agent
-// container. Each agent's public URL may be rewritten between any two
-// domains in the same group (e.g. the dashboard generates an
-// `<uuid>.cloud.eliza.app` link but the agent was originally provisioned with
-// an `<uuid>.waifu.fun` Origin), so token validation tries every alias.
-//
-// `.cloud.eliza.app` is canonical; `.elizacloud.ai`, `.waifu.fun`, and
-// `.eliza.ai` are retained only while old pairing records expire
-// once no DB rows reference them.
-//
-// Intentionally NOT in this list:
-//   - `.shad0w.xyz` — personal handle from the 0xSolace stack, never
-//     served real production sandbox URLs
-// Retired domains are part of the zero-compatibility-domain goal; old bookmarks
-// under them will fail Origin validation, which is the intended outcome.
-//
-// Pure data + pure function — extracted from `pairing-token.ts` so the
-// alias logic stays unit-testable without pulling the Postgres repository
-// import chain.
+/**
+ * Resolves equivalent managed-agent origins for pairing-token validation.
+ * Production and staging aliases are separate trust groups; when compatibility
+ * suffixes overlap, the longest matching suffix owns the origin so a staging
+ * agent can never be rewritten onto a production host.
+ *
+ * `.cloud.eliza.app` is canonical in production. The remaining production
+ * suffixes are retained only while old pairing records expire. Personal or
+ * otherwise retired domains are intentionally excluded and fail validation.
+ */
+
+import { ELIZA_DOMAIN_CONTRACTS, LEGACY_ELIZA_DOMAIN_CONTRACTS } from "@elizaos/shared/elizacloud";
 
 export const DOMAIN_ALIAS_GROUPS: readonly (readonly string[])[] = [
-  [".cloud.eliza.app", ".elizacloud.ai", ".waifu.fun", ".eliza.ai"],
-  [".cloud-staging.eliza.app", ".staging.elizacloud.ai"],
+  [
+    ELIZA_DOMAIN_CONTRACTS.production.dedicatedAgentHostnameSuffix,
+    LEGACY_ELIZA_DOMAIN_CONTRACTS.production.dedicatedAgentHostnameSuffix,
+    ".waifu.fun",
+    ".eliza.ai",
+  ],
+  [
+    ELIZA_DOMAIN_CONTRACTS.staging.dedicatedAgentHostnameSuffix,
+    LEGACY_ELIZA_DOMAIN_CONTRACTS.staging.dedicatedAgentHostnameSuffix,
+  ],
 ];
+
+const MANAGED_AGENT_LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 
 /**
  * Given an origin like https://uuid.waifu.fun, return every other origin
@@ -34,20 +37,36 @@ export function getAlternateDomainOrigins(origin: string): string[] {
   try {
     url = new URL(origin);
   } catch {
+    // error-policy:J3 Invalid origins are explicit non-matches.
     return [];
   }
+  let bestMatch: { group: readonly string[]; suffix: string } | undefined;
+
   for (const group of DOMAIN_ALIAS_GROUPS) {
-    const matched = group.find((suffix) => url.hostname.endsWith(suffix));
-    if (!matched) continue;
-    const prefix = url.hostname.slice(0, -matched.length);
-    const alternates: string[] = [];
-    for (const candidate of group) {
-      if (candidate === matched) continue;
-      const altUrl = new URL(url);
-      altUrl.hostname = prefix + candidate;
-      alternates.push(altUrl.origin);
+    for (const suffix of group) {
+      if (
+        url.hostname.endsWith(suffix) &&
+        (!bestMatch || suffix.length > bestMatch.suffix.length)
+      ) {
+        bestMatch = { group, suffix };
+      }
     }
-    return alternates;
   }
-  return [];
+
+  if (!bestMatch) return [];
+
+  const { group, suffix } = bestMatch;
+  const prefix = url.hostname.slice(0, -suffix.length);
+  // Managed-agent hosts are flat: `<agent-id><suffix>`. Refusing a nested
+  // prefix prevents labels such as `staging` from being smuggled through a
+  // broader production suffix and crossing the environment trust boundary.
+  if (!MANAGED_AGENT_LABEL.test(prefix)) return [];
+
+  return group
+    .filter((candidate) => candidate !== suffix)
+    .map((candidate) => {
+      const alternate = new URL(url);
+      alternate.hostname = prefix + candidate;
+      return alternate.origin;
+    });
 }

--- a/packages/cloud/shared/src/lib/services/pairing-token.browser.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/pairing-token.browser.integration.test.ts
@@ -116,6 +116,29 @@ describe("Worker-owned browser pairing token claim", () => {
     });
   });
 
+  test("keeps an overlapping staging alias out of the production trust group", async () => {
+    const mintedOrigin = `https://${AGENT_ID}.staging.elizacloud.ai`;
+    const token = await mint(mintedOrigin);
+
+    await expect(
+      pairingTokenService.claimBrowserToken(token, {
+        agentId: AGENT_ID,
+        expectedOrigin: `https://${AGENT_ID}.staging.cloud.eliza.app`,
+      }),
+    ).resolves.toEqual({ status: "invalid" });
+    expect(await readOnlyRow()).toMatchObject({ used_at: null });
+
+    await expect(
+      pairingTokenService.claimBrowserToken(token, {
+        agentId: AGENT_ID,
+        expectedOrigin: `https://${AGENT_ID}.cloud-staging.eliza.app`,
+      }),
+    ).resolves.toMatchObject({
+      status: "claimed",
+      pairingToken: { expectedOrigin: mintedOrigin },
+    });
+  });
+
   test("rejects the wrong URL-selected agent or origin without consuming the token", async () => {
     const token = await mint();
     const mismatches = [

--- a/packages/cloud/shared/src/lib/services/pairing-token.test.ts
+++ b/packages/cloud/shared/src/lib/services/pairing-token.test.ts
@@ -4,28 +4,28 @@
 import { describe, expect, it } from "bun:test";
 import { DOMAIN_ALIAS_GROUPS, getAlternateDomainOrigins } from "./pairing-token-domains";
 
-const [CANONICAL_GROUP] = DOMAIN_ALIAS_GROUPS;
+const [PRODUCTION_ALIAS_GROUP, STAGING_ALIAS_GROUP] = DOMAIN_ALIAS_GROUPS;
 
-/** Returns the canonical sibling hostnames for a matched alias suffix. */
-function aliasHostnames(prefix: string, matched: string): string[] {
-  return CANONICAL_GROUP.filter((suffix) => suffix !== matched)
+/** Returns the sibling hostnames for a matched alias suffix. */
+function aliasHostnames(group: readonly string[], prefix: string, matched: string): string[] {
+  return group
+    .filter((suffix) => suffix !== matched)
     .map((suffix) => `${prefix}${suffix}`)
     .sort();
 }
 
 describe("getAlternateDomainOrigins", () => {
   it("returns every other suffix in the same alias group", () => {
-    // The canonical group is the first entry. Verify each domain produces
-    // (group.length - 1) alternates — the matched suffix is excluded.
-    const inputs = CANONICAL_GROUP.map((suffix) => `https://abc${suffix}`);
+    for (const group of DOMAIN_ALIAS_GROUPS) {
+      for (const suffix of group) {
+        const origin = `https://abc${suffix}`;
+        const alternates = getAlternateDomainOrigins(origin);
 
-    for (const origin of inputs) {
-      const alts = getAlternateDomainOrigins(origin);
-      expect(alts).toHaveLength(CANONICAL_GROUP.length - 1);
-      expect(alts).not.toContain(origin);
-      const hostnames = alts.map((url) => new URL(url).hostname);
-      for (const hostname of hostnames) {
-        expect(hostname.startsWith("abc.")).toBe(true);
+        expect(alternates).toHaveLength(group.length - 1);
+        expect(alternates).not.toContain(origin);
+        expect(alternates.map((alternate) => new URL(alternate).hostname).sort()).toEqual(
+          aliasHostnames(group, "abc", suffix),
+        );
       }
     }
   });
@@ -35,7 +35,18 @@ describe("getAlternateDomainOrigins", () => {
       "https://9d77d8b5-1d63-4b4c-9bd1-ec1b5deb4dc8.waifu.fun",
     );
     const hostnames = alts.map((u) => new URL(u).hostname).sort();
-    expect(hostnames).toEqual(aliasHostnames("9d77d8b5-1d63-4b4c-9bd1-ec1b5deb4dc8", ".waifu.fun"));
+    expect(hostnames).toEqual(
+      aliasHostnames(PRODUCTION_ALIAS_GROUP, "9d77d8b5-1d63-4b4c-9bd1-ec1b5deb4dc8", ".waifu.fun"),
+    );
+  });
+
+  it("uses the most specific suffix when staging and production aliases overlap", () => {
+    const origin = "https://agent-7.staging.elizacloud.ai";
+
+    expect(getAlternateDomainOrigins(origin)).toEqual(["https://agent-7.cloud-staging.eliza.app"]);
+    expect(getAlternateDomainOrigins(origin)).not.toContain(
+      "https://agent-7.staging.cloud.eliza.app",
+    );
   });
 
   it("rejects retired 0xSolace-era domains (example.ai, shad0w.xyz)", () => {
@@ -50,21 +61,22 @@ describe("getAlternateDomainOrigins", () => {
     // `URL.origin` keeps non-default ports — the alternate origins must
     // round-trip them so a sandbox served on :8443 still matches its alias.
     const alts = getAlternateDomainOrigins("https://abc.waifu.fun:8443");
-    expect(alts).toHaveLength(CANONICAL_GROUP.length - 1);
+    expect(alts).toHaveLength(PRODUCTION_ALIAS_GROUP.length - 1);
     for (const alt of alts) {
       const url = new URL(alt);
       expect(url.port).toBe("8443");
     }
   });
 
-  it("rewrites only the suffix when the prefix is itself a multi-level subdomain", () => {
-    // Production sandbox URLs are flat (`<uuid>.waifu.fun`), but the
-    // suffix-strip algorithm should treat anything before the matched
-    // suffix as opaque prefix — so `a.b.c.waifu.fun` aliases to
-    // `a.b.c.eliza.ai` without touching the inner labels.
-    const alts = getAlternateDomainOrigins("https://a.b.c.waifu.fun");
-    const hostnames = alts.map((u) => new URL(u).hostname).sort();
-    expect(hostnames).toEqual(aliasHostnames("a.b.c", ".waifu.fun"));
+  it("rejects nested prefixes that are not flat managed-agent hosts", () => {
+    expect(getAlternateDomainOrigins("https://a.b.c.waifu.fun")).toEqual([]);
+    expect(getAlternateDomainOrigins("https://agent-7.staging.cloud.eliza.app")).toEqual([]);
+  });
+
+  it("rejects prefixes that are not valid managed-agent DNS labels", () => {
+    expect(getAlternateDomainOrigins("https://-agent.waifu.fun")).toEqual([]);
+    expect(getAlternateDomainOrigins("https://agent-.waifu.fun")).toEqual([]);
+    expect(getAlternateDomainOrigins(`https://${"a".repeat(64)}.waifu.fun`)).toEqual([]);
   });
 
   it("returns an empty array when no aliased suffix matches", () => {
@@ -84,7 +96,7 @@ describe("getAlternateDomainOrigins", () => {
     // so an Origin header arriving as `https://ABC.WAIFU.FUN` still aliases.
     const alts = getAlternateDomainOrigins("https://ABC.WAIFU.FUN");
     const hostnames = alts.map((u) => new URL(u).hostname).sort();
-    expect(hostnames).toEqual(aliasHostnames("abc", ".waifu.fun"));
+    expect(hostnames).toEqual(aliasHostnames(PRODUCTION_ALIAS_GROUP, "abc", ".waifu.fun"));
   });
 
   it("matches the suffix on the right boundary (no partial-domain false positive)", () => {
@@ -97,8 +109,11 @@ describe("getAlternateDomainOrigins", () => {
 
 describe("DOMAIN_ALIAS_GROUPS", () => {
   it("retains every canonical and compatibility suffix", () => {
-    expect(CANONICAL_GROUP).toEqual(
+    expect(PRODUCTION_ALIAS_GROUP).toEqual(
       expect.arrayContaining([".cloud.eliza.app", ".elizacloud.ai", ".waifu.fun", ".eliza.ai"]),
+    );
+    expect(STAGING_ALIAS_GROUP).toEqual(
+      expect.arrayContaining([".cloud-staging.eliza.app", ".staging.elizacloud.ai"]),
     );
   });
 

--- a/packages/cloud/shared/src/lib/services/pairing-token.ts
+++ b/packages/cloud/shared/src/lib/services/pairing-token.ts
@@ -151,10 +151,10 @@ class PairingTokenService {
     // Try the exact origin first
     let row = await agentPairingTokensRepository.consumeValidToken(tokenHash, normalizedOrigin);
 
-    // If no match, try each alternate domain in the same alias group. The
-    // dashboard may rewrite the agent URL between any two aliased domains
-    // (waifu.fun ↔ eliza.ai ↔ elizacloud.ai), and we cannot predict which
-    // one is stored as `expected_origin` for a given token row.
+    // If no match, try each alternate domain in the same environment-scoped
+    // alias group. The dashboard may rewrite the agent URL between canonical
+    // and compatibility hosts, and we cannot predict which one is stored as
+    // `expected_origin` for a given token row.
     if (!row) {
       for (const alternateOrigin of getAlternateDomainOrigins(normalizedOrigin)) {
         row = await agentPairingTokensRepository.consumeValidToken(tokenHash, alternateOrigin);
@@ -209,8 +209,8 @@ class PairingTokenService {
    * Claim the explicit native exchange. Unlike the browser relay, native
    * WebViews may omit Origin, so the Cloud bearer identity and the origin
    * carried by the authenticated mint response are part of the atomic claim.
-   * This path intentionally uses the exact minted origin; browser-only domain
-   * alias compatibility remains confined to validateToken().
+   * This path intentionally uses the exact minted origin; domain-alias
+   * compatibility remains confined to the browser validation and claim paths.
    */
   async claimAuthenticatedNativeToken(
     token: string,

--- a/packages/cloud/shared/src/lib/steward-url.test.ts
+++ b/packages/cloud/shared/src/lib/steward-url.test.ts
@@ -1,5 +1,6 @@
-// Exercises steward url behavior with deterministic cloud-shared lib fixtures.
+/** Exercises Steward URL resolution with deterministic browser-host fixtures. */
 import { afterEach, describe, expect, test } from "bun:test";
+import { ELIZA_DOMAIN_CONTRACTS } from "@elizaos/shared/elizacloud";
 import { resolveBrowserStewardApiUrl } from "./steward-url";
 
 const originalLocation = globalThis.location;
@@ -20,15 +21,17 @@ afterEach(() => {
 
 describe("resolveBrowserStewardApiUrl", () => {
   test("routes staging cloud host to the staging API worker", () => {
-    setLocation("cloud-staging.eliza.app");
+    const contract = ELIZA_DOMAIN_CONTRACTS.staging;
+    setLocation(new URL(contract.cloudAppOrigin).hostname);
 
-    expect(resolveBrowserStewardApiUrl()).toBe("https://api-staging.eliza.app/steward");
+    expect(resolveBrowserStewardApiUrl()).toBe(`${contract.cloudApiOrigin}/steward`);
   });
 
   test("routes production cloud host to the production API worker", () => {
-    setLocation("cloud.eliza.app");
+    const contract = ELIZA_DOMAIN_CONTRACTS.production;
+    setLocation(new URL(contract.cloudAppOrigin).hostname);
 
-    expect(resolveBrowserStewardApiUrl()).toBe("https://api.eliza.app/steward");
+    expect(resolveBrowserStewardApiUrl()).toBe(`${contract.cloudApiOrigin}/steward`);
   });
 
   test("falls back to same-origin steward mount for unknown hosts", () => {


### PR DESCRIPTION
# Relates to

Consolidates the post-domain-migration Cloud repairs from #19202 into this canonical PR and closes the environment-alias gap identified during review.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased directly on `origin/develop@acb1b6cdc6113eb8a5437eb6c8568201cb807f79` with zero conflicts.
- [x] The original contributor commit is patch-identical after replay.
- [x] Focused routing, domain-contract, browser-claim, and native-claim tests pass on the exact head.
- [x] Both owning packages pass typecheck and lint; Cloud routing also passes build.
- [x] The environment boundary is exercised through the real PGlite token repository and atomic claim path.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`, `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `codex`, `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@acb1b6cdc6113eb8a5437eb6c8568201cb807f79:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Summary

The original contribution correctly updates three stale expectations after the `eliza.app` domain consolidation:

1. Cloud routing now expects the canonical `https://api.eliza.app/api/v1` fallback.
2. The compatibility envelope expects managed-agent UI URLs under `.cloud.eliza.app`.
3. Pairing-token tests derive their expectations from the complete alias contract instead of hardcoded counts.

Review found that the staging compatibility suffix is more specific than the legacy production suffix. The prior first-match alias search could therefore select the wrong environment group. This revision fixes the runtime boundary as well as the tests:

- canonical and legacy suffixes are derived from `@elizaos/shared/elizacloud`, leaving one authoritative domain contract;
- the most-specific matching suffix selects the environment-scoped alias group;
- only a flat, valid managed-agent DNS label may be rewritten;
- browser and native PGlite integration tests prove that a rejected browser claim does not consume the token and that the correct staging alias still claims it exactly once;
- remaining Cloud-shared domain expectations now reference the shared contract rather than repeating retired literals.

# Scope and risk

Nine files change across `packages/cloud/routing` and `packages/cloud/shared`: two stale contract expectations, five domain-oriented tests, and the pairing alias resolver/comment contract.

The runtime change is deliberately narrow but authentication-sensitive. Exact-origin claims are unchanged. Alias compatibility remains browser-only, preserves the URL scheme and port, stays bound to the same agent ID, and can rewrite only within one environment group.

# Testing

Exact head `cdbc096237c465fe0972227414254238793767b2`, pinned Bun 1.3.14 / Node 24.15.0:

```text
focused routing + Cloud-shared contract suite             PASS (111 tests, 1,029 assertions)
pairing unit + browser/native PGlite paths                 PASS (29 tests; included above)
bun run --cwd packages/cloud/shared typecheck             PASS
bun run --cwd packages/cloud/shared lint:check             PASS (1,863 files)
bun run --cwd packages/cloud/routing typecheck            PASS
bun run --cwd packages/cloud/routing lint:check            PASS (5 files)
bun run --cwd packages/cloud/routing build                PASS
Biome check <nine changed files>                          PASS
bun run check:agents-claude                               PASS (153 guide pairs)
git diff --check                                           PASS
```

The repository `bun run test:cloud` sweep reached the Cloud API batch and was blocked by the pre-existing `shared-agent-messages-stream.test.ts` mock-state defect: one test observes two fetches instead of one, and the following test times out on the leaked in-flight state. Running that file alone reproduces the same first failure on both this PR and pinned `develop@1fb83c8c3670a1071f39891f2e4a9a439a87c9cd`; this PR does not change that suite or its runtime path. Hosted exact-head checks remain authoritative for the rest of the lane.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:919e4c8c5e47dab64e4f62807c9a81ecbd54049f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] Exact Bun/PGlite test transcript above exercises the real repository and claim boundary with 111 passing tests.

<details><summary>Exact-head backend test transcript</summary>

```text
focused routing + Cloud-shared contract suite  PASS (111 tests, 1,029 assertions)
pairing browser PGlite integration             PASS (9 tests, including overlapping staging alias)
pairing native PGlite integration              PASS (7 tests, including atomic single-use concurrency)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Real PGlite token rows prove rejected aliases remain unused and the correct staging alias performs one atomic claim.

<details><summary>Observed PGlite token lifecycle</summary>

```text
minted row expected_origin = https://<agent>.staging.elizacloud.ai, used_at = null
cross-environment alias claim returned { status: "invalid" }, used_at remained null
canonical staging alias claim returned { status: "claimed" } and consumed the row exactly once
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Known gaps / merge gate

This is ready for independent exact-head review. Do not merge until all required hosted checks are terminal green and an independent reviewer approves this repaired head.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@acb1b6cdc6113eb8a5437eb6c8568201cb807f79:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@acb1b6cdc6113eb8a5437eb6c8568201cb807f79:packages/skills/skills/contribute-to-eliza"} -->
