### PR TITLE
fix(cloud): harden legacy domain cutover

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -1650,8 +1650,8 @@ jobs:
     name: Verify ${{ inputs.target_environment }} routing
     needs: [deploy-api, deploy-app]
     # Custom domains only exist for the real environments -- PR previews deploy to
-    # a preview branch alias, so skip them. Require all three deploys to have
-    # landed (the beacon is served by the API Worker; both frontend domains by
+    # a preview branch alias, so skip them. Require both deploys to have landed
+    # (the beacon is served by the API Worker; both frontend domains by
     # one Pages project), else there is nothing trustworthy to probe.
     if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.deploy-api.result == 'success' && needs.deploy-app.result == 'success' }}
     runs-on: ubuntu-latest
@@ -1670,9 +1670,18 @@ jobs:
 
       - name: Resolve deployed environment
         id: env
+        env:
+          TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
         run: |
-          echo "environment=${{ inputs.target_environment }}" >> "$GITHUB_OUTPUT"
-          echo "environment=$env" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          case "$TARGET_ENVIRONMENT" in
+            staging|production) ;;
+            *)
+              echo "::error::Unsupported deployed environment: ${TARGET_ENVIRONMENT:-<missing>}"
+              exit 1
+              ;;
+          esac
+          echo "environment=$TARGET_ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
       - name: Verify the just-deployed environment serves itself
         # This run built AND deployed the beacon-carrying Worker for this env, so

--- a/packages/app/functions/_middleware.ts
+++ b/packages/app/functions/_middleware.ts
@@ -31,6 +31,7 @@
 //   default (max-age=14400), which would delay SW update propagation by hours.
 
 import {
+  canonicalCloudPathForLegacyDashboard,
   classifyElizaHostname,
   ELIZA_DOMAIN_CONTRACTS,
 } from "@elizaos/shared/elizacloud/domain-contract";
@@ -66,37 +67,33 @@ export function resolveCanonicalPageRedirect(
   if (!classified.environment) return null;
 
   const contract = ELIZA_DOMAIN_CONTRACTS[classified.environment];
+  const canonicalDashboardPath = canonicalCloudPathForLegacyDashboard(
+    url.pathname,
+    url.search,
+  );
   let origin: string | null = null;
   if (classified.role === "legacy-marketing" && isProtocolPath(url.pathname)) {
     origin = contract.cloudApiOrigin;
-  } else if (
-    classified.role === "legacy-marketing" &&
-    (url.pathname === "/dashboard" || url.pathname.startsWith("/dashboard/"))
-  ) {
+  } else if (classified.role === "legacy-marketing" && canonicalDashboardPath) {
     origin = contract.cloudAppOrigin;
-    url.pathname = url.pathname.replace(/^\/dashboard(?=\/|$)/, "/cloud");
-  } else if (
-    classified.role === "marketing" &&
-    (url.pathname === "/dashboard" || url.pathname.startsWith("/dashboard/"))
-  ) {
+    url.pathname = canonicalDashboardPath;
+  } else if (classified.role === "marketing" && canonicalDashboardPath) {
     origin = contract.cloudAppOrigin;
-    url.pathname = url.pathname.replace(/^\/dashboard(?=\/|$)/, "/cloud");
+    url.pathname = canonicalDashboardPath;
   } else if (
     classified.role === "legacy-marketing" ||
     (classified.role === "marketing" &&
       url.hostname !== new URL(contract.marketingOrigin).hostname)
   ) {
     origin = contract.marketingOrigin;
+  } else if (classified.role === "cloud-app" && canonicalDashboardPath) {
+    origin = contract.cloudAppOrigin;
+    url.pathname = canonicalDashboardPath;
   } else if (classified.role === "legacy-cloud-app") {
     origin = isProtocolPath(url.pathname)
       ? contract.cloudApiOrigin
       : contract.cloudAppOrigin;
-    if (
-      url.pathname === "/dashboard" ||
-      url.pathname.startsWith("/dashboard/")
-    ) {
-      url.pathname = url.pathname.replace(/^\/dashboard(?=\/|$)/, "/cloud");
-    }
+    if (canonicalDashboardPath) url.pathname = canonicalDashboardPath;
   } else if (classified.role === "legacy-cloud-api") {
     origin = contract.cloudApiOrigin;
   }

--- a/packages/app/test/pages-middleware-serving.test.ts
+++ b/packages/app/test/pages-middleware-serving.test.ts
@@ -202,6 +202,39 @@ describe("unified host migration", () => {
     ).toBe("https://cloud.eliza.app/cloud/agents?source=bookmark");
   });
 
