### PR TITLE
fix(cloud): unblock launch auth and staging convergence

### DIFF
--- a/.github/workflows/deploy-tunnel-proxy.yml
+++ b/.github/workflows/deploy-tunnel-proxy.yml
@@ -205,6 +205,69 @@ jobs:
             --json >/dev/null
           echo "Canonical non-secret variables and the protected signing secret were published without printing values."
 
+      - name: Converge persistent tsnet volume
+        shell: bash
+        run: |
+          set -euo pipefail
+          volume_args=(
+            --project "$RAILWAY_PROJECT_ID"
+            --environment "$RAILWAY_ENVIRONMENT_ID"
+            --service "$RAILWAY_SERVICE_ID"
+          )
+          volumes_path="$RUNNER_TEMP/railway-volumes.json"
+          target_mount="/var/lib/tunnel-proxy"
+
+          railway volume "${volume_args[@]}" list --json > "$volumes_path"
+          service_volume_count=$(jq \
+            '[.volumes[] | select(.deletedAt == null and .serviceName == "tunnel-proxy")] | length' \
+            "$volumes_path")
+          target_mount_count=$(jq --arg mount "$target_mount" \
+            '[.volumes[] | select(.deletedAt == null and .mountPath == $mount)] | length' \
+            "$volumes_path")
+
+          if [ "$service_volume_count" -gt 1 ] || [ "$target_mount_count" -gt 1 ]; then
+            echo "::error::tunnel-proxy must have exactly one persistent Railway volume"
+            exit 1
+          fi
+          if [ "$service_volume_count" = "1" ] && [ "$target_mount_count" = "0" ]; then
+            echo "::error::the existing tunnel-proxy volume is mounted at the wrong path"
+            exit 1
+          fi
+          if [ "$service_volume_count" = "0" ] && [ "$target_mount_count" = "0" ]; then
+            railway volume "${volume_args[@]}" add \
+              --mount-path "$target_mount" \
+              --json >/dev/null
+          fi
+
+          for attempt in $(seq 1 30); do
+            railway volume "${volume_args[@]}" list --json > "$volumes_path"
+            service_volume_count=$(jq \
+              '[.volumes[] | select(.deletedAt == null and .serviceName == "tunnel-proxy")] | length' \
+              "$volumes_path")
+            target_mount_count=$(jq --arg mount "$target_mount" \
+              '[.volumes[] | select(.deletedAt == null and .mountPath == $mount)] | length' \
+              "$volumes_path")
+            if [ "$service_volume_count" -gt 1 ] || [ "$target_mount_count" -gt 1 ]; then
+              echo "::error::tunnel-proxy volume convergence produced duplicate volumes"
+              exit 1
+            fi
+            if jq -e --arg mount "$target_mount" \
+              '[.volumes[] | select(
+                .deletedAt == null and
+                .serviceName == "tunnel-proxy" and
+                .mountPath == $mount and
+                .status == "Ready"
+              )] | length == 1' "$volumes_path" >/dev/null; then
+              echo "Persistent tsnet state volume is mounted at $target_mount."
+              break
+            fi
+            if [ "$attempt" = "30" ]; then
+              echo "::error::tunnel-proxy volume did not become ready at $target_mount"
+              exit 1
+            fi
+            sleep 2
+          done
+
       - name: Mint proxy key and publish it without exposing the value
         id: headscale_key
         shell: bash
@@ -293,37 +356,6 @@ jobs:
           unset new_key
           echo "old_ids=$old_ids" >> "$GITHUB_OUTPUT"
           echo "A reusable tag:eliza-proxy key was minted and published without printing its value."
