### PR TITLE
test(ui): pin consolidated cloud settings visibility

### DIFF
--- a/packages/ui/src/cloud/connectors/index.ts
+++ b/packages/ui/src/cloud/connectors/index.ts
@@ -60,7 +60,7 @@ export function registerCloudConnectorsSettingsSection(): void {
     group: "agent",
     titleKey: "settings.sections.cloudConnectors.title",
     defaultTitle: "Cloud Connectors",
-    // Hidden for MVP (kept registered so its route/deep-link still resolves).
+    // Deliberately public in the consolidated Cloud IA.
     viewKind: "release",
     cloudOnly: true,
     Component: CloudConnectorsSettingsSection,

--- a/packages/ui/src/cloud/settings/register-cloud-settings.test.ts
+++ b/packages/ui/src/cloud/settings/register-cloud-settings.test.ts
@@ -9,6 +9,7 @@
  * into the security group with non-colliding ids.
  */
 
+import { isViewVisible } from "@elizaos/core";
 import { beforeAll, describe, expect, it } from "vitest";
 import { listSettingsSections } from "../../components/settings/settings-section-registry";
 import {
@@ -83,6 +84,21 @@ describe("register-cloud-settings", () => {
       expect(section?.cloudOnly).toBe(true);
       expect(section?.Component).toBeTypeOf("function");
     }
+  });
+
+  it("registers Cloud Connectors as visible with Developer Mode off", () => {
+    const connector = listSettingsSections().find(
+      (section) => section.id === "cloud-connectors",
+    );
+
+    expect(connector).toBeDefined();
+    expect(connector?.viewKind).toBe("release");
+    expect(connector?.developerOnly).not.toBe(true);
+    expect(connector?.cloudOnly).toBe(true);
+    expect(
+      connector &&
+        isViewVisible(connector, { developer: false, preview: false }),
+    ).toBe(true);
   });
 
   it("registers the cloud Security additions into the security group with non-colliding ids", () => {


### PR DESCRIPTION
> **Superseded by #19580.** The original contributor base merged and was deleted; the verified repair was rebased directly onto `develop`.

Follow-up to elizaOS/eliza#19265.

Pins `cloud-connectors` through its real registration and runtime visibility predicate with Developer Mode disabled, asserts release visibility, and corrects the stale MVP-hidden comment.

## Verification

- focused Vitest: 10/10 passed
- git diff --check: passed

<!-- evidence-head:d6e899759e5fad65d6446c31fcadf21aef738f3a -->

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Test-only visibility contract follow-up; no rendered production behavior changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - Test-only visibility contract follow-up; the production connector was already public at the base head.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No interactive flow changed; this PR pins existing registration visibility.
<!-- evidence-row:backend-logs -->
- [ ] N/A - No backend service or API behavior changed.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - Focused Vitest evidence is summarized in the PR test plan; no browser network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model invocation or prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No external domain artifact applies to this registration visibility regression test.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Hermes Agent
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Hermes Agent
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [hermes]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Hermes Agent","skill_revision":"N/A - no contribution skill used"} -->

Evidence metadata refreshed and locally validated after the initial CI failure.
