### PR TITLE
fix(elizaresearch): exclude deployment metadata from assets

### DIFF
--- a/packages/elizaresearch/.assetsignore
+++ b/packages/elizaresearch/.assetsignore
@@ -1,0 +1,5 @@
+.wrangler
+node_modules
+README.md
+package.json
+wrangler.toml


### PR DESCRIPTION
Follow-up deployment hygiene fix for #19369. Adds the package asset ignore file so Wrangler publishes only website assets, not generated .wrangler files or package/deployment metadata. Production verification found the generated URL returned 200; after merge this will be redeployed and verified as 404.