### PR TITLE
fix(homepage): gate WhatsApp on verified production sender

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -229,6 +229,7 @@ jobs:
     outputs:
       telegram_bot_id: ${{ steps.telegram.outputs.bot_id }}
       telegram_bot_username: ${{ steps.telegram.outputs.bot_username }}
+      whatsapp_phone_number: ${{ steps.whatsapp.outputs.phone_number }}
     steps:
       - name: Resolve public preview defaults
         id: telegram
@@ -248,6 +249,34 @@ jobs:
           [[ "$TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]+$ ]] || { echo "::error::VITE_TELEGRAM_BOT_USERNAME must be a Telegram username without @"; exit 1; }
           echo "bot_id=$TELEGRAM_BOT_ID" >> "$GITHUB_OUTPUT"
           echo "bot_username=$TELEGRAM_BOT_USERNAME" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve public WhatsApp configuration
+        id: whatsapp
+        env:
+          WHATSAPP_PUBLIC_ENABLED: ${{ vars.WHATSAPP_PUBLIC_ENABLED }}
+          WHATSAPP_PHONE_NUMBER: ${{ vars.VITE_WHATSAPP_PHONE_NUMBER }}
+        run: |
+          set -euo pipefail
+          enabled="$(printf '%s' "$WHATSAPP_PUBLIC_ENABLED" | tr '[:upper:]' '[:lower:]')"
+          case "$enabled" in
+            ""|0|false|no|off)
+              echo "phone_number=" >> "$GITHUB_OUTPUT"
+              ;;
+            1|true|yes|on)
+              [[ "$WHATSAPP_PHONE_NUMBER" =~ ^\+[1-9][0-9]{7,14}$ ]] || { echo "::error::VITE_WHATSAPP_PHONE_NUMBER must be an E.164 number when WHATSAPP_PUBLIC_ENABLED is true"; exit 1; }
+              case "$WHATSAPP_PHONE_NUMBER" in
+                +14155238886|+15551649988|+14159611510)
+                  echo "::error::The public WhatsApp CTA cannot use a shared sandbox, developer test, or unverified sender"
+                  exit 1
+                  ;;
+              esac
+              echo "phone_number=$WHATSAPP_PHONE_NUMBER" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::WHATSAPP_PUBLIC_ENABLED must be a boolean"
+              exit 1
+              ;;
+          esac
 
   build-pages:
     name: Build Pages artifacts
@@ -318,6 +347,7 @@ jobs:
         env:
           VITE_TELEGRAM_BOT_ID: ${{ needs.resolve-pages-preview-config.outputs.telegram_bot_id }}
           VITE_TELEGRAM_BOT_USERNAME: ${{ needs.resolve-pages-preview-config.outputs.telegram_bot_username }}
+          VITE_WHATSAPP_PHONE_NUMBER: ${{ needs.resolve-pages-preview-config.outputs.whatsapp_phone_number }}
           VITE_API_URL: https://api-staging.eliza.app
           NEXT_PUBLIC_API_URL: https://api-staging.eliza.app
           VITE_OIDC_ISSUER_URL: https://api-staging.eliza.app

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -1059,6 +1059,7 @@ jobs:
     outputs:
       telegram_bot_id: ${{ steps.telegram.outputs.bot_id }}
       telegram_bot_username: ${{ steps.telegram.outputs.bot_username }}
+      whatsapp_phone_number: ${{ steps.whatsapp.outputs.phone_number }}
     steps:
       - name: Validate Telegram configuration
         id: telegram
@@ -1079,6 +1080,34 @@ jobs:
           echo "bot_id=$TELEGRAM_BOT_ID" >> "$GITHUB_OUTPUT"
           echo "bot_username=$TELEGRAM_BOT_USERNAME" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve public WhatsApp configuration
