### PR TITLE
fix(ui): clear inbox on credential replacement

### DIFF
--- a/packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs
+++ b/packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs
@@ -80,8 +80,25 @@ const stubClient = {
 // CJS stub (`.cjs` so esbuild wraps it and `module` is defined): arbitrary
 // named imports of core resolve to `undefined` via CJS interop, since the modal
 // never executes any core code path.
+//
+// `ElizaError` is the one exception and must be a real constructor. The graph
+// reaches `api/client-cloud.ts`, which evaluates `class CloudAgentWakeError
+// extends ElizaError` at module scope. A class heritage clause runs on load
+// even though the modal never constructs it, so an empty core stub prevents
+// React from mounting and leaves the runner waiting for the first card.
 const coreStub = join(outDir, "core-stub.cjs");
-await writeFile(coreStub, "module.exports = {};\n");
+await writeFile(
+  coreStub,
+  `class ElizaError extends Error {
+  constructor(message, options) {
+    super(message);
+    this.name = "ElizaError";
+    if (options && options.code) this.code = options.code;
+  }
+}
+module.exports = { ElizaError };
+`,
+);
 const stubCore = {
   name: "stub-core",
   setup(b) {

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -61,6 +61,7 @@ vi.mock("../../api/client", () => ({
 
 const invokeDesktopBridgeRequest = vi.fn();
 vi.mock("../../bridge/electrobun-rpc", () => ({
+  getElectrobunRendererRpc: () => null,
   invokeDesktopBridgeRequest: (...args: unknown[]) =>
     invokeDesktopBridgeRequest(...args),
 }));
@@ -1188,6 +1189,27 @@ describe("notification-store — authority isolation (#18391)", () => {
   // only reacts to that eventual publish) for the whole round-trip.
   // steward-token-sync fires synchronously on the token clear itself.
   describe("credential-sync invalidation ahead of the async auth probe", () => {
+    it("clears account A immediately when a present token is replaced before the auth probe resolves", async () => {
+      __setAuthStatusForTests(authenticated("user-a", "session-a"));
+      const notifA = makeNotification({ id: "a-row", title: "A's row" });
+      listNotifications.mockResolvedValueOnce({
+        notifications: [notifA],
+        unreadCount: 1,
+      });
+      initNotifications();
+      await vi.waitFor(() =>
+        expect(__getStateForTests().notifications).toHaveLength(1),
+      );
+      rotateConnection.mockClear();
+
+      // The canonical token writer knows that the credential changed before
+      // /api/auth/me can publish B's non-secret identity.
+      writeStoredStewardToken("account-b-token");
+
+      expect(__getStateForTests().notifications).toHaveLength(0);
+      expect(rotateConnection).toHaveBeenCalledTimes(1);
+    });
+
     it("clears immediately on a cleared token, before the auth-status probe catches up", async () => {
       __setAuthStatusForTests(authenticated("user-a", "session-a"));
       const notifA = makeNotification({ id: "a-row", title: "A's row" });
@@ -1267,7 +1289,7 @@ describe("notification-store — authority isolation (#18391)", () => {
       expect(__getStateForTests().notifications).toHaveLength(0);
     });
 
-    it("a token install (login/refresh/handoff) is a harmless no-op when the base already reconciled", async () => {
+    it("keeps a token handoff invalidated until the typed auth probe confirms its identity", async () => {
       __setAuthStatusForTests(authenticated("user-a", "session-a"));
       initNotifications();
       await vi.waitFor(() =>
@@ -1288,9 +1310,12 @@ describe("notification-store — authority isolation (#18391)", () => {
       publishStewardSession("present");
       await Promise.resolve();
 
-      // No extra clear/refetch/rotation beyond what the base change already did.
+      // The new credential has no non-secret identity yet. Do not hydrate
+      // under A's stale auth snapshot; the auth-status subscriber will
+      // reconcile and fetch after the probe confirms the new authority.
       expect(listNotifications).toHaveBeenCalledTimes(2);
-      expect(rotateConnection).not.toHaveBeenCalled();
+      expect(__getStateForTests().notifications).toHaveLength(0);
+      expect(rotateConnection).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -466,6 +466,7 @@ function reconcileAuthority(authStatus: AuthStatusState): void {
   // repointBaseUrl, so rotating again here would be redundant).
   const isSubsequentAuthOnlySwitch =
     !isAnonAuthorityKey(currentAuthorityKey) &&
+    currentAuthorityKey !== INVALIDATED_AUTHORITY_KEY &&
     currentAuthorityBaseUrl === baseUrl;
   currentAuthorityKey = nextKey;
   currentAuthorityBaseUrl = baseUrl;
@@ -485,16 +486,21 @@ const INVALIDATED_AUTHORITY_KEY = "credential-invalidated";
 /**
  * `useAuthStatus` deliberately keeps the previous authenticated snapshot
  * until the async `/api/auth/me` probe resolves. The typed Steward session
- * event distinguishes a real clear from login/refresh without consulting the
- * unrelated Eliza API bearer. A clear invalidates synchronously; a present
- * transition reconciles against the latest typed auth snapshot.
+ * event distinguishes a real credential mutation from background auth-status
+ * refreshes without exposing either token or identity. Both present and clear
+ * transitions invalidate synchronously: a direct account-A to account-B token
+ * replacement can otherwise leave A's inbox visible until the asynchronous
+ * auth probe publishes B's identity.
  */
 function onStewardSessionChange(event: Event): void {
   const detail = (event as CustomEvent<StewardSessionChangeDetail>).detail;
   if (!detail || detail.sessionEpoch <= lastStewardSessionEpoch) return;
   lastStewardSessionEpoch = detail.sessionEpoch;
   if (detail.state === "present") {
-    reconcileAuthority(getAuthStatusSnapshot());
+    currentAuthorityKey = INVALIDATED_AUTHORITY_KEY;
+    bindLiveNotificationStream(currentAuthorityKey);
+    clearForAuthorityChange();
+    client.rotateConnection();
     return;
   }
   if (currentAuthorityKey === INVALIDATED_AUTHORITY_KEY) return;


### PR DESCRIPTION
## Summary

- synchronously invalidate notification authority when a present Steward credential is replaced
- clear account A's inbox and rotate the live notification socket before the asynchronous typed auth probe can identify account B
- keep hydration blocked on the explicit invalidated authority until the typed auth snapshot reconciles
- cover direct token replacement and handoff-before-probe behavior
- repair the notification test's Electrobun mock for the current renderer-runtime contract
- repair the permission-priming fixture's minimal core stub so its transitive `CloudAgentWakeError extends ElizaError` definition can load before React mounts

This is the isolated notification identity/socket-authority slice from the Nubs review repair work. It intentionally excludes the broader join-flow, cloud-client, React dependency, and UI documentation changes.

Fixes part of #18960.

## Local validation

```text
bunx @biomejs/biome check packages/ui/src/state/notifications/notification-store.ts packages/ui/src/state/notifications/notification-store.test.ts
Checked 2 files. No fixes applied.

bun run --cwd packages/ui typecheck
PASS

git diff --check origin/develop...fix/nubs-notification-identity
PASS

exact-head archive: bun run --cwd packages/ui test -- src/state/notifications/notification-store.test.ts
62 passed

exact-head archive: bun run --cwd packages/ui test:permission-priming-e2e
PASS — desktop + mobile, 8 screenshots, video, zero page errors

git diff --name-only origin/develop...001c8ba445518aa097f12b3d911e8cb3b8b5f8db
packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs
packages/ui/src/state/notifications/notification-store.test.ts
packages/ui/src/state/notifications/notification-store.ts
```

The first hosted permission-priming run timed out before React mounted. The same failure reproduced on the contemporaneous `develop` push: its generated `@elizaos/core` stub exported `{}`, while the transitive client graph now evaluates `CloudAgentWakeError extends ElizaError` at module scope. Supplying the one required constructor fixes the fixture without widening its mocked runtime surface.

## Evidence boundary

The deterministic store tests cover authority invalidation, inbox clearing, and socket rotation. This draft does not claim live multi-account server or browser-session evidence.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:001c8ba445518aa097f12b3d911e8cb3b8b5f8db -->

<!-- evidence-row:before-screenshots -->
- N/A — the transient credential race changes state authority but introduces no new layout or rendered text.
<!-- evidence-row:after-screenshots -->
- N/A — the transient credential race changes state authority but introduces no new layout or rendered text.
<!-- evidence-row:walkthrough-video -->
- N/A — deterministic contract/authority change with no new interactive visual flow.
<!-- evidence-row:backend-logs -->
- N/A — no live backend log artifact applies; focused deterministic tests are reported above.
<!-- evidence-row:frontend-logs -->
- N/A — no browser console/network artifact applies to this isolated contract proof.
<!-- evidence-row:llm-trajectory -->
- N/A — no prompt, model selection, or generated-output contract changes.
<!-- evidence-row:domain-artifacts -->
- N/A — no external domain artifact applies; executable contract artifacts are contained in the changed tests and reported above.
<!-- evidence-row:ocr-review -->
- N/A — no visual layout or rendered text changed.
