### PR TITLE
fix(core): an exact candidate hint is a retrieval floor, not a tie-breaker

### DIFF
--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -720,3 +720,56 @@ describe("action catalogue and retrieval", () => {
 		expect(parentAliasesForCandidateAction("LAUNCH_APP")).toEqual(["APP"]);
 	});
 });
+
+describe("an exact candidate hint is a floor, not a tie-breaker", () => {
+	// Two real bugs pull in opposite directions and BOTH must hold:
+	//   #18948 — a Stage-1 candidate naming a real parent must not lose to fuzzy
+	//            noise (OWNER_REMINDERS lost to CALENDAR on "remind me in 2 min").
+	//   action-tiering — a WRONG Stage-1 candidate must not displace the parent
+	//            the message genuinely points at (VIEWS displaced WEB_FETCH on
+	//            "weather in tokyo").
+	// They collide only when both saturate the 1.0 ceiling, where the comparator
+	// used to fall through to rrfScore — which the hint itself inflates, so the
+	// hint won by construction. Ties now go to independently-earned evidence.
+	it("lifts a named parent above fuzzy competitors", () => {
+		const catalog = buildActionCatalog([
+			{ name: "OWNER_REMINDERS", description: "Create exact-time reminders." },
+			{
+				name: "CALENDAR",
+				description:
+					"Calendar events, scheduling, time, minutes, days, appointments.",
+			},
+		] as never);
+		const response = retrieveActions({
+			catalog,
+			messageText: "remind me in 2 minutes to stretch",
+			candidateActions: ["OWNER_REMINDERS"],
+		} as never);
+		const reminders = response.results.find(
+			(result) => result.name === "OWNER_REMINDERS",
+		);
+		expect(reminders?.rank).toBe(1);
+		expect(reminders?.stageScores.exact).toBe(1);
+	});
+
+	it("does not let a wrong hint outrank the parent the message points at", () => {
+		const catalog = buildActionCatalog([
+			{
+				name: "WEB_FETCH",
+				description: "Fetch current live data from a URL.",
+				contexts: ["web"],
+				similes: ["CURRENT_WEATHER", "LIVE_INFO"],
+			},
+			{ name: "VIEWS", description: "Open app views and arrange panels." },
+		] as never);
+		const response = retrieveActions({
+			catalog,
+			messageText: "weather in tokyo",
+			candidateActions: ["VIEWS"],
+			selectedContexts: ["web"],
+		} as never);
+		expect(
+			response.results.find((result) => result.name === "WEB_FETCH")?.rank,
+		).toBe(1);
+	});
+});

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -488,9 +488,28 @@ export function retrieveActions(
 		};
 	});
 
