### PR TITLE
fix(ui): derive three cloud suites' expectations from the domain contract

### DIFF
--- a/packages/ui/src/cloud/applications/components/BuyDomainCard.test.tsx
+++ b/packages/ui/src/cloud/applications/components/BuyDomainCard.test.tsx
@@ -10,6 +10,7 @@
  * `sonner` toast are doubled; the card renders for real.
  */
 
+import { ELIZA_DOMAIN_CONTRACTS } from "@elizaos/shared/elizacloud/domain-contract";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -196,7 +197,7 @@ describe("BuyDomainCard (#10246)", () => {
     });
     await user.click(addCredits);
     expect(openExternalUrlMock).toHaveBeenCalledWith(
-      expect.stringContaining("/settings#cloud-billing"),
+      `${ELIZA_DOMAIN_CONTRACTS.production.cloudAppOrigin}/cloud/billing`,
     );
   });
 });

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.render.test.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.render.test.tsx
@@ -10,6 +10,7 @@
  * action, and the deactivate confirm dialog's billing-transparency copy.
  */
 
+import { ELIZA_DOMAIN_CONTRACTS } from "@elizaos/shared/elizacloud/domain-contract";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -266,7 +267,9 @@ describe("ElizaAgentsTable per-row view model", () => {
     const links = screen.getAllByRole("link", { name: "Open Eliza app" });
     expect(links.length).toBeGreaterThanOrEqual(1);
     for (const link of links) {
-      expect(link.getAttribute("href")).toBe("https://app.elizacloud.ai");
+      expect(link.getAttribute("href")).toBe(
+        ELIZA_DOMAIN_CONTRACTS.production.cloudAppOrigin,
+      );
       expect(link.getAttribute("target")).toBe("_blank");
       expect(link.getAttribute("rel")).toBe("noreferrer");
     }

--- a/packages/ui/src/cloud/public-pages/pages/auth/auth-success-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/auth-success-page.test.tsx
@@ -8,6 +8,7 @@
  * state. Harness mocks the cloud API client.
  */
 
+import { ELIZA_DOMAIN_CONTRACTS } from "@elizaos/shared/elizacloud/domain-contract";
 import { act, cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -96,7 +97,7 @@ function setPageOrigin(origin: string): void {
 beforeEach(() => {
   // Default to a Cloud web origin so relative `api()` transport is exercised.
   // jsdom's default host is loopback, which intentionally uses absolute Cloud.
-  setPageOrigin("https://app.elizacloud.ai");
+  setPageOrigin(ELIZA_DOMAIN_CONTRACTS.production.cloudAppOrigin);
 });
 
 afterEach(() => {
@@ -429,9 +430,7 @@ describe("verifyAuthSuccessCandidate", () => {
     expect(apiMock).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringMatching(
-        /^https:\/\/api\.elizacloud\.ai\/api\/v1\/oauth\/success-proof\/verify\?proof=loopback\.sig$/,
-      ),
+      `${ELIZA_DOMAIN_CONTRACTS.production.cloudApiOrigin}/api/v1/oauth/success-proof/verify?proof=loopback.sig`,
       expect.objectContaining({ credentials: "include", method: "GET" }),
     );
   });


### PR DESCRIPTION
# Relates to

Part of #19317 (`Tests (client)` lane inventory).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package gates were run after sync; results below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - maintainer review lane, no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop@1d5b66935d0`; zero conflicts.

# Risks

None to product code. Both files are tests; no `src/` behavior changes.

# Background

## What does this PR do?

Three suites fail the `Tests (client)` lane on clean `develop@d3d5114b0b6` as leftovers of `0468c1850a3` ("feat: consolidate Eliza Cloud into eliza.app"). They are part of the 10-suite inventory in #19317.

Drift ran in **both** directions in that commit, so I checked which side was wrong per suite instead of assuming the tests were stale. In these three the product is already correct and the test asserts a retired literal:

| Suite | Test asserted | Code emits |
| --- | --- | --- |
| `eliza-agents-table.render` | `https://app.elizacloud.ai` | `ELIZA_DOMAIN_CONTRACTS.production.cloudAppOrigin` (`https://cloud.eliza.app`) |
| `BuyDomainCard` | `/settings#cloud-billing` | `<cloudAppOrigin>/cloud/billing` |
| `auth-success-page` | `/^https:\/\/api\.elizacloud\.ai\/...$/` | `<cloudApiOrigin>/api/v1/oauth/success-proof/verify?...` |

Expectations now read the **exported contract** (`ELIZA_DOMAIN_CONTRACTS` from `@elizaos/shared/elizacloud/domain-contract`) rather than being swapped to fresh literals. This is the seventh location of the same rename; deriving from the constant is what stops an eighth. `packages/ui` already imports this module (`api/direct-cloud-endpoints.ts`, `components/auth/CloudPairRelay.tsx`), so no dependency direction is inverted and no literal-with-a-comment fallback is needed.

## Deliberately NOT in this PR

The fourth suite from #19317's drift group, `app-frontend-hosting`, is a **product** fix, not a test fix — the consolidation updated its assertion to expect `buildMeta.source === "cloud"` but left the client emitting `"dashboard"`. Fixing it means editing `app-frontend-hosting.tsx`, which is a rendered-UI source file and trips the evidence gate's surface rule (verified: that file alone flips the gate, while `.test.tsx` files do not). Its pixels do not change — the field is a request-body provenance tag — so rather than attach manufactured before/after captures to a PR that changes no pixels, it ships separately with its own evidence. Splitting also keeps this PR disjoint from #19265 and #19312 so all three land in any order.

## What kind of change is this?

Bug fix (non-breaking; test-only).

# Documentation changes needed?

No.

# Testing

## Detailed testing steps

```bash
bun run --cwd packages/ui test \
  src/cloud/instances/components/eliza-agents-table.render.test.tsx \
  src/cloud/applications/components/BuyDomainCard.test.tsx \
  src/cloud/public-pages/pages/auth/auth-success-page.test.tsx
bun run --cwd packages/ui test src/cloud
```

# Evidence Gate

<!-- evidence-head:fb1f816be8cdd9fa599faf8e8261bf0bb4915fbe -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no rendered surface is added, removed, or restyled.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change; no rendered surface is added, removed, or restyled.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server or API path changes; red/green test transcripts below are the measurement.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer behavior changes; `sw.js` and every `src/` file are untouched.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, wallet, or generated-domain artifacts change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual output.

# Evidence Details

## Backend + frontend logs

**Before — clean `develop@d3d5114b0b6`, no changes applied:**

```
FAIL src/cloud/instances/components/eliza-agents-table.render.test.tsx
  AssertionError: expected 'https://cloud.eliza.app' to be 'https://app.elizacloud.ai'
FAIL src/cloud/applications/components/BuyDomainCard.test.tsx
  -   StringContaining "/settings#cloud-billing",
  +   "https://cloud.eliza.app/cloud/billing",
FAIL src/cloud/public-pages/pages/auth/auth-success-page.test.tsx
  -   StringMatching /^https:\/\/api\.elizacloud\.ai\/api\/v1\/oauth\/success-proof\/verify\?proof=loopback\.sig$/,
```

**After — this branch:**

```
$ bun run --cwd packages/ui test \
    src/cloud/instances/components/eliza-agents-table.render.test.tsx \
    src/cloud/applications/components/BuyDomainCard.test.tsx \
    src/cloud/public-pages/pages/auth/auth-success-page.test.tsx
 Test Files  3 passed (3)
      Tests  41 passed (41)

$ bun run --cwd packages/ui test src/cloud      # no collateral damage
 Test Files  113 passed (113)
      Tests  1078 passed (1078)

$ bunx biome check packages/ui/src/cloud
Checked 375 files in 166ms. No fixes applied.
```

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered visual surface.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT path is changed.

## Known gaps / failures

Root `bun run verify` was not run on this machine. The change is two test files with no `src/` reach; hosted CI covers the full gate.
