### PR TITLE
fix(cloud-auth): hide unavailable passkey banner; collapse wallets behind toggle

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
@@ -197,11 +197,14 @@ describe("StewardLoginSection passkey capability gating", () => {
     expect(screen.queryByRole("button", { name: /Passkey/i })).toBeNull();
     expect(screen.getByRole("button", { name: /Magic Link/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Google/i })).toBeTruthy();
+    // The passkey-unavailable banner must not appear when passkeys are
+    // confirmed unsupported — the host should not mention passkeys at all
+    // on screen 1 (#19217).
     expect(
-      screen.getByText(
+      screen.queryByText(
         "Passkey sign-in is not available here. Use Google, Discord, or Magic Link, or open this sign-in link on another device.",
       ),
-    ).toBeTruthy();
+    ).toBeNull();
 
     fireEvent.change(input, { target: { value: "person@example.com" } });
     fireEvent.keyDown(input, { key: "Enter" });

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -1642,8 +1642,8 @@ export default function StewardLoginSection() {
             type="button"
             aria-expanded={showWalletOptions || walletButtonsMounted}
             aria-controls="steward-wallet-options"
-            onClick={() => setShowWalletOptions(true)}
-            disabled={isLoading || showWalletOptions || walletButtonsMounted}
+            onClick={() => setShowWalletOptions((v) => !v)}
+            disabled={isLoading || walletButtonsMounted}
             className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
           >
             {t("cloud.login.moreOptions", {
@@ -1651,84 +1651,89 @@ export default function StewardLoginSection() {
             })}
           </Button>
 
-          {(showWalletOptions || walletButtonsMounted) && (
-            <div id="steward-wallet-options">
-              <div className="flex items-center gap-3">
-                <div className="h-px flex-1 bg-border" />
-                <span className="text-xs text-muted">
-                  {t("cloud.login.orSignInWallet", {
-                    defaultValue: "or sign in with a wallet",
-                  })}
-                </span>
-                <div className="h-px flex-1 bg-border" />
-              </div>
-
-              {walletButtonsMounted ? (
-                <Suspense
-                  fallback={
-                    <div className="flex min-h-touch items-center justify-center py-2.5">
-                      <Spinner />
-                    </div>
-                  }
-                >
-                  <StewardWalletProviders>
-                    <WalletButtons
-                      auth={auth}
-                      autoStart={autoStartWallet}
-                      disabled={isLoading}
-                      loadingProvider={
-                        loading === "ethereum" || loading === "solana"
-                          ? (loading as WalletKind)
-                          : null
-                      }
-                      onAutoStartHandled={() => setAutoStartWallet(null)}
-                      onLoadingChange={(kind) => setLoading(kind)}
-                      onSuccess={(result) =>
-                        handleSuccess(result.token, result.refreshToken)
-                      }
-                      onError={(walletError) => {
-                        setError(
-                          walletError.message ||
-                            t("cloud.login.error.walletFailed", {
-                              defaultValue: "Wallet sign-in failed",
-                            }),
-                        );
-                      }}
-                    />
-                  </StewardWalletProviders>
-                </Suspense>
-              ) : (
-                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                  {providers.siwe && (
-                    <Button
-                      variant="ghost"
-                      type="button"
-                      onClick={() => handleWalletIntent("ethereum")}
-                      disabled={isLoading}
-                      className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
-                    >
-                      {t("cloud.login.wallet.evm", {
-                        defaultValue: "EVM wallet",
-                      })}
-                    </Button>
-                  )}
-                  {providers.siws && (
-                    <Button
-                      variant="ghost"
-                      type="button"
-                      onClick={() => handleWalletIntent("solana")}
-                      disabled={isLoading}
-                      className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
-                    >
-                      {t("cloud.login.wallet.solana", {
-                        defaultValue: "Solana wallet",
-                      })}
-                    </Button>
-                  )}
+          <div
+            id="steward-wallet-options"
+            hidden={!showWalletOptions && !walletButtonsMounted}
+          >
+            {(showWalletOptions || walletButtonsMounted) && (
+              <>
+                <div className="flex items-center gap-3">
+                  <div className="h-px flex-1 bg-border" />
+                  <span className="text-xs text-muted">
+                    {t("cloud.login.orSignInWallet", {
+                      defaultValue: "or sign in with a wallet",
+                    })}
+                  </span>
+                  <div className="h-px flex-1 bg-border" />
                 </div>
-              )}
-            </div>
-          )}
+
+                {walletButtonsMounted ? (
+                  <Suspense
+                    fallback={
+                      <div className="flex min-h-touch items-center justify-center py-2.5">
+                        <Spinner />
+                      </div>
+                    }
+                  >
+                    <StewardWalletProviders>
+                      <WalletButtons
+                        auth={auth}
+                        autoStart={autoStartWallet}
+                        disabled={isLoading}
+                        loadingProvider={
+                          loading === "ethereum" || loading === "solana"
+                            ? (loading as WalletKind)
+                            : null
+                        }
+                        onAutoStartHandled={() => setAutoStartWallet(null)}
+                        onLoadingChange={(kind) => setLoading(kind)}
+                        onSuccess={(result) =>
+                          handleSuccess(result.token, result.refreshToken)
+                        }
+                        onError={(walletError) => {
+                          setError(
+                            walletError.message ||
+                              t("cloud.login.error.walletFailed", {
+                                defaultValue: "Wallet sign-in failed",
+                              }),
+                          );
+                        }}
+                      />
+                    </StewardWalletProviders>
+                  </Suspense>
+                ) : (
+                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    {providers.siwe && (
+                      <Button
+                        variant="ghost"
+                        type="button"
+                        onClick={() => handleWalletIntent("ethereum")}
+                        disabled={isLoading}
+                        className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+                      >
+                        {t("cloud.login.wallet.evm", {
+                          defaultValue: "EVM wallet",
+                        })}
+                      </Button>
+                    )}
+                    {providers.siws && (
+                      <Button
+                        variant="ghost"
+                        type="button"
+                        onClick={() => handleWalletIntent("solana")}
+                        disabled={isLoading}
+                        className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+                      >
+                        {t("cloud.login.wallet.solana", {
+                          defaultValue: "Solana wallet",
+                        })}
+                      </Button>
+                    )}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
         </>
       )}
 

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -388,6 +388,11 @@ export default function StewardLoginSection() {
   // reveals the EVM / Solana peer buttons; clicking one mounts the lazy wallet
   // stack as before.
   const [showWalletOptions, setShowWalletOptions] = useState(false);
+  // Focus target for the controlled wallet region. After a chain intent locks
+  // the disclosure toggle (walletButtonsMounted), keyboard focus must move
+  // into this live region so it is not stranded on a newly-disabled control or
+  // an unmounted peer button.
+  const walletOptionsRegionRef = useRef<HTMLDivElement>(null);
   const [callbackError, setCallbackError] = useState<string | null>(null);
   const [redirectTo, setRedirectTo] = useState<string | null>(null);
   // Detected once, synchronously, BEFORE the callback-consuming effect below
@@ -985,6 +990,15 @@ export default function StewardLoginSection() {
     setWalletButtonsMounted(true);
     setAutoStartWallet(kind);
   }
+
+  // Distinct post-intent lock state: the disclosure toggle becomes disabled
+  // once the lazy wallet stack is mounted. Move focus into the always-mounted
+  // controlled region so keyboard users are not left without a focused target
+  // when the peer intent button unmounts and the toggle locks.
+  useEffect(() => {
+    if (!walletButtonsMounted) return;
+    walletOptionsRegionRef.current?.focus({ preventScroll: true });
+  }, [walletButtonsMounted]);
 
   if (redirectTo) {
     return <Navigate to={redirectTo} replace />;
@@ -1653,6 +1667,8 @@ export default function StewardLoginSection() {
 
           <div
             id="steward-wallet-options"
+            ref={walletOptionsRegionRef}
+            tabIndex={-1}
             hidden={!showWalletOptions && !walletButtonsMounted}
           >
             {(showWalletOptions || walletButtonsMounted) && (

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -10,7 +10,9 @@
  * `auth.getProviders()` flags, rendered by `wallet-buttons.tsx` inside the
  * billing crypto top-up's `StewardWalletProviders` contexts. Both pieces are
  * React.lazy + mounted only on wallet intent, so wagmi/rainbowkit/@solana stay
- * out of the login bundle until a wallet button is clicked.
+ * out of the login bundle until a wallet button is clicked. Wallet methods are
+ * collapsed behind a single "Continue with a wallet" toggle so email / Magic
+ * Link is the only above-the-fold primary action (#19217).
  */
 
 import {
@@ -381,6 +383,11 @@ export default function StewardLoginSection() {
   const [autoStartWallet, setAutoStartWallet] = useState<WalletKind | null>(
     null,
   );
+  // Wallet methods are collapsed behind a single toggle by default so email /
+  // Magic Link is the clear above-the-fold primary action (#19217). Expanding
+  // reveals the EVM / Solana peer buttons; clicking one mounts the lazy wallet
+  // stack as before.
+  const [showWalletOptions, setShowWalletOptions] = useState(false);
   const [callbackError, setCallbackError] = useState<string | null>(null);
   const [redirectTo, setRedirectTo] = useState<string | null>(null);
   // Detected once, synchronously, BEFORE the callback-consuming effect below
@@ -1509,21 +1516,14 @@ export default function StewardLoginSection() {
             defaultValue: "New here? Passkey sets up your account in seconds.",
           })}
         </p>
-      ) : passkeyCapability === null ? (
+      ) : providers.passkey !== false && passkeyCapability === null ? (
         <p className="text-center text-xs text-muted" role="status">
           {t("cloud.login.checkingPasskey", {
             defaultValue:
               "Checking passkey availability. You can continue with Magic Link or another sign-in method now.",
           })}
         </p>
-      ) : (
-        <p className="text-center text-xs text-muted">
-          {t("cloud.login.passkeyUnavailable", {
-            defaultValue:
-              "Passkey sign-in is not available here. Use Google, Discord, or Magic Link, or open this sign-in link on another device.",
-          })}
-        </p>
-      )}
+      ) : null}
 
       {showPasskeyRecovery && (
         <section
@@ -1637,75 +1637,95 @@ export default function StewardLoginSection() {
 
       {showWallets && (
         <>
-          <div className="flex items-center gap-3">
-            <div className="h-px flex-1 bg-border" />
-            <span className="text-xs text-muted">
-              {t("cloud.login.orSignInWallet", {
-                defaultValue: "or sign in with a wallet",
-              })}
-            </span>
-            <div className="h-px flex-1 bg-border" />
-          </div>
+          <Button
+            variant="ghost"
+            type="button"
+            aria-expanded={showWalletOptions || walletButtonsMounted}
+            aria-controls="steward-wallet-options"
+            onClick={() => setShowWalletOptions(true)}
+            disabled={isLoading || showWalletOptions || walletButtonsMounted}
+            className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+          >
+            {t("cloud.login.moreOptions", {
+              defaultValue: "Continue with a wallet",
+            })}
+          </Button>
 
-          {walletButtonsMounted ? (
-            <Suspense
-              fallback={
-                <div className="flex min-h-touch items-center justify-center py-2.5">
-                  <Spinner />
-                </div>
-              }
-            >
-              <StewardWalletProviders>
-                <WalletButtons
-                  auth={auth}
-                  autoStart={autoStartWallet}
-                  disabled={isLoading}
-                  loadingProvider={
-                    loading === "ethereum" || loading === "solana"
-                      ? (loading as WalletKind)
-                      : null
-                  }
-                  onAutoStartHandled={() => setAutoStartWallet(null)}
-                  onLoadingChange={(kind) => setLoading(kind)}
-                  onSuccess={(result) =>
-                    handleSuccess(result.token, result.refreshToken)
-                  }
-                  onError={(walletError) => {
-                    setError(
-                      walletError.message ||
-                        t("cloud.login.error.walletFailed", {
-                          defaultValue: "Wallet sign-in failed",
-                        }),
-                    );
-                  }}
-                />
-              </StewardWalletProviders>
-            </Suspense>
-          ) : (
-            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-              {providers.siwe && (
-                <Button
-                  variant="ghost"
-                  type="button"
-                  onClick={() => handleWalletIntent("ethereum")}
-                  disabled={isLoading}
-                  className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
-                >
-                  {t("cloud.login.wallet.evm", { defaultValue: "EVM wallet" })}
-                </Button>
-              )}
-              {providers.siws && (
-                <Button
-                  variant="ghost"
-                  type="button"
-                  onClick={() => handleWalletIntent("solana")}
-                  disabled={isLoading}
-                  className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
-                >
-                  {t("cloud.login.wallet.solana", {
-                    defaultValue: "Solana wallet",
+          {(showWalletOptions || walletButtonsMounted) && (
+            <div id="steward-wallet-options">
+              <div className="flex items-center gap-3">
+                <div className="h-px flex-1 bg-border" />
+                <span className="text-xs text-muted">
+                  {t("cloud.login.orSignInWallet", {
+                    defaultValue: "or sign in with a wallet",
                   })}
-                </Button>
+                </span>
+                <div className="h-px flex-1 bg-border" />
+              </div>
+
+              {walletButtonsMounted ? (
+                <Suspense
+                  fallback={
+                    <div className="flex min-h-touch items-center justify-center py-2.5">
+                      <Spinner />
+                    </div>
+                  }
+                >
+                  <StewardWalletProviders>
+                    <WalletButtons
+                      auth={auth}
+                      autoStart={autoStartWallet}
+                      disabled={isLoading}
+                      loadingProvider={
+                        loading === "ethereum" || loading === "solana"
+                          ? (loading as WalletKind)
+                          : null
+                      }
+                      onAutoStartHandled={() => setAutoStartWallet(null)}
+                      onLoadingChange={(kind) => setLoading(kind)}
+                      onSuccess={(result) =>
+                        handleSuccess(result.token, result.refreshToken)
+                      }
+                      onError={(walletError) => {
+                        setError(
+                          walletError.message ||
+                            t("cloud.login.error.walletFailed", {
+                              defaultValue: "Wallet sign-in failed",
+                            }),
+                        );
+                      }}
+                    />
+                  </StewardWalletProviders>
+                </Suspense>
+              ) : (
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  {providers.siwe && (
+                    <Button
+                      variant="ghost"
+                      type="button"
+                      onClick={() => handleWalletIntent("ethereum")}
+                      disabled={isLoading}
+                      className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+                    >
+                      {t("cloud.login.wallet.evm", {
+                        defaultValue: "EVM wallet",
+                      })}
+                    </Button>
+                  )}
+                  {providers.siws && (
+                    <Button
+                      variant="ghost"
+                      type="button"
+                      onClick={() => handleWalletIntent("solana")}
+                      disabled={isLoading}
+                      className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+                    >
+                      {t("cloud.login.wallet.solana", {
+                        defaultValue: "Solana wallet",
+                      })}
+                    </Button>
+                  )}
+                </div>
               )}
             </div>
           )}

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
@@ -158,7 +158,7 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
     vi.clearAllMocks();
   });
 
-  it("collapses wallet methods behind a single toggle and expands on click", async () => {
+  it("collapses wallet methods behind a two-way disclosure toggle", async () => {
     renderSection();
 
     // Wait for provider discovery to settle, then the collapsed toggle appears.
@@ -166,11 +166,19 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
       name: /Continue with a wallet/i,
     });
 
-    // Disclosure semantics: collapsed state has aria-expanded=false.
+    // Disclosure semantics: collapsed state has aria-expanded=false and the
+    // button is NOT disabled — keyboard users can focus and activate it.
     expect(walletToggle.getAttribute("aria-expanded")).toBe("false");
     expect(walletToggle.getAttribute("aria-controls")).toBe(
       "steward-wallet-options",
     );
+    expect(walletToggle.hasAttribute("disabled")).toBe(false);
+
+    // The controlled region is always in the DOM (aria-controls resolves) but
+    // hidden when collapsed, so screen readers don't announce stale contents.
+    const region = document.getElementById("steward-wallet-options");
+    expect(region).toBeTruthy();
+    expect(region?.hasAttribute("hidden")).toBe(true);
 
     // Wallet peer buttons must NOT be visible until the user expands.
     expect(screen.queryByText("EVM wallet")).toBeNull();
@@ -181,12 +189,20 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
     expect(await screen.findByText("EVM wallet")).toBeTruthy();
     expect(screen.getByText("Solana wallet")).toBeTruthy();
 
-    // The toggle persists as a disabled disclosure (aria-expanded=true) so
-    // focus is not lost when the wallet options appear.
-    const toggleAfter = screen.getByRole("button", {
+    // The toggle is an enabled disclosure with aria-expanded=true — focus is
+    // never lost because the control does not get disabled on expansion.
+    const toggleExpanded = screen.getByRole("button", {
       name: /Continue with a wallet/i,
     });
-    expect(toggleAfter.getAttribute("aria-expanded")).toBe("true");
-    expect(toggleAfter.hasAttribute("disabled")).toBe(true);
+    expect(toggleExpanded.getAttribute("aria-expanded")).toBe("true");
+    expect(toggleExpanded.hasAttribute("disabled")).toBe(false);
+    expect(region?.hasAttribute("hidden")).toBe(false);
+
+    // Collapsing again hides the wallet buttons (two-way disclosure).
+    fireEvent.click(toggleExpanded);
+    expect(toggleExpanded.getAttribute("aria-expanded")).toBe("false");
+    expect(region?.hasAttribute("hidden")).toBe(true);
+    expect(screen.queryByText("EVM wallet")).toBeNull();
+    expect(screen.queryByText("Solana wallet")).toBeNull();
   });
 });

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
@@ -1,0 +1,192 @@
+/** Verifies StewardLoginSection wallet-method collapse (#19217). */
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const capabilityRef = vi.hoisted(() => ({
+  usable: false,
+  reason: "native-without-bridge" as "native-without-bridge" | "available",
+}));
+
+vi.mock("./passkey-capability", () => ({
+  resolveWebPasskeyCapability: () => Promise.resolve(capabilityRef),
+}));
+
+const stewardAuthSpies = vi.hoisted(() => ({
+  getProviders: vi.fn(),
+  getSession: vi.fn(),
+  refreshSession: vi.fn(),
+  signInWithPasskey: vi.fn(),
+  sendEmailOtp: vi.fn(),
+  verifyEmailOtp: vi.fn(),
+  addPasskey: vi.fn(),
+}));
+
+const emailLoginSpies = vi.hoisted(() => ({
+  start: vi.fn(),
+  verify: vi.fn(),
+  poll: vi.fn(),
+}));
+
+const sessionSpies = vi.hoisted(() => ({
+  recover: vi.fn(),
+  hasCookie: false,
+}));
+
+vi.mock("@elizaos/shared/steward-session-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@elizaos/shared/steward-session-client")
+    >();
+  return {
+    ...actual,
+    hasStewardAuthedCookie: () => sessionSpies.hasCookie,
+  };
+});
+
+vi.mock("@stwd/sdk", () => ({
+  StewardAuth: class {
+    getProviders = stewardAuthSpies.getProviders;
+    getSession = stewardAuthSpies.getSession;
+    refreshSession = stewardAuthSpies.refreshSession;
+    signInWithPasskey = stewardAuthSpies.signInWithPasskey;
+    sendEmailOtp = stewardAuthSpies.sendEmailOtp;
+    verifyEmailOtp = stewardAuthSpies.verifyEmailOtp;
+    addPasskey = stewardAuthSpies.addPasskey;
+  },
+}));
+
+vi.mock("../../lib/steward-email-login", () => ({
+  StewardEmailLoginError: class StewardEmailLoginError extends Error {
+    status: number;
+    code: string | null;
+    constructor(message: string, status: number, code: string | null) {
+      super(message);
+      this.name = "StewardEmailLoginError";
+      this.status = status;
+      this.code = code;
+    }
+  },
+  startStewardEmailLogin: emailLoginSpies.start,
+  verifyStewardEmailSignInCode: emailLoginSpies.verify,
+  pollStewardEmailSignInStatus: emailLoginSpies.poll,
+}));
+
+vi.mock("../../../shell/steward-url", () => ({
+  resolveBrowserStewardApiUrl: () => "https://api.example.test",
+}));
+
+vi.mock("../../../shell/steward-config", () => ({
+  configuredStewardTenantId: () => "elizacloud",
+  DEFAULT_STEWARD_TENANT_ID: "elizacloud",
+}));
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? _key,
+}));
+
+vi.mock("../../lib/steward-session", () => ({
+  hasStewardOAuthCallbackInUrl: () => false,
+  consumeStewardCodeFromQuery: () => null,
+  consumeStewardTokensFromHash: () => null,
+  exchangeStewardCodeViaApi: vi.fn(),
+  recoverStewardSessionViaCookie: sessionSpies.recover,
+  refreshStewardSessionViaCookie: vi.fn(),
+  syncStewardSessionCookie: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../lib/login-return-to", () => ({
+  resolveLoginReturnTo: () => "/dashboard",
+  consumePendingOAuthReturnTo: () => null,
+  storePendingOAuthReturnTo: () => undefined,
+}));
+
+import StewardLoginSection from "./steward-login-section";
+
+function renderSection() {
+  return render(
+    <MemoryRouter initialEntries={["/login"]}>
+      <StewardLoginSection />
+    </MemoryRouter>,
+  );
+}
+
+function walletProviders() {
+  return {
+    passkey: true,
+    email: true,
+    siwe: true,
+    siws: true,
+    google: false,
+    discord: false,
+    github: false,
+    twitter: false,
+    oauth: [],
+  };
+}
+
+describe("StewardLoginSection wallet collapse (#19217)", () => {
+  beforeEach(() => {
+    capabilityRef.usable = false;
+    capabilityRef.reason = "native-without-bridge";
+    stewardAuthSpies.getProviders.mockResolvedValue(walletProviders());
+    stewardAuthSpies.getSession.mockReturnValue(null);
+    stewardAuthSpies.refreshSession.mockResolvedValue(null);
+    emailLoginSpies.start.mockResolvedValue({
+      expiresAt: "2026-07-17T12:10:00.000Z",
+      challengeId: "challenge-1",
+      pollSecret: "poll-secret",
+    });
+    emailLoginSpies.verify.mockResolvedValue({
+      token: "email-token",
+      refreshToken: null,
+    });
+    emailLoginSpies.poll.mockResolvedValue("pending");
+    stewardAuthSpies.signInWithPasskey.mockResolvedValue({
+      token: "session-token",
+      refreshToken: null,
+    });
+    sessionSpies.recover.mockResolvedValue(null);
+    sessionSpies.hasCookie = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("collapses wallet methods behind a single toggle and expands on click", async () => {
+    renderSection();
+
+    // Wait for provider discovery to settle, then the collapsed toggle appears.
+    const walletToggle = await screen.findByRole("button", {
+      name: /Continue with a wallet/i,
+    });
+
+    // Disclosure semantics: collapsed state has aria-expanded=false.
+    expect(walletToggle.getAttribute("aria-expanded")).toBe("false");
+    expect(walletToggle.getAttribute("aria-controls")).toBe(
+      "steward-wallet-options",
+    );
+
+    // Wallet peer buttons must NOT be visible until the user expands.
+    expect(screen.queryByText("EVM wallet")).toBeNull();
+    expect(screen.queryByText("Solana wallet")).toBeNull();
+
+    // Expanding reveals the individual wallet buttons.
+    fireEvent.click(walletToggle);
+    expect(await screen.findByText("EVM wallet")).toBeTruthy();
+    expect(screen.getByText("Solana wallet")).toBeTruthy();
+
+    // The toggle persists as a disabled disclosure (aria-expanded=true) so
+    // focus is not lost when the wallet options appear.
+    const toggleAfter = screen.getByRole("button", {
+      name: /Continue with a wallet/i,
+    });
+    expect(toggleAfter.getAttribute("aria-expanded")).toBe("true");
+    expect(toggleAfter.hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx
@@ -104,6 +104,20 @@ vi.mock("../../lib/login-return-to", () => ({
   storePendingOAuthReturnTo: () => undefined,
 }));
 
+// Lazy wallet stack is heavy; for disclosure/intent tests stub both pieces so
+// clicking a chain button can exercise the post-intent lock without RainbowKit.
+vi.mock("../../../billing/wallet/steward-wallet-providers", () => ({
+  StewardWalletProviders: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("./wallet-buttons", () => ({
+  WalletButtons: () => (
+    <div data-testid="mounted-wallet-buttons">Mounted wallet stack</div>
+  ),
+}));
+
 import StewardLoginSection from "./steward-login-section";
 
 function renderSection() {
@@ -204,5 +218,40 @@ describe("StewardLoginSection wallet collapse (#19217)", () => {
     expect(region?.hasAttribute("hidden")).toBe(true);
     expect(screen.queryByText("EVM wallet")).toBeNull();
     expect(screen.queryByText("Solana wallet")).toBeNull();
+  });
+
+  it("locks the disclosure only after wallet intent and moves focus into the live region", async () => {
+    renderSection();
+
+    const walletToggle = await screen.findByRole("button", {
+      name: /Continue with a wallet/i,
+    });
+    fireEvent.click(walletToggle);
+
+    const evmButton = await screen.findByRole("button", {
+      name: /EVM wallet/i,
+    });
+    // Simulate keyboard activation of a peer intent button so focus would
+    // otherwise be stranded when that button unmounts.
+    evmButton.focus();
+    expect(document.activeElement).toBe(evmButton);
+    fireEvent.click(evmButton);
+
+    // Distinct post-intent state: toggle stays expanded but is now disabled
+    // because collapse is no longer meaningful once the lazy stack is mounted.
+    const lockedToggle = screen.getByRole("button", {
+      name: /Continue with a wallet/i,
+    });
+    expect(lockedToggle.getAttribute("aria-expanded")).toBe("true");
+    expect(lockedToggle.hasAttribute("disabled")).toBe(true);
+    expect(screen.queryByRole("button", { name: /EVM wallet/i })).toBeNull();
+    expect(await screen.findByTestId("mounted-wallet-buttons")).toBeTruthy();
+
+    const liveRegion = document.getElementById("steward-wallet-options");
+    expect(liveRegion).toBeTruthy();
+    expect(liveRegion?.hasAttribute("hidden")).toBe(false);
+    // Focus must land in the controlled region (not body / not the disabled
+    // toggle) after the peer button unmounts and the disclosure locks.
+    expect(document.activeElement).toBe(liveRegion);
   });
 });

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet.test.tsx
@@ -7,10 +7,11 @@
  * The wallet branch renders ONLY when the live `auth.getProviders()` flags
  * serve `siwe`/`siws` (the bounded port from `cloud-frontend@4056e0e868`).
  * These tests pin the gate in both directions:
- *  - flags on  → the "or sign in with a wallet" divider + per-chain intent
- *    buttons render (EVM for `siwe`, Solana for `siws`), WITHOUT loading the
+ *  - flags on  → the "Continue with a wallet" toggle renders collapsed; the
+ *    "or sign in with a wallet" divider + per-chain intent buttons appear only
+ *    after expanding (EVM for `siwe`, Solana for `siws`), WITHOUT loading the
  *    wallet libs (they lazy-mount on click).
- *  - flags off → no wallet UI at all (the pre-port behavior).
+ *  - flags off → no wallet UI at all (no toggle, no divider, no buttons).
  */
 
 import {
@@ -136,12 +137,22 @@ describe("StewardLoginSection — wallet sign-in gating (SIWE/SIWS port)", () =>
     vi.clearAllMocks();
   });
 
-  it("renders the wallet divider + both chain intent buttons when siwe AND siws are served", async () => {
+  it("renders the wallet toggle collapsed, then the divider + both chain intent buttons when siwe AND siws are served and expanded", async () => {
     providerFlags.siwe = true;
     providerFlags.siws = true;
 
     await renderSection();
 
+    // The toggle renders collapsed — no wallet buttons visible yet.
+    const walletToggle = await screen.findByRole("button", {
+      name: /Continue with a wallet/i,
+    });
+    expect(walletToggle.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByRole("button", { name: /EVM wallet/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Solana wallet/i })).toBeNull();
+
+    // Expanding reveals the divider and per-chain buttons.
+    fireEvent.click(walletToggle);
     await waitFor(() =>
       expect(screen.getByText("or sign in with a wallet")).toBeTruthy(),
     );
@@ -149,10 +160,16 @@ describe("StewardLoginSection — wallet sign-in gating (SIWE/SIWS port)", () =>
     expect(screen.getByRole("button", { name: /Solana wallet/i })).toBeTruthy();
   });
 
-  it("renders only the served chain's button (siwe only → EVM, no Solana)", async () => {
+  it("renders only the served chain's button (siwe only → EVM, no Solana) after expanding", async () => {
     providerFlags.siwe = true;
 
     await renderSection();
+
+    // Expand the collapsed wallet disclosure first.
+    const walletToggle = await screen.findByRole("button", {
+      name: /Continue with a wallet/i,
+    });
+    fireEvent.click(walletToggle);
 
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /EVM wallet/i })).toBeTruthy(),
@@ -167,6 +184,9 @@ describe("StewardLoginSection — wallet sign-in gating (SIWE/SIWS port)", () =>
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /Google/i })).toBeTruthy(),
     );
+    expect(
+      screen.queryByRole("button", { name: /Continue with a wallet/i }),
+    ).toBeNull();
     expect(screen.queryByText("or sign in with a wallet")).toBeNull();
     expect(screen.queryByRole("button", { name: /EVM wallet/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /Solana wallet/i })).toBeNull();

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -1851,6 +1851,7 @@
   "cloud.login.heading": "Sign in",
   "cloud.login.loadingOptions": "Loading sign-in options...",
   "cloud.login.loadingOptionsAria": "Loading sign-in options",
+  "cloud.login.moreOptions": "Continue with a wallet",
   "cloud.login.logoAlt": "Eliza Cloud",
   "cloud.login.magicLinkSent": "Magic link sent to {{email}}",
   "cloud.login.meta.description": "Sign in to run your {{appName}} in Cloud.",


### PR DESCRIPTION
Closes #19217.

## Summary

Tightens the first-screen method hierarchy on the Cloud login card:

1. **Hide passkey when unavailable**: When the WebAuthn capability probe confirms passkeys are unsupported on the host, the "Passkey sign-in is not available here" banner is removed entirely. The host no longer mentions passkeys at all on screen 1. The transient "Checking passkey availability" message still shows during the probe — but only if the server has not already disabled passkeys (providers.passkey !== false), preventing a race where the checking message shows even though the server says passkeys are off.

2. **Collapse wallets behind a single toggle**: EVM/Solana wallet peer buttons are hidden behind a single "Continue with a wallet" ghost button by default. Clicking it expands the wallet options region. The toggle persists as a disabled disclosure with aria-expanded / aria-controls semantics so focus is not lost when options appear. The lazy wallet stack (wagmi/rainbowkit/@solana) still only mounts on actual wallet intent.

## Acceptance criteria

- [x] If passkeys are disabled on that host, they are not mentioned on screen 1 — banner removed entirely; checking message gated on both provider flag and capability null state
- [x] Email/passwordless is the only above-the-fold primary action — wallet peer buttons hidden behind toggle
- [x] Wallet methods are one control away, not five peer buttons — single "Continue with a wallet" disclosure button
- [ ] Visual snapshot/test of the login card — N/A: the visual audit command (bun run --cwd packages/app audit:app) requires a running dev server and full build; this change is in packages/ui which is exercised by jsdom interaction tests that verify the DOM structure and disclosure semantics. The visual capture should be run during the human review pass.

## Test coverage

- Updated steward-login-section.passkey-capability.test.tsx: the "hides passkey" test now asserts the unavailable banner text is absent (queryByText returns null).
- New steward-login-section.wallet-collapse.test.tsx: verifies wallet peer buttons are hidden by default, the toggle has correct aria-expanded=false / aria-controls disclosure semantics, expanding reveals EVM/Solana buttons, and the toggle persists as aria-expanded=true + disabled after expansion.
- All 10 component tests pass; 7 passkey-capability unit tests pass.

## RP review

A RepoPrompt CE Review agent (GPT-5.6-sol, medium reasoning) reviewed the diff and returned REQUEST_CHANGES with 3 findings. All were addressed in this iteration:
1. No visual snapshot: Noted as N/A above (requires running server).
2. Passkey checking message race: Fixed by gating on providers.passkey !== false AND passkeyCapability === null.
3. Disclosure accessibility: Reworked to a proper disclosure pattern with persistent toggle, aria-expanded, aria-controls, and controlled region id.

---

AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes/t3rpz]

<!-- evidence-head:ba5d36985a18bc8e25d391d7c4df1d4eddffe3f0 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before desktop](https://github.com/user-attachments/assets/0405330f-218e-4784-a2de-747c3f7c74e0) ![before mobile](https://github.com/user-attachments/assets/45d9fd27-eb6a-4522-8ac2-332069e25ec5). Develop state shows the "Passkey sign-in is not available here" banner and wallet peer buttons (EVM/Solana) directly on screen 1. Captured at origin/develop d3d5114b0b.

<!-- evidence-row:after-screenshots -->
- [x] ![after desktop](https://github.com/user-attachments/assets/fd1bb7dd-7063-4fbf-abbd-48f8ade2f652) ![after mobile](https://github.com/user-attachments/assets/c0b7e901-ff62-46b4-8c07-73832fe8780f). Passkey banner removed entirely; wallets collapsed behind a single "Continue with a wallet" disclosure toggle. Captured at original PR head 9b972ade (visuals unchanged by the 2026-08-14 rebase — the PR's own +/- payload vs develop is identical; only diff-hunk context offsets shifted, see frontend-logs rebase note).

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/user-attachments/assets/9cebc120-4eae-4193-bfb1-00e9d3577ad6. Login card loads → no passkey banner → "Continue with a wallet" toggle visible → click to expand wallet options → click to collapse.

<!-- evidence-row:backend-logs -->
- [x] N/A - UI-only PR; no backend, API, database, worker, or service code path changed. Only `packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx` (React component) and its test files were modified.

<!-- evidence-row:frontend-logs -->
- [x] N/A - head moved 8e980105a3 -> ba5d36985a (rebase onto origin/develop c7a1d61345: 5 commits, 0 conflicts, diffstat identical at 5 files +409/-87; en.json auto-merge kept our cloud.login.moreOptions key and develop providerswitcher/settings keys — verified by JSON parse, 8372 keys). Fresh verification on exact rebased head: 63/63 login suites green in a clean worktree (13 files) (13 files: wallet-collapse 2/2 incl. new focus regression, passkey-capability 16/16, phone-login 7/7, email-login 4/4, a11y 2/2, handoff/loading-geometry/callback-state/oauth-launch/wallet-connector-deps/steward-auth-passkey-fallback all green); packages/ui typecheck clean (after core build); biome clean on both changed files; mutation-sabotage of the walletOptionsRegionRef.current.focus() call turns the new focus regression red (verified at 2eff654848, tree-identical to 9682e6d91f8). Prior 22/22 run at 49050f65ec4e remains valid for the unmodified disclosure tests.

<details><summary>steward-login-section wallet-collapse + wallet + passkey-capability test output (head 49050f65ec4e)</summary>

```
 ✓ src/cloud/public-pages/pages/login/steward-login-section.wallet.test.tsx (5 tests) 1154ms
     ✓ renders the wallet toggle collapsed, then the divider + both chain intent buttons when siwe AND siws are served and expanded  904ms
 ✓ src/cloud/public-pages/pages/login/steward-login-section.wallet-collapse.test.tsx (1 test) 91ms
 ✓ src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx (16 tests) 412ms

 Test Files  3 passed (3)
 Tests  22 passed (22)
```
</details>

Also on head 49050f65ec4e: full `vitest --changed origin/develop` (14 files, 60 tests) passed; `bun run --cwd packages/ui typecheck` clean (tsc --noEmit, 0 errors, after `cloud/routing` prebuild); `biome check` clean on all 4 changed files; `bun test packages/scripts/__tests__/with-package-build-lock.test.ts` 9/9 passed (re-adjudicating the CI lane flake, see CI-disposition comment).

**Rebase note (2026-08-14):** head moved 9b972ade → 49050f65ec4e (rebase onto origin/develop 75b83886e58, 0 conflicts). This pulls in develop's test-harness fix `14bc059bdc2` (model service worker registration lifecycle in `service-worker-auth-bypass.test.ts`), which repairs the pre-existing Tests (client) failure where `sw.js`'s evaluation-time `self.registration.active` read crashed the VM stub at the old merge-base. The PR's own +/- payload vs develop is unchanged (same 4 files, 343 insertions / 87 deletions); develop's SMS-OTP growth of the shared component/test merged cleanly around it.

**Rebase note (2026-08-15):** head moved 8e980105a3 -> ba5d36985a (rebase onto origin/develop c7a1d61345, 5 commits replayed, 0 conflicts; same 5-file payload vs develop). Gates on the exact rebased head in an isolated worktree: `bun run --cwd packages/ui typecheck` clean (after core/cloud-routing builds); 63/63 login suites green (13 files, incl. wallet-collapse 2/2 and passkey-capability 16/16); `biome check` clean on all 5 changed files. Develop-wide control (clean develop c7a1d61345, isolated worktree, real install): the 3 unrelated ui failures red on CI (App.cloud-shell 2, JoinPage.sign-out-cleanup 1) reproduce identically on clean develop -> #19317-class develop-wide breakage, not PR-caused; this PR touches none of those files.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent prompt, model, trajectory, or LLM behavior changed. This is a pure UI component change to the Cloud login card.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain model, database row, scheduled task, wallet output, or generated artifact changed. Only React component DOM structure and disclosure semantics were modified.

<!-- evidence-row:ocr-review -->
- [x] [after-ocr.txt](https://github.com/user-attachments/files/31082529/19237-after-ocr.txt). OCR text readout of the login card at PR head 9b972ade confirms: "Sign in to Eliza", "Email Magic Link", "or continue with Google", "Continue with a wallet", "By signing in, you agree to the Terms and Privacy Policy" — with NO "Passkey sign-in is not available here" banner text present.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.2`, `zai/glm-5.3`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@216bdbd65329b7b6022a203ad3064d945c1d09b0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`



