### PR TITLE
fix(examples): accept source-form TypeScript imports

### DIFF
--- a/packages/examples/code/tsconfig.json
+++ b/packages/examples/code/tsconfig.json
@@ -18,6 +18,7 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "types": ["node", "bun"]
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
# Relates to

Closes #19355.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop` at `e858e95f0a587c4f7a4c26fc2de1ab08ac100ea4` with zero conflicts.
- [x] `bun install` completed after sync with no dependency or lockfile changes.
- [x] A reviewer can confirm the compiler-contract change from the reproduction and focused evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@52924c0e19eceaaa375b5603efa64a44f5ff02ba:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `e858e95f0a587c4f7a4c26fc2de1ab08ac100ea4`; zero conflicts.
- [x] `TURBO_FORCE=1 bun run verify` is fully green at the exact PR head with 350/350 Turbo tasks executed uncached.

# Risks

Low. This enables a TypeScript resolver option only in the example's existing `noEmit` typecheck configuration. It does not change emitted JavaScript, runtime package resolution, or plugin behavior.

# Background

## What does this PR do?

Allows the `@elizaos/example-code` no-emit typecheck to follow its intentional `eliza-source` package condition into workspace source files whose committed imports end in `.ts` or `.tsx`.

Without the option, an uncached root verification fails with TS5097 in the source dependency graph, including `@elizaos/plugin-goals`. Rewriting those imports would fight the source-package contract and touch unrelated owners; disabling strict checks would mask real errors. The consumer already has `noEmit: true`, which is the TypeScript-supported mode for `allowImportingTsExtensions`.

## What kind of change is this?

Bug fix: one compiler-option addition, with no runtime or rendered-UI behavior change.

# Documentation changes needed?

No. Existing package documentation already states that the example resolves and runs workspace source under the `eliza-source` condition.

# Testing

## Where should a reviewer start?

Review `packages/examples/code/tsconfig.json`, then run the reproduction and fixed typecheck below.

## Detailed testing steps

Exact head: `52924c0e19eceaaa375b5603efa64a44f5ff02ba`

1. Baseline reproduction on the same source tree:

   `bunx tsc --noEmit -p packages/examples/code/tsconfig.json --allowImportingTsExtensions false`

   Result: expected failure with TS5097 across source-form imports, including `.ts` and `.tsx` imports in `plugins/plugin-goals`.

2. Fixed consumer contract:

   `bun run --cwd packages/examples/code typecheck`

   Result: PASS.

3. Effective configuration inspection:

   `bunx tsc -p packages/examples/code/tsconfig.json --showConfig`

   Result: `moduleResolution=bundler`, `customConditions=[eliza-source]`, `noEmit=true`, and `allowImportingTsExtensions=true`.

4. Package gates:

   - `bun run --cwd packages/examples/code test` - PASS, 81 tests / 436 expectations.
   - `bun run --cwd packages/examples/code lint:check` - PASS, 64 files.
   - `bun run --cwd packages/examples/code build` - PASS, both `index.js` and `acp.js` entries built and the runtime shadow tsconfig was emitted.
   - `bun install` after the final rebase - PASS, 3,835 installs checked with no changes.

5. Repository gate:

   `TURBO_FORCE=1 bun run verify`

   Result: PASS. All 350/350 Turbo tasks executed with zero cache hits, including `@elizaos/example-code#typecheck`; the follow-on repository audits also passed.

# Evidence Gate

<!-- evidence-head:52924c0e19eceaaa375b5603efa64a44f5ff02ba -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - compiler configuration only; no rendered surface changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - compiler configuration only; no rendered surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow or UI state changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend/runtime path changed; real compiler commands and results are in the PR body.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser/frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain state or generated product artifact changed.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text or visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - compiler configuration only; no model path changed.

## Backend + frontend logs

N/A - no runtime request path changed. The applicable real artifact is TypeScript's compiler result, summarized in **Detailed testing steps**.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- Direct package typecheck on a pristine worktree also requires the repository's generated keyword sources and built workspace declaration prerequisites. The full root gate materialized those canonical prerequisites, after which the focused package typecheck passed. This PR does not change generated sources or workspace export maps.
- The active GitHub token lacks `read:project`, so Project fields could not be updated. Issue #19355, its assignee, and its claim comment are the durable ownership record.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@52924c0e19eceaaa375b5603efa64a44f5ff02ba:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@52924c0e19eceaaa375b5603efa64a44f5ff02ba:packages/skills/skills/contribute-to-eliza"} -->

