### PR TITLE
fix(google): disable incremental OAuth grants

### DIFF
--- a/plugins/plugin-google-workspace/README.md
+++ b/plugins/plugin-google-workspace/README.md
@@ -6,7 +6,7 @@ Google Workspace integration for [elizaOS](https://github.com/elizaOS/eliza) age
 
 This plugin adds `GoogleWorkspaceService` to an Eliza agent runtime. The service exposes typed methods for reading and writing to Gmail, Calendar, Drive (including Docs and Sheets), and Meet. Authentication is account-scoped: every method call includes an `accountId` that maps to a stored OAuth token, so one agent can operate across multiple Google accounts simultaneously.
 
-The plugin also registers with the elizaOS `ConnectorAccountManager` so the built-in connector HTTP routes can manage Google accounts (list, create, delete) and run the OAuth flow (PKCE, offline access, incremental consent) without extra integration work.
+The plugin also registers with the elizaOS `ConnectorAccountManager` so the built-in connector HTTP routes can manage Google accounts (list, create, delete) and run the OAuth flow (PKCE, offline access, explicit least-privilege consent) without extra integration work.
 
 The plugin also ships the Google Chat connector (`src/chat/`): `GoogleChatService` registers a runtime `MessageConnector` for sending/receiving messages in Chat spaces, DMs, and threads, and `GoogleChatWorkflowCredentialProvider` supplies `googleChatOAuth2Api` credentials to the workflow plugin. Chat authenticates with a **service account** (`GOOGLE_CHAT_SERVICE_ACCOUNT[_FILE]` or `GOOGLE_APPLICATION_CREDENTIALS`, scope `https://www.googleapis.com/auth/chat.bot`) — a deliberately separate auth model from the Workspace OAuth grant. The plugin auto-enables when a `connectors.googlechat` block is configured (see `auto-enable.ts`); the Workspace side remains opt-in.
 

--- a/plugins/plugin-google-workspace/src/auth.ts
+++ b/plugins/plugin-google-workspace/src/auth.ts
@@ -56,7 +56,7 @@ export function getGoogleOAuthProviderConfig(
     authorizationParams: {
       access_type: "offline",
       prompt: "consent",
-      include_granted_scopes: "true",
+      include_granted_scopes: "false",
     },
   };
 }

