### PR TITLE
fix(cloud): remove cold first-turn voice stall

### DIFF
--- a/packages/cloud/api/v1/twilio/voice/inbound/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/inbound/route.ts
@@ -16,6 +16,7 @@ import { normalizePhoneNumber } from "@/lib/utils/phone-normalization";
 import { verifyTwilioSignature } from "@/lib/utils/twilio-api";
 import { recordVoiceSessionJti } from "@/lib/voice-session/jwt";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
+import { scheduleTwilioVoiceScopePrewarm } from "../lib/prewarm-voice-scope";
 import { resolveTwilioVoiceTarget } from "../lib/resolve-voice-target";
 import { mintTwilioStreamToken } from "../lib/twilio-stream-token";
 import {
@@ -114,6 +115,26 @@ app.post("/", async (c) => {
   }
 
   const id = randomUUID();
+  const conversationId = randomUUID();
+  try {
+    scheduleTwilioVoiceScopePrewarm({
+      env: c.env,
+      executionCtx: c.executionCtx,
+      claims: {
+        agentId: phoneNumber.agentId,
+        conversationId,
+        organizationId: phoneNumber.organizationId,
+        userId: phoneNumber.userId,
+      },
+    });
+  } catch (error) {
+    // error-policy:J7 local/test contexts can omit a Worker execution context;
+    // the media session remains the authoritative cold-hydration boundary.
+    logger.warn("[twilio-voice-inbound] early scope prewarm unavailable", {
+      agentId: phoneNumber.agentId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
   const [priorCall] = await dbRead
     .select({ id: twilioInboundCalls.id })
     .from(twilioInboundCalls)
@@ -157,7 +178,6 @@ app.post("/", async (c) => {
     agentId: phoneNumber?.agentId,
   });
 
-  const conversationId = randomUUID();
   const minted = await mintTwilioStreamToken(
     {
       accountSid: event.AccountSid,

--- a/packages/cloud/api/v1/twilio/voice/inbound/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/inbound/route.ts
@@ -118,6 +118,7 @@ app.post("/", async (c) => {
   const conversationId = randomUUID();
   try {
     scheduleTwilioVoiceScopePrewarm({
+      agent: phoneNumber.agent,
       env: c.env,
       executionCtx: c.executionCtx,
       claims: {

--- a/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.test.ts
@@ -1,0 +1,52 @@
+/** Proves inbound Twilio prewarm starts immediately and stays non-fatal. */
+
+import { describe, expect, mock, test } from "bun:test";
+import { scheduleTwilioVoiceScopePrewarm } from "./prewarm-voice-scope";
+
+const claims = {
+  agentId: "agent-voice",
+  conversationId: "conversation-voice",
+  organizationId: "org-voice",
+  userId: "user-voice",
+};
+
+describe("Twilio voice scope prewarm", () => {
+  test("registers and runs hydration without blocking the caller", async () => {
+    const waits: Promise<unknown>[] = [];
+    let releaseHydration: (() => void) | undefined;
+    const hydrateScope = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseHydration = resolve;
+        }),
+    );
+
+    const prewarm = scheduleTwilioVoiceScopePrewarm({
+      claims,
+      env: {} as never,
+      executionCtx: { waitUntil: (promise) => waits.push(promise) },
+      hydrateScope,
+    });
+
+    await Promise.resolve();
+    expect(hydrateScope).toHaveBeenCalledWith({}, claims);
+    expect(waits).toEqual([prewarm]);
+    releaseHydration?.();
+    await prewarm;
+  });
+
+  test("contains hydration failure for the media session fallback", async () => {
+    const waits: Promise<unknown>[] = [];
+    const prewarm = scheduleTwilioVoiceScopePrewarm({
+      claims,
+      env: {} as never,
+      executionCtx: { waitUntil: (promise) => waits.push(promise) },
+      hydrateScope: async () => {
+        throw new Error("database unavailable");
+      },
+    });
+
+    await expect(prewarm).resolves.toBeUndefined();
+    await expect(waits[0]).resolves.toBeUndefined();
+  });
+});

--- a/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.test.ts
@@ -9,6 +9,15 @@ const claims = {
   organizationId: "org-voice",
   userId: "user-voice",
 };
+const agent = {
+  id: claims.agentId,
+  organization_id: claims.organizationId,
+  user_id: claims.userId,
+  character_id: "character-voice",
+  agent_name: "Eliza",
+  agent_config: null,
+  execution_tier: "shared" as const,
+};
 
 describe("Twilio voice scope prewarm", () => {
   test("registers and runs hydration without blocking the caller", async () => {
@@ -22,6 +31,7 @@ describe("Twilio voice scope prewarm", () => {
     );
 
     const prewarm = scheduleTwilioVoiceScopePrewarm({
+      agent: agent as never,
       claims,
       env: {} as never,
       executionCtx: { waitUntil: (promise) => waits.push(promise) },
@@ -29,7 +39,7 @@ describe("Twilio voice scope prewarm", () => {
     });
 
     await Promise.resolve();
-    expect(hydrateScope).toHaveBeenCalledWith({}, claims);
+    expect(hydrateScope).toHaveBeenCalledWith({}, claims, agent);
     expect(waits).toEqual([prewarm]);
     releaseHydration?.();
     await prewarm;

--- a/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.ts
@@ -1,0 +1,52 @@
+/**
+ * Starts shared-runtime cache hydration during the inbound Twilio webhook so
+ * cold database work overlaps call setup, the greeting, and caller speech.
+ */
+
+import { logger } from "@/lib/utils/logger";
+import type { Bindings } from "@/types/cloud-worker-env";
+import type { InternalElizaConversationFetchClaims } from "../../../voice/session/lib/internal-eliza-conversation-fetch";
+
+interface VoicePrewarmExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+type HydrateVoiceScope = (
+  env: Bindings,
+  claims: InternalElizaConversationFetchClaims,
+) => Promise<void>;
+
+interface ScheduleVoiceScopePrewarmOptions {
+  claims: InternalElizaConversationFetchClaims;
+  env: Bindings;
+  executionCtx: VoicePrewarmExecutionContext;
+  hydrateScope?: HydrateVoiceScope;
+}
+
+/** Registers a safe background prewarm at the earliest authenticated call boundary. */
+export function scheduleTwilioVoiceScopePrewarm({
+  claims,
+  env,
+  executionCtx,
+  hydrateScope,
+}: ScheduleVoiceScopePrewarmOptions): Promise<void> {
+  const prewarm = Promise.resolve()
+    .then(async () => {
+      const hydrate =
+        hydrateScope ??
+        (await import("../../../voice/session/lib/voice-agent-scope-hydration"))
+          .hydrateVoiceSharedAgentScope;
+      await hydrate(env, claims);
+    })
+    .catch((error) => {
+      // error-policy:J7 this is a latency hint; the media session retains its
+      // authoritative hydration and retry path if the early prewarm fails.
+      logger.warn("[twilio-voice-inbound] early scope prewarm failed", {
+        agentId: claims.agentId,
+        organizationId: claims.organizationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  executionCtx.waitUntil(prewarm);
+  return prewarm;
+}

--- a/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.ts
@@ -3,6 +3,7 @@
  * cold database work overlaps call setup, the greeting, and caller speech.
  */
 
+import type { AgentSandbox } from "@/db/repositories/agent-sandboxes";
 import { logger } from "@/lib/utils/logger";
 import type { Bindings } from "@/types/cloud-worker-env";
 import type { InternalElizaConversationFetchClaims } from "../../../voice/session/lib/internal-eliza-conversation-fetch";
@@ -14,9 +15,11 @@ interface VoicePrewarmExecutionContext {
 type HydrateVoiceScope = (
   env: Bindings,
   claims: InternalElizaConversationFetchClaims,
+  preloadedAgent?: AgentSandbox,
 ) => Promise<void>;
 
 interface ScheduleVoiceScopePrewarmOptions {
+  agent?: AgentSandbox;
   claims: InternalElizaConversationFetchClaims;
   env: Bindings;
   executionCtx: VoicePrewarmExecutionContext;
@@ -25,6 +28,7 @@ interface ScheduleVoiceScopePrewarmOptions {
 
 /** Registers a safe background prewarm at the earliest authenticated call boundary. */
 export function scheduleTwilioVoiceScopePrewarm({
+  agent,
   claims,
   env,
   executionCtx,
@@ -36,7 +40,7 @@ export function scheduleTwilioVoiceScopePrewarm({
         hydrateScope ??
         (await import("../../../voice/session/lib/voice-agent-scope-hydration"))
           .hydrateVoiceSharedAgentScope;
-      await hydrate(env, claims);
+      await hydrate(env, claims, agent);
     })
     .catch((error) => {
       // error-policy:J7 this is a latency hint; the media session retains its

--- a/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.test.ts
@@ -8,6 +8,22 @@ interface SandboxRow {
   id: string;
   organization_id: string;
   user_id: string;
+  character_id: string | null;
+  agent_name: string | null;
+  agent_config: Record<string, unknown> | null;
+  execution_tier: "shared";
+}
+
+function sandboxRow(id: string): SandboxRow {
+  return {
+    id,
+    organization_id: "org-public",
+    user_id: "user-public",
+    character_id: "character-public",
+    agent_name: "Eliza",
+    agent_config: null,
+    execution_tier: "shared",
+  };
 }
 
 const findById = mock(
@@ -42,15 +58,13 @@ beforeEach(() => {
 
 describe("resolveTwilioVoiceTarget", () => {
   test("resolves the exact public number to the configured sandbox", async () => {
-    findById.mockImplementation(async () => ({
-      id: DEFAULT_AGENT_ID,
-      organization_id: "org-public",
-      user_id: "user-public",
-    }));
+    const agent = sandboxRow(DEFAULT_AGENT_ID);
+    findById.mockImplementation(async () => agent);
 
     await expect(
       resolveTwilioVoiceTarget(publicEnv, PUBLIC_NUMBER),
     ).resolves.toEqual({
+      agent: agent as never,
       agentId: DEFAULT_AGENT_ID,
       organizationId: "org-public",
       userId: "user-public",
@@ -59,15 +73,13 @@ describe("resolveTwilioVoiceTarget", () => {
   });
 
   test("supports a legacy character id for the configured public agent", async () => {
-    findLatestByCharacterId.mockImplementation(async () => ({
-      id: "agent-from-character",
-      organization_id: "org-public",
-      user_id: "user-public",
-    }));
+    const agent = sandboxRow("agent-from-character");
+    findLatestByCharacterId.mockImplementation(async () => agent);
 
     await expect(
       resolveTwilioVoiceTarget(publicEnv, PUBLIC_NUMBER),
     ).resolves.toEqual({
+      agent: agent as never,
       agentId: "agent-from-character",
       organizationId: "org-public",
       userId: "user-public",

--- a/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.ts
@@ -2,9 +2,13 @@
  * Resolves only the exact public eliza.app Twilio line to its configured agent.
  */
 
-import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
+import {
+  type AgentSandbox,
+  agentSandboxesRepository,
+} from "@/db/repositories/agent-sandboxes";
 
 export interface TwilioVoiceTarget {
+  agent: AgentSandbox;
   agentId: string;
   organizationId: string;
   userId: string;
@@ -35,6 +39,7 @@ export async function resolveTwilioVoiceTarget(
     (await agentSandboxesRepository.findLatestByCharacterId(defaultAgentId));
   return sandbox
     ? {
+        agent: sandbox,
         agentId: sandbox.id,
         organizationId: sandbox.organization_id,
         userId: sandbox.user_id,

--- a/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts
@@ -97,6 +97,8 @@ test("real cache + canonical coordinator dispatch performs no response-path DB w
     },
     executionCtx,
   );
+  await fetchImpl.prewarm();
+  expect(background).toHaveLength(0);
   const response = await fetchImpl(
     `https://voice.internal/api/v1/eliza/agents/${AGENT_ID}/api/conversations/${CONVERSATION_ID}/messages/stream`,
     {

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -789,6 +789,44 @@ describe("voice-session WS lifecycle", () => {
     expect(prewarmCalls).toBe(1);
   });
 
+  test("first response joins prewarm and an interruption discards the obsolete turn", async () => {
+    let resolvePrewarm: () => void = () => {};
+    const prewarm = new Promise<void>((resolve) => {
+      resolvePrewarm = resolve;
+    });
+    const requestTexts: string[] = [];
+    const successFetch = makeSseFetch(["Replacement response."]);
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      prewarmElizaContext: () => prewarm,
+      fetchImpl: (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as { text: string };
+        requestTexts.push(body.text);
+        return successFetch(input, init);
+      }) as typeof fetch,
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+    const ttsBefore = FakeCartesiaSocket.instances.length;
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "obsolete first request");
+    await flush();
+    expect(FakeCartesiaSocket.instances.length).toBe(ttsBefore + 1);
+    expect(requestTexts).toEqual([]);
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "replacement request");
+    await flush();
+    expect(requestTexts).toEqual([]);
+
+    resolvePrewarm();
+    await flush();
+    await flush();
+    expect(requestTexts).toEqual(["replacement request"]);
+    expect(client.controlTypes()).toContain("llm_first_text");
+  });
+
   test("caps Cartesia server-side buffer delay for realtime voice", async () => {
     const client = new FakeClientSocket();
     await connectSession({

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -133,7 +133,13 @@ export function createInternalElizaConversationFetchFactory(
       await runWithCloudBindingsAsync(
         env as unknown as Record<string, unknown>,
         async () => {
-          if (!(await readCachedAgent())) scheduleHydration();
+          if (await readCachedAgent()) return;
+          scheduleHydration();
+          // Capture before awaiting: the hydration's finally block clears the
+          // shared slot. Joining this exact promise lets the first voice turn
+          // use the freshly cached scope without cache-miss polling/backoff.
+          const pendingHydration = hydrationPromise;
+          if (pendingHydration) await pendingHydration;
         },
       );
     };

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -213,6 +213,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   private lastSttPartialSentAtMs = Number.NEGATIVE_INFINITY;
   private sttPartialTimer: ReturnType<typeof setTimeout> | null = null;
   private llmAbort: AbortController | null = null;
+  private elizaPrewarm: Promise<void> | null = null;
   private phrase: PhraseAggregator | null = null;
   private turnSttMs = 0;
   private turnTtsChars = 0;
@@ -317,7 +318,14 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     // the first turn never joins that database work and reports retryable
     // warming until a later cache read observes the completed fill.
     if (this.config.prewarmElizaContext) {
-      void this.config.prewarmElizaContext().catch(() => undefined);
+      this.elizaPrewarm = this.config.prewarmElizaContext().catch((error) => {
+        // error-policy:J7 prewarm is latency-only; the response path retains
+        // its typed cache-warming retry fallback and reports the failed hint.
+        logger.warn("[voice-session] Eliza context prewarm failed", {
+          sessionId: this.sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
     }
     // The session-level trace span id is stable until the first turn mints its own.
     const sessionTrace = this.mintTraceId("session");
@@ -763,6 +771,13 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       // turn does not await readiness because outbound phrases queue in the
       // adapter, so consume that designed rejection on fast teardown.
       void prewarmedTts.opened.catch(() => undefined);
+
+      const elizaPrewarm = this.elizaPrewarm;
+      if (elizaPrewarm) {
+        await elizaPrewarm;
+        if (this.elizaPrewarm === elizaPrewarm) this.elizaPrewarm = null;
+        if (abort.signal.aborted || this.currentVoiceTurnId !== traceId) return;
+      }
 
       const request = {
         endpoint: this.config.elizaEndpoint,

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -314,9 +314,8 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
     this.state = "listening";
     // Read immutable tenancy from cache while the user is beginning to speak.
-    // A miss only schedules authoritative hydration under the Worker lifetime;
-    // the first turn never joins that database work and reports retryable
-    // warming until a later cache read observes the completed fill.
+    // A miss schedules authoritative hydration under the Worker lifetime; the
+    // first turn joins that work so it does not burn time polling a cold cache.
     if (this.config.prewarmElizaContext) {
       this.elizaPrewarm = this.config.prewarmElizaContext().catch((error) => {
         // error-policy:J7 prewarm is latency-only; the response path retains

--- a/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
+++ b/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
@@ -6,7 +6,10 @@
  */
 
 import { runWithDbCacheAsync } from "@/db/client";
-import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
+import {
+  type AgentSandbox,
+  agentSandboxesRepository,
+} from "@/db/repositories/agent-sandboxes";
 import { userCharactersRepository } from "@/db/repositories/characters";
 import { cache } from "@/lib/cache/client";
 import { CacheKeys, CacheTTL } from "@/lib/cache/keys";
@@ -19,15 +22,18 @@ import type { InternalElizaConversationFetchClaims } from "./internal-eliza-conv
 export async function hydrateVoiceSharedAgentScope(
   env: Bindings,
   claims: InternalElizaConversationFetchClaims,
+  preloadedAgent?: AgentSandbox,
 ): Promise<void> {
   await runWithCloudBindingsAsync(
     env as unknown as Record<string, unknown>,
     () =>
       runWithDbCacheAsync(async () => {
-        const agent = await agentSandboxesRepository.findByIdAndOrg(
-          claims.agentId,
-          claims.organizationId,
-        );
+        const agent =
+          preloadedAgent ??
+          (await agentSandboxesRepository.findByIdAndOrg(
+            claims.agentId,
+            claims.organizationId,
+          ));
         if (
           !agent ||
           agent.id !== claims.agentId ||


### PR DESCRIPTION
Closes #19421

## What changed
- join the in-flight shared-runtime scope hydration before the first Eliza request instead of polling cache-warming 503s
- begin scope, character, and admission prewarm at the authenticated Twilio inbound webhook so it overlaps call setup, greeting, and caller speech
- reuse the already-authoritatively-resolved voice agent so prewarm does not repeat the agent database lookup
- keep Cartesia socket startup parallel with warmup and preserve interruption cancellation semantics

## Production evidence
Rebased exact head adb1c85b3f237e8d97b134c355b88a9084d7df5b is active on Worker version 62cfd034-bf14-4bcc-a250-a6c4bc67ae66.

Same recorded carrier prompt after cache expiry:
- initial production baseline: caller ended 2.84s, Eliza began 9.30s = 6.46s
- optimized cold call CAed1d3560cb7c1b2f6296323a0d58fc93 / RE92c9900b5b74582de91a55897560218f: caller ended 2.84s, Eliza began 7.08s = 4.24s
- immediate warm baseline CAb6b4c4516327a44fab741e2cee027ec7 / RE41a2f46fea7cfbf673fc7d5a824ebad9: caller ended 2.84s, Eliza began 6.58s = 3.74s
- post-rebase exact-head cold proof CA31d02fd55f935c91ed0d6911cafba359 / REa4c9a0b8632ea5b82d682ae163eda2c0: caller ended 2.84s, Eliza began 7.62s = 4.78s

The former multi-second cold penalty is now about 0.5-1.0s over the measured warm baseline.

## Verification
- focused voice lifecycle, hydration, inbound prewarm, target resolution, and cache hot-path tests
- cloud API typecheck and Worker production dry-run
- cloud API lint
- bun run verify:cloud after rebase: 78/78 successful