### PR TITLE
fix(ui): finish Steward authority teardown

### DIFF
--- a/packages/shared/src/steward-session-client/index.test.ts
+++ b/packages/shared/src/steward-session-client/index.test.ts
@@ -89,6 +89,25 @@ describe("Steward session storage transitions", () => {
     );
   });
 
+  it("does not advance authority when the same token is persisted again", () => {
+    const transitions: StewardSessionChangeDetail[] = [];
+    const listener = (event: Event) => {
+      transitions.push(
+        (event as CustomEvent<StewardSessionChangeDetail>).detail,
+      );
+    };
+    window.addEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
+
+    try {
+      writeStoredStewardToken("same-token");
+      writeStoredStewardToken("same-token");
+    } finally {
+      window.removeEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
+    }
+
+    expect(transitions.map(({ state }) => state)).toEqual(["present"]);
+  });
+
   it("publishes canonical invalidation before stale refresh-key cleanup can fail", () => {
     localStorage.setItem(STEWARD_TOKEN_KEY, "steward-token");
     localStorage.setItem(STEWARD_REFRESH_TOKEN_KEY, "legacy-refresh-token");

--- a/packages/shared/src/steward-session-client/index.ts
+++ b/packages/shared/src/steward-session-client/index.ts
@@ -212,6 +212,7 @@ export function readStoredStewardToken(): string | null {
 /** Persists the canonical token and publishes exactly one authority transition. */
 export function writeStoredStewardToken(token: string): void {
   if (typeof window === "undefined") return;
+  if (window.localStorage.getItem(STEWARD_TOKEN_KEY) === token) return;
   window.localStorage.setItem(STEWARD_TOKEN_KEY, token);
   dispatchStewardSessionChange("present");
 }

--- a/packages/ui/src/cloud/lib/api-client.test.ts
+++ b/packages/ui/src/cloud/lib/api-client.test.ts
@@ -24,7 +24,11 @@ vi.mock("@capacitor/core", () => ({
   },
 }));
 
-import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import {
+  STEWARD_SESSION_CHANGE_EVENT,
+  STEWARD_TOKEN_KEY,
+  type StewardSessionChangeDetail,
+} from "@elizaos/shared/steward-session-client";
 import { setBootConfig } from "../../config/boot-config";
 import { ApiError, api, apiWithStatus } from "./api-client";
 
@@ -348,8 +352,19 @@ describe("cloud api-client transport bridge", () => {
         apiToken: CLOUD_API_KEY,
       });
       nativeOk();
+      const transitions: StewardSessionChangeDetail[] = [];
+      const listener = (event: Event) => {
+        transitions.push(
+          (event as CustomEvent<StewardSessionChangeDetail>).detail,
+        );
+      };
+      window.addEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
 
-      await api("/api/v1/apps");
+      try {
+        await api("/api/v1/apps");
+      } finally {
+        window.removeEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
+      }
 
       expect(capacitorMocks.request).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -359,6 +374,7 @@ describe("cloud api-client transport bridge", () => {
         }),
       );
       expect(window.localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+      expect(transitions.map(({ state }) => state)).toEqual(["cleared"]);
     });
 
     it("web: stays byte-identical — NO Authorization header from the REST token without a Steward JWT", async () => {

--- a/packages/ui/src/cloud/lib/api-client.ts
+++ b/packages/ui/src/cloud/lib/api-client.ts
@@ -26,7 +26,11 @@
 
 import { Capacitor, CapacitorHttp } from "@capacitor/core";
 import { getElizaApiToken } from "@elizaos/shared";
-import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import {
+  clearStoredStewardToken,
+  readStoredStewardToken,
+  STEWARD_TOKEN_KEY,
+} from "@elizaos/shared/steward-session-client";
 import {
   DEFAULT_DIRECT_CLOUD_API_BASE_URL,
   resolveDirectCloudAuthApiBase,
@@ -149,14 +153,9 @@ function readStewardToken(): string | null {
 
 function clearStoredStewardTokenIfCurrent(token: string): void {
   if (typeof window === "undefined") return;
-  try {
-    if (window.localStorage.getItem(STEWARD_TOKEN_KEY) === token) {
-      window.localStorage.removeItem(STEWARD_TOKEN_KEY);
-      window.dispatchEvent(new CustomEvent("steward-token-sync"));
-    }
-  } catch {
-    // error-policy:J6 best-effort drain of a rejected token — the fallback
-    // token path proceeds either way.
+  if (readStoredStewardToken() === token) {
+    clearStoredStewardToken();
+    window.dispatchEvent(new CustomEvent("steward-token-sync"));
   }
 }
 

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.authority.test.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.authority.test.ts
@@ -1,0 +1,38 @@
+/** Verifies a real login persistence and cookie-sync sequence publishes one authority epoch. */
+// @vitest-environment jsdom
+
+import {
+  STEWARD_SESSION_CHANGE_EVENT,
+  type StewardSessionChangeDetail,
+  writeStoredStewardToken,
+} from "@elizaos/shared/steward-session-client";
+import { afterEach, expect, it, vi } from "vitest";
+import { syncStewardSessionCookie } from "./steward-session";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+it("publishes exactly one present transition across login persistence and cookie sync", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  const transitions: StewardSessionChangeDetail[] = [];
+  const listener = (event: Event) => {
+    transitions.push((event as CustomEvent<StewardSessionChangeDetail>).detail);
+  };
+  window.addEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
+
+  try {
+    writeStoredStewardToken("login-token");
+    await syncStewardSessionCookie("login-token");
+  } finally {
+    window.removeEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
+  }
+
+  expect(transitions.map(({ state }) => state)).toEqual(["present"]);
+});

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.ts
@@ -14,8 +14,8 @@ import {
   type StewardNonceExchangeResponse,
   StewardSessionError,
   sanitizeTelegramAccountClaimContinuation,
+  writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
-import { dispatchStewardSessionChange } from "../../../events/steward-session-event";
 import {
   clearPendingOnboardingSession,
   peekPendingOnboardingSession,
@@ -97,7 +97,10 @@ export async function syncStewardSessionCookie(
   if (telegramContinuation) clearPendingOnboardingSession();
 
   if (typeof window !== "undefined") {
-    dispatchStewardSessionChange("present");
+    // The cookie boundary may be entered directly by an SDK callback or after
+    // the login page already persisted the same token. Canonical storage is
+    // idempotent, so both paths publish one authority transition in total.
+    writeStoredStewardToken(token);
     window.dispatchEvent(
       new CustomEvent("steward-token-sync", { detail: { token } }),
     );

--- a/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
@@ -8,7 +8,15 @@
  * JWT `exp` claim.
  */
 
+import {
+  STEWARD_REFRESH_TOKEN_KEY,
+  STEWARD_TOKEN_KEY,
+} from "@elizaos/shared/steward-session-client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  loadAgentProfileRegistry,
+  saveAgentProfileRegistry,
+} from "../../state/agent-profiles";
 import {
   loadPersistedActiveServer,
   savePersistedActiveServer,
@@ -156,6 +164,57 @@ describe("clearStaleStewardSession", () => {
       label: "Eliza Cloud",
       apiBase: "https://dedicated-agent.eliza.app",
     });
+  });
+
+  it("finishes credential teardown before rethrowing obsolete refresh-key cleanup failure", () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "expired-steward-token");
+    localStorage.setItem(STEWARD_REFRESH_TOKEN_KEY, "obsolete-refresh-token");
+    savePersistedActiveServer({
+      id: "cloud:dedicated-agent",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase: "https://dedicated-agent.eliza.app",
+      accessToken: "active-server-mirror",
+    });
+    saveAgentProfileRegistry({
+      version: 1,
+      activeProfileId: "profile-1",
+      profiles: [
+        {
+          id: "profile-1",
+          label: "Remote agent",
+          kind: "remote",
+          apiBase: "https://remote.example.test",
+          accessToken: "profile-mirror",
+          createdAt: "2026-08-13T00:00:00.000Z",
+        },
+      ],
+    });
+    const storageFailure = new Error("legacy refresh storage unavailable");
+    const originalRemoveItem = Storage.prototype.removeItem;
+    const removeItem = vi
+      .spyOn(Storage.prototype, "removeItem")
+      .mockImplementation(function (this: Storage, key: string) {
+        if (key === STEWARD_REFRESH_TOKEN_KEY) throw storageFailure;
+        return Reflect.apply(originalRemoveItem, this, [key]);
+      });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+
+    try {
+      expect(() => clearStaleStewardSession()).toThrow(storageFailure);
+    } finally {
+      removeItem.mockRestore();
+    }
+
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    expect(loadPersistedActiveServer()?.accessToken).toBeUndefined();
+    expect(loadAgentProfileRegistry().profiles[0]?.accessToken).toBeUndefined();
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ method: "DELETE", credentials: "include" }),
+    );
   });
 });
 

