### PR TITLE
fix(core): isolate exact hints from message-only tie evidence

### DIFF
--- a/packages/core/src/runtime/__tests__/action-tiering.test.ts
+++ b/packages/core/src/runtime/__tests__/action-tiering.test.ts
@@ -240,6 +240,36 @@ describe("action tiering", () => {
 		);
 	});
 
+	it("does not count a wrong exact candidate as message evidence in a saturated tie", () => {
+		const catalog = buildActionCatalog([
+			{
+				name: "QUASAR_LOOKUP",
+				description: "Inspect quasar telemetry and measurements.",
+				contexts: ["general"],
+			},
+			{
+				name: "VIEWS",
+				description: "Open app views and arrange panels.",
+				contexts: ["general"],
+			},
+		]);
+		const retrieval = retrieveActions({
+			catalog,
+			messageText: "quasar",
+			candidateActions: ["VIEWS"],
+			selectedContexts: ["general"],
+		});
+
+		expect(retrieval.results.slice(0, 2)).toMatchObject([
+			{ name: "QUASAR_LOOKUP", rank: 1, score: 1 },
+			{ name: "VIEWS", rank: 2, score: 1 },
+		]);
+		expect(retrieval.results[1]?.stageScores).toMatchObject({
+			exact: 1,
+			bm25: 1,
+		});
+	});
+
 	it("does not let tied perfect keyword matches flood a routed candidate", () => {
 		const catalog = buildActionCatalog([
 			...actions,

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -488,9 +488,75 @@ export function retrieveActions(
 		};
 	});
 
+	const saturatedResults = results.filter((result) => result.score === 1);
+	const needsMessageOnlyTieBreak =
+		saturatedResults.length > 1 &&
+		saturatedResults.some((result) => (result.stageScores.exact ?? 0) > 0);
+	const messageEvidenceByParent = new Map<string, number>();
+	if (needsMessageOnlyTieBreak) {
+		// Candidate names intentionally participate in the main fuzzy retrieval
+		// so invented child/simile hints can still resolve to a catalog parent.
+		// Re-score without candidate text only for a saturated exact-hint tie;
+		// otherwise the hint gives itself the BM25/keyword evidence that should
+		// distinguish a wrong Stage-1 guess from the user's actual request.
+		const messageOnlyQueryTexts = [
+			input.messageText ?? "",
+			...recentConversationText,
+		].filter((text) => text.trim().length > 0);
+		const messageOnlyKeywordScores = scoreKeywordMatches(
+			input.catalog.parents,
+			messageOnlyQueryTexts,
+		);
+		const messageOnlyBm25Scores = scoreBm25(
+			input.catalog.parents,
+			tokenizeActionSearchText(messageOnlyQueryTexts.join("\n")),
+		);
+		const maxMessageOnlyKeyword = Math.max(
+			0,
+			...messageOnlyKeywordScores.values(),
+		);
+		const maxMessageOnlyBm25 = Math.max(0, ...messageOnlyBm25Scores.values());
+		for (const parent of input.catalog.parents) {
+			const keywordRaw =
+				messageOnlyKeywordScores.get(parent.normalizedName) ?? 0;
+			const bm25Raw = messageOnlyBm25Scores.get(parent.normalizedName) ?? 0;
+			const embeddingRaw = embeddingScores.get(parent.normalizedName) ?? 0;
+			const keyword =
+				maxMessageOnlyKeyword > 0 ? keywordRaw / maxMessageOnlyKeyword : 0;
+			const bm25 = maxMessageOnlyBm25 > 0 ? bm25Raw / maxMessageOnlyBm25 : 0;
+			const embedding = maxEmbedding > 0 ? embeddingRaw / maxEmbedding : 0;
+			const hasMessageEvidence = keyword > 0 || bm25 > 0 || embedding > 0;
+			const parentContexts: readonly unknown[] = Array.isArray(parent.contexts)
+				? parent.contexts
+				: [];
+			const contextMatch =
+				hasMessageEvidence &&
+				selectedContextSet.size > 0 &&
+				parentContexts.some((context) =>
+					selectedContextSet.has(String(context).toLowerCase()),
+				)
+					? 0.3
+					: 0;
+			messageEvidenceByParent.set(
+				parent.normalizedName,
+				roundScore(keyword + bm25 + embedding + contextMatch),
+			);
+		}
+	}
+
 	results.sort((left, right) => {
+		// Use one key for the whole saturated cohort once an exact hint contests
+		// it. A pair-specific "one side is exact" key can make a three-result
+		// comparator non-transitive; runs without a saturated exact hint still
+		// fall through to their unchanged RRF ordering.
+		const saturatedHintCohortTie =
+			needsMessageOnlyTieBreak && left.score === 1 && right.score === 1;
 		return (
 			right.score - left.score ||
+			(saturatedHintCohortTie
+				? (messageEvidenceByParent.get(right.normalizedName) ?? 0) -
+					(messageEvidenceByParent.get(left.normalizedName) ?? 0)
+				: 0) ||
 			right.rrfScore - left.rrfScore ||
 			left.normalizedName.localeCompare(right.normalizedName)
 		);


### PR DESCRIPTION
Closes #19347.

Alternative to #19314 after exact-head compatibility review.

## What changed

The existing retrieval query still includes Stage-1 candidate text so child and simile hints resolve compatibly. When and only when multiple results saturate at score 1 and that cohort contains an exact hint, retrieval computes a separate message-only keyword/BM25 view and uses that semantic evidence before the existing RRF fallback.

The same message-only key applies across the whole contested saturated cohort. This keeps the comparator transitive when three or more score-1 results are present. Embedding remains message evidence. Context contributes only to a parent that has message evidence. Runs without a saturated exact hint and all non-saturated comparisons retain the existing score then RRF ordering.

## Why #19314 is insufficient

Its independentEvidence uses stageScores.keyword and stageScores.bm25 from the main query. That query includes candidateActionsForSearch, so a wrong candidate gives itself BM25/keyword evidence.

In the generic adversarial case:
- message: quasar
- genuine parent: QUASAR_LOOKUP
- wrong exact candidate: VIEWS
- both contexts: general

Both results saturate at score 1. Under #19314 both independent totals are 1.3, and the candidate-inflated RRF still ranks VIEWS first. This change ranks QUASAR_LOOKUP first using message-only evidence.

## Exact candidate

- Base: ddb40bce684b69864db813061a6dffc3be70ceae
- Head: 2a92a6c9256e0bd5f9eb612b8bfdca0ac2ca4aae
- Tree: 60ba630493113d024f7a1e224bc7d324a9bed349
- Paths: packages/core/src/runtime/action-retrieval.ts and packages/core/src/runtime/__tests__/action-tiering.test.ts

## Verification

| Evidence | Result |
| --- | --- |
| action-retrieval plus action-tiering focused tests | 47 passed |
| Existing WEB_FETCH weather omission regression | passed |
| Existing OWNER_REMINDERS exact-candidate floor regressions | passed |
| New generic adversarial saturated tie | passed |
| Comparator transitivity audit | saturated cohort uses one consistent message-only key |
| Core typecheck | passed |
| Biome on both changed paths | passed |
| Live-model trajectory | N/A; deterministic retrieval comparator |
| Frontend evidence | N/A; no UI surface |

## Attribution

- AI provider/model: openai / gpt-5.6-sol
- Client / agent tooling: Codex desktop
- Lane: ci_19276_detent_webkit

<!-- evidence-head:2a92a6c9256e0bd5f9eb612b8bfdca0ac2ca4aae -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core retrieval has no visual surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - core retrieval has no visual surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic core comparator only

<!-- evidence-row:backend-logs -->
- [ ] N/A - focused deterministic unit tests are the executable evidence

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call or prompt behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no external domain artifact; retrieval invariants are covered by focused tests


## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ddb40bce684b69864db813061a6dffc3be70ceae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual output

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@ddb40bce684b69864db813061a6dffc3be70ceae:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [nubs-review-ci]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@ddb40bce684b69864db813061a6dffc3be70ceae:packages/skills/skills/contribute-to-eliza"} -->