### PR TITLE
fix(ci): expose truncated test failures

### DIFF
--- a/packages/scripts/__tests__/captured-test-output.test.ts
+++ b/packages/scripts/__tests__/captured-test-output.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Exercises the bounded package-output formatter with deterministic synthetic
+ * Vitest output, including ANSI escapes and chunk-split failure lines.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  appendCapturedTestOutput,
+  createCapturedTestOutput,
+  formatCapturedTestOutput,
+  MAX_CAPTURED_OUTPUT_CHARS,
+} from "../lib/captured-test-output.mjs";
+
+describe("captured test output", () => {
+  test("leaves uncapped output intact and indexes failing files", () => {
+    const capture = createCapturedTestOutput();
+    appendCapturedTestOutput(
+      capture,
+      " FAIL  src/first.test.ts > first case\nordinary detail\n",
+    );
+
+    const formatted = formatCapturedTestOutput(capture, "package#test");
+
+    expect(formatted).not.toContain("TRUNCATED");
+    expect(formatted).toContain("ordinary detail");
+    expect(formatted).toContain("[eliza-test] FAILING_FILE src/first.test.ts");
+  });
+
+  test("reports truncation and preserves every failing file from discarded detail", () => {
+    const capture = createCapturedTestOutput();
+    appendCapturedTestOutput(
+      capture,
+      "\u001b[31m FAIL  src/early-one.test.ts > one\u001b[39m\n",
+    );
+    appendCapturedTestOutput(capture, " FAIL  src/early-");
+    appendCapturedTestOutput(capture, "two.spec.tsx > two\n");
+    appendCapturedTestOutput(capture, "x".repeat(MAX_CAPTURED_OUTPUT_CHARS));
+    appendCapturedTestOutput(
+      capture,
+      "\n FAIL  src/retained.test.mts > last\n",
+    );
+
+    const formatted = formatCapturedTestOutput(capture, "package#test");
+
+    expect(formatted).toMatch(
+      /TRUNCATED \d+ earlier character\(s\) omitted; 2 earlier failing test file\(s\) omitted/,
+    );
+    expect(formatted).toContain(
+      "[eliza-test] FAILING_FILE src/early-one.test.ts",
+    );
+    expect(formatted).toContain(
+      "[eliza-test] FAILING_FILE src/early-two.spec.tsx",
+    );
+    expect(formatted).toContain(
+      "[eliza-test] FAILING_FILE src/retained.test.mts",
+    );
+    expect(formatted.match(/\[eliza-test\] FAILING_FILE /g)).toHaveLength(3);
+  });
+
+  test("deduplicates repeated failure detail", () => {
+    const capture = createCapturedTestOutput();
+    appendCapturedTestOutput(capture, " FAIL  src/repeated.test.ts > first\n");
+    appendCapturedTestOutput(capture, " FAIL  src/repeated.test.ts > second\n");
+
+    const formatted = formatCapturedTestOutput(capture, "package#test");
+
+    expect(formatted.match(/\[eliza-test\] FAILING_FILE /g)).toHaveLength(1);
+  });
+
+  test("tracks split stdout and stderr lines independently", () => {
+    const capture = createCapturedTestOutput();
+    appendCapturedTestOutput(capture, " FAIL  src/stdout-", "stdout");
+    appendCapturedTestOutput(
+      capture,
+      " FAIL  |browser| src/stderr.spec.ts > case\n",
+      "stderr",
+    );
+    appendCapturedTestOutput(capture, "file.test.ts > case\n", "stdout");
+
+    const formatted = formatCapturedTestOutput(capture, "package#test");
+
+    expect(formatted).toContain("[eliza-test] FAILING_FILE src/stderr.spec.ts");
+    expect(formatted).toContain(
+      "[eliza-test] FAILING_FILE src/stdout-file.test.ts",
+    );
+  });
+});

