### PR TITLE
fix(plugin-coding-tools): reject malformed SHELL_JOB_TTL_MS at plugin start

### DIFF
--- a/plugins/plugin-coding-tools/AGENTS.md
+++ b/plugins/plugin-coding-tools/AGENTS.md
@@ -100,6 +100,8 @@ All settings are read via `runtime.getSetting(key)` or `process.env`. None are r
 | `CODING_TOOLS_BLOCKED_PATHS_ADD` | — | Comma-separated paths to **add** to the default blocklist. |
 | `CODING_TOOLS_SHELL` | (auto-detected) | Override the shell binary used by SHELL action. Takes priority over `SHELL`. Useful on Android/AOSP where the default shell path may not be executable. |
 | `CODING_TOOLS_SHELL_TIMEOUT_MS` | `120000` | Optional canonical decimal integer from `100` through `600000` used as the default SHELL timeout (ms); invalid values fail before execution and per-call `timeout` takes precedence within the same range. |
+| `SHELL_JOB_TTL_MS` | `1800000` | Optional canonical decimal integer from `60000` through `10800000`; invalid values fail before the plugin starts. |
+
 | `CODING_TOOLS_BACKGROUND_SHELL_BUFFER_CHARS` | `64000` | Per-stream retained stdout/stderr ring size for background shell polling. |
 | `CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS` | `1500` | Grace period between SIGTERM and SIGKILL for background shell termination. |
 | `CODING_TOOLS_MAX_READ_LINES` | `2000` | Max lines returned by FILE action=read before truncation. |

--- a/plugins/plugin-coding-tools/CLAUDE.md
+++ b/plugins/plugin-coding-tools/CLAUDE.md
@@ -100,6 +100,8 @@ All settings are read via `runtime.getSetting(key)` or `process.env`. None are r
 | `CODING_TOOLS_BLOCKED_PATHS_ADD` | — | Comma-separated paths to **add** to the default blocklist. |
 | `CODING_TOOLS_SHELL` | (auto-detected) | Override the shell binary used by SHELL action. Takes priority over `SHELL`. Useful on Android/AOSP where the default shell path may not be executable. |
 | `CODING_TOOLS_SHELL_TIMEOUT_MS` | `120000` | Optional canonical decimal integer from `100` through `600000` used as the default SHELL timeout (ms); invalid values fail before execution and per-call `timeout` takes precedence within the same range. |
+| `SHELL_JOB_TTL_MS` | `1800000` | Optional canonical decimal integer from `60000` through `10800000`; invalid values fail before the plugin starts. |
+
 | `CODING_TOOLS_BACKGROUND_SHELL_BUFFER_CHARS` | `64000` | Per-stream retained stdout/stderr ring size for background shell polling. |
 | `CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS` | `1500` | Grace period between SIGTERM and SIGKILL for background shell termination. |
 | `CODING_TOOLS_MAX_READ_LINES` | `2000` | Max lines returned by FILE action=read before truncation. |

--- a/plugins/plugin-coding-tools/README.md
+++ b/plugins/plugin-coding-tools/README.md
@@ -50,6 +50,7 @@ All settings are optional. Configure via environment variables or agent settings
 | `CODING_TOOLS_BLOCKED_PATHS` | (built-in) | Comma-separated absolute paths to block — replaces the default blocklist. |
 | `CODING_TOOLS_BLOCKED_PATHS_ADD` | — | Paths to add to the default blocklist. |
 | `CODING_TOOLS_SHELL_TIMEOUT_MS` | `120000` | Optional canonical decimal integer from `100` through `600000` used as the default SHELL timeout (ms); invalid values fail before execution and per-call `timeout` takes precedence within the same range. |
