### PR TITLE
fix(cloud): gate canonical Steward wallet origins

### DIFF
--- a/packages/app/functions/_proxy.ts
+++ b/packages/app/functions/_proxy.ts
@@ -48,12 +48,28 @@ export function resolveApiWorkerTarget(
 export function proxyToApiWorker(
   context: PagesProxyContext,
 ): Promise<Response> {
+  const incoming = new URL(context.request.url);
   const target = resolveApiWorkerTarget(context.request.url, context.env);
   const method = context.request.method.toUpperCase();
+  const headers = new Headers(context.request.headers);
+
+  // Browsers omit Origin on same-origin GETs, including Steward's wallet nonce
+  // request. The service binding changes the request URL to api.eliza.app, so
+  // the API Worker cannot recover the browser host after this boundary. Stamp
+  // the trusted Pages origin before forwarding. Preserve an explicit Origin:
+  // browsers send it on cross-origin and mutating requests, where replacing it
+  // would defeat Steward's origin and CSRF checks.
+  if (
+    !headers.has("origin") &&
+    (incoming.pathname === "/steward" ||
+      incoming.pathname.startsWith("/steward/"))
+  ) {
+    headers.set("origin", incoming.origin);
+  }
 
   const upstreamRequest = new Request(target, {
     method,
-    headers: context.request.headers,
+    headers,
     body:
       method === "GET" || method === "HEAD" ? undefined : context.request.body,
     redirect: "manual",

--- a/packages/app/test/pages-middleware-serving.test.ts
+++ b/packages/app/test/pages-middleware-serving.test.ts
@@ -286,6 +286,74 @@ describe("unified host migration", () => {
     ]);
   });
 
+  it("preserves the canonical browser origin across the Steward service binding", async () => {
+    const requests: Request[] = [];
+    const apiWorker = {
+      fetch: async (request: Request) => {
+        requests.push(request);
+        return Response.json({ nonce: "Tk9iR2buAPsSuxF0T" });
+      },
+    };
+
+    for (const origin of [
+      "https://eliza.app",
+      "https://cloud.eliza.app",
+      "https://staging.eliza.app",
+      "https://cloud-staging.eliza.app",
+    ]) {
+      const response = await proxyToApiWorker({
+        request: new Request(`${origin}/steward/auth/nonce`, {
+          headers: { Accept: "application/json" },
+        }),
+        env: { API_WORKER: apiWorker },
+      });
+      expect(response.status).toBe(200);
+    }
+
+    expect(
+      requests.map((request) => ({
+        requestOrigin: new URL(request.url).origin,
+        browserOrigin: request.headers.get("Origin"),
+      })),
+    ).toEqual([
+      {
+        requestOrigin: "https://api.eliza.app",
+        browserOrigin: "https://eliza.app",
+      },
+      {
+        requestOrigin: "https://api.eliza.app",
+        browserOrigin: "https://cloud.eliza.app",
+      },
+      {
+        requestOrigin: "https://api-staging.eliza.app",
+        browserOrigin: "https://staging.eliza.app",
+      },
+      {
+        requestOrigin: "https://api-staging.eliza.app",
+        browserOrigin: "https://cloud-staging.eliza.app",
+      },
+    ]);
+  });
+
+  it("preserves an explicit cross-origin Origin for Steward to reject", async () => {
+    let forwarded: Request | undefined;
+    await proxyToApiWorker({
+      request: new Request(`${ORIGIN}/steward/auth/nonce`, {
+        headers: { Origin: "https://attacker.example" },
+      }),
+      env: {
+        API_WORKER: {
+          fetch: async (request) => {
+            forwarded = request;
+            return new Response(null, { status: 400 });
+          },
+        },
+      },
+    });
+
+    expect(forwarded?.headers.get("Origin")).toBe("https://attacker.example");
+  });
+
   it("fails closed when the deployed API service binding is missing", async () => {
     const response = await proxyToApiWorker({
       request: new Request(`${ORIGIN}/api/health`),

--- a/packages/cloud/api/__tests__/steward-embedded-origin-forward.test.ts
+++ b/packages/cloud/api/__tests__/steward-embedded-origin-forward.test.ts
@@ -112,6 +112,17 @@ describe("embedded Steward proxy — Origin forwarding (SIWE nonce fix)", () => 
     expect(lastUpstreamOrigin).toBe("https://app-staging.elizacloud.ai");
   });
 
+  it("preserves the browser origin stamped before the Pages service binding rewrite", async () => {
+    const app = makeApp();
+    const res = await app.request(
+      "https://api-staging.eliza.app/steward/auth/nonce",
+      { headers: { origin: "https://cloud-staging.eliza.app" } },
+    );
+
+    expect(res.status).toBe(200);
+    expect(lastUpstreamOrigin).toBe("https://cloud-staging.eliza.app");
+  });
+
   it("uses the prod host on a prod-origin request", async () => {
     const app = makeApp();
     const res = await app.request("https://elizacloud.ai/steward/auth/nonce");

--- a/packages/cloud/api/src/steward/embedded.ts
+++ b/packages/cloud/api/src/steward/embedded.ts
@@ -415,13 +415,12 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
   // allowed Origin or Referer"). The SDK calls Steward through THIS same-origin
   // proxy, so on that GET the browser sends no `Origin` at all, and its
   // `Referer` is a fetch-forbidden header that never survives the Worker
-  // subrequest — Steward saw neither and 400'd EVERY wallet sign-in, on prod as
-  // well as staging (the old cloud-frontend e2e mocked `/auth/nonce`, so this
-  // went unnoticed). This proxy is authoritative for the host the browser
-  // connected to, so stamp that host as `Origin` whenever the client didn't
-  // send one. Only fills the gap — a real browser `Origin` (cross-origin/POST
-  // legs) is preserved. `Origin` is not part of the signed canonical request
-  // (see the hashed-header set above), so this is safe for signed mutating legs.
+  // subrequest. The outer Pages proxy fills this gap with the browser-facing
+  // origin before its service binding rewrites the URL to the API host. Direct
+  // API requests have no outer proxy, so use their own request origin as the
+  // fallback. A real browser `Origin` (cross-origin/POST legs) is preserved.
+  // `Origin` is not part of the signed canonical request (see the hashed-header
+  // set above), so this ordering is safe for signed mutating legs.
   if (!headers.has("origin")) {
     headers.set("origin", url.origin);
   }

--- a/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
@@ -1,5 +1,5 @@
 /**
- * Steward canonical-callback deploy probe tests use deterministic fetch fakes;
+ * Steward canonical sign-in deploy probe tests use deterministic fetch fakes;
  * no provider request or tenant mutation leaves the process.
  */
 
@@ -7,6 +7,7 @@ import { describe, expect, test } from "bun:test";
 import {
   parseStewardCallbackProbeArgs,
   verifyStewardOAuthCallbacks,
+  verifyStewardWalletOrigin,
 } from "../verify-steward-oauth-callbacks.mjs";
 
 const CONFIG = {
@@ -88,5 +89,52 @@ describe("Steward OAuth callback deployment probe", () => {
     expect(() => parseStewardCallbackProbeArgs([])).toThrow(
       "--base-url is required",
     );
+  });
+});
+
+describe("Steward wallet-origin deployment probe", () => {
+  test("sends the browser host as the exact Origin and accepts a nonce", async () => {
+    let requestedUrl = "";
+    let requestedInit: RequestInit | undefined;
+    const result = await verifyStewardWalletOrigin(CONFIG, {
+      fetchImpl: async (input: string | URL | Request, init?: RequestInit) => {
+        requestedUrl = String(input);
+        requestedInit = init;
+        return Response.json({ nonce: "deployment-probe-nonce" });
+      },
+    });
+
+    expect(result).toEqual({ origin: CONFIG.baseUrl });
+    expect(requestedUrl).toBe(`${CONFIG.baseUrl}/steward/auth/nonce`);
+    expect(requestedInit).toEqual({
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Origin: CONFIG.baseUrl,
+      },
+    });
+  });
+
+  test("fails closed when Steward rejects the canonical Origin", async () => {
+    await expect(
+      verifyStewardWalletOrigin(CONFIG, {
+        fetchImpl: async () =>
+          Response.json(
+            {
+              ok: false,
+              error: "SIWE nonce requests require an allowed Origin or Referer",
+            },
+            { status: 400 },
+          ),
+      }),
+    ).rejects.toThrow("wallet origin probe returned HTTP 400");
+  });
+
+  test("fails closed on a malformed success response", async () => {
+    await expect(
+      verifyStewardWalletOrigin(CONFIG, {
+        fetchImpl: async () => Response.json({ ok: true }),
+      }),
+    ).rejects.toThrow("wallet origin probe returned no nonce");
   });
 });

--- a/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  main,
   parseStewardCallbackProbeArgs,
   verifyStewardOAuthCallbacks,
   verifyStewardWalletOrigin,
@@ -100,7 +101,7 @@ describe("Steward wallet-origin deployment probe", () => {
       fetchImpl: async (input: string | URL | Request, init?: RequestInit) => {
         requestedUrl = String(input);
         requestedInit = init;
-        return Response.json({ nonce: "deployment-probe-nonce" });
+        return Response.json({ nonce: "Tk9iR2buAPsSuxF0T" });
       },
     });
 
@@ -132,7 +133,29 @@ describe("Steward wallet-origin deployment probe", () => {
       verifyStewardWalletOrigin(CONFIG, {
         fetchImpl: async () => Response.json({ ok: true }),
       }),
-    ).rejects.toThrow("wallet origin probe returned no nonce");
+    ).rejects.toThrow("wallet origin probe returned an invalid nonce");
+  });
+
+  test.each(["", "   ", "a", "bad!nonce", "seven77"])(
+    "rejects unusable nonce %j",
+    async (nonce) => {
+      await expect(
+        verifyStewardWalletOrigin(CONFIG, {
+          fetchImpl: async () => Response.json({ nonce }),
+        }),
+      ).rejects.toThrow("wallet origin probe returned an invalid nonce");
+    },
+  );
+
+  test("fails closed on invalid JSON", async () => {
+    await expect(
+      verifyStewardWalletOrigin(CONFIG, {
+        fetchImpl: async () =>
+          new Response("not-json", {
+            headers: { "Content-Type": "application/json" },
+          }),
+      }),
+    ).rejects.toThrow("wallet origin probe returned invalid JSON");
   });
 
   test("does not follow a redirect away from the canonical browser host", async () => {
@@ -147,5 +170,67 @@ describe("Steward wallet-origin deployment probe", () => {
         },
       }),
     ).rejects.toThrow("wallet origin probe returned HTTP 302");
+  });
+});
+
+describe("Steward deployment probe CLI composition", () => {
+  const ARGS = [
+    "--base-url",
+    CONFIG.baseUrl,
+    "--callback-url",
+    CONFIG.callbackUrl,
+    "--tenant-id",
+    CONFIG.tenantId,
+  ];
+
+  test("runs both OAuth providers and the wallet leg", async () => {
+    const requested: string[] = [];
+    const logs: string[] = [];
+    await main(ARGS, {
+      fetchImpl: async (input: string | URL | Request) => {
+        const url = String(input);
+        requested.push(url);
+        if (url.endsWith("/steward/auth/nonce")) {
+          return Response.json({ nonce: "Tk9iR2buAPsSuxF0T" });
+        }
+        const destination = url.includes("/discord/")
+          ? "https://discord.com/oauth2/authorize"
+          : "https://accounts.google.com/o/oauth2/v2/auth";
+        return new Response(null, {
+          status: 302,
+          headers: { Location: destination },
+        });
+      },
+      log: (message: string) => logs.push(message),
+    });
+
+    expect(requested).toHaveLength(3);
+    expect(requested.at(-1)).toBe(`${CONFIG.baseUrl}/steward/auth/nonce`);
+    expect(logs).toEqual([
+      "Verified discord canonical callback via discord.com.",
+      "Verified google canonical callback via accounts.google.com.",
+      `Verified canonical wallet origin ${CONFIG.baseUrl}.`,
+    ]);
+  });
+
+  test("fails the composed command when the wallet leg is rejected", async () => {
+    await expect(
+      main(ARGS, {
+        fetchImpl: async (input: string | URL | Request) => {
+          const url = String(input);
+          if (url.endsWith("/steward/auth/nonce")) {
+            return Response.json({ error: "origin rejected" }, { status: 400 });
+          }
+          const destination = url.includes("/discord/")
+            ? "https://discord.com/oauth2/authorize"
+            : "https://accounts.google.com/o/oauth2/v2/auth";
+          return new Response(null, {
+            status: 302,
+            headers: { Location: destination },
+          });
+        },
+        log: () => undefined,
+      }),
+    ).rejects.toThrow("wallet origin probe returned HTTP 400");
   });
 });

