### PR TITLE
fix(core): preserve context-aligned retrieval fallback

### DIFF
--- a/packages/core/src/runtime/__tests__/action-tiering.test.ts
+++ b/packages/core/src/runtime/__tests__/action-tiering.test.ts
@@ -193,7 +193,7 @@ describe("action tiering", () => {
 		);
 	});
 
-	it("keeps rank-one WEB_FETCH for a real weather retrieval when Stage-1 omits it", () => {
+	it("keeps context-aligned WEB_FETCH on the surface when Stage-1 omits it", () => {
 		const catalog = buildActionCatalog([
 			{
 				name: "WEB_FETCH",
@@ -221,7 +221,10 @@ describe("action tiering", () => {
 			(result) => result.name === "WEB_FETCH",
 		);
 
-		expect(webFetch).toMatchObject({ rank: 1, score: 1 });
+		// Exact Stage-1 parent hints may sort ahead at the same score. Retrieval
+		// rank is not the safety boundary; planner exposure below is.
+		expect(webFetch).toMatchObject({ score: 1 });
+		expect(webFetch?.stageScores.contextMatch).toBe(0.3);
 		expect(webFetch?.stageScores.bm25).toBeLessThan(0.99);
 
 		const surface = tierActionResults({
@@ -237,6 +240,45 @@ describe("action tiering", () => {
 		]);
 		expect(surface.exposedActionNames).toEqual(
 			expect.arrayContaining(["VIEWS", "WEB_FETCH"]),
+		);
+	});
+
+	it("does not let ambiguous context matches flood a routed candidate", () => {
+		const catalog = buildActionCatalog([
+			{ name: "VIEWS", description: "Open app views." },
+			{
+				name: "WEB_FETCH",
+				description: "Fetch current live data.",
+				contexts: ["web"],
+			},
+			{
+				name: "MESSAGE_SEARCH",
+				description: "Search chat history.",
+				contexts: ["web"],
+			},
+		]);
+		const views = catalog.parentByName.get("VIEWS");
+		const webFetch = catalog.parentByName.get("WEB_FETCH");
+		const messageSearch = catalog.parentByName.get("MESSAGE_SEARCH");
+		if (!views || !webFetch || !messageSearch) {
+			throw new Error("missing context override fixtures");
+		}
+
+		const surface = tierActionResults({
+			catalog,
+			results: [
+				resultFor(views, 1, 1, { exact: 1 }),
+				resultFor(webFetch, 1, 2, { contextMatch: 0.3 }),
+				resultFor(messageSearch, 1, 3, { contextMatch: 0.3 }),
+			],
+			narrowToCandidateActions: ["VIEWS"],
+		});
+
+		expect(surface.tierAParents.map((parent) => parent.name)).toEqual([
+			"VIEWS",
+		]);
+		expect(surface.exposedActionNames).not.toEqual(
+			expect.arrayContaining(["WEB_FETCH", "MESSAGE_SEARCH"]),
 		);
 	});
 

--- a/packages/core/src/runtime/action-tiering.ts
+++ b/packages/core/src/runtime/action-tiering.ts
@@ -29,9 +29,9 @@ export type Tier0ProtocolAction = (typeof TIER0_PROTOCOL_ACTIONS)[number];
 
 // A near-certain non-candidate match may remain on the planner surface when
 // Stage-1 omits it. The absolute retrieval winner is authoritative even when
-// its lexical stages are asymmetric; otherwise independent keyword and BM25
-// agreement identifies one unambiguous user-text-dominant fallback without
-// reopening a broadly saturated surface.
+// its lexical stages are asymmetric; otherwise a unique selected-context match
+// or independent keyword and BM25 agreement identifies one unambiguous
+// fallback without reopening a broadly saturated surface.
 const RETRIEVAL_OVERRIDE_SCORE = 0.97;
 const DOMINANT_LEXICAL_STAGE_SCORE = 0.99;
 
@@ -253,6 +253,16 @@ export function tierActionResults(
 			dominantLexicalOverrides.length === 1
 				? dominantLexicalOverrides[0]
 				: undefined;
+		const contextAlignedOverrides = tierAParents.filter(
+			(parent) =>
+				!matchesCandidate(parent) &&
+				parent.score >= RETRIEVAL_OVERRIDE_SCORE &&
+				(parent.result.stageScores.contextMatch ?? 0) > 0,
+		);
+		const unambiguousContextOverride =
+			contextAlignedOverrides.length === 1
+				? contextAlignedOverrides[0]
+				: undefined;
 		const absoluteRankOneOverride = tierAParents.find(
 			(parent) =>
 				!matchesCandidate(parent) &&
@@ -260,7 +270,9 @@ export function tierActionResults(
 				parent.result.rank === 1,
 		);
 		const retrievalOverride =
-			absoluteRankOneOverride ?? unambiguousLexicalOverride;
+			absoluteRankOneOverride ??
+			unambiguousContextOverride ??
+			unambiguousLexicalOverride;
 		for (const parent of tierAParents) {
 			// Keep a parent the candidates named, OR the absolute near-certain
 			// retrieval winner. When the winner is already a candidate, only one


### PR DESCRIPTION
Fixes #19299

## Summary

- preserve the exact Stage-1 parent as the first planner option
- retain one otherwise-omitted near-certain retrieval fallback when it is uniquely aligned with the selected context
- keep ambiguous context matches out of the surface so a generic context cannot flood a routed turn
- replace the incidental retrieval-rank assertion with the real contract: `WEB_FETCH` remains in Tier A and reaches the planner for the reported weather case

This fixes an actual planner-surface loss, not merely a red assertion. On the current base, `weather in tokyo` with Stage-1 narrowed to `VIEWS` gives `WEB_FETCH` score `1` and context match `0.3`, but its rank becomes `2` after the exact Stage-1 hint is honored. The previous tiering rule then dropped it entirely. Rank is not the behavior boundary; planner exposure is.

The override remains narrow and fail-fast: it does not add a timeout, catch, fabricated fallback, or broad defensive recovery. Candidate authority still wins ordering, and two context-aligned non-candidates are treated as ambiguous and both omitted.

## Verification

Exact source head: `4fcb8ec4d2d31a27aa8fb9dd81e05b826e0366ba`
Base: `origin/develop@d3d5114b0b6813e05795cd9adebbd1e21147d081`

- full `bun install` — PASS; pinned Bun 1.3.14, 3,831 installs checked, native artifacts verified, no dependency changes
- focused action-tiering contract — 22/22 PASS, including the real weather retrieval and ambiguous-context adversary
- core Node-only build — PASS
- core full Node/browser/edge/testing build — PASS (also exercised by root verification)
- core typecheck and lint — PASS; only pre-existing informational diagnostics outside this diff
- root `bun run verify` — 350/350 PASS; all repository audits clean
- live regression-path scenario — PASS: Stage-1 pinned to the reported `VIEWS`-only + `web` input; the real Codex planner received `VIEWS` and `WEB_FETCH`, selected `WEB_FETCH`, and the production action returned HTTP 200 from `https://wttr.in/Tokyo?format=j1`

The full core suite is currently 5,835 passed / 4 failed / 1 skipped plus one host-storage import failure. The four semantic failures reproduce on the current base and are outside this change: two obsolete `elizacloud.ai` expectations now receive canonical `api.eliza.app`, and the duplicated document-ingest expectation still expects `DOCUMENT_FRAGMENT_EMBED_FAILED` after the producer began returning `EMBEDDING_MODEL_OUTPUT_INVALID`. The additional `pii-pseudonymizer` suite import failed with host `ENOSPC`; the exact-head focused lane, builds, typecheck, lint, and root 350/350 gate all pass.

## Evidence

- [Exact-head focused action-tiering lane](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19305-final-focused.log)
- [Exact-head root verification](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19305-final-root-verify.log)
- [Exact-head core Node build](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19305-final-core-node-build.log)
- [Live regression-path scenario report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19305-matrix.json)
- [Full raw model/action trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19305-tj-02eea4d06ab46f.json)

<!-- evidence-head:4fcb8ec4d2d31a27aa8fb9dd81e05b826e0366ba -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - planner/runtime logic only; no rendered surface changed

<!-- evidence-row:after-screenshots -->
- [x] N/A - planner/runtime logic only; no rendered surface changed

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive visual flow changed; the real message-to-tool trajectory is the applicable walkthrough

<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend changed; local runtime and action logs are included in the trajectory/domain artifacts

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser behavior changed

<!-- evidence-row:llm-trajectory -->
- [x] [Full raw Stage-1/planner/tool-result trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19305-tj-02eea4d06ab46f.json)

<!-- evidence-row:domain-artifacts -->
- [x] [Live scenario report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19305-matrix.json) - planner surface assertion, real `WEB_FETCH` call, HTTP 200 action result, and final response

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - repository contribution skill is not available in this session
Attribution status: self-reported
— [codex-19299]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - repository contribution skill is not available in this session"} -->
