### PR TITLE
fix(agent): retain bounded trajectory completeness

### DIFF
--- a/packages/agent/src/runtime/trajectory-bridge.test.ts
+++ b/packages/agent/src/runtime/trajectory-bridge.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   enqueueStepWrite,
   ensureTrajectoriesTable,
+  normalizeLlmCallPayload,
 } from "./trajectory-internals.ts";
 import { installDatabaseTrajectoryLogger } from "./trajectory-persistence.ts";
 import { loadPersistedTrajectoryRows } from "./trajectory-query.ts";
@@ -1364,5 +1365,52 @@ describe("installDatabaseTrajectoryLogger (capture bridge)", () => {
 
     expect(originalExportTrajectories).not.toHaveBeenCalled();
     expect(hasTraceFilter(execute, "trace-1")).toBe(true);
+  });
+});
+
+describe("budgeted LLM capture completeness", () => {
+  it("retains required fields without exceeding the global row budget", () => {
+    const optionalFields = Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [
+        `optional-${index}`,
+        "x".repeat(70_000),
+      ]),
+    );
+    const normalized = normalizeLlmCallPayload([
+      {
+        stepId: "step-budget-exhausted",
+        ...optionalFields,
+        model: "zai-glm-4.7",
+        response: "r".repeat(400_000),
+        purpose: "response",
+        actionType: "llm",
+      },
+    ]);
+
+    expect(normalized?.params).toMatchObject({
+      model: "zai-glm-4.7",
+      purpose: "response",
+      actionType: "llm",
+    });
+    expect(normalized?.params.response).toEqual(
+      expect.stringContaining("...[truncated]"),
+    );
+    expect(
+      new TextEncoder().encode(JSON.stringify(normalized?.params)).byteLength,
+    ).toBeLessThanOrEqual(1024 * 1024);
+  });
+
+  it("leaves a small response byte-identical", () => {
+    const normalized = normalizeLlmCallPayload([
+      {
+        stepId: "step-small",
+        model: "zai-glm-4.7",
+        purpose: "response",
+        actionType: "llm",
+        response: "ok",
+      },
+    ]);
+
+    expect(normalized?.params.response).toBe("ok");
   });
 });

--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -1585,6 +1585,28 @@ function snapshotCaptureParams(
 }
 
 /**
+ * Snapshot an LLM capture with its completeness fields first in the shared
+ * byte budget. Optional prompts and metadata may exhaust that budget, but the
+ * persisted record must still identify the model, purpose, action type, and
+ * bounded response without adding data after sanitization.
+ */
+function snapshotLlmCaptureParams(
+  params: Record<string, unknown>,
+  stepId: string,
+): Record<string, unknown> {
+  return snapshotCaptureParams(
+    {
+      model: params.model,
+      response: params.response,
+      purpose: params.purpose,
+      actionType: params.actionType,
+      ...params,
+    },
+    stepId,
+  );
+}
+
+/**
  * A tool-call-only completion (`finishReason=tool-calls` — a planner turn that
  * emits only a tool call, or a Stage-1 truncated at its completion-token cap)
  * produces no assistant text, so producers hand this recorder
@@ -1626,7 +1648,7 @@ export function normalizeLlmCallPayload(
       }),
     );
     validateLlmCapture(params, stepId);
-    const snapshot = snapshotCaptureParams(params, stepId);
+    const snapshot = snapshotLlmCaptureParams(params, stepId);
     validateLlmCapture(snapshot, stepId);
     return {
       stepId,
@@ -1654,7 +1676,7 @@ export function normalizeLlmCallPayload(
     coerceAbsentLlmResponse(normalizedParams),
   );
   validateLlmCapture(redactedParams, stepId);
-  const snapshot = snapshotCaptureParams(redactedParams, stepId);
+  const snapshot = snapshotLlmCaptureParams(redactedParams, stepId);
   validateLlmCapture(snapshot, stepId);
   return {
     stepId,


### PR DESCRIPTION
# Relates to

Relates to #18960 and supersedes the unsafe implementation approach in #19323.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ddb40bce684b69864db813061a6dffc3be70ceae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Root cause and repair

The LLM capture validator requires `model`, `response`, `purpose`, and `actionType`. The bounded JSON sanitizer traversed input insertion order, so sufficiently large optional fields could exhaust the shared 1 MiB budget before those required fields and make the whole capture fail its post-snapshot validation.

This repair places the four completeness fields first in the same bounded sanitizer. Required strings retain the existing per-field 64 KiB truncation marker, optional data still competes for the remaining global budget, redaction still runs before snapshotting, and nothing is appended after sanitization.

The structured-response coercion proposed in #19323 is deliberately excluded: `response` is a declared string and an existing contract test requires present non-strings to fail fast. Missing tool-call text continues to use the existing explicit empty-string compatibility path.

# Testing

Exact head: `223e64dd1be183265b8888f6712e3cdf5a4508a1`

- focused trajectory bridge + redaction suites: 33/33 passed
- targeted Biome: clean
- red proof on the old ordering: a fixture with twenty 70,000-character optional fields produced a 983,404-byte snapshot with `response` absent
- green proof: the same adversarial fixture retains all four required fields, marks the 400,000-character response truncated, and remains at or below 1 MiB
- small response remains byte-identical

# Security and compatibility

- No unredacted source data is restored after sanitization.
- The hard global row-size limit remains enforced.
- Present non-string responses remain rejected.
- Both supported logger call shapes use the same bounded snapshot helper.

# Evidence Gate

<!-- evidence-head:223e64dd1be183265b8888f6712e3cdf5a4508a1 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - persistence logic only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - persistence logic only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - the persisted payload contract is asserted directly in deterministic tests.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this changes the recorder's bounded persistence path; no model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain state or artifact; the bounded serialized payload contract is asserted directly by focused tests.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual output.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@ddb40bce684b69864db813061a6dffc3be70ceae:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [nubs-review-ci]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@ddb40bce684b69864db813061a6dffc3be70ceae:packages/skills/skills/contribute-to-eliza"} -->