### PR TITLE
fix(core): canonicalize nested replay identities

### DIFF
--- a/packages/core/src/runtime/__tests__/sub-planner.test.ts
+++ b/packages/core/src/runtime/__tests__/sub-planner.test.ts
@@ -13,6 +13,7 @@ import {
 	detectSubActionCycles,
 	resolveSubActions,
 	runSubPlanner,
+	subPlannerCallDigest,
 } from "../sub-planner";
 
 type SubPlannerTestRuntime = Pick<IAgentRuntime, "actions" | "useModel"> & {
@@ -126,6 +127,61 @@ describe("sub-planner helpers", () => {
 		expect(result.finalMessage).toBe("Done.");
 	});
 
+	it("does not replay an exact prior non-retryable nested operation", async () => {
+		const child = makeAction({ name: "CHILD" });
+		const parent = makeAction({
+			name: "PARENT",
+			subActions: ["CHILD"],
+			subPlanner: true,
+		});
+		const call = { name: "CHILD", params: { target: "same" } };
+		const execute = vi.fn(async () => ({ success: true }));
+		const result = await runSubPlanner({
+			runtime: makeRuntime(
+				[parent, child],
+				vi.fn(async () => ({
+					text: "",
+					toolCalls: [
+						{ id: "call-replay", name: "CHILD", arguments: call.params },
+					],
+				})),
+			),
+			action: parent,
+			context: { id: "ctx", events: [] },
+			ctx: {
+				message: makeMessage(),
+				previousResults: [
+					{
+						success: false,
+						data: {
+							subSteps: [
+								{
+									action: "CHILD",
+									success: false,
+									callDigest: subPlannerCallDigest(call),
+									retryable: false,
+								},
+							],
+						},
+					},
+				],
+			},
+			execute,
+			evaluate: async () => ({
+				success: false,
+				decision: "FINISH",
+				messageToUser: "That exact operation cannot be retried this turn.",
+			}),
+		});
+
+		expect(execute).not.toHaveBeenCalled();
+		expect(result.trajectory.steps[0]?.result?.data).toMatchObject({
+			retryable: false,
+			replaySuppressed: true,
+			code: "PRIOR_NON_RETRYABLE_SUBSTEP",
+		});
+	});
+
 	it("resolves child action similes before rejecting sub-planner tool calls", async () => {
 		const child = makeAction({
 			name: "GOOGLE_CALENDAR",
@@ -166,6 +222,142 @@ describe("sub-planner helpers", () => {
 			expect.objectContaining({ name: "GOOGLE_CALENDAR" }),
 			expect.objectContaining({ actions: [child] }),
 		);
+	});
+
+	it("records a simile call under the canonical child identity", async () => {
+		const child = makeAction({
+			name: "GOOGLE_CALENDAR",
+			similes: ["CALENDAR_READ"],
+		});
+		const parent = makeAction({
+			name: "CALENDAR",
+			subActions: ["GOOGLE_CALENDAR"],
+			subPlanner: true,
+		});
+		const result = await runSubPlanner({
+			runtime: makeRuntime(
+				[parent, child],
+				vi.fn(async () => ({
+					text: "",
+					toolCalls: [
+						{
+							id: "call-canonical",
+							name: "CALENDAR_READ",
+							arguments: { calendar: "primary" },
+						},
+					],
+				})),
+			),
+			action: parent,
+			context: { id: "ctx", events: [] },
+			ctx: { message: makeMessage() },
+			execute: vi.fn(async () => ({ success: true, text: "done" })),
+			evaluate: async () => ({
+				success: true,
+				decision: "FINISH",
+				messageToUser: "Done.",
+			}),
+		});
+
+		const recordedCall = result.trajectory.steps[0]?.toolCall;
+		if (!recordedCall) throw new Error("Expected a recorded child call");
+		expect(recordedCall).toMatchObject({
+			name: "GOOGLE_CALENDAR",
+			params: { calendar: "primary" },
+		});
+		expect(subPlannerCallDigest(recordedCall)).toBe(
+			subPlannerCallDigest({
+				name: "GOOGLE_CALENDAR",
+				params: { calendar: "primary" },
+			}),
+		);
+	});
+
+	it("suppresses a second-pass replay when the model changes child aliases", async () => {
+		const child = makeAction({
+			name: "GOOGLE_CALENDAR",
+			similes: ["CALENDAR_READ", "READ_CALENDAR"],
+		});
+		const parent = makeAction({
+			name: "CALENDAR",
+			subActions: ["GOOGLE_CALENDAR"],
+			subPlanner: true,
+		});
+		const params = { calendar: "primary" };
+		const first = await runSubPlanner({
+			runtime: makeRuntime(
+				[parent, child],
+				vi.fn(async () => ({
+					text: "",
+					toolCalls: [
+						{ id: "call-first", name: "CALENDAR_READ", arguments: params },
+					],
+				})),
+			),
+			action: parent,
+			context: { id: "ctx-first", events: [] },
+			ctx: { message: makeMessage() },
+			execute: vi.fn(async () => ({
+				success: false,
+				text: "calendar access is permanently unavailable",
+				data: { retryable: false },
+			})),
+			evaluate: async () => ({
+				success: false,
+				decision: "FINISH",
+				messageToUser: "Calendar access is unavailable.",
+			}),
+		});
+		const firstCall = first.trajectory.steps[0]?.toolCall;
+		if (!firstCall)
+			throw new Error("Expected the first child call to be recorded");
+		expect(firstCall?.name).toBe("GOOGLE_CALENDAR");
+
+		const secondExecute = vi.fn(async () => ({ success: true }));
+		const second = await runSubPlanner({
+			runtime: makeRuntime(
+				[parent, child],
+				vi.fn(async () => ({
+					text: "",
+					toolCalls: [
+						{ id: "call-second", name: "READ_CALENDAR", arguments: params },
+					],
+				})),
+			),
+			action: parent,
+			context: { id: "ctx-second", events: [] },
+			ctx: {
+				message: makeMessage(),
+				previousResults: [
+					{
+						success: false,
+						data: {
+							subSteps: [
+								{
+									action: firstCall.name,
+									success: false,
+									callDigest: subPlannerCallDigest(firstCall),
+									retryable: false,
+								},
+							],
+						},
+					},
+				],
+			},
+			execute: secondExecute,
+			evaluate: async () => ({
+				success: false,
+				decision: "FINISH",
+				messageToUser: "That operation is already known to be unavailable.",
+			}),
+		});
+
+		expect(secondExecute).not.toHaveBeenCalled();
+		expect(second.trajectory.steps[0]?.result?.data).toMatchObject({
+			retryable: false,
+			replaySuppressed: true,
+			code: "PRIOR_NON_RETRYABLE_SUBSTEP",
+		});
 	});
 
 	it("passes child actions to the model as native tool definitions", async () => {

--- a/packages/core/src/runtime/sub-planner.ts
+++ b/packages/core/src/runtime/sub-planner.ts
@@ -164,6 +164,42 @@ export type SubPlannerExecute = (
 	options: ExecutePlannedToolCallOptions,
 ) => Promise<ActionResult> | ActionResult;
 
+export function subPlannerCallDigest(toolCall: PlannerToolCall): string {
+	const canonical = JSON.stringify(toolCall.params ?? {}, (_key, value) =>
+		value && typeof value === "object" && !Array.isArray(value)
+			? Object.fromEntries(
+					Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+						a.localeCompare(b),
+					),
+				)
+			: value,
+	);
+	return `${normalizeSubPlannerActionIdentifier(toolCall.name)}|${canonical}`;
+}
+
+function priorNonRetryableSubstep(
+	previousResults: readonly ActionResult[] | undefined,
+	toolCall: PlannerToolCall,
+): boolean {
+	const digest = subPlannerCallDigest(toolCall);
+	for (const result of [...(previousResults ?? [])].reverse()) {
+		const subSteps = result.data?.subSteps;
+		if (!Array.isArray(subSteps)) continue;
+		for (const candidate of [...subSteps].reverse()) {
+			if (!candidate || typeof candidate !== "object") continue;
+			const record = candidate as Record<string, unknown>;
+			if (
+				record.callDigest === digest &&
+				record.success === false &&
+				record.retryable === false
+			) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 export interface RunSubPlannerParams {
 	runtime: IAgentRuntime & PlannerRuntime;
 	action: Action;
@@ -292,11 +328,32 @@ export async function runSubPlanner(
 					error: `Action ${toolCall.name} is not available to sub-planner ${params.action.name}`,
 				};
 			}
+			// The loop records this same object after execution. Canonicalize it in
+			// place so the persisted sub-step identity is stable when the model uses
+			// a simile on one pass and the canonical name (or another simile) later.
+			// Keeping the alias in the trajectory made the replay guard compare two
+			// different digests for the same child operation.
+			toolCall.name = resolvedChildAction.name;
+			const canonicalCall = toolCall;
+			if (
+				priorNonRetryableSubstep(subPlannerCtx.previousResults, canonicalCall)
+			) {
+				return {
+					success: false,
+					error:
+						"An identical nested operation already reached a non-retryable outcome this turn.",
+					data: {
+						retryable: false,
+						replaySuppressed: true,
+						code: "PRIOR_NON_RETRYABLE_SUBSTEP",
+					},
+				};
+			}
 
 			const rawResult = await execute(
 				params.runtime,
 				subPlannerCtx,
-				{ ...toolCall, name: resolvedChildAction.name },
+				canonicalCall,
 				{
 					...(params.options ?? {}),
 					actions: childActions,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -179,7 +179,11 @@ import type {
 import type { ResponseHandlerFieldSelectionOptions } from "../runtime/response-handler-field-registry";
 import type { RoomHandlerLease } from "../runtime/room-handler-queue";
 import type { ShortcutRegistry } from "../runtime/shortcut-registry";
-import { actionHasSubActions, runSubPlanner } from "../runtime/sub-planner";
+import {
+	actionHasSubActions,
+	runSubPlanner,
+	subPlannerCallDigest,
+} from "../runtime/sub-planner";
 import { buildCanonicalSystemPrompt } from "../runtime/system-prompt";
 import { resolveTraceCorrelationFromEnv } from "../runtime/trace-correlation";
 import {
@@ -6411,6 +6415,8 @@ function plannerToolCallHasActionParameter(toolCall: PlannerToolCall): boolean {
 interface SubPlannerSubStep {
 	action: string;
 	success: boolean;
+	callDigest: string;
+	retryable: boolean;
 	summary?: string;
 	internalTranscriptText?: string;
 	error?: string;
@@ -6446,6 +6452,8 @@ function collectSubPlannerSubSteps(
 		subSteps.push({
 			action: step.toolCall.name,
 			success: result.success,
+			callDigest: subPlannerCallDigest(step.toolCall),
+			retryable: result.data?.retryable !== false,
 			...(summarySource ? { summary: truncateSubStepText(summarySource) } : {}),
 			...(result.transcriptVisibility === "internal" &&
 			typeof result.text === "string"


### PR DESCRIPTION
Closes the remaining planner-authority gap identified while reviewing #18960.

Sub-planner similes are resolved to the canonical child action before trajectory recording. This makes the persisted call digest identical to the replay guard digest, so changing aliases across planner passes cannot bypass prior non-retryable suppression.

Validation:
- `bunx vitest run packages/core/src/runtime/__tests__/sub-planner.test.ts packages/core/src/runtime/__tests__/planner-loop.test.ts packages/core/src/runtime/__tests__/planner-loop-honest-failure.test.ts` (143 passed)
- `bun run --cwd packages/core typecheck`
- Biome check on touched files
- `git diff --check`

Draft pending the broader #18960 review sequence.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence

<!-- evidence-head:c10c57999efc3fc1a677fbcbeb8bd03ca319b893 -->
<!-- evidence-row:before-screenshots -->
- N/A — core runtime replay/digest identity change.
<!-- evidence-row:after-screenshots -->
- N/A — core runtime replay/digest identity change.
<!-- evidence-row:walkthrough-video -->
- N/A — deterministic contract with no interactive visual flow.
<!-- evidence-row:backend-logs -->
- N/A — no live backend log artifact applies; focused deterministic validation is reported above.
<!-- evidence-row:frontend-logs -->
- N/A — no browser console or network artifact applies.
<!-- evidence-row:llm-trajectory -->
- N/A — deterministic replay/digest identity contract; no live-model trajectory was captured for this isolated draft.
<!-- evidence-row:domain-artifacts -->
- N/A — no external domain artifact applies; executable contract artifacts are contained in the changed tests reported above.
<!-- evidence-row:ocr-review -->
- N/A — no visual layout or rendered text changed.