### PR TITLE
fix(plugin-calendar): reject impossible explicit dates

### DIFF
--- a/plugins/plugin-calendar/src/internal/calendar-normalize.ts
+++ b/plugins/plugin-calendar/src/internal/calendar-normalize.ts
@@ -45,14 +45,14 @@ export function normalizeCalendarTimeZone(value: unknown): string {
   return normalizeValidTimeZone(value, "timeZone", resolveDefaultTimeZone());
 }
 
-function validateExplicitCalendarDate(text: string, field: string): void {
-  const match =
-    /^(?<year>[+-]?\d{4,6})-(?<month>\d{1,2})-(?<day>\d{1,2})(?:(?:T| )\d{1,2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?)?(?:[zZ]|[+-]\d{2}:?\d{2})$/.exec(
-      text,
-    );
-  if (!match?.groups) {
-    fail(400, `${field} must be a valid ISO datetime`);
-  }
+function validateIsoCalendarDatePrefix(text: string, field: string): void {
+  const match = /^(?<year>[+-]?\d{4,6})-(?<month>\d{1,2})-(?<day>\d{1,2})/.exec(
+    text,
+  );
+  // Non-ISO compatibility inputs remain the generic parser's responsibility.
+  // Every ISO-like input, however, must prove its civil date before any route
+  // reaches Date.parse, whose permissive legacy grammar normalizes Feb 30.
+  if (!match?.groups) return;
 
   const year = Number(match.groups.year);
   const month = Number(match.groups.month);
@@ -92,8 +92,8 @@ export function normalizeCalendarDateTimeInTimeZone(
     return undefined;
   }
   const text = requireNonEmptyString(value, field);
+  validateIsoCalendarDatePrefix(text, field);
   if (/[zZ]$|[+-]\d{2}:?\d{2}$/.test(text)) {
-    validateExplicitCalendarDate(text, field);
     return normalizeIsoString(text, field);
   }
 

--- a/plugins/plugin-calendar/src/internal/calendar-normalize.ts
+++ b/plugins/plugin-calendar/src/internal/calendar-normalize.ts
@@ -46,12 +46,17 @@ export function normalizeCalendarTimeZone(value: unknown): string {
 }
 
 function validateExplicitCalendarDate(text: string, field: string): void {
-  const match = /^(\d{4})-(\d{1,2})-(\d{1,2})(?:[T ]|$)/.exec(text);
-  if (!match) return;
+  const match =
+    /^(?<year>[+-]?\d{4,6})-(?<month>\d{1,2})-(?<day>\d{1,2})(?:(?:T| )\d{1,2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?)?(?:[zZ]|[+-]\d{2}:?\d{2})$/.exec(
+      text,
+    );
+  if (!match?.groups) {
+    fail(400, `${field} must be a valid ISO datetime`);
+  }
 
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
+  const year = Number(match.groups.year);
+  const month = Number(match.groups.month);
+  const day = Number(match.groups.day);
   const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
   const daysInMonth = [
     31,
@@ -87,7 +92,7 @@ export function normalizeCalendarDateTimeInTimeZone(
     return undefined;
   }
   const text = requireNonEmptyString(value, field);
-  if (/[zZ]|[+-]\d{2}:\d{2}$/.test(text)) {
+  if (/[zZ]$|[+-]\d{2}:?\d{2}$/.test(text)) {
     validateExplicitCalendarDate(text, field);
     return normalizeIsoString(text, field);
   }

--- a/plugins/plugin-calendar/src/internal/calendar-normalize.ts
+++ b/plugins/plugin-calendar/src/internal/calendar-normalize.ts
@@ -45,6 +45,39 @@ export function normalizeCalendarTimeZone(value: unknown): string {
   return normalizeValidTimeZone(value, "timeZone", resolveDefaultTimeZone());
 }
 
+function validateExplicitCalendarDate(text: string, field: string): void {
+  const match = /^(\d{4})-(\d{1,2})-(\d{1,2})(?:[T ]|$)/.exec(text);
+  if (!match) return;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [
+    31,
+    leapYear ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ];
+
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > (daysInMonth[month - 1] ?? 0)
+  ) {
+    fail(400, `${field} must be a valid ISO datetime`);
+  }
+}
+
 export function normalizeCalendarDateTimeInTimeZone(
   value: unknown,
   field: string,
@@ -55,6 +88,7 @@ export function normalizeCalendarDateTimeInTimeZone(
   }
   const text = requireNonEmptyString(value, field);
   if (/[zZ]|[+-]\d{2}:\d{2}$/.test(text)) {
+    validateExplicitCalendarDate(text, field);
     return normalizeIsoString(text, field);
   }
 

--- a/plugins/plugin-calendar/test/calendar-normalize.test.ts
+++ b/plugins/plugin-calendar/test/calendar-normalize.test.ts
@@ -100,6 +100,16 @@ describe("normalizeCalendarDateTimeInTimeZone", () => {
     ).toBe("2026-03-04T15:30:00.000Z");
   });
 
+  it.each([
+    "2026-02-30T09:00:00Z",
+    "2026-02-29T09:00:00+00:00",
+    "2026-04-31T09:00:00Z",
+  ])("rejects an impossible explicit calendar date: %s", (value) => {
+    expect(() =>
+      normalizeCalendarDateTimeInTimeZone(value, "startAt", "UTC"),
+    ).toThrow(CalendarServiceError);
+  });
+
   it("interprets a bare local datetime in the supplied zone", () => {
     // 09:00 local in UTC stays 09:00Z.
     expect(

--- a/plugins/plugin-calendar/test/calendar-normalize.test.ts
+++ b/plugins/plugin-calendar/test/calendar-normalize.test.ts
@@ -104,10 +104,23 @@ describe("normalizeCalendarDateTimeInTimeZone", () => {
     "2026-02-30T09:00:00Z",
     "2026-02-29T09:00:00+00:00",
     "2026-04-31T09:00:00Z",
+    "2026-02-30Z",
+    "2026-02-30T09:00:00+0000",
+    "+010000-02-30T09:00:00Z",
   ])("rejects an impossible explicit calendar date: %s", (value) => {
     expect(() =>
       normalizeCalendarDateTimeInTimeZone(value, "startAt", "UTC"),
     ).toThrow(CalendarServiceError);
+  });
+
+  it.each([
+    "2026-03-04Z",
+    "2026-03-04T09:00:00+0000",
+    "+010000-02-28T09:00:00Z",
+  ])("preserves valid explicit calendar forms: %s", (value) => {
+    expect(() =>
+      normalizeCalendarDateTimeInTimeZone(value, "startAt", "UTC"),
+    ).not.toThrow();
   });
 
   it("interprets a bare local datetime in the supplied zone", () => {

--- a/plugins/plugin-calendar/test/calendar-normalize.test.ts
+++ b/plugins/plugin-calendar/test/calendar-normalize.test.ts
@@ -107,6 +107,11 @@ describe("normalizeCalendarDateTimeInTimeZone", () => {
     "2026-02-30Z",
     "2026-02-30T09:00:00+0000",
     "+010000-02-30T09:00:00Z",
+    "2026-02-30 09:00:00 GMT",
+    "2026-02-30 09:00:00 UTC",
+    "2026-02-30 09:00:00 GMT+05:00",
+    "2026-02-30 09:00:00 +5:00",
+    "2026-02-30t09:00:00.1234567890z",
   ])("rejects an impossible explicit calendar date: %s", (value) => {
     expect(() =>
       normalizeCalendarDateTimeInTimeZone(value, "startAt", "UTC"),
@@ -117,6 +122,12 @@ describe("normalizeCalendarDateTimeInTimeZone", () => {
     "2026-03-04Z",
     "2026-03-04T09:00:00+0000",
     "+010000-02-28T09:00:00Z",
+    "2026-03-04t09:00:00z",
+    "2026-03-04T09:00:00.1234567890Z",
+    "2026-03-04 09:00:00 +05:00",
+    "2026-03-04 09:00:00 GMT+05:00",
+    "2026-03-04 09:00:00 GMT",
+    "2026-03-04 09:00:00 UTC",
   ])("preserves valid explicit calendar forms: %s", (value) => {
     expect(() =>
       normalizeCalendarDateTimeInTimeZone(value, "startAt", "UTC"),


### PR DESCRIPTION
## Relates to

Closes #19222.

## Summary

JavaScript's permissive date parser silently normalizes impossible ISO civil dates—for example, February 30 can become March 2. Calendar create/update requests could therefore persist a different instant than the caller supplied.

This branch now validates the `year-month-day` prefix of every ISO-like calendar input before timezone routing. That catches impossible dates regardless of whether the suffix is RFC3339, compact-offset, lowercase, GMT/UTC, or another supported legacy form, without replacing the plugin's intentionally broad date compatibility grammar.

## Scope

- `plugins/plugin-calendar/src/internal/calendar-normalize.ts`
- `plugins/plugin-calendar/test/calendar-normalize.test.ts`

No provider, UI, cloud, credential, or persistence paths changed.

## Verification

- Isolated, network-disabled plugin suite: 56 test files passed, 538 tests passed; 2 live-only files / 4 tests skipped by design.
- Exact head focused normalization suite: 46/46 passed, including impossible UTC/GMT/offset/lowercase forms and valid compatibility controls.
- `bun run --cwd plugins/plugin-calendar typecheck`: passed.
- Biome on both changed files: passed.
- Calendar JavaScript, view, and declaration builds: passed.
- `git diff --check`: passed.
- Rebased on `origin/develop@1d5b66935d059e75aa78c0920b1a4a057ba3e857`.

<!-- evidence-head:657f72419d559ab2b28bd6eac156e9e11b66fc7e -->
## Evidence gate

<!-- evidence-row:before-screenshots -->
- [x] N/A — no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no user-facing visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A — this is a deterministic request-normalization helper; no running backend is required.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic invalid-date regressions plus paired valid compatibility controls, exercised in the full plugin suite.

<details><summary>Isolated verification transcript</summary>

```text
bun x vitest run plugins/plugin-calendar/test/calendar-normalize.test.ts
Test Files  1 passed (1); Tests  46 passed (46)
bun run --cwd plugins/plugin-calendar test
Test Files  56 passed | 2 skipped (58); Tests  538 passed | 4 skipped (542)
bun run --cwd plugins/plugin-calendar typecheck
Process exited successfully; Biome and JavaScript/view/declaration builds also exited successfully.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered artifact changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

Contributor provider/model: openai / gpt-5.6-sol
Contributor agent tooling: codex
Contributor skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Contributor provenance status: self-reported
Compute receipt: run_01KZYH8YEV2WHS3XNTM2A9VJY6 (bounded, device-signed)
Contributor lane: calendar-invalid-date-19222
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"run_id":"run_01KZYH8YEV2WHS3XNTM2A9VJY6","project":"eliza","repository":"elizaOS/eliza","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","signature_algorithm":"ed25519","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601"}} -->

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@1d5b66935d059e75aa78c0920b1a4a057ba3e857:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@1d5b66935d059e75aa78c0920b1a4a057ba3e857:packages/skills/skills/contribute-to-eliza"} -->