### PR TITLE
fix(ui): cancel and compensate cloud join attempts

### DIFF
--- a/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
+++ b/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
@@ -426,6 +426,124 @@ describe("selectOrProvisionCloudAgent — fresh create follows its job", () => {
     expect((error as CloudAgentWakeError).message).toMatch(/image pull failed/);
     expect(getCloudCompatAgent).not.toHaveBeenCalled();
   });
+
+  it("returns the create receipt when cancellation lands during job polling", async () => {
+    const controller = new AbortController();
+    const reason = new DOMException("cancelled", "AbortError");
+    let markJobReadStarted!: () => void;
+    let releaseJobRead!: () => void;
+    const jobReadStarted = new Promise<void>((resolve) => {
+      markJobReadStarted = resolve;
+    });
+    const releaseJob = new Promise<void>((resolve) => {
+      releaseJobRead = resolve;
+    });
+    const client = fakeClient({
+      getCloudCompatAgents: vi.fn(async () => ({ success: true, data: [] })),
+      createCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        created: true,
+        data: {
+          agentId: "agent-new",
+          agentName: "Eliza",
+          jobId: "job-9",
+          status: "provisioning",
+          nodeId: null,
+          message: "",
+        },
+      })),
+      getCloudCompatJobStatus: vi.fn(async () => {
+        markJobReadStarted();
+        await releaseJob;
+        return {
+          success: true,
+          data: { status: "in_progress", state: "in_progress" },
+        };
+      }),
+    });
+
+    const selection = client.selectOrProvisionCloudAgent({
+      cloudApiBase: "https://api.eliza.app/api/v1",
+      authToken: "test-token",
+      name: "Eliza",
+      signal: controller.signal,
+      wakePollIntervalMs: 1,
+      wakeTimeoutMs: 1_000,
+    });
+    await jobReadStarted;
+    controller.abort(reason);
+    releaseJobRead();
+
+    await expect(selection).resolves.toMatchObject({
+      agentId: "agent-new",
+      created: true,
+    });
+  });
+
+  it("returns the create receipt when cancellation lands during running polling", async () => {
+    const controller = new AbortController();
+    const reason = new DOMException("cancelled", "AbortError");
+    let markRunningReadStarted!: () => void;
+    let resolveRunningRead!: () => void;
+    const runningReadStarted = new Promise<void>((resolve) => {
+      markRunningReadStarted = resolve;
+    });
+    const releaseRunningRead = new Promise<void>((resolve) => {
+      resolveRunningRead = resolve;
+    });
+    const startingAgent = makeAgent({
+      agent_id: "agent-new",
+      status: "starting",
+      web_ui_url: "https://agent-new.cloud.eliza.app",
+      webUiUrl: "https://agent-new.cloud.eliza.app",
+    });
+    const getCloudCompatAgent = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, data: startingAgent })
+      .mockImplementationOnce(async () => {
+        markRunningReadStarted();
+        await releaseRunningRead;
+        return { success: true, data: startingAgent };
+      });
+    const client = fakeClient({
+      getCloudCompatAgents: vi.fn(async () => ({ success: true, data: [] })),
+      createCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        created: true,
+        data: {
+          agentId: "agent-new",
+          agentName: "Eliza",
+          jobId: "job-9",
+          status: "provisioning",
+          nodeId: null,
+          message: "",
+        },
+      })),
+      getCloudCompatJobStatus: vi.fn(async () => ({
+        success: true,
+        data: { status: "completed", state: "completed" },
+      })),
+      getCloudCompatAgent,
+      resumeCloudCompatAgent: vi.fn(async () => ({ success: true })),
+    });
+
+    const selection = client.selectOrProvisionCloudAgent({
+      cloudApiBase: "https://api.eliza.app/api/v1",
+      authToken: "test-token",
+      name: "Eliza",
+      signal: controller.signal,
+      wakePollIntervalMs: 1,
+      wakeTimeoutMs: 1_000,
+    });
+    await runningReadStarted;
+    controller.abort(reason);
+    resolveRunningRead();
+
+    await expect(selection).resolves.toMatchObject({
+      agentId: "agent-new",
+      created: true,
+    });
+  });
 });
 
 describe("CloudAgentWakeError — real typed-error identity", () => {

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -1601,6 +1601,7 @@ declare module "./client-base" {
     getPersonalSharedEliza(options: {
       cloudApiBase: string;
       authToken: string;
+      signal?: AbortSignal;
     }): Promise<{
       agentId: string;
       agentName: string;
@@ -1650,6 +1651,8 @@ declare module "./client-base" {
        */
       wakePollIntervalMs?: number;
       wakeTimeoutMs?: number;
+      /** Cancel selection/wake polling. A completed create remains observable to the caller for compensation. */
+      signal?: AbortSignal;
     }): Promise<{
       agentId: string;
       agentName: string;
@@ -3708,15 +3711,17 @@ export async function waitForCloudAgentRunning(
     pollIntervalMs?: number;
     timeoutMs?: number;
     onProgress?: (status: string, detail?: string) => void;
+    signal?: AbortSignal;
   },
 ): Promise<CloudCompatAgent> {
   const { agentId, onProgress } = options;
+  options.signal?.throwIfAborted();
   const pollIntervalMs = Math.max(
     50,
     options.pollIntervalMs ?? CLOUD_AGENT_WAKE_POLL_INTERVAL_MS,
   );
   const timeoutMs = Math.max(
-    pollIntervalMs,
+    1,
     options.timeoutMs ?? CLOUD_AGENT_WAKE_TIMEOUT_MS,
   );
   const startedAt = Date.now();
@@ -3764,6 +3769,7 @@ export async function waitForCloudAgentRunning(
   let lastStatus = "unknown";
   let backoffMs: number | null = null;
   for (;;) {
+    options.signal?.throwIfAborted();
     backoffMs = null;
     const detail = await client
       .getCloudCompatAgent(agentId)
@@ -3830,16 +3836,27 @@ export async function waitForCloudAgentRunning(
       });
     }
     onProgress?.("starting", describeAgentWakeWait(elapsedMs));
-    await new Promise((r) =>
-      setTimeout(
-        r,
-        Math.min(
-          Math.max(pollIntervalMs, backoffMs ?? 0),
-          timeoutMs - elapsedMs,
-        ),
-      ),
+    await abortableDelay(
+      Math.min(Math.max(pollIntervalMs, backoffMs ?? 0), timeoutMs - elapsedMs),
+      options.signal,
     );
   }
+}
+
+function abortableDelay(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, delayMs));
+  signal.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 /**
@@ -3875,21 +3892,24 @@ export async function waitForCloudProvisionJob(
     pollIntervalMs?: number;
     timeoutMs?: number;
     onProgress?: (status: string, detail?: string) => void;
+    signal?: AbortSignal;
   },
 ): Promise<void> {
   const { agentId, jobId, onProgress } = options;
+  options.signal?.throwIfAborted();
   const pollIntervalMs = Math.max(
     50,
     options.pollIntervalMs ?? CLOUD_AGENT_WAKE_POLL_INTERVAL_MS,
   );
   const timeoutMs = Math.max(
-    pollIntervalMs,
+    1,
     options.timeoutMs ?? CLOUD_AGENT_WAKE_TIMEOUT_MS,
   );
   const startedAt = Date.now();
   let lastStatus = "queued";
   let backoffMs: number | null = null;
   for (;;) {
+    options.signal?.throwIfAborted();
     backoffMs = null;
     const res = await client
       .getCloudCompatJobStatus(jobId)
@@ -3963,14 +3983,9 @@ export async function waitForCloudProvisionJob(
       "provisioning",
       describeProvisioningWait(lastStatus, elapsedMs),
     );
-    await new Promise((r) =>
-      setTimeout(
-        r,
-        Math.min(
-          Math.max(pollIntervalMs, backoffMs ?? 0),
-          timeoutMs - elapsedMs,
-        ),
-      ),
+    await abortableDelay(
+      Math.min(Math.max(pollIntervalMs, backoffMs ?? 0), timeoutMs - elapsedMs),
+      options.signal,
     );
   }
 }
@@ -4018,6 +4033,7 @@ ElizaClient.prototype.getPersonalSharedEliza = async (options) => {
   const cloudApiBase = resolveDirectCloudAuthApiBase(options.cloudApiBase);
   const url = `${cloudApiBase}/api/v1/eliza/shared/messages`;
   const response = await directCloudJsonResponse<unknown>(url, {
+    signal: options.signal,
     headers: {
       Accept: "application/json",
       Authorization: `Bearer ${options.authToken}`,
@@ -4096,6 +4112,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     knownAgents,
     preferStewardAgentAdapter,
   } = options;
+  options.signal?.throwIfAborted();
   const onProgress = options.onProgress;
   const resolvedCloudApiBase = resolveDirectCloudAuthApiBase(cloudApiBase);
   let forceCreateForTerminalAgents = false;
@@ -4182,6 +4199,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
             ? { timeoutMs: options.wakeTimeoutMs }
             : {}),
           ...(onProgress ? { onProgress } : {}),
+          ...(options.signal ? { signal: options.signal } : {}),
         });
       }
       const hasDedicatedBase = Boolean(
@@ -4239,6 +4257,22 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   }
   requireConfirmedFreshCloudAgentCreate(mustForceCreate, created.created);
   const agentId = created.data.agentId;
+  const cancellationReceipt = () => ({
+    agentId,
+    agentName: created.data.agentName || name,
+    apiBase: buildCloudSharedAgentApiBase(resolvedCloudApiBase, agentId),
+    bridgeUrl: null,
+    created: created.created !== false,
+    requiresAgentPairing: false,
+    executionTier: preferSharedTier ? ("shared" as const) : null,
+  });
+  // A create cannot be safely abandoned after the server has accepted it: the
+  // caller needs the authoritative id in order to compensate. Return the
+  // receipt immediately and let the join controller delete it before its
+  // cancellation promise settles.
+  if (options.signal?.aborted) {
+    return cancellationReceipt();
+  }
   // The provisioning-job wait and the running wait below are two halves of ONE
   // join, so they share ONE budget. Giving each the full wake timeout let a job
   // that finished at 5:59 hand a fresh six minutes to the status poll — the
@@ -4253,15 +4287,23 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   // to terminal — its row carries the real failure reason long before the
   // agent-detail poll below would time out — instead of discarding the id.
   if (created.data.jobId) {
-    await waitForCloudProvisionJob(this, {
-      agentId,
-      jobId: created.data.jobId,
-      ...(typeof options.wakePollIntervalMs === "number"
-        ? { pollIntervalMs: options.wakePollIntervalMs }
-        : {}),
-      timeoutMs: remainingWakeMs(),
-      ...(onProgress ? { onProgress } : {}),
-    });
+    try {
+      await waitForCloudProvisionJob(this, {
+        agentId,
+        jobId: created.data.jobId,
+        ...(typeof options.wakePollIntervalMs === "number"
+          ? { pollIntervalMs: options.wakePollIntervalMs }
+          : {}),
+        timeoutMs: remainingWakeMs(),
+        ...(onProgress ? { onProgress } : {}),
+        ...(options.signal ? { signal: options.signal } : {}),
+      });
+    } catch (error) {
+      if (options.signal?.aborted && error === options.signal.reason) {
+        return cancellationReceipt();
+      }
+      throw error;
+    }
   }
   // error-policy:J4 detail is an optimization probe (warm-pool fast path);
   // on failure the standard dedicated subdomain is still the desired default.
@@ -4291,14 +4333,22 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     detailAgent.status !== "running" &&
     isDedicatedCloudAgentBase(initialDedicatedApiBase)
   ) {
-    detailAgent = await waitForCloudAgentRunning(this, {
-      agentId,
-      ...(typeof options.wakePollIntervalMs === "number"
-        ? { pollIntervalMs: options.wakePollIntervalMs }
-        : {}),
-      timeoutMs: remainingWakeMs(),
-      ...(onProgress ? { onProgress } : {}),
-    });
+    try {
+      detailAgent = await waitForCloudAgentRunning(this, {
+        agentId,
+        ...(typeof options.wakePollIntervalMs === "number"
+          ? { pollIntervalMs: options.wakePollIntervalMs }
+          : {}),
+        timeoutMs: remainingWakeMs(),
+        ...(onProgress ? { onProgress } : {}),
+        ...(options.signal ? { signal: options.signal } : {}),
+      });
+    } catch (error) {
+      if (options.signal?.aborted && error === options.signal.reason) {
+        return cancellationReceipt();
+      }
+      throw error;
+    }
   }
   const apiBase = useSharedAdapter
     ? buildCloudSharedAgentApiBase(resolvedCloudApiBase, agentId)

--- a/packages/ui/src/cloud/join/JoinPage.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.tsx
@@ -16,7 +16,7 @@
 import { BRAND_PATHS, LOGO_FILES } from "@elizaos/shared/brand";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Navigate } from "react-router-dom";
-import { client } from "../../api";
+import { client } from "../../api/client";
 import { Button } from "../../components/ui/button";
 import {
   savePersistedActiveServer,
@@ -50,6 +50,7 @@ export default function JoinPage(): React.JSX.Element {
   const [phase, setPhase] = useState<JoinPhase>("connecting");
   const [detail, setDetail] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
+  const [signingOut, setSigningOut] = useState(false);
   const appHandoff =
     typeof window === "undefined"
       ? null
@@ -58,6 +59,10 @@ export default function JoinPage(): React.JSX.Element {
   const [ssoBridging, setSsoBridging] = useState<boolean | null>(null);
   // Guard so React StrictMode's double-mount does not duplicate identity reads.
   const startedRef = useRef(false);
+  const activeAttemptRef = useRef<{
+    controller: AbortController;
+    promise: Promise<void>;
+  } | null>(null);
 
   const start = useCallback(async () => {
     const authToken = resolveJoinAuthToken();
@@ -67,32 +72,55 @@ export default function JoinPage(): React.JSX.Element {
     }
     setPhase("connecting");
     setError(null);
-    try {
-      const result = await runJoinFlow({
-        client,
-        effects: {
-          savePersistedActiveServer,
-          savePersistedFirstRunComplete,
-        },
-        cloudApiBase: resolveJoinCloudApiBase(),
-        authToken,
-        onProgress: (_status, progressDetail) => {
-          if (progressDetail) setDetail(progressDetail);
-        },
-      });
-      setPhase("ready");
-      // Hard navigation to chat home so the startup coordinator restores the
-      // just-persisted cloud connection from a clean boot. `void result` keeps
-      // the resolved agent in scope for future telemetry without unused-var noise.
-      void result;
-      if (typeof window !== "undefined") {
-        appModeNavigation.assign("/");
+    activeAttemptRef.current?.controller.abort(
+      new DOMException("Join attempt superseded", "AbortError"),
+    );
+    const controller = new AbortController();
+    const attempt = (async () => {
+      try {
+        const result = await runJoinFlow({
+          client,
+          effects: {
+            savePersistedActiveServer,
+            savePersistedFirstRunComplete,
+          },
+          cloudApiBase: resolveJoinCloudApiBase(),
+          authToken,
+          signal: controller.signal,
+          onProgress: (_status, progressDetail) => {
+            if (progressDetail) setDetail(progressDetail);
+          },
+        });
+        controller.signal.throwIfAborted();
+        setPhase("ready");
+        // Hard navigation to chat home so the startup coordinator restores the
+        // just-persisted cloud connection from a clean boot. `void result` keeps
+        // the resolved agent in scope for future telemetry without unused-var noise.
+        void result;
+        if (typeof window !== "undefined") {
+          appModeNavigation.assign("/");
+        }
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError(describeJoinError(err));
+        setPhase("error");
       }
-    } catch (err) {
-      setError(describeJoinError(err));
-      setPhase("error");
+    })();
+    activeAttemptRef.current = { controller, promise: attempt };
+    await attempt;
+    if (activeAttemptRef.current?.controller === controller) {
+      activeAttemptRef.current = null;
     }
   }, []);
+
+  useEffect(
+    () => () => {
+      activeAttemptRef.current?.controller.abort(
+        new DOMException("Join page unmounted", "AbortError"),
+      );
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!session.ready) return;
@@ -125,6 +153,23 @@ export default function JoinPage(): React.JSX.Element {
     startedRef.current = true;
     void start();
   }, [start]);
+
+  const handleSignOut = useCallback(async () => {
+    if (signingOut) return;
+    setSigningOut(true);
+    const active = activeAttemptRef.current;
+    active?.controller.abort(
+      new DOMException("User signed out during join", "AbortError"),
+    );
+    // Let the aborted identity read settle before revoking the Steward session,
+    // so no stale completion can bind or persist an account after sign-out.
+    await active?.promise.catch(() => undefined);
+    const { signOutFromSsoBridgedHost } = await import(
+      "../sso-bridge/sso-bridge"
+    );
+    await signOutFromSsoBridgedHost();
+    appModeNavigation.replace("/login");
+  }, [signingOut]);
 
   // Signed out → send to login, returning here once authenticated.
   if (session.ready && !session.authenticated && ssoBridging === false) {
@@ -165,6 +210,17 @@ export default function JoinPage(): React.JSX.Element {
             >
               {t("cloud.join.retry", { defaultValue: "Try again" })}
             </Button>
+            <Button
+              variant="ghost"
+              type="button"
+              disabled={signingOut}
+              onClick={() => void handleSignOut()}
+              className="px-6 py-2 text-sm text-white/70 transition-colors hover:text-white"
+            >
+              {signingOut
+                ? t("cloud.join.signingOut", { defaultValue: "Signing out..." })
+                : t("cloud.join.signOut", { defaultValue: "Sign out" })}
+            </Button>
           </div>
         ) : (
           <div
@@ -179,6 +235,17 @@ export default function JoinPage(): React.JSX.Element {
                   defaultValue: "Opening your personal Eliza...",
                 })}
             </p>
+            <Button
+              variant="ghost"
+              type="button"
+              disabled={signingOut}
+              onClick={() => void handleSignOut()}
+              className="px-6 py-2 text-sm text-white/70 transition-colors hover:text-white"
+            >
+              {signingOut
+                ? t("cloud.join.signingOut", { defaultValue: "Signing out..." })
+                : t("cloud.join.signOut", { defaultValue: "Sign out" })}
+            </Button>
           </div>
         )}
       </div>

--- a/packages/ui/src/cloud/join/lib/run-join-flow.test.ts
+++ b/packages/ui/src/cloud/join/lib/run-join-flow.test.ts
@@ -100,4 +100,66 @@ describe("runJoinFlow", () => {
     expect(h.savePersistedActiveServer).not.toHaveBeenCalled();
     expect(h.savePersistedFirstRunComplete).not.toHaveBeenCalled();
   });
+
+  test("does not bind or persist when identity resolution finishes after cancellation", async () => {
+    const h = harness();
+    let resolveIdentity: (value: {
+      agentId: string;
+      agentName: string;
+      apiBase: string;
+      runtime: "shared";
+    }) => void = () => undefined;
+    h.getPersonalSharedEliza.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveIdentity = resolve;
+        }),
+    );
+    const controller = new AbortController();
+    const flow = runJoinFlow({
+      client: h.client,
+      effects: h.effects,
+      cloudApiBase: CLOUD_API_BASE,
+      authToken: "session-token",
+      signal: controller.signal,
+    });
+
+    controller.abort(new DOMException("User signed out", "AbortError"));
+    resolveIdentity({
+      agentId: PERSONAL_ID,
+      agentName: "Eliza",
+      apiBase: PERSONAL_BASE,
+      runtime: "shared",
+    });
+
+    await expect(flow).rejects.toMatchObject({ name: "AbortError" });
+    expect(h.getPersonalSharedEliza).toHaveBeenCalledWith({
+      cloudApiBase: CLOUD_API_BASE,
+      authToken: "session-token",
+      signal: controller.signal,
+    });
+    expect(h.setBaseUrl).not.toHaveBeenCalled();
+    expect(h.setToken).not.toHaveBeenCalled();
+    expect(h.savePersistedActiveServer).not.toHaveBeenCalled();
+    expect(h.savePersistedFirstRunComplete).not.toHaveBeenCalled();
+  });
+
+  test("rejects a pre-aborted attempt before starting identity resolution", async () => {
+    const h = harness();
+    const controller = new AbortController();
+    controller.abort(new DOMException("Already signed out", "AbortError"));
+
+    await expect(
+      runJoinFlow({
+        client: h.client,
+        effects: h.effects,
+        cloudApiBase: CLOUD_API_BASE,
+        authToken: "session-token",
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    expect(h.getPersonalSharedEliza).not.toHaveBeenCalled();
+    expect(h.savePersistedActiveServer).not.toHaveBeenCalled();
+  });
 });

--- a/packages/ui/src/cloud/join/lib/run-join-flow.ts
+++ b/packages/ui/src/cloud/join/lib/run-join-flow.ts
@@ -20,6 +20,7 @@ export interface JoinFlowClient {
   getPersonalSharedEliza(options: {
     cloudApiBase: string;
     authToken: string;
+    signal?: AbortSignal;
   }): Promise<{
     agentId: string;
     agentName: string;
@@ -48,6 +49,8 @@ export interface RunJoinFlowArgs {
   cloudApiBase: string;
   authToken: string;
   onProgress?: (status: string, detail?: string) => void;
+  /** Cancels identity resolution before local binding or persistence begins. */
+  signal?: AbortSignal;
 }
 
 export interface JoinFlowResult {
@@ -66,12 +69,15 @@ export interface JoinFlowResult {
 export async function runJoinFlow(
   args: RunJoinFlowArgs,
 ): Promise<JoinFlowResult> {
-  const { client, effects, cloudApiBase, authToken, onProgress } = args;
+  const { client, effects, cloudApiBase, authToken, onProgress, signal } = args;
+  signal?.throwIfAborted();
   onProgress?.("connecting", "Opening your personal Eliza…");
   const selected = await client.getPersonalSharedEliza({
     cloudApiBase,
     authToken,
+    ...(signal ? { signal } : {}),
   });
+  signal?.throwIfAborted();
 
   if (!selected.agentId) {
     throw new Error("Cloud did not return an agent to connect to.");

--- a/packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs
+++ b/packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs
@@ -80,8 +80,25 @@ const stubClient = {
 // CJS stub (`.cjs` so esbuild wraps it and `module` is defined): arbitrary
 // named imports of core resolve to `undefined` via CJS interop, since the modal
 // never executes any core code path.
+//
+// `ElizaError` is the one exception and must be a real constructor. The graph
+// reaches `api/client-cloud.ts`, which evaluates `class CloudAgentWakeError
+// extends ElizaError` at module scope. A class heritage clause runs on load
+// even though the modal never constructs it, so an empty core stub prevents
+// React from mounting and leaves the runner waiting for the first card.
 const coreStub = join(outDir, "core-stub.cjs");
-await writeFile(coreStub, "module.exports = {};\n");
+await writeFile(
+  coreStub,
+  `class ElizaError extends Error {
+  constructor(message, options) {
+    super(message);
+    this.name = "ElizaError";
+    if (options && options.code) this.code = options.code;
+  }
+}
+module.exports = { ElizaError };
+`,
+);
 const stubCore = {
   name: "stub-core",
   setup(b) {

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -8205,6 +8205,8 @@
   "cloud.join.errorBody": "Something went wrong. Try again.",
   "cloud.join.errorTitle": "Couldn't open your Eliza",
   "cloud.join.retry": "Try again",
+  "cloud.join.signingOut": "Signing out...",
+  "cloud.join.signOut": "Sign out",
   "cloud.login.back": "Back",
   "cloud.login.callback.codeRejected": "That sign-in link expired or was already used. Please sign in again below.",
   "cloud.login.callback.invalidLink": "We couldn't verify that sign-in link. Request a new one. If it keeps happening, contact support.",


### PR DESCRIPTION
## Summary

Extracted from the Nubs PR review/repair work tracked in #18960. This slice contains only the Cloud join lifecycle changes and their required catalog entries.

- make wake/provision polling abortable while retaining the existing single deadline for the whole join
- serialize retry, unmount, and sign-out cancellation through one active attempt
- preserve an accepted create receipt long enough for the join controller to delete a newly-created agent before cancellation settles
- keep the authenticated session alive until compensation completes
- expose truthful Sign out / Signing out UI states

Excluded: notification-store behavior, balance isolation, and unrelated UI documentation/version updates.

## Verification

- `bun test packages/ui/src/cloud/join/lib/run-join-flow.test.ts packages/ui/src/api/client-cloud-wake-typed-errors.test.ts` (37 passed)
- `bun run --cwd packages/ui typecheck`
- `bunx @biomejs/biome check` on all six changed files
- `git diff --check origin/develop..fix/nubs-cloud-join-cancellation`
- exact-head permission-priming fixture archive: `PERMISSION PRIMING E2E PASSED` (desktop + mobile, 8 screenshots, video, 0 page errors); repairs hosted run `31760136409` by providing the fixture stub with the `ElizaError` constructor now evaluated by the Cloud join import graph

Part of #18960.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-head:9d52ee53861d70c7dc8b41bda2b01a42cb64dbdd -->
<!-- evidence-row:before-screenshots -->
- [x] Desktop (PR base `f8e4497`): ![before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19280-before-desktop.png)
- [x] Mobile (PR base `f8e4497`): ![before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19280-before-mobile.png)
- [x] [render/source provenance](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19280-render-provenance.json)
<!-- evidence-row:after-screenshots -->
- [x] Desktop: ![after desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19280-after-desktop.png)
- [x] Mobile: ![after mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19280-after-mobile.png)
- [x] Cancellation state: ![signing out](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19280-signing-out.png)
- [x] [render/source provenance](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19280-render-provenance.json)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19280-walkthrough.mp4 — 5 s H.264 walkthrough: create accepted → provision job observed → Sign out → compensating DELETE settles → session teardown → login.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no production backend was invoked; the browser contract harness controlled responses and the frontend network artifact records every request and response.
<!-- evidence-row:frontend-logs -->
- [x] [console log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19280-frontend-console.log) (no errors)
- [x] [network log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19280-frontend-network.log) (includes ordered create, job poll, compensating DELETE, session DELETE)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - this deterministic Cloud join lifecycle does not invoke a language model.
<!-- evidence-row:domain-artifacts -->
- [x] [lifecycle timing receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19280-lifecycle.log)
- [x] [exact-equivalent source and renderer receipts](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19280-render-provenance.json)
<!-- evidence-row:ocr-review -->
- [x] [packaged Tesseract.js OCR readout](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19280-ocr-review.json) — desktop/mobile before and after plus flow states; after captures read “Sign out,” cancellation reads “Signing out...,” final capture reads the login page; no capture is pixel-blank.

Draft until exact-head CI and independent review complete.


