### PR TITLE
fix(ui): stabilize MessageScroller API provenance

### DIFF
--- a/packages/ui/scripts/public-api-baseline.json
+++ b/packages/ui/scripts/public-api-baseline.json
@@ -562,15 +562,15 @@
     },
     {
       "name": "useMessageScroller",
-      "source": "../../node_modules/.bun/@shadcn+react@0.3.0+b2e33729a97476bf/node_modules/@shadcn/react/dist/message-scroller/index.d.ts"
+      "source": "src/components/ui/message-scroller.tsx"
     },
     {
       "name": "useMessageScrollerScrollable",
-      "source": "../../node_modules/.bun/@shadcn+react@0.3.0+b2e33729a97476bf/node_modules/@shadcn/react/dist/message-scroller/index.d.ts"
+      "source": "src/components/ui/message-scroller.tsx"
     },
     {
       "name": "useMessageScrollerVisibility",
-      "source": "../../node_modules/.bun/@shadcn+react@0.3.0+b2e33729a97476bf/node_modules/@shadcn/react/dist/message-scroller/index.d.ts"
+      "source": "src/components/ui/message-scroller.tsx"
     }
   ],
   "count": 143

--- a/packages/ui/src/components/ui/message-scroller.test.tsx
+++ b/packages/ui/src/components/ui/message-scroller.test.tsx
@@ -5,40 +5,121 @@
 
 // @vitest-environment jsdom
 
-import { renderHook } from "@testing-library/react";
-import type { PropsWithChildren } from "react";
-import { describe, expect, it } from "vitest";
 import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  MessageScroller,
+  MessageScrollerContent,
+  MessageScrollerItem,
   MessageScrollerProvider,
+  MessageScrollerViewport,
   useMessageScroller,
   useMessageScrollerScrollable,
   useMessageScrollerVisibility,
 } from "./message-scroller";
 
