### PR TITLE
fix(ui): labelled settings selects skip SettingsSelectRow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,9 +147,9 @@ jobs:
         if: needs.changes.outputs.server == 'true'
         run: bun run test:server
 
-      - name: No affected server lane
+      - name: — not affected (server)
         if: needs.changes.outputs.server != 'true'
-        run: echo "No server test lane is affected."
+        run: echo "::notice::Lane not affected by changes — 0 packages executed"
 
   tests_client:
     name: Tests (client)
@@ -175,9 +175,9 @@ jobs:
         if: needs.changes.outputs.client == 'true'
         run: bun run test:client
 
-      - name: No affected client lane
+      - name: — not affected (client)
         if: needs.changes.outputs.client != 'true'
-        run: echo "No client test lane is affected."
+        run: echo "::notice::Lane not affected by changes — 0 packages executed"
 
   tests_plugins:
     name: Tests (plugins)
@@ -203,9 +203,9 @@ jobs:
         if: needs.changes.outputs.plugins == 'true'
         run: bun run test:plugins
 
-      - name: No affected plugin lane
+      - name: — not affected (plugins)
         if: needs.changes.outputs.plugins != 'true'
-        run: echo "No plugin test lane is affected."
+        run: echo "::notice::Lane not affected by changes — 0 packages executed"
 
   smoke:
     name: Smoke
@@ -265,9 +265,9 @@ jobs:
           ELIZA_UI_SMOKE_SHARD: ${{ matrix.shard }}/6
         run: bun run --cwd packages/app test:e2e
 
-      - name: No affected e2e shard
+      - name: — not affected (e2e shard)
         if: needs.changes.outputs.zero_key != 'true'
-        run: echo "No deterministic E2E lane is affected."
+        run: echo "::notice::Lane not affected by changes — 0 packages executed"
 
   # The desktop and cloud lanes are whole-lane work that does not shard. Held
   # off the matrix so no shard carries them: on run 31489483093 the cloud step
@@ -337,9 +337,9 @@ jobs:
         if: needs.changes.outputs.zero_key == 'true'
         run: bun run test:e2e --filter='^(?!.*packages/app\)#test:e2e)'
 
-      - name: No affected smoke lane
+      - name: — not affected (smoke lane)
         if: needs.changes.outputs.desktop != 'true' && needs.changes.outputs.cloud != 'true' && needs.changes.outputs.zero_key != 'true'
-        run: echo "No desktop, cloud, or deterministic E2E lane is affected."
+        run: echo "::notice::Lane not affected by changes — 0 packages executed"
 
   android_aab:
     name: Android release AAB

