### PR TITLE
fix(homepage): copy messaging number on unsupported platforms

### DIFF
--- a/packages/homepage/src/index.css
+++ b/packages/homepage/src/index.css
@@ -1460,30 +1460,27 @@ html:has(.landing-page)::-webkit-scrollbar-thumb:hover {
   margin-top: 1.65rem;
 }
 
-.landing-phone-number {
+.landing-copy-notice {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom));
+  z-index: 40;
   display: inline-flex;
   align-items: center;
   min-height: 2.25rem;
   margin: 0.2rem 0 0;
   padding: 0 0.75rem;
-  border: 0;
   border-radius: 999px;
-  background: transparent;
-  color: #111;
+  background: rgb(255 255 255 / 76%);
+  color: #166534;
   font-size: 0.92rem;
   font-weight: 650;
-  letter-spacing: 0.02em;
-  cursor: pointer;
-  transition: background-color 160ms ease-out;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 14%);
+  transform: translateX(-50%);
 }
 
-.landing-phone-number:hover {
-  background: rgb(255 255 255 / 48%);
-}
-
-.landing-phone-number:focus-visible {
-  outline: 3px solid #111;
-  outline-offset: 2px;
+.landing-copy-notice--error {
+  color: #991b1b;
 }
 
 .landing-secondary-channels {
@@ -1494,6 +1491,7 @@ html:has(.landing-page)::-webkit-scrollbar-thumb:hover {
 }
 
 .landing-channel {
+  border: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1502,6 +1500,7 @@ html:has(.landing-page)::-webkit-scrollbar-thumb:hover {
   border-radius: 50%;
   background: rgb(255 255 255 / 76%);
   box-shadow: 0 6px 18px rgb(0 0 0 / 9%);
+  cursor: pointer;
   transition:
     transform 160ms ease-out,
     background-color 160ms ease-out,
@@ -1520,6 +1519,7 @@ html:has(.landing-page)::-webkit-scrollbar-thumb:hover {
 }
 
 .landing-cta {
+  border: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1529,6 +1529,8 @@ html:has(.landing-page)::-webkit-scrollbar-thumb:hover {
   border-radius: 999px;
   font-weight: 600;
   font-size: 1.05rem;
+  font-family: inherit;
+  cursor: pointer;
   text-decoration: none;
   white-space: nowrap;
   max-width: 100%;
@@ -2174,7 +2176,6 @@ html:has(.landing-page)::-webkit-scrollbar-thumb:hover {
      stray copy competing with the thread for width */
   .landing-hero-actions,
   .landing-secondary-channels,
-  .landing-phone-number,
   .landing-hero-lede {
     display: none;
   }

--- a/packages/homepage/src/lib/contact.ts
+++ b/packages/homepage/src/lib/contact.ts
@@ -2,12 +2,23 @@
  * Contact constants and link builders for homepage messaging entrypoints.
  */
 export const ELIZA_PHONE_NUMBER = "+18087881821";
-export const ELIZA_PHONE_FORMATTED = "+1 (808) 788-1821";
 export const ELIZA_TELEGRAM_BOT_USERNAME = "Elizav2_Bot";
 export const ELIZA_TELEGRAM_BOT_ID = "7684336618";
 export const ELIZA_DISCORD_APPLICATION_ID = "1468649258654630063";
 const DEFAULT_WHATSAPP_PHONE_NUMBER = "+14159611510";
 const IMESSAGE_GREETING = "Hey Eliza, what can you do?";
+
+interface MessageNavigator {
+  clipboard?: Pick<Clipboard, "writeText">;
+  platform?: string;
+  userAgent?: string;
+  userAgentData?: { platform?: string };
+}
+
+interface MessageWindow {
+  location: Pick<Location, "href">;
+  navigator: MessageNavigator;
+}
 
 function normalizeWhatsAppNumber(value: string): string | null {
   const normalized = value.trim();
@@ -49,6 +60,31 @@ export function getDiscordBotApplicationId(): string {
 
 export function buildElizaSmsHref(message: string = IMESSAGE_GREETING): string {
   return `sms:${ELIZA_PHONE_NUMBER}?&body=${encodeURIComponent(message)}`;
+}
+
+/** Whether this browser runs on a platform with a dependable native SMS handler. */
+export function canOpenElizaSmsLink(navigatorValue: MessageNavigator): boolean {
+  const platform =
+    navigatorValue.userAgentData?.platform ?? navigatorValue.platform ?? "";
+  const browserIdentity = `${platform} ${navigatorValue.userAgent ?? ""}`;
+  return /Android|iPhone|iPad|iPod|Mac/i.test(browserIdentity);
+}
+
+/** Open Messages where supported, otherwise copy the sender for manual use. */
+export async function openOrCopyElizaMessage(
+  windowValue: MessageWindow,
+  message: string = IMESSAGE_GREETING,
+): Promise<"opened" | "copied"> {
+  if (canOpenElizaSmsLink(windowValue.navigator)) {
+    windowValue.location.href = buildElizaSmsHref(message);
+    return "opened";
+  }
+
+  if (!windowValue.navigator.clipboard) {
+    throw new Error("Clipboard access is unavailable");
+  }
+  await windowValue.navigator.clipboard.writeText(ELIZA_PHONE_NUMBER);
+  return "copied";
 }
 
 export function buildElizaWhatsAppHref(): string | null {

--- a/packages/homepage/src/pages/connected.tsx
+++ b/packages/homepage/src/pages/connected.tsx
@@ -16,7 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@elizaos/ui/dropdown-menu";
 import { Check, Copy, Info, LogOut } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { ElizaLogo } from "@/components/brand/eliza-logo";
 import {
@@ -26,12 +26,11 @@ import {
 } from "@/components/login/phone-number-input";
 import {
   buildElizaDiscordHref,
-  buildElizaSmsHref,
   buildElizaTelegramHref,
   buildElizaWhatsAppHref,
-  ELIZA_PHONE_FORMATTED,
   ELIZA_PHONE_NUMBER,
   getTelegramBotUsername,
+  openOrCopyElizaMessage,
 } from "@/lib/contact";
 import { useAuth } from "@/lib/context/auth-context";
 import { type Translator, useT } from "@/providers/I18nProvider";
@@ -90,7 +89,10 @@ export default function ConnectedPage() {
   const t = useT();
   const { user, organization, isAuthenticated, isLoading, logout, linkPhone } =
     useAuth();
-  const [copiedPhone, setCopiedPhone] = useState(false);
+  const [phoneCopyState, setPhoneCopyState] = useState<
+    "idle" | "copied" | "error"
+  >("idle");
+  const phoneCopyResetRef = useRef<number | null>(null);
   const [copiedTelegram, setCopiedTelegram] = useState(false);
   const [copiedWhatsApp, setCopiedWhatsApp] = useState(false);
 
@@ -159,10 +161,33 @@ export default function ConnectedPage() {
     }
   }, [isAuthenticated, isLoading, navigate]);
 
+  useEffect(
+    () => () => {
+      if (phoneCopyResetRef.current !== null) {
+        window.clearTimeout(phoneCopyResetRef.current);
+      }
+    },
+    [],
+  );
+
+  const setTemporaryPhoneCopyState = (state: "copied" | "error") => {
+    setPhoneCopyState(state);
+    if (phoneCopyResetRef.current !== null) {
+      window.clearTimeout(phoneCopyResetRef.current);
+    }
+    phoneCopyResetRef.current = window.setTimeout(
+      () => setPhoneCopyState("idle"),
+      2_000,
+    );
+  };
+
   const handleCopyPhone = async () => {
-    await navigator.clipboard.writeText(ELIZA_PHONE_NUMBER);
-    setCopiedPhone(true);
-    setTimeout(() => setCopiedPhone(false), 2000);
+    try {
+      await navigator.clipboard.writeText(ELIZA_PHONE_NUMBER);
+      setTemporaryPhoneCopyState("copied");
+    } catch {
+      setTemporaryPhoneCopyState("error");
+    }
   };
 
   const handleCopyTelegram = async () => {
@@ -195,8 +220,13 @@ export default function ConnectedPage() {
     if (whatsappHref) window.open(whatsappHref, "_blank");
   };
 
-  const handleOpenMessages = () => {
-    window.location.href = buildElizaSmsHref();
+  const handleOpenMessages = async () => {
+    try {
+      const outcome = await openOrCopyElizaMessage(window);
+      if (outcome === "copied") setTemporaryPhoneCopyState("copied");
+    } catch {
+      setTemporaryPhoneCopyState("error");
+    }
   };
 
   if (isLoading) {
@@ -249,6 +279,23 @@ export default function ConnectedPage() {
       className="theme-app brand-section brand-section--orange relative flex min-h-screen flex-col items-center px-4 pb-6 pt-24"
       style={{ fontFamily: "Geist, system-ui, sans-serif" }}
     >
+      {phoneCopyState !== "idle" && (
+        <div
+          className={`fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-full bg-white px-4 py-2 text-sm font-medium shadow-lg ${
+            phoneCopyState === "copied" ? "text-green-700" : "text-red-700"
+          }`}
+          role="status"
+          aria-live="polite"
+        >
+          {phoneCopyState === "copied"
+            ? t("homepage_eliza.connected.phoneCopied", {
+                defaultValue: "Phone number copied",
+              })
+            : t("homepage_eliza.connected.phoneCopyFailed", {
+                defaultValue: "Couldn't copy the phone number",
+              })}
+        </div>
+      )}
       <header className="absolute top-0 inset-x-0 z-10 p-4 flex items-center justify-between pointer-events-none">
         <Link
           to="/"
@@ -447,7 +494,7 @@ export default function ConnectedPage() {
             <div className="w-full h-[72px] bg-white hover:bg-black hover:text-white text-black flex items-center px-5 transition-colors group">
               <button
                 type="button"
-                onClick={handleOpenMessages}
+                onClick={() => void handleOpenMessages()}
                 className="flex h-full min-w-0 flex-1 cursor-pointer items-center gap-4 border-0 bg-transparent p-0 text-left text-black group-hover:text-white"
               >
                 <div className="w-8 h-8 shrink-0 flex items-center justify-center">
@@ -458,9 +505,6 @@ export default function ConnectedPage() {
                     {t("homepage_eliza.connected.imessageLabel", {
                       defaultValue: "iMessage",
                     })}
-                  </span>
-                  <span className="text-sm text-black/70 group-hover:text-white/80">
-                    {ELIZA_PHONE_FORMATTED}
                   </span>
                 </div>
               </button>
@@ -480,7 +524,7 @@ export default function ConnectedPage() {
                   defaultValue: "Copy phone number",
                 })}
               >
-                {copiedPhone ? (
+                {phoneCopyState === "copied" ? (
                   <Check className="size-5 text-green-400" />
                 ) : (
                   <Copy className="size-5" />

--- a/packages/homepage/src/pages/get-started.tsx
+++ b/packages/homepage/src/pages/get-started.tsx
@@ -10,7 +10,7 @@ import {
   TelegramIcon,
   WhatsAppIcon,
 } from "@elizaos/ui/cloud-ui/components/icons";
-import { ArrowLeft, Check, Copy, ExternalLink, Info, Send } from "lucide-react";
+import { ArrowLeft, Check, ExternalLink, Info, Send } from "lucide-react";
 import {
   type CSSProperties,
   lazy,
@@ -42,14 +42,12 @@ const ShaderBackground = lazy(
 
 import { elizacloudAuthFetch } from "@/lib/api/client";
 import {
-  buildElizaSmsHref,
   buildElizaTelegramHref,
-  ELIZA_PHONE_FORMATTED,
-  ELIZA_PHONE_NUMBER,
   getDiscordBotApplicationId,
   getTelegramBotId,
   getTelegramBotUsername,
   getWhatsAppNumber,
+  openOrCopyElizaMessage,
 } from "@/lib/contact";
 import {
   getAuthToken,
@@ -707,13 +705,25 @@ export default function GetStartedPage() {
   const [isSubmittingPhone, setIsSubmittingPhone] = useState(false);
 
   const [suppressRedirect, setSuppressRedirect] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const [messageNotice, setMessageNotice] = useState<
+    "idle" | "copied" | "error"
+  >("idle");
+  const messageNoticeResetRef = useRef<number | null>(null);
   const [showContent, setShowContent] = useState(false);
 
   useEffect(() => {
     const timer = setTimeout(() => setShowContent(true), 100);
     return () => clearTimeout(timer);
   }, []);
+
+  useEffect(
+    () => () => {
+      if (messageNoticeResetRef.current !== null) {
+        window.clearTimeout(messageNoticeResetRef.current);
+      }
+    },
+    [],
+  );
 
   const headerStyle: CSSProperties = {
     opacity: showContent ? 1 : 0,
@@ -1288,14 +1298,20 @@ export default function GetStartedPage() {
     await handleDiscordAuthSubmit();
   }, [handleDiscordAuthSubmit]);
 
-  const handleCopyNumber = async () => {
-    await navigator.clipboard.writeText(ELIZA_PHONE_NUMBER);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  const handleOpenMessages = () => {
-    window.location.href = buildElizaSmsHref();
+  const handleOpenMessages = async () => {
+    try {
+      const outcome = await openOrCopyElizaMessage(window);
+      setMessageNotice(outcome === "copied" ? "copied" : "idle");
+    } catch {
+      setMessageNotice("error");
+    }
+    if (messageNoticeResetRef.current !== null) {
+      window.clearTimeout(messageNoticeResetRef.current);
+    }
+    messageNoticeResetRef.current = window.setTimeout(
+      () => setMessageNotice("idle"),
+      2_000,
+    );
   };
 
   const handleContinueToConnected = () => {
@@ -1792,35 +1808,35 @@ export default function GetStartedPage() {
                 })}
               </p>
 
-              <div className={`w-full p-4 ${GLASS_TILE} rounded-2xl mb-6`}>
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-lg font-medium tabular-nums tracking-wide text-neutral-900">
-                    {ELIZA_PHONE_FORMATTED}
-                  </span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleCopyNumber}
-                    className="shrink-0 text-neutral-500 hover:text-neutral-900 hover:bg-neutral-200/50"
-                  >
-                    {copied ? (
-                      <Check className="size-4 text-green-500" />
-                    ) : (
-                      <Copy className="size-4" />
-                    )}
-                  </Button>
-                </div>
-              </div>
-
               <Button
-                onClick={handleOpenMessages}
+                onClick={() => void handleOpenMessages()}
                 className="w-full h-[52px] rounded-full bg-neutral-900 hover:bg-neutral-800 text-white font-medium gap-2"
               >
                 <IMessageIcon className="size-5 text-[#34C759]" />
                 {t("homepage_eliza.getStarted.openImessage", {
-                  defaultValue: "Open iMessage",
+                  defaultValue: "Message Eliza",
                 })}
               </Button>
+
+              {messageNotice !== "idle" && (
+                <p
+                  role="status"
+                  aria-live="polite"
+                  className={`mt-3 text-center text-sm font-medium ${
+                    messageNotice === "copied"
+                      ? "text-green-700"
+                      : "text-red-700"
+                  }`}
+                >
+                  {messageNotice === "copied"
+                    ? t("homepage_eliza.getStarted.phoneCopied", {
+                        defaultValue: "Phone number copied",
+                      })
+                    : t("homepage_eliza.getStarted.phoneCopyFailed", {
+                        defaultValue: "Couldn't copy the phone number",
+                      })}
+                </p>
+              )}
 
               <button
                 type="button"

--- a/packages/homepage/src/pages/landing.tsx
+++ b/packages/homepage/src/pages/landing.tsx
@@ -28,11 +28,10 @@ import {
 import elizaLogotextUrl from "@/assets/eliza-logotext.svg";
 import {
   buildElizaDiscordHref,
-  buildElizaSmsHref,
   buildElizaTelegramHref,
   buildElizaWhatsAppHref,
-  ELIZA_PHONE_FORMATTED,
   ELIZA_PHONE_NUMBER,
+  openOrCopyElizaMessage,
 } from "@/lib/contact";
 import { resolveHomepageProductNavigation } from "@/lib/product-navigation";
 import { useT } from "@/providers/I18nProvider";
@@ -671,10 +670,10 @@ export default function LandingPage() {
     [],
   );
 
-  const copyPhoneNumber = async () => {
+  const handleMessageEliza = async () => {
     try {
-      await navigator.clipboard.writeText(ELIZA_PHONE_NUMBER);
-      setPhoneCopyState("copied");
+      const outcome = await openOrCopyElizaMessage(window);
+      setPhoneCopyState(outcome === "copied" ? "copied" : "idle");
     } catch {
       setPhoneCopyState("error");
     }
@@ -690,13 +689,11 @@ export default function LandingPage() {
   const phoneCopyLabel =
     phoneCopyState === "copied"
       ? t("homepage_eliza.landing.phoneCopied", {
-          defaultValue: "Copied!",
+          defaultValue: "Phone number copied",
         })
-      : phoneCopyState === "error"
-        ? t("homepage_eliza.landing.phoneCopyFailed", {
-            defaultValue: "Couldn't copy",
-          })
-        : ELIZA_PHONE_FORMATTED;
+      : t("homepage_eliza.landing.phoneCopyFailed", {
+          defaultValue: "Couldn't copy the phone number",
+        });
   return (
     <div className="landing-page theme-app">
       <Suspense fallback={null}>
@@ -710,16 +707,17 @@ export default function LandingPage() {
         })}
       >
         <span className="landing-topbar-channels">
-          <a
+          <button
+            type="button"
             className="landing-channel"
-            href={buildElizaSmsHref()}
+            onClick={() => void handleMessageEliza()}
             aria-label={t("homepage_eliza.landing.channelImessage", {
               defaultValue: "Text Eliza on iMessage",
             })}
           >
             <IMessageIcon className="size-6" style={{ color: "#34C759" }} />
             <span className="sr-only">iMessage</span>
-          </a>
+          </button>
           <a
             className="landing-channel"
             href={`tel:${ELIZA_PHONE_NUMBER}`}
@@ -820,15 +818,16 @@ export default function LandingPage() {
             })}
           </h1>
           <div className="landing-hero-actions">
-            <a
+            <button
+              type="button"
               className="landing-cta landing-cta--black"
-              href={buildElizaSmsHref()}
+              onClick={() => void handleMessageEliza()}
             >
               <IMessageIcon className="size-5" />
               {t("homepage_eliza.landing.ctaText", {
-                defaultValue: "Text Eliza",
+                defaultValue: "Message Eliza",
               })}
-            </a>
+            </button>
             <a
               className="landing-cta landing-cta--white"
               href={`tel:${ELIZA_PHONE_NUMBER}`}
@@ -861,16 +860,15 @@ export default function LandingPage() {
               </a>
             ))}
           </div>
-          <button
-            type="button"
-            className="landing-phone-number"
-            onClick={() => void copyPhoneNumber()}
-            aria-label={t("homepage_eliza.landing.copyPhone", {
-              defaultValue: "Copy Eliza's phone number",
-            })}
-          >
-            <span aria-live="polite">{phoneCopyLabel}</span>
-          </button>
+          {phoneCopyState !== "idle" && (
+            <div
+              className={`landing-copy-notice landing-copy-notice--${phoneCopyState}`}
+              role="status"
+              aria-live="polite"
+            >
+              {phoneCopyLabel}
+            </div>
+          )}
         </div>
         <ResponsivePhoneMockup />
       </main>

--- a/packages/homepage/tests/contact.test.ts
+++ b/packages/homepage/tests/contact.test.ts
@@ -8,21 +8,21 @@ import {
   buildElizaSmsHref,
   buildElizaTelegramHref,
   buildElizaWhatsAppHref,
+  canOpenElizaSmsLink,
   ELIZA_DISCORD_APPLICATION_ID,
-  ELIZA_PHONE_FORMATTED,
   ELIZA_PHONE_NUMBER,
   ELIZA_TELEGRAM_BOT_ID,
   ELIZA_TELEGRAM_BOT_USERNAME,
   getDiscordBotApplicationId,
   getTelegramBotId,
   getWhatsAppNumber,
+  openOrCopyElizaMessage,
   resolveWhatsAppNumber,
 } from "../src/lib/contact";
 
 describe("Eliza contact links", () => {
   test("builds an SMS link to the hosted Blooio number", () => {
     expect(ELIZA_PHONE_NUMBER).toBe("+18087881821");
-    expect(ELIZA_PHONE_FORMATTED).toBe("+1 (808) 788-1821");
     expect(buildElizaSmsHref()).toBe(
       `sms:${ELIZA_PHONE_NUMBER}?&body=Hey%20Eliza%2C%20what%20can%20you%20do%3F`,
     );
@@ -54,5 +54,56 @@ describe("Eliza contact links", () => {
     );
     expect(getTelegramBotId()).toBe(ELIZA_TELEGRAM_BOT_ID);
     expect(getDiscordBotApplicationId()).toBe(ELIZA_DISCORD_APPLICATION_ID);
+  });
+
+  test("opens the native SMS handler only on supported platforms", async () => {
+    for (const platform of ["iPhone", "iPad", "MacIntel", "Android"]) {
+      expect(canOpenElizaSmsLink({ platform })).toBe(true);
+    }
+    expect(canOpenElizaSmsLink({ platform: "Win32" })).toBe(false);
+    expect(canOpenElizaSmsLink({ platform: "Linux x86_64" })).toBe(false);
+
+    const location = { href: "https://eliza.app/" };
+    const clipboardWrites: string[] = [];
+    await expect(
+      openOrCopyElizaMessage({
+        location,
+        navigator: {
+          platform: "MacIntel",
+          clipboard: {
+            writeText: async (value) => {
+              clipboardWrites.push(value);
+            },
+          },
+        },
+      }),
+    ).resolves.toBe("opened");
+    expect(location.href).toBe(buildElizaSmsHref());
+    expect(clipboardWrites).toEqual([]);
+  });
+
+  test("copies the sender on unsupported platforms and fails visibly without a clipboard", async () => {
+    const clipboardWrites: string[] = [];
+    await expect(
+      openOrCopyElizaMessage({
+        location: { href: "https://eliza.app/" },
+        navigator: {
+          platform: "Win32",
+          clipboard: {
+            writeText: async (value) => {
+              clipboardWrites.push(value);
+            },
+          },
+        },
+      }),
+    ).resolves.toBe("copied");
+    expect(clipboardWrites).toEqual([ELIZA_PHONE_NUMBER]);
+
+    await expect(
+      openOrCopyElizaMessage({
+        location: { href: "https://eliza.app/" },
+        navigator: { platform: "Linux x86_64" },
+      }),
+    ).rejects.toThrow("Clipboard access is unavailable");
   });
 });

--- a/packages/homepage/tests/e2e/app-routes-flow.spec.ts
+++ b/packages/homepage/tests/e2e/app-routes-flow.spec.ts
@@ -3,7 +3,6 @@
  */
 
 import { expect, type Page, test } from "playwright/test";
-import { ELIZA_PHONE_FORMATTED } from "../../src/lib/contact";
 import { waitForLandingIntro } from "./landing-readiness";
 
 const TEST_TOKEN = "homepage-e2e-token";
@@ -319,13 +318,8 @@ test("connected page exercises account menu, copy controls, link-phone form, and
   await page.getByLabel("Phone number").fill("416 555 0123");
   await page.getByRole("button", { name: "Link Phone" }).click();
   await expect(page.getByLabel("Phone number", { exact: true })).toHaveCount(0);
-  await expect(
-    page.getByRole("button", {
-      name: new RegExp(
-        `iMessage ${ELIZA_PHONE_FORMATTED.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
-      ),
-    }),
-  ).toBeVisible();
+  await expect(page.getByRole("button", { name: /^iMessage$/ })).toBeVisible();
+  await expect(page.getByText("+1 (808) 788-1821")).toHaveCount(0);
 
   await page.getByRole("button", { name: "Connect Discord" }).click();
   await expect(page).toHaveURL(/\/get-started\?method=discord&link=true/);
@@ -342,20 +336,18 @@ test("landing leads with iMessage and keeps secondary channels available", async
     page.getByRole("heading", { name: /Four hours of your time back/ }),
   ).toBeVisible({ timeout: 20_000 });
 
-  const textCta = page.getByRole("link", { name: "Text Eliza" });
+  const textCta = page.getByRole("button", { name: "Message Eliza" });
   await expect(textCta).toBeVisible();
-  await expect(textCta).toHaveAttribute("href", /^sms:\+18087881821/);
-  const phoneNumber = page.getByRole("button", {
-    name: "Copy Eliza's phone number",
-  });
-  await expect(phoneNumber).toHaveText("+1 (808) 788-1821");
-  await phoneNumber.click();
-  await expect(phoneNumber).toHaveText("Copied!");
+  await textCta.click();
+  await expect(page.getByRole("status")).toHaveText("Phone number copied");
+  await expect(page.getByText("+1 (808) 788-1821")).toHaveCount(0);
   await expect(page.getByRole("link", { name: "Call" })).toHaveAttribute(
     "href",
     "tel:+18087881821",
   );
-  await expect(page.locator(".landing-channel")).toHaveCount(3);
+  await expect(
+    page.locator(".landing-secondary-channels .landing-channel"),
+  ).toHaveCount(3);
   await expect(
     page.getByRole("link", { name: "Message Eliza on Telegram" }),
   ).toBeVisible();
@@ -368,12 +360,7 @@ test("landing leads with iMessage and keeps secondary channels available", async
   const channelRow = await page
     .locator(".landing-secondary-channels")
     .boundingBox();
-  const phoneNumberBox = await phoneNumber.boundingBox();
   expect(channelRow).not.toBeNull();
-  expect(phoneNumberBox).not.toBeNull();
-  expect(phoneNumberBox?.y).toBeGreaterThanOrEqual(
-    (channelRow?.y ?? 0) + (channelRow?.height ?? 0),
-  );
 
   const keyboard = page.locator(".landing-keyboard");
   await expect(keyboard).toHaveAttribute("data-open", "true", {

--- a/packages/homepage/tests/e2e/zoom-reflow.spec.ts
+++ b/packages/homepage/tests/e2e/zoom-reflow.spec.ts
@@ -46,8 +46,10 @@ async function expectFullyInViewport(page: Page, locator: Locator) {
     page.viewportSize()?.width ?? 0,
   );
   expect(bounds?.y).toBeGreaterThanOrEqual(0);
+  // Browser text scaling can place the fractional CSS-pixel edge just past
+  // the integer viewport while the control remains fully painted.
   expect((bounds?.y ?? 0) + (bounds?.height ?? 0)).toBeLessThanOrEqual(
-    page.viewportSize()?.height ?? 0,
+    (page.viewportSize()?.height ?? 0) + 1,
   );
 }
 
@@ -63,11 +65,14 @@ for (const viewport of REFLOW_VIEWPORTS) {
     // Narrow viewports render the full-screen conversation with an icon top
     // bar; wider ones keep the hero's labelled pills. Assert on the entry
     // points themselves so the check holds for whichever layout is painted.
-    const textCta = page.locator('a[href^="sms:"]:visible').first();
+    const textCta = page
+      .getByRole("button", { name: /Message Eliza|Text Eliza on iMessage/ })
+      .filter({ visible: true })
+      .first();
     const _callCta = page.locator('a[href^="tel:"]:visible').first();
     await textCta.scrollIntoViewIfNeeded();
     await expectFullyInViewport(page, textCta);
-    await expect(page.getByText("+1 (808) 788-1821")).toBeVisible();
+    await expect(page.getByText("+1 (808) 788-1821")).toHaveCount(0);
   });
 
   test(`downloads reflows at 200% in ${viewport.width}x${viewport.height}`, async ({


### PR DESCRIPTION
Closes #19388.

## Outcome

- removes the visible `+1 (808) 788-1821` string from landing, get-started, and connected surfaces
- changes messaging entry points to open the native SMS/iMessage handler on Android and Apple platforms
- copies the number on Windows/Linux/other unsupported platforms and shows a visible success notification
- shows an explicit error notification when clipboard access fails
- clears notification timers on unmount and keeps status announcements accessible

## Verification

- `bun run --cwd packages/homepage test` — 101 pass
- `bun run --cwd packages/homepage typecheck` — pass
- `bun run --cwd packages/homepage lint:check` — pass
- focused homepage Playwright route + 200% reflow suite — 12 pass
- homepage contact-sheet capture — 14 pass; desktop and mobile landing captures reviewed
- `git diff --check` — pass
- source scan confirms the formatted number no longer exists in shipped homepage source

The aggregate aesthetic audit was also run. Its route/interaction harness currently fails on pre-existing strict corner-radius findings in the phone mockup, a hidden mobile leaderboard logo, and the unrelated Solana auth redirect; the changed contact sheet and focused browser flows pass.

No secrets or credential values are included.