### PR TITLE
fix(agent): report provider endpoint parity

### DIFF
--- a/packages/agent/src/api/model-config-routes.test.ts
+++ b/packages/agent/src/api/model-config-routes.test.ts
@@ -660,6 +660,101 @@ describe("GET /api/models/config activeChat", () => {
     });
   });
 
+  it("matches provider endpoint precedence across config and process env", async () => {
+    const cases = [
+      {
+        name: "OpenAI nested config wins over process env",
+        config: {
+          serviceRouting: {
+            llmText: {
+              backend: "openai",
+              transport: "direct",
+              accountId: "openai",
+            },
+          },
+          env: {
+            vars: { OPENAI_BASE_URL: " https://nested.openai.example/v1 " },
+          },
+        },
+        processEnv: { OPENAI_BASE_URL: "https://process.openai.example/v1" },
+        endpoint: "nested.openai.example",
+      },
+      {
+        name: "Anthropic whitespace config falls through to process env",
+        config: {
+          serviceRouting: {
+            llmText: {
+              backend: "anthropic",
+              transport: "direct",
+              accountId: "anthropic",
+            },
+          },
+          env: {
+            vars: {
+              ANTHROPIC_BASE_URL: "   ",
+              ELIZA_MOCK_ANTHROPIC_BASE: "https://config-mock.invalid/v1",
+            },
+          },
+        },
+        processEnv: {
+          ANTHROPIC_BASE_URL: " https://process.anthropic.example/v1 ",
+        },
+        endpoint: "process.anthropic.example",
+      },
+      {
+        name: "Cloud nested config wins when direct config is whitespace",
+        config: {
+          serviceRouting: {
+            llmText: {
+              backend: "elizacloud",
+              transport: "cloud-proxy",
+              accountId: "elizacloud",
+            },
+          },
+          env: {
+            ELIZAOS_CLOUD_BASE_URL: "\t",
+            vars: {
+              ELIZAOS_CLOUD_BASE_URL: "https://nested.cloud.example/api/v1",
+            },
+          },
+        },
+        processEnv: {
+          ELIZAOS_CLOUD_BASE_URL: "https://process.cloud.example/api/v1",
+        },
+        endpoint: "nested.cloud.example",
+      },
+      {
+        name: "Cerebras provider default uses its provider-owned base override",
+        config: {
+          serviceRouting: {
+            llmText: {
+              backend: "cerebras",
+              transport: "direct",
+              accountId: "cerebras",
+            },
+          },
+          env: { vars: { OPENAI_BASE_URL: " " } },
+        },
+        processEnv: {
+          CEREBRAS_BASE_URL: "https://process.cerebras.example/v1",
+        },
+        endpoint: "process.cerebras.example",
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const harness = makeHarness("GET", null, {
+        config: testCase.config as never,
+        processEnv: { ...testCase.processEnv },
+      });
+      await handleModelConfigRoutes(harness.ctx as never);
+      expect(
+        responseOf(harness.json).body.activeChat,
+        testCase.name,
+      ).toMatchObject({ endpoint: testCase.endpoint });
+    }
+  });
+
   it("omits activeChat when no routing is configured", async () => {
     const { ctx, json } = makeHarness("GET", null);
     await handleModelConfigRoutes(ctx as never);

--- a/packages/agent/src/api/model-config-routes.ts
+++ b/packages/agent/src/api/model-config-routes.ts
@@ -32,6 +32,9 @@ import {
   type RouteHelpers,
   type RouteRequestMeta,
 } from "@elizaos/core";
+import { resolveAnthropicBaseURL } from "@elizaos/plugin-anthropic/endpoint-config";
+import { resolveElizaCloudBaseURL } from "@elizaos/plugin-elizacloud/endpoint-config";
+import { resolveOpenAIBaseURL } from "@elizaos/plugin-openai/endpoint-config";
 import {
   DEFAULT_ELIZA_CLOUD_LARGE_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
@@ -100,6 +103,7 @@ const LLM_BACKEND_TO_CHAT_PROVIDER: Record<string, string> = {
   cerebras: "cerebras",
   elizacloud: "elizacloud",
   anthropic: "claude-chat",
+  openai: "openai",
 };
 
 interface CodingBackendSeam {
@@ -567,20 +571,39 @@ export function resolveActiveChat(
         ? LLM_BACKEND_TO_CHAT_PROVIDER[backend]
         : undefined;
   const family =
-    provider !== undefined ? CHAT_PROVIDER_KEY_FAMILY[provider] : undefined;
+    provider === "openai"
+      ? "OPENAI"
+      : provider !== undefined
+        ? CHAT_PROVIDER_KEY_FAMILY[provider]
+        : undefined;
   if (provider === undefined || family === undefined) return null;
-  const baseFor = (key: string): string | undefined =>
+  const readSetting = (key: string): string | undefined =>
     resolveEffective(config, processEnv, key)?.value;
+  const baseURL =
+    family === "ELIZAOS_CLOUD"
+      ? resolveElizaCloudBaseURL(readSetting)
+      : family === "ANTHROPIC"
+        ? resolveAnthropicBaseURL(readSetting, {
+            mockBaseURL: processEnv.ELIZA_MOCK_ANTHROPIC_BASE,
+          })
+        : resolveOpenAIBaseURL(
+            (key) =>
+              key === "ELIZA_PROVIDER" && provider === "cerebras"
+                ? "cerebras"
+                : readSetting(key),
+            { mockBaseURL: processEnv.ELIZA_MOCK_OPENAI_BASE },
+          );
   const endpoint =
-    provider === "cerebras"
-      ? (hostOf(baseFor("OPENAI_BASE_URL")) ??
-        hostOf(baseFor("CEREBRAS_BASE_URL")) ??
-        "api.cerebras.ai")
-      : family === "ELIZAOS_CLOUD"
-        ? (hostOf(baseFor("ELIZAOS_CLOUD_BASE_URL")) ?? "api.eliza.app")
+    hostOf(baseURL) ??
+    new URL(
+      family === "ELIZAOS_CLOUD"
+        ? "https://api.eliza.app/api/v1"
         : family === "ANTHROPIC"
-          ? (hostOf(baseFor("ANTHROPIC_BASE_URL")) ?? "api.anthropic.com")
-          : (hostOf(baseFor("OPENAI_BASE_URL")) ?? "api.openai.com");
+          ? "https://api.anthropic.com/v1"
+          : provider === "cerebras"
+            ? "https://api.cerebras.ai/v1"
+            : "https://api.openai.com/v1",
+    ).hostname;
   return { provider, family, endpoint };
 }
 

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -101,7 +101,16 @@
       "@elizaos/plugin-elizacloud": [
         "../../plugins/plugin-elizacloud/src/index.node.ts"
       ],
+      "@elizaos/plugin-elizacloud/endpoint-config": [
+        "../../plugins/plugin-elizacloud/src/utils/config.ts"
+      ],
       "@elizaos/plugin-elizacloud/*": ["../../plugins/plugin-elizacloud/src/*"],
+      "@elizaos/plugin-anthropic/endpoint-config": [
+        "../../plugins/plugin-anthropic/utils/config.ts"
+      ],
+      "@elizaos/plugin-openai/endpoint-config": [
+        "../../plugins/plugin-openai/utils/config.ts"
+      ],
       "@elizaos/plugin-mcp": ["../../plugins/plugin-mcp/src/index.ts"],
       "@elizaos/plugin-mcp/*": ["../../plugins/plugin-mcp/src/*"],
       "@elizaos/plugin-meetings": [

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -133,6 +133,27 @@ export default defineConfig({
         find: /^@elizaos\/core\/security\/(.+)$/,
         replacement: path.join(monorepoRoot, "packages/core/src/security/$1"),
       },
+      {
+        find: /^@elizaos\/plugin-anthropic\/endpoint-config$/,
+        replacement: path.join(
+          monorepoRoot,
+          "plugins/plugin-anthropic/utils/config.ts",
+        ),
+      },
+      {
+        find: /^@elizaos\/plugin-elizacloud\/endpoint-config$/,
+        replacement: path.join(
+          monorepoRoot,
+          "plugins/plugin-elizacloud/src/utils/config.ts",
+        ),
+      },
+      {
+        find: /^@elizaos\/plugin-openai\/endpoint-config$/,
+        replacement: path.join(
+          monorepoRoot,
+          "plugins/plugin-openai/utils/config.ts",
+        ),
+      },
       ...baseAliases,
       {
         find: /^@elizaos\/vault$/,

--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -341,6 +341,10 @@ export default defineConfig({
         replacement: path.join(pluginAnthropicRoot, "index.node.ts"),
       },
       {
+        find: /^@elizaos\/plugin-anthropic\/endpoint-config$/,
+        replacement: path.join(pluginAnthropicRoot, "utils/config.ts"),
+      },
+      {
         find: /^@elizaos\/plugin-anthropic\/(.+)$/,
         replacement: path.join(pluginAnthropicRoot, "$1"),
       },
@@ -401,12 +405,20 @@ export default defineConfig({
         replacement: path.join(pluginElizaCloudSrc, "index.node.ts"),
       },
       {
+        find: /^@elizaos\/plugin-elizacloud\/endpoint-config$/,
+        replacement: path.join(pluginElizaCloudSrc, "utils/config.ts"),
+      },
+      {
         find: /^@elizaos\/plugin-elizacloud\/(.+)$/,
         replacement: path.join(pluginElizaCloudSrc, "$1"),
       },
       {
         find: /^@elizaos\/plugin-openai$/,
         replacement: path.join(pluginOpenAiSrc, "index.node.ts"),
+      },
+      {
+        find: /^@elizaos\/plugin-openai\/endpoint-config$/,
+        replacement: path.join(pluginOpenAiSrc, "utils/config.ts"),
       },
       {
         find: /^@elizaos\/plugin-openai\/(.+)$/,

--- a/packages/scripts/__tests__/vitest-source-aliases.test.ts
+++ b/packages/scripts/__tests__/vitest-source-aliases.test.ts
@@ -1,14 +1,33 @@
 /**
- * Verifies workspace source aliases target both file and directory package
- * subpaths without relying on prebuilt dist artifacts.
+ * Verifies workspace source aliases target source files without prebuilt dist
+ * artifacts, including deterministic package-export fixtures.
  */
 
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 import {
   buildWorkspaceSourceAliases,
   workspaceRepoRoot,
 } from "../vitest/source-aliases.ts";
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function resolveAlias(
+  aliases: ReturnType<typeof buildWorkspaceSourceAliases>,
+  specifier: string,
+): string {
+  const alias = aliases.find(({ find }) => find.test(specifier));
+  expect(alias, `${specifier} must have a source alias`).toBeDefined();
+  return specifier.replace(alias?.find ?? /$^/, alias?.replacement ?? "");
+}
 
 describe("workspace source aliases", () => {
   test("resolve file and directory subpaths to source targets", () => {
@@ -22,19 +41,82 @@ describe("workspace source aliases", () => {
         specifier: "@elizaos/core/security/kms",
         target: "packages/core/src/security/kms/index.ts",
       },
+      {
+        specifier: "@elizaos/plugin-anthropic/endpoint-config",
+        target: "plugins/plugin-anthropic/utils/config.ts",
+      },
+      {
+        specifier: "@elizaos/plugin-elizacloud/endpoint-config",
+        target: "plugins/plugin-elizacloud/src/utils/config.ts",
+      },
+      {
+        specifier: "@elizaos/plugin-openai/endpoint-config",
+        target: "plugins/plugin-openai/utils/config.ts",
+      },
     ] as const;
 
     for (const { specifier, target } of cases) {
-      const alias = aliases.find(({ find }) => find.test(specifier));
-      expect(alias, `${specifier} must have a source alias`).toBeDefined();
-      const replacement = specifier.replace(
-        alias?.find ?? /$^/,
-        alias?.replacement ?? "",
-      );
-      const resolved = target.endsWith("/index.ts")
-        ? path.join(replacement, "index.ts")
-        : `${replacement}.ts`;
+      const replacement = resolveAlias(aliases, specifier);
+      const resolved = replacement.endsWith(".ts")
+        ? replacement
+        : target.endsWith("/index.ts")
+          ? path.join(replacement, "index.ts")
+          : `${replacement}.ts`;
       expect(resolved).toBe(path.join(workspaceRepoRoot, target));
     }
+  });
+
+  test("honors exact eliza-source exports before generic package subpaths", () => {
+    const repoRoot = mkdtempSync(
+      path.join(tmpdir(), "eliza-vitest-source-aliases-"),
+    );
+    temporaryRoots.push(repoRoot);
+    const packageDir = path.join(repoRoot, "plugins", "plugin-fixture");
+    mkdirSync(path.join(packageDir, "src", "internal"), { recursive: true });
+    writeFileSync(path.join(packageDir, "src", "index.ts"), "export {};\n");
+    writeFileSync(
+      path.join(packageDir, "src", "internal", "endpoint.ts"),
+      "export const endpoint = true;\n",
+    );
+    writeFileSync(
+      path.join(packageDir, "src", "internal", "string-endpoint.ts"),
+      "export const endpoint = true;\n",
+    );
+    writeFileSync(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "@elizaos/plugin.fixture",
+        exports: {
+          ".": "./dist/index.js",
+          "./public+endpoint": {
+            "eliza-source": {
+              types: "./src/internal/endpoint.ts",
+              import: "./src/internal/endpoint.ts",
+              default: "./src/internal/endpoint.ts",
+            },
+            import: "./dist/public-endpoint.js",
+          },
+          "./string-endpoint": {
+            "eliza-source": "./src/internal/string-endpoint.ts",
+            import: "./dist/string-endpoint.js",
+          },
+          "./escape": {
+            "eliza-source": "../outside.ts",
+            import: "./dist/escape.js",
+          },
+        },
+      }),
+    );
+
+    const aliases = buildWorkspaceSourceAliases(repoRoot);
+    expect(
+      resolveAlias(aliases, "@elizaos/plugin.fixture/public+endpoint"),
+    ).toBe(path.join(packageDir, "src", "internal", "endpoint.ts"));
+    expect(
+      resolveAlias(aliases, "@elizaos/plugin.fixture/string-endpoint"),
+    ).toBe(path.join(packageDir, "src", "internal", "string-endpoint.ts"));
+    expect(resolveAlias(aliases, "@elizaos/plugin.fixture/escape")).toBe(
+      path.join(packageDir, "src", "escape"),
+    );
   });
 });

--- a/packages/scripts/vitest/source-aliases.ts
+++ b/packages/scripts/vitest/source-aliases.ts
@@ -3,11 +3,13 @@
  *
  * Booting a real PGLite-backed AgentRuntime requires every workspace
  * `@elizaos/*` package to resolve to its TypeScript source (independent of
- * build order), plus the three subpath specials the runtime touches:
+ * build order), plus the core and SQL subpath specials the runtime touches:
  * `@elizaos/core/testing`, `@elizaos/core/node`, `@elizaos/core/connectors`,
- * and `@elizaos/plugin-sql`
- * (the node entry). Shared and per-plugin real-runtime configs need this, and so
- * does every per-plugin runtime config that imports `@elizaos/core/testing`.
+ * and `@elizaos/plugin-sql` (the node entry). Package exports that declare an
+ * exact `eliza-source` condition contribute their own source aliases, including
+ * provider-owned endpoint diagnostics that otherwise require prebuilt dist.
+ * Shared and per-plugin real-runtime configs need this, and so does
+ * every per-plugin runtime config that imports `@elizaos/core/testing`.
  * Both consume this one builder so the alias set never drifts.
  */
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
@@ -32,6 +34,11 @@ interface WorkspaceSourceEntry {
   packageName: string;
   indexPath: string;
   sourceDir: string;
+  exportedSourceAliases: Array<{ subpath: string; sourcePath: string }>;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function getWorkspaceSourceEntry(
@@ -41,16 +48,53 @@ function getWorkspaceSourceEntry(
   if (!existsSync(packageJsonPath)) return undefined;
   const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
     name?: string;
+    exports?: Record<
+      string,
+      | string
+      | {
+          "eliza-source"?:
+            | string
+            | { import?: string; default?: string; types?: string };
+        }
+    >;
   };
   if (!packageJson.name?.startsWith("@elizaos/")) return undefined;
   // The testing surface resolves through the explicit alias below.
   if (packageJson.name === "@elizaos/core/testing") return undefined;
+  const exportedSourceAliases = Object.entries(
+    packageJson.exports ?? {},
+  ).flatMap(([subpath, target]) => {
+    if (subpath === "." || typeof target === "string") return [];
+    const source = target["eliza-source"];
+    const sourcePath =
+      typeof source === "string"
+        ? source
+        : (source?.import ?? source?.default ?? source?.types);
+    if (
+      !sourcePath?.startsWith("./") ||
+      !subpath.startsWith("./") ||
+      subpath.includes("*")
+    )
+      return [];
+    const resolvedSourcePath = path.resolve(packageDir, sourcePath);
+    if (
+      !resolvedSourcePath.startsWith(`${path.resolve(packageDir)}${path.sep}`)
+    )
+      return [];
+    return [
+      {
+        subpath: subpath.slice(2),
+        sourcePath: resolvedSourcePath,
+      },
+    ];
+  });
   const sourceIndex = path.join(packageDir, "src", "index.ts");
   if (existsSync(sourceIndex)) {
     return {
       packageName: packageJson.name,
       indexPath: sourceIndex,
       sourceDir: path.join(packageDir, "src"),
+      exportedSourceAliases,
     };
   }
   const rootIndex = path.join(packageDir, "index.ts");
@@ -59,6 +103,7 @@ function getWorkspaceSourceEntry(
       packageName: packageJson.name,
       indexPath: rootIndex,
       sourceDir: packageDir,
+      exportedSourceAliases,
     };
   }
   return undefined;
@@ -131,24 +176,32 @@ export function buildWorkspaceSourceAliases(
       ? collectWorkspacePackageDirs(dir)
           .map((packageDir) => getWorkspaceSourceEntry(packageDir))
           .filter((entry): entry is WorkspaceSourceEntry => entry !== undefined)
-          .flatMap(({ packageName, indexPath, sourceDir }) => [
-            { find: new RegExp(`^${packageName}$`), replacement: indexPath },
-            // Asset subpaths (JSON data imports like
-            // `@elizaos/registry/first-party/curated-app-definitions.json`)
-            // resolve to the source file as-is; the generic rule below would
-            // otherwise append `.ts` and break the resolve. First-match wins.
-            {
-              find: new RegExp(`^${packageName}/(.*\\.json)$`),
-              replacement: path.join(sourceDir, "$1"),
-            },
-            {
-              find: new RegExp(`^${packageName}/(.*)$`),
-              // Keep the target extensionless so Vite can resolve either a
-              // source file (`foo.ts`) or a public directory entry
-              // (`foo/index.ts`) through the same package-subpath rule.
-              replacement: path.join(sourceDir, "$1"),
-            },
-          ])
+          .flatMap(
+            ({ packageName, indexPath, sourceDir, exportedSourceAliases }) => [
+              ...exportedSourceAliases.map(({ subpath, sourcePath }) => ({
+                find: new RegExp(
+                  `^${escapeRegex(packageName)}/${escapeRegex(subpath)}$`,
+                ),
+                replacement: sourcePath,
+              })),
+              { find: new RegExp(`^${packageName}$`), replacement: indexPath },
+              // Asset subpaths (JSON data imports like
+              // `@elizaos/registry/first-party/curated-app-definitions.json`)
+              // resolve to the source file as-is; the generic rule below would
+              // otherwise append `.ts` and break the resolve. First-match wins.
+              {
+                find: new RegExp(`^${packageName}/(.*\\.json)$`),
+                replacement: path.join(sourceDir, "$1"),
+              },
+              {
+                find: new RegExp(`^${packageName}/(.*)$`),
+                // Keep the target extensionless so Vite can resolve either a
+                // source file (`foo.ts`) or a public directory entry
+                // (`foo/index.ts`) through the same package-subpath rule.
+                replacement: path.join(sourceDir, "$1"),
+              },
+            ],
+          )
       : [],
   );
 

--- a/plugins/plugin-anthropic/__tests__/endpoint-config.test.ts
+++ b/plugins/plugin-anthropic/__tests__/endpoint-config.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Verifies Anthropic inference and diagnostic endpoint resolution share the
+ * same whitespace and process-environment fallback contract.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getBaseURL, resolveAnthropicBaseURL } from "../utils/config";
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("Anthropic endpoint config", () => {
+  it("falls through a whitespace nested runtime setting to valid process env", () => {
+    vi.stubEnv("ANTHROPIC_BASE_URL", " https://process.anthropic.example/v1 ");
+    vi.stubEnv("ELIZA_MOCK_ANTHROPIC_BASE", undefined);
+    const runtime = {
+      getSetting: (key: string) =>
+        key === "ANTHROPIC_BASE_URL"
+          ? "   "
+          : key === "ELIZA_MOCK_ANTHROPIC_BASE"
+            ? "https://config-mock.invalid/v1"
+            : null,
+    } as IAgentRuntime;
+
+    const inferred = getBaseURL(runtime);
+    const diagnosed = resolveAnthropicBaseURL((key) =>
+      key === "ANTHROPIC_BASE_URL" ? process.env.ANTHROPIC_BASE_URL : undefined
+    );
+
+    expect(inferred).toBe("https://process.anthropic.example/v1");
+    expect(diagnosed).toBe(inferred);
+  });
+});

--- a/plugins/plugin-anthropic/build.ts
+++ b/plugins/plugin-anthropic/build.ts
@@ -12,6 +12,12 @@ export declare const anthropicPlugin: Plugin;
 declare const _default: Plugin;
 export default _default;
 `;
+const endpointDeclaration = `export type EndpointSettingReader = (key: string) => string | undefined;
+export declare function resolveAnthropicBaseURL(
+  readSetting: EndpointSettingReader,
+  options?: { browser?: boolean; mockBaseURL?: string },
+): string;
+`;
 
 await buildPlugin({
   name: "@elizaos/plugin-anthropic",
@@ -32,6 +38,14 @@ await buildPlugin({
       format: "cjs",
       renames: [["index.node.js", "index.node.cjs"]],
     },
+    {
+      label: "Endpoint config",
+      entry: "utils/config.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+      naming: { entry: "endpoint-config.[ext]" },
+    },
   ],
   dtsProject: "tsconfig.build.json",
   dtsShims: [
@@ -39,5 +53,6 @@ await buildPlugin({
     { path: "node/index.d.ts", content: reexport },
     { path: "browser/index.d.ts", content: reexport },
     { path: "cjs/index.d.ts", content: reexport },
+    { path: "endpoint-config.d.ts", content: endpointDeclaration },
   ],
 });

--- a/plugins/plugin-anthropic/package.json
+++ b/plugins/plugin-anthropic/package.json
@@ -11,6 +11,16 @@
   },
   "exports": {
     "./package.json": "./package.json",
+    "./endpoint-config": {
+      "types": "./dist/endpoint-config.d.ts",
+      "eliza-source": {
+        "types": "./utils/config.ts",
+        "import": "./utils/config.ts",
+        "default": "./utils/config.ts"
+      },
+      "import": "./dist/endpoint-config.js",
+      "default": "./dist/endpoint-config.js"
+    },
     ".": {
       "types": "./dist/index.d.ts",
       "browser": {

--- a/plugins/plugin-anthropic/utils/config.ts
+++ b/plugins/plugin-anthropic/utils/config.ts
@@ -54,30 +54,35 @@ export function getApiKeyOptional(runtime: IAgentRuntime): ValidatedApiKey | nul
   return apiKey as ValidatedApiKey;
 }
 
+/** Provides setting values to the pure endpoint resolver. */
+export type EndpointSettingReader = (key: string) => string | undefined;
+
 /**
- * Route to the wire-level mock server when one is running. `ELIZA_MOCK_ANTHROPIC_BASE`
- * is set only by the in-process mock runner (`packages/scenario-runner/test/mocks`) and never in
- * production — honoring it directly mirrors how LifeOps consumes its sibling
- * `ELIZA_MOCK_*_BASE` vars (`mockoon-redirect.ts`). It is authoritative when set
- * (a deliberate test action), so it wins over any configured base; in production
- * it is unset and has no effect.
+ * Pure endpoint policy shared by inference and diagnostic surfaces. The
+ * scenario runner's `ELIZA_MOCK_ANTHROPIC_BASE` remains authoritative.
  */
-function getMockBaseURL(): string | undefined {
-  return getEnvValue("ELIZA_MOCK_ANTHROPIC_BASE");
+export function resolveAnthropicBaseURL(
+  readSetting: EndpointSettingReader,
+  options: { browser?: boolean; mockBaseURL?: string } = {}
+): string {
+  const read = (key: string): string | undefined => {
+    const value = readSetting(key)?.trim();
+    return value ? value : undefined;
+  };
+  const mockBaseURL = options.mockBaseURL?.trim();
+  if (mockBaseURL) return mockBaseURL;
+  if (options.browser) {
+    const browserURL = read("ANTHROPIC_BROWSER_BASE_URL");
+    if (browserURL) return browserURL;
+  }
+  return read("ANTHROPIC_BASE_URL") ?? DEFAULT_BASE_URL;
 }
 
 export function getBaseURL(runtime: IAgentRuntime): string {
-  const mockBaseURL = getMockBaseURL();
-  if (mockBaseURL) {
-    return mockBaseURL;
-  }
-  if (isBrowser()) {
-    const browserURL = getRawSetting(runtime, "ANTHROPIC_BROWSER_BASE_URL");
-    if (browserURL) {
-      return browserURL;
-    }
-  }
-  return getRawSetting(runtime, "ANTHROPIC_BASE_URL") ?? DEFAULT_BASE_URL;
+  return resolveAnthropicBaseURL((key) => getRawSetting(runtime, key), {
+    browser: isBrowser(),
+    mockBaseURL: getEnvValue("ELIZA_MOCK_ANTHROPIC_BASE"),
+  });
 }
 
 export function getSmallModel(runtime: IAgentRuntime): ModelName {

--- a/plugins/plugin-elizacloud/__tests__/unit/endpoint-config.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/endpoint-config.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Verifies Eliza Cloud inference and diagnostic endpoint resolution share the
+ * same whitespace and process-environment fallback contract.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getBaseURL, resolveElizaCloudBaseURL } from "../../src/utils/config";
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("Eliza Cloud endpoint config", () => {
+  it("falls through whitespace runtime config to valid process env", () => {
+    vi.stubEnv("ELIZAOS_CLOUD_BASE_URL", " https://process.cloud.example/api/v1 ");
+    const runtime = {
+      getSetting: (key: string) => (key === "ELIZAOS_CLOUD_BASE_URL" ? "   " : null),
+    } as IAgentRuntime;
+
+    const inferred = getBaseURL(runtime);
+    const diagnosed = resolveElizaCloudBaseURL((key) => process.env[key]);
+
+    expect(inferred).toBe("https://process.cloud.example/api/v1");
+    expect(diagnosed).toBe(inferred);
+  });
+});

--- a/plugins/plugin-elizacloud/package.json
+++ b/plugins/plugin-elizacloud/package.json
@@ -13,6 +13,16 @@
   },
   "exports": {
     "./package.json": "./package.json",
+    "./endpoint-config": {
+      "types": "./dist/utils/config.d.ts",
+      "eliza-source": {
+        "types": "./src/utils/config.ts",
+        "import": "./src/utils/config.ts",
+        "default": "./src/utils/config.ts"
+      },
+      "import": "./dist/utils/config.js",
+      "default": "./dist/utils/config.js"
+    },
     ".": {
       "types": "./dist/index.node.d.ts",
       "eliza-source": {

--- a/plugins/plugin-elizacloud/src/utils/config.ts
+++ b/plugins/plugin-elizacloud/src/utils/config.ts
@@ -36,14 +36,36 @@ export function isProxyMode(runtime: IAgentRuntime): boolean {
   return isBrowser() && !!getSetting(runtime, "ELIZAOS_CLOUD_BROWSER_BASE_URL");
 }
 
+export type EndpointSettingReader = (key: string) => string | undefined;
+
+/** Pure endpoint policy shared by inference and diagnostic surfaces. */
+export function resolveElizaCloudBaseURL(
+  readSetting: EndpointSettingReader,
+  options: { browser?: boolean } = {}
+): string {
+  const read = (key: string): string | undefined => {
+    const value = readSetting(key)?.trim();
+    return value ? value : undefined;
+  };
+  return (
+    (options.browser ? read("ELIZAOS_CLOUD_BROWSER_BASE_URL") : undefined) ??
+    read("ELIZAOS_CLOUD_BASE_URL") ??
+    "https://api.eliza.app/api/v1"
+  );
+}
+
 export function getBaseURL(runtime: IAgentRuntime): string {
-  const browserURL = getSetting(runtime, "ELIZAOS_CLOUD_BROWSER_BASE_URL");
-  const baseURL = (
-    isBrowser() && browserURL
-      ? browserURL
-      : getSetting(runtime, "ELIZAOS_CLOUD_BASE_URL", "https://api.eliza.app/api/v1")
-  ) as string;
-  return baseURL;
+  return resolveElizaCloudBaseURL(
+    (key) => {
+      const runtimeValue = runtime.getSetting(key);
+      const normalizedRuntime =
+        runtimeValue === undefined || runtimeValue === null
+          ? undefined
+          : String(runtimeValue).trim() || undefined;
+      return normalizedRuntime ?? resolveSetting(null, key);
+    },
+    { browser: isBrowser() }
+  );
 }
 
 export function getEmbeddingBaseURL(runtime: IAgentRuntime): string {

--- a/plugins/plugin-openai/__tests__/endpoint-config.test.ts
+++ b/plugins/plugin-openai/__tests__/endpoint-config.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Verifies OpenAI-compatible inference and diagnostic endpoint resolution use
+ * one policy for whitespace, process fallback, and Cerebras provider hints.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getBaseURL, resolveOpenAIBaseURL } from "../utils/config";
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("OpenAI-compatible endpoint config", () => {
+  it("falls through whitespace runtime config and preserves Cerebras routing", () => {
+    vi.stubEnv("OPENAI_BASE_URL", undefined);
+    vi.stubEnv("OPENAI_API_KEY", undefined);
+    vi.stubEnv("CEREBRAS_API_KEY", "csk-test");
+    vi.stubEnv("CEREBRAS_BASE_URL", " https://process.cerebras.example/v1 ");
+    vi.stubEnv("ELIZA_MOCK_OPENAI_BASE", undefined);
+    const runtime = {
+      getSetting: (key: string) =>
+        key === "OPENAI_BASE_URL"
+          ? " \t "
+          : key === "ELIZA_MOCK_OPENAI_BASE"
+            ? "https://config-mock.invalid/v1"
+            : null,
+    } as IAgentRuntime;
+
+    const inferred = getBaseURL(runtime);
+    const diagnosed = resolveOpenAIBaseURL((key) =>
+      key === "ELIZA_PROVIDER" ? "cerebras" : process.env[key]
+    );
+
+    expect(inferred).toBe("https://process.cerebras.example/v1");
+    expect(diagnosed).toBe(inferred);
+  });
+});

--- a/plugins/plugin-openai/build.ts
+++ b/plugins/plugin-openai/build.ts
@@ -7,6 +7,12 @@ import { buildPlugin } from "../plugin-build";
 
 // Single-quoted re-export to keep the emitted .d.ts byte-stable.
 const reexport = "export * from '../index';\nexport { default } from '../index';\n";
+const endpointDeclaration = `export type EndpointSettingReader = (key: string) => string | undefined;
+export declare function resolveOpenAIBaseURL(
+  readSetting: EndpointSettingReader,
+  options?: { browser?: boolean; mockBaseURL?: string },
+): string;
+`;
 
 await buildPlugin({
   name: "@elizaos/plugin-openai",
@@ -20,10 +26,19 @@ await buildPlugin({
       format: "esm",
       minify: true,
     },
+    {
+      label: "Endpoint config",
+      entry: "utils/config.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+      naming: { entry: "endpoint-config.[ext]" },
+    },
   ],
   dtsProject: "tsconfig.build.json",
   dtsShims: [
     { path: "node/index.d.ts", content: reexport },
     { path: "browser/index.d.ts", content: reexport },
+    { path: "endpoint-config.d.ts", content: endpointDeclaration },
   ],
 });

--- a/plugins/plugin-openai/package.json
+++ b/plugins/plugin-openai/package.json
@@ -13,6 +13,16 @@
   },
   "exports": {
     "./package.json": "./package.json",
+    "./endpoint-config": {
+      "types": "./dist/endpoint-config.d.ts",
+      "eliza-source": {
+        "types": "./utils/config.ts",
+        "import": "./utils/config.ts",
+        "default": "./utils/config.ts"
+      },
+      "import": "./dist/endpoint-config.js",
+      "default": "./dist/endpoint-config.js"
+    },
     ".": {
       "types": "./dist/index.d.ts",
       "browser": {

--- a/plugins/plugin-openai/utils/config.ts
+++ b/plugins/plugin-openai/utils/config.ts
@@ -197,38 +197,67 @@ function authHeaderForKey(runtime: IAgentRuntime, key: string | undefined): Reco
   return key ? { Authorization: `Bearer ${key}` } : {};
 }
 
+/** Provides setting values to the pure endpoint resolver. */
+export type EndpointSettingReader = (key: string) => string | undefined;
+
+function normalizeEndpointSetting(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
 /**
- * Route to the wire-level mock server when one is running. `ELIZA_MOCK_OPENAI_BASE`
- * is set only by the in-process mock runner (`packages/scenario-runner/test/mocks`) and never in
- * production — honoring it directly mirrors how LifeOps consumes its sibling
- * `ELIZA_MOCK_*_BASE` vars (`mockoon-redirect.ts`). It is authoritative when set
- * (a deliberate test action), so it wins over any configured base or provider
- * mode; in production it is unset and has no effect.
+ * Resolve the text API endpoint from an injected setting reader. Keeping this
+ * pure lets diagnostics use the exact provider policy without constructing a
+ * runtime or depending on the ambient process environment. The scenario
+ * runner's `ELIZA_MOCK_OPENAI_BASE` remains authoritative when present.
  */
-function getMockBaseURL(): string | undefined {
-  const base = getEnvValue("ELIZA_MOCK_OPENAI_BASE")?.trim();
-  return base ? base : undefined;
+export function resolveOpenAIBaseURL(
+  readSetting: EndpointSettingReader,
+  options: { browser?: boolean; mockBaseURL?: string } = {}
+): string {
+  const read = (key: string): string | undefined => normalizeEndpointSetting(readSetting(key));
+  const explicitProvider = read("ELIZA_PROVIDER")?.toLowerCase();
+  const openAIBaseURL = read("OPENAI_BASE_URL");
+  const cerebrasMode =
+    explicitProvider === "cerebras" ||
+    (openAIBaseURL !== undefined && /(^|\.)cerebras\.ai(\/|$)/i.test(openAIBaseURL)) ||
+    (read("CEREBRAS_API_KEY") !== undefined &&
+      read("OPENAI_API_KEY") === undefined &&
+      openAIBaseURL === undefined);
+  const evolinkMode =
+    explicitProvider === "evolink" ||
+    (openAIBaseURL !== undefined && /(^|\.)evolink\.ai(\/|$)/i.test(openAIBaseURL)) ||
+    (read("EVOLINK_API_KEY") !== undefined &&
+      read("OPENAI_API_KEY") === undefined &&
+      openAIBaseURL === undefined);
+
+  if (options.browser) {
+    const browserURL = read("OPENAI_BROWSER_BASE_URL");
+    if (browserURL) return browserURL;
+  }
+  return (
+    normalizeEndpointSetting(options.mockBaseURL) ??
+    openAIBaseURL ??
+    (cerebrasMode ? (read("CEREBRAS_BASE_URL") ?? "https://api.cerebras.ai/v1") : undefined) ??
+    (evolinkMode ? (read("EVOLINK_BASE_URL") ?? "https://direct.evolink.ai/v1") : undefined) ??
+    "https://api.openai.com/v1"
+  );
 }
 
 export function getBaseURL(runtime: IAgentRuntime): string {
-  const browserURL = getSetting(runtime, "OPENAI_BROWSER_BASE_URL");
-  const mockBaseURL = getMockBaseURL();
-  const cerebrasBaseURL =
-    isCerebrasMode(runtime) && !getSetting(runtime, "OPENAI_BASE_URL")
-      ? (getSetting(runtime, "CEREBRAS_BASE_URL") ?? "https://api.cerebras.ai/v1")
-      : undefined;
-  const evolinkBaseURL =
-    isEvoLinkMode(runtime) && !getSetting(runtime, "OPENAI_BASE_URL")
-      ? (getSetting(runtime, "EVOLINK_BASE_URL") ?? "https://direct.evolink.ai/v1")
-      : undefined;
-  const baseURL =
-    isBrowser() && browserURL
-      ? browserURL
-      : (mockBaseURL ??
-        getSetting(runtime, "OPENAI_BASE_URL") ??
-        cerebrasBaseURL ??
-        evolinkBaseURL ??
-        "https://api.openai.com/v1");
+  const baseURL = resolveOpenAIBaseURL(
+    (key) => {
+      const runtimeValue = runtime.getSetting(key);
+      const normalizedRuntime = normalizeEndpointSetting(
+        runtimeValue === undefined || runtimeValue === null ? undefined : String(runtimeValue)
+      );
+      return normalizedRuntime ?? getEnvValue(key);
+    },
+    {
+      browser: isBrowser(),
+      mockBaseURL: getEnvValue("ELIZA_MOCK_OPENAI_BASE"),
+    }
+  );
   logger.debug(`[OpenAI] Base URL: ${baseURL}`);
   return baseURL;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,9 @@
         "./plugins/plugin-agent-skills/src/index.ts"
       ],
       "@elizaos/plugin-anthropic": ["./plugins/plugin-anthropic/index.ts"],
+      "@elizaos/plugin-anthropic/endpoint-config": [
+        "./plugins/plugin-anthropic/utils/config.ts"
+      ],
       "@elizaos/plugin-app-manager": [
         "./plugins/plugin-app-manager/src/index.ts"
       ],
@@ -57,6 +60,9 @@
       "@elizaos/plugin-elizacloud": [
         "./plugins/plugin-elizacloud/src/index.ts"
       ],
+      "@elizaos/plugin-elizacloud/endpoint-config": [
+        "./plugins/plugin-elizacloud/src/utils/config.ts"
+      ],
       "@elizaos/plugin-imessage": ["./plugins/plugin-imessage/src/index.ts"],
       "@elizaos/plugin-personal-assistant": [
         "./plugins/plugin-personal-assistant/src/index.ts"
@@ -64,6 +70,9 @@
       "@elizaos/plugin-mcp": ["./plugins/plugin-mcp/src/index.ts"],
       "@elizaos/plugin-messages": ["./plugins/plugin-messages/src/index.ts"],
       "@elizaos/plugin-openai": ["./plugins/plugin-openai/index.ts"],
+      "@elizaos/plugin-openai/endpoint-config": [
+        "./plugins/plugin-openai/utils/config.ts"
+      ],
       "@elizaos/plugin-phone": ["./plugins/plugin-phone/src/index.ts"],
       "@elizaos/plugin-phone/*": ["./plugins/plugin-phone/src/*"],
       "@elizaos/plugin-registry": ["./plugins/plugin-registry/src/index.ts"],


### PR DESCRIPTION
## Summary

- share each provider endpoint resolver between inference and the model-config diagnostic route
- report OpenAI, Anthropic, Eliza Cloud, and Cerebras endpoints with runtime-equivalent precedence
- export the resolver-only subpaths and cover config/process/mock/default routing parity

## Verification

- `bunx vitest run --config vitest.config.ts src/api/model-config-routes.test.ts` (35 passed)
- provider endpoint-config Vitest files for Anthropic, OpenAI, and Eliza Cloud (1 passed each)
- `git diff-tree --check`

Follow-up slice from #18960.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:c48ff451b1489c120cd73034e6185db837e65a7e -->

<!-- evidence-row:before-screenshots -->
- N/A — provider diagnostics are backend configuration behavior, not a rendered UI change.
<!-- evidence-row:after-screenshots -->
- N/A — provider diagnostics are backend configuration behavior, not a rendered UI change.
<!-- evidence-row:walkthrough-video -->
- N/A — deterministic contract/authority change with no new interactive visual flow.
<!-- evidence-row:backend-logs -->
- N/A — no live backend log artifact applies; focused deterministic tests are reported above.
<!-- evidence-row:frontend-logs -->
- N/A — no browser console/network artifact applies to this isolated contract proof.
<!-- evidence-row:llm-trajectory -->
- N/A — no prompt, model selection, or generated-output contract changes.
<!-- evidence-row:domain-artifacts -->
- N/A — no external domain artifact applies; executable contract artifacts are contained in the changed tests and reported above.
<!-- evidence-row:ocr-review -->
- N/A — no visual layout or rendered text changed.

## Consolidation update

Consolidates #19286 and #19297 into this current-`develop` candidate. It includes deterministic exact `eliza-source` export precedence and traversal-rejection coverage plus the app-core real-consumer alias. Current exact-head validation: agent route 35/35, three provider endpoint suites 1/1 each, source-alias suite 2/2, and all four package typechecks passed.