+        id: whatsapp
+        env:
+          WHATSAPP_PUBLIC_ENABLED: ${{ vars.WHATSAPP_PUBLIC_ENABLED }}
+          WHATSAPP_PHONE_NUMBER: ${{ vars.VITE_WHATSAPP_PHONE_NUMBER }}
+        run: |
+          set -euo pipefail
+          enabled="$(printf '%s' "$WHATSAPP_PUBLIC_ENABLED" | tr '[:upper:]' '[:lower:]')"
+          case "$enabled" in
+            ""|0|false|no|off)
+              echo "phone_number=" >> "$GITHUB_OUTPUT"
+              ;;
+            1|true|yes|on)
+              [[ "$WHATSAPP_PHONE_NUMBER" =~ ^\+[1-9][0-9]{7,14}$ ]] || { echo "::error::VITE_WHATSAPP_PHONE_NUMBER must be an E.164 number when WHATSAPP_PUBLIC_ENABLED is true"; exit 1; }
+              case "$WHATSAPP_PHONE_NUMBER" in
+                +14155238886|+15551649988|+14159611510)
+                  echo "::error::The public WhatsApp CTA cannot use a shared sandbox, developer test, or unverified sender"
+                  exit 1
+                  ;;
+              esac
+              echo "phone_number=$WHATSAPP_PHONE_NUMBER" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::WHATSAPP_PUBLIC_ENABLED must be a boolean"
+              exit 1
+              ;;
+          esac
+
   build-pages:
     name: Build Pages artifacts
     needs: [migrate-db, resolve-pages-environment-config]
@@ -1095,6 +1124,7 @@ jobs:
       artifact_source_sha: ${{ steps.pages-artifact.outputs.source_sha }}
       telegram_bot_id: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_id }}
       telegram_bot_username: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}
+      whatsapp_phone_number: ${{ needs.resolve-pages-environment-config.outputs.whatsapp_phone_number }}
     steps:
       - name: Validate PR preview identity
         if: github.event_name == 'pull_request'
@@ -1148,6 +1178,7 @@ jobs:
         env:
           VITE_TELEGRAM_BOT_ID: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_id }}
           VITE_TELEGRAM_BOT_USERNAME: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}
+          VITE_WHATSAPP_PHONE_NUMBER: ${{ needs.resolve-pages-environment-config.outputs.whatsapp_phone_number }}
           VITE_API_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
           NEXT_PUBLIC_API_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
           VITE_OIDC_ISSUER_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
@@ -1400,6 +1431,7 @@ jobs:
         env:
           VITE_TELEGRAM_BOT_ID: ${{ needs.build-pages.outputs.telegram_bot_id }}
           VITE_TELEGRAM_BOT_USERNAME: ${{ needs.build-pages.outputs.telegram_bot_username }}
+          VITE_WHATSAPP_PHONE_NUMBER: ${{ needs.build-pages.outputs.whatsapp_phone_number }}
           VITE_API_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
           NEXT_PUBLIC_API_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
           VITE_OIDC_ISSUER_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}

--- a/packages/homepage/AGENTS.md
+++ b/packages/homepage/AGENTS.md
@@ -124,7 +124,8 @@ isolated visual harness.
 | `VITE_TELEGRAM_BOT_USERNAME` | `Elizav2_Bot` | Optional Telegram bot username override |
 | `VITE_TELEGRAM_BOT_ID` | `7684336618` | Optional numeric Telegram bot ID override |
 | `VITE_DISCORD_CLIENT_ID` | `1468649258654630063` | Optional Discord Application ID override |
-| `VITE_WHATSAPP_PHONE_NUMBER` | `+14159611510` | WhatsApp Business number (E.164) |
+| `WHATSAPP_PUBLIC_ENABLED` | disabled | Deployment-only switch that admits the public WhatsApp CTA |
+| `VITE_WHATSAPP_PHONE_NUMBER` | — | Production WhatsApp Business sender (E.164); local/test code retains a fixture |
 
 Auth token is stored in `localStorage` under key `eliza_app_session`. The test signer hook is `window.__siwsTestSigner` (used by Playwright e2e to skip wallet interaction).
 

