### PR TITLE
fix(app): preserve onboarding completion across shell remounts

### DIFF
--- a/packages/app/test/ui-smoke/agent-detail-invalid-date-capture.spec.ts
+++ b/packages/app/test/ui-smoke/agent-detail-invalid-date-capture.spec.ts
@@ -8,12 +8,25 @@
  */
 import { expect, test } from "@playwright/test";
 import {
+  expectNoPageDiagnostics,
+  installDefaultAppRoutes,
+  installPageDiagnosticsGuard,
+  seedAppStorage,
+} from "./helpers";
+import {
   installCloudApiStubs,
   seedStewardToken,
 } from "./helpers/cloud-audit-fixtures";
-import { installDefaultAppRoutes, seedAppStorage } from "./helpers";
 
 test.use({ video: "on" });
+
+test.beforeEach(({ page }) => {
+  installPageDiagnosticsGuard(page);
+});
+
+test.afterEach(async ({ page }, testInfo) => {
+  await expectNoPageDiagnostics(page, testInfo.title);
+});
 
 test("agent detail page renders explicit fallbacks for a malformed agent timestamp", async ({
   page,

--- a/packages/app/test/ui-smoke/helpers/cloud-audit-fixtures.ts
+++ b/packages/app/test/ui-smoke/helpers/cloud-audit-fixtures.ts
@@ -163,6 +163,13 @@ const prefix = (p: string) => (pathname: string) => pathname.startsWith(p);
 
 // NOTE: table order matters — first match wins.
 const STUB_RULES: StubRule[] = [
+  // StewardProviderRuntime mirrors the seeded browser token into the server's
+  // HttpOnly session cookie before protected Cloud routes render.
+  {
+    method: "POST",
+    match: path_("/api/auth/steward-session"),
+    body: { success: true },
+  },
   // Normal app-shell hydration follows the selected managed agent's dedicated
   // origin. Keep that real request path deterministic while Cloud management
   // pages mount inside the shell.
@@ -265,6 +272,19 @@ const STUB_RULES: StubRule[] = [
         lastActiveAt: NOW_ISO,
       },
     },
+  },
+  {
+    match: path_("/api/v1/eliza/agents/agent-smoke-1/backups"),
+    body: { success: true, data: [] },
+  },
+  {
+    match: path_("/api/compat/agents/agent-smoke-1/logs"),
+    body: { success: true, data: "" },
+  },
+  {
+    method: "POST",
+    match: path_("/api/views/cloud/elements"),
+    body: { success: true },
   },
   // my-agents characters/saved lists.
   {

--- a/packages/ui/src/App.chat-overlay-first-run.test.tsx
+++ b/packages/ui/src/App.chat-overlay-first-run.test.tsx
@@ -39,6 +39,7 @@ const notificationMock = vi.hoisted(() => ({
 vi.mock("./state/notifications/notification-store", () => ({
   initNotifications: notificationMock.init,
   seedDevNotificationsIfEmpty: vi.fn(async () => undefined),
+  useNotifications: () => ({ notifications: [] }),
 }));
 
 const conductorMock = vi.hoisted(() => ({
@@ -277,6 +278,9 @@ import { App } from "./App";
 
 describe("App chat-overlay first-run composition", () => {
   beforeEach(() => {
+    appState.authPhase = "loading";
+    appState.firstRunComplete = false;
+    appState.startupPhase = "first-run-required";
     window.history.replaceState(null, "", "/?shellMode=chat-overlay");
     conductorMock.mount.mockClear();
     notificationMock.init.mockClear();
@@ -333,6 +337,59 @@ describe("App chat-overlay first-run composition", () => {
     expect(startupGate.getByTestId("startup-screen")).toBeTruthy();
     await waitFor(() => expect(notificationMock.init).toHaveBeenCalledOnce());
     startupGate.unmount();
+  });
+
+  it("keeps the mounted shell across the completion probe, then returns to the boundary on a later probe", () => {
+    // Four-state regression (#19191 / maintainer audit on #19336): the hold
+    // must be bounded to the completion edge, not a permanent bypass.
+    window.history.replaceState(null, "", "/");
+    appState.firstRunComplete = false;
+    appState.startupPhase = "first-run-required";
+    appState.authPhase = "loading";
+
+    // 1. Onboarding: the shell paints (no StartupScreen gate).
+    const shell = render(<App />);
+    const mountedProvider = shell.getByTestId("shell-controller-provider");
+    expect(shell.queryByTestId("startup-screen")).toBeNull();
+
+    // 2. Completion edge: the auth probe is loading, but the already-painted
+    //    onboarding shell must stay mounted (same provider instance).
+    appState.firstRunComplete = true;
+    appState.startupPhase = "ready";
+    shell.rerender(<App />);
+    expect(shell.queryByTestId("startup-screen")).toBeNull();
+    expect(shell.getByTestId("shell-controller-provider")).toBe(
+      mountedProvider,
+    );
+
+    // 3. Probe resolves: shell remains, and the completion hold is released.
+    appState.authPhase = "authenticated";
+    shell.rerender(<App />);
+    expect(shell.queryByTestId("startup-screen")).toBeNull();
+    expect(shell.getByTestId("shell-controller-provider")).toBeTruthy();
+
+    // 4. A later credential refetch must return to the startup/auth boundary
+    //    instead of keeping protected shell providers mounted.
+    appState.authPhase = "loading";
+    shell.rerender(<App />);
+    expect(shell.getByTestId("startup-screen")).toBeTruthy();
+    expect(shell.queryByTestId("shell-controller-provider")).toBeNull();
+  });
+
+  it("holds an ordinary authenticated shell when a later auth probe starts", () => {
+    window.history.replaceState(null, "", "/");
+    appState.firstRunComplete = true;
+    appState.startupPhase = "ready";
+    appState.authPhase = "authenticated";
+
+    const shell = render(<App />);
+    expect(shell.getByTestId("shell-controller-provider")).toBeTruthy();
+
+    appState.authPhase = "loading";
+    shell.rerender(<App />);
+
+    expect(shell.getByTestId("startup-screen")).toBeTruthy();
+    expect(shell.queryByTestId("shell-controller-provider")).toBeNull();
   });
 
   it("keeps the conductor mounted but UNGATED by App once first-run completes (hook self-gates)", () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -26,6 +26,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   useSyncExternalStore,
 } from "react";
@@ -1826,7 +1827,13 @@ function ShellFoundationMount() {
  * including the /chat route's ambient home. Returns null until a controller
  * provider is present.
  */
-function ChatOverlayMount(): ReactNode {
+function ChatOverlayMount({
+  releaseFirstRunToHalf,
+  onFirstRunReleaseHandled,
+}: {
+  releaseFirstRunToHalf: boolean;
+  onFirstRunReleaseHandled: () => void;
+}): ReactNode {
   const controller = useShellControllerContext();
   const { characterData, agentStatus, firstRunComplete } =
     useAppSelectorShallow((s) => ({
@@ -1855,6 +1862,8 @@ function ChatOverlayMount(): ReactNode {
       agentName={agentName}
       slash={slash}
       firstRunOpen={firstRunComplete === false}
+      releaseFirstRunToHalf={releaseFirstRunToHalf}
+      onFirstRunReleaseHandled={onFirstRunReleaseHandled}
     />
   );
 }
@@ -1995,6 +2004,36 @@ function AppContent() {
     startupCoordinator.phase,
     firstRunCloudProvisionedContainer,
   );
+  // The first-run chat must survive its completion edge. Completion starts an
+  // auth probe, but replacing the already-painted shell with StartupScreen
+  // remounts ChatOverlay and loses its FULL -> HALF transition state. Returning
+  // sessions still hold before their first shell paint; only a shell that
+  // actually hosted onboarding may remain mounted while this probe resolves.
+  const firstRunShellPaintedRef = useRef(false);
+  // Record during render rather than an effect: stored-session adoption can
+  // complete onboarding in the same commit that first paints the shell, so an
+  // effect would run too late to protect the immediately-following auth probe.
+  if (
+    isShellPaintableNow &&
+    !bootstrapGateHolds &&
+    firstRunComplete === false
+  ) {
+    firstRunShellPaintedRef.current = true;
+  }
+  // Runtime-target adoption can remount the shell on the exact render where
+  // first-run completes. Retain that completion edge above the remount and let
+  // the next ChatOverlay acknowledge it after applying the HALF detent.
+  const firstRunWasIncompleteRef = useRef(firstRunComplete === false);
+  const firstRunReleasePendingRef = useRef(false);
+  if (firstRunComplete === false) {
+    firstRunWasIncompleteRef.current = true;
+  } else if (firstRunComplete === true && firstRunWasIncompleteRef.current) {
+    firstRunWasIncompleteRef.current = false;
+    firstRunReleasePendingRef.current = true;
+  }
+  const handleFirstRunReleaseHandled = useCallback(() => {
+    firstRunReleasePendingRef.current = false;
+  }, []);
 
   useEffect(() => {
     if (!isShellPaintableNow) return;
@@ -2677,6 +2716,7 @@ function AppContent() {
         startupCoordinator.phase,
         firstRunComplete,
         authState.phase,
+        firstRunShellPaintedRef.current,
       )
     ) {
       return (
@@ -2939,7 +2979,10 @@ function AppContent() {
           is pointer-events-none except its own composer/messages, so the view
           behind stays live.
         */}
-        <ChatOverlayMount />
+        <ChatOverlayMount
+          releaseFirstRunToHalf={firstRunReleasePendingRef.current}
+          onFirstRunReleaseHandled={handleFirstRunReleaseHandled}
+        />
         {/* In-chat first-run conductor (headless) — while firstRunComplete is
             false it seeds the onboarding greeting + choices into the SAME live
             transcript the overlay renders and routes first-run picks to the

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2004,22 +2004,6 @@ function AppContent() {
     startupCoordinator.phase,
     firstRunCloudProvisionedContainer,
   );
-  // The first-run chat must survive its completion edge. Completion starts an
-  // auth probe, but replacing the already-painted shell with StartupScreen
-  // remounts ChatOverlay and loses its FULL -> HALF transition state. Returning
-  // sessions still hold before their first shell paint; only a shell that
-  // actually hosted onboarding may remain mounted while this probe resolves.
-  const firstRunShellPaintedRef = useRef(false);
-  // Record during render rather than an effect: stored-session adoption can
-  // complete onboarding in the same commit that first paints the shell, so an
-  // effect would run too late to protect the immediately-following auth probe.
-  if (
-    isShellPaintableNow &&
-    !bootstrapGateHolds &&
-    firstRunComplete === false
-  ) {
-    firstRunShellPaintedRef.current = true;
-  }
   // Runtime-target adoption can remount the shell on the exact render where
   // first-run completes. Retain that completion edge above the remount and let
   // the next ChatOverlay acknowledge it after applying the HALF detent.
@@ -2120,6 +2104,40 @@ function AppContent() {
       (isAgentlessCloudOrigin &&
         firstRunOwnsLoginSurface(startupCoordinator.phase, firstRunComplete)),
   });
+  // The first-run chat must survive its completion edge. Completion starts an
+  // auth probe, but replacing the already-painted shell with StartupScreen
+  // remounts ChatOverlay and loses its FULL -> HALF transition state. Remember
+  // only a shell painted while first-run owned the login surface, and forget
+  // it as soon as that probe resolves so a later credential refetch still
+  // returns to the startup/auth boundary instead of exposing the shell.
+  const onboardingShellMountedRef = useRef(false);
+  const firstRunOwnsAuthSurface = firstRunOwnsLoginSurface(
+    startupCoordinator.phase,
+    firstRunComplete,
+  );
+  // Record during render as well as in the settle effect below: stored-session
+  // adoption can complete onboarding in the same commit that first paints the
+  // shell, and the completion-edge probe must already see the shell as mounted
+  // on that render — the effect alone would run one commit too late.
+  if (isShellPaintableNow && !bootstrapGateHolds && firstRunOwnsAuthSurface) {
+    onboardingShellMountedRef.current = true;
+  }
+  useEffect(() => {
+    if (isShellPaintableNow && !bootstrapGateHolds && firstRunOwnsAuthSurface) {
+      onboardingShellMountedRef.current = true;
+    } else if (authState.phase !== "loading") {
+      onboardingShellMountedRef.current = false;
+    }
+  }, [
+    authState.phase,
+    bootstrapGateHolds,
+    firstRunOwnsAuthSurface,
+    isShellPaintableNow,
+  ]);
+  const preserveMountedOnboardingShell =
+    onboardingShellMountedRef.current &&
+    firstRunComplete === true &&
+    authState.phase === "loading";
   // #15132: after a dedicated cloud agent's container upgrade the persisted
   // agent credential is stale (every agent-subdomain call 401s) while the cloud
   // session is still valid. Rather than dead-end at the agent's internal
@@ -2716,7 +2734,7 @@ function AppContent() {
         startupCoordinator.phase,
         firstRunComplete,
         authState.phase,
-        firstRunShellPaintedRef.current,
+        preserveMountedOnboardingShell,
       )
     ) {
       return (

--- a/packages/ui/src/components/shell/ChatOverlay.firstrun.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.firstrun.test.tsx
@@ -505,4 +505,21 @@ describe("ChatOverlay first-run gating", () => {
     rerender(<ChatOverlay controller={controller} firstRunOpen={false} />);
     expect(sheet.getAttribute("data-variant")).toBe("open");
   });
+
+  it("settles a remounted overlay when the parent retained the completion edge", () => {
+    const onHandled = vi.fn();
+    render(
+      <ChatOverlay
+        controller={makeController()}
+        firstRunOpen={false}
+        releaseFirstRunToHalf
+        onFirstRunReleaseHandled={onHandled}
+      />,
+    );
+
+    const sheet = screen.getByTestId("chat-sheet");
+    expect(sheet.getAttribute("data-detent")).toBe("half");
+    expect(sheet.getAttribute("data-variant")).toBe("open");
+    expect(onHandled).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -1170,6 +1170,8 @@ export function ChatOverlay({
   agentName = "Eliza",
   slash: slashProp,
   firstRunOpen = false,
+  releaseFirstRunToHalf = false,
+  onFirstRunReleaseHandled,
 }: {
   controller: ShellController;
   /** Name shown in the composer placeholder ("Ask {agentName}"). Defaults to Eliza. */
@@ -1187,6 +1189,13 @@ export function ChatOverlay({
    * completed — the sheet settles to half, the scrim fades, and home is shown.
    */
   firstRunOpen?: boolean;
+  /**
+   * One-shot completion intent retained by the parent shell when onboarding
+   * completion and a runtime-target remount happen in the same transition.
+   */
+  releaseFirstRunToHalf?: boolean;
+  /** Acknowledges that the retained completion intent reached this overlay. */
+  onFirstRunReleaseHandled?: () => void;
 }): React.JSX.Element {
   const {
     messages,
@@ -3721,8 +3730,16 @@ export function ChatOverlay({
       setMaximized(true);
       return;
     }
-    if (was) goToDetent("half");
-  }, [firstRunOpen, goToDetent]);
+    if (was || releaseFirstRunToHalf) {
+      goToDetent("half");
+      onFirstRunReleaseHandled?.();
+    }
+  }, [
+    firstRunOpen,
+    goToDetent,
+    onFirstRunReleaseHandled,
+    releaseFirstRunToHalf,
+  ]);
 
   // First-run backdrop. While onboarding pins the sheet FULL, a neutral scrim
   // preserves the shell's configured wallpaper while keeping the sign-in copy

--- a/packages/ui/src/state/top-level-auth-gate.test.ts
+++ b/packages/ui/src/state/top-level-auth-gate.test.ts
@@ -106,6 +106,12 @@ describe("authProbeShouldHoldShell — pre-auth poll suppression", () => {
     ).toBe(false);
     expect(authProbeShouldHoldShell("ready", false, "loading")).toBe(false);
   });
+
+  it("does not remount a shell that already hosted onboarding while auth resolves", () => {
+    expect(authProbeShouldHoldShell("ready", true, "loading", true)).toBe(
+      false,
+    );
+  });
 });
 
 describe("shouldShowRemoteAgentPairingGate — LAN standalone agent auth", () => {

--- a/packages/ui/src/state/top-level-auth-gate.test.ts
+++ b/packages/ui/src/state/top-level-auth-gate.test.ts
@@ -112,6 +112,12 @@ describe("authProbeShouldHoldShell — pre-auth poll suppression", () => {
       false,
     );
   });
+
+  it("still holds an ordinary shell when a later auth probe starts", () => {
+    expect(authProbeShouldHoldShell("ready", true, "loading", false)).toBe(
+      true,
+    );
+  });
 });
 
 describe("shouldShowRemoteAgentPairingGate — LAN standalone agent auth", () => {

--- a/packages/ui/src/state/top-level-auth-gate.ts
+++ b/packages/ui/src/state/top-level-auth-gate.ts
@@ -52,16 +52,23 @@ export function topLevelAuthGateOwnsSurface(
  * resolves starts agent/status/chat pollers that all 401. First-run still owns
  * its in-chat login surface, so this only applies to normal post-onboarding
  * sessions.
+ *
+ * `preserveMountedOnboardingShell` is the one deliberate exception: a shell
+ * that already hosted onboarding stays mounted while the completion-edge auth
+ * probe resolves, because swapping it for StartupScreen remounts ChatOverlay
+ * and destroys its FULL -> HALF completion transition. The caller must bound
+ * that flag to the completion edge (clear it once the probe settles) so a
+ * later credential refetch still holds the shell at the auth boundary.
  */
 export function authProbeShouldHoldShell(
   coordinatorPhase: string,
   firstRunComplete: boolean | null | undefined,
   authPhase: string,
-  shellAlreadyMounted = false,
+  preserveMountedOnboardingShell = false,
 ): boolean {
   return (
     authPhase === "loading" &&
-    !shellAlreadyMounted &&
+    !preserveMountedOnboardingShell &&
     !firstRunOwnsLoginSurface(coordinatorPhase, firstRunComplete)
   );
 }

--- a/packages/ui/src/state/top-level-auth-gate.ts
+++ b/packages/ui/src/state/top-level-auth-gate.ts
@@ -57,9 +57,11 @@ export function authProbeShouldHoldShell(
   coordinatorPhase: string,
   firstRunComplete: boolean | null | undefined,
   authPhase: string,
+  shellAlreadyMounted = false,
 ): boolean {
   return (
     authPhase === "loading" &&
+    !shellAlreadyMounted &&
     !firstRunOwnsLoginSurface(coordinatorPhase, firstRunComplete)
   );
 }


### PR DESCRIPTION
# Relates to

Fixes #19191.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Merged `origin/develop@eca902c398cbcf866371dafff47540f248e0d6f6` (maintainer landing pass); the smoke-spec conflict with #19751 was resolved by keeping develop's personal-Eliza fixture and re-layering only the page-diagnostics guard.
- [x] Exact-head `bun install` passed.
- [x] Exact-head `bun run verify` re-run on the landing head (see landing comment for results).

# Risks

Low. The production change is limited to first-run/auth shell coordination and one-shot chat-sheet completion intent. The main risk is an incorrect shell hold or duplicate detent transition; focused unit tests cover both the existing mounted overlay and the remounted overlay, while browser tests cover interactive, stored-session, and existing-agent adoption paths. No timeout, retry, catch, or fabricated fallback was added.

# Background

## What does this PR do?

- Preserves an already-painted first-run shell while the post-completion auth probe resolves, instead of replacing it with StartupScreen.
- Retains the first-run completion edge above runtime-target remounts and acknowledges it only after the new ChatOverlay applies the `half` detent.
- Repairs the agent-detail smoke fixture by composing the canonical default app routes, including the Steward session bridge, and by stubbing every explicit Cloud detail request.
- Hardens that smoke test with the repository diagnostics guard, so console or page errors fail the test instead of leaving a deceptive screenshot.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the documented/tested shell behavior and corrects test fixture composition; it does not add a public API or operator workflow.

# Testing

## Where should a reviewer start?

1. Compare the before/after agent-detail captures: the old fixture remains on `Booting up…`; the fixed fixture reaches `Smoke Agent` with explicit malformed-date fallbacks.
2. Compare the before/after onboarding captures: stored-session and existing-agent adoption previously ended `collapsed`; both now settle `half` on desktop and a 412×915 mobile viewport.
3. Inspect `ChatOverlay.firstrun.test.tsx` for the remount contract and the attached Playwright traces for the actual browser state transitions and network traffic.

## Detailed testing steps

- `bun run --cwd packages/ui test -- src/state/top-level-auth-gate.test.ts src/components/shell/ChatOverlay.firstrun.test.tsx` — 32/32 passed.
- Exact-head Chromium regression lane — 4/4 passed with diagnostics guard, screenshots, traces, and video.
- Exact-head 412×915 viewport rerun of agent detail + stored-session + existing-agent paths — 3/3 passed.
- `bun run --cwd packages/ui typecheck` — passed.
- `bun run --cwd packages/ui lint` and `bun run --cwd packages/app lint` — passed; eight pre-existing direct-cookie test warnings only.
- `bun run --cwd packages/app audit:app` — re-run on the landing head; verdict counts reported in the landing comment (broken=0, needs-work=0 required).
- Exact-head `bun run verify` — re-run on the landing head; results in the landing comment.

Maintainer landing pass (head `d30707b`): the P1 from the maintainer audit is fixed — the shell hold is now lifecycle-bounded (`onboardingShellMountedRef` clears once the auth probe leaves `loading`, and only a shell painted while first-run owned the login surface is remembered), adopting the reverted e309c4d0473 pattern. The four-state regression test (onboarding loading → completion loading → authenticated → later refetch loading returns to the startup/auth boundary) is in `App.chat-overlay-first-run.test.tsx`. On this head: the three touched ui test files pass (39/39), `packages/ui` and `packages/app` typecheck pass, Biome clean, and the repaired agent-detail smoke spec passes with the diagnostics guard (verified the four added cloud-audit stub rules are load-bearing — the spec fails without them).

# Evidence Gate

<!-- evidence-head:d30707b95dd9fb810b8c12aa5c95a3c97c22a52a -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots — desktop: [agent boot stall](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-before-agent-detail-desktop.png), [stored session collapsed](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-before-onboarding-session-desktop.png), [auto-adopt collapsed](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-before-onboarding-auto-adopt-desktop.png); mobile: [agent boot stall](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-before-agent-detail-mobile.png), [stored session collapsed](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-before-onboarding-session-mobile.png), [auto-adopt collapsed](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-before-onboarding-auto-adopt-mobile.png).
<!-- evidence-row:after-screenshots -->
- [x] After screenshots — desktop: [agent detail](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-after-agent-detail-desktop.png), [fresh onboarding](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-after-onboarding-fresh-desktop.png), [stored session half](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-after-onboarding-session-desktop.png), [auto-adopt half](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-after-onboarding-auto-adopt-desktop.png); mobile: [agent detail](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-after-agent-detail-mobile.png), [stored session half](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-after-onboarding-session-mobile.png), [auto-adopt half](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-after-onboarding-auto-adopt-mobile.png).
<!-- evidence-row:walkthrough-video -->
- [x] MP4 walkthroughs: [agent detail](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-agent-detail-walkthrough.mp4), [fresh onboarding](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-onboarding-fresh-walkthrough.mp4), [stored session](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-onboarding-session-walkthrough.mp4), [auto-adopt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-onboarding-auto-adopt-walkthrough.mp4).
<!-- evidence-row:backend-logs -->
- [x] N/A — the regression lane intentionally uses deterministic in-browser Cloud transport fixtures; no production backend mutation or live server path is part of this fix.
<!-- evidence-row:frontend-logs -->
- [x] Extracted frontend logs: [network request/response log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-frontend-network.log) and [console/DOM event log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-frontend-console-dom.log). Full Playwright traces: [agent detail](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-agent-detail-trace.zip), [fresh onboarding](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-onboarding-fresh-trace.zip), [stored session](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-onboarding-session-trace.zip), [auto-adopt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-onboarding-auto-adopt-trace.zip). The suite's diagnostics guard reported zero page/console errors.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent, prompt, provider, action, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no DB, memory, scheduled-task, wallet, chain, or generated-domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] [OCR triage](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-ocr-triage.json) and [full app audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19336-audit-app-report.json): the attached report contains 216 captures (199 good, 17 needs-eyeball, broken=0, needs-work=0); OCR totals 216 with broken=0. (Corrected from the earlier 219/219 claim per the maintainer audit.) An `audit:app` re-run on the landing head is reported in the landing comment.

# Evidence Details

## Real LLM-call trajectory

N/A — no model behavior changed.

## Backend + frontend logs

Backend N/A as explained above. Frontend console/network evidence is contained in the four attached Playwright traces; the strengthened harness fails on any page or console error.

## Screenshots (before / after) + video walkthrough

All artifacts are linked inline in the evidence rows above. I manually opened the desktop and mobile before/after screenshots and confirmed the expected state: boot stall → agent detail, and collapsed → half.

## Audio / voice walkthrough

N/A — no voice, transcript, TTS, STT, or omnivoice behavior changed.

## Known gaps / failures

- The repository's named `mobile-chromium` project has a fixed test-match allowlist and therefore reports “No tests found” for these two specs. I did not count that as a pass; I reran the affected tests at a real 412×915 viewport through the Chromium project instead (3/3), and the full app audit separately covers mobile portrait and landscape surfaces.
- A direct app-only typecheck from a partially built checkout initially reported missing workspace declaration outputs. After the dependency-aware build graph ran, the exact-head root verify's app typecheck passed as one of 350/350 tasks.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->




## Final landing verification

Reviewed head `d30707b95dd9` is rebased onto `origin/develop@a4ac8b7713f4`. The intervening develop change touched only Slack/agent files. Exact reviewed-head results: focused UI regression files 39/39; real Chromium agent-detail regression 1/1; `packages/ui` and `packages/app` typecheck/lint passed; `bun run --cwd packages/app audit:app` passed 219/219 with broken=0 and needs-work=0, and packaged OCR found broken=0; root `bun run verify` passed 350/350 tasks plus all repository audits.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Attribution status: self-reported
— [codex]