### PR TITLE
fix(core): bind planner budgets to complete model usage

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -1556,13 +1556,26 @@ describe("v5 planner loop skeleton", () => {
 			useModel: vi
 				.fn()
 				// iter 1 (fresh) → executes; iters 2-3 repeat it → redundant
-				.mockResolvedValueOnce({ text: "", toolCalls: [sameCall] })
-				.mockResolvedValueOnce({ text: "", toolCalls: [sameCall] })
-				.mockResolvedValueOnce({ text: "", toolCalls: [sameCall] })
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [sameCall],
+					usage: { promptTokens: 10, completionTokens: 1, totalTokens: 11 },
+				})
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [sameCall],
+					usage: { promptTokens: 20, completionTokens: 2, totalTokens: 22 },
+				})
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [sameCall],
+					usage: { promptTokens: 30, completionTokens: 3, totalTokens: 33 },
+				})
 				// forced synthesis (no tools) → terminal answer
-				.mockResolvedValueOnce(
-					'{"thought":"I already have the price.","messageToUser":"The price is 42.","toolCalls":[]}',
-				),
+				.mockResolvedValueOnce({
+					text: '{"thought":"I already have the price.","messageToUser":"The price is 42.","toolCalls":[]}',
+					usage: { promptTokens: 40, completionTokens: 4, totalTokens: 44 },
+				}),
 			logger: { debug: vi.fn(), warn: vi.fn() },
 		};
 		const executeToolCall = vi.fn(async () => ({
@@ -1588,6 +1601,119 @@ describe("v5 planner loop skeleton", () => {
 		expect(executeToolCall).toHaveBeenCalledTimes(1);
 		expect(result.status).toBe("finished");
 		expect(result.finalMessage).toContain("42");
+		expect(result.modelUsage).toEqual({
+			promptTokens: 100,
+			completionTokens: 10,
+			modelCalls: 4,
+		});
+		const synthesisParams = runtime.useModel.mock.calls[3]?.[1] as {
+			messages?: Array<{ content?: unknown }>;
+		};
+		const synthesisInput = JSON.stringify(synthesisParams);
+		expect(synthesisInput).toContain("price=42");
+		expect(synthesisInput).not.toContain("https://api.example.test/price");
+	});
+
+	it("bounds forced synthesis to safe observations and compact receipt authority", async () => {
+		const compactionDiagnostic = "COMPACTION_DIAGNOSTIC_DO_NOT_LEAK";
+		const mutationSecret = "MUTATION_PROVIDER_SECRET_DO_NOT_LEAK";
+		const readTail = "READ_TAIL_SHOULD_BE_TRUNCATED";
+		const userFacingTail = "USER_FACING_TAIL_SHOULD_BE_TRUNCATED";
+		const readCall = {
+			id: "read-1",
+			name: "WEB_SEARCH",
+			arguments: { query: "release status" },
+		};
+		const mutationCall = {
+			id: "mutation-1",
+			name: "UPDATE_SECRET",
+			arguments: { value: "planner-parameter-secret" },
+		};
+		const useModel = vi
+			.fn()
+			.mockResolvedValueOnce({ text: "", toolCalls: [readCall] })
+			.mockResolvedValueOnce({ text: "", toolCalls: [mutationCall] })
+			.mockResolvedValueOnce({ text: "", toolCalls: [mutationCall] })
+			.mockResolvedValueOnce({ text: "", toolCalls: [mutationCall] })
+			.mockResolvedValueOnce({
+				text: '{"thought":"Use only safe evidence.","messageToUser":"Done safely.","toolCalls":[]}',
+			});
+		const receipts = Array.from({ length: 6 }, (_, index) => ({
+			receiptId: `receipt-${index}`,
+			operation: `vault.secret.update-${index}`,
+			resource: { kind: "vault.secret", id: `secret-${index}` },
+			artifacts: [],
+			idempotency: { key: `operation-${index}`, replayed: false },
+			observedAt: "2026-08-13T00:00:00.000Z",
+			outcome: "applied" as const,
+			commit: {
+				kind: "durable" as const,
+				id: `provider-commit-secret-${index}`,
+				committedAt: "2026-08-13T00:00:00.000Z",
+			},
+		}));
+		const executeToolCall = vi
+			.fn()
+			.mockResolvedValueOnce({
+				success: true,
+				text: `SAFE_READ_OBSERVATION ${"r".repeat(1_800)} ${readTail}`,
+			})
+			.mockResolvedValueOnce({
+				success: true,
+				text: mutationSecret,
+				userFacingText: `Updated the secret safely. ${"u".repeat(900)} ${userFacingTail}`,
+				effectReceipts: receipts,
+			});
+
+		const result = await runPlannerLoop({
+			runtime: { useModel, logger: { debug: vi.fn(), warn: vi.fn() } },
+			context: {
+				id: "ctx",
+				events: [
+					{
+						id: "old-compaction",
+						type: "segment",
+						source: "planner-loop",
+						segment: {
+							id: "old-compaction",
+							label: "compaction",
+							content: compactionDiagnostic,
+							stable: false,
+						},
+					},
+				],
+			},
+			tools: [
+				{ name: "WEB_SEARCH", description: "Read current status." },
+				{ name: "UPDATE_SECRET", description: "Update a secret." },
+			],
+			config: { maxRepeatedToolCalls: 1 },
+			executeToolCall,
+			evaluate: vi.fn(async () => ({
+				success: true,
+				decision: "CONTINUE" as const,
+				thought: "Continue.",
+			})),
+		});
+
+		expect(executeToolCall).toHaveBeenCalledTimes(2);
+		expect(result.finalMessage).toBe("Done safely.");
+		const synthesisParams = useModel.mock.calls.at(-1)?.[1] as {
+			messages?: Array<{ content?: unknown }>;
+		};
+		const synthesisInput = JSON.stringify(synthesisParams);
+		expect(synthesisInput).toContain("SAFE_READ_OBSERVATION");
+		expect(synthesisInput).toContain("Updated the secret safely.");
+		expect(synthesisInput).toContain(
+			"receipt outcome=applied operation=vault.secret.update-5 resource=vault.secret:secret-5",
+		);
+		expect(synthesisInput).not.toContain(mutationSecret);
+		expect(synthesisInput).not.toContain("planner-parameter-secret");
+		expect(synthesisInput).not.toContain("provider-commit-secret");
+		expect(synthesisInput).not.toContain("vault.secret.update-0");
+		expect(synthesisInput).not.toContain("r".repeat(1_800));
+		expect(synthesisInput).not.toContain("u".repeat(900));
+		expect(synthesisInput).not.toContain(compactionDiagnostic);
 	});
 
 	it("does not re-execute an identical call that failed with retryable:false and forces a terminal synthesis", async () => {

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -234,6 +234,16 @@ export async function runEvaluator(
 		throw error;
 	}
 	const endedAt = Date.now();
+	const usage = extractEvaluatorUsage(raw);
+	if (
+		usage?.promptTokens !== undefined &&
+		usage.completionTokens !== undefined
+	) {
+		params.onUsage?.({
+			promptTokens: usage.promptTokens,
+			completionTokens: usage.completionTokens,
+		});
+	}
 	const output = sanitizeOutputMessage(
 		repairFinishedToolTurnWithoutUserMessage(
 			repairMissingEvaluatorMessage(

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -226,9 +226,31 @@ interface RawPlannerOutput {
 export async function runPlannerLoop(
 	params: PlannerLoopParams,
 ): Promise<PlannerLoopResult> {
-	const result = await runPlannerLoopIterations(params);
-	const honest = await ensureFailedTurnFinalMessage(params, result);
-	return ensureToolTurnFinalMessage(params, honest);
+	const usage = { promptTokens: 0, completionTokens: 0, modelCalls: 0 };
+	const maxPromptTokens = mergeChainingLoopConfig(
+		params.config,
+	).maxTrajectoryPromptTokens;
+	const observeModelUsage = (sample: {
+		promptTokens: number;
+		completionTokens: number;
+	}): void => {
+		usage.promptTokens += sample.promptTokens;
+		usage.completionTokens += sample.completionTokens;
+		usage.modelCalls += 1;
+		params.onModelUsage?.(sample);
+		if (usage.promptTokens > maxPromptTokens) {
+			throw new TrajectoryLimitExceeded({
+				kind: "trajectory_token_budget",
+				max: maxPromptTokens,
+				observed: usage.promptTokens,
+			});
+		}
+	};
+	const trackedParams = { ...params, onModelUsage: observeModelUsage };
+	const result = await runPlannerLoopIterations(trackedParams);
+	const honest = await ensureFailedTurnFinalMessage(trackedParams, result);
+	const final = await ensureToolTurnFinalMessage(trackedParams, honest);
+	return { ...final, modelUsage: usage };
 }
 
 async function runPlannerLoopIterations(
@@ -323,23 +345,11 @@ async function runPlannerLoopIterations(
 	// counters (terminalOnlyContinuations, requiredToolMisses) so the
 	// `maxTrajectoryPromptTokens` guard fires on the very call that crosses
 	// the threshold rather than at the next-iteration check-in.
-	let cumulativePromptTokens = 0;
 	const observePlannerUsage = (usage: {
 		promptTokens: number;
 		completionTokens: number;
 	}): void => {
-		cumulativePromptTokens += usage.promptTokens;
-		if (cumulativePromptTokens > config.maxTrajectoryPromptTokens) {
-			throw new TrajectoryLimitExceeded({
-				kind: "trajectory_token_budget",
-				max: config.maxTrajectoryPromptTokens,
-				observed: cumulativePromptTokens,
-				message:
-					`Trajectory prompt-token budget exceeded ` +
-					`(${cumulativePromptTokens}/${config.maxTrajectoryPromptTokens}) — ` +
-					`this turn is most likely stuck in a replan loop; aborting to bound cost.`,
-			});
-		}
+		params.onModelUsage?.(usage);
 	};
 	// Tracks the most recent planner output's *explicit* `messageToUser` so the
 	// post-tool evaluator gate can use it as the final response when the
@@ -2591,6 +2601,7 @@ async function evaluateTrajectory(
 		trajectoryId: params.trajectoryId,
 		parentStageId: params.parentStageId,
 		iteration,
+		onUsage: params.onModelUsage,
 	});
 }
 
@@ -3624,10 +3635,38 @@ async function finishWithForcedSynthesis(params: {
 				"user now from the tool results already in this trajectory; if they do not " +
 				"contain the answer, say plainly what you found and what was missing.",
 	});
+	// A final user-wire synthesis must not receive the full archival trajectory:
+	// compaction may hold an unbounded number of old raw diagnostics, and mutation
+	// wrappers are observations rather than authority to claim an effect. Keep a
+	// bounded chronological native suffix. Read/search/list/get tools may provide
+	// a scrubbed observation for synthesis; mutations contribute only their
+	// action-owned user-facing projection and receipt-backed status.
+	const synthesisSteps = [...trajectory.archivedSteps, ...trajectory.steps]
+		.slice(-FINAL_SYNTHESIS_MAX_STEPS)
+		.map(projectStepForFinalSynthesis);
+	const synthesisContext = {
+		...trajectory.context,
+		events: trajectory.context.events.filter(
+			(event) =>
+				!(
+					event.type === "segment" &&
+					event.source === "planner-loop" &&
+					"segment" in event &&
+					(event.segment as { label?: unknown }).label === "compaction"
+				),
+		),
+	};
+	const synthesisTrajectory: PlannerTrajectory = {
+		...trajectory,
+		context: synthesisContext,
+		steps: synthesisSteps,
+		archivedSteps: [],
+		plannedQueue: [],
+	};
 	const synthOutput = await callPlanner({
 		runtime: loop.runtime,
-		context: trajectory.context,
-		trajectory,
+		context: synthesisContext,
+		trajectory: synthesisTrajectory,
 		config,
 		modelType: loop.modelType,
 		provider: loop.provider,
@@ -3665,6 +3704,65 @@ async function finishWithForcedSynthesis(params: {
 			),
 			trajectory,
 		),
+	};
+}
+
+const SYNTHESIS_OBSERVATION_TOOL =
+	/(?:^|_)(?:READ|SEARCH|LIST|GET|FETCH|LOOKUP|QUERY|STATUS|INSPECT)(?:_|$)/i;
+
+const FINAL_SYNTHESIS_MAX_STEPS = 12;
+const FINAL_SYNTHESIS_MAX_RECEIPTS = 4;
+
+function synthesisReceiptSummary(
+	result: PlannerToolResult,
+): string | undefined {
+	const receipts = result.effectReceipts?.slice(-FINAL_SYNTHESIS_MAX_RECEIPTS);
+	if (!receipts?.length) return undefined;
+	return receipts
+		.map((receipt) => {
+			const operation = compactText(receipt.operation, 120);
+			const resourceKind = compactText(receipt.resource.kind, 80);
+			const resourceId = compactText(receipt.resource.id, 160);
+			return `receipt outcome=${receipt.outcome} operation=${operation} resource=${resourceKind}:${resourceId}`;
+		})
+		.join("\n");
+}
+
+function projectStepForFinalSynthesis(step: PlannerStep): PlannerStep {
+	if (!step.toolCall || !step.result) {
+		return { ...step, thought: undefined };
+	}
+	const result = step.result;
+	const userFacingText = getNonEmptyString(result.userFacingText);
+	const observation =
+		result.success === true &&
+		SYNTHESIS_OBSERVATION_TOOL.test(step.toolCall.name)
+			? getNonEmptyString(result.text)
+			: undefined;
+	const receiptSummary = synthesisReceiptSummary(result);
+	const primaryProjection = observation
+		? compactText(observation, 1_500)
+		: userFacingText
+			? compactText(userFacingText, 750)
+			: result.success
+				? "Tool completed; no synthesis-safe observation was published."
+				: "Tool failed; no synthesis-safe diagnostic was published.";
+	return {
+		iteration: step.iteration,
+		toolCall: {
+			id: step.toolCall.id,
+			name: step.toolCall.name,
+			params: {},
+		},
+		result: {
+			success: result.success,
+			text: receiptSummary
+				? `${primaryProjection}\n${receiptSummary}`
+				: primaryProjection,
+			...(userFacingText
+				? { userFacingText: compactText(userFacingText, 750) }
+				: {}),
+		},
 	};
 }
 
@@ -3872,6 +3970,7 @@ async function ensureToolTurnFinalMessage(
 				"Do not call any tool. Write the final answer to the user now from the tool " +
 				"results already in this trajectory; if they do not contain the answer, say " +
 				"plainly what you found and what was missing.",
+			onUsage: params.onModelUsage,
 		});
 		const finalMessage = synthesized.finalMessage;
 		const synthesizedUsable =
@@ -3960,6 +4059,7 @@ async function ensureFailedTurnFinalMessage(
 			iteration,
 			instruction,
 			failureAware: true,
+			onUsage: params.onModelUsage,
 		});
 		const finalMessage = synthesized.finalMessage;
 		const synthesizedUsable =
@@ -4082,6 +4182,16 @@ async function rescueReplyFromSuccessfulResults(
 			],
 			maxTokens: 1024,
 		});
+		const usage = extractUsage(raw);
+		if (
+			usage?.promptTokens !== undefined &&
+			usage.completionTokens !== undefined
+		) {
+			params.onModelUsage?.({
+				promptTokens: usage.promptTokens,
+				completionTokens: usage.completionTokens,
+			});
+		}
 		const text =
 			typeof raw === "string" ? raw : (raw as { text?: string })?.text;
 		return userSafeRescueReply(text, trajectory);

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -213,6 +213,12 @@ export interface PlannerLoopResult {
 	 * real action whose result is already recorded.
 	 */
 	silentTerminalAction?: "IGNORE" | "STOP";
+	/** Aggregate provider-reported usage across the complete planner turn. */
+	modelUsage?: {
+		promptTokens: number;
+		completionTokens: number;
+		modelCalls: number;
+	};
 }
 
 export interface PlannerLoopParams {
@@ -244,6 +250,11 @@ export interface PlannerLoopParams {
 	modelType?: TextGenerationModelType;
 	evaluatorEffects?: EvaluatorEffects;
 	provider?: string;
+	/** @internal Shared turn-level observer, including terminal rescue calls. */
+	onModelUsage?: (usage: {
+		promptTokens: number;
+		completionTokens: number;
+	}) => void;
 	/** Native tool definitions exposed to the planner model. */
 	tools?: ToolDefinition[];
 	/** Native tool selection policy. Defaults to "auto" when tools is non-empty. */
@@ -313,4 +324,5 @@ export interface RunEvaluatorParams {
 	trajectoryId?: string;
 	parentStageId?: string;
 	iteration?: number;
+	onUsage?: (usage: { promptTokens: number; completionTokens: number }) => void;
 }


### PR DESCRIPTION
## Summary

Extracted from the Nubs review/repair work tracked in #18960. This branch contains only planner model-usage authority. Media enrichment, forced-synthesis projection, and sub-planner replay changes are excluded.

- aggregate provider-reported prompt/completion usage across planner, evaluator, terminal synthesis, and rescue calls
- enforce the trajectory prompt-token budget at the shared turn observer rather than only inside loop iterations
- expose bounded turn-level usage totals to callers
- retain the current develop evaluator input-compaction loop and over-budget fail-fast behavior unchanged

## Verification

- `bunx vitest run packages/core/src/runtime/__tests__/planner-loop.test.ts packages/core/src/runtime/__tests__/evaluator-input-budget.test.ts` (122 passed)
- `bun run --cwd packages/core typecheck`
- Biome check on all four changed files
- `git diff --check origin/develop..fix/nubs-planner-model-usage-authority`

Part of #18960.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:802eee49aba79f92d805bc20074d910ede743be1 -->

<!-- evidence-row:before-screenshots -->
- N/A — planner token accounting is a core runtime boundary, not a rendered UI change.
<!-- evidence-row:after-screenshots -->
- N/A — planner token accounting is a core runtime boundary, not a rendered UI change.
<!-- evidence-row:walkthrough-video -->
- N/A — deterministic contract/authority change with no new interactive visual flow.
<!-- evidence-row:backend-logs -->
- N/A — no live backend log artifact applies; focused deterministic tests are reported above.
<!-- evidence-row:frontend-logs -->
- N/A — no browser console/network artifact applies to this isolated contract proof.
<!-- evidence-row:llm-trajectory -->
- N/A — no prompt, model selection, or generated-output contract changes.
<!-- evidence-row:domain-artifacts -->
- N/A — no external domain artifact applies; executable contract artifacts are contained in the changed tests and reported above.
<!-- evidence-row:ocr-review -->
- N/A — no visual layout or rendered text changed.

## Consolidation update

Consolidates #19298 into this current-`develop` candidate. The four-file slice now carries complete planner/evaluator model-usage accounting together with bounded forced-synthesis projection and its adversarial authority tests. Exact-head-equivalent validation on the integrated tree: 137 focused planner/evaluator tests, Core typecheck, and Biome all passed.