### PR TITLE
fix(orchestrator): require authoritative ACP receipts

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -223,30 +223,41 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     );
   });
 
-  it("falls back from session/cancel request to notification when rejected", async () => {
+  it("sends session/cancel as a notification and settles from the original prompt result", async () => {
     const { client, p } = await startClient();
 
-    const cancelled = client.cancel("session-1");
+    const prompted = client.prompt("session-1", "keep going");
     await waitForWrites(p, 2);
-    expect(writeAt(p, 1)).toEqual({
+    expect(writeAt(p, 1)).toMatchObject({
       jsonrpc: "2.0",
       id: 2,
-      method: "session/cancel",
+      method: "session/prompt",
       params: { sessionId: "session-1" },
     });
 
-    emitJson(p, {
-      jsonrpc: "2.0",
-      id: 2,
-      error: { code: -32601, message: "Method not found" },
-    });
+    const cancelled = client.cancel("session-1");
     await waitForWrites(p, 3);
     expect(writeAt(p, 2)).toEqual({
       jsonrpc: "2.0",
       method: "session/cancel",
       params: { sessionId: "session-1" },
     });
-    await expect(cancelled).resolves.toBeUndefined();
+    let settled = false;
+    void cancelled.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    // Official ACP wire shape: cancellation is confirmed by the terminal
+    // response to the original prompt id, not a response to session/cancel.
+    emitJson(p, {
+      jsonrpc: "2.0",
+      id: 2,
+      result: { stopReason: "cancelled" },
+    });
+    await expect(prompted).resolves.toEqual({ stopReason: "cancelled" });
+    await expect(cancelled).resolves.toEqual({ stopReason: "cancelled" });
   });
 
   it("triggers cancellation when a prompt request times out", async () => {
@@ -267,7 +278,6 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     await waitForWrites(p, 3);
     expect(writeAt(p, 2)).toEqual({
       jsonrpc: "2.0",
-      id: 3,
       method: "session/cancel",
       params: { sessionId: "session-1" },
     });
@@ -276,7 +286,6 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     expect((timeoutError as Error).message).toBe(
       "ACP request timed out: session/prompt",
     );
-    emitJson(p, { jsonrpc: "2.0", id: 3, result: {} });
   });
 
   it("uses a 5-minute default timeout when none is configured (was 30s, raised after live 30-200s sub-agent runs hit the limit)", async () => {
@@ -312,7 +321,6 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     expect((timeoutError as Error).message).toBe(
       "ACP request timed out: session/prompt",
     );
-    emitJson(p, { jsonrpc: "2.0", id: 3, result: {} });
   });
 
   it("initialize honors the configured session timeout instead of the 300s default", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -2265,7 +2265,7 @@ describe("AcpService", () => {
     expect(client.prompt).toHaveBeenCalledTimes(1);
   });
 
-  it("native cancel preserves cancelled status when the prompt later resolves", async () => {
+  it("native cancel settles from the original prompt's cancelled terminal result", async () => {
     const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
     await service.start();
     const { sessionId } = await service.spawnSession({
@@ -2276,23 +2276,53 @@ describe("AcpService", () => {
     const client = firstNativeClient();
     let resolvePrompt: (value: { stopReason: string }) => void = () =>
       undefined;
-    client.prompt.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolvePrompt = resolve;
-        }),
-    );
+    const terminal = new Promise<{ stopReason: string }>((resolve) => {
+      resolvePrompt = resolve;
+    });
+    client.prompt.mockImplementationOnce(() => terminal);
+    client.cancel.mockImplementationOnce(() => terminal);
 
     const sent = service.sendPrompt(sessionId, "long running");
     await new Promise((resolve) => setImmediate(resolve));
-    await service.cancelSession(sessionId);
-    resolvePrompt({ stopReason: "end_turn" });
+    const cancelled = service.cancelSession(sessionId);
+    resolvePrompt({ stopReason: "cancelled" });
+    await cancelled;
     const result = await sent;
 
     expect(client.cancel).toHaveBeenCalledWith("protocol-session");
     expect(result.stopReason).toBe("cancelled");
     expect(result.error).toBeUndefined();
     expect((await service.getSession(sessionId))?.status).toBe("cancelled");
+  });
+
+  it("does not overwrite a prompt completion that races native cancellation", async () => {
+    const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
+    await service.start();
+    const { sessionId } = await service.spawnSession({
+      name: "native-cancel-race",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    const client = firstNativeClient();
+    let resolvePrompt: (value: { stopReason: string }) => void = () =>
+      undefined;
+    const terminal = new Promise<{ stopReason: string }>((resolve) => {
+      resolvePrompt = resolve;
+    });
+    client.prompt.mockImplementationOnce(() => terminal);
+    client.cancel.mockImplementationOnce(() => terminal);
+
+    const sent = service.sendPrompt(sessionId, "nearly finished");
+    await new Promise((resolve) => setImmediate(resolve));
+    const cancelled = service.cancelSession(sessionId);
+    resolvePrompt({ stopReason: "end_turn" });
+    await expect(cancelled).rejects.toMatchObject({
+      code: "ACP_CANCEL_NOT_CONFIRMED",
+    });
+    const result = await sent;
+
+    expect(result.stopReason).toBe("end_turn");
+    expect((await service.getSession(sessionId))?.status).toBe("ready");
   });
 
   it("native permission requests emit blocked and login_required events", async () => {
@@ -2519,7 +2549,7 @@ describe("AcpService", () => {
     expect(result.response).toBe("done");
   });
 
-  it("accepts direct assistant text updates when adapters provide a role", async () => {
+  it("correlates a terminal response without a synthetic sessionId to its CLI invocation", async () => {
     const create = nextProc();
     const service = new AcpService(runtime());
     await service.start();
@@ -2544,7 +2574,7 @@ describe("AcpService", () => {
     prompt.proc.stdout.emit(
       "data",
       Buffer.from(
-        `{"jsonrpc":"2.0","id":"req-direct","result":{"stopReason":"end_turn"},"sessionId":"${sessionId}"}\n`,
+        '{"jsonrpc":"2.0","id":"req-direct","result":{"stopReason":"end_turn"}}\n',
       ),
     );
     closeOk(prompt);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/model-gateway-lease.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/model-gateway-lease.test.ts
@@ -384,11 +384,29 @@ describe("revoke on task end — all three terminal exit paths + teardown", () =
     configureModelGatewayLease({ broker: gateway.broker() });
     const { service, sessionId, env } = await spawnWith();
     const token = env.OPENAI_API_KEY ?? "";
+    const client = firstNativeClient();
+    let finishPrompt:
+      | ((result: { stopReason: "cancelled" }) => void)
+      | undefined;
+    client.prompt.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishPrompt = resolve;
+        }),
+    );
+    client.cancel.mockImplementationOnce(async () => {
+      finishPrompt?.({ stopReason: "cancelled" });
+      return { stopReason: "cancelled" };
+    });
     expect(gateway.callModel(token)).toBe(200);
 
+    const prompt = service.sendToSession(sessionId, "cancel this turn");
+    await settle();
     await service.cancelSession(sessionId);
+    await prompt;
     await settle();
 
+    expect(client.cancel).toHaveBeenCalledWith("protocol-session");
     expect(gateway.revoked).toEqual(["lease-1"]);
     expect(gateway.callModel(token)).toBe(401);
     await service.stop();

--- a/plugins/plugin-agent-orchestrator/src/__tests__/tasks-effect-receipts.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/tasks-effect-receipts.test.ts
@@ -8,6 +8,7 @@
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { tasksAction } from "../actions/tasks.ts";
+import { CodingWorkspaceService } from "../services/workspace-service.ts";
 
 const SESSION_ID = "session-without-provider-receipt";
 
@@ -131,5 +132,65 @@ describe("TASKS effect receipts", () => {
       expect.objectContaining({ outcome: "noop" }),
     ]);
     expect(result?.userFacingEffectReceiptIds).toBeUndefined();
+  });
+
+  it("settles add_labels as applied only from the authoritative issue readback", async () => {
+    const runtime = {
+      agentId: "00000000-0000-4000-8000-000000000001",
+      character: { name: "Receipt test" },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getSetting: vi.fn(() => undefined),
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+    const workspace = new CodingWorkspaceService(runtime, {
+      baseDir: "/tmp/orchestrator-receipt-test",
+    });
+    workspace.addLabels = vi.fn(async () => ({
+      number: 7,
+      url: "https://github.com/acme/widgets/issues/7",
+      state: "open" as const,
+      title: "Widget",
+      body: "",
+      labels: ["triage", "p1"],
+      assignees: [],
+      createdAt: new Date(0),
+    }));
+    runtime.getService = ((type: string) =>
+      type === CodingWorkspaceService.serviceType
+        ? workspace
+        : undefined) as IAgentRuntime["getService"];
+    const result = await tasksAction.handler(
+      runtime,
+      { ...message(), entityId: runtime.agentId } as Memory,
+      undefined as unknown as State,
+      {
+        parameters: {
+          action: "manage_issues",
+          issueAction: "add_labels",
+          repo: "acme/widgets",
+          issueNumber: 7,
+          labels: ["triage", "p1"],
+        },
+      },
+      async () => [],
+    );
+
+    expect(workspace.addLabels).toHaveBeenCalledWith("acme/widgets", 7, [
+      "triage",
+      "p1",
+    ]);
+    expect(result?.effectReceipts).toEqual([
+      expect.objectContaining({
+        outcome: "applied",
+        resource: {
+          kind: "github.issue",
+          id: "https://github.com/acme/widgets/issues/7",
+        },
+        commit: expect.objectContaining({
+          kind: "provider_accepted",
+          id: "https://github.com/acme/widgets/issues/7",
+        }),
+      }),
+    ]);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/workspace-github-issues.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/workspace-github-issues.test.ts
@@ -46,6 +46,8 @@ class FakeGitHub {
   requests: RecordedRequest[] = [];
   /** When set, the next request gets this failure instead of a 2xx. */
   failNext: { status: number; message: string } | null = null;
+  issueLabels = ["bug"];
+  applyLabelWrites = true;
 
   private issueJson(overrides: Record<string, unknown> = {}) {
     return {
@@ -54,7 +56,7 @@ class FakeGitHub {
       state: "open",
       title: "Broken widget",
       body: "It broke",
-      labels: [{ name: "bug" }],
+      labels: this.issueLabels.map((name) => ({ name })),
       assignees: [{ login: "octocat" }],
       created_at: "2026-07-01T00:00:00Z",
       closed_at: null,
@@ -96,6 +98,10 @@ class FakeGitHub {
           );
           return;
         }
+        if (req.method === "GET" && /\/issues\/\d+$/.test(path)) {
+          res.end(JSON.stringify(this.issueJson()));
+          return;
+        }
         if (req.method === "POST" && /\/issues\/\d+\/comments$/.test(path)) {
           res.statusCode = 201;
           res.end(
@@ -110,6 +116,14 @@ class FakeGitHub {
           return;
         }
         if (req.method === "POST" && /\/issues\/\d+\/labels$/.test(path)) {
+          if (this.applyLabelWrites) {
+            this.issueLabels = Array.from(
+              new Set([
+                ...this.issueLabels,
+                ...((body as { labels?: string[] })?.labels ?? []),
+              ]),
+            );
+          }
           res.end(JSON.stringify([{ name: "triage" }]));
           return;
         }
@@ -521,12 +535,26 @@ describe("issue functions over a real local GitHub API server", () => {
     expect(issue.state).toBe("closed");
   });
 
-  it("addLabels POSTs the label list to the labels endpoint", async () => {
-    await addLabels(ctx, "acme/widgets", 7, ["triage", "p1"]);
-    const req = github.lastRequest();
+  it("addLabels proves the mutation with an authoritative issue readback", async () => {
+    const before = github.requests.length;
+    const issue = await addLabels(ctx, "acme/widgets", 7, ["triage", "p1"]);
+    const [req, readback] = github.requests.slice(before);
     expect(req.method).toBe("POST");
     expect(req.path).toBe("/repos/acme/widgets/issues/7/labels");
     expect(req.body).toMatchObject({ labels: ["triage", "p1"] });
+    expect(readback).toMatchObject({
+      method: "GET",
+      path: "/repos/acme/widgets/issues/7",
+    });
+    expect(issue.labels).toEqual(expect.arrayContaining(["triage", "p1"]));
+  });
+
+  it("rejects label success when provider readback does not contain the requested label", async () => {
+    github.applyLabelWrites = false;
+    await expect(
+      addLabels(ctx, "acme/widgets", 7, ["not-observed"]),
+    ).rejects.toMatchObject({ code: "GITHUB_LABEL_READBACK_MISMATCH" });
+    github.applyLabelWrites = true;
   });
 
   it("addComment POSTs the comment body", async () => {

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -3911,12 +3911,12 @@ async function handleIssueAction(
             text: "Missing the issue number or labels; ask the user for both.",
           };
         }
-        await service.addLabels(repo, issueNumber, labels);
+        const issue = await service.addLabels(repo, issueNumber, labels);
         if (callback)
           await callback({
             text: `Added labels [${labels.join(", ")}] to issue #${issueNumber}`,
           });
-        return { success: true };
+        return { success: true, data: { issue } };
       }
 
       default:
@@ -4286,7 +4286,7 @@ function issueEffectProof(
   data: Record<string, unknown>,
 ): TasksEffectProof | undefined {
   const op = issueOperation(params, content);
-  if (op === "list" || op === "get" || op === "add_labels") return undefined;
+  if (op === "list" || op === "get") return undefined;
   const repo = effectString(params.repo) ?? effectString(content.repo);
   const issue = objectValue(data.issue);
   const issueRecords = [

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -142,6 +142,7 @@ export class NativeAcpClient {
   private readBuffer = "";
   private stderrBuffer = "";
   private pending = new Map<JsonRpcId, PendingRequest>();
+  private activePrompts = new Map<string, Promise<NativeAcpPromptResult>>();
   private terminals = new Map<string, TerminalRecord>();
   private closed = false;
 
@@ -234,33 +235,43 @@ export class NativeAcpClient {
     sessionId: string,
     text: string,
   ): Promise<NativeAcpPromptResult> {
-    const result = asRecord(
-      await this.request(
-        "session/prompt",
-        {
-          sessionId,
-          prompt: [{ type: "text", text }],
-        },
-        this.opts.timeoutMs,
-        () => {
-          // error-policy:J6 best-effort teardown — cancelling a timed-out
-          // prompt; a cancel that itself fails cannot rescue the turn.
-          void this.cancel(sessionId).catch(() => undefined);
-        },
-      ),
-    );
-    return {
-      stopReason: stringValue(result?.stopReason) ?? "end_turn",
-    };
+    const prompt = this.request(
+      "session/prompt",
+      {
+        sessionId,
+        prompt: [{ type: "text", text }],
+      },
+      this.opts.timeoutMs,
+      () => {
+        // error-policy:J6 best-effort teardown — cancelling a timed-out
+        // prompt; a cancel that itself fails cannot rescue the turn.
+        void this.cancel(sessionId).catch(() => undefined);
+      },
+    ).then((value) => {
+      const result = asRecord(value);
+      return {
+        stopReason: stringValue(result?.stopReason) ?? "end_turn",
+      };
+    });
+    this.activePrompts.set(sessionId, prompt);
+    try {
+      return await prompt;
+    } finally {
+      if (this.activePrompts.get(sessionId) === prompt) {
+        this.activePrompts.delete(sessionId);
+      }
+    }
   }
 
-  async cancel(sessionId: string): Promise<void> {
-    // error-policy:J6 best-effort teardown — if the request/cancel round-trip
-    // fails, fall back to a fire-and-forget cancel notification; neither path
-    // can do more than ask a possibly-dead subprocess to stop.
-    await this.request("session/cancel", { sessionId }, 5_000).catch(() => {
-      void this.notify("session/cancel", { sessionId }).catch(() => undefined);
-    });
+  async cancel(sessionId: string): Promise<NativeAcpPromptResult | undefined> {
+    const activePrompt = this.activePrompts.get(sessionId);
+    // ACP defines session/cancel as a notification. It has no independent
+    // acknowledgement: the authoritative terminal result remains the response
+    // to the original session/prompt request, whose JSON-RPC id provides the
+    // correlation. Capture that promise before notifying so a synchronous
+    // terminal response cannot race past this caller.
+    await this.notify("session/cancel", { sessionId });
+    return activePrompt;
   }
 
   async closeSession(sessionId: string): Promise<void> {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -2270,12 +2270,35 @@ export class AcpService extends Service {
     const transportMode = sessionTransportMode(session, this.transportMode);
     if (transportMode === "native") {
       const client = this.nativeClients.get(sessionId);
-      if (this.nativePromptSessionIds.has(sessionId)) {
-        this.nativeCancelledPromptSessionIds.add(sessionId);
+      if (!client) {
+        throw new ElizaError("ACP native session has no attached client", {
+          code: "ACP_NATIVE_CLIENT_MISSING",
+          context: { sessionId },
+        });
       }
-      await client?.cancel(
+      const hadActivePrompt = this.nativePromptSessionIds.has(sessionId);
+      if (!hadActivePrompt) {
+        throw new ElizaError("ACP session has no active prompt to cancel", {
+          code: "ACP_CANCEL_NO_ACTIVE_PROMPT",
+          context: { sessionId },
+        });
+      }
+      const terminal = await client.cancel(
         session.acpxSessionId ?? session.agentSessionId ?? session.id,
       );
+      // session/cancel is a notification, so only the terminal response to the
+      // original session/prompt request can prove cancellation. A completion
+      // racing the notification remains a completion; an idle session has no
+      // prompt result to acknowledge and must not be relabelled cancelled.
+      if (terminal?.stopReason !== "cancelled") {
+        throw new ElizaError(
+          "ACP agent did not confirm cancellation on the active prompt",
+          {
+            code: "ACP_CANCEL_NOT_CONFIRMED",
+            context: { sessionId, stopReason: terminal?.stopReason },
+          },
+        );
+      }
       await this.store.updateStatus(sessionId, "cancelled");
       // Stop the scratch dir counting against the shared cap the moment the
       // session is terminal; the actual rm still happens on close/delete via

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-github.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-github.ts
@@ -631,8 +631,18 @@ export async function addLabels(
   repo: string,
   issueNumber: number,
   labels: string[],
-): Promise<void> {
+): Promise<IssueInfo> {
   const client = await ensureGitHubClient(ctx);
   const { owner, repo: repoName } = parseOwnerRepo(repo);
   await client.addLabels(owner, repoName, issueNumber, labels);
+  const issue = await client.getIssue(owner, repoName, issueNumber);
+  const observed = new Set(issue.labels.map((label) => label.toLowerCase()));
+  const missing = labels.filter((label) => !observed.has(label.toLowerCase()));
+  if (missing.length > 0) {
+    throw new ElizaError("GitHub label write was not visible on readback", {
+      code: "GITHUB_LABEL_READBACK_MISMATCH",
+      context: { repo, issueNumber, requested: labels, observed: issue.labels },
+    });
+  }
+  return issue;
 }

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -1208,7 +1208,7 @@ export class CodingWorkspaceService {
     repo: string,
     issueNumber: number,
     labels: string[],
-  ): Promise<void> {
+  ): Promise<IssueInfo> {
     return ghAddLabels(this.getGitHubContext(), repo, issueNumber, labels);
   }
 


### PR DESCRIPTION
## Summary

Extracted from the Nubs PR review/repair work tracked in #18960. This branch contains only ACP and orchestrator mutation-receipt authority; Smithers database/runtime/dependency work is intentionally excluded.

- send ACP `session/cancel` with its protocol-defined notification shape and settle cancellation from the original prompt terminal response
- reject idle or raced completion as unconfirmed cancellation instead of relabelling a session
- correlate CLI terminal responses to their invocation without a synthetic session id
- prove model-gateway lease revocation through the real active-prompt cancellation path
- verify GitHub label mutations with authoritative issue readback before emitting an applied effect receipt

## Verification

- native ACP transport: 21 passed
- targeted ACP service cancellation/correlation: 3 passed
- native cancellation lease-revocation path: 1 passed
- TASKS authoritative label receipt: 1 passed
- initial combined run: 137 passed across the five focused files; three unrelated workspace-allocation cases were blocked by the host free-disk safety floor
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck`
- Biome check on all ten changed files
- `git diff --check origin/develop..fix/nubs-acp-authoritative-receipts`

Part of #18960.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:4d1563968e584992a208b1f53c9ca4aa14e5d6f3 -->

<!-- evidence-row:before-screenshots -->
- N/A — orchestrator transport and mutation receipts are backend-only.
<!-- evidence-row:after-screenshots -->
- N/A — orchestrator transport and mutation receipts are backend-only.
<!-- evidence-row:walkthrough-video -->
- N/A — deterministic contract/authority change with no new interactive visual flow.
<!-- evidence-row:backend-logs -->
- N/A — no live backend log artifact applies; focused deterministic tests are reported above.
<!-- evidence-row:frontend-logs -->
- N/A — no browser console/network artifact applies to this isolated contract proof.
<!-- evidence-row:llm-trajectory -->
- N/A — no prompt, model selection, or generated-output contract changes.
<!-- evidence-row:domain-artifacts -->
- N/A — no external domain artifact applies; executable contract artifacts are contained in the changed tests and reported above.
<!-- evidence-row:ocr-review -->
- N/A — no visual layout or rendered text changed.