### PR TITLE
fix(gateway-webhook): preserve Blooio v4 channel metadata for channel-aware replies

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/blooio-adapter.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/blooio-adapter.test.ts
@@ -182,7 +182,43 @@ describe("blooio extractEvent", () => {
     expect(event?.chatId).toBe("+15551234567");
     expect(event?.senderId).toBe("+15551234567");
     expect(event?.text).toBe("hey from v4");
+    expect(event?.channelId).toBe("ch_abc123");
+    expect(event?.channelType).toBe("blooio");
     expect(event?.rawPayload).toEqual(JSON.parse(body));
+  });
+
+  test("preserves v4 channel_id and channel_type for WhatsApp channels", async () => {
+    const event = await blooioAdapter.extractEvent(
+      v4InboundPayload({
+        channel_id: "ch_whatsapp_001",
+        channel_type: "whatsapp",
+        protocol: "whatsapp",
+      }),
+    );
+
+    expect(event?.channelId).toBe("ch_whatsapp_001");
+    expect(event?.channelType).toBe("whatsapp");
+  });
+
+  test("omits channelId/channelType when a v4 delivery lacks channel metadata", async () => {
+    const event = await blooioAdapter.extractEvent(
+      v4InboundPayload({
+        channel_id: null,
+        channel_type: null,
+      }),
+    );
+
+    expect(event).not.toBeNull();
+    expect(event?.channelId).toBeUndefined();
+    expect(event?.channelType).toBeUndefined();
+  });
+
+  test("v2 events never carry channel metadata", async () => {
+    const event = await blooioAdapter.extractEvent(inboundPayload());
+
+    expect(event).not.toBeNull();
+    expect(event?.channelId).toBeUndefined();
+    expect(event?.channelType).toBeUndefined();
   });
 
   test("uses the v4 contact identity when sender is absent", async () => {
@@ -356,6 +392,104 @@ describe("blooio sendReply", () => {
       blooioAdapter.sendReply(makeConfig(), chatEvent, "hi"),
     ).rejects.toThrow("Blooio send error (429): rate limited");
   });
+
+  const v4ChatEvent: ChatEvent = {
+    platform: "blooio",
+    messageId: "msg_v4_abc123",
+    chatId: "+15551234567",
+    senderId: "+15551234567",
+    text: "hey from v4",
+    channelId: "ch_abc123",
+    channelType: "blooio",
+    rawPayload: {},
+  };
+
+  test("POSTs to the v4 channel-aware endpoint when channelId is present", async () => {
+    let captured: { url: string; init: RequestInit } | null = null;
+    globalThis.fetch = (async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      captured = { url: String(url), init: init ?? {} };
+      return new Response(JSON.stringify({ message_id: "out_v4" }), {
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    await blooioAdapter.sendReply(makeConfig(), v4ChatEvent, "reply via v4");
+
+    expect(captured).not.toBeNull();
+    const { url, init } = captured as unknown as {
+      url: string;
+      init: RequestInit;
+    };
+    expect(url).toBe(
+      "https://api.blooio.com/v4/api/channels/ch_abc123/messages",
+    );
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer bl_live_test");
+    expect(headers["Idempotency-Key"]).toBe("gw-reply-msg_v4_abc123");
+    expect(JSON.parse(String(init.body))).toEqual({
+      text: "reply via v4",
+      channel_id: "ch_abc123",
+      channel_type: "blooio",
+    });
+  });
+
+  test("includes channel_id but omits channel_type from v4 body when absent", async () => {
+    let captured: { init: RequestInit } | null = null;
+    globalThis.fetch = (async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      captured = { init: init ?? {} };
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const eventWithoutType: ChatEvent = {
+      ...v4ChatEvent,
+      channelType: undefined,
+    };
+    await blooioAdapter.sendReply(makeConfig(), eventWithoutType, "hi");
+
+    expect(captured).not.toBeNull();
+    expect(JSON.parse(String(captured?.init.body))).toEqual({
+      text: "hi",
+      channel_id: "ch_abc123",
+    });
+  });
+
+  test("falls back to v2 chat endpoint when no channelId is present", async () => {
+    let captured: { url: string } | null = null;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      captured = { url: String(url) };
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const v2Event: ChatEvent = {
+      platform: "blooio",
+      messageId: "msg_v2",
+      chatId: "+15551234567",
+      senderId: "+15551234567",
+      text: "hey",
+      rawPayload: {},
+    };
+    await blooioAdapter.sendReply(makeConfig(), v2Event, "legacy reply");
+
+    expect(captured).not.toBeNull();
+    expect(captured?.url).toBe(
+      "https://api.blooio.com/v2/api/chats/%2B15551234567/messages",
+    );
+  });
+
+  test("v4 sendReply throws with status and body on a non-ok response", async () => {
+    globalThis.fetch = (async () =>
+      new Response("forbidden", { status: 403 })) as typeof fetch;
+
+    await expect(
+      blooioAdapter.sendReply(makeConfig(), v4ChatEvent, "hi"),
+    ).rejects.toThrow("Blooio send error (403): forbidden");
+  });
 });
 describe("blooio sendTypingIndicator", () => {
   const chatEvent: ChatEvent = {
@@ -385,9 +519,42 @@ describe("blooio sendTypingIndicator", () => {
     }) as typeof fetch;
 
     await blooioAdapter.sendTypingIndicator(
-      makeConfig({ apiKey: undefined }),
+      makeConfig({ apiKey: "" }),
       chatEvent,
     );
     expect(called).toBe(false);
+  });
+
+  test("uses the v4 channel-aware read endpoint when channelId is present", async () => {
+    let capturedUrl: string | null = null;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      capturedUrl = String(url);
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const v4Event: ChatEvent = {
+      ...chatEvent,
+      channelId: "ch_abc123",
+      channelType: "blooio",
+    };
+    await blooioAdapter.sendTypingIndicator(makeConfig(), v4Event);
+
+    expect(capturedUrl).toBe(
+      "https://api.blooio.com/v4/api/channels/ch_abc123/read",
+    );
+  });
+
+  test("uses the v2 chat read endpoint when no channelId is present", async () => {
+    let capturedUrl: string | null = null;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      capturedUrl = String(url);
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    await blooioAdapter.sendTypingIndicator(makeConfig(), chatEvent);
+
+    expect(capturedUrl).toBe(
+      "https://api.blooio.com/v2/api/chats/%2B15551234567/read",
+    );
   });
 });

--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
@@ -8,6 +8,7 @@ import { logger } from "../logger";
 import type { ChatEvent, PlatformAdapter, WebhookConfig } from "./types";
 
 const BLOOIO_API_BASE = "https://api.blooio.com/v2/api";
+const BLOOIO_V4_API_BASE = "https://api.blooio.com/v4/api";
 
 const BlooioAttachmentSchema = z.union([
   z.string(),
@@ -33,6 +34,8 @@ const BlooioV4MessageSchema = z
     id: z.string().trim().min(1).nullish(),
     message_id: z.string().trim().min(1).nullish(),
     chat_id: z.string().nullish(),
+    channel_id: z.string().trim().min(1).nullish(),
+    channel_type: z.string().trim().min(1).nullish(),
     sender: z.string().trim().min(1).nullish(),
     recipient: z.string().nullish(),
     channel_address: z.string().nullish(),
@@ -54,7 +57,10 @@ const BlooioV4WebhookEnvelopeSchema = z.object({
   data: BlooioV4MessageSchema,
 });
 
-type BlooioWebhookEvent = z.infer<typeof BlooioV2WebhookEventSchema>;
+type BlooioWebhookEvent = z.infer<typeof BlooioV2WebhookEventSchema> & {
+  channel_id?: string | null;
+  channel_type?: string | null;
+};
 
 function parseWebhookEvent(data: unknown): BlooioWebhookEvent | null {
   const v2 = BlooioV2WebhookEventSchema.safeParse(data);
@@ -77,6 +83,8 @@ function parseWebhookEvent(data: unknown): BlooioWebhookEvent | null {
     is_group: message.is_group ?? message.group != null,
     received_at: v4.data.created_at,
     timestamp: v4.data.created_at,
+    channel_id: message.channel_id,
+    channel_type: message.channel_type,
   };
 }
 
@@ -238,6 +246,14 @@ export const blooioAdapter: PlatformAdapter = {
 
     const mediaUrls = extractMediaUrls(event.attachments);
 
+    // Blooio v4 envelopes carry channel_id and channel_type on the message
+    // data; legacy v2 deliveries never do. When present, the channel metadata
+    // lets sendReply route to the v4 channel-aware message endpoint so the
+    // outbound reply is pinned to the exact inbound channel (e.g. a WhatsApp
+    // channel instead of the default iMessage/SMS channel).
+    const channelId = event.channel_id ?? undefined;
+    const channelType = event.channel_type ?? undefined;
+
     return {
       platform: "blooio",
       messageId: event.message_id,
@@ -248,6 +264,8 @@ export const blooioAdapter: PlatformAdapter = {
           ? `[media: ${mediaUrls.join(", ")}]`
           : text,
       mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
+      channelId,
+      channelType,
       rawPayload: data,
     };
   },
@@ -259,7 +277,15 @@ export const blooioAdapter: PlatformAdapter = {
   ): Promise<void> {
     if (!config.apiKey) throw new Error("Missing apiKey for Blooio reply");
 
-    const url = `${BLOOIO_API_BASE}/chats/${encodeURIComponent(event.senderId)}/messages`;
+    // When the inbound v4 envelope carried a channel_id, reply through the v4
+    // channel-aware endpoint so the message is pinned to the exact channel
+    // that delivered the inbound. Legacy v2 deliveries and v4 deliveries
+    // without a channel_id fall back to the v2 chat-scoped endpoint.
+    const { channelId } = event;
+    const url =
+      channelId != null
+        ? `${BLOOIO_V4_API_BASE}/channels/${encodeURIComponent(channelId)}/messages`
+        : `${BLOOIO_API_BASE}/chats/${encodeURIComponent(event.senderId)}/messages`;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${config.apiKey}`,
       "Content-Type": "application/json",
@@ -271,10 +297,19 @@ export const blooioAdapter: PlatformAdapter = {
     };
     if (config.fromNumber) headers["X-From-Number"] = config.fromNumber;
 
+    const body =
+      channelId != null
+        ? JSON.stringify({
+            text,
+            channel_id: channelId,
+            ...(event.channelType ? { channel_type: event.channelType } : {}),
+          })
+        : JSON.stringify({ text });
+
     const response = await fetch(url, {
       method: "POST",
       headers,
-      body: JSON.stringify({ text }),
+      body,
     });
 
     if (!response.ok) {
@@ -289,7 +324,11 @@ export const blooioAdapter: PlatformAdapter = {
   ): Promise<void> {
     if (!config.apiKey) return;
     try {
-      const url = `${BLOOIO_API_BASE}/chats/${encodeURIComponent(event.senderId)}/read`;
+      const { channelId } = event;
+      const url =
+        channelId != null
+          ? `${BLOOIO_V4_API_BASE}/channels/${encodeURIComponent(channelId)}/read`
+          : `${BLOOIO_API_BASE}/chats/${encodeURIComponent(event.senderId)}/read`;
       const headers: Record<string, string> = {
         Authorization: `Bearer ${config.apiKey}`,
         "Content-Type": "application/json",

--- a/packages/cloud/services/gateway-webhook/src/adapters/types.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/types.ts
@@ -12,6 +12,10 @@ export interface ChatEvent {
   text: string;
   isCommand?: boolean;
   mediaUrls?: string[];
+  /** Blooio v4 channel id, preserved from the inbound envelope for channel-aware replies. */
+  channelId?: string;
+  /** Blooio v4 channel type (e.g. "blooio", "whatsapp"), preserved from the inbound envelope. */
+  channelType?: string;
   rawPayload: unknown;
 }
 


### PR DESCRIPTION
## Summary

The Blooio gateway adapter accepted v4 `message.received` envelopes but discarded `channel_id` and `channel_type`, then always replied through the legacy v2 chat endpoint. When a separately provisioned WhatsApp channel delivered an inbound message, the reply was sent back through the default iMessage/SMS channel instead of the originating channel.

## Changes

- **`ChatEvent`** gains optional `channelId` and `channelType` fields (additive, no adapter or consumer breaks)
- **`BlooioV4MessageSchema`** now parses `channel_id` and `channel_type` from the v4 message data
- **`parseWebhookEvent`** carries channel metadata through the intermediate event type into `extractEvent`
- **`sendReply`** routes to `/v4/api/channels/{channelId}/messages` when a `channelId` is present, including `channel_id` and `channel_type` in the request body; falls back to the v2 `/chats/{senderId}/messages` endpoint for legacy deliveries
- **`sendTypingIndicator`** similarly routes to the v4 channel-aware read endpoint

## Backward compatibility

- v2-first parse order preserved — v2 events never acquire channel metadata
- v4 deliveries without `channel_id` fall back to the v2 chat endpoint
- The idempotency key (`gw-reply-{messageId}`) is unchanged across both branches

## Tests (35 in blooio-adapter suite, 127 package-wide — all pass)

- v4 extraction preserves `channelId` and `channelType`
- WhatsApp channel metadata preserved
- Missing channel metadata → `channelId`/`channelType` undefined
- v2 events never carry channel metadata
- v4 `sendReply` POSTs to channel-aware endpoint with correct body
- v4 body omits `channel_type` when absent
- v2 fallback `sendReply` uses chat endpoint
- v4 `sendReply` error propagation
- v4 `sendTypingIndicator` uses channel-aware read endpoint
- v2 fallback `sendTypingIndicator` uses chat read endpoint

## Verification

- `bun run --cwd packages/cloud/services/gateway-webhook typecheck` — ✅ clean
- `bun run --cwd packages/cloud/services/gateway-webhook lint` — ✅ clean
- `bun run --cwd packages/cloud/services/gateway-webhook test` — ✅ 127/127 pass
- `bun run --cwd packages/cloud/services/gateway-webhook build` — ✅ clean
- Independent RP review: APPROVED with two fixes applied (null-check consistency, typing test coverage)

## Design note (non-blocking)

The v2 fallback fires only on *absent* channel metadata, not on v4 send *failure*. A stale/deprovisioned `channelId` presents as a delivery failure instead of silently downgrading to the v2 endpoint. This is deliberate — a silent downgrade could resurrect the wrong-channel bug this fix addresses.

Closes #19391

AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@17e94f45a958f87c6a2a2c77daab4cdb33a6d3df:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes/t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.2","client":"Hermes Agent","skill_revision":"elizaOS/eliza@17e94f45a958f87c6a2a2c77daab4cdb33a6d3df:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:44dc10a3f87e2b106f0c26c9c89771258d03c0a3 -->

<!-- evidence-row:backend-logs -->
- [ ] N/A - gateway-webhook service package; no server boot or live runtime exercised. Deterministic bun test output (127/127 pass) and tsc/biome/bun build output documented in PR body.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - gateway-webhook backend service with no rendered UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - gateway-webhook backend service with no rendered UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend webhook adapter change with no interactive UI to record

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend or browser surface touched

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changes

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain state changes
