### PR TITLE
fix(ui): route remaining labelled settings fields through shared rows

### DIFF
--- a/packages/ui/src/cloud/account-security/components/privacy-panel.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/privacy-panel.test.tsx
@@ -1,0 +1,66 @@
+/** Verifies PrivacyPanel vision/trajectory toggles through SettingsSwitchRow. */
+// @vitest-environment jsdom
+/**
+ * Renders PrivacyPanel with a mocked translator and consent store and asserts
+ * the two labelled booleans are SettingsSwitchRow switches. jsdom, no backend.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? _key,
+}));
+
+vi.mock("../../../cloud-ui", () => ({
+  BrandButton: ({
+    children,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  BrandCard: ({ children }: { children: ReactNode }) => (
+    <section>{children}</section>
+  ),
+  CornerBrackets: () => null,
+}));
+
+const consentMock = vi.hoisted(() => ({
+  getTrajectoryLoggingEnabled: vi.fn(() => false),
+  getVisionEnabled: vi.fn(() => false),
+  setTrajectoryLoggingEnabled: vi.fn(),
+  setVisionEnabled: vi.fn(),
+}));
+
+vi.mock("../data/audit-client", () => ({
+  emitAuditEvent: vi.fn(),
+}));
+
+vi.mock("../data/consent-store", () => consentMock);
+
+import { PrivacyPanel } from "./privacy-panel";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PrivacyPanel", () => {
+  it("routes vision and trajectory toggles through SettingsSwitchRow", () => {
+    render(<PrivacyPanel />);
+    const vision = screen.getByTestId("vision-toggle");
+    const trajectory = screen.getByTestId("trajectory-toggle");
+    expect(vision.getAttribute("role")).toBe("switch");
+    expect(trajectory.getAttribute("role")).toBe("switch");
+    expect(vision.getAttribute("data-agent-id")).toBe("cloud-privacy-vision");
+    expect(trajectory.getAttribute("data-agent-id")).toBe(
+      "cloud-privacy-trajectory",
+    );
+    expect(screen.getByLabelText("Allow vision / screen capture")).toBe(vision);
+    fireEvent.click(vision);
+    expect(consentMock.setVisionEnabled).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/ui/src/cloud/account-security/components/privacy-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/privacy-panel.tsx
@@ -10,12 +10,12 @@
 
 import { Camera, Download, ScrollText, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
+import { BrandButton, BrandCard, CornerBrackets } from "../../../cloud-ui";
+import { SettingsSwitchRow } from "../../../components/settings/settings-agent-rows";
 import {
-  BrandButton,
-  BrandCard,
-  CornerBrackets,
-  Switch,
-} from "../../../cloud-ui";
+  SettingsGroup,
+  SettingsStack,
+} from "../../../components/settings/settings-layout";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import { emitAuditEvent } from "../data/audit-client";
 import {
@@ -65,59 +65,40 @@ export function PrivacyPanel() {
           </p>
         </div>
 
-        {/* Vision toggle */}
-        <div className="flex items-start justify-between gap-3 rounded-sm border border-border bg-surface p-4">
-          <div className="flex items-start gap-3">
-            <div className="rounded-sm border border-purple-500/40 bg-purple-500/20 p-2">
-              <Camera className="h-4 w-4 text-purple-300" />
-            </div>
-            <div className="space-y-1">
-              <p className="text-sm font-medium text-txt-strong">
-                {t("cloud.privacyPanel.visionTitle", {
-                  defaultValue: "Allow vision / screen capture",
-                })}
-              </p>
-              <p className="text-xs text-muted">
-                {t("cloud.privacyPanel.visionDescription", {
-                  defaultValue:
-                    "Off by default. When on, plugins may request screen frames or webcam capture. Remote models charge per image — review your model's per-call fee in Settings → Billing before enabling.",
-                })}
-              </p>
-            </div>
-          </div>
-          <Switch
-            checked={vision}
-            onCheckedChange={onVisionChange}
-            data-testid="vision-toggle"
-          />
-        </div>
-
-        {/* Trajectory logging toggle */}
-        <div className="flex items-start justify-between gap-3 rounded-sm border border-border bg-surface p-4">
-          <div className="flex items-start gap-3">
-            <div className="rounded-sm border border-border bg-muted p-2">
-              <ScrollText className="h-4 w-4 text-muted" />
-            </div>
-            <div className="space-y-1">
-              <p className="text-sm font-medium text-txt-strong">
-                {t("cloud.privacyPanel.trajectoryTitle", {
-                  defaultValue: "Trajectory logging",
-                })}
-              </p>
-              <p className="text-xs text-muted">
-                {t("cloud.privacyPanel.trajectoryDescription", {
-                  defaultValue:
-                    "Off by default. When on, Eliza records per-step plan/action traces locally with a 30-day retention. Redacted content is marked separately from raw.",
-                })}
-              </p>
-            </div>
-          </div>
-          <Switch
-            checked={trajectory}
-            onCheckedChange={onTrajectoryChange}
-            data-testid="trajectory-toggle"
-          />
-        </div>
+        <SettingsStack>
+          <SettingsGroup>
+            <SettingsSwitchRow
+              agentId="cloud-privacy-vision"
+              group="cloud-privacy"
+              icon={Camera}
+              testId="vision-toggle"
+              label={t("cloud.privacyPanel.visionTitle", {
+                defaultValue: "Allow vision / screen capture",
+              })}
+              description={t("cloud.privacyPanel.visionDescription", {
+                defaultValue:
+                  "Off by default. When on, plugins may request screen frames or webcam capture. Remote models charge per image — review your model's per-call fee in Settings → Billing before enabling.",
+              })}
+              checked={vision}
+              onCheckedChange={onVisionChange}
+            />
+            <SettingsSwitchRow
+              agentId="cloud-privacy-trajectory"
+              group="cloud-privacy"
+              icon={ScrollText}
+              testId="trajectory-toggle"
+              label={t("cloud.privacyPanel.trajectoryTitle", {
+                defaultValue: "Trajectory logging",
+              })}
+              description={t("cloud.privacyPanel.trajectoryDescription", {
+                defaultValue:
+                  "Off by default. When on, Eliza records per-step plan/action traces locally with a 30-day retention. Redacted content is marked separately from raw.",
+              })}
+              checked={trajectory}
+              onCheckedChange={onTrajectoryChange}
+            />
+          </SettingsGroup>
+        </SettingsStack>
 
         {/* DSR — Export */}
         <div className="flex items-start justify-between gap-3 rounded-sm border border-border bg-surface p-4">

--- a/packages/ui/src/cloud/billing/components/pay-as-you-go-card.tsx
+++ b/packages/ui/src/cloud/billing/components/pay-as-you-go-card.tsx
@@ -10,10 +10,12 @@
 
 "use client";
 
