### PR TITLE
test(client): realign two client-lane suites with shipped behavior

### DIFF
--- a/packages/app/test/service-worker-auth-bypass.test.ts
+++ b/packages/app/test/service-worker-auth-bypass.test.ts
@@ -29,6 +29,14 @@ function loadServiceWorker() {
       listeners.set(type, [...(listeners.get(type) ?? []), listener]);
     },
     skipWaiting: () => Promise.resolve(),
+    // sw.js reads `self.registration` twice: it snapshots `.active` at
+    // evaluation time to tell a first install (null) from an update (the
+    // previous worker), and `activate` gates navigation-preload setup on
+    // `.navigationPreload`. A worker-like stub without `registration` makes
+    // the first read throw before any listener is registered, killing the
+    // script on load; stubbing only `.active` defers the same crash to the
+    // first test that dispatches `activate`. Both keys model a first install.
+    registration: { active: null, navigationPreload: null },
     clients: {
       claim: () => Promise.resolve(),
       matchAll: () => Promise.resolve([]),

--- a/packages/ui/src/components/settings/settings-sections.mvp-hidden.test.ts
+++ b/packages/ui/src/components/settings/settings-sections.mvp-hidden.test.ts
@@ -1,9 +1,13 @@
 /**
  * Guards the MVP settings declutter: the tabs hidden for MVP (Capabilities,
- * Apps, Cloud Connectors, Runtime, My Runtimes, Wallet & RPC, and the
+ * Apps, App Permissions, Runtime, My Runtimes, Wallet & RPC, and the
  * consolidated-away standalone Background) drop out of the nav when Developer
  * Mode is off, but stay REGISTERED (kept, not deleted) so their routes/
  * deep-links still resolve and they reappear when Developer Mode is on.
+ *
+ * Cloud Connectors is deliberately NOT in that set: the eliza.app
+ * consolidation promoted the cloud sections to `viewKind: "release"`, so it is
+ * public. Its gating is pinned by `register-cloud-settings.test.ts`.
  */
 import { isViewVisible } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
@@ -13,7 +17,6 @@ const MVP_HIDDEN = [
   "capabilities",
   "apps",
   "app-permissions",
-  "cloud-connectors",
   "runtime",
   "my-runtimes",
   "wallet-rpc",


### PR DESCRIPTION
# Relates to

Closes #19220 (re-scoped — see below).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package gates were run after sync; results below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - maintainer review lane, no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop@1d5b66935d0`; zero conflicts.

# Risks

None to product code. Both files are tests; no `src/` behavior changes.

# Background

## What does this PR do?

Two suites fail on **clean `develop@1d5b66935d0`** and take the whole `Tests (client)` lane with them, so every open PR touching `packages/ui` or `packages/app` is red for reasons unrelated to its own diff.

**1. `packages/app/test/service-worker-auth-bypass.test.ts` — 4 failures.**
The suite evaluates the real `public/sw.js` inside a worker-like VM. `sw.js:90` snapshots `self.registration.active` at module scope to distinguish a first install from an update:

```js
const IS_SERVICE_WORKER_UPDATE = Boolean(self.registration.active);
```

The stub `self` had no `registration`, so the script threw before registering any listener:

```
TypeError: Cannot read properties of undefined (reading 'active')
 ❯ sw.js:90:60
 ❯ loadServiceWorker test/service-worker-auth-bypass.test.ts:57:6
```

The stub now models a first install (`registration: { active: null }`). This fixes the harness, not the product — `sw.js` is unchanged.

**2. `packages/ui/src/components/settings/settings-sections.mvp-hidden.test.ts` — 1 failure.**

```
AssertionError: section "cloud-connectors" is hidden with developer off: expected true to be false
```

`0468c1850a3` ("feat: consolidate Eliza Cloud into eliza.app") deliberately promoted the cloud settings sections from `developerOnly: true` to `viewKind: "release"` across `cloud/connectors`, `cloud/mcps`, `cloud/settings`, and `register-managed-cloud-page`, and updated `register-cloud-settings.test.ts` to assert the new gating. This one list still named `cloud-connectors` as MVP-hidden and was missed. Cloud Connectors is public by design now, so it leaves the hidden set; its gating stays pinned by `register-cloud-settings.test.ts`, which this PR leaves untouched and which still passes.

I originally filed #19220 as a product regression (revert the gating). That diagnosis was wrong — reading the full commit shows the promotion was intentional and consistently applied everywhere except this list. The test is what drifted.

## What kind of change is this?

Bug fix (non-breaking; test-only).

# Documentation changes needed?

No.

# Testing

## Detailed testing steps

```bash
bun run --cwd packages/app test test/service-worker-auth-bypass.test.ts
bun run --cwd packages/ui test src/components/settings/settings-sections.mvp-hidden.test.ts \
  src/cloud/settings/register-cloud-settings.test.ts
```

# Evidence Gate

<!-- evidence-head:1de95f57e13844082446b6fc9ab6a1070aefb1e0 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no rendered surface is added, removed, or restyled.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change; no rendered surface is added, removed, or restyled.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server or API path changes; red/green test transcripts below are the measurement.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer behavior changes; `sw.js` and every `src/` file are untouched.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, wallet, or generated-domain artifacts change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual output.

# Evidence Details

## Backend + frontend logs

**Before — clean `develop@1d5b66935d0`, no changes applied:**

```
$ bun run --cwd packages/app test test/service-worker-auth-bypass.test.ts
 FAIL  test/service-worker-auth-bypass.test.ts > takes over /login only for uncached network passthrough
 FAIL  test/service-worker-auth-bypass.test.ts > takes over /login?code=one-time only for uncached network passthrough
 FAIL  test/service-worker-auth-bypass.test.ts > takes over /chat?token=handoff only for uncached network passthrough
 FAIL  test/service-worker-auth-bypass.test.ts > still intercepts ordinary app-shell navigations
TypeError: Cannot read properties of undefined (reading 'active')
 Test Files  1 failed (1)
      Tests  4 failed (4)

$ bun run --cwd packages/ui test src/components/settings/settings-sections.mvp-hidden.test.ts
 FAIL  MVP settings declutter > hides every MVP section from the nav when Developer Mode is off
AssertionError: section "cloud-connectors" is hidden with developer off: expected true to be false
 Test Files  1 failed (1) | Tests 1 failed | 3 passed (4)
```

**After — this branch:**

```
$ bun run --cwd packages/app test test/service-worker-auth-bypass.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)

$ bun run --cwd packages/ui test src/components/settings/settings-sections.mvp-hidden.test.ts \
    src/cloud/settings/register-cloud-settings.test.ts
 Test Files  2 passed (2)
      Tests  9 passed (9)

$ bunx biome check packages/app/test/service-worker-auth-bypass.test.ts \
    packages/ui/src/components/settings/settings-sections.mvp-hidden.test.ts
Checked 2 files in 40ms. No fixes applied.
```

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered visual surface.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT path is changed.

## Known gaps / failures

Root `bun run verify` was not run on this machine. The change is two test files with no `src/` reach; hosted CI covers the full gate.
