### PR TITLE
fix(vitest): discover source export aliases

### DIFF
--- a/packages/scripts/__tests__/vitest-source-aliases.test.ts
+++ b/packages/scripts/__tests__/vitest-source-aliases.test.ts
@@ -1,14 +1,33 @@
 /**
- * Verifies workspace source aliases target both file and directory package
- * subpaths without relying on prebuilt dist artifacts.
+ * Verifies workspace source aliases target source files without prebuilt dist
+ * artifacts, including deterministic package-export fixtures.
  */
 
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 import {
   buildWorkspaceSourceAliases,
   workspaceRepoRoot,
 } from "../vitest/source-aliases.ts";
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function resolveAlias(
+  aliases: ReturnType<typeof buildWorkspaceSourceAliases>,
+  specifier: string,
+): string {
+  const alias = aliases.find(({ find }) => find.test(specifier));
+  expect(alias, `${specifier} must have a source alias`).toBeDefined();
+  return specifier.replace(alias?.find ?? /$^/, alias?.replacement ?? "");
+}
 
 describe("workspace source aliases", () => {
   test("resolve file and directory subpaths to source targets", () => {
@@ -25,16 +44,67 @@ describe("workspace source aliases", () => {
     ] as const;
 
     for (const { specifier, target } of cases) {
-      const alias = aliases.find(({ find }) => find.test(specifier));
-      expect(alias, `${specifier} must have a source alias`).toBeDefined();
-      const replacement = specifier.replace(
-        alias?.find ?? /$^/,
-        alias?.replacement ?? "",
-      );
-      const resolved = target.endsWith("/index.ts")
-        ? path.join(replacement, "index.ts")
-        : `${replacement}.ts`;
+      const replacement = resolveAlias(aliases, specifier);
+      const resolved = replacement.endsWith(".ts")
+        ? replacement
+        : target.endsWith("/index.ts")
+          ? path.join(replacement, "index.ts")
+          : `${replacement}.ts`;
       expect(resolved).toBe(path.join(workspaceRepoRoot, target));
     }
+  });
+
+  test("honors exact eliza-source exports before generic package subpaths", () => {
+    const repoRoot = mkdtempSync(
+      path.join(tmpdir(), "eliza-vitest-source-aliases-"),
+    );
+    temporaryRoots.push(repoRoot);
+    const packageDir = path.join(repoRoot, "plugins", "plugin-fixture");
+    mkdirSync(path.join(packageDir, "src", "internal"), { recursive: true });
+    writeFileSync(path.join(packageDir, "src", "index.ts"), "export {};\n");
+    writeFileSync(
+      path.join(packageDir, "src", "internal", "endpoint.ts"),
+      "export const endpoint = true;\n",
+    );
+    writeFileSync(
+      path.join(packageDir, "src", "internal", "string-endpoint.ts"),
+      "export const endpoint = true;\n",
+    );
+    writeFileSync(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "@elizaos/plugin.fixture",
+        exports: {
+          ".": "./dist/index.js",
+          "./public+endpoint": {
+            "eliza-source": {
+              types: "./src/internal/endpoint.ts",
+              import: "./src/internal/endpoint.ts",
+              default: "./src/internal/endpoint.ts",
+            },
+            import: "./dist/public-endpoint.js",
+          },
+          "./string-endpoint": {
+            "eliza-source": "./src/internal/string-endpoint.ts",
+            import: "./dist/string-endpoint.js",
+          },
+          "./escape": {
+            "eliza-source": "../outside.ts",
+            import: "./dist/escape.js",
+          },
+        },
+      }),
+    );
+
+    const aliases = buildWorkspaceSourceAliases(repoRoot);
+    expect(
+      resolveAlias(aliases, "@elizaos/plugin.fixture/public+endpoint"),
+    ).toBe(path.join(packageDir, "src", "internal", "endpoint.ts"));
+    expect(
+      resolveAlias(aliases, "@elizaos/plugin.fixture/string-endpoint"),
+    ).toBe(path.join(packageDir, "src", "internal", "string-endpoint.ts"));
+    expect(resolveAlias(aliases, "@elizaos/plugin.fixture/escape")).toBe(
+      path.join(packageDir, "src", "escape"),
+    );
   });
 });

--- a/packages/scripts/vitest/source-aliases.ts
+++ b/packages/scripts/vitest/source-aliases.ts
@@ -3,11 +3,13 @@
  *
  * Booting a real PGLite-backed AgentRuntime requires every workspace
  * `@elizaos/*` package to resolve to its TypeScript source (independent of
- * build order), plus the three subpath specials the runtime touches:
+ * build order), plus the core and SQL subpath specials the runtime touches:
  * `@elizaos/core/testing`, `@elizaos/core/node`, `@elizaos/core/connectors`,
