### PR TITLE
test(ui): provide required launcher startup state

### DIFF
--- a/packages/ui/src/components/pages/LauncherSurface.test.tsx
+++ b/packages/ui/src/components/pages/LauncherSurface.test.tsx
@@ -18,7 +18,10 @@ import type { AppLaunchResult } from "../../api";
 import type { ViewRegistryEntry } from "../../hooks/useAvailableViews";
 import { type ViewEntry, viewToEntry } from "../../hooks/view-catalog";
 import { __setAppValueForTests } from "../../state/app-store";
-import type { AppContextValue } from "../../state/types";
+import type {
+  AppContextValue,
+  StartupCoordinatorView,
+} from "../../state/types";
 import { useEnabledViewKinds } from "../../state/useViewKinds";
 import { LauncherSurface } from "./LauncherSurface";
 
@@ -63,6 +66,32 @@ vi.mock("../../navigation", () => {
 
 const useEnabledViewKindsMock = vi.mocked(useEnabledViewKinds);
 
+function makeReadyStartupCoordinator(): StartupCoordinatorView {
+  return {
+    state: { phase: "ready" },
+    dispatch: vi.fn(),
+    retry: vi.fn(),
+    reset: vi.fn(),
+    pairingSuccess: vi.fn(),
+    firstRunComplete: vi.fn(),
+    policy: {
+      supportsLocalRuntime: true,
+      backendTimeoutMs: 30_000,
+      agentReadyTimeoutMs: 30_000,
+      probeForExistingInstall: true,
+      defaultTarget: "embedded-local",
+    },
+    loading: false,
+    terminal: false,
+    isShellPaintable: true,
+    isInteractive: true,
+    statusMessageKey: "startupshell.Loading",
+    error: null,
+    target: "embedded-local",
+    phase: "ready",
+  };
+}
+
 function view(
   id: string,
   label: string,
@@ -102,14 +131,28 @@ beforeEach(() => {
   window.localStorage.clear();
   window.history.replaceState(null, "", "/");
   getMock.mockResolvedValue(null);
-  __setAppValueForTests({
+  const launcherState = {
     appRuns: [],
     elizaCloudConnected: false,
+    startupCoordinator: makeReadyStartupCoordinator(),
     setActionNotice: setActionNoticeMock,
     setState: setStateMock,
     setTab: setTabMock,
     t: (key: string) => key,
-  } as unknown as AppContextValue);
+  } satisfies Pick<
+    AppContextValue,
+    | "appRuns"
+    | "elizaCloudConnected"
+    | "startupCoordinator"
+    | "setActionNotice"
+    | "setState"
+    | "setTab"
+    | "t"
+  >;
+  // This isolated renderer selects only the fields above; keep the single
+  // partial-context cast here while checking each selected field against the
+  // real store contract.
+  __setAppValueForTests(launcherState as unknown as AppContextValue);
   useEnabledViewKindsMock.mockReturnValue({ developer: true, preview: true });
   setViews([
     view("chat", "Chat", "/chat"),


### PR DESCRIPTION
# Relates to

Fixes #19319.

- [x] This PR targets `develop` and was rebased onto current `origin/develop` before exact-head validation.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] The production `LauncherSurface` read remains required and unguarded.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact head `9a6164ae344542661071dced53765a9d52fc090b` was rebased on `develop@8ba13ff68c26135e7d66596a236e21e69112ab0a`; zero conflicts.
- [x] Exact-head `bun run verify` passes: 350/350 workspace tasks plus repository audits.

# Risks

Very low. This changes one test fixture only. Production code, runtime behavior, routes, error handling, and rendered pixels are unchanged.

# Background

## What does this PR do?

- Supplies the required `startupCoordinator` slice to the Launcher test store.
- Builds a complete ready-state coordinator typed against `StartupCoordinatorView` instead of weakening the product read.
- Uses `satisfies Pick<AppContextValue, ...>` for every field selected by this isolated renderer, keeping the partial-context cast contained at the test boundary.

## What kind of change is this?

Test-harness bug fix.

# Documentation changes needed?

No. This restores an existing suite and does not alter product behavior.

# Testing

## Where should a reviewer start?

```bash
bun run --cwd packages/ui test src/components/pages/LauncherSurface.test.tsx --reporter=verbose
```

## Detailed testing steps

- Clean-base reproduction: 0/9 assertions ran; all 9 tests threw on `state.startupCoordinator.target`.
- Exact-head focused suite: 9/9 passed.
- UI typecheck: passed.
- UI lint: passed with 8 pre-existing direct-cookie warnings.
- Root `bun run verify`: 350/350 plus all audits passed.
- Full UI lane: 10,011 passed, 7 skipped, 45 failed across 20 unrelated current-base suites; the Launcher suite passed. Failures are existing stale-domain expectations, timing flakes, mock drift, and other already-triaged clusters, including #19329 before its PR merges.

# Evidence Gate

<!-- evidence-head:9a6164ae344542661071dced53765a9d52fc090b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-harness-only diff; production rendering and pixels are unchanged.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-harness-only diff; production rendering and pixels are unchanged.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend path changed or executed by this isolated renderer suite.
<!-- evidence-row:frontend-logs -->
- [x] [19383-19319-focused.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19383-19319-focused.log)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifact or persisted state changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI source changed.

# Evidence Details

The failure and repair are observable entirely through the real component suite: before the change React render throws before all nine assertions; after the typed fixture is supplied, the same nine tests execute and pass. No optional chaining, default value, timeout, retry, catch-and-continue, or fabricated success was added.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->

