### PR TITLE
fix(ci): cover cloud-cf-release.yml in the Bun-version contract gate

### DIFF
--- a/packages/scripts/__tests__/ci-bun-version-contract.test.ts
+++ b/packages/scripts/__tests__/ci-bun-version-contract.test.ts
@@ -57,7 +57,12 @@ interface InventorySite {
 const CANONICAL = "1.3.14";
 const SHA = "0c5077e51419868618aeaa5fe8019c62421857d6";
 
-const GATE_WORKFLOWS = ["test.yml", "develop-pr.yml", "cloud-cf-deploy.yml"];
+const GATE_WORKFLOWS = [
+  "test.yml",
+  "develop-pr.yml",
+  "cloud-cf-deploy.yml",
+  "cloud-cf-release.yml",
+];
 
 // A gate stub that pins via a BUN_VERSION env literal and references it from
 // the step by expression — the shape the real gates use. The comment naming
@@ -213,6 +218,16 @@ describe("ci-bun-version-contract", () => {
     expectViolation(
       buildRepo({ overrides: { "cloud-cf-deploy.yml": null } }),
       /cloud-cf-deploy\.yml/,
+    );
+  });
+
+  test("fails loudly when the canonical release workflow is missing (#19183)", () => {
+    // After #18996 split the canary deploy from the canonical release, the
+    // release workflow publishes to production. A missing release gate must
+    // fail loudly the same way a missing canary gate does, not silently pass.
+    expectViolation(
+      buildRepo({ overrides: { "cloud-cf-release.yml": null } }),
+      /cloud-cf-release\.yml/,
     );
   });
 

--- a/packages/scripts/ci-bun-version-contract.mjs
+++ b/packages/scripts/ci-bun-version-contract.mjs
@@ -138,9 +138,18 @@ const EXCLUDED_SURFACES = [
 
 // Required, scheduled, and deploy-critical install lanes that must wire the
 // concrete pin directly (not merely resolve through indirection). The required
-// `ci-ok` aggregate (test.yml), the develop PR gate, and the canonical cloud
-// deploy are the load-bearing paths.
-const GATE_WORKFLOWS = ["test.yml", "develop-pr.yml", "cloud-cf-deploy.yml"];
+// `ci-ok` aggregate (test.yml), the develop PR gate, the canary deploy, and
+// the canonical cloud release are the load-bearing paths. After #18996 split
+// the canary deploy (`cloud-cf-deploy.yml`) from the canonical release
+// (`cloud-cf-release.yml`), the release workflow is the one that actually
+// publishes to production; the gate must cover it or a float there passes
+// silently (#19183).
+const GATE_WORKFLOWS = [
+  "test.yml",
+  "develop-pr.yml",
+  "cloud-cf-deploy.yml",
+  "cloud-cf-release.yml",
+];
 
 // Both the post-merge suite and the required develop PR gate must execute the
 // contract and publish its exact-head inventory. Keeping the PR lane here is

--- a/packages/scripts/ci-bun-version-contract.mjs
+++ b/packages/scripts/ci-bun-version-contract.mjs
@@ -142,8 +142,10 @@ const EXCLUDED_SURFACES = [
 // the canonical cloud release are the load-bearing paths. After #18996 split
 // the canary deploy (`cloud-cf-deploy.yml`) from the canonical release
 // (`cloud-cf-release.yml`), the release workflow is the one that actually
-// publishes to production; the gate must cover it or a float there passes
-// silently (#19183).
+// publishes to production. The general workflow scan already rejects floating
+// pins; gate membership additionally prevents the release file from
+// disappearing or replacing its direct canonical literal with indirection
+// (#19183).
 const GATE_WORKFLOWS = [
   "test.yml",
   "develop-pr.yml",


### PR DESCRIPTION
# Relates to

Closes #19183

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Maintainer isolated verification on the exact head passed the focused contract regression suite, changed-file lint and formatting, and the patch whitespace check; hosted repository gates remain authoritative.
- [x] A reviewer can confirm the change from the contract test, the matching `GATE_WORKFLOWS` array, and the updated comment.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `hermes grokbot g-slop-eliza`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - contributor used a local skill mirror without a repository commit revision.`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Problem

After #18996 split the canary deploy (`cloud-cf-deploy.yml`) from the canonical release (`cloud-cf-release.yml`), the release workflow is the one that actually publishes to production. The general workflow scan already rejects floating or divergent Bun values in `cloud-cf-release.yml`, but the load-bearing gate did not require that release workflow to remain present or to wire the canonical pin directly. That left the release lane free to disappear from the tracked contract or replace its direct literal with unprovable indirection.

# Change

- Add `cloud-cf-release.yml` to `GATE_WORKFLOWS` in `packages/scripts/ci-bun-version-contract.mjs`.
- Mirror the same array in `packages/scripts/__tests__/ci-bun-version-contract.test.ts` so the synthetic-tree fixture writes the release gate and the real-repo test passes with the new gate.
- Add a regression test that asserts the contract fails loudly when `cloud-cf-release.yml` is missing.
- Update the `GATE_WORKFLOWS` comment to describe the post-#18996 split.

# Risks

Low. The contract now rejects a wider set of inputs; the only failure mode is that the new gate's `manifest` shape disagrees with what the contract expects, which is what the existing fixture tree authors explicitly.

# Maintainer verification

- Exact evidence head: `58044433c6e35e51f2ca81fd318b0d0296f915c8`.
- Network-disabled Bun 1.3.14 run: the four gate-workflow regressions passed, including the new canonical-release missing-file case.
- Biome lint and format checks passed for both changed files.
- `git diff --check origin/develop...HEAD` passed.
- A full repository `bun run verify` remains delegated to the hosted required checks; no runtime, UI, backend, or integration surface changes in this PR.

<!-- evidence-head:58044433c6e35e51f2ca81fd318b0d0296f915c8 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Deterministic CI contract; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Deterministic CI contract; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No user-facing interaction flow.

<!-- evidence-row:backend-logs -->
- [ ] N/A - No backend or runtime path changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - Contract-only change; the exact-head deterministic test transcript is recorded in Maintainer verification.

<!-- evidence-row:ocr-review -->
- [ ] N/A - No visual artifact.

AI provider/model: xai / grok-4.6
Client / agent tooling: hermes grokbot g-slop-eliza
Contribution skill revision: N/A - contributor used a local skill mirror without a repository commit revision.
Attribution status: self-reported
— [g-slop-eliza]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"hermes-grokbot","skill_revision\":\"N/A - contributor used a local skill mirror without a repository commit revision."} -->

