### PR TITLE
fix(cloud): preserve Blooio v4 channel affinity

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/blooio-adapter.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/blooio-adapter.test.ts
@@ -1,6 +1,6 @@
 /**
- * Exercises the Blooio iMessage adapter with deterministic signature,
- * malformed-delivery, deduplication, and outbound idempotency coverage.
+ * Exercises the multi-channel Blooio adapter with deterministic signature,
+ * malformed-delivery, channel affinity, and outbound idempotency coverage.
  */
 import { afterEach, describe, expect, test } from "bun:test";
 import crypto from "node:crypto";
@@ -181,6 +181,9 @@ describe("blooio extractEvent", () => {
     expect(event?.messageId).toBe("msg_v4_abc123");
     expect(event?.chatId).toBe("+15551234567");
     expect(event?.senderId).toBe("+15551234567");
+    expect(event?.channelId).toBe("ch_abc123");
+    expect(event?.channelType).toBe("blooio");
+    expect(event?.protocol).toBe("imessage");
     expect(event?.text).toBe("hey from v4");
     expect(event?.rawPayload).toEqual(JSON.parse(body));
   });
@@ -194,6 +197,20 @@ describe("blooio extractEvent", () => {
     );
 
     expect(event?.senderId).toBe("+15557654321");
+  });
+
+  test("preserves a v4 WhatsApp channel for the outbound reply", async () => {
+    const event = await blooioAdapter.extractEvent(
+      v4InboundPayload({
+        channel_id: "ch_whatsapp_123",
+        channel_type: "whatsapp_business",
+        protocol: "whatsapp",
+      }),
+    );
+
+    expect(event?.channelId).toBe("ch_whatsapp_123");
+    expect(event?.channelType).toBe("whatsapp_business");
+    expect(event?.protocol).toBe("whatsapp");
   });
 
   test("skips an event with no sender instead of emitting an unroutable ChatEvent", async () => {
@@ -291,7 +308,7 @@ describe("blooio sendReply", () => {
     rawPayload: {},
   };
 
-  test("POSTs to the chat with bearer auth, from-number, and an idempotency key", async () => {
+  test("POSTs through v4 with bearer auth, a fallback sender, and an idempotency key", async () => {
     let captured: { url: string; init: RequestInit } | null = null;
     globalThis.fetch = (async (
       url: string | URL | Request,
@@ -310,23 +327,51 @@ describe("blooio sendReply", () => {
       url: string;
       init: RequestInit;
     };
-    expect(url).toBe(
-      "https://api.blooio.com/v2/api/chats/%2B15551234567/messages",
-    );
+    expect(url).toBe("https://api.blooio.com/v4/messages");
     const headers = init.headers as Record<string, string>;
     expect(headers.Authorization).toBe("Bearer bl_live_test");
-    expect(headers["X-From-Number"]).toBe("+15550001111");
     expect(headers["Idempotency-Key"]).toBe("gw-reply-msg_abc123");
-    expect(JSON.parse(String(init.body))).toEqual({ text: "hello back" });
+    expect(JSON.parse(String(init.body))).toEqual({
+      to: "+15551234567",
+      from: "+15550001111",
+      text: "hello back",
+    });
   });
 
-  test("omits X-From-Number when no fromNumber is configured", async () => {
-    let headers: Record<string, string> = {};
+  test("pins a v4 reply to the exact inbound WhatsApp channel", async () => {
+    let body: Record<string, unknown> = {};
     globalThis.fetch = (async (
       _url: string | URL | Request,
       init?: RequestInit,
     ) => {
-      headers = (init?.headers ?? {}) as Record<string, string>;
+      body = JSON.parse(String(init?.body));
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    await blooioAdapter.sendReply(
+      makeConfig(),
+      {
+        ...chatEvent,
+        channelId: "ch_whatsapp_123",
+        channelType: "whatsapp_business",
+        protocol: "whatsapp",
+      },
+      "hi",
+    );
+    expect(body).toEqual({
+      to: "+15551234567",
+      from: "ch_whatsapp_123",
+      text: "hi",
+    });
+  });
+
+  test("allows v4 priority routing when no channel or fromNumber is available", async () => {
+    let body: Record<string, unknown> = {};
+    globalThis.fetch = (async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      body = JSON.parse(String(init?.body));
       return new Response("{}", { status: 200 });
     }) as typeof fetch;
 
@@ -335,7 +380,7 @@ describe("blooio sendReply", () => {
       chatEvent,
       "hi",
     );
-    expect(headers["X-From-Number"]).toBeUndefined();
+    expect(body).toEqual({ to: "+15551234567", text: "hi" });
   });
 
   test("throws when the API key is missing", async () => {

--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
@@ -7,7 +7,8 @@ import { z } from "zod";
 import { logger } from "../logger";
 import type { ChatEvent, PlatformAdapter, WebhookConfig } from "./types";
 
-const BLOOIO_API_BASE = "https://api.blooio.com/v2/api";
+const BLOOIO_V2_API_BASE = "https://api.blooio.com/v2/api";
+const BLOOIO_V4_MESSAGES_URL = "https://api.blooio.com/v4/messages";
 
 const BlooioAttachmentSchema = z.union([
   z.string(),
@@ -20,6 +21,8 @@ const BlooioV2WebhookEventSchema = z.object({
   external_id: z.string().nullish(),
   internal_id: z.string().nullish(),
   sender: z.string().trim().min(1).nullish(),
+  channel_id: z.string().trim().min(1).nullish(),
+  channel_type: z.string().trim().min(1).nullish(),
   text: z.string().nullish(),
   attachments: z.array(BlooioAttachmentSchema).nullish(),
   protocol: z.string().nullish(),
@@ -33,6 +36,8 @@ const BlooioV4MessageSchema = z
     id: z.string().trim().min(1).nullish(),
     message_id: z.string().trim().min(1).nullish(),
     chat_id: z.string().nullish(),
+    channel_id: z.string().trim().min(1).nullish(),
+    channel_type: z.string().trim().min(1).nullish(),
     sender: z.string().trim().min(1).nullish(),
     recipient: z.string().nullish(),
     channel_address: z.string().nullish(),
@@ -71,6 +76,8 @@ function parseWebhookEvent(data: unknown): BlooioWebhookEvent | null {
     external_id: sender,
     internal_id: message.recipient ?? message.channel_address,
     sender,
+    channel_id: message.channel_id,
+    channel_type: message.channel_type,
     text: message.text,
     attachments: message.attachments,
     protocol: message.protocol,
@@ -242,6 +249,9 @@ export const blooioAdapter: PlatformAdapter = {
       platform: "blooio",
       messageId: event.message_id,
       chatId: event.sender,
+      channelId: event.channel_id ?? undefined,
+      channelType: event.channel_type ?? undefined,
+      protocol: event.protocol ?? undefined,
       senderId: event.sender,
       text:
         mediaUrls.length > 0 && !text
@@ -259,7 +269,6 @@ export const blooioAdapter: PlatformAdapter = {
   ): Promise<void> {
     if (!config.apiKey) throw new Error("Missing apiKey for Blooio reply");
 
-    const url = `${BLOOIO_API_BASE}/chats/${encodeURIComponent(event.senderId)}/messages`;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${config.apiKey}`,
       "Content-Type": "application/json",
@@ -269,12 +278,18 @@ export const blooioAdapter: PlatformAdapter = {
       // double-text the user when retried.
       "Idempotency-Key": `gw-reply-${event.messageId}`,
     };
-    if (config.fromNumber) headers["X-From-Number"] = config.fromNumber;
 
-    const response = await fetch(url, {
+    const from = event.channelId ?? config.fromNumber;
+    const body: { to: string; text: string; from?: string } = {
+      to: event.senderId,
+      text,
+    };
+    if (from) body.from = from;
+
+    const response = await fetch(BLOOIO_V4_MESSAGES_URL, {
       method: "POST",
       headers,
-      body: JSON.stringify({ text }),
+      body: JSON.stringify(body),
     });
 
     if (!response.ok) {
@@ -289,7 +304,7 @@ export const blooioAdapter: PlatformAdapter = {
   ): Promise<void> {
     if (!config.apiKey) return;
     try {
-      const url = `${BLOOIO_API_BASE}/chats/${encodeURIComponent(event.senderId)}/read`;
+      const url = `${BLOOIO_V2_API_BASE}/chats/${encodeURIComponent(event.senderId)}/read`;
       const headers: Record<string, string> = {
         Authorization: `Bearer ${config.apiKey}`,
         "Content-Type": "application/json",

--- a/packages/cloud/services/gateway-webhook/src/adapters/types.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/types.ts
@@ -7,6 +7,9 @@ export interface ChatEvent {
   platformRecordId?: string;
   chatId: string;
   chatType?: string;
+  channelId?: string;
+  channelType?: string;
+  protocol?: string;
   senderId: string;
   senderName?: string;
   text: string;


### PR DESCRIPTION
Closes #19391

## What changed

- preserve v4 `channel_id`, `channel_type`, and `protocol` on normalized inbound events
- send all Blooio replies through `POST /v4/messages`
- use the exact inbound channel id as `from`, so replies stay on a provisioned WhatsApp channel
- retain `BLOOIO_PHONE_NUMBER` as the legacy-v2 fallback and let Blooio priority routing apply when neither is available
- keep stable per-inbound-message idempotency keys

## Validation

- `bun run test` — 120 passed
- `bun run typecheck`
- `bun run lint:check`
- `bun run build`
- focused v4 tests cover Blooio metadata, WhatsApp channel affinity, fallback sender, provider priority routing, malformed input, authentication, and error responses

## Live constraint

The current production Blooio organization lists one active `blooio` channel with iMessage/SMS/RCS protocols and no WhatsApp-capable channel. This change makes inbound/outbound routing channel-correct, but a real WhatsApp round trip remains blocked until Blooio provisions or exposes a `whatsapp` / `whatsapp_business` channel in that organization.