### PR TITLE
fix(ui): add the missing oidcContinue sessionUnavailable catalog key

### DIFF
--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -7170,6 +7170,7 @@
   "cloud.oidcContinue.issuerUnconfigured": "Single sign-on is not configured for this deployment: {{envVar}} is unset, so there is no identity provider to return to.",
   "cloud.oidcContinue.metaTitle": "Signing in | Eliza Cloud",
   "cloud.oidcContinue.redirecting": "Completing sign-in…",
+  "cloud.oidcContinue.sessionUnavailable": "Your Eliza session could not be securely transferred to the identity provider. Sign in again to continue.",
   "cloud.organizationInfo.notAvailable": "N/A",
   "cloud.organizationInfo.title": "Organization",
   "cloud.organizationInfo.subtitle": "Information about your organization",


### PR DESCRIPTION
# Relates to

Trunk repair: `check-i18n.test.ts > the real repo satisfies the contract` is red
on `develop` itself (CI run `31733424110`, `workflow_dispatch` on `1d80a9e2b` —
no PR code in the tree), and still reproduces at `20c58a5c270`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` was run after sync; the affected contract test and the two
      locale-consuming suites were run directly (output below).
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched off `20c58a5c2702b72ef500e81db831083ed693a80b` (current
      `origin/develop`); zero conflicts.
- [x] Targeted suites pass post-sync; see **Known gaps / failures** for the
      full-`verify` note.

# Risks

Low. One added key in the English message catalog. No rendered copy changes —
the call site already supplied the identical string as `defaultValue`.

# Background

## What does this PR do?

#19075 (`c1f29856b25`) added a `cloud.oidcContinue.sessionUnavailable` lookup to
the OIDC continuation page's `session_missing` / `session_sync_failed` recovery
panel, but never added the key to `packages/ui/src/i18n/locales/en.json`.

Proof the producer moved without its catalog:

```
$ git log -S 'cloud.oidcContinue.sessionUnavailable' --oneline \
    -- packages/ui/src/cloud/public-pages/pages/oidc/oidc-continue-page.tsx
c1f29856b25 fix(cloud): restore canonical Steward sign-in (#19075)

$ git show --stat c1f29856b25 | grep -E 'en.json|locales'
(no output — the catalog was never touched)
```

The English catalog is the source of truth the i18n contract enforces, so
`check-i18n` reports a hard error and the contract test fails. This is
producer-side incompleteness, not a stale expectation, so the fix is on the
source side: register the key. The test is left exactly as it is.

Non-English locales are deliberately untouched — the checker keeps their gaps as
*warnings* precisely so translation debt stays visible, and copying English into
them would hide it.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/scripts/__tests__/check-i18n.test.ts`.

## Detailed testing steps

```bash
bun install
cd packages/app-core && bunx vitest run scripts/__tests__/check-i18n.test.ts
```

RED at `20c58a5c270` before the change:

```
 FAIL  scripts/__tests__/check-i18n.test.ts > check-i18n contract > the real repo satisfies the contract (wireable: gaps stay warnings)
AssertionError: expected [ …(2) ] to deeply equal []

- Expected
+ Received

- []
+ [
+   "[i18n] en.json missing 1 key(s) used in source:",
+   "  - cloud.oidcContinue.sessionUnavailable   (packages/ui/src/cloud/public-pages/pages/oidc/oidc-continue-page.tsx:95)",
+ ]

 Test Files  1 failed (1)
      Tests  1 failed | 13 passed (14)
```

GREEN with the change:

```
 Test Files  1 passed (1)
      Tests  14 passed (14)
   Duration  4.06s
```

Locale-consuming suites in `packages/ui` stay green:

```
$ bunx vitest run src/i18n/messages.test.ts src/shared-nav-contract.test.ts
 Test Files  2 passed (2)
      Tests  9 passed (9)

$ bunx vitest run src/cloud/public-pages/pages/oidc/oidc-continue-page.test.tsx
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

# Evidence Gate

<!-- evidence-head:c08bea15d0c986eaffda93624bbc182113c821bb -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - message-catalog JSON only; the rendered string is byte-identical to the defaultValue the call site already passed, so there is no visual before-state to capture.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - message-catalog JSON only; no rendered output changes.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-visible flow changes; the fix restores a repo-wide i18n contract test.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no server code path is touched; the contract-test output above is the end-to-end proof.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change; the key resolves through the same i18n lookup with the same string.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model surface is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] The changed artifact is the message catalog itself. Generated-file diff plus
      the checker verdict on it:

```
$ git diff --stat 20c58a5c270..HEAD
 packages/ui/src/i18n/locales/en.json | 1 +
 1 file changed, 1 insertion(+)

$ git diff 20c58a5c270..HEAD -- packages/ui/src/i18n/locales/en.json
   "cloud.oidcContinue.redirecting": "Completing sign-in…",
+  "cloud.oidcContinue.sessionUnavailable": "Your Eliza session could not be securely transferred to the identity provider. Sign in again to continue.",
   "cloud.organizationInfo.notAvailable": "N/A",

$ node packages/app-core/scripts/check-i18n.mjs   # after the change; exit 0
[i18n] OK — 4511 literal keys, 7 wildcard prefixes, 74 dynamic sites, 84 indirect-only keys; 8303 source keys × 8 locales (translation gaps above are warnings; --strict-translations upgrades them).
```

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - see the evidence rows above; the i18n checker output is the executed code path.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered surface changes; the diff is one JSON key whose value equals the existing inline defaultValue.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, or STT surface is touched.`

## Known gaps / failures

Full `bun run verify` was not run for this one-key catalog change; the CI queue
is heavily backed up and the affected contract is covered directly by the red/green
runs above plus the two locale-consuming `packages/ui` suites.
