### PR TITLE
fix(cloud): flush buffered phone audio on barge-in

### DIFF
--- a/packages/cloud/api/v1/twilio/voice/media/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/media/route.ts
@@ -277,6 +277,11 @@ app.get("/", async (c) => {
     sendControl(frame) {
       if (frame.t === "interrupted" && streamSid) {
         sendEvent({ event: "clear", streamSid });
+        logger.info("[twilio-media] caller barge-in cleared audio", {
+          streamSid,
+          traceId: frame.traceId,
+          reason: frame.reason,
+        });
       }
       if (frame.t === "error") {
         logger.warn("[twilio-media] voice session error", {
@@ -305,6 +310,13 @@ app.get("/", async (c) => {
         event: "media",
         streamSid,
         media: { payload: encodeTwilioMedia(bytes) },
+      });
+    },
+    clearAudio() {
+      if (!streamSid) return;
+      sendEvent({ event: "clear", streamSid });
+      logger.info("[twilio-media] caller turn-start flushed buffered audio", {
+        streamSid,
       });
     },
     close(code, reason) {

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -446,6 +446,7 @@ async function connectSession(opts: {
   prewarmElizaContext?: () => Promise<void>;
   openingGreeting?: string;
   cacheWarmingRetryDelaysMs?: readonly number[];
+  onClearAudio?: () => void;
   fish?: {
     enabled?: boolean;
     firstAudioTimeoutMs?: number;
@@ -494,7 +495,9 @@ async function connectSession(opts: {
           : {}),
         usageStore,
         usageLimits: { organizationDailyMinutes: 600, userDailyMinutes: 120 },
-        downlink,
+        downlink: opts.onClearAudio
+          ? { ...downlink, clearAudio: opts.onClearAudio }
+          : downlink,
       }),
   });
 
@@ -1604,6 +1607,32 @@ describe("voice-session WS lifecycle", () => {
     await flush();
     expect(FakeCartesiaSocket.instances.at(-1)).not.toBe(cartesia);
     expect(client.audioFrames.length).toBeGreaterThan(audioBeforeInterruption);
+  });
+
+  test("semantic turn-start flushes transport audio after server TTS completed", async () => {
+    const client = new FakeClientSocket();
+    let clearCount = 0;
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["A response Twilio may buffer."]),
+      onClearAudio: () => {
+        clearCount += 1;
+      },
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "say something");
+    await flush();
+    await flush();
+    FakeCartesiaSocket.instances.at(-1)!.emitDone();
+    await flush();
+    expect(client.controlTypes()).toContain("speaking_end");
+    clearCount = 0;
+
+    ink.emitTurn("turn.start");
+    await flush();
+    expect(clearCount).toBe(1);
   });
 
   test("a final-only caller transcript still interrupts the active response", async () => {

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -491,7 +491,12 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         // so Eliza never talks over the caller while transcription continues.
         this.resetSttPartialDelivery();
         this.activeSttTurn = true;
+        const responseActive = Boolean(this.currentVoiceTurnId);
         this.interrupt("acoustic");
+        // A transport such as Twilio can still be playing audio it buffered
+        // before TTS reported completion. There is no active turn to emit an
+        // `interrupted` frame in that state, so flush the transport directly.
+        if (!responseActive) this.config.downlink.clearAudio?.();
         this.state = "transcribing";
         break;
       }

--- a/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.test.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.test.ts
@@ -124,6 +124,12 @@ describe("Cartesia Ink realtime adapter", () => {
     expect(url.searchParams.get("turn_end_timeout_ms")).toBe(
       String(CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS),
     );
+    expect(CARTESIA_INK_TURN_START_THRESHOLD).toBeGreaterThan(
+      CARTESIA_INK_TURN_EAGER_END_THRESHOLD,
+    );
+    expect(CARTESIA_INK_TURN_EAGER_END_THRESHOLD).toBeGreaterThan(
+      CARTESIA_INK_TURN_END_THRESHOLD,
+    );
     expect(url.searchParams.get("cartesia_version")).toBe(
       CARTESIA_INK_API_VERSION,
     );

--- a/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.ts
@@ -13,9 +13,11 @@ export const CARTESIA_INK_SAMPLE_RATE = 16_000;
 export const CARTESIA_INK_AUDIO_ENCODING = "pcm_s16le";
 export const CARTESIA_INK_CHUNK_MILLISECONDS = 100;
 export const CARTESIA_INK_CHUNK_BYTES = 3_200;
-export const CARTESIA_INK_TURN_START_THRESHOLD = 0.8;
-export const CARTESIA_INK_TURN_EAGER_END_THRESHOLD = 0.5;
-export const CARTESIA_INK_TURN_END_THRESHOLD = 0.4;
+// Lowest supported semantic start threshold: phone callers must get the floor
+// before buffered TTS can talk over the beginning of their interruption.
+export const CARTESIA_INK_TURN_START_THRESHOLD = 0.5;
+export const CARTESIA_INK_TURN_EAGER_END_THRESHOLD = 0.4;
+export const CARTESIA_INK_TURN_END_THRESHOLD = 0.3;
 export const CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS = 1_200;
 
 const DEFAULT_CLOSE_CODE = 1000;

--- a/packages/cloud/shared/src/lib/voice-session/ws-handler.ts
+++ b/packages/cloud/shared/src/lib/voice-session/ws-handler.ts
@@ -37,6 +37,8 @@ import {
 export interface VoiceSessionDownlink {
   sendControl(frame: ServerControlFrame): void;
   sendAudio(bytes: Uint8Array): void;
+  /** Flush transport-buffered playback that may outlive server-side TTS. */
+  clearAudio?(): void;
   close(code: number, reason: string): void;
 }
 


### PR DESCRIPTION
Closes #19395

## Root cause

Twilio can continue playing audio it buffered after server-side TTS has emitted `done` and the voice session has cleared its active turn id. A subsequent caller `turn.start` therefore had no active response to interrupt and never sent Twilio `clear`, so stale speech played over the caller.

## Fix

- use Cartesia's fastest valid semantic turn profile (`0.5 > 0.4 > 0.3`)
- flush transport-buffered playback on every caller turn-start when no server response remains active
- retain the existing active-turn cancellation and zero-post-cancel guarantees
- log both active-response clears and post-TTS buffered-audio flushes
- assert strict threshold ordering and the completed-TTS transport-flush regression

## Verification

- voice lifecycle and Cartesia adapter suites passed, including completed-TTS buffered playback
- cloud API typecheck and production Worker dry-run passed
- cloud API lint passed
- `bun run verify:cloud`: 78/78 tasks passed
- exact head `a619af60cac881efbd3fc84d9ee140926a201483` deployed as Worker `ce9c6642-a8fb-4adb-876b-d60d261c3b01`

## Live carrier evidence

Call `CAe3294817e02f641137bdd67fc2812ddf`, dual-channel recording `RE05c024b1c1a630c1b14044975830ea5d`:

- Eliza audio: 9.86–13.74s
- caller interruption begins: 13.74s
- Eliza audio ends: 13.74s (zero overlap)
- caller finishes: 15.88s
- replacement reply begins: 17.20s

## AI provenance

Implemented with Codex following interactive production feedback. The initial evidence was rejected as insufficient; this revision was diagnosed and accepted only after a genuine overlap-boundary recording.
