### PR TITLE
fix(ui): refresh dynamically registered settings sections

### DIFF
--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -9,7 +9,13 @@
  */
 import { isViewVisible } from "@elizaos/core";
 import { isPermissionId, type PermissionId } from "@elizaos/shared";
-import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { useAgentElement } from "../../agent-surface";
 import { isManagedCloudRuntime } from "../../cloud/managed-cloud-runtime";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
@@ -22,6 +28,10 @@ import { useEnabledViewKinds } from "../../state/useViewKinds";
 import { PermissionPrimingModal } from "../permissions/PermissionPrimingModal";
 import { DesktopSettingsNavigation } from "../settings/DesktopSettingsNavigation";
 import { SettingsHubList } from "../settings/SettingsHubList";
+import {
+  getSettingsSectionRegistryVersion,
+  subscribeSettingsSections,
+} from "../settings/settings-section-registry";
 import {
   backFromConnectorDetail,
   type GroupedSettingsSections,
@@ -236,6 +246,11 @@ export function SettingsView({
   const managedCloudRuntime = isManagedCloudRuntime(runtimeTarget);
   const enabledKinds = useEnabledViewKinds();
   const isDesktop = useMediaQuery("(min-width: 1024px)");
+  useSyncExternalStore(
+    subscribeSettingsSections,
+    getSettingsSectionRegistryVersion,
+    getSettingsSectionRegistryVersion,
+  );
   const [activeSection, setActiveSection] = useState<string | null>(
     () => initialSection ?? readSettingsHashSection(),
   );
@@ -246,23 +261,18 @@ export function SettingsView({
     null,
   );
 
-  const visibleSections = useMemo(() => {
-    return getAllSettingsSections().filter((section) => {
-      if (section.id === "wallet-rpc" && walletEnabled === false) return false;
-      if (section.cloudOnly && !managedCloudRuntime) return false;
-      if (!isViewVisible(section, enabledKinds)) return false;
-      if (section.hideOnCloud && isAndroidCloudBuild()) return false;
-      return true;
-    });
-  }, [walletEnabled, managedCloudRuntime, enabledKinds]);
-  const visibleSectionIds = useMemo(
-    () => new Set(visibleSections.map((section) => section.id)),
-    [visibleSections],
+  const visibleSections = getAllSettingsSections().filter((section) => {
+    if (section.id === "wallet-rpc" && walletEnabled === false) return false;
+    if (section.cloudOnly && !managedCloudRuntime) return false;
+    if (!isViewVisible(section, enabledKinds)) return false;
+    if (section.hideOnCloud && isAndroidCloudBuild()) return false;
+    return true;
+  });
+  const visibleSectionIds = new Set(
+    visibleSections.map((section) => section.id),
   );
-  const grouped: GroupedSettingsSections = useMemo(
-    () => groupSettingsSections(visibleSections),
-    [visibleSections],
-  );
+  const grouped: GroupedSettingsSections =
+    groupSettingsSections(visibleSections);
 
   useEffect(() => {
     void loadPlugins();

--- a/packages/ui/src/components/settings/settings-section-registry.test.ts
+++ b/packages/ui/src/components/settings/settings-section-registry.test.ts
@@ -10,9 +10,11 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { resetUiRegistryHostForTests } from "../../registry-host";
 import {
   getSettingsSection,
+  getSettingsSectionRegistryVersion,
   listSettingsSections,
   registerSettingsSection,
   type SettingsSectionDef,
+  subscribeSettingsSections,
 } from "./settings-section-registry";
 
 function makeSection(
@@ -63,5 +65,19 @@ describe("settings-section-registry", () => {
     expect(ordered.indexOf("order-early")).toBeLessThan(
       ordered.indexOf("order-late"),
     );
+  });
+
+  it("notifies live consumers when a section registers", () => {
+    const versions: number[] = [];
+    const unsubscribe = subscribeSettingsSections(() => {
+      versions.push(getSettingsSectionRegistryVersion());
+    });
+
+    registerSettingsSection(makeSection("live-plugin-section"));
+    unsubscribe();
+    registerSettingsSection(makeSection("after-unsubscribe"));
+
+    expect(versions).toHaveLength(1);
+    expect(versions[0]).toBeGreaterThan(0);
   });
 });

--- a/packages/ui/src/components/settings/settings-section-registry.ts
+++ b/packages/ui/src/components/settings/settings-section-registry.ts
@@ -102,6 +102,7 @@ interface SettingsSectionRegistryStore {
 }
 
 const SETTINGS_SECTION_REGISTRY_STORE = "settings-sections";
+const registryListeners = new Set<() => void>();
 
 function getStore(): SettingsSectionRegistryStore {
   return getUiRegistryStore(SETTINGS_SECTION_REGISTRY_STORE, () => ({
@@ -119,6 +120,18 @@ export function registerSettingsSection(section: SettingsSectionDef): void {
   const order = section.order ?? store.seq;
   store.seq += 1;
   store.entries.set(section.id, { ...section, order });
+  for (const listener of registryListeners) listener();
+}
+
+/** Monotonic snapshot used by React consumers of the dynamic registry. */
+export function getSettingsSectionRegistryVersion(): number {
+  return getStore().seq;
+}
+
+/** Re-render subscribers after a host or lazy domain registers a section. */
+export function subscribeSettingsSections(listener: () => void): () => void {
+  registryListeners.add(listener);
+  return () => registryListeners.delete(listener);
 }
 
 /** All registered sections, sorted by `order` then registration sequence. */


### PR DESCRIPTION
# Relates to

Fixes #19332

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based directly on the latest fetched `origin/develop` (`6f18a97d5d32c8c2edc6fe4fbcf231e86e503ab5`).
- [ ] `bun install` and `bun run verify` were not run yet; this is a draft pending the repository-wide gate.
- [ ] Reviewer-facing visual evidence is pending before this draft is marked ready.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Commit is parented directly on the latest fetched `origin/develop`; zero conflicts.
- [ ] `bun run verify` is pending; focused validation is recorded below.

# Risks

Low. This adds a small external-store notification boundary to the existing settings registry. The affected surface is section discovery/rendering; registration ownership and section definitions are unchanged.

# Background

## What does this PR do?

Makes `SettingsView` subscribe to the dynamic settings-section registry. Sections registered by asynchronously loaded cloud surfaces now appear without requiring a reload or remount.

It also adds a deterministic subscription/unsubscription regression test.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is needed; this restores the intended behavior of the existing dynamic registry contract.

# Testing

## Where should a reviewer start?

- `packages/ui/src/components/settings/settings-section-registry.ts`
- `packages/ui/src/components/pages/SettingsView.tsx`
- `packages/ui/src/components/settings/settings-section-registry.test.ts`

## Detailed testing steps

Focused automated validation completed on the source commit:

```text
bun run --cwd packages/ui test -- src/components/settings/settings-section-registry.test.ts src/components/pages/SettingsView.test.tsx
2 test files passed; 21 tests passed
```

Biome checks for all three changed files passed. Exact-head visual evidence was captured through the real Settings browser fixture at desktop and mobile widths; repository-wide `bun run verify` remains a draft follow-up.

# Evidence Gate

<!-- evidence-head:806d90ea1b7b94d1932ca7f8b476bbbbf774e17b -->

Refresh provenance: current head `806d90ea1b7b94d1932ca7f8b476bbbbf774e17b` reapplies the same scoped patch as prior head `325c0929d33fc1ac5b3d9e8dfa0b4ddbfa43ce04` onto `develop` `6f18a97d5d32c8c2edc6fe4fbcf231e86e503ab5`. Existing media and logs from the prior head remain identified as patch-equivalent evidence; current-head workflow results are authoritative.

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19333-before-desktop-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19333-after-desktop-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19333-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend path changes or fires for this in-browser registry notification.
<!-- evidence-row:frontend-logs -->
- [x] [19333-frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19333-frontend.log)
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no persisted domain state changes.
<!-- evidence-row:ocr-review -->
- [x] [19333-ocr-review.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19333-ocr-review.log)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model changes.

## Backend + frontend logs

Backend: N/A - browser-only subscription behavior.

Frontend: the attached exact-parent/exact-head log records the commit identities and browser assertions. The deterministic regression suite passes 21/21 tests, and the real Settings fixture reported zero uncaught page errors.

## Screenshots (before / after) + video walkthrough

The attached before/after contact sheets contain full-page desktop (1440×900) and mobile (390×844) captures. The parent `6f18a97d5d32c8c2edc6fe4fbcf231e86e503ab5` omits the late-registered row; exact head `325c0929d33fc1ac5b3d9e8dfa0b4ddbfa43ce04` shows it without reload or remount. The attached MP4 records the exact-head walkthrough.

# Known gaps / failures

- Repository-wide `bun run verify` has not yet run on this isolated draft head.
- UI screenshots, MP4, frontend logs, and OCR review are attached and exact-head-bound.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@6f18a97d5d32c8c2edc6fe4fbcf231e86e503ab5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [ci-smoke-1-3]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@6f18a97d5d32c8c2edc6fe4fbcf231e86e503ab5:packages/skills/skills/contribute-to-eliza"} -->

