### PR TITLE
fix(cloud): add fallback for default video generation

### DIFF
--- a/packages/cloud/api/__tests__/generate-video-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/generate-video-credit-leak.test.ts
@@ -9,7 +9,7 @@
  * These tests drive the real route handler with a faithful ledger-backed
  * reservation (the reconcile math is REAL) and assert:
  *  - post-settle DB failure: reconciled exactly once to totalCost, NOT refunded;
- *  - pre-settle provider failure: reconciled once to 0, balance fully restored;
+ *  - definitive pre-settle rejection: reconciled once to 0, balance restored;
  *  - clean success: reconciled once to totalCost.
  * Everything else is mocked at the module boundary.
  */
@@ -23,7 +23,8 @@ import * as contentSafetyActual from "@/lib/services/content-safety";
 import * as creditsActual from "@/lib/services/credits";
 import * as generationsActual from "@/lib/services/generations";
 
-const falActual = require("@fal-ai/client") as Record<string, unknown>;
+const falActual = require("@fal-ai/client") as typeof import("@fal-ai/client");
+const { ApiError: FalApiError } = falActual;
 
 const ORG = "00000000-0000-4000-8000-0000000000aa";
 const USER = "00000000-0000-4000-8000-0000000000bb";
@@ -65,8 +66,10 @@ mock.module("@/lib/services/ai-pricing-definitions", () => ({
   getSupportedVideoModelDefinition: (model: string) =>
     model === MODEL
       ? {
+          modelId: MODEL,
           provider: "fal",
           billingSource: "fal",
+          defaultParameters: { durationSeconds: 8, audio: true },
         }
       : undefined,
   SUPPORTED_VIDEO_MODEL_IDS: [MODEL],
@@ -240,15 +243,18 @@ describe("generate-video — post-settle failure must not refund (#10278)", () =
   });
 });
 