--- a/packages/scripts/__tests__/run-all-tests-captured-output.test.ts
+++ b/packages/scripts/__tests__/run-all-tests-captured-output.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Runs the real package-test orchestrator against a temporary failing workspace
+ * to verify its parallel capture path exposes truncation and every failed file.
+ */
+import { expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "../lib/spawn-sync-captured.mjs";
+
+const runner = fileURLToPath(new URL("../run-all-tests.mjs", import.meta.url));
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const fixtureDir = join(
+  repoRoot,
+  "packages",
+  "__run_all_tests_captured_output_fixture__",
+);
+
+test("parallel package failures retain a complete file inventory after truncation", () => {
+  rmSync(fixtureDir, { recursive: true, force: true });
+  mkdirSync(fixtureDir, { recursive: true });
+  try {
+    writeFileSync(
+      join(fixtureDir, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "@elizaos/run-all-tests-captured-output-fixture",
+          private: true,
+          type: "module",
+          scripts: { test: "node fail.mjs" },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    writeFileSync(
+      join(fixtureDir, "fail.mjs"),
+      [
+        'process.stdout.write(" FAIL  src/early.test.ts > early case\\n");',
+        'process.stdout.write("x".repeat(17_000));',
+        'process.stdout.write("\\n FAIL  src/late.spec.tsx > late case\\n");',
+        "process.exitCode = 1;",
+        "",
+      ].join("\n"),
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        runner,
+        "--only=test",
+        "--no-cloud",
+        "--concurrency=2",
+        "--filter=@elizaos/run-all-tests-captured-output-fixture",
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        maxBuffer: 8 * 1024 * 1024,
+        env: process.env,
+      },
+    );
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+
+    expect(result.status).toBe(1);
+    expect(output).toMatch(
+      /TRUNCATED \d+ earlier character\(s\) omitted; 1 earlier failing test file\(s\) omitted/,
+    );
+    expect(output).toContain("[eliza-test] FAILING_FILE src/early.test.ts");
+    expect(output).toContain("[eliza-test] FAILING_FILE src/late.spec.tsx");
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
+});

--- a/packages/scripts/lib/captured-test-output.mjs
+++ b/packages/scripts/lib/captured-test-output.mjs
@@ -1,0 +1,89 @@
+/**
+ * Retains bounded child-process diagnostics while indexing every failing test file.
+ * The formatted failure block makes tail truncation explicit and preserves a
+ * complete, machine-readable file inventory even when detailed output is capped.
+ */
+
+const ANSI_ESCAPE_PATTERN = new RegExp(
+  `${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`,
+  "g",
+);
+const FAILING_TEST_FILE_PATTERN =
+  /(?:^|\s)FAIL\s+(?:\[[^\]\r\n]+\]\s+)?(?:\|[^|\r\n]+\|\s+)?([^\r\n]*?\.(?:test|spec)\.[cm]?[jt]sx?)(?=\s|$)/g;
+
+// Per-package parallel output retains this tail; the failure-file index below
+// spans the entire child stream so the cap never hides which suites failed.
+export const MAX_CAPTURED_OUTPUT_CHARS = 16_000;
+
+function collectFailingTestFiles(line, files) {
+  const plainLine = line.replace(ANSI_ESCAPE_PATTERN, "");
+  for (const match of plainLine.matchAll(FAILING_TEST_FILE_PATTERN)) {
+    files.add(match[1].trim());
+  }
+}
+
+export function createCapturedTestOutput() {
+  return {
+    failingTestFiles: new Set(),
+    omittedChars: 0,
+    pendingLines: new Map(),
+    retained: "",
+  };
+}
+
+export function appendCapturedTestOutput(capture, chunk, source = "combined") {
+  const value = String(chunk);
+  const combinedLines = `${capture.pendingLines.get(source) ?? ""}${value}`;
+  const lines = combinedLines.split(/\r?\n/);
+  capture.pendingLines.set(source, lines.pop() ?? "");
+  for (const line of lines) {
+    collectFailingTestFiles(line, capture.failingTestFiles);
+  }
+
+  const next = `${capture.retained}${value}`;
+  if (next.length <= MAX_CAPTURED_OUTPUT_CHARS) {
+    capture.retained = next;
+    return;
+  }
+
+  const omittedNow = next.length - MAX_CAPTURED_OUTPUT_CHARS;
+  capture.omittedChars += omittedNow;
+  capture.retained = next.slice(omittedNow);
+}
+
+export function retainedCapturedTestOutput(capture) {
+  return capture.retained;
+}
+
+export function formatCapturedTestOutput(capture, label) {
+  for (const pendingLine of capture.pendingLines.values()) {
+    collectFailingTestFiles(pendingLine, capture.failingTestFiles);
+  }
+
+  const retainedFiles = new Set();
+  for (const line of capture.retained.split(/\r?\n/)) {
+    collectFailingTestFiles(line, retainedFiles);
+  }
+  const omittedFailureCount = [...capture.failingTestFiles].filter(
+    (file) => !retainedFiles.has(file),
+  ).length;
+
+  const sections = ["", `[eliza-test] ----- captured output: ${label} -----`];
+  if (capture.omittedChars > 0) {
+    sections.push(
+      `[eliza-test] TRUNCATED ${capture.omittedChars} earlier character(s) omitted; ${omittedFailureCount} earlier failing test file(s) omitted from retained detail.`,
+    );
+  }
+  sections.push(capture.retained);
+
+  if (capture.failingTestFiles.size > 0) {
+    const files = [...capture.failingTestFiles].sort();
+    sections.push(
+      `[eliza-test] ----- failing test files: ${label} (${files.length} total) -----`,
+      ...files.map((file) => `[eliza-test] FAILING_FILE ${file}`),
+      `[eliza-test] ----- end failing test files: ${label} -----`,
+    );
+  }
+  sections.push(`[eliza-test] ----- end output: ${label} -----`, "");
+  return sections.join("\n");
+}

--- a/packages/scripts/run-all-tests.mjs
+++ b/packages/scripts/run-all-tests.mjs
@@ -71,7 +71,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-
+import {
+  appendCapturedTestOutput,
+  createCapturedTestOutput,
+  formatCapturedTestOutput,
+  retainedCapturedTestOutput,
+} from "./lib/captured-test-output.mjs";
 import { MAX_JUNIT_BYTES, parseJunitSummary } from "./lib/junit-summary.mjs";
 import {
   computeRealLiveAccounting,
@@ -419,7 +424,6 @@ const TEST_FILE_SKIP_DIRS = new Set([
   "node_modules",
   "target",
 ]);
-const MAX_CAPTURED_OUTPUT_CHARS = 16_000;
 const ADDITIONAL_PACKAGE_DIRS = [
   path.join(repoRoot, "packages", "app-core", "platforms", "electrobun"),
 ];
@@ -729,14 +733,6 @@ function collectScriptsToRun(scripts) {
   }
 
   return scriptNames;
-}
-
-function appendCapturedOutput(current, chunk) {
-  const next = `${current}${chunk}`;
-  if (next.length <= MAX_CAPTURED_OUTPUT_CHARS) {
-    return next;
-  }
-  return next.slice(-MAX_CAPTURED_OUTPUT_CHARS);
 }
 
 function outputIndicatesNoTests(output) {
@@ -1123,7 +1119,7 @@ function runScript(
         stdio: ["ignore", "pipe", "pipe"],
       },
     );
-    let capturedOutput = "";
+    const capturedOutput = createCapturedTestOutput();
     // A non-zero exit may only be reclassified as a benign "no tests" skip when
     // BOTH hold:
     //   1. the command is a single vitest/bun-test invocation, AND
@@ -1144,18 +1140,20 @@ function runScript(
       if (stream) {
         process.stdout.write(chunk);
       }
-      capturedOutput = appendCapturedOutput(
+      appendCapturedTestOutput(
         capturedOutput,
         chunk.toString("utf8"),
+        "stdout",
       );
     });
     child.stderr?.on("data", (chunk) => {
       if (stream) {
         process.stderr.write(chunk);
       }
-      capturedOutput = appendCapturedOutput(
+      appendCapturedTestOutput(
         capturedOutput,
         chunk.toString("utf8"),
+        "stderr",
       );
     });
 
@@ -1188,9 +1186,9 @@ function runScript(
           });
         } catch (error) {
           // error-policy:J2 add the package identity before rejecting invalid evidence.
-          if (!stream && capturedOutput) {
+          if (!stream && retainedCapturedTestOutput(capturedOutput)) {
             process.stdout.write(
-              `\n[eliza-test] ----- captured output: ${label} -----\n${capturedOutput}\n[eliza-test] ----- end output: ${label} -----\n`,
+              formatCapturedTestOutput(capturedOutput, label),
             );
           }
           reject(
@@ -1201,7 +1199,10 @@ function runScript(
         }
         return;
       }
-      if (canSkipNoTests && shouldSkipAsNoTests(capturedOutput)) {
+      if (
+        canSkipNoTests &&
+        shouldSkipAsNoTests(retainedCapturedTestOutput(capturedOutput))
+      ) {
         resolve({
           skipped: true,
           skipReason: "no test files found",
@@ -1209,10 +1210,8 @@ function runScript(
         });
         return;
       }
-      if (!stream && capturedOutput) {
-        process.stdout.write(
-          `\n[eliza-test] ----- captured output: ${label} -----\n${capturedOutput}\n[eliza-test] ----- end output: ${label} -----\n`,
-        );
+      if (!stream && retainedCapturedTestOutput(capturedOutput)) {
+        process.stdout.write(formatCapturedTestOutput(capturedOutput, label));
       }
       reject(
         new Error(
@@ -1242,20 +1241,11 @@ function runCloudTests() {
       stdio: ["ignore", "pipe", "pipe"],
     });
 
-    let capturedOutput = "";
     child.stdout?.on("data", (chunk) => {
       process.stdout.write(chunk);
-      capturedOutput = appendCapturedOutput(
-        capturedOutput,
-        chunk.toString("utf8"),
-      );
     });
     child.stderr?.on("data", (chunk) => {
       process.stderr.write(chunk);
-      capturedOutput = appendCapturedOutput(
-        capturedOutput,
-        chunk.toString("utf8"),
-      );
     });
 
     child.on("error", reject);


### PR DESCRIPTION
# Relates to

Fixes #19375.

- [x] This PR targets `develop` and is rebased onto `origin/develop@91ec63bd63bafdc970b57636761cee7627e541fb` with zero conflicts.
- [x] Full `bun install` completed, including SHA-256 verification and extraction of the 971 MiB artifact bundle; the exact-head `bun run verify` outcome is documented below.
- [x] The deterministic real-runner evidence below lets a reviewer confirm the behavior without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex CLI 0.147.0`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2eb78473d30c5c2610db05c8e3d9e02a23b9fdf0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passed at exact head `2eb78473d30c5c2610db05c8e3d9e02a23b9fdf0`: 350/350 Turbo tasks plus all follow-on audits.

# Risks

Low. This changes only the buffered failure diagnostics used when package tests run concurrently. Passing tasks, serial streaming, exit codes, and failure classification are unchanged. The index is bounded by the number of unique failing test files; detailed output remains capped at 16,000 characters.

# Background

## What does this PR do?

The package test runner previously kept only the last 16,000 characters of a concurrent task log. It silently discarded earlier failure detail, so CI attribution could mistake missing `FAIL` rows for passing suites.

This PR keeps the bounded tail while:

- emitting an explicit truncation marker with omitted character and omitted failing-file counts;
- indexing every Vitest `FAIL <file>` line across the complete stdout/stderr streams;
- printing a stable, deduplicated `[eliza-test] FAILING_FILE <path>` inventory after the retained detail;
- parsing stdout and stderr lines independently so interleaved chunks cannot corrupt paths;
- documenting the 16,000-character cap where capture is implemented.

## What kind of change is this?

Bug fix (non-breaking CI observability repair).

# Documentation changes needed?

No external documentation change is needed. The retained cap and completeness invariant are documented at the output implementation.

# Testing

## Where should a reviewer start?

Run:

```bash
bun test packages/scripts/__tests__/captured-test-output.test.ts packages/scripts/__tests__/run-all-tests-captured-output.test.ts
```

The integration case spawns the real `run-all-tests.mjs` parallel path against a temporary failing workspace. It emits an early failing file, more than 16,000 characters, then a late failing file. The test requires a nonzero runner exit, an explicit one-file omission marker, and both paths in the final inventory.

## Detailed testing steps

- Exact-head focused and adjacent script contracts: **33 passed, 0 failed, 129 assertions** across the formatter/integration tests plus existing plan, concurrency-usage, and vacuous-green guards.
- Exact-head root `bun run verify`: **350/350 Turbo tasks passed**, followed by clean build-model, Turbo dependency, secret-leak, fleet-routing, script-inventory, view-inventory, and focused-test audits.
- Full `bun install`: **7,150 packages installed**; the 971 MiB artifact bundle was downloaded, SHA-256 verified, and extracted successfully.
- Broader `bun test packages/scripts/__tests__` found one unrelated current-base failure: `release-workflow-authority.test.ts` expects an unsorted filesystem order for two workflow names. Neither that test nor either workflow is changed here. All #19375-focused and adjacent runner contracts pass.

# Evidence Gate

<!-- evidence-head:2eb78473d30c5c2610db05c8e3d9e02a23b9fdf0 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI log formatting has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI log formatting has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - The behavior is a deterministic terminal-output contract, not an interactive flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - No backend service or request path changes; real runner output is recorded in Testing.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend code, console, network, or state transition changes.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No database, memory, scheduler, wallet, audio, or generated domain artifact changes.
<!-- evidence-row:ocr-review -->
- [ ] N/A - No visual surface or UI text is rendered.

# Evidence Details

## Real LLM-call trajectory

N/A - no model path changes.

## Backend + frontend logs

N/A - this is the CI runner boundary itself. The real-runner subprocess contract and exact pass counts are recorded above.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Known gaps / failures

None. The owning focused and adjacent script contracts pass at exact head, and repository-wide verification is green on the current `develop` base.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex CLI 0.147.0
Contribution skill revision: elizaOS/eliza@2eb78473d30c5c2610db05c8e3d9e02a23b9fdf0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex CLI 0.147.0","skill_revision":"elizaOS/eliza@2eb78473d30c5c2610db05c8e3d9e02a23b9fdf0:packages/skills/skills/contribute-to-eliza"} -->



Independent exact-head review confirmed the bounded-tail algorithm, per-stream chunk handling, ANSI-stripped Vitest failure parsing, deterministic deduplication, and the real orchestrator failure path. No implementation change was required after rebase.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - independent review and mechanical rebase only
Attribution status: self-reported
— [codex-review]
