### PR TITLE
fix(cloud): validate inference auth hydration deadline

### DIFF
--- a/packages/cloud/shared/AGENTS.md
+++ b/packages/cloud/shared/AGENTS.md
@@ -82,6 +82,8 @@ bun run --cwd packages/cloud/shared generate:email-templates
 
 `CREDIT_COST_BUFFER` (`credits-config.ts`, default `1.5`) sizes the safety margin on every pre-request credit reservation and affiliate-admission check (`credits.ts`'s `reserve()` and `organization-inference-admission.ts`). Must be a canonical decimal from `1` through `1000` (`1` = no buffer); unset/blank uses the default, anything else throws `ElizaError` (`INVALID_CREDIT_COST_BUFFER`) at module load. The minimum is `1`, not `0` — a buffer below `1` underflows the reservation calculation back toward `MIN_RESERVATION`, defeating the purpose of the setting.
 
+`INFERENCE_AUTH_HYDRATION_DEADLINE_MS` (`inference-auth-context.ts`, default `10000`) bounds a background auth hydration attempt. It must be a canonical decimal integer from `1` through `2147483647`; unset/blank uses the default, and invalid values throw `ElizaError` (`INVALID_INFERENCE_AUTH_HYDRATION_DEADLINE`) at module load.
+
 ## How to extend
 
 - **New table:** add a schema in `src/db/schemas/`, then `bun run --cwd packages/cloud/shared db:generate`, review the SQL in `src/db/migrations/`, run `db:migrate`, commit schema + migration together. Add a repository in `src/db/repositories/` (reader and writer split per CQRS).

--- a/packages/cloud/shared/CLAUDE.md
+++ b/packages/cloud/shared/CLAUDE.md
@@ -82,6 +82,8 @@ bun run --cwd packages/cloud/shared generate:email-templates
 
 `CREDIT_COST_BUFFER` (`credits-config.ts`, default `1.5`) sizes the safety margin on every pre-request credit reservation and affiliate-admission check (`credits.ts`'s `reserve()` and `organization-inference-admission.ts`). Must be a canonical decimal from `1` through `1000` (`1` = no buffer); unset/blank uses the default, anything else throws `ElizaError` (`INVALID_CREDIT_COST_BUFFER`) at module load. The minimum is `1`, not `0` — a buffer below `1` underflows the reservation calculation back toward `MIN_RESERVATION`, defeating the purpose of the setting.
 
+`INFERENCE_AUTH_HYDRATION_DEADLINE_MS` (`inference-auth-context.ts`, default `10000`) bounds a background auth hydration attempt. It must be a canonical decimal integer from `1` through `2147483647`; unset/blank uses the default, and invalid values throw `ElizaError` (`INVALID_INFERENCE_AUTH_HYDRATION_DEADLINE`) at module load.
+
 ## How to extend
 
 - **New table:** add a schema in `src/db/schemas/`, then `bun run --cwd packages/cloud/shared db:generate`, review the SQL in `src/db/migrations/`, run `db:migrate`, commit schema + migration together. Add a repository in `src/db/repositories/` (reader and writer split per CQRS).

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -82,8 +82,12 @@ mock.module("./inference-app-key-scope", () => ({
   loadInferenceAppKeyScope: async () => null,
 }));
 
-const { __clearInferenceApiKeyHydrations, resolveInferenceAuthContext, extractApiKeyCredential } =
-  await import("./inference-auth-context");
+const {
+  __clearInferenceApiKeyHydrations,
+  resolveInferenceAuthContext,
+  extractApiKeyCredential,
+  resolveInferenceAuthHydrationDeadlineMs,
+} = await import("./inference-auth-context");
 const { cache } = await import("../cache/client");
 const { CacheKeys } = await import("../cache/keys");
 const {
@@ -118,6 +122,36 @@ beforeEach(async () => {
 
 afterEach(() => {
   mock.restore();
+});
+
+describe("resolveInferenceAuthHydrationDeadlineMs", () => {
+  test.each([
+    [undefined, 10_000],
+    ["", 10_000],
+    ["  ", 10_000],
+    ["1", 1],
+    [" 60 ", 60],
+    ["2147483647", 2_147_483_647],
+  ])("resolves a timer-safe hydration deadline from %p", (raw, expected) => {
+    expect(resolveInferenceAuthHydrationDeadlineMs(raw)).toBe(expected);
+  });
+
+  test.each([
+    "0",
+    "-1",
+    "+1",
+    "1.5",
+    "1e3",
+    "60ms",
+    "NaN",
+    "Infinity",
+    "2147483648",
+    "9007199254740992",
+  ])("rejects an invalid hydration deadline %p", (raw) => {
+    expect(() => resolveInferenceAuthHydrationDeadlineMs(raw)).toThrow(
+      "INFERENCE_AUTH_HYDRATION_DEADLINE_MS must be an integer from 1 through 2147483647 milliseconds",
+    );
+  });
 });
 
 describe("extractApiKeyCredential", () => {

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -148,9 +148,19 @@ describe("resolveInferenceAuthHydrationDeadlineMs", () => {
     "2147483648",
     "9007199254740992",
   ])("rejects an invalid hydration deadline %p", (raw) => {
-    expect(() => resolveInferenceAuthHydrationDeadlineMs(raw)).toThrow(
-      "INFERENCE_AUTH_HYDRATION_DEADLINE_MS must be an integer from 1 through 2147483647 milliseconds",
-    );
+    let thrown: unknown;
+    try {
+      resolveInferenceAuthHydrationDeadlineMs(raw);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toMatchObject({
+      code: "INVALID_INFERENCE_AUTH_HYDRATION_DEADLINE",
+      context: {
+        envKey: "INFERENCE_AUTH_HYDRATION_DEADLINE_MS",
+        configured: raw,
+      },
+    });
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -157,6 +157,8 @@ interface MutableInferenceAuthTrace {
 
 const apiKeyHydrations = new Map<string, Promise<void>>();
 const AUTH_CONTEXT_REFRESH_AFTER_MS = 30_000;
+const DEFAULT_HYDRATION_DEADLINE_MS = 10_000;
+const MAX_HYDRATION_DEADLINE_MS = 2_147_483_647;
 
 const OPAQUE_TRACE_ID =
   /^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
@@ -286,7 +288,28 @@ export function extractApiKeyCredential(req: Request): string | null {
  * settled). On deadline the slot clears so the next request starts a fresh
  * attempt, and the miss counts toward the authoritative-escape threshold.
  */
-const HYDRATION_DEADLINE_MS = Number(process.env.INFERENCE_AUTH_HYDRATION_DEADLINE_MS ?? "10000");
+export function resolveInferenceAuthHydrationDeadlineMs(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === "") {
+    return DEFAULT_HYDRATION_DEADLINE_MS;
+  }
+  const normalized = raw.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(
+      `INFERENCE_AUTH_HYDRATION_DEADLINE_MS must be an integer from 1 through ${MAX_HYDRATION_DEADLINE_MS} milliseconds`,
+    );
+  }
+  const parsed = Number(normalized);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > MAX_HYDRATION_DEADLINE_MS) {
+    throw new Error(
+      `INFERENCE_AUTH_HYDRATION_DEADLINE_MS must be an integer from 1 through ${MAX_HYDRATION_DEADLINE_MS} milliseconds`,
+    );
+  }
+  return parsed;
+}
+
+const HYDRATION_DEADLINE_MS = resolveInferenceAuthHydrationDeadlineMs(
+  process.env.INFERENCE_AUTH_HYDRATION_DEADLINE_MS,
+);
 
 /**
  * After this many consecutive failed or timed-out hydrations for one key,

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -23,6 +23,7 @@
  */
 
 import { createHash, timingSafeEqual } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
 import { getErrorStatusCode } from "../api/errors";
 import { type CacheBackendKind, cache } from "../cache/client";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
@@ -294,17 +295,24 @@ export function resolveInferenceAuthHydrationDeadlineMs(raw: string | undefined)
   }
   const normalized = raw.trim();
   if (!/^\d+$/.test(normalized)) {
-    throw new Error(
-      `INFERENCE_AUTH_HYDRATION_DEADLINE_MS must be an integer from 1 through ${MAX_HYDRATION_DEADLINE_MS} milliseconds`,
-    );
+    throw invalidHydrationDeadline(raw);
   }
   const parsed = Number(normalized);
   if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > MAX_HYDRATION_DEADLINE_MS) {
-    throw new Error(
-      `INFERENCE_AUTH_HYDRATION_DEADLINE_MS must be an integer from 1 through ${MAX_HYDRATION_DEADLINE_MS} milliseconds`,
-    );
+    throw invalidHydrationDeadline(raw);
   }
   return parsed;
+}
+
+function invalidHydrationDeadline(configured: string): ElizaError {
+  return new ElizaError(
+    `INFERENCE_AUTH_HYDRATION_DEADLINE_MS must be an integer from 1 through ${MAX_HYDRATION_DEADLINE_MS} milliseconds`,
+    {
+      code: "INVALID_INFERENCE_AUTH_HYDRATION_DEADLINE",
+      context: { envKey: "INFERENCE_AUTH_HYDRATION_DEADLINE_MS", configured },
+      severity: "fatal",
+    },
+  );
 }
 
 const HYDRATION_DEADLINE_MS = resolveInferenceAuthHydrationDeadlineMs(


### PR DESCRIPTION
# Relates to

this is a self-found bug, there is no numbered issue.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package checks (tests, typecheck, Biome) were run after sync; full `bun run verify` not run for this narrow, two-file, non-UI fix.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] rebased onto latest `origin/develop`, zero conflicts
- [x] focused package gates (tests, typecheck, biome) all pass on the exact rebased head

**re-rebase note (review-requested):** standujar's review found this head was 103 commits behind `develop` with no current-base CI proof (GitHub's tested merge ref only combined the old base plus this head). No code defect was raised — static audit confirmed the parser is fail-closed, exposes no supplied value, and changes no auth/cache-key/decision contract. Rebased fresh onto `origin/develop`, re-ran the focused suite/typecheck/biome on the new head, and refreshed the evidence-head marker below.

# Risks

low. this only tightens one operator-supplied timeout setting at module startup. unset and blank values still use `10000`, whitespace around valid decimal integers is still accepted, and valid values from `1` through `2147483647` are unchanged. deployments that currently rely on malformed values will now stop with an actionable configuration error instead of starting with a broken watchdog.

# Background

## What does this PR do?

`packages/cloud/shared/src/lib/services/inference-auth-context.ts:289` parsed `INFERENCE_AUTH_HYDRATION_DEADLINE_MS` with unrestricted `Number(...)`. zero, negative, fractional, non-finite, and timer-overflow values then reached the literal `setTimeout` delay at `packages/cloud/shared/src/lib/services/inference-auth-context.ts:390`.

that timeout is the guard that releases a stuck inference-auth hydration from the per-key single-flight map. malformed operator input could make the deadline fire immediately or overflow to an effectively immediate timer, so cold api-key requests could repeatedly record hydration failures and enter the authoritative escape path instead of getting the configured watchdog behavior.

the fix validates the setting as a complete decimal integer from `1` through `2147483647` and fails during module initialization when an explicit value is invalid. the existing unset or blank default remains `10000`.

the exact live consumers are:

- `packages/cloud/api/src/lib/generative-route-auth.ts:183`, used by generative api routes
- `packages/cloud/api/v1/embeddings/route.ts:35`
- `packages/cloud/api/v1/chat/route.ts:63`
- `packages/cloud/api/v1/chat/completions/route.ts:100`
- `packages/cloud/api/v1/messages/route.ts:87`

## What kind of change is this?

bug fix, non-breaking for valid configuration.

# Documentation changes needed?

no project documentation change is needed. the setting is internal cloud runtime configuration and the accepted range now matches the timer boundary it directly feeds.

# Testing

## Where should a reviewer start?

start with `resolveInferenceAuthHydrationDeadlineMs` and its table tests in `packages/cloud/shared/src/lib/services/inference-auth-context.test.ts`.

## Detailed testing steps

run:

```bash
bun test --reporter=dot /absolute/path/to/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
bunx @biomejs/biome check packages/cloud/shared/src/lib/services/inference-auth-context.ts packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
bun run --cwd packages/cloud/shared typecheck
```

the test matrix covers the unset and blank default, valid minimum and maximum values, surrounding whitespace, zero, negative and signed input, fractional and scientific notation, suffixes, non-finite text, node timer overflow, and an unsafe integer.

# Evidence Gate
<!-- evidence-head:496eea02409e135980b5dd13444fc62eff744315 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - backend timeout validation only, no rendered ui changed
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - backend timeout validation only, no rendered ui changed
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive or rendered flow changed
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - the change is startup configuration validation, the focused command output is included under domain artifacts
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code or request contract changed
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: focused validation and existing hydration behavior both passed

```text
bun test --reporter=dot /Users/mac/Desktop/coding/eliza-oss/eliza/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
43 pass
0 fail
124 expect() calls
Ran 43 tests across 1 file. [1335.00ms]

bunx @biomejs/biome check packages/cloud/shared/src/lib/services/inference-auth-context.ts packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
Checked 2 files in 19ms. No fixes applied.

bun run --cwd packages/cloud/shared typecheck
$ node ../../shared/scripts/generate-keywords.mjs && tsc --noEmit
Done!
```

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface changed

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - this is module-startup validation with no frontend path. the deterministic focused test transcript is included directly in the domain-artifacts row.

## Screenshots (before / after) + video walkthrough

N/A - no rendered ui changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, tts, or stt path changed.

## Known gaps / failures

the implementing sandbox couldn't write git metadata (`.git/index.lock: Operation not permitted`), so branching, committing, and evidence-head finalization happened outside that sandbox after independently re-running every check below against the original commit `c139cb645e404bff07682a90dbd37cfacdfb8491`. standujar's review then found that head had gone 103 commits stale with no current-base CI proof; rebased fresh onto `origin/develop` (new head `496eea02409e135980b5dd13444fc62eff744315`) and re-ran the full focused suite/typecheck/biome on the exact rebased head, all shown above.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [hunt-and-implement-21]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZZCTWN6Z8D6169RSF8BKZVD","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-14T05:45:04.934Z","completed_at":"2026-08-14T05:57:37.303Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAVq8Ggvxg2RCIBwXtE9az5b_tYKj9qVj_3nvqPhhTcAA","device_key_id":"e60c0d298778b55b0d73aec8f38dfc80913a79223c40de61bea259417fe35ec3","device_signature":"LplM40FbWL6AvtLf-JSw4bQGtxMAUohjn7UpuRPmsil5d5HZYHwifjggTsAQwbANecmgyb9uT-oczFckMtMKDQ"}} -->
