### PR TITLE
feat(registry): add @suedeai/plugin-suede community entry

### DIFF
--- a/packages/registry/entries/third-party/suedeai__plugin-suede.json
+++ b/packages/registry/entries/third-party/suedeai__plugin-suede.json
@@ -1,0 +1,9 @@
+{
+  "package": "@suedeai/plugin-suede",
+  "repository": "github:JasonColapietro/elizaos-plugin-suede",
+  "kind": "plugin",
+  "description": "Music, video, and image generation from Suede AI, paid for per call by the agent's own wallet over x402 — USDC on Base, no service API key. Registers GENERATE_MUSIC_SUEDE, GENERATE_VIDEO_SUEDE, and GENERATE_IMAGE_SUEDE, and exports a SuedeClient that answers the 402 challenge by signing an EIP-3009 TransferWithAuthorization with viem.",
+  "homepage": "https://suedeai.ai",
+  "version": "1.0.0",
+  "tags": ["x402", "agent-commerce", "music-generation", "video-generation", "image-generation", "base", "usdc", "programmable-ip"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -487,6 +487,54 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@suedeai/plugin-suede": {
+      "git": {
+        "repo": "JasonColapietro/elizaos-plugin-suede",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@suedeai/plugin-suede",
+        "v0": null,
+        "v1": null,
+        "v2": "1.0.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Music, video, and image generation from Suede AI, paid for per call by the agent's own wallet over x402 — USDC on Base, no service API key. Registers GENERATE_MUSIC_SUEDE, GENERATE_VIDEO_SUEDE, and GENERATE_IMAGE_SUEDE, and exports a SuedeClient that answers the 402 challenge by signing an EIP-3009 TransferWithAuthorization with viem.",
+      "homepage": "https://suedeai.ai",
+      "topics": [
+        "x402",
+        "agent-commerce",
+        "music-generation",
+        "video-generation",
+        "image-generation",
+        "base",
+        "usdc",
+        "programmable-ip"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@thecolony/elizaos-plugin": {
       "git": {
         "repo": "TheColonyCC/elizaos-plugin",


### PR DESCRIPTION
Lists [`@suedeai/plugin-suede`](https://www.npmjs.com/package/@suedeai/plugin-suede) as a third-party plugin, following `packages/registry/README.md` → "Adding a third-party plugin".

This is the follow-up to #8016, which added a `plugins/plugin-suede/` directory to the monorepo and was closed. That approach was wrong — community plugins belong in the registry, not in-tree — so this PR drops the in-tree wrapper entirely and adds the entry instead. The two files here are the only diff.

**What it does.** Music, video, and image generation from [Suede AI](https://suedeai.ai), paid for per call by the agent's own wallet over [x402](https://x402.org) — USDC on Base, no service API key and no signup. The agent gets three actions (`GENERATE_MUSIC_SUEDE`, `GENERATE_VIDEO_SUEDE`, `GENERATE_IMAGE_SUEDE`) plus an exported `SuedeClient` for programmatic use. Endpoint discovery is served at [`/.well-known/x402.json`](https://app.suedeai.ai/.well-known/x402.json).

**Config.**

| Variable | Required | Default | Notes |
| --- | --- | --- | --- |
| `SUEDE_WALLET_PRIVATE_KEY` | Yes | — | 0x-prefixed hex. The wallet the agent pays from. |
| `SUEDE_SERVICE_URL` | No | `https://app.suedeai.ai` | Override for staging. |
| `SUEDE_NETWORK` | No | `base-mainnet` | `base-sepolia` to exercise the flow without real USDC. |

**On the private key** — flagged on the previous PR, and a fair thing to ask about. The source is now public and MIT at https://github.com/JasonColapietro/elizaos-plugin-suede, so the handling is auditable rather than taken on trust. Concretely, in [`src/x402-client.ts`](https://github.com/JasonColapietro/elizaos-plugin-suede/blob/main/src/x402-client.ts) the key is passed to viem's `privateKeyToAccount` and used for exactly one thing: signing an EIP-3009 `TransferWithAuthorization` for the amount quoted in the server's 402 challenge. The signature travels in the `X-PAYMENT` header; the key is never written to disk, logged, or sent over the network. The README documents the blast radius, recommends a dedicated agent wallet over a treasury wallet, and points at `base-sepolia` for testing.

**Checklist from the guide:**

- [x] Published to npm, outside the reserved `@elizaos/*` scope — `@suedeai/plugin-suede@1.0.0`
- [x] `elizaos` in `package.json` keywords (runtime auto-discovery)
- [x] Public GitHub repository: https://github.com/JasonColapietro/elizaos-plugin-suede (MIT)
- [x] README with setup steps and the required env vars
- [x] `@elizaos/core` declared as a `peerDependency` (`^1.0.0`, against the current stable 1.7.2 line)

**Verified locally before opening this:**

- `bun run --cwd packages/registry validate` → 44 third-party entries validated
- `bun run --cwd packages/registry generate` → regenerated `generated-registry.json` (the only two files in this diff, no unrelated churn)
- `bun test packages/registry/src/registry.test.ts` → 13/13 pass
- On the plugin itself: `tsc` build clean and 6/6 vitest against a fresh `npm install`

Happy to adjust the description length, tags, or entry shape.