--- a/packages/homepage/CLAUDE.md
+++ b/packages/homepage/CLAUDE.md
@@ -124,7 +124,8 @@ isolated visual harness.
 | `VITE_TELEGRAM_BOT_USERNAME` | `Elizav2_Bot` | Optional Telegram bot username override |
 | `VITE_TELEGRAM_BOT_ID` | `7684336618` | Optional numeric Telegram bot ID override |
 | `VITE_DISCORD_CLIENT_ID` | `1468649258654630063` | Optional Discord Application ID override |
-| `VITE_WHATSAPP_PHONE_NUMBER` | `+14159611510` | WhatsApp Business number (E.164) |
+| `WHATSAPP_PUBLIC_ENABLED` | disabled | Deployment-only switch that admits the public WhatsApp CTA |
+| `VITE_WHATSAPP_PHONE_NUMBER` | — | Production WhatsApp Business sender (E.164); local/test code retains a fixture |
 
 Auth token is stored in `localStorage` under key `eliza_app_session`. The test signer hook is `window.__siwsTestSigner` (used by Playwright e2e to skip wallet interaction).
 

--- a/packages/homepage/README.md
+++ b/packages/homepage/README.md
@@ -24,11 +24,33 @@ cp .env.example .env.local
 | `VITE_TELEGRAM_BOT_USERNAME` | Optional Telegram bot username override (default `Elizav2_Bot`) |
 | `VITE_TELEGRAM_BOT_ID` | Optional numeric Telegram bot ID override (default `7684336618`) |
 | `VITE_DISCORD_CLIENT_ID` | Optional Discord Application ID override (default `1468649258654630063`) |
-| `VITE_WHATSAPP_PHONE_NUMBER` | WhatsApp Business phone number in E.164 format (defaults to `+14159611510`) |
+| `WHATSAPP_PUBLIC_ENABLED` | Deployment switch that must be true before the public WhatsApp CTA is built |
+| `VITE_WHATSAPP_PHONE_NUMBER` | Production WhatsApp Business sender in E.164 format; omitted by default |
 
 OAuth provider callback configuration belongs to the unified Cloud auth routes
 and API deployment. Do not register a callback against this source package or
 its optional test-harness port.
+
+### WhatsApp production activation
+
+The homepage is provider-neutral: it opens the admitted Business sender with
+`wa.me`, while the gateway can receive and reply through either the direct Meta
+Cloud API adapter or the Twilio adapter. Leave `WHATSAPP_PUBLIC_ENABLED=false`
+until one provider owns a registered production sender and a real handset
+round trip has succeeded.
+
+1. Register a production sender with Meta or Twilio and configure the matching
+   gateway credentials and webhook.
+2. Set the target GitHub environment's `VITE_WHATSAPP_PHONE_NUMBER` variable to
+   that exact sender.
+3. Set `WHATSAPP_PUBLIC_ENABLED=true` in the same environment and deploy the
+   consolidated app.
+4. Verify the rendered `wa.me` target, receive a handset message through the
+   signed webhook, and confirm the agent reply reaches the same handset.
+
+The release workflow rejects the Twilio shared sandbox (`+14155238886`), the
+current Meta developer test sender (`+15551649988`), and the former unverified
+homepage number (`+14159611510`).
 
 ### 2. Run the unified development server
 

--- a/packages/homepage/src/lib/contact.ts
+++ b/packages/homepage/src/lib/contact.ts
@@ -9,9 +9,25 @@ export const ELIZA_DISCORD_APPLICATION_ID = "1468649258654630063";
 const DEFAULT_WHATSAPP_PHONE_NUMBER = "+14159611510";
 const IMESSAGE_GREETING = "Hey Eliza, what can you do?";
 
