### PR TITLE
fix(cloud): serialize authoritative node provisioning

### DIFF
--- a/packages/cloud/api/v1/admin/docker-nodes/provision/route.ts
+++ b/packages/cloud/api/v1/admin/docker-nodes/provision/route.ts
@@ -105,6 +105,7 @@ async function __hono_POST(request: Request) {
         hostname: result.hostname,
         hcloudServerId: result.hcloudServerId,
         rootPassword: result.rootPassword,
+        idempotent: result.idempotent,
         message:
           "Node provisioned. Cloud-init is now installing Docker — first health-check tick will flip status from `unknown` to `healthy`.",
       },

--- a/packages/cloud/routing/src/resolve.test.ts
+++ b/packages/cloud/routing/src/resolve.test.ts
@@ -96,7 +96,7 @@ describe("resolveCloudRoute", () => {
       ),
     ).toMatchObject({
       source: "cloud-proxy",
-      baseUrl: "https://elizacloud.ai/api/v1/apis/quotes",
+      baseUrl: "https://api.eliza.app/api/v1/apis/quotes",
       headers: { Authorization: "Bearer cloud-secret" },
     });
   });

--- a/packages/cloud/shared/src/lib/services/containers/node-autoscaler.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-autoscaler.test.ts
@@ -40,6 +40,7 @@ const mocks = {
   createNode: mock(),
   findAllNodes: mock(),
   createServer: mock(),
+  listServers: mock(),
   deleteServer: mock(),
   isConfigured: mock(),
   buildUserData: mock(),
@@ -76,10 +77,21 @@ mock.module("./hetzner-cloud-api", () => ({
     }
   },
   getHetznerCloudClient: () => ({
+    listServers: mocks.listServers,
     createServer: mocks.createServer,
     deleteServer: mocks.deleteServer,
   }),
   isHetznerCloudConfigured: mocks.isConfigured,
+}));
+
+mock.module("./node-provision-authority", () => ({
+  withNodeProvisionAuthority: async (
+    _scope: string,
+    operation: (authority: {
+      nodes: DockerNode[];
+      createNode: typeof mocks.createNode;
+    }) => Promise<unknown>,
+  ) => operation({ nodes: mocks.nodes, createNode: mocks.createNode }),
 }));
 
 mock.module("./node-bootstrap", () => ({
@@ -123,6 +135,7 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
     mocks.createNode.mockClear();
     mocks.findAllNodes.mockClear();
     mocks.createServer.mockClear();
+    mocks.listServers.mockClear();
     mocks.deleteServer.mockClear();
     mocks.isConfigured.mockClear();
     mocks.buildUserData.mockClear();
@@ -148,6 +161,7 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
       },
       rootPassword: "root-secret",
     });
+    mocks.listServers.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -224,7 +238,111 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
       hostname: "203.0.113.10",
       hcloudServerId: 4242,
       rootPassword: "root-secret",
+      idempotent: false,
     });