--- a/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
@@ -93,7 +93,7 @@ describe("Steward OAuth callback deployment probe", () => {
 });
 
 describe("Steward wallet-origin deployment probe", () => {
-  test("sends the browser host as the exact Origin and accepts a nonce", async () => {
+  test("exercises the real same-origin no-Origin proxy path and accepts a nonce", async () => {
     let requestedUrl = "";
     let requestedInit: RequestInit | undefined;
     const result = await verifyStewardWalletOrigin(CONFIG, {
@@ -107,11 +107,8 @@ describe("Steward wallet-origin deployment probe", () => {
     expect(result).toEqual({ origin: CONFIG.baseUrl });
     expect(requestedUrl).toBe(`${CONFIG.baseUrl}/steward/auth/nonce`);
     expect(requestedInit).toEqual({
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-        Origin: CONFIG.baseUrl,
-      },
+      headers: { Accept: "application/json" },
+      redirect: "manual",
     });
   });
 
@@ -136,5 +133,19 @@ describe("Steward wallet-origin deployment probe", () => {
         fetchImpl: async () => Response.json({ ok: true }),
       }),
     ).rejects.toThrow("wallet origin probe returned no nonce");
+  });
+
+  test("does not follow a redirect away from the canonical browser host", async () => {
+    await expect(
+      verifyStewardWalletOrigin(CONFIG, {
+        fetchImpl: async (_input, init) => {
+          expect(init?.redirect).toBe("manual");
+          return new Response(null, {
+            status: 302,
+            headers: { Location: "https://attacker.example/nonce" },
+          });
+        },
+      }),
+    ).rejects.toThrow("wallet origin probe returned HTTP 302");
   });
 });

--- a/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
+++ b/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
@@ -14,6 +14,12 @@ const PROVIDER_DESTINATIONS = Object.freeze({
   google: "accounts.google.com",
 });
 
+// ERC-4361 defines a SIWE nonce as at least eight ASCII alphanumeric
+// characters. Steward shares this nonce across its SIWE and SIWS launch paths,
+// so accepting a weaker shape would let the deploy gate bless an unusable
+// wallet response.
+const WALLET_NONCE_PATTERN = /^[A-Za-z0-9]{8,}$/;
+
 function requiredUrl(value, flag) {
   if (!value) throw new Error(`${flag} is required`);
   const url = new URL(value);
@@ -122,24 +128,27 @@ export async function verifyStewardWalletOrigin(
     typeof payload !== "object" ||
     payload === null ||
     typeof payload.nonce !== "string" ||
-    payload.nonce.length === 0
+    !WALLET_NONCE_PATTERN.test(payload.nonce)
   ) {
-    throw new Error("wallet origin probe returned no nonce");
+    throw new Error("wallet origin probe returned an invalid nonce");
   }
 
   return { origin: baseUrl };
 }
 
-export async function main(argv = process.argv.slice(2)) {
+export async function main(
+  argv = process.argv.slice(2),
+  { fetchImpl = fetch, log = console.log } = {},
+) {
   const config = parseStewardCallbackProbeArgs(argv);
-  const results = await verifyStewardOAuthCallbacks(config);
+  const results = await verifyStewardOAuthCallbacks(config, { fetchImpl });
   for (const result of results) {
-    console.log(
+    log(
       `Verified ${result.provider} canonical callback via ${result.destinationHostname}.`,
     );
   }
-  const wallet = await verifyStewardWalletOrigin(config);
-  console.log(`Verified canonical wallet origin ${wallet.origin}.`);
+  const wallet = await verifyStewardWalletOrigin(config, { fetchImpl });
+  log(`Verified canonical wallet origin ${wallet.origin}.`);
 }
 
 const invokedPath = process.argv[1]

--- a/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
+++ b/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /**
- * Verify that a deployed Eliza browser host can begin every supported Steward
- * OAuth flow with its exact canonical callback. The probe stops at the first
- * provider redirect, so it validates Pages routing, tenant allowlists, and
- * provider configuration without authenticating a user or mutating a session.
+ * Verify the externally managed Steward sign-in configuration for a deployed
+ * Eliza browser host. OAuth probes stop at the provider redirect, while the
+ * wallet probe requests only the public nonce used before SIWE/SIWS signing;
+ * neither path authenticates a user or creates an Eliza session.
  */
 
 import { createHash } from "node:crypto";
@@ -94,6 +94,43 @@ export async function verifyStewardOAuthCallbacks(
   return results;
 }
 
+export async function verifyStewardWalletOrigin(
+  { baseUrl },
+  { fetchImpl = fetch } = {},
+) {
+  const response = await fetchImpl(`${baseUrl}/steward/auth/nonce`, {
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Origin: baseUrl,
+    },
+  });
+
+  if (response.status !== 200) {
+    throw new Error(
+      `wallet origin probe returned HTTP ${response.status}; expected a nonce response`,
+    );
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (cause) {
+    // error-policy:J1 Translate the deployed HTTP boundary into a fail-closed probe result.
+    throw new Error("wallet origin probe returned invalid JSON", { cause });
+  }
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    typeof payload.nonce !== "string" ||
+    payload.nonce.length === 0
+  ) {
+    throw new Error("wallet origin probe returned no nonce");
+  }
+
+  return { origin: baseUrl };
+}
+
 export async function main(argv = process.argv.slice(2)) {
   const config = parseStewardCallbackProbeArgs(argv);
   const results = await verifyStewardOAuthCallbacks(config);
@@ -102,6 +139,8 @@ export async function main(argv = process.argv.slice(2)) {
       `Verified ${result.provider} canonical callback via ${result.destinationHostname}.`,
     );
   }
+  const wallet = await verifyStewardWalletOrigin(config);
+  console.log(`Verified canonical wallet origin ${wallet.origin}.`);
 }
 
 const invokedPath = process.argv[1]

--- a/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
+++ b/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
@@ -99,11 +99,10 @@ export async function verifyStewardWalletOrigin(
   { fetchImpl = fetch } = {},
 ) {
   const response = await fetchImpl(`${baseUrl}/steward/auth/nonce`, {
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      Origin: baseUrl,
-    },
+    // Same-origin browser GETs omit Origin. The embedded proxy must synthesize
+    // the canonical browser origin before forwarding the request to Steward.
+    headers: { Accept: "application/json" },
+    redirect: "manual",
   });
 
   if (response.status !== 200) {


### PR DESCRIPTION
# Relates to

Closes #19261.

- [x] This PR targets `develop` and is based on the latest `origin/develop` at implementation time with zero conflicts.
- [x] `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change from the live, non-authenticating deployed-host evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on `origin/develop` commit `f8e449712d38dd0b4ab5344853f8ca8152968c0d`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 Turbo tasks plus every repository audit.

# Risks

Low and scoped. The Pages proxy now stamps the canonical browser Origin only when a same-origin Steward request omitted it; an explicit cross-origin or mutating-request Origin is preserved for Steward and CSRF rejection. The non-authenticating release probe fails closed and cannot create a session or complete a wallet signature.

# Background

## What does this PR do?

- Preserves the exact canonical browser Origin across the Pages-to-API service binding for same-origin Steward requests on production and staging.
- Extends the canonical Steward release probe to request the public SIWE/SIWS nonce through each exact browser host.
- Sends the request as a real same-origin browser GET: `Accept` only, no synthetic client `Origin`, and manual redirect handling.
- Fails closed on origin rejection, redirects, malformed JSON, or a nonce that violates the ERC-4361 minimum eight-character alphanumeric contract.
- Covers the composed CLI so removing or bypassing the wallet leg fails tests.
- Keeps the probe non-authenticating and suitable for both staging and production release verification.

## What kind of change is this?

Bug fix and deployment-verification hardening.

# Documentation changes needed?

No product documentation change is required; the script header and tests document the deployment contract.

# Testing

## Where should a reviewer start?

Review `packages/app/functions/_proxy.ts`, the embedded Steward origin test, and `packages/cloud/scripts/verify-steward-oauth-callbacks.mjs`. The key invariant is that a same-origin wallet GET reaches Steward with the exact browser origin after the service-binding rewrite, while an explicit cross-origin Origin is never replaced.

## Detailed testing steps

1. Run `bun test packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts packages/app/test/pages-middleware-serving.test.ts packages/cloud/api/__tests__/steward-embedded-origin-forward.test.ts packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts`.
2. Run the probe against each canonical host with its exact `/login` callback and tenant.
3. Confirm Google resolves only to `accounts.google.com`, Discord only to `discord.com`, and the wallet probe returns a non-empty nonce without authenticating.
4. Run `bun run verify`.

# Evidence Gate

<!-- evidence-head:dd9874f9037ad138003f82fc1bfb61782727661c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - deployment-verification script only; no rendered UI changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - deployment-verification script only; no rendered UI changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - non-interactive release gate with no UI flow
<!-- evidence-row:backend-logs -->
- [x] [19264-steward-origin-evidence-dd9874f.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19264-steward-origin-evidence-dd9874f.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - exact same-origin browser request shape is asserted in the focused test; no rendered state changes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no durable user, session, signature, or database artifact; the public probe may issue only short-lived nonce state
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changes

# Evidence Details

## Real LLM-call trajectory

N/A - no model or agent behavior changes.

## Backend + frontend logs

The exact-head local integration tests prove the Pages request is rewritten to the API Worker while retaining each browser origin, and the command-level test proves both OAuth providers plus the wallet leg execute. The attached log records the exact SHA, timestamp, commands, statuses, full app audit, root verification, and a non-authenticating live compatibility baseline.

Canonical origins covered:

- `https://staging.eliza.app`
- `https://cloud-staging.eliza.app`
- `https://eliza.app`
- `https://cloud.eliza.app`

No provider redirect was followed, no wallet was connected or signed, and no user session was created.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

None in scope. Verification passed:

- focused Pages, embedded Steward, deployment-probe, and workflow contracts: 58 tests / 297 expectations;
- Biome and `git diff --check`;
- live nonce-shape compatibility on all four canonical browser hosts;
- full app audit: 216 captures, 0 broken, 0 needs-work, 0 OCR regressions;
- app and Cloud API typechecks through `bun run verify`;
- `bun run verify`: 350/350 Turbo tasks and all repository audits.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->


