### PR TITLE
fix(homepage): promote durable messaging feedback

### DIFF
--- a/packages/homepage/src/pages/connected.tsx
+++ b/packages/homepage/src/pages/connected.tsx
@@ -16,7 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@elizaos/ui/dropdown-menu";
 import { Check, Copy, Info, LogOut } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { ElizaLogo } from "@/components/brand/eliza-logo";
 import {
@@ -92,7 +92,6 @@ export default function ConnectedPage() {
   const [phoneCopyState, setPhoneCopyState] = useState<
     "idle" | "copied" | "error"
   >("idle");
-  const phoneCopyResetRef = useRef<number | null>(null);
   const [copiedTelegram, setCopiedTelegram] = useState(false);
   const [copiedWhatsApp, setCopiedWhatsApp] = useState(false);
 
@@ -161,32 +160,13 @@ export default function ConnectedPage() {
     }
   }, [isAuthenticated, isLoading, navigate]);
 
-  useEffect(
-    () => () => {
-      if (phoneCopyResetRef.current !== null) {
-        window.clearTimeout(phoneCopyResetRef.current);
-      }
-    },
-    [],
-  );
-
-  const setTemporaryPhoneCopyState = (state: "copied" | "error") => {
-    setPhoneCopyState(state);
-    if (phoneCopyResetRef.current !== null) {
-      window.clearTimeout(phoneCopyResetRef.current);
-    }
-    phoneCopyResetRef.current = window.setTimeout(
-      () => setPhoneCopyState("idle"),
-      2_000,
-    );
-  };
-
   const handleCopyPhone = async () => {
     try {
       await navigator.clipboard.writeText(ELIZA_PHONE_NUMBER);
-      setTemporaryPhoneCopyState("copied");
+      setPhoneCopyState("copied");
     } catch {
-      setTemporaryPhoneCopyState("error");
+      // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
+      setPhoneCopyState("error");
     }
   };
 