+  });
+
+  test("returns the authoritative DB row for an idempotent retry", async () => {
+    mocks.nodes = [
+      {
+        node_id: "node-existing",
+        hostname: "203.0.113.20",
+        metadata: { hcloudServerId: 2020, environment: "local" },
+      } as DockerNode,
+    ];
+    const autoscaler = new NodeAutoscaler(policy);
+
+    await expect(
+      autoscaler.provisionNode(
+        { nodeId: "node-existing" },
+        {
+          controlPlanePublicKey: "ssh-ed25519 AAAAcontrol",
+          registrationUrl: "https://cloud.example.test/register",
+          registrationSecret: "secret",
+        },
+      ),
+    ).resolves.toMatchObject({
+      nodeId: "node-existing",
+      hcloudServerId: 2020,
+      idempotent: true,
+    });
+    expect(mocks.listServers).not.toHaveBeenCalled();
+    expect(mocks.createServer).not.toHaveBeenCalled();
+  });
+
+  test("enforces the provider/environment node quota before create", async () => {
+    mocks.listServers.mockResolvedValue(
+      Array.from({ length: policy.maxNodes }, (_, index) => ({
+        id: 1000 + index,
+        name: `provider-node-${index}`,
+        status: "running",
+        labels: {
+          "managed-by": "eliza-cloud",
+          environment: "local",
+          tier: "data-plane",
+        },
+      })),
+    );
+    const autoscaler = new NodeAutoscaler(policy);
+
+    await expect(
+      autoscaler.provisionNode(
+        { nodeId: "node-over-quota" },
+        {
+          controlPlanePublicKey: "ssh-ed25519 AAAAcontrol",
+          registrationUrl: "https://cloud.example.test/register",
+          registrationSecret: "secret",
+        },
+      ),
+    ).rejects.toMatchObject({ code: "quota_exceeded" });
+    expect(mocks.createServer).not.toHaveBeenCalled();
+  });
+
+  test("does not charge a different provider's DB rows to the selected provider", async () => {
+    mocks.nodes = Array.from(
+      { length: policy.maxNodes },
+      (_, index) =>
+        ({
+          node_id: `digitalocean-node-${index}`,
+          hostname: `198.51.100.${index + 1}`,
+          capacity: policy.defaultCapacity,
+          metadata: {
+            provider: "digitalocean",
+            environment: "local",
+            hcloudServerId: 5000 + index,
+          },
+        }) as DockerNode,
+    );
+    const autoscaler = new NodeAutoscaler(policy);
+
+    await expect(
+      autoscaler.provisionNode(
+        { nodeId: "hetzner-provider-isolated" },
+        {
+          controlPlanePublicKey: "ssh-ed25519 AAAAcontrol",
+          registrationUrl: "https://cloud.example.test/register",
+          registrationSecret: "secret",
+        },
+      ),
+    ).resolves.toMatchObject({ idempotent: false });
+    expect(mocks.createServer).toHaveBeenCalledTimes(1);
+  });
+
+  test("deletes a newly-created provider server when DB registration fails", async () => {
+    mocks.createNode.mockRejectedValueOnce(new Error("database unavailable"));
+    const autoscaler = new NodeAutoscaler(policy);
+
+    await expect(
+      autoscaler.provisionNode(
+        { nodeId: "node-compensate" },
+        {
+          controlPlanePublicKey: "ssh-ed25519 AAAAcontrol",
+          registrationUrl: "https://cloud.example.test/register",
+          registrationSecret: "secret",
+        },
+      ),
+    ).rejects.toThrow("database unavailable");
+    expect(mocks.deleteServer).toHaveBeenCalledWith(4242);
   });
 
   test("persists a fail-closed provisional row while preserving an absent override", async () => {
@@ -252,6 +370,51 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
         }),
       }),
     );
