### PR TITLE
test(app): assert the automations workflow-editor round trip in the all-views crawler

### DIFF
--- a/packages/app/test/ui-smoke/all-views-interaction.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-interaction.spec.ts
@@ -834,6 +834,30 @@ test.describe("every-view interaction coverage", () => {
         if (failureText === "net::ERR_ABORTED") return;
         networkFailures.push(`requestfailed: ${url} ${failureText}`);
       });
+      // The generic ladders cannot see a rejected workflow create: a 4xx
+      // still bumps the API request count and the rendered error state is a
+      // legitimate DOM outcome, so the editor follow-ons silently vanish
+      // while the case stays green. Record the whole workflow surface so the
+      // automations case can assert the successful sequence explicitly.
+      const workflowSurfaceResponses: Array<{
+        method: string;
+        pathname: string;
+        status: number;
+      }> = [];
+      page.on("response", (response) => {
+        const pathname = new URL(response.url()).pathname;
+        if (
+          pathname !== "/api/triggers" &&
+          !pathname.startsWith("/api/workflow/")
+        ) {
+          return;
+        }
+        workflowSurfaceResponses.push({
+          method: response.request().method(),
+          pathname,
+          status: response.status(),
+        });
+      });
 
       await page.setViewportSize({ width: 1440, height: 1000 });
       await seedAppStorage(page);
@@ -966,6 +990,53 @@ test.describe("every-view interaction coverage", () => {
           ...networkFailures,
         ].join("\n"),
       ).toHaveLength(0);
+      // The automations crawl must complete the workflow-editor round trip,
+      // not merely generate traffic toward it: the create must succeed and
+      // the editor's follow-on reads must land, and no workflow-surface
+      // request may be rejected. Without this, an invalid or rejecting
+      // fixture prunes the editor coverage while the case stays green.
+      if (view.id === "automations") {
+        const observed = workflowSurfaceResponses
+          .map((r) => `${r.method} ${r.pathname} -> ${r.status}`)
+          .join("\n");
+        const rejected = workflowSurfaceResponses.filter(
+          (r) => r.status < 200 || r.status >= 300,
+        );
+        expect(
+          rejected.map((r) => `${r.method} ${r.pathname} -> ${r.status}`),
+          `automations: workflow-surface request was rejected\nobserved:\n${observed}`,
+        ).toHaveLength(0);
+        const succeeded = (method: string, pattern: RegExp) =>
+          workflowSurfaceResponses.some(
+            (r) =>
+              r.method === method &&
+              pattern.test(r.pathname) &&
+              r.status >= 200 &&
+              r.status < 300,
+          );
+        const missing = (
+          [
+            ["POST", /^\/api\/workflow\/workflows$/, "workflow create"],
+            ["GET", /^\/api\/triggers$/, "editor trigger-list read"],
+            [
+              "GET",
+              /^\/api\/workflow\/workflows\/[^/]+\/executions$/,
+              "editor executions read",
+            ],
+            [
+              "GET",
+              /^\/api\/workflow\/workflows\/[^/]+\/revisions$/,
+              "editor revisions read",
+            ],
+          ] as const
+        )
+          .filter(([method, pattern]) => !succeeded(method, pattern))
+          .map(([, , label]) => label);
+        expect(
+          missing,
+          `automations: workflow-editor sequence incomplete; missing: ${missing.join(", ")}\nobserved:\n${observed}`,
+        ).toHaveLength(0);
+      }
     });
   }
 });


### PR DESCRIPTION
# Relates to

Closes #19331.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      (`75b83886e`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker — **see Known gaps:
      full verify is delegated to PR CI per operator hardware constraint.**
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] Full `bun run verify` — delegated to PR CI; see Known gaps.

# Risks

**Minimal — pure test infrastructure.** The diff is now additive-only against
`develop`: a passive response recorder plus two assertions scoped to the
`automations` case of one Playwright spec. Zero production code, zero stub
code, zero shared-helper code. No route registration changes, so nothing can
shadow the sibling specs' fixtures.

# Background

## What does this PR do?