-
-      - name: Converge persistent tsnet volume
-        shell: bash
-        run: |
-          set -euo pipefail
-          volume_args=(
-            --project "$RAILWAY_PROJECT_ID"
-            --environment "$RAILWAY_ENVIRONMENT_ID"
-            --service "$RAILWAY_SERVICE_ID"
-          )
-          volumes_path="$RUNNER_TEMP/railway-volumes.json"
-          railway volume "${volume_args[@]}" list --json > "$volumes_path"
-          service_volume_count=$(jq \
-            '[.volumes[] | select(.serviceName == "tunnel-proxy")] | length' \
-            "$volumes_path")
-          if [ "$service_volume_count" = "0" ]; then
-            railway volume "${volume_args[@]}" add \
-              --mount-path /var/lib/tunnel-proxy \
-              --json >/dev/null
-            railway volume "${volume_args[@]}" list --json > "$volumes_path"
-          elif [ "$service_volume_count" != "1" ]; then
-            echo "::error::tunnel-proxy must have exactly one persistent Railway volume"
-            exit 1
-          fi
-          jq -e \
-            '[.volumes[] | select(.serviceName == "tunnel-proxy" and .mountPath == "/var/lib/tunnel-proxy")] | length == 1' \
-            "$volumes_path" >/dev/null || {
-            echo "::error::tunnel-proxy volume is not mounted at /var/lib/tunnel-proxy"
-            exit 1
-          }
-          echo "Persistent tsnet state volume is mounted at /var/lib/tunnel-proxy."
 
       - name: Deploy tunnel-proxy source to Railway
         working-directory: packages/cloud/services/tunnel-proxy

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -411,6 +411,22 @@ command -v headscale >/dev/null 2>&1 || {
   exit 1
 }
 
+if ! getent group headscale >/dev/null; then
+  sudo groupadd --system headscale
+fi
+if ! id -u headscale >/dev/null 2>&1; then
+  sudo useradd \\
+    --system \\
+    --gid headscale \\
+    --home-dir ${HEADSCALE_STATE_DIR} \\
+    --no-create-home \\
+    --shell /usr/sbin/nologin \\
+    headscale
+elif ! id -nG headscale | grep -Eq '(^|[[:space:]])headscale([[:space:]]|$)'; then
+  echo "existing headscale user is not a member of the headscale group"
+  exit 1
+fi
+
 sudo install -d -m 0755 /etc/headscale
 sudo install -d -o headscale -g headscale -m 0750 ${HEADSCALE_STATE_DIR}
 

--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -48,14 +48,16 @@ gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza --ref main 
 The workflow:
 
 1. writes the committed `acl.hujson` to `/etc/headscale/acl.hujson`;
-2. converges `server_url`, `listen_addr`, metrics, and gRPC addresses in
+2. ensures the package-compatible `headscale` system user and group exist,
+   including on legacy hosts where the binary was installed manually;
+3. converges `server_url`, `listen_addr`, metrics, and gRPC addresses in
    `/etc/headscale/config.yaml`;
-3. ensures Headscale users `agent` and `tunnel` exist;
-4. upserts `HEADSCALE_PUBLIC_URL`, `HEADSCALE_API_URL`,
+4. ensures Headscale users `agent` and `tunnel` exist;
+5. upserts `HEADSCALE_PUBLIC_URL`, `HEADSCALE_API_URL`,
    `HEADSCALE_API_KEY`, `HEADSCALE_USER`, and optional agent-token secrets into
    `/opt/eliza/cloud/.env.local`;
-5. restarts `headscale` and `eliza-provisioning-worker.service`;
-6. fails if local `/health` is not green.
+6. restarts `headscale` and `eliza-provisioning-worker.service`;
+7. fails if local `/health` is not green.
 
 The matching Cloudflare Worker secrets still need to be set through the normal
 Worker secret path. Keep host and Worker values identical for

--- a/packages/cloud/services/tunnel-proxy/README.md
+++ b/packages/cloud/services/tunnel-proxy/README.md
@@ -52,9 +52,10 @@ token must be scoped to the selected project/environment. The signing secret
 must be the same environment-owned value published to the Cloud Worker by
 `cloud-cf-deploy.yml`.
 
-The workflow mints a replacement reusable `tag:eliza-proxy` Headscale preauth
-key over SSH, sends both sensitive Railway values through CLI stdin, creates or
-verifies the `/var/lib/tunnel-proxy` volume, uploads this directory, and
+The workflow creates or verifies the `/var/lib/tunnel-proxy` volume and waits
+for Railway's eventually consistent service attachment before it mints a
+replacement reusable `tag:eliza-proxy` Headscale preauth key over SSH. It sends
+both sensitive Railway values through CLI stdin, uploads this directory, and
 converges the exact apex and wildcard Railway custom domains. It expires prior
 matching reusable keys only after the canonical `/health` endpoint returns
 `{"status":"pass"}` and an arbitrary unsigned wildcard hostname returns 404.

--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -68,6 +68,28 @@ describe("protected Headscale arm workflow", () => {
     expect(workflowSource).not.toContain("ssh-keyscan");
   });
 