-describe("generate-video — pre-settle failure still refunds", () => {
-  test("provider throws BEFORE settle: refunds and returns provider diagnostics", async () => {
+describe("generate-video — definitive pre-settle rejection still refunds", () => {
+  test("provider rejects before enqueue: refunds and returns provider diagnostics", async () => {
     const ledger = makeLedgerReservation(100, COST);
     reserve.mockResolvedValue(ledger.reservation);
     const providerError = Object.assign(
-      new Error("fal upstream 503 api_key=secret-token"),
+      new FalApiError({
+        message: "fal rejected input api_key=secret-token",
+        status: 422,
+        body: undefined,
+      }),
       {
-        status: 503,
-        code: "FAL_UPSTREAM_UNAVAILABLE",
+        code: "FAL_INVALID_INPUT",
       },
     );
     subscribe.mockRejectedValue(providerError);
@@ -265,9 +271,9 @@ describe("generate-video — pre-settle failure still refunds", () => {
         provider: "fal",
         model: MODEL,
         billingSource: "fal",
-        upstreamStatus: 503,
-        upstreamCode: "FAL_UPSTREAM_UNAVAILABLE",
-        upstreamMessage: "fal upstream 503 api_key=[REDACTED]",
+        upstreamStatus: 422,
+        upstreamCode: "FAL_INVALID_INPUT",
+        upstreamMessage: "fal rejected input api_key=[REDACTED]",
       },
     });
     expect(generationsCreate).not.toHaveBeenCalled();

--- a/packages/cloud/api/__tests__/generate-video-provider-fallback.test.ts
+++ b/packages/cloud/api/__tests__/generate-video-provider-fallback.test.ts
@@ -1,0 +1,570 @@
+/**
+ * Exercises default video provider failover through the real Hono route and
+ * provider registry with deterministic auth, billing, fal, and Atlas edges.
+ * The suite verifies configuration filtering, terminal fallback, pending-job
+ * preservation, actual-provider persistence, and single-settlement billing.
+ */
+
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+import * as aiPricingActual from "@/lib/services/ai-pricing";
+import * as contentSafetyActual from "@/lib/services/content-safety";
+import * as creditsActual from "@/lib/services/credits";
+import * as generationsActual from "@/lib/services/generations";
+
+const falActual = require("@fal-ai/client") as typeof import("@fal-ai/client");
+const { ApiError: FalApiError } = falActual;
+const originalFetch = globalThis.fetch;
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+const FAL_MODEL = "fal-ai/veo3";
+const ATLAS_MODEL = "vidu/q3-turbo/text-to-video";
+const FAL_COST = 0.8;
+const ATLAS_COST = 0.3;
+
+const requireUserOrApiKeyWithOrg = mock();
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...workersHonoAuthActual,
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/content-safety", () => ({
+  ...contentSafetyActual,
+  contentSafetyService: {
+    ...contentSafetyActual.contentSafetyService,
+    assertSafeForPublicUse: async () => undefined,
+  },
+}));
+
+const calculateVideoGenerationCostFromCatalog = mock(
+  async ({ model }: { model: string }) => {
+    const totalCost = model === FAL_MODEL ? FAL_COST : ATLAS_COST;
+    return {
+      totalCost,
+      baseTotalCost: totalCost / 1.2,
+      platformMarkup: totalCost - totalCost / 1.2,
+    };
+  },
+);
+mock.module("@/lib/services/ai-pricing", () => ({
+  ...aiPricingActual,
+  calculateVideoGenerationCostFromCatalog,
+  getDefaultVideoBillingDimensions: (model: string) => ({
+    durationSeconds: model === FAL_MODEL ? 8 : 5,
+    dimensions:
+      model === FAL_MODEL
+        ? { audio: true }
+        : { resolution: "720p", audio: false },
+  }),
+}));
+
+const reserve = mock();
+mock.module("@/lib/services/credits", () => ({
+  ...creditsActual,
+  creditsService: { ...creditsActual.creditsService, reserve },
+}));
+
+const generationsCreate = mock();
+mock.module("@/lib/services/generations", () => ({
+  ...generationsActual,
+  generationsService: {
+    ...generationsActual.generationsService,
+    create: generationsCreate,
+  },
+}));
+
+const subscribe = mock();
+const queueStatus = mock();
+const queueResult = mock();
+mock.module("@fal-ai/client", () => ({
+  ...falActual,
+  createFalClient: () => ({
+    subscribe,
+    queue: { status: queueStatus, result: queueResult },
+  }),
+}));
+
+const fetchMock = mock(
+  async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+    throw new Error("Unexpected fetch in video fallback test");
+  },
+);
+globalThis.fetch = Object.assign(fetchMock, {
+  preconnect: originalFetch.preconnect,
+});
+
+const videoRoute = (await import("../v1/generate-video/route")).default;
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+  mock.module("@/lib/auth/workers-hono-auth", () => workersHonoAuthActual);
+  mock.module("@/lib/services/content-safety", () => contentSafetyActual);
+  mock.module("@/lib/services/ai-pricing", () => aiPricingActual);
+  mock.module("@/lib/services/credits", () => creditsActual);
+  mock.module("@/lib/services/generations", () => generationsActual);
+  mock.module("@fal-ai/client", () => falActual);
+});
+
+type AppCtx = { set: (key: string, value: unknown) => void };
+
+function makeLedgerReservation(
+  startBalance: number,
+  hold: number,
+  reservationTransactionId = "11111111-1111-4111-8111-111111111111",
+) {
+  let balance = startBalance - hold;
+  let reconcileCalls = 0;
+  let lastActual = Number.NaN;
+  return {
+    startBalance,
+    get balance() {
+      return balance;
+    },
+    get reconcileCalls() {
+      return reconcileCalls;
+    },
+    get lastActual() {
+      return lastActual;
+    },
+    reservation: {
+      reservedAmount: hold,
+      reservationTransactionId,
+      reconcile: async (actualCost: number) => {
+        reconcileCalls++;
+        lastActual = actualCost;
+        balance += hold - actualCost;
+        return undefined;
+      },
+    },
+  };
+}
+
+function atlasSuccess(url = "https://atlas.media/video.mp4") {
+  return new Response(
+    JSON.stringify({
+      data: {
+        id: "atlas-request-1",
+        status: "completed",
+        outputs: [url],
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function post(
+  env: Record<string, unknown>,
+  body: Record<string, unknown> = { prompt: "a neon cat" },
+) {
+  return videoRoute.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer eliza_test_key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+beforeEach(() => {
+  requireUserOrApiKeyWithOrg.mockReset();
+  calculateVideoGenerationCostFromCatalog.mockClear();
+  calculateVideoGenerationCostFromCatalog.mockImplementation(
+    async ({ model }) => {
+      const totalCost = model === FAL_MODEL ? FAL_COST : ATLAS_COST;
+      return {
+        totalCost,
+        baseTotalCost: totalCost / 1.2,
+        platformMarkup: totalCost - totalCost / 1.2,
+      };
+    },
+  );
+  reserve.mockReset();
+  generationsCreate.mockReset();
+  subscribe.mockReset();
+  queueStatus.mockReset();
+  queueResult.mockReset();
+  fetchMock.mockReset();
+
+  requireUserOrApiKeyWithOrg.mockImplementation(async (c: AppCtx) => {
+    c.set("apiKeyId", "key-1");
+    return {
+      id: USER,
+      organization_id: ORG,
+      organization: { id: ORG, name: "Org", is_active: true },
+      is_active: true,
+    };
+  });
+  generationsCreate.mockResolvedValue({ id: "generation-1" });
+});
+
+describe("generate-video — default provider fallback", () => {
+  test("rejects an unconfigured default chain before pricing or credit work", async () => {
+    const response = await post({});
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      error: "Video generation is not configured",
+    });
+    expect(calculateVideoGenerationCostFromCatalog).not.toHaveBeenCalled();
+    expect(reserve).not.toHaveBeenCalled();
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("uses Atlas directly when fal credentials are absent", async () => {
+    const ledger = makeLedgerReservation(100, ATLAS_COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    fetchMock.mockResolvedValue(atlasSuccess());
+
+    const response = await post({ ATLASCLOUD_API_KEY: "atlas-key" });
+
+    expect(response.status).toBe(200);
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.lastActual).toBeCloseTo(ATLAS_COST, 10);
+    expect(generationsCreate).toHaveBeenCalledTimes(1);
+    expect(generationsCreate.mock.calls[0]?.[0]).toMatchObject({
+      model: ATLAS_MODEL,
+      provider: "vidu",
+      cost: String(ATLAS_COST),
+      result: { billingSource: "atlascloud" },
+      storage_url: "https://atlas.media/video.mp4",
+    });
+  });
+
+  test("does not price an unused fallback when the primary succeeds", async () => {
+    const ledger = makeLedgerReservation(100, FAL_COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    calculateVideoGenerationCostFromCatalog.mockImplementation(
+      async ({ model }) => {
+        if (model === ATLAS_MODEL) throw new Error("Atlas pricing unavailable");
+        return {
+          totalCost: FAL_COST,
+          baseTotalCost: FAL_COST / 1.2,
+          platformMarkup: FAL_COST - FAL_COST / 1.2,
+        };
+      },
+    );
+    subscribe.mockResolvedValue({
+      data: { video: { url: "https://fal.media/video.mp4" } },
+      requestId: "fal-request-1",
+    });
+
+    const response = await post({
+      FAL_KEY: "fal-key",
+      ATLASCLOUD_API_KEY: "atlas-key",
+    });
+
+    expect(response.status).toBe(200);
+    expect(calculateVideoGenerationCostFromCatalog).toHaveBeenCalledTimes(1);
+    expect(
+      calculateVideoGenerationCostFromCatalog.mock.calls[0]?.[0],
+    ).toMatchObject({
+      model: FAL_MODEL,
+      billingSource: "fal",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ledger.lastActual).toBeCloseTo(FAL_COST, 10);
+  });
+
+  test("keeps an explicit model request pinned to its provider", async () => {
+    const response = await post(
+      { ATLASCLOUD_API_KEY: "atlas-key" },
+      { model: FAL_MODEL, prompt: "a neon cat" },
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      error: "Fal video generation is not configured",
+    });
+    expect(reserve).not.toHaveBeenCalled();
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("uses separate provider-priced reservations across a safe fallback", async () => {
+    const falLedger = makeLedgerReservation(
+      100,
+      FAL_COST,
+      "11111111-1111-4111-8111-111111111111",
+    );
+    const atlasLedger = makeLedgerReservation(
+      100,
+      ATLAS_COST,
+      "22222222-2222-4222-8222-222222222222",
+    );
+    reserve
+      .mockResolvedValueOnce(falLedger.reservation)
+      .mockResolvedValueOnce(atlasLedger.reservation);
+    subscribe.mockRejectedValue(
+      new FalApiError({
+        message: "invalid fal input",
+        status: 422,
+        body: undefined,
+      }),
+    );
+    fetchMock.mockResolvedValue(atlasSuccess());
+
+    const response = await post({
+      FAL_KEY: "fal-key",
+      ATLASCLOUD_API_KEY: "atlas-key",
+    });
+
+    expect(response.status).toBe(200);
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(reserve).toHaveBeenCalledTimes(2);
+    expect(reserve.mock.calls[0]?.[0]).toMatchObject({
+      amount: FAL_COST,
+      model: "veo3",
+      provider: "fal",
+      billingSource: "fal",
+    });
+    expect(reserve.mock.calls[1]?.[0]).toMatchObject({
+      amount: ATLAS_COST,
+      model: "q3-turbo",
+      provider: "vidu",
+      billingSource: "atlascloud",
+    });
+    expect(falLedger.reconcileCalls).toBe(1);
+    expect(falLedger.lastActual).toBe(0);
+    expect(atlasLedger.reconcileCalls).toBe(1);
+    expect(atlasLedger.lastActual).toBeCloseTo(ATLAS_COST, 10);
+    expect(generationsCreate.mock.calls[0]?.[0]).toMatchObject({
+      model: ATLAS_MODEL,
+      provider: "vidu",
+      result: { billingSource: "atlascloud" },
+    });
+  });
+
+  test("releases each attempt when both providers reject terminally", async () => {
+    const falLedger = makeLedgerReservation(
+      100,
+      FAL_COST,
+      "11111111-1111-4111-8111-111111111111",
+    );
+    const atlasLedger = makeLedgerReservation(
+      100,
+      ATLAS_COST,
+      "22222222-2222-4222-8222-222222222222",
+    );
+    reserve
+      .mockResolvedValueOnce(falLedger.reservation)
+      .mockResolvedValueOnce(atlasLedger.reservation);
+    subscribe.mockRejectedValue(
+      new FalApiError({
+        message: "invalid fal input",
+        status: 422,
+        body: undefined,
+      }),
+    );
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ message: "invalid atlas input" }), {
+        status: 422,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const response = await post({
+      FAL_KEY: "fal-key",
+      ATLASCLOUD_API_KEY: "atlas-key",
+    });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      error: "Video provider request failed",
+      details: {
+        provider: "vidu",
+        model: ATLAS_MODEL,
+        billingSource: "atlascloud",
+      },
+    });
+    expect(reserve).toHaveBeenCalledTimes(2);
+    expect(falLedger.reconcileCalls).toBe(1);
+    expect(falLedger.lastActual).toBe(0);
+    expect(atlasLedger.reconcileCalls).toBe(1);
+    expect(atlasLedger.lastActual).toBe(0);
+    expect(generationsCreate).not.toHaveBeenCalled();
+  });
+
+  test("does not dispatch Atlas when fal submission may have been accepted", async () => {
+    const ledger = makeLedgerReservation(100, FAL_COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    subscribe.mockRejectedValue(new Error("connection reset after upload"));
+
+    const response = await post({
+      FAL_KEY: "fal-key",
+      ATLASCLOUD_API_KEY: "atlas-key",
+    });
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      status: "submission_unknown",
+      requestId: expect.stringMatching(/^generate-video:[^:]+:0$/),
+    });
+    expect(reserve).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.lastActual).toBeCloseTo(FAL_COST, 10);
+    expect(generationsCreate).not.toHaveBeenCalled();
+  });
+
+  test("does not fall back when fal may still complete upstream", async () => {
+    const ledger = makeLedgerReservation(100, FAL_COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    subscribe.mockImplementation(
+      async (_model: string, options: Record<string, unknown>) => {
+        (options.onEnqueue as (requestId: string) => void)("fal-pending-1");
+        throw new Error("fal poll timed out");
+      },
+    );
+    queueStatus.mockResolvedValue({ status: "IN_PROGRESS", logs: [] });
+
+    const response = await post({
+      FAL_KEY: "fal-key",
+      ATLASCLOUD_API_KEY: "atlas-key",
+    });
+
+    expect(response.status).toBe(202);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ledger.reconcileCalls).toBe(0);
+    expect(generationsCreate).toHaveBeenCalledTimes(1);
+    expect(generationsCreate.mock.calls[0]?.[0]).toMatchObject({
+      model: FAL_MODEL,
+      provider: "fal",
+      status: "pending",
+      job_id: "fal-pending-1",
+    });
+  });
+
+  test("does not refund or dispatch Atlas when a completed fal result probe is rate limited", async () => {
+    const ledger = makeLedgerReservation(100, FAL_COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    subscribe.mockImplementation(
+      async (_model: string, options: Record<string, unknown>) => {
+        (options.onEnqueue as (requestId: string) => void)("fal-completed-1");
+        throw new Error("fal subscription lost");
+      },
+    );
+    queueStatus.mockResolvedValue({ status: "COMPLETED" });
+    queueResult.mockRejectedValue(
+      new FalApiError({
+        message: "rate limited",
+        status: 429,
+        body: undefined,
+      }),
+    );
+
+    const response = await post({
+      FAL_KEY: "fal-key",
+      ATLASCLOUD_API_KEY: "atlas-key",
+    });
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      status: "pending",
+      requestId: "fal-completed-1",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ledger.reconcileCalls).toBe(0);
+    expect(generationsCreate.mock.calls[0]?.[0]).toMatchObject({
+      model: FAL_MODEL,
+      provider: "fal",
+      status: "pending",
+      job_id: "fal-completed-1",
+    });
+  });
+
+  test("pins Atlas billing and recovery identity when fallback polling is ambiguous", async () => {
+    const falLedger = makeLedgerReservation(
+      100,
+      FAL_COST,
+      "11111111-1111-4111-8111-111111111111",
+    );
+    const atlasLedger = makeLedgerReservation(
+      100,
+      ATLAS_COST,
+      "22222222-2222-4222-8222-222222222222",
+    );
+    reserve
+      .mockResolvedValueOnce(falLedger.reservation)
+      .mockResolvedValueOnce(atlasLedger.reservation);
+    subscribe.mockRejectedValue(
+      new FalApiError({
+        message: "invalid fal input",
+        status: 422,
+        body: undefined,
+      }),
+    );
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: { id: "atlas-pending-1", status: "starting" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockRejectedValueOnce(new Error("atlas poll unavailable"));
+    const runTimerImmediately = ((handler: TimerHandler) => {
+      if (typeof handler === "function") handler();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout;
+    const timer = spyOn(globalThis, "setTimeout").mockImplementation(
+      runTimerImmediately,
+    );
+
+    const response = await (async () => {
+      try {
+        return await post({
+          FAL_KEY: "fal-key",
+          ATLASCLOUD_API_KEY: "atlas-key",
+        });
+      } finally {
+        timer.mockRestore();
+      }
+    })();
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      status: "pending",
+      requestId: "atlas-pending-1",
+    });
+    expect(falLedger.reconcileCalls).toBe(1);
+    expect(falLedger.lastActual).toBe(0);
+    expect(atlasLedger.reconcileCalls).toBe(0);
+    expect(generationsCreate).toHaveBeenCalledTimes(1);
+    expect(generationsCreate.mock.calls[0]?.[0]).toMatchObject({
+      model: ATLAS_MODEL,
+      provider: "vidu",
+      status: "pending",
+      job_id: "atlas-pending-1",
+      metadata: {
+        reservation_transaction_id: "22222222-2222-4222-8222-222222222222",
+        billed_cost: ATLAS_COST,
+        billing_source: "atlascloud",
+      },
+    });
+  });
+});

--- a/packages/cloud/api/__tests__/generate-video-timeout-pending.test.ts
+++ b/packages/cloud/api/__tests__/generate-video-timeout-pending.test.ts
@@ -70,8 +70,10 @@ mock.module("@/lib/services/ai-pricing-definitions", () => ({
   getSupportedVideoModelDefinition: (model: string) =>
     model === MODEL
       ? {
+          modelId: MODEL,
           provider: "fal",
           billingSource: "fal",
+          defaultParameters: { durationSeconds: 8, audio: true },
         }
       : undefined,
   SUPPORTED_VIDEO_MODEL_IDS: [MODEL],
@@ -312,10 +314,16 @@ describe("generate-video — verified terminal failures still refund exactly onc
     expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
   });
 
-  test("pre-enqueue provider failure (no upstream job): reconciled once to 0", async () => {
+  test("definitive pre-enqueue rejection: reconciled once to 0", async () => {
     const ledger = makeLedgerReservation(100, COST);
     reserve.mockResolvedValue(ledger.reservation);
-    subscribe.mockRejectedValue(new Error("fal upstream 503"));
+    subscribe.mockRejectedValue(
+      new ApiError({
+        message: "invalid input",
+        status: 422,
+        body: undefined,
+      }),
+    );
 
     const res = await post();
 

--- a/packages/cloud/api/__tests__/generative-route-auth-video-settlement.test.ts
+++ b/packages/cloud/api/__tests__/generative-route-auth-video-settlement.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Verifies the real generative admission helper keeps long-running video work
+ * on a durable credit reservation even when a Worker execution context would
+ * normally select the deferred Durable Object admission path.
+ */
+
+import { afterAll, expect, mock, test } from "bun:test";
+import * as aiBillingActual from "@/lib/services/ai-billing";
+
+const reserveFlatUsageCredits = mock();
+mock.module("@/lib/services/ai-billing", () => ({
+  ...aiBillingActual,
+  reserveFlatUsageCredits,
+}));
+
+const { admitFlatGenerativeOperation } = await import(
+  "../src/lib/generative-route-auth"
+);
+
+afterAll(() => {
+  mock.module("@/lib/services/ai-billing", () => aiBillingActual);
+});
+
+test("video settlement mode forces a provider-specific durable reservation in Workers", async () => {
+  const reconcile = mock(async () => undefined);
+  reserveFlatUsageCredits.mockResolvedValue({
+    reservedAmount: 0.3,
+    reservationTransactionId: "22222222-2222-4222-8222-222222222222",
+    affiliateAttribution: null,
+    reconcile,
+  });
+  const waitUntil = mock();
+  const context = {
+    executionCtx: { waitUntil },
+  } as unknown as Parameters<typeof admitFlatGenerativeOperation>[0]["c"];
+  const billingContext = {
+    organizationId: "00000000-0000-4000-8000-0000000000aa",
+    userId: "00000000-0000-4000-8000-0000000000bb",
+    apiKeyId: "key-1",
+    model: "vidu/q3-turbo/text-to-video",
+    provider: "vidu",
+    billingSource: "atlascloud" as const,
+    requestId: "generate-video:request:1",
+  };
+  const cost = {
+    totalCost: 0.3,
+    baseTotalCost: 0.25,
+    platformMarkup: 0.05,
+  };
+
+  const admission = await admitFlatGenerativeOperation({
+    c: context,
+    context: billingContext,
+    apiKeyId: "key-1",
+    cost,
+    idempotencyKey: billingContext.requestId,
+    settlementMode: "synchronous_reservation",
+  });
+
+  expect(admission.mode).toBe("synchronous_reservation");
+  expect(admission.reservation?.reservationTransactionId).toBe(
+    "22222222-2222-4222-8222-222222222222",
+  );
+  expect(reserveFlatUsageCredits).toHaveBeenCalledWith(billingContext, cost, {
+    idempotencyKey: billingContext.requestId,
+  });
+  expect(waitUntil).not.toHaveBeenCalled();
+
+  await admission.settleUnknown();
+  expect(reconcile).toHaveBeenCalledWith(cost.totalCost);
+});

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -76,6 +76,13 @@ export async function admitFlatGenerativeOperation(params: {
   cost: FlatBillingCost;
   idempotencyKey?: string;
   admissionSnapshot?: InferenceAdmissionSnapshot;
+  /**
+   * Long-running media jobs need a durable reservation transaction id for
+   * provider-status reconciliation. Force that lane even in Workers instead
+   * of creating a Durable Object lease that would later need a non-atomic
+   * cross-system handoff to the reservation ledger.
+   */
+  settlementMode?: "default" | "synchronous_reservation";
 }): Promise<OrganizationInferenceAdmission> {
   const executionCtx = getGenerativeExecutionContext(params.c);
   const { provider, billingSource, requestId } = params.context;
@@ -90,7 +97,7 @@ export async function admitFlatGenerativeOperation(params: {
     billingSource,
     requestId,
   };
-  if (!executionCtx) {
+  if (!executionCtx || params.settlementMode === "synchronous_reservation") {
     const { reserveFlatUsageCredits } = await import(
       "@/lib/services/ai-billing"
     );

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -15,20 +15,29 @@ import {
 } from "@/lib/api/cloud-worker-errors";
 import {
   collectVideoProviderApiKeys,
-  getVideoProvider,
+  getConfiguredVideoProviderCandidates,
 } from "@/lib/providers/video/registry";
 import {
+  type GeneratedVideo,
   VIDEO_PENDING_SETTLEMENT_MARKER,
   VideoGenerationPendingError,
+  VideoGenerationSubmissionUnknownError,
+  VideoGenerationTerminalError,
 } from "@/lib/providers/video/types";
-import { type BillingContext, billFlatUsage } from "@/lib/services/ai-billing";
+import {
+  type BillingContext,
+  billFlatUsage,
+  type FlatBillingCost,
+} from "@/lib/services/ai-billing";
 import {
   calculateVideoGenerationCostFromCatalog,
   getDefaultVideoBillingDimensions,
 } from "@/lib/services/ai-pricing";
 import {
+  DEFAULT_VIDEO_MODEL_IDS,
   getSupportedVideoModelDefinition,
   SUPPORTED_VIDEO_MODEL_IDS,
+  type SupportedVideoModelDefinition,
 } from "@/lib/services/ai-pricing-definitions";
 import { contentSafetyService } from "@/lib/services/content-safety";
 import { InsufficientCreditsError } from "@/lib/services/credits";
@@ -37,12 +46,11 @@ import { persistPendingVideoSettlement } from "@/lib/services/pending-video-sett
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
-const DEFAULT_VIDEO_MODEL = "fal-ai/veo3";
 const MAX_PROMPT_LENGTH = 4000;
 
 const videoRequestSchema = z.object({
   prompt: z.string().trim().min(1).max(MAX_PROMPT_LENGTH),
-  model: z.string().trim().default(DEFAULT_VIDEO_MODEL),
+  model: z.string().trim().min(1).optional(),
   referenceUrl: z.string().trim().url().optional(),
   durationSeconds: z.coerce.number().int().min(1).max(30).optional(),
   resolution: z.string().trim().max(32).optional(),
@@ -63,6 +71,35 @@ interface PendingSettlementContext {
   totalCost: number;
   durationSeconds: number;
   parameters: Record<string, unknown>;
+}
+
+interface PricedVideoCandidate {
+  definition: SupportedVideoModelDefinition;
+  provider: ReturnType<
+    typeof getConfiguredVideoProviderCandidates
+  >[number]["provider"];
+  billingContext: BillingContext;
+  cost: FlatBillingCost;
+  durationSeconds: number;
+  resolution?: string;
+  audio?: boolean;
+  voiceControl?: boolean;
+}
+
+function providerDisplayName(
+  definition: SupportedVideoModelDefinition,
+): string {
+  return definition.provider === "fal" ? "Fal" : definition.provider;
+}
+
+function requireDefaultVideoModelDefinitions(): SupportedVideoModelDefinition[] {
+  return DEFAULT_VIDEO_MODEL_IDS.map((modelId) => {
+    const definition = getSupportedVideoModelDefinition(modelId);
+    if (!definition) {
+      throw new Error(`Default video model is not supported: ${modelId}`);
+    }
+    return definition;
+  });
 }
 
 function redactProviderErrorMessage(message: string): string {
@@ -121,13 +158,16 @@ app.post("/", async (c) => {
   // the already-correct charge, giving a free video. Mirrors generate-image.
   let chargeSettled = false;
   let pendingContext: PendingSettlementContext | null = null;
+  let activeBillingRequestId: string | null = null;
 
   try {
     const { user, apiKeyId, admissionSnapshot } =
       await requireGenerativeRouteCaller(c, { rateLimitEndpoint: "strict" });
     const request = videoRequestSchema.parse(await c.req.json());
-    const definition = getSupportedVideoModelDefinition(request.model);
-    if (!definition) {
+    const requestedDefinition = request.model
+      ? getSupportedVideoModelDefinition(request.model)
+      : undefined;
+    if (request.model && !requestedDefinition) {
       return jsonError(
         c,
         400,
@@ -139,133 +179,214 @@ app.post("/", async (c) => {
       );
     }
 
-    const provider = getVideoProvider(definition.billingSource);
+    const definitions = requestedDefinition
+      ? [requestedDefinition]
+      : requireDefaultVideoModelDefinitions();
     const apiKeys = collectVideoProviderApiKeys(c.env);
-    if (provider.isConfigured && !provider.isConfigured(apiKeys)) {
-      const providerName =
-        definition.provider === "fal" ? "Fal" : definition.provider;
-      return jsonError(
-        c,
-        503,
-        `${providerName} video generation is not configured`,
-        "internal_error",
-      );
+    const providerCandidates = getConfiguredVideoProviderCandidates(
+      definitions,
+      apiKeys,
+    );
+    if (providerCandidates.length === 0) {
+      const message = requestedDefinition
+        ? `${providerDisplayName(requestedDefinition)} video generation is not configured`
+        : "Video generation is not configured";
+      return jsonError(c, 503, message, "internal_error");
     }
 
-    const defaults = getDefaultVideoBillingDimensions(request.model);
-    const durationSeconds = request.durationSeconds ?? defaults.durationSeconds;
-    const dimensions = {
-      ...defaults.dimensions,
-      ...(request.resolution ? { resolution: request.resolution } : {}),
-      ...(request.audio !== undefined ? { audio: request.audio } : {}),
-      ...(request.voiceControl !== undefined
-        ? { voiceControl: request.voiceControl }
-        : {}),
-      ...(defaults.dimensions.durationSeconds !== undefined
-        ? { durationSeconds }
-        : {}),
-    };
-    const [, cost] = await Promise.all([
-      contentSafetyService.assertSafeForPublicUse({
-        surface: "media_generation_prompt",
-        organizationId: user.organization_id,
-        userId: user.id,
-        text: [
-          `Video prompt: ${request.prompt}`,
-          request.referenceUrl
-            ? `Reference URL: ${request.referenceUrl}`
-            : undefined,
-        ],
-        imageUrls: request.referenceUrl ? [request.referenceUrl] : undefined,
-        metadata: { type: "video", model: request.model },
-      }),
-      calculateVideoGenerationCostFromCatalog({
-        model: request.model,
+    await contentSafetyService.assertSafeForPublicUse({
+      surface: "media_generation_prompt",
+      organizationId: user.organization_id,
+      userId: user.id,
+      text: [
+        `Video prompt: ${request.prompt}`,
+        request.referenceUrl
+          ? `Reference URL: ${request.referenceUrl}`
+          : undefined,
+      ],
+      imageUrls: request.referenceUrl ? [request.referenceUrl] : undefined,
+      metadata: { type: "video", model: definitions[0].modelId },
+    });
+
+    const operationRequestId = `generate-video:${crypto.randomUUID()}`;
+
+    let generated: GeneratedVideo | undefined;
+    let selectedCandidate: PricedVideoCandidate | undefined;
+    let lastFailure:
+      | { candidate: PricedVideoCandidate; error: unknown }
+      | undefined;
+    for (const [
+      index,
+      { definition, provider },
+    ] of providerCandidates.entries()) {
+      // Price only the attempt that is about to dispatch. An unavailable
+      // fallback catalog must not prevent a configured primary from serving a
+      // request, while every paid dispatch still has a fail-closed quote.
+      const defaults = getDefaultVideoBillingDimensions(definition.modelId);
+      const durationSeconds =
+        request.durationSeconds ?? defaults.durationSeconds;
+      const resolution =
+        request.resolution ?? definition.defaultParameters.resolution;
+      const audio = request.audio ?? definition.defaultParameters.audio;
+      const voiceControl =
+        request.voiceControl ?? definition.defaultParameters.voiceControl;
+      const dimensions = {
+        ...defaults.dimensions,
+        ...(resolution ? { resolution } : {}),
+        ...(audio !== undefined ? { audio } : {}),
+        ...(voiceControl !== undefined ? { voiceControl } : {}),
+        ...(defaults.dimensions.durationSeconds !== undefined
+          ? { durationSeconds }
+          : {}),
+      };
+      const cost = await calculateVideoGenerationCostFromCatalog({
+        model: definition.modelId,
         billingSource: definition.billingSource,
         durationSeconds,
         dimensions,
         cache: getGenerativePricingCacheOptions(c),
-      }),
-    ]);
-    const billingContext: BillingContext = {
-      organizationId: user.organization_id,
-      userId: user.id,
-      apiKeyId,
-      model: request.model,
-      provider: definition.provider,
-      billingSource: definition.billingSource,
-      requestId: `generate-video:${crypto.randomUUID()}`,
-      affiliateCode: c.req.header("X-Affiliate-Code"),
-      description: `Video generation: ${request.model}`,
-    };
-
-    try {
-      admission = await admitFlatGenerativeOperation({
-        c,
-        context: billingContext,
-        apiKeyId,
-        cost,
-        admissionSnapshot,
       });
-    } catch (error) {
-      if (error instanceof InsufficientCreditsError) {
-        return c.json(
-          {
-            success: false,
-            error: "Insufficient credits",
-            required: error.required,
-          },
-          402,
+      const billingContext: BillingContext = {
+        organizationId: user.organization_id,
+        userId: user.id,
+        apiKeyId,
+        model: definition.modelId,
+        provider: definition.provider,
+        billingSource: definition.billingSource,
+        requestId: `${operationRequestId}:${index}`,
+        affiliateCode: c.req.header("X-Affiliate-Code"),
+        description: `Video generation: ${definition.modelId}`,
+      };
+      const candidate: PricedVideoCandidate = {
+        definition,
+        provider,
+        billingContext,
+        cost,
+        durationSeconds,
+        resolution,
+        audio,
+        voiceControl,
+      };
+      let attemptAdmission: Awaited<
+        ReturnType<typeof admitFlatGenerativeOperation>
+      >;
+      try {
+        attemptAdmission = await admitFlatGenerativeOperation({
+          c,
+          context: candidate.billingContext,
+          apiKeyId,
+          cost: candidate.cost,
+          idempotencyKey: candidate.billingContext.requestId ?? undefined,
+          admissionSnapshot,
+          // Pending video reconciliation is keyed by the reservation
+          // transaction. Keeping every provider attempt on that one durable
+          // ledger avoids a non-atomic DO-lease → DB-reservation handoff.
+          settlementMode: "synchronous_reservation",
+        });
+      } catch (error) {
+        // error-policy:J1 the HTTP boundary translates insufficient-credit
+        // admission into the stable route response and rethrows other failures.
+        if (error instanceof InsufficientCreditsError) {
+          return c.json(
+            {
+              success: false,
+              error: "Insufficient credits",
+              required: error.required,
+            },
+            402,
+          );
+        }
+        throw error;
+      }
+      admission = attemptAdmission;
+      activeBillingRequestId = candidate.billingContext.requestId ?? null;
+      pendingContext = {
+        organizationId: user.organization_id,
+        userId: user.id,
+        model: candidate.definition.modelId,
+        prompt: request.prompt,
+        provider: candidate.definition.provider,
+        billingSource: candidate.definition.billingSource,
+        totalCost: candidate.cost.totalCost,
+        durationSeconds: candidate.durationSeconds,
+        parameters: {
+          referenceUrl: request.referenceUrl,
+          durationSeconds: candidate.durationSeconds,
+          resolution: candidate.resolution,
+          audio: candidate.audio,
+          voiceControl: candidate.voiceControl,
+        },
+      };
+      await attemptAdmission.markProviderDispatched?.();
+      try {
+        generated = await candidate.provider.generate({
+          model: candidate.definition.modelId,
+          prompt: request.prompt,
+          referenceUrl: request.referenceUrl,
+          durationSeconds: candidate.durationSeconds,
+          resolution: candidate.resolution,
+          audio: candidate.audio,
+          voiceControl: candidate.voiceControl,
+          apiKeys,
+        });
+        selectedCandidate = candidate;
+        break;
+      } catch (error) {
+        // error-policy:J1 only a typed, verified terminal result authorizes
+        // releasing this provider-specific reservation and trying another
+        // paid provider. Unknown submission state and known pending work retain
+        // their hold and stop the chain.
+        if (
+          error instanceof VideoGenerationPendingError ||
+          error instanceof VideoGenerationSubmissionUnknownError
+        ) {
+          throw error;
+        }
+        if (!(error instanceof VideoGenerationTerminalError)) {
+          throw new VideoGenerationSubmissionUnknownError(
+            error instanceof Error ? error.message : String(error),
+            error,
+          );
+        }
+        lastFailure = { candidate, error: error.providerCause ?? error };
+        await attemptAdmission.settle(0);
+        admission = undefined;
+        activeBillingRequestId = null;
+        pendingContext = null;
+        if (index < providerCandidates.length - 1) {
+          logger.warn("[GenerateVideo] Provider failed; trying fallback", {
+            provider: candidate.definition.provider,
+            model: candidate.definition.modelId,
+            error: redactProviderErrorMessage(
+              error instanceof Error ? error.message : String(error),
+            ),
+          });
+        }
+      }
+    }
+    if (!generated || !selectedCandidate) {
+      if (!lastFailure) {
+        throw new Error(
+          "Video provider candidate loop completed without a result",
         );
       }
-      throw error;
-    }
-
-    pendingContext = {
-      organizationId: user.organization_id,
-      userId: user.id,
-      model: request.model,
-      prompt: request.prompt,
-      provider: definition.provider,
-      billingSource: definition.billingSource,
-      totalCost: cost.totalCost,
-      durationSeconds,
-      parameters: {
-        referenceUrl: request.referenceUrl,
-        durationSeconds,
-        resolution: request.resolution,
-        audio: request.audio,
-        voiceControl: request.voiceControl,
-      },
-    };
-
-    let generated: Awaited<ReturnType<typeof provider.generate>>;
-    try {
-      await admission.markProviderDispatched?.();
-      generated = await provider.generate({
-        ...request,
-        // Bill-what-you-deliver: the org is charged for the RESOLVED duration
-        // (request.durationSeconds ?? the catalog default), but the raw request
-        // spread would forward an undefined durationSeconds when the client omits
-        // it — the provider then renders its OWN default (potentially longer),
-        // so the platform pays for a longer clip than it billed. Forward the
-        // resolved value so the generated duration matches the charge.
-        durationSeconds,
-        apiKeys,
-      });
-    } catch (error) {
-      if (error instanceof VideoGenerationPendingError) throw error;
       throw new ApiError(
         503,
         "internal_error",
         "Video provider request failed",
         providerFailureDetails({
-          provider: definition.provider,
-          model: request.model,
-          billingSource: definition.billingSource,
-          error,
+          provider: lastFailure.candidate.definition.provider,
+          model: lastFailure.candidate.definition.modelId,
+          billingSource: lastFailure.candidate.definition.billingSource,
+          error: lastFailure.error,
         }),
       );
+    }
+    const { definition, billingContext, cost, durationSeconds } =
+      selectedCandidate;
+    const successfulAdmission = admission;
+    if (!successfulAdmission) {
+      throw new Error("Successful video generation has no billing admission");
     }
     if (generated.hasNsfwConcepts?.some(Boolean)) {
       throw new ApiError(
@@ -275,7 +396,7 @@ app.post("/", async (c) => {
         {
           surface: "media_generation_output",
           provider: definition.provider,
-          model: request.model,
+          model: definition.modelId,
           issues: ["provider_nsfw_signal"],
         },
       );
@@ -284,7 +405,11 @@ app.post("/", async (c) => {
     const generationId = crypto.randomUUID();
     let billingApplied = false;
     const persistenceTask = (async () => {
-      await billFlatUsage(billingContext, cost, admission?.reservation);
+      await billFlatUsage(
+        billingContext,
+        cost,
+        successfulAdmission.reservation,
+      );
       billingApplied = true;
       chargeSettled = true;
       await generationsService.create({
@@ -292,7 +417,7 @@ app.post("/", async (c) => {
         organization_id: user.organization_id,
         user_id: user.id,
         type: "video",
-        model: request.model,
+        model: definition.modelId,
         provider: definition.provider,
         prompt: request.prompt,
         result: {
@@ -311,9 +436,9 @@ app.post("/", async (c) => {
         parameters: {
           referenceUrl: request.referenceUrl,
           durationSeconds,
-          resolution: request.resolution,
-          audio: request.audio,
-          voiceControl: request.voiceControl,
+          resolution: selectedCandidate.resolution,
+          audio: selectedCandidate.audio,
+          voiceControl: selectedCandidate.voiceControl,
         },
         dimensions: {
           width: generated.video.width,
@@ -326,9 +451,9 @@ app.post("/", async (c) => {
         completed_at: new Date(),
       });
     })().catch(async (error) => {
-      if (!billingApplied) await admission?.settleUnknown();
       // error-policy:J7 successful video billing/history persistence runs
       // outside the response; conservative settlement remains observable.
+      if (!billingApplied) await successfulAdmission.settleUnknown();
       logger.error("[GenerateVideo] Background persistence failed", {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -348,6 +473,8 @@ app.post("/", async (c) => {
       cost,
     });
   } catch (error) {
+    // error-policy:J1 this route boundary preserves pending work, releases
+    // terminal failures, and translates the final error into an HTTP response.
     // Poll timeout with the upstream job still live (#11862): the render may
     // still complete and bill the platform, so the hold must NOT be refunded.
     // Persist the job for the reconcile sweep, which verifies the upstream
@@ -412,10 +539,48 @@ app.post("/", async (c) => {
         202,
       );
     }
+    if (
+      error instanceof VideoGenerationSubmissionUnknownError &&
+      admission &&
+      !chargeSettled
+    ) {
+      const unknownAdmission = admission;
+      chargeSettled = true;
+      const conservativeSettlement = unknownAdmission
+        .settleUnknown()
+        .catch((settleError) => {
+          // error-policy:J7 the reservation sweep retains the same pinned
+          // provider/model identity if immediate conservative settlement fails.
+          logger.error(
+            "[GenerateVideo] Failed to settle an ambiguous provider submission",
+            {
+              error:
+                settleError instanceof Error
+                  ? settleError.message
+                  : String(settleError),
+            },
+          );
+        });
+      const executionCtx = getGenerativeExecutionContext(c);
+      if (executionCtx) executionCtx.waitUntil(conservativeSettlement);
+      else await conservativeSettlement;
+      return c.json(
+        {
+          success: false,
+          status: "submission_unknown",
+          requestId: activeBillingRequestId,
+          error:
+            "The provider may have accepted this video request, so no fallback was dispatched and the provider-specific reservation settles conservatively. This request is not safe to retry automatically.",
+        },
+        202,
+      );
+    }
     if (admission && !chargeSettled) {
       const release = admission.settle(0);
       const executionCtx = getGenerativeExecutionContext(c);
       const observed = release.catch((reconcileError) => {
+        // error-policy:J7 settlement diagnostics must not hide the original
+        // route failure; the reservation sweep remains the durable backstop.
         logger.error("[GenerateVideo] Failed to release admission", {
           error:
             reconcileError instanceof Error

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -342,7 +342,7 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 #   CEREBRAS_API_KEY                   Cerebras — ultra-fast inference for provisioning chat agent
 #   FAL_KEY                            Fal.ai video gen
 #   FAL_API_KEY                        Alias for FAL_KEY used by image/video/music generation
-#   ATLASCLOUD_API_KEY                 AtlasCloud image generation billing key
+#   ATLASCLOUD_API_KEY                 AtlasCloud image and fallback video generation billing key
 #   ATLASCLOUD_BASE_URL                Optional AtlasCloud API base URL override
 #   BIRDEYE_API_KEY                    Birdeye defi/price proxy key
 #   ELEVENLABS_API_KEY                 ElevenLabs TTS

--- a/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.test.ts
@@ -1,5 +1,9 @@
-// Exercises atlascloud video generation behavior with deterministic cloud-shared lib fixtures.
-import { afterEach, describe, expect, test } from "bun:test";
+/**
+ * Exercises Atlas Cloud video submission and reconciliation with deterministic
+ * fetch fixtures, plus real loopback HTTP servers for the redirect-containment
+ * tests so the true fetch redirect behavior is under test rather than a mock.
+ */
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import {
   atlasCloudVideoProvider,
   buildAtlasVideoInput,
@@ -7,6 +11,11 @@ import {
   generateAtlasCloudVideo,
   getAtlasCloudVideoJobStatus,
 } from "./atlascloud-video-generation";
+import {
+  VideoGenerationPendingError,
+  VideoGenerationSubmissionUnknownError,
+  VideoGenerationTerminalError,
+} from "./types";
 
 const originalFetch = globalThis.fetch;
 
@@ -129,6 +138,332 @@ describe("Atlas Cloud video provider", () => {
     ).rejects.toThrow("AI services are not configured on this deployment");
     expect(atlasCloudVideoProvider.isConfigured?.({})).toBe(false);
     expect(called).toBe(false);
+  });
+
+  test("classifies a definitive submit rejection as terminal", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ message: "invalid input" }), {
+        status: 422,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch;
+
+    await expect(
+      generateAtlasCloudVideo({
+        model: "vidu/q3-turbo/text-to-video",
+        prompt: "a lighthouse",
+        apiKeys: { ATLASCLOUD_API_KEY: "atlas-key" },
+      }),
+    ).rejects.toBeInstanceOf(VideoGenerationTerminalError);
+  });
+
+  test("classifies submit transport failure as unknown, not terminal", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("connection reset after upload");
+    }) as typeof fetch;
+
+    await expect(
+      generateAtlasCloudVideo({
+        model: "vidu/q3-turbo/text-to-video",
+        prompt: "a lighthouse",
+        apiKeys: { ATLASCLOUD_API_KEY: "atlas-key" },
+      }),
+    ).rejects.toBeInstanceOf(VideoGenerationSubmissionUnknownError);
+  });
+
+  test("classifies an invalid successful submit response as unknown", async () => {
+    globalThis.fetch = (async () =>
+      new Response("not-json", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch;
+
+    await expect(
+      generateAtlasCloudVideo({
+        model: "vidu/q3-turbo/text-to-video",
+        prompt: "a lighthouse",
+        apiKeys: { ATLASCLOUD_API_KEY: "atlas-key" },
+      }),
+    ).rejects.toBeInstanceOf(VideoGenerationSubmissionUnknownError);
+  });
+
+  test("classifies a submit server error as unknown", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ message: "gateway timeout" }), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch;
+
+    await expect(
+      generateAtlasCloudVideo({
+        model: "vidu/q3-turbo/text-to-video",
+        prompt: "a lighthouse",
+        apiKeys: { ATLASCLOUD_API_KEY: "atlas-key" },
+      }),
+    ).rejects.toBeInstanceOf(VideoGenerationSubmissionUnknownError);
+  });
+
+  test("retains the Atlas prediction id when polling is unreachable", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      if (fetchCalls === 1) {
+        return new Response(
+          JSON.stringify({
+            data: { id: "atlas-prediction", status: "starting" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error("prediction status unavailable");
+    }) as typeof fetch;
+    const timer = spyOn(globalThis, "setTimeout").mockImplementation((handler: TimerHandler) => {
+      if (typeof handler === "function") handler();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+
+    try {
+      const error = await generateAtlasCloudVideo({
+        model: "vidu/q3-turbo/text-to-video",
+        prompt: "a lighthouse",
+        apiKeys: { ATLASCLOUD_API_KEY: "atlas-key" },
+      }).catch((caught) => caught);
+      expect(error).toBeInstanceOf(VideoGenerationPendingError);
+      expect((error as InstanceType<typeof VideoGenerationPendingError>).requestId).toBe(
+        "atlas-prediction",
+      );
+    } finally {
+      timer.mockRestore();
+    }
+  });
+
+  test("never sends the Atlas bearer credential to an off-origin poll URL", async () => {
+    const calls: Array<{ url: string; authorization?: string }> = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      calls.push({
+        url: String(url),
+        authorization: headers.get("authorization") ?? undefined,
+      });
+      if (calls.length === 1) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: "atlas-prediction",
+              status: "starting",
+              urls: { get: "https://attacker.invalid/collect" },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          data: {
+            id: "atlas-prediction",
+            status: "completed",
+            outputs: ["https://cdn.atlas/video.mp4"],
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+    const timer = spyOn(globalThis, "setTimeout").mockImplementation((handler: TimerHandler) => {
+      if (typeof handler === "function") handler();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+
+    try {
+      await expect(
+        generateAtlasCloudVideo({
+          model: "vidu/q3-turbo/text-to-video",
+          prompt: "a lighthouse",
+          apiKeys: {
+            ATLASCLOUD_API_KEY: "atlas-key",
+            ATLASCLOUD_BASE_URL: "https://atlas.test",
+          },
+        }),
+      ).resolves.toMatchObject({ requestId: "atlas-prediction" });
+      expect(calls.map((call) => call.url)).toEqual([
+        "https://atlas.test/api/v1/model/generateVideo",
+        "https://atlas.test/api/v1/model/prediction/atlas-prediction",
+      ]);
+      expect(calls.every((call) => call.authorization === "Bearer atlas-key")).toBe(true);
+      expect(calls.some((call) => call.url.includes("attacker.invalid"))).toBe(false);
+    } finally {
+      timer.mockRestore();
+    }
+  });
+
+  test("refuses to follow a poll redirect that would re-send the bearer credential", async () => {
+    const attackerRequests: Array<{ url: string; authorization: string | null }> = [];
+    const attacker = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        attackerRequests.push({
+          url: request.url,
+          authorization: request.headers.get("authorization"),
+        });
+        return Response.json({
+          data: {
+            id: "atlas-prediction",
+            status: "completed",
+            outputs: ["https://cdn.atlas/video.mp4"],
+          },
+        });
+      },
+    });
+    let pollRequests = 0;
+    const origin = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/api/v1/model/generateVideo") {
+          return Response.json({ data: { id: "atlas-prediction", status: "starting" } });
+        }
+        pollRequests++;
+        return new Response(null, {
+          status: 302,
+          headers: { location: `http://127.0.0.1:${attacker.port}${url.pathname}` },
+        });
+      },
+    });
+    const timer = spyOn(globalThis, "setTimeout").mockImplementation((handler: TimerHandler) => {
+      if (typeof handler === "function") handler();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+
+    try {
+      const error = await generateAtlasCloudVideo({
+        model: "vidu/q3-turbo/text-to-video",
+        prompt: "a lighthouse",
+        apiKeys: {
+          ATLASCLOUD_API_KEY: "atlas-key",
+          ATLASCLOUD_BASE_URL: `http://127.0.0.1:${origin.port}`,
+        },
+      }).catch((caught) => caught);
+      expect(error).toBeInstanceOf(VideoGenerationPendingError);
+      expect((error as InstanceType<typeof VideoGenerationPendingError>).requestId).toBe(
+        "atlas-prediction",
+      );
+      expect(pollRequests).toBe(1);
+      expect(attackerRequests).toEqual([]);
+    } finally {
+      timer.mockRestore();
+      origin.stop(true);
+      attacker.stop(true);
+    }
+  });
+
+  test("keeps the status-probe credential on the configured origin when redirected", async () => {
+    const attackerRequests: Array<{ url: string; authorization: string | null }> = [];
+    const attacker = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        attackerRequests.push({
+          url: request.url,
+          authorization: request.headers.get("authorization"),
+        });
+        return Response.json({
+          data: {
+            id: "atlas-prediction",
+            status: "succeeded",
+            outputs: ["https://cdn.atlas/video.mp4"],
+          },
+        });
+      },
+    });
+    const origin = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        return new Response(null, {
+          status: 302,
+          headers: { location: `http://127.0.0.1:${attacker.port}${url.pathname}` },
+        });
+      },
+    });
+
+    try {
+      await expect(
+        getAtlasCloudVideoJobStatus({
+          model: "vidu/q3-turbo/text-to-video",
+          requestId: "atlas-prediction",
+          apiKeys: {
+            ATLASCLOUD_API_KEY: "atlas-key",
+            ATLASCLOUD_BASE_URL: `http://127.0.0.1:${origin.port}`,
+          },
+        }),
+      ).rejects.toThrow("Atlas prediction status failed: 302");
+      expect(attackerRequests).toEqual([]);
+    } finally {
+      origin.stop(true);
+      attacker.stop(true);
+    }
+  });
+
+  test("returns a pending error with the prediction id on poll timeout", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          data: { id: "atlas-prediction", status: "starting" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as typeof fetch;
+    const clock = spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValue(180_001);
+
+    try {
+      const error = await generateAtlasCloudVideo({
+        model: "vidu/q3-turbo/text-to-video",
+        prompt: "a lighthouse",
+        apiKeys: { ATLASCLOUD_API_KEY: "atlas-key" },
+      }).catch((caught) => caught);
+      expect(error).toBeInstanceOf(VideoGenerationPendingError);
+      expect((error as InstanceType<typeof VideoGenerationPendingError>).requestId).toBe(
+        "atlas-prediction",
+      );
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  test("keeps a known prediction pending when its poll payload is invalid", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      return fetchCalls === 1
+        ? new Response(
+            JSON.stringify({
+              data: { id: "atlas-prediction", status: "starting" },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        : new Response("not-json", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+    }) as typeof fetch;
+    const timer = spyOn(globalThis, "setTimeout").mockImplementation((handler: TimerHandler) => {
+      if (typeof handler === "function") handler();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+
+    try {
+      const error = await generateAtlasCloudVideo({
+        model: "vidu/q3-turbo/text-to-video",
+        prompt: "a lighthouse",
+        apiKeys: { ATLASCLOUD_API_KEY: "atlas-key" },
+      }).catch((caught) => caught);
+      expect(error).toBeInstanceOf(VideoGenerationPendingError);
+      expect((error as InstanceType<typeof VideoGenerationPendingError>).requestId).toBe(
+        "atlas-prediction",
+      );
+    } finally {
+      timer.mockRestore();
+    }
   });
 
   test("reports Atlas job status success with normalized output", async () => {

--- a/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.ts
@@ -1,4 +1,4 @@
-// Defines cloud shared atlascloud video generation behavior for backend service consumers.
+/** Implements Atlas Cloud video submission, polling, and status reconciliation. */
 import { getAiProviderConfigurationError } from "../language-model";
 import type {
   GeneratedVideo,
@@ -8,12 +8,33 @@ import type {
   VideoJobStatusRequest,
   VideoProvider,
 } from "./types";
+import {
+  VideoGenerationPendingError,
+  VideoGenerationSubmissionUnknownError,
+  VideoGenerationTerminalError,
+} from "./types";
 
 const ATLAS_POLL_INTERVAL_MS = 2_000;
 const ATLAS_POLL_TIMEOUT_MS = 180_000;
 
 function atlasBaseUrl(request: VideoGenerationRequest): string {
   return (request.apiKeys.ATLASCLOUD_BASE_URL || "https://api.atlascloud.ai").replace(/\/+$/, "");
+}
+
+function atlasPollUrl(baseUrl: string, predictionId: string, candidate?: string): string {
+  const canonical = `${baseUrl}/api/v1/model/prediction/${predictionId}`;
+  if (!candidate) return canonical;
+  try {
+    const base = new URL(baseUrl);
+    const resolved = new URL(candidate, `${baseUrl}/`);
+    return resolved.protocol === "https:" && resolved.origin === base.origin
+      ? resolved.toString()
+      : canonical;
+  } catch {
+    // error-policy:J3 Provider response URLs are untrusted; an invalid value
+    // falls back to the canonical same-provider prediction endpoint.
+    return canonical;
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -26,6 +47,26 @@ function stringValue(value: unknown): string | undefined {
 
 function numberValue(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+type AtlasJsonResult =
+  | { kind: "parsed"; payload: Record<string, unknown> }
+  | { kind: "invalid"; error: unknown };
+
+async function parseAtlasJson(response: Response): Promise<AtlasJsonResult> {
+  try {
+    const payload: unknown = await response.json();
+    return isRecord(payload)
+      ? { kind: "parsed", payload }
+      : {
+          kind: "invalid",
+          error: new Error("Atlas Cloud returned a non-object JSON payload"),
+        };
+  } catch (error) {
+    // error-policy:J3 provider JSON is untrusted input; callers receive an
+    // explicit invalid result and decide using the known HTTP/job state.
+    return { kind: "invalid", error };
+  }
 }
 
 interface AtlasPrediction {
@@ -107,22 +148,50 @@ export async function generateAtlasCloudVideo(
 
   const baseUrl = atlasBaseUrl(request);
   const authHeader = { authorization: `Bearer ${apiKey}` };
-  const submitResponse = await fetch(`${baseUrl}/api/v1/model/generateVideo`, {
-    method: "POST",
-    headers: { ...authHeader, "content-type": "application/json" },
-    body: JSON.stringify(buildAtlasVideoInput(request)),
-  });
-
-  const submitPayload = (await submitResponse.json().catch(() => ({}))) as Record<string, unknown>;
-  if (!submitResponse.ok) {
-    const message =
-      stringValue(submitPayload.msg) ??
-      stringValue(submitPayload.message) ??
-      `Atlas video generation failed: ${submitResponse.status}`;
-    throw new Error(message);
+  let submitResponse: Response;
+  try {
+    submitResponse = await fetch(`${baseUrl}/api/v1/model/generateVideo`, {
+      method: "POST",
+      headers: { ...authHeader, "content-type": "application/json" },
+      body: JSON.stringify(buildAtlasVideoInput(request)),
+    });
+  } catch (error) {
+    // error-policy:J1 submission transport is the provider boundary; without
+    // a response or job id the paid-work state is explicitly unknown.
+    throw new VideoGenerationSubmissionUnknownError(
+      error instanceof Error ? error.message : String(error),
+      error,
+    );
   }
 
-  const submitted = parsePrediction(submitPayload);
+  const submitJson = await parseAtlasJson(submitResponse);
+  const submitPayload = submitJson.kind === "parsed" ? submitJson.payload : undefined;
+  if (!submitResponse.ok) {
+    const message =
+      stringValue(submitPayload?.msg) ??
+      stringValue(submitPayload?.message) ??
+      `Atlas video generation failed: ${submitResponse.status}`;
+    const providerCause = Object.assign(new Error(message), {
+      status: submitResponse.status,
+      ...(submitJson.kind === "invalid" ? { cause: submitJson.error } : {}),
+    });
+    if (
+      submitResponse.status >= 400 &&
+      submitResponse.status < 500 &&
+      ![408, 409, 425, 429].includes(submitResponse.status)
+    ) {
+      throw new VideoGenerationTerminalError(message, providerCause);
+    }
+    throw new VideoGenerationSubmissionUnknownError(message, providerCause);
+  }
+  if (submitJson.kind === "invalid") {
+    throw new VideoGenerationSubmissionUnknownError(
+      "Atlas video provider returned an invalid submission response",
+      submitJson.error,
+    );
+  }
+
+  const submitted = parsePrediction(submitJson.payload);
   const inlineVideo = firstAtlasVideoOutput(submitted.outputs);
   if (inlineVideo) {
     return { requestId: submitted.id, video: inlineVideo, timings: null };
@@ -130,37 +199,63 @@ export async function generateAtlasCloudVideo(
 
   const predictionId = submitted.id;
   if (!predictionId) {
-    throw new Error("Atlas video provider returned no prediction id");
+    throw new VideoGenerationSubmissionUnknownError(
+      "Atlas video provider returned no prediction id",
+    );
   }
-  const pollUrl = submitted.urls?.get ?? `${baseUrl}/api/v1/model/prediction/${predictionId}`;
+  const pollUrl = atlasPollUrl(baseUrl, predictionId, submitted.urls?.get);
   const deadline = Date.now() + ATLAS_POLL_TIMEOUT_MS;
 
   while (Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, ATLAS_POLL_INTERVAL_MS));
 
-    const pollResponse = await fetch(pollUrl, { headers: authHeader });
-    const pollPayload = (await pollResponse.json().catch(() => ({}))) as Record<string, unknown>;
+    let pollResponse: Response;
+    try {
+      // Following a redirect would re-send the bearer credential wherever the
+      // provider response points, so a 3xx is returned as-is and settles as a
+      // pending provider state through the non-ok branch below.
+      pollResponse = await fetch(pollUrl, { headers: authHeader, redirect: "manual" });
+    } catch (error) {
+      // error-policy:J1 a known prediction id makes poll transport failure a
+      // pending provider state that the durable reconciliation path can query.
+      throw new VideoGenerationPendingError(
+        predictionId,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
     if (!pollResponse.ok) {
-      throw new Error(`Atlas prediction poll failed: ${pollResponse.status}`);
+      throw new VideoGenerationPendingError(
+        predictionId,
+        `Atlas prediction poll failed: ${pollResponse.status}`,
+      );
+    }
+    const pollJson = await parseAtlasJson(pollResponse);
+    if (pollJson.kind === "invalid") {
+      throw new VideoGenerationPendingError(
+        predictionId,
+        "Atlas prediction poll returned an invalid response",
+      );
     }
 
-    const prediction = parsePrediction(pollPayload);
+    const prediction = parsePrediction(pollJson.payload);
     const status = (prediction.status ?? "").toLowerCase();
     if (TERMINAL_FAIL.has(status)) {
-      throw new Error(
+      throw new VideoGenerationTerminalError(
         `Atlas video generation failed${prediction.error ? `: ${prediction.error}` : ""}`,
       );
     }
     if (TERMINAL_OK.has(status)) {
       const video = firstAtlasVideoOutput(prediction.outputs);
       if (!video) {
-        throw new Error("Atlas video provider completed without an output video");
+        throw new VideoGenerationTerminalError(
+          "Atlas video provider completed without an output video",
+        );
       }
       return { requestId: prediction.id ?? predictionId, video, timings: null };
     }
   }
 
-  throw new Error("Atlas video generation timed out");
+  throw new VideoGenerationPendingError(predictionId, "Atlas video generation timed out");
 }
 
 export async function getAtlasCloudVideoJobStatus(
@@ -175,11 +270,13 @@ export async function getAtlasCloudVideoJobStatus(
     /\/+$/,
     "",
   );
+  // Same credential-containment rule as the generation poll: never follow a
+  // redirect with the bearer header; a 3xx throws below and the reconcile
+  // boundary retries the probe on its next tick.
   const response = await fetch(`${baseUrl}/api/v1/model/prediction/${req.requestId}`, {
     headers: { authorization: `Bearer ${apiKey}` },
+    redirect: "manual",
   });
-  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
-
   if (response.status === 404) {
     return {
       state: "failed",
@@ -190,7 +287,14 @@ export async function getAtlasCloudVideoJobStatus(
     throw new Error(`Atlas prediction status failed: ${response.status}`);
   }
 
-  const prediction = parsePrediction(payload);
+  const responseJson = await parseAtlasJson(response);
+  if (responseJson.kind === "invalid") {
+    throw new Error("Atlas prediction status returned an invalid response", {
+      cause: responseJson.error,
+    });
+  }
+
+  const prediction = parsePrediction(responseJson.payload);
   const status = (prediction.status ?? "").toLowerCase();
   if (TERMINAL_FAIL.has(status)) {
     return {

--- a/packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts
@@ -1,4 +1,4 @@
-// Exercises fal video generation behavior with deterministic cloud-shared lib fixtures.
+/** Exercises fal video submission and reconciliation with deterministic provider fixtures. */
 import { describe, expect, mock, test } from "bun:test";
 
 const falActual = require("@fal-ai/client") as typeof import("@fal-ai/client");
@@ -24,7 +24,11 @@ const {
   getFalVideoJobStatus,
   normalizeFalVideoResult,
 } = await import("./fal-video-generation");
-const { VideoGenerationPendingError } = await import("./types");
+const {
+  VideoGenerationPendingError,
+  VideoGenerationSubmissionUnknownError,
+  VideoGenerationTerminalError,
+} = await import("./types");
 
 describe("FAL video provider", () => {
   test("maps Cloud video request fields to FAL input aliases", () => {
@@ -224,6 +228,19 @@ describe("getFalVideoJobStatus — upstream terminal-state verification (#11862)
     expect(status).toEqual({ state: "failed", error: "render failed" });
   });
 
+  test("COMPLETED job whose result endpoint is rate limited stays inconclusive", async () => {
+    resetFalMocks();
+    queueStatus.mockResolvedValue({ status: "COMPLETED" });
+    queueResult.mockRejectedValue(
+      new ApiError({ message: "rate limited", status: 429, body: undefined }),
+    );
+
+    await expect(getFalVideoJobStatus(REQ)).rejects.toMatchObject({
+      message: "rate limited",
+      status: 429,
+    });
+  });
+
   test("transport failure on the status probe propagates (never a failed verdict)", async () => {
     resetFalMocks();
     queueStatus.mockRejectedValue(new Error("network unreachable"));
@@ -273,14 +290,18 @@ describe("generateFalVideo — post-enqueue failures never present as refundable
     expect(result.video.url).toBe("https://fal.media/recovered.mp4");
   });
 
-  test("poll failure with a verified terminal failure → original error (refund is safe)", async () => {
+  test("poll failure with a verified terminal failure → typed terminal error", async () => {
     resetFalMocks();
     subscribeFailsAfterEnqueue();
     queueStatus.mockRejectedValue(
       new ApiError({ message: "Not found", status: 404, body: undefined }),
     );
 
-    await expect(generateFalVideo(request)).rejects.toThrow("poll timed out");
+    const error = await generateFalVideo(request).catch((caught) => caught);
+    expect(error).toBeInstanceOf(VideoGenerationTerminalError);
+    expect(
+      (error as InstanceType<typeof VideoGenerationTerminalError>).providerCause,
+    ).toBeInstanceOf(Error);
   });
 
   test("poll failure with an unreachable status probe → VideoGenerationPendingError", async () => {
@@ -291,11 +312,42 @@ describe("generateFalVideo — post-enqueue failures never present as refundable
     await expect(generateFalVideo(request)).rejects.toBeInstanceOf(VideoGenerationPendingError);
   });
 
-  test("pre-enqueue failure keeps the original error (no upstream job exists)", async () => {
+  test("poll failure with a rate-limited completed-result probe stays pending", async () => {
     resetFalMocks();
-    subscribe.mockRejectedValue(new Error("invalid input"));
+    subscribeFailsAfterEnqueue();
+    queueStatus.mockResolvedValue({ status: "COMPLETED" });
+    queueResult.mockRejectedValue(
+      new ApiError({ message: "rate limited", status: 429, body: undefined }),
+    );
 
-    await expect(generateFalVideo(request)).rejects.toThrow("invalid input");
+    const error = await generateFalVideo(request).catch((caught) => caught);
+    expect(error).toBeInstanceOf(VideoGenerationPendingError);
+    expect((error as InstanceType<typeof VideoGenerationPendingError>).requestId).toBe("req-42");
+  });
+
+  test("definitive pre-enqueue rejection is safe for provider fallback", async () => {
+    resetFalMocks();
+    subscribe.mockRejectedValue(
+      new ApiError({
+        message: "invalid input",
+        status: 422,
+        body: undefined,
+      }),
+    );
+
+    await expect(generateFalVideo(request)).rejects.toBeInstanceOf(VideoGenerationTerminalError);
+    expect(queueStatus).not.toHaveBeenCalled();
+  });
+
+  test("pre-enqueue transport ambiguity cannot dispatch a paid fallback", async () => {
+    resetFalMocks();
+    subscribe.mockRejectedValue(new Error("connection reset after upload"));
+
+    const error = await generateFalVideo(request).catch((caught) => caught);
+    expect(error).toBeInstanceOf(VideoGenerationSubmissionUnknownError);
+    expect(
+      (error as InstanceType<typeof VideoGenerationSubmissionUnknownError>).providerCause,
+    ).toBeInstanceOf(Error);
     expect(queueStatus).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts
@@ -1,4 +1,4 @@
-// Defines cloud shared fal video generation behavior for backend service consumers.
+/** Implements fal.ai video submission, queue polling, and status reconciliation. */
 import { ApiError, createFalClient } from "@fal-ai/client";
 import { getAiProviderConfigurationError } from "../language-model";
 import {
@@ -6,10 +6,17 @@ import {
   type GeneratedVideoObject,
   VideoGenerationPendingError,
   type VideoGenerationRequest,
+  VideoGenerationSubmissionUnknownError,
+  VideoGenerationTerminalError,
   type VideoJobStatus,
   type VideoJobStatusRequest,
   type VideoProvider,
 } from "./types";
+
+function isDefinitiveFalRejection(error: unknown): error is InstanceType<typeof ApiError> {
+  if (!(error instanceof ApiError)) return false;
+  return error.status >= 400 && error.status < 500 && ![408, 409, 425, 429].includes(error.status);
+}
 
 function falKey(apiKeys: Record<string, string | undefined>): string | null {
   const key = apiKeys.FAL_KEY ?? apiKeys.FAL_API_KEY;
@@ -137,6 +144,8 @@ export async function getFalVideoJobStatus(req: VideoJobStatusRequest): Promise<
   try {
     status = await fal.queue.status(req.model, { requestId: req.requestId });
   } catch (error) {
+    // error-policy:J1 the provider status boundary only translates a verified
+    // unknown job; transport failures propagate so callers retain the hold.
     if (error instanceof ApiError && error.status === 404) {
       return {
         state: "failed",
@@ -154,10 +163,12 @@ export async function getFalVideoJobStatus(req: VideoJobStatusRequest): Promise<
   try {
     result = await fal.queue.result(req.model, { requestId: req.requestId });
   } catch (error) {
+    // error-policy:J1 the completed-result boundary distinguishes a terminal
+    // provider rejection from an inconclusive transport failure.
     // A COMPLETED job whose result endpoint answers with a definitive client
     // error is a terminally failed render (fal serves render errors through
     // the result endpoint). Anything else is a transport fault — propagate.
-    if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
+    if (isDefinitiveFalRejection(error)) {
       return { state: "failed", error: error.message };
     }
     throw error;
@@ -178,8 +189,16 @@ export async function generateFalVideo(request: VideoGenerationRequest): Promise
     });
     return normalizeFalVideoResult(result, requestId);
   } catch (error) {
+    // error-policy:J1 the provider adapter translates submission/poll outcomes
+    // into the typed states required by route billing and reconciliation.
     if (!requestId) {
-      throw error;
+      if (isDefinitiveFalRejection(error)) {
+        throw new VideoGenerationTerminalError(error.message, error);
+      }
+      throw new VideoGenerationSubmissionUnknownError(
+        error instanceof Error ? error.message : String(error),
+        error,
+      );
     }
     // The job is already enqueued upstream; a poll/transport failure here does
     // NOT mean the render died — fal may still complete it and bill the
@@ -193,6 +212,8 @@ export async function generateFalVideo(request: VideoGenerationRequest): Promise
         apiKeys: request.apiKeys,
       });
     } catch {
+      // error-policy:J1 a failed status probe cannot prove terminal failure;
+      // retain the known job id so reconciliation keeps the charge hold open.
       throw new VideoGenerationPendingError(
         requestId,
         error instanceof Error ? error.message : String(error),
@@ -202,8 +223,7 @@ export async function generateFalVideo(request: VideoGenerationRequest): Promise
       return probe.result;
     }
     if (probe.state === "failed") {
-      // Verified terminal failure — refunding is safe.
-      throw error;
+      throw new VideoGenerationTerminalError(probe.error, error);
     }
     throw new VideoGenerationPendingError(
       requestId,

--- a/packages/cloud/shared/src/lib/providers/video/registry.ts
+++ b/packages/cloud/shared/src/lib/providers/video/registry.ts
@@ -1,5 +1,8 @@
-// Defines cloud shared registry behavior for backend service consumers.
-import type { PricingBillingSource } from "../../services/ai-pricing-definitions";
+/** Registers video providers and resolves configured candidates for Cloud routes. */
+import type {
+  PricingBillingSource,
+  SupportedVideoModelDefinition,
+} from "../../services/ai-pricing-definitions";
 import { atlasCloudVideoProvider } from "./atlascloud-video-generation";
 import { falVideoProvider } from "./fal-video-generation";
 import type { VideoProvider } from "./types";
@@ -25,6 +28,27 @@ export function getVideoProvider(billingSource: PricingBillingSource): VideoProv
  */
 export function findVideoProvider(billingSource: string): VideoProvider | undefined {
   return PROVIDERS.get(billingSource as PricingBillingSource);
+}
+
+export interface ConfiguredVideoProviderCandidate {
+  definition: SupportedVideoModelDefinition;
+  provider: VideoProvider;
+}
+
+/**
+ * Resolves an ordered model list to providers that have usable credentials.
+ * Callers retain model order so the first entry is primary and later entries
+ * are fallbacks.
+ */
+export function getConfiguredVideoProviderCandidates(
+  definitions: readonly SupportedVideoModelDefinition[],
+  apiKeys: Record<string, string | undefined>,
+): ConfiguredVideoProviderCandidate[] {
+  return definitions.flatMap((definition) => {
+    const provider = getVideoProvider(definition.billingSource);
+    if (provider.isConfigured && !provider.isConfigured(apiKeys)) return [];
+    return [{ definition, provider }];
+  });
 }
 
 /**

--- a/packages/cloud/shared/src/lib/providers/video/types.ts
+++ b/packages/cloud/shared/src/lib/providers/video/types.ts
@@ -1,4 +1,5 @@
-// Defines cloud shared types behavior for backend service consumers.
+/** Defines provider-neutral video generation and reconciliation contracts. */
+
 import type { PricingBillingSource } from "../../services/ai-pricing-definitions";
 
 export interface VideoGenerationRequest {
@@ -61,6 +62,36 @@ export class VideoGenerationPendingError extends Error {
     super(message);
     this.name = "VideoGenerationPendingError";
     this.requestId = requestId;
+  }
+}
+
+/**
+ * A provider has definitively rejected or terminally failed work and no paid
+ * job can still complete. Only this error authorizes a provider fallback or a
+ * zero-cost settlement.
+ */
+export class VideoGenerationTerminalError extends Error {
+  readonly providerCause: unknown;
+
+  constructor(message: string, providerCause?: unknown) {
+    super(message);
+    this.name = "VideoGenerationTerminalError";
+    this.providerCause = providerCause;
+  }
+}
+
+/**
+ * Submission may have reached a paid provider but yielded no durable job id.
+ * The route must not dispatch a fallback or refund; its reservation backstop
+ * settles conservatively because no provider status lookup is possible.
+ */
+export class VideoGenerationSubmissionUnknownError extends Error {
+  readonly providerCause: unknown;
+
+  constructor(message: string, providerCause?: unknown) {
+    super(message);
+    this.name = "VideoGenerationSubmissionUnknownError";
+    this.providerCause = providerCause;
   }
 }
 

--- a/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service ai pricing definitions behavior behind route handlers.
+/** Defines supported AI models and their authoritative Cloud billing sources. */
 export type PricingProductFamily =
   | "language"
   | "embedding"
@@ -314,6 +314,13 @@ export const SUPPORTED_IMAGE_MODELS: SupportedImageModelDefinition[] = [
  * confirmed `image:generation` catalog row (see ai-pricing/providers/atlascloud.ts).
  */
 export const DEFAULT_IMAGE_MODEL_ID = "google/nano-banana-2/text-to-image";
+
+/**
+ * Ordered models for an unspecified video request. The first configured model
+ * is primary and later entries are terminal-failure fallbacks; explicit model
+ * requests never use this chain.
+ */
+export const DEFAULT_VIDEO_MODEL_IDS = ["fal-ai/veo3", "vidu/q3-turbo/text-to-video"] as const;
 
 export const SUPPORTED_VIDEO_MODELS: SupportedVideoModelDefinition[] = [
   {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #18518

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop@7e04c64c73f007610e5da4654803589fdee7c96d` with zero conflicts.
- [x] `bun install` and the full `bun run verify` repository gate passed on the exact repaired head (356/356 Turbo tasks; anti-larp 8,375 files clean).
- [ ] A live deployed Fal-to-Atlas fallback log and playable MP4 are still required before merge.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [ ] Full repository verify is documented as a remaining gate below.

# Risks

Medium-high because this route can dispatch paid asynchronous jobs. Each provider attempt now has a provider-specific durable credit reservation. Only a typed, verified terminal provider verdict releases that reservation and permits fallback. Known pending jobs retain their job ID and reservation for reconciliation. A submission whose acceptance cannot be determined and has no recoverable job ID does not fall back or refund; it returns `202 submission_unknown` and settles conservatively. This is intentionally platform-safe but may charge a request whose provider-side outcome cannot be recovered.

Video attempts force the synchronous durable-reservation lane even in Workers. This adds an authoritative ledger call, but avoids a non-atomic Durable Object lease-to-database-reservation handoff for jobs that may outlive the request.

# Background

## What does this PR do?

Adds an ordered default video chain (`fal-ai/veo3`, then Atlas-hosted `vidu/q3-turbo/text-to-video`) for requests that omit `model`. Explicit model requests remain pinned to their provider.

The maintainer repair makes fallback and settlement attempt-scoped:

- Fal and Atlas distinguish terminal rejection, known pending work, and unknown submission state.
- A fallback gets a new reservation with the fallback provider/model/billing source; the prior reservation must settle to zero first.
- Atlas poll transport errors, non-2xx responses, invalid payloads, and timeout preserve the prediction ID for the existing reconciliation sweep.
- Fal pre-enqueue transport ambiguity and Atlas submit ambiguity never dispatch a second paid provider.
- Billing, affiliate/recovery identity, generation history, defaults, and pending metadata all use the provider/model that actually ran.

## What kind of change is this?

Bug fix and billing-safety hardening. The request remains backward compatible: omitting `model` previously selected Fal and now selects the first configured default candidate. A new `202 submission_unknown` error state is returned when upstream acceptance cannot be determined safely.

# Documentation changes needed?

The Worker environment reference now identifies `ATLASCLOUD_API_KEY` as the Atlas image and fallback-video credential. This route has no standalone public API reference in the repository; the new response state is covered by route contract tests and the response carries a stable billing request ID.

# Testing

## Where should a reviewer start?

Start with `packages/cloud/api/__tests__/generate-video-provider-fallback.test.ts`, then `packages/cloud/api/v1/generate-video/route.ts`, the Fal/Atlas provider adapters, and `packages/cloud/api/__tests__/generative-route-auth-video-settlement.test.ts`.

## Detailed testing steps

Executed in a sealed container with network disabled, pinned Bun 1.3.14, and Node 24.15.0:

```bash
node packages/cloud/api/test/run-unit-isolated.mjs generate-video-
node packages/cloud/api/test/run-unit-isolated.mjs generative-route-auth-video-settlement
bun test --coverage-reporter=lcov --coverage-dir=/tmp/video-provider-coverage \
  packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts \
  packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.test.ts
bun test --coverage-reporter=lcov --coverage-dir=/tmp/video-reconcile-coverage \
  packages/cloud/shared/src/lib/services/__tests__/video-generation-reconcile.test.ts
bun run --cwd packages/cloud/shared typecheck
bun run --cwd packages/cloud/api typecheck
bun x biome check <13 affected source/test files>
```

Results:

- 22/22 generate-video route tests passed.
- 1/1 Worker admission-path test passed.
- 36/36 Fal/Atlas provider tests passed.
- 3/3 route-shaped Atlas video pricing tests passed.
- 10/10 DB-backed pending-video reconciliation tests passed.
- Cloud shared typecheck passed.
- Cloud API typecheck and production Worker dry-run bundle passed.
- Biome passed on all 13 affected source/test files.

Full focused proof: https://github.com/elizaOS/eliza/pull/19302#issuecomment-5289012440

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:cf1c610c15d4e01bf30c7387fd31f6949ec1a450 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only routing and billing change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only routing and billing change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend flow or rendered UI changed.
<!-- evidence-row:backend-logs -->
- [ ] Missing - an authorized operator must deploy with both provider credentials and capture a real terminal Fal-to-Atlas fallback log; this remains a merge blocker.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser request state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic media-provider routing; no LLM prompt or reasoning path changed.
<!-- evidence-row:domain-artifacts -->
- [ ] Missing - the required playable fallback MP4 needs a deployed Worker and provisioned Fal/Atlas credentials; this remains a merge blocker.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM prompt, agent reasoning, or language-model call path changed.

## Backend + frontend logs

Deterministic network-disabled backend proof is linked above. A live provider log is still missing and remains a merge blocker. No frontend code changed.

## Screenshots (before / after) + video walkthrough

N/A - backend-only provider routing with no rendered UI.

### Before

N/A - no rendered UI.

### After

N/A - no rendered UI.

### Walkthrough video

N/A - no frontend flow changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changed.

## Known gaps / failures

- Independent approval is required because the maintainer repair is substantive; the repairing reviewer did not self-approve.
- Production acceptance still requires an authorized operator to provision both providers, deploy the exact head, force or observe a terminal Fal failure, and attach the Atlas fallback log plus playable MP4.
- Full `bun run verify` passed on the exact final head: 356/356 Turbo tasks plus all repository audit gates; anti-larp scanned 8,403 test files clean.
- Hosted checks triggered by the repaired head must finish successfully. The exact repaired head also refuses Atlas poll redirects with `redirect: manual`; real loopback regressions prove the bearer is never re-sent off-origin.

# Deploy Notes

Provision `ATLASCLOUD_API_KEY` in the Cloud API production environment before relying on fallback availability. `ATLASCLOUD_BASE_URL` remains optional. No database migration is required.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 21531798 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [synapz-org]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZXPS2Q7CXHR68YKECGJYVX1","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-13T14:00:22.503Z","completed_at":"2026-08-13T14:22:40.772Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":300661,"output_tokens":44833,"cache_creation_tokens":0,"cache_read_tokens":21186304,"total_tokens":21531798,"cost_micro_usd":"13441447","session_count":1},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAhZH18YZOumLzScna2ZyDOP25JOBwpTrTwX6qb9ZqbbE","device_key_id":"ea68406aa2e612b80483e71bd39662955ca6099e58f9ac01e63d6c629dab20d0","device_signature":"R0t-1Qo5jgTqg-_606bPKqxUnRmUzPD-xNpNAedn9xazo90EVWnr5qnlg_DUcRbNJL8ayl3AAzbYRpU6EnCkAw"}} -->


Maintainer landing pass on head `ea14c17a589e49d84a7614f9c44ef95a3027a255` (clean rebase of `66f33987` onto current `origin/develop`, no conflicts, no code changes): in a full workspace checkout, `bun install` plus all four cloud API video suites (isolated runner: 21 tests), both shared provider suites (32 tests), `packages/cloud/api` and `packages/cloud/shared` typechecks, and changed-path Biome all pass. Atlas response-provided poll URLs are accepted only when they resolve to HTTPS on the configured Atlas origin, with a committed adversarial regression proving an off-origin URL never receives `ATLASCLOUD_API_KEY`. Required live Fal-primary/Atlas-fallback provider logs and playable video evidence remain pending — they need an operator holding both `FAL_KEY` and `ATLASCLOUD_API_KEY` to deploy this head — so this PR is not yet merge-authorized.




Final maintainer repair on exact head `cf1c610c15d4e01bf30c7387fd31f6949ec1a450`, rebased without conflicts onto `origin/develop@7e04c64c73f007610e5da4654803589fdee7c96d`:

- A Fal job reported `COMPLETED` whose result probe returns an ambiguous/retryable 408/409/425/429 now remains pending. It is never refunded and never launches Atlas, preventing two paid jobs at the completed-result boundary.
- Fallback pricing is resolved per attempt immediately before admission. A catalog failure for an unused backup can no longer take down a successful configured primary, while every dispatched provider still requires a fail-closed quote.
- Exact-head proof: 22/22 generate-video route tests, 1/1 Worker durable-reservation test, 36/36 provider tests, 3/3 Atlas route-shaped pricing tests, and all 10 DB-backed reconciliation scenarios passed. Both Cloud package typechecks, the production Worker dry-run, changed-file Biome, and full root `bun run verify` passed (356/356 Turbo tasks; 8,403 test files anti-larp clean).

The source is now locally correct and fully verified, but the PR remains intentionally unmerged: neither `FAL_KEY` nor `ATLASCLOUD_API_KEY` is available in the review environment, and repository policy requires the deployed terminal-Fal→Atlas log plus playable MP4 and independent approval on this substantive final head.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@7e04c64c73f007610e5da4654803589fdee7c96d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