This PR was re-scoped by the exact-head audit review and a concurrent
upstream fix; the current diff delivers the audit's P1 requirement.

**Original scope (superseded upstream):** the `automations` case redded on
`http 501: /api/workflow/workflows` because the ui-smoke stub server models
no workflow route (full root-cause in #19331). The original diff added
spec-local workflow fixtures. While this PR was under audit, `develop` landed
`8c819716d` ("test(ui): repair current smoke boundary contracts"), which
installs a **stateful, id-anchored** workflow + trigger stub inside this
spec's own `installInteractionAuditRoutes`. That upstream stub is a superset
of this PR's fixtures and already uses the anchored
`/api/workflow/workflows/:id/{executions,revisions}` matching the audit's P2
required. After rebasing, this PR's older fixtures were duplicates registered
*later* in the same function — under Playwright's last-registered-wins
routing they would have shadowed the richer upstream stub — so they are
dropped rather than repaired. **P2 is resolved by that removal**: no
`endsWith` matching remains in the diff.

**Delivered scope (audit P1):** the audit proved the case could pass
vacuously — mutating the create response to `400` still reported `1 passed`,
because a rejected create bumps the API request count (a legitimate
`semanticDelta`) and renders a legitimate error state, while every editor
follow-on request silently disappears and the `>= 500` network collector
never fires. The diff adds:

- a passive recorder of every workflow-surface response
  (`/api/workflow/*` + `/api/triggers`): method, pathname, status;
- for the `automations` view only, two assertions after the existing
  contract checks: **no workflow-surface response outside 2xx**, and the
  **required round trip completed** — successful `POST` create plus the
  editor's trigger-list, executions, and revisions reads. A rejected or
  invalid create now reds the case instead of truncating its coverage.

## What kind of change is this?

Test-integrity fix (non-breaking) — closes the vacuous-pass gap the audit
demonstrated on the previous head.

# Documentation changes needed?

None; the recorder and assertions carry explanatory comments at the seam.

# Testing

## Where should a reviewer start?

```bash
ELIZA_UI_SMOKE_FORCE_STUB=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=chromium -g "automations" test/ui-smoke/all-views-interaction.spec.ts
```
(from `packages/app`)

## Detailed testing steps

All runs below are on this exact head (`70af4fa99`), freshly executed after
the rebase; mutation controls modify the upstream stub in the working tree,
run, and are reverted (verified clean) before the next run.

1. **Unmodified head:** the focused automations case passes.
2. **Audit's mutation (create → 400):** the case now **fails** through the
   new rejected-response assertion — the exact vacuous pass the audit
   demonstrated is closed.
3. **Invalid-fixture mutation (create → 201 with empty body):** the case
   fails — the editor navigates to `/workflows/undefined` and its reads fall
   through to the stub server's 501, caught by the pre-existing network
   collector. Every mutation angle lands on some gate; the new sequence
   assertion additionally covers the zero-traffic angle (a crawl that never
   reaches create at all), which no existing collector can see.
4. **Full spec file:** 31/33 pass; the two reds are proven pre-existing at
   `develop` tip (control transcripts below): `memories` (filed as #19610,
   with mechanism) and `pendant-transcript` (#19437, closed as
   not-reproducible on maintainer environment; still reds on this machine).

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:2db0d4c24c9caffa629698351fca91f07b2f3633 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - headless Playwright test-integrity change; the before-state artifact is the audit's vacuous-pass transcript, reproduced below.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - same reason; the after-state artifact is the mutation-control failure transcript below.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - no user-facing flow changes; rendered UI is identical.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend code in the diff; the stubbed API server is unchanged
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs — the spec's own assertion output is
      the artifact:

<details>
<summary>new assertion output under the audit's mutation (create → 400)</summary>

```
Error: automations: workflow-surface request was rejected
observed:
POST /api/workflow/workflows -> 400
POST /api/workflow/workflows -> 400

expect(received).toHaveLength(expected)
> 1000 |         ).toHaveLength(0);
```
</details>
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent, action, provider, prompt, or model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — all on exact head `70af4fa99`, from `packages/app`
      with `ELIZA_UI_SMOKE_FORCE_STUB=1 ELIZA_UI_SMOKE_DISABLE_VIDEO=1`:

<details>
<summary>1. unmodified head — focused automations case passes</summary>

```
$ node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts \
  --project=chromium -g "automations" test/ui-smoke/all-views-interaction.spec.ts

Running 1 test using 1 worker
  ✓  1 [chromium] › test/ui-smoke/all-views-interaction.spec.ts:797:5 ›
     every-view interaction coverage › automations — exercise every control
     with semantic outcomes (4.3s)
  1 passed (15.7s)
exit 0
```
</details>

<details>
<summary>2. audit mutation control — create mutated to 400 now FAILS via the new assertion</summary>

```
# upstream stub's create response: status: 201 -> status: 400, then the same command

  ✘  1 [chromium] › test/ui-smoke/all-views-interaction.spec.ts:797:5 ›
     every-view interaction coverage › automations — ... (4.1s)

    Error: automations: workflow-surface request was rejected
    observed:
    POST /api/workflow/workflows -> 400
    POST /api/workflow/workflows -> 400

  1 failed
exit 1
# mutation reverted; git status clean on the spec
```
</details>

<details>
<summary>3. invalid-fixture control — create at 201 with empty body FAILS via the pre-existing 501 collector</summary>

```
# upstream stub's create body: JSON.stringify(interactionWorkflow) -> "{}", same command

  ✘  1 [chromium] › ... › automations — ... (4.1s)

    Error: automations: a control interaction threw an uncaught error
    http 501: /api/workflow/workflows/undefined/revisions
    http 501: /api/workflow/workflows/undefined/revisions

  1 failed
exit 1
# mutation reverted; git status clean on the spec
```
</details>

<details>
<summary>4. full spec file on this head — 31/33; both reds proven pre-existing at develop tip</summary>

```
$ node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts \
  --project=chromium test/ui-smoke/all-views-interaction.spec.ts

  2 failed
    [chromium] › ... › pendant-transcript — exercise every control with semantic outcomes
    [chromium] › ... › memories — exercise every control with semantic outcomes
  31 passed (3.8m)
```

Control for `memories` — the spec file checked out from `origin/develop`
(this PR's only diff removed), same command, `-g "memories"`:

```
  ✘  1 [chromium] › ... › memories — exercise every control with semantic
     outcomes (8.7s)
    Error: memories: every exercised input/click/Escape interaction needs an
    observable semantic outcome or an explicit documented no-op
    click 4: button type=button label="Ask Eliza" produced no URL, API, DOM
    state, dialog/menu, value, checked, text, or documented no-op outcome
  1 failed
```

Identical failure with and without this diff → base-era; root-caused and
filed as #19610 (the memories empty-state CTA's only outcome is the overlay
this spec itself hides). `pendant-transcript` fails with the same
browser-context closure documented in #19437 (closed not-reproducible on
maintainer environment; disclosed as a local observation).
</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface in the diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt, or model behavior changes.`

## Backend + frontend logs

The relevant artifact is the spec's own assertion output, captured in the
transcripts above.

## Screenshots (before / after) + video walkthrough

`N/A - test-integrity change with identical rendered UI.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

- **Full `bun run verify` was not run locally on this head.** Per the
  recorded operator hardware constraint it is delegated to this PR's CI; the
  proportional local evidence is the mutation-control matrix plus the full
  spec-file run above. If any CI lane reds, I will fix or record it here.
- **Two base-era reds in the full spec file**, both proven independent of
  this diff by control runs: `memories` (#19610, filed from this
  attribution work with mechanism and fix directions) and
  `pendant-transcript` (#19437). A hosted full-file run of this spec will
  red on `memories` until #19610 is resolved — that red is attributable to
  the base, not this diff.
- The webServer's app build OOM-crashes on the operator machine at default
  Node heap (SIGABRT during `vite build`); evidence runs used
  `NODE_OPTIONS=--max-old-space-size=8192`. Environment-only; no repo change.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->


