### PR TITLE
test(ui): preserve agents when balance read fails

### DIFF
--- a/packages/ui/src/cloud/instances/AgentsPage.balance-isolation.test.tsx
+++ b/packages/ui/src/cloud/instances/AgentsPage.balance-isolation.test.tsx
@@ -1,0 +1,82 @@
+/** Verifies agent rows remain available when the independent credit-balance read fails. */
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import AgentsPage from "./AgentsPage";
+
+vi.mock("@elizaos/ui/cloud-ui", () => ({
+  ContainersSkeleton: () => <div>Loading agents</div>,
+  DashboardErrorState: ({ message }: { message: string }) => (
+    <div role="alert">{message}</div>
+  ),
+  DashboardLoadingState: ({ label }: { label: string }) => <div>{label}</div>,
+  DashboardPageContainer: ({ children }: { children: ReactNode }) => children,
+  ElizaAgentsPageWrapper: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("../lib/use-document-title", () => ({ useDocumentTitle: vi.fn() }));
+vi.mock("../lib/use-session-auth", () => ({
+  useSessionAuth: () => ({ ready: true, authenticated: true }),
+}));
+vi.mock("./components/eliza-agent-pricing-banner", () => ({
+  ElizaAgentPricingBanner: ({
+    creditBalance,
+  }: {
+    creditBalance: number | null;
+  }) => (
+    <div>Balance: {creditBalance === null ? "unavailable" : creditBalance}</div>
+  ),
+}));
+vi.mock("./components/eliza-agents-table", () => ({
+  ElizaAgentsTable: ({
+    sandboxes,
+  }: {
+    sandboxes: Array<{ agent_name: string }>;
+  }) => <div>{sandboxes.map((sandbox) => sandbox.agent_name).join(", ")}</div>,
+}));
+vi.mock("./lib/data/eliza-agents", () => ({
+  useAgents: () => ({
+    data: [
+      {
+        id: "agent-1",
+        agentName: "Persistent agent",
+        status: "running",
+        webUiUrl: null,
+        dockerImage: null,
+        executionTier: "shared",
+        errorMessage: null,
+        lastHeartbeatAt: null,
+        createdAt: "2026-08-12T00:00:00.000Z",
+        updatedAt: "2026-08-12T00:00:00.000Z",
+      },
+    ],
+    error: null,
+    isError: false,
+    isLoading: false,
+  }),
+}));
+vi.mock("./lib/data/credits", () => ({
+  useCreditsBalance: () => ({
+    data: undefined,
+    error: new Error("balance service unavailable"),
+    isError: true,
+    isLoading: false,
+  }),
+}));
+vi.mock("./lib/i18n", () => ({
+  useT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? _key,
+}));
+
+afterEach(cleanup);
+
+describe("AgentsPage balance isolation", () => {
+  it("renders authoritative agent rows and marks only balance unavailable", () => {
+    render(<AgentsPage />);
+
+    expect(screen.getByText("Persistent agent")).toBeTruthy();
+    expect(screen.getByText("Balance: unavailable")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs
+++ b/packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs
@@ -80,8 +80,25 @@ const stubClient = {
 // CJS stub (`.cjs` so esbuild wraps it and `module` is defined): arbitrary
 // named imports of core resolve to `undefined` via CJS interop, since the modal
 // never executes any core code path.
+//
+// `ElizaError` is the one exception and must be a real constructor. The graph
+// reaches `api/client-cloud.ts`, which evaluates `class CloudAgentWakeError
+// extends ElizaError` at module scope. A class heritage clause runs on load
+// even though the modal never constructs it, so an empty core stub prevents
+// React from mounting and leaves the runner waiting for the first card.
 const coreStub = join(outDir, "core-stub.cjs");
-await writeFile(coreStub, "module.exports = {};\n");
+await writeFile(
+  coreStub,
+  `class ElizaError extends Error {
+  constructor(message, options) {
+    super(message);
+    this.name = "ElizaError";
+    if (options && options.code) this.code = options.code;
+  }
+}
+module.exports = { ElizaError };
+`,
+);
 const stubCore = {
   name: "stub-core",
   setup(b) {


### PR DESCRIPTION
## Summary

- prove the authoritative agent query continues rendering rows when the independent credit-balance request fails
- assert only the pricing balance degrades to unavailable and no page-level agent error is shown

## Verification

- `bunx @biomejs/biome check packages/ui/src/cloud/instances/AgentsPage.balance-isolation.test.tsx`
- focused AgentsPage Vitest: 1 passed
- `bun run --cwd packages/ui test:permission-priming-e2e`: passed desktop + mobile flow, 8 screenshots, 0 page errors
- fixture-e2e repair: provide the module-scope `ElizaError` constructor required before React mounts
- `git diff-tree --check`

Follow-up slice from #18960.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:bf7acacc5fb823dd84b3e3473d964fba6ba8d575 -->

<!-- evidence-row:before-screenshots -->
- N/A — test-only coverage does not change production layout or rendered text.
<!-- evidence-row:after-screenshots -->
- N/A — test-only coverage does not change production layout or rendered text.
<!-- evidence-row:walkthrough-video -->
- N/A — deterministic contract/authority change with no new interactive visual flow.
<!-- evidence-row:backend-logs -->
- N/A — no live backend log artifact applies; focused deterministic tests are reported above.
<!-- evidence-row:frontend-logs -->
- N/A — no browser console/network artifact applies to this isolated contract proof.
<!-- evidence-row:llm-trajectory -->
- N/A — no prompt, model selection, or generated-output contract changes.
<!-- evidence-row:domain-artifacts -->
- N/A — no external domain artifact applies; executable contract artifacts are contained in the changed tests and reported above.
<!-- evidence-row:ocr-review -->
- N/A — no visual layout or rendered text changed.