--- a/packages/scripts/__tests__/ci-affected-scoped-lanes.test.ts
+++ b/packages/scripts/__tests__/ci-affected-scoped-lanes.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Validates affected-scoped test lane markers in CI workflows (#19351).
+ *
+ * These tests ensure that test lanes gated on changed paths (affected-scoped)
+ * are visibly distinct from passing lanes when zero packages execute. The
+ * "— not affected" marker and GitHub notice output make the vacuous case clear.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const ciWorkflowPath = join(repoRoot, ".github", "workflows", "ci.yml");
+
+describe("affected-scoped test lane markers (#19351)", () => {
+  const ciContent = readFileSync(ciWorkflowPath, "utf8");
+
+  const lanes = [
+    { name: "server", jobName: "tests_server" },
+    { name: "client", jobName: "tests_client" },
+    { name: "plugins", jobName: "tests_plugins" },
+    { name: "e2e shard", jobName: "smoke" },
+    { name: "smoke lane", jobName: "smoke_lanes" },
+  ];
+
+  test("all affected-scoped lanes have '— not affected' markers", () => {
+    for (const { name } of lanes) {
+      expect(
+        ciContent,
+        `lane "${name}" should have '— not affected' marker`,
+      ).toContain(`— not affected (${name})`);
+    }
+  });
+
+  test("all '— not affected' markers use GitHub notice output", () => {
+    for (const { name } of lanes) {
+      const marker = `— not affected (${name})`;
+      const markerIndex = ciContent.indexOf(marker);
+      expect(markerIndex, `marker "${marker}" should be found`).toBeGreaterThan(
+        -1,
+      );
+
+      const section = ciContent.slice(
+        markerIndex,
+        markerIndex + 500,
+      );
+      expect(
+        section,
+        `lane "${name}" should use GitHub notice output`,
+      ).toContain("::notice::Lane not affected by changes");
+    }
+  });
+
+  test("'— not affected' markers include vacuous-case message", () => {
+    for (const { name } of lanes) {
+      const marker = `— not affected (${name})`;
+      const markerIndex = ciContent.indexOf(marker);
+      const section = ciContent.slice(
+        markerIndex,
+        markerIndex + 500,
+      );
+      expect(
+        section,
+        `lane "${name}" should document zero packages executed`,
+      ).toContain("0 packages executed");
+    }
+  });
+
+  test("no lanes use the old 'No affected' naming", () => {
+    // Ensure all old-style messages have been replaced
+    expect(ciContent).not.toContain("No affected server lane");
+    expect(ciContent).not.toContain("No affected client lane");
+    expect(ciContent).not.toContain("No affected plugin lane");
+    expect(ciContent).not.toContain("No affected e2e shard");
+    expect(ciContent).not.toContain("No affected smoke lane");
+    expect(ciContent).not.toContain("No server test lane is affected");
+    expect(ciContent).not.toContain("No client test lane is affected");
+    expect(ciContent).not.toContain("No deterministic E2E lane is affected");
+    expect(ciContent).not.toContain("No desktop, cloud, or deterministic E2E");
+  });
+
+  test("'— not affected' steps maintain conditional gates", () => {
+    // Verify each not-affected step has its conditional if clause
+    const gateTests = [
+      {
+        lane: "server",
+        gate: "needs.changes.outputs.server != 'true'",
+      },
+      {
+        lane: "client",
+        gate: "needs.changes.outputs.client != 'true'",
+      },
+      {
+        lane: "plugins",
+        gate: "needs.changes.outputs.plugins != 'true'",
+      },
+      {
+        lane: "e2e shard",
+        gate: "needs.changes.outputs.zero_key != 'true'",
+      },
+      {
+        lane: "smoke lane",
+        gate: "needs.changes.outputs.desktop != 'true' && needs.changes.outputs.cloud != 'true' && needs.changes.outputs.zero_key != 'true'",
+      },
+    ];
+
+    for (const { lane, gate } of gateTests) {
+      const marker = `— not affected (${lane})`;
+      const markerIndex = ciContent.indexOf(marker);
+      const section = ciContent.slice(markerIndex, markerIndex + 300);
+
+      expect(
+        section,
+        `lane "${lane}" should have correct conditional gate`,
+      ).toContain(`if: ${gate}`);
+    }
+  });
+});

--- a/packages/ui/src/components/settings/IdentitySettingsSection.tsx
+++ b/packages/ui/src/components/settings/IdentitySettingsSection.tsx
@@ -9,7 +9,6 @@
 
 import { Volume2, VolumeX } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAgentElement } from "../../agent-surface";
 import { client, type VoiceConfig } from "../../api";
 import { dispatchWindowEvent, VOICE_CONFIG_UPDATED_EVENT } from "../../events";
 import { useAppSelectorShallow } from "../../state";
@@ -25,121 +24,9 @@ import {
   ELEVENLABS_VOICE_GROUPS,
 } from "../character/character-voice-config";
 import { SaveFooter } from "../ui/save-footer";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectValue,
-} from "../ui/select";
-import { SettingsSelectTrigger } from "../ui/settings-controls";
-import { SettingsActionButton } from "./settings-agent-rows";
+import { SettingsSelectRow } from "./settings-agent-rows";
 import { useSettingsSave } from "./settings-control-primitives.hooks";