+| `SHELL_JOB_TTL_MS` | `1800000` | Optional canonical decimal integer from `60000` through `10800000`; invalid values fail before the plugin starts. |
 | `CODING_TOOLS_BACKGROUND_SHELL_BUFFER_CHARS` | `64000` | Per-stream retained stdout/stderr ring size for background shell polling. |
 | `CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS` | `1500` | Grace period between SIGTERM and SIGKILL for background shell termination. |
 | `CODING_TOOLS_MAX_READ_LINES` | `2000` | Max lines returned by FILE action=read. |

--- a/plugins/plugin-coding-tools/package.json
+++ b/plugins/plugin-coding-tools/package.json
@@ -144,6 +144,15 @@
         "required": false,
         "default": 250,
         "sensitive": false
+      },
+      "SHELL_JOB_TTL_MS": {
+        "type": "number",
+        "description": "Finished-process TTL in milliseconds. The registry sweeper evicts finished records this many ms after their end time. Must be a canonical decimal integer from 60000 through 10800000; invalid values fail before the plugin starts.",
+        "required": false,
+        "default": 1800000,
+        "min": 60000,
+        "max": 10800000,
+        "sensitive": false
       }
     }
   },

--- a/plugins/plugin-coding-tools/registry-entry.json
+++ b/plugins/plugin-coding-tools/registry-entry.json
@@ -3,10 +3,22 @@
   "name": "Coding Tools",
   "description": "Native coding tools (FILE, SHELL, WORKTREE) running directly in the agent. AST-validated commands, mtime-gated writes, sealed workspace roots, optional per-OS process sandboxing (sandbox-exec on macOS, bwrap on Linux).",
   "npmName": "@elizaos/plugin-coding-tools",
-  "shortIds": ["coding-agent", "codingAgent", "coding-tools", "codingTools"],
+  "shortIds": [
+    "coding-agent",
+    "codingAgent",
+    "coding-tools",
+    "codingTools"
+  ],
   "version": "0.1.0",
   "source": "bundled",
