### PR TITLE
fix(plugin-slack): expand user ID validation, handle invalid dates, and trim link ts

### DIFF
--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -13,6 +13,7 @@ import {
   extractUrlFromSlackLink,
   extractUserIdFromMention,
   formatSlackChannelMention,
+  formatSlackDate,
   formatSlackLink,
   formatSlackSpecialMention,
   formatSlackUserGroupMention,
@@ -22,6 +23,7 @@ import {
   stripSlackFormatting,
   truncateText,
 } from "./formatting.ts";
+import { isValidUserId, parseSlackMessageLink } from "./types.ts";
 
 describe("escapeSlackMrkdwn", () => {
   it("escapes the three Slack control chars, leaves clean text untouched", () => {
@@ -40,11 +42,23 @@ describe("markdownToSlackMrkdwn", () => {
 });
 
 describe("mention builders + extractors round-trip", () => {
-  it("user mention", () => {
+  it("user mention with U, W, B, E, A prefixes", () => {
     const m = formatSlackUserMention("U12345");
     expect(m).toBe("<@U12345>");
     expect(extractUserIdFromMention(m)).toBe("U12345");
+    expect(extractUserIdFromMention("<@B98765432>")).toBe("B98765432");
+    expect(extractUserIdFromMention("<@E11223344>")).toBe("E11223344");
+    expect(extractUserIdFromMention("<@A55667788>")).toBe("A55667788");
     expect(extractUserIdFromMention("not a mention")).toBeNull();
+  });
+
+  it("isValidUserId validates bot, app, and enterprise IDs", () => {
+    expect(isValidUserId("U12345678")).toBe(true);
+    expect(isValidUserId("W12345678")).toBe(true);
+    expect(isValidUserId("B12345678")).toBe(true);
+    expect(isValidUserId("E12345678")).toBe(true);
+    expect(isValidUserId("A12345678")).toBe(true);
+    expect(isValidUserId("invalid")).toBe(false);
   });
 
   it("channel mention", () => {
@@ -180,6 +194,41 @@ describe("permalink build/parse round-trip", () => {
       parseSlackMessagePermalink(
         "https://acme.slack.com/archives/C0ABCDE/p12345",
       ),
+    ).toBeNull();
+  });
+});
+
+describe("formatSlackDate", () => {
+  it("formats valid Date or timestamp into Slack <!date...>", () => {
+    const d = new Date(1700000000000);
+    expect(formatSlackDate(d)).toBe(
+      "<!date^1700000000^{date_short_pretty} at {time}|2023-11-14T22:13:20.000Z>",
+    );
+  });
+
+  it("safely handles invalid dates and non-finite timestamps", () => {
+    expect(formatSlackDate(new Date("invalid"))).toBe("Invalid date");
+    expect(formatSlackDate(NaN, "{date}", "Fallback")).toBe("Fallback");
+    expect(formatSlackDate(Infinity)).toBe("Invalid date");
+  });
+});
+
+describe("parseSlackMessageLink", () => {
+  it("parses archives link without leaving trailing dot on 10-digit timestamps", () => {
+    expect(
+      parseSlackMessageLink(
+        "https://acme.slack.com/archives/C12345678/p1700000000123456",
+      ),
+    ).toEqual({ channelId: "C12345678", messageTs: "1700000000.123456" });
+
+    expect(
+      parseSlackMessageLink(
+        "https://acme.slack.com/archives/C12345678/p1700000000",
+      ),
+    ).toEqual({ channelId: "C12345678", messageTs: "1700000000" });
+
+    expect(
+      parseSlackMessageLink("https://acme.slack.com/archives/C12345678/p123"),
     ).toBeNull();
   });
 });

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -317,9 +317,12 @@ export function formatSlackDate(
   format: string = "{date_short_pretty} at {time}",
   fallbackText?: string,
 ): string {
-  const unix = Math.floor(
-    (typeof timestamp === "number" ? timestamp : timestamp.getTime()) / 1000,
-  );
+  const timeMs =
+    typeof timestamp === "number" ? timestamp : timestamp.getTime();
+  if (!Number.isFinite(timeMs)) {
+    return fallbackText || "Invalid date";
+  }
+  const unix = Math.floor(timeMs / 1000);
   const fallback = fallbackText || new Date(unix * 1000).toISOString();
   return `<!date^${unix}^${format}|${fallback}>`;
 }
@@ -328,7 +331,7 @@ export function formatSlackDate(
  * Extracts user ID from a Slack mention
  */
 export function extractUserIdFromMention(mention: string): string | null {
-  const match = mention.match(/^<@([UW][A-Z0-9]+)(?:\|[^>]*)?>$/i);
+  const match = mention.match(/^<@([UWBEA][A-Z0-9]+)(?:\|[^>]*)?>$/i);
   return match ? match[1] : null;
 }
 
@@ -446,7 +449,7 @@ export function stripSlackFormatting(text: string): string {
     .replace(/_([^_]+)_/g, "$1") // Italic
     .replace(/~([^~]+)~/g, "$1") // Strikethrough
     .replace(/`([^`]+)`/g, "$1") // Inline code
-    .replace(/<@[UW][A-Z0-9]+(?:\|[^>]*)?>/gi, "") // User mentions
+    .replace(/<@[UWBEA][A-Z0-9]+(?:\|[^>]*)?>/gi, "") // User mentions
     .replace(/<#[CGD][A-Z0-9]+(?:\|[^>]*)?>/gi, "") // Channel mentions
     .replace(/<!subteam\^[A-Z0-9]+(?:\|[^>]*)?>/gi, "") // User group mentions
     .replace(/<!(?:here|channel|everyone)(?:\|[^>]*)?>/gi, "") // Special mentions

--- a/plugins/plugin-slack/src/types.ts
+++ b/plugins/plugin-slack/src/types.ts
@@ -361,8 +361,8 @@ export function isValidChannelId(id: string): boolean {
  * Validates a Slack user ID format
  */
 export function isValidUserId(id: string): boolean {
-  // Slack user IDs start with U or W (enterprise grid)
-  return /^[UW][A-Z0-9]{8,}$/i.test(id);
+  // Slack user/bot/app/enterprise IDs start with U, W, B, E, or A
+  return /^[UWBEA][A-Z0-9]{8,}$/i.test(id);
 }
 
 /**
@@ -393,8 +393,13 @@ export function parseSlackMessageLink(
 
   const channelId = match[1];
   const ts = match[2];
+  if (ts.length < 10) return null;
+
   // Convert the timestamp: p1234567890123456 -> 1234567890.123456
-  const messageTs = `${ts.slice(0, 10)}.${ts.slice(10)}`;
+  const fractional = ts.slice(10);
+  const messageTs = fractional
+    ? `${ts.slice(0, 10)}.${fractional}`
+    : ts.slice(0, 10);
 
   return { channelId, messageTs };
 }


### PR DESCRIPTION
## Summary
Ships leftover Agy work that was implemented and tested locally but not opened as a PR (prior GitHub workflow-scope block).

## Evidence
- Focused plugin-slack tests were reported passing at implementation time (44/44).
- Rebased onto current origin/develop before push.

N/A - leftover ship of already-verified local commit; re-run focused tests in CI.