### PR TITLE
fix(scripts): close package-build-lock replacement takeover race

### DIFF
--- a/packages/scripts/__tests__/with-package-build-lock.test.ts
+++ b/packages/scripts/__tests__/with-package-build-lock.test.ts
@@ -71,12 +71,14 @@ function spawnWrapper(
   packageKey: string,
   command: string[],
   staleMs = "1000",
+  envOverrides: NodeJS.ProcessEnv = {},
 ): ChildProcessWithoutNullStreams {
   return spawn(NODE_BIN, [WRAPPER, packageKey, "--", ...command], {
     cwd: REPO_ROOT,
     env: {
       ...process.env,
       ELIZA_PACKAGE_BUILD_LOCK_STALE_MS: staleMs,
+      ...envOverrides,
     },
     stdio: ["pipe", "pipe", "pipe"],
   });
@@ -104,6 +106,25 @@ async function waitForPath(target: string, timeoutMs = 5_000): Promise<void> {
   while (!existsSync(target)) {
     if (Date.now() >= deadline)
       throw new Error(`Timed out waiting for ${target}`);
+    await Bun.sleep(10);
+  }
+}
+
+async function waitForFileContent(
+  target: string,
+  expected: string,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    try {
+      if (readFileSync(target, "utf8") === expected) return;
+    } catch (error) {
+      // error-policy:J3 a missing file remains an explicit not-ready state.
+      if (error?.code !== "ENOENT") throw error;
+    }
+    if (Date.now() >= deadline)
+      throw new Error(`Timed out waiting for expected content at ${target}`);
     await Bun.sleep(10);
   }
 }
@@ -227,12 +248,12 @@ describe("with-package-build-lock", () => {
     expect(readFileSync(observationPath, "utf8")).toBe("after");
   });
 
