### PR TITLE
fix(ios): audit final cloud artifacts

### DIFF
--- a/packages/app-core/scripts/audit-ios-cloud-artifact.mjs
+++ b/packages/app-core/scripts/audit-ios-cloud-artifact.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Standalone final-artifact audit for exported iOS cloud `.app`/`.ipa`
+ * products. It delegates to the build-integrated policy and prints only the
+ * artifact-evidence result; it never claims device or runtime validation.
+ */
+import path from "node:path";
+
+import { auditIosCloudArtifact } from "./lib/ios-cloud-artifact-audit.mjs";
+
+const artifactPath = process.argv[2];
+if (!artifactPath) {
+  console.error(
+    "Usage: node scripts/audit-ios-cloud-artifact.mjs <App.app|App.ipa>",
+  );
+  process.exit(2);
+}
+
+const requireCodesign =
+  /^(1|true|yes|on)$/i.test(
+    process.env.ELIZA_IOS_ARTIFACT_REQUIRE_CODESIGN ?? "",
+  ) || artifactPath.toLowerCase().endsWith(".ipa");
+const result = auditIosCloudArtifact({
+  artifactPath,
+  freshDistDir: path.resolve(
+    process.env.ELIZA_IOS_FRESH_RENDERER_DIST ?? "dist",
+  ),
+  expectedRuntimeMode: process.env.ELIZA_IOS_ARTIFACT_RUNTIME_MODE ?? "cloud",
+  requireCodesign,
+  ...(process.env.ELIZA_IOS_ARTIFACT_ATTESTATION_PATH?.trim()
+    ? {
+        attestationPath: process.env.ELIZA_IOS_ARTIFACT_ATTESTATION_PATH.trim(),
+      }
+    : {}),
+});
+console.log(
+  `[ios-cloud-artifact] PASS ${result.artifact} sha256=${result.artifactSha256} ` +
+    `renderer=${result.renderer.buildId} signature=${result.signature.status} ` +
+    `attestation=${result.attestationFile}`,
+);

