### PR TITLE
fix(ui): preserve focused shell modes during navigation

### DIFF
--- a/packages/ui/src/App.cloud-shell.test.tsx
+++ b/packages/ui/src/App.cloud-shell.test.tsx
@@ -11,6 +11,10 @@ import { resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 import {
+  FOCUSED_APP_SHELL_MODES,
+  resolveAppShellMode,
+} from "./platform/app-shell-mode";
+import {
   isChatOverlayWindowShell,
   isDetachedWindowShell,
   isStandaloneWindowShell,
@@ -120,16 +124,21 @@ describe("App standalone chat-overlay wiring", () => {
 
   it("preserves chat-overlay shell mode during shell-window navigation", () => {
     expect(USE_NAVIGATION_STATE_TS).toContain("pathWithCurrentShellMode");
-    expect(USE_NAVIGATION_STATE_TS).toContain("isDetachedShell");
-    expect(USE_NAVIGATION_STATE_TS).toContain("eliza-chat-overlay-shell");
-    expect(USE_NAVIGATION_STATE_TS).toContain(
-      "if (!isDetachedShell) return path",
-    );
-    expect(USE_NAVIGATION_STATE_TS).toContain('params.get("shellMode")');
-    expect(USE_NAVIGATION_STATE_TS).toContain('params.get("shell-mode")');
     expect(USE_NAVIGATION_STATE_TS).toContain(
       'shellHistory.pushState(null, "", pathWithCurrentShellMode(path))',
     );
+    expect(FOCUSED_APP_SHELL_MODES).toEqual([
+      "chat-overlay",
+      "tray-popover",
+      "voice-selftest",
+      "voice-workbench",
+      "launcher",
+      "kiosk",
+    ]);
+    expect(resolveAppShellMode("?shellMode=voice-workbench", "")).toBe(
+      "voice-workbench",
+    );
+    expect(resolveAppShellMode("?shellMode=full", "")).toBe("full");
   });
 
   it("lets existing shell windows advance after onboarding finishes elsewhere", () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -161,6 +161,10 @@ import {
   titleForTab,
 } from "./navigation";
 import { applyLaunchConnection } from "./platform";
+import {
+  type AppShellMode,
+  resolveAppShellMode,
+} from "./platform/app-shell-mode";
 import { isIOS, isNative } from "./platform/init";
 import { RetainedLazyComponent } from "./retained-lazy";
 import {
@@ -280,41 +284,22 @@ function useIsPopout(): boolean {
  * read from the URL (`?shellMode=` / `?shell-mode=`) or the
  * `ELIZAOS_SHELL_MODE` global the native shell may inject. Unset = full app.
  */
-type ShellMode =
-  | "chat-overlay"
-  | "tray-popover"
-  | "voice-selftest"
-  | "voice-workbench"
-  | "launcher"
-  | "kiosk"
-  | "full";
-
 declare global {
   interface Window {
     ELIZAOS_SHELL_MODE?: string;
   }
 }
 
-function readShellMode(): ShellMode {
+function readShellMode(): AppShellMode {
   if (typeof window === "undefined") return "full";
-  const params = new URLSearchParams(
-    window.location.search || window.location.hash.split("?")[1] || "",
+  return resolveAppShellMode(
+    window.location.search,
+    window.location.hash,
+    window.ELIZAOS_SHELL_MODE,
   );
-  const raw =
-    params.get("shellMode") ??
-    params.get("shell-mode") ??
-    window.ELIZAOS_SHELL_MODE ??
-    "";
-  if (raw === "chat-overlay") return "chat-overlay";
-  if (raw === "tray-popover") return "tray-popover";
-  if (raw === "voice-selftest") return "voice-selftest";
-  if (raw === "voice-workbench") return "voice-workbench";
-  if (raw === "launcher") return "launcher";
-  if (raw === "kiosk") return "kiosk";
-  return "full";
 }
 
-function useShellMode(): ShellMode {
+function useShellMode(): AppShellMode {
   const [mode] = useState(readShellMode);
   return mode;
 }

--- a/packages/ui/src/platform/app-shell-mode.ts
+++ b/packages/ui/src/platform/app-shell-mode.ts
@@ -1,0 +1,36 @@
+/** Defines the focused renderer modes that must survive in-app path navigation. */
+
+export const FOCUSED_APP_SHELL_MODES = [
+  "chat-overlay",
+  "tray-popover",
+  "voice-selftest",
+  "voice-workbench",
+  "launcher",
+  "kiosk",
+] as const;
+
+export type FocusedAppShellMode = (typeof FOCUSED_APP_SHELL_MODES)[number];
+export type AppShellMode = FocusedAppShellMode | "full";
+
+const FOCUSED_APP_SHELL_MODE_SET = new Set<string>(FOCUSED_APP_SHELL_MODES);
+
+export function parseFocusedAppShellMode(
+  value: string | null | undefined,
+): FocusedAppShellMode | null {
+  return value && FOCUSED_APP_SHELL_MODE_SET.has(value)
+    ? (value as FocusedAppShellMode)
+    : null;
+}
+
+export function resolveAppShellMode(
+  search: string,
+  hash: string,
+  injectedMode?: string,
+): AppShellMode {
+  const params = new URLSearchParams(search || hash.split("?")[1] || "");
+  return (
+    parseFocusedAppShellMode(
+      params.get("shellMode") ?? params.get("shell-mode") ?? injectedMode ?? "",
+    ) ?? "full"
+  );
+}

--- a/packages/ui/src/state/useNavigationState.test.tsx
+++ b/packages/ui/src/state/useNavigationState.test.tsx
@@ -33,4 +33,22 @@ describe("useNavigationState", () => {
     expect(onPopState).toHaveBeenCalledTimes(1);
     window.removeEventListener("popstate", onPopState);
   });
+
+  it("preserves focused shell modes when startup navigation commits the initial tab", () => {
+    window.history.replaceState(null, "", "/?shellMode=voice-workbench");
+    const { result } = renderHook(() =>
+      useNavigationState({
+        tab: "chat" as Tab,
+        setTabRaw: vi.fn(),
+        uiShellMode: "native",
+        hasActiveGameRun: false,
+        setAppsSubTab: vi.fn(),
+      }),
+    );
+
+    act(() => result.current.setTab("chat"));
+
+    expect(window.location.pathname).toBe("/chat");
+    expect(window.location.search).toBe("?shellMode=voice-workbench");
+  });
 });

--- a/packages/ui/src/state/useNavigationState.ts
+++ b/packages/ui/src/state/useNavigationState.ts
@@ -15,6 +15,7 @@ import {
   useState,
 } from "react";
 import { pathForTab, shouldUseHashNavigation, type Tab } from "../navigation";
+import { parseFocusedAppShellMode } from "../platform/app-shell-mode";
 import { shellHistory } from "../surface-realm-channel";
 import {
   loadLastNativeTab,
@@ -28,14 +29,10 @@ import { getTabForShellView } from "./shell-routing";
 
 function pathWithCurrentShellMode(path: string): string {
   if (typeof window === "undefined") return path;
-  const html = window.document?.documentElement;
-  const body = window.document?.body;
-  const isDetachedShell =
-    html?.classList.contains("eliza-chat-overlay-shell") === true ||
-    body?.classList.contains("eliza-chat-overlay-shell") === true;
-  if (!isDetachedShell) return path;
   const params = new URLSearchParams(window.location.search);
-  const shellMode = params.get("shellMode") ?? params.get("shell-mode");
+  const shellMode = parseFocusedAppShellMode(
+    params.get("shellMode") ?? params.get("shell-mode"),
+  );
   if (!shellMode) return path;
   const nextParams = new URLSearchParams();
   nextParams.set("shellMode", shellMode);


### PR DESCRIPTION
# Relates to

Relates to #18960. This is a baseline repair discovered while reviewing #19276; it is intentionally isolated from that PR's iOS artifact-audit diff.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6f18a97d5d32c8c2edc6fe4fbcf231e86e503ab5:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based directly on exact `origin/develop` `6f18a97d5d32c8c2edc6fe4fbcf231e86e503ab5`; zero conflicts.
- [ ] Full repository verification is pending while this PR remains draft.

# Risks

Low, narrowly scoped navigation risk. Only the six focused renderer modes already recognized by `App.tsx` are preserved. Normal `full` mode and invalid query values are deliberately excluded, preventing arbitrary parameters from leaking into ordinary navigation.

# Background

## What does this PR do?

Startup tab synchronization replaced URLs such as `/?shellMode=voice-workbench` with `/chat` before the lazy app shell read the mode. The old preservation check depended on a DOM class that App had not mounted yet, so voice-workbench, voice-selftest, kiosk, launcher, tray-popover, and chat-overlay could silently boot the full app.

This change moves the focused-mode allowlist and parser into one shared module used by both App shell selection and path synchronization. It preserves only a validated focused mode while navigation changes the path.

The stale #19276 run demonstrated the impact across [Smoke (5)](https://github.com/elizaOS/eliza/actions/runs/31759720885/job/94650497945), [Smoke (6)](https://github.com/elizaOS/eliza/actions/runs/31759720885/job/94650497921), and kiosk/launcher failures in [Smoke (3)](https://github.com/elizaOS/eliza/actions/runs/31759720885/job/94650498021). #19276 itself touches only iOS audit scripts and did not cause the bug.

# Testing

Exact head: `65b052aff27c112f0eedc36d7a60eace795a85b2`

- targeted Biome check: 5 files clean
- `bun run --cwd packages/ui test -- src/state/useNavigationState.test.tsx src/App.cloud-shell.test.tsx`: 15/15 passed
- `bun run --cwd packages/ui typecheck`: passed
- `bun run --cwd packages/app test:e2e -- --project=chromium test/ui-smoke/voice-workbench-agent-room-metadata.spec.ts`: 1/1 passed against the real app shell
- before repair, that exact E2E deterministically failed because `voice-workbench-shell` was absent; trace logging showed `shell mode: main (search="?shellMode=voice-workbench")`

# Evidence Gate

<!-- evidence-head:65b052aff27c112f0eedc36d7a60eace795a85b2 -->

Refresh provenance: current head `65b052aff27c112f0eedc36d7a60eace795a85b2` reapplies the same scoped patch as prior head `916bd27b719392a3da7e15dbece83f0c42134f0f` onto `develop` `6f18a97d5d32c8c2edc6fe4fbcf231e86e503ab5`. Existing media and logs from the prior head remain identified as patch-equivalent evidence; current-head workflow results are authoritative.

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19315-before-desktop-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19315-after-desktop-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19315-walkthrough-v2.mp4
<!-- evidence-row:backend-logs -->
- [x] N/A - this is renderer URL/shell selection; no backend request or state mutation is involved.
<!-- evidence-row:frontend-logs -->
- [x] [19315-frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19315-frontend.log)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database or external domain artifact is produced; the browser URL and rendered focused-shell marker are the contract.
<!-- evidence-row:ocr-review -->
- [x] [19315-ocr-review.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19315-ocr-review.log)

# Evidence Details

## Known gaps / failures

Required UI evidence is attached and exact-head-bound. The before contact sheet was captured from parent `6f18a97d5d32c8c2edc6fe4fbcf231e86e503ab5` at desktop (1440×1000) and mobile (390×844): startup drops the focused query and renders the full shell. The after contact sheet, MP4, and frontend/network log were captured from exact head `916bd27b719392a3da7e15dbece83f0c42134f0f`: both widths retain `?shellMode=voice-workbench` and render the Voice workbench shell. OCR confirms the expected visible text transition. Broader repository gates remain pending while this PR is draft.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@6f18a97d5d32c8c2edc6fe4fbcf231e86e503ab5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [nubs-review-ci]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@6f18a97d5d32c8c2edc6fe4fbcf231e86e503ab5:packages/skills/skills/contribute-to-eliza"} -->


