### PR TITLE
ci(cloud): canary realtime auth with rollback

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -933,6 +933,93 @@ jobs:
           echo "::error::API health did not serve the deployed commit ${expected_commit} for ${expected_environment}."
           exit 1
 
+      - name: Canary authenticated staging realtime and rollback on failure
+        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true' && steps.env.outputs.deploy_environment == 'staging'
+        working-directory: ${{ env.CHECKOUT_DIR }}/packages/cloud/api
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          STAGING_ELIZACLOUD_API_KEY: ${{ secrets.ELIZACLOUD_API_KEY }}
+          VOICE_REALTIME_WS_ENABLED: ${{ contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED) && 'true' || 'false' }}
+          ELIZA_TTS_FISH_ENABLED: ${{ contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.ELIZA_TTS_FISH_ENABLED) && 'true' || 'false' }}
+          FISH_AUDIO_DATA_GOVERNANCE_APPROVED: ${{ contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.FISH_AUDIO_DATA_GOVERNANCE_APPROVED) && 'true' || 'false' }}
+          FISH_AUDIO_MODEL: ${{ vars.FISH_AUDIO_MODEL || 's2.1-pro' }}
+          FISH_AUDIO_SAMPLE_RATE: "16000"
+          FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS: ${{ vars.FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS || '1500' }}
+          KOKORO_TTS_URL: ${{ vars.ELIZA_VOICE_KOKORO_TTS_URL }}
+        run: |
+          set -euo pipefail
+          if [ "$VOICE_REALTIME_WS_ENABLED" != "true" ]; then
+            echo "Realtime remains disabled; authenticated staging canary is not applicable."
+            exit 0
+          fi
+          rollback_realtime() {
+            echo "::warning::Realtime canary failed; redeploying the exact commit with its served gate off"
+            rollback_args=(
+              --env staging
+              --var ELIZA_DEPLOY_COMMIT:"$GITHUB_SHA"
+              --var VOICE_REALTIME_WS_ENABLED:"false"
+              --var ELIZA_TTS_FISH_ENABLED:"$ELIZA_TTS_FISH_ENABLED"
+              --var FISH_AUDIO_DATA_GOVERNANCE_APPROVED:"$FISH_AUDIO_DATA_GOVERNANCE_APPROVED"
+              --var FISH_AUDIO_MODEL:"$FISH_AUDIO_MODEL"
+              --var FISH_AUDIO_SAMPLE_RATE:"$FISH_AUDIO_SAMPLE_RATE"
+              --var FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS:"$FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS"
+            )
+            if [ -n "${KOKORO_TTS_URL:-}" ]; then
+              rollback_args+=(--var KOKORO_TTS_URL:"$KOKORO_TTS_URL")
+            fi
+            bunx wrangler deploy "${rollback_args[@]}"
+            for attempt in 1 2 3 4 5 6; do
+              code="$(curl -sS -o /tmp/realtime-rollback.json -w '%{http_code}' -m 20 \
+                -X POST -H "X-API-Key: $STAGING_ELIZACLOUD_API_KEY" \
+                https://api-staging.eliza.app/api/v1/voice/session/consent || echo '000')"
+              [ "$code" = "404" ] && return 0
+              [ "$attempt" -lt 6 ] && sleep 10
+            done
+            echo "::error::Realtime rollback redeployed but served-state 404 was not confirmed"
+            return 1
+          }
+
+          canary_proven=false
+          rollback_on_unproven_exit() {
+            status=$?
+            if [ "$canary_proven" != "true" ]; then
+              rollback_realtime || status=1
+            fi
+            exit "$status"
+          }
+          trap rollback_on_unproven_exit EXIT
+          trap 'exit 1' INT TERM
+
+          if [ -z "${STAGING_ELIZACLOUD_API_KEY//[[:space:]]/}" ]; then
+            echo "::error::Enabled staging realtime requires an authenticated canary credential"
+            exit 1
+          fi
+
+          for attempt in 1 2 3 4 5 6; do
+            body="$(mktemp)"
+            code="$(curl -sS -o "$body" -w '%{http_code}' -m 20 \
+              -X POST -H "X-API-Key: $STAGING_ELIZACLOUD_API_KEY" \
+              https://api-staging.eliza.app/api/v1/voice/session/consent || echo '000')"
+            if [ "$code" = "200" ] && node - "$body" <<'NODE'
+          const fs = require("fs");
+          const body = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          if (typeof body.consentNonce !== "string" || body.consentNonce.length < 1) process.exit(1);
+          if (typeof body.expiresAt !== "string" || Number.isNaN(Date.parse(body.expiresAt))) process.exit(1);
+          NODE
+            then
+              rm -f "$body"
+              canary_proven=true
+              trap - EXIT INT TERM
+              echo "Authenticated staging realtime consent canary passed."
+              exit 0
+            fi
+            rm -f "$body"
+            [ "$attempt" -lt 6 ] && sleep 10
+          done
+          echo "::error::Authenticated staging realtime canary did not prove the deployed route"
+          exit 1
+
       - name: Activate and verify staging session exchange after deploy proof
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true' && steps.env.outputs.deploy_environment == 'staging'
         working-directory: ${{ env.CHECKOUT_DIR }}/packages/cloud/api

