### PR TITLE
fix(cloud): make payment request transitions atomic

### DIFF
--- a/packages/cloud/api/cron/cleanup-expired-payment-requests/route.test.ts
+++ b/packages/cloud/api/cron/cleanup-expired-payment-requests/route.test.ts
@@ -1,0 +1,45 @@
+/** Pins cron authentication and canonical payment-request expiry dispatch. */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const expirePast = mock(async () => ["pr-1", "pr-2"]);
+
+mock.module("@/lib/services/payment-requests-default", () => ({
+  getPaymentRequestsService: () => ({ expirePast }),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(), info: mock(), warn: mock() },
+}));
+
+const { default: app } = await import("./route");
+const ENV = { CRON_SECRET: "cron-secret" } as Record<string, string>;
+
+function call(secret?: string, env: Record<string, string> = ENV) {
+  return app.fetch(
+    new Request("https://api.example.test/", {
+      method: "POST",
+      headers: secret ? { authorization: `Bearer ${secret}` } : {},
+    }),
+    env,
+  );
+}
+
+describe("cleanup-expired-payment-requests cron route", () => {
+  beforeEach(() => expirePast.mockClear());
+
+  test("requires a configured matching cron secret", async () => {
+    expect((await call("cron-secret", {})).status).toBe(403);
+    expect((await call("wrong")).status).toBe(401);
+    expect(expirePast).not.toHaveBeenCalled();
+  });
+
+  test("runs the global canonical sweep exactly once", async () => {
+    const response = await call("cron-secret");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      expiredCount: 2,
+    });
+    expect(expirePast).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/api/cron/cleanup-expired-payment-requests/route.ts
+++ b/packages/cloud/api/cron/cleanup-expired-payment-requests/route.ts
@@ -1,0 +1,23 @@
+/** Expires canonical payment requests whose checkout deadline has elapsed. */
+import { Hono } from "hono";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { requireCronSecret } from "@/lib/auth/workers-hono-auth";
+import { getPaymentRequestsService } from "@/lib/services/payment-requests-default";
+import { logger } from "@/lib/utils/logger";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const app = new Hono<AppEnv>();
+
+app.post("/", async (c) => {
+  try {
+    requireCronSecret(c);
+    const expiredIds = await getPaymentRequestsService(c.env).expirePast();
+    return c.json({ success: true, expiredCount: expiredIds.length });
+  } catch (error) {
+    // error-policy:J1 cron route boundary converts failure into a non-2xx response.
+    logger.error("[PaymentRequests] expiry cron failed", { error });
+    return failureResponse(c, error);
+  }
+});
+
+export default app;

--- a/packages/cloud/api/src/_router.generated.ts
+++ b/packages/cloud/api/src/_router.generated.ts
@@ -69,6 +69,7 @@ import _route_cron_auto_top_up_route from "../cron/auto-top-up/route";
 import _route_cron_cleanup_anonymous_sessions_route from "../cron/cleanup-anonymous-sessions/route";
 import _route_cron_cleanup_cli_sessions_route from "../cron/cleanup-cli-sessions/route";
 import _route_cron_cleanup_expired_crypto_payments_route from "../cron/cleanup-expired-crypto-payments/route";
+import _route_cron_cleanup_expired_payment_requests_route from "../cron/cleanup-expired-payment-requests/route";
 import _route_cron_cleanup_priorities_route from "../cron/cleanup-priorities/route";
 import _route_cron_cleanup_stuck_provisioning_route from "../cron/cleanup-stuck-provisioning/route";
 import _route_cron_cleanup_webhook_events_route from "../cron/cleanup-webhook-events/route";
@@ -805,6 +806,10 @@ export function mountRoutes(app: Hono<AppEnv>): void {
   app.route(
     "/api/cron/cleanup-expired-crypto-payments",
     _route_cron_cleanup_expired_crypto_payments_route,
+  );
+  app.route(
+    "/api/cron/cleanup-expired-payment-requests",
+    _route_cron_cleanup_expired_payment_requests_route,
   );
   app.route(
     "/api/cron/cleanup-priorities",

--- a/packages/cloud/api/v1/payment-requests/[id]/expire/route.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/expire/route.ts
@@ -3,9 +3,10 @@
  *
  * POST /api/v1/payment-requests/:id/expire
  *
- * Forces the request into `expired` status if it has passed its expiry. The
- * underlying service decides whether the row is actually past expiry; the
- * route only authorizes the call.
+ * Expires a past-due request only when no provider intent was delivered. A
+ * provider-backed request remains settlement-eligible until reconciliation
+ * owns its terminal state. The service decides whether the row is actually
+ * past expiry; the route only authorizes the call.
  */
 
 import { Hono } from "hono";

--- a/packages/cloud/api/v1/payment-requests/[id]/route.test.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/route.test.ts
@@ -75,9 +75,9 @@ const paymentRequest: PaymentRequestRow = {
   settledAt: null,
   settlementTxRef: "provider-tx-ref",
   settlementProof: { signature: "proof-secret" },
-  expiresAt: new Date("2026-08-12T12:00:00.000Z"),
-  createdAt: new Date("2026-08-12T11:00:00.000Z"),
-  updatedAt: new Date("2026-08-12T11:00:00.000Z"),
+  expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+  createdAt: new Date(),
+  updatedAt: new Date(),
   metadata: { internal: "do-not-expose" },
 };
 
@@ -106,12 +106,29 @@ describe("GET /api/v1/payment-requests/:id", () => {
         reason: "Premium plan",
         status: "pending",
         hostedUrl: "https://checkout.example.test/session",
-        expiresAt: "2026-08-12T12:00:00.000Z",
+        expiresAt: paymentRequest.expiresAt.toISOString(),
       },
     });
     expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
     expect(getMock).not.toHaveBeenCalled();
     expect(getPublicMock).toHaveBeenCalledWith("pr-1");
+  });
+
+  test("derives expiration and removes the stale public checkout URL", async () => {
+    getPublicMock.mockResolvedValue({
+      ...paymentRequest,
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+
+    const response = await app.request("/pr-1?public=1");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      paymentRequest: {
+        status: "expired",
+        hostedUrl: null,
+      },
+    });
   });
 
   test("returns not found for a missing public payment request without authenticating", async () => {

--- a/packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts
@@ -1,27 +1,6 @@
 /**
- * Fail-closed money boundary for `payment_requests.amount_cents` reads
- * (#13416, cloud-shared DB-repository fallback-slop sweep).
- *
- * `amount_cents` is a NOT NULL `bigint` column. Before this slice `toDomain`
- * read it with a bare `Number(row.amount_cents)`, which fails open two ways and
- * flows straight into the Stripe adapter:
- *
- *   - `Number(veryLargeBigInt)` loses precision above `2^53 - 1`, so the
- *     `unit_amount: request.amountCents` sent to Stripe no longer equals the
- *     authorized amount — a mischarge with no error.
- *   - `Number(<malformed string from a raw-query/driver path>)` is `NaN`, and
- *     the adapter's reject guard `if (request.amountCents <= 0)` evaluates
- *     `NaN <= 0` as `false`, so a request with no readable amount slips past the
- *     zero/negative check and a checkout session is created for `NaN`.
- *
- * The parser suite pins the boundary exhaustively (deterministic, no DB). The
- * PGlite wiring test proves `getPaymentRequest` round-trips a real stored amount
- * (incl. a large-but-safe value) through the parser without precision loss and
- * returns `null` — not a fabricated row — for a genuinely-missing id. A corrupt
- * bigint cannot be *stored* in Postgres/PGlite, so the corrupt/oversized
- * fail-closed behavior is proven at the parser boundary the method calls (the
- * regression cases below), which is exactly the read-time driver-quirk /
- * raw-query failure mode this guards.
+ * Exercises amount parsing and lifecycle compare-and-set behavior with deterministic fixtures.
+ * Parser cases cover malformed driver values; repository cases use an isolated real PGlite database.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
@@ -36,6 +15,8 @@ process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
 
 import { pushSchema } from "drizzle-kit/api";
+import { eq } from "drizzle-orm";
+import { createPaymentRequestsService } from "../../../lib/services/payment-requests";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
 import {
   appDeploymentStatusEnum,
@@ -44,7 +25,7 @@ import {
   userDatabaseStatusEnum,
 } from "../../schemas/apps";
 import { organizations } from "../../schemas/organizations";
-import { paymentRequests } from "../../schemas/payment-requests";
+import { paymentRequestEvents, paymentRequests } from "../../schemas/payment-requests";
 import { users } from "../../schemas/users";
 import { PaymentRequestsRepository } from "../payment-requests";
 import { parsePaymentAmountCents } from "../payment-requests-numeric";
@@ -123,7 +104,7 @@ describe("parsePaymentAmountCents", () => {
   });
 });
 
-describe("PaymentRequestsRepository.getPaymentRequest fail-closed wiring", () => {
+describe("PaymentRequestsRepository real PGlite wiring", () => {
   const PGLITE_TIMEOUT = 60_000;
   const repo = new PaymentRequestsRepository();
   let pgliteReady = true;
@@ -148,6 +129,7 @@ describe("PaymentRequestsRepository.getPaymentRequest fail-closed wiring", () =>
         users,
         apps,
         paymentRequests,
+        paymentRequestEvents,
         appDeploymentStatusEnum,
         appReviewStatusEnum,
         userDatabaseStatusEnum,
@@ -165,6 +147,7 @@ describe("PaymentRequestsRepository.getPaymentRequest fail-closed wiring", () =>
 
   beforeEach(async () => {
     expect(pgliteReady).toBe(true);
+    await dbWrite.delete(paymentRequestEvents);
     await dbWrite.delete(paymentRequests);
     await dbWrite.delete(organizations);
   });
@@ -238,5 +221,217 @@ describe("PaymentRequestsRepository.getPaymentRequest fail-closed wiring", () =>
 
     const fetched = await repo.getPaymentRequest(created.id);
     expect(fetched?.amountCents).toBe(0);
+  });
+
+  const createRequest = (organizationId: string, expiresAt: Date) =>
+    repo.createPaymentRequest({
+      organizationId,
+      provider: "stripe",
+      amountCents: 500,
+      currency: "usd",
+      paymentContext: { kind: "any_payer" },
+      expiresAt,
+    });
+
+  const eventsFor = (paymentRequestId: string) =>
+    dbWrite
+      .select()
+      .from(paymentRequestEvents)
+      .where(eq(paymentRequestEvents.payment_request_id, paymentRequestId));
+
+  const transitionEventsFor = async (paymentRequestId: string) =>
+    (await eventsFor(paymentRequestId)).filter((event) => event.event_name !== "payment.created");
+
+  test("creates the request and its lifecycle event atomically", async () => {
+    const created = await createRequest(await seedOrg(), new Date("2030-01-01T00:00:00Z"));
+
+    expect((await eventsFor(created.id)).map((event) => event.event_name)).toEqual([
+      "payment.created",
+    ]);
+  });
+
+  test("duplicate settlement callbacks commit one transition and event", async () => {
+    const created = await createRequest(await seedOrg(), new Date("2030-01-01T00:00:00Z"));
+    const recordedAt = new Date("2029-12-31T23:59:59Z");
+
+    const results = await Promise.all([
+      repo.settlePaymentRequest(created.id, recordedAt, "pi-same", {}),
+      repo.settlePaymentRequest(created.id, recordedAt, "pi-same", {}),
+    ]);
+
+    expect(results.filter(Boolean)).toHaveLength(1);
+    expect((await repo.getPaymentRequest(created.id))?.settlementTxRef).toBe("pi-same");
+    expect((await transitionEventsFor(created.id)).map((event) => event.event_name)).toEqual([
+      "payment.settled",
+    ]);
+  });
+
+  test("settle and fail cannot commit mixed terminal state", async () => {
+    const created = await createRequest(await seedOrg(), new Date("2030-01-01T00:00:00Z"));
+    const recordedAt = new Date("2029-12-31T23:59:59Z");
+
+    const results = await Promise.all([
+      repo.settlePaymentRequest(created.id, recordedAt, "pi-race", { event: "synthetic" }),
+      repo.failPaymentRequest(created.id, "synthetic failure", recordedAt),
+    ]);
+    expect(results.filter(Boolean)).toHaveLength(1);
+
+    const row = await repo.getPaymentRequest(created.id);
+    const events = await transitionEventsFor(created.id);
+    if (row?.status === "settled") {
+      expect(row.settlementTxRef).toBe("pi-race");
+      expect(events.map((event) => event.event_name)).toEqual(["payment.settled"]);
+    } else {
+      expect(row).toMatchObject({
+        status: "failed",
+        settledAt: null,
+        settlementTxRef: null,
+        settlementProof: null,
+      });
+      expect(events.map((event) => event.event_name)).toEqual(["payment.failed"]);
+    }
+  });
+
+  test("settle and cancel commit one matching terminal event", async () => {
+    const organizationId = await seedOrg();
+    const created = await createRequest(organizationId, new Date("2030-01-01T00:00:00Z"));
+    const recordedAt = new Date("2029-12-31T23:59:59Z");
+
+    const results = await Promise.all([
+      repo.settlePaymentRequest(created.id, recordedAt, "pi-cancel-race", {}),
+      repo.cancelPaymentRequest(created.id, organizationId, "synthetic cancel", recordedAt),
+    ]);
+    expect(results.filter(Boolean)).toHaveLength(1);
+
+    const row = await repo.getPaymentRequest(created.id);
+    const events = await transitionEventsFor(created.id);
+    expect(row?.status === "settled" ? row.settlementTxRef : row?.status).toBe(
+      row?.status === "settled" ? "pi-cancel-race" : "canceled",
+    );
+    expect(events.map((event) => event.event_name)).toEqual([
+      row?.status === "settled" ? "payment.settled" : "payment.canceled",
+    ]);
+  });
+
+  test("expiry wins at the exact deadline before checkout initialization", async () => {
+    const deadline = new Date("2030-01-01T00:00:00Z");
+    const created = await createRequest(await seedOrg(), deadline);
+
+    const [initialized, expired] = await Promise.all([
+      repo.initializePaymentRequest(
+        created.id,
+        { stripe_session_id: "cs_too_late" },
+        "https://checkout.example.test/too-late",
+        deadline,
+      ),
+      repo.expirePastPaymentRequest(created.id, deadline),
+    ]);
+
+    expect(initialized).toBeNull();
+    expect(expired).toBe(true);
+    expect(await repo.getPaymentRequest(created.id)).toMatchObject({
+      status: "expired",
+      hostedUrl: null,
+      providerIntent: {},
+    });
+    expect((await transitionEventsFor(created.id)).map((event) => event.event_name)).toEqual([
+      "payment.expired",
+    ]);
+  });
+
+  test("keeps a delivered request settlement-eligible after its public deadline", async () => {
+    const deadline = new Date("2030-01-01T00:00:00Z");
+    const created = await createRequest(await seedOrg(), deadline);
+    const delivered = await repo.initializePaymentRequest(
+      created.id,
+      { stripe_session_id: "cs_delivered" },
+      "https://checkout.example.test/delivered",
+      new Date("2029-12-31T23:59:59Z"),
+    );
+
+    expect(delivered?.status).toBe("delivered");
+    expect(await repo.expirePastPaymentRequests(deadline)).toEqual([]);
+    expect(
+      await repo.settlePaymentRequest(
+        created.id,
+        new Date("2030-01-01T00:00:01Z"),
+        "pi-after-deadline",
+        {},
+      ),
+    ).toMatchObject({ status: "settled", settlementTxRef: "pi-after-deadline" });
+    expect((await transitionEventsFor(created.id)).map((event) => event.event_name)).toEqual([
+      "payment.delivered",
+      "payment.settled",
+    ]);
+  });
+
+  test("create cannot persist or return a provider URL after expiry wins", async () => {
+    let releaseIntent: (() => void) | undefined;
+    const intentBlocked = new Promise<void>((resolve) => {
+      releaseIntent = resolve;
+    });
+    let requestCreated:
+      | ((row: Awaited<ReturnType<typeof repo.createPaymentRequest>>) => void)
+      | undefined;
+    const createdRequest = new Promise<Awaited<ReturnType<typeof repo.createPaymentRequest>>>(
+      (resolve) => {
+        requestCreated = resolve;
+      },
+    );
+    const service = createPaymentRequestsService({
+      repository: repo,
+      adapters: [
+        {
+          provider: "stripe",
+          async createIntent({ request }) {
+            requestCreated?.(request);
+            await intentBlocked;
+            return {
+              hostedUrl: "https://checkout.example.test/orphan",
+              providerIntent: { stripe_session_id: "cs_orphan" },
+            };
+          },
+        },
+      ],
+    });
+
+    const creating = service.create({
+      organizationId: await seedOrg(),
+      provider: "stripe",
+      amountCents: 500,
+      currency: "usd",
+      paymentContext: { kind: "any_payer" },
+    });
+    const created = await createdRequest;
+    expect(await repo.expirePastPaymentRequest(created.id, created.expiresAt)).toBe(true);
+    releaseIntent?.();
+
+    await expect(creating).rejects.toThrow('already in terminal status "expired"');
+    expect(await repo.getPaymentRequest(created.id)).toMatchObject({
+      status: "expired",
+      hostedUrl: null,
+      providerIntent: {},
+    });
+    expect((await eventsFor(created.id)).map((event) => event.event_name)).toEqual([
+      "payment.created",
+      "payment.expired",
+    ]);
+  });
+
+  test("expiry sweep commits an event for each transitioned request", async () => {
+    const organizationId = await seedOrg();
+    const deadline = new Date("2030-01-01T00:00:00Z");
+    const first = await createRequest(organizationId, deadline);
+    const second = await createRequest(organizationId, deadline);
+
+    expect((await repo.expirePastPaymentRequests(deadline)).sort()).toEqual(
+      [first.id, second.id].sort(),
+    );
+    expect((await transitionEventsFor(first.id)).map((event) => event.event_name)).toEqual([
+      "payment.expired",
+    ]);
+    expect((await transitionEventsFor(second.id)).map((event) => event.event_name)).toEqual([
+      "payment.expired",
+    ]);
   });
 });

--- a/packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts
@@ -266,6 +266,35 @@ describe("PaymentRequestsRepository real PGlite wiring", () => {
     ]);
   });
 
+  test("settle and expiry commit one matching terminal state and event", async () => {
+    const deadline = new Date("2030-01-01T00:00:00Z");
+    const created = await createRequest(await seedOrg(), deadline);
+
+    const results = await Promise.all([
+      repo.settlePaymentRequest(created.id, deadline, "pi-expiry-race", { event: "synthetic" }),
+      repo.expirePastPaymentRequest(created.id, deadline),
+    ]);
+    expect(results.filter(Boolean)).toHaveLength(1);
+
+    const row = await repo.getPaymentRequest(created.id);
+    const events = await transitionEventsFor(created.id);
+    if (row?.status === "settled") {
+      expect(row).toMatchObject({
+        settlementTxRef: "pi-expiry-race",
+        settlementProof: { event: "synthetic" },
+      });
+      expect(events.map((event) => event.event_name)).toEqual(["payment.settled"]);
+    } else {
+      expect(row).toMatchObject({
+        status: "expired",
+        settledAt: null,
+        settlementTxRef: null,
+        settlementProof: null,
+      });
+      expect(events.map((event) => event.event_name)).toEqual(["payment.expired"]);
+    }
+  });
+
   test("settle and fail cannot commit mixed terminal state", async () => {
     const created = await createRequest(await seedOrg(), new Date("2030-01-01T00:00:00Z"));
     const recordedAt = new Date("2029-12-31T23:59:59Z");

--- a/packages/cloud/shared/src/db/repositories/payment-requests.ts
+++ b/packages/cloud/shared/src/db/repositories/payment-requests.ts
@@ -1,9 +1,8 @@
-// Persists payment requests records for cloud services through the shared DB boundary.
-import { and, desc, eq, gte, inArray, lt, lte, sql } from "drizzle-orm";
+/** Persists payment requests and their lifecycle events through the shared database boundary. */
+import { and, desc, eq, gt, gte, inArray, isNull, lte, sql } from "drizzle-orm";
 import { dbWrite as db } from "../client";
 import {
   type NewPaymentRequest as NewPaymentRequestDbRow,
-  type NewPaymentRequestEvent as NewPaymentRequestEventDbRow,
   type PaymentContext,
   type PaymentRequestRow as PaymentRequestDbRow,
   type PaymentRequestEventRow as PaymentRequestEventDbRow,
@@ -79,12 +78,6 @@ export interface NewPaymentRequest {
   metadata?: Record<string, unknown>;
 }
 
-export interface NewPaymentRequestEvent {
-  paymentRequestId: string;
-  eventName: NewPaymentRequestEventDbRow["event_name"];
-  redactedPayload?: Record<string, unknown>;
-}
-
 export type PaymentRequestEventRow = PaymentRequestEventDbRow;
 
 function toDbInsert(input: NewPaymentRequest): NewPaymentRequestDbRow {
@@ -110,31 +103,6 @@ function toDbInsert(input: NewPaymentRequest): NewPaymentRequestDbRow {
     expires_at: input.expiresAt,
     metadata: input.metadata ?? {},
   };
-}
-
-function toDbPatch(input: Partial<NewPaymentRequest>): Partial<NewPaymentRequestDbRow> {
-  const patch: Partial<NewPaymentRequestDbRow> = {};
-  if (input.organizationId !== undefined) patch.organization_id = input.organizationId;
-  if (input.agentId !== undefined) patch.agent_id = input.agentId;
-  if (input.appId !== undefined) patch.app_id = input.appId;
-  if (input.provider !== undefined) patch.provider = input.provider;
-  if (input.amountCents !== undefined) patch.amount_cents = BigInt(input.amountCents);
-  if (input.currency !== undefined) patch.currency = input.currency;
-  if (input.reason !== undefined) patch.reason = input.reason;
-  if (input.paymentContext !== undefined) patch.payment_context = input.paymentContext;
-  if (input.payerIdentityId !== undefined) patch.payer_identity_id = input.payerIdentityId;
-  if (input.payerUserId !== undefined) patch.payer_user_id = input.payerUserId;
-  if (input.status !== undefined) patch.status = input.status;
-  if (input.hostedUrl !== undefined) patch.hosted_url = input.hostedUrl;
-  if (input.callbackUrl !== undefined) patch.callback_url = input.callbackUrl;
-  if (input.callbackSecret !== undefined) patch.callback_secret = input.callbackSecret;
-  if (input.providerIntent !== undefined) patch.provider_intent = input.providerIntent;
-  if (input.settledAt !== undefined) patch.settled_at = input.settledAt;
-  if (input.settlementTxRef !== undefined) patch.settlement_tx_ref = input.settlementTxRef;
-  if (input.settlementProof !== undefined) patch.settlement_proof = input.settlementProof;
-  if (input.expiresAt !== undefined) patch.expires_at = input.expiresAt;
-  if (input.metadata !== undefined) patch.metadata = input.metadata;
-  return patch;
 }
 
 function toDomain(row: PaymentRequestDbRow): PaymentRequestRow {
@@ -166,18 +134,34 @@ function toDomain(row: PaymentRequestDbRow): PaymentRequestRow {
   };
 }
 
-function toDbEvent(input: NewPaymentRequestEvent): NewPaymentRequestEventDbRow {
+function lifecycleEventPayload(
+  row: PaymentRequestDbRow,
+  status: "pending" | "delivered" | "settled" | "failed" | "expired" | "canceled",
+  detail?: { error?: string; txRef?: string },
+): Record<string, unknown> {
   return {
-    payment_request_id: input.paymentRequestId,
-    event_name: input.eventName,
-    redacted_payload: input.redactedPayload ?? {},
+    paymentRequestId: row.id,
+    organizationId: row.organization_id,
+    provider: row.provider,
+    amountCents: parsePaymentAmountCents(row.amount_cents, "amount_cents"),
+    currency: row.currency,
+    status,
+    txRef: detail?.txRef ?? null,
+    error: detail?.error,
   };
 }
 
 export class PaymentRequestsRepository {
   async createPaymentRequest(input: NewPaymentRequest): Promise<PaymentRequestRow> {
-    const [row] = await db.insert(paymentRequests).values(toDbInsert(input)).returning();
-    return toDomain(row);
+    return db.transaction(async (tx) => {
+      const [row] = await tx.insert(paymentRequests).values(toDbInsert(input)).returning();
+      await tx.insert(paymentRequestEvents).values({
+        payment_request_id: row.id,
+        event_name: "payment.created",
+        redacted_payload: lifecycleEventPayload(row, row.status),
+      });
+      return toDomain(row);
+    });
   }
 
   async getPaymentRequest(id: string): Promise<PaymentRequestRow | null> {
@@ -210,76 +194,210 @@ export class PaymentRequestsRepository {
     return rows.map(toDomain);
   }
 
-  async updatePaymentRequestStatus(
+  async initializePaymentRequest(
     id: string,
-    status: PaymentRequestStatus | null,
-    patch: Partial<NewPaymentRequest> = {},
+    providerIntent: Record<string, unknown>,
+    hostedUrl: string | null,
+    initializedAt: Date,
   ): Promise<PaymentRequestRow | null> {
-    const dbPatch = toDbPatch(patch);
-    const [row] = await db
-      .update(paymentRequests)
-      .set({ ...dbPatch, ...(status ? { status } : {}), updated_at: new Date() })
-      .where(eq(paymentRequests.id, id))
-      .returning();
-    return row ? toDomain(row) : null;
+    return db.transaction(async (tx) => {
+      const [row] = await tx
+        .update(paymentRequests)
+        .set({
+          status: "delivered",
+          provider_intent: providerIntent,
+          hosted_url: hostedUrl,
+          updated_at: initializedAt,
+        })
+        .where(
+          and(
+            eq(paymentRequests.id, id),
+            eq(paymentRequests.status, "pending"),
+            gt(paymentRequests.expires_at, initializedAt),
+          ),
+        )
+        .returning();
+      if (!row) return null;
+      await tx.insert(paymentRequestEvents).values({
+        payment_request_id: row.id,
+        event_name: "payment.delivered",
+        redacted_payload: lifecycleEventPayload(row, "delivered"),
+      });
+      return toDomain(row);
+    });
   }
 
-  async recordPaymentRequestEvent(input: NewPaymentRequestEvent): Promise<PaymentRequestEventRow> {
-    const [row] = await db.insert(paymentRequestEvents).values(toDbEvent(input)).returning();
-    return row;
+  async failPaymentRequest(
+    id: string,
+    error: string,
+    failedAt: Date,
+  ): Promise<PaymentRequestRow | null> {
+    const failable: PaymentRequestStatus[] = ["pending", "delivered"];
+    return db.transaction(async (tx) => {
+      const [row] = await tx
+        .update(paymentRequests)
+        .set({ status: "failed", updated_at: failedAt })
+        .where(and(eq(paymentRequests.id, id), inArray(paymentRequests.status, failable)))
+        .returning();
+      if (!row) return null;
+      await tx.insert(paymentRequestEvents).values({
+        payment_request_id: row.id,
+        event_name: "payment.failed",
+        redacted_payload: lifecycleEventPayload(row, "failed", { error }),
+      });
+      return toDomain(row);
+    });
+  }
+
+  async cancelPaymentRequest(
+    id: string,
+    organizationId: string,
+    reason: string | undefined,
+    canceledAt: Date,
+  ): Promise<PaymentRequestRow | null> {
+    const cancelable: PaymentRequestStatus[] = ["pending", "delivered"];
+    return db.transaction(async (tx) => {
+      const [row] = await tx
+        .update(paymentRequests)
+        .set({ status: "canceled", updated_at: canceledAt })
+        .where(
+          and(
+            eq(paymentRequests.id, id),
+            eq(paymentRequests.organization_id, organizationId),
+            inArray(paymentRequests.status, cancelable),
+            gt(paymentRequests.expires_at, canceledAt),
+          ),
+        )
+        .returning();
+      if (!row) return null;
+      await tx.insert(paymentRequestEvents).values({
+        payment_request_id: row.id,
+        event_name: "payment.canceled",
+        redacted_payload: lifecycleEventPayload(row, "canceled", { error: reason }),
+      });
+      return toDomain(row);
+    });
+  }
+
+  async settlePaymentRequest(
+    id: string,
+    settledAt: Date,
+    settlementTxRef: string,
+    settlementProof: Record<string, unknown>,
+  ): Promise<PaymentRequestRow | null> {
+    const payable: PaymentRequestStatus[] = ["pending", "delivered"];
+    return db.transaction(async (tx) => {
+      const [row] = await tx
+        .update(paymentRequests)
+        .set({
+          status: "settled",
+          settled_at: settledAt,
+          settlement_tx_ref: settlementTxRef,
+          settlement_proof: settlementProof,
+          updated_at: settledAt,
+        })
+        .where(and(eq(paymentRequests.id, id), inArray(paymentRequests.status, payable)))
+        .returning();
+      if (!row) return null;
+      await tx.insert(paymentRequestEvents).values({
+        payment_request_id: row.id,
+        event_name: "payment.settled",
+        redacted_payload: lifecycleEventPayload(row, "settled", { txRef: settlementTxRef }),
+      });
+      return toDomain(row);
+    });
   }
 
   async expirePastPaymentRequests(now: Date): Promise<string[]> {
-    const expirable: PaymentRequestStatus[] = ["pending", "delivered"];
-    const rows = await db
-      .update(paymentRequests)
-      .set({ status: "expired", updated_at: now })
-      .where(and(inArray(paymentRequests.status, expirable), lt(paymentRequests.expires_at, now)))
-      .returning({ id: paymentRequests.id });
-    return rows.map((r) => r.id);
+    return db.transaction(async (tx) => {
+      const rows = await tx
+        .update(paymentRequests)
+        .set({ status: "expired", updated_at: now })
+        .where(
+          and(
+            eq(paymentRequests.status, "pending"),
+            isNull(paymentRequests.hosted_url),
+            sql`${paymentRequests.provider_intent} = '{}'::jsonb`,
+            lte(paymentRequests.expires_at, now),
+          ),
+        )
+        .returning();
+      if (rows.length > 0) {
+        await tx.insert(paymentRequestEvents).values(
+          rows.map((row) => ({
+            payment_request_id: row.id,
+            event_name: "payment.expired" as const,
+            redacted_payload: lifecycleEventPayload(row, "expired"),
+          })),
+        );
+      }
+      return rows.map((row) => row.id);
+    });
   }
 
   /**
    * Org-scoped variant of {@link expirePastPaymentRequests}: only flips past-due
-   * `pending`/`delivered` rows belonging to `organizationId`. The global
-   * variant stays for the system cron janitor.
+   * never-delivered `pending` rows belonging to `organizationId`. Provider-backed
+   * rows remain settlement-eligible until reconciliation owns their terminal state.
    */
   async expirePastPaymentRequestsForOrg(organizationId: string, now: Date): Promise<string[]> {
-    const expirable: PaymentRequestStatus[] = ["pending", "delivered"];
-    const rows = await db
-      .update(paymentRequests)
-      .set({ status: "expired", updated_at: now })
-      .where(
-        and(
-          eq(paymentRequests.organization_id, organizationId),
-          inArray(paymentRequests.status, expirable),
-          lt(paymentRequests.expires_at, now),
-        ),
-      )
-      .returning({ id: paymentRequests.id });
-    return rows.map((r) => r.id);
+    return db.transaction(async (tx) => {
+      const rows = await tx
+        .update(paymentRequests)
+        .set({ status: "expired", updated_at: now })
+        .where(
+          and(
+            eq(paymentRequests.organization_id, organizationId),
+            eq(paymentRequests.status, "pending"),
+            isNull(paymentRequests.hosted_url),
+            sql`${paymentRequests.provider_intent} = '{}'::jsonb`,
+            lte(paymentRequests.expires_at, now),
+          ),
+        )
+        .returning();
+      if (rows.length > 0) {
+        await tx.insert(paymentRequestEvents).values(
+          rows.map((row) => ({
+            payment_request_id: row.id,
+            event_name: "payment.expired" as const,
+            redacted_payload: lifecycleEventPayload(row, "expired"),
+          })),
+        );
+      }
+      return rows.map((row) => row.id);
+    });
   }
 
   /**
    * Expire a SINGLE past-due payment request by id. Caller (service) enforces
    * org ownership, mirroring cancel(). Only flips a row still in an expirable
-   * status AND past its expiry, so it is idempotent and never touches a
-   * settled/canceled request. Returns true iff a row changed.
+   * state AND past its expiry. Provider-backed rows stay nonterminal so an
+   * authenticated delayed settlement cannot be rejected before reconciliation
+   * policy lands. Returns true iff a row changed.
    */
   async expirePastPaymentRequest(id: string, now: Date): Promise<boolean> {
-    const expirable: PaymentRequestStatus[] = ["pending", "delivered"];
-    const rows = await db
-      .update(paymentRequests)
-      .set({ status: "expired", updated_at: now })
-      .where(
-        and(
-          eq(paymentRequests.id, id),
-          inArray(paymentRequests.status, expirable),
-          lt(paymentRequests.expires_at, now),
-        ),
-      )
-      .returning({ id: paymentRequests.id });
-    return rows.length > 0;
+    return db.transaction(async (tx) => {
+      const [row] = await tx
+        .update(paymentRequests)
+        .set({ status: "expired", updated_at: now })
+        .where(
+          and(
+            eq(paymentRequests.id, id),
+            eq(paymentRequests.status, "pending"),
+            isNull(paymentRequests.hosted_url),
+            sql`${paymentRequests.provider_intent} = '{}'::jsonb`,
+            lte(paymentRequests.expires_at, now),
+          ),
+        )
+        .returning();
+      if (!row) return false;
+      await tx.insert(paymentRequestEvents).values({
+        payment_request_id: row.id,
+        event_name: "payment.expired",
+        redacted_payload: lifecycleEventPayload(row, "expired"),
+      });
+      return true;
+    });
   }
 
   async findPaymentRequestByProviderIntentKey(

--- a/packages/cloud/shared/src/lib/cron/cloudflare-cron.test.ts
+++ b/packages/cloud/shared/src/lib/cron/cloudflare-cron.test.ts
@@ -1,0 +1,34 @@
+/** Verifies the scheduled handler reaches the canonical payment expiry route. */
+import { describe, expect, test } from "bun:test";
+import { makeCronHandler } from "./cloudflare-cron";
+
+describe("payment-request cron fanout", () => {
+  test("dispatches the authenticated canonical expiry route every ten minutes", async () => {
+    const requests: Request[] = [];
+    let work: Promise<unknown> | undefined;
+    const scheduled = makeCronHandler(async (request) => {
+      requests.push(request);
+      return new Response(null, { status: 200 });
+    });
+
+    await scheduled(
+      { cron: "*/10 * * * *", scheduledTime: Date.now() },
+      {
+        CRON_SECRET: "cron-secret",
+        NEXT_PUBLIC_APP_URL: "https://api.example.test",
+      } as never,
+      {
+        waitUntil(promise: Promise<unknown>) {
+          work = promise;
+        },
+      } as never,
+    );
+    await work;
+
+    const expiryRequest = requests.find(
+      (request) => new URL(request.url).pathname === "/api/cron/cleanup-expired-payment-requests",
+    );
+    expect(expiryRequest?.method).toBe("POST");
+    expect(expiryRequest?.headers.get("x-cron-secret")).toBe("cron-secret");
+  });
+});

--- a/packages/cloud/shared/src/lib/cron/cloudflare-cron.ts
+++ b/packages/cloud/shared/src/lib/cron/cloudflare-cron.ts
@@ -52,7 +52,11 @@ export const CRON_FANOUT: Record<string, string[]> = {
     // to it — see packages/cloud/scripts/admin/daemons/provisioning-worker.ts.
   ],
   "*/2 * * * *": ["/api/v1/cron/pool-health-check"],
-  "*/10 * * * *": ["/api/cron/cleanup-expired-crypto-payments", "/api/v1/cron/pool-image-rollout"],
+  "*/10 * * * *": [
+    "/api/cron/cleanup-expired-crypto-payments",
+    "/api/cron/cleanup-expired-payment-requests",
+    "/api/v1/cron/pool-image-rollout",
+  ],
   "*/15 * * * *": [
     "/api/cron/auto-top-up",
     "/api/cron/agent-budgets",

--- a/packages/cloud/shared/src/lib/services/payment-requests.test.ts
+++ b/packages/cloud/shared/src/lib/services/payment-requests.test.ts
@@ -2,8 +2,6 @@
 import { describe, expect, test } from "bun:test";
 import {
   type NewPaymentRequest,
-  type NewPaymentRequestEvent,
-  type PaymentRequestEventRow,
   type PaymentRequestRow,
   PaymentRequestsRepository,
 } from "../../db/repositories/payment-requests";
@@ -57,6 +55,7 @@ describe("toPublicPaymentRequest", () => {
       payerIdentityId: "identity-secret",
       payerUserId: "user-secret",
       payerOrganizationId: "payer-org-secret",
+      status: "delivered",
       hostedUrl: "https://checkout.example.test/session",
       callbackUrl: "https://merchant.example.test/callback",
       callbackSecret: "callback-secret",
@@ -66,16 +65,26 @@ describe("toPublicPaymentRequest", () => {
       metadata: { internal: "metadata-secret" },
     };
 
-    expect(toPublicPaymentRequest(row)).toEqual({
+    expect(toPublicPaymentRequest(row, new Date(1))).toEqual({
       id: "pr-public",
       provider: "stripe",
       amountCents: 100,
       currency: "USD",
       reason: "Premium plan",
       status: "expired",
-      hostedUrl: "https://checkout.example.test/session",
+      hostedUrl: null,
       expiresAt: new Date(0),
     });
+  });
+
+  test("preserves the hosted URL for non-expired terminal rows", () => {
+    const row = {
+      ...fakeRow("pr-settled-public", "org-secret"),
+      status: "settled" as const,
+      hostedUrl: "https://checkout.example.test/session",
+    };
+
+    expect(toPublicPaymentRequest(row, new Date(1)).hostedUrl).toBe(row.hostedUrl);
   });
 });
 
@@ -85,7 +94,6 @@ describe("toPublicPaymentRequest", () => {
  */
 class ExpireScopingRepository extends PaymentRequestsRepository {
   forOrgCalls: Array<{ organizationId: string; now: Date }> = [];
-  events: NewPaymentRequestEvent[] = [];
   private readonly orgById: Record<string, string>;
 
   constructor(orgById: Record<string, string>) {
@@ -112,13 +120,6 @@ class ExpireScopingRepository extends PaymentRequestsRepository {
   override async getPaymentRequest(id: string): Promise<PaymentRequestRow | null> {
     const org = this.orgById[id];
     return org ? fakeRow(id, org) : null;
-  }
-
-  override async recordPaymentRequestEvent(
-    input: NewPaymentRequestEvent,
-  ): Promise<PaymentRequestEventRow> {
-    this.events.push(input);
-    return { id: `evt-${this.events.length}` } as unknown as PaymentRequestEventRow;
   }
 }
 
@@ -159,12 +160,6 @@ describe("expirePastForOrg (least-privilege expire, #10117)", () => {
     // Only org-1's rows are returned; org-2's row is untouched.
     expect(expired.sort()).toEqual(["pr-mine-1", "pr-mine-2"]);
     expect(repository.forOrgCalls).toEqual([{ organizationId: "org-1", now }]);
-    // An expired event was recorded for each of the caller's rows only.
-    expect(repository.events.map((e) => e.paymentRequestId).sort()).toEqual([
-      "pr-mine-1",
-      "pr-mine-2",
-    ]);
-    expect(repository.events.every((e) => e.eventName === "payment.expired")).toBe(true);
   });
 
   test("expirePast (cron) still uses the global sweep", async () => {
@@ -177,15 +172,9 @@ describe("expirePastForOrg (least-privilege expire, #10117)", () => {
   });
 });
 
-/**
- * In-memory settlement state machine — backs the webhook-replay idempotency
- * tests. Settlement webhooks (Stripe + OxaPay) rely on these exact semantics
- * for "user is credited exactly once" under provider redelivery.
- */
-class SettlementRepository extends PaymentRequestsRepository {
-  row: PaymentRequestRow;
-  events: NewPaymentRequestEvent[] = [];
-  updateCalls = 0;
+/** Returns a stable current row after every simulated compare-and-set miss. */
+class CasMissRepository extends PaymentRequestsRepository {
+  readonly row: PaymentRequestRow;
 
   constructor(row: PaymentRequestRow) {
     super();
@@ -196,90 +185,89 @@ class SettlementRepository extends PaymentRequestsRepository {
     return this.row.id === id ? this.row : null;
   }
 
-  override async updatePaymentRequestStatus(
-    id: string,
-    status: Parameters<PaymentRequestsRepository["updatePaymentRequestStatus"]>[1],
-    patch: Parameters<PaymentRequestsRepository["updatePaymentRequestStatus"]>[2] = {},
-  ): Promise<PaymentRequestRow | null> {
-    if (this.row.id !== id) return null;
-    this.updateCalls += 1;
-    this.row = {
-      ...this.row,
-      ...(status ? { status } : {}),
-      ...(patch?.settledAt !== undefined ? { settledAt: patch.settledAt } : {}),
-      ...(patch?.settlementTxRef !== undefined ? { settlementTxRef: patch.settlementTxRef } : {}),
-      ...(patch?.settlementProof !== undefined ? { settlementProof: patch.settlementProof } : {}),
+  override async settlePaymentRequest(): Promise<PaymentRequestRow | null> {
+    return null;
+  }
+
+  override async failPaymentRequest(): Promise<PaymentRequestRow | null> {
+    return null;
+  }
+
+  override async initializePaymentRequest(): Promise<PaymentRequestRow | null> {
+    return null;
+  }
+}
+
+describe("compare-and-set replay handling", () => {
+  test("returns the existing row for an identical settlement replay", async () => {
+    const row = {
+      ...fakeRow("pr-settle", "org-1"),
+      status: "settled" as const,
+      settlementTxRef: "trk-1",
+      settledAt: new Date(),
     };
-    return this.row;
-  }
+    const service = createPaymentRequestsService({
+      repository: new CasMissRepository(row),
+      adapters: [],
+    });
 
-  override async recordPaymentRequestEvent(
-    input: NewPaymentRequestEvent,
-  ): Promise<PaymentRequestEventRow> {
-    this.events.push(input);
-    return { id: `evt-${this.events.length}` } as unknown as PaymentRequestEventRow;
-  }
-}
-
-function pendingRow(id: string): PaymentRequestRow {
-  return { ...fakeRow(id, "org-1"), status: "pending" };
-}
-
-describe("settlement idempotency under webhook replay (#10732)", () => {
-  test("markSettled replay with the same txRef is a no-op: one update, one settled event", async () => {
-    const repository = new SettlementRepository(pendingRow("pr-settle"));
-    const service = createPaymentRequestsService({ repository, adapters: [] });
-
-    const first = await service.markSettled("pr-settle", "trk-1", { provider: "oxapay" });
-    expect(first.status).toBe("settled");
-    expect(repository.updateCalls).toBe(1);
-    expect(repository.events.map((e) => e.eventName)).toEqual(["payment.settled"]);
-
-    // Provider redelivers the identical callback (same txRef): no second
-    // update, no second settled event → no double credit downstream.
-    const replay = await service.markSettled("pr-settle", "trk-1", { provider: "oxapay" });
-    expect(replay.status).toBe("settled");
-    expect(replay.settlementTxRef).toBe("trk-1");
-    expect(repository.updateCalls).toBe(1);
-    expect(repository.events.map((e) => e.eventName)).toEqual(["payment.settled"]);
+    await expect(service.markSettled(row.id, "trk-1", {})).resolves.toBe(row);
   });
 
-  test("markSettled with a DIFFERENT txRef after settlement throws (terminal CAS)", async () => {
-    const repository = new SettlementRepository(pendingRow("pr-settle-2"));
-    const service = createPaymentRequestsService({ repository, adapters: [] });
+  test("rejects a different settlement reference after the terminal CAS", async () => {
+    const row = {
+      ...fakeRow("pr-settle-conflict", "org-1"),
+      status: "settled" as const,
+      settlementTxRef: "trk-a",
+      settledAt: new Date(),
+    };
+    const service = createPaymentRequestsService({
+      repository: new CasMissRepository(row),
+      adapters: [],
+    });
 
-    await service.markSettled("pr-settle-2", "trk-a", {});
-    await expect(service.markSettled("pr-settle-2", "trk-b", {})).rejects.toThrow(
+    await expect(service.markSettled(row.id, "trk-b", {})).rejects.toThrow(
       'already in terminal status "settled"',
     );
-    expect(repository.updateCalls).toBe(1);
   });
 
-  test("a late failure callback cannot clobber a settled request", async () => {
-    const repository = new SettlementRepository(pendingRow("pr-settle-3"));
-    const service = createPaymentRequestsService({ repository, adapters: [] });
+  test("returns the existing row for an identical initialization replay", async () => {
+    const row = {
+      ...fakeRow("pr-delivered", "org-1"),
+      status: "delivered" as const,
+      hostedUrl: "https://checkout.example.test/session",
+      providerIntent: { stripe_session_id: "cs_1" },
+      expiresAt: new Date(Date.now() + 60_000),
+    };
+    const service = createPaymentRequestsService({
+      repository: new CasMissRepository(row),
+      adapters: [],
+    });
 
-    await service.markSettled("pr-settle-3", "trk-c", {});
-    await expect(service.markFailed("pr-settle-3", "late failure")).rejects.toThrow(
-      'already in terminal status "settled"',
+    await expect(service.markInitialized(row.id, row.providerIntent, row.hostedUrl)).resolves.toBe(
+      row,
     );
-    expect(repository.row.status).toBe("settled");
   });
 
-  test("markFailed replay is a no-op and a late settle after failure throws", async () => {
-    const repository = new SettlementRepository(pendingRow("pr-fail"));
-    const service = createPaymentRequestsService({ repository, adapters: [] });
+  test("rejects a changed initialization after another writer wins", async () => {
+    const row = {
+      ...fakeRow("pr-delivered-conflict", "org-1"),
+      status: "delivered" as const,
+      hostedUrl: "https://checkout.example.test/first",
+      providerIntent: { stripe_session_id: "cs_first" },
+      expiresAt: new Date(Date.now() + 60_000),
+    };
+    const service = createPaymentRequestsService({
+      repository: new CasMissRepository(row),
+      adapters: [],
+    });
 
-    await service.markFailed("pr-fail", "invoice expired");
-    expect(repository.updateCalls).toBe(1);
-
-    const replay = await service.markFailed("pr-fail", "invoice expired");
-    expect(replay.status).toBe("failed");
-    expect(repository.updateCalls).toBe(1);
-    expect(repository.events.map((e) => e.eventName)).toEqual(["payment.failed"]);
-
-    await expect(service.markSettled("pr-fail", "trk-x", {})).rejects.toThrow(
-      'already in terminal status "failed"',
-    );
+    await expect(
+      service.markInitialized(
+        row.id,
+        { stripe_session_id: "cs_second" },
+        "https://checkout.example.test/second",
+      ),
+    ).rejects.toThrow('state changed concurrently to "delivered"');
   });
 });

--- a/packages/cloud/shared/src/lib/services/payment-requests.ts
+++ b/packages/cloud/shared/src/lib/services/payment-requests.ts
@@ -148,24 +148,6 @@ function validateCreateInput(input: CreatePaymentRequestInput): void {
   }
 }
 
-function redactSettlementPayload(args: {
-  paymentRequest: PaymentRequestRow;
-  status: PaymentRequestStatus;
-  txRef?: string | null;
-  error?: string;
-}): Record<string, unknown> {
-  return {
-    paymentRequestId: args.paymentRequest.id,
-    organizationId: args.paymentRequest.organizationId,
-    provider: args.paymentRequest.provider,
-    amountCents: args.paymentRequest.amountCents,
-    currency: args.paymentRequest.currency,
-    status: args.status,
-    txRef: args.txRef ?? null,
-    error: args.error,
-  };
-}
-
 function assertNotTerminal(row: PaymentRequestRow, action: string): void {
   if (TERMINAL_STATUSES.has(row.status)) {
     throw new Error(
@@ -244,21 +226,11 @@ class PaymentRequestsServiceImpl implements PaymentRequestsService {
     });
 
     const intent = await adapter.createIntent({ request: created });
-
-    const persisted = await this.repository.updatePaymentRequestStatus(created.id, null, {
-      hostedUrl: intent.hostedUrl ?? null,
-      providerIntent: intent.providerIntent,
-    });
-    const row = requireRow(persisted, created.id, "post-intent persist");
-
-    await this.repository.recordPaymentRequestEvent({
-      paymentRequestId: row.id,
-      eventName: "payment.created",
-      redactedPayload: redactSettlementPayload({
-        paymentRequest: row,
-        status: row.status,
-      }),
-    });
+    const row = await this.markInitialized(
+      created.id,
+      intent.providerIntent,
+      intent.hostedUrl ?? null,
+    );
 
     logger.info("[PaymentRequests] Created payment request", {
       paymentRequestId: row.id,
@@ -268,7 +240,7 @@ class PaymentRequestsServiceImpl implements PaymentRequestsService {
       currency: row.currency,
     });
 
-    return { paymentRequest: row, hostedUrl: intent.hostedUrl };
+    return { paymentRequest: row, hostedUrl: row.hostedUrl ?? undefined };
   }
 
   async get(id: string, organizationId: string): Promise<PaymentRequestRow | null> {
@@ -296,27 +268,34 @@ class PaymentRequestsServiceImpl implements PaymentRequestsService {
   }
 
   async cancel(id: string, organizationId: string, reason?: string): Promise<PaymentRequestRow> {
-    const existing = requireRow(await this.repository.getPaymentRequest(id), id, "cancel lookup");
-    if (existing.organizationId !== organizationId) {
-      throw new Error(`Payment request ${id} does not belong to organization ${organizationId}`);
-    }
-    assertCancelable(existing);
-
-    const updated = requireRow(
-      await this.repository.updatePaymentRequestStatus(id, "canceled"),
+    const canceledAt = new Date();
+    const updated = await this.repository.cancelPaymentRequest(
       id,
-      "cancel update",
+      organizationId,
+      reason,
+      canceledAt,
     );
-
-    await this.repository.recordPaymentRequestEvent({
-      paymentRequestId: id,
-      eventName: "payment.canceled",
-      redactedPayload: redactSettlementPayload({
-        paymentRequest: updated,
-        status: "canceled",
-        error: reason,
-      }),
-    });
+    if (!updated) {
+      const existing = requireRow(
+        await this.repository.getPaymentRequest(id),
+        id,
+        "cancel compare-and-set",
+      );
+      if (existing.organizationId !== organizationId) {
+        throw new Error(`Payment request ${id} does not belong to organization ${organizationId}`);
+      }
+      if (existing.status === "canceled") return existing;
+      if (
+        (existing.status === "pending" || existing.status === "delivered") &&
+        existing.expiresAt.getTime() <= canceledAt.getTime()
+      ) {
+        throw new Error(
+          `Cannot cancel payment request ${id}: expired at ${existing.expiresAt.toISOString()}`,
+        );
+      }
+      assertCancelable(existing);
+      throw new Error(`Cannot cancel payment request ${id}: state changed concurrently`);
+    }
 
     logger.info("[PaymentRequests] Canceled payment request", {
       paymentRequestId: id,
@@ -339,17 +318,6 @@ class PaymentRequestsServiceImpl implements PaymentRequestsService {
 
     const expired = await this.repository.expirePastPaymentRequest(id, now);
     if (expired) {
-      const row = await this.repository.getPaymentRequest(id);
-      if (row) {
-        await this.repository.recordPaymentRequestEvent({
-          paymentRequestId: id,
-          eventName: "payment.expired",
-          redactedPayload: redactSettlementPayload({
-            paymentRequest: row,
-            status: "expired",
-          }),
-        });
-      }
       logger.info("[PaymentRequests] Expired payment request", {
         paymentRequestId: id,
         organizationId,
@@ -362,7 +330,6 @@ class PaymentRequestsServiceImpl implements PaymentRequestsService {
 
   async expirePast(now: Date = new Date()): Promise<string[]> {
     const expiredIds = await this.repository.expirePastPaymentRequests(now);
-    await this.recordExpiredEvents(expiredIds);
     if (expiredIds.length > 0) {
       logger.info("[PaymentRequests] Expired payment requests", {
         count: expiredIds.length,
@@ -373,7 +340,6 @@ class PaymentRequestsServiceImpl implements PaymentRequestsService {
 
   async expirePastForOrg(organizationId: string, now: Date = new Date()): Promise<string[]> {
     const expiredIds = await this.repository.expirePastPaymentRequestsForOrg(organizationId, now);
-    await this.recordExpiredEvents(expiredIds);
     if (expiredIds.length > 0) {
       logger.info("[PaymentRequests] Expired payment requests", {
         organizationId,
@@ -383,56 +349,30 @@ class PaymentRequestsServiceImpl implements PaymentRequestsService {
     return expiredIds;
   }
 
-  private async recordExpiredEvents(expiredIds: string[]): Promise<void> {
-    for (const id of expiredIds) {
-      const row = await this.repository.getPaymentRequest(id);
-      if (!row) continue;
-      await this.repository.recordPaymentRequestEvent({
-        paymentRequestId: id,
-        eventName: "payment.expired",
-        redactedPayload: redactSettlementPayload({
-          paymentRequest: row,
-          status: "expired",
-        }),
-      });
-    }
-  }
-
   async markSettled(
     id: string,
     settlementTxRef: string,
     settlementProof: Record<string, unknown>,
   ): Promise<PaymentRequestRow> {
-    const existing = requireRow(
-      await this.repository.getPaymentRequest(id),
-      id,
-      "markSettled lookup",
-    );
-    if (existing.status === "settled" && existing.settlementTxRef === settlementTxRef) {
-      return existing;
-    }
-    assertNotTerminal(existing, "settle");
-
     const settledAt = new Date();
-    const updated = requireRow(
-      await this.repository.updatePaymentRequestStatus(id, "settled", {
-        settledAt,
-        settlementTxRef,
-        settlementProof,
-      }),
+    const updated = await this.repository.settlePaymentRequest(
       id,
-      "markSettled update",
+      settledAt,
+      settlementTxRef,
+      settlementProof,
     );
-
-    await this.repository.recordPaymentRequestEvent({
-      paymentRequestId: id,
-      eventName: "payment.settled",
-      redactedPayload: redactSettlementPayload({
-        paymentRequest: updated,
-        status: "settled",
-        txRef: settlementTxRef,
-      }),
-    });
+    if (!updated) {
+      const existing = requireRow(
+        await this.repository.getPaymentRequest(id),
+        id,
+        "markSettled compare-and-set",
+      );
+      if (existing.status === "settled" && existing.settlementTxRef === settlementTxRef) {
+        return existing;
+      }
+      assertNotTerminal(existing, "settle");
+      throw new Error(`Cannot settle payment request ${id}: state changed concurrently`);
+    }
 
     logger.info("[PaymentRequests] Settled payment request", {
       paymentRequestId: id,
@@ -449,53 +389,50 @@ class PaymentRequestsServiceImpl implements PaymentRequestsService {
     providerIntent: Record<string, unknown>,
     hostedUrl?: string | null,
   ): Promise<PaymentRequestRow> {
-    const updated = requireRow(
-      await this.repository.updatePaymentRequestStatus(id, "delivered", {
-        providerIntent,
-        hostedUrl,
-      }),
+    const initializedAt = new Date();
+    const updated = await this.repository.initializePaymentRequest(
       id,
-      "markInitialized update",
+      providerIntent,
+      hostedUrl ?? null,
+      initializedAt,
     );
+    if (updated) return updated;
 
-    await this.repository.recordPaymentRequestEvent({
-      paymentRequestId: id,
-      eventName: "payment.delivered",
-      redactedPayload: redactSettlementPayload({
-        paymentRequest: updated,
-        status: updated.status,
-      }),
-    });
-
-    return updated;
-  }
-
-  async markFailed(id: string, error: string): Promise<PaymentRequestRow> {
     const existing = requireRow(
       await this.repository.getPaymentRequest(id),
       id,
-      "markFailed lookup",
+      "markInitialized compare-and-set",
     );
-    if (existing.status === "failed") {
+    if (
+      existing.status === "delivered" &&
+      existing.hostedUrl === (hostedUrl ?? null) &&
+      JSON.stringify(existing.providerIntent) === JSON.stringify(providerIntent)
+    ) {
       return existing;
     }
-    assertNotTerminal(existing, "fail");
-
-    const updated = requireRow(
-      await this.repository.updatePaymentRequestStatus(id, "failed"),
-      id,
-      "markFailed update",
+    if (existing.status === "pending" && existing.expiresAt.getTime() <= initializedAt.getTime()) {
+      throw new Error(
+        `Cannot initialize payment request ${id}: expired at ${existing.expiresAt.toISOString()}`,
+      );
+    }
+    assertNotTerminal(existing, "initialize");
+    throw new Error(
+      `Cannot initialize payment request ${id}: state changed concurrently to "${existing.status}"`,
     );
+  }
 
-    await this.repository.recordPaymentRequestEvent({
-      paymentRequestId: id,
-      eventName: "payment.failed",
-      redactedPayload: redactSettlementPayload({
-        paymentRequest: updated,
-        status: "failed",
-        error,
-      }),
-    });
+  async markFailed(id: string, error: string): Promise<PaymentRequestRow> {
+    const updated = await this.repository.failPaymentRequest(id, error, new Date());
+    if (!updated) {
+      const existing = requireRow(
+        await this.repository.getPaymentRequest(id),
+        id,
+        "markFailed compare-and-set",
+      );
+      if (existing.status === "failed") return existing;
+      assertNotTerminal(existing, "fail");
+      throw new Error(`Cannot fail payment request ${id}: state changed concurrently`);
+    }
 
     logger.warn("[PaymentRequests] Failed payment request", {
       paymentRequestId: id,
@@ -513,15 +450,23 @@ export function createPaymentRequestsService(
   return new PaymentRequestsServiceImpl(deps);
 }
 
-export function toPublicPaymentRequest(row: PaymentRequestRow): PublicPaymentRequest {
+export function toPublicPaymentRequest(
+  row: PaymentRequestRow,
+  now: Date = new Date(),
+): PublicPaymentRequest {
+  const status =
+    (row.status === "pending" || row.status === "delivered") &&
+    row.expiresAt.getTime() <= now.getTime()
+      ? "expired"
+      : row.status;
   return {
     id: row.id,
     provider: row.provider,
     amountCents: row.amountCents,
     currency: row.currency,
     reason: row.reason,
-    status: row.status,
-    hostedUrl: row.hostedUrl,
+    status,
+    hostedUrl: status === "expired" ? null : row.hostedUrl,
     expiresAt: row.expiresAt,
   };
 }


### PR DESCRIPTION
# Relates to

Part of #18814. This is the transactional core reland requested in
https://github.com/elizaOS/eliza/pull/18862#issuecomment-5285654381; it does not
close the issue. Provider-authoritative timestamps, reconciliation policy,
checkout lifetime/idempotency, webhook retry/publication semantics, and UI work
remain a separate follow-up.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`; its two commits are rebased onto `origin/develop@62537f6bf1b9ea9b0e14f893a660aab25355a312`, and a fresh merge-tree is clean against live `develop@b8320ff38d9afd3bb129106dde8b65daf08123e6`.
- [x] Before the conflict-only rebase, the full verifier and Cloud gates passed on the same PR patch; post-rebase codegen, range-diff, merge-tree, diff-check, and Biome checks pass.
- [x] A reviewer can confirm the transition behavior from the real PGlite interleaving tests described below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@90c2cd8de48eef5920746c78b9aa54e82ffdb48c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] The two PR commits are rebased onto `origin/develop@62537f6bf1b9ea9b0e14f893a660aab25355a312`; a fresh merge-tree against live `develop@b8320ff38d9afd3bb129106dde8b65daf08123e6` has zero conflicts.
- [x] The conflict resolution is generated-only: upstream's 666 routes plus this PR's expiry route regenerate to 667 routes, with no other range-diff change.

# Risks

Medium. This changes payment lifecycle persistence and scheduled expiry. The
risk is contained by explicit compare-and-set transactions, in-transaction
lifecycle events, and real PGlite interleaving coverage. The janitor
deliberately expires only never-delivered requests; provider-backed requests
remain settlement-eligible until the separate reconciliation policy lands.

# Background

## What does this PR do?

- Replaces generic payment status/intent/event mutation methods with explicit
  transactional initialize, fail, cancel, settle, and expire operations.
- Creates each payment request and its `payment.created` event atomically.
- Derives overdue public requests as expired server-side and suppresses their
  stale checkout URL without changing the existing `Date` service contract.
- Adds an authenticated ten-minute expiry route and canonical cron fanout that
  terminalizes only never-delivered requests.
- Adds real PGlite coverage for duplicate settlement; settle/expire,
  settle/fail, settle/cancel, and initialize/expire races; exact deadlines; delayed
  settlement after public expiry; and provider creation losing to expiry.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is required. The behavior is captured in the
repository/service contracts and focused tests.

# Testing

## Where should a reviewer start?

Start with
`packages/cloud/shared/src/db/repositories/payment-requests.ts` and
`packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts`.
The latter uses a real in-memory PGlite database and asserts both the winning
row and the matching lifecycle-event history.

## Detailed testing steps

These results were recorded on the semantically equivalent pre-rebase patch; fresh hosted CI is running on the exact rebased head.

```text
ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile
# no lockfile changes

DATABASE_URL=pglite://memory TEST_DATABASE_URL=pglite://memory NODE_ENV=test MOCK_REDIS=1 \
  bun run --cwd packages/cloud/shared test \
  src/db/repositories/__tests__/payment-requests-numeric.test.ts \
  src/lib/services/payment-requests.test.ts \
  src/lib/cron/cloudflare-cron.test.ts
# 33 passed, 0 failed

bun run --cwd packages/cloud/api test \
  cron/cleanup-expired-payment-requests/route.test.ts
# 2 passed, 0 failed

bun run --cwd packages/cloud/api test \
  'v1/payment-requests/[id]/route.test.ts'
# 6 passed, 0 failed

bun run verify
# 348 successful, 348 total; all audits pass

bun run verify:cloud
# 78 successful, 78 total

bun run --cwd packages/cloud/shared check:tenant-scope
# 99 repository files checked

bun run --cwd packages/cloud/api codegen
# 667 mounted, 0 unconverted; a second run is byte-identical
```

# Evidence Gate

<!-- evidence-head:7b7dc9941e25305b8d5f3c767ce5c9be1673468b -->

This is a backend persistence/cron change with no rendered UI surface.

<!-- evidence-row:before-screenshots -->
- [x] N/A - this backend-only change has no rendered visual surface to capture before.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this backend-only change has no rendered visual surface to capture after.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this backend-only transaction and cron change has no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployment is part of this PR; the real PGlite transaction results are reproduced by the commands above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend log surface applies; the changed public API response is covered by `v1/payment-requests/[id]/route.test.ts`.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the domain artifacts are ephemeral PGlite rows and lifecycle events asserted directly by the committed real-database tests.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text or visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior changes.

## Backend + frontend logs

N/A - no deployment or frontend surface is changed. The detailed test commands
above exercise the real repository transaction boundary and mounted API route.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface is changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changes.

## Known gaps / failures

Hosted checks are re-running on exact rebased head `7b7dc9941e25305b8d5f3c767ce5c9be1673468b`.

The same payment-request patch passed the focused suites 41/41, the full verifier,
Cloud verification, tenant-scope audit, and codegen before this conflict-only
rebase. Post-rebase validation confirms a clean merge-tree against live
`develop@b8320ff38d9afd3bb129106dde8b65daf08123e6`, an equivalent commit
range-diff except for the generated route count (666 + 1 = 667), idempotent
codegen, a clean diff check, and Biome across all 11 changed files. Fresh hosted
CI is authoritative for the combined base.
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@90c2cd8de48eef5920746c78b9aa54e82ffdb48c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@90c2cd8de48eef5920746c78b9aa54e82ffdb48c:packages/skills/skills/contribute-to-eliza"} -->






Final merge-captain sync: the two semantic commits are cleanly rebased onto `develop@da93a6b29aa75506e7fd7131d8319e0f298214bf`; changed-file Biome and `git diff --check` pass on exact head `7b7dc9941e25305b8d5f3c767ce5c9be1673468b`. The prior exact-patch PGlite proof was 41/41, and the previous hosted gitleaks and Security Advisory Gate both completed successfully before this clean rebase.
