### PR TITLE
fix(orchestrator): reject invalid framework preflight timeouts

### DIFF
--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -308,6 +308,7 @@ README → "GitHub credentials".
 | `ELIZAOS_CLOUD_API_KEY` / `ELIZAOS_CLOUD_URL` | unset | Owner Cloud creds. **Broker-first (#14118): NOT forwarded to sub-agents by default** — a child reaches Cloud via the parent broker (`apps.create` / `containers.create`, spend-gated). Set `ELIZA_FORWARD_CLOUD_KEY_TO_SUBAGENTS=1` to restore raw forwarding. |
 | `ELIZA_FORWARD_CLOUD_KEY_TO_SUBAGENTS` | unset (OFF) | Opt IN to forwarding the owner's raw `ELIZAOS_CLOUD*` creds into every child env. Default OFF; broker-first is preferred. A structured warning logs when active. |
 | `ACPX_DEFAULT_TIMEOUT_MS` | `300000` | Per-prompt timeout in ms |
+| `ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS` | `5000` | Maximum adapter-availability preflight wait. Values must be exact decimal integers from `250` through `2147483647`; missing/blank uses the default, and invalid values fail before the adapter probe starts. |
 | `ACP_COMMIT_LOCK_POLL_MS` | `25` | Poll cadence for the shared-worktree git commit lock. Values must be exact integers from `1` through `2147483647`; invalid values use the default, and each sleep is clipped to the remaining acquisition deadline. |
 | `ACP_COMMIT_LOCK_WAIT_MS` | `120000` | Maximum time to acquire the shared-worktree git commit lock. Values use the same bounded exact-integer contract. |
 | `ACP_COMMIT_LOCK_STALE_MS` | `30000` | Age after which an unrefreshed commit lock can be reclaimed. Values use the same bounded exact-integer contract; live holders refresh the lock through a heartbeat. |

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -308,6 +308,7 @@ README → "GitHub credentials".
 | `ELIZAOS_CLOUD_API_KEY` / `ELIZAOS_CLOUD_URL` | unset | Owner Cloud creds. **Broker-first (#14118): NOT forwarded to sub-agents by default** — a child reaches Cloud via the parent broker (`apps.create` / `containers.create`, spend-gated). Set `ELIZA_FORWARD_CLOUD_KEY_TO_SUBAGENTS=1` to restore raw forwarding. |
 | `ELIZA_FORWARD_CLOUD_KEY_TO_SUBAGENTS` | unset (OFF) | Opt IN to forwarding the owner's raw `ELIZAOS_CLOUD*` creds into every child env. Default OFF; broker-first is preferred. A structured warning logs when active. |
 | `ACPX_DEFAULT_TIMEOUT_MS` | `300000` | Per-prompt timeout in ms |
+| `ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS` | `5000` | Maximum adapter-availability preflight wait. Values must be exact decimal integers from `250` through `2147483647`; missing/blank uses the default, and invalid values fail before the adapter probe starts. |
 | `ACP_COMMIT_LOCK_POLL_MS` | `25` | Poll cadence for the shared-worktree git commit lock. Values must be exact integers from `1` through `2147483647`; invalid values use the default, and each sleep is clipped to the remaining acquisition deadline. |
 | `ACP_COMMIT_LOCK_WAIT_MS` | `120000` | Maximum time to acquire the shared-worktree git commit lock. Values use the same bounded exact-integer contract. |
 | `ACP_COMMIT_LOCK_STALE_MS` | `30000` | Age after which an unrefreshed commit lock can be reclaimed. Values use the same bounded exact-integer contract; live holders refresh the lock through a heartbeat. |

--- a/plugins/plugin-agent-orchestrator/README.md
+++ b/plugins/plugin-agent-orchestrator/README.md
@@ -159,6 +159,7 @@ second credential broker, and child trajectories retain their session join key.
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command override. |
 | `ELIZA_ACP_DEFAULT_APPROVAL` | `autonomous` | Approval preset (`read-only`, `auto`, `permissive`, `autonomous`, `full-access`). |
 | `ELIZA_ACP_PROMPT_TIMEOUT_MS` / `ACPX_DEFAULT_TIMEOUT_MS` | `300000` (5m) | Per-prompt timeout. |
+| `ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS` | `5000` (5s) | Maximum adapter-availability preflight wait. Values must be exact decimal integers from `250` through `2147483647`; missing/blank uses the default, and invalid values fail before the adapter probe starts. |
 | `ELIZA_SMITHERS_TIMEOUT_MS` | `300000` (5m) | Maximum Smithers durable-run wall-clock time. Values must be exact decimal integers from `1` through `2147483647`; missing/blank uses the default, and invalid environment or request overrides fail before a worker starts. |
 | `ELIZA_ACP_STATE_DIR` | `~/.eliza/plugin-acp` | Where to persist session state when no runtime DB. |
 | `ACPX_DEFAULT_CWD` | runtime cwd | Base directory for spawned agent workdirs. |

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
@@ -388,9 +388,15 @@ describe("getTaskAgentFrameworkState", () => {
 
   it("accepts Node's maximum timer delay for framework preflight", async () => {
     setEnv({ ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS: "2147483647" });
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
 
     const state = await getTaskAgentFrameworkState(runtime(), installedProbe());
 
+    expect(setTimeoutSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      2_147_483_647,
+    );
+    setTimeoutSpy.mockRestore();
     expect(
       state.frameworks.find((item) => item.id === "codex")?.installed,
     ).toBe(true);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
@@ -27,6 +27,7 @@ const ENV_KEYS = [
   "ELIZA_CONFIG_PATH",
   "ELIZA_DEFAULT_AGENT_TYPE",
   "ELIZA_ELIZAOS_ACP_COMMAND",
+  "ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS",
   "ELIZA_LLM_PROVIDER",
   "ELIZA_PI_AGENT_ACP_COMMAND",
   "ELIZA_PROVIDER",
@@ -346,6 +347,34 @@ describe("getTaskAgentFrameworkState", () => {
     ).toBe(true);
     expect(
       second.frameworks.find((item) => item.id === "codex")?.installed,
+    ).toBe(true);
+  });
+
+  it.each([
+    "249",
+    "250oops",
+    "250.5",
+    "2.5e2",
+    "0250",
+    "2147483648",
+    "9007199254740992",
+  ])("rejects malformed framework preflight timeout %s", async (value) => {
+    const probe = installedProbe();
+    setEnv({ ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS: value });
+
+    await expect(getTaskAgentFrameworkState(runtime(), probe)).rejects.toThrow(
+      "ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS must be a decimal integer between 250 and 2147483647",
+    );
+    expect(probe.checkAvailableAgents).not.toHaveBeenCalled();
+  });
+
+  it("accepts the minimum framework preflight timeout", async () => {
+    setEnv({ ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS: "250" });
+
+    const state = await getTaskAgentFrameworkState(runtime(), installedProbe());
+
+    expect(
+      state.frameworks.find((item) => item.id === "codex")?.installed,
     ).toBe(true);
   });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
@@ -362,14 +362,32 @@ describe("getTaskAgentFrameworkState", () => {
     const probe = installedProbe();
     setEnv({ ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS: value });
 
-    await expect(getTaskAgentFrameworkState(runtime(), probe)).rejects.toThrow(
-      "ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS must be a decimal integer between 250 and 2147483647",
-    );
+    await expect(
+      getTaskAgentFrameworkState(runtime(), probe),
+    ).rejects.toMatchObject({
+      name: "ElizaError",
+      code: "FRAMEWORK_PREFLIGHT_TIMEOUT_INVALID",
+      context: {
+        configured: value,
+        minimum: 250,
+        maximum: 2_147_483_647,
+      },
+    });
     expect(probe.checkAvailableAgents).not.toHaveBeenCalled();
   });
 
   it("accepts the minimum framework preflight timeout", async () => {
     setEnv({ ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS: "250" });
+
+    const state = await getTaskAgentFrameworkState(runtime(), installedProbe());
+
+    expect(
+      state.frameworks.find((item) => item.id === "codex")?.installed,
+    ).toBe(true);
+  });
+
+  it("accepts Node's maximum timer delay for framework preflight", async () => {
+    setEnv({ ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS: "2147483647" });
 
     const state = await getTaskAgentFrameworkState(runtime(), installedProbe());
 

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -219,14 +219,27 @@ const STANDARD_FRAMEWORKS: SupportedTaskAgentAdapter[] = [
 ];
 
 const DEFAULT_FRAMEWORK_PREFLIGHT_TIMEOUT_MS = 5_000;
+const MAX_FRAMEWORK_PREFLIGHT_TIMEOUT_MS = 2_147_483_647;
 
 function resolveFrameworkPreflightTimeoutMs(): number {
   const raw = process.env.ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS?.trim();
   if (!raw) return DEFAULT_FRAMEWORK_PREFLIGHT_TIMEOUT_MS;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed >= 250
-    ? parsed
-    : DEFAULT_FRAMEWORK_PREFLIGHT_TIMEOUT_MS;
+  if (!/^[1-9]\d*$/u.test(raw)) {
+    throw new TypeError(
+      `ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS must be a decimal integer between 250 and ${MAX_FRAMEWORK_PREFLIGHT_TIMEOUT_MS}; received ${JSON.stringify(raw)}`,
+    );
+  }
+  const parsed = Number(raw);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < 250 ||
+    parsed > MAX_FRAMEWORK_PREFLIGHT_TIMEOUT_MS
+  ) {
+    throw new TypeError(
+      `ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS must be a decimal integer between 250 and ${MAX_FRAMEWORK_PREFLIGHT_TIMEOUT_MS}; received ${JSON.stringify(raw)}`,
+    );
+  }
+  return parsed;
 }
 
 async function withTimeout<T>(
@@ -685,10 +698,11 @@ async function computeTaskAgentFrameworkState(
   >();
 
   if (probe?.checkAvailableAgents) {
+    const preflightTimeoutMs = resolveFrameworkPreflightTimeoutMs();
     try {
       const results = await withTimeout(
         probe.checkAvailableAgents(STANDARD_FRAMEWORKS),
-        resolveFrameworkPreflightTimeoutMs(),
+        preflightTimeoutMs,
         "task-agent framework preflight",
       );
       // checkAdapters returns `adapter` as the human-readable display name

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -13,6 +13,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  ElizaError,
   getElizaNamespace,
   type IAgentRuntime,
   resolveStateDir,
@@ -224,19 +225,22 @@ const MAX_FRAMEWORK_PREFLIGHT_TIMEOUT_MS = 2_147_483_647;
 function resolveFrameworkPreflightTimeoutMs(): number {
   const raw = process.env.ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS?.trim();
   if (!raw) return DEFAULT_FRAMEWORK_PREFLIGHT_TIMEOUT_MS;
-  if (!/^[1-9]\d*$/u.test(raw)) {
-    throw new TypeError(
-      `ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS must be a decimal integer between 250 and ${MAX_FRAMEWORK_PREFLIGHT_TIMEOUT_MS}; received ${JSON.stringify(raw)}`,
-    );
-  }
-  const parsed = Number(raw);
+  const parsed = /^[1-9]\d*$/u.test(raw) ? Number(raw) : Number.NaN;
   if (
     !Number.isSafeInteger(parsed) ||
     parsed < 250 ||
     parsed > MAX_FRAMEWORK_PREFLIGHT_TIMEOUT_MS
   ) {
-    throw new TypeError(
-      `ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS must be a decimal integer between 250 and ${MAX_FRAMEWORK_PREFLIGHT_TIMEOUT_MS}; received ${JSON.stringify(raw)}`,
+    throw new ElizaError(
+      `ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS must be a decimal integer between 250 and ${MAX_FRAMEWORK_PREFLIGHT_TIMEOUT_MS}`,
+      {
+        code: "FRAMEWORK_PREFLIGHT_TIMEOUT_INVALID",
+        context: {
+          configured: raw,
+          minimum: 250,
+          maximum: MAX_FRAMEWORK_PREFLIGHT_TIMEOUT_MS,
+        },
+      },
     );
   }
   return parsed;


### PR DESCRIPTION
# Relates to

Self-found operator-configuration bug; no numbered issue exists.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Focused tests, package typecheck, lint, build, guide parity, Markdown links, and diff hygiene pass on the exact head.
- [x] A reviewer can verify the accepted/rejected configuration matrix below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6c121807e5cebded3c612d75569ffccea4c0f6e4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@6c121807e5cebded3c612d75569ffccea4c0f6e4`; zero conflicts.
- [x] The contributor commit is patch-identical after replay (`b6c6bf4 = 1907663`); the maintainer correction is a separate second commit.

# Risks

Low and bounded to one operator-supplied timeout. Missing and whitespace-only values retain the 5000 ms default. Canonical decimal integers from 250 through 2147483647 retain their literal value. Malformed, fractional, prefixed, suffixed, leading-zero, unsafe, and timer-overflow values now fail before the adapter probe starts instead of being partially parsed, silently replaced, or coerced by Node to a 1 ms timer.

# Background

## What does this PR do?

- Replaces `Number.parseInt` prefix parsing for `ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS` with an exact decimal-integer contract.
- Bounds the value to Node's supported timer range; Node documents that delays above 2147483647 are changed to 1 ms: https://nodejs.org/api/timers.html#settimeoutcallback-delay-args
- Resolves and validates configuration before starting `checkAvailableAgents`, so invalid operator configuration cannot begin side effects and then degrade as a transient probe error.
- Throws a machine-classifiable `ElizaError` (`FRAMEWORK_PREFLIGHT_TIMEOUT_INVALID`) with the configured value and allowed bounds.
- Documents the setting in both package guides and the public README.

The live probe-backed consumers are `GET /api/coding-agents/settings`, `CODING_AGENT_EXAMPLES`, and `ACTIVE_WORKSPACE_CONTEXT`. The static `AVAILABLE_AGENTS` inventory intentionally does not invoke the preflight timer.

## What kind of change is this?

Bug fix and operator-configuration hardening.

# Documentation changes needed?

Completed in this PR: `README.md`, `CLAUDE.md`, and its required byte-identical `AGENTS.md` pair now state the default, range, exact-integer rule, and fail-fast behavior.

# Testing

```bash
bunx vitest run --config vitest.config.ts __tests__/unit/task-agent-frameworks.test.ts --coverage.enabled=false
bun run --cwd plugins/plugin-agent-orchestrator typecheck
bun run --cwd plugins/plugin-agent-orchestrator lint:check
bun run --cwd plugins/plugin-agent-orchestrator build
bun run check:agents-claude
node scripts/check-markdown-links.mjs
git diff --check origin/develop..HEAD
```

Exact-head results: 1 file / 27 tests passed; package typecheck, lint (401 files), build, 153 guide pairs, Markdown links, and diff checks passed in an isolated no-network sandbox.

The expanded package unit lane passed 148 files / 1938 tests. Its remaining 22 failures in 5 untouched files were environment/current-checkout failures: Smithers child processes resolved an incompatible shared `@ai-sdk/provider-utils` installation, one route fixture lacked the current permission attestation and returned 403, and one workdir test deliberately rejected the review checkout as its runtime root. None imports or exercises the changed timeout resolver; hosted exact-head gates remain authoritative for those lanes.

# Evidence Gate

<!-- evidence-head:e9d5a32761dbbdf56ac22311f2585134cdef997d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend operator-configuration parsing only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend operator-configuration parsing only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive frontend flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head isolated verification:

```text
Test Files  1 passed (1)
Tests       27 passed (27)
Typecheck, lint (401 files), build, 153 guide pairs, Markdown links, and git diff --check passed.
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, console, network, or state surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider output, action planning, or inference behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Configuration matrix pinned by exact-head tests:

```text
accepted: unset, blank, 250, 2147483647
rejected before probe: 249, 250oops, 250.5, 2.5e2, 0250, 2147483648, 9007199254740992
error: FRAMEWORK_PREFLIGHT_TIMEOUT_INVALID
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text.

# Evidence Details

## Known gaps / warnings

- No live ACP adapter was invoked because the changed boundary must reject invalid configuration before any adapter call; the real parser/probe wrapper is exercised with a deterministic probe spy.
- Hosted exact-head gates and an independent maintainer approval remain required before merge.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@6c121807e5cebded3c612d75569ffccea4c0f6e4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@6c121807e5cebded3c612d75569ffccea4c0f6e4:packages/skills/skills/contribute-to-eliza"} -->

The original contributor attribution remains recorded in the PR history for commit `b6c6bf4` (OpenAI GPT-5.6 Sol via Codex, self-reported, `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`).
