### PR TITLE
fix(ui): hide Cloud Connectors outside developer mode

### DIFF
--- a/packages/ui/src/cloud/connectors/index.ts
+++ b/packages/ui/src/cloud/connectors/index.ts
@@ -60,8 +60,8 @@ export function registerCloudConnectorsSettingsSection(): void {
     group: "agent",
     titleKey: "settings.sections.cloudConnectors.title",
     defaultTitle: "Cloud Connectors",
-    // Hidden for MVP (kept registered so its route/deep-link still resolves).
-    viewKind: "release",
+    // Hidden for MVP while remaining registered for route/deep-link resolution.
+    viewKind: "developer",
     cloudOnly: true,
     Component: CloudConnectorsSettingsSection,
   });

--- a/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
@@ -205,6 +205,7 @@ const HIDDEN_SECTIONS = [
   "wallet-rpc",
   "secrets",
   "app-permissions",
+  "cloud-connectors",
 ];
 
 const browser = await chromium.launch();


### PR DESCRIPTION
Fixes #19220

## Summary

- classify Cloud Connectors as a Developer view so the canonical settings filter hides it when Developer Mode is off
- preserve the registered route, managed-cloud constraint, and Developer Mode access
- add Cloud Connectors to the real-browser hidden-section contract for desktop and mobile

The explicit `viewKind` takes precedence in `resolveViewKind`, so adding `developerOnly` while leaving this view classified as `release` would be a no-op. Changing the owning classification fixes the source contract instead of layering on a second flag.

## Verification

Exact source head: `068f1d9219000c7642dfdc8170417169d4187c6d`
Base: `origin/develop@15c8bc849f219712a084ebf225a777d7d9909e42`

- frozen `bun install` — PASS; native artifact bundle SHA-256 verified and extracted with no lockfile changes
- focused red baseline — reproduced the defect: expected hidden, received visible
- settings registration and MVP visibility contracts — 18/18 PASS
- real-browser settings run — PASS on desktop/mobile; Cloud Connectors hidden, everyday sections retained, deep links exercised, 0 uncaught page errors
- `@elizaos/ui` lint and typecheck — PASS
- full app aesthetic audit — 219/219 PASS; broken=0, needs-work=0, minimalism/hover/density failures=0
- OCR review — 216 views, 200 verified, broken=0, 16 unchanged needs-eyeball
- root `bun run verify` — 350/350 PASS; all repository audits pass

## Visual evidence

| Surface | Before | After |
| --- | --- | --- |
| Desktop settings rail | [Cloud Connectors visible](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-before-desktop.png) | [Cloud Connectors hidden](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-after-desktop.png) |
| Mobile settings hub | [Cloud Connectors visible](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-before-mobile.png) | [Cloud Connectors hidden](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-after-mobile.png) |

- [MP4 desktop/mobile walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-walkthrough.mp4)
- [Hardened browser transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-settings-e2e.log)
- [App audit transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-audit-app.log)
- [OCR triage](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-ocr-triage.json)
- [Root verification transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-root-verify.log)
- [Structured evidence and checksums](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-evidence.json)

<!-- evidence-head:068f1d9219000c7642dfdc8170417169d4187c6d -->

<!-- evidence-row:before-screenshots -->
- [x] [Desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-before-desktop.png) and [mobile before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-before-mobile.png)

<!-- evidence-row:after-screenshots -->
- [x] [Desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-after-desktop.png) and [mobile after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-after-mobile.png)

<!-- evidence-row:walkthrough-video -->
- [x] [Desktop/mobile MP4 walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-walkthrough.mp4)

<!-- evidence-row:backend-logs -->
- [x] N/A - client-side view registry only; no backend route or service changed

<!-- evidence-row:frontend-logs -->
- [x] [Real-browser transcript with zero uncaught page errors](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-settings-e2e.log)

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic settings visibility; no model invocation

<!-- evidence-row:domain-artifacts -->
- [x] [Structured result and SHA-256 manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-evidence.json) and [full audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-audit-report.json)

<!-- evidence-row:ocr-review -->
- [x] [OCR triage: 216 views, broken=0](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19220-ocr-triage.json)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - repository contribution skill is not available in this session
Attribution status: self-reported
— [codex-19220]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - repository contribution skill is not available in this session"} -->