@@ -223,9 +203,10 @@ export default function ConnectedPage() {
   const handleOpenMessages = async () => {
     try {
       const outcome = await openOrCopyElizaMessage(window);
-      if (outcome === "copied") setTemporaryPhoneCopyState("copied");
+      if (outcome === "copied") setPhoneCopyState("copied");
     } catch {
-      setTemporaryPhoneCopyState("error");
+      // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
+      setPhoneCopyState("error");
     }
   };
 
@@ -284,7 +265,7 @@ export default function ConnectedPage() {
           className={`fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-full bg-white px-4 py-2 text-sm font-medium shadow-lg ${
             phoneCopyState === "copied" ? "text-green-700" : "text-red-700"
           }`}
-          role="status"
+          role={phoneCopyState === "error" ? "alert" : "status"}
           aria-live="polite"
         >
           {phoneCopyState === "copied"

--- a/packages/homepage/src/pages/get-started.tsx
+++ b/packages/homepage/src/pages/get-started.tsx
@@ -708,22 +708,12 @@ export default function GetStartedPage() {
   const [messageNotice, setMessageNotice] = useState<
     "idle" | "copied" | "error"
   >("idle");
-  const messageNoticeResetRef = useRef<number | null>(null);
   const [showContent, setShowContent] = useState(false);
 
   useEffect(() => {
     const timer = setTimeout(() => setShowContent(true), 100);
     return () => clearTimeout(timer);
   }, []);
-
-  useEffect(
-    () => () => {
-      if (messageNoticeResetRef.current !== null) {
-        window.clearTimeout(messageNoticeResetRef.current);
-      }
-    },
-    [],
-  );
 
   const headerStyle: CSSProperties = {
     opacity: showContent ? 1 : 0,
@@ -1303,15 +1293,9 @@ export default function GetStartedPage() {
       const outcome = await openOrCopyElizaMessage(window);
       setMessageNotice(outcome === "copied" ? "copied" : "idle");
     } catch {
+      // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
       setMessageNotice("error");
     }
-    if (messageNoticeResetRef.current !== null) {
-      window.clearTimeout(messageNoticeResetRef.current);
-    }
-    messageNoticeResetRef.current = window.setTimeout(
-      () => setMessageNotice("idle"),
-      2_000,
-    );
   };
 
   const handleContinueToConnected = () => {
@@ -1820,7 +1804,7 @@ export default function GetStartedPage() {
 
               {messageNotice !== "idle" && (
                 <p
-                  role="status"
+                  role={messageNotice === "error" ? "alert" : "status"}
                   aria-live="polite"
                   className={`mt-3 text-center text-sm font-medium ${
                     messageNotice === "copied"

--- a/packages/homepage/src/pages/landing.tsx
+++ b/packages/homepage/src/pages/landing.tsx
@@ -534,7 +534,6 @@ export default function LandingPage() {
   const [phoneCopyState, setPhoneCopyState] = useState<
     "idle" | "copied" | "error"
   >("idle");
-  const phoneCopyResetRef = useRef<number | null>(null);
   const whatsappHref = buildElizaWhatsAppHref();
   const signedIn =
     typeof window !== "undefined" &&
@@ -573,29 +572,14 @@ export default function LandingPage() {
     },
   ];
 
-  useEffect(
-    () => () => {
-      if (phoneCopyResetRef.current !== null) {
-        window.clearTimeout(phoneCopyResetRef.current);
-      }
-    },
-    [],
-  );
-
   const handleMessageEliza = async () => {
     try {
       const outcome = await openOrCopyElizaMessage(window);
       setPhoneCopyState(outcome === "copied" ? "copied" : "idle");
     } catch {
+      // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
       setPhoneCopyState("error");
     }
-    if (phoneCopyResetRef.current !== null) {
-      window.clearTimeout(phoneCopyResetRef.current);
-    }
-    phoneCopyResetRef.current = window.setTimeout(
-      () => setPhoneCopyState("idle"),
-      2_000,
-    );
   };
 
   const phoneCopyLabel =
@@ -688,7 +672,7 @@ export default function LandingPage() {
           {phoneCopyState !== "idle" && (
             <div
               className={`landing-copy-notice landing-copy-notice--${phoneCopyState}`}
-              role="status"
+              role={phoneCopyState === "error" ? "alert" : "status"}
               aria-live="polite"
             >
               {phoneCopyLabel}

--- a/packages/homepage/tests/e2e/app-routes-flow.spec.ts
+++ b/packages/homepage/tests/e2e/app-routes-flow.spec.ts
@@ -329,7 +329,7 @@ test("landing page renders its hero and messaging entrypoints", async ({
   context,
   page,
 }) => {
-  await context.grantPermissions(["clipboard-write"]);
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
   await page.goto("/");
 
   await expect(
@@ -341,6 +341,11 @@ test("landing page renders its hero and messaging entrypoints", async ({
   });
   await expect(textCta).toBeVisible();
   await textCta.click();
+  await expect(page.getByRole("status")).toHaveText("Phone number copied");
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe("+18087881821");
+  await page.waitForTimeout(2_250);
   await expect(page.getByRole("status")).toHaveText("Phone number copied");
   await expect(page.getByText("+1 (808) 788-1821")).toHaveCount(0);
   const callCta = page.getByRole("link", { name: "Call" });
@@ -362,8 +367,10 @@ test("landing page renders its hero and messaging entrypoints", async ({
 });
 
 test("landing keeps content reachable on a small viewport", async ({
+  context,
   page,
 }) => {
+  await context.grantPermissions(["clipboard-write"]);
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");
   await waitForLandingIntro(page);
@@ -378,4 +385,31 @@ test("landing keeps content reachable on a small viewport", async ({
   const composer = page.locator(".landing-phone-composer");
   await composer.scrollIntoViewIfNeeded();
   await expect(composer).toBeVisible();
+
+  await page.getByRole("button", { name: "Message Eliza" }).click();
+  await expect(page.getByRole("status")).toHaveText("Phone number copied");
+  await page.waitForTimeout(2_250);
+  await expect(page.getByRole("status")).toHaveText("Phone number copied");
+});
+
+test("landing keeps clipboard rejection visible", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: () =>
+          Promise.reject(new DOMException("denied", "NotAllowedError")),
+      },
+    });
+  });
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Message Eliza" }).click();
+  await expect(page.getByRole("alert")).toHaveText(
+    "Couldn't copy the phone number",
+  );
+  await page.waitForTimeout(2_250);
+  await expect(page.getByRole("alert")).toHaveText(
+    "Couldn't copy the phone number",
+  );
 });


### PR DESCRIPTION
## Summary

Promotes the already-reviewed and merged homepage messaging feedback fix from #19411 to the production branch. Copy success and clipboard rejection remain visible after the former two-second reset; failures are exposed as alerts.

Closes #19388.

## Verification

- `bun run verify` — 350/350 tasks, all audits passed
- `bun run --cwd packages/homepage test` — 97/97 passed
- homepage typecheck and lint — passed
- isolated fresh-server Playwright landing paths — 3/3 passed, including persistence beyond 2.25 seconds and clipboard rejection
- live pre-promotion Windows path already verified: copied `+18087881821`, announced `Phone number copied`, formatted number absent

This is a production promotion of #19411; no unrelated develop commits are included.