-import { BrandCard, CornerBrackets, Label, Switch } from "@elizaos/ui/cloud-ui";
+import { BrandCard, CornerBrackets } from "@elizaos/ui/cloud-ui";
 import { Coins, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
+import { SettingsSwitchRow } from "../../../components/settings/settings-agent-rows";
+import { SettingsRow } from "../../../components/settings/settings-layout";
 import { ApiError, api } from "../../lib/api-client";
 
 const ENDPOINT = "/api/v1/billing/settings";
@@ -69,30 +71,27 @@ export function PayAsYouGoCard() {
           </h3>
         </div>
 
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1 flex-1 min-w-0">
-            <Label className="text-txt-strong font-mono text-sm flex items-center gap-2">
-              <Coins className="h-4 w-4 text-muted" />
-              Use my app earnings to pay container hosting
-            </Label>
-            <p className="text-xs font-mono text-muted leading-relaxed">
-              When on, daily container bills are paid from your redeemable
-              earnings first, then from credits. When off, hosting bills come
-              purely from credits and your earnings stay untouched (cashout
-              only).
-            </p>
-          </div>
-          {enabled === null ? (
-            <Loader2 className="h-5 w-5 animate-spin text-muted flex-shrink-0" />
-          ) : (
-            <Switch
-              checked={enabled}
-              onCheckedChange={handleToggle}
-              disabled={saving}
-              className="flex-shrink-0"
-            />
-          )}
-        </div>
+        {enabled === null ? (
+          <SettingsRow
+            icon={Coins}
+            label="Use my app earnings to pay container hosting"
+            description="When on, daily container bills are paid from your redeemable earnings first, then from credits. When off, hosting bills come purely from credits and your earnings stay untouched (cashout only)."
+            control={
+              <Loader2 className="h-5 w-5 shrink-0 animate-spin text-muted" />
+            }
+          />
+        ) : (
+          <SettingsSwitchRow
+            agentId="cloud-billing-pay-as-you-go"
+            group="cloud-billing"
+            icon={Coins}
+            label="Use my app earnings to pay container hosting"
+            description="When on, daily container bills are paid from your redeemable earnings first, then from credits. When off, hosting bills come purely from credits and your earnings stay untouched (cashout only)."
+            checked={enabled}
+            disabled={saving}
+            onCheckedChange={(next) => void handleToggle(next)}
+          />
+        )}
       </div>
     </BrandCard>
   );

--- a/packages/ui/src/components/pages/config-page-sections.tsx
+++ b/packages/ui/src/components/pages/config-page-sections.tsx
@@ -13,8 +13,9 @@ import { defaultRegistry } from "../../components/config-ui/config-renderer.help
 import type { JsonSchemaObject } from "../../config/config-catalog";
 import { useAppSelector } from "../../state";
 import type { TranslateFn as AppTranslateFn, ConfigUiHint } from "../../types";
+import { SettingsSwitchRow } from "../settings/settings-agent-rows";
+import { SettingsGroup, SettingsStack } from "../settings/settings-layout";
 import { Button } from "../ui/button";
-import { Switch } from "../ui/switch";
 
 /* ── Types ─────────────────────────────────────────────────────────── */
 
@@ -350,8 +351,7 @@ export function CloudServicesSection() {
   }, [setActionNotice, t]);
 
   const handleToggle = useCallback(
-    async (key: CloudServiceKey) => {
-      const newValue = !services[key];
+    async (key: CloudServiceKey, newValue: boolean) => {
       const updated = { ...services, [key]: newValue };
       setServices(updated);
       setSaving(true);
@@ -397,22 +397,21 @@ export function CloudServicesSection() {
   if (!loaded) return null;
 
   return (
-    <div className="mt-6">
-      <div className="flex items-center justify-between mb-3">
-        <div className="text-sm font-semibold">
-          {t("configpageview.CloudServices", {
-            defaultValue: "Cloud Services",
-          })}
-        </div>
-        {needsRestart && (
-          <span className="text-xs-tight font-medium text-accent">
-            {t("configpageview.RestartRequired", {
-              defaultValue: "Restart required",
-            })}
-          </span>
-        )}
-      </div>
-      <div className="flex flex-col gap-2">
+    <SettingsStack className="mt-6">
+      <SettingsGroup
+        title={t("configpageview.CloudServices", {
+          defaultValue: "Cloud Services",
+        })}
+        action={
+          needsRestart ? (
+            <span className="text-xs-tight font-medium text-accent">
+              {t("configpageview.RestartRequired", {
+                defaultValue: "Restart required",
+              })}
+            </span>
+          ) : undefined
+        }
+      >
         {CLOUD_SERVICE_DEFS.map(
           ({
             key,
@@ -421,29 +420,21 @@ export function CloudServicesSection() {
             descriptionKey,
             descriptionDefault,
           }) => (
-            /* Flat — no card/border. The Switch is the single state signal. */
-            <div key={key} className="flex items-center justify-between p-3">
-              <div className="flex-1 min-w-0 mr-4">
-                <div
-                  id={`cloud-service-${key}`}
-                  className="text-sm font-medium text-txt"
-                >
-                  {t(labelKey, { defaultValue: labelDefault })}
-                </div>
-                <div className="text-xs-tight text-muted mt-0.5">
-                  {t(descriptionKey, { defaultValue: descriptionDefault })}
-                </div>
-              </div>
-              <Switch
-                checked={services[key]}
-                disabled={saving}
-                onCheckedChange={() => void handleToggle(key)}
-                aria-labelledby={`cloud-service-${key}`}
-              />
-            </div>
+            <SettingsSwitchRow
+              key={key}
+              agentId={`config-cloud-service-${key}`}
+              group="config-cloud-services"
+              label={t(labelKey, { defaultValue: labelDefault })}
+              description={t(descriptionKey, {
+                defaultValue: descriptionDefault,
+              })}
+              checked={services[key]}
+              disabled={saving}
+              onCheckedChange={(checked) => void handleToggle(key, checked)}
+            />
           ),
         )}
-      </div>
-    </div>
+      </SettingsGroup>
+    </SettingsStack>
   );
 }

--- a/packages/ui/src/components/settings/AppsManagementSection.tsx
+++ b/packages/ui/src/components/settings/AppsManagementSection.tsx
@@ -15,10 +15,13 @@ import type {
 import { useAppSelector } from "../../state";
 import { Button } from "../ui/button";
 import { Checkbox } from "../ui/checkbox";
-import { SettingsInput, SettingsTextarea } from "../ui/settings-controls";
 import { AdvancedToggle } from "./AdvancedToggle";
 import { useAdvancedSettingsEnabled } from "./AdvancedToggle.hooks";
-import { SettingsSelectRow } from "./settings-agent-rows";
+import {
+  SettingsInputRow,
+  SettingsSelectRow,
+  SettingsTextareaRow,
+} from "./settings-agent-rows";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
 
 /**
@@ -415,17 +418,6 @@ export function AppsManagementSection() {
       status: verifyOnRelaunch ? "active" : "inactive",
       onActivate: () => setVerifyOnRelaunch((v) => !v),
     });
-  const { ref: createIntentRef, agentProps: createIntentAgentProps } =
-    useAgentElement<HTMLTextAreaElement>({
-      id: "apps-create-intent",
-      role: "textarea",
-      label: t("settings.sections.apps.intentLabel", {
-        defaultValue: "What should the app do?",
-      }),
-      group: "apps-create",
-      getValue: () => createIntent,
-      onFill: setCreateIntent,
-    });
   const { ref: createSubmitRef, agentProps: createSubmitAgentProps } =
     useAgentElement<HTMLButtonElement>({
       id: "apps-create-submit",
@@ -451,17 +443,6 @@ export function AppsManagementSection() {
         setCreateEditTarget("");
         setCreateStatus({ state: "idle" });
       },
-    });
-  const { ref: loadDirectoryRef, agentProps: loadDirectoryAgentProps } =
-    useAgentElement<HTMLInputElement>({
-      id: "apps-load-directory",
-      role: "text-input",
-      label: t("settings.sections.apps.directoryLabel", {
-        defaultValue: "Directory path",
-      }),
-      group: "apps-load",
-      getValue: () => loadDirectory,
-      onFill: setLoadDirectory,
     });
   const { ref: loadSubmitRef, agentProps: loadSubmitAgentProps } =
     useAgentElement<HTMLButtonElement>({
@@ -564,27 +545,21 @@ export function AppsManagementSection() {
               ) : undefined
             }
           >
-            <SettingsRow
-              htmlFor="apps-create-intent"
-              stacked
+            <SettingsTextareaRow
+              agentId="apps-create-intent"
+              group="apps-create"
               label={t("settings.sections.apps.intentLabel", {
                 defaultValue: "What should the app do?",
               })}
-            >
-              <SettingsTextarea
-                ref={createIntentRef}
-                id="apps-create-intent"
-                rows={3}
-                value={createIntent}
-                disabled={isCreating}
-                onChange={(e) => setCreateIntent(e.target.value)}
-                className="block w-full resize-y font-sans text-sm text-txt"
-                placeholder={t("settings.sections.apps.intentPlaceholder", {
-                  defaultValue: "Describe what the app should do.",
-                })}
-                {...createIntentAgentProps}
-              />
-            </SettingsRow>
+              value={createIntent}
+              disabled={isCreating}
+              rows={3}
+              onValueChange={setCreateIntent}
+              textareaClassName="block w-full resize-y font-sans text-sm text-txt"
+              placeholder={t("settings.sections.apps.intentPlaceholder", {
+                defaultValue: "Describe what the app should do.",
+              })}
+            />
             {advancedEnabled ? (
               <SettingsSelectRow
                 agentId="apps-create-edit-target"
@@ -675,28 +650,19 @@ export function AppsManagementSection() {
               ) : undefined
             }
           >
-            <SettingsRow
-              htmlFor="apps-load-directory"
-              stacked
+            <SettingsInputRow
+              agentId="apps-load-directory"
+              group="apps-load"
               label={t("settings.sections.apps.directoryLabel", {
                 defaultValue: "Directory path",
               })}
-            >
-              <SettingsInput
-                ref={loadDirectoryRef}
-                id="apps-load-directory"
-                variant="touch"
-                type="text"
-                value={loadDirectory}
-                disabled={isLoading}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setLoadDirectory(e.target.value)
-                }
-                placeholder="/Users/me/code/my-app"
-                className="w-full"
-                {...loadDirectoryAgentProps}
-              />
-            </SettingsRow>
+              value={loadDirectory}
+              disabled={isLoading}
+              type="text"
+              onValueChange={setLoadDirectory}
+              placeholder="/Users/me/code/my-app"
+              inputClassName="w-full"
+            />
             <SettingsRow label="" stacked>
               <div className="flex items-center gap-2">
                 <Button

--- a/packages/ui/src/components/settings/AppsManagementSection.tsx
+++ b/packages/ui/src/components/settings/AppsManagementSection.tsx
@@ -14,12 +14,12 @@ import type {
 } from "../../api/client-types-cloud";
 import { useAppSelector } from "../../state";
 import { Button } from "../ui/button";
-import { Checkbox } from "../ui/checkbox";
 import { AdvancedToggle } from "./AdvancedToggle";
 import { useAdvancedSettingsEnabled } from "./AdvancedToggle.hooks";
 import {
   SettingsInputRow,
   SettingsSelectRow,
+  SettingsSwitchRow,
   SettingsTextareaRow,
 } from "./settings-agent-rows";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
@@ -407,17 +407,6 @@ export function AppsManagementSection() {
         setShowCreate(false);
       },
     });
-  const { ref: verifyRef, agentProps: verifyAgentProps } =
-    useAgentElement<HTMLButtonElement>({
-      id: "apps-verify-on-relaunch",
-      role: "toggle",
-      label: t("settings.sections.apps.verifyOnRelaunch", {
-        defaultValue: "Verify on relaunch",
-      }),
-      group: "apps-management",
-      status: verifyOnRelaunch ? "active" : "inactive",
-      onActivate: () => setVerifyOnRelaunch((v) => !v),
-    });
   const { ref: createSubmitRef, agentProps: createSubmitAgentProps } =
     useAgentElement<HTMLButtonElement>({
       id: "apps-create-submit",
@@ -509,24 +498,15 @@ export function AppsManagementSection() {
           </Button>
         </div>
         {advancedEnabled ? (
-          <SettingsRow
+          <SettingsSwitchRow
+            agentId="apps-verify-on-relaunch"
+            group="apps-management"
             label={t("settings.sections.apps.verifyOnRelaunch", {
               defaultValue: "Verify on relaunch",
             })}
-            control={
-              <Checkbox
-                ref={verifyRef}
-                checked={verifyOnRelaunch}
-                onCheckedChange={(checked: boolean | "indeterminate") =>
-                  setVerifyOnRelaunch(!!checked)
-                }
-                aria-current={verifyOnRelaunch ? "true" : undefined}
-                aria-label={t("settings.sections.apps.verifyOnRelaunchLabel", {
-                  defaultValue: "Verify on relaunch",
-                })}
-                {...verifyAgentProps}
-              />
-            }
+            checked={verifyOnRelaunch}
+            agentStatus={verifyOnRelaunch ? "active" : "inactive"}
+            onCheckedChange={setVerifyOnRelaunch}
           />
         ) : null}
       </SettingsGroup>

--- a/packages/ui/src/components/settings/VoiceConfigView.tsx
+++ b/packages/ui/src/components/settings/VoiceConfigView.tsx
@@ -41,10 +41,10 @@ import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Input } from "../ui/input";
 import { SaveFooter } from "../ui/save-footer";
-import { SettingsInput } from "../ui/settings-controls";
 import { Switch } from "../ui/switch";
 import { AdvancedToggle } from "./AdvancedToggle";
 import { useAdvancedSettingsEnabled } from "./AdvancedToggle.hooks";
+import { SettingsInputRow } from "./settings-agent-rows";
 import { useSettingsSave } from "./settings-control-primitives.hooks";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
 
@@ -1184,17 +1184,7 @@ export function VoiceConfigView() {
     setDirty(true);
   }, []);
 
-  const { ref: apiKeyRef, agentProps: apiKeyAgentProps } =
-    useAgentElement<HTMLInputElement>({
-      id: "voice-tts-elevenlabs-key",
-      role: "text-input",
-      label: t("settings.voice.elevenLabsApiKey", {
-        defaultValue: "ElevenLabs API key",
-      }),
-      group: "voice-tts",
-      getValue: () => voiceConfig.elevenlabs?.apiKey ?? "",
-      onFill: handleApiKeyChange,
-    });
+  const [apiKeyDraft, setApiKeyDraft] = useState("");
 
   const handleTestVoice = useCallback((previewUrl: string) => {
     if (audioRef.current) {
@@ -1355,8 +1345,13 @@ export function VoiceConfigView() {
             </SettingsRow>
           ) : null}
           {currentMode === "own-key" ? (
-            <SettingsRow
-              label={t("settings.voice.elevenLabsApiKey")}
+            <SettingsInputRow
+              agentId="voice-tts-elevenlabs-key"
+              group="voice-tts"
+              type="password"
+              label={t("settings.voice.elevenLabsApiKey", {
+                defaultValue: "ElevenLabs API key",
+              })}
               description={
                 <>
                   {t("voiceconfigview.GetYourKeyAt")}{" "}
@@ -1373,22 +1368,18 @@ export function VoiceConfigView() {
                   <code>{DEFAULT_ELEVEN_FAST_MODEL}</code>
                 </>
               }
-              stacked
-            >
-              <SettingsInput
-                ref={apiKeyRef}
-                variant="touch"
-                className="w-full"
-                type="password"
-                placeholder={
-                  voiceConfig.elevenlabs?.apiKey
-                    ? t("mediasettingssection.ApiKeySetLeaveBlank")
-                    : t("mediasettingssection.EnterApiKey")
-                }
-                onChange={(e) => handleApiKeyChange(e.target.value)}
-                {...apiKeyAgentProps}
-              />
-            </SettingsRow>
+              value={apiKeyDraft}
+              onValueChange={(next) => {
+                setApiKeyDraft(next);
+                handleApiKeyChange(next);
+              }}
+              placeholder={
+                voiceConfig.elevenlabs?.apiKey
+                  ? t("mediasettingssection.ApiKeySetLeaveBlank")
+                  : t("mediasettingssection.EnterApiKey")
+              }
+              inputClassName="w-full"
+            />
           ) : null}
           <SettingsRow label={t("common.voice")} stacked>
             <div className="grid gap-1.5 sm:grid-cols-2 xl:grid-cols-3">

--- a/packages/ui/src/components/settings/WalletKeysSection.test.tsx
+++ b/packages/ui/src/components/settings/WalletKeysSection.test.tsx
@@ -10,7 +10,13 @@
  * keys panel surfaces instead of a raw `HTTP 502` / `HTTP 500` banner.
  */
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const clientMock = vi.hoisted(() => ({
@@ -97,6 +103,20 @@ describe("WalletKeysSection - requests route through the shared client", () => {
     await screen.findByTestId("wallet-keys-empty");
     expect(screen.queryByTestId("wallet-keys-error")).toBeNull();
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("routes the add-key fields through SettingsInputRow", async () => {
+    clientMock.rawRequest.mockResolvedValue(jsonResponse(200, { entries: [] }));
+    renderAsOwner();
+    await screen.findByTestId("wallet-keys-empty");
+    fireEvent.click(screen.getByTestId("wallet-keys-add-toggle"));
+    const name = screen.getByLabelText("Key name");
+    const secret = screen.getByLabelText("Private key");
+    expect(name.getAttribute("data-agent-id")).toBe("wallet-keys-key-name");
+    expect(secret.getAttribute("data-agent-id")).toBe(
+      "wallet-keys-private-key",
+    );
+    expect(secret.getAttribute("type")).toBe("password");
   });
 });
 

--- a/packages/ui/src/components/settings/WalletKeysSection.tsx
+++ b/packages/ui/src/components/settings/WalletKeysSection.tsx
@@ -17,8 +17,7 @@ import { client } from "../../api/client";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { OwnerOnlyNotice, RoleGate } from "../RoleGate";
 import { Button } from "../ui/button";
-import { Label } from "../ui/label";
-import { SettingsInput } from "../ui/settings-controls";
+import { SettingsInputRow } from "./settings-agent-rows";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
 import { isVaultEntryMeta, type VaultEntryMeta } from "./vault-tabs/types";
 
@@ -135,25 +134,6 @@ function WalletKeysSectionBody() {
       label: "Add wallet key",
       group: "wallet-keys",
       description: "Show the form to add a wallet private key",
-    });
-  const { ref: addKeyRef, agentProps: addKeyAgentProps } =
-    useAgentElement<HTMLInputElement>({
-      id: "wallet-keys-key-name",
-      role: "text-input",
-      label: "Wallet key name",
-      group: "wallet-keys-add",
-      description: "Env-var name like EVM_PRIVATE_KEY",
-      getValue: () => addKey,
-      onFill: (v) => setAddKey(v),
-    });
-  const { ref: addValueRef, agentProps: addValueAgentProps } =
-    useAgentElement<HTMLInputElement>({
-      id: "wallet-keys-private-key",
-      role: "text-input",
-      label: "Wallet private key value",
-      group: "wallet-keys-add",
-      getValue: () => addValue,
-      onFill: (v) => setAddValue(v),
     });
   const { ref: addCancelRef, agentProps: addCancelAgentProps } =
     useAgentElement<HTMLButtonElement>({
@@ -351,36 +331,29 @@ function WalletKeysSectionBody() {
           className="space-y-2 pt-1"
           data-testid="wallet-keys-add-form"
         >
-          <div>
-            <Label className="text-xs text-muted">
-              {t("walletkeys.keyName", { defaultValue: "Key name" })}
-            </Label>
-            <SettingsInput
-              ref={addKeyRef}
-              {...addKeyAgentProps}
-              variant="touch"
-              value={addKey}
-              onChange={(e) => setAddKey(e.target.value)}
-              placeholder="EVM_PRIVATE_KEY"
-              autoComplete="off"
-              required
-            />
-          </div>
-          <div>
-            <Label className="text-xs text-muted">
-              {t("walletkeys.privateKey", { defaultValue: "Private key" })}
-            </Label>
-            <SettingsInput
-              ref={addValueRef}
-              {...addValueAgentProps}
-              variant="touch"
-              type="password"
-              value={addValue}
-              onChange={(e) => setAddValue(e.target.value)}
-              autoComplete="new-password"
-              required
-            />
-          </div>
+          <SettingsInputRow
+            agentId="wallet-keys-key-name"
+            agentLabel="Wallet key name"
+            group="wallet-keys-add"
+            label={t("walletkeys.keyName", { defaultValue: "Key name" })}
+            description={t("walletkeys.keyNameHint", {
+              defaultValue: "Env-var name like EVM_PRIVATE_KEY",
+            })}
+            value={addKey}
+            onValueChange={setAddKey}
+            placeholder="EVM_PRIVATE_KEY"
+            autoComplete="off"
+          />
+          <SettingsInputRow
+            agentId="wallet-keys-private-key"
+            agentLabel="Wallet private key value"
+            group="wallet-keys-add"
+            label={t("walletkeys.privateKey", { defaultValue: "Private key" })}
+            type="password"
+            value={addValue}
+            onValueChange={setAddValue}
+            autoComplete="new-password"
+          />
           <div className="flex justify-end gap-2 pt-1">
             <Button
               ref={addCancelRef}

--- a/packages/ui/src/components/settings/no-raw-select.test.ts
+++ b/packages/ui/src/components/settings/no-raw-select.test.ts
@@ -46,9 +46,9 @@ const RAW_SELECT_OCCURRENCES = new Map<
   [
     "vault-tabs/RoutingTab.tsx",
     {
-      count: 5,
+      count: 4,
       reason:
-        "routing table cells and default-profile compact picker, not labelled settings rows",
+        "add-rule form scope/agent/app/profile pickers, not settings rows",
     },
   ],
 ]);

--- a/packages/ui/src/components/settings/no-raw-switch.test.ts
+++ b/packages/ui/src/components/settings/no-raw-switch.test.ts
@@ -42,14 +42,6 @@ const RAW_SWITCH_OCCURRENCES = new Map<
         "compact enable switch inside a custom status chip, not a SettingsRow",
     },
   ],
-  [
-    "permission-controls.tsx",
-    {
-      count: 1,
-      reason:
-        "PermissionRow shell toggle shares the row with a badge and grant button",
-    },
-  ],
 ]);
 
 function posixRelative(from: string, to: string): string {

--- a/packages/ui/src/components/settings/no-raw-switch.test.ts
+++ b/packages/ui/src/components/settings/no-raw-switch.test.ts
@@ -45,9 +45,9 @@ const RAW_SWITCH_OCCURRENCES = new Map<
   [
     "permission-controls.tsx",
     {
-      count: 2,
+      count: 1,
       reason:
-        "compound permission rows mix badges with Switch or Button trailing controls",
+        "PermissionRow shell toggle shares the row with a badge and grant button",
     },
   ],
 ]);

--- a/packages/ui/src/components/settings/permission-controls.test.tsx
+++ b/packages/ui/src/components/settings/permission-controls.test.tsx
@@ -1,0 +1,97 @@
+/** Verifies CapabilityToggle through the package's configured test harness. */
+// @vitest-environment jsdom
+/**
+ * Renders CapabilityToggle with a mocked translator and asserts the shared
+ * SettingsSwitchRow wiring, unavailable/missing-permission badges, and
+ * click-to-toggle. jsdom, no backend.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginInfo } from "../../api";
+import { CapabilityToggle } from "./permission-controls";
+import type { CapabilityDef } from "./permission-types";
+
+const appMock = vi.hoisted(() => ({
+  t: (key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? key,
+}));
+
+vi.mock("../../state", () => ({
+  useAppSelector: (sel: (value: typeof appMock) => unknown) => sel(appMock),
+  useAppSelectorShallow: (sel: (value: typeof appMock) => unknown) =>
+    sel(appMock),
+}));
+
+const browserCap: CapabilityDef = {
+  id: "browser",
+  label: "Browser Control",
+  labelKey: "permissionssection.capability.browser.label",
+  description: "Automated web browsing and interaction",
+  descriptionKey: "permissionssection.capability.browser.description",
+  requiredPermissions: ["accessibility"],
+};
+
+function plugin(overrides: Partial<PluginInfo> = {}): PluginInfo {
+  return {
+    id: "browser",
+    name: "Browser",
+    description: "Browser plugin",
+    enabled: true,
+    configured: true,
+    envKey: null,
+    category: "feature",
+    source: "bundled",
+    parameters: [],
+    validationErrors: [],
+    validationWarnings: [],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CapabilityToggle", () => {
+  beforeEach(() => {
+    appMock.t = (key, options) => options?.defaultValue ?? key;
+  });
+
+  it("routes an enabled capability through SettingsSwitchRow", () => {
+    const onToggle = vi.fn();
+    render(
+      <CapabilityToggle
+        cap={browserCap}
+        plugin={plugin()}
+        permissionsGranted
+        onToggle={onToggle}
+      />,
+    );
+    const sw = screen.getByRole("switch");
+    expect(sw.getAttribute("data-agent-id")).toBe("perm-capability-browser");
+    expect(sw.getAttribute("data-agent-role")).toBe("toggle");
+    expect(sw.getAttribute("data-agent-label")).toBe("Browser Control");
+    expect(sw.getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByText("Browser Control")).toBeTruthy();
+    fireEvent.click(sw);
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+
+  it("stays disabled and shows badges when the plugin or permissions are missing", () => {
+    render(
+      <CapabilityToggle
+        cap={browserCap}
+        plugin={null}
+        permissionsGranted={false}
+        onToggle={() => {}}
+      />,
+    );
+    const sw = screen.getByRole("switch");
+    expect(sw).toHaveProperty("disabled", true);
+    expect(screen.getByText("Plugin unavailable")).toBeTruthy();
+    expect(
+      screen.getByText("permissionssection.MissingPermissions"),
+    ).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/settings/permission-controls.test.tsx
+++ b/packages/ui/src/components/settings/permission-controls.test.tsx
@@ -9,8 +9,9 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginInfo } from "../../api";
-import { CapabilityToggle } from "./permission-controls";
+import { CapabilityToggle, PermissionRow } from "./permission-controls";
 import type { CapabilityDef } from "./permission-types";
+import { SYSTEM_PERMISSIONS } from "./permission-types";
 
 const appMock = vi.hoisted(() => ({
   t: (key: string, options?: { defaultValue?: string }) =>
@@ -93,5 +94,37 @@ describe("CapabilityToggle", () => {
     expect(
       screen.getByText("permissionssection.MissingPermissions"),
     ).toBeTruthy();
+  });
+});
+
+const shellDef = SYSTEM_PERMISSIONS.find((def) => def.id === "shell");
+if (!shellDef) {
+  throw new Error("SYSTEM_PERMISSIONS must include shell");
+}
+
+describe("PermissionRow shell toggle", () => {
+  it("routes the shell enable switch through SettingsSwitchRow", () => {
+    const onToggleShell = vi.fn();
+    render(
+      <PermissionRow
+        def={shellDef}
+        status="granted"
+        platform="darwin"
+        canRequest={false}
+        onRequest={() => {}}
+        onOpenSettings={() => {}}
+        isShell
+        shellEnabled
+        onToggleShell={onToggleShell}
+      />,
+    );
+    const sw = screen.getByRole("switch");
+    expect(sw.getAttribute("data-agent-id")).toBe("perm-shell-shell");
+    expect(sw.getAttribute("data-agent-label")).toBe(
+      "Shell Access shell access",
+    );
+    expect(sw.getAttribute("aria-checked")).toBe("true");
+    fireEvent.click(sw);
+    expect(onToggleShell).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/ui/src/components/settings/permission-controls.tsx
+++ b/packages/ui/src/components/settings/permission-controls.tsx
@@ -39,7 +39,6 @@ import type { PermissionStatus, PluginInfo } from "../../api";
 import { useAppSelector } from "../../state";
 import { Button } from "../ui/button";
 import { StatusBadge } from "../ui/status-badge";
-import { Switch } from "../ui/switch";
 import type { CapabilityDef, PermissionDef } from "./permission-types";
 import {
   getPermissionAction,
@@ -117,18 +116,6 @@ export function PermissionRow({
   const showShellToggle =
     isShell && onToggleShell && status !== "not-applicable";
 
-  const { ref: shellRef, agentProps: shellAgentProps } =
-    useAgentElement<HTMLButtonElement>({
-      id: `perm-shell-${def.id}`,
-      role: "toggle",
-      label: `${name} shell access`,
-      group: "permissions",
-      status: shellEnabled ? "on" : "off",
-      getValue: () => shellEnabled,
-      onActivate: onToggleShell
-        ? () => onToggleShell(!shellEnabled)
-        : undefined,
-    });
   const { ref: actionRef, agentProps: actionAgentProps } =
     useAgentElement<HTMLButtonElement>({
       id: `perm-action-${def.id}`,
@@ -141,40 +128,6 @@ export function PermissionRow({
           : onOpenSettings
         : undefined,
     });
-
-  const control = showShellToggle ? (
-    <Switch
-      ref={shellRef}
-      checked={shellEnabled}
-      onCheckedChange={onToggleShell}
-      title={
-        shellEnabled
-          ? translateWithFallback(
-              t,
-              "permissionssection.DisableShellAccess",
-              "Disable shell access",
-            )
-          : translateWithFallback(
-              t,
-              "permissionssection.EnableShellAccess",
-              "Enable shell access",
-            )
-      }
-      {...shellAgentProps}
-    />
-  ) : !isShell && action ? (
-    <Button
-      ref={actionRef}
-      variant="default"
-      size="sm"
-      className="min-h-11 rounded-sm px-3 text-xs font-semibold"
-      onClick={action.type === "request" ? onRequest : onOpenSettings}
-      aria-label={`${action.ariaLabelPrefix} ${name}`}
-      {...actionAgentProps}
-    >
-      {action.label}
-    </Button>
-  ) : undefined;
 
   const label = (
     <span className="flex flex-wrap items-center gap-2">
@@ -197,19 +150,49 @@ export function PermissionRow({
     </span>
   );
 
+  const descriptionNode = (
+    <>
+      {description}
+      {reason ? <span className="mt-1 block text-txt">{reason}</span> : null}
+    </>
+  );
+
+  if (showShellToggle) {
+    return (
+      <SettingsSwitchRow
+        agentId={`perm-shell-${def.id}`}
+        agentLabel={`${name} shell access`}
+        group="permissions"
+        icon={permissionIcon(def.icon)}
+        label={label}
+        description={descriptionNode}
+        checked={shellEnabled}
+        agentStatus={shellEnabled ? "on" : "off"}
+        onCheckedChange={(checked) => onToggleShell?.(checked)}
+      />
+    );
+  }
+
   return (
     <SettingsRow
       icon={permissionIcon(def.icon)}
       label={label}
-      control={control}
-      description={
-        <>
-          {description}
-          {reason ? (
-            <span className="mt-1 block text-txt">{reason}</span>
-          ) : null}
-        </>
+      control={
+        !isShell && action ? (
+          <Button
+            ref={actionRef}
+            variant="default"
+            size="sm"
+            className="min-h-11 rounded-sm px-3 text-xs font-semibold"
+            onClick={action.type === "request" ? onRequest : onOpenSettings}
+            aria-label={`${action.ariaLabelPrefix} ${name}`}
+            {...actionAgentProps}
+          >
+            {action.label}
+          </Button>
+        ) : undefined
       }
+      description={descriptionNode}
     />
   );
 }

--- a/packages/ui/src/components/settings/permission-controls.tsx
+++ b/packages/ui/src/components/settings/permission-controls.tsx
@@ -1,9 +1,9 @@
 /**
  * Presentational rows for the Permissions settings section. `PermissionRow`
  * renders one OS/app permission (icon, name, status badge, request/open-settings
- * action, and the optional shell-enable switch); `CapabilityToggle` renders a
- * capability on/off row. Status/badge/action copy is resolved through
- * `permission-types`; the controls are agent-addressable via `useAgentElement`.
+ * action, and the optional shell-enable switch); `CapabilityToggle` is a
+ * SettingsSwitchRow for a capability on/off. Status/badge/action copy is
+ * resolved through `permission-types`.
  */
 
 import {
@@ -46,6 +46,7 @@ import {
   getPermissionBadge,
   translateWithFallback,
 } from "./permission-types";
+import { SettingsSwitchRow } from "./settings-agent-rows";
 import { SettingsRow } from "./settings-layout";
 
 const PERMISSION_ICONS: Record<string, LucideIcon> = {
@@ -234,24 +235,6 @@ export function CapabilityToggle({
     cap.descriptionKey,
     cap.description,
   );
-  const toggleActionLabel = `${
-    enabled
-      ? translateWithFallback(t, "permissionssection.Disable", "Disable")
-      : translateWithFallback(t, "permissionssection.Enable", "Enable")
-  } ${label}`;
-
-  const { ref: toggleRef, agentProps: toggleAgentProps } =
-    useAgentElement<HTMLButtonElement>({
-      id: `perm-capability-${cap.id}`,
-      role: "toggle",
-      label,
-      group: "permissions",
-      description,
-      status: enabled ? "on" : "off",
-      getValue: () => enabled,
-      onActivate: canEnable ? () => onToggle(!enabled) : undefined,
-    });
-
   const rowLabel = (
     <span className="flex flex-wrap items-center gap-2">
       {label}
@@ -273,44 +256,16 @@ export function CapabilityToggle({
   );
 
   return (
-    <SettingsRow
+    <SettingsSwitchRow
+      agentId={`perm-capability-${cap.id}`}
+      agentLabel={label}
+      group="permissions"
       label={rowLabel}
       description={description}
-      control={
-        <Switch
-          ref={toggleRef}
-          checked={enabled}
-          onCheckedChange={onToggle}
-          disabled={!canEnable}
-          aria-label={toggleActionLabel}
-          {...toggleAgentProps}
-          title={
-            !available
-              ? translateWithFallback(
-                  t,
-                  "permissionssection.PluginNotAvailable",
-                  "Plugin not available",
-                )
-              : !permissionsGranted
-                ? translateWithFallback(
-                    t,
-                    "permissionssection.GrantRequiredPermissionsFirst",
-                    "Grant required permissions first",
-                  )
-                : enabled
-                  ? translateWithFallback(
-                      t,
-                      "permissionssection.Disable",
-                      "Disable",
-                    )
-                  : translateWithFallback(
-                      t,
-                      "permissionssection.Enable",
-                      "Enable",
-                    )
-          }
-        />
-      }
+      checked={enabled}
+      disabled={!canEnable}
+      agentStatus={enabled ? "on" : "off"}
+      onCheckedChange={onToggle}
     />
   );
 }

--- a/packages/ui/src/components/settings/settings-agent-rows.tsx
+++ b/packages/ui/src/components/settings/settings-agent-rows.tsx
@@ -512,6 +512,11 @@ export function SettingsTextareaRow({
     onFill: disabled ? undefined : (next: string) => onValueChange(next),
   });
 
+  const {
+    "aria-label": _ignoredTextareaAccessibleName,
+    ...textareaAgentProps
+  } = agentProps;
+
   return (
     <SettingsRow
       icon={icon}
@@ -519,18 +524,19 @@ export function SettingsTextareaRow({
       label={label}
       description={description}
       className={className}
+      htmlFor={agentId}
       stacked
     >
       <SettingsTextarea
         ref={ref}
+        id={agentId}
         value={value}
         onChange={(event) => onValueChange(event.target.value)}
         placeholder={placeholder}
         rows={rows}
         disabled={disabled}
-        aria-label={resolvedLabel}
         className={textareaClassName}
-        {...agentProps}
+        {...textareaAgentProps}
       />
     </SettingsRow>
   );

--- a/packages/ui/src/components/settings/settings-layout.test.tsx
+++ b/packages/ui/src/components/settings/settings-layout.test.tsx
@@ -13,6 +13,7 @@ import {
   SettingsInputRow,
   SettingsSelectRow,
   SettingsSwitchRow,
+  SettingsTextareaRow,
 } from "./settings-agent-rows";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
 
@@ -246,5 +247,24 @@ describe("agent-addressable rows", () => {
     const trigger = screen.getByTestId("identity-voice-trigger");
     expect(trigger.getAttribute("data-agent-id")).toBe("identity-voice");
     expect(screen.getByText("Preview")).toBeTruthy();
+  });
+
+  it("SettingsTextareaRow labels the field and exposes agent data attributes", () => {
+    const onValueChange = vi.fn();
+    render(
+      <SettingsTextareaRow
+        agentId="apps-create-intent"
+        label="What should the app do?"
+        value=""
+        onValueChange={onValueChange}
+      />,
+    );
+    const field = screen.getByLabelText("What should the app do?");
+    expect(field.getAttribute("data-agent-id")).toBe("apps-create-intent");
+    expect(field.getAttribute("data-agent-role")).toBe("textarea");
+    expect(field.getAttribute("id")).toBe("apps-create-intent");
+    expect(field.getAttribute("aria-label")).toBeNull();
+    fireEvent.change(field, { target: { value: "Summarize updates" } });
+    expect(onValueChange).toHaveBeenCalledWith("Summarize updates");
   });
 });

--- a/packages/ui/src/components/settings/vault-tabs/RoutingTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/RoutingTab.tsx
@@ -31,6 +31,7 @@ import {
   SelectValue,
 } from "../../ui/select";
 import { SettingsSelectTrigger } from "../../ui/settings-controls";
+import { SettingsSelectRow } from "../settings-agent-rows";
 import type {
   AgentSummary,
   InstalledApp,
@@ -76,16 +77,6 @@ export function RoutingTab(props: RoutingTabProps) {
   const [profileId, setProfileId] = useState("");
   const [rulesFilter, setRulesFilter] = useState("");
 
-  const { ref: defaultProfileRef, agentProps: defaultProfileAgentProps } =
-    useAgentElement<HTMLButtonElement>({
-      id: "routing-default-profile",
-      role: "select",
-      label: "Default routing profile",
-      group: "routing",
-      description: "Profile applied when no rule matches",
-      getValue: () => config.defaultProfile ?? "default",
-      onFill: (v) => void onDefaultProfileChange(v),
-    });
   const { ref: addRuleToggleRef, agentProps: addRuleToggleAgentProps } =
     useAgentElement<HTMLButtonElement>({
       id: "routing-add-rule-toggle",
@@ -330,46 +321,23 @@ export function RoutingTab(props: RoutingTabProps) {
 
   return (
     <div data-testid="routing-tab" className="space-y-4">
-      {/* Default profile */}
-      <section className="space-y-2 rounded-sm border border-border/40 bg-card/30 p-3">
-        <div className="flex items-center justify-between gap-2">
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-txt">
-              {t("routing.defaultProfile.title", {
-                defaultValue: "Default profile",
-              })}
-            </p>
-            <p className="text-2xs text-muted">
-              {t("routing.defaultProfile.description", {
-                defaultValue:
-                  'Applied when no rule matches. Falls back to "default".',
-              })}
-            </p>
-          </div>
-          <Select
-            value={config.defaultProfile ?? "default"}
-            onValueChange={(value) => void onDefaultProfileChange(value)}
-            disabled={saving}
-          >
-            <SettingsSelectTrigger
-              ref={defaultProfileRef}
-              {...defaultProfileAgentProps}
-              variant="filter"
-              data-testid="routing-default-profile"
-              className="w-40"
-            >
-              <SelectValue />
-            </SettingsSelectTrigger>
-            <SelectContent>
-              {allProfileIds.map((id) => (
-                <SelectItem key={id} value={id}>
-                  {id}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </section>
+      <SettingsSelectRow
+        agentId="routing-default-profile"
+        agentLabel="Default routing profile"
+        group="routing"
+        label={t("routing.defaultProfile.title", {
+          defaultValue: "Default profile",
+        })}
+        description={t("routing.defaultProfile.description", {
+          defaultValue:
+            'Applied when no rule matches. Falls back to "default".',
+        })}
+        value={config.defaultProfile ?? "default"}
+        onValueChange={(value) => void onDefaultProfileChange(value)}
+        disabled={saving}
+        testId="routing-default-profile"
+        options={allProfileIds.map((id) => ({ value: id, label: id }))}
+      />
 
       {/* Rules table */}
       <section className="space-y-2">

--- a/packages/ui/src/testing/builtin-view-action-ratchet.test.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.test.ts
@@ -116,7 +116,7 @@ describe("builtin view action ratchet (#14369)", () => {
         }),
         expect.objectContaining({
           viewId: "my-apps",
-          observedMutationSites: 25,
+          observedMutationSites: 24,
           semanticActions: ["APP", "VIEWS"],
         }),
         expect.objectContaining({
@@ -285,7 +285,7 @@ describe("builtin view action ratchet (#14369)", () => {
 
     expect(Object.fromEntries(claimedByFile)).toEqual({
       "packages/ui/src/components/pages/MyAppsView.tsx": 1,
-      "packages/ui/src/components/settings/AppsManagementSection.tsx": 24,
+      "packages/ui/src/components/settings/AppsManagementSection.tsx": 23,
     });
     expect(
       myApps.mutationAuthorities?.map((authority) => ({

--- a/packages/ui/src/testing/builtin-view-action-ratchet.test.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.test.ts
@@ -116,7 +116,7 @@ describe("builtin view action ratchet (#14369)", () => {
         }),
         expect.objectContaining({
           viewId: "my-apps",
-          observedMutationSites: 27,
+          observedMutationSites: 25,
           semanticActions: ["APP", "VIEWS"],
         }),
         expect.objectContaining({
@@ -285,7 +285,7 @@ describe("builtin view action ratchet (#14369)", () => {
 
     expect(Object.fromEntries(claimedByFile)).toEqual({
       "packages/ui/src/components/pages/MyAppsView.tsx": 1,
-      "packages/ui/src/components/settings/AppsManagementSection.tsx": 26,
+      "packages/ui/src/components/settings/AppsManagementSection.tsx": 24,
     });
     expect(
       myApps.mutationAuthorities?.map((authority) => ({

--- a/packages/ui/src/testing/builtin-view-action-ratchet.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.ts
@@ -385,8 +385,7 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
         id: "relaunch.verify.agent",
         sourceFile:
           "packages/ui/src/components/settings/AppsManagementSection.tsx",
-        sourceSignature:
-          'useAgentElement<HTMLButtonElement>({\n      id: "apps-verify-on-relaunch",',
+        sourceSignature: "onCheckedChange={setVerifyOnRelaunch}",
         semanticAction: "APP",
         actionOperations: ["relaunch"],
       },
@@ -443,15 +442,6 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
           "onClick={() => {\n              setShowLoad((v) => !v);",
         semanticAction: "APP",
         actionOperations: ["load_from_directory"],
-      },
-      {
-        id: "relaunch.verify.pointer",
-        sourceFile:
-          "packages/ui/src/components/settings/AppsManagementSection.tsx",
-        sourceSignature:
-          'onCheckedChange={(checked: boolean | "indeterminate") =>\n                  setVerifyOnRelaunch(!!checked)',
-        semanticAction: "APP",
-        actionOperations: ["relaunch"],
       },
       {
         id: "create.submit.pointer",
@@ -553,7 +543,7 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
         actionOperations: ["stop"],
       },
     ],
-    maxMutationSites: 25,
+    maxMutationSites: 24,
     notes:
       "The standalone page mounts AppsManagementSection, so its complete app-control surface is inventoried here instead of disappearing behind a child component. APP owns app lifecycle; VIEWS owns the signed-in Cloud Apps shell navigation.",
   },

--- a/packages/ui/src/testing/builtin-view-action-ratchet.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.ts
@@ -391,15 +391,6 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
         actionOperations: ["relaunch"],
       },
       {
-        id: "create.intent.agent",
-        sourceFile:
-          "packages/ui/src/components/settings/AppsManagementSection.tsx",
-        sourceSignature:
-          'useAgentElement<HTMLTextAreaElement>({\n      id: "apps-create-intent",',
-        semanticAction: "APP",
-        actionOperations: ["create"],
-      },
-      {
         id: "create.submit.agent",
         sourceFile:
           "packages/ui/src/components/settings/AppsManagementSection.tsx",
@@ -416,15 +407,6 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
           'useAgentElement<HTMLButtonElement>({\n      id: "apps-create-cancel",',
         semanticAction: "APP",
         actionOperations: ["create"],
-      },
-      {
-        id: "load.directory.agent",
-        sourceFile:
-          "packages/ui/src/components/settings/AppsManagementSection.tsx",
-        sourceSignature:
-          'useAgentElement<HTMLInputElement>({\n      id: "apps-load-directory",',
-        semanticAction: "APP",
-        actionOperations: ["load_from_directory"],
       },
       {
         id: "load.submit.agent",
@@ -483,7 +465,7 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
         id: "create.intent.pointer",
         sourceFile:
           "packages/ui/src/components/settings/AppsManagementSection.tsx",
-        sourceSignature: "onChange={(e) => setCreateIntent(e.target.value)}",
+        sourceSignature: "onValueChange={setCreateIntent}",
         semanticAction: "APP",
         actionOperations: ["create"],
       },
@@ -517,8 +499,7 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
         id: "load.directory.pointer",
         sourceFile:
           "packages/ui/src/components/settings/AppsManagementSection.tsx",
-        sourceSignature:
-          "onChange={(e: React.ChangeEvent<HTMLInputElement>) =>\n                  setLoadDirectory(e.target.value)",
+        sourceSignature: "onValueChange={setLoadDirectory}",
         semanticAction: "APP",
         actionOperations: ["load_from_directory"],
       },
@@ -572,7 +553,7 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
         actionOperations: ["stop"],
       },
     ],
-    maxMutationSites: 27,
+    maxMutationSites: 25,
     notes:
       "The standalone page mounts AppsManagementSection, so its complete app-control surface is inventoried here instead of disappearing behind a child component. APP owns app lifecycle; VIEWS owns the signed-in Cloud Apps shell navigation.",
   },


### PR DESCRIPTION
# Relates to

Closes #19440

Follow-up to #19146 / #19150 / #19438.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ae3edda7446d1baa3c4e226346d80a87741cee16:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Behaviour-preserving reuse of existing `Settings*Row` primitives.
Compact chips (`VoiceConfigView` wake enable, `AdvancedToggle`), vault/billing
custom forms, and desktop-console compound rows stay on their ratchets.

# Background

## What does this PR do?

One PR for the remaining **1:1 labelled settings row + single control** sites:

- Permissions `CapabilityToggle` and `PermissionRow` shell → `SettingsSwitchRow`
- Apps create intent → `SettingsTextareaRow`
- Apps load directory → `SettingsInputRow`
- Voice ElevenLabs API key → `SettingsInputRow`
- `SettingsTextareaRow` now associates `htmlFor`/`id` and lets the visible
  label own the accessible name (same as Input/Select/Switch)

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`permission-controls.tsx`, `AppsManagementSection.tsx`, `VoiceConfigView.tsx`,
`settings-agent-rows.tsx`.

## Detailed testing steps

```bash
bun run --cwd packages/ui test -- src/components/settings/permission-controls.test.tsx src/components/settings/settings-layout.test.tsx src/components/settings/no-raw-switch.test.ts src/components/settings/AppsManagementSection.test.tsx src/testing/builtin-view-action-ratchet.test.ts src/components/settings/VoiceConfigView.test.tsx
```

93 tests passed after rebase.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:461c41dae380effb538d90285517a954980ea279 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19443-all-fullpage-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19443-all-fullpage-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19443-all-walkthrough-v2.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or API path is changed.
<!-- evidence-row:frontend-logs -->
- [x] [19443-all-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19443-all-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, wallet, scheduled-task, or generated domain artifact is involved.
<!-- evidence-row:ocr-review -->
- [x] [19443-all-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19443-all-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Backend + frontend logs

Backend: N/A - no server path is changed.

Frontend: capture console is attached.

## Screenshots (before / after) + video walkthrough

Isolated fixture of every 1:1 labelled-row conversion: Permissions,
Apps (verify / intent / directory), Voice ElevenLabs key, Wallet keys,
Cloud Services, Privacy, Pay Hosting From Earnings, Vault default profile.
Real SettingsRow / SettingsGroup / SettingsStack + extracted theme.
Desktop 1280×900 and mobile 390×844. Walkthrough (11.6s) scrolls every
section, toggles the switches, and fills the text fields. Per-section
crops are in the latest evidence comment.

## Known gaps / failures

- `bun run verify` was not run for the whole monorepo in this turn.
- Full-page `audit:app` Settings captures are still blocked by the
  `startupCoordinator.target` fixture crash.
- Left out of this PR on purpose: `AdvancedToggle`, `VoiceConfigView` compact
  wake-word chip, vault/billing custom forms, desktop-console compound rows.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok-cli
Contribution skill revision: elizaOS/eliza@ae3edda7446d1baa3c4e226346d80a87741cee16:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-4.6]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-cli","skill_revision":"elizaOS/eliza@ae3edda7446d1baa3c4e226346d80a87741cee16:packages/skills/skills/contribute-to-eliza"} -->







