### PR TITLE
fix(ui): preserve Steward refresh error boundary

### DIFF
--- a/packages/ui/src/state/useCloudState.steward-refresh-error-boundary.test.tsx
+++ b/packages/ui/src/state/useCloudState.steward-refresh-error-boundary.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Exercises the native Steward refresh endpoint boundary through useCloudState.
+ *
+ * The deterministic jsdom harness replaces the Cloud transport and endpoint
+ * resolver collaborators while retaining the production hook lifecycle, so it
+ * can distinguish malformed configured input from an unexpected resolver
+ * defect without contacting Steward.
+ */
+// @vitest-environment jsdom
+
+import { logger } from "@elizaos/logger";
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../config/boot-config";
+
+const clientCloudMocks = vi.hoisted(() => ({
+  refreshCloudStewardSession: vi.fn(),
+  resolveDirectCloudAuthApiBase: vi.fn(),
+}));
+
+vi.mock("../api/client-cloud", () => ({
+  cloudTokenSecsRemaining: () => 0,
+  refreshCloudStewardSession: clientCloudMocks.refreshCloudStewardSession,
+  resolveDirectCloudAuthApiBase: clientCloudMocks.resolveDirectCloudAuthApiBase,
+}));
+
+vi.mock("../bridge", () => ({
+  invokeDesktopBridgeRequestWithTimeout: vi.fn(),
+  isElectrobunRuntime: () => true,
+}));
+
+import { useCloudState } from "./useCloudState";
+
+function makeParams() {
+  return {
+    setActionNotice: vi.fn(),
+    loadWalletConfig: vi.fn(async () => {}),
+    t: (key: string) => key,
+  };
+}
+
+function armStewardRefresh(): void {
+  localStorage.setItem(STEWARD_TOKEN_KEY, "near-expiry-steward-jwt");
+  renderHook(() => useCloudState(makeParams()));
+}
+
+describe("useCloudState — Steward refresh endpoint error boundary", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "https://api.example.com",
+    });
+    clientCloudMocks.refreshCloudStewardSession.mockReset();
+    clientCloudMocks.refreshCloudStewardSession.mockResolvedValue({
+      token: "fresh",
+    });
+    clientCloudMocks.resolveDirectCloudAuthApiBase.mockReset();
+    clientCloudMocks.resolveDirectCloudAuthApiBase.mockImplementation(
+      (base: string) => base,
+    );
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("passes a validated configured API endpoint to the Electrobun refresh", async () => {
+    armStewardRefresh();
+
+    await waitFor(() =>
+      expect(clientCloudMocks.refreshCloudStewardSession).toHaveBeenCalledWith({
+        endpoint: "https://api.example.com/api/auth/steward-refresh",
+      }),
+    );
+  });
+
+  it("uses the documented default endpoint for malformed configured input", async () => {
+    setBootConfig({ branding: {}, cloudApiBase: "not a URL" });
+
+    armStewardRefresh();
+
+    await waitFor(() =>
+      expect(clientCloudMocks.refreshCloudStewardSession).toHaveBeenCalledWith({
+        endpoint: undefined,
+      }),
+    );
+  });
+
+  it("reports an unexpected resolver failure without fabricating an endpoint", async () => {
+    const resolverFailure = new Error("resolver unavailable");
+    clientCloudMocks.resolveDirectCloudAuthApiBase.mockImplementationOnce(
+      () => {
+        throw resolverFailure;
+      },
+    );
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    armStewardRefresh();
+
+    await waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(
+        { err: resolverFailure },
+        "[useCloudState] steward session refresh failed",
+      ),
+    );
+    expect(clientCloudMocks.refreshCloudStewardSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -379,13 +379,15 @@ function resolveStewardRefreshEndpoint(): string | undefined {
   if (!isCapacitorNativeRuntime() && !isElectrobunRuntime()) return undefined;
   const cloudBase =
     getBootConfig().cloudApiBase?.trim() || DEFAULT_DIRECT_CLOUD_BASE_URL;
+  const apiBase = resolveDirectCloudAuthApiBase(cloudBase);
   try {
-    return `${resolveDirectCloudAuthApiBase(cloudBase)}${STEWARD_REFRESH_PATH}`;
+    new URL(apiBase);
   } catch {
     // error-policy:J3 malformed cloud base URL → use the shared default
     // refresh endpoint (the documented `undefined` contract of this helper).
     return undefined;
   }
+  return `${apiBase}${STEWARD_REFRESH_PATH}`;
 }
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -1524,15 +1526,18 @@ export function useCloudState({
       // No `exp` (opaque token / device-code session) → nothing to refresh.
       if (secs === null) return;
       if (secs >= STEWARD_REFRESH_AHEAD_SECS) return;
-      // error-policy:J4 pre-emptive token refresh; a failed refresh keeps the
-      // still-valid stored token until it actually expires (the next authed
-      // call then surfaces the re-auth path). No token rotation on failure.
-      const result = await refreshCloudStewardSession({
-        endpoint: resolveStewardRefreshEndpoint(),
-      }).catch((err: unknown) => {
+      let result: Awaited<ReturnType<typeof refreshCloudStewardSession>>;
+      try {
+        result = await refreshCloudStewardSession({
+          endpoint: resolveStewardRefreshEndpoint(),
+        });
+      } catch (err: unknown) {
+        // error-policy:J4 pre-emptive token refresh; a resolution or transport
+        // failure is reported and keeps the stored token until the next authed
+        // call surfaces the re-auth path. No token rotation on failure.
         logger.warn({ err }, "[useCloudState] steward session refresh failed");
-        return null;
-      });
+        return;
+      }
       if (disposed) return;
       if (result?.token) {
         writeStoredStewardToken(result.token);


### PR DESCRIPTION
# Relates to

Closes #19313.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - contributor used an external contribution skill without an elizaOS/eliza repository revision`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased cleanly onto `origin/develop@fa816c29eb1a0d3b1d93b79b299e456e7994ba7d`.
- [x] Exact-head package checks were rerun in a disposable, network-disabled Linux container using pinned Bun 1.3.14 and Node 24.

# Risks

Low and limited to native/Electrobun pre-emptive Steward session refresh. Malformed configured bases retain the documented default-endpoint behavior. Unexpected resolver/configuration defects now reach the existing lifecycle warning boundary instead of being disguised as `endpoint: undefined`; failed refreshes do not rotate or clear the stored token.

# Background

## What does this PR do?

`resolveStewardRefreshEndpoint` previously wrapped both the canonical endpoint resolver and malformed-URL parsing in one J3 catch. That catch converted any resolver defect into a plausible absent endpoint. The repair:

- resolves the canonical Cloud auth base outside the J3 parse catch;
- validates the resolved base explicitly before appending the refresh path;
- preserves `undefined` only for malformed configured input; and
- expands the existing J4 lifecycle boundary so synchronous resolution and asynchronous transport failures are both logged without fabricating or rotating a token.

The implementation intentionally reuses `resolveDirectCloudAuthApiBase`; it does not duplicate the canonical domain map.

## What kind of change is this?

Bug fix. No public type, API, or rendered UI contract changes.

# Documentation changes needed?

No. This restores the repository error-policy contract and the helper's documented `undefined` fallback.

# Testing

## Where should a reviewer start?

Start with `packages/ui/src/state/useCloudState.steward-refresh-error-boundary.test.tsx`, then inspect `resolveStewardRefreshEndpoint` and the pre-emptive refresh effect in `useCloudState.ts`.

## Exact-head validation

Executed against `1e264ace91e5d9c79f3b4b14541218ac407dabaa`:

```text
Focused UI tests: 4 files passed; 30 tests passed
Changed-file Biome: 2 files checked; no fixes
Full UI Biome: 2,951 files checked; exit 0 (8 existing cookie-test warnings)
UI typecheck: exit 0
UI production build: exit 0; 46 runtime exports verified
git diff --check: exit 0
```

The related `useCloudState.steward-refresh-electrobun.test.tsx` still omits `resolveDirectCloudAuthApiBase` from its old module mock. It fails on untouched `develop` with the same expected-endpoint mismatch and is already owned by #19312; this PR does not duplicate that separately claimed test repair.

The mandatory app audit was attempted twice in the isolated environment. With a 4 GiB Node heap it completed all 19 view-bundle builds and the full renderer build, then the capture lane could not launch because the offline review image has no Playwright Chromium binary. No screenshot assertion ran, and this patch changes no rendered state.

# Evidence Gate

<!-- evidence-head:1e264ace91e5d9c79f3b4b14541218ac407dabaa -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this changes a non-rendered hook error boundary; no UI surface is altered.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this changes a non-rendered hook error boundary; no UI surface is altered.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no rendered user flow; deterministic production-hook tests exercise the lifecycle.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code or live service is changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - the failure path is asserted through the structured logger boundary without a live credential.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, schedule, wallet, on-chain, or generated domain state changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or visual text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-facing behavior changes.

## Backend + frontend logs

N/A for live logs. The deterministic hook test asserts the exact structured warning for a resolver defect and proves the transport is not invoked with a fabricated endpoint.

## Screenshots (before / after) + video walkthrough

N/A - the diff contains hook logic and a test harness only; no rendered component, CSS, SVG, layout, copy, or interaction changes.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changes.

## Known gaps / failures

- Hosted required checks remain the merge gate.
- The offline visual-capture image lacks the Playwright browser binary; renderer and view-bundle compilation passed before that environment-only stop.

## Discord username

`otakucomrade`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@fa816c29eb1a0d3b1d93b79b299e456e7994ba7d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@fa816c29eb1a0d3b1d93b79b299e456e7994ba7d:packages/skills/skills/contribute-to-eliza"} -->
