### PR TITLE
fix(plugin-codex-cli): preserve BOM-prefixed SSE events

### DIFF
--- a/plugins/plugin-codex-cli/__tests__/codex-backend.test.ts
+++ b/plugins/plugin-codex-cli/__tests__/codex-backend.test.ts
@@ -81,6 +81,32 @@ describe("SSE parser", () => {
       },
     ]);
   });
+
+  it("strips one leading UTF-8 BOM even when its bytes are split across chunks", async () => {
+    const chunks = [
+      new Uint8Array([0xef]),
+      new Uint8Array([0xbb, 0xbf, ...new TextEncoder().encode("data: first\n\n")]),
+    ];
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        const chunk = chunks.shift();
+        if (chunk) controller.enqueue(chunk);
+        else controller.close();
+      },
+    });
+
+    const events = [];
+    for await (const event of parseSSE(stream)) events.push(event);
+    expect(events).toEqual([{ data: "first" }]);
+  });
+
+  it("preserves later BOM characters as event data", async () => {
+    const stream = new Response("data: before\uFEFFafter\n\n").body;
+    expect(stream).toBeTruthy();
+    const events = [];
+    for await (const event of parseSSE(stream as ReadableStream<Uint8Array>)) events.push(event);
+    expect(events).toEqual([{ data: "before\uFEFFafter" }]);
+  });
 });
 
 describe("tool translation", () => {

--- a/plugins/plugin-codex-cli/__tests__/codex-backend.test.ts
+++ b/plugins/plugin-codex-cli/__tests__/codex-backend.test.ts
@@ -100,6 +100,14 @@ describe("SSE parser", () => {
     expect(events).toEqual([{ data: "first" }]);
   });
 
+  it("preserves a second consecutive leading BOM", async () => {
+    const stream = new Response("\uFEFF\uFEFFdata: first\n\n").body;
+    expect(stream).toBeTruthy();
+    const events = [];
+    for await (const event of parseSSE(stream as ReadableStream<Uint8Array>)) events.push(event);
+    expect(events).toEqual([{ data: "\uFEFFfirst" }]);
+  });
+
   it("preserves later BOM characters as event data", async () => {
     const stream = new Response("data: before\uFEFFafter\n\n").body;
     expect(stream).toBeTruthy();

--- a/plugins/plugin-codex-cli/src/sse-parser.ts
+++ b/plugins/plugin-codex-cli/src/sse-parser.ts
@@ -7,7 +7,7 @@ export interface SSEEvent {
 }
 
 export async function* parseSSE(stream: ReadableStream<Uint8Array>): AsyncGenerator<SSEEvent> {
-  const decoder = new TextDecoder();
+  const decoder = new TextDecoder("utf-8", { ignoreBOM: true });
   const reader = stream.getReader();
   let buffer = "";
   let eventName: string | undefined;
@@ -56,10 +56,13 @@ export async function* parseSSE(stream: ReadableStream<Uint8Array>): AsyncGenera
         }
         if (line.startsWith(":")) continue;
 
-        const colon = line.indexOf(":");
-        const field = colon === -1 ? line : line.slice(0, colon);
-        let valueText = colon === -1 ? "" : line.slice(colon + 1);
+        const hasLeadingBom = line.startsWith("\uFEFF");
+        const normalizedLine = hasLeadingBom ? line.slice(1) : line;
+        const colon = normalizedLine.indexOf(":");
+        const field = colon === -1 ? normalizedLine : normalizedLine.slice(0, colon);
+        let valueText = colon === -1 ? "" : normalizedLine.slice(colon + 1);
         if (valueText.startsWith(" ")) valueText = valueText.slice(1);
+        if (hasLeadingBom && field === "data") valueText = `\uFEFF${valueText}`;
 
         if (field === "event") eventName = valueText;
         else if (field === "data") dataLines.push(valueText);
@@ -79,10 +82,13 @@ export async function* parseSSE(stream: ReadableStream<Uint8Array>): AsyncGenera
           const event = emit();
           if (event) yield event;
         } else if (!line.startsWith(":")) {
-          const colon = line.indexOf(":");
-          const field = colon === -1 ? line : line.slice(0, colon);
-          let valueText = colon === -1 ? "" : line.slice(colon + 1);
+          const hasLeadingBom = line.startsWith("\uFEFF");
+          const normalizedLine = hasLeadingBom ? line.slice(1) : line;
+          const colon = normalizedLine.indexOf(":");
+          const field = colon === -1 ? normalizedLine : normalizedLine.slice(0, colon);
+          let valueText = colon === -1 ? "" : normalizedLine.slice(colon + 1);
           if (valueText.startsWith(" ")) valueText = valueText.slice(1);
+          if (hasLeadingBom && field === "data") valueText = `\uFEFF${valueText}`;
           if (field === "event") eventName = valueText;
           else if (field === "data") dataLines.push(valueText);
           else if (field === "id") eventId = valueText;

--- a/plugins/plugin-codex-cli/src/sse-parser.ts
+++ b/plugins/plugin-codex-cli/src/sse-parser.ts
@@ -14,6 +14,13 @@ export async function* parseSSE(stream: ReadableStream<Uint8Array>): AsyncGenera
   let eventId: string | undefined;
   let retry: number | undefined;
   let dataLines: string[] = [];
+  let bomChecked = false;
+
+  const stripLeadingBom = () => {
+    if (bomChecked || buffer.length === 0) return;
+    if (buffer.startsWith("\uFEFF")) buffer = buffer.slice(1);
+    bomChecked = true;
+  };
 
   const emit = (): SSEEvent | null => {
     if (dataLines.length === 0 && eventName === undefined && eventId === undefined && retry === undefined) {
@@ -34,6 +41,7 @@ export async function* parseSSE(stream: ReadableStream<Uint8Array>): AsyncGenera
       const { value, done } = await reader.read();
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
+      stripLeadingBom();
       while (true) {
         const nl = buffer.search(/\r\n|\r|\n/);
         if (nl === -1) break;
@@ -64,6 +72,7 @@ export async function* parseSSE(stream: ReadableStream<Uint8Array>): AsyncGenera
     }
 
     buffer += decoder.decode();
+    stripLeadingBom();
     if (buffer.length > 0) {
       for (const line of buffer.split(/\r\n|\r|\n/)) {
         if (line === "") {


### PR DESCRIPTION
## Summary
- strip exactly one leading U+FEFF before Codex SSE field parsing
- cover UTF-8 BOM bytes split across chunks and preserve later BOM data

Closes #19260

## Validation
- `bun run --cwd packages/core build` ✅
- `bun run --cwd plugins/plugin-codex-cli test` ✅ (12 passed)
- `bun run --cwd plugins/plugin-codex-cli lint:check` ✅
- `bun run --cwd plugins/plugin-codex-cli typecheck` ✅
- `git diff --check` ✅

## Evidence rows
- Before screenshots: N/A - parser-only runtime fix
- After screenshots: N/A - parser-only runtime fix
- Walkthrough video: N/A - parser-only runtime fix
- Backend logs: N/A - deterministic unit parser coverage; no live backend invoked
- Frontend logs: N/A - node-only plugin
- Real-LLM trajectory: N/A - parser-only fix; no model call
- Domain artifacts: N/A - parser-only fix

Model: openai/gpt-5.6-sol via Codex.

<!-- evidence-head:6b448a1dde07d94dbfb93139867d8ae73805d6a7 -->