### PR TITLE
fix(telegram): stop italicizing intra-word underscores in prose

### DIFF
--- a/plugins/plugin-telegram/src/utils.test.ts
+++ b/plugins/plugin-telegram/src/utils.test.ts
@@ -31,6 +31,35 @@ describe("convertMarkdownToTelegram", () => {
     expect(convertMarkdownToTelegram("a-b!")).toBe("a\\-b\\!");
   });
 
+  it("escapes intra-word underscores instead of italicizing identifiers (#19373)", () => {
+    // Prose naming an identifier must reach Telegram verbatim. The old
+    // unanchored italic pattern consumed `_id_` as formatting, so the reserved
+    // underscores went out unescaped and rendered as italic "id".
+    expect(convertMarkdownToTelegram("call the user_id_field helper")).toBe(
+      "call the user\\_id\\_field helper",
+    );
+    expect(convertMarkdownToTelegram("set MAX_RETRY_COUNT today")).toBe(
+      "set MAX\\_RETRY\\_COUNT today",
+    );
+  });
+
+  it("keeps flanked underscore italic working", () => {
+    expect(convertMarkdownToTelegram("_actually italic_")).toBe(
+      "_actually italic_",
+    );
+    expect(convertMarkdownToTelegram("say _hi_ now")).toBe("say _hi_ now");
+    expect(convertMarkdownToTelegram("(_parenthesized_)")).toBe(
+      "\\(_parenthesized_\\)",
+    );
+  });
+
+  it("keeps single intra-word underscores escaped and __x__ inner italic unchanged", () => {
+    expect(convertMarkdownToTelegram("snake_case")).toBe("snake\\_case");
+    // Historical behavior: double-underscore delimiters still produce the
+    // inner italic because underscore flanks remain permitted.
+    expect(convertMarkdownToTelegram("__x__")).toBe("\\__x_\\_");
+  });
+
   it("preserves links (url chars other than ) and \\ stay raw)", () => {
     expect(convertMarkdownToTelegram("[docs](http://x.com)")).toBe(
       "[docs](http://x.com)",

--- a/plugins/plugin-telegram/src/utils.test.ts
+++ b/plugins/plugin-telegram/src/utils.test.ts
@@ -53,6 +53,25 @@ describe("convertMarkdownToTelegram", () => {
     );
   });
 
+  it("treats canonically equivalent flanks identically (#19373 review)", () => {
+    // A decomposed word flank (e + U+0301) must suppress the delimiter exactly
+    // like its precomposed form: marks are word continuations.
+    expect(convertMarkdownToTelegram("caf\u00e9_id_")).toBe(
+      "caf\u00e9\\_id\\_",
+    );
+    expect(convertMarkdownToTelegram("cafe\u0301_id_")).toBe(
+      "cafe\u0301\\_id\\_",
+    );
+  });
+
+  it("suppresses the delimiter after non-Latin combining-mark clusters", () => {
+    // Devanagari KA + virama: the mark ends the flank word, so the underscores
+    // are identifier characters, not italic delimiters.
+    expect(convertMarkdownToTelegram("\u0915\u094d_id_")).toBe(
+      "\u0915\u094d\\_id\\_",
+    );
+  });
+
   it("keeps single intra-word underscores escaped and __x__ inner italic unchanged", () => {
     expect(convertMarkdownToTelegram("snake_case")).toBe("snake\\_case");
     // Historical behavior: double-underscore delimiters still produce the

--- a/plugins/plugin-telegram/src/utils.ts
+++ b/plugins/plugin-telegram/src/utils.ts
@@ -145,12 +145,23 @@ export function convertMarkdownToTelegram(markdown: string): string {
       return storeReplacement(formatted);
     },
   );
-  //    Then underscore-based italic.
-  converted = converted.replace(/_([^_\n]+)_/g, (_match, content) => {
-    const formattedContent = escapePlainText(content);
-    const formatted = `_${formattedContent}_`;
-    return storeReplacement(formatted);
-  });
+  //    Then underscore-based italic. Flanking letters/digits suppress the
+  //    delimiter (CommonMark's intra-word rule): prose naming an identifier
+  //    like `user_id_field` must reach the escaper as plain text — the old
+  //    unanchored pattern consumed `_id_` as formatting, so the reserved
+  //    underscores were re-emitted unescaped and Telegram rendered the
+  //    identifier with italic "id" and the underscores eaten (#19373).
+  //    Underscore flanks stay permitted so the historical `__x__` inner-italic
+  //    behavior is unchanged; a preceding backslash means an already-escaped
+  //    delimiter and never opens italic.
+  converted = converted.replace(
+    /(?<![\p{L}\p{N}\\])_([^_\n]+)_(?![\p{L}\p{N}])/gu,
+    (_match, content) => {
+      const formattedContent = escapePlainText(content);
+      const formatted = `_${formattedContent}_`;
+      return storeReplacement(formatted);
+    },
+  );
 
   // 7. Headers: Convert markdown headers (lines starting with '#' characters)
   //    to bold text. This avoids unescaped '#' characters (which crash Telegram)

--- a/plugins/plugin-telegram/src/utils.ts
+++ b/plugins/plugin-telegram/src/utils.ts
@@ -151,11 +151,15 @@ export function convertMarkdownToTelegram(markdown: string): string {
   //    unanchored pattern consumed `_id_` as formatting, so the reserved
   //    underscores were re-emitted unescaped and Telegram rendered the
   //    identifier with italic "id" and the underscores eaten (#19373).
-  //    Underscore flanks stay permitted so the historical `__x__` inner-italic
-  //    behavior is unchanged; a preceding backslash means an already-escaped
-  //    delimiter and never opens italic.
+  //    Word characters include marks and the ZWJ/ZWNJ join controls, so a
+  //    decomposed flank (cafe + U+0301) or an Indic cluster suppresses the
+  //    delimiter exactly like its precomposed form — canonically equivalent
+  //    inputs must not diverge into italic (#19373 review). Underscore flanks
+  //    stay permitted so the historical `__x__` inner-italic behavior is
+  //    unchanged; a preceding backslash means an already-escaped delimiter and
+  //    never opens italic.
   converted = converted.replace(
-    /(?<![\p{L}\p{N}\\])_([^_\n]+)_(?![\p{L}\p{N}])/gu,
+    /(?<![\p{L}\p{N}\p{M}\u200c\u200d\\])_([^_\n]+)_(?![\p{L}\p{N}\p{M}\u200c\u200d])/gu,
     (_match, content) => {
       const formattedContent = escapePlainText(content);
       const formatted = `_${formattedContent}_`;


### PR DESCRIPTION
# Relates to

Fixes #19373 (filed with byte-level reproduction; this PR is the promised fix).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, branched from the latest `origin/develop`, zero conflicts.
- [x] Full plugin suite, Biome, and the focused both-ways proof run on the exact
      head; the root-gate environment blocker is disclosed in **Known gaps**.
- [x] A reviewer can confirm the behavior from the deterministic tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] On the exact head: focused suite 10/10 (1 fails on develop, unescaped
      output visible in the assertion), full plugin suite **21 files / 156
      tests green**, Biome clean on changed files.

# Risks

Low. One regex in `convertMarkdownToTelegram`'s underscore-italic pass plus
tests. Flanked italic (`_hi_`, parenthesized, line-initial) is unchanged;
the quirky-but-historical `__x__` output is **byte-identical** (pinned by a
new test and verified against develop before writing it); only intra-word
underscore pairs change — from silent italic corruption to the escaped
verbatim identifier.

# Background

## What does this PR do?

The underscore-italic pass was unanchored (`/_([^_\n]+)_/g`), so prose naming
an identifier with two or more underscores had its middle segment consumed as
an italic token:

| input | before (wire bytes) | Telegram renders | after |
| --- | --- | --- | --- |
| `call the user_id_field helper` | underscores UNESCAPED (consumed as formatting) | "user*id*field" — italic id, underscores eaten | `user\_id\_field` verbatim |
| `set MAX_RETRY_COUNT today` | same corruption | italic RETRY | `MAX\_RETRY\_COUNT` verbatim |
| `snake_case` (single `_`) | `snake\_case` ✓ | verbatim | unchanged |
| `_actually italic_` | italic ✓ | italic | unchanged |
| `__x__` | `\__x_\_` | inner italic | byte-identical |

The fix applies CommonMark's intra-word rule: the delimiter requires
non-letter/digit flanks (`(?<![\p{L}\p{N}\\])_…_(?![\p{L}\p{N}])`, `u` flag),
with a backslash guard so an escaped opener never starts italic. Underscore
flanks remain permitted, which is what keeps `__x__` unchanged. Agent replies
discuss identifiers constantly, so the corrupted path is common in practice;
it also plausibly contributes to the MarkdownV2 rejection fallback at
`messageManager.ts:1111` firing on unbalanced underscores.

## What kind of change is this?

Bug fix (non-breaking; only the corrupted intra-word path changes).

# Documentation changes needed?

None; the rule is documented at the regex.

# Testing

## Where should a reviewer start?

The four new cases in `plugins/plugin-telegram/src/utils.test.ts`, then the
one regex in `utils.ts`.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-telegram test src/utils.test.ts
bun run --cwd plugins/plugin-telegram test   # full suite
```

**Against `develop`:**

```
 FAIL  src/utils.test.ts > escapes intra-word underscores instead of italicizing identifiers (#19373)
AssertionError: expected 'call the user_id_field helper' to be 'call the user\_id\_field helper'
      Tests  1 failed | 9 passed (10)
```

**With this fix (exact head, rebased onto current `develop`):** `12 passed
(12)`; full plugin suite `21 files / 160 tests` green; `__x__` verified
byte-identical on both versions before the pin was written.

Review follow-up on this head: the flank classes now include `\p{M}` and the
ZWJ/ZWNJ join controls, so canonically equivalent flanks behave identically
(`caf\u00e9_id_` and `cafe\u0301_id_` both escape to the literal
identifier) and a Devanagari cluster flank (`\u0915\u094d_id_`) suppresses
the delimiter — both pinned with exact outbound-byte regressions.

# Evidence Gate

<!-- evidence-head:1eb6c40c112e86d0414f987dae51af526080715e -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - pure text-conversion utility; no rendered-UI source file in the diff`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - pure text-conversion utility; no rendered-UI source file in the diff`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-facing flow changes; the change is outbound wire bytes proven by the unit tests`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - pure function with no logging or server code path; the deterministic tests above are the applicable proof`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - Telegram-outbound path; no frontend code involved`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - formats model OUTPUT for Telegram delivery; no model, provider, action, prompt, or evaluator logic is touched`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - produces no database rows, memories, tasks, files, or on-chain output`.
<!-- evidence-row:ocr-review -->
- [ ] OCR review `N/A - no rendered visual surface changes; no .tsx/CSS/SVG file in the diff`.

# Evidence Details

## Real LLM-call trajectory

`N/A - outbound formatting of already-generated text`.

## Backend + frontend logs

`N/A - pure utility; deterministic tests in Testing are the applicable proof`.

## Screenshots (before / after) + video walkthrough

`N/A - no rendered-UI source file changes (.ts only)`.

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change`.

## Known gaps / failures

Root `bun run verify` not run to completion in this environment (pinned Node
24.15.0 vs local 25.2.1; unfetchable cross-platform native optionals — same
limitation disclosed on my prior merged PRs, unrelated to this change). Owning
package gates all pass on the exact head. Live Telegram delivery was not
exercised (no bot credentials in this environment); the wire-byte contract the
unit tests pin is exactly what `messageManager` hands to Telegraf.

---

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [freesoldev-cc]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZZ9ZPZTAW0WE27P1V9BP1X0","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-14T04:55:17.243Z","completed_at":"2026-08-14T04:58:15.613Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAlLzquoL3Gkw72mIFndBJOfLMFIypwYpDpM977u8wnLM","device_key_id":"4bc1698a54f1d212421e7c9fb7995eedfb360fe9ead936dd2c7430a78a61632d","device_signature":"T8cGPQvMsULzdCUaerQRqiwsy-3QLVWtcThZg3L4T2Hu8nAAmznzlklnWClSSPgxHgFWWxC_MHhWfiGQIonUDw"}} -->