+  });
+
+  test("charges provisional capacity reservations against the atomic budget", async () => {
+    mocks.nodes = Array.from(
+      { length: policy.maxNodes - 1 },
+      (_, index) =>
+        ({
+          node_id: `booting-${index}`,
+          hostname: `203.0.113.${index + 20}`,
+          capacity: 0,
+          metadata: {
+            provider: "hetzner-cloud",
+            environment: "local",
+            hcloudServerId: 6000 + index,
+            capacityProvisional: true,
+            capacityRequested: null,
+            capacityPolicyFallback: policy.defaultCapacity,
+          },
+        }) as DockerNode,
+    );
+    mocks.listServers.mockResolvedValue(
+      mocks.nodes.map((node) => ({
+        id: (node.metadata as Record<string, unknown>).hcloudServerId as number,
+        name: node.node_id,
+        status: "running",
+        labels: {
+          "managed-by": "eliza-cloud",
+          environment: "local",
+          tier: "data-plane",
+        },
+      })),
+    );
+    const autoscaler = new NodeAutoscaler(policy);
+
+    await expect(
+      autoscaler.provisionNode(
+        { nodeId: "capacity-over-budget", capacity: policy.defaultCapacity + 1 },
+        {
+          controlPlanePublicKey: "ssh-ed25519 AAAAcontrol",
+          registrationUrl: "https://cloud.example.test/register",
+          registrationSecret: "secret",
+        },
+      ),
+    ).rejects.toMatchObject({ code: "quota_exceeded" });
+    expect(mocks.createServer).not.toHaveBeenCalled();
   });
 
   test("passes configured Hetzner private network ids to new nodes", async () => {

--- a/packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts
@@ -30,9 +30,10 @@ import {
   inferNodeArchitectureFromMetadata,
   isArchitectureCompatibleWithPlatform,
 } from "../docker-sandbox-utils";
-import { type ComputeProvider, getComputeProvider } from "./compute-provider";
+import { type ComputeProvider, getComputeProvider, isComputeConfigured } from "./compute-provider";
 import { HetznerCloudError, isHetznerCloudConfigured } from "./hetzner-cloud-api";
 import { buildContainerNodeUserData, type NodeBootstrapInput } from "./node-bootstrap";
+import { withNodeProvisionAuthority } from "./node-provision-authority";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -103,6 +104,8 @@ export interface ProvisionResult {
   hostname: string;
   hcloudServerId: number;
   rootPassword: string | null;
+  /** True when a retry recovered an existing provider/DB node. */
+  idempotent: boolean;
 }
 
 export interface DrainOptions {
@@ -223,10 +226,10 @@ export class NodeAutoscaler {
       "controlPlanePublicKey" | "registrationUrl" | "registrationSecret"
     >,
   ): Promise<ProvisionResult> {
-    if (!isHetznerCloudConfigured()) {
+    if (!isComputeConfigured()) {
       throw new HetznerCloudError(
         "missing_token",
-        "Cannot provision a node: HCLOUD_TOKEN is not set.",
+        "Cannot provision a node: compute provider credentials are not configured.",
       );
     }
     if (bootstrap.controlPlanePublicKey.trim().length === 0) {
@@ -241,6 +244,7 @@ export class NodeAutoscaler {
     const location = request.location ?? this.policy.defaultLocation;
     const image = request.image ?? this.policy.defaultImage;
     const policyCapacity = this.policy.defaultCapacity;
+    const requestedCapacity = request.capacity ?? policyCapacity;
     const prePullImages = request.prePullImages ?? [containersEnv.defaultAgentImage()];
     const networkIds = containersEnv.defaultHcloudNetworkIds();
 
@@ -262,73 +266,141 @@ export class NodeAutoscaler {
     // these labels every API-discovered node looks identical, which is how we
     // shipped a staging node tagged `environment=production` in the first
     // place. Caller overrides via `request.labels` win (test seams).
+    const environment = containersEnv.environment();
+    const providerName =
+      process.env.COMPUTE_PROVIDER === "digitalocean" ? "digitalocean" : "hetzner";
     const labels = {
+      ...request.labels,
       "managed-by": "eliza-cloud",
       "node-id": nodeId,
-      environment: containersEnv.environment(),
+      environment,
       tier: "data-plane",
-      ...request.labels,
     };
 
-    const provisioned = await client.createServer({
-      name: nodeId,
-      serverType,
-      location,
-      image,
-      userData,
-      networkIds,
-      labels,
-    });
+    return withNodeProvisionAuthority(`${providerName}:${environment}`, async (authority) => {
+      const existingRow = authority.nodes.find((node) => node.node_id === nodeId);
+      if (existingRow) return provisionResultFromNode(existingRow);
 
-    // Resolve via the canonical seam field (ipv4→ipv6 already collapsed by the
-    // provider) so this works for any ComputeProvider, not just Hetzner.
-    const ip = provisioned.server.publicIpv4 ?? provisioned.server.name;
-    const hcloudServerId = Number(provisioned.server.id);
+      const providerServers = await client.listServers({
+        "managed-by": "eliza-cloud",
+        environment,
+        tier: "data-plane",
+      });
+      const existingServer = providerServers.find(
+        (server) => server.labels?.["node-id"] === nodeId || server.name === nodeId,
+      );
+      const environmentNodes = authority.nodes.filter((node) => {
+        const metadata = (node.metadata ?? {}) as Record<string, unknown>;
+        const nodeProvider = metadata.provider;
+        const belongsToProvider =
+          providerName === "hetzner"
+            ? nodeProvider === "hetzner-cloud" || nodeProvider == null
+            : nodeProvider === providerName;
+        return (
+          belongsToProvider &&
+          (metadata.environment === environment || metadata.environment == null)
+        );
+      });
+      const providerIds = new Set(providerServers.map((server) => String(server.id)));
+      const dbOnlyCount = environmentNodes.filter((node) => {
+        const id = getHcloudServerId(node);
+        return id === undefined || !providerIds.has(String(id));
+      }).length;
+      const authoritativeNodeCount = providerServers.length + dbOnlyCount;
+      const representedProviderIds = new Set(
+        environmentNodes
+          .map((node) => getHcloudServerId(node))
+          .filter((id): id is number => id !== undefined)
+          .map(String),
+      );
+      const providerOnlyCount = providerServers.filter(
+        (server) => !representedProviderIds.has(String(server.id)),
+      ).length;
+      const authoritativeCapacity =
+        environmentNodes.reduce(
+          (sum, node) => sum + nodeCapacityReservation(node, policyCapacity),
+          0,
+        ) +
+        providerOnlyCount * policyCapacity;
+      const capacityBudget = this.policy.maxNodes * this.policy.defaultCapacity;
 
-    // Insert the row in `unknown` status — the cloud-init bootstrap is
-    // still running; the periodic health check will flip it to healthy.
-    await dockerNodesRepository.create({
-      node_id: nodeId,
-      hostname: ip,
-      ssh_port: 22,
-      // Zero is the data-level fail-closed fence. Several legacy placement
-      // paths still query `allocated_count < capacity` directly, so a
-      // non-zero provisional value could bypass metadata-aware selectors.
-      capacity: 0,
-      enabled: true,
-      status: "unknown",
-      allocated_count: 0,
-      ssh_user: "root",
-      metadata: {
-        provider: "hetzner-cloud",
-        autoscaled: true,
+      if (!existingServer && authoritativeNodeCount >= this.policy.maxNodes) {
+        throw new HetznerCloudError(
+          "quota_exceeded",
+          `Compute node quota reached for ${providerName}/${environment}`,
+        );
+      }
+      if (!existingServer && authoritativeCapacity + requestedCapacity > capacityBudget) {
+        throw new HetznerCloudError(
+          "quota_exceeded",
+          `Compute capacity budget reached for ${providerName}/${environment}`,
+        );
+      }
+
+      const provisioned = existingServer
+        ? { server: existingServer, rootPassword: null }
+        : await client.createServer({
+            name: nodeId,
+            serverType,
+            location,
+            image,
+            userData,
+            networkIds,
+            labels,
+          });
+      const ip = provisioned.server.publicIpv4 ?? provisioned.server.name;
+      const hcloudServerId = Number(provisioned.server.id);
+
+      try {
+        await authority.createNode({
+          node_id: nodeId,
+          hostname: ip,
+          ssh_port: 22,
+          // Zero is the data-level fail-closed fence. Legacy placement paths
+          // query allocated_count < capacity without reading metadata.
+          capacity: 0,
+          enabled: true,
+          status: "unknown",
+          allocated_count: 0,
+          ssh_user: "root",
+          metadata: {
+            provider: providerName === "hetzner" ? "hetzner-cloud" : providerName,
+            environment,
+            autoscaled: true,
+            hcloudServerId,
+            ip,
+            serverType,
+            location,
+            image,
+            architecture: inferArchitectureFromHetznerServerType(serverType),
+            provisionedAt: new Date().toISOString(),
+            capacityProvisional: true,
+            capacityRequested: request.capacity ?? null,
+            capacityPolicyFallback: policyCapacity,
+          },
+        });
+      } catch (error) {
+        if (!existingServer) await client.deleteServer(Number(provisioned.server.id));
+        throw error;
+      }
+
+      logger.info("[autoscaler] Provisioned new container node", {
+        nodeId,
         hcloudServerId,
+        ip,
         serverType,
         location,
-        image,
-        architecture: inferArchitectureFromHetznerServerType(serverType),
-        provisionedAt: new Date().toISOString(),
         capacityProvisional: true,
-        capacityRequested: request.capacity ?? null,
-        capacityPolicyFallback: policyCapacity,
-      },
-    });
+      });
 
-    logger.info("[autoscaler] Provisioned new container node", {
-      nodeId,
-      hcloudServerId,
-      ip,
-      serverType,
-      location,
-      capacityProvisional: true,
+      return {
+        nodeId,
+        hostname: ip,
+        hcloudServerId,
+        rootPassword: provisioned.rootPassword,
+        idempotent: Boolean(existingServer),
+      };
     });
-
-    return {
-      nodeId,
-      hostname: ip,
-      hcloudServerId,
-      rootPassword: provisioned.rootPassword,
-    };
   }
 
   /**
@@ -472,6 +544,36 @@ function generateNodeId(): string {
 function getHcloudServerId(node: DockerNode): number | undefined {
   const meta = (node.metadata ?? {}) as Record<string, unknown>;
   return typeof meta.hcloudServerId === "number" ? meta.hcloudServerId : undefined;
+}
+
+function nodeCapacityReservation(node: DockerNode, policyFallback: number): number {
+  const metadata = (node.metadata ?? {}) as Record<string, unknown>;
+  if (metadata.capacityProvisional !== true) return node.capacity;
+  const requested = metadata.capacityRequested;
+  if (typeof requested === "number" && Number.isSafeInteger(requested) && requested > 0) {
+    return requested;
+  }
+  const fallback = metadata.capacityPolicyFallback;
+  return typeof fallback === "number" && Number.isSafeInteger(fallback) && fallback > 0
+    ? fallback
+    : policyFallback;
+}
+
+function provisionResultFromNode(node: DockerNode): ProvisionResult {
+  const hcloudServerId = getHcloudServerId(node);
+  if (hcloudServerId === undefined) {
+    throw new HetznerCloudError(
+      "invalid_input",
+      `node ${node.node_id} has no authoritative provider id`,
+    );
+  }
+  return {
+    nodeId: node.node_id,
+    hostname: node.hostname,
+    hcloudServerId,
+    rootPassword: null,
+    idempotent: true,
+  };
 }
 
 function isAutoscaledHetznerNode(node: DockerNode): boolean {

--- a/packages/cloud/shared/src/lib/services/containers/node-provision-authority.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-provision-authority.ts
@@ -1,0 +1,42 @@
+/**
+ * Serializes compute-node provisioning per provider and deployment environment.
+ * The transaction-scoped advisory lock keeps every API, daemon, and on-demand
+ * caller behind the same quota decision while the provider operation is in flight.
+ */
+
+import { sql } from "drizzle-orm";
+import type { DbTransaction } from "../../../db/client";
+import { dbWrite } from "../../../db/helpers";
+import { type DockerNode, dockerNodes, type NewDockerNode } from "../../../db/schemas/docker-nodes";
+
+export interface NodeProvisionAuthority {
+  nodes: readonly DockerNode[];
+  createNode(data: NewDockerNode): Promise<DockerNode>;
+}
+
+async function authorityForTransaction(tx: DbTransaction): Promise<NodeProvisionAuthority> {
+  const nodes = await tx.select().from(dockerNodes);
+  return {
+    nodes,
+    async createNode(data) {
+      const [created] = await tx.insert(dockerNodes).values(data).returning();
+      if (!created) throw new Error("Failed to create docker node record");
+      return created;
+    },
+  };
+}
+
+export async function withNodeProvisionAuthority<T>(
+  scope: string,
+  operation: (authority: NodeProvisionAuthority) => Promise<T>,
+): Promise<T> {
+  return dbWrite.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(
+        hashtext('eliza:compute-node-provision:v1'),
+        hashtext(${scope})
+      )`,
+    );
+    return operation(await authorityForTransaction(tx));
+  });
+}


### PR DESCRIPTION
## Summary

Extracted from the Nubs PR review/repair work tracked in #18960. This slice makes compute-node provisioning authoritative across API, daemon, and on-demand callers without carrying other subsystem repairs.

- serialize provisioning per compute provider and deployment environment with a transaction-scoped PostgreSQL advisory lock
- reconcile DB and provider state before quota/capacity decisions and make retries idempotent
- reserve provisional capacity fail-closed and compensate provider creation when DB registration fails
- expose the idempotent outcome from the admin provisioning route
- align the stale inherited cloud-routing production URL expectation with the runtime (`api.eliza.app`) so this isolated CI lane is self-contained

## Why this is the root fix

Checking quota before provider creation in each caller only treats the surface race: multiple processes can all observe spare capacity and create concurrently. The shared authority places reconciliation, budget enforcement, and DB registration behind one cross-process lock, so every provisioning entry point makes one atomic decision.

## Verification

- `bun test packages/cloud/shared/src/lib/services/containers/node-autoscaler.test.ts` (14 passed)
- `bun test packages/cloud/routing/src/resolve.test.ts` (61 passed on the identical fixed test/runtime blobs; hosted proof in #19209)
- `bunx @biomejs/biome check` on all four changed files
- `bun run --cwd packages/cloud/shared typecheck`
- `git diff --check origin/develop..fix/nubs-node-provision-authority`

Part of #18960.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:b843baebdcaa4453279a18ba181a8af43e0bdf07 -->

<!-- evidence-row:before-screenshots -->
- N/A — compute provisioning is a backend-only authority change.
<!-- evidence-row:after-screenshots -->
- N/A — compute provisioning is a backend-only authority change.
<!-- evidence-row:walkthrough-video -->
- N/A — deterministic contract/authority change with no new interactive visual flow.
<!-- evidence-row:backend-logs -->
- N/A — no live backend log artifact applies; focused deterministic tests are reported above.
<!-- evidence-row:frontend-logs -->
- N/A — no browser console/network artifact applies to this isolated contract proof.
<!-- evidence-row:llm-trajectory -->
- N/A — no prompt, model selection, or generated-output contract changes.
<!-- evidence-row:domain-artifacts -->
- N/A — no external domain artifact applies; executable contract artifacts are contained in the changed tests and reported above.
<!-- evidence-row:ocr-review -->
- N/A — no visual layout or rendered text changed.

