### PR TITLE
fix(ui): route Voice settings toggles through SettingsSwitchRow

### DIFF
--- a/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
@@ -347,18 +347,19 @@ const transcriptionShortcutConsent = mobile.locator(
   '[data-testid="voice-section-intent-autostart-transcription"]',
 );
 assert(
-  !(await voiceShortcutConsent.isChecked()) &&
-    !(await transcriptionShortcutConsent.isChecked()),
+  (await voiceShortcutConsent.getAttribute("aria-checked")) === "false" &&
+    (await transcriptionShortcutConsent.getAttribute("aria-checked")) ===
+      "false",
   "mobile Voice settings default both shortcut microphone permissions off",
 );
-await voiceShortcutConsent.check();
+await voiceShortcutConsent.click();
 assert(
-  await voiceShortcutConsent.isChecked(),
+  (await voiceShortcutConsent.getAttribute("aria-checked")) === "true",
   "mobile Voice settings can grant voice-shortcut microphone permission",
 );
-await voiceShortcutConsent.uncheck();
+await voiceShortcutConsent.click();
 assert(
-  !(await voiceShortcutConsent.isChecked()),
+  (await voiceShortcutConsent.getAttribute("aria-checked")) === "false",
   "mobile Voice settings can revoke voice-shortcut microphone permission",
 );
 await mobile.waitForTimeout(450);

