### PR TITLE
fix(cloud): prewarm first voice conversation turn

### DIFF
--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -249,6 +249,58 @@ function makeInvoke(object: { fetch(request: Request): Promise<Response> }) {
   };
 }
 
+test("prewarm joins cold hydration without writing a conversation turn", async () => {
+  repositoryReads = 0;
+  repositoryWrites = 0;
+  repositoryRow = [{ role: "assistant", content: "migrated" }];
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    {} as never,
+  );
+
+  const response = await object.fetch(
+    new Request("https://shared-runtime.internal/prewarm", {
+      method: "POST",
+      body: JSON.stringify({
+        operation: "prewarm",
+        agentId: AGENT_FIXTURE.id,
+        roomId: "room-1",
+      }),
+    }),
+  );
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toEqual({ success: true });
+  expect(repositoryReads).toBe(1);
+  expect(repositoryWrites).toBe(0);
+  expect(data.get("conversation")).toMatchObject({
+    agentId: AGENT_FIXTURE.id,
+    channelId: "room-1",
+    history: repositoryRow,
+    dirty: false,
+  });
+
+  const warmResponse = await object.fetch(
+    new Request("https://shared-runtime.internal/prewarm", {
+      method: "POST",
+      body: JSON.stringify({
+        operation: "prewarm",
+        agentId: AGENT_FIXTURE.id,
+        roomId: "room-1",
+      }),
+    }),
+  );
+  expect(warmResponse.status).toBe(200);
+  await warmResponse.arrayBuffer();
+  expect(repositoryReads).toBe(1);
+
+  const result = await makeInvoke(object)("first-real-turn");
+  expect(result).toMatchObject({ result: { historyLength: 2 } });
+  expect(repositoryReads).toBe(1);
+});
+
 test("warm coordinated turns use local history and mirror asynchronously", async () => {
   repositoryReads = 0;
   repositoryWrites = 0;

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -26,6 +26,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 type ConversationRequest =
   | { operation: "bridge"; agent: CachedAgentSandbox; rpc: BridgeRequest }
   | { operation: "stream"; agent: CachedAgentSandbox; rpc: BridgeRequest }
+  | { operation: "prewarm"; agentId: string; roomId: string }
   | { operation: "history"; agentId: string; roomId: string }
   | { operation: "delete"; agentId: string };
 
@@ -180,6 +181,33 @@ export class SharedRuntimeConversation {
     throw new ConversationCacheWarmingError();
   }
 
+  /**
+   * Join cold history hydration and load the modules used at turn ingress.
+   * This is deliberately read-only: voice startup can pay the exact room's
+   * initialization cost under its fixed greeting without landing a fake turn.
+   */
+  private async prewarmConversation(
+    agentId: string,
+    channelId: string,
+  ): Promise<void> {
+    try {
+      await this.loadConversation(agentId, channelId);
+    } catch (error) {
+      if (!(error instanceof ConversationCacheWarmingError)) throw error;
+      const hydration = this.hydration;
+      if (hydration) await hydration;
+    }
+    if (!this.conversation) {
+      throw new Error("Conversation prewarm failed to hydrate history.");
+    }
+    await this.runWithBindings(async () => {
+      await Promise.all([
+        import("@/lib/services/shared-runtime/shared-runtime-chat"),
+        import("@/lib/services/shared-runtime/cached-agent-dates"),
+      ]);
+    });
+  }
+
   private async mirrorConversation(
     snapshot: StoredConversation,
   ): Promise<void> {
@@ -301,6 +329,10 @@ export class SharedRuntimeConversation {
     const payload = (await request.json()) as ConversationRequest;
     const historyStore = this.historyStore();
     const turnClaims = this.turnClaims();
+    if (payload.operation === "prewarm") {
+      await this.prewarmConversation(payload.agentId, payload.roomId);
+      return Response.json({ success: true });
+    }
     if (payload.operation === "history") {
       const history = await this.runWithBindings(async () => {
         const { sharedRuntimeChatService } = await import(

--- a/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts
@@ -118,9 +118,17 @@ test("real cache + canonical coordinator dispatch performs no response-path DB w
   expect(response.status).toBe(200);
   await expect(response.text()).resolves.toContain("cache only");
   expect(background).toHaveLength(0);
-  expect(coordinatorCalls).toHaveLength(1);
-  expect(coordinatorCalls[0]?.name).toBe(`${AGENT_ID}:${CONVERSATION_ID}`);
-  expect(JSON.parse(String(coordinatorCalls[0]?.init?.body))).toMatchObject({
+  expect(coordinatorCalls).toHaveLength(2);
+  expect(coordinatorCalls.map(({ name }) => name)).toEqual([
+    `${AGENT_ID}:${CONVERSATION_ID}`,
+    `${AGENT_ID}:${CONVERSATION_ID}`,
+  ]);
+  expect(JSON.parse(String(coordinatorCalls[0]?.init?.body))).toEqual({
+    operation: "prewarm",
+    agentId: AGENT_ID,
+    roomId: CONVERSATION_ID,
+  });
+  expect(JSON.parse(String(coordinatorCalls[1]?.init?.body))).toMatchObject({
     operation: "stream",
     agent: cachedAgent,
     rpc: {

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -17,6 +17,7 @@ import {
   runWithCloudBindingsAsync,
 } from "@/lib/runtime/cloud-bindings";
 import { handleCanonicalScopedAgentStream } from "@/lib/services/shared-runtime/canonical-scoped-stream";
+import { coordinateSharedConversationPrewarm } from "@/lib/services/shared-runtime/conversation-coordinator";
 import type { BridgeExecutionContext } from "@/lib/services/shared-runtime/shared-runtime-chat";
 import { logger } from "@/lib/utils/logger";
 import type {
@@ -129,17 +130,27 @@ export function createInternalElizaConversationFetchFactory(
     };
 
     const prewarm = async (): Promise<void> => {
-      if (!env.SHARED_RUNTIME_CONVERSATIONS || !executionCtx) return;
+      const namespace = env.SHARED_RUNTIME_CONVERSATIONS;
+      if (!namespace || !executionCtx) return;
       await runWithCloudBindingsAsync(
         env as unknown as Record<string, unknown>,
         async () => {
-          if (await readCachedAgent()) return;
-          scheduleHydration();
-          // Capture before awaiting: the hydration's finally block clears the
-          // shared slot. Joining this exact promise lets the first voice turn
-          // use the freshly cached scope without cache-miss polling/backoff.
-          const pendingHydration = hydrationPromise;
-          if (pendingHydration) await pendingHydration;
+          let agent = await readCachedAgent();
+          if (!agent) {
+            scheduleHydration();
+            // Capture before awaiting: the hydration's finally block clears the
+            // shared slot. Joining this exact promise lets the first voice turn
+            // use the freshly cached scope without cache-miss polling/backoff.
+            const pendingHydration = hydrationPromise;
+            if (pendingHydration) await pendingHydration;
+            agent = await readCachedAgent();
+          }
+          if (!agent) return;
+          await coordinateSharedConversationPrewarm(
+            agent.id,
+            claims.conversationId,
+            { namespace },
+          );
         },
       );
     };

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
@@ -29,13 +29,14 @@ mock.module("../eliza-sandbox", () => ({
 
 const {
   coordinateSharedBridge,
+  coordinateSharedConversationPrewarm,
   coordinateSharedHistory,
   coordinateSharedStream,
   purgeSharedConversationRooms,
 } = await import("./conversation-coordinator");
 
 describe("shared conversation coordinator", () => {
-  test("routes bridge, stream, and history through one room object", async () => {
+  test("routes bridge, stream, prewarm, and history through one room object", async () => {
     const names: string[] = [];
     const envelopes: unknown[] = [];
     const signals: Array<AbortSignal | null | undefined> = [];
@@ -56,6 +57,9 @@ describe("shared conversation coordinator", () => {
               return Response.json({
                 history: [{ role: "assistant", content: "cached" }],
               });
+            }
+            if (envelope.operation === "prewarm") {
+              return Response.json({ success: true });
             }
             return Response.json({
               jsonrpc: "2.0",
@@ -93,17 +97,19 @@ describe("shared conversation coordinator", () => {
         })
       )?.text(),
     ).toContain("event: done");
+    await coordinateSharedConversationPrewarm("agent-1", "room-1", { namespace });
     expect(await coordinateSharedHistory("agent-1", "room-1", { namespace })).toEqual([
       { role: "assistant", content: "cached" },
     ]);
 
-    expect(names).toEqual(["agent-1:room-1", "agent-1:room-1", "agent-1:room-1"]);
+    expect(names).toEqual(["agent-1:room-1", "agent-1:room-1", "agent-1:room-1", "agent-1:room-1"]);
     expect(envelopes.map((value) => (value as { operation: string }).operation)).toEqual([
       "bridge",
       "stream",
+      "prewarm",
       "history",
     ]);
-    expect(signals).toEqual([undefined, abortController.signal, undefined]);
+    expect(signals).toEqual([undefined, abortController.signal, undefined, undefined]);
     expect(directBridge).not.toHaveBeenCalled();
     expect(directStream).not.toHaveBeenCalled();
     expect(directHistory).not.toHaveBeenCalled();
@@ -141,6 +147,13 @@ describe("shared conversation coordinator", () => {
     });
     await expect(
       coordinateSharedStream(agent, rpc, { namespace, executionCtx }),
+    ).rejects.toMatchObject({
+      name: "SharedRuntimeCacheWarmingError",
+    });
+    await expect(
+      coordinateSharedConversationPrewarm("agent-1", "room-1", {
+        namespace,
+      }),
     ).rejects.toMatchObject({
       name: "SharedRuntimeCacheWarmingError",
     });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -26,6 +26,30 @@ export interface SharedConversationHistoryCoordinatorOptions {
 }
 
 /**
+ * Hydrate one conversation object's read-only history and turn-ingress modules.
+ * Voice startup uses this under its fixed greeting; no message is created.
+ */
+export async function coordinateSharedConversationPrewarm(
+  agentId: string,
+  roomId: string,
+  options: SharedConversationHistoryCoordinatorOptions,
+): Promise<void> {
+  const namespace = requireHistoryCoordinator(options);
+  const response = await coordinatorStub(namespace, agentId, roomId).fetch(
+    "https://shared-runtime.internal/prewarm",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ operation: "prewarm", agentId, roomId }),
+    },
+  );
+  await requireCoordinatorResponse(response, "conversation prewarm");
+  // The Durable Object releases its per-room queue when the response body is
+  // consumed. Drain this tiny acknowledgement before the first real turn.
+  await response.arrayBuffer();
+}
+
+/**
  * One normalization for the Durable Object instance name. Turn dispatch and
  * history reads MUST agree — a whitespace/empty variant addressing a second
  * object would migrate the same Postgres row twice and serve a frozen copy.


### PR DESCRIPTION
## Summary

- prewarm the exact conversation Durable Object while the fixed phone greeting plays
- join cold history hydration and prime turn-ingress modules without creating a fake message or changing history
- drain the prewarm acknowledgement before releasing the per-room queue
- retain the existing cache-only authorization and first-turn fallback behavior

Closes #19450

## Verification

- `bun test packages/cloud/api/src/shared-runtime-conversation.test.ts` (8 pass)
- `bun test packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts` (6 pass)
- `bun test packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts` (4 pass)
- `bun run --cwd packages/cloud/api typecheck`
- `bun run verify:cloud` (78/78)

## Production evidence

Pre-change dual-channel Twilio recording: caller “hello” ends at 0.36s; Eliza response starts at 5.18s (4.82s silence). A post-deploy recording will be attached after merge/deployment.