### PR TITLE
fix(core): budget evaluator input for model failovers

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -222,6 +222,7 @@ import {
 	type MessageConnectorRegistration,
 	type MessageSearchHit,
 	type Metadata,
+	type ModelAttemptContext,
 	type ModelHandler,
 	type ModelParamsMap,
 	type ModelRegistrationInfo,
@@ -1207,6 +1208,8 @@ interface ResolvedModelRegistration {
 }
 
 export class AgentRuntime implements IAgentRuntime {
+	/** The runtime invokes request preparation before each resolved model handler. */
+	readonly supportsModelAttemptPreparation = true;
 	#conversationLength = 100;
 	readonly agentId: UUID;
 	readonly character: Character;
@@ -6735,6 +6738,7 @@ export class AgentRuntime implements IAgentRuntime {
 			// (line ~6578). Once assigned, all later reads reference the scope's
 			// live mutable object, not this placeholder.
 			let recordingStateRef: { recorded: boolean } = { recorded: false };
+			let attemptPreparationFailed = false;
 
 			try {
 				const binaryModels: string[] = [
@@ -6808,6 +6812,31 @@ export class AgentRuntime implements IAgentRuntime {
 							modelParamsRecord.user = this.character.name;
 						}
 					}
+				}
+				const prepareModelAttempt =
+					isPlainObject(modelParams) &&
+					typeof (modelParams as GenerateTextParams).prepareModelAttempt ===
+						"function"
+						? (modelParams as GenerateTextParams).prepareModelAttempt
+						: undefined;
+				if (prepareModelAttempt) {
+					const attempt: ModelAttemptContext = {
+						modelType: String(resolvedModelKey),
+						provider: resolvedModel.provider ?? "unknown",
+						...(resolvedModel.metadata
+							? { metadata: resolvedModel.metadata }
+							: {}),
+					};
+					try {
+						await prepareModelAttempt(
+							attempt,
+							modelParams as GenerateTextParams,
+						);
+					} catch (error) {
+						attemptPreparationFailed = true;
+						throw error;
+					}
+					delete (modelParams as GenerateTextParams).prepareModelAttempt;
 				}
 				let startTime =
 					typeof performance !== "undefined" &&
@@ -7644,6 +7673,41 @@ export class AgentRuntime implements IAgentRuntime {
 				);
 				return resultRef.current as R;
 			} catch (error) {
+				if (attemptPreparationFailed) {
+					recordInferenceSpan(
+						`model-preprocess:${String(modelType)}`,
+						Date.now() - preprocessingStartedAt,
+						{ ...attemptMeta, outcome: "error" },
+					);
+					if (
+						!(
+							error instanceof ElizaError &&
+							error.code === "EVALUATOR_INPUT_OVER_BUDGET"
+						)
+					) {
+						throw error;
+					}
+					// A preparation rejection is attempt-local: the hook refused THIS
+					// registration (e.g. its context window cannot fit the stable
+					// input) before its handler ran, so no provider failure happened
+					// and no failed-attempt trajectory entry is recorded. Registration
+					// order is fallback tier + priority, not descending window size,
+					// so a later registration may still fit — advance the chain and
+					// rethrow the typed error only when the caller pinned a provider
+					// or no candidate remains.
+					lastModelError = error;
+					const nextAfterPreparation = resolvedModels[resolvedIndex + 1];
+					if (requestedProvider !== undefined || !nextAfterPreparation) {
+						throw error;
+					}
+					this.logModelProviderFailover({
+						requestedModelKey,
+						failedModel: resolvedModel,
+						nextModel: nextAfterPreparation,
+						error,
+					});
+					continue;
+				}
 				// error-policy:J4 Provider failover is an explicit degraded path;
 				// the final provider failure is rethrown if no alternative succeeds.
 				if (handlerStartedAt === null) {

--- a/packages/core/src/runtime/__tests__/evaluator-input-budget.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator-input-budget.test.ts
@@ -8,6 +8,10 @@
  * canned envelope, no live model.
  */
 import { describe, expect, it, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../runtime";
+import { type Character, ModelType } from "../../types";
+import { computePrefixHashes } from "../context-hash";
 import { runEvaluator } from "../evaluator";
 import {
 	DEFAULT_MAX_KEPT_STEP_CHARS,
@@ -48,6 +52,7 @@ interface CapturedRequest {
 			  }>;
 	}>;
 	promptSegments?: Array<{ content: string; stable?: boolean }>;
+	providerOptions?: { eliza?: { thinking?: unknown } };
 }
 
 function makeStep(iteration: number, resultText: string) {
@@ -84,6 +89,28 @@ function makeRuntime() {
 	return { runtime, captured };
 }
 
+function makeRegisteredRuntime(
+	registrations: Array<{
+		modelType: string;
+		provider: string;
+		model: string;
+	}>,
+) {
+	const base = makeRuntime();
+	return {
+		...base,
+		runtime: {
+			...base.runtime,
+			getModelRegistrations: () =>
+				registrations.map((registration) => ({
+					modelType: registration.modelType,
+					provider: registration.provider,
+					metadata: { displayModel: registration.model },
+				})),
+		},
+	};
+}
+
 function toolMessageValues(request: CapturedRequest): string[] {
 	return request.messages
 		.filter((message) => message.role === "tool")
@@ -102,6 +129,343 @@ function systemMessageContent(request: CapturedRequest): string {
 }
 
 describe("runEvaluator — over-window input trims to fit (never context_length_exceeded)", () => {
+	it("preserves a large-context candidate's 30k tool result byte-for-byte", async () => {
+		const result = "large-context-result-".repeat(1_600);
+		const { runtime, captured } = makeRegisteredRuntime([
+			{
+				modelType: "RESPONSE_HANDLER",
+				provider: "large",
+				model: "claude-sonnet-5",
+			},
+		]);
+
+		await runEvaluator({
+			runtime,
+			context: CONTEXT,
+			trajectory: makeTrajectory([makeStep(1, result)]),
+			effects: {},
+		});
+
+		const request = captured[0];
+		if (!request) throw new Error("no captured request");
+		expect(toolMessageValues(request)[0]).toContain(result);
+		expect(toolMessageValues(request)[0]).not.toContain("chars truncated]");
+	});
+
+	it("preserves the selected primary input and lets AgentRuntime compact a smaller failover", async () => {
+		const result = "x".repeat(500_000);
+		const { runtime, captured } = makeRegisteredRuntime([
+			{
+				modelType: "RESPONSE_HANDLER",
+				provider: "primary",
+				model: "claude-sonnet-5",
+			},
+			{
+				modelType: "TEXT_SMALL",
+				provider: "backup",
+				model: "llama3.1-8b",
+			},
+		]);
+
+		await runEvaluator({
+			runtime,
+			context: CONTEXT,
+			trajectory: makeTrajectory([makeStep(1, result)]),
+			effects: {},
+		});
+
+		const request = captured[0];
+		if (!request) throw new Error("no captured request");
+		const value = toolMessageValues(request)[0] ?? "";
+		expect(value).toContain(result);
+		expect(value).not.toContain("chars truncated]");
+	});
+
+	it("rebudgets on a real AgentRuntime failover attempt", async () => {
+		const primaryRequests: CapturedRequest[] = [];
+		const backupRequests: CapturedRequest[] = [];
+		const runtime = new AgentRuntime({
+			character: { name: "EvaluatorAgent", bio: "test" } as Character,
+			adapter: new InMemoryDatabaseAdapter(),
+			logLevel: "fatal",
+		});
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			async (_runtime, request) => {
+				primaryRequests.push(request as CapturedRequest);
+				throw new Error("[cli-inference:sdk] subscription rate limit reached");
+			},
+			"primary",
+			100,
+			{ displayModel: "claude-sonnet-5" },
+		);
+		runtime.registerModel(
+			ModelType.TEXT_NANO,
+			async (_runtime, request) => {
+				backupRequests.push(request as CapturedRequest);
+				return ENVELOPE;
+			},
+			"backup",
+			10,
+			{ displayModel: "llama3.1-8b" },
+		);
+		const result = "x".repeat(100_000);
+		await runEvaluator({
+			runtime,
+			context: CONTEXT,
+			trajectory: makeTrajectory([makeStep(1, result)]),
+			effects: {},
+		});
+		expect(primaryRequests).toHaveLength(1);
+		expect(backupRequests).toHaveLength(1);
+		const primaryRequest = primaryRequests[0];
+		const backupRequest = backupRequests[0];
+		if (!primaryRequest || !backupRequest)
+			throw new Error("missing failover request");
+		expect(toolMessageValues(primaryRequest)[0]).toContain(result);
+		expect(toolMessageValues(backupRequest)[0]).toContain("chars truncated]");
+		expect(backupRequest.providerOptions?.eliza?.thinking).toBe("off");
+	});
+
+	it("rebudgets a smaller backup registered under the same model type", async () => {
+		const primaryRequests: CapturedRequest[] = [];
+		const backupRequests: CapturedRequest[] = [];
+		const runtime = new AgentRuntime({
+			character: { name: "EvaluatorAgent", bio: "test" } as Character,
+			adapter: new InMemoryDatabaseAdapter(),
+			logLevel: "fatal",
+		});
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			async (_runtime, request) => {
+				primaryRequests.push(request as CapturedRequest);
+				throw new Error("[cli-inference:sdk] subscription rate limit reached");
+			},
+			"primary",
+			100,
+			{ displayModel: "claude-sonnet-5" },
+		);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			async (_runtime, request) => {
+				backupRequests.push(request as CapturedRequest);
+				return ENVELOPE;
+			},
+			"backup",
+			10,
+			{ displayModel: "llama3.1-8b" },
+		);
+		const result = "x".repeat(100_000);
+
+		await runEvaluator({
+			runtime,
+			context: CONTEXT,
+			trajectory: makeTrajectory([makeStep(1, result)]),
+			effects: {},
+		});
+
+		expect(primaryRequests).toHaveLength(1);
+		expect(backupRequests).toHaveLength(1);
+		expect(
+			toolMessageValues(primaryRequests[0] as CapturedRequest)[0],
+		).toContain(result);
+		expect(
+			toolMessageValues(backupRequests[0] as CapturedRequest)[0],
+		).toContain("chars truncated]");
+	});
+
+	it("does not fail over after an unrelated attempt-preparation error", async () => {
+		const primaryHandler = vi.fn(async () => ENVELOPE);
+		const backupHandler = vi.fn(async () => ENVELOPE);
+		const prepareModelAttempt = vi.fn((attempt: { provider: string }) => {
+			if (attempt.provider === "primary") {
+				throw new Error("attempt preparation defect");
+			}
+		});
+		const runtime = new AgentRuntime({
+			character: { name: "EvaluatorAgent", bio: "test" } as Character,
+			adapter: new InMemoryDatabaseAdapter(),
+			logLevel: "fatal",
+		});
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			primaryHandler,
+			"primary",
+			100,
+			{ displayModel: "claude-sonnet-5" },
+		);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			backupHandler,
+			"backup",
+			10,
+			{ displayModel: "llama3.1-8b" },
+		);
+
+		await expect(
+			runtime.useModel(ModelType.RESPONSE_HANDLER, {
+				messages: [{ role: "user", content: "test" }],
+				prepareModelAttempt,
+			}),
+		).rejects.toThrow("attempt preparation defect");
+
+		expect(prepareModelAttempt).toHaveBeenCalledTimes(1);
+		expect(primaryHandler).not.toHaveBeenCalled();
+		expect(backupHandler).not.toHaveBeenCalled();
+	});
+
+	it("rejects a known-over-budget fallback before its provider handler", async () => {
+		const backupHandler = vi.fn(async () => ENVELOPE);
+		const runtime = new AgentRuntime({
+			character: { name: "EvaluatorAgent", bio: "test" } as Character,
+			adapter: new InMemoryDatabaseAdapter(),
+			logLevel: "fatal",
+		});
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			async () => {
+				throw new Error("[cli-inference:sdk] subscription rate limit reached");
+			},
+			"primary",
+			100,
+			{ displayModel: "claude-sonnet-5" },
+		);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			backupHandler,
+			"backup",
+			10,
+			{ displayModel: "llama3.1-8b" },
+		);
+
+		await expect(
+			runEvaluator({
+				runtime,
+				context: {
+					...CONTEXT,
+					staticPrefix: {
+						characterPrompt: {
+							content: "characterization ".repeat(10_000),
+							stable: true,
+						},
+					},
+				},
+				trajectory: makeTrajectory([makeStep(1, "small result")]),
+				effects: {},
+			}),
+		).rejects.toMatchObject({ code: "EVALUATOR_INPUT_OVER_BUDGET" });
+		expect(backupHandler).not.toHaveBeenCalled();
+	});
+
+	it("budgets the actual owner-selected provider before its first attempt", async () => {
+		const largeRequests: CapturedRequest[] = [];
+		const smallHandler = vi.fn(async () => ENVELOPE);
+		const runtime = new AgentRuntime({
+			character: {
+				name: "EvaluatorAgent",
+				bio: "test",
+				settings: {
+					ELIZA_BRAIN_PROVIDER: "large",
+					SMALL_EVALUATOR_MODEL: "llama3.1-8b",
+				},
+			} as Character,
+			adapter: new InMemoryDatabaseAdapter(),
+			logLevel: "fatal",
+		});
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			smallHandler,
+			"small",
+			100,
+			{ displayModelSetting: "SMALL_EVALUATOR_MODEL" },
+		);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			async (_runtime, request) => {
+				largeRequests.push(request as CapturedRequest);
+				return ENVELOPE;
+			},
+			"large",
+			10,
+			{ displayModel: "claude-sonnet-5" },
+		);
+		const result = "x".repeat(100_000);
+
+		await runEvaluator({
+			runtime,
+			context: CONTEXT,
+			trajectory: makeTrajectory([makeStep(1, result)]),
+			effects: {},
+		});
+
+		expect(smallHandler).not.toHaveBeenCalled();
+		expect(largeRequests).toHaveLength(1);
+		expect(toolMessageValues(largeRequests[0] as CapturedRequest)[0]).toContain(
+			result,
+		);
+	});
+
+	it("uses env-backed model metadata and the ACTION_PLANNER fallback chain", async () => {
+		vi.stubEnv("EVALUATOR_ACTION_MODEL", "claude-sonnet-5");
+		try {
+			const { runtime, captured } = makeRegisteredRuntime([
+				{
+					modelType: "ACTION_PLANNER",
+					provider: "primary",
+					model: "env-placeholder",
+				},
+				{ modelType: "TEXT_MEDIUM", provider: "medium", model: "llama3.1-8b" },
+				{ modelType: "TEXT_SMALL", provider: "small", model: "llama3.1-8b" },
+			]);
+			const registered = runtime.getModelRegistrations?.() ?? [];
+			(runtime.getModelRegistrations as () => Array<Record<string, unknown>>) =
+				() => [
+					{
+						modelType: "ACTION_PLANNER",
+						provider: "primary",
+						metadata: { displayModelSetting: "EVALUATOR_ACTION_MODEL" },
+					},
+					...registered.slice(1),
+				];
+			await runEvaluator({
+				runtime,
+				modelType: ModelType.ACTION_PLANNER,
+				context: CONTEXT,
+				trajectory: makeTrajectory([makeStep(1, "x".repeat(500_000))]),
+				effects: {},
+			});
+			const request = captured[0];
+			if (!request) throw new Error("missing action planner request");
+			expect(toolMessageValues(request)[0]).toContain("x".repeat(500_000));
+		} finally {
+			vi.unstubAllEnvs();
+		}
+	});
+
+	it("keeps a usable input budget for a sub-10k custom model window", async () => {
+		vi.stubEnv("MODEL_CONTEXT_WINDOWS_JSON", '{"tiny-evaluator":8000}');
+		try {
+			const { runtime, captured } = makeRegisteredRuntime([
+				{
+					modelType: "RESPONSE_HANDLER",
+					provider: "tiny",
+					model: "tiny-evaluator",
+				},
+			]);
+
+			await runEvaluator({
+				runtime,
+				context: CONTEXT,
+				trajectory: makeTrajectory([makeStep(1, "small result")]),
+				effects: {},
+			});
+
+			expect(captured).toHaveLength(1);
+		} finally {
+			vi.unstubAllEnvs();
+		}
+	});
+
 	it("caps a single 5MB tool result so the sent input fits the window, without touching the system message", async () => {
 		// All-emoji payload: every possible cut index lands on a surrogate
 		// boundary, exercising the surrogate-safe head/tail truncation.
@@ -270,5 +634,250 @@ describe("runEvaluator — bottom-out guard (stable segments alone over budget)"
 		).rejects.toMatchObject({ code: "EVALUATOR_INPUT_OVER_BUDGET" });
 
 		expect(runtime.useModel).not.toHaveBeenCalled();
+	});
+
+	it("records structured-parameter budget failure before making a provider call", async () => {
+		const recorded: Array<{ stage: Record<string, unknown> }> = [];
+		const { runtime } = makeRuntime();
+		const runtimeWithRecorder = {
+			...runtime,
+			getModelRegistrations: () => [
+				{
+					modelType: "RESPONSE_HANDLER",
+					provider: "small",
+					metadata: { displayModel: "llama3.1-8b" },
+				},
+			],
+		};
+		const oversizedParams = { payload: "p".repeat(200_000) };
+		await expect(
+			runEvaluator({
+				runtime: runtimeWithRecorder,
+				recorder: {
+					recordStage: vi.fn(
+						async (_id: string, stage: Record<string, unknown>) => {
+							recorded.push({ stage });
+						},
+					),
+				} as never,
+				trajectoryId: "budget-params",
+				context: CONTEXT,
+				trajectory: makeTrajectory([
+					{
+						...makeStep(1, "ok"),
+						toolCall: {
+							id: "tool-1-0",
+							name: "BIG_PARAMS",
+							params: oversizedParams,
+						},
+					},
+				]),
+				effects: {},
+			}),
+		).rejects.toMatchObject({ code: "EVALUATOR_INPUT_OVER_BUDGET" });
+		expect(runtimeWithRecorder.useModel).not.toHaveBeenCalled();
+		expect(recorded).toHaveLength(1);
+		expect(recorded[0]?.stage).toMatchObject({
+			kind: "evaluation",
+			evaluation: { protocolFailure: true },
+		});
+		expect(String(recorded[0]?.stage.model?.response)).toContain(
+			"EVALUATOR_INPUT_OVER_BUDGET",
+		);
+	});
+});
+
+describe("runEvaluator — failover continues past an over-budget mid-chain registration", () => {
+	const OVERSIZED_STABLE_CONTEXT = {
+		...CONTEXT,
+		staticPrefix: {
+			characterPrompt: {
+				content: "characterization ".repeat(10_000),
+				stable: true,
+			},
+		},
+	};
+
+	function registerRateLimitedPrimary(runtime: AgentRuntime) {
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			async () => {
+				throw new Error("[cli-inference:sdk] subscription rate limit reached");
+			},
+			"primary",
+			100,
+			{ displayModel: "claude-sonnet-5" },
+		);
+	}
+
+	it("skips a rejected smaller registration and succeeds on a later larger one", async () => {
+		const smallHandler = vi.fn(async () => ENVELOPE);
+		const finalRequests: CapturedRequest[] = [];
+		const runtime = new AgentRuntime({
+			character: { name: "EvaluatorAgent", bio: "test" } as Character,
+			adapter: new InMemoryDatabaseAdapter(),
+			logLevel: "fatal",
+		});
+		registerRateLimitedPrimary(runtime);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			smallHandler,
+			"small",
+			50,
+			{
+				displayModel: "llama3.1-8b",
+			},
+		);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			async (_runtime, request) => {
+				finalRequests.push(request as CapturedRequest);
+				return ENVELOPE;
+			},
+			"backup-large",
+			10,
+			{ displayModel: "claude-sonnet-5" },
+		);
+
+		const output = await runEvaluator({
+			runtime,
+			context: OVERSIZED_STABLE_CONTEXT,
+			trajectory: makeTrajectory([makeStep(1, "small result")]),
+			effects: {},
+		});
+
+		// The chain must be: large primary rate-limits -> small candidate is
+		// rejected pre-handler (its handler never runs) -> the LATER large
+		// registration still serves the turn instead of the typed budget error
+		// stranding it.
+		expect(output.success).toBe(true);
+		expect(smallHandler).not.toHaveBeenCalled();
+		expect(finalRequests).toHaveLength(1);
+		expect(toolMessageValues(finalRequests[0] as CapturedRequest)[0]).toContain(
+			"small result",
+		);
+	});
+
+	it("records the terminal budget failure with the last rejected attempt's request", async () => {
+		const recordedStages: Array<Record<string, unknown>> = [];
+		const smallHandler = vi.fn(async () => ENVELOPE);
+		const runtime = new AgentRuntime({
+			character: { name: "EvaluatorAgent", bio: "test" } as Character,
+			adapter: new InMemoryDatabaseAdapter(),
+			logLevel: "fatal",
+		});
+		registerRateLimitedPrimary(runtime);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			smallHandler,
+			"small",
+			10,
+			{
+				displayModel: "llama3.1-8b",
+			},
+		);
+
+		await expect(
+			runEvaluator({
+				runtime,
+				recorder: {
+					recordStage: vi.fn(
+						async (_id: string, stage: Record<string, unknown>) => {
+							recordedStages.push(stage);
+						},
+					),
+				} as never,
+				trajectoryId: "terminal-budget",
+				context: OVERSIZED_STABLE_CONTEXT,
+				trajectory: makeTrajectory([makeStep(1, "small result")]),
+				effects: {},
+			}),
+		).rejects.toMatchObject({ code: "EVALUATOR_INPUT_OVER_BUDGET" });
+
+		expect(smallHandler).not.toHaveBeenCalled();
+		expect(recordedStages).toHaveLength(1);
+		const stage = recordedStages[0] as {
+			kind: string;
+			model: { provider?: string; response: string };
+			evaluation: { protocolFailure?: boolean };
+		};
+		expect(stage.kind).toBe("evaluation");
+		expect(stage.evaluation.protocolFailure).toBe(true);
+		expect(stage.model.response).toContain("EVALUATOR_INPUT_OVER_BUDGET");
+		// The stage must attribute the failure to the registration that
+		// rejected the input, not the preflight provider selection.
+		expect(stage.model.provider).toBe("small");
+	});
+});
+
+describe("runEvaluator — trajectory stage records the per-attempt prepared request", () => {
+	it("persists the successful failover attempt's request, not the preflight snapshot", async () => {
+		const backupRequests: CapturedRequest[] = [];
+		const recordedStages: Array<Record<string, unknown>> = [];
+		const runtime = new AgentRuntime({
+			character: { name: "EvaluatorAgent", bio: "test" } as Character,
+			adapter: new InMemoryDatabaseAdapter(),
+			logLevel: "fatal",
+		});
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			async () => {
+				throw new Error("[cli-inference:sdk] subscription rate limit reached");
+			},
+			"primary",
+			100,
+			{ displayModel: "claude-sonnet-5" },
+		);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			async (_runtime, request) => {
+				backupRequests.push(request as CapturedRequest);
+				return ENVELOPE;
+			},
+			"backup",
+			10,
+			{ displayModel: "llama3.1-8b" },
+		);
+
+		await runEvaluator({
+			runtime,
+			recorder: {
+				recordStage: vi.fn(
+					async (_id: string, stage: Record<string, unknown>) => {
+						recordedStages.push(stage);
+					},
+				),
+			} as never,
+			trajectoryId: "attempt-snapshot",
+			context: CONTEXT,
+			trajectory: makeTrajectory([makeStep(1, "x".repeat(100_000))]),
+			effects: {},
+		});
+
+		expect(backupRequests).toHaveLength(1);
+		expect(recordedStages).toHaveLength(1);
+		const backupRequest = backupRequests[0] as CapturedRequest;
+		const stage = recordedStages[0] as {
+			model: {
+				provider?: string;
+				messages: unknown;
+				providerOptions?: unknown;
+			};
+			cache: { segmentHashes: string[]; prefixHash: string };
+		};
+		// The recorded request must be byte-identical to what the selected
+		// handler received — including the failover compaction the preflight
+		// snapshot (rendered for the large primary) does not have.
+		expect(stage.model.messages).toEqual(backupRequest.messages);
+		expect(stage.model.providerOptions).toEqual(backupRequest.providerOptions);
+		expect(JSON.stringify(stage.model.messages)).toContain("chars truncated]");
+		expect(stage.model.provider).toBe("backup");
+		// Cache metadata must describe the prepared attempt's segments too.
+		const expectedHashes = computePrefixHashes(
+			(backupRequest.promptSegments ?? []) as never,
+		);
+		expect(stage.cache.segmentHashes).toEqual(
+			expectedHashes.map((entry) => entry.segmentHash),
+		);
 	});
 });

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -20,10 +20,14 @@ import {
 import type { EvaluationResult } from "../types/components";
 import {
 	type ChatMessage,
+	getModelFallbackChain,
+	type ModelAttemptContext,
+	type ModelRegistrationMetadata,
 	ModelType,
 	type PromptSegment,
 } from "../types/model";
 import { modelProviderErrorDetail } from "../utils/model-errors";
+import { resolveSetting } from "../utils/resolve-setting";
 import { computePrefixHashes } from "./context-hash";
 import {
 	buildStageChatMessages,
@@ -38,6 +42,8 @@ import {
 import { DEFAULT_MAX_KEPT_STEP_CHARS } from "./limits";
 import {
 	buildModelInputBudget,
+	DEFAULT_COMPACTION_RESERVE_TOKENS,
+	MODEL_WINDOW_RESERVE_FRACTION,
 	withModelInputBudgetProviderOptions,
 } from "./model-input-budget";
 import {
@@ -99,21 +105,161 @@ const EVALUATOR_ENVELOPE_KEYS = new Set([
 
 const DEFAULT_EVALUATOR_MAX_TOKENS = 1024;
 
+type EvaluatorBudgetResolution = {
+	contextWindowTokens?: number;
+	modelNames: string[];
+	unknownReachableModel: boolean;
+};
+
+function modelNameFromMetadata(
+	runtime: EvaluatorRuntime,
+	metadata: ModelRegistrationMetadata | undefined,
+): string | undefined {
+	if (!metadata) return undefined;
+	if (
+		typeof metadata.displayModel === "string" &&
+		metadata.displayModel.trim()
+	) {
+		return metadata.displayModel.trim();
+	}
+	for (const setting of [
+		...(metadata.displayModelSettings ?? []),
+		metadata.displayModelSetting,
+	]) {
+		if (!setting) continue;
+		const value = resolveSetting(
+			runtime.getSetting
+				? {
+						getSetting: (key: string) => runtime.getSetting?.(key) ?? null,
+					}
+				: undefined,
+			setting,
+		);
+		if (value?.trim()) return value.trim();
+	}
+	if (
+		typeof metadata.displayModelDefault === "string" &&
+		metadata.displayModelDefault.trim()
+	) {
+		return metadata.displayModelDefault.trim();
+	}
+	return undefined;
+}
+
+function resolveEvaluatorBudget(
+	runtime: EvaluatorRuntime,
+	modelType: string,
+	provider: string | undefined,
+): EvaluatorBudgetResolution {
+	const registrations = runtime.getModelRegistrations?.() ?? [];
+	if (registrations.length === 0) {
+		return { modelNames: [], unknownReachableModel: false };
+	}
+	const fallbackChain = getModelFallbackChain(modelType as never);
+	const reachableTypes = new Set(fallbackChain);
+	const candidates = registrations
+		.filter(
+			(registration) =>
+				reachableTypes.has(registration.modelType) &&
+				(provider === undefined || registration.provider === provider),
+		)
+		.sort(
+			(a, b) =>
+				fallbackChain.indexOf(a.modelType) - fallbackChain.indexOf(b.modelType),
+		);
+	if (candidates.length === 0) {
+		return { modelNames: [], unknownReachableModel: false };
+	}
+	const modelNames: string[] = [];
+	const windows: number[] = [];
+	let unknownReachableModel = false;
+	for (const registration of candidates) {
+		const modelName = modelNameFromMetadata(runtime, registration.metadata);
+		if (!modelName) {
+			unknownReachableModel = true;
+			windows.push(128_000);
+			continue;
+		}
+		modelNames.push(modelName);
+		const budget = buildModelInputBudget({ modelName });
+		if (budget.resolvedModelKey === null) {
+			unknownReachableModel = true;
+		}
+		windows.push(budget.contextWindowTokens);
+	}
+	return {
+		contextWindowTokens: windows.length > 0 ? windows[0] : undefined,
+		modelNames,
+		unknownReachableModel,
+	};
+}
+
+function evaluatorBudgetOptions(contextWindowTokens: number): {
+	contextWindowTokens: number;
+	reserveTokens: number;
+} {
+	const desiredReserve = Math.max(
+		DEFAULT_COMPACTION_RESERVE_TOKENS,
+		Math.floor(contextWindowTokens * MODEL_WINDOW_RESERVE_FRACTION),
+	);
+	// Custom/local model windows can be smaller than the global 10k reserve.
+	// Keep enough room for input and the requested evaluator output instead of
+	// turning such models into an unconditional one-token bottom-out.
+	const smallWindowCap = Math.max(
+		DEFAULT_EVALUATOR_MAX_TOKENS,
+		Math.floor(contextWindowTokens * 0.4),
+	);
+	return {
+		contextWindowTokens,
+		reserveTokens: Math.min(
+			Math.max(0, contextWindowTokens - 1),
+			desiredReserve,
+			smallWindowCap,
+		),
+	};
+}
+
+function structuredParameterChars(messages: readonly ChatMessage[]): number {
+	return messages.reduce((total, message) => {
+		if (message.role !== "assistant" || !Array.isArray(message.content)) {
+			return total;
+		}
+		return (
+			total +
+			message.content.reduce((messageTotal, part) => {
+				if (part.type !== "tool-call") return messageTotal;
+				return messageTotal + JSON.stringify(part.input ?? {}).length;
+			}, 0)
+		);
+	}, 0);
+}
+
 export async function runEvaluator(
 	params: RunEvaluatorParams,
 ): Promise<EvaluatorOutput> {
 	const streamingContext = getStreamingContext();
+	const modelType = params.modelType ?? ModelType.RESPONSE_HANDLER;
+	const startedAt = Date.now();
+	const budgetResolution = resolveEvaluatorBudget(
+		params.runtime,
+		String(modelType),
+		params.provider,
+	);
 	const redactDiagnosticText = composeToolDiagnosticRedactor(params.runtime);
 	const EVALUATOR_MIN_TOOL_RESULT_CHARS = 2_000;
 	let toolResultCap = DEFAULT_MAX_KEPT_STEP_CHARS;
 	let renderedInput = renderEvaluatorModelInput({
 		context: params.context,
 		trajectory: params.trajectory,
+		maxToolResultChars: undefined,
 		redactText: redactDiagnosticText,
 	});
 	let modelInputBudget = buildModelInputBudget({
 		messages: renderedInput.messages,
 		promptSegments: renderedInput.promptSegments,
+		...(budgetResolution.contextWindowTokens
+			? evaluatorBudgetOptions(budgetResolution.contextWindowTokens)
+			: {}),
 	});
 	// Degrade, don't fail: when the assembled input would exceed the window
 	// (threshold = window - output reserve), shrink only the rendered tool
@@ -139,51 +285,224 @@ export async function runEvaluator(
 		modelInputBudget = buildModelInputBudget({
 			messages: renderedInput.messages,
 			promptSegments: renderedInput.promptSegments,
+			...(budgetResolution.contextWindowTokens
+				? evaluatorBudgetOptions(budgetResolution.contextWindowTokens)
+				: {}),
 		});
 	}
+	const buildAttemptProviderOptions = (
+		input: ReturnType<typeof renderEvaluatorModelInput>,
+		budget: ReturnType<typeof buildModelInputBudget>,
+		provider: string | undefined,
+	): {
+		providerOptions: Record<string, unknown>;
+		prefixHashes: ReturnType<typeof computePrefixHashes>;
+		prefixHash: string;
+	} => {
+		const prefixHashes = computePrefixHashes(input.promptSegments);
+		const prefixHash =
+			computePrefixHashes(input.cacheKeySegments).at(-1)?.hash ??
+			"no-context-segments";
+		const providerOptions = withModelInputBudgetProviderOptions(
+			cacheProviderOptions({
+				prefixHash,
+				segmentHashes: prefixHashes.map((entry) => entry.segmentHash),
+				promptSegments: input.promptSegments,
+				provider,
+				conversationId: params.trajectoryId,
+			}),
+			budget,
+		) as Record<string, unknown> & { eliza?: Record<string, unknown> };
+		providerOptions.eliza = {
+			...(providerOptions.eliza ?? {}),
+			thinking: "off",
+		};
+		return { providerOptions, prefixHashes, prefixHash };
+	};
+	const initialAttempt = buildAttemptProviderOptions(
+		renderedInput,
+		modelInputBudget,
+		params.provider,
+	);
+	const providerOptions = initialAttempt.providerOptions;
+	const prefixHashes = initialAttempt.prefixHashes;
+	const prefixHash = initialAttempt.prefixHash;
+
+	// Authoritative request snapshot for the most recently prepared failover
+	// attempt. `prepareModelAttempt` rerenders per registration, so the outer
+	// preflight snapshot can differ from what the selected handler actually
+	// received; stage recording below must persist this snapshot when present
+	// so the trajectory reports the real model input (and, on a terminal
+	// budget rejection, the last input that failed to fit).
+	let preparedAttempt:
+		| {
+				input: ReturnType<typeof renderEvaluatorModelInput>;
+				providerOptions: Record<string, unknown>;
+				prefixHashes: ReturnType<typeof computePrefixHashes>;
+				prefixHash: string;
+				provider: string | undefined;
+		  }
+		| undefined;
+
+	const buildInputBudgetError = (args: {
+		input: ReturnType<typeof renderEvaluatorModelInput>;
+		budget: ReturnType<typeof buildModelInputBudget>;
+		toolResultCap: number;
+		resolvedModelNames: string[];
+		unknownReachableModel: boolean;
+	}): ElizaError =>
+		new ElizaError(
+			"Evaluator model input exceeds the context budget even after tool results were compacted to the floor",
+			{
+				code: "EVALUATOR_INPUT_OVER_BUDGET",
+				context: {
+					estimatedInputTokens: args.budget.estimatedInputTokens,
+					compactionThresholdTokens: args.budget.compactionThresholdTokens,
+					contextWindowTokens: args.budget.contextWindowTokens,
+					toolResultCap: args.toolResultCap,
+					structuredParameterChars: structuredParameterChars(
+						args.input.messages,
+					),
+					resolvedModelNames: args.resolvedModelNames,
+					unknownReachableModel: args.unknownReachableModel,
+				},
+			},
+		);
+
+	const recordInputBudgetFailure = async (args: {
+		error: ElizaError;
+		input: ReturnType<typeof renderEvaluatorModelInput>;
+		provider: string | undefined;
+		providerOptions: Record<string, unknown>;
+	}): Promise<void> => {
+		const failurePrefixHashes = computePrefixHashes(args.input.promptSegments);
+		await recordEvaluationStage({
+			runtime: params.runtime,
+			recorder: params.recorder,
+			trajectoryId: params.trajectoryId,
+			parentStageId: params.parentStageId,
+			iteration: params.iteration ?? 1,
+			modelType: String(modelType),
+			provider: args.provider,
+			messages: args.input.messages,
+			providerOptions: args.providerOptions,
+			raw: `[evaluator input budget failure] ${args.error.message} | code: EVALUATOR_INPUT_OVER_BUDGET`,
+			output: {
+				success: false,
+				decision: "CONTINUE",
+				thought:
+					"Evaluator input exceeded the resolved model budget before provider call.",
+				protocolFailure: true,
+				raw: { code: "EVALUATOR_INPUT_OVER_BUDGET" },
+			},
+			startedAt,
+			endedAt: Date.now(),
+			segmentHashes: failurePrefixHashes.map((entry) => entry.segmentHash),
+			prefixHash:
+				computePrefixHashes(args.input.cacheKeySegments).at(-1)?.hash ??
+				"no-context-segments",
+			logger: params.runtime.logger,
+		});
+	};
+
+	const prepareModelAttempt = async (
+		attempt: ModelAttemptContext,
+		request: {
+			messages: ChatMessage[];
+			promptSegments?: PromptSegment[];
+			providerOptions?: Record<string, unknown>;
+		},
+	): Promise<void> => {
+		const modelName = modelNameFromMetadata(params.runtime, attempt.metadata);
+		const resolvedBudget = buildModelInputBudget({ modelName });
+		const attemptWindow = resolvedBudget.contextWindowTokens;
+		let attemptCap = DEFAULT_MAX_KEPT_STEP_CHARS;
+		let attemptInput = renderEvaluatorModelInput({
+			context: params.context,
+			trajectory: params.trajectory,
+			maxToolResultChars: undefined,
+			redactText: redactDiagnosticText,
+		});
+		let attemptBudget = buildModelInputBudget({
+			messages: attemptInput.messages,
+			promptSegments: attemptInput.promptSegments,
+			...evaluatorBudgetOptions(attemptWindow),
+		});
+		while (
+			attemptBudget.shouldCompact &&
+			attemptCap > EVALUATOR_MIN_TOOL_RESULT_CHARS
+		) {
+			attemptCap = Math.max(
+				EVALUATOR_MIN_TOOL_RESULT_CHARS,
+				Math.floor(attemptCap / 4),
+			);
+			attemptInput = renderEvaluatorModelInput({
+				context: params.context,
+				trajectory: params.trajectory,
+				maxToolResultChars: attemptCap,
+				redactText: redactDiagnosticText,
+			});
+			attemptBudget = buildModelInputBudget({
+				messages: attemptInput.messages,
+				promptSegments: attemptInput.promptSegments,
+				...evaluatorBudgetOptions(attemptWindow),
+			});
+		}
+		const attemptOptions = buildAttemptProviderOptions(
+			attemptInput,
+			attemptBudget,
+			attempt.provider,
+		);
+		preparedAttempt = {
+			input: attemptInput,
+			providerOptions: attemptOptions.providerOptions,
+			prefixHashes: attemptOptions.prefixHashes,
+			prefixHash: attemptOptions.prefixHash,
+			provider: attempt.provider,
+		};
+		if (attemptBudget.shouldCompact) {
+			// Attempt-local rejection: this registration's window cannot fit the
+			// stable input even at the tool-result floor. The runtime treats a
+			// preparation throw as a skip and advances to the next registration;
+			// the stage is recorded only if the rejection turns out terminal
+			// (see the EVALUATOR_INPUT_OVER_BUDGET branch in the catch below).
+			throw buildInputBudgetError({
+				input: attemptInput,
+				budget: attemptBudget,
+				toolResultCap: attemptCap,
+				resolvedModelNames: modelName ? [modelName] : [],
+				unknownReachableModel: resolvedBudget.resolvedModelKey === null,
+			});
+		}
+		request.messages = attemptInput.messages;
+		request.promptSegments = attemptInput.promptSegments;
+		request.providerOptions = attemptOptions.providerOptions;
+	};
 	// Bottom-out guard: if the input is still over the compaction threshold at
 	// the 2k floor, the overflow lives in the stable/context segments this loop
 	// deliberately never touches. Calling the provider anyway is a guaranteed
 	// context_length_exceeded 400 that burns a round trip and surfaces as an
 	// opaque provider error — fail fast with a typed error instead so the
 	// planner-loop's degrade/propagate policy sees the real cause.
-	if (modelInputBudget.shouldCompact) {
-		throw new ElizaError(
-			"Evaluator model input exceeds the context budget even after tool results were compacted to the floor",
-			{
-				code: "EVALUATOR_INPUT_OVER_BUDGET",
-				context: {
-					estimatedInputTokens: modelInputBudget.estimatedInputTokens,
-					compactionThresholdTokens: modelInputBudget.compactionThresholdTokens,
-					toolResultCap,
-				},
-			},
-		);
-	}
-	const prefixHashes = computePrefixHashes(renderedInput.promptSegments);
-	const cachePrefixHashes = computePrefixHashes(renderedInput.cacheKeySegments);
-	const prefixHash =
-		cachePrefixHashes[cachePrefixHashes.length - 1]?.hash ??
-		"no-context-segments";
-	const providerOptions = withModelInputBudgetProviderOptions(
-		cacheProviderOptions({
-			prefixHash,
-			segmentHashes: prefixHashes.map((entry) => entry.segmentHash),
-			promptSegments: renderedInput.promptSegments,
+	if (
+		modelInputBudget.shouldCompact &&
+		params.runtime.supportsModelAttemptPreparation !== true
+	) {
+		const preflightError = buildInputBudgetError({
+			input: renderedInput,
+			budget: modelInputBudget,
+			toolResultCap,
+			resolvedModelNames: budgetResolution.modelNames,
+			unknownReachableModel: budgetResolution.unknownReachableModel,
+		});
+		await recordInputBudgetFailure({
+			error: preflightError,
+			input: renderedInput,
 			provider: params.provider,
-			conversationId: params.trajectoryId,
-		}),
-		modelInputBudget,
-	);
-	const typedProviderOptions = providerOptions as Record<string, unknown> & {
-		eliza?: Record<string, unknown>;
-	};
-	typedProviderOptions.eliza = {
-		...(typedProviderOptions.eliza ?? {}),
-		thinking: "off",
-	};
-	const startedAt = Date.now();
-	const modelType = params.modelType ?? ModelType.RESPONSE_HANDLER;
+			providerOptions,
+		});
+		throw preflightError;
+	}
 	let raw: Awaited<ReturnType<EvaluatorRuntime["useModel"]>>;
 	try {
 		raw = await runWithStreamingContext(
@@ -193,20 +512,46 @@ export async function runEvaluator(
 						onStreamChunk: async () => undefined,
 					}
 				: undefined,
-			() =>
-				params.runtime.useModel(
+			() => {
+				const modelRequest = {
+					messages: renderedInput.messages,
+					maxTokens: DEFAULT_EVALUATOR_MAX_TOKENS,
+					responseSchema: evaluatorSchema,
+					promptSegments: renderedInput.promptSegments,
+					providerOptions,
+					prepareModelAttempt: (
+						attempt: ModelAttemptContext,
+						attemptParams: {
+							messages: ChatMessage[];
+							promptSegments?: PromptSegment[];
+							providerOptions?: Record<string, unknown>;
+						},
+					) => prepareModelAttempt(attempt, attemptParams),
+				};
+				return params.runtime.useModel(
 					modelType,
-					{
-						messages: renderedInput.messages,
-						maxTokens: DEFAULT_EVALUATOR_MAX_TOKENS,
-						responseSchema: evaluatorSchema,
-						promptSegments: renderedInput.promptSegments,
-						providerOptions,
-					},
+					modelRequest,
 					params.provider,
-				),
+				);
+			},
 		);
 	} catch (error) {
+		if (
+			error instanceof ElizaError &&
+			error.code === "EVALUATOR_INPUT_OVER_BUDGET"
+		) {
+			// Terminal budget rejection: every reachable registration was either
+			// exhausted or refused the input pre-handler. Record the last
+			// prepared (and rejected) request so the trajectory shows what
+			// failed to fit, then rethrow for the planner-loop policy.
+			await recordInputBudgetFailure({
+				error,
+				input: preparedAttempt?.input ?? renderedInput,
+				provider: preparedAttempt?.provider ?? params.provider,
+				providerOptions: preparedAttempt?.providerOptions ?? providerOptions,
+			});
+			throw error;
+		}
 		// error-policy:J2 context-adding rethrow — the evaluator model call is
 		// the one whose REQUEST is otherwise never persisted: on success the
 		// stage records below, but a provider failure (e.g. an intermittent
@@ -222,9 +567,9 @@ export async function runEvaluator(
 			parentStageId: params.parentStageId,
 			iteration: params.iteration ?? 1,
 			modelType: String(modelType),
-			provider: params.provider,
-			messages: renderedInput.messages,
-			providerOptions,
+			provider: preparedAttempt?.provider ?? params.provider,
+			messages: (preparedAttempt?.input ?? renderedInput).messages,
+			providerOptions: preparedAttempt?.providerOptions ?? providerOptions,
 			raw: `[evaluator model call failed] ${
 				error instanceof Error ? error.message : String(error)
 			}${detail?.providerMessage ? ` | provider: ${detail.providerMessage}` : ""}${
@@ -239,8 +584,10 @@ export async function runEvaluator(
 			},
 			startedAt,
 			endedAt: Date.now(),
-			segmentHashes: prefixHashes.map((entry) => entry.segmentHash),
-			prefixHash,
+			segmentHashes: (preparedAttempt?.prefixHashes ?? prefixHashes).map(
+				(entry) => entry.segmentHash,
+			),
+			prefixHash: preparedAttempt?.prefixHash ?? prefixHash,
 			logger: params.runtime.logger,
 		});
 		throw error;
@@ -291,15 +638,17 @@ export async function runEvaluator(
 		parentStageId: params.parentStageId,
 		iteration: params.iteration ?? 1,
 		modelType: String(modelType),
-		provider: params.provider,
-		messages: renderedInput.messages,
-		providerOptions,
+		provider: preparedAttempt?.provider ?? params.provider,
+		messages: (preparedAttempt?.input ?? renderedInput).messages,
+		providerOptions: preparedAttempt?.providerOptions ?? providerOptions,
 		raw,
 		output,
 		startedAt,
 		endedAt,
-		segmentHashes: prefixHashes.map((entry) => entry.segmentHash),
-		prefixHash,
+		segmentHashes: (preparedAttempt?.prefixHashes ?? prefixHashes).map(
+			(entry) => entry.segmentHash,
+		),
+		prefixHash: preparedAttempt?.prefixHash ?? prefixHash,
 		logger: params.runtime.logger,
 	});
 
@@ -451,10 +800,9 @@ function renderEvaluatorModelInput(params: {
 	redactText: ToolDiagnosticTextRedactor;
 	/**
 	 * Per-tool-result render cap (chars) applied via
-	 * `trajectoryStepsToMessages`. Defaults to `DEFAULT_MAX_KEPT_STEP_CHARS`
-	 * so a single pathological tool result can never blow the evaluator
-	 * call's context window on its own; `runEvaluator` passes tighter caps
-	 * when the total estimate still exceeds the compaction threshold.
+	 * `trajectoryStepsToMessages`. Undefined preserves the trajectory result
+	 * byte-for-byte; `runEvaluator` applies the cap only after the resolved
+	 * model budget requires compaction.
 	 */
 	maxToolResultChars?: number;
 }): {
@@ -468,8 +816,7 @@ function renderEvaluatorModelInput(params: {
 		template.split("context_object:")[0] ?? template
 	).trim();
 	const stepMessages = trajectoryStepsToMessages(params.trajectory.steps, {
-		maxToolResultChars:
-			params.maxToolResultChars ?? DEFAULT_MAX_KEPT_STEP_CHARS,
+		maxToolResultChars: params.maxToolResultChars,
 		redactText: params.redactText,
 	});
 	// Mirrors planner-loop: the evaluator stage instructions are template-derived

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -11,6 +11,8 @@ import type { EffectReceipt } from "../types/effects";
 import type {
 	ChatMessage,
 	GenerateTextResult,
+	ModelAttemptContext,
+	ModelRegistrationInfo,
 	PromptSegment,
 	TextGenerationModelType,
 	ToolChoice,
@@ -31,6 +33,12 @@ export interface PlannerToolCall {
 export type EvaluatorRoute = EvaluationResult["decision"];
 
 export interface EvaluatorRuntime {
+	/** True when useModel invokes prepareModelAttempt before every provider handler. */
+	supportsModelAttemptPreparation?: boolean;
+	/** Optional model registry access used to resolve evaluator context ceilings. */
+	getModelRegistrations?(): ModelRegistrationInfo[];
+	/** Optional setting access used by model registration metadata resolvers. */
+	getSetting?(key: string): string | boolean | number | null;
 	reportError?(
 		scope: string,
 		error: unknown,
@@ -46,6 +54,14 @@ export interface EvaluatorRuntime {
 			responseSchema?: unknown;
 			promptSegments?: PromptSegment[];
 			providerOptions?: Record<string, unknown>;
+			prepareModelAttempt?: (
+				attempt: ModelAttemptContext,
+				params: {
+					messages: ChatMessage[];
+					promptSegments?: PromptSegment[];
+					providerOptions?: Record<string, unknown>;
+				},
+			) => Promise<void> | void;
 		},
 		provider?: string,
 	): Promise<

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -533,6 +533,11 @@ export interface SpanSamplerPlan {
  * request still works, just without forcing.
  */
 export interface GenerateTextParams {
+	/** Runtime-only hook used to prepare request content for each resolved model attempt. */
+	prepareModelAttempt?: (
+		attempt: ModelAttemptContext,
+		params: GenerateTextParams,
+	) => Promise<void> | void;
 	/**
 	 * Legacy concatenated prompt string. v5 paths emit `messages` instead and
 	 * leave this field undefined. Adapters that haven't migrated to native chat
@@ -706,6 +711,13 @@ export interface GenerateTextParams {
 	 *           via the `x-eliza-span-samplers` header.
 	 */
 	spanSamplerPlan?: SpanSamplerPlan;
+}
+
+/** Exact registration identity selected for one runtime model attempt. */
+export interface ModelAttemptContext {
+	modelType: string;
+	provider: string;
+	metadata?: ModelRegistrationMetadata;
 }
 
 /**


### PR DESCRIPTION
# Relates to

Closes #19176

- [x] This PR targets `develop` and is rebased on the current `origin/develop`.
- [x] The exact repaired head has passed focused core verification in an isolated, network-disabled container.
- [x] A reviewer can confirm the behavior from the deterministic evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@cc3df4096d33b16990590d0842e5a5fa74a12157:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased on `origin/develop` commit `1d5b66935d059e75aa78c0920b1a4a057ba3e857`; no conflicts.
- [x] Exact-head core tests, typecheck, build, formatting, and diff checks passed.

# Risks

The change is isolated to core model routing and evaluator input budgeting. It adds an internal per-attempt preparation hook so the budget is derived from the provider registration that the runtime actually selected, including owner overrides and same-model-type failovers. Unknown model metadata retains the conservative 128k fallback and is identified as unresolved in terminal diagnostics.

# Background

## What does this PR do?

- Resolves and applies the evaluator context budget for every actual provider attempt instead of pre-compacting all input to the smallest reachable fallback.
- Preserves large-context input byte-for-byte until a smaller selected attempt requires compaction.
- Recomputes cache metadata and keeps evaluator thinking disabled after every rerender.
- Guards structured tool-call parameters and rejects a still-over-budget attempt before its provider handler runs.
- Records a typed `EVALUATOR_INPUT_OVER_BUDGET` evaluation stage without falsely recording a provider failure.
- Keeps custom sub-10k context windows usable by capping the output reserve relative to the model window.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No documentation changes are needed; this is an internal runtime contract fix.

# Testing

## Where should a reviewer start?

Start with `packages/core/src/runtime/evaluator.ts`, the per-attempt hook in `packages/core/src/runtime.ts`, and `packages/core/src/runtime/__tests__/evaluator-input-budget.test.ts`.

## Detailed testing steps

All commands below passed on exact head `506a4dc3161515d59e97238e5e16d1742556a1c2`, rebased onto current `develop`:

- `vitest run` over `evaluator-input-budget.test.ts`, `evaluator.test.ts`, `model-provider-failover.test.ts`, `use-model-provider-fallback.test.ts`, `model-registrations.test.ts` — 5 files, 91 tests passed, including large-rate-limited -> small-rejected -> later-large-succeeds failover, authoritative per-attempt recorder snapshots, terminal budget-failure attribution, and a regression proving unrelated preparation defects do not silently advance to another provider.
- `tsc --noEmit -p packages/core/tsconfig.json` — passed.
- `biome check` over all five changed files — passed.
- `bun run --cwd packages/core build:node` and `bun run --cwd packages/core build` — Node, browser, edge, testing, and declarations passed.
- `bun run verify` — 351/351 tasks passed.

# Evidence Gate

Evidence combines the deterministic exact-head suite with a sanctioned live Cerebras evaluator call. The uploaded trajectory records the raw model response and proves the 92,050-character tool result reached the selected model attempt without premature fallback compaction.
<!-- evidence-head:506a4dc3161515d59e97238e5e16d1742556a1c2 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - the evaluator was invoked through the in-process real-runtime harness, so no HTTP backend transport was started.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] [19248-pr19248-live-trajectory.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19248-pr19248-live-trajectory.json)
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, schedule, wallet, or generated domain artifact is changed.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed.

# Evidence Details

## Deterministic runtime evidence

The exact-head tests prove:

- a large-context primary receives a large tool result unchanged;
- a smaller fallback under another model type is compacted only for that attempt;
- a smaller fallback under the same model type is also compacted using its own registration metadata;
- an owner-selected low-priority large provider is budgeted before the first attempt rather than inheriting a registry-first small-provider ceiling;
- settings and environment-backed model metadata resolve through the canonical setting path;
- the fallback request retains `thinking: "off"`;
- stable or structured input that still cannot fit rejects before the selected provider handler;
- terminal failure is typed and recorded; and
- custom 8k model windows retain a usable input budget.

## Known gaps / failures

- No known implementation or evidence gap remains at the exact head; hosted checks may still be in flight after the rebased force-push.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@1d5b66935d059e75aa78c0920b1a4a057ba3e857:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@1d5b66935d059e75aa78c0920b1a4a057ba3e857:packages/skills/skills/contribute-to-eliza"} -->