-function Provider({ children }: PropsWithChildren) {
-  return <MessageScrollerProvider>{children}</MessageScrollerProvider>;
-}
+type Controls = ReturnType<typeof useMessageScroller>;
+type ScrollableState = ReturnType<typeof useMessageScrollerScrollable>;
+type VisibilityState = ReturnType<typeof useMessageScrollerVisibility>;
 
 describe("message-scroller public hooks", () => {
-  it("delegates controls and observable state through the real provider", () => {
-    const { result } = renderHook(
-      () => ({
-        controls: useMessageScroller(),
-        scrollable: useMessageScrollerScrollable(),
-        visibility: useMessageScrollerVisibility(),
-      }),
-      { wrapper: Provider },
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("delegates controls and live state transitions through the real provider", async () => {
+    vi.stubGlobal("IntersectionObserver", undefined);
+    let controls: Controls | null = null;
+    let scrollable: ScrollableState | null = null;
+    let visibility: VisibilityState | null = null;
+
+    function HookProbe() {
+      controls = useMessageScroller();
+      scrollable = useMessageScrollerScrollable();
+      visibility = useMessageScrollerVisibility();
+      return null;
+    }
+
+    render(
+      <MessageScrollerProvider>
+        <HookProbe />
+        <MessageScroller>
+          <MessageScrollerViewport>
+            <MessageScrollerContent>
+              <MessageScrollerItem messageId="message-1" scrollAnchor>
+                Message
+              </MessageScrollerItem>
+            </MessageScrollerContent>
+          </MessageScrollerViewport>
+        </MessageScroller>
+      </MessageScrollerProvider>,
     );
 
-    expect(result.current.controls).toEqual({
+    expect(controls).toEqual({
       scrollToEnd: expect.any(Function),
       scrollToMessage: expect.any(Function),
       scrollToStart: expect.any(Function),
     });
-    expect(result.current.scrollable).toEqual({ start: false, end: false });
-    expect(result.current.visibility).toEqual({
+    expect(scrollable).toEqual({ start: false, end: false });
+    expect(visibility).toEqual({
       currentAnchorId: null,
       visibleMessageIds: [],
+    });
+
+    const viewport = screen.getByRole("region", { name: "Messages" });
+    const item = screen.getByText("Message");
+    if (!(viewport instanceof HTMLElement) || !(item instanceof HTMLElement)) {
+      throw new Error("message scroller test DOM did not mount");
+    }
+
+    Object.defineProperties(viewport, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 240 },
+      scrollTop: { configurable: true, value: 20, writable: true },
+    });
+    viewport.getBoundingClientRect = () =>
+      DOMRect.fromRect({ x: 0, y: 0, width: 100, height: 100 });
+    item.getBoundingClientRect = () =>
+      DOMRect.fromRect({ x: 0, y: 0, width: 100, height: 200 });
+    function scrollTo(options?: ScrollToOptions): void;
+    function scrollTo(x: number, y: number): void;
+    function scrollTo(first?: ScrollToOptions | number, y?: number): void {
+      viewport.scrollTop =
+        typeof first === "number"
+          ? (y ?? viewport.scrollTop)
+          : (first?.top ?? viewport.scrollTop);
+    }
+    viewport.scrollTo = scrollTo;
+
+    fireEvent.scroll(viewport);
+    await waitFor(() => {
+      expect(scrollable).toEqual({ start: true, end: true });
+      expect(visibility).toEqual({
+        currentAnchorId: "message-1",
+        visibleMessageIds: ["message-1"],
+      });
+    });
+
+    await act(async () => {
+      expect(controls?.scrollToStart({ behavior: "instant" })).toBe(true);
+      expect(viewport.scrollTop).toBe(0);
+      expect(
+        controls?.scrollToMessage("message-1", {
+          align: "start",
+          behavior: "instant",
+          scrollMargin: 4,
+        }),
+      ).toBe(true);
+      expect(controls?.scrollToEnd({ behavior: "instant" })).toBe(true);
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve()),
+      );
     });
   });
 });

--- a/packages/ui/src/components/ui/message-scroller.test.tsx
+++ b/packages/ui/src/components/ui/message-scroller.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Verifies the locally owned message-scroller hooks retain the dependency's
+ * real provider behavior while keeping stable elizaOS declaration provenance.
+ */
+
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  MessageScrollerProvider,
+  useMessageScroller,
+  useMessageScrollerScrollable,
+  useMessageScrollerVisibility,
+} from "./message-scroller";
+
+function Provider({ children }: PropsWithChildren) {
+  return <MessageScrollerProvider>{children}</MessageScrollerProvider>;
+}
+
+describe("message-scroller public hooks", () => {
+  it("delegates controls and observable state through the real provider", () => {
+    const { result } = renderHook(
+      () => ({
+        controls: useMessageScroller(),
+        scrollable: useMessageScrollerScrollable(),
+        visibility: useMessageScrollerVisibility(),
+      }),
+      { wrapper: Provider },
+    );
+
+    expect(result.current.controls).toEqual({
+      scrollToEnd: expect.any(Function),
+      scrollToMessage: expect.any(Function),
+      scrollToStart: expect.any(Function),
+    });
+    expect(result.current.scrollable).toEqual({ start: false, end: false });
+    expect(result.current.visibility).toEqual({
+      currentAnchorId: null,
+      visibleMessageIds: [],
+    });
+  });
+});

--- a/packages/ui/src/components/ui/message-scroller.tsx
+++ b/packages/ui/src/components/ui/message-scroller.tsx
@@ -6,15 +6,52 @@
 
 import {
   MessageScroller as MessageScrollerPrimitive,
-  useMessageScroller,
-  useMessageScrollerScrollable,
-  useMessageScrollerVisibility,
+  useMessageScroller as useMessageScrollerPrimitive,
+  useMessageScrollerScrollable as useMessageScrollerScrollablePrimitive,
+  useMessageScrollerVisibility as useMessageScrollerVisibilityPrimitive,
 } from "@shadcn/react/message-scroller";
 import { ArrowDown } from "lucide-react";
 import type * as React from "react";
 
 import { cn } from "../../lib/utils";
 import { Button } from "./button";
+
+type MessageScrollerScrollOptions = {
+  align?: "start" | "center" | "end" | "nearest";
+  behavior?: ScrollBehavior;
+  scrollMargin?: number;
+};
+
+type MessageScrollerControls = {
+  scrollToEnd: (options?: MessageScrollerScrollOptions) => boolean;
+  scrollToMessage: (
+    messageId: string,
+    options?: MessageScrollerScrollOptions,
+  ) => boolean;
+  scrollToStart: (options?: MessageScrollerScrollOptions) => boolean;
+};
+
+type MessageScrollerScrollableState = {
+  start: boolean;
+  end: boolean;
+};
+
+type MessageScrollerVisibilityState = {
+  currentAnchorId: string | null;
+  visibleMessageIds: string[];
+};
+
+function useMessageScroller(): MessageScrollerControls {
+  return useMessageScrollerPrimitive();
+}
+
+function useMessageScrollerScrollable(): MessageScrollerScrollableState {
+  return useMessageScrollerScrollablePrimitive();
+}
+
+function useMessageScrollerVisibility(): MessageScrollerVisibilityState {
+  return useMessageScrollerVisibilityPrimitive();
+}
 
 const MessageScrollerProvider = MessageScrollerPrimitive.Provider;
 


### PR DESCRIPTION
Closes #18830.

## What

The three public MessageScroller hooks now have stable, locally owned declarations with explicit return types while delegating directly to the existing `@shadcn/react` primitives. This removes Bun cache-path provenance from the public API baseline without changing runtime scrolling behavior or public names.

## Independent review and fixes

The submitted smoke test was mutation-insensitive: replacing all three wrappers with inert values still passed. It has been replaced with a real provider transition test that exercises:

- all three public wrappers;
- real scrollable and visibility state transitions;
- `scrollToStart`, `scrollToMessage`, and `scrollToEnd` through the actual provider and viewport.

Mutation proof: temporarily replacing all three wrappers with inert controls/fixed states now fails at the state-transition assertion; restoring the delegates passes.

## Verification

Exact PR head: `d78c9e0f4e58f50d67230c1142e05fedc18dc3f8`, rebased without conflicts onto `develop@eca902c398cbcf866371dafff47540f248e0d6f6` before the final gate.

- Focused MessageScroller and public-export tests: passed.
- Public API audit: 143/143.
- `packages/ui` typecheck and lint: passed; eight existing `document.cookie` warnings remain advisory.
- `bun install --frozen-lockfile && bun run verify`: 350/350 plus every repository audit.
- App capture: 219/219, `broken=0`, `needs-work=0`, no minimalism, hover, or density failures.
- Packaged OCR emitted one false negative for the visibly present “Mostly clear” / “Learn conversational Spanish” text in the iPad chat capture. The screenshot was manually inspected; layout, content, console, and DOM readiness were correct.

## Risk

Low. The runtime implementation remains a thin delegate to the same dependency hooks. The added transition test is specifically mutation-sensitive to accidental inert wrappers or state snapshots.

## Evidence

<!-- evidence-head:d78c9e0f4e58f50d67230c1142e05fedc18dc3f8 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19439-before-mobile-autoscroll.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19439-after-desktop-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19439-chat-autoscroll-desktop-mobile.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - declaration provenance and browser scroll behavior do not invoke a backend route.
<!-- evidence-row:frontend-logs -->
- [x] [19439-frontend-browser.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19439-frontend-browser.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [19439-public-api-contract.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19439-public-api-contract.log)
<!-- evidence-row:ocr-review -->
- [x] [19439-ocr-manual-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19439-ocr-manual-review.txt)

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`; independent review and test repair: `OpenAI / gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