--- a/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
@@ -191,12 +191,16 @@ describe("clearStaleStewardSession", () => {
       ],
     });
     const storageFailure = new Error("legacy refresh storage unavailable");
-    const originalRemoveItem = Storage.prototype.removeItem;
+    // Spy on the localStorage instance, not Storage.prototype: the setup file
+    // may substitute an in-memory Storage (Node ≥25 ships a broken global that
+    // shadows jsdom's), and the instance spy intercepts on both paths.
+    const storage = window.localStorage;
+    const originalRemoveItem = storage.removeItem.bind(storage);
     const removeItem = vi
-      .spyOn(Storage.prototype, "removeItem")
-      .mockImplementation(function (this: Storage, key: string) {
+      .spyOn(storage, "removeItem")
+      .mockImplementation((key: string) => {
         if (key === STEWARD_REFRESH_TOKEN_KEY) throw storageFailure;
-        return Reflect.apply(originalRemoveItem, this, [key]);
+        return originalRemoveItem(key);
       });
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")

--- a/packages/ui/src/cloud/shell/StewardProviderShared.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.ts
@@ -160,7 +160,15 @@ export function tokenSecsRemaining(token: string): number | null {
 
 export function clearStaleStewardSession(): void {
   if (typeof window === "undefined") return;
-  clearStoredStewardToken();
+  let storedTokenClearError: unknown;
+  try {
+    clearStoredStewardToken();
+  } catch (error) {
+    // error-policy:J2 canonical invalidation may already have succeeded before
+    // obsolete refresh-key cleanup failed. Finish every credential teardown,
+    // then rethrow the original storage error with its stack intact.
+    storedTokenClearError = error;
+  }
   // Every shared-agent profile belongs to the ending Steward account, even
   // when a dedicated or self-hosted target happens to be active at sign-out.
   removeManagedSharedCloudAgentProfiles();
@@ -186,4 +194,5 @@ export function clearStaleStewardSession(): void {
   } catch {
     // error-policy:J6 best-effort sync notification after credentials are scrubbed.
   }
+  if (storedTokenClearError !== undefined) throw storedTokenClearError;
 }


### PR DESCRIPTION
Fixes #18747

## Summary

- finish every Steward credential teardown even when obsolete refresh-key cleanup fails after canonical invalidation, then rethrow the original storage error
- route native expired-token rejection through the canonical typed `cleared` boundary instead of silently deleting local storage
- make canonical same-token persistence idempotent so login persistence plus cookie synchronization publishes exactly one `present` authority epoch
- retain the legacy sync event only as a compatibility notification after the typed authority transition

This repairs the three sequences reproduced after #19022. It does not add a timeout, retry, catch-and-continue data path, or fabricated fallback. The one retained cleanup catch is `error-policy:J2`: it completes security teardown and then fails fast with the original error.

## Verification

Exact source head: `435fee69ba437ef11f65e795d7c3e17fa643c1ca`
Base: `origin/develop@f8e449712d38dd0b4ab5344853f8ca8152968c0d`

- full `bun install` — PASS; pinned Bun 1.3.14, 971 MiB native artifact bundle synchronized, 7,138 packages installed
- focused UI authority contracts — 35/35 PASS
- shared Steward storage contract — 8/8 PASS
- UI typecheck — PASS
- shared typecheck — PASS
- root `bun run verify` — 350/350 PASS; repository audits clean
- app visual audit — 219/219 PASS; 216 findings, broken=0, needs-work=0; packaged OCR broken=0

The complete UI package lane also ran: 941 files and 9,935 tests passed, while 19 files / 33 tests failed in current-base clusters outside this eight-file diff (including obsolete Cloud hostname expectations and fixtures missing newer startup/notification exports). Those failures remain visible and are not suppressed; every changed authority path is covered by the focused green contracts above.

## Evidence

- [Focused UI authority tests](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18747-ui-focused.log)
- [Shared storage tests](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18747-shared-focused.log)
- [Root verification](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18747-root-verify.log)
- [App audit and OCR transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18747-audit-app.log)
- [Cloud desktop capture](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18747-cloud-desktop.png)
- [Cloud mobile capture](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18747-cloud-mobile.png)
- [Packaged OCR report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18747-ocr-triage.json)

The desktop and mobile Cloud captures were manually inspected. This state-authority repair changes no JSX, CSS, SVG, layout, or interaction; the screenshots establish that the shared UI change leaves the shipped Cloud surface healthy at both target sizes.

<!-- evidence-head:4936a20bb47156b98203ea78ef67c0c2c7d6ff16 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - the defect is a post-login storage/event sequence and has no distinct rendered before-state

<!-- evidence-row:after-screenshots -->
- [x] [Desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18747-cloud-desktop.png) and [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18747-cloud-mobile.png) Cloud captures; 0 broken / 0 needs-work

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changed; deterministic authority-event contracts exercise the complete sequence

<!-- evidence-row:backend-logs -->
- [x] N/A - browser/native client storage and event authority only; no backend behavior changed

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser request or rendered interaction changed; deterministic client authority contracts are supplied as domain artifacts

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, action, or provider behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [Shared canonical storage transitions](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18747-shared-focused.log) and [UI teardown/native rejection transitions](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18747-ui-focused.log)

<!-- evidence-row:ocr-review -->
- [x] [Packaged OCR report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/18747-ocr-triage.json) — 216 views, broken=0

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - repository contribution skill is not available in this session
Attribution status: self-reported
— [codex-18747]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - repository contribution skill is not available in this session"} -->