### PR TITLE
test(cloud): seed migration checkpoint relation

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -131,6 +131,13 @@ async function seedAppliedPrefix(
     CREATE TABLE users (
       id uuid PRIMARY KEY
     );
+    -- This fixture records the pre-checkpoint ledger without replaying its SQL.
+    -- It must therefore materialize every pre-checkpoint relation referenced by
+    -- pending migrations. Keep this checkpoint schema in lockstep when a new
+    -- post-checkpoint migration depends on an older table.
+    CREATE TABLE docker_nodes (
+      id uuid PRIMARY KEY
+    );
     CREATE SCHEMA drizzle;
     CREATE TABLE drizzle.__drizzle_migrations (
       id serial PRIMARY KEY,
@@ -269,7 +276,7 @@ describe.skipIf(!ENABLED)(
 
       const first = await runScript(MIGRATOR, database.url);
       expect(first.exitCode, first.output).toBe(0);
-      expect(first.output).toContain("pending migrations: 13");
+      expect(first.output).toContain("pending migrations: 14");
 
       const catalog = await database.client.query<{
         data_type: string;
@@ -297,6 +304,23 @@ describe.skipIf(!ENABLED)(
         terminal_backfills: "1",
       });
 
+      const placementState = await database.client.query<{
+        data_type: string;
+        is_nullable: string;
+        column_default: string;
+      }>(`
+        SELECT data_type, is_nullable, column_default
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'docker_nodes'
+          AND column_name = 'placement_state'
+      `);
+      expect(placementState.rows[0]).toEqual({
+        data_type: "text",
+        is_nullable: "NO",
+        column_default: "'open'::text",
+      });
+
       const second = await runScript(MIGRATOR, database.url);
       expect(second.exitCode, second.output).toBe(0);
       expect(second.output).toContain("pending migrations: 0");
@@ -317,7 +341,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 13");
+      expect(migrated.output).toContain("pending migrations: 14");
 
       await database.client.query(
         "UPDATE drizzle.__drizzle_migrations SET hash = 'checkpoint-drift' WHERE created_at = $1",
@@ -363,7 +387,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 13");
+      expect(migrated.output).toContain("pending migrations: 14");
       await database.client.end();
     }, 120_000);
 
@@ -373,7 +397,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 13");
+      expect(migrated.output).toContain("pending migrations: 14");
       await database.client.end();
     }, 120_000);
 
@@ -405,7 +429,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 13");
+      expect(migrated.output).toContain("pending migrations: 14");
       await database.client.end();
     }, 120_000);
 
@@ -425,7 +449,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 13");
+      expect(migrated.output).toContain("pending migrations: 14");
 
       const remaining = await database.client.query<{ count: string }>(
         "SELECT count(*)::text AS count FROM drizzle.__drizzle_migrations WHERE created_at = ANY($1::bigint[])",

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -131,6 +131,9 @@ async function seedAppliedPrefix(
     CREATE TABLE users (
       id uuid PRIMARY KEY
     );
+    CREATE TABLE organizations (
+      id uuid PRIMARY KEY
+    );
     -- This fixture records the pre-checkpoint ledger without replaying its SQL.
     -- It must therefore materialize every pre-checkpoint relation referenced by
     -- pending migrations. Keep this checkpoint schema in lockstep when a new
@@ -276,7 +279,7 @@ describe.skipIf(!ENABLED)(
 
       const first = await runScript(MIGRATOR, database.url);
       expect(first.exitCode, first.output).toBe(0);
-      expect(first.output).toContain("pending migrations: 14");
+      expect(first.output).toContain("pending migrations: 15");
 
       const catalog = await database.client.query<{
         data_type: string;
@@ -341,7 +344,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 14");
+      expect(migrated.output).toContain("pending migrations: 15");
 
       await database.client.query(
         "UPDATE drizzle.__drizzle_migrations SET hash = 'checkpoint-drift' WHERE created_at = $1",
@@ -387,7 +390,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 14");
+      expect(migrated.output).toContain("pending migrations: 15");
       await database.client.end();
     }, 120_000);
 
@@ -397,7 +400,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 14");
+      expect(migrated.output).toContain("pending migrations: 15");
       await database.client.end();
     }, 120_000);
 
@@ -429,7 +432,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 14");
+      expect(migrated.output).toContain("pending migrations: 15");
       await database.client.end();
     }, 120_000);
 
@@ -449,7 +452,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 14");
+      expect(migrated.output).toContain("pending migrations: 15");
 
       const remaining = await database.client.query<{ count: string }>(
         "SELECT count(*)::text AS count FROM drizzle.__drizzle_migrations WHERE created_at = ANY($1::bigint[])",


### PR DESCRIPTION
Fixes #19270

## Summary

- seed the pre-checkpoint `docker_nodes` relation in the synthetic migration-ledger fixture
- document that the checkpoint fixture must materialize every older relation referenced by forward migrations
- update the pending migration count from 13 to the current 14
- assert that migration 0198 creates `docker_nodes.placement_state` as `text NOT NULL DEFAULT 'open'`

Migration 0198 remains unchanged and fail-fast. The repair does not add an `IF EXISTS` guard that could hide a broken production catalog; it makes the synthetic checkpoint model honest about the pre-checkpoint table that production must already have.

## Verification

Exact source head: `fffdd30fb3a475391a71d5409c55a4109d2337b5`
Base: `origin/develop@f8e449712d3b4b4d4bc30fac2fb4a330bd87ebdf`

- full `bun install` — PASS; pinned Bun 1.3.14, 971 MiB artifact bundle verified/extracted, 3,831 installs checked with no dependency changes
- real PostgreSQL 17 migration fencing/contention lane — 10/10 PASS, 47 assertions
- `bun run verify:cloud` — 78/78 PASS, including production Worker dry-run
- root `bun run verify` — 350/350 PASS; repository audits clean
- Biome changed-file check and `git diff --check` — PASS

The PostgreSQL test uses disposable local databases and drops them through the suite teardown. No staging, production, deployment, or persistent database state was touched.

## Evidence

- [Real PostgreSQL migration lane](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19270-real-postgres-final.log)
- [Cloud lint/typecheck/Worker dry-run](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19270-verify-cloud.log)
- [Root verification](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19270-root-verify.log)
- [Full install transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19270-bun-install.log)

<!-- evidence-head:fffdd30fb3a475391a71d5409c55a4109d2337b5 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - PostgreSQL migration-fixture test only; no rendered surface changed

<!-- evidence-row:after-screenshots -->
- [x] N/A - PostgreSQL migration-fixture test only; no rendered surface changed

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow changed; the production migrator is exercised directly against real PostgreSQL

<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend or deployment changed; the applicable migrator output is supplied as a domain artifact

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser behavior changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, planner, or provider behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [Real PostgreSQL migration transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19270-real-postgres-final.log) — 10/10 cases, including catalog, hash, order, lock, and partial-state assertions

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - repository contribution skill is not available in this session
Attribution status: self-reported
— [codex-19270]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - repository contribution skill is not available in this session"} -->