### PR TITLE
fix(telegram): preserve intra-word underscores

### DIFF
--- a/plugins/plugin-telegram/src/utils.test.ts
+++ b/plugins/plugin-telegram/src/utils.test.ts
@@ -31,6 +31,35 @@ describe("convertMarkdownToTelegram", () => {
     expect(convertMarkdownToTelegram("a-b!")).toBe("a\\-b\\!");
   });
 
+  it("escapes intra-word underscores instead of italicizing identifiers (#19373)", () => {
+    // Prose naming an identifier must reach Telegram verbatim. The old
+    // unanchored italic pattern consumed `_id_` as formatting, so the reserved
+    // underscores went out unescaped and rendered as italic "id".
+    expect(convertMarkdownToTelegram("call the user_id_field helper")).toBe(
+      "call the user\\_id\\_field helper",
+    );
+    expect(convertMarkdownToTelegram("set MAX_RETRY_COUNT today")).toBe(
+      "set MAX\\_RETRY\\_COUNT today",
+    );
+  });
+
+  it("keeps flanked underscore italic working", () => {
+    expect(convertMarkdownToTelegram("_actually italic_")).toBe(
+      "_actually italic_",
+    );
+    expect(convertMarkdownToTelegram("say _hi_ now")).toBe("say _hi_ now");
+    expect(convertMarkdownToTelegram("(_parenthesized_)")).toBe(
+      "\\(_parenthesized_\\)",
+    );
+  });
+
+  it("keeps single intra-word underscores escaped and __x__ inner italic unchanged", () => {
+    expect(convertMarkdownToTelegram("snake_case")).toBe("snake\\_case");
+    // Historical behavior: double-underscore delimiters still produce the
+    // inner italic because underscore flanks remain permitted.
+    expect(convertMarkdownToTelegram("__x__")).toBe("\\__x_\\_");
+  });
+
   it("preserves links (url chars other than ) and \\ stay raw)", () => {
     expect(convertMarkdownToTelegram("[docs](http://x.com)")).toBe(
       "[docs](http://x.com)",

--- a/plugins/plugin-telegram/src/utils.test.ts
+++ b/plugins/plugin-telegram/src/utils.test.ts
@@ -53,6 +53,25 @@ describe("convertMarkdownToTelegram", () => {
     );
   });
 
+  it("treats canonically equivalent flanks identically (#19373 review)", () => {
+    // A decomposed word flank (e + U+0301) must suppress the delimiter exactly
+    // like its precomposed form: marks are word continuations.
+    expect(convertMarkdownToTelegram("caf\u00e9_id_")).toBe(
+      "caf\u00e9\\_id\\_",
+    );
+    expect(convertMarkdownToTelegram("cafe\u0301_id_")).toBe(
+      "cafe\u0301\\_id\\_",
+    );
+  });
+
+  it("suppresses the delimiter after non-Latin combining-mark clusters", () => {
+    // Devanagari KA + virama: the mark ends the flank word, so the underscores
+    // are identifier characters, not italic delimiters.
+    expect(convertMarkdownToTelegram("\u0915\u094d_id_")).toBe(
+      "\u0915\u094d\\_id\\_",
+    );
+  });
+
   it("keeps single intra-word underscores escaped and __x__ inner italic unchanged", () => {
     expect(convertMarkdownToTelegram("snake_case")).toBe("snake\\_case");
     // Historical behavior: double-underscore delimiters still produce the

--- a/plugins/plugin-telegram/src/utils.ts
+++ b/plugins/plugin-telegram/src/utils.ts
@@ -145,12 +145,23 @@ export function convertMarkdownToTelegram(markdown: string): string {
       return storeReplacement(formatted);
     },
   );
-  //    Then underscore-based italic.
-  converted = converted.replace(/_([^_\n]+)_/g, (_match, content) => {
-    const formattedContent = escapePlainText(content);
-    const formatted = `_${formattedContent}_`;
-    return storeReplacement(formatted);
-  });
+  //    Then underscore-based italic. Flanking letters/digits suppress the
+  //    delimiter (CommonMark's intra-word rule): prose naming an identifier
+  //    like `user_id_field` must reach the escaper as plain text — the old
+  //    unanchored pattern consumed `_id_` as formatting, so the reserved
+  //    underscores were re-emitted unescaped and Telegram rendered the
+  //    identifier with italic "id" and the underscores eaten (#19373).
+  //    Underscore flanks stay permitted so the historical `__x__` inner-italic
+  //    behavior is unchanged; a preceding backslash means an already-escaped
+  //    delimiter and never opens italic.
+  converted = converted.replace(
+    /(?<![\p{L}\p{N}\\])_([^_\n]+)_(?![\p{L}\p{N}])/gu,
+    (_match, content) => {
+      const formattedContent = escapePlainText(content);
+      const formatted = `_${formattedContent}_`;
+      return storeReplacement(formatted);
+    },
+  );
 
   // 7. Headers: Convert markdown headers (lines starting with '#' characters)
   //    to bold text. This avoids unescaped '#' characters (which crash Telegram)

--- a/plugins/plugin-telegram/src/utils.ts
+++ b/plugins/plugin-telegram/src/utils.ts
@@ -159,7 +159,7 @@ export function convertMarkdownToTelegram(markdown: string): string {
   //    unchanged; a preceding backslash means an already-escaped delimiter and
   //    never opens italic.
   converted = converted.replace(
-    /(?<![\p{L}\p{N}\p{M}\u200c\u200d\\])_([^_\n]+)_(?![\p{L}\p{N}\p{M}\u200c\u200d])/gu,
+    /(?<![\p{L}\p{N}\p{M}\\])(?<!\u200c)(?<!\u200d)_([^_\n]+)_(?![\p{L}\p{N}\p{M}]|\u200c|\u200d)/gu,
     (_match, content) => {
       const formattedContent = escapePlainText(content);
       const formatted = `_${formattedContent}_`;

--- a/plugins/plugin-telegram/src/utils.ts
+++ b/plugins/plugin-telegram/src/utils.ts
@@ -151,11 +151,15 @@ export function convertMarkdownToTelegram(markdown: string): string {
   //    unanchored pattern consumed `_id_` as formatting, so the reserved
   //    underscores were re-emitted unescaped and Telegram rendered the
   //    identifier with italic "id" and the underscores eaten (#19373).
-  //    Underscore flanks stay permitted so the historical `__x__` inner-italic
-  //    behavior is unchanged; a preceding backslash means an already-escaped
-  //    delimiter and never opens italic.
+  //    Word characters include marks and the ZWJ/ZWNJ join controls, so a
+  //    decomposed flank (cafe + U+0301) or an Indic cluster suppresses the
+  //    delimiter exactly like its precomposed form — canonically equivalent
+  //    inputs must not diverge into italic (#19373 review). Underscore flanks
+  //    stay permitted so the historical `__x__` inner-italic behavior is
+  //    unchanged; a preceding backslash means an already-escaped delimiter and
+  //    never opens italic.
   converted = converted.replace(
-    /(?<![\p{L}\p{N}\\])_([^_\n]+)_(?![\p{L}\p{N}])/gu,
+    /(?<![\p{L}\p{N}\p{M}\u200c\u200d\\])_([^_\n]+)_(?![\p{L}\p{N}\p{M}\u200c\u200d])/gu,
     (_match, content) => {
       const formattedContent = escapePlainText(content);
       const formatted = `_${formattedContent}_`;


### PR DESCRIPTION
## Summary
- stop Telegram MarkdownV2 conversion from interpreting identifier underscores as italic delimiters
- handle Unicode combining marks and ZWJ/ZWNJ word flanks consistently
- keep the regular expression compliant with Biome misleading-character-class checks

Supersedes #19376 with the contributor commits rebased onto current `develop` plus the required lint fix.

## Verification
- `bun test ./src/utils.test.ts` (12/12)
- `bun run typecheck` in `plugins/plugin-telegram`
- `bun run lint` in `plugins/plugin-telegram`
- `bun run verify` (350/350 tasks; anti-larp clean)