-import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
-
-interface VoiceSelectRowProps {
-  label: string;
-  placeholder: string;
-  value: string | null;
-  options: readonly string[];
-  groups: Array<{
-    label: string;
-    items: Array<{ id: string; text: string; hint?: string }>;
-  }>;
-  onValueChange: (value: string) => void;
-  previewLabel: string;
-  stopLabel: string;
-  previewing: boolean;
-  previewDisabled: boolean;
-  onPreviewToggle: () => void;
-}
-
-function VoiceSelectRow({
-  label,
-  placeholder,
-  value,
-  options,
-  groups,
-  onValueChange,
-  previewLabel,
-  stopLabel,
-  previewing,
-  previewDisabled,
-  onPreviewToggle,
-}: VoiceSelectRowProps) {
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: "identity-voice",
-    role: "select",
-    label,
-    group: "settings",
-    status: value || undefined,
-    options,
-    getValue: () => value ?? "",
-    onFill: (next: string) => onValueChange(next),
-  });
-
-  return (
-    <SettingsRow
-      label={<span id="settings-identity-voice-label">{label}</span>}
-      stacked
-    >
-      <div className="flex items-center gap-2">
-        <Select value={value ?? undefined} onValueChange={onValueChange}>
-          <SettingsSelectTrigger
-            ref={ref}
-            variant="touch"
-            aria-labelledby="settings-identity-voice-label"
-            className="min-w-0 flex-1"
-            {...agentProps}
-          >
-            <SelectValue placeholder={placeholder} />
-          </SettingsSelectTrigger>
-          <SelectContent className="border-border/60 bg-bg/92">
-            {groups.map((group) => (
-              <SelectGroup key={group.label}>
-                <SelectLabel className="px-2.5 py-1 text-2xs font-semibold text-muted">
-                  {group.label}
-                </SelectLabel>
-                {group.items.map((item) => (
-                  <SelectItem
-                    key={item.id}
-                    value={item.id}
-                    textValue={item.text}
-                  >
-                    <div className="flex w-full items-center justify-between gap-2">
-                      <span className="font-semibold">{item.text}</span>
-                      {item.hint ? (
-                        <span className="text-muted text-xs">{item.hint}</span>
-                      ) : null}
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-            ))}
-          </SelectContent>
-        </Select>
-        <SettingsActionButton
-          agentId="identity-voice-preview"
-          agentLabel={previewing ? stopLabel : previewLabel}
-          type="button"
-          variant={previewing ? "destructive" : "ghost"}
-          size="icon"
-          className="h-11 w-11 shrink-0 rounded-md"
-          onClick={onPreviewToggle}
-          aria-label={previewing ? stopLabel : previewLabel}
-          disabled={previewDisabled}
-        >
-          {previewing ? (
-            <VolumeX className="h-4 w-4" />
-          ) : (
-            <Volume2 className="h-4 w-4" />
-          )}
-        </SettingsActionButton>
-      </div>
-    </SettingsRow>
-  );
-}
+import { SettingsGroup, SettingsStack } from "./settings-layout";
 
 function resolveEditableVoiceSelectionKey(config: VoiceConfig | null): string {
   const elevenLabsVoiceId =
@@ -313,8 +200,8 @@ export function IdentitySettingsSection() {
         items: group.items.map((item) => {
           const preset = PREMADE_VOICES.find((entry) => entry.id === item.id);
           return {
-            id: item.id,
-            text: preset?.nameKey
+            value: item.id,
+            label: preset?.nameKey
               ? t(preset.nameKey, { defaultValue: preset.name })
               : (preset?.name ?? item.text),
             hint: preset?.hintKey
@@ -330,8 +217,8 @@ export function IdentitySettingsSection() {
       items: group.items.map((item) => {
         const preset = EDGE_BACKUP_VOICES.find((entry) => entry.id === item.id);
         return {
-          id: item.id,
-          text: preset?.nameKey
+          value: item.id,
+          label: preset?.nameKey
             ? t(preset.nameKey, { defaultValue: preset.name })
             : (preset?.name ?? item.text),
           hint: preset?.hintKey
@@ -343,7 +230,7 @@ export function IdentitySettingsSection() {
   }, [t, useElevenLabs]);
 
   const voiceOptions = useMemo(
-    () => voiceGroups.flatMap((group) => group.items.map((item) => item.id)),
+    () => voiceGroups.flatMap((group) => group.items.map((item) => item.value)),
     [voiceGroups],
   );
 
@@ -440,24 +327,25 @@ export function IdentitySettingsSection() {
       <SettingsGroup
         title={t("settings.identity.groupTitle", { defaultValue: "Identity" })}
       >
-        <VoiceSelectRow
+        <SettingsSelectRow
+          agentId="identity-voice"
           label={t("common.voice", { defaultValue: "Voice" })}
+          agentLabel={t("common.voice", { defaultValue: "Voice" })}
           placeholder={t("charactereditor.SelectAVoice", {
             defaultValue: "Select a voice",
           })}
-          value={visibleVoicePresetId}
-          options={voiceOptions}
-          groups={voiceGroups}
+          value={visibleVoicePresetId ?? ""}
+          optionGroups={voiceGroups}
           onValueChange={handleVoiceSelect}
-          previewLabel={t("settings.identity.previewVoice", {
-            defaultValue: "Preview voice",
-          })}
-          stopLabel={t("settings.identity.stopVoicePreview", {
-            defaultValue: "Stop voice preview",
-          })}
-          previewing={voiceTesting}
-          previewDisabled={!activeVoicePreset?.previewUrl || voiceLoading}
-          onPreviewToggle={voiceTesting ? stopVoicePreview : handlePreviewVoice}
+          trailingAction={{
+            node: voiceTesting ? (
+              <VolumeX className="h-4 w-4" />
+            ) : (
+              <Volume2 className="h-4 w-4" />
+            ),
+            onClick: voiceTesting ? stopVoicePreview : handlePreviewVoice,
+            disabled: !activeVoicePreset?.previewUrl || voiceLoading,
+          }}
         />
       </SettingsGroup>
 

--- a/packages/ui/src/components/settings/VoiceProfileSection.tsx
+++ b/packages/ui/src/components/settings/VoiceProfileSection.tsx
@@ -29,8 +29,7 @@ import { Button } from "../ui/button";
 import { Checkbox } from "../ui/checkbox";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
-import { Select, SelectContent, SelectItem, SelectValue } from "../ui/select";
-import { SettingsSelectTrigger } from "../ui/settings-controls";
+import { SettingsInputRow, SettingsSelectRow } from "./settings-agent-rows";
 
 export interface VoiceProfileSectionProps {
   /** Adapter supplied by the parent that holds the `ElizaClient`. */
@@ -156,33 +155,17 @@ function VoiceProfileLifecycleEditor({
 
       {!profile.isOwner && mergeTargets.length > 0 ? (
         <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
-          <div className="grid gap-1.5">
-            <Label htmlFor={`voice-profile-merge-${profile.id}`}>
-              {t("voiceprofile.merge.target", {
-                defaultValue: "Merge into",
-              })}
-            </Label>
-            <Select value={mergeIntoId} onValueChange={setMergeIntoId}>
-              <SettingsSelectTrigger
-                id={`voice-profile-merge-${profile.id}`}
-                className="min-h-11"
-                data-testid={`voice-profile-merge-target-${profile.id}`}
-              >
-                <SelectValue
-                  placeholder={t("voiceprofile.merge.choose", {
-                    defaultValue: "Choose destination profile",
-                  })}
-                />
-              </SettingsSelectTrigger>
-              <SelectContent>
-                {mergeTargets.map((candidate) => (
-                  <SelectItem key={candidate.id} value={candidate.id}>
-                    {candidate.displayName}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+          <SettingsSelectRow
+            agentId={`voice-profile-merge-target-${profile.id}`}
+            label={t("voiceprofile.merge.target", { defaultValue: "Merge into" })}
+            value={mergeIntoId}
+            onValueChange={setMergeIntoId}
+            placeholder={t("voiceprofile.merge.choose", { defaultValue: "Choose destination profile" })}
+            options={mergeTargets.map((candidate) => ({ value: candidate.id, label: candidate.displayName }))}
+            triggerClassName="min-h-11"
+            testId={`voice-profile-merge-target-${profile.id}`}
+            disabled={pending}
+          />
           <Button
             type="button"
             variant="secondary"
@@ -268,32 +251,28 @@ function VoiceProfileLifecycleEditor({
       {!profile.entityId ? (
         <div className="grid gap-2">
           <div className="grid gap-2 sm:grid-cols-2">
-            <div className="grid gap-1.5">
-              <Label htmlFor={`voice-profile-entity-${profile.id}`}>
-                {t("voiceprofile.bind.entity", { defaultValue: "Entity ID" })}
-              </Label>
-              <Input
-                id={`voice-profile-entity-${profile.id}`}
-                value={entityId}
-                onChange={(event) => setEntityId(event.target.value)}
-                className="h-11"
-                data-testid={`voice-profile-bind-entity-${profile.id}`}
-              />
-            </div>
-            <div className="grid gap-1.5">
-              <Label htmlFor={`voice-profile-entity-label-${profile.id}`}>
-                {t("voiceprofile.bind.label", {
-                  defaultValue: "Binding label (optional)",
-                })}
-              </Label>
-              <Input
-                id={`voice-profile-entity-label-${profile.id}`}
-                value={entityLabel}
-                onChange={(event) => setEntityLabel(event.target.value)}
-                className="h-11"
-                data-testid={`voice-profile-bind-label-${profile.id}`}
-              />
-            </div>
+            <SettingsInputRow
+              agentId={`voice-profile-bind-entity-${profile.id}`}
+              label={t("voiceprofile.bind.entity", { defaultValue: "Entity ID" })}
+              value={entityId}
+              onValueChange={setEntityId}
+              disabled={pending}
+              group="voice-profiles"
+              inputClassName="h-11"
+              testId={`voice-profile-bind-entity-${profile.id}`}
+            />
+            <SettingsInputRow
+              agentId={`voice-profile-bind-label-${profile.id}`}
+              label={t("voiceprofile.bind.label", {
+                defaultValue: "Binding label (optional)",
+              })}
+              value={entityLabel}
+              onValueChange={setEntityLabel}
+              disabled={pending}
+              group="voice-profiles"
+              inputClassName="h-11"
+              testId={`voice-profile-bind-label-${profile.id}`}
+            />
           </div>
           <Button
             type="button"
@@ -389,24 +368,6 @@ const VoiceProfileRow = React.memo(function VoiceProfileRow({
       group: "voice-profiles-list",
       getValue: () => renameValue,
       onFill: setRenameValue,
-    });
-  const { ref: relationshipRef, agentProps: relationshipAgentProps } =
-    useAgentElement<HTMLButtonElement>({
-      id: `voice-profile-relationship-${profile.id}`,
-      role: "select",
-      label: t("voiceprofile.setRelationship", {
-        defaultValue: "Set relationship",
-      }),
-      group: "voice-profiles-list",
-      getValue: () => profile.relationshipLabel ?? NO_RELATIONSHIP_VALUE,
-      onFill: (value) =>
-        void dispatch({
-          type: "set-relationship",
-          id: profile.id,
-          relationshipLabel:
-            value && value !== NO_RELATIONSHIP_VALUE ? value : null,
-        }),
-      options: [NO_RELATIONSHIP_VALUE, ...COMMON_RELATIONSHIPS],
     });
   const { ref: renameBtnRef, agentProps: renameBtnAgentProps } =
     useAgentElement<HTMLButtonElement>({
@@ -536,7 +497,11 @@ const VoiceProfileRow = React.memo(function VoiceProfileRow({
           {!profile.isOwner ? (
             <>
               <div className="w-full sm:w-36">
-                <Select
+                <SettingsSelectRow
+                  agentId={`voice-profile-relationship-${profile.id}`}
+                  label={t("voiceprofile.setRelationship", {
+                    defaultValue: "Set relationship",
+                  })}
                   value={profile.relationshipLabel ?? NO_RELATIONSHIP_VALUE}
                   onValueChange={(value) =>
                     void dispatch({
@@ -546,32 +511,21 @@ const VoiceProfileRow = React.memo(function VoiceProfileRow({
                         value === NO_RELATIONSHIP_VALUE ? null : value,
                     })
                   }
-                >
-                  <SettingsSelectTrigger
-                    ref={relationshipRef}
-                    variant="soft"
-                    className="min-h-11"
-                    data-testid={`voice-profile-relationship-select-${profile.id}`}
-                    aria-label={t("voiceprofile.setRelationship", {
-                      defaultValue: "Set relationship",
-                    })}
-                    {...relationshipAgentProps}
-                  >
-                    <SelectValue />
-                  </SettingsSelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={NO_RELATIONSHIP_VALUE}>
-                      {t("voiceprofile.noLabel", {
+                  options={[
+                    {
+                      value: NO_RELATIONSHIP_VALUE,
+                      label: t("voiceprofile.noLabel", {
                         defaultValue: "(no label)",
-                      })}
-                    </SelectItem>
-                    {COMMON_RELATIONSHIPS.map((relationship) => (
-                      <SelectItem key={relationship} value={relationship}>
-                        {relationship}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                      }),
+                    },
+                    ...COMMON_RELATIONSHIPS.map((relationship) => ({
+                      value: relationship,
+                      label: relationship,
+                    })),
+                  ]}
+                  triggerClassName="min-h-11"
+                  testId={`voice-profile-relationship-select-${profile.id}`}
+                />
               </div>
               <Button
                 ref={renameBtnRef}

--- a/packages/ui/src/components/settings/settings-agent-rows.tsx
+++ b/packages/ui/src/components/settings/settings-agent-rows.tsx
@@ -16,7 +16,14 @@ import * as React from "react";
 import { useAgentElement } from "../../agent-surface";
 import { cn } from "../../lib/utils";
 import { Button, type ButtonProps } from "../ui/button";
-import { Select, SelectContent, SelectItem, SelectValue } from "../ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectValue,
+} from "../ui/select";
 import {
   SettingsInput,
   type SettingsInputVariant,
@@ -103,6 +110,13 @@ export function SettingsSwitchRow({
 export interface SettingsSelectRowOption {
   value: string;
   label: React.ReactNode;
+  /** Optional descriptive text below the label. */
+  hint?: React.ReactNode;
+}
+
+export interface SettingsSelectRowGroup {
+  label: React.ReactNode;
+  items: SettingsSelectRowOption[];
 }
 
 export interface SettingsSelectRowProps {
@@ -114,11 +128,22 @@ export interface SettingsSelectRowProps {
   iconClassName?: string;
   value: string;
   onValueChange: (value: string) => void;
-  options: SettingsSelectRowOption[];
+  /** Flat options array. For grouped options, use `optionGroups` instead. */
+  options?: SettingsSelectRowOption[];
+  /** Grouped options. Mutually exclusive with `options`. */
+  optionGroups?: SettingsSelectRowGroup[];
   placeholder?: string;
   disabled?: boolean;
   group?: string;
   triggerClassName?: string;
+  /** Optional data-testid for the select trigger. */
+  testId?: string;
+  /** Optional trailing action button (e.g. preview, test). */
+  trailingAction?: {
+    node: React.ReactNode;
+    onClick: () => void;
+    disabled?: boolean;
+  };
 }
 
 export function SettingsSelectRow({
@@ -131,12 +156,21 @@ export function SettingsSelectRow({
   value,
   onValueChange,
   options,
+  optionGroups,
   placeholder,
   disabled = false,
   group = "settings",
   triggerClassName,
+  testId,
+  trailingAction,
 }: SettingsSelectRowProps) {
   const resolvedLabel = agentLabel ?? labelToString(label, agentId);
+
+  // Flatten options for agent surface
+  const flatOptions = optionGroups
+    ? optionGroups.flatMap((g) => g.items.map((item) => item.value))
+    : (options?.map((option) => option.value) ?? []);
+
   const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
     id: agentId,
     role: "select",
@@ -144,10 +178,85 @@ export function SettingsSelectRow({
     group,
     description: typeof description === "string" ? description : undefined,
     status: value || undefined,
-    options: options.map((option) => option.value),
+    options: flatOptions,
     getValue: () => value,
     onFill: disabled ? undefined : (next: string) => onValueChange(next),
   });
+
+  const selectContent = (
+    <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+      <SettingsSelectTrigger
+        ref={ref}
+        variant="touch"
+        className={triggerClassName}
+        aria-label={resolvedLabel}
+        data-testid={testId}
+        {...agentProps}
+      >
+        <SelectValue placeholder={placeholder} />
+      </SettingsSelectTrigger>
+      <SelectContent>
+        {optionGroups
+          ? optionGroups.map((optGroup) => (
+              <SelectGroup key={typeof optGroup.label === "string" ? optGroup.label : "group"}>
+                <SelectLabel className="px-2.5 py-1 text-2xs font-semibold text-muted">
+                  {optGroup.label}
+                </SelectLabel>
+                {optGroup.items.map((item) => (
+                  <SelectItem
+                    key={item.value}
+                    value={item.value}
+                    textValue={typeof item.label === "string" ? item.label : item.value}
+                  >
+                    <div className="flex w-full items-center justify-between gap-2">
+                      <span className="font-semibold">{item.label}</span>
+                      {item.hint ? (
+                        <span className="text-muted text-xs">{item.hint}</span>
+                      ) : null}
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            ))
+          : options?.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                <div className="flex w-full items-center justify-between gap-2">
+                  <span className="font-semibold">{option.label}</span>
+                  {option.hint ? (
+                    <span className="text-muted text-xs">{option.hint}</span>
+                  ) : null}
+                </div>
+              </SelectItem>
+            ))}
+      </SelectContent>
+    </Select>
+  );
+
+  if (trailingAction) {
+    return (
+      <SettingsRow
+        icon={icon}
+        iconClassName={iconClassName}
+        label={label}
+        description={description}
+        stacked
+      >
+        <div className="flex items-center gap-2">
+          {selectContent}
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-11 w-11 shrink-0 rounded-md"
+            onClick={trailingAction.onClick}
+            disabled={trailingAction.disabled ?? disabled}
+          >
+            {trailingAction.node}
+          </Button>
+        </div>
+      </SettingsRow>
+    );
+  }
 
   return (
     <SettingsRow
@@ -157,24 +266,7 @@ export function SettingsSelectRow({
       description={description}
       stacked
     >
-      <Select value={value} onValueChange={onValueChange} disabled={disabled}>
-        <SettingsSelectTrigger
-          ref={ref}
-          variant="touch"
-          className={triggerClassName}
-          aria-label={resolvedLabel}
-          {...agentProps}
-        >
-          <SelectValue placeholder={placeholder} />
-        </SettingsSelectTrigger>
-        <SelectContent>
-          {options.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      {selectContent}
     </SettingsRow>
   );
 }
@@ -294,6 +386,8 @@ export interface SettingsInputRowProps {
   group?: string;
   className?: string;
   inputClassName?: string;
+  /** Optional data-testid for the input element. */
+  testId?: string;
 }
 
 /** A labelled text/number field that the agent can read and fill from chat. */
@@ -315,6 +409,7 @@ export function SettingsInputRow({
   group = "settings",
   className,
   inputClassName,
+  testId,
 }: SettingsInputRowProps) {
   const resolvedLabel = agentLabel ?? labelToString(label, agentId);
   const { ref, agentProps } = useAgentElement<HTMLInputElement>({
@@ -347,6 +442,7 @@ export function SettingsInputRow({
         autoComplete={autoComplete}
         disabled={disabled}
         aria-label={resolvedLabel}
+        data-testid={testId}
         className={inputClassName}
         {...agentProps}
       />


### PR DESCRIPTION
## Summary
- Replace hand-rolled Label+Select patterns with SettingsSelectRow component
- Ensures consistent layout and accessibility across settings sections
- Modified settings-agent-rows.tsx, IdentitySettingsSection.tsx, VoiceProfileSection.tsx

## Fixes
Closes #19149

## Test Evidence
All 10 UI tests passing