### PR TITLE
fix(elizaresearch): color mobile overscroll orange

### DIFF
--- a/packages/elizaresearch/index.html
+++ b/packages/elizaresearch/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="theme-color" content="#ff5800" />
 <title>Eliza Research — AI and people</title>
 <meta name="description" content="Eliza Research builds products at the intersection of AI and people: Eliza, a personal agent and open source operating system, and slop.cash, a swarm contribution platform." />
 <meta property="og:title" content="Eliza Research" />
@@ -45,7 +46,7 @@
     --z-nav: 10;
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
-  html { scroll-behavior: smooth; }
+  html { scroll-behavior: smooth; background: var(--orange); }
   body {
     font-family: "Geist", Arial, sans-serif;
     background: var(--bg);


### PR DESCRIPTION
Closes #19400. Sets the document root canvas and browser theme to Eliza orange and enables viewport-fit, preventing white rubber-band flashes above and below the page on mobile while preserving the white content body. Verified at 390×844: root #ff5800, body white, zero horizontal overflow, zero console warnings/errors.