+  test("repairs legacy hosts that have a binary but no package user", () => {
+    const groupGuard = scriptSource.indexOf(
+      "if ! getent group headscale >/dev/null; then",
+    );
+    const userGuard = scriptSource.indexOf(
+      "if ! id -u headscale >/dev/null 2>&1; then",
+    );
+    const stateDirectory = scriptSource.indexOf(
+      "sudo install -d -o headscale -g headscale",
+    );
+
+    expect(groupGuard).toBeGreaterThan(-1);
+    expect(userGuard).toBeGreaterThan(groupGuard);
+    expect(stateDirectory).toBeGreaterThan(userGuard);
+    expect(scriptSource).toContain("sudo groupadd --system headscale");
+    expect(scriptSource).toContain("sudo useradd \\\\");
+    expect(scriptSource).toContain("--shell /usr/sbin/nologin");
+    expect(scriptSource).toContain(
+      "existing headscale user is not a member of the headscale group",
+    );
+  });
+
   test("cleans both temporary SSH identity files on every outcome", () => {
     const cleanup = step("Remove deploy SSH identity");
     expect(cleanup.run).toContain('"$RUNNER_TEMP/headscale-deploy-key"');

--- a/packages/scripts/__tests__/tunnel-proxy-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/tunnel-proxy-deploy-workflow.test.ts
@@ -93,8 +93,23 @@ describe("protected tunnel-proxy deployment workflow", () => {
 
     const volume = step("Converge persistent tsnet volume");
     expect(volume.run).toContain("railway volume");
-    expect(volume.run).toContain("--mount-path /var/lib/tunnel-proxy");
-    expect(volume.run).toContain('.mountPath == "/var/lib/tunnel-proxy"');
+    expect(volume.run).toContain('--mount-path "$target_mount"');
+    expect(volume.run).toContain("for attempt in $(seq 1 30)");
+    expect(volume.run).toContain(".mountPath == $mount");
+    expect(volume.run).toContain('.status == "Ready"');
+    expect(volume.run).toContain('.serviceName == "tunnel-proxy"');
+    expect(volume.run).toContain("target_mount_count");
+
+    const volumeIndex = steps.findIndex(
+      (candidate) => candidate.name === "Converge persistent tsnet volume",
+    );
+    const keyIndex = steps.findIndex(
+      (candidate) =>
+        candidate.name ===
+        "Mint proxy key and publish it without exposing the value",
+    );
+    expect(volumeIndex).toBeGreaterThan(-1);
+    expect(keyIndex).toBeGreaterThan(volumeIndex);
 
     const deploySource = step("Deploy tunnel-proxy source to Railway");
     expect(deploySource["working-directory"]).toBe(

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.handoff.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.handoff.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Managed-cloud login handoff tests use a deterministic jsdom navigation
+ * boundary to prove the transient bridge screen always falls back to a usable
+ * Steward login when initiation is blocked, rejected, or never navigates.
+ */
+// @vitest-environment jsdom
+// @vitest-environment-options {"url": "https://cloud.eliza.app/login?intent=launch"}
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { StrictMode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const bridge = vi.hoisted(() => ({
+  redirect: vi.fn<() => Promise<boolean>>(),
+  shouldAttempt: vi.fn<() => boolean>(),
+}));
+
+vi.mock("../../../sso-bridge/sso-bridge", () => ({
+  redirectToSsoBridge: bridge.redirect,
+  sanitizeBridgeReturnTo: (value: string | null) => value ?? "/",
+  shouldAttemptSsoBridge: bridge.shouldAttempt,
+}));
+
+vi.mock("./steward-login-section", () => ({
+  default: () => <div>Steward login options</div>,
+}));
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? _key,
+}));
+
+vi.mock("../../lib/use-page-title", () => ({ usePageTitle: () => {} }));
+
+import LoginPage from "./login-page";
+
+async function renderLogin(): Promise<void> {
+  await act(async () => {
+    render(
+      <StrictMode>
+        <MemoryRouter initialEntries={["/login?intent=launch"]}>
+          <LoginPage />
+        </MemoryRouter>
+      </StrictMode>,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  bridge.redirect.mockReset();
+  bridge.shouldAttempt.mockReset();
+  bridge.shouldAttempt.mockReturnValue(true);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("managed-cloud login handoff", () => {
+  it("uses the redirect-loop guard before starting another bridge", async () => {
+    bridge.shouldAttempt.mockReturnValue(false);
+
+    await renderLogin();
+
+    expect(bridge.redirect).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("heading", { name: "Sign in to Eliza" }),
+    ).toBeTruthy();
+  });
+
+  it("falls back when bridge initiation rejects", async () => {
+    bridge.redirect.mockRejectedValue(new Error("navigation unavailable"));
+
+    await renderLogin();
+
+    expect(
+      screen.getByRole("heading", { name: "Sign in to Eliza" }),
+    ).toBeTruthy();
+  });
+
+  it("leaves the transient screen after a bounded stalled navigation", async () => {
+    bridge.redirect.mockResolvedValue(true);
+
+    await renderLogin();
+    expect(screen.getByText("Taking you to Eliza sign in")).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(bridge.redirect).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole("heading", { name: "Sign in to Eliza" }),
+    ).toBeTruthy();
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
@@ -8,7 +8,7 @@
 import { BRAND_PATHS, LOGO_FILES } from "@elizaos/shared/brand";
 import { isElizaManagedCloudUiHostname } from "@elizaos/shared/elizacloud";
 import { CheckCircle2 } from "lucide-react";
-import { lazy, Suspense, useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { Button } from "../../../../components/primitives";
 import { isAppModeHost } from "../../../app-mode/app-mode";
@@ -17,11 +17,13 @@ import { useCloudT } from "../../../shell/CloudI18nProvider";
 import {
   redirectToSsoBridge,
   sanitizeBridgeReturnTo,
+  shouldAttemptSsoBridge,
 } from "../../../sso-bridge/sso-bridge";
 import { usePageTitle } from "../../lib/use-page-title";
 import { LoginOptionsSkeleton } from "./login-section-skeleton";
 
 const StewardLoginSection = lazy(() => import("./steward-login-section"));
+const MANAGED_CLOUD_HANDOFF_TIMEOUT_MS = 5_000;
 
 // Chunk-load fallback with the SAME geometry as the section's own
 // provider-discovery skeleton and the final option stack, so the card holds
@@ -94,13 +96,42 @@ function sessionIdFromLoginReturnTo(returnTo: string | null): string | null {
 function ManagedCloudLoginHandoff(): React.JSX.Element {
   const [searchParams] = useSearchParams();
   const [failed, setFailed] = useState(false);
+  const attemptRef = useRef<Promise<boolean> | null>(null);
+  const returnTo = sanitizeBridgeReturnTo(searchParams.get("returnTo"));
 
   useEffect(() => {
-    const returnTo = sanitizeBridgeReturnTo(searchParams.get("returnTo"));
-    void redirectToSsoBridge(returnTo).then((started) => {
-      if (!started) setFailed(true);
-    });
-  }, [searchParams]);
+    let attempt = attemptRef.current;
+    if (!attempt) {
+      if (!shouldAttemptSsoBridge()) {
+        setFailed(true);
+        return;
+      }
+      attempt = redirectToSsoBridge(returnTo);
+      attemptRef.current = attempt;
+    }
+
+    let active = true;
+    const timeout = window.setTimeout(() => {
+      if (!active) return;
+      active = false;
+      setFailed(true);
+    }, MANAGED_CLOUD_HANDOFF_TIMEOUT_MS);
+
+    void attempt
+      .then((started) => {
+        if (active && !started) setFailed(true);
+      })
+      .catch(() => {
+        // error-policy:J4 bridge initiation failed before navigation; keep
+        // sign-in available on this host through the normal Steward form.
+        if (active) setFailed(true);
+      });
+
+    return () => {
+      active = false;
+      window.clearTimeout(timeout);
+    };
+  }, [returnTo]);
 
   if (failed) return <PublicLoginPage />;
   return (


### PR DESCRIPTION
# Relates to

Closes the remaining code-side blockers in #18806.

- [x] Targets `develop` and is rebased onto `origin/develop` with zero conflicts.
- [x] The supported CI install mode completed post-sync; the optional 971 MiB artifact archive initially hit host disk pressure and is not required by these lanes.
- [x] A reviewer can confirm the behavior from the evidence and linked failed staging runs below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `646b1f08ddc28c274843f30e96c596a88780a5ba`; zero conflicts.
- [x] `bun run verify` passes on exact head: 350/350 workspace tasks plus every repository audit.

# Risks

Medium. This touches the canonical login handoff and two protected staging convergence workflows. The login change fails visibly to the existing Steward form after five seconds; it never fabricates a session. The workflows remain fail-closed and now avoid minting a replacement Headscale key until Railway persistence is ready.

# Background

## What does this PR do?

- Prevents `cloud.eliza.app/login?intent=launch` from remaining indefinitely on “Taking you to Eliza sign in”. A stalled/rejected bridge falls back after five seconds, reuses exactly one bridge promise under React Strict Mode, and honors the existing five-minute loop guard.
- Repairs legacy Headscale hosts where the binary exists but the package-created `headscale` system user/group does not.
- Moves Railway volume convergence before key minting and waits for the exact `tunnel-proxy` volume to report `Ready`, covering Railway's eventually consistent service attachment.

## What kind of change is this?

Bug fix and protected-deployment reliability improvement.

# Documentation changes needed?

Updated the Headscale deployment checklist and tunnel-proxy protected-deployment contract.

# Testing

## Where should a reviewer start?

1. `packages/ui/src/cloud/public-pages/pages/login/login-page.tsx`
2. `packages/ui/src/cloud/public-pages/pages/login/login-page.handoff.test.tsx`
3. `.github/workflows/deploy-tunnel-proxy.yml`
4. `packages/cloud/scripts/admin/arm-headscale-control-plane.mjs`

## Detailed testing steps

- Stall `crypto.subtle.digest` before loading `/login?intent=launch`; the deployed production build remains on the handoff screen, while this branch renders the existing sign-in form after five seconds.
- Run the focused UI tests under React Strict Mode: 5/5 passed.
- Run both UI and app typechecks: passed.
- Run protected Headscale/tunnel workflow contracts: 9/9 tests, 110 expectations passed.
- Run Biome, actionlint, Node syntax checking, and `git diff --check`: passed.
- Run `bun run --cwd packages/app audit:app`: 219/219 captures passed; broken=0, needs-work=0, all strict visual budgets green; packaged OCR reports 216 views, broken=0.

# Evidence Gate

<!-- evidence-head:e69b8ae4dfe1db5015e488fa2a4bb77578b0ef06 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots captured from deployed `cloud.eliza.app` under a deterministic stalled bridge: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-before-desktop.jpg), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-before-mobile.jpg).
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots captured from this exact commit under the identical stalled bridge: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-after-desktop.jpg), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-after-mobile.jpg).
<!-- evidence-row:walkthrough-video -->
- [x] [MP4 walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-after-walkthrough.mp4) shows the transient handoff screen recovering to sign-in at five seconds.
<!-- evidence-row:backend-logs -->
- [x] N/A - no application backend route is changed; protected workflow failure logs are linked below.
<!-- evidence-row:frontend-logs -->
- [x] Before/after console and network JSON captured with zero console errors, zero failed requests, and zero non-2xx responses: [before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-before-desktop-frontend.json), [before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-before-mobile-frontend.json), [after desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-after-desktop-frontend.json), [after mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-after-mobile-frontend.json).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, model, provider, or action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this PR changes source only; live staging convergence happens after merge through protected environments.
<!-- evidence-row:ocr-review -->
- [x] [Apple Vision OCR review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-ocr-review.jsonl) recognized the before handoff text and the complete after sign-in form on desktop/mobile.

# Evidence Details

## Backend + frontend logs

- Headscale failure: https://github.com/elizaOS/eliza/actions/runs/31702192116
- Tunnel failure: https://github.com/elizaOS/eliza/actions/runs/31702276699
- The deterministic browser capture blocks service workers and stalls only SHA-256, then compares deployed production with this exact source. Provider discovery is fulfilled with the current public Steward provider inventory so the after image isolates the handoff behavior without a local cloud backend.

## Screenshots (before / after) + video walkthrough

### Before

![Before desktop: stalled launch handoff](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-before-desktop.jpg)

![Before mobile: stalled launch handoff](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-before-mobile.jpg)

### After

![After desktop: usable canonical sign-in fallback](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-after-desktop.jpg)

![After mobile: usable canonical sign-in fallback](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-after-mobile.jpg)

### Walkthrough video

[Watch the MP4 recovery walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19232-after-walkthrough.mp4).

## Known gaps / failures

- A normal `bun install` downloaded 640 MiB of the optional 971 MiB artifact archive before the host returned `ENOSPC`; the downloader removed its partial file. `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install` then completed with all 3,831 installs and no dependency changes. The archive is unrelated to UI/workflow validation.
- The former repository-wide `audit:hetzner-fleet-routing` base-branch failure is resolved by merged PR #19205. `bun run verify` now passes in full on this exact rebased head.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@646b1f08ddc28c274843f30e96c596a88780a5ba:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-cloud-consolidation]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@646b1f08ddc28c274843f30e96c596a88780a5ba:packages/skills/skills/contribute-to-eliza"} -->
