### PR TITLE
test(ui): repin automations mutation authority

### DIFF
--- a/packages/ui/src/testing/builtin-view-action-ratchet.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.ts
@@ -261,9 +261,9 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
       "packages/ui/src/components/pages/WorkflowTriggerPanel.tsx",
     ],
     semanticActions: ["SCHEDULED_TASKS", "TRIGGER"],
-    maxMutationSites: 65,
+    maxMutationSites: 67,
     notes:
-      "Automations feed plus its task/workflow editors all write ScheduledTask records through the one scheduler; SCHEDULED_TASKS is the umbrella twin and TRIGGER pairs the trigger steps inside workflow editing.",
+      "Automations feed plus its task/workflow editors all write ScheduledTask records through the one scheduler; SCHEDULED_TASKS covers the workflow/prompt creation chooser and remains the umbrella twin, while TRIGGER pairs the trigger steps inside workflow editing.",
   },
   {
     viewId: "triggers",


### PR DESCRIPTION
## Summary

The workflow/prompt creation chooser added two real state-setting sites to `AutomationsFeed`, both still governed by the existing `SCHEDULED_TASKS` action authority. This repins the fail-closed mutation ratchet from 65 to the observed 67 and records why the semantic authority remains complete.

The change adds no headroom: the adversarial suite still fails on either one additional mutation or any future count reduction.

Relates to #18960.

## Exact-head validation

Validated at `45672c79ec21810848ea65138b507fb0cb9ab3ab`, rebased on `origin/develop` `15ecb8e4a3bf971a97fb759b52a88151a0bcc494`:

```text
bun test packages/ui/src/testing/builtin-view-action-ratchet.test.ts
22 pass, 0 fail, 100 assertions

bun run --cwd packages/ui typecheck
PASS

bunx @biomejs/biome check packages/ui/src/testing/builtin-view-action-ratchet.ts
PASS

git diff --check origin/develop...HEAD
PASS

bun run verify
PASS; 350/350 workspace tasks and all repository audits clean
```

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@15ecb8e4a3bf971a97fb759b52a88151a0bcc494:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:45672c79ec21810848ea65138b507fb0cb9ab3ab -->
<!-- evidence-row:before-screenshots -->
- N/A - audit metadata only; no rendered source changed.
<!-- evidence-row:after-screenshots -->
- N/A - audit metadata only; no rendered source changed.
<!-- evidence-row:walkthrough-video -->
- N/A - no user flow changed.
<!-- evidence-row:backend-logs -->
- N/A - no backend behavior changed; deterministic test results are above.
<!-- evidence-row:frontend-logs -->
- N/A - no browser runtime changed.
<!-- evidence-row:llm-trajectory -->
- N/A - no agent/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- N/A - no external state changed; the exact mutation-count report is the audit artifact.
<!-- evidence-row:ocr-review -->
- N/A - no visual output changed.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@15ecb8e4a3bf971a97fb759b52a88151a0bcc494:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-workflows]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@15ecb8e4a3bf971a97fb759b52a88151a0bcc494:packages/skills/skills/contribute-to-eliza"} -->
