### PR TITLE
feat(elizaresearch): animate particle face entrance

### DIFF
--- a/packages/elizaresearch/index.html
+++ b/packages/elizaresearch/index.html
@@ -250,8 +250,9 @@
 </footer>
 
 <script>
-// Hero: particles assemble the Eliza face wireframe, drift apart in pieces,
-// periodically re-form, and react to pointer/touch (hover repels, drag shoves).
+// The face arrives as nine coherent fragments before the established shimmer
+// and pointer response take over. The grouped entrance makes facial structure
+// legible immediately without adding a separate loader or animation system.
 (() => {
   const canvas = document.getElementById("swarm");
   const header = canvas.parentElement;
@@ -260,6 +261,11 @@
   let W = 0, H = 0, dpr = 1, resizeFrame = 0;
   const boids = [];
   let targets = [];
+  let born = 0;
+  let entranceStarted = false;
+  let entranceComplete = reduced;
+  const entranceMs = 1800;
+  const fadeMs = 480;
   const pointer = { x: -1e4, y: -1e4, vx: 0, vy: 0, down: false, touch: false, t: 0 };
 
   function resize() {
@@ -315,15 +321,45 @@
     if (!img.complete || !img.naturalWidth || W === 0) return;
     targets = sampleFace();
     boids.length = 0;
+    let minX = W, minY = H, maxX = 0, maxY = 0;
+    for (const target of targets) {
+      minX = Math.min(minX, target.x); minY = Math.min(minY, target.y);
+      maxX = Math.max(maxX, target.x); maxY = Math.max(maxY, target.y);
+    }
+    const faceWidth = maxX - minX;
+    const faceHeight = maxY - minY;
+    const faceSize = Math.min(faceWidth, faceHeight);
+    const faceX = (minX + maxX) / 2;
+    const faceY = (minY + maxY) / 2;
+    const groupDelays = [90, 20, 70, 130, 0, 110, 170, 55, 150];
+    if (!entranceStarted && !reduced) {
+      born = performance.now();
+      entranceStarted = true;
+    }
     for (const t of targets) {
-      const sx = t.x;
-      const sy = t.y;
+      const gx = Math.min(2, Math.max(0, Math.floor((t.x - minX) / faceWidth * 3)));
+      const gy = Math.min(2, Math.max(0, Math.floor((t.y - minY) / faceHeight * 3)));
+      const group = gy * 3 + gx;
+      const groupX = minX + (gx + 0.5) * faceWidth / 3;
+      const groupY = minY + (gy + 0.5) * faceHeight / 3;
+      let outX = groupX - faceX;
+      let outY = groupY - faceY;
+      const outLength = Math.hypot(outX, outY);
+      if (outLength < 1) { outX = 0; outY = -1; }
+      else { outX /= outLength; outY /= outLength; }
+      const distance = faceSize * (0.07 + Math.random() * 0.025);
+      const radius = faceSize * 0.008 * Math.sqrt(Math.random());
+      const angle = Math.random() * Math.PI * 2;
+      const sx = entranceComplete ? t.x : t.x + outX * distance + Math.cos(angle) * radius;
+      const sy = entranceComplete ? t.y : t.y + outY * distance + Math.sin(angle) * radius;
+      const arc = entranceComplete ? 0 : faceSize * (0.028 + Math.random() * 0.017) * (group % 2 ? -1 : 1);
       boids.push({
         x: sx, y: sy, sx, sy,
         vx: 0, vy: 0, tx: t.x, ty: t.y,
+        arcX: -outY * arc, arcY: outX * arc, delay: groupDelays[group],
         size: Math.random() * 0.95 + 0.85, life: Math.random() * 100 + 50 });
     }
-    if (reduced) draw();
+    if (reduced) draw(performance.now());
   }
 
   // Pointer interaction on the header (canvas sits behind the copy).
@@ -361,8 +397,22 @@
     document.body.addEventListener(type, (event) => event.preventDefault());
   }
 
-  function step() {
+  function step(now) {
     if (!boids.length) { tryInit(); return; }
+    if (!entranceComplete) {
+      let forming = false;
+      for (const b of boids) {
+        const progress = Math.min(1, Math.max(0, (now - born - b.delay) / (entranceMs - b.delay)));
+        const eased = progress * progress * progress * (progress * (progress * 6 - 15) + 10);
+        const arc = 4 * eased * (1 - eased);
+        b.x = b.sx + (b.tx - b.sx) * eased + b.arcX * arc;
+        b.y = b.sy + (b.ty - b.sy) * eased + b.arcY * arc;
+        if (progress < 1) forming = true;
+      }
+      if (forming) return;
+      entranceComplete = true;
+      for (const b of boids) { b.x = b.tx; b.y = b.ty; }
+    }
     for (const b of boids) {
       const px = pointer.x - b.x, py = pointer.y - b.y;
       const pd2 = px * px + py * py;
@@ -383,17 +433,22 @@
     }
   }
 
-  function draw() {
+  function draw(now) {
     ctx.fillStyle = "#ff5800";
     ctx.fillRect(0, 0, W, H);
-    ctx.globalAlpha = 1;
+    const fade = entranceComplete ? 1 : Math.min(1, Math.max(0, (now - born) / fadeMs));
+    const visible = 1 - (1 - fade) * (1 - fade) * (1 - fade);
+    const dotScale = 0.35 + visible * 0.65;
+    ctx.globalAlpha = visible;
     ctx.fillStyle = "#fff";
     for (const b of boids) {
-      ctx.fillRect(b.x, b.y, b.size, b.size);
+      const size = b.size * dotScale;
+      ctx.fillRect(b.x - (size - b.size) / 2, b.y - (size - b.size) / 2, size, size);
     }
+    ctx.globalAlpha = 1;
   }
 
-  function loop() { step(); draw(); requestAnimationFrame(loop); }
+  function loop(now) { step(now); draw(now); requestAnimationFrame(loop); }
   if (!reduced) requestAnimationFrame(loop);
 })();
 


### PR DESCRIPTION
Closes #19422

## What changed
- Adds one 1.8-second authored particle-face entrance to the existing hero.
- Preserves each face region while nine displaced fragments curve into the final mask.
- Keeps the final density, shimmer, color, pointer behavior, copy, and layout unchanged.
- Renders the completed face immediately for reduced-motion users.

## Verification
- Inline JavaScript syntax: pass
- Biome 2.5.7: pass with the two pre-existing reduced-motion `!important` warnings
- `git diff --check`: pass
- Impeccable detector: only the incumbent Geist font warning
- Browser QA: 1280x720, 390x844, and 844x390
- No horizontal overflow
- Reduced-motion screenshots remain byte-identical over one second
- No page-origin console warnings/errors or network failures

## Visual behavior
The face is recognizable from the first visible frame as separated eye, hair, cheek, and mouth fragments. It resolves crisply at 1.8 seconds, then hands off to the existing shimmer and hover implementation without replaying on ordinary mobile height changes.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes — independent review and evidence remediation; the source commit remains authored by NubsCarson`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7c4c74632040025dcc6e473a72263d37b115fe8f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-head:f94ebf20763950a36705d5e337c28192fb143f5f -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19424-before-f94ebf20-desktop-mobile.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19424-after-f94ebf20-desktop-mobile-reduced.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19424-walkthrough-f94ebf20-desktop-mobile.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - static asset-only page; no application backend or server route fires in this flow

<!-- evidence-row:frontend-logs -->
- [x] [19424-frontend-network-f94ebf20.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19424-frontend-network-f94ebf20.json)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic canvas animation; no agent, model, prompt, provider, or action path changes

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - visual-only static page animation; no data, persistence, protocol, or domain output changes

<!-- evidence-row:ocr-review -->
- [x] [19424-ocr-review-f94ebf20.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19424-ocr-review-f94ebf20.txt)

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@7c4c74632040025dcc6e473a72263d37b115fe8f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [nubs-review-evidence]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@7c4c74632040025dcc6e473a72263d37b115fe8f:packages/skills/skills/contribute-to-eliza"} -->

