### PR TITLE
test(voice): wire live Railway browser matrix

### DIFF
--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -72,6 +72,11 @@ on:
         required: false
         default: true
         type: boolean
+      run_web_live_railway:
+        description: "Run the provisioned browser mic→agent→audio Railway lane"
+        required: false
+        default: false
+        type: boolean
       run_macos_electrobun:
         description: "Attempt the macOS Electrobun live-voice matrix lane"
         required: false
@@ -167,6 +172,105 @@ jobs:
         run: |
           set -euo pipefail
           bun test packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts
+
+  # The service contract above does not exercise the shipped browser surface.
+  # This separately gated job runs the exact live matrix cell from #16937 only
+  # when a runner has been provisioned with Railway voice endpoints and a real
+  # model credential. The schedule stays opt-in through the repository variable
+  # so an unprovisioned nightly cannot turn into a misleading red run.
+  voice-web-live-railway:
+    name: Web Railway live mic → agent → audible TTS
+    if: ${{ (github.event_name == 'schedule' && vars.ELIZA_VOICE_WEB_LIVE_READY == '1') || (github.event_name == 'workflow_dispatch' && inputs.run_web_live_railway) }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      E2E_RECORD: "1"
+      ELIZA_UI_SMOKE_LIVE_STACK: "1"
+      ELIZA_VOICE_LIVE_RAILWAY: "1"
+      ELIZA_PROVIDER: "cerebras"
+      KOKORO_TTS_URL: ${{ vars.ELIZA_VOICE_KOKORO_TTS_URL }}
+      WHISPER_STT_URL: ${{ vars.ELIZA_VOICE_WHISPER_STT_URL }}
+      WHISPER_STT_MODEL: ${{ vars.ELIZA_VOICE_WHISPER_STT_MODEL }}
+      CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          show-progress: false
+
+      - name: Free disk space for browser recording
+        run: |
+          set -euxo pipefail
+          df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android || true
+          docker system prune -af || true
+          df -h /
+
+      - name: Require a live model credential
+        run: |
+          set -euo pipefail
+          if [ -z "${CEREBRAS_API_KEY:-}" ]; then
+            echo "::error::The web Railway voice lane requires the provisioned CEREBRAS_API_KEY live model credential."
+            exit 1
+          fi
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          install-command: bun install --frozen-lockfile --ignore-scripts
+          install-native-deps: "false"
+          install-protoc: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Install Playwright Chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
+
+      - name: Generate shared i18n assets
+        run: bun run --cwd packages/shared build:i18n
+
+      - name: Build browser bundles
+        run: |
+          set -euo pipefail
+          bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
+          bun run --cwd packages/app build:web
+
+      - name: Prove the live cell is explicit when ungated
+        env:
+          ELIZA_VOICE_LIVE_RAILWAY: ""
+        run: |
+          set -euo pipefail
+          bun run voice:matrix -- \
+            --platform web.live.railway-roundtrip \
+            --out "$RUNNER_TEMP/voice-web-live-ungated"
+
+      - name: Run the provisioned live browser matrix cell
+        env:
+          ELIZA_UI_SMOKE_BACKEND_LOG_PATH: ${{ runner.temp }}/voice-web-live/backend.log
+        run: |
+          set -euo pipefail
+          bun run voice:matrix -- \
+            --run \
+            --require-green \
+            --platform web.live.railway-roundtrip \
+            --out "$RUNNER_TEMP/voice-web-live-matrix"
+
+      - name: Upload web Railway voice evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: voice-web-live-railway
+          path: |
+            ${{ runner.temp }}/voice-web-live-ungated
+            ${{ runner.temp }}/voice-web-live-matrix
+            ${{ runner.temp }}/voice-web-live
+            packages/app/playwright-report/
+            packages/app/test-results/
+            e2e-recordings/app/test-results/
+          if-no-files-found: ignore
+          retention-days: 14
 
   # Build the fused libelizainference from the in-repo llama.cpp fork so the
   # self-hosted jobs never depend on hand-staged native libs. CPU variant with


### PR DESCRIPTION
# Relates to

Closes #16937 (bounded CI-wiring slice; hardware-dependent desktop evidence remains open).

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the workflow behavior from the exact matrix command and static CI checks below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@4cd5af9ed9f03e97f795c171dd890879b423ba83:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. The change adds a separately gated GitHub Actions job and does not alter runtime, app, provider, or voice-test behavior. The scheduled job is opt-in through `ELIZA_VOICE_WEB_LIVE_READY=1`; manual dispatch is opt-in through `run_web_live_railway`.

# Background

## What does this PR do?

- Adds a `run_web_live_railway` workflow-dispatch input.
- Adds the `voice-web-live-railway` job for the existing `web.live.railway-roundtrip` matrix cell.
- Requires the explicit `CEREBRAS_API_KEY` provider path and Railway voice endpoint variables before spending live resources.
- Installs the pinned workspace/browser toolchain, builds the browser bundles, records backend/browser artifacts, and uploads the matrix report.
- Runs an ungated preflight proving the cell is an explicit `skip`, then runs the provisioned cell with `--require-green` so missing execution cannot report green.

## What kind of change is this?

CI test/evidence improvement.

# Documentation changes needed?

No documentation change is needed; the workflow input and repository variable are self-describing in `.github/workflows/voice-live-e2e.yml`.

# Testing

## Where should a reviewer start?

Review `.github/workflows/voice-live-e2e.yml` at the `voice-web-live-railway` job, then inspect the exact matrix invocation in the `Run the provisioned live browser matrix cell` step.

## Detailed testing steps

- `bun install --frozen-lockfile --ignore-scripts` (Bun 1.3.14; clean isolated worktree)
- `bun run verify` (all 141 workspace typecheck/lint lanes and repository audits passed)
- `actionlint -config-file .github/actionlint.yaml .github/workflows/voice-live-e2e.yml` (pass)
- `bun test packages/app-core/scripts/voice/__tests__/voice-matrix.test.ts` (2 pass)
- `bun run voice:matrix -- --platform web.live.railway-roundtrip --out <tmp>` (explicit ungated result: `pass=0 fail=0 pending=0 skip=1`)
- Ruby YAML parse of `.github/workflows/voice-live-e2e.yml` (pass)
- `git diff --check` (pass)

# Evidence Gate

Evidence matches commit `7abec562cc1006e9031e81c4d1bf13ac3bee1e83`.

<!-- evidence-head:7abec562cc1006e9031e81c4d1bf13ac3bee1e83 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - workflow-only change; no rendered UI surface is modified.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - workflow-only change; no rendered UI surface is modified.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - workflow-only change; the live browser recording is produced by the provisioned CI job.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no local Railway/model credential was available; the new CI job uploads its backend log when provisioned.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no local live browser run was authorized or provisioned; the existing test owns this evidence in the CI artifact.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - this PR changes CI wiring only and does not change agent/provider behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no database, memory, scheduled-task, wallet, or generated-domain output changes.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered UI surface is modified.

# Evidence Details

## Web live-cell contract

The workflow first runs the exact cell without `ELIZA_VOICE_LIVE_RAILWAY` and records `skip=1`; it then runs the same cell with `ELIZA_VOICE_LIVE_RAILWAY=1`, `ELIZA_UI_SMOKE_LIVE_STACK=1`, `ELIZA_PROVIDER=cerebras`, Railway endpoint variables, and `--require-green`. The live job uploads the matrix JSON/Markdown/HTML, Playwright report/results, video recordings, and backend log for maintainer inspection.

## Audio / voice walkthrough

N/A - this change wires the existing real-audio browser lane into CI. The live MP4/audio evidence is intentionally generated only by the provisioned workflow job and is not fabricated locally.

## Known gaps / failures

- The upstream remote rejects direct pushes from `SYMBaiEX` (HTTP 403); the branch was pushed to the writable `SYMBaiEX/eliza` fork and this PR targets `elizaOS/eliza:develop`.
- The live Railway/browser execution itself is gated on repository configuration (`ELIZA_VOICE_WEB_LIVE_READY=1`, Railway endpoint variables, and `CEREBRAS_API_KEY`) and was not run locally because those credentials are not present.
- Issue #16937's hardware-dependent desktop live capture, visible failure-path recordings, and live trajectory review remain separate acceptance rows outside this CI-wiring slice.

Compute receipt: 33391696 project-attributed tokens (bounded; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@4cd5af9ed9f03e97f795c171dd890879b423ba83:skills/contribute-to-eliza
Attribution status: self-reported
— [symbiex-sol]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@4cd5af9ed9f03e97f795c171dd890879b423ba83:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZZCA0MCKW4YVDJYQ7X094QQ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-14T05:35:51.949Z","completed_at":"2026-08-14T05:48:33.376Z","skill_sha256":"86ebbdf48745c94b57f5459f60acf318b15415b654520084b351854759cf4f28","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":946748,"output_tokens":65684,"cache_creation_tokens":0,"cache_read_tokens":32379264,"total_tokens":33391696,"cost_micro_usd":"22893892","session_count":4},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAgRqPUr6n5gIfjCXCYQr0eQIYz7H8A21PEb7__wUY9mw","device_key_id":"31163bfbacce454737e1438d5fcccd89c93bddb71486e0fefd5dfa2315fe78c5","device_signature":"t_CSrL0OLKD12JF0lH_3EssbOpBJ4ztWvtx1kOA7tcX_xAGbE1FEjaCAPGS9ArzvBSPtzJCUFpp2mDSLWLwBg"}} -->


