### PR TITLE
fix(homepage): keep messaging outcomes visible

### DIFF
--- a/packages/homepage/src/pages/connected.tsx
+++ b/packages/homepage/src/pages/connected.tsx
@@ -16,7 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@elizaos/ui/dropdown-menu";
 import { Check, Copy, Info, LogOut } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { ElizaLogo } from "@/components/brand/eliza-logo";
 import {
@@ -92,7 +92,6 @@ export default function ConnectedPage() {
   const [phoneCopyState, setPhoneCopyState] = useState<
     "idle" | "copied" | "error"
   >("idle");
-  const phoneCopyResetRef = useRef<number | null>(null);
   const [copiedTelegram, setCopiedTelegram] = useState(false);
   const [copiedWhatsApp, setCopiedWhatsApp] = useState(false);
 
@@ -161,32 +160,13 @@ export default function ConnectedPage() {
     }
   }, [isAuthenticated, isLoading, navigate]);
 
-  useEffect(
-    () => () => {
-      if (phoneCopyResetRef.current !== null) {
-        window.clearTimeout(phoneCopyResetRef.current);
-      }
-    },
-    [],
-  );
-
-  const setTemporaryPhoneCopyState = (state: "copied" | "error") => {
-    setPhoneCopyState(state);
-    if (phoneCopyResetRef.current !== null) {
-      window.clearTimeout(phoneCopyResetRef.current);
-    }
-    phoneCopyResetRef.current = window.setTimeout(
-      () => setPhoneCopyState("idle"),
-      2_000,
-    );
-  };
-
   const handleCopyPhone = async () => {
     try {
       await navigator.clipboard.writeText(ELIZA_PHONE_NUMBER);
-      setTemporaryPhoneCopyState("copied");
+      setPhoneCopyState("copied");
     } catch {
-      setTemporaryPhoneCopyState("error");
+      // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
+      setPhoneCopyState("error");
     }
   };
 