- * and `@elizaos/plugin-sql`
- * (the node entry). Shared and per-plugin real-runtime configs need this, and so
- * does every per-plugin runtime config that imports `@elizaos/core/testing`.
+ * and `@elizaos/plugin-sql` (the node entry). Package exports that declare an
+ * exact `eliza-source` condition contribute their own source aliases, including
+ * provider-owned endpoint diagnostics that otherwise require prebuilt dist.
+ * Shared and per-plugin real-runtime configs need this, and so does
+ * every per-plugin runtime config that imports `@elizaos/core/testing`.
  * Both consume this one builder so the alias set never drifts.
  */
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
@@ -32,6 +34,11 @@ interface WorkspaceSourceEntry {
   packageName: string;
   indexPath: string;
   sourceDir: string;
+  exportedSourceAliases: Array<{ subpath: string; sourcePath: string }>;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function getWorkspaceSourceEntry(
@@ -41,16 +48,53 @@ function getWorkspaceSourceEntry(
   if (!existsSync(packageJsonPath)) return undefined;
   const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
     name?: string;
+    exports?: Record<
+      string,
+      | string
+      | {
+          "eliza-source"?:
+            | string
+            | { import?: string; default?: string; types?: string };
+        }
+    >;
   };
   if (!packageJson.name?.startsWith("@elizaos/")) return undefined;
   // The testing surface resolves through the explicit alias below.
   if (packageJson.name === "@elizaos/core/testing") return undefined;
+  const exportedSourceAliases = Object.entries(
+    packageJson.exports ?? {},
+  ).flatMap(([subpath, target]) => {
+    if (subpath === "." || typeof target === "string") return [];
+    const source = target["eliza-source"];
+    const sourcePath =
+      typeof source === "string"
+        ? source
+        : (source?.import ?? source?.default ?? source?.types);
+    if (
+      !sourcePath?.startsWith("./") ||
+      !subpath.startsWith("./") ||
+      subpath.includes("*")
+    )
+      return [];
+    const resolvedSourcePath = path.resolve(packageDir, sourcePath);
+    if (
+      !resolvedSourcePath.startsWith(`${path.resolve(packageDir)}${path.sep}`)
+    )
+      return [];
+    return [
+      {
+        subpath: subpath.slice(2),
+        sourcePath: resolvedSourcePath,
+      },
+    ];
+  });
   const sourceIndex = path.join(packageDir, "src", "index.ts");
   if (existsSync(sourceIndex)) {
     return {
       packageName: packageJson.name,
       indexPath: sourceIndex,
       sourceDir: path.join(packageDir, "src"),
+      exportedSourceAliases,
     };
   }
   const rootIndex = path.join(packageDir, "index.ts");
@@ -59,6 +103,7 @@ function getWorkspaceSourceEntry(
       packageName: packageJson.name,
       indexPath: rootIndex,
       sourceDir: packageDir,
+      exportedSourceAliases,
     };
   }
   return undefined;
@@ -131,24 +176,32 @@ export function buildWorkspaceSourceAliases(
       ? collectWorkspacePackageDirs(dir)
           .map((packageDir) => getWorkspaceSourceEntry(packageDir))
           .filter((entry): entry is WorkspaceSourceEntry => entry !== undefined)
-          .flatMap(({ packageName, indexPath, sourceDir }) => [
-            { find: new RegExp(`^${packageName}$`), replacement: indexPath },
-            // Asset subpaths (JSON data imports like
-            // `@elizaos/registry/first-party/curated-app-definitions.json`)
-            // resolve to the source file as-is; the generic rule below would
-            // otherwise append `.ts` and break the resolve. First-match wins.
-            {
-              find: new RegExp(`^${packageName}/(.*\\.json)$`),
-              replacement: path.join(sourceDir, "$1"),
-            },
-            {
-              find: new RegExp(`^${packageName}/(.*)$`),
-              // Keep the target extensionless so Vite can resolve either a
-              // source file (`foo.ts`) or a public directory entry
-              // (`foo/index.ts`) through the same package-subpath rule.
-              replacement: path.join(sourceDir, "$1"),
-            },
-          ])
+          .flatMap(
+            ({ packageName, indexPath, sourceDir, exportedSourceAliases }) => [
+              ...exportedSourceAliases.map(({ subpath, sourcePath }) => ({
+                find: new RegExp(
+                  `^${escapeRegex(packageName)}/${escapeRegex(subpath)}$`,
+                ),
+                replacement: sourcePath,
+              })),
+              { find: new RegExp(`^${packageName}$`), replacement: indexPath },
+              // Asset subpaths (JSON data imports like
+              // `@elizaos/registry/first-party/curated-app-definitions.json`)
+              // resolve to the source file as-is; the generic rule below would
+              // otherwise append `.ts` and break the resolve. First-match wins.
+              {
+                find: new RegExp(`^${packageName}/(.*\\.json)$`),
+                replacement: path.join(sourceDir, "$1"),
+              },
+              {
+                find: new RegExp(`^${packageName}/(.*)$`),
+                // Keep the target extensionless so Vite can resolve either a
+                // source file (`foo.ts`) or a public directory entry
+                // (`foo/index.ts`) through the same package-subpath rule.
+                replacement: path.join(sourceDir, "$1"),
+              },
+            ],
+          )
       : [],
   );
 


### PR DESCRIPTION
## Summary

- discover exact package `eliza-source` subpath exports before generic workspace aliases
- support string and conditional source declarations while rejecting paths outside their package root
- cover exact remapping, regex metacharacters, generic fallback, and traversal rejection with a deterministic workspace fixture

## Verification

- Biome check on both changed files
- source-alias contract: 2 passed
- scenario-runner consumer: 3 passed
- plugin-health consumer: 3 passed
- `git diff-tree --check`

Follow-up slice from #18960.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:252368d49f805bdbaac7eb049d1fcbceae1f8e40 -->

<!-- evidence-row:before-screenshots -->
- N/A — test resolver configuration has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- N/A — test resolver configuration has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- N/A — deterministic contract/authority change with no new interactive visual flow.
<!-- evidence-row:backend-logs -->
- N/A — no live backend log artifact applies; focused deterministic tests are reported above.
<!-- evidence-row:frontend-logs -->
- N/A — no browser console/network artifact applies to this isolated contract proof.
<!-- evidence-row:llm-trajectory -->
- N/A — no prompt, model selection, or generated-output contract changes.
<!-- evidence-row:domain-artifacts -->
- N/A — no external domain artifact applies; executable contract artifacts are contained in the changed tests and reported above.
<!-- evidence-row:ocr-review -->
- N/A — no visual layout or rendered text changed.