### PR TITLE
fix(core): bound media enrichment authority

### DIFF
--- a/packages/core/src/services/message.processAttachments.test.ts
+++ b/packages/core/src/services/message.processAttachments.test.ts
@@ -248,9 +248,14 @@ describe("DefaultMessageService.processAttachments", () => {
 		expect(out[0].text).toBeUndefined();
 		expect(out[0].url).toBe("/api/media/abc.mp3");
 		expect(out[0].notProcessed).toMatch(/audio transcription unavailable/i);
-		expect(out[0].notProcessed).toContain(
+		expect(out[0].notProcessed).not.toContain(
 			"no transcription provider configured",
 		);
+		expect(out[0].enrichmentFailure).toEqual({
+			phase: "transcribe",
+			code: "unavailable",
+			retryable: true,
+		});
 	});
 
 	it("marks notProcessed when audio transcription returns empty text", async () => {
@@ -299,8 +304,14 @@ describe("DefaultMessageService.processAttachments", () => {
 
 			expect(out[0].text).toBeUndefined();
 			expect(out[0].notProcessed).toBe(
-				`${kind} attachment could not be fetched: ${err.message}`,
+				`${kind} attachment could not be fetched for enrichment`,
 			);
+			expect(out[0].notProcessed).not.toContain(err.message);
+			expect(out[0].enrichmentFailure).toEqual({
+				phase: "fetch",
+				code: "unavailable",
+				retryable: true,
+			});
 			// Never the marker prefix the read action keys on.
 			expect(out[0].notProcessed).not.toMatch(
 				/^(?:(?:audio|video)\s+)?transcription unavailable/i,
@@ -338,7 +349,7 @@ describe("DefaultMessageService.processAttachments", () => {
 
 			expect(out[0].text).toBeUndefined();
 			expect(out[0].notProcessed).toMatch(/could not be fetched/i);
-			expect(out[0].notProcessed).toContain(`HTTP ${status}`);
+			expect(out[0].notProcessed).not.toContain(`HTTP ${status}`);
 			expect(out[0].notProcessed).not.toContain(statusText);
 			expect(out[0].notProcessed).not.toMatch(
 				/^(?:(?:audio|video)\s+)?transcription unavailable/i,
@@ -447,6 +458,69 @@ describe("DefaultMessageService.processAttachments", () => {
 		expect(out[0].text).toBe("spoken words in the clip");
 		expect(out[0].description).toBe("Transcript: spoken words in the clip");
 		expect(out[0].notProcessed).toBeUndefined();
+	});
+
+	it("serializes transcription model calls in attachment order", async () => {
+		const bytes = Buffer.from("media");
+		const localFetch = localDocFetch(bytes, "audio/mpeg");
+		const runtime = mockRuntime(localFetch as unknown as typeof fetch);
+		let active = 0;
+		let maxActive = 0;
+		(runtime.useModel as ReturnType<typeof vi.fn>).mockImplementation(
+			async () => {
+				active += 1;
+				maxActive = Math.max(maxActive, active);
+				await Promise.resolve();
+				active -= 1;
+				return "transcript";
+			},
+		);
+		const svc = new DefaultMessageService();
+
+		await svc.processAttachments(runtime, [
+			{ id: "one", url: "/api/media/one.mp3", contentType: ContentType.AUDIO },
+			{ id: "two", url: "/api/media/two.mp3", contentType: ContentType.AUDIO },
+		]);
+
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+		expect(maxActive).toBe(1);
+	});
+
+	it("enforces the cumulative declared-byte budget before a third enrichment", async () => {
+		const bytes = Buffer.from("small test body");
+		const localFetch = localDocFetch(bytes, "audio/mpeg");
+		const runtime = mockRuntime(localFetch as unknown as typeof fetch);
+		(runtime.useModel as ReturnType<typeof vi.fn>).mockResolvedValue("ok");
+		const svc = new DefaultMessageService();
+		const declaredSize = 40 * 1024 * 1024;
+
+		const out = await svc.processAttachments(runtime, [
+			{
+				id: "one",
+				url: "/api/media/one.mp3",
+				size: declaredSize,
+				contentType: ContentType.AUDIO,
+			},
+			{
+				id: "two",
+				url: "/api/media/two.mp3",
+				size: declaredSize,
+				contentType: ContentType.AUDIO,
+			},
+			{
+				id: "three",
+				url: "/api/media/three.mp3",
+				size: declaredSize,
+				contentType: ContentType.AUDIO,
+			},
+		]);
+
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+		expect(out[2].enrichmentFailure).toEqual({
+			phase: "budget",
+			code: "byte_limit",
+			retryable: true,
+		});
 	});
 
 	it("extracts real text from an application/pdf document (previously skipped)", async () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1387,6 +1387,38 @@ type MediaWithInlineData = Media & {
  */
 const ATTACHMENT_FETCH_MAX_BYTES = 50 * 1024 * 1024;
 
+/** Aggregate bytes admitted to enrichment for one message turn. */
+const ATTACHMENT_TURN_MAX_BYTES = 100 * 1024 * 1024;
+
+type AttachmentByteBudget = { remaining: number };
+
+function attachmentFailure(
+	phase: NonNullable<Media["enrichmentFailure"]>["phase"],
+	code: NonNullable<Media["enrichmentFailure"]>["code"],
+	retryable: boolean,
+	message: string,
+): Pick<Media, "notProcessed" | "enrichmentFailure"> {
+	return {
+		notProcessed: message,
+		enrichmentFailure: { phase, code, retryable },
+	};
+}
+
+function sanitizedAttachmentDiagnostic(
+	code: string,
+	message: string,
+	attachment: Media,
+): ElizaError {
+	return new ElizaError(message, {
+		code,
+		severity: "ephemeral",
+		context: {
+			attachmentId: attachment.id,
+			contentType: attachment.contentType,
+		},
+	});
+}
+
 function sanitizeAttachmentsForStorage(
 	attachments: Media[] | undefined,
 ): Media[] | undefined {
@@ -13274,8 +13306,15 @@ export class DefaultMessageService implements IMessageService {
 			"Processing attachments",
 		);
 
-		const processedAttachments = await Promise.all(
-			attachments.map(async (attachment) => {
+		const processedAttachments: Media[] = [];
+		const byteBudget: AttachmentByteBudget = {
+			remaining: ATTACHMENT_TURN_MAX_BYTES,
+		};
+		// Enrichment is deliberately ordered. In particular, transcription models
+		// are often backed by one local GPU/process; launching an attacker-sized
+		// attachment array concurrently caused memory spikes and provider storms.
+		for (const attachment of attachments) {
+			const processed = await (async () => {
 				const processedAttachment: Media = { ...attachment };
 
 				const isRemote = /^(http|https):\/\//.test(attachment.url);
@@ -13323,6 +13362,8 @@ export class DefaultMessageService implements IMessageService {
 								attachment.url,
 								url,
 								isRemote,
+								byteBudget,
+								attachment.size,
 							);
 							imageUrl = `data:${contentType};base64,${buffer.toString("base64")}`;
 						}
@@ -13369,6 +13410,8 @@ export class DefaultMessageService implements IMessageService {
 							attachment.url,
 							url,
 							isRemote,
+							byteBudget,
+							attachment.size,
 						);
 						// Any text/* document (plain, csv, markdown) and application/json —
 						// all on the chat upload allow-list — is readable as UTF-8 text;
@@ -13419,7 +13462,15 @@ export class DefaultMessageService implements IMessageService {
 								"Extracted PDF text content",
 							);
 						} else {
-							processedAttachment.notProcessed = `Unsupported document type (${contentType}); stored but text not extracted`;
+							Object.assign(
+								processedAttachment,
+								attachmentFailure(
+									"extract",
+									"unsupported_type",
+									false,
+									`Unsupported document type (${contentType}); stored but text not extracted`,
+								),
+							);
 							runtime.logger.warn(
 								{ src: "service:message", contentType },
 								"Skipping unsupported document type",
@@ -13443,6 +13494,8 @@ export class DefaultMessageService implements IMessageService {
 								attachment.url,
 								url,
 								isRemote,
+								byteBudget,
+								attachment.size,
 							);
 
 							const transcript = await runtime.useModel(
@@ -13467,8 +13520,15 @@ export class DefaultMessageService implements IMessageService {
 									"Transcribed audio attachment",
 								);
 							} else {
-								processedAttachment.notProcessed =
-									"Audio transcription returned no text (empty or no speech detected)";
+								Object.assign(
+									processedAttachment,
+									attachmentFailure(
+										"transcribe",
+										"empty_result",
+										false,
+										"Audio transcription returned no text (empty or no speech detected)",
+									),
+								);
 							}
 						} catch (err) {
 							// error-policy:J4 The attachment remains available with an
@@ -13478,17 +13538,41 @@ export class DefaultMessageService implements IMessageService {
 							// the "transcription unavailable" marker is reserved for genuine
 							// provider failures because the read action treats it as
 							// STT-is-disabled evidence.
-							processedAttachment.notProcessed =
+							Object.assign(
+								processedAttachment,
 								err instanceof Error && err.name === "MediaFetchError"
-									? `Audio attachment could not be fetched: ${err.message}`
-									: `Audio transcription unavailable: ${err instanceof Error ? err.message : String(err)}`;
+									? attachmentFailure(
+											err.message.includes("turn byte budget")
+												? "budget"
+												: "fetch",
+											err.message.includes("turn byte budget")
+												? "byte_limit"
+												: "unavailable",
+											true,
+											"Audio attachment could not be fetched for enrichment",
+										)
+									: attachmentFailure(
+											"transcribe",
+											"unavailable",
+											true,
+											"Audio transcription unavailable",
+										),
+							);
 							runtime.logger.warn(
-								{ src: "service:message", err },
+								{
+									src: "service:message",
+									errorName: err instanceof Error ? err.name : "UnknownError",
+								},
 								"Audio transcription failed, continuing without transcript",
 							);
-							runtime.reportError("MessageService.audioTranscription", err, {
-								url: attachment.url,
-							});
+							runtime.reportError(
+								"MessageService.audioTranscription",
+								sanitizedAttachmentDiagnostic(
+									"ATTACHMENT_AUDIO_TRANSCRIPTION_FAILED",
+									"Audio attachment enrichment failed",
+									attachment,
+								),
+							);
 						}
 					} else if (
 						attachment.contentType === ContentType.VIDEO &&
@@ -13508,6 +13592,8 @@ export class DefaultMessageService implements IMessageService {
 								attachment.url,
 								url,
 								isRemote,
+								byteBudget,
+								attachment.size,
 							);
 
 							const transcript = await runtime.useModel(
@@ -13532,8 +13618,15 @@ export class DefaultMessageService implements IMessageService {
 									"Transcribed video attachment",
 								);
 							} else {
-								processedAttachment.notProcessed =
-									"Video transcription returned no text (empty or no speech detected)";
+								Object.assign(
+									processedAttachment,
+									attachmentFailure(
+										"transcribe",
+										"empty_result",
+										false,
+										"Video transcription returned no text (empty or no speech detected)",
+									),
+								);
 							}
 						} catch (err) {
 							// error-policy:J4 The attachment remains available with an
@@ -13543,17 +13636,41 @@ export class DefaultMessageService implements IMessageService {
 							// the "transcription unavailable" marker is reserved for genuine
 							// provider failures because the read action treats it as
 							// STT-is-disabled evidence.
-							processedAttachment.notProcessed =
+							Object.assign(
+								processedAttachment,
 								err instanceof Error && err.name === "MediaFetchError"
-									? `Video attachment could not be fetched: ${err.message}`
-									: `Video transcription unavailable: ${err instanceof Error ? err.message : String(err)}`;
+									? attachmentFailure(
+											err.message.includes("turn byte budget")
+												? "budget"
+												: "fetch",
+											err.message.includes("turn byte budget")
+												? "byte_limit"
+												: "unavailable",
+											true,
+											"Video attachment could not be fetched for enrichment",
+										)
+									: attachmentFailure(
+											"transcribe",
+											"unavailable",
+											true,
+											"Video transcription unavailable",
+										),
+							);
 							runtime.logger.warn(
-								{ src: "service:message", err },
+								{
+									src: "service:message",
+									errorName: err instanceof Error ? err.name : "UnknownError",
+								},
 								"Video transcription failed, continuing without transcript",
 							);
-							runtime.reportError("MessageService.videoTranscription", err, {
-								url: attachment.url,
-							});
+							runtime.reportError(
+								"MessageService.videoTranscription",
+								sanitizedAttachmentDiagnostic(
+									"ATTACHMENT_VIDEO_TRANSCRIPTION_FAILED",
+									"Video attachment enrichment failed",
+									attachment,
+								),
+							);
 						}
 					}
 
@@ -13565,19 +13682,35 @@ export class DefaultMessageService implements IMessageService {
 					// Degrade to the un-enriched attachment (marking remote ones
 					// ephemeral so the UI can offer a retry) and keep processing.
 					runtime.logger.warn(
-						{ src: "service:message", url: attachment.url, err },
+						{
+							src: "service:message",
+							attachmentId: attachment.id,
+							errorName: err instanceof Error ? err.name : "UnknownError",
+						},
 						"Attachment processing failed; keeping un-enriched attachment",
 					);
-					runtime.reportError("MessageService.attachmentEnrichment", err, {
-						url: attachment.url,
-					});
+					runtime.reportError(
+						"MessageService.attachmentEnrichment",
+						sanitizedAttachmentDiagnostic(
+							"ATTACHMENT_ENRICHMENT_FAILED",
+							"Attachment enrichment failed",
+							attachment,
+						),
+					);
 					return {
 						...attachment,
+						...attachmentFailure(
+							"extract",
+							"unavailable",
+							true,
+							"Attachment enrichment unavailable",
+						),
 						ephemeral: isRemote ? true : attachment.ephemeral,
 					};
 				}
-			}),
-		);
+			})();
+			processedAttachments.push(processed);
+		}
 
 		return processedAttachments;
 	}
@@ -13601,12 +13734,34 @@ export class DefaultMessageService implements IMessageService {
 		rawUrl: string,
 		resolvedLocalUrl: string,
 		isRemote: boolean,
+		budget: AttachmentByteBudget,
+		expectedBytes?: number,
 	): Promise<{ buffer: Buffer; contentType: string }> {
+		if (budget.remaining <= 0) {
+			throw new MediaFetchError(
+				"max_bytes",
+				"Attachment turn byte budget exhausted",
+			);
+		}
+		const maxBytes = Math.min(ATTACHMENT_FETCH_MAX_BYTES, budget.remaining);
+		if (
+			typeof expectedBytes === "number" &&
+			Number.isFinite(expectedBytes) &&
+			expectedBytes > maxBytes
+		) {
+			throw new MediaFetchError(
+				"max_bytes",
+				expectedBytes > budget.remaining
+					? "Attachment exceeds turn byte budget"
+					: `Attachment exceeds ${ATTACHMENT_FETCH_MAX_BYTES} bytes`,
+			);
+		}
 		if (isRemote) {
 			const { buffer, contentType } = await fetchRemoteMedia({
 				url: rawUrl,
-				maxBytes: ATTACHMENT_FETCH_MAX_BYTES,
+				maxBytes,
 			});
+			budget.remaining -= Math.max(buffer.byteLength, expectedBytes ?? 0);
 			return {
 				buffer,
 				contentType: contentType ?? "application/octet-stream",
@@ -13627,21 +13782,18 @@ export class DefaultMessageService implements IMessageService {
 			// Reject on the declared size before reading; the streamed read below
 			// cancels at the cap when the header is absent or lying.
 			const declaredLength = Number(res.headers.get("content-length"));
-			if (
-				Number.isFinite(declaredLength) &&
-				declaredLength > ATTACHMENT_FETCH_MAX_BYTES
-			) {
+			if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
 				throw new MediaFetchError(
 					"max_bytes",
-					`Attachment exceeds ${ATTACHMENT_FETCH_MAX_BYTES} bytes`,
+					declaredLength > budget.remaining
+						? "Attachment exceeds turn byte budget"
+						: `Attachment exceeds ${ATTACHMENT_FETCH_MAX_BYTES} bytes`,
 				);
 			}
 			const contentType =
 				res.headers.get("content-type") || "application/octet-stream";
-			const buffer = await readResponseWithLimit(
-				res,
-				ATTACHMENT_FETCH_MAX_BYTES,
-			);
+			const buffer = await readResponseWithLimit(res, maxBytes);
+			budget.remaining -= Math.max(buffer.byteLength, expectedBytes ?? 0);
 			return { buffer, contentType };
 		} catch (err) {
 			// error-policy:J2 typed transient-class rethrow covering the whole

--- a/packages/core/src/types/primitives.ts
+++ b/packages/core/src/types/primitives.ts
@@ -315,6 +315,17 @@ export interface Media {
 	notProcessed?: string;
 
 	/**
+	 * Machine-readable attachment enrichment failure. The public message may be
+	 * persisted, so this shape deliberately carries only bounded enums and never
+	 * provider error text, response bodies, signed URLs, or local paths.
+	 */
+	enrichmentFailure?: {
+		phase: "fetch" | "describe" | "extract" | "transcribe" | "budget";
+		code: "unavailable" | "empty_result" | "unsupported_type" | "byte_limit";
+		retryable: boolean;
+	};
+
+	/**
 	 * Served URL of this attachment's PII-scrubbed variant — a SEPARATE
 	 * content-addressed media object under its own sha256 (#14781; per #8876
 	 * redacted variants are new bytes, never an edit of the original). When a


### PR DESCRIPTION
## Summary

Extracted from the Nubs review/repair work tracked in #18960. This branch contains only attachment/media enrichment authority; planner and sub-planner changes are excluded.

- serialize per-message attachment enrichment to avoid local model/provider storms
- enforce a cumulative 100 MiB declared/observed byte budget in addition to the per-file cap
- add a bounded machine-readable enrichment failure shape without exposing provider errors, signed URLs, or local paths
- sanitize reported diagnostics while preserving visibly distinct retryable/unavailable states

## Verification

- `bunx vitest run packages/core/src/services/message.processAttachments.test.ts` (24 passed)
- `bun run --cwd packages/core typecheck`
- Biome check on all three changed files
- `git diff --check origin/develop..fix/nubs-media-enrichment-authority`

Part of #18960.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:ca41ac680fa47a2bada382230638bbc650e09387 -->

<!-- evidence-row:before-screenshots -->
- N/A — media enrichment is a core message-service boundary, not a rendered UI change.
<!-- evidence-row:after-screenshots -->
- N/A — media enrichment is a core message-service boundary, not a rendered UI change.
<!-- evidence-row:walkthrough-video -->
- N/A — deterministic contract/authority change with no new interactive visual flow.
<!-- evidence-row:backend-logs -->
- N/A — no live backend log artifact applies; focused deterministic tests are reported above.
<!-- evidence-row:frontend-logs -->
- N/A — no browser console/network artifact applies to this isolated contract proof.
<!-- evidence-row:llm-trajectory -->
- N/A — no prompt, model selection, or generated-output contract changes.
<!-- evidence-row:domain-artifacts -->
- N/A — no external domain artifact applies; executable contract artifacts are contained in the changed tests and reported above.
<!-- evidence-row:ocr-review -->
- N/A — no visual layout or rendered text changed.