### PR TITLE
fix(cloud): preserve canonical and legacy Headscale TLS

### DIFF
--- a/.github/workflows/arm-headscale-control-plane.yml
+++ b/.github/workflows/arm-headscale-control-plane.yml
@@ -69,10 +69,12 @@ jobs:
 
           if [ "$TARGET_ENVIRONMENT" = "production" ]; then
             expected_public_url="https://headscale.eliza.app"
+            expected_legacy_public_url="https://headscale.elizacloud.ai"
             default_api_url="http://127.0.0.1:8081"
             default_listen_addr="127.0.0.1:8081"
           else
             expected_public_url="https://headscale-staging.eliza.app"
+            expected_legacy_public_url="https://headscale-staging.elizacloud.ai"
             default_api_url="http://127.0.0.1:8080"
             default_listen_addr="127.0.0.1:8080"
           fi
@@ -81,6 +83,7 @@ jobs:
             exit 1
           fi
 
+          echo "resolved_legacy_public_url=$expected_legacy_public_url" >> "$GITHUB_ENV"
           echo "resolved_api_url=${HEADSCALE_API_URL:-$default_api_url}" >> "$GITHUB_ENV"
           echo "resolved_listen_addr=${HEADSCALE_LISTEN_ADDR:-$default_listen_addr}" >> "$GITHUB_ENV"
 
@@ -112,22 +115,29 @@ jobs:
             --ssh-key "$DEPLOY_SSH_KEY_PATH" \
             --ssh-known-hosts "${{ steps.key.outputs.known_hosts_path }}" \
             --headscale-public-url "$HEADSCALE_PUBLIC_URL" \
+            --headscale-legacy-public-url "$resolved_legacy_public_url" \
             --headscale-api-url "$resolved_api_url" \
             --listen-addr "$resolved_listen_addr"
 
-      - name: Verify canonical public health
+      - name: Verify canonical and legacy public health
         shell: bash
         run: |
           set -euo pipefail
-          for _ in $(seq 1 30); do
-            if curl --fail --silent --show-error --max-time 10 \
-              "$HEADSCALE_PUBLIC_URL/health" >/dev/null; then
-              exit 0
+          for public_url in "$HEADSCALE_PUBLIC_URL" "$resolved_legacy_public_url"; do
+            healthy=false
+            for _ in $(seq 1 30); do
+              if curl --fail --silent --show-error --max-time 10 \
+                "$public_url/health" >/dev/null; then
+                healthy=true
+                break
+              fi
+              sleep 5
+            done
+            if [ "$healthy" != "true" ]; then
+              echo "::error::Headscale health did not become ready at $public_url"
+              exit 1
             fi
-            sleep 5
           done
-          echo "::error::Canonical Headscale health did not become ready"
-          exit 1
 
       - name: Remove deploy SSH identity
         if: always()

--- a/.github/workflows/arm-headscale-control-plane.yml
+++ b/.github/workflows/arm-headscale-control-plane.yml
@@ -10,14 +10,6 @@ on:
         options:
           - staging
           - production
-      headscale_api_url:
-        description: Loopback Headscale API URL (blank uses the environment default)
-        required: false
-        type: string
-      listen_addr:
-        description: Loopback Headscale listen address (blank uses the environment default)
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -39,12 +31,30 @@ jobs:
       DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.ELIZA_PROVISIONING_SSH_KNOWN_HOSTS }}
       HEADSCALE_API_KEY: ${{ secrets.HEADSCALE_API_KEY }}
       HEADSCALE_PUBLIC_URL: ${{ vars.HEADSCALE_PUBLIC_URL }}
-      HEADSCALE_API_URL: ${{ inputs.headscale_api_url }}
-      HEADSCALE_LISTEN_ADDR: ${{ inputs.listen_addr }}
       AGENT_TOKEN_PRIVATE_KEY_PEM: ${{ secrets.AGENT_TOKEN_PRIVATE_KEY_PEM }}
       ELIZA_LOCAL_ROOT_KEY: ${{ secrets.ELIZA_LOCAL_ROOT_KEY }}
     steps:
+      - name: Validate protected deploy source
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$TARGET_ENVIRONMENT" in
+            staging) expected_ref="refs/heads/develop" ;;
+            production) expected_ref="refs/heads/main" ;;
+            *)
+              echo "::error::Unsupported Headscale target environment"
+              exit 1
+              ;;
+          esac
+          if [ "$GITHUB_REF" != "$expected_ref" ]; then
+            echo "::error::$TARGET_ENVIRONMENT Headscale deploys must run from $expected_ref"
+            exit 1
+          fi
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
@@ -67,25 +77,26 @@ jobs:
             exit 1
           fi
 
-          if [ "$TARGET_ENVIRONMENT" = "production" ]; then
-            expected_public_url="https://headscale.eliza.app"
-            expected_legacy_public_url="https://headscale.elizacloud.ai"
-            default_api_url="http://127.0.0.1:8081"
-            default_listen_addr="127.0.0.1:8081"
-          else
-            expected_public_url="https://headscale-staging.eliza.app"
-            expected_legacy_public_url="https://headscale-staging.elizacloud.ai"
-            default_api_url="http://127.0.0.1:8080"
-            default_listen_addr="127.0.0.1:8080"
-          fi
+          case "$TARGET_ENVIRONMENT" in
+            production)
+              expected_public_url="https://headscale.eliza.app"
+              expected_legacy_public_url="https://headscale.elizacloud.ai"
+              ;;
+            staging)
+              expected_public_url="https://headscale-staging.eliza.app"
+              expected_legacy_public_url="https://headscale-staging.elizacloud.ai"
+              ;;
+            *)
+              echo "::error::Unsupported Headscale target environment"
+              exit 1
+              ;;
+          esac
           if [ "$HEADSCALE_PUBLIC_URL" != "$expected_public_url" ]; then
             echo "::error::HEADSCALE_PUBLIC_URL does not match the canonical $TARGET_ENVIRONMENT contract"
             exit 1
           fi
 
           echo "resolved_legacy_public_url=$expected_legacy_public_url" >> "$GITHUB_ENV"
-          echo "resolved_api_url=${HEADSCALE_API_URL:-$default_api_url}" >> "$GITHUB_ENV"
-          echo "resolved_listen_addr=${HEADSCALE_LISTEN_ADDR:-$default_listen_addr}" >> "$GITHUB_ENV"
 
       - name: Install deploy SSH identity
         id: key
@@ -115,11 +126,9 @@ jobs:
             --ssh-key "$DEPLOY_SSH_KEY_PATH" \
             --ssh-known-hosts "${{ steps.key.outputs.known_hosts_path }}" \
             --headscale-public-url "$HEADSCALE_PUBLIC_URL" \
-            --headscale-legacy-public-url "$resolved_legacy_public_url" \
-            --headscale-api-url "$resolved_api_url" \
-            --listen-addr "$resolved_listen_addr"
+            --headscale-legacy-public-url "$resolved_legacy_public_url"
 
-      - name: Verify canonical and legacy public health
+      - name: Verify dual-SAN public identity and health
         shell: bash
         run: |
           set -euo pipefail
@@ -138,6 +147,51 @@ jobs:
               exit 1
             fi
           done
+
+          leaf_has_exact_san() {
+            local leaf_pem="$1"
+            local required_hostname="$2"
+            printf '%s\n' "$leaf_pem" \
+              | openssl x509 -noout -ext subjectAltName \
+              | tr ',' '\n' \
+              | sed -n 's/^[[:space:]]*DNS://p' \
+              | grep -Fx -- "$required_hostname" >/dev/null
+          }
+
+          expected_fingerprint=""
+          for public_url in "$HEADSCALE_PUBLIC_URL" "$resolved_legacy_public_url"; do
+            host="${public_url#https://}"
+            leaf_pem="$(
+              openssl s_client \
+                -connect "$host:443" \
+                -servername "$host" \
+                -verify_hostname "$host" \
+                -verify_return_error \
+                -showcerts </dev/null 2>/dev/null \
+                | openssl x509 -outform PEM
+            )"
+            for required_hostname in \
+              "${HEADSCALE_PUBLIC_URL#https://}" \
+              "${resolved_legacy_public_url#https://}"; do
+              if ! leaf_has_exact_san "$leaf_pem" "$required_hostname"; then
+                echo "::error::$host did not serve a leaf with exact SAN $required_hostname"
+                exit 1
+              fi
+            done
+            fingerprint="$(
+              printf '%s\n' "$leaf_pem" \
+                | openssl x509 -outform DER \
+                | openssl dgst -sha256 -r \
+                | awk '{print $1}'
+            )"
+            if [ -z "$expected_fingerprint" ]; then
+              expected_fingerprint="$fingerprint"
+            elif [ "$fingerprint" != "$expected_fingerprint" ]; then
+              echo "::error::Canonical and legacy SNI names served different certificate leaves"
+              exit 1
+            fi
+          done
+          echo "Both Headscale SNI names served the same exact dual-SAN certificate leaf"
 
       - name: Remove deploy SSH identity
         if: always()

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -133,9 +133,9 @@ jobs:
       # Headscale wiring for the provisioning worker (the CONSUMER of the
       # control plane). These are reconciled into /opt/eliza/cloud/.env.local
       # on every deploy so the box can never silently drift to a stale,
-      # hand-edited headscale URL/key again. Reuse the canonical GH names
-      # already established by arm-headscale-control-plane.yml.
-      HEADSCALE_API_URL: ${{ vars.HEADSCALE_API_URL }}
+      # hand-edited headscale URL/key again. The daemon API URL is derived from
+      # the protected environment below and stays loopback-only; it is not an
+      # operator variable that can redirect the protected bearer key.
       HEADSCALE_PUBLIC_URL: ${{ vars.HEADSCALE_PUBLIC_URL }}
       HEADSCALE_API_KEY: ${{ secrets.HEADSCALE_API_KEY }}
       # Base64 private key used by the daemon to reach dedicated-agent nodes.