-  test("serializes simultaneous takeovers of one dead-owner lock", async () => {
+  test("serializes simultaneous takeovers of a directory-style dead-owner lock", async () => {
     const packageKey = uniquePackageKey("dead-race");
     const lockPath = lockPathFor(packageKey);
-    mkdirSync(path.dirname(lockPath), { recursive: true });
+    mkdirSync(lockPath, { recursive: true });
     writeFileSync(
-      lockPath,
+      path.join(lockPath, "metadata.json"),
       `${JSON.stringify({ pid: 2_147_483_647, ownerId: "dead", createdAt: new Date().toISOString() })}\n`,
     );
     const evidenceDir = mkdtempSync(path.join(tmpdir(), "eliza-lock-race-"));
@@ -249,28 +270,58 @@ describe("with-package-build-lock", () => {
     expect(existsSync(overlapPath)).toBe(false);
   });
 
-  test("keeps replacement owners exclusive during repeated stale takeovers", async () => {
-    const packageKey = uniquePackageKey("takeover-stress");
+  test("preserves a live replacement installed before atomic stale takeover", async () => {
+    const packageKey = uniquePackageKey("replacement-barrier");
     const lockPath = lockPathFor(packageKey);
     mkdirSync(path.dirname(lockPath), { recursive: true });
     writeFileSync(
       lockPath,
       `${JSON.stringify({ pid: 2_147_483_647, ownerId: "dead", createdAt: new Date().toISOString() })}\n`,
     );
-    const evidenceDir = mkdtempSync(path.join(tmpdir(), "eliza-lock-stress-"));
+    const evidenceDir = mkdtempSync(path.join(tmpdir(), "eliza-lock-barrier-"));
     cleanupPaths.add(evidenceDir);
-    const activePath = path.join(evidenceDir, "active");
-    const overlapPath = path.join(evidenceDir, "overlap");
-    const childCode = `const fs=require("node:fs");const active=${JSON.stringify(activePath)};const overlap=${JSON.stringify(overlapPath)};if(fs.existsSync(active))fs.appendFileSync(overlap,"overlap\\n");fs.writeFileSync(active,String(process.pid));setTimeout(()=>fs.rmSync(active,{force:true}),40);`;
-
-    const outcomes = await Promise.all(
-      Array.from({ length: 8 }, () =>
-        collect(spawnWrapper(packageKey, [NODE_BIN, "-e", childCode])),
-      ),
+    const readyPath = path.join(evidenceDir, "rename-ready");
+    const releasePath = path.join(evidenceDir, "rename-release");
+    const preloadPath = path.join(evidenceDir, "rename-barrier.mjs");
+    writeFileSync(
+      preloadPath,
+      `import fs from "node:fs/promises";\nconst originalRename=fs.rename.bind(fs);\nfs.rename=async(source,destination)=>{if(source===process.env.ELIZA_BUILD_LOCK_TEST_TARGET){await fs.writeFile(process.env.ELIZA_BUILD_LOCK_TEST_READY,"ready");while(true){try{await fs.access(process.env.ELIZA_BUILD_LOCK_TEST_RELEASE);break;}catch(error){/* error-policy:J3 a missing release marker remains an explicit blocked state. */if(error?.code!=="ENOENT")throw error;}await new Promise(resolve=>setTimeout(resolve,5));}}return originalRename(source,destination);};\n`,
     );
 
-    expect(outcomes.every((outcome) => outcome.code === 0)).toBe(true);
-    expect(existsSync(overlapPath)).toBe(false);
+    const contender = spawnWrapper(
+      packageKey,
+      [NODE_BIN, "-e", "process.exit(0)"],
+      "1",
+      {
+        NODE_OPTIONS: `--import=${preloadPath}`,
+        ELIZA_BUILD_LOCK_TEST_TARGET: lockPath,
+        ELIZA_BUILD_LOCK_TEST_READY: readyPath,
+        ELIZA_BUILD_LOCK_TEST_RELEASE: releasePath,
+      },
+    );
+    const contenderResult = collect(contender);
+    await waitForPath(readyPath);
+
+    const replacementId = randomUUID();
+    const replacement = `${JSON.stringify({
+      pid: process.pid,
+      ownerId: replacementId,
+      createdAt: new Date().toISOString(),
+    })}\n`;
+    rmSync(lockPath, { force: true });
+    writeFileSync(lockPath, replacement, { flag: "wx" });
+    writeFileSync(releasePath, "release");
+
+    await waitForFileContent(lockPath, replacement);
+    expect(readFileSync(lockPath, "utf8")).toBe(replacement);
+    expect(JSON.parse(readFileSync(lockPath, "utf8")).ownerId).toBe(
+      replacementId,
+    );
+
+    contender.kill("SIGTERM");
+    const outcome = await contenderResult;
+    expect(outcome.code).not.toBe(0);
+    expect(readFileSync(lockPath, "utf8")).toBe(replacement);
   });
 
   test("waits for the age bound before reclaiming incomplete metadata", () => {

--- a/packages/scripts/with-package-build-lock.mjs
+++ b/packages/scripts/with-package-build-lock.mjs
@@ -172,36 +172,10 @@ async function restoreChangedLock(quarantinePath, movedSnapshot) {
 
 async function quarantineAndRemove(snapshot, reason) {
   const quarantinePath = `${lockPath}.${reason}-${process.pid}-${randomUUID()}`;
-  if (snapshot.stats.isFile()) {
-    try {
-      await fs.link(lockPath, quarantinePath);
-    } catch (error) {
-      if (error?.code === "ENOENT") return false;
-      throw error;
-    }
-
-    const linkedSnapshot = await readLockSnapshot(quarantinePath);
-    const currentSnapshot = await readLockSnapshot();
-    if (
-      !sameSnapshot(snapshot, linkedSnapshot) ||
-      !sameSnapshot(snapshot, currentSnapshot)
-    ) {
-      await removePath(quarantinePath);
-      return false;
-    }
-
-    try {
-      await fs.unlink(lockPath);
-    } catch (error) {
-      if (error?.code !== "ENOENT") throw error;
-    }
-    await removePath(quarantinePath);
-    return true;
-  }
-
   try {
     await fs.rename(lockPath, quarantinePath);
   } catch (error) {
+    // error-policy:J3 a peer removal invalidates this stale snapshot explicitly.
     if (error?.code === "ENOENT") return false;
     throw error;
   }


### PR DESCRIPTION
# Relates to

Closes #19311. Restores the replacement-exclusivity acceptance criterion from #18575.

- #18579 introduced the original owner-aware package build lock.
- #18767 fixed fresh-tree teardown.
- #18973 added hard-link/double-snapshot validation, but its later pathname-based `unlink(lockPath)` could still delete a newly installed live replacement.
- This change closes the remaining gap reported by @Zorba-the-buddhah and @HomunculusLabs in their independent CHANGES_REQUESTED reviews of #18973, following lalalune's concurrency audit at `c267370f26`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop@7e847856f784fee0ae2fbe0d33e399ca3e319de0` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change from the deterministic interleaving and process-suite evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@7e847856f784fee0ae2fbe0d33e399ca3e319de0`; zero conflicts.
- [x] Pinned Node 24.15.0, Bun 1.3.14, `bun install`, focused tests, Biome, and forced-uncached `bun run verify` all pass post-sync.

# Risks

Low. The change deletes a special-case file takeover protocol and routes both regular-file and legacy directory locks through the already-existing atomic rename/post-move-validation/self-heal path. The affected surface is build-process locking; a regression could block or overlap package builds, so both file and directory takeover paths have real-process coverage.

# Background

## What does this PR do?

`quarantineAndRemove` no longer validates a regular-file inode and then removes whatever inode a pathname happens to resolve to later. All lock types now use the existing atomic `fs.rename(lockPath, quarantinePath)` takeover. The moved inode is validated after the atomic move; if another owner installed a replacement before the rename, `restoreChangedLock` restores that moved live lock and the stale contender does not acquire it.

This directly addresses both named reviewers' finding: the correctness argument no longer depends on timing or a green stress run. There is no later pathname `unlink` that can target a different inode than the one moved.

The tests now:

- deterministically pause the real wrapper immediately before its rename, replace the stale file with a live-owner file, release the rename, and prove the exact replacement contents and owner ID are restored;
- restore dedicated legacy directory-lock takeover coverage; and
- remove the probabilistic eight-contender stress test that did not force the vulnerable interleaving.

## What kind of change is this?

Bug fix (non-breaking).

## Acceptance criteria

- [x] Regular-file stale takeover cannot remove a different live replacement; the atomic rename is bound to the pathname transition and post-move identity is validated.
- [x] The directory/rename branch retains a dedicated directory-style stale-lock process test.
- [x] New/changed catch handlers carry `error-policy:J3`; the unsafe unlink/swallow path is deleted.
- [x] Regression coverage deterministically forces the snapshot-validation → removal boundary with a preload scheduling barrier.
- [x] Focused tests, Biome, install, and full repository verification pass on the final synced head.

# Documentation changes needed?

No. This corrects internal build-lock behavior without changing a public interface or operator workflow.

# Testing

## Where should a reviewer start?

1. `packages/scripts/with-package-build-lock.mjs` — `quarantineAndRemove`.
2. `packages/scripts/__tests__/with-package-build-lock.test.ts` — “preserves a live replacement installed before atomic stale takeover” and the directory-style takeover test.

## Detailed testing steps

```bash
PATH=/private/tmp/node-v24.15.0-darwin-arm64/bin:$PATH bun test packages/scripts/__tests__/with-package-build-lock.test.ts
./node_modules/.bin/biome check packages/scripts/with-package-build-lock.mjs packages/scripts/__tests__/with-package-build-lock.test.ts
PATH=/private/tmp/node-v24.15.0-darwin-arm64/bin:$PATH RUN_TURBO_CONCURRENCY=4 TURBO_FORCE=true bun run verify
```

Focused real-process suite:

```text
(pass) with-package-build-lock > serializes simultaneous takeovers of a directory-style dead-owner lock
(pass) with-package-build-lock > preserves a live replacement installed before atomic stale takeover

 9 pass
 0 fail
 103 expect() calls
Ran 9 tests across 1 file. [3.16s]
```

Biome:

```text
Checked 2 files in 59ms. No fixes applied.
Found 1 warning.
```

The warning is the pre-existing `noUndeclaredEnvVars` warning for `ELIZA_PACKAGE_BUILD_LOCK_STALE_MS` on an unmodified line; this PR does not add or change that environment read.

Install:

```text
bun install v1.3.14 (0d9b296a)
Checked 3835 installs across 4134 packages (no changes) [2.19s]
```

Forced-uncached repository gate, using Node 24.15.0, Bun 1.3.14, and `RUN_TURBO_CONCURRENCY=4`:

```text
 Tasks:    350 successful, 350 total
Cached:    0 cached, 350 total
  Time:    2m21.495s
[anti-larp] scanned 8006 test files — 0 focused, 0 orphaned skip(s)
[anti-larp] clean — no focused tests, no untracked skips.
```

# Evidence Gate

Evidence matches commit `61e3218dc41cbf0435c8eaa7824df6906cfe77ac`.
<!-- evidence-head:61e3218dc41cbf0435c8eaa7824df6906cfe77ac -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - deterministic repository build tooling only; no rendered UI surface changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - deterministic repository build tooling only; no rendered UI surface changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow or rendered UI is changed
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend service path is changed; the real wrapper process transcript is inline in the PR
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request, console, network, or state surface is changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior is changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent application-domain artifact is produced; filesystem lock evidence is inline in the PR
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text or UI surface is changed

# Evidence Details

## Before: independently reproduced pathname-unlink failure

Both CHANGES_REQUESTED reviews reproduced the same filesystem boundary:

- [@Zorba-the-buddhah review](https://github.com/elizaOS/eliza/pull/18973#pullrequestreview-4924489295): validated stale inode `184025534`, installed replacement inode `184025537`, then pathname unlink left `canonicalExistsAfterContenderAUnlink: false`.
- [@HomunculusLabs review](https://github.com/elizaOS/eliza/pull/18973#pullrequestreview-4929600461): validated stale inode `293382517`, installed replacement inode `293382520`, then pathname unlink reported `Canonical lockPath exists after unlink: false` while the quarantine still named the stale inode.

That is the exact TOCTOU boundary this PR removes.

## After: deterministic real-process interleaving

The new test preload wraps only the contender process's `fs.rename` and signals a barrier immediately before the atomic syscall. The parent test then:

1. removes the original stale file;
2. creates a fresh live-owner replacement with `wx`;
3. releases the contender's rename;
4. waits until `restoreChangedLock` has restored the exact replacement bytes;
5. verifies the replacement owner ID and bytes both before and after terminating the blocked contender.

```text
(pass) with-package-build-lock > preserves a live replacement installed before atomic stale takeover
```

The rename moves whichever inode is canonical at that instant; post-move mismatch prevents takeover and self-heals the moved live replacement. There is no later pathname deletion.

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model surface changes.

## Backend + frontend logs

N/A - no backend or frontend service path changes. Focused wrapper-process and full repository transcripts are quoted above.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changes.

## Audio / voice walkthrough

N/A - no audio, voice, TTS, or STT surface changes.

## Known gaps / failures

- The first sandboxed `bun install` attempts could not access Bun's default temporary directory. Re-running with a writable dedicated `BUN_TMPDIR` completed successfully with no dependency or lockfile changes.
- One pinned-Node verification attempt used an intentionally narrowed temporary PATH that omitted `bunx`; `@elizaos/plugin-reminders#build` stopped at 216/219 with exit 127. The corrected PATH exposed Node 24.15.0, Bun/Bunx 1.3.14, and the forced-uncached final run passed 350/350. This was a local harness configuration error, not a code failure.
- Wrangler printed a non-fatal EPERM while attempting to write its optional user-level diagnostic log inside the sandbox. The cloud-api typecheck and the complete verification gate still passed.
- No UI/media/LLM/domain artifacts apply because this PR changes deterministic repository build tooling only.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-eliza
Compute receipt: 10489251 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [package-build-lock-atomic-takeover]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZZ3A2633CNMQZ94FFCPXZ50","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-14T02:58:36.355Z","completed_at":"2026-08-14T04:06:58.216Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":295302,"output_tokens":20253,"cache_creation_tokens":0,"cache_read_tokens":10173696,"total_tokens":10489251,"cost_micro_usd":"6926868","session_count":2},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEABGe4fV_PPi4aKX7l-LF2u0-A5ZUoJEgkLr-PwrXlgEw","device_key_id":"1ef5dc9a7ed9b85d08d30f10597a4600d5dbd4eff9254abeefd0722c483dc368","device_signature":"KI6rtJ16ymHX1NXQ7VWHHq2luB3n4Mi_rS7xdjVas9NcuiZEAfEYNV_50TWJ6lblr0ywNhwmw78dvuCvB1laCQ"}} -->