-  "tags": ["coding", "filesystem", "shell", "git", "code", "claude-code"],
+  "tags": [
+    "coding",
+    "filesystem",
+    "shell",
+    "git",
+    "code",
+    "claude-code"
+  ],
   "config": {
     "CODING_TOOLS_WORKSPACE_ROOTS": {
       "type": "string",
@@ -52,6 +64,17 @@
       "label": "OS-level sandbox",
       "help": "Wrap bash invocations in sandbox-exec (macOS) or bwrap (Linux) when available. AST analysis runs regardless.",
       "advanced": true
+    },
+    "SHELL_JOB_TTL_MS": {
+      "type": "number",
+      "required": false,
+      "sensitive": false,
+      "label": "Finished-session TTL",
+      "help": "How long finished-process records are kept before the registry sweeper evicts them. Must be a canonical decimal integer from 60000 through 10800000; invalid values fail before the plugin starts.",
+      "advanced": true,
+      "min": 60000,
+      "max": 10800000,
+      "unit": "ms"
     }
   },
   "render": {
@@ -61,7 +84,10 @@
     "icon": "Puzzle",
     "group": "devtools",
     "groupOrder": 5,
-    "actions": ["enable", "configure"]
+    "actions": [
+      "enable",
+      "configure"
+    ]
   },
   "resources": {
     "homepage": "https://github.com/elizaos/eliza#readme",

--- a/plugins/plugin-coding-tools/src/shell/services/index.ts
+++ b/plugins/plugin-coding-tools/src/shell/services/index.ts
@@ -12,6 +12,7 @@ export {
   listRunningSessions,
   markBackgrounded,
   markExited,
+  parseJobTtlMs,
   resetProcessRegistryForTests,
   setJobTtlMs,
   tail,

--- a/plugins/plugin-coding-tools/src/shell/services/processRegistry.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/services/processRegistry.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Boundary tests for `parseJobTtlMs` (the SHELL_JOB_TTL_MS validator). The
+ * bug (#19303) was that `Number.parseInt` followed by `Math.min/max` silently
+ * clamped malformed values to the minimum. The contract now mirrors the
+ * other folded ShellService numeric compatibility settings: canonical
+ * decimal integer in [`60000`, `10800000`] or a typed error.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+import { parseJobTtlMs } from "./processRegistry";
+
+const MIN = 60_000;
+const MAX = 3 * 60 * 60 * 1000;
+const DEFAULT = 30 * 60 * 1000;
+
+describe("parseJobTtlMs (SHELL_JOB_TTL_MS)", () => {
+  test("returns undefined on missing or empty so the source-of-truth default holds", () => {
+    expect(parseJobTtlMs(undefined)).toBeUndefined();
+    expect(parseJobTtlMs("")).toBeUndefined();
+  });
+
+  test("accepts canonical decimal integers across the documented range", () => {
+    expect(parseJobTtlMs(String(MIN))).toEqual({ value: MIN });
+    expect(parseJobTtlMs(String(MAX))).toEqual({ value: MAX });
+    expect(parseJobTtlMs("1800000")).toEqual({ value: DEFAULT });
+    expect(parseJobTtlMs("100000")).toEqual({ value: 100_000 });
+  });
+
+  test.each([
+    ["123junk", "trailing junk"],
+    ["1.5", "fraction"],
+    ["-1", "negative"],
+    ["0", "below minimum"],
+    ["59999", "just below minimum"],
+    ["10800001", "just above maximum"],
+    ["1e6", "exponent notation"],
+    ["0x10", "hex"],
+    [" 1", "leading whitespace"],
+    ["1 ", "trailing whitespace"],
+    ["+1", "sign prefix"],
+    ["", "empty (covered above)"],
+  ])("rejects %s (%s) with the typed error", (raw, _label) => {
+    const result = parseJobTtlMs(raw);
+    if (raw === "") {
+      expect(result).toBeUndefined();
+      return;
+    }
+    expect(result).toEqual({
+      error: `SHELL_JOB_TTL_MS must be a canonical decimal integer between ${MIN} and ${MAX}.`,
+    });
+  });
+
+  test("does not silently clamp — boundary inputs return the parsed value, not the minimum", () => {
+    // The original bug: `123junk` would resolve to NaN and then clamp to
+    // MIN_JOB_TTL_MS. The fix forces a typed error instead.
+    expect(parseJobTtlMs("123junk")).toEqual({
+      error: expect.stringContaining("must be a canonical decimal integer"),
+    });
+    expect(parseJobTtlMs("1")).toEqual({
+      error: expect.stringContaining("must be a canonical decimal integer"),
+    });
+  });
+});

--- a/plugins/plugin-coding-tools/src/shell/services/processRegistry.ts
+++ b/plugins/plugin-coding-tools/src/shell/services/processRegistry.ts
@@ -7,10 +7,40 @@
 
 import type { FinishedSession, ProcessSession, ProcessStatus } from "../types";
 
-const DEFAULT_JOB_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const env = process.env;
+
+const DEFAULT_JOB_TTL_MS = 30 * 60 * 1000; // 30 minutes (also the unset/blank default)
 const MIN_JOB_TTL_MS = 60 * 1000; // 1 minute
 const MAX_JOB_TTL_MS = 3 * 60 * 60 * 1000; // 3 hours
+const CANONICAL_DECIMAL_INTEGER = /^(?:0|[1-9]\d*)$/;
 const DEFAULT_PENDING_OUTPUT_CHARS = 30_000;
+
+/**
+ * Strictly parse `SHELL_JOB_TTL_MS` to a bounded canonical integer, matching
+ * the shaped-error contract used by the other folded ShellService numeric
+ * compatibility settings (#19303). A missing or empty value falls back to
+ * {@link DEFAULT_JOB_TTL_MS}; any non-canonical string, fraction, negative,
+ * unsafe-integer, or out-of-range value returns a typed error so the plugin
+ * boot fails loudly instead of silently clamping to the minimum.
+ */
+export function parseJobTtlMs(
+  raw: string | undefined,
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): { value: number } | { error: string } | undefined {
+  if (raw == null || raw === "") return undefined;
+  if (!CANONICAL_DECIMAL_INTEGER.test(raw)) {
+    return {
+      error: `SHELL_JOB_TTL_MS must be a canonical decimal integer between ${MIN_JOB_TTL_MS} and ${MAX_JOB_TTL_MS}.`,
+    };
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < MIN_JOB_TTL_MS || value > MAX_JOB_TTL_MS) {
+    return {
+      error: `SHELL_JOB_TTL_MS must be a canonical decimal integer between ${MIN_JOB_TTL_MS} and ${MAX_JOB_TTL_MS}.`,
+    };
+  }
+  return { value };
+}
 
 function clampTtl(value: number | undefined): number {
   if (!value || Number.isNaN(value)) {
@@ -19,9 +49,11 @@ function clampTtl(value: number | undefined): number {
   return Math.min(Math.max(value, MIN_JOB_TTL_MS), MAX_JOB_TTL_MS);
 }
 
-let jobTtlMs = clampTtl(
-  Number.parseInt(process.env.SHELL_JOB_TTL_MS ?? "", 10),
-);
+const initialTtl = parseJobTtlMs(env.SHELL_JOB_TTL_MS);
+if (initialTtl && "error" in initialTtl) {
+  throw new Error(initialTtl.error);
+}
+let jobTtlMs = clampTtl(initialTtl?.value);
 
 const runningSessions = new Map<string, ProcessSession>();
 const finishedSessions = new Map<string, FinishedSession>();


### PR DESCRIPTION
## fix(plugin-coding-tools): reject malformed SHELL_JOB_TTL_MS at plugin start

`processRegistry.ts` parsed `SHELL_JOB_TTL_MS` with `Number.parseInt` and
clamped the result via `Math.min/max`, so malformed values like `123junk`,
`1.5`, and `-1` silently resolved to the one-minute minimum. The other
folded ShellService numeric compatibility settings already fail startup
with a typed configuration error; this variable did not.

Route the value through a strict `parseJobTtlMs` validator that mirrors
the canonical-decimal-integer pattern used by `CODING_TOOLS_SHELL_TIMEOUT_MS`:
missing/blank falls back to the 30-minute default, all other inputs that
fail the canonical-decimal regex or fall outside [60000, 10800000] return
a typed error before the service starts. The boot-time throw replaces
the silent clamp.

Also adds the compatibility setting to the plugin's registry entry,
package.json schema, and README/AGENTS env table so it is visible to
operators.

Closes #19303

### Diff
```
 plugins/plugin-coding-tools/AGENTS.md              |  2 +
 plugins/plugin-coding-tools/CLAUDE.md              |  2 +
 plugins/plugin-coding-tools/README.md              |  1 +
 plugins/plugin-coding-tools/package.json           |  9 ++++
 plugins/plugin-coding-tools/registry-entry.json    | 32 +++++++++--
 .../src/shell/services/index.ts                    |  1 +
 .../src/shell/services/processRegistry.test.ts     | 62 ++++++++++++++++++++++
 .../src/shell/services/processRegistry.ts          | 40 ++++++++++++--
 8 files changed, 142 insertions(+), 7 deletions(-)
```

### Tests
- New unit coverage in `processRegistry.test.ts` for malformed, out-of-range, negative, and boundary inputs (62 added lines).
- Existing happy-path and TTL-expiry tests unchanged and still green.

AI provider/model: minimax / MiniMax-M3
Client / agent tooling: hermes grokbot g-slop-eliza
Contribution skill revision: local:slop-eliza/skills/contribute-to-eliza (mirror of slop.cash contribute-to-eliza)
Attribution status: self-reported
— [g-slop-eliza]
<!-- eliza-computer-attribution:v1 {"provider":"minimax","model":"MiniMax-M3","client":"hermes-grokbot","skill_revision":"local:slop-eliza/skills/contribute-to-eliza"} -->