### PR TITLE
fix(agent): gate pending permissions to attested owners

### DIFF
--- a/packages/agent/src/providers/pending-permissions-provider.test.ts
+++ b/packages/agent/src/providers/pending-permissions-provider.test.ts
@@ -10,8 +10,14 @@
  * Deterministic: the registry and runtime are in-memory vi fakes.
  */
 import {
+  AgentRuntime,
+  attestDeliveryAudienceFromCanonicalRoom,
+  ChannelType,
+  type Character,
   type IAgentRuntime,
+  type Memory,
   selectV5PlannerStateProviderNames,
+  type UUID,
 } from "@elizaos/core";
 import type { IPermissionsRegistry, PermissionState } from "@elizaos/shared";
 import { describe, expect, it, vi } from "vitest";
@@ -36,14 +42,33 @@ function makeRegistry(pending: PermissionState[]): IPermissionsRegistry {
   };
 }
 
+const OWNER_ID = "00000000-0000-4000-8000-000000000001" as UUID;
+const GUEST_ID = "00000000-0000-4000-8000-000000000002" as UUID;
+const AGENT_ID = "00000000-0000-4000-8000-000000000003" as UUID;
+const ROOM_ID = "00000000-0000-4000-8000-000000000004" as UUID;
+
+function ownerMessage(entityId: UUID = OWNER_ID): Memory {
+  return {
+    id: "00000000-0000-4000-8000-000000000005" as UUID,
+    agentId: AGENT_ID,
+    entityId,
+    roomId: ROOM_ID,
+    content: { text: "Why was reminders blocked?", source: "test" },
+  } as Memory;
+}
+
 function makeRuntime(registry: IPermissionsRegistry | null): IAgentRuntime {
   return {
+    agentId: AGENT_ID,
+    getSetting: (key: string) =>
+      key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER_ID : undefined,
     getService: vi.fn((id: string) => {
       if (id === PERMISSIONS_REGISTRY_SERVICE_ID && registry) {
         return { getRegistry: () => registry };
       }
       return null;
     }),
+    reportError: vi.fn(),
   } as unknown as IAgentRuntime;
 }
 
