### PR TITLE
fix(plugin-coding-tools): complete shell redaction boundaries

### DIFF
--- a/plugins/plugin-coding-tools/__tests__/plugin-integration.test.ts
+++ b/plugins/plugin-coding-tools/__tests__/plugin-integration.test.ts
@@ -222,6 +222,7 @@ describe("@elizaos/plugin-coding-tools — end-to-end smoke", () => {
       agentId: "00000000-0000-0000-0000-000000000000" as UUID,
       getSetting: (_key: string) => undefined,
       getService: (key: string) => services.get(key) ?? null,
+      redactSecrets: (text: string) => text,
     } as IAgentRuntime;
 
     const fileState = await FileStateService.start(runtime);

--- a/plugins/plugin-coding-tools/src/actions/bash.error-path.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.error-path.test.ts
@@ -22,6 +22,7 @@ async function makeHostRuntime(): Promise<IAgentRuntime> {
     agentId: "11111111-1111-1111-1111-111111111111" as UUID,
     getSetting: vi.fn(() => undefined),
     getService: vi.fn(<T>(type: string) => services.get(type) as T | null),
+    redactSecrets: vi.fn((text: string) => text),
     reportError: vi.fn(),
   } as unknown as IAgentRuntime;
   services.set(SANDBOX_SERVICE, await SandboxService.start(runtime));

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -13,6 +13,7 @@ import {
   type ActionResult,
   CAPABILITY_ROUTER_SERVICE_TYPE,
   CapabilityError,
+  logger as coreLogger,
   type ElizaCapabilityRouter,
   type IAgentRuntime,
   type Memory,
@@ -152,6 +153,9 @@ async function makeRuntime(opts: RuntimeOptions = {}): Promise<{
   const services = new Map<string, unknown>();
   const runtime = {
     agentId: "11111111-1111-1111-1111-111111111111" as UUID,
+    character: opts.configuredSecret
+      ? { settings: { secrets: { TEST_SECRET: opts.configuredSecret } } }
+      : {},
     getSetting: vi.fn((key: string) => settings[key]),
     getService: vi.fn(<T>(type: string) => services.get(type) as T | null),
     redactSecrets: vi.fn((text: string) =>
@@ -1883,6 +1887,116 @@ describeIfPosix("shellAction", () => {
     expect(exposed).not.toContain(secret);
   });
 
+  it("applies pattern redaction even without a configured literal secret", async () => {
+    const token = "token-value-123456789";
+    const router = makeShellRouter(async () => ({
+      output: `Bearer ${token}\n`,
+      exitCode: 0,
+      timedOut: false,
+    }));
+    const { runtime } = await makeRuntime({ capabilityRouter: router });
+
+    const result = requireActionResult(
+      await shellAction.handler?.(runtime, makeMessage(), undefined, {
+        command: `printf 'Bearer ${token}'`,
+      }),
+    );
+
+    expect(JSON.stringify(result)).not.toContain(token);
+  });
+
+  it("redacts cwd validation and destructive-confirmation failures", async () => {
+    const secret = "orchid42";
+    const blockedCwd = path.join(process.cwd(), secret);
+    const { runtime } = await makeRuntime({
+      blockedPaths: blockedCwd,
+      configuredSecret: secret,
+    });
+
+    const cwdFailure = requireActionResult(
+      await shellAction.handler?.(runtime, makeMessage(), undefined, {
+        command: "true",
+        cwd: blockedCwd,
+      }),
+    );
+    const destructiveFailure = requireActionResult(
+      await shellAction.handler?.(runtime, makeMessage(), undefined, {
+        command: `mkfs.${secret} /tmp/${secret}`,
+      }),
+    );
+
+    expect(cwdFailure.success).toBe(false);
+    expect(destructiveFailure.success).toBe(false);
+    expect(JSON.stringify({ cwdFailure, destructiveFailure })).not.toContain(
+      secret,
+    );
+  });
+
+  it("builds planner summaries only from the redacted result command", async () => {
+    const secret = "summary-secret";
+    const router = makeShellRouter(async () => ({
+      output: "ok\n",
+      exitCode: 0,
+      timedOut: false,
+    }));
+    const { runtime } = await makeRuntime({
+      capabilityRouter: router,
+      configuredSecret: secret,
+    });
+    const params = { command: `printf '%s' '${secret}'` };
+    const result = requireActionResult(
+      await shellAction.handler?.(runtime, makeMessage(), undefined, params),
+    );
+
+    const summary = shellAction.summarize?.(result, params);
+    expect(summary).toContain("[REDACTED:TEST_SECRET]");
+    expect(summary).not.toContain(secret);
+  });
+
+  it("redacts cwd values in structured shell logs", async () => {
+    const secret = "log-secret";
+    const missingCwd = path.join(process.cwd(), `${secret}-missing`);
+    const router = makeShellRouter(async () => ({
+      output: "ok\n",
+      exitCode: 0,
+      timedOut: false,
+    }));
+    const { runtime } = await makeRuntime({
+      capabilityRouter: router,
+      configuredSecret: secret,
+    });
+    const logger = coreLogger as unknown as Record<
+      "debug" | "info" | "warn",
+      (...args: unknown[]) => void
+    >;
+    const original = {
+      debug: logger.debug,
+      info: logger.info,
+      warn: logger.warn,
+    };
+    const logs: unknown[] = [];
+    logger.debug = (...args) => logs.push(args);
+    logger.info = (...args) => logs.push(args);
+    logger.warn = (...args) => logs.push(args);
+
+    try {
+      const result = requireActionResult(
+        await shellAction.handler?.(runtime, makeMessage(), undefined, {
+          command: "true",
+          cwd: missingCwd,
+        }),
+      );
+      expect(result.success).toBe(true);
+    } finally {
+      logger.debug = original.debug;
+      logger.info = original.info;
+      logger.warn = original.warn;
+    }
+
+    expect(JSON.stringify(logs)).not.toContain(secret);
+    expect(JSON.stringify(logs)).toContain("[REDACTED:TEST_SECRET]");
+  });
+
   it("redacts a configured bare secret from every background session projection", async () => {
     const secret = "violet73";
     const { runtime } = await makeRuntime({ configuredSecret: secret });
@@ -1922,7 +2036,68 @@ describeIfPosix("shellAction", () => {
           unknown
         >
       ).startOffset,
-    ).toBe(0);
+    ).toBe(3);
+    expect(partialPoll.text).toContain("[REDACTED:chunk-boundary]");
+  });
+
+  it("keeps an eviction-split configured secret inside the private overlap", async () => {
+    const secret = "violet73";
+    const payload = `${"a".repeat(6)}${secret}${"z".repeat(36)}`;
+    const { runtime } = await makeRuntime({
+      backgroundBufferChars: 20,
+      configuredSecret: secret,
+    });
+    const actor = makeMessage();
+    const start = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "start_background",
+        command: `printf '%s' '${payload}'`,
+      }),
+    );
+    const handle = (start.data as Record<string, unknown>).handle as string;
+    const poll = await pollUntil(runtime, actor, handle, (data) => {
+      const stdout = data.stdout as Record<string, unknown> | undefined;
+      return data.status === "exited" && stdout?.truncatedBefore === 30;
+    });
+    const stdout = (poll.data as Record<string, unknown>).stdout as Record<
+      string,
+      unknown
+    >;
+
+    expect(stdout.text).toBe("z".repeat(20));
+    expect(stdout.startOffset).toBe(30);
+    expect(JSON.stringify(poll)).not.toContain(secret);
+    expect(JSON.stringify(poll)).not.toContain(secret.slice(4));
+  });
+
+  it("expands the private overlap when a configured secret rotates", async () => {
+    const rotatedSecret = "rotated-secret-value-LEAK_SENTINEL_9Q";
+    const payload = `${"a".repeat(10)}${rotatedSecret}${"z".repeat(8)}`;
+    const { runtime } = await makeRuntime({ backgroundBufferChars: 20 });
+    runtime.character.settings = {
+      secrets: { ROTATED_SECRET: rotatedSecret },
+    };
+    vi.mocked(runtime.redactSecrets).mockImplementation((text: string) =>
+      text.replaceAll(rotatedSecret, "[REDACTED:ROTATED_SECRET]"),
+    );
+    const actor = makeMessage();
+    const start = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "start_background",
+        command: `printf '%s' '${payload}'`,
+      }),
+    );
+    const handle = (start.data as Record<string, unknown>).handle as string;
+    const poll = await pollUntil(runtime, actor, handle, (data) => {
+      const stdout = data.stdout as Record<string, unknown> | undefined;
+      return (
+        data.status === "exited" &&
+        stdout?.truncatedBefore === payload.length - 20
+      );
+    });
+
+    expect(poll.text).toContain("[REDACTED:chunk-boundary]");
+    expect(JSON.stringify(poll)).not.toContain(rotatedSecret.slice(-12));
   });
 });
 

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -2042,7 +2042,7 @@ describeIfPosix("shellAction", () => {
 
   it("keeps an eviction-split configured secret inside the private overlap", async () => {
     const secret = "violet73";
-    const payload = `${"a".repeat(6)}${secret}${"z".repeat(36)}`;
+    const payload = `${"a".repeat(26)}${secret}${"z".repeat(16)}`;
     const { runtime } = await makeRuntime({
       backgroundBufferChars: 20,
       configuredSecret: secret,
@@ -2064,7 +2064,7 @@ describeIfPosix("shellAction", () => {
       unknown
     >;
 
-    expect(stdout.text).toBe("z".repeat(20));
+    expect(stdout.text).toContain("[REDACTED:chunk-boundary]");
     expect(stdout.startOffset).toBe(30);
     expect(JSON.stringify(poll)).not.toContain(secret);
     expect(JSON.stringify(poll)).not.toContain(secret.slice(4));

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -1255,8 +1255,16 @@ export const shellAction: Action = {
     },
   ],
   validate: async () => true,
-  summarize: (result, params) =>
-    result?.success === true ? summarizeShellCommand(params) : undefined,
+  summarize: (result) => {
+    if (result?.success !== true) return undefined;
+    const data =
+      result.data &&
+      typeof result.data === "object" &&
+      !Array.isArray(result.data)
+        ? (result.data as Record<string, unknown>)
+        : undefined;
+    return summarizeShellCommand(data?.command);
+  },
   handler: async (
     runtime: IAgentRuntime,
     message: Memory,
@@ -1527,7 +1535,7 @@ export const shellAction: Action = {
       if (v.ok === false) {
         return failureToActionResult({
           reason: v.reason === "blocked" ? "path_blocked" : "invalid_param",
-          message: v.message,
+          message: redactShellText(runtime, v.message),
         });
       }
       try {
@@ -1552,11 +1560,19 @@ export const shellAction: Action = {
         const fallback = await session.getExistingCwd(conversationId);
         cwd = fallback.cwd;
         coreLogger.warn(
-          `${CODING_TOOLS_LOG_PREFIX} SHELL cwd not found; using session cwd (requested=${cwdParam}, fallback=${cwd})`,
+          {
+            requestedCwd: redactShellText(runtime, cwdParam),
+            fallbackCwd: redactShellText(runtime, cwd),
+          },
+          `${CODING_TOOLS_LOG_PREFIX} SHELL cwd not found; using session cwd`,
         );
         if (fallback.reset && fallback.previousCwd) {
           coreLogger.warn(
-            `${CODING_TOOLS_LOG_PREFIX} SHELL reset missing session cwd (previous=${fallback.previousCwd}, fallback=${cwd})`,
+            {
+              previousCwd: redactShellText(runtime, fallback.previousCwd),
+              fallbackCwd: redactShellText(runtime, cwd),
+            },
+            `${CODING_TOOLS_LOG_PREFIX} SHELL reset missing session cwd`,
           );
         }
       }
@@ -1570,11 +1586,19 @@ export const shellAction: Action = {
       ) {
         cwd = sessionCwd.cwd;
         coreLogger.warn(
-          `${CODING_TOOLS_LOG_PREFIX} SHELL ignored ungrounded runtime cwd; using session cwd (requested=${v.resolved}, fallback=${cwd})`,
+          {
+            requestedCwd: redactShellText(runtime, v.resolved),
+            fallbackCwd: redactShellText(runtime, cwd),
+          },
+          `${CODING_TOOLS_LOG_PREFIX} SHELL ignored ungrounded runtime cwd; using session cwd`,
         );
         if (sessionCwd.reset && sessionCwd.previousCwd) {
           coreLogger.warn(
-            `${CODING_TOOLS_LOG_PREFIX} SHELL reset missing session cwd (previous=${sessionCwd.previousCwd}, fallback=${cwd})`,
+            {
+              previousCwd: redactShellText(runtime, sessionCwd.previousCwd),
+              fallbackCwd: redactShellText(runtime, cwd),
+            },
+            `${CODING_TOOLS_LOG_PREFIX} SHELL reset missing session cwd`,
           );
         }
       }
@@ -1584,7 +1608,11 @@ export const shellAction: Action = {
       cwd = sessionCwd.cwd;
       if (sessionCwd.reset && sessionCwd.previousCwd) {
         coreLogger.warn(
-          `${CODING_TOOLS_LOG_PREFIX} SHELL reset missing session cwd (previous=${sessionCwd.previousCwd}, fallback=${cwd})`,
+          {
+            previousCwd: redactShellText(runtime, sessionCwd.previousCwd),
+            fallbackCwd: redactShellText(runtime, cwd),
+          },
+          `${CODING_TOOLS_LOG_PREFIX} SHELL reset missing session cwd`,
         );
       }
     }
@@ -1597,7 +1625,8 @@ export const shellAction: Action = {
     if (groundedCommand !== command) {
       command = groundedCommand;
       coreLogger.warn(
-        `${CODING_TOOLS_LOG_PREFIX} SHELL removed ungrounded runtime directory override; using cwd=${cwd}`,
+        { cwd: redactShellText(runtime, cwd) },
+        `${CODING_TOOLS_LOG_PREFIX} SHELL removed ungrounded runtime directory override`,
       );
     }
     // The disk / memory / source-search / crypto command rewrites below are
@@ -1630,21 +1659,25 @@ export const shellAction: Action = {
       const verdict = classifyDestructiveCommand(command);
       const confirmed = readBoolParam(options, "confirm") === true;
       if (verdict.destructive && !confirmed) {
+        const redactedReason = verdict.reason
+          ? redactShellText(runtime, verdict.reason)
+          : undefined;
+        const redactedTargets = verdict.targets.map((target) =>
+          redactShellText(runtime, target),
+        );
         const targetList =
-          verdict.targets.filter(Boolean).join(", ") || "its targets";
+          redactedTargets.filter(Boolean).join(", ") || "its targets";
         return failureToActionResult(
           {
             reason: "needs_confirmation",
             message:
-              `this ${verdict.reason ?? "destructive operation"} would permanently affect: ${targetList}. ` +
+              `this ${redactedReason ?? "destructive operation"} would permanently affect: ${targetList}. ` +
               "ask the user to confirm the exact operation, then re-run with confirm=true.",
           },
           {
             command: redactShellText(runtime, command),
-            destructive_reason: verdict.reason,
-            targets: verdict.targets.map((target) =>
-              redactShellText(runtime, target),
-            ),
+            destructive_reason: redactedReason,
+            targets: redactedTargets,
           },
         );
       }
@@ -1768,12 +1801,16 @@ export const shellAction: Action = {
     );
 
     coreLogger.debug(
-      `${CODING_TOOLS_LOG_PREFIX} SHELL cwd=${cwd} timeout=${timeout}ms`,
+      { cwd: redactedCwd, timeoutMs: timeout },
+      `${CODING_TOOLS_LOG_PREFIX} SHELL dispatch configuration`,
     );
 
     const startedAt = Date.now();
     const mode = resolveRuntimeExecutionMode(runtime);
-    coreLogger.info(`${CODING_TOOLS_LOG_PREFIX} SHELL mode=${mode} cwd=${cwd}`);
+    coreLogger.info(
+      { mode, cwd: redactedCwd },
+      `${CODING_TOOLS_LOG_PREFIX} SHELL dispatch`,
+    );
 
     let result: ShellResult;
     try {

--- a/plugins/plugin-coding-tools/src/actions/summaries.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/summaries.test.ts
@@ -29,9 +29,7 @@ describe("coding tool planner summaries", () => {
   });
 
   it("summarizes shell commands with bounded text", () => {
-    expect(summarizeShellCommand({ command: "bun test" })).toBe(
-      "ran `bun test`",
-    );
+    expect(summarizeShellCommand("bun test")).toBe("ran `bun test`");
     expect(
       compactSummaryText(
         "bun run test --filter very-long-package-name -- --reporter verbose",

--- a/plugins/plugin-coding-tools/src/actions/summaries.ts
+++ b/plugins/plugin-coding-tools/src/actions/summaries.ts
@@ -30,9 +30,9 @@ export function summarizeFileOperation(
 }
 
 export function summarizeShellCommand(
-  params: Record<string, unknown>,
+  redactedCommand: unknown,
 ): string | undefined {
-  const command = params.command;
+  const command = redactedCommand;
   if (typeof command !== "string" || command.trim().length === 0) {
     return undefined;
   }

--- a/plugins/plugin-coding-tools/src/services/background-shell-service.ts
+++ b/plugins/plugin-coding-tools/src/services/background-shell-service.ts
@@ -18,7 +18,10 @@ import {
   signalHostProcessGroup,
   startBackgroundShellOnHost,
 } from "../lib/run-shell.js";
-import { redactShellText } from "../shell/redaction.js";
+import {
+  redactShellText,
+  resolveShellRedactionOverlapChars,
+} from "../shell/redaction.js";
 import { BACKGROUND_SHELL_SERVICE, CODING_TOOLS_LOG_PREFIX } from "../types.js";
 
 const DEFAULT_BUFFER_CHARS = 64_000;
@@ -114,6 +117,13 @@ export class BackgroundShellService extends Service {
     this.sessions.clear();
   }
 
+  private getRedactionOverlapChars(): number {
+    // Character secrets can rotate while the service is running. Recompute at
+    // each stream boundary so a newly introduced longer value cannot be split
+    // by an overlap window sized from stale startup configuration.
+    return resolveShellRedactionOverlapChars(this.runtime, this.bufferChars);
+  }
+
   startSession(args: {
     conversationId: string;
     command: string;
@@ -146,10 +156,20 @@ export class BackgroundShellService extends Service {
       throw new Error("background shell process did not expose output streams");
     }
     started.process.stdout.on("data", (chunk: Buffer) => {
-      appendRing(session.stdout, chunk.toString("utf8"), this.bufferChars);
+      appendRing(
+        session.stdout,
+        chunk.toString("utf8"),
+        this.bufferChars,
+        this.getRedactionOverlapChars(),
+      );
     });
     started.process.stderr.on("data", (chunk: Buffer) => {
-      appendRing(session.stderr, chunk.toString("utf8"), this.bufferChars);
+      appendRing(
+        session.stderr,
+        chunk.toString("utf8"),
+        this.bufferChars,
+        this.getRedactionOverlapChars(),
+      );
     });
     started.process.stdin?.on?.("error", (error: Error) => {
       session.stdinError = error;
@@ -157,6 +177,7 @@ export class BackgroundShellService extends Service {
         session.stderr,
         `[stdin unavailable: ${error.message}]`,
         this.bufferChars,
+        this.getRedactionOverlapChars(),
       );
     });
     started.process.on("close", (code, signal) => {
@@ -173,7 +194,12 @@ export class BackgroundShellService extends Service {
       session.exitCode = -1;
       session.signal = null;
       session.endedAt = Date.now();
-      appendRing(session.stderr, error.message, this.bufferChars);
+      appendRing(
+        session.stderr,
+        error.message,
+        this.bufferChars,
+        this.getRedactionOverlapChars(),
+      );
     });
     this.sessions.set(handle, session);
     return snapshot(this.runtime, session);
@@ -329,15 +355,21 @@ function emptyRing(): StreamRing {
   return { text: "", startOffset: 0, endOffset: 0, truncatedBefore: 0 };
 }
 
-function appendRing(ring: StreamRing, text: string, cap: number): void {
+function appendRing(
+  ring: StreamRing,
+  text: string,
+  cap: number,
+  redactionOverlapChars: number,
+): void {
   if (!text) return;
   ring.text += text;
   ring.endOffset += text.length;
-  if (ring.text.length > cap) {
-    const drop = ring.text.length - cap;
+  ring.truncatedBefore = Math.max(ring.truncatedBefore, ring.endOffset - cap);
+  const storageCap = cap + redactionOverlapChars;
+  if (ring.text.length > storageCap) {
+    const drop = ring.text.length - storageCap;
     ring.text = ring.text.slice(drop);
     ring.startOffset += drop;
-    ring.truncatedBefore = ring.startOffset;
   }
 }
 
@@ -348,22 +380,26 @@ function readRing(
 ): BackgroundShellChunk {
   const offset =
     requestedOffset === undefined || !Number.isFinite(requestedOffset)
-      ? ring.startOffset
+      ? ring.truncatedBefore
       : Math.max(0, Math.floor(requestedOffset));
-  const start = Math.max(offset, ring.startOffset);
+  const start = Math.min(
+    ring.endOffset,
+    Math.max(offset, ring.truncatedBefore),
+  );
   const index = start - ring.startOffset;
   const redactedFull = redactShellText(runtime, ring.text);
   const redactedPrefix = redactShellText(runtime, ring.text.slice(0, index));
-  // A credential can straddle the requested offset. When redacting the full
-  // retained ring changes the prefix, replay the sanitized retained window
-  // rather than risk returning a partial secret.
+  // A credential can straddle the requested offset. The retained overlap lets
+  // full-window redaction see across both the logical cap and chunk boundaries;
+  // if replacement changes the prefix, suppress the ambiguous projection
+  // instead of returning either side of the credential.
   const canSliceAtRequestedOffset = redactedFull.startsWith(redactedPrefix);
   const text = canSliceAtRequestedOffset
     ? redactedFull.slice(redactedPrefix.length)
-    : redactedFull;
+    : "[REDACTED:chunk-boundary]";
   return {
     text,
-    startOffset: canSliceAtRequestedOffset ? start : ring.startOffset,
+    startOffset: start,
     endOffset: ring.endOffset,
     truncatedBefore: ring.truncatedBefore,
   };

--- a/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
@@ -127,7 +127,8 @@ describePosixShell("shell plugin real local integration", () => {
     // ShellService whose history read throws must NOT be reported to the model
     // as empty, success-shaped context. The failure has to reach the model loop
     // (non-empty status text + values) and the developer logs (logger.error).
-    const boom = new Error("history backend exploded");
+    const secret = "orchid42";
+    const boom = new Error(`history ${secret} exploded`);
     const reported: Array<{ scope: string; error: unknown }> = [];
     const throwingService = {
       getCommandHistory() {
@@ -145,7 +146,7 @@ describePosixShell("shell plugin real local integration", () => {
         return name === "shell" ? throwingService : null;
       },
       redactSecrets(text: string) {
-        return text;
+        return text.replaceAll(secret, "[REDACTED:TEST_SECRET]");
       },
       reportError(scope: string, error: unknown) {
         reported.push({ scope, error });
@@ -161,16 +162,27 @@ describePosixShell("shell plugin real local integration", () => {
     // Model-visible: not blank, and it names the failure.
     expect(provider.text).not.toBe("");
     expect(provider.text).toContain("unavailable");
-    expect(provider.text).toContain("history backend exploded");
-    expect(provider.values?.shellHistory).toContain("history backend exploded");
-    expect(provider.data?.error).toBe("history backend exploded");
+    expect(provider.text).toContain("history [REDACTED:TEST_SECRET] exploded");
+    expect(provider.values?.shellHistory).toContain(
+      "history [REDACTED:TEST_SECRET] exploded",
+    );
+    expect(provider.data?.error).toBe(
+      "history [REDACTED:TEST_SECRET] exploded",
+    );
 
     // Diagnostic boundary: the failure was routed through runtime.reportError
     // (which emits ERROR_REPORTED + feeds the RECENT_ERRORS provider) instead
     // of being silently swallowed.
     expect(reported).toHaveLength(1);
     expect(reported[0]?.scope).toBe("shellHistoryProvider");
-    expect(reported[0]?.error).toBe(boom);
+    expect(reported[0]?.error).toMatchObject({
+      name: "ElizaError",
+      code: "SHELL_HISTORY_PROVIDER_FAILED",
+      context: {
+        redactedMessage: "history [REDACTED:TEST_SECRET] exploded",
+      },
+    });
+    expect(JSON.stringify({ provider, reported })).not.toContain(secret);
   });
 
   it("still logs the failure when the runtime lacks reportError (older runtimes/test doubles)", async () => {

--- a/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.ts
+++ b/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.ts
@@ -6,6 +6,7 @@
  */
 import {
   addHeader,
+  ElizaError,
   type IAgentRuntime,
   logger,
   type Memory,
@@ -182,7 +183,14 @@ ${addHeader("# Shell History (Last 10)", historyText)}${fileOpsText}`;
         error instanceof Error ? error.message : String(error),
       );
       if (typeof runtime?.reportError === "function") {
-        runtime.reportError("shellHistoryProvider", error, {
+        const diagnosticError = new ElizaError(
+          `Shell history context failed: ${errMsg}`,
+          {
+            code: "SHELL_HISTORY_PROVIDER_FAILED",
+            context: { redactedMessage: errMsg },
+          },
+        );
+        runtime.reportError("shellHistoryProvider", diagnosticError, {
           roomId: message.roomId,
           agentId: message.agentId,
         });

--- a/plugins/plugin-coding-tools/src/shell/redaction.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/redaction.test.ts
@@ -1,18 +1,24 @@
 /**
- * Verifies shell projections always apply pattern redaction while using
- * runtime-owned configured-secret redaction when the host provides it.
+ * Verifies shell projections require runtime-owned configured-secret redaction
+ * and then apply pattern redaction before output leaves the shell boundary.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
-import { redactShellText } from "./redaction.ts";
+import {
+  redactShellText,
+  resolveShellRedactionOverlapChars,
+} from "./redaction.ts";
 
 describe("shell redaction boundary", () => {
-  it("remains pattern-safe for lightweight runtimes without redactSecrets", () => {
+  it("fails closed when a runtime omits the required secret redactor", () => {
     const runtime = {} as IAgentRuntime;
 
-    expect(
-      redactShellText(runtime, "Bearer token-value-123456789"),
-    ).not.toContain("token-value-123456789");
+    expect(() => redactShellText(runtime, "ordinary output")).toThrow(
+      expect.objectContaining({
+        name: "ElizaError",
+        code: "SHELL_REDACTION_UNAVAILABLE",
+      }),
+    );
   });
 
   it("composes runtime-known and pattern redaction", () => {
@@ -29,5 +35,29 @@ describe("shell redaction boundary", () => {
     expect(result).toContain("[REDACTED:configured]");
     expect(result).not.toContain("ordinary configured value");
     expect(result).not.toContain("flag-value-123456789");
+  });
+
+  it("propagates a runtime redactor failure instead of degrading open", () => {
+    const failure = new Error("secret store unavailable");
+    const runtime = {
+      redactSecrets: vi.fn(() => {
+        throw failure;
+      }),
+    } as unknown as IAgentRuntime;
+
+    expect(() => redactShellText(runtime, "must stay private")).toThrow(
+      failure,
+    );
+  });
+
+  it("retains enough overlap for the longest configured literal secret", () => {
+    const runtime = {
+      character: {
+        settings: { secrets: { SHORT: "abcd", LONG: "x".repeat(96) } },
+      },
+      redactSecrets: (text: string) => text,
+    } as unknown as IAgentRuntime;
+
+    expect(resolveShellRedactionOverlapChars(runtime, 32)).toBe(96);
   });
 });

--- a/plugins/plugin-coding-tools/src/shell/redaction.ts
+++ b/plugins/plugin-coding-tools/src/shell/redaction.ts
@@ -4,15 +4,35 @@
  * Character secrets may be ordinary strings with no recognizable credential
  * shape, so pattern redaction alone is insufficient.
  */
-import { type IAgentRuntime, redactSensitiveText } from "@elizaos/core";
+import {
+  ElizaError,
+  type IAgentRuntime,
+  redactSensitiveText,
+} from "@elizaos/core";
 
 export function redactShellText(runtime: IAgentRuntime, text: string): string {
-  const runtimeRedactor = Reflect.get(runtime, "redactSecrets");
-  const runtimeRedacted =
-    typeof runtimeRedactor === "function"
-      ? runtimeRedactor.call(runtime, text)
-      : text;
+  if (typeof runtime.redactSecrets !== "function") {
+    throw new ElizaError("Shell output redaction is unavailable", {
+      code: "SHELL_REDACTION_UNAVAILABLE",
+    });
+  }
+  const runtimeRedacted = runtime.redactSecrets(text);
   return redactSensitiveText(runtimeRedacted, { mode: "tools" });
+}
+
+export function resolveShellRedactionOverlapChars(
+  runtime: IAgentRuntime,
+  minimum: number,
+): number {
+  const configuredSecrets = runtime.character?.settings?.secrets;
+  if (!configuredSecrets || typeof configuredSecrets !== "object") {
+    return minimum;
+  }
+  return Object.values(configuredSecrets).reduce<number>(
+    (maximum, value) =>
+      typeof value === "string" ? Math.max(maximum, value.length) : maximum,
+    minimum,
+  );
 }
 
 export function redactShellValue<T>(runtime: IAgentRuntime, value: T): T {


### PR DESCRIPTION
Closes the remaining exact-head review findings from #18947 and #19418. The original contribution in this branch is already present on `develop` through `8d2cc881e87`, `a6f0fbc9ba8`, and `4b5f37b9a32`; Git therefore dropped that duplicate commit during rebase. The current one-commit diff is the focused post-integration repair for the boundaries the independent reviews found.

## What

- requires the non-optional `IAgentRuntime.redactSecrets` collaborator and fails closed with `SHELL_REDACTION_UNAVAILABLE` when a malformed lightweight runtime omits it
- sanitizes cwd validation failures and structured cwd logs before they reach planner or operator surfaces
- derives planner summaries only from the already-redacted successful result command, never the raw input parameters
- sanitizes destructive-operation reasons and targets in both visible text and structured result data
- rebuilds shell-history diagnostics as a typed `ElizaError` from sanitized text before calling `runtime.reportError`, so `ERROR_REPORTED` and `RECENT_ERRORS` cannot receive the raw cause
- retains a private background-stream overlap before logical eviction, sizes it dynamically from the current longest configured secret after secret rotation, redacts the retained window before slicing, and emits a fail-closed boundary marker when an offset bisects a credential
- adds adversarial coverage for literal and pattern credentials, missing/throwing redactors, cwd and destructive failures, planner summaries, structured logs, history diagnostics, offset splits, eviction splits, and post-startup secret rotation
- fixes the incomplete test runtimes by implementing the required redaction contract instead of weakening the production boundary

The transcript-echo and timeout behavior from the original contribution are already on `develop` and are not changed by this final diff.

## Validation

- exact head `b2b60c343942635dd1e7fd18a0e68ec3728a7ed9`, rebased onto `develop` `c614ea05e24511d4f7131469a3f4734088f780fe`
- `bun run --cwd plugins/plugin-coding-tools test`: 35 files, 530 tests passed
- excluded real integration `src/shell/__tests__/shell.real.test.ts`: 1 file, 5 tests passed
- `bun run --cwd plugins/plugin-coding-tools typecheck`: passed
- `bun run --cwd plugins/plugin-coding-tools lint:check`: 102 maintained package files passed
- `bun run --cwd plugins/plugin-coding-tools build`: passed
- `bun run audit:focused-tests`: 8,045 test files scanned; no focused or orphaned skips
- `bun run audit:tee-secret-leak`: passed
- `bun run verify`: 135/137 Turbo tasks passed; the only failure was unrelated `@elizaos/cloud-api` typechecking against two Hono versions from the shared dependency tree (`4.13.1` versus `4.12.34`), producing pre-existing `Context`/`HonoRequest` incompatibilities outside this diff
- `git diff --check`: passed

All executable PR code was run offline in a macOS sandbox restricted to writes inside the isolated review worktree and temporary directories.

## Evidence

<!-- evidence-head:b2b60c343942635dd1e7fd18a0e68ec3728a7ed9 -->

<!-- evidence-row:before-screenshots -->
N/A - backend shell-security boundaries only; no rendered UI layout or styling changed.

<!-- evidence-row:after-screenshots -->
N/A - backend shell-security boundaries only; no rendered UI layout or styling changed.

<!-- evidence-row:walkthrough-video -->
N/A - no rendered user-flow surface changed; action, service, background-stream, and provider delivery are exercised directly.

<!-- evidence-row:backend-logs -->
<details><summary>Exact-head local execution transcript</summary>

```text
bun run --cwd plugins/plugin-coding-tools test: 35 files passed, 530 tests passed
dedicated shell.real.test.ts lane: 1 file passed, 5 tests passed
package typecheck + lint:check + build: passed; focused-test and tee-secret-leak audits: passed
```

</details>

<!-- evidence-row:frontend-logs -->
N/A - no frontend code or browser behavior changed.

<!-- evidence-row:llm-trajectory -->
N/A - no model invocation or planner policy changed; the planner-summary test exercises the sanitized fallback projection directly.

<!-- evidence-row:domain-artifacts -->
N/A - no external domain artifact or account state changed; serialized `ActionResult`, callback, background polling, provider, log, and diagnostic projections are asserted directly by tests.

<!-- evidence-row:ocr-review -->
N/A - no rendered visual surface changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Models: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Client / agent tooling: codex
<!-- attribution-row:skill-revision -->
- Contribution skill revision: elizaOS/eliza@c614ea05e24511d4f7131469a3f4734088f780fe:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@c614ea05e24511d4f7131469a3f4734088f780fe:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@c614ea05e24511d4f7131469a3f4734088f780fe:packages/skills/skills/contribute-to-eliza"} -->
