### PR TITLE
fix(cloud): redirect legacy agent hosts after cutover

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -606,7 +606,7 @@ describe("cloud-api worker entrypoint", () => {
     }
   });
 
-  test("keeps legacy UUID agents proxied while redirecting public service hosts", () => {
+  test("redirects legacy UUID agents and public service hosts", () => {
     const response = redirectFrontendHost(
       new URL(
         "https://e06bb509-6c52-4c33-a9f7-66addc43e8c8.elizacloud.ai/chat?room=1",
@@ -614,7 +614,20 @@ describe("cloud-api worker entrypoint", () => {
       { ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app" },
     );
 
-    expect(response).toBeNull();
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe(
+      "https://e06bb509-6c52-4c33-a9f7-66addc43e8c8.cloud.eliza.app/chat?room=1",
+    );
+    const stagingResponse = redirectFrontendHost(
+      new URL(
+        "https://e06bb509-6c52-4c33-a9f7-66addc43e8c8.staging.elizacloud.ai/api/health?probe=1",
+      ),
+      { ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud-staging.eliza.app" },
+    );
+    expect(stagingResponse?.status).toBe(308);
+    expect(stagingResponse?.headers.get("location")).toBe(
+      "https://e06bb509-6c52-4c33-a9f7-66addc43e8c8.cloud-staging.eliza.app/api/health?probe=1",
+    );
     const serviceCases = [
       [
         "https://blob.elizacloud.ai/object.bin",
@@ -698,7 +711,7 @@ describe("cloud-api worker entrypoint", () => {
     }
   });
 
-  test("extracts canonical and legacy UUID hosts for the dedicated-agent proxy", () => {
+  test("extracts only canonical UUID hosts for the dedicated-agent proxy", () => {
     const env = { ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app" };
     const agentId = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
 
@@ -713,7 +726,7 @@ describe("cloud-api worker entrypoint", () => {
         new URL(`https://${agentId}.elizacloud.ai/api/health`),
         env,
       ),
-    ).toBe(agentId);
+    ).toBeNull();
     expect(
       getGeneratedAgentId(new URL("https://blob.elizacloud.ai/object"), env),
     ).toBeNull();

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -519,17 +519,7 @@ export function getGeneratedAgentId(
     const subdomain = hostname.slice(0, -suffix.length);
     if (AGENT_ID_RE.test(subdomain)) return subdomain;
   }
-
-  // Keep legacy UUID agent hosts on the authenticated dedicated-agent proxy
-  // until the canonical nested-wildcard DNS and certificate cutover is live.
-  // Redirecting these bridge requests first strips them from the only working
-  // host and makes fail-closed snapshots/restarts time out (#19047).
-  const classified = hostname ? classifyElizaHostname(hostname) : null;
-  return classified?.role === "legacy-dedicated-agent" &&
-    classified.agentId &&
-    AGENT_ID_RE.test(classified.agentId)
-    ? classified.agentId
-    : null;
+  return null;
 }
 
 export function redirectFrontendHost(
@@ -578,10 +568,7 @@ export function redirectFrontendHost(
     classified.agentId &&
     AGENT_ID_RE.test(classified.agentId)
   ) {
-    // UUID agent hosts remain on the legacy hostname until the canonical
-    // nested-wildcard DNS/certificate cutover is complete. The worker proxies
-    // them below through the same authenticated dedicated-agent path.
-    return null;
+    canonicalHostname = classified.canonicalHostname;
   } else {
     canonicalHostname = canonicalElizaServiceHostname(hostname);
     if (!canonicalHostname && hostname === "os.elizacloud.ai") {


### PR DESCRIPTION
Closes the final wildcard redirect leg of #18806.

## What changes

- UUID agent hosts under `*.elizacloud.ai` and `*.staging.elizacloud.ai` return path/query-preserving 308s to their canonical `*.cloud.eliza.app` / `*.cloud-staging.eliza.app` peers.
- The dedicated-agent proxy accepts only canonical agent hostnames after the redirect boundary.
- Exact browser/API/service redirects remain unchanged.

## Deployment ordering — precondition satisfied

The prior hold was correct: canonical nested-wildcard TLS had to be live before enabling redirects. A fresh external probe on 2026-08-16 confirms DNS resolution and certificate verification (`ssl_verify_result=0`) for all four relevant production/staging legacy and canonical UUID hosts. Each reached the Cloudflare edge and returned HTTP 404 for the deliberately nonexistent probe path, proving the TLS precondition is now satisfied.

## Verification

Exact head: `daf2a4d19a06097473070a1c1f6469b3c952b822`  
Exact base: `2a6f2642efd6ab5d821527a163de72fcc412ce47`

- `bun --config=/dev/null test packages/cloud/api/src/index.test.ts packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts` — 81 pass, 0 fail, 400 expectations
- `bun run --cwd packages/cloud/api lint` — pass, no fixes
- `bun run --cwd packages/cloud/api typecheck` — pass, including production Worker bundle dry-run
- `bun run verify` — pass; 353/353 Turbo tasks plus all repository audits
- `git diff --check origin/develop...HEAD` — pass
- Live TLS/HTTP probe — all four hosts `tls_verify=0`, HTTP 404

## Generation provenance

- Provider: OpenAI
- Model: gpt-5
- Agent: Codex desktop