### PR TITLE
fix(cloud): retry failed Telegram webhook replies

### DIFF
--- a/packages/cloud/api/v1/telegram/webhook/[orgId]/onboarding-precedence.test.ts
+++ b/packages/cloud/api/v1/telegram/webhook/[orgId]/onboarding-precedence.test.ts
@@ -5,9 +5,12 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 import { Hono } from "hono";
+import type { PostResult } from "@/lib/services/telegram-automation/app-automation";
 
 const replies: string[] = [];
+const boundaryErrors: unknown[] = [];
 interface TestMessage {
   message_id: number;
   text: string;
@@ -60,7 +63,9 @@ class FakeTelegraf {
 mock.module("telegraf", () => ({ Telegraf: FakeTelegraf }));
 
 const activeApps = mock(async () => [] as TestApp[]);
-const handleIncomingMessage = mock(async () => undefined);
+const handleIncomingMessage = mock(
+  async (): Promise<PostResult> => ({ success: true }),
+);
 mock.module("@/lib/services/telegram-automation/app-automation", () => ({
   telegramAppAutomationService: {
     getAppsWithActiveAutomation: activeApps,
@@ -77,7 +82,7 @@ mock.module("@/lib/services/telegram-automation", () => ({
 
 interface TestRouteResult {
   handled: boolean;
-  reason: "unknown_owner";
+  reason: "unknown_owner" | "owner_org_mismatch";
   replyText?: string;
 }
 
@@ -100,11 +105,13 @@ mock.module("@/db/repositories/telegram-chats", () => ({
   },
 }));
 
+const tryCreate = mock(async () => ({
+  created: true,
+  event: { id: "event" },
+}));
+const deleteByEventId = mock(async () => undefined);
 mock.module("@/db/repositories/webhook-events", () => ({
-  webhookEventsRepository: {
-    tryCreate: mock(async () => ({ created: true, event: { id: "event" } })),
-    deleteByEventId: mock(async () => undefined),
-  },
+  webhookEventsRepository: { tryCreate, deleteByEventId },
 }));
 
 mock.module("@/lib/auth/cron", () => ({
@@ -118,9 +125,13 @@ mock.module("@/lib/api/hono-next-style-params", () => ({
   }),
 }));
 mock.module("@/lib/api/cloud-worker-errors", () => ({
-  failureResponse: (context: {
-    json: (body: unknown, status: number) => Response;
-  }) => context.json({ error: "internal" }, 500),
+  failureResponse: (
+    context: { json: (body: unknown, status: number) => Response },
+    error: unknown,
+  ) => {
+    boundaryErrors.push(error);
+    return context.json({ error: "internal" }, 500);
+  },
 }));
 mock.module("@/lib/utils/telegram-helpers", () => ({
   isCommand: (text: string) => text.startsWith("/"),
@@ -171,10 +182,16 @@ async function deliver(): Promise<Response> {
 describe("per-organization Telegram first-contact precedence", () => {
   beforeEach(() => {
     replies.length = 0;
+    boundaryErrors.length = 0;
     textHandler = undefined;
     activeApps.mockReset();
     activeApps.mockResolvedValue([]);
-    handleIncomingMessage.mockClear();
+    handleIncomingMessage.mockReset();
+    handleIncomingMessage.mockResolvedValue({ success: true });
+    tryCreate.mockReset();
+    tryCreate.mockResolvedValue({ created: true, event: { id: "event" } });
+    deleteByEventId.mockReset();
+    deleteByEventId.mockResolvedValue(undefined);
     routeTelegramMessage.mockClear();
     routeTelegramMessage.mockResolvedValue({
       handled: true,
@@ -220,5 +237,74 @@ describe("per-organization Telegram first-contact precedence", () => {
     );
     expect(handleIncomingMessage).not.toHaveBeenCalled();
     expect(replies).toEqual(["Connect your Eliza account"]);
+  });
+
+  test("failed onboarding rolls back the replay marker and reaches the boundary", async () => {
+    routeTelegramMessage.mockRejectedValue(new Error("onboarding unavailable"));
+
+    expect((await deliver()).status).toBe(500);
+    expect(deleteByEventId).toHaveBeenCalledWith(
+      "telegram:org-1:1001",
+      "telegram",
+    );
+    expect(boundaryErrors).toHaveLength(1);
+    expect(boundaryErrors[0]).toEqual(
+      expect.objectContaining({ message: "onboarding unavailable" }),
+    );
+    expect(replies).toEqual([]);
+  });
+
+  test("failed active-app delivery rolls back instead of returning success", async () => {
+    activeApps.mockResolvedValue([appAutomation(true)]);
+    routeTelegramMessage.mockResolvedValue({
+      handled: false,
+      reason: "unknown_owner",
+      replyText: undefined,
+    });
+    handleIncomingMessage.mockResolvedValue({
+      success: false,
+      error: "Telegram API unavailable",
+    });
+
+    expect((await deliver()).status).toBe(500);
+    expect(deleteByEventId).toHaveBeenCalledWith(
+      "telegram:org-1:1001",
+      "telegram",
+    );
+    expect(boundaryErrors[0]).toBeInstanceOf(ElizaError);
+    expect((boundaryErrors[0] as ElizaError).code).toBe(
+      "TELEGRAM_APP_AUTOMATION_REPLY_FAILED",
+    );
+  });
+
+  test("preserves handler and rollback failures when both operations fail", async () => {
+    routeTelegramMessage.mockRejectedValue(new Error("onboarding unavailable"));
+    deleteByEventId.mockRejectedValue(new Error("dedupe unavailable"));
+
+    expect((await deliver()).status).toBe(500);
+    const boundaryError = boundaryErrors[0];
+    expect(boundaryError).toBeInstanceOf(ElizaError);
+    expect((boundaryError as ElizaError).code).toBe(
+      "TELEGRAM_WEBHOOK_ROLLBACK_FAILED",
+    );
+    const aggregate = (boundaryError as ElizaError).cause;
+    expect(aggregate).toBeInstanceOf(AggregateError);
+    expect((aggregate as AggregateError).errors).toEqual([
+      expect.objectContaining({ message: "onboarding unavailable" }),
+      expect.objectContaining({ message: "dedupe unavailable" }),
+    ]);
+  });
+
+  test("an owner linked to another organization remains fail-closed", async () => {
+    routeTelegramMessage.mockResolvedValue({
+      handled: false,
+      reason: "owner_org_mismatch",
+      replyText: undefined,
+    });
+
+    expect((await deliver()).status).toBe(200);
+    expect(handleIncomingMessage).not.toHaveBeenCalled();
+    expect(replies).toEqual([]);
+    expect(deleteByEventId).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/telegram/webhook/[orgId]/route.ts
+++ b/packages/cloud/api/v1/telegram/webhook/[orgId]/route.ts
@@ -5,6 +5,7 @@
  * Each organization has their own webhook URL with their orgId.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { Hono } from "hono";
 import { Telegraf } from "telegraf";
 import type { ChatMemberUpdated, Message, Update } from "telegraf/types";
@@ -156,32 +157,25 @@ async function handleTelegramWebhook(
 
     setupBotHandlers(bot, orgId, activeApps);
 
-    try {
-      await bot.handleUpdate(update);
-    } catch (error) {
-      // Telegraf handler errors are intentionally swallowed (a bad single
-      // handler shouldn't force endless provider retries); the update was still
-      // "seen", so the dedupe marker stays.
-      logger.error("[Telegram Webhook] Error processing update", {
-        orgId,
-        updateId: update.update_id,
-        error: error instanceof Error ? error.message : "Unknown error",
-      });
-    }
+    await bot.handleUpdate(update);
   } catch (error) {
     if (dedupeEventId) {
-      await webhookEventsRepository
-        .deleteByEventId(dedupeEventId, "telegram")
-        .catch((rollbackError) => {
-          logger.error("[Telegram Webhook] Dedupe rollback failed", {
-            orgId,
-            updateId: update.update_id,
-            error:
-              rollbackError instanceof Error
-                ? rollbackError.message
-                : String(rollbackError),
-          });
-        });
+      try {
+        await webhookEventsRepository.deleteByEventId(
+          dedupeEventId,
+          "telegram",
+        );
+      } catch (rollbackError) {
+        // error-policy:J2 Preserve both failures for the transport boundary.
+        throw new ElizaError(
+          "Telegram webhook handling and dedupe rollback both failed",
+          {
+            code: "TELEGRAM_WEBHOOK_ROLLBACK_FAILED",
+            context: { orgId, updateId: update.update_id },
+            cause: new AggregateError([error, rollbackError]),
+          },
+        );
+      }
     }
     throw error;
   }
@@ -406,27 +400,37 @@ ${matchingApp.website_url ? `🌐 Website: ${matchingApp.website_url}` : ""}`;
         }
         return;
       }
+
+      if (routed.reason === "owner_org_mismatch") {
+        logger.warn(
+          "[Telegram Webhook] Refusing cross-organization owner fallback",
+          { orgId, chatId, telegramUserId },
+        );
+        return;
+      }
     }
 
     // Route to app automation
     if (matchingApp?.telegram_automation?.autoReply) {
-      try {
-        await telegramAppAutomationService.handleIncomingMessage(
-          orgId,
-          matchingApp.id,
-          {
-            chatId,
-            messageId: message.message_id,
-            text,
-            userName,
-          },
-        );
-      } catch (error) {
-        logger.error("[Telegram Webhook] Error handling message", {
-          orgId,
-          appId: matchingApp.id,
+      const result = await telegramAppAutomationService.handleIncomingMessage(
+        orgId,
+        matchingApp.id,
+        {
           chatId,
-          error: error instanceof Error ? error.message : "Unknown error",
+          messageId: message.message_id,
+          text,
+          userName,
+        },
+      );
+      if (!result.success) {
+        throw new ElizaError("Telegram app automation reply failed", {
+          code: "TELEGRAM_APP_AUTOMATION_REPLY_FAILED",
+          context: {
+            orgId,
+            appId: matchingApp.id,
+            chatId,
+            error: result.error,
+          },
         });
       }
     } else if (!matchingApp) {


### PR DESCRIPTION
Fixes #19211

## Summary

- let Telegram handler failures reach the existing Hono transport boundary instead of acknowledging them with HTTP 200
- roll back the replay marker on handler or typed delivery failure so Telegram can retry; if rollback also fails, preserve both causes in `TELEGRAM_WEBHOOK_ROLLBACK_FAILED`
- treat `{ success: false }` from app automation as `TELEGRAM_APP_AUTOMATION_REPLY_FAILED` instead of fabricated success
- keep `owner_org_mismatch` fail-closed so a sender linked to another organization cannot fall through to app automation or the generic reply

## Verification

Exact source head: `95a929b67b4d88f9a6859e8790f8f9353509d397`
Base: `origin/develop@15c8bc849f219712a084ebf225a777d7d9909e42`

- frozen `bun install` — PASS; 971 MiB artifact bundle SHA-256 verified, 638 files extracted, 3,831 installs checked with no lockfile changes
- signed Hono webhook contract — 7/7 PASS, 30 expectations
- Cloud API lint — PASS, 1,031 files, no fixes
- Cloud API typecheck — PASS
- production Worker dry-run — PASS, 17,383.13 KiB upload / 3,841.31 KiB gzip, with declared Durable Object bindings
- root `bun run verify` — 350/350 PASS; all repository audits pass

## Real boundary evidence

The focused suite signs and sends updates through the real Hono route. It proves:

1. onboarding failure returns 500, reaches `failureResponse`, and deletes `telegram:org-1:1001`;
2. active-app `{ success: false }` returns 500, rolls back, and exposes the typed delivery error;
3. simultaneous handler and rollback failures retain both original errors in one `AggregateError` cause;
4. an owner linked to another organization returns without app or generic fallback.

- [Structured evidence summary](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19211-evidence.json)
- [Focused signed-route transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19211-focused.log)
- [Frozen install transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19211-bun-install.log)
- [Cloud API lint transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19211-api-lint.log)
- [Cloud API typecheck + production dry-run](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19211-api-typecheck.log)
- [Root verification transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19211-root-verify-final.log)

## Evidence matrix

- Desktop/mobile screenshots: N/A — backend-only signed webhook error/retry boundary; no rendered UI changed.
- MP4 walkthrough: N/A — no interactive UI flow changed; the signed Hono route is exercised directly.
- Backend logs/artifacts: linked above with checksums in the structured summary.
- Frontend console/network logs: N/A — no frontend or browser code changed.
- Live-model trajectory: N/A — deterministic webhook routing and persistence; no model invocation.

<!-- evidence-head:95a929b67b4d88f9a6859e8790f8f9353509d397 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only webhook boundary; no visual surface changed

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only webhook boundary; no visual surface changed

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI changed; the signed Hono request path is automated

<!-- evidence-row:backend-logs -->
- [x] [Worker/typecheck transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19211-api-typecheck.log) and [root transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19211-root-verify-final.log); the focused signed-route transcript is also linked above

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser transport changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic webhook routing does not invoke a model

<!-- evidence-row:domain-artifacts -->
- [x] [Structured result and SHA-256 manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19211-evidence.json)

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - repository contribution skill is not available in this session
Attribution status: self-reported
— [codex-19211]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - repository contribution skill is not available in this session"} -->