### PR TITLE
fix(ui): preserve onboarding shell through auth settle

### DIFF
--- a/packages/ui/src/App.chat-overlay-first-run.test.tsx
+++ b/packages/ui/src/App.chat-overlay-first-run.test.tsx
@@ -39,6 +39,7 @@ const notificationMock = vi.hoisted(() => ({
 vi.mock("./state/notifications/notification-store", () => ({
   initNotifications: notificationMock.init,
   seedDevNotificationsIfEmpty: vi.fn(async () => undefined),
+  useNotifications: () => ({ notifications: [] }),
 }));
 
 const conductorMock = vi.hoisted(() => ({
@@ -277,6 +278,9 @@ import { App } from "./App";
 
 describe("App chat-overlay first-run composition", () => {
   beforeEach(() => {
+    appState.authPhase = "loading";
+    appState.firstRunComplete = false;
+    appState.startupPhase = "first-run-required";
     window.history.replaceState(null, "", "/?shellMode=chat-overlay");
     conductorMock.mount.mockClear();
     notificationMock.init.mockClear();
@@ -333,6 +337,42 @@ describe("App chat-overlay first-run composition", () => {
     expect(startupGate.getByTestId("startup-screen")).toBeTruthy();
     await waitFor(() => expect(notificationMock.init).toHaveBeenCalledOnce());
     startupGate.unmount();
+  });
+
+  it("keeps the mounted shell across the first-run completion auth-probe edge", () => {
+    window.history.replaceState(null, "", "/");
+    appState.firstRunComplete = false;
+    appState.startupPhase = "first-run-required";
+    appState.authPhase = "loading";
+
+    const shell = render(<App />);
+    const mountedProvider = shell.getByTestId("shell-controller-provider");
+    expect(shell.queryByTestId("startup-screen")).toBeNull();
+
+    appState.firstRunComplete = true;
+    appState.startupPhase = "ready";
+    shell.rerender(<App />);
+
+    expect(shell.queryByTestId("startup-screen")).toBeNull();
+    expect(shell.getByTestId("shell-controller-provider")).toBe(
+      mountedProvider,
+    );
+  });
+
+  it("holds an ordinary authenticated shell when a later auth probe starts", () => {
+    window.history.replaceState(null, "", "/");
+    appState.firstRunComplete = true;
+    appState.startupPhase = "ready";
+    appState.authPhase = "authenticated";
+
+    const shell = render(<App />);
+    expect(shell.getByTestId("shell-controller-provider")).toBeTruthy();
+
+    appState.authPhase = "loading";
+    shell.rerender(<App />);
+
+    expect(shell.getByTestId("startup-screen")).toBeTruthy();
+    expect(shell.queryByTestId("shell-controller-provider")).toBeNull();
   });
 
   it("keeps the conductor mounted but UNGATED by App once first-run completes (hook self-gates)", () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -26,6 +26,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   useSyncExternalStore,
 } from "react";
@@ -2010,7 +2011,6 @@ function AppContent() {
     startupCoordinator.phase,
     firstRunCloudProvisionedContainer,
   );
-
   useEffect(() => {
     if (!isShellPaintableNow) return;
 
@@ -2096,6 +2096,38 @@ function AppContent() {
       (isAgentlessCloudOrigin &&
         firstRunOwnsLoginSurface(startupCoordinator.phase, firstRunComplete)),
   });
+  const topLevelAuthOwnsSurface = topLevelAuthGateOwnsSurface(
+    startupCoordinator.phase,
+    firstRunComplete,
+    authState.phase,
+    isAgentlessCloudOrigin,
+  );
+  // Remember only a shell painted while first-run owned the login surface.
+  // When completion flips, briefly replacing that live onboarding shell with
+  // StartupScreen destroys its FULL→HALF completion transition and remounts
+  // chat collapsed. This ref is cleared as soon as the auth probe resolves, so
+  // an ordinary later credential probe still holds the shell.
+  const onboardingShellMountedRef = useRef(false);
+  const firstRunOwnsAuthSurface = firstRunOwnsLoginSurface(
+    startupCoordinator.phase,
+    firstRunComplete,
+  );
+  useEffect(() => {
+    if (isShellPaintableNow && !bootstrapGateHolds && firstRunOwnsAuthSurface) {
+      onboardingShellMountedRef.current = true;
+    } else if (authState.phase !== "loading") {
+      onboardingShellMountedRef.current = false;
+    }
+  }, [
+    authState.phase,
+    bootstrapGateHolds,
+    firstRunOwnsAuthSurface,
+    isShellPaintableNow,
+  ]);
+  const preserveMountedOnboardingShell =
+    onboardingShellMountedRef.current &&
+    firstRunComplete === true &&
+    authState.phase === "loading";
   // #15132: after a dedicated cloud agent's container upgrade the persisted
   // agent credential is stale (every agent-subdomain call 401s) while the cloud
   // session is still valid. Rather than dead-end at the agent's internal
@@ -2677,21 +2709,13 @@ function AppContent() {
   // Restored sessions usually arrive here already decided: the restore phase
   // primes the probe (primeAuthStatusProbe) so it overlaps backend polling /
   // hydration instead of serializing an extra round-trip after first paint.
-  if (
-    isShellPaintableNow &&
-    !isPopout &&
-    topLevelAuthGateOwnsSurface(
-      startupCoordinator.phase,
-      firstRunComplete,
-      authState.phase,
-      isAgentlessCloudOrigin,
-    )
-  ) {
+  if (isShellPaintableNow && !isPopout && topLevelAuthOwnsSurface) {
     if (
       authProbeShouldHoldShell(
         startupCoordinator.phase,
         firstRunComplete,
         authState.phase,
+        preserveMountedOnboardingShell,
       )
     ) {
       return (

--- a/packages/ui/src/state/top-level-auth-gate.test.ts
+++ b/packages/ui/src/state/top-level-auth-gate.test.ts
@@ -106,6 +106,18 @@ describe("authProbeShouldHoldShell — pre-auth poll suppression", () => {
     ).toBe(false);
     expect(authProbeShouldHoldShell("ready", false, "loading")).toBe(false);
   });
+
+  it("does not unmount an already-painted onboarding shell on the completion edge", () => {
+    expect(authProbeShouldHoldShell("ready", true, "loading", true)).toBe(
+      false,
+    );
+  });
+
+  it("still holds an ordinary shell when a later auth probe starts", () => {
+    expect(authProbeShouldHoldShell("ready", true, "loading", false)).toBe(
+      true,
+    );
+  });
 });
 
 describe("shouldShowRemoteAgentPairingGate — LAN standalone agent auth", () => {

--- a/packages/ui/src/state/top-level-auth-gate.ts
+++ b/packages/ui/src/state/top-level-auth-gate.ts
@@ -57,9 +57,11 @@ export function authProbeShouldHoldShell(
   coordinatorPhase: string,
   firstRunComplete: boolean | null | undefined,
   authPhase: string,
+  preserveMountedOnboardingShell = false,
 ): boolean {
   return (
     authPhase === "loading" &&
+    !preserveMountedOnboardingShell &&
     !firstRunOwnsLoginSurface(coordinatorPhase, firstRunComplete)
   );
 }


### PR DESCRIPTION
# Relates to

Closes #19325. Found while reviewing the non-voice failures in #19276; the original PR does not touch this shared UI path.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and its sole commit is based directly on current `origin/develop` (`6c033a6d10e6af64e773bc715d96efac06be396f`).
- [ ] `bun install` and full `bun run verify` — pending before ready-for-review.
- [ ] Reviewer-facing visual evidence — pending while the targeted smoke lane completes.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6c033a6d10e6af64e773bc715d96efac06be396f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Scoped commit created directly atop the latest fetched `origin/develop`; zero conflicts.
- [ ] `bun run verify` pending before ready-for-review.

# Risks

Low and narrowly scoped to the transition between in-chat first-run completion and the top-level auth gate. The bypass is remembered only for a shell painted while first-run owns authentication, applies only while completion has flipped true and auth remains loading, and is cleared when the probe resolves. A regression test proves an ordinary authenticated shell is still held when a later auth probe begins.

# Background

## What does this PR do?

Prevents `App` from replacing an already-mounted onboarding shell with `StartupScreen` during the short interval where `firstRunComplete` is true but `/api/auth/me` is still loading. Preserving the same `ShellControllerProvider`/`ChatOverlay` instance allows the existing onboarding FULL → HALF detent effect to finish instead of remounting chat at its collapsed default.

The original CI evidence showed two independent onboarding paths reach FULL, then report `collapsed` for all 57 settle polls. PR #19276 only changes iOS artifact audit/build files, so this fixes the deeper shared race rather than papering over the smoke assertion.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No product documentation change is needed; this preserves the documented onboarding transition.

# Testing

## Where should a reviewer start?

- `packages/ui/src/App.tsx`: transition-scoped preservation state.
- `packages/ui/src/App.chat-overlay-first-run.test.tsx`: provider node continuity and later-auth-probe regression.
- `packages/ui/src/state/top-level-auth-gate.test.ts`: pure gate contract.

## Detailed testing steps

- `bun run --cwd packages/ui test -- src/state/top-level-auth-gate.test.ts src/App.chat-overlay-first-run.test.tsx` — 2 files, 20 tests passed.
- `bun run --cwd packages/ui typecheck` — passed.
- `bunx @biomejs/biome check packages/ui/src/App.tsx packages/ui/src/App.chat-overlay-first-run.test.tsx packages/ui/src/state/top-level-auth-gate.ts packages/ui/src/state/top-level-auth-gate.test.ts` — passed.
- Targeted onboarding Playwright smoke — in progress; result will be attached before ready-for-review.

# Evidence Gate

<!-- evidence-head:b4a743c7850c3a3a1e8e90e5ea9552304ba89650 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page desktop/mobile screenshots — pending capture; this is a transient state-continuity bug.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page desktop/mobile screenshots — pending capture.
<!-- evidence-row:walkthrough-video -->
- [ ] MP4 walkthrough of onboarding completion — pending capture.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend path changes; the auth result is mocked only to reproduce UI transition ordering.
<!-- evidence-row:frontend-logs -->
- [x] Existing failing frontend assertion log: [Smoke (4), job 94650497944](https://github.com/elizaOS/eliza/actions/runs/31759720885/job/94650497944) records FULL followed by 57 collapsed detent polls in both onboarding paths. Passing targeted log will be added when the queued lane completes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, audio, or generated domain artifacts.
<!-- evidence-row:ocr-review -->
- [ ] OCR review — pending with visual capture.

# Evidence Details

## Backend + frontend logs

Backend: N/A - no backend code changes.

Frontend failure evidence: PR #19276 run 31759720885 / Smoke (4), job 94650497944. The stored-session and existing-agent zero-interaction paths both reached FULL before onboarding completion, then remained collapsed through 57 settle polls instead of reaching HALF.

## Screenshots (before / after) + video walkthrough

Pending before this draft is marked ready.

## Known gaps / failures

- Full repository `bun run verify` and the required app visual audit remain pending.
- Targeted Playwright onboarding smoke is queued/running behind the shared UI-smoke lock.
- This PR intentionally does not address the separately classified walkthrough gesture and WebKit history flakes.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6c033a6d10e6af64e773bc715d96efac06be396f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [ci_19276_detent_webkit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6c033a6d10e6af64e773bc715d96efac06be396f:packages/skills/skills/contribute-to-eliza"} -->