--- a/packages/cloud/api/src/blob-host.test.ts
+++ b/packages/cloud/api/src/blob-host.test.ts
@@ -96,11 +96,11 @@ describe("serveBlobHostRequest", () => {
   test("respects R2_PUBLIC_HOST for the per-env host (staging)", async () => {
     const { env } = makeEnv(
       { "avatars/eliza.png": { body: "AVATAR" } },
-      "blob-staging.elizacloud.ai",
+      "blob-staging.eliza.app",
     );
 
     const [hitReq, hitUrl] = req(
-      "https://blob-staging.elizacloud.ai/avatars/eliza.png",
+      "https://blob-staging.eliza.app/avatars/eliza.png",
     );
     const hit = await serveBlobHostRequest(hitReq, hitUrl, env);
     expect(hit?.status).toBe(200);

--- a/packages/cloud/api/src/registry-host.test.ts
+++ b/packages/cloud/api/src/registry-host.test.ts
@@ -1,7 +1,7 @@
 /**
- * The registry host (`plugins.eliza.app`) must serve the committed registry
- * artifacts from the worker itself: the managed-agent wildcard
- * route shadows the host, so before this handler the canonical registry URL
+ * The registry hosts (`plugins.eliza.app` / `plugins-staging.eliza.app`) must
+ * serve committed registry artifacts only from the matching deployment. The
+ * managed-agent wildcard route shadows the host, so before this handler the canonical registry URL
  * (`packages/registry` README) 404'd on the JSON router on every env.
  * Deterministic — upstream raw-GitHub fetch is stubbed via the global fetch;
  * no network.
@@ -66,15 +66,14 @@ describe("serveRegistryHostRequest", () => {
     );
   });
 
-  test("serves the staging host from the same allowlist", async () => {
-    stubUpstream(() => new Response("{}", { status: 200 }));
+  test("does not serve the staging host from a production deployment", async () => {
+    const { calls } = stubUpstream(() => new Response("{}", { status: 200 }));
     const [request, url] = req(
       "https://plugins-staging.eliza.app/generated-registry.json",
     );
-    const response = await serveRegistryHostRequest(request, url, {
-      ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud-staging.eliza.app",
-    } as typeof ENV);
-    expect(response?.status).toBe(200);
+    const response = await serveRegistryHostRequest(request, url, ENV);
+    expect(response).toBeNull();
+    expect(calls).toHaveLength(0);
   });
 
   test("404s paths outside the artifact allowlist without touching upstream", async () => {
@@ -131,6 +130,17 @@ describe("serveRegistryHostRequest", () => {
     const response = await serveRegistryHostRequest(request, url, ENV);
     expect(response?.status).toBe(200);
     expect(await response?.text()).toBe("");
+  });
+
+  test("selects the staging registry host from the configured agent domain", async () => {
+    stubUpstream(() => new Response("{}", { status: 200 }));
+    const [request, url] = req(
+      "https://plugins-staging.eliza.app/generated-registry.json",
+    );
+    const response = await serveRegistryHostRequest(request, url, {
+      ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud-staging.eliza.app",
+    } as typeof ENV);
+    expect(response?.status).toBe(200);
   });
 
   test("does not synthesize registry hosts from arbitrary agent domains", async () => {

--- a/packages/cloud/routing/src/resolve.test.ts
+++ b/packages/cloud/routing/src/resolve.test.ts
@@ -96,7 +96,7 @@ describe("resolveCloudRoute", () => {
       ),
     ).toMatchObject({
       source: "cloud-proxy",
-      baseUrl: "https://elizacloud.ai/api/v1/apis/quotes",
+      baseUrl: "https://api.eliza.app/api/v1/apis/quotes",
       headers: { Authorization: "Bearer cloud-secret" },
     });
   });

--- a/packages/cloud/scripts/__tests__/voice-realtime-deploy-contract.test.ts
+++ b/packages/cloud/scripts/__tests__/voice-realtime-deploy-contract.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Locks the authenticated staging realtime canary and its fail-closed rollback
+ * to the authoritative Cloudflare deployment workflow.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse } from "yaml";
+
+interface WorkflowStep {
+  env?: Record<string, string>;
+  if?: string;
+  name?: string;
+  run?: string;
+}
+
+interface Workflow {
+  jobs: {
+    "deploy-api": { steps: WorkflowStep[] };
+  };
+}
+
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+const workflow = parse(
+  readFileSync(
+    resolve(repoRoot, ".github/workflows/cloud-cf-release.yml"),
+    "utf8",
+  ),
+) as Workflow;
+
+function namedStep(name: string): WorkflowStep {
+  const step = workflow.jobs["deploy-api"].steps.find(
+    (candidate) => candidate.name === name,
+  );
+  if (!step) throw new Error(`Missing Cloud deploy step: ${name}`);
+  return step;
+}
+
+describe("realtime staging deploy contract", () => {
+  const canary = namedStep(
+    "Canary authenticated staging realtime and rollback on failure",
+  );
+  const run = canary.run ?? "";
+
+  test("runs only after the exact staging API deployment", () => {
+    const steps = workflow.jobs["deploy-api"].steps;
+    expect(steps.indexOf(canary)).toBeGreaterThan(
+      steps.indexOf(namedStep("Verify deployed API commit")),
+    );
+    expect(canary.if).toContain("deploy_environment == 'staging'");
+    expect(canary.env?.STAGING_ELIZACLOUD_API_KEY).toContain(
+      "secrets.ELIZACLOUD_API_KEY",
+    );
+  });
+
+  test("proves an authenticated, stateful realtime edge", () => {
+    expect(run).toContain('if [ "$VOICE_REALTIME_WS_ENABLED" != "true" ]');
+    expect(run).toContain('-H "X-API-Key: $STAGING_ELIZACLOUD_API_KEY"');
+    expect(run).toContain("/api/v1/voice/session/consent");
+    expect(run).toContain(
+      "https://api-staging.eliza.app/api/v1/voice/session/consent",
+    );
+    expect(run).not.toContain("api-staging.elizacloud.ai");
+    expect(run).toContain("body.consentNonce");
+    expect(run).toContain("body.expiresAt");
+  });
+
+  test("keeps rollback armed until proof and verifies the served gate is off", () => {
+    const rollbackDeploy = [
+      'bunx wrangler deploy "$',
+      '{rollback_args[@]}"',
+    ].join("");
+    expect(run).toContain("trap rollback_on_unproven_exit EXIT");
+    expect(run).toContain("canary_proven=false");
+    expect(run).toContain('--var VOICE_REALTIME_WS_ENABLED:"false"');
+    expect(run).toContain('[ "$code" = "404" ] && return 0');
+    expect(run).toContain(rollbackDeploy);
+    expect(run.indexOf(rollbackDeploy)).toBeLessThan(
+      run.indexOf('[ "$code" = "404" ] && return 0'),
+    );
+    expect(run.indexOf("trap rollback_on_unproven_exit EXIT")).toBeLessThan(
+      run.indexOf("requires an authenticated canary credential"),
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/api/compat-envelope.test.ts
+++ b/packages/cloud/shared/src/lib/api/compat-envelope.test.ts
@@ -68,7 +68,7 @@ describe("toCompatStatus", () => {
       containerId: "container-1",
       containerUrl: "https://runtime.example",
       bridgeUrl: "https://runtime.example",
-      webUiUrl: "https://123e4567-e89b-12d3-a456-426614174000.elizacloud.ai",
+      webUiUrl: "https://123e4567-e89b-12d3-a456-426614174000.cloud.eliza.app",
       status: "running",
       databaseStatus: "ready",
       account: {

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-host-contract.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-host-contract.test.ts
@@ -95,10 +95,10 @@ async function resolveOnboardingOrigins(
 }
 
 /**
- * `appOrigin` is the Eliza *app* host, never the console apex: production pins
- * app.elizacloud.ai while its NEXT_PUBLIC_APP_URL is the apex elizacloud.ai, and
- * staging's peer of that app host is app-staging.elizacloud.ai (the `eliza-app`
- * Pages domain, same environment-peer rule as STAGING_ELIZA_APP_ORIGIN in
+ * `appOrigin` is the Eliza *app* host, never the homepage apex: production pins
+ * cloud.eliza.app while its public homepage is eliza.app, and staging's peer
+ * of that app host is cloud-staging.eliza.app (the `eliza-app` Pages domain,
+ * following the same environment-peer rule as STAGING_ELIZA_APP_ORIGIN in
  * packages/ui/src/utils/cloud-agent-base.ts).
  *
  * `loginOrigin` is the messaging-continuation Connect CTA target. It now equals
@@ -116,22 +116,22 @@ const ONBOARDING_HOST_CONTRACT: ReadonlyArray<{
 }> = [
   {
     section: "vars",
-    loginOrigin: "https://app.elizacloud.ai",
-    appOrigin: "https://app.elizacloud.ai",
+    loginOrigin: "https://cloud.eliza.app",
+    appOrigin: "https://cloud.eliza.app",
   },
   {
     section: "env.production.vars",
-    loginOrigin: "https://app.elizacloud.ai",
-    appOrigin: "https://app.elizacloud.ai",
+    loginOrigin: "https://cloud.eliza.app",
+    appOrigin: "https://cloud.eliza.app",
   },
   {
     section: "env.staging.vars",
-    loginOrigin: "https://app-staging.elizacloud.ai",
-    appOrigin: "https://app-staging.elizacloud.ai",
+    loginOrigin: "https://cloud-staging.eliza.app",
+    appOrigin: "https://cloud-staging.eliza.app",
   },
 ];
 
-const PRODUCTION_APP_ORIGINS = ["https://app.elizacloud.ai", "https://elizacloud.ai"];
+const PRODUCTION_APP_ORIGINS = ["https://cloud.eliza.app", "https://eliza.app"];
 
 describe("onboarding host deployment contract", () => {
   test.each(ONBOARDING_HOST_CONTRACT)(
@@ -170,7 +170,7 @@ describe("onboarding host deployment contract", () => {
     // Resolution alone cannot tell a pin from a fallback: NEXT_PUBLIC_APP_URL
     // would answer for ELIZA_ONBOARDING_APP_URL and quietly hand back the
     // console apex the moment the explicit key is dropped.
-    expect(staging.ELIZA_ONBOARDING_APP_URL).toBe("https://app-staging.elizacloud.ai");
-    expect(staging.NEXT_PUBLIC_APP_URL).toBe("https://staging.elizacloud.ai");
+    expect(staging.ELIZA_ONBOARDING_APP_URL).toBe("https://cloud-staging.eliza.app");
+    expect(staging.NEXT_PUBLIC_APP_URL).toBe("https://cloud-staging.eliza.app");
   });
 });

--- a/packages/cloud/shared/src/lib/services/pairing-token.test.ts
+++ b/packages/cloud/shared/src/lib/services/pairing-token.test.ts
@@ -1,16 +1,27 @@
-// Exercises pairing token behavior with deterministic cloud-shared lib fixtures.
+/**
+ * Deterministically exercises pairing-token domain aliases without network or storage.
+ */
 import { describe, expect, it } from "bun:test";
 import { DOMAIN_ALIAS_GROUPS, getAlternateDomainOrigins } from "./pairing-token-domains";
+
+const [CANONICAL_GROUP] = DOMAIN_ALIAS_GROUPS;
+
+/** Returns the canonical sibling hostnames for a matched alias suffix. */
+function aliasHostnames(prefix: string, matched: string): string[] {
+  return CANONICAL_GROUP.filter((suffix) => suffix !== matched)
+    .map((suffix) => `${prefix}${suffix}`)
+    .sort();
+}
 
 describe("getAlternateDomainOrigins", () => {
   it("returns every other suffix in the same alias group", () => {
     // The canonical group is the first entry. Verify each domain produces
     // (group.length - 1) alternates — the matched suffix is excluded.
-    const inputs = ["https://abc.waifu.fun", "https://abc.eliza.ai", "https://abc.elizacloud.ai"];
+    const inputs = CANONICAL_GROUP.map((suffix) => `https://abc${suffix}`);
 
     for (const origin of inputs) {
       const alts = getAlternateDomainOrigins(origin);
-      expect(alts).toHaveLength(2);
+      expect(alts).toHaveLength(CANONICAL_GROUP.length - 1);
       expect(alts).not.toContain(origin);
       const hostnames = alts.map((url) => new URL(url).hostname);
       for (const hostname of hostnames) {
@@ -24,12 +35,7 @@ describe("getAlternateDomainOrigins", () => {
       "https://9d77d8b5-1d63-4b4c-9bd1-ec1b5deb4dc8.waifu.fun",
     );
     const hostnames = alts.map((u) => new URL(u).hostname).sort();
-    expect(hostnames).toEqual(
-      [
-        "9d77d8b5-1d63-4b4c-9bd1-ec1b5deb4dc8.eliza.ai",
-        "9d77d8b5-1d63-4b4c-9bd1-ec1b5deb4dc8.elizacloud.ai",
-      ].sort(),
-    );
+    expect(hostnames).toEqual(aliasHostnames("9d77d8b5-1d63-4b4c-9bd1-ec1b5deb4dc8", ".waifu.fun"));
   });
 
   it("rejects retired 0xSolace-era domains (example.ai, shad0w.xyz)", () => {
@@ -44,7 +50,7 @@ describe("getAlternateDomainOrigins", () => {
     // `URL.origin` keeps non-default ports — the alternate origins must
     // round-trip them so a sandbox served on :8443 still matches its alias.
     const alts = getAlternateDomainOrigins("https://abc.waifu.fun:8443");
-    expect(alts).toHaveLength(2);
+    expect(alts).toHaveLength(CANONICAL_GROUP.length - 1);
     for (const alt of alts) {
       const url = new URL(alt);
       expect(url.port).toBe("8443");
@@ -58,7 +64,7 @@ describe("getAlternateDomainOrigins", () => {
     // `a.b.c.eliza.ai` without touching the inner labels.
     const alts = getAlternateDomainOrigins("https://a.b.c.waifu.fun");
     const hostnames = alts.map((u) => new URL(u).hostname).sort();
-    expect(hostnames).toEqual(["a.b.c.eliza.ai", "a.b.c.elizacloud.ai"].sort());
+    expect(hostnames).toEqual(aliasHostnames("a.b.c", ".waifu.fun"));
   });
 
   it("returns an empty array when no aliased suffix matches", () => {
@@ -78,7 +84,7 @@ describe("getAlternateDomainOrigins", () => {
     // so an Origin header arriving as `https://ABC.WAIFU.FUN` still aliases.
     const alts = getAlternateDomainOrigins("https://ABC.WAIFU.FUN");
     const hostnames = alts.map((u) => new URL(u).hostname).sort();
-    expect(hostnames).toEqual(["abc.eliza.ai", "abc.elizacloud.ai"].sort());
+    expect(hostnames).toEqual(aliasHostnames("abc", ".waifu.fun"));
   });
 
   it("matches the suffix on the right boundary (no partial-domain false positive)", () => {
@@ -90,14 +96,10 @@ describe("getAlternateDomainOrigins", () => {
 });
 
 describe("DOMAIN_ALIAS_GROUPS", () => {
-  it("declares the rebrand-target domain `.elizacloud.ai` so the suffix matches", () => {
-    // This is the load-bearing guarantee for the rebrand: pairing tokens
-    // issued against `.waifu.fun` must validate when the dashboard rewrites
-    // the agent URL to `.elizacloud.ai`. If someone removes elizacloud.ai
-    // from the group, this test fails loudly.
-    const allDomains = DOMAIN_ALIAS_GROUPS.flat();
-    expect(allDomains).toContain(".elizacloud.ai");
-    expect(allDomains).toContain(".waifu.fun");
+  it("retains every canonical and compatibility suffix", () => {
+    expect(CANONICAL_GROUP).toEqual(
+      expect.arrayContaining([".cloud.eliza.app", ".elizacloud.ai", ".waifu.fun", ".eliza.ai"]),
+    );
   });
 
   it("uses leading-dot suffixes so subdomain matching is anchored", () => {

--- a/packages/cloud/shared/src/lib/steward-url.test.ts
+++ b/packages/cloud/shared/src/lib/steward-url.test.ts
@@ -20,15 +20,15 @@ afterEach(() => {
 
 describe("resolveBrowserStewardApiUrl", () => {
   test("routes staging cloud host to the staging API worker", () => {
-    setLocation("staging.elizacloud.ai");
+    setLocation("cloud-staging.eliza.app");
 
-    expect(resolveBrowserStewardApiUrl()).toBe("https://api-staging.elizacloud.ai/steward");
+    expect(resolveBrowserStewardApiUrl()).toBe("https://api-staging.eliza.app/steward");
   });
 
   test("routes production cloud host to the production API worker", () => {
-    setLocation("elizacloud.ai");
+    setLocation("cloud.eliza.app");
 
-    expect(resolveBrowserStewardApiUrl()).toBe("https://api.elizacloud.ai/steward");
+    expect(resolveBrowserStewardApiUrl()).toBe("https://api.eliza.app/steward");
   });
 
   test("falls back to same-origin steward mount for unknown hosts", () => {

--- a/packages/cloud/shared/src/lib/web-push/config.test.ts
+++ b/packages/cloud/shared/src/lib/web-push/config.test.ts
@@ -44,7 +44,7 @@ describe("getWebPushVapidConfig", () => {
     expect(cfg).toEqual({
       publicKey: "PUB",
       privateKey: "PRIV",
-      subject: "mailto:push@elizacloud.ai",
+      subject: "mailto:push@eliza.app",
     });
   });
 


### PR DESCRIPTION
## Summary

- canary the authenticated staging realtime consent route only after the exact deployed commit is verified
- keep rollback armed until the stateful response is proven, then fail closed by redeploying the same commit with realtime disabled
- verify the rollback served state is a 404 and lock ordering, authentication, and response contracts in a focused test
- place the canary in the authoritative reusable Cloud CF release workflow
- keep this isolated head self-contained against every stale domain assertion reported by its hosted unit lane: cloud routing, blob/registry hosts, compat status, onboarding origins, pairing aliases, Steward API routing, and the web-push VAPID subject now follow the authoritative `eliza.app` contracts

## Verification

- `actionlint -config-file .github/actionlint.yaml .github/workflows/cloud-cf-release.yml`
- focused Cloud CF workflow suites: 36 passed
- complete eight-file failure set: focused `bun test` invocation covering every file with an actual `(fail)` record in hosted job `94644025613` — 116 passed, 0 failed
- `bunx @biomejs/biome check` across all eight corrected failure files
- `git diff-tree --check`

The hosted unit-test failure was not caused by the realtime canary: every actual failing assertion was inherited drift left behind when the production domain implementation moved from `elizacloud.ai` to `eliza.app`. The baseline assertions are synchronized here so this exact PR head is independently green. Expected error-path log messages were excluded from this failure inventory.

Follow-up slice from #18960.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:ef9afe5022695b37e01286e3e6ad21d18d5b6b1b -->

<!-- evidence-row:before-screenshots -->
- N/A — deployment workflow logic has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- N/A — deployment workflow logic has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- N/A — deterministic contract/authority change with no new interactive visual flow.
<!-- evidence-row:backend-logs -->
- N/A — no live backend log artifact applies; focused deterministic tests are reported above.
<!-- evidence-row:frontend-logs -->
- N/A — no browser console/network artifact applies to this isolated contract proof.
<!-- evidence-row:llm-trajectory -->
- N/A — no prompt, model selection, or generated-output contract changes.
<!-- evidence-row:domain-artifacts -->
- N/A — no external domain artifact applies; executable contract artifacts are contained in the changed tests and reported above.
<!-- evidence-row:ocr-review -->
- N/A — no visual layout or rendered text changed.