--- a/packages/app-core/scripts/lib/ios-cloud-artifact-audit.mjs
+++ b/packages/app-core/scripts/lib/ios-cloud-artifact-audit.mjs
@@ -1,0 +1,382 @@
+/**
+ * Post-build evidence gate for iOS cloud-only `.app` and `.ipa` artifacts.
+ * It inspects the bytes Xcode produced, rejects embedded local-runtime products
+ * and native link/symbol indicators, proves the packaged renderer matches the
+ * fresh dist, verifies device signatures when required, and writes a bounded
+ * attestation. This is artifact evidence only; it does not claim simulator,
+ * physical-device, login, network, or runtime behavior.
+ */
+import { spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import AdmZip from "adm-zip";
+
+import { assertStagedRendererMatchesBuild } from "./renderer-build-manifest.mjs";
+
+export const IOS_CLOUD_ARTIFACT_ATTESTATION_SCHEMA =
+  "elizaos.ios-cloud-artifact-attestation/v1";
+
+const FORBIDDEN_PRODUCT_PATTERNS = Object.freeze([
+  /(?:^|[/_.-])ElizaBunEngine(?:$|[/_.-])/i,
+  /(?:^|[/_.-])ElizaosCapacitorBunRuntime(?:$|[/_.-])/i,
+  /(?:^|[/_.-])ElizaosCapacitorMobileAgentBridge(?:$|[/_.-])/i,
+  /(?:^|[/_.-])MobileAgentBridge(?:$|[/_.-])/i,
+  /(?:^|[/_.-])LlamaCpp(?:Capacitor)?(?:$|[/_.-])/i,
+  /(?:^|[/_.-])llama-cpp(?:$|[/_.-])/i,
+  /(?:^|\/)agent-bundle\.js$/i,
+  /\.(?:gguf|ggml)$/i,
+]);
+
+const FORBIDDEN_NATIVE_INDICATORS = Object.freeze([
+  /ElizaBunEngine/i,
+  /ElizaosCapacitorBunRuntime/i,
+  /ElizaosCapacitorMobileAgentBridge/i,
+  /MobileAgentBridgePlugin/i,
+  /LlamaCppCapacitor/i,
+  /(?:^|[^A-Za-z0-9])_?llama_(?:model|context|backend|load|decode|encode)/im,
+  /(?:^|[^A-Za-z0-9])_?ggml_(?:backend|graph|tensor|alloc)/im,
+  /agent-bundle\.js/i,
+]);
+
+const MACH_O_MAGICS = new Set([
+  "feedface",
+  "cefaedfe",
+  "feedfacf",
+  "cffaedfe",
+  "cafebabe",
+  "bebafeca",
+  "cafebabf",
+  "bfbafeca",
+]);
+
+function sha256File(filePath) {
+  const hash = crypto.createHash("sha256");
+  const handle = fs.openSync(filePath, "r");
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  try {
+    for (;;) {
+      const count = fs.readSync(handle, buffer, 0, buffer.length, null);
+      if (count === 0) break;
+      hash.update(buffer.subarray(0, count));
+    }
+  } finally {
+    fs.closeSync(handle);
+  }
+  return hash.digest("hex");
+}
+
+function defaultCommand(command, args) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed (${result.status}): ${result.stderr || result.stdout}`,
+    );
+  }
+  return result.stdout;
+}
+
+function isMachO(filePath) {
+  const handle = fs.openSync(filePath, "r");
+  const magic = Buffer.alloc(4);
+  try {
+    if (fs.readSync(handle, magic, 0, magic.length, 0) !== magic.length) {
+      return false;
+    }
+  } finally {
+    fs.closeSync(handle);
+  }
+  return MACH_O_MAGICS.has(magic.toString("hex"));
+}
+
+function walkFiles(root) {
+  const files = [];
+  const visit = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) visit(fullPath);
+      else if (entry.isFile()) files.push(fullPath);
+    }
+  };
+  visit(root);
+  if (files.length > 100_000) {
+    throw new Error(`iOS app has ${files.length} files; audit limit is 100000`);
+  }
+  return files.sort();
+}
+
+function sha256AppTree(appPath, files) {
+  const hash = crypto.createHash("sha256");
+  for (const filePath of files) {
+    const relativePath = path
+      .relative(appPath, filePath)
+      .split(path.sep)
+      .join("/");
+    hash.update(`${relativePath}\0${fs.statSync(filePath).size}\0`);
+    hash.update(sha256File(filePath));
+    hash.update("\n");
+  }
+  return hash.digest("hex");
+}
+
+function extractIpa(ipaPath, tempRoot) {
+  const zip = new AdmZip(ipaPath);
+  const entries = zip.getEntries();
+  if (entries.length > 100_000) {
+    throw new Error(`IPA has ${entries.length} entries; audit limit is 100000`);
+  }
+  let expandedBytes = 0;
+  for (const entry of entries) {
+    const normalized = path.posix.normalize(entry.entryName);
+    if (
+      path.posix.isAbsolute(normalized) ||
+      normalized === ".." ||
+      normalized.startsWith("../")
+    ) {
+      throw new Error(`IPA contains unsafe entry path: ${entry.entryName}`);
+    }
+    expandedBytes += entry.header.size;
+    if (expandedBytes > 2 * 1024 * 1024 * 1024) {
+      throw new Error("IPA expanded size exceeds the 2 GiB audit limit");
+    }
+  }
+  zip.extractAllTo(tempRoot, true, false);
+  const payloadDir = path.join(tempRoot, "Payload");
+  const apps = fs.existsSync(payloadDir)
+    ? fs
+        .readdirSync(payloadDir)
+        .filter((name) => name.endsWith(".app"))
+        .sort()
+    : [];
+  if (apps.length !== 1) {
+    throw new Error(
+      `IPA must contain exactly one Payload/*.app; found ${apps.length}`,
+    );
+  }
+  return path.join(payloadDir, apps[0]);
+}
+
+function resolveAppArtifact(artifactPath) {
+  const resolved = path.resolve(artifactPath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`iOS artifact does not exist: ${resolved}`);
+  }
+  if (resolved.endsWith(".app") && fs.statSync(resolved).isDirectory()) {
+    return { appPath: resolved, cleanup: () => {}, kind: "app" };
+  }
+  if (resolved.endsWith(".ipa") && fs.statSync(resolved).isFile()) {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ios-cloud-audit-"));
+    try {
+      const appPath = extractIpa(resolved, tempRoot);
+      return {
+        appPath,
+        cleanup: () => fs.rmSync(tempRoot, { recursive: true, force: true }),
+        kind: "ipa",
+      };
+    } catch (error) {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+      throw error;
+    }
+  }
+  throw new Error(`Expected an iOS .app directory or .ipa file: ${resolved}`);
+}
+
+function indicatorMatches(text) {
+  return FORBIDDEN_NATIVE_INDICATORS.filter((pattern) =>
+    pattern.test(text),
+  ).map((pattern) => pattern.source);
+}
+
+/** Audits a final cloud-only iOS artifact and writes its machine-readable proof. */
+export function auditIosCloudArtifact({
+  artifactPath,
+  freshDistDir,
+  expectedRuntimeMode = null,
+  requireCodesign = false,
+  attestationPath = `${path.resolve(artifactPath)}.eliza-cloud-attestation.json`,
+  command = defaultCommand,
+  now = () => new Date().toISOString(),
+}) {
+  const findings = [];
+  const binaries = [];
+  let renderer = null;
+  let signature = { status: "not-required", verified: false };
+  let artifactSha256 = null;
+  let resolved;
+  try {
+    resolved = resolveAppArtifact(artifactPath);
+    const { appPath } = resolved;
+    const files = walkFiles(appPath);
+    artifactSha256 =
+      resolved.kind === "ipa"
+        ? sha256File(path.resolve(artifactPath))
+        : sha256AppTree(appPath, files);
+    for (const filePath of files) {
+      const relativePath = path
+        .relative(appPath, filePath)
+        .split(path.sep)
+        .join("/");
+      if (
+        FORBIDDEN_PRODUCT_PATTERNS.some((pattern) => pattern.test(relativePath))
+      ) {
+        findings.push(`forbidden local-runtime product: ${relativePath}`);
+      }
+      if (!isMachO(filePath)) continue;
+      const sha256 = sha256File(filePath);
+      const outputs = [];
+      for (const [tool, args] of [
+        ["xcrun", ["otool", "-L", filePath]],
+        ["xcrun", ["nm", "-gjU", filePath]],
+        ["xcrun", ["strings", "-a", filePath]],
+      ]) {
+        try {
+          outputs.push(command(tool, args));
+        } catch (error) {
+          throw new Error(
+            `Cannot inspect Mach-O ${relativePath}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+      const indicators = indicatorMatches(outputs.join("\n"));
+      if (indicators.length > 0) {
+        findings.push(
+          `forbidden local-runtime native indicator in ${relativePath}: ${indicators.join(", ")}`,
+        );
+      }
+      binaries.push({ path: relativePath, sha256, indicators });
+    }
+    if (binaries.length === 0) {
+      findings.push("artifact contains no inspectable Mach-O binaries");
+    }
+
+    const publicDir = path.join(appPath, "public");
+    const manifest = assertStagedRendererMatchesBuild(
+      path.resolve(freshDistDir),
+      publicDir,
+      { label: "iOS cloud artifact" },
+    );
+    renderer = {
+      buildId: manifest.buildId,
+      commit: manifest.commit ?? null,
+      runtimeMode: manifest.runtimeMode ?? null,
+      variant: manifest.variant ?? null,
+    };
+    if (expectedRuntimeMode && renderer.runtimeMode !== expectedRuntimeMode) {
+      findings.push(
+        `renderer runtimeMode is ${JSON.stringify(renderer.runtimeMode)}; expected ${JSON.stringify(expectedRuntimeMode)}`,
+      );
+    }
+    if (renderer.runtimeMode === "local") {
+      findings.push(
+        "renderer runtimeMode local contradicts a cloud-only artifact",
+      );
+    }
+
+    const signaturePresent = fs.existsSync(
+      path.join(appPath, "_CodeSignature"),
+    );
+    if (requireCodesign || signaturePresent) {
+      try {
+        command("codesign", [
+          "--verify",
+          "--deep",
+          "--strict",
+          "--verbose=2",
+          appPath,
+        ]);
+        signature = { status: "verified", verified: true };
+      } catch (error) {
+        signature = {
+          status: "failed",
+          verified: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+        throw new Error(
+          `iOS artifact codesign verification failed: ${signature.error}`,
+        );
+      }
+    } else {
+      signature = {
+        status: "not-applicable-unsigned-simulator-or-development-build",
+        verified: false,
+      };
+    }
+  } catch (error) {
+    findings.push(error instanceof Error ? error.message : String(error));
+  } finally {
+    resolved?.cleanup();
+  }
+
+  const attestation = {
+    schema: IOS_CLOUD_ARTIFACT_ATTESTATION_SCHEMA,
+    generatedAt: now(),
+    artifact: path.basename(path.resolve(artifactPath)),
+    artifactKind: resolved?.kind ?? null,
+    artifactSha256,
+    attestationFile: path.resolve(attestationPath),
+    verdict: findings.length === 0 ? "pass" : "fail",
+    policy: "ios-cloud-no-local-execution-products",
+    renderer,
+    signature,
+    machOBinaries: binaries,
+    findings,
+    claimBoundary:
+      "final-artifact-contents-and-signature-only_not_simulator_device_login_network_or_runtime-evidence",
+  };
+  fs.mkdirSync(path.dirname(path.resolve(attestationPath)), {
+    recursive: true,
+  });
+  fs.writeFileSync(
+    path.resolve(attestationPath),
+    `${JSON.stringify(attestation, null, 2)}\n`,
+  );
+  if (findings.length > 0) {
+    throw new Error(
+      `[mobile-build] iOS cloud artifact audit failed; attestation: ${path.resolve(attestationPath)}\n${findings
+        .map((finding) => `  - ${finding}`)
+        .join("\n")}`,
+    );
+  }
+  return attestation;
+}
+
+/** Resolves the main `.app` from `xcodebuild -showBuildSettings -json`. */
+export function resolveIosAppFromBuildSettingsJson(jsonText) {
+  let entries;
+  try {
+    entries = JSON.parse(jsonText);
+  } catch (error) {
+    throw new Error(
+      `Could not parse xcodebuild settings JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const candidates = Array.isArray(entries)
+    ? entries.filter((entry) => {
+        const settings = entry?.buildSettings;
+        return (
+          settings?.WRAPPER_EXTENSION === "app" &&
+          typeof settings.TARGET_BUILD_DIR === "string" &&
+          typeof settings.WRAPPER_NAME === "string"
+        );
+      })
+    : [];
+  const main =
+    candidates.find((entry) => entry.target === "App") ?? candidates[0];
+  if (!main || candidates.length === 0) {
+    throw new Error(
+      "xcodebuild settings did not identify an application product",
+    );
+  }
+  return path.join(
+    main.buildSettings.TARGET_BUILD_DIR,
+    main.buildSettings.WRAPPER_NAME,
+  );
+}

--- a/packages/app-core/scripts/lib/ios-cloud-artifact-audit.test.mjs
+++ b/packages/app-core/scripts/lib/ios-cloud-artifact-audit.test.mjs
@@ -1,0 +1,200 @@
+/**
+ * Deterministic final-artifact contracts for the iOS cloud-only audit. The
+ * fixtures are synthetic `.app`/`.ipa` packages and injected native-tool
+ * output; they prove rejection and attestation behavior, not Apple-device
+ * execution or real code-signing.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import AdmZip from "adm-zip";
+import { describe, expect, it } from "vitest";
+
+import {
+  auditIosCloudArtifact,
+  IOS_CLOUD_ARTIFACT_ATTESTATION_SCHEMA,
+  resolveIosAppFromBuildSettingsJson,
+} from "./ios-cloud-artifact-audit.mjs";
+import { writeRendererBuildManifest } from "./renderer-build-manifest.mjs";
+
+function makeFixture({ runtimeMode = "cloud" } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ios-cloud-artifact-"));
+  const dist = path.join(root, "dist");
+  fs.mkdirSync(path.join(dist, "assets"), { recursive: true });
+  fs.writeFileSync(path.join(dist, "index.html"), "<main>cloud</main>\n");
+  fs.writeFileSync(path.join(dist, "assets", "app-deadbeef.js"), "cloud();\n");
+  writeRendererBuildManifest(dist, {
+    builtAt: "2026-08-12T00:00:00.000Z",
+    commit: "0123456789abcdef",
+    variant: "store",
+    capacitorTarget: "ios",
+    runtimeMode,
+  });
+
+  const app = path.join(root, "App.app");
+  fs.cpSync(dist, path.join(app, "public"), { recursive: true });
+  // Thin 64-bit Mach-O magic is sufficient because native-tool output is
+  // injected below; no host architecture or Xcode installation is required.
+  fs.writeFileSync(
+    path.join(app, "App"),
+    Buffer.from("cffaedfe00000000", "hex"),
+  );
+  return { app, dist, root };
+}
+
+function cleanNativeCommand(calls = []) {
+  return (command, args) => {
+    calls.push([command, ...args]);
+    if (command === "codesign") return "valid on disk\n";
+    if (args[0] === "otool") {
+      return "App:\n\t/System/Library/Frameworks/WebKit.framework/WebKit\n";
+    }
+    if (args[0] === "nm") return "_main\n";
+    if (args[0] === "strings") return "WKWebView\nEliza Cloud\n";
+    throw new Error(`unexpected command: ${command} ${args.join(" ")}`);
+  };
+}
+
+describe("iOS cloud final-artifact audit", () => {
+  it("attests renderer identity, native inspection, signature verification, and claim boundary", () => {
+    const fixture = makeFixture();
+    const attestationPath = path.join(fixture.root, "attestation.json");
+    const calls = [];
+    try {
+      const result = auditIosCloudArtifact({
+        artifactPath: fixture.app,
+        freshDistDir: fixture.dist,
+        expectedRuntimeMode: "cloud",
+        requireCodesign: true,
+        attestationPath,
+        command: cleanNativeCommand(calls),
+        now: () => "2026-08-12T01:02:03.000Z",
+      });
+      expect(result.schema).toBe(IOS_CLOUD_ARTIFACT_ATTESTATION_SCHEMA);
+      expect(result.verdict).toBe("pass");
+      expect(result.artifactSha256).toMatch(/^[a-f0-9]{64}$/);
+      expect(result.renderer.runtimeMode).toBe("cloud");
+      expect(result.signature).toEqual({ status: "verified", verified: true });
+      expect(result.machOBinaries).toHaveLength(1);
+      expect(result.claimBoundary).toContain("not_simulator_device");
+      expect(calls.some(([command]) => command === "codesign")).toBe(true);
+      expect(JSON.parse(fs.readFileSync(attestationPath, "utf8"))).toEqual(
+        result,
+      );
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects forbidden products and Mach-O load/symbol indicators and preserves failure evidence", () => {
+    const fixture = makeFixture();
+    const forbidden = path.join(
+      fixture.app,
+      "Frameworks",
+      "ElizaBunEngine.framework",
+      "ElizaBunEngine",
+    );
+    fs.mkdirSync(path.dirname(forbidden), { recursive: true });
+    fs.writeFileSync(forbidden, Buffer.from("cffaedfe00000000", "hex"));
+    const attestationPath = path.join(fixture.root, "failed.json");
+    try {
+      expect(() =>
+        auditIosCloudArtifact({
+          artifactPath: fixture.app,
+          freshDistDir: fixture.dist,
+          expectedRuntimeMode: "cloud",
+          attestationPath,
+          command: (_command, args) =>
+            args[0] === "otool"
+              ? "@rpath/ElizaBunEngine.framework/ElizaBunEngine\n"
+              : args[0] === "nm"
+                ? "_llama_model_load_from_file\n"
+                : "agent-bundle.js\n",
+        }),
+      ).toThrow(/forbidden local-runtime product/);
+      const failed = JSON.parse(fs.readFileSync(attestationPath, "utf8"));
+      expect(failed.verdict).toBe("fail");
+      expect(failed.findings).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("ElizaBunEngine.framework"),
+          expect.stringContaining("native indicator"),
+        ]),
+      );
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("audits an IPA payload and marks an unsigned fixture as non-runtime evidence", () => {
+    const fixture = makeFixture();
+    const ipa = path.join(fixture.root, "Eliza.ipa");
+    const zip = new AdmZip();
+    zip.addLocalFolder(fixture.app, "Payload/App.app");
+    zip.writeZip(ipa);
+    try {
+      const result = auditIosCloudArtifact({
+        artifactPath: ipa,
+        freshDistDir: fixture.dist,
+        expectedRuntimeMode: "cloud",
+        command: cleanNativeCommand(),
+      });
+      expect(result.artifactKind).toBe("ipa");
+      expect(result.signature.status).toBe(
+        "not-applicable-unsigned-simulator-or-development-build",
+      );
+      expect(result.signature.verified).toBe(false);
+    } finally {
+      fs.rmSync(`${ipa}.eliza-cloud-attestation.json`, { force: true });
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("selects the App product from Xcode build-settings JSON", () => {
+    const json = JSON.stringify([
+      {
+        target: "Widget",
+        buildSettings: {
+          WRAPPER_EXTENSION: "appex",
+          TARGET_BUILD_DIR: "/tmp/build",
+          WRAPPER_NAME: "Widget.appex",
+        },
+      },
+      {
+        target: "App",
+        buildSettings: {
+          WRAPPER_EXTENSION: "app",
+          TARGET_BUILD_DIR: "/tmp/build",
+          WRAPPER_NAME: "Eliza.app",
+        },
+      },
+    ]);
+    expect(resolveIosAppFromBuildSettingsJson(json)).toBe(
+      path.join("/tmp/build", "Eliza.app"),
+    );
+  });
+
+  it("keeps the final artifact audit after xcodebuild and out of local-runtime lanes", () => {
+    const runMobileBuild = fs.readFileSync(
+      path.join(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "run-mobile-build.mjs",
+      ),
+      "utf8",
+    );
+    const nativeBuild = runMobileBuild.indexOf('await run(\n    "xcodebuild",');
+    const thinLaneGate = runMobileBuild.indexOf(
+      "if (!includesLocalAgentPayload)",
+      nativeBuild,
+    );
+    const finalAudit = runMobileBuild.indexOf(
+      "auditIosCloudArtifact({",
+      thinLaneGate,
+    );
+    expect(nativeBuild).toBeGreaterThan(-1);
+    expect(thinLaneGate).toBeGreaterThan(nativeBuild);
+    expect(finalAudit).toBeGreaterThan(thinLaneGate);
+  });
+});

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -86,6 +86,10 @@ import {
 } from "./lib/capacitor-platform-templates.mjs";
 import { ElizaError } from "./lib/eliza-error.mjs";
 import {
+  auditIosCloudArtifact,
+  resolveIosAppFromBuildSettingsJson,
+} from "./lib/ios-cloud-artifact-audit.mjs";
+import {
   androidUsesAppDirFor,
   MTP_FORK_SRC_CANDIDATES,
   mtpForceRebuildRequested,
@@ -8636,19 +8640,22 @@ async function buildIos({ local = false } = {}) {
   )
     ? ["-allowProvisioningUpdates", "-allowProvisioningDeviceRegistration"]
     : [];
+  const buildSelectionArgs = [
+    ...projectArgs,
+    "-scheme",
+    "App",
+    ...(derivedDataPath ? ["-derivedDataPath", derivedDataPath] : []),
+    "-configuration",
+    resolveIosBuildConfiguration(),
+    "-destination",
+    buildTarget.destination,
+    "-sdk",
+    buildTarget.sdk,
+  ];
   await run(
     "xcodebuild",
     [
-      ...projectArgs,
-      "-scheme",
-      "App",
-      ...(derivedDataPath ? ["-derivedDataPath", derivedDataPath] : []),
-      "-configuration",
-      resolveIosBuildConfiguration(),
-      "-destination",
-      buildTarget.destination,
-      "-sdk",
-      buildTarget.sdk,
+      ...buildSelectionArgs,
       ...provisioningArgs,
       `IPHONEOS_DEPLOYMENT_TARGET=${resolveIosDeploymentTarget()}`,
       `CODE_SIGNING_ALLOWED=${process.env.ELIZA_IOS_CODE_SIGNING_ALLOWED ?? "NO"}`,
@@ -8661,6 +8668,49 @@ async function buildIos({ local = false } = {}) {
     ],
     { cwd: iosDir },
   );
+
+  // A source/native-graph policy cannot prove what Xcode actually linked and
+  // copied. Thin iOS builds therefore inspect the final app product before it
+  // can be treated as release evidence. Local-runtime lanes intentionally do
+  // not use this prohibition audit.
+  if (!includesLocalAgentPayload) {
+    const settings = runCaptureSync(
+      "xcodebuild",
+      [...buildSelectionArgs, "-showBuildSettings", "-json"],
+      { cwd: iosDir, maxBuffer: 32 * 1024 * 1024 },
+    );
+    if (settings.error || settings.status !== 0) {
+      throw new Error(
+        `[mobile-build] Could not resolve final iOS app for cloud artifact audit: ${
+          settings.stderr?.trim() ||
+          settings.stdout?.trim() ||
+          settings.error?.message ||
+          `xcodebuild exited ${String(settings.status)}`
+        }`,
+      );
+    }
+    const artifactPath = resolveIosAppFromBuildSettingsJson(settings.stdout);
+    const attestation = auditIosCloudArtifact({
+      artifactPath,
+      freshDistDir: path.join(appDir, "dist"),
+      expectedRuntimeMode: process.env.VITE_ELIZA_IOS_RUNTIME_MODE ?? null,
+      requireCodesign:
+        !isIosSimulatorBuildTarget(buildTarget) &&
+        isTruthyEnv(process.env.ELIZA_IOS_CODE_SIGNING_ALLOWED),
+      ...(process.env.ELIZA_IOS_ARTIFACT_ATTESTATION_PATH?.trim()
+        ? {
+            attestationPath:
+              process.env.ELIZA_IOS_ARTIFACT_ATTESTATION_PATH.trim(),
+          }
+        : {}),
+    });
+    console.log(
+      `[mobile-build] iOS cloud artifact audit passed: ${artifactPath} ` +
+        `(renderer=${attestation.renderer.buildId.slice(0, 12)}, ` +
+        `Mach-O=${attestation.machOBinaries.length}, signature=${attestation.signature.status}); ` +
+        `attestation=${attestation.attestationFile}`,
+    );
+  }
 }
 
 // ── Entry point ─────────────────────────────────────────────────────────

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -101,6 +101,7 @@
     "build:ios:chat-harness": "ELIZA_CHAT_UI_HARNESS=1 ELIZA_IOS_APP_STORE_LOCAL_RUNTIME=0 ELIZA_IOS_BUILD_DESTINATION='generic/platform=iOS Simulator' ELIZA_IOS_BUILD_SDK=iphonesimulator node ../../packages/app-core/scripts/run-mobile-build.mjs ios",
     "build:ios:cloud:device": "ELIZA_IOS_APP_STORE_LOCAL_RUNTIME=0 ELIZA_IOS_CODE_SIGNING_ALLOWED=YES ELIZA_IOS_ALLOW_PROVISIONING_UPDATES=1 ELIZA_IOS_BUILD_DESTINATION='generic/platform=iOS' ELIZA_IOS_BUILD_SDK=iphoneos node ../../packages/app-core/scripts/run-mobile-build.mjs ios",
     "build:ios:cloud:sim": "ELIZA_IOS_APP_STORE_LOCAL_RUNTIME=0 ELIZA_IOS_BUILD_DESTINATION='generic/platform=iOS Simulator' ELIZA_IOS_BUILD_SDK=iphonesimulator node ../../packages/app-core/scripts/run-mobile-build.mjs ios",
+    "audit:ios:cloud-artifact": "node ../../packages/app-core/scripts/audit-ios-cloud-artifact.mjs",
     "build:ios:local": "ELIZA_IOS_FULL_BUN_ENGINE=1 node ../../packages/app-core/scripts/run-mobile-build.mjs ios-local",
     "build:ios:local:sim": "ELIZA_IOS_FULL_BUN_ENGINE=1 ELIZA_IOS_BUILD_DESTINATION='generic/platform=iOS Simulator' ELIZA_IOS_BUILD_SDK=iphonesimulator node ../../packages/app-core/scripts/run-mobile-build.mjs ios-local",
     "build:ios:local:device": "ELIZA_IOS_FULL_BUN_ENGINE=1 ELIZA_IOS_BUILD_DESTINATION='generic/platform=iOS' ELIZA_IOS_BUILD_SDK=iphoneos node ../../packages/app-core/scripts/run-mobile-build.mjs ios-local",


### PR DESCRIPTION
## Summary

- audit the final Xcode-produced cloud-only `.app`/`.ipa`, not only the source/native dependency graph
- reject bundled local-runtime products and native link/symbol indicators
- verify the staged renderer identity and runtime mode against the fresh build
- verify code signing when required and write a bounded machine-readable attestation
- expose a standalone artifact-audit command for release/operator use

This is the isolated iOS final-artifact/release-contract slice from the Nubs review repair work. It intentionally excludes unrelated desktop release, cloud, runtime, UI, and plugin changes.

Fixes part of #18960.

## Local validation

Exact focused contract on the isolated contents:

```text
bun test packages/app-core/scripts/lib/ios-cloud-artifact-audit.test.mjs
5 pass, 0 fail, 19 assertions
```

`git diff --check origin/develop...fix/nubs-ios-cloud-artifact-audit` passes. The branch differs from `develop` in exactly five files.

## Evidence boundary

The deterministic fixtures prove post-build policy, attestation, renderer-identity, native-indicator rejection, IPA handling, and build-order integration. They do not claim simulator, physical-device, Apple signing-service, login, network, or runtime evidence; those remain release-operator validation.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7e847856f784fee0ae2fbe0d33e399ca3e319de0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:50435e2776077959fd13056a58f512af173dd59c -->

<!-- evidence-row:before-screenshots -->
- N/A — final-artifact release tooling has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- N/A — final-artifact release tooling has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- N/A — deterministic contract/authority change with no new interactive visual flow.
<!-- evidence-row:backend-logs -->
- N/A — no live backend log artifact applies; focused deterministic tests are reported above.
<!-- evidence-row:frontend-logs -->
- N/A — no browser console/network artifact applies to this isolated contract proof.
<!-- evidence-row:llm-trajectory -->
- N/A — no prompt, model selection, or generated-output contract changes.
<!-- evidence-row:domain-artifacts -->
- N/A — no external domain artifact applies; executable contract artifacts are contained in the changed tests and reported above.
<!-- evidence-row:ocr-review -->
- N/A — no visual layout or rendered text changed.