@@ -198,7 +198,6 @@ jobs:
           required_deploy_settings=(
             DEPLOY_HOST
             DEPLOY_SSH_KEY
-            HEADSCALE_API_URL
             HEADSCALE_PUBLIC_URL
             HEADSCALE_API_KEY
             DATABASE_URL
@@ -235,16 +234,17 @@ jobs:
 
           if [ "$TARGET_ENVIRONMENT" = "production" ]; then
             require_exact DEPLOY_BRANCH "$DEPLOY_BRANCH" "main"
-            require_exact HEADSCALE_API_URL "$HEADSCALE_API_URL" "https://headscale.eliza.app"
             require_exact HEADSCALE_PUBLIC_URL "$HEADSCALE_PUBLIC_URL" "https://headscale.eliza.app"
             require_exact ELIZA_CLOUD_AGENT_BASE_DOMAIN "$ELIZA_CLOUD_AGENT_BASE_DOMAIN" "cloud.eliza.app"
+            resolved_headscale_api_url="http://127.0.0.1:8081"
           else
             require_exact DEPLOY_BRANCH "$DEPLOY_BRANCH" "develop"
-            require_exact HEADSCALE_API_URL "$HEADSCALE_API_URL" "https://headscale-staging.eliza.app"
             require_exact HEADSCALE_PUBLIC_URL "$HEADSCALE_PUBLIC_URL" "https://headscale-staging.eliza.app"
             require_exact ELIZA_CLOUD_AGENT_BASE_DOMAIN "$ELIZA_CLOUD_AGENT_BASE_DOMAIN" "cloud-staging.eliza.app"
+            resolved_headscale_api_url="http://127.0.0.1:8080"
           fi
 
+          echo "HEADSCALE_API_URL=$resolved_headscale_api_url" >> "$GITHUB_ENV"
           echo "configured=true" >> "$GITHUB_OUTPUT"
 
       - name: Ensure host prereqs (Node 24, swap, bunx symlink)

--- a/packages/cloud/infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud/infra/cloud/terraform/hetzner/control-plane/README.md
@@ -108,13 +108,12 @@ For the normal staging/prod path, use the idempotent workflow:
 
 ```bash
 gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza --ref main \
-  -f environment=production \
-  -f headscale_api_url=http://127.0.0.1:8081 \
-  -f listen_addr=127.0.0.1:8081
+  -f environment=production
 ```
 
-That workflow installs the committed ACL, converges `server_url` and
-`listen_addr`, ensures the `agent`/`tunnel` users exist, upserts the daemon's
+That workflow installs the committed ACL, converges `server_url` and the fixed
+environment-specific loopback `listen_addr`, ensures the `agent`/`tunnel`
+users exist, upserts the daemon's
 Headscale env in `/opt/eliza/cloud/.env.local`, restarts both services, and
 checks local `/health`. It also converges the last-mile public-edge bits that
 used to be hand-run on every CP (and lost on a rebuild — a DR gap):
@@ -122,9 +121,10 @@ used to be hand-run on every CP (and lost on a rebuild — a DR gap):
 - the **nginx vhost + Let's Encrypt cert** that front the public headscale URL
   (`/etc/nginx/conf.d/headscale.conf` → `127.0.0.1:<listen-port>`), as a
   no-http2 vhost with `Upgrade`/`Connection` passthrough + 86400s timeouts (the
-  TS2021/noise control protocol needs it). Renewal rides certbot's own
-  `certbot.timer`. Cert issuance is idempotent (`certbot certonly`, skipped when
-  a valid cert already exists).
+  TS2021/noise control protocol needs it). Renewal rides the required
+  `certbot.timer`; a root-owned deploy hook verifies the renewed leaf still has
+  both exact SANs and validates nginx before reloading it. Cert issuance is
+  idempotent (`certbot certonly`, skipped when a valid cert already exists).
 - the **`cp-<env>-router` tailscale self-enrollment** (`tag:eliza-proxy`, owned
   by the `tunnel` user) so the daemon on the CP can reach agent `tag:agent`
   `100.64.x` IPs. Idempotent (skips if already enrolled).

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -240,16 +240,18 @@ const parsedLegacyPublicUrl = parseHttpsOrigin(
 // and listener values are deliberately not operator inputs: accepting an
 // external daemon API URL could exfiltrate the protected Headscale bearer key.
 const headscaleHostname = parsedPublicUrl.hostname;
-const environmentConfig = HEADSCALE_ENVIRONMENT_BY_CANONICAL_HOST.get(
-  headscaleHostname,
-);
+const environmentConfig =
+  HEADSCALE_ENVIRONMENT_BY_CANONICAL_HOST.get(headscaleHostname);
 if (!environmentConfig) {
   die(
     `HEADSCALE_PUBLIC_URL must use a canonical Headscale hostname (received ${headscaleHostname})`,
   );
 }
-const { legacyHostname: expectedLegacyHostname, apiUrl, listenAddr } =
-  environmentConfig;
+const {
+  legacyHostname: expectedLegacyHostname,
+  apiUrl,
+  listenAddr,
+} = environmentConfig;
 const legacyHeadscaleHostname = parsedLegacyPublicUrl.hostname;
 if (legacyHeadscaleHostname !== expectedLegacyHostname) {
   die(
@@ -326,6 +328,7 @@ HS_PORT=${shellQuote(headscalePort)}
 CERTBOT_EMAIL=${shellQuote(certbotEmail)}
 HS_VHOST=/etc/nginx/conf.d/headscale.conf
 HS_ACME_VHOST=/etc/nginx/conf.d/00-headscale-acme.conf
+HS_RENEW_HOOK=/etc/letsencrypt/renewal-hooks/deploy/eliza-headscale-nginx-reload
 ACME_WEBROOT=/var/lib/letsencrypt
 LE_LIVE=/etc/letsencrypt/live/$HS_HOST
 LE_FULLCHAIN=$LE_LIVE/fullchain.pem
@@ -549,12 +552,50 @@ sudo systemctl reload nginx
 rm -f "$HS_VHOST_BACKUP" "$HS_VHOST_STAGE"
 trap - EXIT
 
-# Confirm the cert renewal timer is active (renewal is certbot's own systemd
-# timer, not a cron entry we manage). Non-fatal: surfaces a warning if the
-# distro shipped certbot without the timer.
-sudo systemctl is-active certbot.timer >/dev/null 2>&1 \\
-  && echo "certbot.timer active (auto-renewal wired)" \\
-  || echo "WARN: certbot.timer not active — check auto-renewal on this host"
+# Certbot's webroot renewal updates the certificate files in place. Install a
+# deploy hook on every arm, including no-op certificate runs, so nginx adopts
+# only a leaf that still covers both migration-overlap names. The hook is
+# root-owned and validates both the certificate and nginx before reloading.
+HS_RENEW_HOOK_STAGE=$(mktemp)
+tee "$HS_RENEW_HOOK_STAGE" >/dev/null <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_LINEAGE=${shellQuote(`/etc/letsencrypt/live/${headscaleHostname}`)}
+CANONICAL_HOST=${shellQuote(headscaleHostname)}
+LEGACY_HOST=${shellQuote(legacyHeadscaleHostname)}
+
+if [ "\${RENEWED_LINEAGE:-}" != "$EXPECTED_LINEAGE" ]; then
+  exit 0
+fi
+
+leaf_has_exact_san() {
+  test -s "$EXPECTED_LINEAGE/fullchain.pem" \\
+    && openssl x509 -in "$EXPECTED_LINEAGE/fullchain.pem" -noout -ext subjectAltName 2>/dev/null \\
+      | tr ',' '\\n' \\
+      | sed -n 's/^[[:space:]]*DNS://p' \\
+      | grep -Fx -- "$1" >/dev/null
+}
+
+if ! leaf_has_exact_san "$CANONICAL_HOST" \\
+    || ! leaf_has_exact_san "$LEGACY_HOST"; then
+  echo "renewed Headscale certificate does not cover both required hostnames" >&2
+  exit 1
+fi
+
+nginx -t
+systemctl reload nginx
+HOOK
+sudo install -d -o root -g root -m 0755 "$(dirname "$HS_RENEW_HOOK")"
+sudo install -o root -g root -m 0755 "$HS_RENEW_HOOK_STAGE" "$HS_RENEW_HOOK"
+rm -f "$HS_RENEW_HOOK_STAGE"
+
+# Renewal is part of the converged contract, not an advisory. Ensure certbot's
+# systemd schedule exists, is enabled, and is running before the arm succeeds.
+sudo systemctl enable --now certbot.timer
+sudo systemctl is-enabled --quiet certbot.timer
+sudo systemctl is-active --quiet certbot.timer
+echo "certbot.timer active (auto-renewal wired)"
 `;
 
 // ── CP self-enrollment as a tailscale node (cp-<env>-router) ─────────────────

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -37,9 +37,23 @@ const HEADSCALE_ACL = "/etc/headscale/acl.hujson";
 const HEADSCALE_STATE_DIR = "/var/lib/headscale";
 const SYSTEMD_UNIT = "eliza-provisioning-worker.service";
 
-const HEADSCALE_LEGACY_HOST_BY_CANONICAL_HOST = new Map([
-  ["headscale.eliza.app", "headscale.elizacloud.ai"],
-  ["headscale-staging.eliza.app", "headscale-staging.elizacloud.ai"],
+const HEADSCALE_ENVIRONMENT_BY_CANONICAL_HOST = new Map([
+  [
+    "headscale.eliza.app",
+    {
+      legacyHostname: "headscale.elizacloud.ai",
+      apiUrl: "http://127.0.0.1:8081",
+      listenAddr: "127.0.0.1:8081",
+    },
+  ],
+  [
+    "headscale-staging.eliza.app",
+    {
+      legacyHostname: "headscale-staging.elizacloud.ai",
+      apiUrl: "http://127.0.0.1:8080",
+      listenAddr: "127.0.0.1:8080",
+    },
+  ],
 ]);
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -142,8 +156,6 @@ Required:
   --headscale-api-key <key>            Existing Headscale API key.
 
 Optional:
-  --headscale-api-url <url>            Daemon API URL (default http://127.0.0.1:8081).
-  --listen-addr <addr:port>            Headscale listen_addr (default 127.0.0.1:8081).
   --headscale-user <user>              User for agent preauth keys (default agent).
   --cp-router-hostname <name>          Tailscale hostname the CP enrolls itself as
                                        (default derived from the public URL, e.g.
@@ -180,12 +192,7 @@ const legacyPublicUrl = readArg(
   "headscale-legacy-public-url",
   "HEADSCALE_LEGACY_PUBLIC_URL",
 );
-const apiUrl =
-  readArg(args, "headscale-api-url", "HEADSCALE_API_URL") ??
-  "http://127.0.0.1:8081";
 const apiKey = readArg(args, "headscale-api-key", "HEADSCALE_API_KEY");
-const listenAddr =
-  readArg(args, "listen-addr", "HEADSCALE_LISTEN_ADDR") ?? "127.0.0.1:8081";
 const headscaleUser =
   readArg(args, "headscale-user", "HEADSCALE_USER") ?? "agent";
 const agentTokenPrivateKey = readArg(
@@ -229,18 +236,20 @@ const parsedLegacyPublicUrl = parseHttpsOrigin(
   legacyPublicUrl,
 );
 
-// The nginx vhost fronts the public hostname (host part of the URL) and proxies
-// to the loopback port headscale listens on (port part of listen_addr). Both
-// are already env-correct on the workflow inputs — staging is :8080, prod :8081
-// — so the vhost upstream tracks listen_addr automatically with no extra flag.
+// The canonical hostname selects the whole environment contract. Loopback API
+// and listener values are deliberately not operator inputs: accepting an
+// external daemon API URL could exfiltrate the protected Headscale bearer key.
 const headscaleHostname = parsedPublicUrl.hostname;
-const expectedLegacyHostname =
-  HEADSCALE_LEGACY_HOST_BY_CANONICAL_HOST.get(headscaleHostname);
-if (!expectedLegacyHostname) {
+const environmentConfig = HEADSCALE_ENVIRONMENT_BY_CANONICAL_HOST.get(
+  headscaleHostname,
+);
+if (!environmentConfig) {
   die(
     `HEADSCALE_PUBLIC_URL must use a canonical Headscale hostname (received ${headscaleHostname})`,
   );
 }
+const { legacyHostname: expectedLegacyHostname, apiUrl, listenAddr } =
+  environmentConfig;
 const legacyHeadscaleHostname = parsedLegacyPublicUrl.hostname;
 if (legacyHeadscaleHostname !== expectedLegacyHostname) {
   die(
@@ -342,7 +351,14 @@ if certificate_covers_overlap; then
   echo "LE cert already covers canonical and legacy Headscale hosts; skipping issuance"
 else
   sudo install -d -o root -g root -m 0755 "$ACME_WEBROOT"
-  sudo tee "$HS_ACME_VHOST" >/dev/null <<NGINX
+  HS_ACME_BACKUP=$(mktemp)
+  HS_ACME_STAGE=$(mktemp)
+  HS_ACME_VHOST_EXISTED=false
+  if sudo test -f "$HS_ACME_VHOST"; then
+    sudo cp "$HS_ACME_VHOST" "$HS_ACME_BACKUP"
+    HS_ACME_VHOST_EXISTED=true
+  fi
+  tee "$HS_ACME_STAGE" >/dev/null <<NGINX
 server {
     listen 80;
     listen [::]:80;
@@ -355,15 +371,23 @@ server {
     location / { return 404; }
 }
 NGINX
-  sudo nginx -t
-  sudo systemctl reload nginx
 
-  cleanup_acme_vhost() {
-    sudo rm -f "$HS_ACME_VHOST"
+  restore_acme_vhost() {
+    trap - EXIT
+    if [ "$HS_ACME_VHOST_EXISTED" = "true" ]; then
+      sudo cp "$HS_ACME_BACKUP" "$HS_ACME_VHOST"
+    else
+      sudo rm -f "$HS_ACME_VHOST"
+    fi
+    rm -f "$HS_ACME_BACKUP" "$HS_ACME_STAGE"
     sudo nginx -t
     sudo systemctl reload nginx
   }
-  trap cleanup_acme_vhost EXIT
+  trap restore_acme_vhost EXIT
+
+  sudo install -o root -g root -m 0644 "$HS_ACME_STAGE" "$HS_ACME_VHOST"
+  sudo nginx -t
+  sudo systemctl reload nginx
 
   certbot_args=(
     certonly
@@ -385,14 +409,37 @@ NGINX
     echo "issued Headscale certificate does not cover both required hostnames"
     exit 1
   fi
-  cleanup_acme_vhost
-  trap - EXIT
+  restore_acme_vhost
 fi
 
 # Final no-http2 TLS vhost: 80→443 redirect + 443 proxy to Headscale
 #    loopback listener, with the Upgrade/Connection map + long timeouts the
 #    noise protocol needs. Both exact hostnames stay available during migration.
-sudo tee "$HS_VHOST" >/dev/null <<NGINX
+HS_VHOST_BACKUP=$(mktemp)
+HS_VHOST_STAGE=$(mktemp)
+HS_VHOST_EXISTED=false
+if sudo test -f "$HS_VHOST"; then
+  sudo cp "$HS_VHOST" "$HS_VHOST_BACKUP"
+  HS_VHOST_EXISTED=true
+fi
+
+rollback_headscale_vhost() {
+  trap - EXIT
+  if [ "$HS_VHOST_EXISTED" = "true" ]; then
+    sudo cp "$HS_VHOST_BACKUP" "$HS_VHOST"
+  else
+    sudo rm -f "$HS_VHOST"
+  fi
+  if sudo nginx -t; then
+    sudo systemctl reload nginx
+  else
+    echo "rollback restored the previous Headscale vhost bytes, but nginx validation failed"
+  fi
+  rm -f "$HS_VHOST_BACKUP" "$HS_VHOST_STAGE"
+}
+trap rollback_headscale_vhost EXIT
+
+tee "$HS_VHOST_STAGE" >/dev/null <<NGINX
 # headscale control-protocol (TS2021/noise) needs the Upgrade header passed
 # through on HTTP/1.1. NO http2 on this vhost: an h2 client connection would
 # drop the Upgrade header (RFC 7540), which is exactly what broke headscale
@@ -433,11 +480,74 @@ server {
     }
 }
 NGINX
+sudo install -o root -g root -m 0644 "$HS_VHOST_STAGE" "$HS_VHOST"
 sudo nginx -t
-sudo systemctl reload nginx
+
+effective_nginx_config=$(sudo nginx -T 2>&1)
+overlap_warnings=$(printf '%s\n' "$effective_nginx_config" \
+  | grep -F 'conflicting server name' \
+  | grep -F -e "$HS_HOST" -e "$HS_LEGACY_HOST" || true)
+hostname_owners=$(printf '%s\n' "$effective_nginx_config" | awk \
+  -v canonical="$HS_HOST" \
+  -v legacy="$HS_LEGACY_HOST" '
+  function inspect_names(text, fields, count, i, name) {
+    count = split(text, fields, /[[:space:]]+/)
+    for (i = 1; i <= count; i += 1) {
+      name = fields[i]
+      if (name == "") continue
+      if (name ~ /;$/) collecting = 0
+      sub(/;$/, "", name)
+      gsub(/^"|"$/, "", name)
+      if (name == canonical || name == legacy) print config_file "\t" name
+    }
+  }
+  /^# configuration file / {
+    config_file = $0
+    sub(/^# configuration file /, "", config_file)
+    sub(/:$/, "", config_file)
+    collecting = 0
+    next
+  }
+  {
+    line = $0
+    sub(/[[:space:]]*#.*/, "", line)
+    if (collecting) {
+      inspect_names(line)
+      next
+    }
+    if (line ~ /^[[:space:]]*server_name[[:space:]]+/) {
+      sub(/^[[:space:]]*server_name[[:space:]]+/, "", line)
+      collecting = 1
+      inspect_names(line)
+    }
+  }
+')
+unexpected_owners=$(printf '%s\n' "$hostname_owners" \
+  | awk -F '\t' -v expected="$HS_VHOST" 'NF == 2 && $1 != expected { print }')
+canonical_owner_count=$(printf '%s\n' "$hostname_owners" \
+  | awk -F '\t' -v host="$HS_HOST" '$2 == host { count += 1 } END { print count + 0 }')
+legacy_owner_count=$(printf '%s\n' "$hostname_owners" \
+  | awk -F '\t' -v host="$HS_LEGACY_HOST" '$2 == host { count += 1 } END { print count + 0 }')
+if [ -n "$overlap_warnings" ] \
+    || [ -n "$unexpected_owners" ] \
+    || [ "$canonical_owner_count" -ne 2 ] \
+    || [ "$legacy_owner_count" -ne 2 ]; then
+  if [ -n "$overlap_warnings" ]; then
+    echo "nginx reported conflicting Headscale server names:"
+    printf '%s\n' "$overlap_warnings"
+  fi
+  echo "Headscale hostname ownership is not exclusive to $HS_VHOST:"
+  printf '%s\n' "$hostname_owners"
+  echo "Leaving unknown nginx configs untouched and restoring the prior $HS_VHOST"
+  exit 1
+fi
 
 certificate_has_exact_san "$HS_HOST"
 certificate_has_exact_san "$HS_LEGACY_HOST"
+sudo systemctl reload nginx
+
+rm -f "$HS_VHOST_BACKUP" "$HS_VHOST_STAGE"
+trap - EXIT
 
 # Confirm the cert renewal timer is active (renewal is certbot's own systemd
 # timer, not a cron entry we manage). Non-fatal: surfaces a warning if the

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -6,9 +6,10 @@
  *   - converge /etc/headscale/config.yaml to the public URL + loopback listener
  *   - install the committed ACL policy
  *   - ensure the `agent` and `tunnel` users exist
- *   - provision the nginx vhost + Let's Encrypt cert that fronts the public
- *     Headscale URL (TS2021/noise needs a no-http2 vhost with Upgrade/Connection
- *     passthrough + long timeouts — a CF-proxied or h2 origin breaks it)
+ *   - provision the nginx vhost + Let's Encrypt cert that front the canonical
+ *     and temporary legacy Headscale names during the eliza.app migration
+ *     (TS2021/noise needs a no-http2 vhost with Upgrade/Connection passthrough
+ *     + long timeouts — a CF-proxied or h2 origin breaks it)
  *   - enroll the CP itself as a tailscale node (cp-<env>-router, tag:eliza-proxy)
  *     against its local Headscale, so the daemon can reach agent 100.64.x IPs
  *   - upsert the daemon env that makes sandbox provisioning require Headscale
@@ -35,6 +36,11 @@ const HEADSCALE_CONFIG = "/etc/headscale/config.yaml";
 const HEADSCALE_ACL = "/etc/headscale/acl.hujson";
 const HEADSCALE_STATE_DIR = "/var/lib/headscale";
 const SYSTEMD_UNIT = "eliza-provisioning-worker.service";
+
+const HEADSCALE_LEGACY_HOST_BY_CANONICAL_HOST = new Map([
+  ["headscale.eliza.app", "headscale.elizacloud.ai"],
+  ["headscale-staging.eliza.app", "headscale-staging.elizacloud.ai"],
+]);
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "../../../..");
@@ -102,12 +108,23 @@ function envValueQuote(value) {
     .replaceAll('"', '\\"')}"`;
 }
 
-function validateHttpsUrl(name, value) {
+function parseHttpsOrigin(name, value) {
   try {
     const url = new URL(value);
-    if (url.protocol !== "https:") throw new Error("must be https");
+    if (
+      url.protocol !== "https:" ||
+      url.username !== "" ||
+      url.password !== "" ||
+      url.port !== "" ||
+      url.pathname !== "/" ||
+      url.search !== "" ||
+      url.hash !== ""
+    ) {
+      throw new Error("must be an exact HTTPS origin");
+    }
+    return url;
   } catch {
-    die(`${name} must be an https URL (received ${value})`);
+    die(`${name} must be an exact HTTPS origin (received ${value})`);
   }
 }
 
@@ -121,6 +138,7 @@ Required:
   --ssh-key <path>                     Deploy-user SSH private key.
   --ssh-known-hosts <path>             Independently verified known_hosts inventory.
   --headscale-public-url <https-url>   Public Headscale URL.
+  --headscale-legacy-public-url <url>  Temporary legacy HTTPS overlap URL.
   --headscale-api-key <key>            Existing Headscale API key.
 
 Optional:
@@ -157,6 +175,11 @@ const sshKnownHosts = readArg(
   "DEPLOY_SSH_KNOWN_HOSTS",
 );
 const publicUrl = readArg(args, "headscale-public-url", "HEADSCALE_PUBLIC_URL");
+const legacyPublicUrl = readArg(
+  args,
+  "headscale-legacy-public-url",
+  "HEADSCALE_LEGACY_PUBLIC_URL",
+);
 const apiUrl =
   readArg(args, "headscale-api-url", "HEADSCALE_API_URL") ??
   "http://127.0.0.1:8081";
@@ -194,15 +217,36 @@ if (!existsSync(sshKnownHosts))
   die(`SSH known_hosts inventory not found: ${sshKnownHosts}`);
 if (!publicUrl)
   die("--headscale-public-url or HEADSCALE_PUBLIC_URL is required");
+if (!legacyPublicUrl)
+  die(
+    "--headscale-legacy-public-url or HEADSCALE_LEGACY_PUBLIC_URL is required",
+  );
 if (!apiKey) die("--headscale-api-key or HEADSCALE_API_KEY is required");
 if (!existsSync(aclPath)) die(`ACL file not found: ${aclPath}`);
-validateHttpsUrl("HEADSCALE_PUBLIC_URL", publicUrl);
+const parsedPublicUrl = parseHttpsOrigin("HEADSCALE_PUBLIC_URL", publicUrl);
+const parsedLegacyPublicUrl = parseHttpsOrigin(
+  "HEADSCALE_LEGACY_PUBLIC_URL",
+  legacyPublicUrl,
+);
 
 // The nginx vhost fronts the public hostname (host part of the URL) and proxies
 // to the loopback port headscale listens on (port part of listen_addr). Both
 // are already env-correct on the workflow inputs — staging is :8080, prod :8081
 // — so the vhost upstream tracks listen_addr automatically with no extra flag.
-const headscaleHostname = new URL(publicUrl).hostname;
+const headscaleHostname = parsedPublicUrl.hostname;
+const expectedLegacyHostname =
+  HEADSCALE_LEGACY_HOST_BY_CANONICAL_HOST.get(headscaleHostname);
+if (!expectedLegacyHostname) {
+  die(
+    `HEADSCALE_PUBLIC_URL must use a canonical Headscale hostname (received ${headscaleHostname})`,
+  );
+}
+const legacyHeadscaleHostname = parsedLegacyPublicUrl.hostname;
+if (legacyHeadscaleHostname !== expectedLegacyHostname) {
+  die(
+    `HEADSCALE_LEGACY_PUBLIC_URL must be https://${expectedLegacyHostname} for ${headscaleHostname}`,
+  );
+}
 // .pop() on the colon-split yields the port for "addr:port" and the whole
 // string for a bare "port" — no need to branch on includes(":").
 const headscalePort = listenAddr.split(":").pop();
@@ -251,60 +295,103 @@ const upserts = Object.entries(daemonEnv)
   })
   .join("\n");
 
-// ── nginx vhost + Let's Encrypt cert for the public Headscale URL ────────────
-// Reproduces the proven-good /etc/nginx/conf.d/headscale.conf that was hand-
-// written on each CP (the DR gap). The vhost MUST be no-http2 with Upgrade/
-// Connection passthrough + 86400s timeouts — the headscale TS2021/noise control
-// protocol rides a long-lived HTTP/1.1 Upgrade that an h2 origin (RFC 7540) or
-// a short proxy timeout drops. Upstream port tracks the headscale listen_addr.
+// ── nginx vhost + Let's Encrypt migration-overlap certificate ────────────────
+// The canonical hostname owns Headscale identity and daemon configuration. The
+// legacy exact hostname remains an additive TLS/vhost alias only while clients
+// migrate. Both names terminate on the same no-http2 nginx listener because the
+// TS2021/noise control protocol needs Upgrade/Connection passthrough and long
+// timeouts. Upstream port tracks the Headscale listen_addr.
 //
-// Cert flow: write an HTTP-only bootstrap vhost so certbot's nginx authenticator
-// can solve HTTP-01, run `certbot certonly` (idempotent — no-op if a valid cert
-// already exists), THEN drop the final TLS vhost referencing the LE cert paths.
-// `certonly` (not `--nginx` install) keeps the final vhost fully deterministic
-// here instead of letting certbot rewrite it. Renewal is certbot's own
-// systemd certbot.timer (installed by the certbot package) — no cron added.
+// Cert flow: retain the currently loaded TLS vhost while an earlier-loading,
+// HTTP-only webroot vhost answers ACME for both names. A certificate directory
+// is not proof of correctness, so every run checks both hostnames against the
+// live leaf certificate and expands/reissues when either SAN is absent. The
+// final port-80 vhost keeps the webroot challenge path for certbot.timer renewal.
 const nginxCertSteps = skipNginxCert
   ? `echo "skip-nginx-cert set: leaving nginx vhost + LE cert untouched"`
   : `
-echo "--- nginx vhost + Let's Encrypt cert for ${headscaleHostname} ---"
+echo "--- nginx vhost + Let's Encrypt cert for ${headscaleHostname} and ${legacyHeadscaleHostname} ---"
 HS_HOST=${shellQuote(headscaleHostname)}
+HS_LEGACY_HOST=${shellQuote(legacyHeadscaleHostname)}
 HS_PORT=${shellQuote(headscalePort)}
 CERTBOT_EMAIL=${shellQuote(certbotEmail)}
 HS_VHOST=/etc/nginx/conf.d/headscale.conf
+HS_ACME_VHOST=/etc/nginx/conf.d/00-headscale-acme.conf
+ACME_WEBROOT=/var/lib/letsencrypt
 LE_LIVE=/etc/letsencrypt/live/$HS_HOST
+LE_FULLCHAIN=$LE_LIVE/fullchain.pem
+LE_PRIVKEY=$LE_LIVE/privkey.pem
 
-command -v certbot >/dev/null 2>&1 || sudo apt-get install -y certbot python3-certbot-nginx
+command -v openssl >/dev/null 2>&1 || { echo "openssl is required to verify Headscale certificate SANs"; exit 1; }
+command -v certbot >/dev/null 2>&1 || sudo apt-get install -y certbot
 
-# 1. Bootstrap HTTP-only vhost so certbot --nginx can answer the HTTP-01
-#    challenge on :80. Overwritten by the final vhost below once the cert
-#    exists. Idempotent: re-running just rewrites the same bytes.
-sudo tee "$HS_VHOST" >/dev/null <<NGINX
+certificate_has_exact_san() {
+  sudo test -s "$LE_FULLCHAIN" \\
+    && sudo openssl x509 -in "$LE_FULLCHAIN" -noout -ext subjectAltName 2>/dev/null \\
+      | tr ',' '\\n' \\
+      | sed -n 's/^[[:space:]]*DNS://p' \\
+      | grep -Fx -- "$1" >/dev/null
+}
+
+certificate_covers_overlap() {
+  certificate_has_exact_san "$HS_HOST" \\
+    && certificate_has_exact_san "$HS_LEGACY_HOST"
+}
+
+if certificate_covers_overlap; then
+  echo "LE cert already covers canonical and legacy Headscale hosts; skipping issuance"
+else
+  sudo install -d -o root -g root -m 0755 "$ACME_WEBROOT"
+  sudo tee "$HS_ACME_VHOST" >/dev/null <<NGINX
 server {
     listen 80;
     listen [::]:80;
-    server_name $HS_HOST;
+    server_name $HS_HOST $HS_LEGACY_HOST;
+    location ^~ /.well-known/acme-challenge/ {
+        root $ACME_WEBROOT;
+        default_type text/plain;
+        try_files \\$uri =404;
+    }
     location / { return 404; }
 }
 NGINX
-sudo nginx -t
-sudo systemctl reload nginx
+  sudo nginx -t
+  sudo systemctl reload nginx
 
-# 2. Obtain the cert if absent / not yet valid. certonly is idempotent and
-#    exits 0 when a live cert is already present and not near expiry, so a
-#    re-arm never re-issues (and never trips LE rate limits). --nginx
-#    authenticator reuses the running nginx for the HTTP-01 challenge.
-if sudo test -d "$LE_LIVE"; then
-  echo "LE cert already present for $HS_HOST; skipping issuance"
-else
-  sudo certbot certonly --nginx --non-interactive --agree-tos \\
-    -m "$CERTBOT_EMAIL" -d "$HS_HOST"
+  cleanup_acme_vhost() {
+    sudo rm -f "$HS_ACME_VHOST"
+    sudo nginx -t
+    sudo systemctl reload nginx
+  }
+  trap cleanup_acme_vhost EXIT
+
+  certbot_args=(
+    certonly
+    --webroot
+    --webroot-path "$ACME_WEBROOT"
+    --non-interactive
+    --agree-tos
+    --cert-name "$HS_HOST"
+    -m "$CERTBOT_EMAIL"
+    -d "$HS_HOST"
+    -d "$HS_LEGACY_HOST"
+  )
+  if sudo test -s "$LE_FULLCHAIN"; then
+    certbot_args+=(--expand)
+  fi
+  sudo certbot "\${certbot_args[@]}"
+
+  if ! certificate_covers_overlap; then
+    echo "issued Headscale certificate does not cover both required hostnames"
+    exit 1
+  fi
+  cleanup_acme_vhost
+  trap - EXIT
 fi
 
-# 3. Final no-http2 TLS vhost: 80→443 redirect + 443 proxy to the headscale
+# Final no-http2 TLS vhost: 80→443 redirect + 443 proxy to Headscale
 #    loopback listener, with the Upgrade/Connection map + long timeouts the
-#    noise protocol needs. This is the byte-for-byte proven-good prod/staging
-#    vhost, templated for env hostname + port.
+#    noise protocol needs. Both exact hostnames stay available during migration.
 sudo tee "$HS_VHOST" >/dev/null <<NGINX
 # headscale control-protocol (TS2021/noise) needs the Upgrade header passed
 # through on HTTP/1.1. NO http2 on this vhost: an h2 client connection would
@@ -317,15 +404,20 @@ map \\$http_upgrade \\$hs_connection_upgrade {
 server {
     listen 80;
     listen [::]:80;
-    server_name $HS_HOST;
-    return 301 https://\\$host\\$request_uri;
+    server_name $HS_HOST $HS_LEGACY_HOST;
+    location ^~ /.well-known/acme-challenge/ {
+        root $ACME_WEBROOT;
+        default_type text/plain;
+        try_files \\$uri =404;
+    }
+    location / { return 301 https://\\$host\\$request_uri; }
 }
 server {
     listen 443 ssl;
     listen [::]:443 ssl;
-    server_name $HS_HOST;
-    ssl_certificate     /etc/letsencrypt/live/$HS_HOST/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/$HS_HOST/privkey.pem;
+    server_name $HS_HOST $HS_LEGACY_HOST;
+    ssl_certificate     $LE_FULLCHAIN;
+    ssl_certificate_key $LE_PRIVKEY;
     location / {
         proxy_pass http://127.0.0.1:$HS_PORT;
         proxy_http_version 1.1;
@@ -343,6 +435,9 @@ server {
 NGINX
 sudo nginx -t
 sudo systemctl reload nginx
+
+certificate_has_exact_san "$HS_HOST"
+certificate_has_exact_san "$HS_LEGACY_HOST"
 
 # Confirm the cert renewal timer is active (renewal is certbot's own systemd
 # timer, not a cron entry we manage). Non-fatal: surfaces a warning if the

--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -66,7 +66,10 @@ The workflow:
    canonical and legacy exact hostnames, then serves both names from the same
    no-http2 nginx vhost; after the ACME vhost is gone, `nginx -T` must report no
    conflicting-name warning and only `/etc/nginx/conf.d/headscale.conf` may own
-   either exact hostname, exactly once on HTTP and HTTPS;
+   either exact hostname, exactly once on HTTP and HTTPS; every arm also
+   installs a root-owned certbot deploy hook that requires both SANs and a valid
+   nginx config before reload, and fails unless `certbot.timer` is enabled and
+   active;
 7. restarts `headscale` and `eliza-provisioning-worker.service`;
 8. fails unless local health and both public HTTPS health endpoints are green,
    and both public SNI names serve the same leaf fingerprint whose SANs contain

--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -41,14 +41,14 @@ from the selected environment. Operators do not provide or override that alias.
 
 ```bash
 gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza --ref main \
-  -f environment=production \
-  -f headscale_api_url=http://127.0.0.1:8081 \
-  -f listen_addr=127.0.0.1:8081
+  -f environment=production
 ```
 
 > `workflow_dispatch` runs the copy of the workflow on the dispatched ref, so
-> `--ref main` only works once this workflow has merged to `main`. Before then,
-> dispatch against the branch that already carries it (e.g. `--ref develop`).
+> production is accepted only from `main`, while staging is accepted only from
+> `develop`. Checkout is pinned to the dispatched `github.sha` with persisted
+> Git credentials disabled. Test the change on staging after it merges to
+> `develop`; do not dispatch a feature branch.
 
 The workflow:
 
@@ -56,17 +56,31 @@ The workflow:
 2. ensures the package-compatible `headscale` system user and group exist,
    including on legacy hosts where the binary was installed manually;
 3. converges `server_url`, `listen_addr`, metrics, and gRPC addresses in
-   `/etc/headscale/config.yaml`;
+   `/etc/headscale/config.yaml`; the canonical hostname selects fixed loopback
+   API/listen values, and dispatch callers cannot override them;
 4. ensures Headscale users `agent` and `tunnel` exist;
 5. upserts `HEADSCALE_PUBLIC_URL`, `HEADSCALE_API_URL`,
    `HEADSCALE_API_KEY`, `HEADSCALE_USER`, and optional agent-token secrets into
    `/opt/eliza/cloud/.env.local`;
 6. obtains or expands one Let's Encrypt certificate whose SANs cover both the
    canonical and legacy exact hostnames, then serves both names from the same
-   no-http2 nginx vhost;
+   no-http2 nginx vhost; after the ACME vhost is gone, `nginx -T` must report no
+   conflicting-name warning and only `/etc/nginx/conf.d/headscale.conf` may own
+   either exact hostname, exactly once on HTTP and HTTPS;
 7. restarts `headscale` and `eliza-provisioning-worker.service`;
-8. fails unless local health and both public HTTPS health endpoints are green
-   with normal certificate verification.
+8. fails unless local health and both public HTTPS health endpoints are green,
+   and both public SNI names serve the same leaf fingerprint whose SANs contain
+   both exact hostnames, with normal certificate verification.
+
+The ACME and final vhost bytes are staged before installation. Rollback traps
+are installed before either loaded config path is changed. If `nginx -t`,
+reload, effective ownership, or exact-SAN validation fails, the script restores
+the prior file bytes and reloads the prior valid config. An ownership failure
+prints only the conflicting config paths and hostnames, leaves unknown nginx
+files untouched, and fails the workflow. Review the explicit conflict path and
+land a separate targeted cleanup; do not add a generic config deletion rule.
+Certificate expansion can succeed before a later vhost ownership failure, but
+the prior active vhost is still restored.
 
 The matching Cloudflare Worker secrets still need to be set through the normal
 Worker secret path. Keep host and Worker values identical for
@@ -89,8 +103,6 @@ node packages/cloud/scripts/admin/arm-headscale-control-plane.mjs \
   --ssh-known-hosts <verified-known-hosts-file> \
   --headscale-public-url https://headscale.eliza.app \
   --headscale-legacy-public-url https://headscale.elizacloud.ai \
-  --headscale-api-url http://127.0.0.1:8081 \
-  --listen-addr 127.0.0.1:8081 \
   --headscale-api-key "$HEADSCALE_API_KEY"
 ```
 

--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -32,6 +32,11 @@ Set these on each GitHub Environment (`staging`, `production`):
 | `ELIZA_LOCAL_ROOT_KEY` | secret | Optional but launch-critical for local root-token paths; must match the Worker secret. |
 | `HEADSCALE_PUBLIC_URL` | variable | `https://headscale-staging.eliza.app` or `https://headscale.eliza.app`. |
 
+`HEADSCALE_PUBLIC_URL` is always the canonical Eliza URL and remains the only
+value written to Headscale `server_url` and the provisioning daemon. During the
+domain migration, the arm workflow derives the matching legacy exact hostname
+from the selected environment. Operators do not provide or override that alias.
+
 ### Run the arm workflow
 
 ```bash
@@ -56,8 +61,12 @@ The workflow:
 5. upserts `HEADSCALE_PUBLIC_URL`, `HEADSCALE_API_URL`,
    `HEADSCALE_API_KEY`, `HEADSCALE_USER`, and optional agent-token secrets into
    `/opt/eliza/cloud/.env.local`;
-6. restarts `headscale` and `eliza-provisioning-worker.service`;
-7. fails if local `/health` is not green.
+6. obtains or expands one Let's Encrypt certificate whose SANs cover both the
+   canonical and legacy exact hostnames, then serves both names from the same
+   no-http2 nginx vhost;
+7. restarts `headscale` and `eliza-provisioning-worker.service`;
+8. fails unless local health and both public HTTPS health endpoints are green
+   with normal certificate verification.
 
 The matching Cloudflare Worker secrets still need to be set through the normal
 Worker secret path. Keep host and Worker values identical for
@@ -79,6 +88,7 @@ node packages/cloud/scripts/admin/arm-headscale-control-plane.mjs \
   --ssh-key <deploy-key> \
   --ssh-known-hosts <verified-known-hosts-file> \
   --headscale-public-url https://headscale.eliza.app \
+  --headscale-legacy-public-url https://headscale.elizacloud.ai \
   --headscale-api-url http://127.0.0.1:8081 \
   --listen-addr 127.0.0.1:8081 \
   --headscale-api-key "$HEADSCALE_API_KEY"
@@ -110,10 +120,23 @@ Hetzner provisioning-worker host.
 
 - `headscale.eliza.app` / `headscale-staging.eliza.app` → A-record → the
   Hetzner control-plane VM (`eliza-production-1` / `eliza-staging-1`), with
-  nginx + Let's Encrypt terminating TLS in front of local headscale. NOT a CNAME
-  to Railway — the Railway headscale service was removed (see note above).
+  nginx + Let's Encrypt terminating TLS in front of local headscale. The
+  matching `headscale.elizacloud.ai` / `headscale-staging.elizacloud.ai` record
+  remains pointed at the same VM during migration and is covered by the same
+  certificate. These are NOT CNAMEs to Railway — the Railway headscale service
+  was removed (see note above).
 - `tunnel.eliza.app` AND `*.tunnel.eliza.app` → CNAME/ALIAS → Railway public domain for the tunnel-proxy service.
 - Railway terminates public TLS for the tunnel-proxy custom domains; the proxy then uses `tsnet` to reach private tailnet hosts.
+
+### Retiring the legacy Headscale hostname
+
+Legacy retirement is a separate reviewed operation after Worker, tunnel proxy,
+agent, and access-log evidence shows no remaining legacy clients. Remove the
+legacy nginx `server_name`, certificate SAN, and DNS record together; then
+re-run the arm and public-health proofs using the retirement-aware workflow
+revision. Do not delete the DNS record or legacy SAN while this overlap contract
+is active, and do not change `HEADSCALE_PUBLIC_URL` away from the canonical
+Eliza URL.
 
 ## 2. Protected tunnel-proxy convergence
 

--- a/packages/cloud/services/headscale/README.md
+++ b/packages/cloud/services/headscale/README.md
@@ -40,6 +40,9 @@ which writes this directory's `acl.hujson` to the host, converges
 upserts the Worker-facing env. During the eliza.app migration it also serves the
 canonical and legacy exact hostnames from one explicitly verified TLS
 certificate while keeping the canonical URL authoritative inside Headscale.
+The protected workflow fixes API/listen values to environment-specific loopback
+constants, fails on any competing loaded nginx owner, and proves both public
+SNI names return the same exact dual-SAN leaf before it succeeds.
 Full checklist + required GitHub Environment values are in
 [`DEPLOY.md`](./DEPLOY.md). The `HEADSCALE_API_KEY` is generated on the host and
 stored as a GitHub/Worker secret — never pasted into issues or workflow inputs.

--- a/packages/cloud/services/headscale/README.md
+++ b/packages/cloud/services/headscale/README.md
@@ -37,10 +37,12 @@ Headscale is armed on the Hetzner control-plane VM by
 `arm-headscale-control-plane.yml` / `packages/cloud/scripts/admin/arm-headscale-control-plane.mjs`,
 which writes this directory's `acl.hujson` to the host, converges
 `/etc/headscale/config.yaml`, ensures the `agent` and `tunnel` users, and
-upserts the Worker-facing env. Full checklist + required GitHub Environment
-values are in [`DEPLOY.md`](./DEPLOY.md). The `HEADSCALE_API_KEY` is generated on
-the host and stored as a GitHub/Worker secret — never pasted into issues or
-workflow inputs.
+upserts the Worker-facing env. During the eliza.app migration it also serves the
+canonical and legacy exact hostnames from one explicitly verified TLS
+certificate while keeping the canonical URL authoritative inside Headscale.
+Full checklist + required GitHub Environment values are in
+[`DEPLOY.md`](./DEPLOY.md). The `HEADSCALE_API_KEY` is generated on the host and
+stored as a GitHub/Worker secret — never pasted into issues or workflow inputs.
 
 ## Local dev
 

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -261,7 +261,6 @@ describe("canonical cloud deployment environment contract", () => {
     for (const name of [
       "DEPLOY_HOST",
       "DEPLOY_SSH_KEY",
-      "HEADSCALE_API_URL",
       "HEADSCALE_PUBLIC_URL",
       "HEADSCALE_API_KEY",
       "DATABASE_URL",
@@ -279,6 +278,11 @@ describe("canonical cloud deployment environment contract", () => {
     expect(preflight.run).not.toContain('echo "$value"');
     expect(preflight.run).toContain("https://headscale.eliza.app");
     expect(preflight.run).toContain("https://headscale-staging.eliza.app");
+    expect(preflight.run).toContain("http://127.0.0.1:8081");
+    expect(preflight.run).toContain("http://127.0.0.1:8080");
+    expect(preflight.run).toContain(
+      'echo "HEADSCALE_API_URL=$resolved_headscale_api_url" >> "$GITHUB_ENV"',
+    );
     expect(preflight.run).toContain('"cloud.eliza.app"');
     expect(preflight.run).toContain('"cloud-staging.eliza.app"');
 

--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -31,6 +31,8 @@ const scriptPath = fileURLToPath(
 interface WorkflowStep {
   name?: string;
   run?: string;
+  uses?: string;
+  with?: Record<string, string | boolean>;
 }
 
 interface WorkflowJob {
@@ -49,6 +51,15 @@ function step(name: string): WorkflowStep {
   const found = arm?.steps?.find((candidate) => candidate.name === name);
   if (!found) throw new Error(`Missing Headscale arm workflow step: ${name}`);
   return found;
+}
+
+function expectBashSyntax(source: string) {
+  const syntax = spawnSync("bash", ["-n"], {
+    encoding: "utf8",
+    input: source,
+  });
+  expect(syntax.status).toBe(0);
+  expect(syntax.stderr).toBe("");
 }
 
 function runDryArm(publicUrl: string, legacyPublicUrl: string) {
@@ -88,6 +99,16 @@ function runDryArm(publicUrl: string, legacyPublicUrl: string) {
   } finally {
     rmSync(fixtureDir, { recursive: true, force: true });
   }
+}
+
+function ownershipAwkProgram(remoteScript: string) {
+  const startMarker = '-v legacy="$HS_LEGACY_HOST" \'\n';
+  const start = remoteScript.indexOf(startMarker);
+  if (start === -1) throw new Error("Missing Headscale ownership awk start");
+  const bodyStart = start + startMarker.length;
+  const end = remoteScript.indexOf("\n')", bodyStart);
+  if (end === -1) throw new Error("Missing Headscale ownership awk end");
+  return remoteScript.slice(bodyStart, end);
 }
 
 describe("protected Headscale arm workflow", () => {
@@ -163,16 +184,68 @@ describe("protected Headscale arm workflow", () => {
     ).run;
     expect(converge).toContain("--headscale-legacy-public-url");
     expect(converge).toContain('"$resolved_legacy_public_url"');
+    expect(
+      converge
+        ?.trimEnd()
+        .endsWith(
+          '--headscale-legacy-public-url "$resolved_legacy_public_url"',
+        ),
+    ).toBe(true);
   });
 
-  test("verifies canonical and legacy health with normal TLS validation", () => {
-    const verify = step("Verify canonical and legacy public health").run;
+  test("does not accept dispatch overrides for loopback API or listen addresses", () => {
+    expect(workflowSource).not.toContain("headscale_api_url:");
+    expect(workflowSource).not.toContain("listen_addr:");
+    expect(arm?.env).not.toHaveProperty("HEADSCALE_API_URL");
+    expect(arm?.env).not.toHaveProperty("HEADSCALE_LISTEN_ADDR");
+
+    expect(scriptSource).not.toContain(
+      'readArg(args, "headscale-api-url", "HEADSCALE_API_URL")',
+    );
+    expect(scriptSource).not.toContain(
+      'readArg(args, "listen-addr", "HEADSCALE_LISTEN_ADDR")',
+    );
+    expect(scriptSource).toContain('apiUrl: "http://127.0.0.1:8081"');
+    expect(scriptSource).toContain('listenAddr: "127.0.0.1:8081"');
+    expect(scriptSource).toContain('apiUrl: "http://127.0.0.1:8080"');
+    expect(scriptSource).toContain('listenAddr: "127.0.0.1:8080"');
+  });
+
+  test("pins staging and production deploys to their canonical branch SHA", () => {
+    const sourceGate = step("Validate protected deploy source").run;
+    expect(sourceGate).toContain('staging) expected_ref="refs/heads/develop"');
+    expect(sourceGate).toContain('production) expected_ref="refs/heads/main"');
+    expect(sourceGate).toContain('if [ "$GITHUB_REF" != "$expected_ref" ]');
+
+    const checkout = arm?.steps?.find((candidate) =>
+      candidate.uses?.startsWith("actions/checkout@"),
+    );
+    expect(checkout?.with?.ref).toContain("github.sha");
+    expect(checkout?.with?.["persist-credentials"]).toBe(false);
+  });
+
+  test("verifies dual-SAN SNI identity and health with normal TLS", () => {
+    const verify = step("Verify dual-SAN public identity and health").run;
     expect(verify).toContain(
       'for public_url in "$HEADSCALE_PUBLIC_URL" "$resolved_legacy_public_url"',
     );
     expect(verify).toContain('"$public_url/health"');
+    expect(verify).toContain("openssl s_client");
+    expect(verify).toContain('-servername "$host"');
+    expect(verify).toContain('-verify_hostname "$host"');
+    expect(verify).toContain("leaf_has_exact_san");
+    expect(verify).toContain("openssl dgst -sha256 -r");
+    expect(verify).toContain(
+      'if [ "$fingerprint" != "$expected_fingerprint" ]',
+    );
     expect(verify).not.toContain("--insecure");
     expect(verify).not.toMatch(/(^|\s)-k(\s|$)/);
+    expectBashSyntax(verify);
+  });
+
+  test("keeps validation gates syntactically valid in bash", () => {
+    expectBashSyntax(step("Validate protected deploy source").run ?? "");
+    expectBashSyntax(step("Validate canonical control-plane inputs").run ?? "");
   });
 });
 
@@ -201,6 +274,45 @@ describe("Headscale migration-overlap remote script", () => {
       expect(result.stdout).toContain(`HS_HOST='${canonicalHost}'`);
       expect(result.stdout).toContain(`HS_LEGACY_HOST='${legacyHost}'`);
       expect(result.stdout).toContain("server_name $HS_HOST $HS_LEGACY_HOST;");
+      expect(result.stdout).toContain(
+        "effective_nginx_config=$(sudo nginx -T 2>&1)",
+      );
+      expect(result.stdout).toContain("conflicting server name");
+      expect(result.stdout).toContain('-v expected="$HS_VHOST"');
+      expect(result.stdout).toContain("$1 != expected { print }");
+      expect(result.stdout).toContain('[ "$canonical_owner_count" -ne 2 ]');
+      expect(result.stdout).toContain('[ "$legacy_owner_count" -ne 2 ]');
+      expect(result.stdout).toContain(
+        "Leaving unknown nginx configs untouched and restoring the prior $HS_VHOST",
+      );
+      expect(result.stdout).toContain("rollback_headscale_vhost()");
+      const acmeTrap = result.stdout.indexOf("trap restore_acme_vhost EXIT");
+      const acmeInstall = result.stdout.indexOf(
+        'sudo install -o root -g root -m 0644 "$HS_ACME_STAGE" "$HS_ACME_VHOST"',
+      );
+      expect(acmeTrap).toBeGreaterThan(-1);
+      expect(acmeInstall).toBeGreaterThan(-1);
+      expect(acmeTrap).toBeLessThan(acmeInstall);
+
+      const finalTrap = result.stdout.indexOf(
+        "trap rollback_headscale_vhost EXIT",
+      );
+      const finalInstall = result.stdout.indexOf(
+        'sudo install -o root -g root -m 0644 "$HS_VHOST_STAGE" "$HS_VHOST"',
+      );
+      expect(finalTrap).toBeGreaterThan(-1);
+      expect(finalInstall).toBeGreaterThan(-1);
+      expect(finalTrap).toBeLessThan(finalInstall);
+      const ownershipProof = result.stdout.indexOf(
+        "effective_nginx_config=$(sudo nginx -T 2>&1)",
+        finalInstall,
+      );
+      const finalReload = result.stdout.indexOf(
+        "sudo systemctl reload nginx",
+        ownershipProof,
+      );
+      expect(ownershipProof).toBeGreaterThan(finalInstall);
+      expect(finalReload).toBeGreaterThan(ownershipProof);
       expect(result.stdout).toContain('-d "$HS_HOST"');
       expect(result.stdout).toContain('-d "$HS_LEGACY_HOST"');
       expect(result.stdout).toContain(
@@ -213,14 +325,45 @@ describe("Headscale migration-overlap remote script", () => {
       expect(result.stdout).toContain('set_config server_url "$PUBLIC_URL"');
       expect(result.stdout).not.toContain(`PUBLIC_URL='${legacyPublicUrl}'`);
 
-      const syntax = spawnSync("bash", ["-n"], {
-        encoding: "utf8",
-        input: result.stdout,
-      });
-      expect(syntax.status).toBe(0);
-      expect(syntax.stderr).toBe("");
+      expectBashSyntax(result.stdout);
     },
   );
+
+  test("enumerates multiline exact hostname owners by loaded nginx config", () => {
+    const result = runDryArm(
+      "https://headscale.eliza.app",
+      "https://headscale.elizacloud.ai",
+    );
+    expect(result.status).toBe(0);
+    const fixture = `# configuration file /etc/nginx/conf.d/headscale.conf:
+server {
+  server_name headscale.eliza.app
+    headscale.elizacloud.ai;
+}
+# configuration file /etc/nginx/sites-enabled/legacy-headscale:
+server {
+  server_name headscale.elizacloud.ai;
+}
+`;
+    const parsed = spawnSync(
+      "awk",
+      [
+        "-v",
+        "canonical=headscale.eliza.app",
+        "-v",
+        "legacy=headscale.elizacloud.ai",
+        ownershipAwkProgram(result.stdout),
+      ],
+      { encoding: "utf8", input: fixture },
+    );
+    expect(parsed.status).toBe(0);
+    expect(parsed.stderr).toBe("");
+    expect(parsed.stdout.trim().split("\n")).toEqual([
+      "/etc/nginx/conf.d/headscale.conf\theadscale.eliza.app",
+      "/etc/nginx/conf.d/headscale.conf\theadscale.elizacloud.ai",
+      "/etc/nginx/sites-enabled/legacy-headscale\theadscale.elizacloud.ai",
+    ]);
+  });
 
   test("rejects a cross-environment legacy hostname", () => {
     const result = runDryArm(

--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -1,9 +1,13 @@
 /**
- * Guards the protected Headscale arm workflow and operator script against
- * canonical-host drift and deployment-time SSH trust acquisition.
+ * Exercises the protected Headscale arm workflow and generated remote script
+ * against hostname drift, incomplete TLS overlap, and SSH trust acquisition.
  */
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const repoRoot = new URL("../../../", import.meta.url);
 const workflowSource = readFileSync(
@@ -16,6 +20,12 @@ const scriptSource = readFileSync(
     repoRoot,
   ),
   "utf8",
+);
+const scriptPath = fileURLToPath(
+  new URL(
+    "packages/cloud/scripts/admin/arm-headscale-control-plane.mjs",
+    repoRoot,
+  ),
 );
 
 interface WorkflowStep {
@@ -39,6 +49,45 @@ function step(name: string): WorkflowStep {
   const found = arm?.steps?.find((candidate) => candidate.name === name);
   if (!found) throw new Error(`Missing Headscale arm workflow step: ${name}`);
   return found;
+}
+
+function runDryArm(publicUrl: string, legacyPublicUrl: string) {
+  const fixtureDir = mkdtempSync(join(tmpdir(), "headscale-arm-test-"));
+  const sshKey = join(fixtureDir, "deploy-key");
+  const knownHosts = join(fixtureDir, "known-hosts");
+  writeFileSync(sshKey, "test-only-key\n", { mode: 0o600 });
+  writeFileSync(knownHosts, "test-only-known-hosts\n", { mode: 0o600 });
+
+  try {
+    return spawnSync(
+      "node",
+      [
+        scriptPath,
+        "--host",
+        "192.0.2.10",
+        "--ssh-key",
+        sshKey,
+        "--ssh-known-hosts",
+        knownHosts,
+        "--headscale-public-url",
+        publicUrl,
+        "--headscale-legacy-public-url",
+        legacyPublicUrl,
+        "--headscale-api-key",
+        "test-only-api-key",
+        "--skip-cp-router",
+        "--dry-run",
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          PATH: process.env.PATH ?? "",
+        },
+      },
+    );
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
 }
 
 describe("protected Headscale arm workflow", () => {
@@ -95,5 +144,112 @@ describe("protected Headscale arm workflow", () => {
     expect(cleanup.run).toContain('"$RUNNER_TEMP/headscale-deploy-key"');
     expect(cleanup.run).toContain('"$RUNNER_TEMP/headscale-known-hosts"');
     expect(cleanup.run).toContain("shred -u");
+  });
+
+  test("derives and passes the exact environment-specific legacy overlap", () => {
+    const validate = step("Validate canonical control-plane inputs").run;
+    expect(validate).toContain(
+      'expected_legacy_public_url="https://headscale.elizacloud.ai"',
+    );
+    expect(validate).toContain(
+      'expected_legacy_public_url="https://headscale-staging.elizacloud.ai"',
+    );
+    expect(validate).toContain(
+      "resolved_legacy_public_url=$expected_legacy_public_url",
+    );
+
+    const converge = step(
+      "Converge Headscale, canonical TLS, and control-plane router",
+    ).run;
+    expect(converge).toContain("--headscale-legacy-public-url");
+    expect(converge).toContain('"$resolved_legacy_public_url"');
+  });
+
+  test("verifies canonical and legacy health with normal TLS validation", () => {
+    const verify = step("Verify canonical and legacy public health").run;
+    expect(verify).toContain(
+      'for public_url in "$HEADSCALE_PUBLIC_URL" "$resolved_legacy_public_url"',
+    );
+    expect(verify).toContain('"$public_url/health"');
+    expect(verify).not.toContain("--insecure");
+    expect(verify).not.toMatch(/(^|\s)-k(\s|$)/);
+  });
+});
+
+describe("Headscale migration-overlap remote script", () => {
+  test.each([
+    [
+      "production",
+      "https://headscale.eliza.app",
+      "https://headscale.elizacloud.ai",
+      "headscale.eliza.app",
+      "headscale.elizacloud.ai",
+    ],
+    [
+      "staging",
+      "https://headscale-staging.eliza.app",
+      "https://headscale-staging.elizacloud.ai",
+      "headscale-staging.eliza.app",
+      "headscale-staging.elizacloud.ai",
+    ],
+  ])(
+    "generates both %s server names and certificate SAN checks",
+    (_environment, publicUrl, legacyPublicUrl, canonicalHost, legacyHost) => {
+      const result = runDryArm(publicUrl, legacyPublicUrl);
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toContain(`HS_HOST='${canonicalHost}'`);
+      expect(result.stdout).toContain(`HS_LEGACY_HOST='${legacyHost}'`);
+      expect(result.stdout).toContain("server_name $HS_HOST $HS_LEGACY_HOST;");
+      expect(result.stdout).toContain('-d "$HS_HOST"');
+      expect(result.stdout).toContain('-d "$HS_LEGACY_HOST"');
+      expect(result.stdout).toContain(
+        'openssl x509 -in "$LE_FULLCHAIN" -noout -ext subjectAltName',
+      );
+      expect(result.stdout).toContain('grep -Fx -- "$1"');
+      expect(result.stdout).toContain("certbot_args+=(--expand)");
+      expect(result.stdout).not.toContain('test -d "$LE_LIVE"');
+      expect(result.stdout).toContain(`PUBLIC_URL='${publicUrl}'`);
+      expect(result.stdout).toContain('set_config server_url "$PUBLIC_URL"');
+      expect(result.stdout).not.toContain(`PUBLIC_URL='${legacyPublicUrl}'`);
+
+      const syntax = spawnSync("bash", ["-n"], {
+        encoding: "utf8",
+        input: result.stdout,
+      });
+      expect(syntax.status).toBe(0);
+      expect(syntax.stderr).toBe("");
+    },
+  );
+
+  test("rejects a cross-environment legacy hostname", () => {
+    const result = runDryArm(
+      "https://headscale.eliza.app",
+      "https://headscale-staging.elizacloud.ai",
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "HEADSCALE_LEGACY_PUBLIC_URL must be https://headscale.elizacloud.ai for headscale.eliza.app",
+    );
+  });
+
+  test("rejects non-origin canonical and legacy URLs", () => {
+    const canonicalResult = runDryArm(
+      "https://headscale.eliza.app/path",
+      "https://headscale.elizacloud.ai",
+    );
+    expect(canonicalResult.status).toBe(1);
+    expect(canonicalResult.stderr).toContain(
+      "HEADSCALE_PUBLIC_URL must be an exact HTTPS origin",
+    );
+
+    const legacyResult = runDryArm(
+      "https://headscale.eliza.app",
+      "https://headscale.elizacloud.ai?unexpected=1",
+    );
+    expect(legacyResult.status).toBe(1);
+    expect(legacyResult.stderr).toContain(
+      "HEADSCALE_LEGACY_PUBLIC_URL must be an exact HTTPS origin",
+    );
   });
 });

--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -4,7 +4,13 @@
  */
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,6 +18,17 @@ import { fileURLToPath } from "node:url";
 const repoRoot = new URL("../../../", import.meta.url);
 const workflowSource = readFileSync(
   new URL(".github/workflows/arm-headscale-control-plane.yml", repoRoot),
+  "utf8",
+);
+const provisioningWorkflowSource = readFileSync(
+  new URL(".github/workflows/deploy-eliza-provisioning-worker.yml", repoRoot),
+  "utf8",
+);
+const controlPlaneRunbookSource = readFileSync(
+  new URL(
+    "packages/cloud/infra/cloud/terraform/hetzner/control-plane/README.md",
+    repoRoot,
+  ),
   "utf8",
 );
 const scriptSource = readFileSync(
@@ -109,6 +126,66 @@ function ownershipAwkProgram(remoteScript: string) {
   const end = remoteScript.indexOf("\n')", bodyStart);
   if (end === -1) throw new Error("Missing Headscale ownership awk end");
   return remoteScript.slice(bodyStart, end);
+}
+
+function renewalHookScript(remoteScript: string) {
+  const startMarker = "<<'HOOK'\n";
+  const start = remoteScript.indexOf(startMarker);
+  if (start === -1) throw new Error("Missing certbot renewal hook start");
+  const bodyStart = start + startMarker.length;
+  const end = remoteScript.indexOf("\nHOOK\n", bodyStart);
+  if (end === -1) throw new Error("Missing certbot renewal hook end");
+  return remoteScript.slice(bodyStart, end);
+}
+
+function runRenewalHook(hookSource: string, certificateSans: string) {
+  const fixtureDir = mkdtempSync(join(tmpdir(), "headscale-renew-hook-test-"));
+  const binDir = join(fixtureDir, "bin");
+  const lineageDir = join(fixtureDir, "lineage");
+  const hookPath = join(fixtureDir, "renew-hook");
+  const logPath = join(fixtureDir, "commands.log");
+  mkdirSync(binDir);
+  mkdirSync(lineageDir);
+  writeFileSync(join(lineageDir, "fullchain.pem"), "test-only-certificate\n");
+  writeFileSync(logPath, "");
+  writeFileSync(
+    join(binDir, "openssl"),
+    "#!/usr/bin/env bash\nprintf 'X509v3 Subject Alternative Name:\\n    %s\\n' \"$TEST_CERT_SANS\"\n",
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    join(binDir, "nginx"),
+    '#!/usr/bin/env bash\nprintf \'nginx %s\\n\' "$*" >> "$HOOK_LOG"\n',
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    join(binDir, "systemctl"),
+    '#!/usr/bin/env bash\nprintf \'systemctl %s\\n\' "$*" >> "$HOOK_LOG"\n',
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    hookPath,
+    hookSource.replace(
+      /^EXPECTED_LINEAGE=.*$/m,
+      `EXPECTED_LINEAGE=${JSON.stringify(lineageDir)}`,
+    ),
+    { mode: 0o755 },
+  );
+
+  try {
+    const result = spawnSync("bash", [hookPath], {
+      encoding: "utf8",
+      env: {
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        HOOK_LOG: logPath,
+        RENEWED_LINEAGE: lineageDir,
+        TEST_CERT_SANS: certificateSans,
+      },
+    });
+    return { ...result, commandLog: readFileSync(logPath, "utf8") };
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
 }
 
 describe("protected Headscale arm workflow", () => {
@@ -209,6 +286,30 @@ describe("protected Headscale arm workflow", () => {
     expect(scriptSource).toContain('listenAddr: "127.0.0.1:8081"');
     expect(scriptSource).toContain('apiUrl: "http://127.0.0.1:8080"');
     expect(scriptSource).toContain('listenAddr: "127.0.0.1:8080"');
+  });
+
+  test("keeps every control-plane writer on the environment-fixed loopback API", () => {
+    expect(provisioningWorkflowSource).not.toContain(
+      "HEADSCALE_API_URL: $" + "{{ vars.HEADSCALE_API_URL }}",
+    );
+    expect(provisioningWorkflowSource).not.toContain(
+      "require_exact HEADSCALE_API_URL",
+    );
+    expect(provisioningWorkflowSource).toContain(
+      'resolved_headscale_api_url="http://127.0.0.1:8081"',
+    );
+    expect(provisioningWorkflowSource).toContain(
+      'resolved_headscale_api_url="http://127.0.0.1:8080"',
+    );
+    expect(provisioningWorkflowSource).toContain(
+      'echo "HEADSCALE_API_URL=$resolved_headscale_api_url" >> "$GITHUB_ENV"',
+    );
+  });
+
+  test("documents only the canonical protected dispatch inputs", () => {
+    expect(controlPlaneRunbookSource).toContain("-f environment=production");
+    expect(controlPlaneRunbookSource).not.toContain("-f headscale_api_url=");
+    expect(controlPlaneRunbookSource).not.toContain("-f listen_addr=");
   });
 
   test("pins staging and production deploys to their canonical branch SHA", () => {
@@ -363,6 +464,47 @@ server {
       "/etc/nginx/conf.d/headscale.conf\theadscale.elizacloud.ai",
       "/etc/nginx/sites-enabled/legacy-headscale\theadscale.elizacloud.ai",
     ]);
+  });
+
+  test("installs a fail-closed renewal hook that validates both SANs before reload", () => {
+    const result = runDryArm(
+      "https://headscale.eliza.app",
+      "https://headscale.elizacloud.ai",
+    );
+    expect(result.status).toBe(0);
+    const hook = renewalHookScript(result.stdout);
+    expectBashSyntax(hook);
+    expect(result.stdout).toContain(
+      "HS_RENEW_HOOK=/etc/letsencrypt/renewal-hooks/deploy/eliza-headscale-nginx-reload",
+    );
+    expect(result.stdout).toContain(
+      'sudo install -o root -g root -m 0755 "$HS_RENEW_HOOK_STAGE" "$HS_RENEW_HOOK"',
+    );
+    expect(result.stdout).toContain(
+      "sudo systemctl enable --now certbot.timer",
+    );
+    expect(result.stdout).toContain(
+      "sudo systemctl is-enabled --quiet certbot.timer",
+    );
+    expect(result.stdout).toContain(
+      "sudo systemctl is-active --quiet certbot.timer",
+    );
+    expect(result.stdout).not.toContain("WARN: certbot.timer not active");
+
+    const valid = runRenewalHook(
+      hook,
+      "DNS:headscale.eliza.app, DNS:headscale.elizacloud.ai",
+    );
+    expect(valid.status).toBe(0);
+    expect(valid.stderr).toBe("");
+    expect(valid.commandLog).toBe("nginx -t\nsystemctl reload nginx\n");
+
+    const missingLegacySan = runRenewalHook(hook, "DNS:headscale.eliza.app");
+    expect(missingLegacySan.status).not.toBe(0);
+    expect(missingLegacySan.stderr).toContain(
+      "renewed Headscale certificate does not cover both required hostnames",
+    );
+    expect(missingLegacySan.commandLog).toBe("");
   });
 
   test("rejects a cross-environment legacy hostname", () => {


### PR DESCRIPTION
# Relates to

Closes #19316.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] The pinned install completed through `bun run install:light` (`ELIZA_SKIP_ARTIFACT_SYNC=1 bun install`).
- [x] Exact-head `bun run verify:cloud` and uncached `bun run verify` pass.
- [x] A reviewer can confirm the contract from the executed renewal-hook fixture, generated deployment artifacts, and gate results below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6c033a6d10e6af64e773bc715d96efac06be396f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `033b9478dc3aea4286cc8c1de64fddea3732d8c4`; zero conflicts.
- [x] The two independently reviewed commits remain patch-equivalent after rebase (`f47f2077...` and `90ef94f9...` stable patch IDs).
- [x] Exact-head gates below bind to `688b9fc3a0db5f8a90ed9c0321310e0050f0e8b3`.

# Risks

Medium operational risk, limited to the protected Headscale arm path when it is dispatched after merge. A dispatch can request or expand a Let's Encrypt certificate and replace the nginx vhost. Both ACME and final vhost bytes are staged; rollback traps are installed before either loaded config path changes; any validation or reload failure restores the prior file bytes. The legacy DNS name must still resolve to the same control-plane VM for dual-name HTTP-01.

The workflow deliberately fails if any loaded config other than `/etc/nginx/conf.d/headscale.conf` owns either exact hostname. The expected live owner contract is exactly two records per exact hostname in that file (one HTTP and one HTTPS server). A conflicting loaded path is printed diagnostically, the prior intended vhost is restored, and unknown nginx files are left untouched. Prior staging logs do not independently prove the currently loaded owner path; the protected post-merge staging arm is the required live proof.

Renewal is now fail-closed. Every arm installs a root-owned `0755` certbot deploy hook, the hook validates both exact SANs and `nginx -t` before reload, and the arm requires `certbot.timer` to be enabled and active. The normal provisioning-worker deploy also derives the same fixed loopback API URL (`127.0.0.1:8081` production, `127.0.0.1:8080` staging), so it cannot undo the arm boundary through a public GitHub variable.

No workflow was dispatched and no Cloudflare, Hetzner, DNS, certificate, environment, or other live provider state was changed by this PR.

# Background

## What does this PR do?

- Keeps canonical `HEADSCALE_PUBLIC_URL` authoritative for Headscale `server_url`, control-plane router enrollment, and daemon configuration.
- Derives the exact legacy hostname and fixed loopback API/listen values from the canonical environment; dispatch callers cannot override those protected values.
- Prevents the provisioning-worker workflow from redirecting the daemon API or protected bearer key through `vars.HEADSCALE_API_URL`.
- Converges one no-http2 nginx vhost and one certificate covering both exact canonical and legacy hostnames.
- Stages and rolls back every nginx config mutation, retaining the currently loaded TLS vhost during ACME issuance.
- Requires `nginx -T` to report no conflicting-name warning and exactly two owners per hostname, both in the intended file.
- Installs a validated certbot renewal deploy hook and requires the renewal timer to be enabled and active.
- Verifies both public `/health` endpoints, then proves both SNI names serve the same SHA-256 leaf fingerprint and that each leaf has both exact SANs.
- Pins staging dispatches to `develop`, production dispatches to `main`, and checkout to `github.sha` with persisted credentials disabled.
- Removes stale runbook guidance for the retired API/listen dispatch overrides.

## What kind of change is this?

Bug fix and deployment hardening (non-breaking migration-overlap repair).

# Documentation changes needed?

Documentation was required. `packages/cloud/services/headscale/README.md`, `packages/cloud/services/headscale/DEPLOY.md`, and the Hetzner control-plane runbook describe the overlap, fail-closed ownership/renewal behavior, and canonical dispatch contract.

# Testing

## Where should a reviewer start?

Run `bun test packages/scripts/__tests__/headscale-arm-workflow.test.ts`. It parses both protected writers, syntax-checks their security and identity gates, executes production and staging dry-runs, executes the generated certbot hook with dual-SAN and missing-SAN fixtures, and proves that no reload occurs when the legacy SAN is missing. A synthetic multiline `nginx -T` fixture proves the owner parser reports an unexpected legacy config path.

## Exact-head gates

```text
$ bun test packages/scripts/__tests__/headscale-arm-workflow.test.ts packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
35 pass
0 fail
377 expect() calls

$ bun run verify:cloud
Tasks: 78 successful, 78 total

$ TURBO_FORCE=true bun run verify
Tasks: 350 successful, 350 total
Cached: 0 cached, 350 total
All subsequent repository audits passed.
```

Additional exact-head checks passed:

```text
bunx actionlint .github/workflows/arm-headscale-control-plane.yml
bunx actionlint -ignore 'unexpected key "queue"' .github/workflows/deploy-eliza-provisioning-worker.yml
bunx biome check packages/cloud/scripts/admin/arm-headscale-control-plane.mjs packages/scripts/__tests__/headscale-arm-workflow.test.ts packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
node --check packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
git diff --check origin/develop...HEAD
```

Raw Actionlint reports the repository's existing `queue: max` extension in the provisioning workflow; the same diagnostic reproduces on `origin/develop`. With only that unrelated base diagnostic ignored, both changed workflows pass.

# Evidence Gate

Evidence matches the exact commit reviewed.
<!-- evidence-head:688b9fc3a0db5f8a90ed9c0321310e0050f0e8b3 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - source-only infrastructure workflow change has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - source-only infrastructure workflow change has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - source-only infrastructure workflow change has no interactive user flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - live workflow dispatch was explicitly out of scope; deterministic executed backend fixtures are inline above.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser request path changed in this PR.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent action, provider, prompt, model, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Sanitized production and staging generated remote-script artifacts are identified by exact SHA-256 below, with the renewal artifact contract reproduced inline.

<details><summary>Exact generated Headscale artifacts</summary>

```text
production remote script SHA-256: 5c33507d61b6c825e7bf15d74cb48fd85dfb3091ed51ea98dc7e6a8193beaa64
staging remote script SHA-256:    575fc201001b76e0ec0e3b31d6e6bc422df6ef6f8f182d522f1ff14d8d73e19a
owner contract: /etc/nginx/conf.d/headscale.conf, exactly two records per exact hostname
renewal contract: both exact SANs -> nginx -t -> systemctl reload nginx; timer enabled and active
```

</details>
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface exists for OCR review in this change.

# Evidence Details

## Generated deployment-domain artifact

Exact-head dry-runs used only documentation IP `192.0.2.10`, `/dev/null` SSH fixtures, and a test-only API key:

```text
production remote script SHA-256: 5c33507d61b6c825e7bf15d74cb48fd85dfb3091ed51ea98dc7e6a8193beaa64
staging remote script SHA-256:    575fc201001b76e0ec0e3b31d6e6bc422df6ef6f8f182d522f1ff14d8d73e19a

intended owner: /etc/nginx/conf.d/headscale.conf
required owners: two per exact hostname (HTTP + HTTPS)
renewal hook: /etc/letsencrypt/renewal-hooks/deploy/eliza-headscale-nginx-reload
renewal sequence: exact canonical SAN + exact legacy SAN -> nginx -t -> systemctl reload nginx
timer convergence: enable --now -> is-enabled --quiet -> is-active --quiet
```

The test executes the extracted generated hook twice: the dual-SAN fixture records `nginx -t` followed by `systemctl reload nginx`; the missing-legacy-SAN fixture exits nonzero and records no nginx or systemd command.

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

N/A - this PR deliberately did not dispatch the protected arm workflow. The deterministic generated-script, executed renewal-hook fixture, synthetic owner fixture, and workflow contract results are included above.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no audio or voice surface changed.

## Known gaps / failures

- Live SAN, nginx, loaded-owner, fingerprint, and dual-host health proof requires a separately authorized protected staging workflow dispatch after merge. This PR intentionally performs no deployment or provider mutation.
- Current public evidence shows canonical and legacy names resolve to the same VM but serve different single-SAN leaves. If staging reveals a competing config path, the workflow will fail closed and restore the prior intended vhost; a separate targeted cleanup must then be reviewed.
- The GitHub token could open and claim #19316 but lacks Project scope, so the issue could not be added to or updated on a GitHub Project.

# Deploy Notes

After merge and explicit operator approval, dispatch staging from `develop`. Inspect any reported nginx owner path; do not delete unknown configs generically. Once staging proves exclusive ownership, identical public leaf fingerprints, both exact SANs, and both health endpoints, promote the reviewed source to `main` and follow the protected production approval path. Do not retire legacy DNS or its SAN in this deployment.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@6c033a6d10e6af64e773bc715d96efac06be396f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@6c033a6d10e6af64e773bc715d96efac06be396f:packages/skills/skills/contribute-to-eliza"} -->

