### PR TITLE
fix(cloud): make phone voice responsive and interruptible

### DIFF
--- a/packages/cloud/api/v1/twilio/voice/inbound/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/inbound/route.ts
@@ -4,9 +4,10 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
-import { dbWrite } from "@/db/helpers";
+import { dbRead, dbWrite } from "@/db/helpers";
 import { twilioInboundCalls } from "@/db/schemas";
 import { ObjectNamespaces } from "@/lib/storage/object-namespace";
 import { offloadJsonField } from "@/lib/storage/object-store";
@@ -113,6 +114,17 @@ app.post("/", async (c) => {
   }
 
   const id = randomUUID();
+  const [priorCall] = await dbRead
+    .select({ id: twilioInboundCalls.id })
+    .from(twilioInboundCalls)
+    .where(
+      and(
+        eq(twilioInboundCalls.from_number, normalizedFrom),
+        eq(twilioInboundCalls.to_number, normalizedTo),
+        eq(twilioInboundCalls.agent_id, phoneNumber.agentId),
+      ),
+    )
+    .limit(1);
   const rawPayload = await offloadJsonField<Record<string, string>>({
     namespace: ObjectNamespaces.TwilioInboundPayloads,
     organizationId: phoneNumber?.organizationId ?? "twilio",
@@ -155,6 +167,7 @@ app.post("/", async (c) => {
       agentId: phoneNumber.agentId,
       conversationId,
       calledNumber: normalizedTo,
+      returningCaller: Boolean(priorCall),
     },
     authToken,
   );
@@ -173,7 +186,6 @@ app.post("/", async (c) => {
       streamUrl: publicUrl.toString(),
       sessionId: minted.claims.sessionId,
       token: minted.token,
-      greeting: "Hi, you're connected to Eliza.",
     }),
     {
       headers: { "Content-Type": "text/xml" },

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.test.ts
@@ -14,6 +14,7 @@ const input = {
   agentId: "agent-1",
   conversationId: "11111111-1111-4111-8111-111111111111",
   calledNumber: "+14484080429",
+  returningCaller: true,
 };
 
 describe("Twilio stream token", () => {

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.ts
@@ -21,6 +21,7 @@ const ClaimsSchema = z.object({
   agentId: z.string().min(1),
   conversationId: z.string().uuid(),
   calledNumber: z.string().min(1),
+  returningCaller: z.boolean(),
 });
 
 const WireClaimsSchema = z.object({
@@ -35,6 +36,7 @@ const WireClaimsSchema = z.object({
   g: z.string().min(1),
   n: z.string().uuid(),
   p: z.string().min(1),
+  r: z.boolean(),
 });
 
 export type TwilioStreamTokenClaims = z.infer<typeof ClaimsSchema>;
@@ -95,6 +97,7 @@ export async function mintTwilioStreamToken(
         g: claims.agentId,
         n: claims.conversationId,
         p: claims.calledNumber,
+        r: claims.returningCaller,
       }),
     ),
   );
@@ -139,6 +142,7 @@ export async function verifyTwilioStreamToken(
       agentId: wire.data.g,
       conversationId: wire.data.n,
       calledNumber: wire.data.p,
+      returningCaller: wire.data.r,
     });
     if (!parsed.success) return null;
     const nowSeconds = Math.floor(now() / 1_000);

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.test.ts
@@ -12,11 +12,12 @@ describe("Twilio voice TwiML", () => {
       streamUrl: "wss://api.eliza.app/api/v1/twilio/voice/media",
       sessionId: "11111111-1111-4111-8111-111111111111",
       token: "signed",
-      greeting: "Hi, you're connected to Eliza.",
     });
 
-    expect(xml).toContain("<Say>Hi, you&apos;re connected to Eliza.</Say>");
-    expect(xml).toContain('<Connect><Stream url="wss://api.eliza.app/');
+    expect(xml).toContain(
+      '<Response><Connect><Stream url="wss://api.eliza.app/',
+    );
+    expect(xml).not.toContain("<Say>");
     expect(xml).toContain(
       'name="sessionId" value="11111111-1111-4111-8111-111111111111"',
     );
@@ -28,14 +29,12 @@ describe("Twilio voice TwiML", () => {
       streamUrl: "wss://example.test/a?x=1&y=<bad>",
       sessionId: '"session"',
       token: "token'one",
-      greeting: "A & B < C",
     });
 
     expect(xml).not.toContain("<bad>");
     expect(xml).toContain("x=1&amp;y=&lt;bad&gt;");
     expect(xml).toContain("&quot;session&quot;");
     expect(xml).toContain("token&apos;one");
-    expect(xml).toContain("A &amp; B &lt; C");
   });
 
   test("builds a terminal spoken response", () => {

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.ts
@@ -17,7 +17,6 @@ export function buildRealtimeVoiceTwiML(options: {
   streamUrl: string;
   sessionId: string;
   token: string;
-  greeting: string;
 }): string {
-  return `<?xml version="1.0" encoding="UTF-8"?><Response><Say>${escapeXml(options.greeting)}</Say><Connect><Stream url="${escapeXml(options.streamUrl)}"><Parameter name="sessionId" value="${escapeXml(options.sessionId)}"/><Parameter name="token" value="${escapeXml(options.token)}"/></Stream></Connect></Response>`;
+  return `<?xml version="1.0" encoding="UTF-8"?><Response><Connect><Stream url="${escapeXml(options.streamUrl)}"><Parameter name="sessionId" value="${escapeXml(options.sessionId)}"/><Parameter name="token" value="${escapeXml(options.token)}"/></Stream></Connect></Response>`;
 }

--- a/packages/cloud/api/v1/twilio/voice/media/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/media/route.ts
@@ -63,6 +63,8 @@ const app = new Hono<AppEnv>();
 // window instead of terminating ordinary first calls before setup completes.
 const MAX_PENDING_MEDIA_FRAMES = 512;
 const DEFAULT_MAX_CALL_SECONDS = 30 * 60;
+const FIRST_CALL_GREETING = "hello? who's this?";
+const RETURNING_CALLER_GREETING = "hey whats up";
 const bootstrapGate = new TwilioBootstrapGate();
 
 const TwilioStreamEventSchema = z.discriminatedUnion("event", [
@@ -397,6 +399,9 @@ app.get("/", async (c) => {
       elizaModel: resolveElizaModel(env),
       fetchImpl: elizaFetch,
       prewarmElizaContext: elizaFetch.prewarm,
+      openingGreeting: claims.returningCaller
+        ? RETURNING_CALLER_GREETING
+        : FIRST_CALL_GREETING,
       usageStore,
       usageLimits: resolveVoiceUsageLimits(env),
       isRevoked: (jti) =>

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -444,6 +444,7 @@ async function connectSession(opts: {
   client: FakeClientSocket;
   fetchImpl: typeof fetch;
   prewarmElizaContext?: () => Promise<void>;
+  openingGreeting?: string;
   cacheWarmingRetryDelaysMs?: readonly number[];
   fish?: {
     enabled?: boolean;
@@ -482,6 +483,9 @@ async function connectSession(opts: {
         fetchImpl: opts.fetchImpl,
         ...(opts.prewarmElizaContext
           ? { prewarmElizaContext: opts.prewarmElizaContext }
+          : {}),
+        ...(opts.openingGreeting
+          ? { openingGreeting: opts.openingGreeting }
           : {}),
         ...(opts.cacheWarmingRetryDelaysMs
           ? {
@@ -531,6 +535,30 @@ function pcmChunk(bytes: number): Uint8Array {
 // --- tests ----------------------------------------------------------------
 
 describe("voice-session WS lifecycle", () => {
+  test("speaks a live opening greeting while the agent context warms", async () => {
+    const client = new FakeClientSocket();
+    let responseRequests = 0;
+    await connectSession({
+      client,
+      openingGreeting: "hello? who's this?",
+      fetchImpl: (async () => {
+        responseRequests += 1;
+        return makeCanonicalChunkFetch(["unused"])("", {});
+      }) as unknown as typeof fetch,
+    });
+    await flush();
+
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    expect(cartesia.sentText()).toBe("hello? who's this?");
+    expect(client.audioFrames.length).toBeGreaterThan(0);
+    expect(client.controlTypes()).toContain("speaking_start");
+    expect(responseRequests).toBe(0);
+
+    cartesia.emitDone();
+    await flush();
+    expect(client.controlTypes()).toContain("speaking_end");
+  });
+
   test("stt_final posts the transcript to the canonical agent conversation stream with scoped identity", async () => {
     const requests: Array<{
       url: string;
@@ -1540,6 +1568,69 @@ describe("voice-session WS lifecycle", () => {
     // Flushing here proves no late frame leaks through after the barge-in.
     await flush();
     expect(client.audioFrames.length).toBe(framesAfterInterrupt);
+  });
+
+  test("acoustic activity interrupts only after Ink registers caller words", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch([
+        "I will keep speaking until you say something.",
+      ]),
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "please explain");
+    await flush();
+    await flush();
+
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    expect(client.controlTypes()).toContain("speaking_start");
+    expect(cartesia.closed).toBe(false);
+
+    // Acoustic turn-start and punctuation-only revisions can be background
+    // noise or echo. They must not clear audio or cancel the active response.
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.update", "...");
+    await flush();
+    expect(client.controlTypes()).not.toContain("interrupted");
+    expect(cartesia.closed).toBe(false);
+
+    // The first partial containing a letter/number is confirmed caller speech.
+    ink.emitTurn("turn.update", "wait");
+    await flush();
+    expect(client.controlFrames).toContainEqual(
+      expect.objectContaining({ t: "interrupted", reason: "acoustic" }),
+    );
+    expect(cartesia.closed).toBe(true);
+  });
+
+  test("a final-only caller transcript still interrupts the active response", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["The response is still in progress."]),
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "start talking");
+    await flush();
+    await flush();
+
+    const activeCartesia = FakeCartesiaSocket.instances.at(-1)!;
+    expect(client.controlTypes()).toContain("speaking_start");
+    expect(activeCartesia.closed).toBe(false);
+
+    // Ink may finalize a short utterance without sending an interim update.
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "stop");
+    await flush();
+    expect(client.controlFrames).toContainEqual(
+      expect.objectContaining({ t: "interrupted", reason: "acoustic" }),
+    );
+    expect(activeCartesia.closed).toBe(true);
   });
 
   test("interruption aborts the in-flight Eliza SSE fetch", async () => {

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -13,9 +13,9 @@
  *     `CartesiaSonicTtsAdapter` (#15949). Phrase-aggregated deltas stream in;
  *     adapters' strict no-post-cancel guarantee makes barge-in correct.
  *
- * Interruption (contract §7.5): acoustic speech-start / Ink turn / explicit
- * `barge_in` -> under one `voiceTurnId`, cancel the active TTS stream (no
- * post-cancel frames), abort the Eliza SSE fetch, flush the downlink, drop pending phrase
+ * Interruption (contract §7.5): confirmed caller words / explicit `barge_in`
+ * -> under one `voiceTurnId`, cancel the active TTS stream (no post-cancel
+ * frames), abort the Eliza SSE fetch, flush the downlink, drop pending phrase
  * aggregation, emit `interrupted`, return to listening. Target <250ms.
  *
  * Metering (SEC-15): server-derived uplink duration only; the client is NEVER
@@ -105,6 +105,7 @@ const CACHE_WARMING_CODES = new Set([
   "shared_runtime_cache_warming",
   "conversation_cache_warming",
 ]);
+const SPOKEN_TRANSCRIPT_RE = /[\p{L}\p{N}]/u;
 
 // Cartesia's server buffers streamed transcript for up to 3000ms by default
 // before starting synthesis, which measured ~2.7s of the speaking_start gap on
@@ -144,6 +145,8 @@ export interface VoiceSessionConfig {
   fetchImpl?: typeof fetch;
   /** Session-start DB/tenancy warmup, injected only by the live Worker route. */
   prewarmElizaContext?: () => Promise<void>;
+  /** Optional provider-synthesized opener that runs while agent context warms. */
+  openingGreeting?: string;
   /** Deterministic test override; production uses bounded exponential backoff. */
   cacheWarmingRetryDelaysMs?: readonly number[];
 
@@ -320,6 +323,9 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     const sessionTrace = this.mintTraceId("session");
     this.currentTraceId = sessionTrace;
     this.send({ t: "ready", sessionId: this.sessionId, traceId: sessionTrace });
+    if (this.config.openingGreeting?.trim()) {
+      this.speakOpeningGreeting(this.config.openingGreeting.trim());
+    }
   }
 
   /**
@@ -480,23 +486,24 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         break;
       }
       case "start-of-turn": {
-        // A new user turn started. If the agent is mid-speech, this is a
-        // barge-in (acoustic speech-start via Ink's native turn detector).
-        if (this.state === "speaking" || this.state === "thinking") {
-          this.interrupt("acoustic");
-        }
+        // Ink's acoustic turn detector also fires for line noise, breathing,
+        // and speaker echo. Keep transcribing alongside the active response;
+        // only a non-empty transcript-update below proves caller speech and
+        // earns the right to cancel model/TTS work.
         this.resetSttPartialDelivery();
         this.activeSttTurn = true;
-        this.state = "transcribing";
+        if (!this.currentVoiceTurnId) this.state = "transcribing";
         break;
       }
       case "transcript-update": {
         if (this.activeSttTurn && event.transcript) {
+          this.interruptForConfirmedSpeech(event.transcript);
           this.queueSttPartial(event.transcript);
         }
         break;
       }
       case "eager-end-of-turn": {
+        this.interruptForConfirmedSpeech(event.transcript);
         this.flushSttPartial();
         this.send({
           t: "stt_eager_eot",
@@ -506,6 +513,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       }
       case "end-of-turn": {
         if (!this.activeSttTurn) return;
+        this.interruptForConfirmedSpeech(event.transcript);
         this.activeSttTurn = false;
         this.resetSttPartialDelivery();
         // A missing transcript commits as "" on purpose: commitTurn's empty-
@@ -532,6 +540,15 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         break;
       }
     }
+  }
+
+  /** Cancel an active response only after Ink has produced caller words. */
+  private interruptForConfirmedSpeech(transcript: string): void {
+    if (!this.currentVoiceTurnId || !SPOKEN_TRANSCRIPT_RE.test(transcript)) {
+      return;
+    }
+    this.interrupt("acoustic");
+    this.state = "transcribing";
   }
 
   /**
@@ -616,6 +633,63 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     void this.runResponseTurn(transcript, traceId);
   }
 
+  /** Speak a fixed live opener while the first agent context is warming. */
+  private speakOpeningGreeting(text: string): void {
+    if (this.closed || this.currentVoiceTurnId) return;
+    const traceId = this.mintTraceId("turn");
+    this.currentTraceId = traceId;
+    this.currentVoiceTurnId = traceId;
+    this.turnTtsChars = text.length;
+    this.firstLlmTextEmitted = false;
+
+    const stream = this.createTtsStream(traceId, {
+      onFirstAudio: () => {
+        if (this.currentVoiceTurnId !== traceId) return;
+        this.state = "speaking";
+        this.send({ t: "speaking_start", traceId });
+      },
+      onAudioFrame: (frame) => {
+        if (this.currentVoiceTurnId !== traceId) return;
+        this.config.downlink.sendAudio(frame.bytes);
+      },
+      onComplete: () => {
+        if (this.currentVoiceTurnId !== traceId) return;
+        this.send({ t: "speaking_end", traceId });
+        this.finishTurn(traceId);
+      },
+      onProviderError: (error) => {
+        if (this.currentVoiceTurnId !== traceId) return;
+        this.send({
+          t: "error",
+          code: error.code ?? "tts_error",
+          retryable: true,
+        });
+        this.finishTurn(traceId);
+      },
+    });
+    this.ttsStream = stream;
+    void stream.opened.catch(() => undefined);
+    stream.sendPhrase({ text, continueContext: false });
+  }
+
+  private createTtsStream(
+    traceId: string,
+    callbacks: RealtimeTtsStreamCallbacks,
+  ): RealtimeTtsStream {
+    const createCartesia = () =>
+      this.cartesiaAdapter.createStream(
+        { traceId, maxBufferDelayMs: VOICE_TTS_MAX_BUFFER_DELAY_MS },
+        callbacks,
+      );
+    if (!this.fishAudioAdapter) return createCartesia();
+    return new FishPrimaryRealtimeTtsStream({
+      traceId,
+      fishAudioAdapter: this.fishAudioAdapter,
+      createCartesia,
+      callbacks,
+    });
+  }
+
   private async runResponseTurn(
     transcript: string,
     traceId: string,
@@ -668,21 +742,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
           this.finishTurn(traceId);
         },
       };
-      const createCartesia = () =>
-        this.cartesiaAdapter.createStream(
-          { traceId, maxBufferDelayMs: VOICE_TTS_MAX_BUFFER_DELAY_MS },
-          callbacks,
-        );
-      if (this.fishAudioAdapter) {
-        tts = new FishPrimaryRealtimeTtsStream({
-          traceId,
-          fishAudioAdapter: this.fishAudioAdapter,
-          createCartesia,
-          callbacks,
-        });
-      } else {
-        tts = createCartesia();
-      }
+      tts = this.createTtsStream(traceId, callbacks);
       this.ttsStream = tts;
       return tts;
     };

--- a/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.test.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.test.ts
@@ -10,6 +10,10 @@ import {
   CARTESIA_INK_API_VERSION,
   CARTESIA_INK_CHUNK_BYTES,
   CARTESIA_INK_MODEL_ID,
+  CARTESIA_INK_TURN_EAGER_END_THRESHOLD,
+  CARTESIA_INK_TURN_END_THRESHOLD,
+  CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS,
+  CARTESIA_INK_TURN_START_THRESHOLD,
   CARTESIA_INK_WEBSOCKET_URL,
   CartesiaInkAudioChunkError,
   CartesiaInkConfigError,
@@ -108,6 +112,18 @@ describe("Cartesia Ink realtime adapter", () => {
     expect(url.searchParams.get("model")).toBe(CARTESIA_INK_MODEL_ID);
     expect(url.searchParams.get("encoding")).toBe("pcm_s16le");
     expect(url.searchParams.get("sample_rate")).toBe("16000");
+    expect(url.searchParams.get("turn_start_threshold")).toBe(
+      String(CARTESIA_INK_TURN_START_THRESHOLD),
+    );
+    expect(url.searchParams.get("turn_eager_end_threshold")).toBe(
+      String(CARTESIA_INK_TURN_EAGER_END_THRESHOLD),
+    );
+    expect(url.searchParams.get("turn_end_threshold")).toBe(
+      String(CARTESIA_INK_TURN_END_THRESHOLD),
+    );
+    expect(url.searchParams.get("turn_end_timeout_ms")).toBe(
+      String(CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS),
+    );
     expect(url.searchParams.get("cartesia_version")).toBe(
       CARTESIA_INK_API_VERSION,
     );

--- a/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.ts
@@ -13,6 +13,10 @@ export const CARTESIA_INK_SAMPLE_RATE = 16_000;
 export const CARTESIA_INK_AUDIO_ENCODING = "pcm_s16le";
 export const CARTESIA_INK_CHUNK_MILLISECONDS = 100;
 export const CARTESIA_INK_CHUNK_BYTES = 3_200;
+export const CARTESIA_INK_TURN_START_THRESHOLD = 0.8;
+export const CARTESIA_INK_TURN_EAGER_END_THRESHOLD = 0.5;
+export const CARTESIA_INK_TURN_END_THRESHOLD = 0.4;
+export const CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS = 1_200;
 
 const DEFAULT_CLOSE_CODE = 1000;
 
@@ -167,6 +171,22 @@ export function buildCartesiaInkUrl(config: CartesiaInkConfig): string {
   url.searchParams.set("encoding", CARTESIA_INK_AUDIO_ENCODING);
   url.searchParams.set("sample_rate", String(CARTESIA_INK_SAMPLE_RATE));
   url.searchParams.set("cartesia_version", CARTESIA_INK_API_VERSION);
+  url.searchParams.set(
+    "turn_start_threshold",
+    String(CARTESIA_INK_TURN_START_THRESHOLD),
+  );
+  url.searchParams.set(
+    "turn_eager_end_threshold",
+    String(CARTESIA_INK_TURN_EAGER_END_THRESHOLD),
+  );
+  url.searchParams.set(
+    "turn_end_threshold",
+    String(CARTESIA_INK_TURN_END_THRESHOLD),
+  );
+  url.searchParams.set(
+    "turn_end_timeout_ms",
+    String(CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS),
+  );
   return url.toString();
 }
 


### PR DESCRIPTION
Closes #19385

## Outcome

- removes the blocking Twilio `<Say>` opener and enters the bidirectional media stream immediately
- speaks a live Cartesia opener while the first agent context warms: `hello? who's this?` for a new caller and `hey whats up` for a returning caller
- tunes Cartesia Ink semantic endpointing to a 1.2-second silence ceiling
- keeps agent audio running through acoustic/noise onset and interrupts only after Ink has emitted caller words
- preserves explicit UI barge-in and zero post-cancel audio

## Verification

- focused voice/Twilio tests: 62 passed, 0 failed
- cloud API typecheck and Worker production dry-run: passed
- cloud API lint: passed
- `bun run verify:cloud`: 78/78 tasks passed
- deployed exact commit `ae654af309d39ccaf193fac0c981a8c3ce55fb72` as production Worker version `75b8262e-2a5b-4f87-8bcc-eb5158e2fe08`

## Live carrier evidence

- greeting/first-response call `CA0eef92f9423b29da2a92ff327f165c6c`, dual-channel recording `REaa5e6b382fdf3bb13f0c65b06ba51f38`: live greeting starts at 0.72s; first answer starts 4.76s after prompt end; no Twilio canned intro
- spoken barge-in call `CAd1e872bc7a601fee1ae34de262604ac6`, dual-channel recording `RE9691a54ab7cd8357cff6becbd5e0e9fd`: Eliza continues after acoustic onset, stops once caller words register (10.50s), caller continues through 12.56s, and Eliza replies to the interruption at 13.86s

## AI provenance

Implemented and verified with Codex. The contributor reviewed the production behavior and evidence through the requested voice setup task.
