### PR TITLE
fix(cloud): stop voice output on caller turn start

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -1570,7 +1570,7 @@ describe("voice-session WS lifecycle", () => {
     expect(client.audioFrames.length).toBe(framesAfterInterrupt);
   });
 
-  test("acoustic activity interrupts only after Ink registers caller words", async () => {
+  test("semantic turn-start interrupts immediately and the caller gets the next response", async () => {
     const client = new FakeClientSocket();
     await connectSession({
       client,
@@ -1589,21 +1589,21 @@ describe("voice-session WS lifecycle", () => {
     expect(client.controlTypes()).toContain("speaking_start");
     expect(cartesia.closed).toBe(false);
 
-    // Acoustic turn-start and punctuation-only revisions can be background
-    // noise or echo. They must not clear audio or cancel the active response.
+    const audioBeforeInterruption = client.audioFrames.length;
     ink.emitTurn("turn.start");
-    ink.emitTurn("turn.update", "...");
-    await flush();
-    expect(client.controlTypes()).not.toContain("interrupted");
-    expect(cartesia.closed).toBe(false);
-
-    // The first partial containing a letter/number is confirmed caller speech.
-    ink.emitTurn("turn.update", "wait");
     await flush();
     expect(client.controlFrames).toContainEqual(
       expect.objectContaining({ t: "interrupted", reason: "acoustic" }),
     );
     expect(cartesia.closed).toBe(true);
+    expect(client.audioFrames).toHaveLength(audioBeforeInterruption);
+
+    ink.emitTurn("turn.update", "wait");
+    ink.emitTurn("turn.end", "wait");
+    await flush();
+    await flush();
+    expect(FakeCartesiaSocket.instances.at(-1)).not.toBe(cartesia);
+    expect(client.audioFrames.length).toBeGreaterThan(audioBeforeInterruption);
   });
 
   test("a final-only caller transcript still interrupts the active response", async () => {

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -13,7 +13,7 @@
  *     `CartesiaSonicTtsAdapter` (#15949). Phrase-aggregated deltas stream in;
  *     adapters' strict no-post-cancel guarantee makes barge-in correct.
  *
- * Interruption (contract §7.5): confirmed caller words / explicit `barge_in`
+ * Interruption (contract §7.5): Ink semantic turn-start / explicit `barge_in`
  * -> under one `voiceTurnId`, cancel the active TTS stream (no post-cancel
  * frames), abort the Eliza SSE fetch, flush the downlink, drop pending phrase
  * aggregation, emit `interrupted`, return to listening. Target <250ms.
@@ -486,13 +486,13 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         break;
       }
       case "start-of-turn": {
-        // Ink's acoustic turn detector also fires for line noise, breathing,
-        // and speaker echo. Keep transcribing alongside the active response;
-        // only a non-empty transcript-update below proves caller speech and
-        // earns the right to cancel model/TTS work.
+        // Ink's semantic turn detector is the earliest reliable signal that
+        // the caller has begun a new utterance. Stop current audio immediately
+        // so Eliza never talks over the caller while transcription continues.
         this.resetSttPartialDelivery();
         this.activeSttTurn = true;
-        if (!this.currentVoiceTurnId) this.state = "transcribing";
+        this.interrupt("acoustic");
+        this.state = "transcribing";
         break;
       }
       case "transcript-update": {


### PR DESCRIPTION
Closes #19395

## Outcome

- stops active Eliza LLM/TTS output immediately when Cartesia Ink emits semantic `turn.start`
- continues transcribing the caller and generates the replacement reply on `turn.end`
- preserves the existing zero-post-cancel-audio guarantee

## Verification

- full voice-session lifecycle suite passed, including immediate interruption followed by the next response
- cloud API typecheck and production Worker dry-run passed
- cloud API lint passed
- `bun run verify:cloud`: 78/78 tasks passed
- deployed exact commit `341d1c31fba6b8148014ec55ca8583920ca930f2` as production Worker version `d0639bd7-33e3-4469-9cd5-8bf2d7ca834e`

## Live carrier evidence

- call `CA555367c6e0ac270a2bc48c97da60c30b`, dual-channel recording `RE111c08afa7477228c165624a46663089`: Eliza audio ended at 7.10s; caller interruption began at 9.30s; no overlap; replacement reply followed
- call `CA791c69fce43fc58b56eefb45d431b824`, dual-channel recording `REf65fe8f4b7eb9d02318c0db207914e05`: tighter caller turn interrupted the obsolete response while it was still thinking, so only the replacement response played

## AI provenance

Implemented and verified with Codex in response to interactive production call feedback.
