### PR TITLE
fix(android): close periodic wake review blockers

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/AndroidManifest.xml
+++ b/packages/app-core/platforms/android/app/src/main/AndroidManifest.xml
@@ -330,6 +330,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
     

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -1761,7 +1761,7 @@ public class ElizaAgentService extends Service {
                     if (restartFirst) {
                         stopAgentProcess(false);
                     }
-                    startAgentProcess();
+                    startAgentProcess(!restartFirst);
                 } finally {
                     synchronized (processLock) {
                         startWorker = null;
@@ -1773,6 +1773,10 @@ public class ElizaAgentService extends Service {
     }
 
     private void startAgentProcess() {
+        startAgentProcess(true);
+    }
+
+    private void startAgentProcess(boolean allowAdoption) {
         synchronized (processLock) {
             if (agentProcess != null && agentProcess.isAlive()) {
                 return;
@@ -1797,7 +1801,7 @@ public class ElizaAgentService extends Service {
             // pkill a perfectly healthy surviving agent (the exact churn the
             // comment above describes). Mark the instance detached on adopt so
             // an explicit ACTION_STOP still tears the adopted agent down.
-            if (isLocalAgentSocketListening()) {
+            if (allowAdoption && isLocalAgentSocketListening()) {
                 detachedAgentMode = true;
                 restoreAdoptedRuntimeOwnership();
                 if (!"running".equals(currentStatus)) {
@@ -2749,15 +2753,15 @@ public class ElizaAgentService extends Service {
             wasDetached = detachedAgentMode;
             detachedAgentMode = false;
             detachedLaunchStartedAtMs = 0L;
-            if (terminalStop) {
-                currentLocalAgentToken = null;
-                currentTerminalRunToken = null;
-            }
+            currentLocalAgentToken = null;
+            currentTerminalRunToken = null;
         }
-        if (terminalStop) {
-            ElizaWorkScheduler.runtimeStopped(getApplicationContext());
-            deleteLocalAgentTokenFile();
-        }
+        ElizaWorkScheduler.runtimeStopped(getApplicationContext());
+        appendDiagnosticEvent(
+            terminalStop ? "runtime-ownership-stopped" : "runtime-ownership-restarting",
+            null
+        );
+        deleteLocalAgentTokenFile();
         persistDetachedLaunchTimestamp(0L);
         if (wasDetached) {
             appendDiagnosticEvent("stop-detached-agent", null);
@@ -3415,6 +3419,10 @@ public class ElizaAgentService extends Service {
     }
 
     private void scheduleRestart() {
+        scheduleRestart(false);
+    }
+
+    private void scheduleRestart(boolean requireFreshProcess) {
         if (shuttingDown) return;
         ElizaAgentWatchdogPolicy.RestartDecision decision =
             ElizaAgentWatchdogPolicy.nextRestart(restartAttempts, MAX_RESTART_ATTEMPTS);
@@ -3445,7 +3453,7 @@ public class ElizaAgentService extends Service {
                 return;
             }
             if (shuttingDown) return;
-            startAgentProcess();
+            startAgentProcess(!requireFreshProcess);
         }, "ElizaAgent-restart").start();
     }
 
@@ -3709,7 +3717,7 @@ public class ElizaAgentService extends Service {
                     if (decision.restartRequired) {
                         Log.w(TAG, "Agent unresponsive — force-restarting.");
                         stopAgentProcess(false);
-                        scheduleRestart();
+                        scheduleRestart(true);
                     }
                 }
             }

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -192,6 +192,7 @@ public class ElizaAgentService extends Service {
     private static final long AGENT_BOOT_GRACE_MS = 120_000L;
 
     private final Object processLock = new Object();
+    private final Object notificationLock = new Object();
     private Process agentProcess;
     private Thread stdoutPump;
     private Thread stderrPump;
@@ -199,13 +200,14 @@ public class ElizaAgentService extends Service {
     /** In-process bionic GPU inference host; non-null only when delegating. */
     private volatile ElizaBionicInferenceServer bionicInferenceServer;
     private volatile Thread startWorker;
+    private volatile Thread notificationWorker;
     private volatile boolean shuttingDown;
     private volatile boolean foregroundStartDenied;
     private volatile boolean detachedAgentMode;
     private volatile long detachedLaunchStartedAtMs;
     private long detachedProbeArmedForLaunchMs;
     private int restartAttempts;
-    private String currentStatus = "starting";
+    private volatile String currentStatus = "starting";
 
     // Per-boot bearer token for the WebView↔agent loopback. Generated when
     // the service first starts the agent process and cleared on stop.
@@ -751,7 +753,7 @@ public class ElizaAgentService extends Service {
         activeInstance = this;
         ensureNotificationChannel();
 
-        Notification notification = buildNotification("Eliza agent", "Starting…");
+        Notification notification = buildBootstrapNotification("Eliza agent", "Starting…");
 
         // Enter the foreground BEFORE any diagnostic IO. Android's FGS-start
         // timeout begins ticking at onCreate; spending it on the synchronous
@@ -3808,6 +3810,39 @@ public class ElizaAgentService extends Service {
     }
 
     private void updateNotification() {
+        synchronized (notificationLock) {
+            if (notificationWorker != null && notificationWorker.isAlive()) {
+                return;
+            }
+            notificationWorker = new Thread(() -> {
+                try {
+                    pushNotification();
+                } finally {
+                    synchronized (notificationLock) {
+                        notificationWorker = null;
+                    }
+                }
+            }, "ElizaAgent-notification");
+            notificationWorker.start();
+        }
+    }
+
+    /**
+     * The first foreground notification must avoid PendingIntent binder calls:
+     * a loaded system_server can stall them beyond Android's service timeout.
+     */
+    private Notification buildBootstrapNotification(String title, String text) {
+        return new NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .build();
+    }
+
+    private void pushNotification() {
         String title;
         String text;
         switch (currentStatus) {

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -198,7 +198,7 @@ public class ElizaAgentService extends Service {
     private WatchdogThread watchdog;
     /** In-process bionic GPU inference host; non-null only when delegating. */
     private volatile ElizaBionicInferenceServer bionicInferenceServer;
-    private Thread startWorker;
+    private volatile Thread startWorker;
     private volatile boolean shuttingDown;
     private volatile boolean foregroundStartDenied;
     private volatile boolean detachedAgentMode;
@@ -1771,6 +1771,15 @@ public class ElizaAgentService extends Service {
         // start, before the agent-already-running guards below — so it binds
         // even when the agent is adopted rather than freshly spawned.
         ensureBionicVoiceHost();
+
+        // Android may redeliver the sticky service start while a cold boot is
+        // still extracting assets. That worker holds processLock, so waiting
+        // for the lock here would block the main thread and trigger a service
+        // ANR merely to discover that a start is already in progress.
+        Thread activeStartWorker = startWorker;
+        if (activeStartWorker != null && activeStartWorker.isAlive()) {
+            return;
+        }
         synchronized (processLock) {
             if (!restartFirst && agentProcess != null && agentProcess.isAlive()) {
                 return;

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -17,6 +17,7 @@ import android.net.LocalSocket;
 import android.net.LocalSocketAddress;
 import android.os.Build;
 import android.os.IBinder;
+import android.os.SystemClock;
 import android.provider.Settings;
 import android.util.Log;
 
@@ -32,6 +33,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -488,9 +490,10 @@ public class ElizaAgentService extends Service {
             .put("stream", true)
             .put("payload", payload);
 
-        LocalSocket socket = connectLocalAgentSocket(timeoutMs);
+        long deadlineElapsedMs = SystemClock.elapsedRealtime() + timeoutMs;
+        LocalSocket socket = connectLocalAgentSocket(deadlineElapsedMs);
         try {
-            socket.setSoTimeout(timeoutMs);
+            socket.setSoTimeout(remainingSocketTimeout(deadlineElapsedMs));
             writeFrameLine(socket.getOutputStream(), frame);
             InputStream in = socket.getInputStream();
             for (String line = readFrameLine(in); line != null; line = readFrameLine(in)) {
@@ -565,9 +568,10 @@ public class ElizaAgentService extends Service {
             .put("method", "http_request")
             .put("payload", payload);
 
-        LocalSocket socket = connectLocalAgentSocket(timeoutMs);
+        long deadlineElapsedMs = SystemClock.elapsedRealtime() + timeoutMs;
+        LocalSocket socket = connectLocalAgentSocket(deadlineElapsedMs);
         try {
-            socket.setSoTimeout(timeoutMs);
+            socket.setSoTimeout(remainingSocketTimeout(deadlineElapsedMs));
             writeFrameLine(socket.getOutputStream(), frame);
             String line = readFrameLine(socket.getInputStream());
             if (line == null || line.isEmpty()) {
@@ -593,10 +597,11 @@ public class ElizaAgentService extends Service {
      * the socket yet, or its accept loop is stalled mid-decode). Returns a
      * connected {@link LocalSocket}; the caller owns closing it.
      */
-    private static LocalSocket connectLocalAgentSocket(int timeoutMs) throws IOException {
+    private static LocalSocket connectLocalAgentSocket(long deadlineElapsedMs) throws IOException {
         final int connectRetries = 15;
         IOException lastError = null;
         for (int attempt = 0; attempt <= connectRetries; attempt++) {
+            remainingSocketTimeout(deadlineElapsedMs);
             LocalSocket socket = new LocalSocket();
             try {
                 socket.connect(new LocalSocketAddress(
@@ -607,8 +612,13 @@ public class ElizaAgentService extends Service {
                 lastError = connectError;
             }
             if (attempt < connectRetries) {
+                long remainingMs = deadlineElapsedMs - SystemClock.elapsedRealtime();
+                if (remainingMs <= 0L) {
+                    throw new SocketTimeoutException("local agent socket connect deadline exceeded");
+                }
+                long retryDelayMs = Math.min(250L * (attempt + 1), remainingMs);
                 try {
-                    Thread.sleep(250L * (attempt + 1));
+                    Thread.sleep(retryDelayMs);
                 } catch (InterruptedException interrupted) {
                     Thread.currentThread().interrupt();
                     throw lastError;
@@ -616,6 +626,14 @@ public class ElizaAgentService extends Service {
             }
         }
         throw lastError != null ? lastError : new IOException("local agent socket unreachable");
+    }
+
+    private static int remainingSocketTimeout(long deadlineElapsedMs) throws SocketTimeoutException {
+        long remainingMs = deadlineElapsedMs - SystemClock.elapsedRealtime();
+        if (remainingMs <= 0L) {
+            throw new SocketTimeoutException("local agent request deadline exceeded");
+        }
+        return (int) Math.min((long) Integer.MAX_VALUE, remainingMs);
     }
 
     /** Write one NDJSON frame line (UTF-8, newline-terminated) to the socket. */
@@ -823,7 +841,7 @@ public class ElizaAgentService extends Service {
             bionicInferenceServer = null;
         }
         if (requestedStop) {
-            stopAgentProcess();
+            stopAgentProcess(true);
         } else {
             // AMS tore this record down without an explicit stop request (an
             // ANR'd duplicate record whose startForeground never got processed
@@ -1741,7 +1759,7 @@ public class ElizaAgentService extends Service {
             startWorker = new Thread(() -> {
                 try {
                     if (restartFirst) {
-                        stopAgentProcess();
+                        stopAgentProcess(false);
                     }
                     startAgentProcess();
                 } finally {
@@ -1781,6 +1799,7 @@ public class ElizaAgentService extends Service {
             // an explicit ACTION_STOP still tears the adopted agent down.
             if (isLocalAgentSocketListening()) {
                 detachedAgentMode = true;
+                restoreAdoptedRuntimeOwnership();
                 if (!"running".equals(currentStatus)) {
                     currentStatus = "running";
                     updateNotification();
@@ -1918,7 +1937,7 @@ public class ElizaAgentService extends Service {
             currentTerminalRunToken = terminalToken;
             try {
                 writeLocalAgentTokenFile(token);
-                ElizaWorkScheduler.reconcile(getApplicationContext());
+                ElizaWorkScheduler.credentialProvisioned(getApplicationContext());
             } catch (IOException error) {
                 Log.w(TAG, "Failed to persist local-agent token file: " + error.getMessage());
             }
@@ -2715,7 +2734,7 @@ public class ElizaAgentService extends Service {
         }
     }
 
-    private void stopAgentProcess() {
+    private void stopAgentProcess(boolean terminalStop) {
         Process toStop;
         Thread outPump;
         Thread errPump;
@@ -2730,11 +2749,15 @@ public class ElizaAgentService extends Service {
             wasDetached = detachedAgentMode;
             detachedAgentMode = false;
             detachedLaunchStartedAtMs = 0L;
-            currentLocalAgentToken = null;
-            currentTerminalRunToken = null;
+            if (terminalStop) {
+                currentLocalAgentToken = null;
+                currentTerminalRunToken = null;
+            }
         }
-        deleteLocalAgentTokenFile();
-        ElizaWorkScheduler.reconcile(getApplicationContext());
+        if (terminalStop) {
+            ElizaWorkScheduler.runtimeStopped(getApplicationContext());
+            deleteLocalAgentTokenFile();
+        }
         persistDetachedLaunchTimestamp(0L);
         if (wasDetached) {
             appendDiagnosticEvent("stop-detached-agent", null);
@@ -2790,12 +2813,24 @@ public class ElizaAgentService extends Service {
         }
     }
 
+    /** Reasserts scheduler ownership when a restart adopts the prior socket. */
+    private void restoreAdoptedRuntimeOwnership() {
+        Context context = getApplicationContext();
+        String token = localAgentToken(context);
+        if (token == null || token.trim().isEmpty()) {
+            Log.w(TAG, "Adopted local agent has no durable credential; periodic wake remains disabled.");
+            ElizaWorkScheduler.reconcile(context);
+            return;
+        }
+        ElizaWorkScheduler.credentialProvisioned(context);
+    }
+
     /**
      * Persist the detached-agent launch timestamp so the cold-boot guard in
      * {@link #startAgentProcess()} survives service-instance churn (AMS
      * record teardown, process restart). 0 clears the stamp; written on every
-     * launch and cleared by {@link #stopAgentProcess()} (explicit stops and
-     * restart-first restarts).
+     * launch and cleared by {@link #stopAgentProcess(boolean)} (explicit stops
+     * and restart-first restarts).
      */
     private void persistDetachedLaunchTimestamp(long timestampMs) {
         getSharedPreferences(EXIT_INFO_PREFS, Context.MODE_PRIVATE)
@@ -3673,7 +3708,7 @@ public class ElizaAgentService extends Service {
                         + " consecutive).");
                     if (decision.restartRequired) {
                         Log.w(TAG, "Agent unresponsive — force-restarting.");
-                        stopAgentProcess();
+                        stopAgentProcess(false);
                         scheduleRestart();
                     }
                 }

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -493,10 +493,13 @@ public class ElizaAgentService extends Service {
         long deadlineElapsedMs = SystemClock.elapsedRealtime() + timeoutMs;
         LocalSocket socket = connectLocalAgentSocket(deadlineElapsedMs);
         try {
-            socket.setSoTimeout(remainingSocketTimeout(deadlineElapsedMs));
             writeFrameLine(socket.getOutputStream(), frame);
             InputStream in = socket.getInputStream();
-            for (String line = readFrameLine(in); line != null; line = readFrameLine(in)) {
+            for (
+                String line = readFrameLine(socket, in, deadlineElapsedMs);
+                line != null;
+                line = readFrameLine(socket, in, deadlineElapsedMs)
+            ) {
                 if (line.isEmpty()) continue;
                 JSONObject response = new JSONObject(line);
                 String phase = response.optString("stream", "");
@@ -571,9 +574,12 @@ public class ElizaAgentService extends Service {
         long deadlineElapsedMs = SystemClock.elapsedRealtime() + timeoutMs;
         LocalSocket socket = connectLocalAgentSocket(deadlineElapsedMs);
         try {
-            socket.setSoTimeout(remainingSocketTimeout(deadlineElapsedMs));
             writeFrameLine(socket.getOutputStream(), frame);
-            String line = readFrameLine(socket.getInputStream());
+            String line = readFrameLine(
+                socket,
+                socket.getInputStream(),
+                deadlineElapsedMs
+            );
             if (line == null || line.isEmpty()) {
                 throw new IOException("local agent closed the connection with no response");
             }
@@ -648,10 +654,19 @@ public class ElizaAgentService extends Service {
      * without the trailing newline, or null at end-of-stream. Caps a single
      * frame at the response-byte budget so a runaway agent can't exhaust memory.
      */
-    private static String readFrameLine(InputStream in) throws IOException {
+    private static String readFrameLine(
+        LocalSocket socket,
+        InputStream in,
+        long deadlineElapsedMs
+    ) throws IOException {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        int b;
-        while ((b = in.read()) != -1) {
+        while (true) {
+            // Android's SO_TIMEOUT applies to each read. Recompute it for every
+            // byte so a peer cannot extend the request indefinitely by slowly
+            // dripping bytes or frames just inside a per-read timeout.
+            socket.setSoTimeout(remainingSocketTimeout(deadlineElapsedMs));
+            int b = in.read();
+            if (b == -1) break;
             if (b == '\n') {
                 return buffer.toString(StandardCharsets.UTF_8.name());
             }

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -659,12 +659,26 @@ public class ElizaAgentService extends Service {
         InputStream in,
         long deadlineElapsedMs
     ) throws IOException {
+        return readFrameLine(
+            in,
+            () -> socket.setSoTimeout(remainingSocketTimeout(deadlineElapsedMs))
+        );
+    }
+
+    @FunctionalInterface
+    interface BeforeSocketRead {
+        void run() throws IOException;
+    }
+
+    /** Package-visible seam for deterministic absolute-deadline policy tests. */
+    static String readFrameLine(InputStream in, BeforeSocketRead beforeRead)
+        throws IOException {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         while (true) {
             // Android's SO_TIMEOUT applies to each read. Recompute it for every
             // byte so a peer cannot extend the request indefinitely by slowly
             // dripping bytes or frames just inside a per-read timeout.
-            socket.setSoTimeout(remainingSocketTimeout(deadlineElapsedMs));
+            beforeRead.run();
             int b = in.read();
             if (b == -1) break;
             if (b == '\n') {

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaBootReceiver.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaBootReceiver.java
@@ -17,9 +17,7 @@ public class ElizaBootReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         String action = intent != null ? intent.getAction() : null;
-        if (!Intent.ACTION_BOOT_COMPLETED.equals(action)
-                && !Intent.ACTION_LOCKED_BOOT_COMPLETED.equals(action)
-                && !"android.intent.action.MY_PACKAGE_REPLACED".equals(action)) {
+        if (!shouldHandleAction(action)) {
             return;
         }
         // PACKAGE_USAGE_STATS has both a manifest permission (granted via
@@ -45,6 +43,12 @@ public class ElizaBootReceiver extends BroadcastReceiver {
         // runtime, background preference, or native token may have changed.
         // Reconciliation is idempotent and cancels any stale unique work.
         ElizaWorkScheduler.reconcile(context);
+    }
+
+    static boolean shouldHandleAction(String action) {
+        return Intent.ACTION_BOOT_COMPLETED.equals(action)
+            || Intent.ACTION_LOCKED_BOOT_COMPLETED.equals(action)
+            || "android.intent.action.MY_PACKAGE_REPLACED".equals(action);
     }
 
     private static boolean isAospBuild(Context context) {

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaWorkScheduler.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaWorkScheduler.java
@@ -24,6 +24,8 @@ final class ElizaWorkScheduler {
     static final String BACKGROUND_ENABLED_KEY = "eliza:background-enabled";
     static final String RUNTIME_MODE_KEY = "eliza:mobile-runtime-mode";
     static final String UNIQUE_WORK_NAME = "eliza.tasks.refresh";
+    private static final String OWNERSHIP_PREFS = "eliza-work-scheduler";
+    private static final String RUNTIME_STOPPED_KEY = "runtime-stopped";
 
     // Android caps periodic WorkManager intervals at a minimum of 15 minutes.
     private static final long PERIOD_MINUTES = 15L;
@@ -55,14 +57,37 @@ final class ElizaWorkScheduler {
      * Makes the desired state authoritative: exactly one periodic job for a
      * provisioned on-device runtime, and no job for every other state.
      */
-    static void reconcile(@NonNull Context context) {
+    static synchronized void reconcile(@NonNull Context context) {
         Decision decision = readDecision(context);
-        reconcileDecision(decision, new WorkManagerBackend(context.getApplicationContext()));
-        Log.i(
-            TAG,
-            "periodic wake " + (decision.shouldSchedule ? "scheduled" : "cancelled")
-                + " reason=" + decision.reason
-        );
+        applyDecision(context, decision);
+    }
+
+    /** Clears the stop tombstone only after the replacement credential is durable. */
+    static synchronized void credentialProvisioned(@NonNull Context context) {
+        boolean persisted = ownershipPrefs(context)
+            .edit()
+            .putBoolean(RUNTIME_STOPPED_KEY, false)
+            .commit();
+        if (!persisted) {
+            applyDecision(context, new Decision(false, "ownership-state-unavailable", null));
+            return;
+        }
+        applyDecision(context, readDecision(context));
+    }
+
+    /**
+     * Tombstones native ownership and cancels without consulting the removable
+     * token file, so failed token deletion cannot resurrect periodic work.
+     */
+    static synchronized void runtimeStopped(@NonNull Context context) {
+        boolean persisted = ownershipPrefs(context)
+            .edit()
+            .putBoolean(RUNTIME_STOPPED_KEY, true)
+            .commit();
+        if (!persisted) {
+            Log.w(TAG, "unable to persist stopped runtime ownership; cancelling in-process");
+        }
+        applyDecision(context, new Decision(false, "runtime-stopped", null));
     }
 
     static Decision readDecision(@NonNull Context context) {
@@ -73,11 +98,24 @@ final class ElizaWorkScheduler {
         return decide(
             isBackgroundEnabled(prefs),
             readString(prefs, RUNTIME_MODE_KEY),
-            ElizaAgentService.localAgentToken(context)
+            ElizaAgentService.localAgentToken(context),
+            ownershipPrefs(context).getBoolean(RUNTIME_STOPPED_KEY, false)
         );
     }
 
     static Decision decide(boolean backgroundEnabled, String runtimeMode, String deviceSecret) {
+        return decide(backgroundEnabled, runtimeMode, deviceSecret, false);
+    }
+
+    static Decision decide(
+        boolean backgroundEnabled,
+        String runtimeMode,
+        String deviceSecret,
+        boolean runtimeStopped
+    ) {
+        if (runtimeStopped) {
+            return new Decision(false, "runtime-stopped", null);
+        }
         if (!backgroundEnabled) {
             return new Decision(false, "background-disabled", null);
         }
@@ -98,6 +136,22 @@ final class ElizaWorkScheduler {
         } else {
             backend.cancel();
         }
+    }
+
+    private static SharedPreferences ownershipPrefs(Context context) {
+        return context.getApplicationContext().getSharedPreferences(
+            OWNERSHIP_PREFS,
+            Context.MODE_PRIVATE
+        );
+    }
+
+    private static void applyDecision(Context context, Decision decision) {
+        reconcileDecision(decision, new WorkManagerBackend(context.getApplicationContext()));
+        Log.i(
+            TAG,
+            "periodic wake " + (decision.shouldSchedule ? "scheduled" : "cancelled")
+                + " reason=" + decision.reason
+        );
     }
 
     static boolean isBackgroundEnabled(SharedPreferences prefs) {

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/GatewayConnectionService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/GatewayConnectionService.java
@@ -50,7 +50,8 @@ public class GatewayConnectionService extends Service {
     public static final String STATUS_DISCONNECTED = "disconnected";
     public static final String STATUS_RECONNECTING = "reconnecting";
 
-    private String currentStatus = STATUS_DISCONNECTED;
+    private volatile String currentStatus = STATUS_DISCONNECTED;
+    private volatile Thread notificationWorker;
 
     // ── Lifecycle ────────────────────────────────────────────────────────
 
@@ -59,7 +60,7 @@ public class GatewayConnectionService extends Service {
         super.onCreate();
         ensureNotificationChannel();
 
-        Notification notification = buildNotification("Eliza Gateway", "Starting…");
+        Notification notification = buildBootstrapNotification("Eliza Gateway", "Starting…");
 
         // API 34+ requires explicit foreground service type when calling startForeground().
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
@@ -71,6 +72,7 @@ public class GatewayConnectionService extends Service {
         } else {
             startForeground(NOTIFICATION_ID, notification);
         }
+        updateNotificationAsync();
     }
 
     @Override
@@ -165,6 +167,32 @@ public class GatewayConnectionService extends Service {
         }
 
         return builder.build();
+    }
+
+    /** Avoid PendingIntent binder calls on the service-start main-thread path. */
+    private Notification buildBootstrapNotification(String title, String text) {
+        return new NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .build();
+    }
+
+    private synchronized void updateNotificationAsync() {
+        if (notificationWorker != null && notificationWorker.isAlive()) {
+            return;
+        }
+        notificationWorker = new Thread(() -> {
+            try {
+                updateNotification();
+            } finally {
+                notificationWorker = null;
+            }
+        }, "ElizaGateway-notification");
+        notificationWorker.start();
     }
 
     private boolean isNotificationStop(Intent intent) {

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaWorkSchedulerPolicyTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaWorkSchedulerPolicyTest.java
@@ -40,6 +40,31 @@ public class ElizaWorkSchedulerPolicyTest {
     }
 
     @Test
+    public void stoppedRuntimeCancelsEvenWhenTheStaleCredentialStillExists() {
+        assertCancel(
+            ElizaWorkScheduler.decide(true, "local", SECRET, true),
+            "runtime-stopped"
+        );
+    }
+
+    @Test
+    public void bootReceiverAcceptsBootAndPackageReplacementOnly() {
+        assertTrue(ElizaBootReceiver.shouldHandleAction("android.intent.action.BOOT_COMPLETED"));
+        assertTrue(
+            ElizaBootReceiver.shouldHandleAction(
+                "android.intent.action.LOCKED_BOOT_COMPLETED"
+            )
+        );
+        assertTrue(
+            ElizaBootReceiver.shouldHandleAction(
+                "android.intent.action.MY_PACKAGE_REPLACED"
+            )
+        );
+        assertFalse(ElizaBootReceiver.shouldHandleAction("android.intent.action.PACKAGE_ADDED"));
+        assertFalse(ElizaBootReceiver.shouldHandleAction(null));
+    }
+
+    @Test
     public void reconciliationCallsExactlyOneBackendOperation() {
         RecordingBackend schedule = new RecordingBackend();
         ElizaWorkScheduler.reconcileDecision(

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaWorkSchedulerPolicyTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaWorkSchedulerPolicyTest.java
@@ -7,6 +7,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.net.SocketTimeoutException;
 
 import org.junit.Test;
 
@@ -81,6 +85,29 @@ public class ElizaWorkSchedulerPolicyTest {
         );
         assertEquals(0, cancel.enqueueCalls);
         assertEquals(1, cancel.cancelCalls);
+    }
+
+    @Test
+    public void slowMultiFrameResponseCannotExtendAbsoluteDeadline() throws Exception {
+        ByteArrayInputStream response = new ByteArrayInputStream(
+            "ok\nstill-streaming\n".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        );
+        final int[] elapsedMs = {0};
+        ElizaAgentService.BeforeSocketRead deadline = () -> {
+            if (elapsedMs[0] >= 50) {
+                throw new SocketTimeoutException("absolute deadline exceeded");
+            }
+            elapsedMs[0] += 10;
+        };
+
+        assertEquals("ok", ElizaAgentService.readFrameLine(response, deadline));
+        try {
+            ElizaAgentService.readFrameLine(response, deadline);
+            fail("a slow second frame must not reset the request deadline");
+        } catch (SocketTimeoutException expected) {
+            assertEquals("absolute deadline exceeded", expected.getMessage());
+        }
+        assertEquals(50, elapsedMs[0]);
     }
 
     private static void assertSchedule(ElizaWorkScheduler.Decision decision) {

--- a/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
+++ b/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
@@ -145,4 +145,17 @@ describe("Android periodic wake reconciliation (#17874)", () => {
     expect(worker).not.toContain('"eliza:device-secret"');
     expect(worker).not.toContain('"eliza:agent-base"');
   });
+
+  it("returns repeated service starts before the cold-boot process lock", () => {
+    const service = source("ElizaAgentService.java");
+    const requestStartBody = service.match(
+      /private void requestAgentStart\(boolean restartFirst\) \{([\s\S]*?)\n    \}\n\n    private void startAgentProcess/,
+    )?.[1];
+
+    expect(service).toContain("private volatile Thread startWorker");
+    expect(requestStartBody).toBeDefined();
+    expect(requestStartBody).toMatch(
+      /Thread activeStartWorker = startWorker;[\s\S]*activeStartWorker != null[\s\S]*activeStartWorker\.isAlive\(\)[\s\S]*return;[\s\S]*synchronized \(processLock\)/,
+    );
+  });
 });

--- a/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
+++ b/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
@@ -85,26 +85,25 @@ describe("Android periodic wake reconciliation (#17874)", () => {
     expect(service).toMatch(
       /writeLocalAgentTokenFile\(token\);\s*ElizaWorkScheduler\.credentialProvisioned/,
     );
-    expect(service).toMatch(
-      /ElizaWorkScheduler\.runtimeStopped\(getApplicationContext\(\)\);\s*deleteLocalAgentTokenFile\(\)/,
-    );
     expect(scheduler).toContain("putBoolean(RUNTIME_STOPPED_KEY, true)");
     expect(scheduler).toMatch(
       /ElizaAgentService\.localAgentToken\(context\),\s*ownershipPrefs\(context\)\.getBoolean\(RUNTIME_STOPPED_KEY, false\)/,
     );
     expect(service).toMatch(
-      /if \(restartFirst\) \{\s*stopAgentProcess\(false\);\s*\}\s*startAgentProcess\(\)/,
+      /if \(restartFirst\) \{\s*stopAgentProcess\(false\);\s*\}\s*startAgentProcess\(!restartFirst\)/,
     );
     expect(service).toMatch(
-      /if \(terminalStop\) \{\s*ElizaWorkScheduler\.runtimeStopped\(getApplicationContext\(\)\);\s*deleteLocalAgentTokenFile\(\);\s*\}/,
+      /ElizaWorkScheduler\.runtimeStopped\(getApplicationContext\(\)\);[\s\S]*?deleteLocalAgentTokenFile\(\)/,
     );
     expect(service).toMatch(
-      /if \(isLocalAgentSocketListening\(\)\) \{[\s\S]*restoreAdoptedRuntimeOwnership\(\);[\s\S]*return;/,
+      /if \(allowAdoption && isLocalAgentSocketListening\(\)\) \{[\s\S]*restoreAdoptedRuntimeOwnership\(\);[\s\S]*return;/,
     );
     expect(service).toMatch(
       /restoreAdoptedRuntimeOwnership\(\)[\s\S]*localAgentToken\(context\)[\s\S]*ElizaWorkScheduler\.credentialProvisioned\(context\)/,
     );
-    expect(service).not.toContain("stopAgentProcess();");
+    expect(service).toMatch(
+      /stopAgentProcess\(false\);\s*scheduleRestart\(true\)/,
+    );
   });
 
   it("serializes decisions and bounds socket retries by one deadline", () => {

--- a/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
+++ b/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
@@ -7,11 +7,16 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
+import { ensureElizaBootReceiverManifest } from "./run-mobile-build.mjs";
 
 const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
 const javaRoot = path.resolve(
   scriptsDir,
   "../platforms/android/app/src/main/java/ai/elizaos/app",
+);
+const androidManifest = path.resolve(
+  scriptsDir,
+  "../platforms/android/app/src/main/AndroidManifest.xml",
 );
 
 function source(name) {
@@ -27,8 +32,37 @@ describe("Android periodic wake reconciliation (#17874)", () => {
       "ElizaWorkScheduler.reconcile(getApplicationContext())",
     );
     expect(bootReceiver).toContain("ElizaWorkScheduler.reconcile(context)");
+    expect(fs.readFileSync(androidManifest, "utf8")).toContain(
+      "android.intent.action.MY_PACKAGE_REPLACED",
+    );
     expect(activity).not.toContain("ElizaWorkScheduler.enqueuePeriodic");
     expect(bootReceiver).not.toContain("ElizaWorkScheduler.enqueuePeriodic");
+    expect(bootReceiver).toMatch(
+      /if \(!shouldHandleAction\(action\)\) \{\s*return;\s*\}[\s\S]*ElizaWorkScheduler\.reconcile\(context\)/,
+    );
+    expect(bootReceiver).toMatch(
+      /shouldHandleAction\(String action\)[\s\S]*MY_PACKAGE_REPLACED/,
+    );
+  });
+
+  it("preserves package replacement in the post-overlay receiver manifest", () => {
+    const input = `
+      <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+        <application>
+          <receiver android:name="ai.elizaos.app.ElizaBootReceiver">
+            <intent-filter>
+              <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+          </receiver>
+        </application>
+      </manifest>`;
+
+    const overlaid = ensureElizaBootReceiverManifest(input, "ai.elizaos.app");
+
+    expect(overlaid).toContain("android.intent.action.LOCKED_BOOT_COMPLETED");
+    expect(overlaid).toContain("android.intent.action.BOOT_COMPLETED");
+    expect(overlaid).toContain("android.intent.action.MY_PACKAGE_REPLACED");
+    expect(overlaid.match(/ElizaBootReceiver/g)).toHaveLength(1);
   });
 
   it("reconciles runtime/background preference changes while the app is alive", () => {
@@ -46,13 +80,44 @@ describe("Android periodic wake reconciliation (#17874)", () => {
 
   it("reconciles native token provisioning and removal", () => {
     const service = source("ElizaAgentService.java");
+    const scheduler = source("ElizaWorkScheduler.java");
 
     expect(service).toMatch(
-      /writeLocalAgentTokenFile\(token\);\s*ElizaWorkScheduler\.reconcile/,
+      /writeLocalAgentTokenFile\(token\);\s*ElizaWorkScheduler\.credentialProvisioned/,
     );
     expect(service).toMatch(
-      /deleteLocalAgentTokenFile\(\);\s*ElizaWorkScheduler\.reconcile/,
+      /ElizaWorkScheduler\.runtimeStopped\(getApplicationContext\(\)\);\s*deleteLocalAgentTokenFile\(\)/,
     );
+    expect(scheduler).toContain("putBoolean(RUNTIME_STOPPED_KEY, true)");
+    expect(scheduler).toMatch(
+      /ElizaAgentService\.localAgentToken\(context\),\s*ownershipPrefs\(context\)\.getBoolean\(RUNTIME_STOPPED_KEY, false\)/,
+    );
+    expect(service).toMatch(
+      /if \(restartFirst\) \{\s*stopAgentProcess\(false\);\s*\}\s*startAgentProcess\(\)/,
+    );
+    expect(service).toMatch(
+      /if \(terminalStop\) \{\s*ElizaWorkScheduler\.runtimeStopped\(getApplicationContext\(\)\);\s*deleteLocalAgentTokenFile\(\);\s*\}/,
+    );
+    expect(service).toMatch(
+      /if \(isLocalAgentSocketListening\(\)\) \{[\s\S]*restoreAdoptedRuntimeOwnership\(\);[\s\S]*return;/,
+    );
+    expect(service).toMatch(
+      /restoreAdoptedRuntimeOwnership\(\)[\s\S]*localAgentToken\(context\)[\s\S]*ElizaWorkScheduler\.credentialProvisioned\(context\)/,
+    );
+    expect(service).not.toContain("stopAgentProcess();");
+  });
+
+  it("serializes decisions and bounds socket retries by one deadline", () => {
+    const scheduler = source("ElizaWorkScheduler.java");
+    const service = source("ElizaAgentService.java");
+
+    expect(scheduler).toContain("static synchronized void reconcile");
+    expect(scheduler).toContain(
+      "static synchronized void credentialProvisioned",
+    );
+    expect(scheduler).toContain("static synchronized void runtimeStopped");
+    expect(service).toContain("remainingSocketTimeout(deadlineElapsedMs)");
+    expect(service).toContain("Math.min(250L * (attempt + 1), remainingMs)");
   });
 
   it("keeps the worker on authenticated app-owned IPC", () => {

--- a/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
+++ b/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
@@ -126,7 +126,7 @@ describe("Android periodic wake reconciliation (#17874)", () => {
     );
     expect(scheduler).toContain("static synchronized void runtimeStopped");
     expect(service).toMatch(
-      /readFrameLine\([\s\S]*?socket\.setSoTimeout\(remainingSocketTimeout\(deadlineElapsedMs\)\);[\s\S]*?int b = in\.read\(\)/,
+      /readFrameLine\([\s\S]*?socket\.setSoTimeout\(remainingSocketTimeout\(deadlineElapsedMs\)\)[\s\S]*?beforeRead\.run\(\);[\s\S]*?int b = in\.read\(\)/,
     );
     expect(service).toMatch(
       /for \([\s\S]*readFrameLine\(socket, in, deadlineElapsedMs\)[\s\S]*line = readFrameLine\(socket, in, deadlineElapsedMs\)/,

--- a/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
+++ b/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
@@ -18,6 +18,7 @@ const androidManifest = path.resolve(
   scriptsDir,
   "../platforms/android/app/src/main/AndroidManifest.xml",
 );
+const mobileBuildScript = path.resolve(scriptsDir, "run-mobile-build.mjs");
 
 function source(name) {
   return fs.readFileSync(path.join(javaRoot, name), "utf8");
@@ -63,6 +64,15 @@ describe("Android periodic wake reconciliation (#17874)", () => {
     expect(overlaid).toContain("android.intent.action.BOOT_COMPLETED");
     expect(overlaid).toContain("android.intent.action.MY_PACKAGE_REPLACED");
     expect(overlaid.match(/ElizaBootReceiver/g)).toHaveLength(1);
+
+    const buildSource = fs.readFileSync(mobileBuildScript, "utf8");
+    const overlayBody = buildSource.match(
+      /function overlayAndroid\([\s\S]*?\n}\n\nfunction /,
+    )?.[0];
+    expect(overlayBody).toBeDefined();
+    expect(overlayBody).toContain(
+      "xml = ensureElizaBootReceiverManifest(xml, androidPackage)",
+    );
   });
 
   it("reconciles runtime/background preference changes while the app is alive", () => {
@@ -115,7 +125,12 @@ describe("Android periodic wake reconciliation (#17874)", () => {
       "static synchronized void credentialProvisioned",
     );
     expect(scheduler).toContain("static synchronized void runtimeStopped");
-    expect(service).toContain("remainingSocketTimeout(deadlineElapsedMs)");
+    expect(service).toMatch(
+      /readFrameLine\([\s\S]*?socket\.setSoTimeout\(remainingSocketTimeout\(deadlineElapsedMs\)\);[\s\S]*?int b = in\.read\(\)/,
+    );
+    expect(service).toMatch(
+      /for \([\s\S]*readFrameLine\(socket, in, deadlineElapsedMs\)[\s\S]*line = readFrameLine\(socket, in, deadlineElapsedMs\)/,
+    );
     expect(service).toContain("Math.min(250L * (attempt + 1), remainingMs)");
   });
 

--- a/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
+++ b/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
@@ -158,4 +158,24 @@ describe("Android periodic wake reconciliation (#17874)", () => {
       /Thread activeStartWorker = startWorker;[\s\S]*activeStartWorker != null[\s\S]*activeStartWorker\.isAlive\(\)[\s\S]*return;[\s\S]*synchronized \(processLock\)/,
     );
   });
+
+  it("enters foreground without PendingIntent binder work on the main thread", () => {
+    for (const name of [
+      "ElizaAgentService.java",
+      "GatewayConnectionService.java",
+    ]) {
+      const service = source(name);
+      const onCreateBody = service.match(
+        /public void onCreate\(\) \{([\s\S]*?)\n    \}\n\n    @Override\n    public int onStartCommand/,
+      )?.[1];
+      const bootstrapBody = service.match(
+        /private Notification buildBootstrapNotification\([\s\S]*?\) \{([\s\S]*?)\n    \}/,
+      )?.[1];
+
+      expect(onCreateBody).toContain("buildBootstrapNotification");
+      expect(onCreateBody).not.toContain("buildNotification(");
+      expect(bootstrapBody).toBeDefined();
+      expect(bootstrapBody).not.toContain("PendingIntent");
+    }
+  });
 });

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -2875,6 +2875,34 @@ function restoreAndroidManifestFromPlatformTemplateIfMissing() {
   return true;
 }
 
+/**
+ * Replaces the boot receiver with the exact block shipped by local-capable
+ * Android targets. Keeping this transformation pure lets tests inspect the
+ * post-overlay manifest instead of only the platform input template.
+ */
+export function ensureElizaBootReceiverManifest(xml, androidPackage) {
+  let next = removeApplicationComponentBlock(
+    xml,
+    `${androidPackage}.ElizaBootReceiver`,
+  );
+  next = removeApplicationComponentClassBlock(next, "ElizaBootReceiver");
+  return appendMissingApplicationBlock(
+    next,
+    `${androidPackage}.ElizaBootReceiver`,
+    `
+        <receiver
+            android:name="${androidPackage}.ElizaBootReceiver"
+            android:directBootAware="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>`,
+  );
+}
+
 function overlayAndroid({ includeAospRoleLaunchers = false } = {}) {
   assertSharedTreeOnlyForEliza("overlay Java sources");
   const templateJavaRoot = path.join(
@@ -3421,20 +3449,7 @@ function overlayAndroid({ includeAospRoleLaunchers = false } = {}) {
             </intent-filter>
         </activity>`,
     );
-    xml = appendMissingApplicationBlock(
-      xml,
-      `${androidPackage}.ElizaBootReceiver`,
-      `
-        <receiver
-            android:name="${androidPackage}.ElizaBootReceiver"
-            android:directBootAware="true"
-            android:exported="false">
-            <intent-filter>
-                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
-            </intent-filter>
-        </receiver>`,
-    );
+    xml = ensureElizaBootReceiverManifest(xml, androidPackage);
     // Browser: replaces stripped Browser2 as the only http(s) handler.
     xml = appendMissingApplicationBlock(
       xml,

--- a/packages/app-core/src/api/internal-routes.test.ts
+++ b/packages/app-core/src/api/internal-routes.test.ts
@@ -2,8 +2,8 @@
  * Unit tests for the `POST /api/internal/wake` handler and `getDeviceSecret`,
  * driving fake req/res objects. Covers device-secret bearer auth (401s), wake
  * body validation, the happy path (runDueTasks fired, telemetry mirrored),
- * runtime / task-service unavailability, error capture, deadline→maxWallTimeMs
- * clamping, routing pass-through, and on-disk device-secret persistence + mode.
+ * runtime / task-service unavailability, error capture, expired-deadline
+ * rejection, routing pass-through, and on-disk device-secret persistence + mode.
  */
 import fs from "node:fs";
 import * as http from "node:http";
@@ -82,6 +82,18 @@ function stateWithTaskService(service: unknown): CompatRuntimeState {
     pendingAgentName: null,
     pendingRestartReasons: [],
   };
+}
+
+async function waitForInvocation(callCount: () => number): Promise<void> {
+  for (let attempt = 0; attempt < 20 && callCount() === 0; attempt += 1) {
+    await Promise.resolve();
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    await Promise.resolve();
+  }
 }
 
 const SECRET = "test-secret-0123456789abcdef0123456789abcdef";
@@ -266,13 +278,8 @@ describe("POST /api/internal/wake — happy path", () => {
     expect(getWakeTelemetry().lastWakeKind).toBe("processing");
   });
 
-  it("passes maxWallTimeMs derived from deadlineMs to runDueTasks", async () => {
-    const calls: Array<{ maxWallTimeMs?: number }> = [];
-    const runDueTasks = vi.fn(
-      async (options: { maxWallTimeMs?: number } = {}) => {
-        calls.push(options);
-      },
-    );
+  it("runs the canonical no-options TaskService contract before the deadline", async () => {
+    const runDueTasks = vi.fn(async () => {});
     const res = fakeRes();
     const deadlineMs = Date.now() + 10_000;
     await handleInternalWakeRoute(
@@ -283,22 +290,87 @@ describe("POST /api/internal/wake — happy path", () => {
       res.res,
       stateWithTaskService({ runDueTasks }),
     );
-    expect(calls.length).toBe(1);
-    const passed = calls[0].maxWallTimeMs;
-    expect(typeof passed).toBe("number");
-    if (typeof passed !== "number") return;
-    expect(passed).toBeGreaterThan(0);
-    // Should be at most the original window.
-    expect(passed).toBeLessThanOrEqual(10_000);
+    expect(runDueTasks).toHaveBeenCalledOnce();
+    expect(runDueTasks).toHaveBeenCalledWith();
   });
 
-  it("clamps an already-expired deadline to a 1s floor", async () => {
-    const calls: Array<{ maxWallTimeMs?: number }> = [];
-    const runDueTasks = vi.fn(
-      async (options: { maxWallTimeMs?: number } = {}) => {
-        calls.push(options);
-      },
+  it("coalesces concurrent wakes for the same TaskService", async () => {
+    let settleWake: (() => void) | undefined;
+    const wake = new Promise<void>((resolve) => {
+      settleWake = resolve;
+    });
+    const runDueTasks = vi.fn(() => wake);
+    const service = { runDueTasks };
+    const firstRes = fakeRes();
+    const secondRes = fakeRes();
+    const request = () =>
+      fakeReq("/api/internal/wake", {
+        auth: `Bearer ${SECRET}`,
+        body: { kind: "refresh", deadlineMs: Date.now() + 5000 },
+      });
+
+    const first = handleInternalWakeRoute(
+      request(),
+      firstRes.res,
+      stateWithTaskService(service),
     );
+    await waitForInvocation(() => runDueTasks.mock.calls.length);
+    expect(runDueTasks).toHaveBeenCalledOnce();
+    const second = handleInternalWakeRoute(
+      request(),
+      secondRes.res,
+      stateWithTaskService(service),
+    );
+    await flushMicrotasks();
+    expect(runDueTasks).toHaveBeenCalledOnce();
+
+    settleWake?.();
+    await Promise.all([first, second]);
+    expect(firstRes.body()).toMatchObject({ ok: true, coalesced: false });
+    expect(secondRes.body()).toMatchObject({ ok: true, coalesced: true });
+  });
+
+  it("runs a replacement runtime while the previous TaskService is in flight", async () => {
+    let settlePrevious: (() => void) | undefined;
+    const previousWake = new Promise<void>((resolve) => {
+      settlePrevious = resolve;
+    });
+    const previousRun = vi.fn(() => previousWake);
+    const replacementRun = vi.fn(async () => {});
+    const request = () =>
+      fakeReq("/api/internal/wake", {
+        auth: `Bearer ${SECRET}`,
+        body: { kind: "processing", deadlineMs: Date.now() + 5000 },
+      });
+    const previousRes = fakeRes();
+    const replacementRes = fakeRes();
+
+    const previous = handleInternalWakeRoute(
+      request(),
+      previousRes.res,
+      stateWithTaskService({ runDueTasks: previousRun }),
+    );
+    await waitForInvocation(() => previousRun.mock.calls.length);
+    expect(previousRun).toHaveBeenCalledOnce();
+    const replacement = handleInternalWakeRoute(
+      request(),
+      replacementRes.res,
+      stateWithTaskService({ runDueTasks: replacementRun }),
+    );
+    await waitForInvocation(() => replacementRun.mock.calls.length);
+    expect(replacementRun).toHaveBeenCalledOnce();
+
+    settlePrevious?.();
+    await Promise.all([previous, replacement]);
+    expect(previousRes.body()).toMatchObject({ ok: true, coalesced: false });
+    expect(replacementRes.body()).toMatchObject({
+      ok: true,
+      coalesced: false,
+    });
+  });
+
+  it("rejects an already-expired deadline without running tasks", async () => {
+    const runDueTasks = vi.fn(async () => {});
     const res = fakeRes();
     await handleInternalWakeRoute(
       fakeReq("/api/internal/wake", {
@@ -308,7 +380,9 @@ describe("POST /api/internal/wake — happy path", () => {
       res.res,
       stateWithTaskService({ runDueTasks }),
     );
-    expect(calls[0].maxWallTimeMs).toBe(1000);
+    expect(res.status()).toBe(408);
+    expect(res.body()).toEqual({ ok: false, error: "wake_deadline_expired" });
+    expect(runDueTasks).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/app-core/src/api/internal-routes.ts
+++ b/packages/app-core/src/api/internal-routes.ts
@@ -25,13 +25,8 @@ import type { CompatRuntimeState } from "./compat-route-shared";
 import { readCompatJsonBody } from "./compat-route-shared";
 import { sendJson } from "./response";
 
-/**
- * The runtime contract is `runDueTasks(): Promise<void>`. The optional
- * `maxWallTimeMs` is currently advisory and is passed through for services
- * that support deadline-bounded execution.
- */
 interface TaskServiceLike {
-  runDueTasks(options?: { maxWallTimeMs?: number }): Promise<unknown>;
+  runDueTasks(): Promise<unknown>;
 }
 
 function isTaskServiceLike(
@@ -170,22 +165,25 @@ function safeEqual(a: string, b: string): boolean {
   return diff === 0;
 }
 
-let runDueTasksInFlight: Promise<unknown> | null = null;
+const runDueTasksInFlight = new WeakMap<TaskServiceLike, Promise<unknown>>();
 
 async function runDueTasksOnce(
   service: Service & TaskServiceLike,
-  options: { maxWallTimeMs: number },
 ): Promise<{ coalesced: boolean }> {
-  if (runDueTasksInFlight !== null) {
-    await runDueTasksInFlight;
+  const existing = runDueTasksInFlight.get(service);
+  if (existing !== undefined) {
+    await existing;
     return { coalesced: true };
   }
-  runDueTasksInFlight = service.runDueTasks(options);
+  const wake = service.runDueTasks();
+  runDueTasksInFlight.set(service, wake);
   try {
-    await runDueTasksInFlight;
+    await wake;
     return { coalesced: false };
   } finally {
-    runDueTasksInFlight = null;
+    if (runDueTasksInFlight.get(service) === wake) {
+      runDueTasksInFlight.delete(service);
+    }
   }
 }
 
@@ -254,13 +252,16 @@ export async function handleInternalWakeRoute(
   }
 
   const startedAt = Date.now();
-  // Deadline is the absolute target wall time the caller wants us done by.
-  // Clamp to at least 1s so an already-expired deadline can't pin runDueTasks
-  // to a zero/negative budget.
-  const maxWallTimeMs = Math.max(1000, parsed.deadlineMs - startedAt);
+  if (parsed.deadlineMs <= startedAt) {
+    sendJson(res, 408, { ok: false, error: "wake_deadline_expired" });
+    return true;
+  }
 
   try {
-    const result = await runDueTasksOnce(taskService, { maxWallTimeMs });
+    // TaskService has no preemptive execution budget. The native transport owns
+    // its hard IPC timeout while this promise remains registered for coalescing
+    // until the real task run settles.
+    const result = await runDueTasksOnce(taskService);
     const durationMs = Date.now() - startedAt;
     wakeTelemetry.lastWakeFiredAt = startedAt;
     wakeTelemetry.lastWakeKind = parsed.kind;

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
@@ -125,9 +125,7 @@ describe("dispatchBufferedRequest", () => {
 				coalesced: false,
 			});
 			expect(runDueTasks).toHaveBeenCalledOnce();
-			expect(runDueTasks).toHaveBeenCalledWith({
-				maxWallTimeMs: expect.any(Number),
-			});
+			expect(runDueTasks).toHaveBeenCalledWith();
 			expect(calls).toHaveLength(0);
 		} finally {
 			if (previousToken === undefined) delete process.env.ELIZA_API_TOKEN;
@@ -158,6 +156,18 @@ describe("dispatchBufferedRequest", () => {
 				body: "not-json",
 			});
 			expect(invalid.status).toBe(400);
+
+			const expired = await dispatchBufferedRequest(wakeRuntime, route, {
+				method: "POST",
+				path: "/api/internal/wake",
+				headers: { authorization: `Bearer ${"b".repeat(64)}` },
+				body: { kind: "refresh", deadlineMs: Date.now() - 1 },
+			});
+			expect(expired.status).toBe(408);
+			expect(JSON.parse(expired.body)).toEqual({
+				ok: false,
+				error: "wake_deadline_expired",
+			});
 			expect(runDueTasks).not.toHaveBeenCalled();
 		} finally {
 			if (previousToken === undefined) delete process.env.ELIZA_API_TOKEN;
@@ -173,7 +183,7 @@ describe("dispatchBufferedRequest", () => {
 			method: "POST",
 			path: "/api/internal/wake",
 			headers: { authorization: `Bearer ${"c".repeat(64)}` },
-			body: { kind: "processing", deadlineMs: Date.now() - 1 },
+			body: { kind: "processing", deadlineMs: Date.now() + 5_000 },
 		};
 		try {
 			const unavailable = await dispatchBufferedRequest(
@@ -206,8 +216,8 @@ describe("dispatchBufferedRequest", () => {
 				payload,
 			);
 			expect(recovered.status).toBe(200);
-			expect(runDueTasks).toHaveBeenNthCalledWith(1, { maxWallTimeMs: 1_000 });
-			expect(runDueTasks).toHaveBeenNthCalledWith(2, { maxWallTimeMs: 1_000 });
+			expect(runDueTasks).toHaveBeenNthCalledWith(1);
+			expect(runDueTasks).toHaveBeenNthCalledWith(2);
 		} finally {
 			if (previousToken === undefined) delete process.env.ELIZA_API_TOKEN;
 			else process.env.ELIZA_API_TOKEN = previousToken;
@@ -238,7 +248,8 @@ describe("dispatchBufferedRequest", () => {
 		};
 		try {
 			const first = dispatchBufferedRequest(firstRuntime, route, payload);
-			await vi.waitFor(() => expect(firstRun).toHaveBeenCalledOnce());
+			await Promise.resolve();
+			expect(firstRun).toHaveBeenCalledOnce();
 			const coalesced = dispatchBufferedRequest(firstRuntime, route, payload);
 			const replacement = await dispatchBufferedRequest(
 				replacementRuntime,

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
@@ -158,7 +158,7 @@ function jsonResponse(
 }
 
 interface AndroidTaskServiceLike {
-	runDueTasks(options?: { maxWallTimeMs?: number }): Promise<unknown>;
+	runDueTasks(): Promise<unknown>;
 }
 
 // Runtime replacement can overlap an outgoing agent's final wake with the new
@@ -247,7 +247,9 @@ async function directAndroidWakeRoute(
 	}
 
 	const startedAt = Date.now();
-	const maxWallTimeMs = Math.max(1_000, parsed.deadlineMs - startedAt);
+	if (parsed.deadlineMs <= startedAt) {
+		return jsonResponse(408, { ok: false, error: "wake_deadline_expired" });
+	}
 	let coalesced = false;
 	try {
 		const existing = androidWakeInFlight.get(runtime);
@@ -257,7 +259,7 @@ async function directAndroidWakeRoute(
 		} else {
 			const wake = (
 				service as typeof service & AndroidTaskServiceLike
-			).runDueTasks({ maxWallTimeMs });
+			).runDueTasks();
 			androidWakeInFlight.set(runtime, wake);
 			try {
 				await wake;


### PR DESCRIPTION
# Relates to

Closes the remaining review blockers for #17874 and #19112.

# What changes

- reconciles Android periodic work from runtime ownership, background settings, token provisioning/removal, boot, and package replacement
- preserves `MY_PACKAGE_REPLACED` in the actual local-capable Android manifest overlay
- scopes Node wake coalescing to the active `TaskService`, so a replacement runtime is never suppressed by an outgoing runtime
- distinguishes terminal stop from restart teardown and restores durable ownership when adopting a live detached runtime
- rejects expired wake deadlines before task execution
- enforces the native socket's absolute request deadline on every frame and every byte
- returns repeated service starts before the cold-boot process lock, preventing the service main thread from waiting behind asset extraction
- enters both Android foreground services with binder-free bootstrap notifications and builds interactive notifications off the main thread

# Maintainer review repairs

The exact head includes mutation-sensitive proof for the post-overlay receiver transform, runtime ownership and restart behavior, absolute socket deadlines, repeated-start lock ordering, and binder-free foreground bootstrap paths.

# Validation

<!-- evidence-head:da14c9adeace017a03868da35d7ce923336cf72e -->

Exact head: `da14c9adeace017a03868da35d7ce923336cf72e` (rebased on validated `develop` `e21e3e2a18c1e1366c74bb0e56fea2774c261b58`; clean merge-tree against current `develop` `f5a3111c07ed7e4441dcd2ef8c2c6ff8fd38b196`)

- Android periodic-wake reconciliation: 8/8 passed.
- Capacitor Android dispatch: 23/23 passed.
- Internal wake deadline/authentication routes: 19/19 passed.
- Combined focused contract suite: 50/50 passed with 193 assertions.
- Android host-side policy and Java compilation: `ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB=1 ./gradlew testDebugUnitTest` passed.
- `bun run verify`: passed at the exact head and base above.
- Exact-head Android sideload build: 765 tasks; repository artifact audit passed.
- Exact-head APK SHA-256: `5852e91b5b5ac50562636b2c9f9e4ab28b662e08ba57829148fe594ebcafcca2`.
- `git diff --check`: passed.

# Installed Android evidence

Target: Android 15 arm64 emulator with 12 GiB RAM, package `ai.elizaos.app`.

The clean-data cold boot on the prior patch-equivalent reviewed head `241b7250ea936e8a88cc67cd9aee50f1483f9b31` naturally redelivered `ACTION_START` 15 times while the detached agent was starting. The app remained PID `8306`, the agent remained PID `8477`, and filtered ActivityManager logs contained no service timeout, process kill, or new ANR. After sending the app to the background, both PIDs remained unchanged beyond the prior 20-second ANR window.

The namespaced WorkManager job was then force-fired through JobScheduler and completed over authenticated app-owned IPC:

```text
ElizaTasksWorker: wake delivered via agent-service IPC status=200
WM-WorkerWrapper: Worker result SUCCESS for Work [tags={ ai.elizaos.app.ElizaTasksWorker }]
```

That installed APK had SHA-256 `fd6686ff0fa68a681dbad0c10e5272c7b6f96c6265e6c06bf216ff3e8fd6e561`, and its on-device digest matched. The current rebased exact head preserves the six reviewed patch commits and was rebuilt and artifact-audited locally; the current exact-head APK has the separate digest recorded above. No claim is made that the newly rebased APK was reinstalled on hardware.

# Evidence gate

<!-- evidence-row:before-screenshots -->
- [x] N/A — no rendered UI changed; a screenshot cannot show process ownership or wake delivery.
<!-- evidence-row:after-screenshots -->
- [x] N/A — installed state is proven by APK digest, system process state, and WorkManager logs rather than pixels.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — this is a background service/IPC contract with no user-visible interaction sequence.
<!-- evidence-row:backend-logs -->
- [x] Android background wake logs from the installed patch-equivalent head:

<details><summary>Android background wake log</summary>

```text
WM-WorkerWrapper: Starting work for ai.elizaos.app.ElizaTasksWorker
ElizaTasksWorker: wake delivered via agent-service IPC status=200
WM-WorkerWrapper: Worker result SUCCESS for Work [tags={ ai.elizaos.app.ElizaTasksWorker }]
ActivityManager review after backgrounding: no service timeout, process kill, or new ANR
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A — no WebView/frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model or action-planning behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Current exact-head APK build/audit plus prior installed digest, JobScheduler/WorkManager execution, app/agent PID continuity, and exit review:

<details><summary>Artifact and process evidence</summary>

```text
current_head=da14c9adeace017a03868da35d7ce923336cf72e validated_base=e21e3e2a18c1e1366c74bb0e56fea2774c261b58 current_develop=f5a3111c07ed7e4441dcd2ef8c2c6ff8fd38b196 merge_tree=clean
current_apk_sha256=5852e91b5b5ac50562636b2c9f9e4ab28b662e08ba57829148fe594ebcafcca2 artifact_audit=true installed=false
installed_patch_equivalent_head=241b7250ea936e8a88cc67cd9aee50f1483f9b31
installed_apk_sha256=fd6686ff0fa68a681dbad0c10e5272c7b6f96c6265e6c06bf216ff3e8fd6e561 on_device_match=true
clean_cold_boot_before_background app_pid=8306 agent_pid=8477 start_redeliveries=15 new_anr=false
clean_cold_boot_after_background app_pid=8306 agent_pid=8477 work_result=SUCCESS ipc_status=200
```
</details>
<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered text changed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - repository contribution skill is not available in this session
Attribution status: self-reported
— [codex-17874-postmerge]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - repository contribution skill is not available in this session"} -->
