### PR TITLE
fix(coding-tools): redact shell result surfaces

### DIFF
--- a/plugins/plugin-coding-tools/README.md
+++ b/plugins/plugin-coding-tools/README.md
@@ -50,6 +50,7 @@ All settings are optional. Configure via environment variables or agent settings
 | `CODING_TOOLS_BLOCKED_PATHS` | (built-in) | Comma-separated absolute paths to block — replaces the default blocklist. |
 | `CODING_TOOLS_BLOCKED_PATHS_ADD` | — | Paths to add to the default blocklist. |
 | `CODING_TOOLS_SHELL_TIMEOUT_MS` | `120000` | Optional canonical decimal integer from `100` through `600000` used as the default SHELL timeout (ms); invalid values fail before execution and per-call `timeout` takes precedence within the same range. |
+| `ELIZA_SHELL_ECHO_TRANSCRIPT` | unset | Set to `1` or `true` to emit the sanitized foreground shell transcript callback before the planner reply. |
 | `CODING_TOOLS_BACKGROUND_SHELL_BUFFER_CHARS` | `64000` | Per-stream retained stdout/stderr ring size for background shell polling. |
 | `CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS` | `1500` | Grace period between SIGTERM and SIGKILL for background shell termination. |
 | `CODING_TOOLS_MAX_READ_LINES` | `2000` | Max lines returned by FILE action=read. |

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -19,7 +19,7 @@ import {
   UnavailableCapabilityRouter,
   type UUID,
 } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // These tests exercise the SHELL action through `pwd`, `cd`, `git -C`, and
 // inline pipelines. The action itself does run on Windows (it routes to
@@ -44,6 +44,7 @@ import {
   SANDBOX_SERVICE,
   SESSION_CWD_SERVICE,
 } from "../types.js";
+
 import {
   type CommandPlatform,
   localResourceUserFacingText,
@@ -54,6 +55,16 @@ import {
   resolveSourceInspectionCommand,
   shellAction,
 } from "./bash.js";
+
+const originalEchoTranscript = process.env.ELIZA_SHELL_ECHO_TRANSCRIPT;
+
+afterEach(() => {
+  if (originalEchoTranscript === undefined) {
+    delete process.env.ELIZA_SHELL_ECHO_TRANSCRIPT;
+  } else {
+    process.env.ELIZA_SHELL_ECHO_TRANSCRIPT = originalEchoTranscript;
+  }
+});
 
 const execFileAsync = promisify(execFile);
 
@@ -110,6 +121,7 @@ interface RuntimeOptions {
   withShellHistoryService?: boolean;
   capabilityRouter?: ElizaCapabilityRouter;
   backgroundBufferChars?: number;
+  configuredSecret?: string;
 }
 
 function requireActionResult(result: ActionResult | undefined): ActionResult {
@@ -142,6 +154,11 @@ async function makeRuntime(opts: RuntimeOptions = {}): Promise<{
     agentId: "11111111-1111-1111-1111-111111111111" as UUID,
     getSetting: vi.fn((key: string) => settings[key]),
     getService: vi.fn(<T>(type: string) => services.get(type) as T | null),
+    redactSecrets: vi.fn((text: string) =>
+      opts.configuredSecret
+        ? text.replaceAll(opts.configuredSecret, "[REDACTED:TEST_SECRET]")
+        : text,
+    ),
   } as IAgentRuntime;
 
   const sandbox = await SandboxService.start(runtime);
@@ -506,6 +523,7 @@ describeIfPosix("shellAction", () => {
   });
 
   it("caps only the visible callback for long foreground output", async () => {
+    process.env.ELIZA_SHELL_ECHO_TRANSCRIPT = "1";
     const lines = Array.from(
       { length: 300 },
       (_, index) =>
@@ -659,6 +677,7 @@ describeIfPosix("shellAction", () => {
   });
 
   it("fences every user-facing background/history relay (#16563)", async () => {
+    process.env.ELIZA_SHELL_ECHO_TRANSCRIPT = "1";
     const { runtime } = await makeRuntime();
     const message = makeMessage();
     const posts: Array<{ text: string; source?: string }> = [];
@@ -1831,6 +1850,79 @@ describeIfPosix("shellAction", () => {
     );
     const data = result.data as Record<string, unknown> | undefined;
     expect(data?.action).toBe("view_history");
+  });
+
+  it("redacts a configured bare secret from foreground text, callback, data, and user-facing output", async () => {
+    process.env.ELIZA_SHELL_ECHO_TRANSCRIPT = "1";
+    const secret = "orchid42";
+    const router = makeShellRouter(async () => ({
+      output: `${secret}\n`,
+      exitCode: 0,
+      timedOut: false,
+    }));
+    const { runtime } = await makeRuntime({
+      capabilityRouter: router,
+      configuredSecret: secret,
+    });
+    const posts: Array<{ text: string }> = [];
+
+    const result = requireActionResult(
+      await shellAction.handler?.(
+        runtime,
+        makeMessage(),
+        undefined,
+        { command: `rg Authorization --token ${secret}` },
+        async (content) => {
+          posts.push(content as { text: string });
+          return [];
+        },
+      ),
+    );
+
+    const exposed = JSON.stringify({ result, posts });
+    expect(exposed).not.toContain(secret);
+  });
+
+  it("redacts a configured bare secret from every background session projection", async () => {
+    const secret = "violet73";
+    const { runtime } = await makeRuntime({ configuredSecret: secret });
+    const actor = makeMessage();
+    const start = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "start_background",
+        command: `printf '%s\\n' '${secret}'`,
+      }),
+    );
+    const handle = (start.data as Record<string, unknown>).handle as string;
+    const poll = await pollUntil(
+      runtime,
+      actor,
+      handle,
+      (data) => data.status === "exited",
+    );
+    const partialPoll = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "poll_background",
+        handle,
+        stdout_offset: 3,
+      }),
+    );
+    const list = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "list_background",
+      }),
+    );
+
+    const exposed = JSON.stringify({ start, poll, partialPoll, list });
+    expect(exposed).not.toContain(secret);
+    expect(
+      (
+        (partialPoll.data as Record<string, unknown>).stdout as Record<
+          string,
+          unknown
+        >
+      ).startOffset,
+    ).toBe(0);
   });
 });
 

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -37,6 +37,7 @@ import { resolveHostShell } from "../lib/terminal-capabilities.js";
 import type { BackgroundShellService } from "../services/background-shell-service.js";
 import type { SandboxService } from "../services/sandbox-service.js";
 import type { SessionCwdService } from "../services/session-cwd-service.js";