@@ -223,9 +203,10 @@ export default function ConnectedPage() {
   const handleOpenMessages = async () => {
     try {
       const outcome = await openOrCopyElizaMessage(window);
-      if (outcome === "copied") setTemporaryPhoneCopyState("copied");
+      if (outcome === "copied") setPhoneCopyState("copied");
     } catch {
-      setTemporaryPhoneCopyState("error");
+      // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
+      setPhoneCopyState("error");
     }
   };
 
@@ -284,7 +265,7 @@ export default function ConnectedPage() {
           className={`fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-full bg-white px-4 py-2 text-sm font-medium shadow-lg ${
             phoneCopyState === "copied" ? "text-green-700" : "text-red-700"
           }`}
-          role="status"
+          role={phoneCopyState === "error" ? "alert" : "status"}
           aria-live="polite"
         >
           {phoneCopyState === "copied"

--- a/packages/homepage/src/pages/get-started.tsx
+++ b/packages/homepage/src/pages/get-started.tsx
@@ -708,22 +708,12 @@ export default function GetStartedPage() {
   const [messageNotice, setMessageNotice] = useState<
     "idle" | "copied" | "error"
   >("idle");
-  const messageNoticeResetRef = useRef<number | null>(null);
   const [showContent, setShowContent] = useState(false);
 
   useEffect(() => {
     const timer = setTimeout(() => setShowContent(true), 100);
     return () => clearTimeout(timer);
   }, []);
-
-  useEffect(
-    () => () => {
-      if (messageNoticeResetRef.current !== null) {
-        window.clearTimeout(messageNoticeResetRef.current);
-      }
-    },
-    [],
-  );
 
   const headerStyle: CSSProperties = {
     opacity: showContent ? 1 : 0,
@@ -1303,15 +1293,9 @@ export default function GetStartedPage() {
       const outcome = await openOrCopyElizaMessage(window);
       setMessageNotice(outcome === "copied" ? "copied" : "idle");
     } catch {
+      // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
       setMessageNotice("error");
     }
-    if (messageNoticeResetRef.current !== null) {
-      window.clearTimeout(messageNoticeResetRef.current);
-    }
-    messageNoticeResetRef.current = window.setTimeout(
-      () => setMessageNotice("idle"),
-      2_000,
-    );
   };
 
   const handleContinueToConnected = () => {
@@ -1820,7 +1804,7 @@ export default function GetStartedPage() {
 
               {messageNotice !== "idle" && (
                 <p
-                  role="status"
+                  role={messageNotice === "error" ? "alert" : "status"}
                   aria-live="polite"
                   className={`mt-3 text-center text-sm font-medium ${
                     messageNotice === "copied"

--- a/packages/homepage/src/pages/landing.tsx
+++ b/packages/homepage/src/pages/landing.tsx
@@ -1,11 +1,12 @@
 /**
  * eliza.app landing page: a single-viewport, personal-feeling lander.
  *
- * The first action opens a real iMessage thread; account and app setup stay out
- * of the way until someone wants the richer companion experience. The phone
- * demo stays within the immediately available product: conversation memory and
- * current web search. It is decorative and intentionally English-only.
- * Reduced motion shows its settled intro, which keeps screenshots deterministic.
+ * The first action opens a native message handler where supported and copies
+ * the number elsewhere; account and app setup stay out of the way until someone
+ * wants the richer companion experience. The phone demo stays within the
+ * immediately available product: conversation memory and current web search.
+ * It is decorative and intentionally English-only. Reduced motion shows its
+ * settled intro, which keeps screenshots deterministic.
  */
 
 import {
@@ -619,7 +620,6 @@ export default function LandingPage() {
   const [phoneCopyState, setPhoneCopyState] = useState<
     "idle" | "copied" | "error"
   >("idle");
-  const phoneCopyResetRef = useRef<number | null>(null);
   const whatsappHref = buildElizaWhatsAppHref();
   const browserWindow = typeof window === "undefined" ? null : window;
   const signedIn =
@@ -661,29 +661,14 @@ export default function LandingPage() {
     },
   ];
 
-  useEffect(
-    () => () => {
-      if (phoneCopyResetRef.current !== null) {
-        window.clearTimeout(phoneCopyResetRef.current);
-      }
-    },
-    [],
-  );
-
   const handleMessageEliza = async () => {
     try {
       const outcome = await openOrCopyElizaMessage(window);
       setPhoneCopyState(outcome === "copied" ? "copied" : "idle");
     } catch {
+      // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
       setPhoneCopyState("error");
     }
-    if (phoneCopyResetRef.current !== null) {
-      window.clearTimeout(phoneCopyResetRef.current);
-    }
-    phoneCopyResetRef.current = window.setTimeout(
-      () => setPhoneCopyState("idle"),
-      2_000,
-    );
   };
 
   const phoneCopyLabel =
@@ -778,7 +763,7 @@ export default function LandingPage() {
           {phoneCopyState !== "idle" && (
             <div
               className={`landing-copy-notice landing-copy-notice--${phoneCopyState}`}
-              role="status"
+              role={phoneCopyState === "error" ? "alert" : "status"}
               aria-live="polite"
             >
               {phoneCopyLabel}

--- a/packages/homepage/tests/e2e/app-routes-flow.spec.ts
+++ b/packages/homepage/tests/e2e/app-routes-flow.spec.ts
@@ -329,7 +329,7 @@ test("landing leads with iMessage and keeps secondary channels available", async
   context,
   page,
 }) => {
-  await context.grantPermissions(["clipboard-write"]);
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
   await page.goto("/");
 
   await expect(
@@ -339,6 +339,11 @@ test("landing leads with iMessage and keeps secondary channels available", async
   const textCta = page.getByRole("button", { name: "Message Eliza" });
   await expect(textCta).toBeVisible();
   await textCta.click();
+  await expect(page.getByRole("status")).toHaveText("Phone number copied");
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe("+18087881821");
+  await page.waitForTimeout(2_250);
   await expect(page.getByRole("status")).toHaveText("Phone number copied");
   await expect(page.getByText("+1 (808) 788-1821")).toHaveCount(0);
   await expect(page.getByRole("link", { name: "Call" })).toHaveAttribute(
@@ -383,8 +388,10 @@ test("landing leads with iMessage and keeps secondary channels available", async
 });
 
 test("landing keeps content reachable on a small viewport", async ({
+  context,
   page,
 }) => {
+  await context.grantPermissions(["clipboard-write"]);
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");
   await waitForLandingIntro(page);
@@ -399,4 +406,31 @@ test("landing keeps content reachable on a small viewport", async ({
   const composer = page.locator(".landing-phone-composer");
   await composer.scrollIntoViewIfNeeded();
   await expect(composer).toBeVisible();
+
+  await page.getByRole("button", { name: "Message Eliza" }).click();
+  await expect(page.getByRole("status")).toHaveText("Phone number copied");
+  await page.waitForTimeout(2_250);
+  await expect(page.getByRole("status")).toHaveText("Phone number copied");
+});
+
+test("landing keeps clipboard rejection visible", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: () =>
+          Promise.reject(new DOMException("denied", "NotAllowedError")),
+      },
+    });
+  });
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Message Eliza" }).click();
+  await expect(page.getByRole("alert")).toHaveText(
+    "Couldn't copy the phone number",
+  );
+  await page.waitForTimeout(2_250);
+  await expect(page.getByRole("alert")).toHaveText(
+    "Couldn't copy the phone number",
+  );
 });


### PR DESCRIPTION
# Relates to

Closes #19388. Follow-up to #19397.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change from the evidence below without reading the code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@bff61aeda88e0a1ddb28c02b19a7ca325b2f403c`; zero conflicts.
- [x] Exact-head `bun run verify` passes.

# Risks

Low. The change removes only the timers that erased messaging outcomes and adds accessibility semantics to the existing failure notices. Native SMS routing, platform detection, clipboard contents, and WhatsApp behavior are unchanged.

# Background

## What does this PR do?

#19397 correctly removed the public sender number and introduced the native-message/clipboard fallback, but it also cleared both success and failure feedback after two seconds. That made a real clipboard rejection disappear even though nothing had recovered—the timeout hid the error.

This follow-up keeps the last honest outcome visible until the user tries again or leaves the page. Clipboard failures use `role="alert"`; successful copy feedback remains a polite status. Desktop, mobile, and rejection tests cross the former 2-second boundary to prove the outcome is not erased.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is required; this corrects transient feedback behavior on existing homepage CTAs.

# Testing

## Where should a reviewer start?

Open `/`, `/get-started`, or `/connected` on a desktop browser, activate **Message Eliza**, and observe that the copy result remains visible. Deny clipboard writes to verify the error remains visible as an alert.

## Detailed testing steps

- `bun install` — passed; 7,144 packages, native artifact bundle verified.
- `bun run verify` — passed at exact head: 350/350 tasks plus all repository audits; anti-larp scanned 8,030 test files with zero focused/orphaned skips.
- `bun run --cwd packages/homepage test` — passed, 101/101.
- `bun run --cwd packages/homepage typecheck` — passed.
- `bunx biome check packages/homepage/src/pages/{landing,get-started,connected}.tsx packages/homepage/tests/e2e/app-routes-flow.spec.ts` — passed.
- `bunx playwright test tests/e2e/app-routes-flow.spec.ts` from `packages/homepage` — passed, 9/9.
- Focused recorded desktop/mobile/error persistence paths — passed, 3/3 after waiting beyond 2,000 ms.
- `bun run --cwd packages/app audit:app` — passed: 219/219, broken=0, needs-work=0; OCR verified 216 views.
- `bun run evidence:doctor -- --strict` — all required tools present.

# Evidence Gate

<!-- evidence-head:221c41ec78553f1b776855db95c3f5713f0e2c55 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19411-before-desktop-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19411-after-persistent-states.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19411-walkthrough-persistent-desktop-mobile-error.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - browser clipboard/native URL action does not invoke a backend route
<!-- evidence-row:frontend-logs -->
- [x] [19411-frontend-console-network.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19411-frontend-console-network.json)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic homepage UI behavior; no model call
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain state is created by the CTA
<!-- evidence-row:ocr-review -->
- [x] [19411-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19411-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic homepage UI behavior; no model call.

## Backend + frontend logs

Backend: N/A - the browser clipboard/native URL action does not invoke a backend route.

Frontend log is attached in the evidence row above. It records zero console errors, zero page errors, zero non-2xx responses, exact clipboard text `+18087881821`, zero rendered copies of that number, and persistent success state after the former timeout boundary.

## Screenshots (before / after) + video walkthrough

Artifacts are attached in the evidence rows above. The issue-level before image records the public number before #19397; the after image and MP4 record this PR's persistent desktop/mobile success and desktop failure states. The capture's homepage tree is byte-identical to this head; the final rebase changed cloud-only files.

## Audio / voice walkthrough

N/A - no audio or voice behavior changes.

## Known gaps / failures

- Homepage `test:audit` reaches the real pages with clean console/page-error checks, then reports existing current-base findings: strict corner-radius checks in the iPhone mockup/keyboard, the intentionally hidden mobile leaderboard logo, and an unrelated Solana auth redirect. The scoped 9/9 route flow, recorded 3/3 persistence proof, and required app audit are green.
- Hosted visual artifacts were captured on a frontend-tree-equivalent commit before the final cloud-only base rebase. All affected homepage bytes are identical at the exact PR head; exact-head root verification is green.
- Backend, LLM, domain, and audio evidence are inapplicable for this browser-only feedback correction, as described above.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->