@@ -229,7 +254,7 @@ describe("pendingPermissionsProvider", () => {
     const runtime = makeRuntime(null);
     const result = await pendingPermissionsProvider.get?.(
       runtime,
-      {} as never,
+      ownerMessage(),
       {} as never,
     );
     expect(result.text).toBe("");
@@ -239,13 +264,13 @@ describe("pendingPermissionsProvider", () => {
     const runtime = makeRuntime(makeRegistry([]));
     const result = await pendingPermissionsProvider.get?.(
       runtime,
-      {} as never,
+      ownerMessage(),
       {} as never,
     );
     expect(result.text).toBe("");
   });
 
-  it("emits a populated section when registry returns pending state", async () => {
+  it("fails closed for a direct owner call without audience attestation", async () => {
     const NOW = Date.now();
     const runtime = makeRuntime(
       makeRegistry([
@@ -265,35 +290,189 @@ describe("pendingPermissionsProvider", () => {
     );
     const result = await pendingPermissionsProvider.get?.(
       runtime,
-      {} as never,
+      ownerMessage(),
       {} as never,
     );
-    expect(result.text).toContain("PENDING PERMISSIONS:");
-    expect(result.text).toContain("reminders: denied");
-    expect(result.values?.pendingPermissionCount).toBe(1);
+    expect(result).toEqual({ text: "", values: {}, data: {} });
+  });
+
+  it("fails closed when invoked directly for a non-owner", async () => {
+    const runtime = makeRuntime(
+      makeRegistry([
+        {
+          id: "reminders",
+          status: "denied",
+          lastChecked: Date.now(),
+          canRequest: false,
+          platform: "darwin",
+        },
+      ]),
+    );
+    const result = await pendingPermissionsProvider.get?.(
+      runtime,
+      ownerMessage(GUEST_ID),
+      {} as never,
+    );
+
+    expect(result).toEqual({ text: "", values: {}, data: {} });
   });
 
   it("registers at position -5", () => {
     expect(pendingPermissionsProvider.position).toBe(-5);
   });
 
-  it("opts into response-state composition across narrow planner contexts", () => {
-    expect(pendingPermissionsProvider.alwaysInResponseState).toBe(true);
-    for (const selectedContexts of [["settings"], ["tasks"], ["code"], []]) {
-      const selected = selectV5PlannerStateProviderNames({
-        runtime: {
-          providers: [pendingPermissionsProvider],
-        } as unknown as IAgentRuntime,
-        message: {
-          id: "00000000-0000-0000-0000-000000000001",
-          entityId: "00000000-0000-0000-0000-000000000002",
-          roomId: "00000000-0000-0000-0000-000000000003",
-          content: { text: "Why was reminders blocked?" },
-        } as never,
-        selectedContexts: selectedContexts as never,
-        userRoles: ["MEMBER"],
+  it("survives narrow routing after production registration and composes for an attested owner DM", async () => {
+    const runtime = new AgentRuntime({
+      character: { name: "pending-permission-routing" } as Character,
+      settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+    });
+    const turn = {
+      ...ownerMessage(),
+      agentId: runtime.agentId,
+    } as Memory;
+    vi.spyOn(runtime, "getRoom").mockResolvedValue({
+      id: ROOM_ID,
+      agentId: runtime.agentId,
+      source: "test",
+      type: ChannelType.DM,
+    });
+    vi.spyOn(runtime, "getParticipantsForRoom").mockResolvedValue([
+      OWNER_ID,
+      runtime.agentId,
+    ]);
+    const registry = makeRegistry([
+      {
+        id: "reminders",
+        status: "denied",
+        lastChecked: Date.now(),
+        canRequest: false,
+        platform: "darwin",
+        lastBlockedFeature: {
+          app: "lifeops",
+          action: "reminders.create",
+          at: Date.now(),
+        },
+      },
+    ]);
+    vi.spyOn(runtime, "getService").mockReturnValue({
+      getRegistry: () => registry,
+    } as never);
+    runtime.registerProvider(pendingPermissionsProvider);
+
+    const materialized = runtime.providers.find(
+      (provider) => provider.name === pendingPermissionsProvider.name,
+    );
+    expect(materialized?.contexts).toEqual(["general"]);
+    expect(materialized?.alwaysInResponseState).toBe(true);
+    expect(materialized?.disclosureGate).toEqual({
+      require: "owner_exclusive",
+    });
+    const selected = selectV5PlannerStateProviderNames({
+      runtime,
+      message: turn,
+      selectedContexts: ["settings"],
+      userRoles: ["OWNER"],
+    });
+    expect(selected).toContain("elizaPendingPermissions");
+
+    await attestDeliveryAudienceFromCanonicalRoom(runtime, turn);
+    const state = await runtime.composeState(turn, selected, true, true);
+    expect(state.text).toContain("PENDING PERMISSIONS:");
+    expect(state.values.pendingPermissionCount).toBe(1);
+    const providerRecord = (
+      state.data.providers as Record<
+        string,
+        { data?: { pendingPermissions?: unknown } }
+      >
+    ).elizaPendingPermissions;
+    expect(providerRecord?.data?.pendingPermissions).toEqual([
+      {
+        id: "reminders",
+        status: "denied",
+        feature: "lifeops.reminders.create",
+      },
+    ]);
+  });
+
+  it("omits owner-private text and structured data for guest, shared, and unattested turns", async () => {
+    async function composeDenied(params: {
+      sender: UUID;
+      participants: UUID[];
+      attest: boolean;
+    }) {
+      const runtime = new AgentRuntime({
+        character: { name: "pending-permission-privacy" } as Character,
+        settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
       });
-      expect(selected).toContain("elizaPendingPermissions");
+      const turn = {
+        ...ownerMessage(params.sender),
+        agentId: runtime.agentId,
+      } as Memory;
+      vi.spyOn(runtime, "getRoom").mockResolvedValue({
+        id: ROOM_ID,
+        agentId: runtime.agentId,
+        source: "test",
+        type: ChannelType.DM,
+      });
+      vi.spyOn(runtime, "getParticipantsForRoom").mockResolvedValue([
+        ...params.participants,
+        runtime.agentId,
+      ]);
+      vi.spyOn(runtime, "getService").mockReturnValue({
+        getRegistry: () =>
+          makeRegistry([
+            {
+              id: "reminders",
+              status: "denied",
+              lastChecked: Date.now(),
+              canRequest: false,
+              platform: "darwin",
+              lastBlockedFeature: {
+                app: "private-canary-app",
+                action: "private-canary-action",
+                at: Date.now(),
+              },
+            },
+          ]),
+      } as never);
+      runtime.registerProvider(pendingPermissionsProvider);
+      const selected = selectV5PlannerStateProviderNames({
+        runtime,
+        message: turn,
+        selectedContexts: ["settings"],
+        userRoles: [params.sender === OWNER_ID ? "OWNER" : "GUEST"],
+      });
+      if (params.attest) {
+        await attestDeliveryAudienceFromCanonicalRoom(runtime, turn);
+      }
+      return runtime.composeState(turn, selected, true, true);
+    }
+
+    const states = await Promise.all([
+      composeDenied({
+        sender: GUEST_ID,
+        participants: [GUEST_ID],
+        attest: true,
+      }),
+      composeDenied({
+        sender: OWNER_ID,
+        participants: [OWNER_ID, GUEST_ID],
+        attest: true,
+      }),
+      composeDenied({
+        sender: OWNER_ID,
+        participants: [OWNER_ID],
+        attest: false,
+      }),
+    ]);
+    for (const state of states) {
+      expect(state.text).not.toContain("PENDING PERMISSIONS:");
+      expect(state.text).not.toContain("private-canary-app");
+      expect(state.values.pendingPermissionCount).toBeUndefined();
+      expect(
+        (state.data.providers as Record<string, unknown> | undefined)
+          ?.elizaPendingPermissions,
+      ).toBeUndefined();
     }
   });
 });

--- a/packages/agent/src/providers/pending-permissions-provider.ts
+++ b/packages/agent/src/providers/pending-permissions-provider.ts
@@ -11,12 +11,14 @@
  * on non-finite timestamps so provider text never shows "NaN days ago".
  */
 
-import type {
-  IAgentRuntime,
-  Memory,
-  Provider,
-  ProviderResult,
-  State,
+import {
+  type IAgentRuntime,
+  type Memory,
+  OWNER_EXCLUSIVE_DISCLOSURE_GATE,
+  type Provider,
+  type ProviderResult,
+  revalidateOwnerExclusiveDisclosure,
+  type State,
 } from "@elizaos/core";
 import type { IPermissionsRegistry, PermissionState } from "@elizaos/shared";
 import { PERMISSIONS_REGISTRY_SERVICE } from "../services/permissions-registry.ts";
@@ -124,15 +126,25 @@ export const pendingPermissionsProvider: Provider = {
   // on the very turn that needs it instead of being materialized as `general`
   // and filtered out before the model call.
   alwaysInResponseState: true,
+  disclosureGate: OWNER_EXCLUSIVE_DISCLOSURE_GATE,
   position: -5,
   cacheStable: false,
   cacheScope: "turn",
 
   async get(
     runtime: IAgentRuntime,
-    _message: Memory,
+    message: Memory,
     _state: State,
   ): Promise<ProviderResult> {
+    // Keep the provider fail-closed even when invoked directly outside the
+    // central composeState disclosure gate (tests, plugins, or future callers).
+    const disclosure = await revalidateOwnerExclusiveDisclosure(
+      runtime,
+      message,
+    );
+    if (!disclosure.allowed) {
+      return { text: "", values: {}, data: {} };
+    }
     const registry = resolveRegistry(runtime);
     if (!registry) return { text: "", values: {}, data: {} };
 


### PR DESCRIPTION
Follow-up to elizaOS/eliza#19263.

Adds the non-overridable owner-exclusive disclosure gate plus direct audience revalidation, and replaces raw-provider routing evidence with materialized registration → planner selection → `composeState` coverage. Owner-attested inclusion and guest/shared/unattested omission are asserted for text, values, and structured provider data.

## Verification

- focused Vitest: 15/15 passed
- git diff --check: passed

<!-- evidence-head:7bc16b2fea5d57a960a35242941f388e378b46b6 -->

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Agent provider privacy repair has no visual surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - Agent provider privacy repair has no visual surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No interactive or user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - Focused provider composition tests are summarized in the PR test plan; no backend service was started.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend runtime or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - Disclosure is proven with deterministic composeState tests; no real-LLM call is required.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No external domain artifact applies to this owner-audience disclosure boundary.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Hermes Agent
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Hermes Agent
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [hermes]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Hermes Agent","skill_revision":"N/A - no contribution skill used"} -->