-export function getWhatsAppNumber(): string {
-  return (
-    import.meta.env.VITE_WHATSAPP_PHONE_NUMBER || DEFAULT_WHATSAPP_PHONE_NUMBER
+function normalizeWhatsAppNumber(value: string): string | null {
+  const normalized = value.trim();
+  return /^\+[1-9]\d{7,14}$/.test(normalized) ? normalized : null;
+}
+
+/** Resolve a deploy-configured E.164 sender without leaking a fixture to production. */
+export function resolveWhatsAppNumber(
+  configuredValue: string | undefined,
+  production: boolean,
+): string | null {
+  const configured = normalizeWhatsAppNumber(configuredValue ?? "");
+  if (configured) return configured;
+  return production ? null : DEFAULT_WHATSAPP_PHONE_NUMBER;
+}
+
+export function getWhatsAppNumber(): string | null {
+  return resolveWhatsAppNumber(
+    import.meta.env.VITE_WHATSAPP_PHONE_NUMBER,
+    import.meta.env.PROD,
   );
 }
 
@@ -35,8 +51,9 @@ export function buildElizaSmsHref(message: string = IMESSAGE_GREETING): string {
   return `sms:${ELIZA_PHONE_NUMBER}?&body=${encodeURIComponent(message)}`;
 }
 
-export function buildElizaWhatsAppHref(): string {
-  return `https://wa.me/${getWhatsAppNumber().replace(/\D/g, "")}`;
+export function buildElizaWhatsAppHref(): string | null {
+  const number = getWhatsAppNumber();
+  return number ? `https://wa.me/${number.replace(/\D/g, "")}` : null;
 }
 
 export function buildElizaTelegramHref(): string {

--- a/packages/homepage/src/pages/connected.tsx
+++ b/packages/homepage/src/pages/connected.tsx
@@ -101,6 +101,7 @@ export default function ConnectedPage() {
   const [isLinkingPhone, setIsLinkingPhone] = useState(false);
 
   const countryOptions = useCountryOptions();
+  const whatsappHref = buildElizaWhatsAppHref();
 
   const getFullPhoneNumber = useCallback(() => {
     return buildFullPhoneNumber(phoneValue, selectedCountry, countryOptions);
@@ -171,7 +172,8 @@ export default function ConnectedPage() {
   };
 
   const handleCopyWhatsApp = async () => {
-    await navigator.clipboard.writeText(buildElizaWhatsAppHref());
+    if (!whatsappHref) return;
+    await navigator.clipboard.writeText(whatsappHref);
     setCopiedWhatsApp(true);
     setTimeout(() => setCopiedWhatsApp(false), 2000);
   };
@@ -190,7 +192,7 @@ export default function ConnectedPage() {
   };
 
   const handleOpenWhatsApp = () => {
-    window.open(buildElizaWhatsAppHref(), "_blank");
+    if (whatsappHref) window.open(whatsappHref, "_blank");
   };
 
   const handleOpenMessages = () => {
@@ -554,12 +556,56 @@ export default function ConnectedPage() {
             </div>
           )}
 
-          {user.whatsapp_id ? (
-            <div className="w-full h-[72px] bg-white hover:bg-black hover:text-white text-black flex items-center px-5 transition-colors group">
+          {whatsappHref &&
+            (user.whatsapp_id ? (
+              <div className="w-full h-[72px] bg-white hover:bg-black hover:text-white text-black flex items-center px-5 transition-colors group">
+                <button
+                  type="button"
+                  onClick={handleOpenWhatsApp}
+                  className="flex h-full min-w-0 flex-1 cursor-pointer items-center gap-4 border-0 bg-transparent p-0 text-left text-black group-hover:text-white"
+                >
+                  <div className="w-8 h-8 shrink-0 flex items-center justify-center">
+                    <WhatsAppIcon className="size-8 text-[#25D366]" />
+                  </div>
+                  <div className="flex flex-col items-start flex-1">
+                    <span className="text-lg font-medium">
+                      {t("homepage_eliza.connected.whatsappLabel", {
+                        defaultValue: "WhatsApp",
+                      })}
+                    </span>
+                    <span className="text-sm text-black/70 group-hover:text-white/80">
+                      {user.whatsapp_name ||
+                        t("homepage_eliza.connected.openWhatsapp", {
+                          defaultValue: "Open WhatsApp",
+                        })}
+                    </span>
+                  </div>
+                </button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleCopyWhatsApp();
+                  }}
+                  className="shrink-0 text-black/70 group-hover:text-white/80 hover:text-white hover:bg-white/10"
+                  title={t("homepage_eliza.connected.copyWhatsappTitle", {
+                    defaultValue: "Copy WhatsApp link",
+                  })}
+                >
+                  {copiedWhatsApp ? (
+                    <Check className="size-5 text-green-400" />
+                  ) : (
+                    <Copy className="size-5" />
+                  )}
+                </Button>
+              </div>
+            ) : (
               <button
                 type="button"
+                className="w-full h-[72px] bg-white hover:bg-black hover:text-white text-black flex items-center gap-4 px-5 cursor-pointer transition-colors"
                 onClick={handleOpenWhatsApp}
-                className="flex h-full min-w-0 flex-1 cursor-pointer items-center gap-4 border-0 bg-transparent p-0 text-left text-black group-hover:text-white"
               >
                 <div className="w-8 h-8 shrink-0 flex items-center justify-center">
                   <WhatsAppIcon className="size-8 text-[#25D366]" />
@@ -570,52 +616,9 @@ export default function ConnectedPage() {
                       defaultValue: "WhatsApp",
                     })}
                   </span>
-                  <span className="text-sm text-black/70 group-hover:text-white/80">
-                    {user.whatsapp_name ||
-                      t("homepage_eliza.connected.openWhatsapp", {
-                        defaultValue: "Open WhatsApp",
-                      })}
-                  </span>
                 </div>
               </button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleCopyWhatsApp();
-                }}
-                className="shrink-0 text-black/70 group-hover:text-white/80 hover:text-white hover:bg-white/10"
-                title={t("homepage_eliza.connected.copyWhatsappTitle", {
-                  defaultValue: "Copy WhatsApp link",
-                })}
-              >
-                {copiedWhatsApp ? (
-                  <Check className="size-5 text-green-400" />
-                ) : (
-                  <Copy className="size-5" />
-                )}
-              </Button>
-            </div>
-          ) : (
-            <button
-              type="button"
-              className="w-full h-[72px] bg-white hover:bg-black hover:text-white text-black flex items-center gap-4 px-5 cursor-pointer transition-colors"
-              onClick={handleOpenWhatsApp}
-            >
-              <div className="w-8 h-8 shrink-0 flex items-center justify-center">
-                <WhatsAppIcon className="size-8 text-[#25D366]" />
-              </div>
-              <div className="flex flex-col items-start flex-1">
-                <span className="text-lg font-medium">
-                  {t("homepage_eliza.connected.whatsappLabel", {
-                    defaultValue: "WhatsApp",
-                  })}
-                </span>
-              </div>
-            </button>
-          )}
+            ))}
 
           {user.discord_id ? (
             <div className="w-full h-[72px] bg-white hover:bg-black hover:text-white text-black flex items-center px-5 transition-colors group">

--- a/packages/homepage/src/pages/get-started.tsx
+++ b/packages/homepage/src/pages/get-started.tsx
@@ -738,6 +738,7 @@ export default function GetStartedPage() {
   });
 
   const countryOptions = useCountryOptions();
+  const whatsappNumber = getWhatsAppNumber();
 
   const hasPhoneNumber = phoneValue.trim().length > 0;
 
@@ -884,7 +885,7 @@ export default function GetStartedPage() {
       } else if (methodParam === "discord") {
         setSelectedMethod("discord");
         handleDiscordOAuthRedirect();
-      } else if (methodParam === "whatsapp") {
+      } else if (methodParam === "whatsapp" && whatsappNumber) {
         setSelectedMethod("whatsapp");
         setStep("WHATSAPP_DIRECT");
       }
@@ -901,6 +902,7 @@ export default function GetStartedPage() {
     isLinkMode,
     handleDiscordOAuthRedirect,
     t,
+    whatsappNumber,
   ]);
 
   useEffect(() => {
@@ -985,7 +987,7 @@ export default function GetStartedPage() {
       if (!handleDiscordOAuthRedirect()) {
         setSelectedMethod(null);
       }
-    } else if (method === "whatsapp") {
+    } else if (method === "whatsapp" && whatsappNumber) {
       setStep("WHATSAPP_DIRECT");
     } else if (method === "solana") {
       void handleSolanaConnect();
@@ -1548,23 +1550,25 @@ export default function GetStartedPage() {
                   </div>
                 </button>
 
-                <button
-                  type="button"
-                  onClick={() => handleMethodSelect("whatsapp")}
-                  className={`w-full h-16 ${GLASS_TILE} hover:bg-white/60 rounded-full transition-colors flex items-center gap-4 pl-2.5 pr-6 cursor-pointer`}
-                  style={cardStyle(2)}
-                >
-                  <div className="size-11 rounded-full bg-white/60 flex items-center justify-center shrink-0">
-                    <WhatsAppIcon className="size-6 text-[#25D366]" />
-                  </div>
-                  <div className="flex-1 text-left">
-                    <p className="font-medium text-neutral-900">
-                      {t("homepage_eliza.getStarted.btnWhatsapp", {
-                        defaultValue: "WhatsApp",
-                      })}
-                    </p>
-                  </div>
-                </button>
+                {whatsappNumber && (
+                  <button
+                    type="button"
+                    onClick={() => handleMethodSelect("whatsapp")}
+                    className={`w-full h-16 ${GLASS_TILE} hover:bg-white/60 rounded-full transition-colors flex items-center gap-4 pl-2.5 pr-6 cursor-pointer`}
+                    style={cardStyle(2)}
+                  >
+                    <div className="size-11 rounded-full bg-white/60 flex items-center justify-center shrink-0">
+                      <WhatsAppIcon className="size-6 text-[#25D366]" />
+                    </div>
+                    <div className="flex-1 text-left">
+                      <p className="font-medium text-neutral-900">
+                        {t("homepage_eliza.getStarted.btnWhatsapp", {
+                          defaultValue: "WhatsApp",
+                        })}
+                      </p>
+                    </div>
+                  </button>
+                )}
 
                 <button
                   type="button"
@@ -1833,7 +1837,7 @@ export default function GetStartedPage() {
             </>
           )}
 
-          {step === "WHATSAPP_DIRECT" && (
+          {step === "WHATSAPP_DIRECT" && whatsappNumber && (
             <>
               <div
                 className={`w-16 h-16 rounded-full ${GLASS_TILE} flex items-center justify-center mb-6`}
@@ -1855,7 +1859,7 @@ export default function GetStartedPage() {
 
               <Button
                 onClick={() => {
-                  const waNumber = getWhatsAppNumber().replace(/\D/g, "");
+                  const waNumber = whatsappNumber.replace(/\D/g, "");
                   window.open(`https://wa.me/${waNumber}`, "_blank");
                 }}
                 className="w-full h-[52px] rounded-full bg-neutral-900 hover:bg-neutral-800 text-white font-medium gap-2"

--- a/packages/homepage/src/pages/landing.tsx
+++ b/packages/homepage/src/pages/landing.tsx
@@ -621,6 +621,7 @@ export default function LandingPage() {
     "idle" | "copied" | "error"
   >("idle");
   const phoneCopyResetRef = useRef<number | null>(null);
+  const whatsappHref = buildElizaWhatsAppHref();
   const browserWindow = typeof window === "undefined" ? null : window;
   const signedIn =
     browserWindow !== null &&
@@ -637,14 +638,20 @@ export default function LandingPage() {
       }),
       icon: <TelegramIcon className="size-6" style={{ color: "#2AABEE" }} />,
     },
-    {
-      key: "whatsapp",
-      href: buildElizaWhatsAppHref(),
-      label: t("homepage_eliza.landing.channelWhatsapp", {
-        defaultValue: "Message Eliza on WhatsApp",
-      }),
-      icon: <WhatsAppIcon className="size-6" style={{ color: "#25D366" }} />,
-    },
+    ...(whatsappHref
+      ? [
+          {
+            key: "whatsapp",
+            href: whatsappHref,
+            label: t("homepage_eliza.landing.channelWhatsapp", {
+              defaultValue: "Message Eliza on WhatsApp",
+            }),
+            icon: (
+              <WhatsAppIcon className="size-6" style={{ color: "#25D366" }} />
+            ),
+          },
+        ]
+      : []),
     {
       key: "discord",
       href: buildElizaDiscordHref(),

--- a/packages/homepage/tests/contact.test.ts
+++ b/packages/homepage/tests/contact.test.ts
@@ -16,6 +16,7 @@ import {
   getDiscordBotApplicationId,
   getTelegramBotId,
   getWhatsAppNumber,
+  resolveWhatsAppNumber,
 } from "../src/lib/contact";
 
 describe("Eliza contact links", () => {
@@ -35,6 +36,12 @@ describe("Eliza contact links", () => {
 
   test("keeps the WhatsApp fallback separate from the Blooio number", () => {
     expect(getWhatsAppNumber()).toBe("+14159611510");
+  });
+
+  test("fails closed when a production WhatsApp sender is absent or invalid", () => {
+    expect(resolveWhatsAppNumber(undefined, true)).toBeNull();
+    expect(resolveWhatsAppNumber("14159611510", true)).toBeNull();
+    expect(resolveWhatsAppNumber("+15551234567", true)).toBe("+15551234567");
   });
 
   test("builds direct web links for every supported messaging channel", () => {

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -120,6 +120,32 @@ describe("homepage deployment workflow", () => {
     );
   });
 
+  it("keeps WhatsApp disabled until a production sender is explicitly enabled", () => {
+    for (const source of [workflow, releaseWorkflow]) {
+      expect(source).toContain("WHATSAPP_PUBLIC_ENABLED");
+      expect(source).toContain(
+        "VITE_WHATSAPP_PHONE_NUMBER must be an E.164 number when WHATSAPP_PUBLIC_ENABLED is true",
+      );
+      expect(source).toContain(
+        "The public WhatsApp CTA cannot use a shared sandbox, developer test, or unverified sender",
+      );
+      expect(source).toContain("+14155238886|+15551649988|+14159611510");
+      expect(source).toContain('echo "phone_number=" >> "$GITHUB_OUTPUT"');
+    }
+    expect(workflow).toContain(
+      "VITE_WHATSAPP_PHONE_NUMBER: $" +
+        "{{ needs.resolve-pages-preview-config.outputs.whatsapp_phone_number }}",
+    );
+    expect(releaseWorkflow).toContain(
+      "VITE_WHATSAPP_PHONE_NUMBER: $" +
+        "{{ needs.resolve-pages-environment-config.outputs.whatsapp_phone_number }}",
+    );
+    expect(releaseWorkflow).toContain(
+      "VITE_WHATSAPP_PHONE_NUMBER: $" +
+        "{{ needs.build-pages.outputs.whatsapp_phone_number }}",
+    );
+  });
+
   it("validates homepage source while building only packages/app in quality CI", () => {
     expect(qualityWorkflow).toContain("consolidated-frontend-build:");
     expect(qualityWorkflow).toContain("Validate homepage source contracts");


### PR DESCRIPTION
Closes #19381.

## Outcome

The homepage no longer publishes WhatsApp links from a fixture/default in production. All WhatsApp entry points disappear unless the deployment resolves an explicitly enabled, valid E.164 sender. Release and preview builds reject invalid booleans, malformed numbers, and known sandbox/developer/unverified senders.

This intentionally does **not** enable WhatsApp yet. Live transport proof with the current Blooio sender resolved outbound delivery to `imessage`, while a WhatsApp inbound marker never appeared in Blooio contacts or its active production webhook. The public CTA must remain disabled until Blooio reports `protocol: whatsapp` and the inbound → production webhook → agent reply path is proven.

## Verification

- `bun run --cwd packages/homepage test` — 99 pass
- `bun run --cwd packages/homepage typecheck` — pass
- `bun run --cwd packages/homepage lint:check` — pass
- `bun test packages/scripts/__tests__/homepage-deploy-workflow.test.ts` — 6 pass
- `bun run check:agents-claude` — pass (153 pairs)
- `git diff --check` — pass

No secrets or credential values are included.
