### PR TITLE
fix(documents): validate upload MIME boundaries

### DIFF
--- a/packages/core/src/features/documents/service-mime-regression.test.ts
+++ b/packages/core/src/features/documents/service-mime-regression.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Exercises MIME-variant PDF ingestion through the real DocumentService,
+ * unpdf parser, fragmenter, AgentRuntime, and in-memory persistence. The
+ * checked-in audit fixture is deliberately uploaded with a non-PDF filename so
+ * MIME routing, rather than the extension fallback, determines extraction.
+ */
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter.ts";
+import { AgentRuntime } from "../../runtime.ts";
+import type { Character, Memory, UUID } from "../../types/index.ts";
+import { DocumentService } from "./service.ts";
+
+const AGENT_ID = "00000000-0000-4000-8000-000000019153" as UUID;
+const PDF_FIXTURE_PATH = fileURLToPath(
+	new URL(
+		"../../../../app-core/test/contracts/lib/openzeppelin-contracts/audits/2025-10-v5.5.pdf",
+		import.meta.url,
+	),
+);
+
+type ExtractionSnapshot = {
+	length: number;
+	text: string;
+	digest: string;
+};
+
+function fragmentPosition(fragment: Memory): number {
+	const position = fragment.metadata?.position;
+	if (typeof position !== "number") {
+		throw new Error(`Fragment ${fragment.id} has no numeric position`);
+	}
+	return position;
+}
+
+async function ingestPdf(
+	pdfBase64: string,
+	contentType: string,
+): Promise<ExtractionSnapshot> {
+	const adapter = new InMemoryDatabaseAdapter();
+	await adapter.initialize();
+	const runtime = new AgentRuntime({
+		agentId: AGENT_ID,
+		character: {
+			name: "DocumentMimeRegressionTestAgent",
+			bio: "Exercises deterministic PDF MIME routing.",
+			settings: {},
+		} as Character,
+		adapter,
+		logLevel: "fatal",
+	});
+	const service = new DocumentService(runtime);
+	const result = await service.addDocument({
+		agentId: AGENT_ID,
+		worldId: AGENT_ID,
+		roomId: AGENT_ID,
+		entityId: AGENT_ID,
+		clientDocumentId: AGENT_ID,
+		contentType,
+		originalFilename: "openzeppelin-v5.5-audit.bin",
+		content: pdfBase64,
+	});
+
+	const fragments = (
+		await runtime.getMemories({
+			tableName: "document_fragments",
+			agentId: AGENT_ID,
+			roomId: AGENT_ID,
+			count: 10_000,
+		})
+	)
+		.filter(
+			(fragment) => fragment.metadata?.documentId === result.clientDocumentId,
+		)
+		.sort((left, right) => fragmentPosition(left) - fragmentPosition(right));
+	expect(fragments).toHaveLength(result.fragmentCount);
+
+	const text = fragments
+		.map((fragment) => {
+			if (typeof fragment.content.text !== "string") {
+				throw new Error(`Fragment ${fragment.id} has no text`);
+			}
+			return fragment.content.text;
+		})
+		.join("\n");
+
+	return {
+		length: text.length,
+		text,
+		digest: createHash("sha256").update(text).digest("hex"),
+	};
+}
+
+describe("DocumentService PDF MIME routing regression", () => {
+	it("extracts identical text for canonical, uppercase, and parameterized PDF MIME values", async () => {
+		const pdfBase64 = (await readFile(PDF_FIXTURE_PATH)).toString("base64");
+		const canonical = await ingestPdf(pdfBase64, "application/pdf");
+		const uppercase = await ingestPdf(pdfBase64, "APPLICATION/PDF");
+		const parameterized = await ingestPdf(
+			pdfBase64,
+			"application/pdf; charset=UTF-8",
+		);
+
+		expect(canonical.length).toBeGreaterThan(1_000);
+		for (const variant of [uppercase, parameterized]) {
+			expect(variant.length).toBe(canonical.length);
+			expect(variant.text).toBe(canonical.text);
+			expect(variant.digest).toBe(canonical.digest);
+		}
+	}, 120_000);
+});

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -162,6 +162,9 @@ function validateDocumentContentType(
 }
 
 function isTextBackedContentType(contentType: string): boolean {
+  // This selects the upload wire encoding, not every MIME type that can contain
+  // text. Existing callers base64-encode all non-text types outside this legacy
+  // set, so widening it would persist the encoded string instead of the bytes.
   return (
     contentType.startsWith("text/") ||
     contentType === "application/json" ||

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -77,6 +77,10 @@ const DOCUMENT_FRAGMENTS_TABLE = "document_fragments";
 const FRAGMENT_BATCH_SIZE = 500;
 const DOCUMENT_UPLOAD_MAX_BODY_BYTES = 32 * 1_048_576; // 32 MB
 const MAX_BULK_DOCUMENTS = 100;
+const DOCUMENT_CONTENT_TYPE_VALIDATION_ERROR =
+  "contentType must be a valid non-empty MIME type string when provided";
+const MIME_ESSENCE_PATTERN =
+  /^[a-z0-9][a-z0-9!#$%&'*+.^_`|~-]*\/[a-z0-9][a-z0-9!#$%&'*+.^_`|~-]*$/;
 
 type DocumentFilter = SharedDocumentFilter & {
   /**
@@ -119,7 +123,7 @@ function parseKnowledgeFacet(
 type DocumentUploadBody = {
   content: string;
   filename: string;
-  contentType?: string;
+  contentType?: unknown;
   metadata?: Record<string, unknown>;
   roomId?: string;
   worldId?: string;
@@ -129,30 +133,46 @@ type DocumentUploadBody = {
   addedFrom?: string;
 };
 
-function isTextBackedContentType(
-  contentType: string,
-  filename: string,
-): boolean {
-  const normalizedContentType = normalizeDocumentContentType(contentType);
-  if (normalizedContentType.startsWith("text/")) return true;
-  if (
-    normalizedContentType === "application/json" ||
-    normalizedContentType === "application/xml" ||
-    normalizedContentType === "application/javascript" ||
-    normalizedContentType === "text/markdown"
-  ) {
-    return true;
+type ValidatedDocumentContentType = {
+  essence: string;
+  original: string;
+};
+
+function validateDocumentContentType(
+  contentType: unknown,
+):
+  | { ok: true; value: ValidatedDocumentContentType }
+  | { ok: false; error: string } {
+  if (contentType === undefined) {
+    return {
+      ok: true,
+      value: { essence: "text/plain", original: "text/plain" },
+    };
+  }
+  if (typeof contentType !== "string") {
+    return { ok: false, error: DOCUMENT_CONTENT_TYPE_VALIDATION_ERROR };
   }
 
-  const lowerFilename = filename.toLowerCase();
+  const essence = normalizeDocumentContentType(contentType);
+  if (!MIME_ESSENCE_PATTERN.test(essence)) {
+    return { ok: false, error: DOCUMENT_CONTENT_TYPE_VALIDATION_ERROR };
+  }
+
+  return { ok: true, value: { essence, original: contentType } };
+}
+
+function isTextBackedContentType(contentType: string): boolean {
   return (
-    lowerFilename.endsWith(".md") ||
-    lowerFilename.endsWith(".mdx") ||
-    lowerFilename.endsWith(".txt") ||
-    lowerFilename.endsWith(".json") ||
-    lowerFilename.endsWith(".xml") ||
-    lowerFilename.endsWith(".csv") ||
-    lowerFilename.endsWith(".tsv")
+    contentType.startsWith("text/") ||
+    contentType === "application/json" ||
+    contentType.endsWith("+json") ||
+    contentType === "application/xml" ||
+    contentType.endsWith("+xml") ||
+    contentType === "application/javascript" ||
+    contentType === "application/typescript" ||
+    contentType === "application/yaml" ||
+    contentType === "application/x-yaml" ||
+    contentType === "application/x-sh"
   );
 }
 
@@ -1097,6 +1117,7 @@ export async function handleDocumentsRoutes(
   async function addDocument(
     service: DocumentsServiceLike,
     document: DocumentUploadBody,
+    validatedContentType: ValidatedDocumentContentType,
     actor: RouteActor,
   ): Promise<{
     documentId: UUID;
@@ -1107,14 +1128,12 @@ export async function handleDocumentsRoutes(
     // Capture the bytes exactly as uploaded before any content rewrite (e.g.
     // image → description text), so the linked original-bytes file is faithful.
     const originalContent = document.content;
-    const originalContentType = document.contentType || "text/plain";
-    let contentType =
-      normalizeDocumentContentType(originalContentType) || "text/plain";
+    const originalContentType = validatedContentType.original;
+    const uploadedContentType = validatedContentType.essence;
+    let contentType = uploadedContentType;
     const warnings: string[] = [];
-    const textBacked = isTextBackedContentType(
-      originalContentType,
-      document.filename,
-    );
+    const originalBytesAreTextBacked =
+      isTextBackedContentType(uploadedContentType);
 
     if (contentType.startsWith("image/")) {
       const includeDescriptions =
@@ -1154,9 +1173,7 @@ export async function handleDocumentsRoutes(
       contentType = "text/plain";
     }
 
-    if (document.filename.endsWith(".mdx")) {
-      contentType = "text/markdown";
-    }
+    const textBacked = isTextBackedContentType(contentType);
 
     const uploadFilters = filtersFromUploadBody(document, actor);
     if (uploadFilters.error) {
@@ -1196,10 +1213,10 @@ export async function handleDocumentsRoutes(
         if (fileStorage) {
           // Text uploads carry UTF-8 text; binary/non-text uploads (images,
           // PDFs, …) arrive base64-encoded in `content`.
-          const bytes = textBacked
+          const bytes = originalBytesAreTextBacked
             ? Buffer.from(originalContent, "utf8")
             : Buffer.from(originalContent, "base64");
-          const stored = await fileStorage.store(bytes, originalContentType);
+          const stored = await fileStorage.store(bytes, uploadedContentType);
           mediaLink = {
             mediaUrl: stored.url,
             mediaHash: stored.hash,
@@ -1278,13 +1295,24 @@ export async function handleDocumentsRoutes(
       return true;
     }
 
+    const contentType = validateDocumentContentType(body.contentType);
+    if (!contentType.ok) {
+      error(res, contentType.error, 400);
+      return true;
+    }
+
     let result: {
       documentId: string;
       fragmentCount: number;
       warnings?: string[];
     };
     try {
-      result = await addDocument(documentsService, body, routeActor);
+      result = await addDocument(
+        documentsService,
+        body,
+        contentType.value,
+        routeActor,
+      );
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       error(
@@ -1331,6 +1359,26 @@ export async function handleDocumentsRoutes(
       return true;
     }
 
+    const validatedContentTypes = new Map<
+      number,
+      ValidatedDocumentContentType
+    >();
+    for (const [index, document] of body.documents.entries()) {
+      if (
+        !document ||
+        typeof document !== "object" ||
+        Array.isArray(document)
+      ) {
+        continue;
+      }
+      const contentType = validateDocumentContentType(document.contentType);
+      if (!contentType.ok) {
+        error(res, contentType.error, 400);
+        return true;
+      }
+      validatedContentTypes.set(index, contentType.value);
+    }
+
     const results: Array<{
       index: number;
       ok: boolean;
@@ -1354,6 +1402,12 @@ export async function handleDocumentsRoutes(
           error: "content and filename must be non-empty strings",
         });
         continue;
+      }
+
+      const contentType = validatedContentTypes.get(index);
+      if (!contentType) {
+        error(res, DOCUMENT_CONTENT_TYPE_VALIDATION_ERROR, 400);
+        return true;
       }
 
       const filename = document.filename || `document-${index + 1}`;
@@ -1384,6 +1438,7 @@ export async function handleDocumentsRoutes(
         const uploadResult = await addDocument(
           documentsService,
           normalizedDocument,
+          contentType,
           routeActor,
         );
         results.push({

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -165,14 +165,8 @@ function isTextBackedContentType(contentType: string): boolean {
   return (
     contentType.startsWith("text/") ||
     contentType === "application/json" ||
-    contentType.endsWith("+json") ||
     contentType === "application/xml" ||
-    contentType.endsWith("+xml") ||
-    contentType === "application/javascript" ||
-    contentType === "application/typescript" ||
-    contentType === "application/yaml" ||
-    contentType === "application/x-yaml" ||
-    contentType === "application/x-sh"
+    contentType === "application/javascript"
   );
 }
 

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -176,6 +176,13 @@ function isTextBackedContentType(contentType: string): boolean {
   );
 }
 
+function hasTextBackedFilename(filename: string): boolean {
+  const lowerFilename = filename.toLowerCase();
+  return [".md", ".mdx", ".txt", ".json", ".xml", ".csv", ".tsv"].some(
+    (extension) => lowerFilename.endsWith(extension),
+  );
+}
+
 function getOwnerEntityId(runtime: AgentRuntime | null): UUID | undefined {
   if (!runtime || typeof runtime.getSetting !== "function") return undefined;
   return asUuid(runtime.getSetting("ELIZA_ADMIN_ENTITY_ID"));
@@ -1133,7 +1140,8 @@ export async function handleDocumentsRoutes(
     let contentType = uploadedContentType;
     const warnings: string[] = [];
     const originalBytesAreTextBacked =
-      isTextBackedContentType(uploadedContentType);
+      isTextBackedContentType(uploadedContentType) ||
+      hasTextBackedFilename(document.filename);
 
     if (contentType.startsWith("image/")) {
       const includeDescriptions =
@@ -1173,7 +1181,13 @@ export async function handleDocumentsRoutes(
       contentType = "text/plain";
     }
 
-    const textBacked = isTextBackedContentType(contentType);
+    if (document.filename.endsWith(".mdx")) {
+      contentType = "text/markdown";
+    }
+
+    const textBacked =
+      isTextBackedContentType(contentType) ||
+      hasTextBackedFilename(document.filename);
 
     const uploadFilters = filtersFromUploadBody(document, actor);
     if (uploadFilters.error) {

--- a/plugins/plugin-documents/test/routes.test.ts
+++ b/plugins/plugin-documents/test/routes.test.ts
@@ -331,6 +331,15 @@ describe("document routes", () => {
       expectedTextBacked: false,
       expectedBytes: "pdf bytes",
     },
+    {
+      content: Buffer.from("#!/bin/sh\necho hello\n").toString("base64"),
+      filename: "run.bin",
+      contentType: "application/x-sh",
+      expectedContentType: "application/x-sh",
+      expectedFileType: "application/x-sh",
+      expectedTextBacked: false,
+      expectedBytes: "#!/bin/sh\necho hello\n",
+    },
   ])(
     "canonicalizes case and parameters before document service routing %#",
     async ({

--- a/plugins/plugin-documents/test/routes.test.ts
+++ b/plugins/plugin-documents/test/routes.test.ts
@@ -340,6 +340,21 @@ describe("document routes", () => {
       expectedTextBacked: false,
       expectedBytes: "#!/bin/sh\necho hello\n",
     },
+    ...[
+      "application/problem+json",
+      "application/soap+xml",
+      "application/typescript",
+      "application/yaml",
+      "application/x-yaml",
+    ].map((contentType) => ({
+      content: Buffer.from("wire-compatible bytes").toString("base64"),
+      filename: "payload.bin",
+      contentType,
+      expectedContentType: contentType,
+      expectedFileType: contentType,
+      expectedTextBacked: false,
+      expectedBytes: "wire-compatible bytes",
+    })),
   ])(
     "canonicalizes case and parameters before document service routing %#",
     async ({

--- a/plugins/plugin-documents/test/routes.test.ts
+++ b/plugins/plugin-documents/test/routes.test.ts
@@ -315,7 +315,7 @@ describe("document routes", () => {
     },
     {
       content: Buffer.from("pdf bytes").toString("base64"),
-      filename: "report.txt",
+      filename: "report.bin",
       contentType: "APPLICATION/PDF",
       expectedContentType: "application/pdf",
       expectedFileType: "APPLICATION/PDF",
@@ -383,6 +383,116 @@ describe("document routes", () => {
             contentType: expectedContentType,
             fileType: expectedFileType,
             textBacked: expectedTextBacked,
+          }),
+        }),
+      );
+    },
+  );
+
+  it.each(["single", "bulk"] as const)(
+    "uses the text filename fallback for original byte decoding in %s upload",
+    async (uploadKind) => {
+      const content = "plain text sent with a generic MIME type";
+      const document = {
+        content,
+        filename: "notes.txt",
+        contentType: "application/octet-stream",
+      };
+      const store = vi.fn(async () => ({
+        url: "/api/media/deadbeef.bin",
+        hash: "deadbeef",
+        fileName: "deadbeef.bin",
+        mimeType: "application/octet-stream",
+        size: Buffer.byteLength(content),
+      }));
+      addDocument.mockResolvedValueOnce({
+        clientDocumentId: "doc-id",
+        fragmentCount: 1,
+      });
+      const pathname =
+        uploadKind === "single" ? "/api/documents" : "/api/documents/bulk";
+      const { ctx, res } = buildCtx({
+        method: "POST",
+        pathname,
+        runtime: {
+          getService: vi.fn(() => ({ store })),
+        } as Partial<NonNullable<DocumentRouteContext["runtime"]>>,
+        body: uploadKind === "single" ? document : { documents: [document] },
+      });
+
+      await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+      expect(res.statusCode).toBe(200);
+      expect(store).toHaveBeenCalledWith(
+        expect.any(Buffer),
+        "application/octet-stream",
+      );
+      expect((store.mock.calls[0][0] as Buffer).toString("utf8")).toBe(content);
+      expect(addDocument).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content,
+          contentType: "application/octet-stream",
+          metadata: expect.objectContaining({
+            contentType: "application/octet-stream",
+            fileType: "application/octet-stream",
+            textBacked: true,
+          }),
+        }),
+      );
+    },
+  );
+
+  it.each(["single", "bulk"] as const)(
+    "routes an omitted or fallback-MIME .mdx document as text/markdown in %s upload",
+    async (uploadKind) => {
+      const content = "# Compatibility note";
+      const document = {
+        content,
+        filename: "note.mdx",
+        ...(uploadKind === "bulk"
+          ? { contentType: "application/octet-stream" }
+          : {}),
+      };
+      const uploadedContentType =
+        uploadKind === "bulk" ? "application/octet-stream" : "text/plain";
+      const store = vi.fn(async () => ({
+        url: "/api/media/deadbeef.txt",
+        hash: "deadbeef",
+        fileName: "deadbeef.txt",
+        mimeType: uploadedContentType,
+        size: Buffer.byteLength(content),
+      }));
+      addDocument.mockResolvedValueOnce({
+        clientDocumentId: "doc-id",
+        fragmentCount: 1,
+      });
+      const pathname =
+        uploadKind === "single" ? "/api/documents" : "/api/documents/bulk";
+      const { ctx, res } = buildCtx({
+        method: "POST",
+        pathname,
+        runtime: {
+          getService: vi.fn(() => ({ store })),
+        } as Partial<NonNullable<DocumentRouteContext["runtime"]>>,
+        body: uploadKind === "single" ? document : { documents: [document] },
+      });
+
+      await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+      expect(res.statusCode).toBe(200);
+      expect(store).toHaveBeenCalledWith(
+        expect.any(Buffer),
+        uploadedContentType,
+      );
+      expect((store.mock.calls[0][0] as Buffer).toString("utf8")).toBe(content);
+      expect(addDocument).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content,
+          contentType: "text/markdown",
+          metadata: expect.objectContaining({
+            contentType: "text/markdown",
+            fileType: uploadedContentType,
+            textBacked: true,
           }),
         }),
       );

--- a/plugins/plugin-documents/test/routes.test.ts
+++ b/plugins/plugin-documents/test/routes.test.ts
@@ -149,6 +149,86 @@ describe("document routes", () => {
     expect(addDocument).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["empty", ""],
+    ["whitespace", "   "],
+    ["empty essence", "; charset=UTF-8"],
+    ["non-string", 42],
+    ["null", null],
+    ["malformed", "not-a-mime"],
+  ])(
+    "rejects a supplied %s contentType before single-upload persistence",
+    async (_label, contentType) => {
+      const store = vi.fn();
+      const getService = vi.fn(() => ({ store }));
+      const { ctx, res } = buildCtx({
+        method: "POST",
+        pathname: "/api/documents",
+        runtime: { getService } as Partial<
+          NonNullable<DocumentRouteContext["runtime"]>
+        >,
+        body: {
+          content: "hello",
+          filename: "doc.txt",
+          contentType,
+        },
+      });
+
+      await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({
+        error:
+          "contentType must be a valid non-empty MIME type string when provided",
+      });
+      expect(getService).not.toHaveBeenCalled();
+      expect(store).not.toHaveBeenCalled();
+      expect(addDocument).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["empty", ""],
+    ["whitespace", "   "],
+    ["empty essence", "; charset=UTF-8"],
+    ["non-string", { type: "text/plain" }],
+    ["null", null],
+    ["malformed", "not-a-mime"],
+  ])(
+    "rejects a supplied %s contentType before bulk-upload persistence",
+    async (_label, contentType) => {
+      const store = vi.fn();
+      const getService = vi.fn(() => ({ store }));
+      const { ctx, res } = buildCtx({
+        method: "POST",
+        pathname: "/api/documents/bulk",
+        runtime: { getService } as Partial<
+          NonNullable<DocumentRouteContext["runtime"]>
+        >,
+        body: {
+          documents: [
+            {
+              content: "hello",
+              filename: "doc.txt",
+              contentType,
+            },
+          ],
+        },
+      });
+
+      await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({
+        error:
+          "contentType must be a valid non-empty MIME type string when provided",
+      });
+      expect(getService).not.toHaveBeenCalled();
+      expect(store).not.toHaveBeenCalled();
+      expect(addDocument).not.toHaveBeenCalled();
+    },
+  );
+
   it("rejects image uploads that would otherwise store placeholder text", async () => {
     const { ctx, res } = buildCtx({
       method: "POST",
@@ -200,6 +280,11 @@ describe("document routes", () => {
         contentType: "text/plain",
         content:
           "[Image: receipt.png]\n\nA receipt for coffee with total $4.50.",
+        metadata: expect.objectContaining({
+          contentType: "text/plain",
+          fileType: "image/png",
+          textBacked: true,
+        }),
       }),
     );
     expect(res.body).toEqual({
@@ -213,16 +298,27 @@ describe("document routes", () => {
     {
       content: "hello world",
       filename: "notes.txt",
+      contentType: undefined,
+      expectedContentType: "text/plain",
+      expectedFileType: "text/plain",
+      expectedTextBacked: true,
+      expectedBytes: "hello world",
+    },
+    {
+      content: "hello world",
+      filename: "notes.txt",
       contentType: "TEXT/PLAIN; charset=UTF-8",
       expectedContentType: "text/plain",
+      expectedFileType: "TEXT/PLAIN; charset=UTF-8",
       expectedTextBacked: true,
       expectedBytes: "hello world",
     },
     {
       content: Buffer.from("pdf bytes").toString("base64"),
-      filename: "report.bin",
+      filename: "report.txt",
       contentType: "APPLICATION/PDF",
       expectedContentType: "application/pdf",
+      expectedFileType: "APPLICATION/PDF",
       expectedTextBacked: false,
       expectedBytes: "pdf bytes",
     },
@@ -231,6 +327,7 @@ describe("document routes", () => {
       filename: "report.bin",
       contentType: "application/pdf; charset=UTF-8",
       expectedContentType: "application/pdf",
+      expectedFileType: "application/pdf; charset=UTF-8",
       expectedTextBacked: false,
       expectedBytes: "pdf bytes",
     },
@@ -241,6 +338,7 @@ describe("document routes", () => {
       filename,
       contentType,
       expectedContentType,
+      expectedFileType,
       expectedTextBacked,
       expectedBytes,
     }) => {
@@ -248,7 +346,7 @@ describe("document routes", () => {
         url: "/api/media/deadbeef.bin",
         hash: "deadbeef",
         fileName: "deadbeef.bin",
-        mimeType: contentType,
+        mimeType: expectedContentType,
         size: expectedBytes.length,
       }));
       addDocument.mockResolvedValueOnce({
@@ -261,13 +359,21 @@ describe("document routes", () => {
         runtime: {
           getService: vi.fn(() => ({ store })),
         } as Partial<NonNullable<DocumentRouteContext["runtime"]>>,
-        body: { content, filename, contentType },
+        body: {
+          content,
+          filename,
+          ...(contentType === undefined ? {} : { contentType }),
+        },
       });
 
       await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
 
       expect(res.statusCode).toBe(200);
       expect(store.mock.calls).toHaveLength(1);
+      expect(store).toHaveBeenCalledWith(
+        expect.any(Buffer),
+        expectedContentType,
+      );
       const storedContent = store.mock.calls[0][0] as Buffer;
       expect(storedContent.toString("utf8")).toBe(expectedBytes);
       expect(addDocument).toHaveBeenCalledWith(
@@ -275,7 +381,7 @@ describe("document routes", () => {
           contentType: expectedContentType,
           metadata: expect.objectContaining({
             contentType: expectedContentType,
-            fileType: contentType,
+            fileType: expectedFileType,
             textBacked: expectedTextBacked,
           }),
         }),


### PR DESCRIPTION
# Relates to

Closes #19153.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install --frozen-lockfile` and `bun run verify` passed on the exact rebased head.
- [x] A reviewer can confirm the change works without reading the code, from the
      deterministic HTTP-boundary and real-PDF evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@34953f555be973d5d9c1e71e02f756bd597291fe:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased patch-identically onto current `origin/develop@9765baab799aacc564407f9ab4f966390a08c116`; zero conflicts.
- [x] The contributor's frozen-lockfile install passed before the patch-identical rebase; this PR changes no manifests or lockfiles.
- [x] Full `bun run verify` passed on the independently approved patch-identical head. On this final rebase, owning tests/typechecks/lint/builds passed; the isolated root rerun stopped only on unrelated checkout prerequisites (`node-swiftlint`, Cloudflare worker types) and an existing `plugin-video` lint diagnostic.

# Risks

Low. This tightens the public JSON upload boundary: omitted `contentType` still
defaults to `text/plain`, while a supplied empty string no longer takes that
default and now receives HTTP 400, as do parameter-only, malformed, and
non-string values. Callers that were relying on malformed or explicitly empty
MIME values being silently accepted will need to omit the field or send a valid
MIME type.

Original-file storage now intentionally records the normalized lowercase MIME
essence, so its stored media content type no longer retains caller casing or
parameters. The original valid caller value remains available as
`metadata.fileType`; single and bulk route tests pin this split.

# Background

## What does this PR do?

- Validates an optional upload MIME once for single and bulk document requests.
- Uses the validated lowercase MIME essence consistently for byte decoding,
  original-file storage, document-service routing, and canonical metadata.
  Stored media MIME therefore drops caller casing and parameters by design.
- Retains the caller's valid original MIME string only as `metadata.fileType`;
  focused single and bulk assertions pin both representations.
- Preserves legacy text-extension UTF-8 byte decoding and lowercase `.mdx` routing to `text/markdown` for single and bulk uploads.
- Preserves legacy binary MIME decoding; `application/x-sh` remains base64-backed.
- Adds a real `DocumentService` regression over the checked-in OpenZeppelin PDF
  for canonical, uppercase, and parameterized `application/pdf` values.

## What kind of change is this?

Bug fix (non-breaking for valid upload requests).

# Documentation changes needed?

No project documentation change is needed. The accepted API contract is
unchanged for omitted and valid MIME values; the malformed-input behavior is
covered by focused tests.

# Testing

## Where should a reviewer start?

Start with `plugins/plugin-documents/test/routes.test.ts` for the public API
boundary, then `packages/core/src/features/documents/service-mime-regression.test.ts`
for the checked-in PDF's real service/extraction path.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-documents test -- test/routes.test.ts
bun run --cwd packages/core test -- src/features/documents/service-mime-regression.test.ts
bun run --cwd packages/core test -- src/media/mime.test.ts
bun run --cwd plugins/plugin-documents typecheck
bun run --cwd plugins/plugin-documents lint:check
bun run --cwd packages/core typecheck
node packages/scripts/run-turbo.mjs run build --filter=@elizaos/plugin-documents... --concurrency=8 --cache=local:rw,remote:r --output-logs=errors-only
bun run verify
```

Results on final head: route tests 48/48, real-PDF regression 1/1, MIME utility tests 5/5, plugin/core typechecks passed, scoped lint and both owning builds passed. The four commits are patch-identical to the independently approved head, where the dependency-graph build and full `bun run verify` passed.

# Evidence Gate

<!-- evidence-head:39bd1e61e9463aac851b5dbe8442fdf5a9ffe2ad -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only MIME validation and document processing; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only MIME validation and document processing; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend or interactive user flow changed.
<!-- evidence-row:backend-logs -->
- [x] Real route-test and DocumentService/unpdf logs:

<details>
<summary>Focused backend transcript at the reviewed head</summary>

```text
$ bun run --cwd plugins/plugin-documents test -- test/routes.test.ts
Test Files  1 passed (1)
Tests       48 passed (48)
$ bun run --cwd packages/core test -- src/features/documents/service-mime-regression.test.ts --reporter=verbose
Processing "openzeppelin-v5.5-audit.bin" (application/pdf) -> Split into 6 chunks
Processing "openzeppelin-v5.5-audit.bin" (APPLICATION/PDF) -> Split into 6 chunks
Processing "openzeppelin-v5.5-audit.bin" (application/pdf; charset=UTF-8) -> Split into 6 chunks
Test Files  1 passed (1)
Tests       1 passed (1)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/state code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Checked-in PDF persistence artifact:

<details>
<summary>Persisted fragment equivalence</summary>

```text
source_pdf=packages/app-core/test/contracts/lib/openzeppelin-contracts/audits/2025-10-v5.5.pdf
filename=openzeppelin-v5.5-audit.bin
variants=application/pdf | APPLICATION/PDF | application/pdf; charset=UTF-8
persisted_fragments=6 per variant
reconstructed_text_length=9245 per variant
sha256=ee5a73d670e7912542ba0ff8c723312687a042e003c35e8228eff7915dfe8346 per variant
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - this change has no rendered visual surface or visual text.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change and no live-model call is
part of document MIME routing.

## Backend + frontend logs

Real `DocumentService` + `AgentRuntime` + `InMemoryDatabaseAdapter` +
`unpdf` execution over the checked-in
`packages/app-core/test/contracts/lib/openzeppelin-contracts/audits/2025-10-v5.5.pdf`:

```text
Processing "openzeppelin-v5.5-audit.bin" (application/pdf)
Split into 6 chunks
Processing "openzeppelin-v5.5-audit.bin" (APPLICATION/PDF)
Split into 6 chunks
Processing "openzeppelin-v5.5-audit.bin" (application/pdf; charset=UTF-8)
Split into 6 chunks
Test Files  1 passed (1)
Tests       1 passed (1)
```

Public HTTP-boundary regression:

```text
Test Files  1 passed (1)
Tests       48 passed (48)
```

Frontend logs: N/A - no frontend code path changed.

## Screenshots (before / after) + video walkthrough

### Before

N/A - backend-only change.

### After

N/A - backend-only change.

### Walkthrough video

N/A - no rendered or interactive flow changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / warnings

- Exact-head verification at `39bd1e61e9463aac851b5dbe8442fdf5a9ffe2ad` passed the 48 route tests and 1 real-PDF regression after the final patch-identical replay. The identical patch also passed 5 MIME utility tests, both package typechecks, changed-file Biome, frozen-lockfile install, and full `bun run verify` (350/350 tasks plus audits) before the rebase. Hosted full gates remain required. The historical maintainer repair at `c0bfeebc17cc7fe66b4a36e82e0e57ef2a7d3b32` remains represented by the final rebased commit.
- `unpdf`/PDF.js printed non-fatal `Math.sumPrecise` and embedded-font
  substitution warnings under pinned Node 24.15.0. All three variants still
  persisted six fragments with identical reconstructed text: 9,245 characters,
  SHA-256 `ee5a73d670e7912542ba0ff8c723312687a042e003c35e8228eff7915dfe8346`.

## Maintainer repair at c0bfeebc17cc7fe66b4a36e82e0e57ef2a7d3b32

The final repair documents that the text-backed predicate is a wire-encoding contract and expands the regression matrix across every MIME form that the first draft accidentally widened. Existing `+json`, `+xml`, TypeScript, YAML, and shell uploads remain base64-decoded, while the contributor's filename fallbacks and canonical MIME validation remain intact.

Exact-head isolated proof after patch-identical replay onto `develop@9765baab799aacc564407f9ab4f966390a08c116`: 48 route tests and the real-PDF regression passed. The identical pre-rebase patch also passed both owning-package typechecks, all 5 MIME utility tests, both owning builds, plugin lint, changed-file Biome, guide parity, and diff checks. The isolated root verify rerun reached the workspace lanes before unrelated missing native/Cloud dependencies and an existing plugin-video lint diagnostic stopped it.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@9765baab799aacc564407f9ab4f966390a08c116:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@9765baab799aacc564407f9ab4f966390a08c116:packages/skills/skills/contribute-to-eliza"} -->

Original contribution provider/model: openai / gpt-5.6-sol
Original contribution client/tooling: codex
Original contribution skill revision: elizaOS/army@34953f555be973d5d9c1e71e02f756bd597291fe:skills/contribute-to-eliza
Original contribution compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Original contribution attribution: self-reported
Original contribution lane: 0xinbeta-codex
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@34953f555be973d5d9c1e71e02f756bd597291fe:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZYGWTYB2CS8FVNTA2VZTTM6","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T21:36:48.587Z","completed_at":"2026-08-13T22:02:48.086Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAW5HfifnKcIVwLYWhP4P5NE7OycGralve4Zdq8TmCrZk","device_key_id":"b66ae644643ce17eb9ba8ee00827db1a578019abaa33143c64bdd29e2ac9fd15","device_signature":"q3yGhG2EzpSuSFjjW7F-OwFt-edRDKHzFWG1U8Jd6SVBSZ7epJuZwRb2594A-ztyE7_hBhZUonMgi3BOou7gAg"}} -->