--- a/packages/ui/src/components/settings/VoiceSection.test.tsx
+++ b/packages/ui/src/components/settings/VoiceSection.test.tsx
@@ -40,7 +40,7 @@ describe("VoiceSection", () => {
     expect(screen.getByTestId("voice-section")).toBeTruthy();
     expect(screen.getByTestId("voice-tier-banner")).toBeTruthy();
     expect(screen.getByTestId("voice-section-continuous-row")).toBeTruthy();
-    expect(screen.getByTestId("voice-section-wake-row")).toBeTruthy();
+    expect(screen.getByTestId("voice-section-wake-toggle")).toBeTruthy();
     expect(screen.getByTestId("voice-section-models")).toBeTruthy();
     expect(screen.getByTestId("voice-profile-section")).toBeTruthy();
     // The local-vs-cloud strategy control was removed — per-modality routing
@@ -87,6 +87,29 @@ describe("VoiceSection", () => {
     expect(screen.getByTestId("voice-section-models-empty")).toBeTruthy();
   });
 
+  it("toggles wake word through SettingsSwitchRow", () => {
+    const onWakeWordToggle = vi.fn();
+    render(
+      <VoiceSection
+        {...baseProps}
+        prefs={DEFAULT_VOICE_SECTION_PREFS}
+        onPrefsChange={() => {}}
+        wakeWordEnabled={false}
+        onWakeWordToggle={onWakeWordToggle}
+      />,
+    );
+    const wake = screen.getByTestId("voice-section-wake-toggle");
+    expect(wake.getAttribute("role")).toBe("switch");
+    expect(wake.getAttribute("data-agent-id")).toBe(
+      "voice-section-wake-toggle",
+    );
+    expect(wake.getAttribute("aria-checked")).toBe("false");
+    expect(wake.getAttribute("aria-label")).toBeNull();
+    expect(screen.getByLabelText("Wake word")).toBe(wake);
+    fireEvent.click(wake);
+    expect(onWakeWordToggle).toHaveBeenCalledWith(true);
+  });
+
   it("propagates continuous-mode changes", () => {
     const onPrefsChange = vi.fn();
     render(
@@ -114,14 +137,13 @@ describe("VoiceSection", () => {
         onPrefsChange={onPrefsChange}
       />,
     );
-    const voice = screen.getByTestId(
-      "voice-section-intent-autostart-voice",
-    ) as HTMLInputElement;
+    const voice = screen.getByTestId("voice-section-intent-autostart-voice");
     const transcription = screen.getByTestId(
       "voice-section-intent-autostart-transcription",
-    ) as HTMLInputElement;
-    expect(voice.checked).toBe(false);
-    expect(transcription.checked).toBe(false);
+    );
+    expect(voice.getAttribute("role")).toBe("switch");
+    expect(voice.getAttribute("aria-checked")).toBe("false");
+    expect(transcription.getAttribute("aria-checked")).toBe("false");
 
     fireEvent.click(voice);
     expect(onPrefsChange).toHaveBeenLastCalledWith({

--- a/packages/ui/src/components/settings/VoiceSection.tsx
+++ b/packages/ui/src/components/settings/VoiceSection.tsx
@@ -19,6 +19,7 @@ import { Input } from "../ui/input";
 import { AdvancedToggle } from "./AdvancedToggle";
 import { useAdvancedSettingsEnabled } from "./AdvancedToggle.hooks";
 import { PendantSettingsCard } from "./PendantSettingsCard";
+import { SettingsSwitchRow } from "./settings-agent-rows";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
 import { VoiceProfileSection } from "./VoiceProfileSection";
 import { DEFAULT_VAD_AUTO_STOP_PREFS } from "./VoiceSection.helpers";
@@ -180,45 +181,6 @@ export function VoiceSection({
     [prefs.vadAutoStop, updatePrefs],
   );
 
-  const { ref: wakeWordRef, agentProps: wakeWordAgentProps } =
-    useAgentElement<HTMLInputElement>({
-      id: "voice-section-wake-toggle",
-      role: "toggle",
-      label: t("voicesection.toggleWakeWord", {
-        defaultValue: "Toggle wake word",
-      }),
-      group: "voice-section",
-      status: wakeWordEnabled ? "active" : "inactive",
-      onActivate: () => onWakeWordToggle?.(!wakeWordEnabled),
-    });
-  const { ref: intentVoiceRef, agentProps: intentVoiceAgentProps } =
-    useAgentElement<HTMLInputElement>({
-      id: "voice-section-intent-autostart-voice",
-      role: "toggle",
-      label: t("voicesection.intentAutoStartVoice", {
-        defaultValue: "Allow voice shortcuts to start the microphone",
-      }),
-      group: "voice-section",
-      status: prefs.osIntentAutoStartVoice ? "active" : "inactive",
-      onActivate: () =>
-        updatePrefs({ osIntentAutoStartVoice: !prefs.osIntentAutoStartVoice }),
-    });
-  const {
-    ref: intentTranscriptionRef,
-    agentProps: intentTranscriptionAgentProps,
-  } = useAgentElement<HTMLInputElement>({
-    id: "voice-section-intent-autostart-transcription",
-    role: "toggle",
-    label: t("voicesection.intentAutoStartTranscription", {
-      defaultValue: "Allow transcription shortcuts to start the microphone",
-    }),
-    group: "voice-section",
-    status: prefs.osIntentAutoStartTranscription ? "active" : "inactive",
-    onActivate: () =>
-      updatePrefs({
-        osIntentAutoStartTranscription: !prefs.osIntentAutoStartTranscription,
-      }),
-  });
   return (
     <section data-testid="voice-section" className={cn(className)}>
       <SettingsStack>
@@ -253,99 +215,53 @@ export function VoiceSection({
             </div>
           </SettingsRow>
 
-          <SettingsRow
+          <SettingsSwitchRow
+            agentId="voice-section-wake-toggle"
+            testId="voice-section-wake-toggle"
+            group="voice-section"
             icon={Sliders}
             label={t("voicesection.wakeWord", { defaultValue: "Wake word" })}
-            control={
-              <label
-                htmlFor="voice-section-wake-toggle"
-                className="inline-flex min-h-[44px] cursor-pointer items-center gap-2 text-sm"
-                data-testid="voice-section-wake-row"
-              >
-                <Input
-                  id="voice-section-wake-toggle"
-                  ref={wakeWordRef}
-                  type="checkbox"
-                  checked={wakeWordEnabled}
-                  onChange={(e) => onWakeWordToggle?.(e.target.checked)}
-                  data-testid="voice-section-wake-toggle"
-                  className="h-5 w-5 rounded-sm border-border p-0 accent-accent"
-                  aria-current={wakeWordEnabled ? "true" : undefined}
-                  aria-label={t("voicesection.toggleWakeWord", {
-                    defaultValue: "Toggle wake word",
-                  })}
-                  {...wakeWordAgentProps}
-                />
-                <span className="text-muted">
-                  {wakeWordEnabled
-                    ? t("voicesection.on", { defaultValue: "On" })
-                    : t("voicesection.off", { defaultValue: "Off" })}
-                </span>
-              </label>
-            }
+            checked={wakeWordEnabled}
+            disabled={!onWakeWordToggle}
+            agentStatus={wakeWordEnabled ? "active" : "inactive"}
+            onCheckedChange={(checked) => onWakeWordToggle?.(checked)}
           />
 
-          <SettingsRow
+          <SettingsSwitchRow
+            agentId="voice-section-intent-autostart-voice"
+            testId="voice-section-intent-autostart-voice"
+            group="voice-section"
             icon={Mic}
-            label={t("voicesection.intentAutoStart", {
-              defaultValue: "Shortcut auto-start",
+            label={t("voicesection.intentAutoStartVoice", {
+              defaultValue: "Allow voice shortcuts to start the microphone",
             })}
-            stacked
-          >
-            <div className="flex flex-col gap-2 text-sm text-muted">
-              <label
-                htmlFor="voice-section-intent-autostart-voice"
-                className="inline-flex min-h-11 cursor-pointer items-center gap-2"
-              >
-                <Input
-                  ref={intentVoiceRef}
-                  id="voice-section-intent-autostart-voice"
-                  type="checkbox"
-                  checked={prefs.osIntentAutoStartVoice}
-                  onChange={(event) =>
-                    updatePrefs({
-                      osIntentAutoStartVoice: event.target.checked,
-                    })
-                  }
-                  className="h-5 w-5 rounded-sm border-border p-0 accent-accent"
-                  data-testid="voice-section-intent-autostart-voice"
-                  {...intentVoiceAgentProps}
-                />
-                {t("voicesection.intentAutoStartVoice", {
-                  defaultValue: "Allow voice shortcuts to start the microphone",
-                })}
-              </label>
-              <label
-                htmlFor="voice-section-intent-autostart-transcription"
-                className="inline-flex min-h-11 cursor-pointer items-center gap-2"
-              >
-                <Input
-                  ref={intentTranscriptionRef}
-                  id="voice-section-intent-autostart-transcription"
-                  type="checkbox"
-                  checked={prefs.osIntentAutoStartTranscription}
-                  onChange={(event) =>
-                    updatePrefs({
-                      osIntentAutoStartTranscription: event.target.checked,
-                    })
-                  }
-                  className="h-5 w-5 rounded-sm border-border p-0 accent-accent"
-                  data-testid="voice-section-intent-autostart-transcription"
-                  {...intentTranscriptionAgentProps}
-                />
-                {t("voicesection.intentAutoStartTranscription", {
-                  defaultValue:
-                    "Allow transcription shortcuts to start the microphone",
-                })}
-              </label>
-              <span>
-                {t("voicesection.intentAutoStartHint", {
-                  defaultValue:
-                    "Off by default. Turn either option off here at any time.",
-                })}
-              </span>
-            </div>
-          </SettingsRow>
+            checked={prefs.osIntentAutoStartVoice}
+            agentStatus={prefs.osIntentAutoStartVoice ? "active" : "inactive"}
+            onCheckedChange={(checked) =>
+              updatePrefs({ osIntentAutoStartVoice: checked })
+            }
+          />
+          <SettingsSwitchRow
+            agentId="voice-section-intent-autostart-transcription"
+            testId="voice-section-intent-autostart-transcription"
+            group="voice-section"
+            icon={Mic}
+            label={t("voicesection.intentAutoStartTranscription", {
+              defaultValue:
+                "Allow transcription shortcuts to start the microphone",
+            })}
+            description={t("voicesection.intentAutoStartHint", {
+              defaultValue:
+                "Off by default. Turn either option off here at any time.",
+            })}
+            checked={prefs.osIntentAutoStartTranscription}
+            agentStatus={
+              prefs.osIntentAutoStartTranscription ? "active" : "inactive"
+            }
+            onCheckedChange={(checked) =>
+              updatePrefs({ osIntentAutoStartTranscription: checked })
+            }
+          />
         </SettingsGroup>
 
         <SettingsGroup

--- a/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
@@ -73,10 +73,9 @@ describe("VoiceSectionMount — wake-word toggle wiring (FIX 3)", () => {
 
   it("defaults the wake-word toggle ON (no stored pref) and reflects it", async () => {
     render(<VoiceSectionMount />);
-    const toggle = (await screen.findByTestId(
-      "voice-section-wake-toggle",
-    )) as HTMLInputElement;
-    expect(toggle.checked).toBe(true);
+    const toggle = await screen.findByTestId("voice-section-wake-toggle");
+    expect(toggle.getAttribute("role")).toBe("switch");
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
     // Let the mount-time async config/tier fetches settle to avoid act warnings.
     await waitFor(() =>
       expect(clientMock.getLocalInferenceDeviceTier).toHaveBeenCalled(),
@@ -86,28 +85,28 @@ describe("VoiceSectionMount — wake-word toggle wiring (FIX 3)", () => {
   it("persists the toggle so the shell's wake pref maps to actual enablement", async () => {
     const user = userEvent.setup();
     render(<VoiceSectionMount />);
-    const toggle = (await screen.findByTestId(
-      "voice-section-wake-toggle",
-    )) as HTMLInputElement;
+    const toggle = await screen.findByTestId("voice-section-wake-toggle");
 
     // Turning it off writes the persisted pref the shell reads for wake gating.
     await user.click(toggle);
-    await waitFor(() => expect(toggle.checked).toBe(false));
+    await waitFor(() =>
+      expect(toggle.getAttribute("aria-checked")).toBe("false"),
+    );
     expect(window.localStorage.getItem(WAKE_KEY)).toBe("false");
 
     // Turning it back on flips the pref again.
     await user.click(toggle);
-    await waitFor(() => expect(toggle.checked).toBe(true));
+    await waitFor(() =>
+      expect(toggle.getAttribute("aria-checked")).toBe("true"),
+    );
     expect(window.localStorage.getItem(WAKE_KEY)).toBe("true");
   });
 
   it("reflects a persisted wake-word-disabled pref on mount", async () => {
     window.localStorage.setItem(WAKE_KEY, "false");
     render(<VoiceSectionMount />);
-    const toggle = (await screen.findByTestId(
-      "voice-section-wake-toggle",
-    )) as HTMLInputElement;
-    expect(toggle.checked).toBe(false);
+    const toggle = await screen.findByTestId("voice-section-wake-toggle");
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
   });
 });
 
@@ -180,17 +179,19 @@ describe("VoiceSectionMount — shortcut microphone consent", () => {
   it("defaults off and persists an explicit voice auto-start opt-in", async () => {
     const user = userEvent.setup();
     render(<VoiceSectionMount />);
-    const toggle = (await screen.findByTestId(
+    const toggle = await screen.findByTestId(
       "voice-section-intent-autostart-voice",
-    )) as HTMLInputElement;
-    expect(toggle.checked).toBe(false);
+    );
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
     expect(loadOsIntentAutoStartConsent()).toEqual({
       voice: false,
       transcription: false,
     });
 
     await user.click(toggle);
-    await waitFor(() => expect(toggle.checked).toBe(true));
+    await waitFor(() =>
+      expect(toggle.getAttribute("aria-checked")).toBe("true"),
+    );
     expect(loadOsIntentAutoStartConsent()).toEqual({
       voice: true,
       transcription: false,
@@ -204,10 +205,10 @@ describe("VoiceSectionMount — shortcut microphone consent", () => {
 
   it("reflects a chat-driven consent broadcast while the panel is open", async () => {
     render(<VoiceSectionMount />);
-    const toggle = (await screen.findByTestId(
+    const toggle = await screen.findByTestId(
       "voice-section-intent-autostart-transcription",
-    )) as HTMLInputElement;
-    expect(toggle.checked).toBe(false);
+    );
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
     act(() => {
       emitViewEvent(
         VOICE_SETTINGS_APPLY_EVENT,
@@ -215,7 +216,9 @@ describe("VoiceSectionMount — shortcut microphone consent", () => {
         "agent",
       );
     });
-    await waitFor(() => expect(toggle.checked).toBe(true));
+    await waitFor(() =>
+      expect(toggle.getAttribute("aria-checked")).toBe("true"),
+    );
   });
 });
 

--- a/packages/ui/src/components/settings/no-raw-labelled-input.test.ts
+++ b/packages/ui/src/components/settings/no-raw-labelled-input.test.ts
@@ -76,8 +76,8 @@ const RAW_INPUT_OCCURRENCES = new Map<
   [
     "VoiceSection.tsx",
     {
-      count: 4,
-      reason: "checkbox consent controls, not labelled text/password fields",
+      count: 1,
+      reason: "end-of-turn range sliders, not labelled text/password fields",
     },
   ],
   [

--- a/packages/ui/src/components/settings/settings-agent-rows.tsx
+++ b/packages/ui/src/components/settings/settings-agent-rows.tsx
@@ -55,6 +55,8 @@ export interface SettingsSwitchRowProps {
   /** Override the agent-surface status token (defaults to on/off). */
   agentStatus?: string;
   className?: string;
+  /** Stable test hook on the switch control. */
+  testId?: string;
 }
 
 export function SettingsSwitchRow({
@@ -70,6 +72,7 @@ export function SettingsSwitchRow({
   group = "settings",
   agentStatus,
   className,
+  testId,
 }: SettingsSwitchRowProps) {
   const resolvedLabel = agentLabel ?? labelToString(label, agentId);
   const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
@@ -82,6 +85,8 @@ export function SettingsSwitchRow({
     getValue: () => checked,
     onActivate: disabled ? undefined : () => onCheckedChange(!checked),
   });
+  const { "aria-label": _ignoredSwitchAccessibleName, ...switchAgentProps } =
+    agentProps;
 
   return (
     <SettingsRow
@@ -98,9 +103,8 @@ export function SettingsSwitchRow({
           checked={checked}
           onCheckedChange={onCheckedChange}
           disabled={disabled}
-          {...agentProps}
-          aria-label={resolvedLabel}
-          aria-checked={checked}
+          data-testid={testId}
+          {...switchAgentProps}
         />
       }
     />

--- a/packages/ui/src/components/settings/settings-layout.test.tsx
+++ b/packages/ui/src/components/settings/settings-layout.test.tsx
@@ -75,12 +75,14 @@ describe("agent-addressable rows", () => {
     render(
       <SettingsSwitchRow
         agentId="toggle-dark"
+        testId="toggle-dark-switch"
         label="Dark mode"
         checked={false}
         onCheckedChange={onCheckedChange}
       />,
     );
     const sw = screen.getByRole("switch");
+    expect(sw.getAttribute("data-testid")).toBe("toggle-dark-switch");
     expect(sw.getAttribute("data-agent-id")).toBe("toggle-dark");
     expect(sw.getAttribute("data-agent-role")).toBe("toggle");
     expect(sw.getAttribute("data-agent-label")).toBe("Dark mode");
@@ -91,6 +93,26 @@ describe("agent-addressable rows", () => {
     );
     fireEvent.click(sw);
     expect(onCheckedChange).toHaveBeenCalledWith(true);
+    expect(screen.getByLabelText("Dark mode")).toBe(sw);
+    expect(sw.getAttribute("aria-label")).toBeNull();
+  });
+
+  it("SettingsSwitchRow keeps the visible label as the accessible name", () => {
+    render(
+      <SettingsSwitchRow
+        agentId="voice-section-wake-toggle"
+        label="Wake word"
+        agentLabel="Toggle wake-word listening"
+        checked={false}
+        onCheckedChange={() => {}}
+      />,
+    );
+    const sw = screen.getByLabelText("Wake word");
+    expect(sw.getAttribute("data-agent-label")).toBe(
+      "Toggle wake-word listening",
+    );
+    expect(sw.getAttribute("aria-label")).toBeNull();
+    expect(screen.queryByLabelText("Toggle wake-word listening")).toBeNull();
   });
 
   it("SettingsSwitchRow stays disabled when the agent status is unavailable", () => {


### PR DESCRIPTION
# Relates to

Closes #19434

Follow-up to #19146 / #19150.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@03ba10865ec384c82ed9d70c5dd1f96a926d05a7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Behaviour-preserving reuse of the existing `SettingsSwitchRow` primitive.
Voice still persists the same wake-word and shortcut-consent prefs. Existing
testids stay on the switch. The extra `aria-label` on `SettingsSwitchRow` is
removed so the visible `<label>` owns the accessible name (same fix already
applied to Input/Select). A false-positive raw-`<Input` ratchet failure is the
main regression risk if Voice later adds another range slider without updating
the recorded count.

# Background

## What does this PR do?

A static scan of Settings → Voice found three labelled boolean controls still
implemented as checkbox `<Input>`s after Appearance / Web Push / Advanced / App
Permissions had moved to `SettingsSwitchRow`. This PR:

1. Routes wake word and both shortcut-consent toggles through `SettingsSwitchRow`.
2. Adds an optional `testId` on the switch so existing Voice testids stay put.
3. Stops `SettingsSwitchRow` from stamping `aria-label`, so the visible label
   owns the accessible name even when `agentLabel` differs.
4. Lowers the Voice raw-`<Input` ratchet from 4 to the remaining range-slider
   occurrence.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/settings/VoiceSection.tsx` and
`packages/ui/src/components/settings/settings-layout.test.tsx`.

## Detailed testing steps

Focused checks after rebase:

```bash
bun run --cwd packages/ui test -- src/components/settings/VoiceSection.test.tsx src/components/settings/VoiceSectionMount.test.tsx src/components/settings/settings-layout.test.tsx src/components/settings/no-raw-labelled-input.test.ts src/components/settings/no-raw-switch.test.ts
bunx biome check packages/ui/src/components/settings/VoiceSection.tsx packages/ui/src/components/settings/VoiceSection.test.tsx packages/ui/src/components/settings/VoiceSectionMount.test.tsx packages/ui/src/components/settings/settings-agent-rows.tsx packages/ui/src/components/settings/settings-layout.test.tsx packages/ui/src/components/settings/no-raw-labelled-input.test.ts packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
```

130 tests passed. `packages/ui` typecheck still fails on
`steward-auth-passkey-fallback.test.ts` / `steward-login-section.tsx` on
`origin/develop`; those files are not in this diff.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:03ba10865ec384c82ed9d70c5dd1f96a926d05a7 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19438-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19438-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19438-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or API path is changed; wake-word and shortcut consent still write the same local prefs.
<!-- evidence-row:frontend-logs -->
- [x] [19438-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19438-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, wallet, scheduled-task, or generated domain artifact is involved.
<!-- evidence-row:ocr-review -->
- [x] [19438-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19438-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Backend + frontend logs

Backend: N/A - no server path is changed; wake-word and shortcut consent still
write the same local prefs / config keys.

Frontend: capture console is attached. Only React DevTools `file://` hints;
no page errors while toggling the switches.

## Screenshots (before / after) + video walkthrough

Isolated Settings → Voice chat group, using the real `SettingsRow` /
`Switch` / `Input` primitives and the extracted settings theme. Packaged
`audit:app` / full Settings fixture still crash before paint on
`startupCoordinator.target` (same blocker as #19150). Desktop 1280×800 and
mobile 390×844 rest states plus an MP4 of toggling wake word and voice
shortcut consent.

### Before

Checkbox wake-word and shortcut-consent controls.

### After

Themed `SettingsSwitchRow` tracks; visible labels wrap on mobile.

### Walkthrough video

Click wake word off/on, then voice-shortcut consent on/off.

## Audio / voice walkthrough

N/A - this change is the settings control chrome, not capture/TTS audio.

## Known gaps / failures

- `bun run --cwd packages/ui typecheck` fails on develop-owned steward login
  files (`Expected 1 arguments, but got 2`). Not in this diff.
- `bun run verify` was not run for the whole monorepo in this turn.
- Full-page `audit:app` Settings captures are still blocked by the
  `startupCoordinator.target` fixture crash. Evidence is the Voice chat group
  before/after at desktop and mobile, plus the walkthrough MP4.
- Packaged tesseract returned empty text on the dark captures; the attached
  OCR file is a visual-text review of the produced JPGs.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok-cli
Contribution skill revision: elizaOS/eliza@03ba10865ec384c82ed9d70c5dd1f96a926d05a7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-4.6]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-cli","skill_revision":"elizaOS/eliza@03ba10865ec384c82ed9d70c5dd1f96a926d05a7:packages/skills/skills/contribute-to-eliza"} -->