+	// Evidence this parent earned from the MESSAGE rather than from Stage-1's
+	// hint. `exact` and `regex` are both computed from `candidateActions`, so
+	// they only say "Stage-1 named me"; keyword/bm25/embedding/contextMatch say
+	// "the user's words and this turn's context point here".
+	const independentEvidence = (result: {
+		stageScores: ActionRetrievalResult["stageScores"];
+	}): number =>
+		(result.stageScores.keyword ?? 0) +
+		(result.stageScores.bm25 ?? 0) +
+		(result.stageScores.embedding ?? 0) +
+		(result.stageScores.contextMatch ?? 0);
+
 	results.sort((left, right) => {
 		return (
 			right.score - left.score ||
+			// Both saturated at the ceiling. An exact hint is a FLOOR — it keeps a
+			// named parent from losing to fuzzy noise (#18948: OWNER_REMINDERS lost
+			// to CALENDAR on "remind me in 2 minutes to stretch") — but it must not
+			// also win ties, or a WRONG Stage-1 guess outranks a genuine match, as
+			// candidate VIEWS did to WEB_FETCH on "weather in tokyo". When
+			// confidence is equal, prefer the parent the message itself points at.
+			independentEvidence(right) - independentEvidence(left) ||
 			right.rrfScore - left.rrfScore ||
 			left.normalizedName.localeCompare(right.normalizedName)
 		);


### PR DESCRIPTION
## What

An exact candidate hint is a retrieval **floor**, not a tie-breaker.

#18948 exact-scores a Stage-1 `candidateAction` that names a real catalog parent, so a named parent cannot lose to fuzzy noise. That fixed a real routing bug — `OWNER_REMINDERS` losing to `CALENDAR` on "remind me in 2 minutes to stretch".

It also left an existing test failing on `develop`:

```
packages/core/src/runtime/__tests__/action-tiering.test.ts
  × keeps rank-one WEB_FETCH for a real weather retrieval when Stage-1 omits it
    expected { rank: 1, score: 1 }
    received   "rank": 2
```

A **wrong** Stage-1 candidate (`VIEWS` on "weather in tokyo") saturates to 1.0 and displaces the parent the message actually points at.

Both parents reach the 1.0 ceiling, so the comparator fell through to `rrfScore` — which the hint itself inflates, so the hint won by construction.

This breaks saturated ties on evidence the parent earned from the **message**: `exact` and `regex` are both computed from `candidateActions` (`scoreCandidateRegex(parents, candidateActions)`), so they only say "Stage-1 named me"; `keyword`/`bm25`/`embedding`/`contextMatch` say the user's words and this turn's context point here. The hint keeps its floor and stops deciding ties.

Measured on the failing case: `VIEWS` independent evidence = 1.00 (bm25 only); `WEB_FETCH` = 2.01 (keyword 1.0 + bm25 0.71 + contextMatch 0.3).

Both invariants are now pinned together in one test so neither can be restored by re-breaking the other.

## Exact candidate

- Base: `f9000084200cd131cb9e9d3ced63aad19e9c5960`
- Head: `3c1eb23924a07e03c26d3a0c4d90fadf03825371`
- Tree: `80f9a90b888d203375cdf18362f6f0bb738c95bc`
- Paths: two under `packages/core/src/runtime` (`action-retrieval.ts`, `__tests__/action-retrieval.test.ts`)

## Verification

Run in a clean worktree created from `origin/develop` at `f9000084200cd131cb9e9d3ced63aad19e9c5960`.

| Evidence | Result |
| --- | --- |
| `bun run --cwd packages/core test -- src/runtime/__tests__/action-retrieval.test.ts src/runtime/__tests__/action-tiering.test.ts` | **48 passed** (2 files) |
| Same two files, fix reverted (develop as-is) | **1 failed** — `keeps rank-one WEB_FETCH`, rank 2 |
| Full core suite with this change | **5541 passed**, 11 skipped, 506/506 files |
| `bunx @biomejs/biome check` on both paths | passed |
| `bun run --cwd packages/core typecheck` | passed |
| Live-model trajectory | N/A — pure ranking comparator; no model call, provider, or action path changes. Behavior is covered by the two deterministic invariant tests above. |
| Frontend screenshots / MP4 | N/A — no UI surface touched. |

Reverting only `action-retrieval.ts` and re-running reproduces the develop failure exactly, which is the before/after pair for this fix.

## Evidence

<!-- evidence-head:3c1eb23924a07e03c26d3a0c4d90fadf03825371 -->

<!-- evidence-row:before-screenshots -->
N/A - no UI surface; this is a retrieval ranking comparator

<!-- evidence-row:after-screenshots -->
N/A - no UI surface; this is a retrieval ranking comparator

<!-- evidence-row:walkthrough-video -->
N/A - no user-facing flow; deterministic ranking change

<!-- evidence-row:backend-logs -->
N/A - no runtime logging path changed; failure is observable only as a test assertion (rank 2 vs rank 1)

<!-- evidence-row:frontend-logs -->
N/A - no frontend code path touched

<!-- evidence-row:llm-trajectory -->
N/A - the comparator runs before any model call; covered by two deterministic invariant tests pinned together

<!-- evidence-row:domain-artifacts -->
N/A - no persisted domain artifact; the artifact under test is the ranked action list, asserted directly

<!-- evidence-row:ocr-review -->
N/A - no rendered text or imagery



<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes - agent-authored under human direction, reviewed against live trajectories
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no packaged skill was used; work was driven from live trajectory evidence
<!-- attribution-row:status -->
- Provenance status: self-reported
