### PR TITLE
fix(cloud): keep sandbox reply scans app-compatible

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
@@ -1088,7 +1088,7 @@ export class ElizaSandboxBridgeService {
       if (!res.ok) return null;
       const body = await res.json().catch(() => ({}));
       const messages = this.getBridgeMessages(body);
-      for (const message of messages.toReversed()) {
+      for (const message of messages.slice().reverse()) {
         const record = this.nestedBridgeRecord(message);
         if (!record || !this.isBridgeAgentMessage(record, runtimeAgentId)) continue;
         const text = this.extractBridgeMessageText(record);

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -6025,7 +6025,7 @@ export class ElizaSandboxService {
       if (!res.ok) return null;
       const body = await res.json().catch(() => ({}));
       const messages = this.getBridgeMessages(body);
-      for (const message of messages.toReversed()) {
+      for (const message of messages.slice().reverse()) {
         const record = this.nestedBridgeRecord(message);
         if (!record || !this.isBridgeAgentMessage(record, runtimeAgentId)) continue;
         const text = this.extractBridgeMessageText(record);
@@ -6054,7 +6054,7 @@ export class ElizaSandboxService {
       if (!res.ok) return null;
       const body = await res.json().catch(() => ({}));
       const messages = this.getBridgeMessages(body);
-      for (const message of messages.toReversed()) {
+      for (const message of messages.slice().reverse()) {
         const record = this.nestedBridgeRecord(message);
         if (!record || !this.isBridgeAgentMessage(record, runtimeAgentId)) continue;
         const text = this.extractBridgeMessageText(record);


### PR DESCRIPTION
## Summary

- replace three ES2023-only `toReversed()` calls in cloud sandbox reply scans with copy-then-reverse
- preserve newest-first iteration without mutating the message arrays
- restore the app TypeScript gate on the current develop baseline

## Evidence

- `bun run --cwd packages/app typecheck` — pass after the patch (the exact pre-patch baseline failed at these three calls)
- `bun run --cwd packages/cloud/shared typecheck` — pass
- `bun run --cwd packages/cloud/shared lint` — pass
- `git diff --check` — pass

No runtime behavior changes; this only uses the repository app target’s supported array API.