+import { redactShellText } from "../shell/redaction.js";
 import {
   BACKGROUND_SHELL_SERVICE,
   CODING_TOOLS_CONTEXTS,
@@ -1318,8 +1319,8 @@ export const shellAction: Action = {
             .map((entry, index) => {
               const command =
                 typeof entry.command === "string"
-                  ? entry.command
-                  : JSON.stringify(entry);
+                  ? redactShellText(runtime, entry.command)
+                  : redactShellText(runtime, JSON.stringify(entry));
               return `${index + 1}. ${command}`;
             })
             .join("\n")
@@ -1375,7 +1376,7 @@ export const shellAction: Action = {
                 .join("\n")
             : "(no background shell sessions for this conversation)";
           const text = `Background shell sessions (${sessions.length}):\n${lines}`;
-          // Fenced (#16563): per-session lines embed raw command strings.
+          // Fenced (#16563): per-session lines embed command strings.
           if (callback)
             await callback({
               text: fencePreformatted(text),
@@ -1479,7 +1480,7 @@ export const shellAction: Action = {
         // tool failures.
         return failureToActionResult({
           reason: "internal",
-          message: (err as Error).message,
+          message: redactShellText(runtime, (err as Error).message),
         });
       }
     }
@@ -1534,7 +1535,7 @@ export const shellAction: Action = {
         if (!stat.isDirectory()) {
           return failureToActionResult({
             reason: "invalid_param",
-            message: `cwd is not a directory: ${cwdParam}`,
+            message: `cwd is not a directory: ${redactShellText(runtime, cwdParam)}`,
           });
         }
       } catch (err) {
@@ -1545,7 +1546,7 @@ export const shellAction: Action = {
         if (!isMissingPathError(err)) {
           return failureToActionResult({
             reason: "io_error",
-            message: `cwd stat failed: ${(err as Error).message}`,
+            message: `cwd stat failed: ${redactShellText(runtime, (err as Error).message)}`,
           });
         }
         const fallback = await session.getExistingCwd(conversationId);
@@ -1639,9 +1640,11 @@ export const shellAction: Action = {
               "ask the user to confirm the exact operation, then re-run with confirm=true.",
           },
           {
-            command,
+            command: redactShellText(runtime, command),
             destructive_reason: verdict.reason,
-            targets: verdict.targets,
+            targets: verdict.targets.map((target) =>
+              redactShellText(runtime, target),
+            ),
           },
         );
       }
@@ -1702,6 +1705,7 @@ export const shellAction: Action = {
         message: timeoutSetting.error,
       });
     }
+    const redactedCwd = redactShellText(runtime, cwd);
 
     if (subaction === "start_background") {
       const backgroundShell = getBackgroundShellService(runtime);
@@ -1717,13 +1721,14 @@ export const shellAction: Action = {
           command,
           cwd,
         });
+        const redactedCommand = redactShellText(runtime, command);
         const text = [
-          `$ ${command}`,
-          `[background ${session.handle}] (pid=${session.pid ?? "unknown"}, cwd=${cwd})`,
+          `$ ${redactedCommand}`,
+          `[background ${session.handle}] (pid=${session.pid ?? "unknown"}, cwd=${redactedCwd})`,
           `poll with stdout_offset=${session.stdoutOffset} stderr_offset=${session.stderrOffset}`,
         ].join("\n");
-        // Fenced (#16563): the echoed `$ command` line is the literal
-        // italics-eaten failure shape from #16542's repro.
+        // Starting a background process is itself the requested operation, so
+        // retain its immediate acknowledgement while sanitizing the command.
         if (callback)
           await callback({
             text: fencePreformatted(text),
@@ -1732,8 +1737,8 @@ export const shellAction: Action = {
         return successActionResult(text, {
           actionName: "SHELL",
           [CANONICAL_SUBACTION_KEY]: "start_background",
-          command,
-          cwd,
+          command: redactedCommand,
+          cwd: redactedCwd,
           handle: session.handle,
           session,
           execution_route: session.sandbox === "host" ? "host" : "sandbox",
@@ -1744,8 +1749,14 @@ export const shellAction: Action = {
         // and spawn failures must be visible to the planner instead of falling
         // back to a host-spawned process.
         return failureToActionResult(
-          { reason: "internal", message: (err as Error).message },
-          { command, cwd },
+          {
+            reason: "internal",
+            message: redactShellText(runtime, (err as Error).message),
+          },
+          {
+            command: redactShellText(runtime, command),
+            cwd: redactedCwd,
+          },
         );
       }
     }
@@ -1771,25 +1782,33 @@ export const shellAction: Action = {
       // error-policy:J1 SHELL action boundary; a dispatch failure is logged and
       // returned as a success:false ActionResult carrying the real message, so
       // the planner loop shows the failure to the model.
-      const message = (err as Error).message;
+      const message = redactShellText(runtime, (err as Error).message);
       coreLogger.error(
         `${CODING_TOOLS_LOG_PREFIX} SHELL dispatch failed: ${message}`,
       );
-      return failureToActionResult({ reason: "internal", message }, { cwd });
+      return failureToActionResult(
+        { reason: "internal", message },
+        { cwd: redactedCwd },
+      );
     }
 
     const took = Date.now() - startedAt;
     const timedOut = result.timedOut;
     const signal = result.signal;
+    const redactedCommand = redactShellText(runtime, command);
+    const redactedStdout = redactShellText(runtime, result.stdout);
+    const redactedStderr = redactShellText(runtime, result.stderr);
     const head = timedOut
-      ? `$ ${command}\n[timeout ${timeout}ms] (cwd=${cwd}, took=${took}ms)`
-      : `$ ${command}\n[exit ${result.exitCode}] (cwd=${cwd}, took=${took}ms)`;
-    const streams = formatStreams(result.stdout, result.stderr, {
+      ? `$ ${redactedCommand}\n[timeout ${timeout}ms] (cwd=${redactedCwd}, took=${took}ms)`
+      : `$ ${redactedCommand}\n[exit ${result.exitCode}] (cwd=${redactedCwd}, took=${took}ms)`;
+    const streams = formatStreams(redactedStdout, redactedStderr, {
       showEmptyStreams: !result.stdout && !result.stderr,
     });
     const text = streams.length > 0 ? `${head}\n${streams}` : head;
 
-    if (callback)
+    const echoTranscript =
+      process.env.ELIZA_SHELL_ECHO_TRANSCRIPT?.trim().toLowerCase();
+    if (callback && (echoTranscript === "1" || echoTranscript === "true"))
       await callback({
         text: fencePreformatted(capTranscriptForChat(text)),
         source: "coding-tools",
@@ -1798,7 +1817,7 @@ export const shellAction: Action = {
     if (timedOut) {
       return failureToActionResult(
         { reason: "timeout", message: `command timed out after ${timeout}ms` },
-        { command, cwd, output: text },
+        { command: redactedCommand, cwd: redactedCwd, output: text },
       );
     }
     if (result.exitCode !== 0) {
@@ -1807,13 +1826,18 @@ export const shellAction: Action = {
           reason: "command_failed",
           message: `command exited with code ${result.exitCode}`,
         },
-        { command, exit_code: result.exitCode, cwd, output: text },
+        {
+          command: redactedCommand,
+          exit_code: result.exitCode,
+          cwd: redactedCwd,
+          output: text,
+        },
       );
     }
     const actionResult = successActionResult(text, {
-      command,
+      command: redactedCommand,
       exit_code: result.exitCode,
-      cwd,
+      cwd: redactedCwd,
       execution_route: result.sandbox === "host" ? "host" : "sandbox",
       sandbox_backend: result.sandbox,
       signal,
@@ -1834,14 +1858,14 @@ export const shellAction: Action = {
         : (cryptoSpotUserFacingText({
             message,
             command,
-            stdout: result.stdout,
+            stdout: redactedStdout,
           }) ??
-          localResourceUserFacingText({ message, stdout: result.stdout }) ??
-          localStatusUserFacingText({ message, stdout: result.stdout }))) ??
+          localResourceUserFacingText({ message, stdout: redactedStdout }) ??
+          localStatusUserFacingText({ message, stdout: redactedStdout }))) ??
       safeSmallStdoutUserFacingText({
         command,
-        stdout: result.stdout,
-        stderr: result.stderr,
+        stdout: redactedStdout,
+        stderr: redactedStderr,
       });
     return userFacingText
       ? { ...actionResult, userFacingText, verifiedUserFacing: true }

--- a/plugins/plugin-coding-tools/src/services/background-shell-service.ts
+++ b/plugins/plugin-coding-tools/src/services/background-shell-service.ts
@@ -18,6 +18,7 @@ import {
   signalHostProcessGroup,
   startBackgroundShellOnHost,
 } from "../lib/run-shell.js";
+import { redactShellText } from "../shell/redaction.js";
 import { BACKGROUND_SHELL_SERVICE, CODING_TOOLS_LOG_PREFIX } from "../types.js";
 
 const DEFAULT_BUFFER_CHARS = 64_000;
@@ -175,7 +176,7 @@ export class BackgroundShellService extends Service {
       appendRing(session.stderr, error.message, this.bufferChars);
     });
     this.sessions.set(handle, session);
-    return snapshot(session);
+    return snapshot(this.runtime, session);
   }
 
   poll(args: {
@@ -186,16 +187,16 @@ export class BackgroundShellService extends Service {
   }): BackgroundShellPollResult {
     const session = this.requireSession(args.conversationId, args.handle);
     return {
-      ...snapshot(session),
-      stdout: readRing(session.stdout, args.stdoutOffset),
-      stderr: readRing(session.stderr, args.stderrOffset),
+      ...snapshot(this.runtime, session),
+      stdout: readRing(this.runtime, session.stdout, args.stdoutOffset),
+      stderr: readRing(this.runtime, session.stderr, args.stderrOffset),
     };
   }
 
   list(conversationId: string): BackgroundShellSessionSnapshot[] {
     return [...this.sessions.values()]
       .filter((session) => session.conversationId === conversationId)
-      .map((session) => snapshot(session));
+      .map((session) => snapshot(this.runtime, session));
   }
 
   write(args: {
@@ -223,7 +224,7 @@ export class BackgroundShellService extends Service {
       );
     }
     session.process.stdin.write(args.stdin);
-    return snapshot(session);
+    return snapshot(this.runtime, session);
   }
 
   async kill(args: {
@@ -232,13 +233,13 @@ export class BackgroundShellService extends Service {
   }): Promise<BackgroundShellSessionSnapshot> {
     const session = this.requireSession(args.conversationId, args.handle);
     await this.killSession(session);
-    return snapshot(session);
+    return snapshot(this.runtime, session);
   }
 
   private async killSession(
     session: BackgroundShellSession,
   ): Promise<BackgroundShellSessionSnapshot> {
-    if (session.status !== "running") return snapshot(session);
+    if (session.status !== "running") return snapshot(this.runtime, session);
     session.status = "killed";
     signalHostProcessGroup(session.process, "SIGTERM");
     try {
@@ -271,7 +272,7 @@ export class BackgroundShellService extends Service {
     coreLogger.debug(
       `${CODING_TOOLS_LOG_PREFIX} background SHELL reaped handle=${session.handle} pid=${session.pid ?? "unknown"}`,
     );
-    return snapshot(session);
+    return snapshot(this.runtime, session);
   }
 
   private ensureCapacity(conversationId: string): void {
@@ -341,6 +342,7 @@ function appendRing(ring: StreamRing, text: string, cap: number): void {
 }
 
 function readRing(
+  runtime: IAgentRuntime,
   ring: StreamRing,
   requestedOffset?: number,
 ): BackgroundShellChunk {
@@ -350,22 +352,32 @@ function readRing(
       : Math.max(0, Math.floor(requestedOffset));
   const start = Math.max(offset, ring.startOffset);
   const index = start - ring.startOffset;
+  const redactedFull = redactShellText(runtime, ring.text);
+  const redactedPrefix = redactShellText(runtime, ring.text.slice(0, index));
+  // A credential can straddle the requested offset. When redacting the full
+  // retained ring changes the prefix, replay the sanitized retained window
+  // rather than risk returning a partial secret.
+  const canSliceAtRequestedOffset = redactedFull.startsWith(redactedPrefix);
+  const text = canSliceAtRequestedOffset
+    ? redactedFull.slice(redactedPrefix.length)
+    : redactedFull;
   return {
-    text: ring.text.slice(index),
-    startOffset: start,
+    text,
+    startOffset: canSliceAtRequestedOffset ? start : ring.startOffset,
     endOffset: ring.endOffset,
     truncatedBefore: ring.truncatedBefore,
   };
 }
 
 function snapshot(
+  runtime: IAgentRuntime,
   session: BackgroundShellSession,
 ): BackgroundShellSessionSnapshot {
   return {
     handle: session.handle,
     conversationId: session.conversationId,
-    command: session.command,
-    cwd: session.cwd,
+    command: redactShellText(runtime, session.command),
+    cwd: redactShellText(runtime, session.cwd),
     pid: session.pid,
     status: session.status,
     exitCode: session.exitCode,

--- a/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
@@ -12,11 +12,19 @@ import { shellHistoryProvider } from "../providers/shellHistoryProvider";
 import { resetProcessRegistryForTests } from "../services/processRegistry";
 import { ShellService } from "../services/shellService";
 
-function createRuntime(service: ShellService | null): IAgentRuntime {
+function createRuntime(
+  service: ShellService | null,
+  configuredSecret?: string,
+): IAgentRuntime {
   return {
     character: {},
     getService(name: string) {
       return name === "shell" ? service : null;
+    },
+    redactSecrets(text: string) {
+      return configuredSecret
+        ? text.replaceAll(configuredSecret, "[REDACTED:TEST_SECRET]")
+        : text;
     },
   } as IAgentRuntime;
 }
@@ -81,6 +89,29 @@ describePosixShell("shell plugin real local integration", () => {
     expect(provider.values?.currentWorkingDirectory).toBe(allowedDirectory);
   });
 
+  it("stores and provides only redacted configured bare secrets", async () => {
+    const secret = "marigold9";
+    await service.stop();
+    service = await ShellService.start(createRuntime(null, secret));
+    runtime = createRuntime(service, secret);
+    const result = await service.executeCommand(
+      `printf '%s\\n' '${secret}'`,
+      "room-secret",
+    );
+    expect(result.success).toBe(true);
+    expect(JSON.stringify(result)).not.toContain(secret);
+
+    const history = service.getCommandHistory("room-secret", 10);
+    const provider = await shellHistoryProvider.get(
+      runtime,
+      { roomId: "room-secret", agentId: "agent-1" } as never,
+      {} as never,
+    );
+
+    expect(JSON.stringify(history)).not.toContain(secret);
+    expect(JSON.stringify(provider)).not.toContain(secret);
+  });
+
   it("fails closed when a command tries to escape the allowed directory", async () => {
     const result = await service.executeCommand("cd ../..", "room-1");
 
@@ -112,6 +143,9 @@ describePosixShell("shell plugin real local integration", () => {
       character: {},
       getService(name: string) {
         return name === "shell" ? throwingService : null;
+      },
+      redactSecrets(text: string) {
+        return text;
       },
       reportError(scope: string, error: unknown) {
         reported.push({ scope, error });

--- a/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.ts
+++ b/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.ts
@@ -13,6 +13,7 @@ import {
   type State,
 } from "@elizaos/core";
 import { requireProviderSpec } from "../generated/specs/spec-helpers";
+import { redactShellText } from "../redaction";
 import type { ShellService } from "../services/shellService";
 import type { CommandHistoryEntry, FileOperation } from "../types";
 
@@ -62,28 +63,39 @@ export const shellHistoryProvider: Provider = {
         };
       }
       const history = shellService.getCommandHistory(conversationId, 10);
-      const cwd = shellService.getCurrentDirectory(conversationId);
-      const allowedDir = shellService.getAllowedDirectory();
+      const cwd = redactShellText(
+        runtime,
+        shellService.getCurrentDirectory(conversationId),
+      );
+      const allowedDir = redactShellText(
+        runtime,
+        shellService.getAllowedDirectory(),
+      );
 
       let historyText = "No commands in history.";
       if (history.length > 0) {
         historyText = history
           .map((entry: CommandHistoryEntry) => {
-            let entryStr = `[${new Date(entry.timestamp).toISOString()}] ${entry.workingDirectory}> ${entry.command}`;
+            const stdout = redactShellText(runtime, entry.stdout ?? "");
+            const stderr = redactShellText(runtime, entry.stderr ?? "");
+            let entryStr = redactShellText(
+              runtime,
+              `[${new Date(entry.timestamp).toISOString()}] ${entry.workingDirectory}> ${entry.command}`,
+            );
 
-            if (entry.stdout) {
-              if (entry.stdout.length > MAX_OUTPUT_LENGTH) {
-                entryStr += `\n  Output: ${entry.stdout.substring(0, TRUNCATE_SEGMENT_LENGTH)}\n  ... [TRUNCATED] ...\n  ${entry.stdout.substring(entry.stdout.length - TRUNCATE_SEGMENT_LENGTH)}`;
+            if (stdout) {
+              if (stdout.length > MAX_OUTPUT_LENGTH) {
+                entryStr += `\n  Output: ${stdout.substring(0, TRUNCATE_SEGMENT_LENGTH)}\n  ... [TRUNCATED] ...\n  ${stdout.substring(stdout.length - TRUNCATE_SEGMENT_LENGTH)}`;
               } else {
-                entryStr += `\n  Output: ${entry.stdout}`;
+                entryStr += `\n  Output: ${stdout}`;
               }
             }
 
-            if (entry.stderr) {
-              if (entry.stderr.length > MAX_OUTPUT_LENGTH) {
-                entryStr += `\n  Error: ${entry.stderr.substring(0, TRUNCATE_SEGMENT_LENGTH)}\n  ... [TRUNCATED] ...\n  ${entry.stderr.substring(entry.stderr.length - TRUNCATE_SEGMENT_LENGTH)}`;
+            if (stderr) {
+              if (stderr.length > MAX_OUTPUT_LENGTH) {
+                entryStr += `\n  Error: ${stderr.substring(0, TRUNCATE_SEGMENT_LENGTH)}\n  ... [TRUNCATED] ...\n  ${stderr.substring(stderr.length - TRUNCATE_SEGMENT_LENGTH)}`;
               } else {
-                entryStr += `\n  Error: ${entry.stderr}`;
+                entryStr += `\n  Error: ${stderr}`;
               }
             }
 
@@ -93,9 +105,9 @@ export const shellHistoryProvider: Provider = {
               entryStr += "\n  File Operations:";
               entry.fileOperations.forEach((op: FileOperation) => {
                 if (op.secondaryTarget) {
-                  entryStr += `\n    - ${op.type}: ${op.target} → ${op.secondaryTarget}`;
+                  entryStr += `\n    - ${op.type}: ${redactShellText(runtime, op.target)} → ${redactShellText(runtime, op.secondaryTarget)}`;
                 } else {
-                  entryStr += `\n    - ${op.type}: ${op.target}`;
+                  entryStr += `\n    - ${op.type}: ${redactShellText(runtime, op.target)}`;
                 }
               });
             }
@@ -122,9 +134,9 @@ export const shellHistoryProvider: Provider = {
             recentFileOps
               .map((op: FileOperation) => {
                 if (op.secondaryTarget) {
-                  return `- ${op.type}: ${op.target} → ${op.secondaryTarget}`;
+                  return `- ${op.type}: ${redactShellText(runtime, op.target)} → ${redactShellText(runtime, op.secondaryTarget)}`;
                 }
-                return `- ${op.type}: ${op.target}`;
+                return `- ${op.type}: ${redactShellText(runtime, op.target)}`;
               })
               .join("\n"),
           );
@@ -165,7 +177,10 @@ ${addHeader("# Shell History (Last 10)", historyText)}${fileOpsText}`;
       // become observable to the agent), and drives owner escalation. It never
       // throws. Fall back to logger.error on runtimes/test doubles that predate
       // it so the failure is never silently swallowed.
-      const errMsg = error instanceof Error ? error.message : String(error);
+      const errMsg = redactShellText(
+        runtime,
+        error instanceof Error ? error.message : String(error),
+      );
       if (typeof runtime?.reportError === "function") {
         runtime.reportError("shellHistoryProvider", error, {
           roomId: message.roomId,
@@ -173,7 +188,7 @@ ${addHeader("# Shell History (Last 10)", historyText)}${fileOpsText}`;
         });
       } else {
         logger.error(
-          { src: "shellHistoryProvider", error },
+          { src: "shellHistoryProvider", error: errMsg },
           `[shellHistoryProvider] Failed to build shell history context: ${errMsg}`,
         );
       }

--- a/plugins/plugin-coding-tools/src/shell/redaction.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/redaction.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Verifies shell projections always apply pattern redaction while using
+ * runtime-owned configured-secret redaction when the host provides it.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { redactShellText } from "./redaction.ts";
+
+describe("shell redaction boundary", () => {
+  it("remains pattern-safe for lightweight runtimes without redactSecrets", () => {
+    const runtime = {} as IAgentRuntime;
+
+    expect(
+      redactShellText(runtime, "Bearer token-value-123456789"),
+    ).not.toContain("token-value-123456789");
+  });
+
+  it("composes runtime-known and pattern redaction", () => {
+    const redactSecrets = vi.fn((text: string) =>
+      text.replaceAll("ordinary configured value", "[REDACTED:configured]"),
+    );
+    const runtime = { redactSecrets } as unknown as IAgentRuntime;
+    const result = redactShellText(
+      runtime,
+      "ordinary configured value --token=flag-value-123456789",
+    );
+
+    expect(redactSecrets).toHaveBeenCalledOnce();
+    expect(result).toContain("[REDACTED:configured]");
+    expect(result).not.toContain("ordinary configured value");
+    expect(result).not.toContain("flag-value-123456789");
+  });
+});

--- a/plugins/plugin-coding-tools/src/shell/redaction.ts
+++ b/plugins/plugin-coding-tools/src/shell/redaction.ts
@@ -1,0 +1,32 @@
+/**
+ * Composes runtime-configured and shape-based redaction for shell boundaries.
+ *
+ * Character secrets may be ordinary strings with no recognizable credential
+ * shape, so pattern redaction alone is insufficient.
+ */
+import { type IAgentRuntime, redactSensitiveText } from "@elizaos/core";
+
+export function redactShellText(runtime: IAgentRuntime, text: string): string {
+  const runtimeRedactor = Reflect.get(runtime, "redactSecrets");
+  const runtimeRedacted =
+    typeof runtimeRedactor === "function"
+      ? runtimeRedactor.call(runtime, text)
+      : text;
+  return redactSensitiveText(runtimeRedacted, { mode: "tools" });
+}
+
+export function redactShellValue<T>(runtime: IAgentRuntime, value: T): T {
+  if (typeof value === "string") return redactShellText(runtime, value) as T;
+  if (Array.isArray(value)) {
+    return value.map((item) => redactShellValue(runtime, item)) as T;
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        redactShellValue(runtime, item),
+      ]),
+    ) as T;
+  }
+  return value;
+}

--- a/plugins/plugin-coding-tools/src/shell/services/shellService.ts
+++ b/plugins/plugin-coding-tools/src/shell/services/shellService.ts
@@ -16,6 +16,7 @@ import {
   shouldUseSandboxExecution,
 } from "@elizaos/shared";
 import spawn from "cross-spawn";
+import { redactShellText, redactShellValue } from "../redaction";
 import type {
   CommandHistoryEntry,
   CommandResult,
@@ -76,6 +77,40 @@ import {
 } from "./processRegistry";
 
 const DEFAULT_TIMEOUT_SEC = 1800; // 30 minutes
+
+function redactProcessSession(
+  runtime: IAgentRuntime,
+  session: ProcessSession,
+): ProcessSession {
+  return {
+    ...session,
+    command: redactShellText(runtime, session.command),
+    cwd: session.cwd ? redactShellText(runtime, session.cwd) : undefined,
+    pendingStdout: session.pendingStdout.map((text) =>
+      redactShellText(runtime, text),
+    ),
+    pendingStderr: session.pendingStderr.map((text) =>
+      redactShellText(runtime, text),
+    ),
+    aggregated: redactShellText(runtime, session.aggregated),
+    tail: redactShellText(runtime, session.tail),
+    child: undefined,
+    stdin: undefined,
+  };
+}
+
+function redactFinishedSession(
+  runtime: IAgentRuntime,
+  session: FinishedSession,
+): FinishedSession {
+  return {
+    ...session,
+    command: redactShellText(runtime, session.command),
+    cwd: session.cwd ? redactShellText(runtime, session.cwd) : undefined,
+    aggregated: redactShellText(runtime, session.aggregated),
+    tail: redactShellText(runtime, session.tail),
+  };
+}
 
 interface RuntimeSandboxManager {
   getState?: () => string;
@@ -198,7 +233,7 @@ export class ShellService extends Service {
     }
 
     logger.info(
-      `[shell:sandbox] routing exec via SandboxManager: ${command.substring(0, 100)}`,
+      `[shell:sandbox] routing exec via SandboxManager: ${redactShellText(this.runtime, command.substring(0, 100))}`,
     );
     const result = await sandboxManager.exec({
       command,
@@ -236,6 +271,16 @@ export class ShellService extends Service {
    * Simple command execution (original API for backward compatibility)
    */
   async executeCommand(
+    command: string,
+    conversationId?: string,
+  ): Promise<CommandResult> {
+    return redactShellValue(
+      this.runtime,
+      await this.executeCommandUnredacted(command, conversationId),
+    );
+  }
+
+  private async executeCommandUnredacted(
     command: string,
     conversationId?: string,
   ): Promise<CommandResult> {
@@ -287,7 +332,7 @@ export class ShellService extends Service {
         "http://localhost:2138";
       const runtimeFetch = this.runtime.fetch ?? globalThis.fetch;
       logger.info(
-        `[shell:sandbox] routing exec to ${hostApiUrl}: ${command.substring(0, 100)}`,
+        `[shell:sandbox] routing exec to ${hostApiUrl}: ${redactShellText(this.runtime, command.substring(0, 100))}`,
       );
       try {
         const response = await runtimeFetch(`${hostApiUrl}/api/sandbox/exec`, {
@@ -320,7 +365,10 @@ export class ShellService extends Service {
         // error-policy:J1 execution boundary; a sandbox exec failure is
         // translated into a structured `success:false` ExecResult carrying the
         // real message, which the SHELL action forwards to the model.
-        const errMsg = err instanceof Error ? err.message : String(err);
+        const errMsg = redactShellText(
+          this.runtime,
+          err instanceof Error ? err.message : String(err),
+        );
         logger.error(`[shell:sandbox] exec failed: ${errMsg}`);
         return {
           success: false,
@@ -408,6 +456,24 @@ export class ShellService extends Service {
    * This is the main execution method that supports all advanced features
    */
   async exec(
+    command: string,
+    options: ExecuteOptions = {},
+  ): Promise<ExecResult> {
+    const onUpdate = options.onUpdate;
+    const safeOptions = onUpdate
+      ? {
+          ...options,
+          onUpdate: (session: ProcessSession) =>
+            onUpdate(redactProcessSession(this.runtime, session)),
+        }
+      : options;
+    return redactShellValue(
+      this.runtime,
+      await this.execUnredacted(command, safeOptions),
+    );
+  }
+
+  private async execUnredacted(
     command: string,
     options: ExecuteOptions = {},
   ): Promise<ExecResult> {
@@ -679,6 +745,17 @@ export class ShellService extends Service {
    * Supports: list, poll, log, write, send-keys, submit, paste, kill, clear, remove
    */
   async processAction(params: ProcessActionParams): Promise<{
+    success: boolean;
+    message: string;
+    data?: Record<string, unknown>;
+  }> {
+    return redactShellValue(
+      this.runtime,
+      await this.processActionUnredacted(params),
+    );
+  }
+
+  private async processActionUnredacted(params: ProcessActionParams): Promise<{
     success: boolean;
     message: string;
     data?: Record<string, unknown>;
@@ -1124,9 +1201,9 @@ export class ShellService extends Service {
    */
   listRunningSessions(): ProcessSession[] {
     const scopeKey = this.scopeKey;
-    return listRunningSessions().filter(
-      (s) => !scopeKey || s.scopeKey === scopeKey,
-    );
+    return listRunningSessions()
+      .filter((s) => !scopeKey || s.scopeKey === scopeKey)
+      .map((session) => redactProcessSession(this.runtime, session));
   }
 
   /**
@@ -1134,9 +1211,9 @@ export class ShellService extends Service {
    */
   listFinishedSessions(): FinishedSession[] {
     const scopeKey = this.scopeKey;
-    return listFinishedSessions().filter(
-      (s) => !scopeKey || s.scopeKey === scopeKey,
-    );
+    return listFinishedSessions()
+      .filter((s) => !scopeKey || s.scopeKey === scopeKey)
+      .map((session) => redactFinishedSession(this.runtime, session));
   }
 
   /**
@@ -1146,7 +1223,7 @@ export class ShellService extends Service {
     const session = getSession(id);
     if (!session) return undefined;
     if (this.scopeKey && session.scopeKey !== this.scopeKey) return undefined;
-    return session;
+    return redactProcessSession(this.runtime, session);
   }
 
   /**
@@ -1156,15 +1233,16 @@ export class ShellService extends Service {
     const session = getFinishedSession(id);
     if (!session) return undefined;
     if (this.scopeKey && session.scopeKey !== this.scopeKey) return undefined;
-    return session;
+    return redactFinishedSession(this.runtime, session);
   }
 
   /**
    * Kill a session by ID
    */
   killSessionById(id: string): boolean {
-    const session = this.getSession(id);
+    const session = getSession(id);
     if (!session) return false;
+    if (this.scopeKey && session.scopeKey !== this.scopeKey) return false;
     killSession(session);
     markExited(session, null, "SIGKILL", "killed");
     return true;
@@ -1285,14 +1363,14 @@ export class ShellService extends Service {
         cmd = shell.shell;
         args = [...shell.args, command];
         logger.info(
-          `Executing shell command: ${cmd} ${shell.args.join(" ")} "${command}" in ${this.currentDirectory}`,
+          `Executing shell command: ${cmd} ${shell.args.join(" ")} "${redactShellText(this.runtime, command)}" in ${redactShellText(this.runtime, this.currentDirectory)}`,
         );
       } else {
         const parts = command.split(/\s+/);
         cmd = parts[0];
         args = parts.slice(1);
         logger.info(
-          `Executing command: ${cmd} ${args.join(" ")} in ${this.currentDirectory}`,
+          `Executing command: ${redactShellText(this.runtime, `${cmd} ${args.join(" ")}`)} in ${redactShellText(this.runtime, this.currentDirectory)}`,
         );
       }
 
@@ -1721,13 +1799,19 @@ export class ShellService extends Service {
     if (!conversationId) return;
 
     const historyEntry: CommandHistoryEntry = {
-      command,
-      stdout: result.stdout,
-      stderr: result.stderr,
+      command: redactShellText(this.runtime, command),
+      stdout: redactShellText(this.runtime, result.stdout),
+      stderr: redactShellText(this.runtime, result.stderr),
       exitCode: result.exitCode,
       timestamp: Date.now(),
-      workingDirectory: result.executedIn,
-      fileOperations,
+      workingDirectory: redactShellText(this.runtime, result.executedIn),
+      fileOperations: fileOperations?.map((operation) => ({
+        ...operation,
+        target: redactShellText(this.runtime, operation.target),
+        secondaryTarget: operation.secondaryTarget
+          ? redactShellText(this.runtime, operation.secondaryTarget)
+          : undefined,
+      })),
     };
 
     if (!this.commandHistory.has(conversationId)) {


### PR DESCRIPTION
Relates to #18960. This is the first reviewable split from closed #18994 and repairs the security gap identified while reviewing #18947.

## What changed

- composes runtime-configured secret redaction with mandatory shape-based redaction;
- sanitizes foreground text/data/user-facing/callback and compatibility-service results;
- sanitizes background snapshots, list/poll/kill/write surfaces, and redacts the full retained ring before applying offsets;
- sanitizes shell history at storage and provider projection boundaries;
- preserves develop’s fail-closed operator timeout validation;
- keeps transcript echo opt-in and sanitized.

## Validation

- plugin-coding-tools: 35 files, 512 tests passed
- package typecheck passed
- package lint passed
- root lint: 132/132
- root build: 123/123 plus 19/19 view bundles
- root typecheck: 218/218
- root verify: 350/350; 8,007 test files passed integrity audit

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-head:9284d15fa2de32fbf12a3989103a92e88683cf6b -->
<!-- evidence-row:before-screenshots -->
- N/A — backend tool-result security boundary; no UI pixels changed.
<!-- evidence-row:after-screenshots -->
- N/A — backend tool-result security boundary; no UI pixels changed.
<!-- evidence-row:walkthrough-video -->
- N/A — no frontend interaction changed.
<!-- evidence-row:backend-logs -->
- N/A — no live backend log artifact applies; focused deterministic tests are reported above.
<!-- evidence-row:frontend-logs -->
- N/A — no browser console/network artifact applies to this isolated contract proof.
<!-- evidence-row:llm-trajectory -->
- N/A — deterministic tool projection contract; no model routing or prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
- N/A — no external domain artifact applies; executable contract artifacts are contained in the changed tests and reported above.
<!-- evidence-row:ocr-review -->
- N/A — no user interface changed.

This remains draft until exact-head CI and independent security review complete.