+  it.each([
+    [
+      "https://elizacloud.ai/dashboard/image?source=bookmark",
+      "https://cloud.eliza.app/cloud/api-explorer?source=bookmark",
+    ],
+    [
+      "https://app.elizacloud.ai/dashboard/build/new?template=starter",
+      "https://cloud.eliza.app/cloud/my-agents?template=starter",
+    ],
+    [
+      "https://staging.eliza.app/dashboard/containers/agents/agent-7",
+      "https://cloud-staging.eliza.app/cloud/agents/agent-7",
+    ],
+    [
+      "https://app-staging.elizacloud.ai/dashboard/agents/agent-8/chat?room=1",
+      "https://cloud-staging.eliza.app/cloud/agents/agent-8?room=1",
+    ],
+    [
+      "https://eliza.app/dashboard/settings?tab=billing&payment=success",
+      "https://cloud.eliza.app/cloud/billing?tab=billing&payment=success",
+    ],
+    [
+      "https://cloud.eliza.app/dashboard/voices?source=bookmark",
+      "https://cloud.eliza.app/cloud/api-explorer?source=bookmark",
+    ],
+    [
+      "https://elizacloud.ai/dashboard/api-keys?source=legacy",
+      "https://cloud.eliza.app/cloud/api-keys?source=legacy",
+    ],
+  ])("semantically migrates live-shaped dashboard URL %s", (legacy, target) => {
+    expect(resolveCanonicalPageRedirect(legacy)).toBe(target);
+  });
+
   it("moves protocol paths on legacy hosts to the canonical API", () => {
     expect(
       resolveCanonicalPageRedirect("https://elizacloud.ai/api/v1/models"),

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -9,6 +9,7 @@ import cloudApiWorker, {
   isCanonicalInferencePath,
   isThinInferenceEnabled,
   isThinStewardPublicPath,
+  isUnsupportedLegacyWildcardHostname,
   redirectFrontendHost,
   SharedRuntimeConversation,
 } from "./index";
@@ -341,6 +342,26 @@ describe("cloud-api worker entrypoint", () => {
         "https://cloud.eliza.app/cloud/billing?from=legacy",
       ],
       [
+        "https://app.elizacloud.ai/dashboard/image?from=legacy",
+        "https://cloud.eliza.app/cloud/api-explorer?from=legacy",
+      ],
+      [
+        "https://elizacloud.ai/dashboard/build/new?template=starter",
+        "https://cloud.eliza.app/cloud/my-agents?template=starter",
+      ],
+      [
+        "https://app.elizacloud.ai/dashboard/containers/agents/agent-7",
+        "https://cloud.eliza.app/cloud/agents/agent-7",
+      ],
+      [
+        "https://app-staging.elizacloud.ai/dashboard/agents/agent-8/chat?room=1",
+        "https://cloud-staging.eliza.app/cloud/agents/agent-8?room=1",
+      ],
+      [
+        "https://elizacloud.ai/dashboard/settings?tab=billing&payment=success",
+        "https://cloud.eliza.app/cloud/billing?tab=billing&payment=success",
+      ],
+      [
         "https://api.elizacloud.ai/api/health?probe=1",
         "https://api.eliza.app/api/health?probe=1",
       ],
@@ -410,6 +431,10 @@ describe("cloud-api worker entrypoint", () => {
         "https://blob.elizacloud.ai/object.bin",
         "https://blob.eliza.app/object.bin",
       ],
+      [
+        "https://blob.elizacloud.ai/dashboard/image",
+        "https://blob.eliza.app/dashboard/image",
+      ],
       ["https://x402.elizacloud.ai/pay", "https://x402.eliza.app/pay"],
       [
         "https://relay.elizacloud.ai/v1/agent-tunnel",
@@ -438,6 +463,49 @@ describe("cloud-api worker entrypoint", () => {
       });
       expect(serviceResponse?.status).toBe(308);
       expect(serviceResponse?.headers.get("location")).toBe(canonicalUrl);
+    }
+  });
+
+  test("identifies only unhandled legacy wildcard hosts", () => {
+    expect(isUnsupportedLegacyWildcardHostname("unknown.elizacloud.ai")).toBe(
+      true,
+    );
+    expect(isUnsupportedLegacyWildcardHostname("app-dev.elizacloud.ai")).toBe(
+      true,
+    );
+    expect(
+      isUnsupportedLegacyWildcardHostname("nested.unknown.elizacloud.ai"),
+    ).toBe(true);
+    expect(
+      isUnsupportedLegacyWildcardHostname(
+        "e06bb509-6c52-4c33-a9f7-66addc43e8c8.elizacloud.ai",
+      ),
+    ).toBe(false);
+    expect(isUnsupportedLegacyWildcardHostname("blob.elizacloud.ai")).toBe(
+      false,
+    );
+    expect(isUnsupportedLegacyWildcardHostname("app.elizacloud.ai")).toBe(
+      false,
+    );
+    expect(isUnsupportedLegacyWildcardHostname("unknown.example.com")).toBe(
+      false,
+    );
+  });
+
+  test("fails unknown legacy wildcard requests closed before API dispatch", async () => {
+    for (const hostname of [
+      "unknown.elizacloud.ai",
+      "app-dev.elizacloud.ai",
+      "nested.unknown.elizacloud.ai",
+    ]) {
+      const response = await cloudApiWorker.fetch(
+        new Request(`https://${hostname}/api/health`),
+        {} as never,
+        {} as never,
+      );
+      expect(response.status).toBe(404);
+      expect(response.headers.get("cache-control")).toBe("no-store, max-age=0");
+      expect(await response.text()).toBe('{"error":"not_found"}');
     }
   });
 

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -13,6 +13,7 @@
 import "./worker-polyfills";
 
 import {
+  canonicalCloudPathForLegacyDashboard,
   canonicalElizaServiceHostname,
   classifyElizaHostname,
   ELIZA_DOMAIN_CONTRACTS,
@@ -387,6 +388,10 @@ export function redirectFrontendHost(
     );
   }
   const classified = classifyElizaHostname(hostname);
+  const canonicalDashboardPath = canonicalCloudPathForLegacyDashboard(
+    url.pathname,
+    url.search,
+  );
   let canonicalHostname: string | null = null;
   if (hostname === "www.eliza.app") {
     canonicalHostname = new URL(
@@ -397,12 +402,9 @@ export function redirectFrontendHost(
       ELIZA_DOMAIN_CONTRACTS[classified.environment ?? "production"];
     if (isFrontendAliasBackendPath(url)) {
       canonicalHostname = new URL(contract.cloudApiOrigin).hostname;
-    } else if (
-      url.pathname === "/dashboard" ||
-      url.pathname.startsWith("/dashboard/")
-    ) {
+    } else if (canonicalDashboardPath) {
       canonicalHostname = new URL(contract.cloudAppOrigin).hostname;
-      url.pathname = url.pathname.replace(/^\/dashboard(?=\/|$)/, "/cloud");
+      url.pathname = canonicalDashboardPath;
     } else {
       canonicalHostname = classified.canonicalHostname;
     }
@@ -429,17 +431,53 @@ export function redirectFrontendHost(
   if (!canonicalHostname || canonicalHostname === hostname) return null;
 
   if (
+    canonicalDashboardPath &&
     (classified.role === "legacy-marketing" ||
-      classified.role === "legacy-cloud-app" ||
-      classified.role === "legacy-dedicated-agent") &&
-    (url.pathname === "/dashboard" || url.pathname.startsWith("/dashboard/"))
+      classified.role === "legacy-cloud-app")
   ) {
-    url.pathname = url.pathname.replace(/^\/dashboard(?=\/|$)/, "/cloud");
+    url.pathname = canonicalDashboardPath;
   }
 
   const targetUrl = new URL(url);
   targetUrl.hostname = canonicalHostname;
   return Response.redirect(targetUrl.toString(), 308);
+}
+
+/** Identify legacy wildcard hosts with no explicit redirect or UUID agent. */
+export function isUnsupportedLegacyWildcardHostname(
+  rawHostname: string,
+): boolean {
+  const hostname = normalizeHostname(rawHostname);
+  if (!hostname?.endsWith(".elizacloud.ai")) return false;
+  if (hostname === "docs.elizacloud.ai" || hostname === "os.elizacloud.ai") {
+    return false;
+  }
+  if (canonicalElizaServiceHostname(hostname)) return false;
+
+  const classified = classifyElizaHostname(hostname);
+  if (
+    classified.role === "legacy-marketing" ||
+    classified.role === "legacy-cloud-app" ||
+    classified.role === "legacy-cloud-api"
+  ) {
+    return false;
+  }
+  return !(
+    classified.role === "legacy-dedicated-agent" &&
+    classified.agentId &&
+    AGENT_ID_RE.test(classified.agentId)
+  );
+}
+
+function rejectUnsupportedLegacyWildcardHost(url: URL): Response | null {
+  if (!isUnsupportedLegacyWildcardHostname(url.hostname)) return null;
+  return Response.json(
+    { error: "not_found" },
+    {
+      status: 404,
+      headers: { "Cache-Control": "no-store, max-age=0" },
+    },
+  );
 }
 
 const FRONTEND_ALIAS_PROXY_HEADER_DENYLIST = new Set([
@@ -630,6 +668,8 @@ export default {
     if (frontendAliasResponse) return frontendAliasResponse;
     const frontendRedirect = redirectFrontendHost(url, env);
     if (frontendRedirect) return frontendRedirect;
+    const unsupportedLegacyHost = rejectUnsupportedLegacyWildcardHost(url);
+    if (unsupportedLegacyHost) return unsupportedLegacyHost;
     const blobResponse = await serveBlobHostRequest(request, url, env);
     if (blobResponse) return blobResponse;
     const registryResponse = await serveRegistryHostRequest(request, url, env);

--- a/packages/cloud/services/gateway-webhook/AGENTS.md
+++ b/packages/cloud/services/gateway-webhook/AGENTS.md
@@ -100,8 +100,8 @@ Redis (at least one of these must resolve, or `createRedis()` throws):
 - `MOCK_REDIS=1` — in-memory mock (tests / local).
 
 Canonical transport fallback (both values are required together; when either
-is absent or invalid the gateway fails closed and does not contact a legacy
-agent hostname):
+is absent or invalid the process rejects startup before binding `/health` or
+`/ready` and does not contact a legacy agent hostname):
 
 - `AGENT_ROUTER_ORIGIN_HOST` — canonical dedicated-agent router origin used
   after a direct transport failure. Production is

--- a/packages/cloud/services/gateway-webhook/AGENTS.md
+++ b/packages/cloud/services/gateway-webhook/AGENTS.md
@@ -99,19 +99,26 @@ Redis (at least one of these must resolve, or `createRedis()` throws):
 - `REDIS_URL` — native Redis (ioredis).
 - `MOCK_REDIS=1` — in-memory mock (tests / local).
 
+Canonical transport fallback (both values are required together; when either
+is absent or invalid the gateway fails closed and does not contact a legacy
+agent hostname):
+
+- `AGENT_ROUTER_ORIGIN_HOST` — canonical dedicated-agent router origin used
+  after a direct transport failure. Production is
+  `eliza-production-1.eliza.app`; staging is `eliza-staging-1.eliza.app`.
+  The gateway sends the validated
+  `<agent-id>.<ELIZA_CLOUD_AGENT_BASE_DOMAIN>` value as `X-Forwarded-Host`.
+  Validation applies to the complete generated hostname, including the
+  253-character total and 63-character per-label DNS limits.
+- `ELIZA_CLOUD_AGENT_BASE_DOMAIN` — canonical dedicated-agent hostname suffix:
+  `cloud.eliza.app` in production or `cloud-staging.eliza.app` in staging.
+
 Other:
 
 - `GATEWAY_INTERNAL_SECRET` — required to accept `POST /internal/event`; when
   unset, every internal-event request is rejected (logged as a warning at boot).
 - `AGENT_SERVER_SHARED_SECRET` — sent as `X-Server-Token` on forwards to
   agent-server pods.
-- `AGENT_ROUTER_ORIGIN_HOST` — canonical dedicated-agent router origin used
-  after a direct transport failure. The gateway sends the validated
-  `<agent-id>.<ELIZA_CLOUD_AGENT_BASE_DOMAIN>` value as `X-Forwarded-Host`.
-  Validation applies to the complete generated hostname, including the
-  253-character total and 63-character per-label DNS limits.
-- `ELIZA_CLOUD_AGENT_BASE_DOMAIN` — dedicated-agent hostname suffix used with
-  the router origin (default `cloud.eliza.app`).
 - `PORT` (default 3000; `dev`/`start` scripts set 3002), `POD_NAME` /
   `HOSTNAME`.
 - `KEDA_COOLDOWN_SECONDS` (default 900) — TTL on the KEDA activity key.

--- a/packages/cloud/services/gateway-webhook/CLAUDE.md
+++ b/packages/cloud/services/gateway-webhook/CLAUDE.md
@@ -100,8 +100,8 @@ Redis (at least one of these must resolve, or `createRedis()` throws):
 - `MOCK_REDIS=1` — in-memory mock (tests / local).
 
 Canonical transport fallback (both values are required together; when either
-is absent or invalid the gateway fails closed and does not contact a legacy
-agent hostname):
+is absent or invalid the process rejects startup before binding `/health` or
+`/ready` and does not contact a legacy agent hostname):
 
 - `AGENT_ROUTER_ORIGIN_HOST` — canonical dedicated-agent router origin used
   after a direct transport failure. Production is

--- a/packages/cloud/services/gateway-webhook/CLAUDE.md
+++ b/packages/cloud/services/gateway-webhook/CLAUDE.md
@@ -99,19 +99,26 @@ Redis (at least one of these must resolve, or `createRedis()` throws):
 - `REDIS_URL` — native Redis (ioredis).
 - `MOCK_REDIS=1` — in-memory mock (tests / local).
 
+Canonical transport fallback (both values are required together; when either
+is absent or invalid the gateway fails closed and does not contact a legacy
+agent hostname):
+
+- `AGENT_ROUTER_ORIGIN_HOST` — canonical dedicated-agent router origin used
+  after a direct transport failure. Production is
+  `eliza-production-1.eliza.app`; staging is `eliza-staging-1.eliza.app`.
+  The gateway sends the validated
+  `<agent-id>.<ELIZA_CLOUD_AGENT_BASE_DOMAIN>` value as `X-Forwarded-Host`.
+  Validation applies to the complete generated hostname, including the
+  253-character total and 63-character per-label DNS limits.
+- `ELIZA_CLOUD_AGENT_BASE_DOMAIN` — canonical dedicated-agent hostname suffix:
+  `cloud.eliza.app` in production or `cloud-staging.eliza.app` in staging.
+
 Other:
 
 - `GATEWAY_INTERNAL_SECRET` — required to accept `POST /internal/event`; when
   unset, every internal-event request is rejected (logged as a warning at boot).
 - `AGENT_SERVER_SHARED_SECRET` — sent as `X-Server-Token` on forwards to
   agent-server pods.
-- `AGENT_ROUTER_ORIGIN_HOST` — canonical dedicated-agent router origin used
-  after a direct transport failure. The gateway sends the validated
-  `<agent-id>.<ELIZA_CLOUD_AGENT_BASE_DOMAIN>` value as `X-Forwarded-Host`.
-  Validation applies to the complete generated hostname, including the
-  253-character total and 63-character per-label DNS limits.
-- `ELIZA_CLOUD_AGENT_BASE_DOMAIN` — dedicated-agent hostname suffix used with
-  the router origin (default `cloud.eliza.app`).
 - `PORT` (default 3000; `dev`/`start` scripts set 3002), `POD_NAME` /
   `HOSTNAME`.
 - `KEDA_COOLDOWN_SECONDS` (default 900) — TTL on the KEDA activity key.

--- a/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
@@ -10,29 +10,23 @@ const AGENT_ID = "4602b3be-2c01-4e7e-9cdc-849604e1bef7";
 const RUNTIME_AGENT_ID = "b850bc30-45f8-0041-a00a-83df46d8555d";
 const originalFetch = globalThis.fetch;
 
-function domainWithLength(length: number): string {
-  const labels: string[] = [];
-  let remaining = length;
-  while (remaining > 0) {
-    const labelLength = Math.min(63, remaining);
-    labels.push("a".repeat(labelLength));
-    remaining -= labelLength;
-    if (remaining > 0) remaining -= 1;
-  }
-  return labels.join(".");
-}
-
 afterEach(() => {
   globalThis.fetch = originalFetch;
 });
 
 describe("canonical agent forwarding fallback", () => {
-  test("derives a fixed-domain fallback only for UUID agent ids", () => {
-    expect(getCanonicalAgentFallbackBase(AGENT_ID)).toBe(
-      `https://${AGENT_ID}.elizacloud.ai/api`,
+  test("derives a configured canonical fallback only for UUID agent ids", () => {
+    const env = {
+      AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.eliza.app",
+      ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
+    };
+    expect(getCanonicalAgentFallbackBase(AGENT_ID, env)).toBe(
+      "https://eliza-production-1.eliza.app/api",
     );
-    expect(getCanonicalAgentFallbackBase("../../attacker.example")).toBeNull();
-    expect(getCanonicalAgentFallbackBase("not-an-agent-id")).toBeNull();
+    expect(
+      getCanonicalAgentFallbackBase("../../attacker.example", env),
+    ).toBeNull();
+    expect(getCanonicalAgentFallbackBase("not-an-agent-id", env)).toBeNull();
   });
 
   test("routes through the configured canonical origin with a validated forwarded host", () => {
@@ -53,35 +47,26 @@ describe("canonical agent forwarding fallback", () => {
     ).toBeNull();
   });
 
-  test("validates the complete forwarded hostname at the DNS length boundary", () => {
-    const maxBaseDomain = domainWithLength(216);
-    const overlongBaseDomain = domainWithLength(217);
-
+  test("accepts only the exact environment-specific canonical routing pairs", () => {
     expect(
       getCanonicalAgentFallbackTarget(AGENT_ID, {
-        AGENT_ROUTER_ORIGIN_HOST: "router.eliza.app",
-        ELIZA_CLOUD_AGENT_BASE_DOMAIN: maxBaseDomain,
-      })?.forwardedHost,
-    ).toHaveLength(253);
+        AGENT_ROUTER_ORIGIN_HOST: " ELIZA-STAGING-1.ELIZA.APP ",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: " CLOUD-STAGING.ELIZA.APP ",
+      }),
+    ).toEqual({
+      baseUrl: "https://eliza-staging-1.eliza.app/api",
+      forwardedHost: `${AGENT_ID}.cloud-staging.eliza.app`,
+    });
     expect(
       getCanonicalAgentFallbackTarget(AGENT_ID, {
-        AGENT_ROUTER_ORIGIN_HOST: "router.eliza.app",
-        ELIZA_CLOUD_AGENT_BASE_DOMAIN: overlongBaseDomain,
+        AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.eliza.app",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud-staging.eliza.app",
       }),
     ).toBeNull();
-  });
-
-  test("accepts a 63-character base-domain label and rejects 64", () => {
     expect(
       getCanonicalAgentFallbackTarget(AGENT_ID, {
-        AGENT_ROUTER_ORIGIN_HOST: "router.eliza.app",
-        ELIZA_CLOUD_AGENT_BASE_DOMAIN: `${"a".repeat(63)}.app`,
-      }),
-    ).not.toBeNull();
-    expect(
-      getCanonicalAgentFallbackTarget(AGENT_ID, {
-        AGENT_ROUTER_ORIGIN_HOST: "router.eliza.app",
-        ELIZA_CLOUD_AGENT_BASE_DOMAIN: `${"a".repeat(64)}.app`,
+        AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.elizacloud.ai",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
       }),
     ).toBeNull();
   });
@@ -143,37 +128,26 @@ describe("canonical agent forwarding fallback", () => {
     ]);
   });
 
-  test("uses the canonical agent route after a primary transport failure", async () => {
-    const requests: string[] = [];
-    globalThis.fetch = mock(async (input: string | URL | Request) => {
-      const url = input instanceof Request ? input.url : String(input);
-      requests.push(url);
-      if (url.startsWith("http://stale-sandbox.example")) {
-        throw new TypeError("connection timed out");
-      }
-      return new Response(JSON.stringify({ response: "agent is live" }), {
-        status: 200,
-      });
-    }) as typeof fetch;
-
-    await expect(
-      forwardToServer(
-        "http://stale-sandbox.example/api",
-        "sandbox-stale",
-        AGENT_ID,
-        "user-1",
-        "hello",
-      ),
-    ).resolves.toBe("agent is live");
-
-    expect(requests).toEqual([
-      `http://stale-sandbox.example/api/agents/${AGENT_ID}/message`,
-      `https://${AGENT_ID}.elizacloud.ai/api/agents/${AGENT_ID}/message`,
-    ]);
+  test("fails closed when either canonical routing variable is absent", () => {
+    expect(getCanonicalAgentFallbackTarget(AGENT_ID, {})).toBeNull();
+    expect(
+      getCanonicalAgentFallbackTarget(AGENT_ID, {
+        AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.eliza.app",
+      }),
+    ).toBeNull();
+    expect(
+      getCanonicalAgentFallbackTarget(AGENT_ID, {
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
+      }),
+    ).toBeNull();
   });
 
   test("discovers the sole running dedicated runtime when its id differs", async () => {
     const requests: string[] = [];
+    const previousOrigin = process.env.AGENT_ROUTER_ORIGIN_HOST;
+    const previousDomain = process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN;
+    process.env.AGENT_ROUTER_ORIGIN_HOST = "eliza-production-1.eliza.app";
+    process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN = "cloud.eliza.app";
     globalThis.fetch = mock(async (input: string | URL | Request) => {
       const url = input instanceof Request ? input.url : String(input);
       requests.push(url);
@@ -200,21 +174,34 @@ describe("canonical agent forwarding fallback", () => {
       });
     }) as typeof fetch;
 
-    await expect(
-      forwardToServer(
-        "http://stale-sandbox.example/api",
-        "sandbox-stale",
-        AGENT_ID,
-        "user-1",
-        "hello",
-      ),
-    ).resolves.toBe("runtime is live");
+    try {
+      await expect(
+        forwardToServer(
+          "http://stale-sandbox.example/api",
+          "sandbox-stale",
+          AGENT_ID,
+          "user-1",
+          "hello",
+        ),
+      ).resolves.toBe("runtime is live");
+    } finally {
+      if (previousOrigin === undefined) {
+        delete process.env.AGENT_ROUTER_ORIGIN_HOST;
+      } else {
+        process.env.AGENT_ROUTER_ORIGIN_HOST = previousOrigin;
+      }
+      if (previousDomain === undefined) {
+        delete process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN;
+      } else {
+        process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN = previousDomain;
+      }
+    }
 
     expect(requests).toEqual([
       `http://stale-sandbox.example/api/agents/${AGENT_ID}/message`,
-      `https://${AGENT_ID}.elizacloud.ai/api/agents/${AGENT_ID}/message`,
-      `https://${AGENT_ID}.elizacloud.ai/api/agents`,
-      `https://${AGENT_ID}.elizacloud.ai/api/agents/${RUNTIME_AGENT_ID}/message`,
+      `https://eliza-production-1.eliza.app/api/agents/${AGENT_ID}/message`,
+      "https://eliza-production-1.eliza.app/api/agents",
+      `https://eliza-production-1.eliza.app/api/agents/${RUNTIME_AGENT_ID}/message`,
     ]);
   });
 });

--- a/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
@@ -4,6 +4,7 @@ import {
   forwardToServer,
   getCanonicalAgentFallbackBase,
   getCanonicalAgentFallbackTarget,
+  requireCanonicalAgentRoutingConfiguration,
 } from "../src/server-router";
 
 const AGENT_ID = "4602b3be-2c01-4e7e-9cdc-849604e1bef7";
@@ -140,6 +141,36 @@ describe("canonical agent forwarding fallback", () => {
         ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
       }),
     ).toBeNull();
+  });
+
+  test("rejects gateway startup unless an exact canonical pair is configured", () => {
+    expect(
+      requireCanonicalAgentRoutingConfiguration({
+        AGENT_ROUTER_ORIGIN_HOST: " ELIZA-STAGING-1.ELIZA.APP ",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: " CLOUD-STAGING.ELIZA.APP ",
+      }),
+    ).toEqual({
+      routerOriginHost: "eliza-staging-1.eliza.app",
+      agentBaseDomain: "cloud-staging.eliza.app",
+    });
+
+    for (const env of [
+      {},
+      { AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.eliza.app" },
+      { ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app" },
+      {
+        AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.eliza.app",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud-staging.eliza.app",
+      },
+      {
+        AGENT_ROUTER_ORIGIN_HOST: "https://eliza-production-1.eliza.app",
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
+      },
+    ]) {
+      expect(() => requireCanonicalAgentRoutingConfiguration(env)).toThrow(
+        "must be configured as an exact canonical production or staging pair",
+      );
+    }
   });
 
   test("discovers the sole running dedicated runtime when its id differs", async () => {

--- a/packages/cloud/services/gateway-webhook/__tests__/startup-routing-config.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/startup-routing-config.test.ts
@@ -1,0 +1,37 @@
+/** Verifies the real gateway process rejects unsafe routing configuration before binding its health server. */
+import { describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = fileURLToPath(new URL("../", import.meta.url));
+
+describe("gateway startup routing configuration", () => {
+  test("exits before serving when the canonical routing pair is absent", async () => {
+    const env = {
+      ...process.env,
+      ELIZA_CLOUD_URL: "https://api.example.invalid",
+      GATEWAY_BOOTSTRAP_SECRET: "startup-test-secret",
+      MOCK_REDIS: "1",
+    };
+    delete env.AGENT_ROUTER_ORIGIN_HOST;
+    delete env.ELIZA_CLOUD_AGENT_BASE_DOMAIN;
+
+    const child = Bun.spawn([process.execPath, "run", "src/index.ts"], {
+      cwd: packageRoot,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    const output = `${stdout}\n${stderr}`;
+
+    expect(exitCode).toBe(1);
+    expect(output).toContain(
+      "must be configured as an exact canonical production or staging pair",
+    );
+    expect(output).not.toContain("Webhook gateway listening");
+  });
+});

--- a/packages/cloud/services/gateway-webhook/railway.toml
+++ b/packages/cloud/services/gateway-webhook/railway.toml
@@ -4,10 +4,14 @@
 # Hono HTTP handler on port 3000 (PORT env overrides).
 #
 # Required env vars / secrets:
+#   ELIZA_CLOUD_URL            Canonical cloud API origin.
+#   GATEWAY_BOOTSTRAP_SECRET   Secret used to acquire the gateway service JWT.
 #   GATEWAY_INTERNAL_SECRET     Shared secret for internal routes from cloud-api.
 #   AGENT_SERVER_SHARED_SECRET  Shared secret for forwards to agent-server.
 #   REDIS_URL                   Upstash Redis REST URL (or KV_REST_API_URL).
 #   KV_REST_API_TOKEN           Upstash Redis REST token.
+#   AGENT_ROUTER_ORIGIN_HOST    Canonical control-plane router origin hostname.
+#   ELIZA_CLOUD_AGENT_BASE_DOMAIN  Canonical dedicated-agent hostname suffix.
 #
 # Optional:
 #   TWILIO_PUBLIC_URL                  Public URL Twilio status callbacks point at.

--- a/packages/cloud/services/gateway-webhook/src/index.ts
+++ b/packages/cloud/services/gateway-webhook/src/index.ts
@@ -11,6 +11,7 @@ import { handleInternalEvent } from "./internal-event-handler";
 import { logger } from "./logger";
 import { initProjectConfig, shutdownProjectConfig } from "./project-config";
 import { createRedis } from "./redis";
+import { requireCanonicalAgentRoutingConfiguration } from "./server-router";
 import {
   getSharedWhatsAppVerifyToken,
   resolveWebhookConfig,
@@ -161,6 +162,7 @@ app.post("/webhook/:project/:platform/:agentId", async (c) => {
 });
 
 async function start() {
+  requireCanonicalAgentRoutingConfiguration();
   logger.info("Starting webhook gateway", { pod: POD_NAME, port: PORT });
 
   await initProjectConfig();

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -29,6 +29,11 @@ interface CanonicalAgentFallbackTarget {
 
 type CanonicalAgentFallbackEnv = Record<string, string | undefined>;
 
+export interface CanonicalAgentRoutingConfiguration {
+  agentBaseDomain: string;
+  routerOriginHost: string;
+}
+
 interface ServerRoute {
   serverName: string;
   serverUrl: string;
@@ -48,6 +53,38 @@ export interface ResolvedIdentity {
   agentId: string | null;
 }
 
+/** Resolves one of the two supported production/staging routing pairs. */
+export function getCanonicalAgentRoutingConfiguration(
+  env: CanonicalAgentFallbackEnv = process.env,
+): CanonicalAgentRoutingConfiguration | null {
+  const routerOriginHost = env.AGENT_ROUTER_ORIGIN_HOST?.trim().toLowerCase();
+  const agentBaseDomain =
+    env.ELIZA_CLOUD_AGENT_BASE_DOMAIN?.trim().toLowerCase();
+  if (!routerOriginHost || !agentBaseDomain) return null;
+  if (
+    !DNS_HOSTNAME_PATTERN.test(routerOriginHost) ||
+    !DNS_HOSTNAME_PATTERN.test(agentBaseDomain) ||
+    CANONICAL_ROUTER_ORIGIN_BY_AGENT_DOMAIN[agentBaseDomain] !==
+      routerOriginHost
+  ) {
+    return null;
+  }
+  return { agentBaseDomain, routerOriginHost };
+}
+
+/** Rejects startup before health endpoints bind when routing is unsafe. */
+export function requireCanonicalAgentRoutingConfiguration(
+  env: CanonicalAgentFallbackEnv = process.env,
+): CanonicalAgentRoutingConfiguration {
+  const configuration = getCanonicalAgentRoutingConfiguration(env);
+  if (!configuration) {
+    throw new Error(
+      "AGENT_ROUTER_ORIGIN_HOST and ELIZA_CLOUD_AGENT_BASE_DOMAIN must be configured as an exact canonical production or staging pair",
+    );
+  }
+  return configuration;
+}
+
 /** Resolves a validated public or router-origin fallback for a cloud agent. */
 export function getCanonicalAgentFallbackTarget(
   agentId: string,
@@ -55,26 +92,14 @@ export function getCanonicalAgentFallbackTarget(
 ): CanonicalAgentFallbackTarget | null {
   if (!AGENT_ID_PATTERN.test(agentId)) return null;
   const normalizedAgentId = agentId.toLowerCase();
-  const routerOriginHost = env.AGENT_ROUTER_ORIGIN_HOST?.trim();
-  const agentBaseDomain = env.ELIZA_CLOUD_AGENT_BASE_DOMAIN?.trim();
-  if (!routerOriginHost || !agentBaseDomain) return null;
-  const normalizedRouterOriginHost = routerOriginHost.toLowerCase();
-  const normalizedAgentBaseDomain = agentBaseDomain.toLowerCase();
-  if (
-    CANONICAL_ROUTER_ORIGIN_BY_AGENT_DOMAIN[normalizedAgentBaseDomain] !==
-    normalizedRouterOriginHost
-  ) {
-    return null;
-  }
-  const forwardedHost = `${normalizedAgentId}.${normalizedAgentBaseDomain}`;
-  if (
-    !DNS_HOSTNAME_PATTERN.test(normalizedRouterOriginHost) ||
-    !DNS_HOSTNAME_PATTERN.test(forwardedHost)
-  ) {
+  const configuration = getCanonicalAgentRoutingConfiguration(env);
+  if (!configuration) return null;
+  const forwardedHost = `${normalizedAgentId}.${configuration.agentBaseDomain}`;
+  if (!DNS_HOSTNAME_PATTERN.test(forwardedHost)) {
     return null;
   }
   return {
-    baseUrl: `https://${normalizedRouterOriginHost}/api`,
+    baseUrl: `https://${configuration.routerOriginHost}/api`,
     forwardedHost,
   };
 }

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -15,6 +15,12 @@ const AGENT_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const DNS_HOSTNAME_PATTERN =
   /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
+const CANONICAL_ROUTER_ORIGIN_BY_AGENT_DOMAIN: Readonly<
+  Record<string, string>
+> = Object.freeze({
+  "cloud.eliza.app": "eliza-production-1.eliza.app",
+  "cloud-staging.eliza.app": "eliza-staging-1.eliza.app",
+});
 
 interface CanonicalAgentFallbackTarget {
   baseUrl: string;
@@ -50,29 +56,35 @@ export function getCanonicalAgentFallbackTarget(
   if (!AGENT_ID_PATTERN.test(agentId)) return null;
   const normalizedAgentId = agentId.toLowerCase();
   const routerOriginHost = env.AGENT_ROUTER_ORIGIN_HOST?.trim();
-  if (!routerOriginHost) {
-    return {
-      baseUrl: `https://${normalizedAgentId}.elizacloud.ai/api`,
-    };
-  }
-  const agentBaseDomain =
-    env.ELIZA_CLOUD_AGENT_BASE_DOMAIN?.trim() || "cloud.eliza.app";
-  const forwardedHost = `${normalizedAgentId}.${agentBaseDomain.toLowerCase()}`;
+  const agentBaseDomain = env.ELIZA_CLOUD_AGENT_BASE_DOMAIN?.trim();
+  if (!routerOriginHost || !agentBaseDomain) return null;
+  const normalizedRouterOriginHost = routerOriginHost.toLowerCase();
+  const normalizedAgentBaseDomain = agentBaseDomain.toLowerCase();
   if (
-    !DNS_HOSTNAME_PATTERN.test(routerOriginHost) ||
+    CANONICAL_ROUTER_ORIGIN_BY_AGENT_DOMAIN[normalizedAgentBaseDomain] !==
+    normalizedRouterOriginHost
+  ) {
+    return null;
+  }
+  const forwardedHost = `${normalizedAgentId}.${normalizedAgentBaseDomain}`;
+  if (
+    !DNS_HOSTNAME_PATTERN.test(normalizedRouterOriginHost) ||
     !DNS_HOSTNAME_PATTERN.test(forwardedHost)
   ) {
     return null;
   }
   return {
-    baseUrl: `https://${routerOriginHost}/api`,
+    baseUrl: `https://${normalizedRouterOriginHost}/api`,
     forwardedHost,
   };
 }
 
 /** Returns the selected fallback base URL for compatibility callers. */
-export function getCanonicalAgentFallbackBase(agentId: string): string | null {
-  return getCanonicalAgentFallbackTarget(agentId)?.baseUrl ?? null;
+export function getCanonicalAgentFallbackBase(
+  agentId: string,
+  env: CanonicalAgentFallbackEnv = process.env,
+): string | null {
+  return getCanonicalAgentFallbackTarget(agentId, env)?.baseUrl ?? null;
 }
 
 export async function resolveIdentity(

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -432,4 +432,31 @@ describe("canonical cloud deployment environment contract", () => {
       "pages project create eliza-app --production-branch=main 2>/dev/null || true",
     );
   });
+
+  test("scopes post-deploy routing verification to the deployed environment", () => {
+    const resolve = step(
+      cloud,
+      "verify-routing",
+      "Resolve deployed environment",
+    );
+    expect(resolve.env?.TARGET_ENVIRONMENT).toContain(
+      "inputs.target_environment",
+    );
+    expect(resolve.run).toContain("set -euo pipefail");
+    expect(resolve.run).toContain("staging|production");
+    expect(resolve.run).toContain(
+      'echo "environment=$TARGET_ENVIRONMENT" >> "$GITHUB_OUTPUT"',
+    );
+    expect(resolve.run).not.toContain('echo "environment=$env"');
+
+    const verify = step(
+      cloud,
+      "verify-routing",
+      "Verify the just-deployed environment serves itself",
+    );
+    expect(verify.run).toContain(
+      '--environment "${' + '{ steps.env.outputs.environment }}"',
+    );
+    expect(verify.run).toContain("--require-beacon");
+  });
 });

--- a/packages/shared/src/elizacloud/domain-contract.test.ts
+++ b/packages/shared/src/elizacloud/domain-contract.test.ts
@@ -1,12 +1,13 @@
 /**
- * Canonical and legacy Eliza hostname classification is exercised as a pure
- * compatibility matrix so redirects, API routing, and managed-runtime gates
- * cannot silently disagree during the domain migration.
+ * Canonical and legacy Eliza hostname and retired-dashboard route contracts
+ * are exercised as a pure compatibility matrix so redirects, API routing, and
+ * managed-runtime gates cannot silently disagree during the domain migration.
  */
 
 import { describe, expect, it } from "vitest";
 import {
   buildElizaDedicatedAgentOrigin,
+  canonicalCloudPathForLegacyDashboard,
   canonicalElizaServiceHostname,
   classifyElizaHostname,
   ELIZA_DOMAIN_CONTRACTS,
@@ -155,5 +156,33 @@ describe("Eliza domain contract", () => {
     expect(canonicalElizaServiceHostname(legacyHostname)).toBe(
       canonicalHostname,
     );
+  });
+
+  it.each([
+    ["/dashboard", "", "/cloud"],
+    ["/dashboard/build/new", "?template=starter", "/cloud/my-agents"],
+    ["/dashboard/image", "", "/cloud/api-explorer"],
+    ["/dashboard/containers", "", "/cloud/agents"],
+    ["/dashboard/containers/agents/agent-7", "", "/cloud/agents/agent-7"],
+    ["/dashboard/containers/agent-8", "", "/cloud/agents/agent-8"],
+    ["/dashboard/agents/agent-9/chat", "", "/cloud/agents/agent-9"],
+    ["/dashboard/apps/create", "", "/cloud/apps"],
+    ["/dashboard/affiliates", "", "/cloud/monetization"],
+    ["/dashboard/documents", "", "/cloud/agents"],
+    ["/dashboard/settings", "?tab=billing", "/cloud/billing"],
+    ["/dashboard/settings", "?tab=unknown", "/cloud"],
+    ["/dashboard/api-keys", "", "/cloud/api-keys"],
+  ])(
+    "maps retired dashboard path %s with search %s",
+    (pathname, search, canonicalPathname) => {
+      expect(canonicalCloudPathForLegacyDashboard(pathname, search)).toBe(
+        canonicalPathname,
+      );
+    },
+  );
+
+  it("does not rewrite non-dashboard paths", () => {
+    expect(canonicalCloudPathForLegacyDashboard("/cloud/agents")).toBeNull();
+    expect(canonicalCloudPathForLegacyDashboard("/dashboard-old")).toBeNull();
   });
 });

--- a/packages/shared/src/elizacloud/domain-contract.ts
+++ b/packages/shared/src/elizacloud/domain-contract.ts
@@ -1,8 +1,8 @@
 /**
- * Canonical hostname contract for the public Eliza site, managed Cloud app,
- * Cloud API, and dedicated managed-agent ingress. Legacy elizacloud.ai names
- * remain classified so request boundaries can redirect or proxy them without
- * treating them as canonical product origins.
+ * Canonical public-domain and retired-dashboard route contract for the Eliza
+ * site, managed Cloud app, Cloud API, and managed-agent ingress. Legacy
+ * elizacloud.ai names remain classified so request boundaries can redirect or
+ * proxy them without treating them as canonical product origins.
  */
 
 export type ElizaCloudEnvironment = "production" | "staging";
@@ -133,6 +133,28 @@ export interface ElizaHostnameClassification {
   agentId: string | null;
 }
 
+const LEGACY_DASHBOARD_STATIC_TARGETS: Readonly<Record<string, string>> =
+  Object.freeze({
+    "/dashboard": "/cloud",
+    "/dashboard/image": "/cloud/api-explorer",
+    "/dashboard/video": "/cloud/api-explorer",
+    "/dashboard/gallery": "/cloud/api-explorer",
+    "/dashboard/voices": "/cloud/api-explorer",
+    "/dashboard/containers": "/cloud/agents",
+    "/dashboard/apps/create": "/cloud/apps",
+    "/dashboard/earnings": "/cloud/monetization",
+    "/dashboard/affiliates": "/cloud/monetization",
+    "/dashboard/documents": "/cloud/agents",
+  });
+
+const LEGACY_DASHBOARD_SETTINGS_TARGETS: Readonly<Record<string, string>> =
+  Object.freeze({
+    connections: "/cloud/connectors",
+    billing: "/cloud/billing",
+    organization: "/cloud/organization",
+    agents: "/cloud/agents",
+  });
+
 function hostnameOf(origin: string): string {
   return new URL(origin).hostname;
 }
@@ -180,6 +202,52 @@ export function canonicalElizaServiceHostname(
     if (mapped) return mapped;
   }
   return null;
+}
+
+/** Map a retired dashboard pathname onto its equivalent managed Cloud route. */
+export function canonicalCloudPathForLegacyDashboard(
+  pathname: string,
+  search = "",
+): string | null {
+  if (pathname !== "/dashboard" && !pathname.startsWith("/dashboard/")) {
+    return null;
+  }
+
+  const normalizedPathname =
+    pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+  const staticTarget = LEGACY_DASHBOARD_STATIC_TARGETS[normalizedPathname];
+  if (staticTarget) return staticTarget;
+
+  if (
+    normalizedPathname === "/dashboard/build" ||
+    normalizedPathname.startsWith("/dashboard/build/")
+  ) {
+    return "/cloud/my-agents";
+  }
+
+  const nestedContainerMatch = normalizedPathname.match(
+    /^\/dashboard\/containers\/agents\/([^/]+)$/,
+  );
+  if (nestedContainerMatch) {
+    return `/cloud/agents/${nestedContainerMatch[1]}`;
+  }
+
+  const containerMatch = normalizedPathname.match(
+    /^\/dashboard\/containers\/([^/]+)$/,
+  );
+  if (containerMatch) return `/cloud/agents/${containerMatch[1]}`;
+
+  const agentChatMatch = normalizedPathname.match(
+    /^\/dashboard\/agents\/([^/]+)\/chat$/,
+  );
+  if (agentChatMatch) return `/cloud/agents/${agentChatMatch[1]}`;
+
+  if (normalizedPathname === "/dashboard/settings") {
+    const tab = new URLSearchParams(search).get("tab") ?? "";
+    return LEGACY_DASHBOARD_SETTINGS_TARGETS[tab] ?? "/cloud";
+  }
+
+  return pathname.replace(/^\/dashboard(?=\/|$)/, "/cloud");
 }
 
 function dedicatedAgentId(hostname: string, suffix: string): string | null {

--- a/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
@@ -16,7 +16,6 @@ import {
   AppCatchAllRoute,
   CLOUD_MANAGEMENT_COMPAT_REDIRECTS,
   LEGACY_DASHBOARD_REDIRECTS,
-  LEGACY_SETTINGS_TAB_TARGETS,
   resolveLegacyCloudSettingsTarget,
 } from "./CloudRouterShell";
 
@@ -374,13 +373,11 @@ describe("CloudRouterShell retired dashboard redirects", () => {
       ).toBe(concreteTarget);
     }
 
-    for (const [tab, target] of Object.entries(LEGACY_SETTINGS_TAB_TARGETS)) {
+    for (const tab of ["connections", "billing", "organization", "agents"]) {
       const search = `?tab=${encodeURIComponent(tab)}&return=1`;
-      expect(
+      expect(resolveLegacyCloudSettingsTarget(search), tab).toBe(
         canonicalCloudPathForLegacyDashboard("/dashboard/settings", search),
-        tab,
-      ).toBe(target);
-      expect(resolveLegacyCloudSettingsTarget(search), tab).toBe(target);
+      );
     }
 
     const unknownSearch = "?tab=unknown&return=1";

--- a/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
@@ -1,5 +1,6 @@
-/** Verifies the CloudRouterShell catch-all host matrix — apex console redirects (with zero network), app-mode gating on the Eliza app hosts, and untouched fall-through everywhere else — through the package's configured test harness. */
+/** Verifies the CloudRouterShell host matrix and its parity with the shared edge redirect contract through the package's configured test harness. */
 // @vitest-environment jsdom
+import { canonicalCloudPathForLegacyDashboard } from "@elizaos/shared/elizacloud";
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
@@ -15,6 +16,7 @@ import {
   AppCatchAllRoute,
   CLOUD_MANAGEMENT_COMPAT_REDIRECTS,
   LEGACY_DASHBOARD_REDIRECTS,
+  LEGACY_SETTINGS_TAB_TARGETS,
   resolveLegacyCloudSettingsTarget,
 } from "./CloudRouterShell";
 
@@ -359,6 +361,37 @@ describe("CloudRouterShell app-mode catch-all (app.elizacloud.ai)", () => {
 });
 
 describe("CloudRouterShell retired dashboard redirects", () => {
+  it("keeps every shell redirect in parity with the shared edge contract", () => {
+    const routeParameter = "agent-7";
+    for (const { from, to } of LEGACY_DASHBOARD_REDIRECTS) {
+      const concreteSource = `/${from}`
+        .replace(":id", routeParameter)
+        .replace("*", "saved-path");
+      const concreteTarget = to.replace(":id", routeParameter);
+      expect(
+        canonicalCloudPathForLegacyDashboard(concreteSource),
+        concreteSource,
+      ).toBe(concreteTarget);
+    }
+
+    for (const [tab, target] of Object.entries(LEGACY_SETTINGS_TAB_TARGETS)) {
+      const search = `?tab=${encodeURIComponent(tab)}&return=1`;
+      expect(
+        canonicalCloudPathForLegacyDashboard("/dashboard/settings", search),
+        tab,
+      ).toBe(target);
+      expect(resolveLegacyCloudSettingsTarget(search), tab).toBe(target);
+    }
+
+    const unknownSearch = "?tab=unknown&return=1";
+    expect(
+      canonicalCloudPathForLegacyDashboard(
+        "/dashboard/settings",
+        unknownSearch,
+      ),
+    ).toBe(resolveLegacyCloudSettingsTarget(unknownSearch));
+  });
+
   it("lets the generic dashboard fallback own direct surface migrations", () => {
     const standalone = new Set([
       "dashboard/billing",

--- a/packages/ui/src/cloud/shell/CloudRouterShell.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.tsx
@@ -129,7 +129,7 @@ function ParamRedirect({ to }: { to: string }): React.JSX.Element {
  * Settings-tab URLs issued by older OAuth and billing flows map onto their
  * canonical managed Cloud pages. Unknown/absent tabs land on Cloud home.
  */
-export const LEGACY_SETTINGS_TAB_TARGETS: Readonly<Record<string, string>> = {
+const LEGACY_SETTINGS_TAB_TARGETS: Readonly<Record<string, string>> = {
   connections: "/cloud/connectors",
   billing: "/cloud/billing",
   organization: "/cloud/organization",

--- a/packages/ui/src/cloud/shell/CloudRouterShell.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.tsx
@@ -129,7 +129,7 @@ function ParamRedirect({ to }: { to: string }): React.JSX.Element {
  * Settings-tab URLs issued by older OAuth and billing flows map onto their
  * canonical managed Cloud pages. Unknown/absent tabs land on Cloud home.
  */
-const LEGACY_SETTINGS_TAB_TARGETS: Readonly<Record<string, string>> = {
+export const LEGACY_SETTINGS_TAB_TARGETS: Readonly<Record<string, string>> = {
   connections: "/cloud/connectors",
   billing: "/cloud/billing",
   organization: "/cloud/organization",


### PR DESCRIPTION
# Relates to

Relates to #18806 and the final `elizacloud.ai` retirement/cutover.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Full `bun install` and `bun run verify` were run after sync at the initial hardening head; exact-head incremental parity and startup gates are attached below.
- [x] A reviewer can confirm the route and workflow contracts from the focused execution log and live-shaped tests.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on exact `origin/develop` commit `1d5b66935d059e75aa78c0920b1a4a057ba3e857`; zero conflicts.
- [x] Initial-head `bun run verify` passed: 350/350 Turbo tasks plus all repository audits; exact-head focused gates are attached below.

# Risks

Medium. This changes browser redirects, rejects unsupported legacy wildcard hosts before API dispatch, and makes the webhook gateway reject startup before binding health/readiness when canonical router configuration is absent or mismatched. Known legacy service hosts and UUID agent compatibility remain intact; UUID redirect retirement stays isolated in #19240 until canonical wildcard TLS is live.

# Background

## What does this PR do?

- Centralizes the retired `/dashboard/*` semantic map so Pages and the Cloud Worker send old media, build, container, agent-chat, document, monetization, and settings links to their real managed Cloud destinations.
- Returns a no-store JSON 404 for unsupported `*.elizacloud.ai` wildcard hosts before `/api/health` or other app dispatch, while preserving exact service aliases and UUID-agent compatibility.
- Removes the gateway webhook's implicit `https://<uuid>.elizacloud.ai/api` fallback. Forwarding now requires an exact canonical production or staging router/base-domain pair.
- Fixes the Cloud post-deploy environment resolver so it writes one validated `staging` or `production` output instead of overwriting the correct value with an empty shell variable.
- Cross-checks every CloudRouterShell retired dashboard target and settings redirect against the shared edge resolver without introducing a shared-to-UI dependency.
- Rejects gateway startup before health/readiness bind unless one exact production or staging routing pair is configured.

## What kind of change is this?

Bug fix, cutover hardening, and deployment-verification correction.

# Documentation changes needed?

The gateway package's paired `CLAUDE.md`/`AGENTS.md` and Railway manifest now document the required canonical routing variables. No user documentation changes are needed.

# Testing

## Where should a reviewer start?

Start with the shared domain contract, then compare its use in the Pages middleware and Cloud Worker. Review the gateway fallback validation and the single-output workflow step last.

## Detailed testing steps

1. Run the focused edge/backend contract suites; require 120/120 passing, then run the CloudRouterShell parity suite; require 19/19 passing.
2. Verify `/dashboard/image`, build, containers, agent chat, documents, monetization, and settings links preserve relevant query strings and reach the mapped `/cloud/*` destination in production and staging shapes.
3. Verify arbitrary legacy wildcard hosts return no-store 404 before API health dispatch; known services and UUID agents remain compatible.
4. Verify the gateway accepts only `eliza-production-1.eliza.app` + `cloud.eliza.app` or `eliza-staging-1.eliza.app` + `cloud-staging.eliza.app`, and that a real child process exits before binding when either variable is absent.
5. Run gateway and Cloud API typechecks, Wrangler production dry-run, YAML parse, actionlint, Biome, guide parity, and root `bun run verify`.

# Evidence Gate

<!-- evidence-head:1fbfff122c08906598a9d95fee2793d386eaa8cf -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - redirect, proxy, and workflow behavior only; no rendered UI changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - redirect, proxy, and workflow behavior only; no rendered UI changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered interaction flow changed
<!-- evidence-row:backend-logs -->
- [x] [19268-cutover-contract-hardening-1fbfff122c0.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19268-cutover-contract-hardening-1fbfff122c0.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime state or rendering change; Pages behavior is covered by the edge execution log
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, credential, wallet, scheduled item, or generated-domain artifact is created
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changes

# Evidence Details

## Real LLM-call trajectory

N/A - no model behavior change.

## Backend + frontend logs

The attached exact-head focused log records the new parity/startup guards plus the shared Pages/workflow contracts; the unchanged Cloud Worker suite remains covered by the initial focused run:

- shared production/staging domain classification and semantic dashboard mapping;
- Cloudflare Pages middleware redirects and API service binding behavior;
- Cloud Worker exact aliases, unknown-host rejection, UUID compatibility, and environment routing;
- gateway canonical-only fallback and missing/mismatched configuration;
- protected release workflow environment scoping.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

No source/test gap. Live deployment remains intentionally outside this PR. The exact production pair was already present; the exact staging pair is now also configured and independently read back from Railway with deploys suppressed, so the next manual gateway deployment can satisfy the fail-closed startup contract.

- Exact-head incremental suites: CloudRouterShell 19/19; gateway 8/8, including a real startup process; shared/app/workflow 80/80.
- Unchanged Cloud API suite at the initial head: 32/32.
- Gateway typecheck: passed.
- Cloud API typecheck and production Wrangler dry-run: passed.
- Biome, YAML parse, actionlint, guide parity, and diff checks: passed.
- Full `bun install`: passed; generated artifacts excluded from the commit.
- Initial-head root `bun run verify`: 350/350 Turbo tasks and every repository audit passed; exact-head CI reruns repository gates.

Deployment requires these exact Railway gateway pairs before service restart:

- production: `AGENT_ROUTER_ORIGIN_HOST=eliza-production-1.eliza.app`, `ELIZA_CLOUD_AGENT_BASE_DOMAIN=cloud.eliza.app`;
- staging: `AGENT_ROUTER_ORIGIN_HOST=eliza-staging-1.eliza.app`, `ELIZA_CLOUD_AGENT_BASE_DOMAIN=cloud-staging.eliza.app`.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->