--- a/plugins/plugin-google-workspace/src/connector-account-provider.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.ts
@@ -482,7 +482,7 @@ export function createGoogleConnectorAccountProvider(
         prompt: "consent",
         code_challenge: codeChallenge,
         code_challenge_method: "S256",
-        include_granted_scopes: "true",
+        include_granted_scopes: "false",
       });
 
       return {

--- a/plugins/plugin-google-workspace/src/index.test.ts
+++ b/plugins/plugin-google-workspace/src/index.test.ts
@@ -36,6 +36,10 @@ import googlePlugin, {
   scopesForGoogleCapabilities,
 } from "./index.js";
 
+function expectIncrementalGrantingDisabled(url: URL): void {
+  expect(url.searchParams.get("include_granted_scopes")).toBe("false");
+}
+
 describe("google plugin", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -82,7 +86,7 @@ describe("google plugin", () => {
     ).toEqual(GOOGLE_CAPABILITIES);
   });
 
-  it("normalizes capability input and preserves opt-in OAuth metadata", () => {
+  it("normalizes capability input and preserves opt-in OAuth metadata without incremental grants", () => {
     const config = getGoogleOAuthProviderConfig(
       normalizeGoogleCapabilities(["drive.read", "drive.read", "meet.read", "unknown"])
     );
@@ -92,7 +96,7 @@ describe("google plugin", () => {
     expect(config.scopes).toContain(GOOGLE_OAUTH_SCOPES.drive.read);
     expect(config.scopes).toContain(GOOGLE_OAUTH_SCOPES.meet.read);
     expect(config.scopes).not.toContain(GOOGLE_OAUTH_SCOPES.gmail.send);
-    expect(config.authorizationParams.include_granted_scopes).toBe("true");
+    expect(config.authorizationParams.include_granted_scopes).toBe("false");
   });
 
   it("rejects unknown connector OAuth capabilities instead of widening access", async () => {
@@ -240,6 +244,7 @@ describe("google plugin", () => {
 
     expect(getAccount).toHaveBeenCalledWith("google", "acct-reauth-1");
     const url = new URL(result?.authUrl ?? "");
+    expectIncrementalGrantingDisabled(url);
     const requestedScopes = new Set(
       (url.searchParams.get("scope") ?? "").split(" ").filter(Boolean)
     );
@@ -372,6 +377,7 @@ describe("google plugin", () => {
 
     expect(getAccount).not.toHaveBeenCalled();
     const url = new URL(result?.authUrl ?? "");
+    expectIncrementalGrantingDisabled(url);
     const requestedScopes = new Set(
       (url.searchParams.get("scope") ?? "").split(" ").filter(Boolean)
     );
@@ -408,6 +414,7 @@ describe("google plugin", () => {
       {} as never
     );
     const url = new URL(result?.authUrl ?? "");
+    expectIncrementalGrantingDisabled(url);
     const requestedScopes = new Set(
       (url.searchParams.get("scope") ?? "").split(" ").filter(Boolean)
     );
@@ -458,6 +465,7 @@ describe("google plugin", () => {
       {} as never
     );
     const url = new URL(result?.authUrl ?? "");
+    expectIncrementalGrantingDisabled(url);
     const requestedScopes = new Set(
       (url.searchParams.get("scope") ?? "").split(" ").filter(Boolean)
     );

--- a/plugins/plugin-google-workspace/src/types.ts
+++ b/plugins/plugin-google-workspace/src/types.ts
@@ -60,7 +60,7 @@ export interface GoogleOAuthProviderConfig {
   authorizationParams: {
     access_type: "offline";
     prompt: "consent";
-    include_granted_scopes: "true";
+    include_granted_scopes: "false";
   };
 }
 


### PR DESCRIPTION
# Relates to

Relates to #18931 and #18454.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d9ed54afbe81522f25c091d9bb3a68dd497a6be1:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The only OAuth behavior change is disabling Google incremental grant carryover, so users may be prompted for the explicitly requested scopes instead of Google silently adding scopes from older grants. Token exchange, credential persistence, callback validation, and capability mapping are unchanged.

# Background

## What does this PR do?

Sets Google OAuth `include_granted_scopes` to `false` in both provider config and connector auth URL generation so a narrower auth request cannot be widened by Google's incremental authorization carryover.

The PR also updates the public config type, README wording, and URL/provider tests so future changes keep the least-privilege OAuth parameter pinned.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes require a documentation change. I updated the Google Workspace README wording from incremental consent to explicit least-privilege consent.

# Testing

## Where should a reviewer start?

Start with:

- `plugins/plugin-google-workspace/src/auth.ts`
- `plugins/plugin-google-workspace/src/connector-account-provider.ts`
- `plugins/plugin-google-workspace/src/index.test.ts`

## Detailed testing steps

- PASS `bun run --cwd plugins/plugin-google-workspace test`
  - 15 files / 154 tests passed.
- PASS `bun run --cwd plugins/plugin-google-workspace lint:check`
  - 39 files checked. No fixes applied.
- PASS `bun run --cwd plugins/plugin-google-workspace typecheck`
- PASS `bun run --cwd plugins/plugin-google-workspace build`
  - `@elizaos/plugin-google-workspace build finished in 5.61s`.
- PASS `git diff --check`
  - Only Windows line-ending warnings were printed.
- PASS `bun install --frozen-lockfile`
  - Exit 0, no lockfile changes. Windows symlink `EPERM` warnings and missing local `patch` utility warnings were printed, but install completed successfully.
- FAIL `bun run verify`
  - Unrelated existing blocker: `@elizaos/electrobun#lint:check` fails on `packages/electrobun/src/preload.js` / scoped `src\preload.js` with `lint/complexity/noCommaOperator` and `lint/suspicious/noAssignInExpressions`. This PR does not touch `packages/electrobun`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:61de9ea5b6de9f8f4e47045b162bf77620701c53 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-visual Google OAuth parameter change; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-visual Google OAuth parameter change; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - non-visual Google OAuth parameter change; covered by deterministic OAuth URL tests.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no live Google credentials were used; deterministic OAuth URL and config tests exercise the changed boundary.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend/browser runtime path changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model runtime behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no live Google grant was minted; unit tests assert the outgoing OAuth request parameter.
<!-- evidence-row:ocr-review -->
- [ ] N/A - non-visual Google OAuth parameter change; no rendered UI surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model runtime behavior changed.

## Backend + frontend logs

N/A - no live Google OAuth credentials or secrets are available in this environment, and no frontend/browser runtime path changed. The plugin tests assert the generated OAuth URL contains `include_granted_scopes=false`.

## Screenshots (before / after) + video walkthrough

N/A - non-visual Google OAuth parameter change; no rendered UI surface changed.

### Before

N/A - non-visual Google OAuth parameter change; no rendered UI surface changed.

### After

N/A - non-visual Google OAuth parameter change; no rendered UI surface changed.

### Walkthrough video

N/A - non-visual Google OAuth parameter change; covered by deterministic OAuth URL tests.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice behavior changed.

## Known gaps / failures

`bun run verify` currently fails outside this PR at `@elizaos/electrobun#lint:check`. The failing diagnostics are in scoped `src\preload.js` / `packages/electrobun/src/preload.js`: `lint/complexity/noCommaOperator` and `lint/suspicious/noAssignInExpressions`. This PR only changes `plugins/plugin-google-workspace` files.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@d9ed54afbe81522f25c091d9bb3a68dd497a6be1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [OxBenji-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@d9ed54afbe81522f25c091d9bb3a68dd497a6be1:packages/skills/skills/contribute-to-eliza"} -->




