### PR TITLE
docs(skills): point the app-auth login source-of-truth at the consolidated app

### DIFF
--- a/packages/skills/skills/eliza-cloud/references/cloud-backend-and-monetization.md
+++ b/packages/skills/skills/eliza-cloud/references/cloud-backend-and-monetization.md
@@ -142,4 +142,4 @@ Prefer these implementation surfaces:
 - `packages/cloud/api/v1/x402/requests/route.ts`
 - `packages/ui/src/cloud/applications/components/app-monetization-settings.tsx`
 - `packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx`
-- `packages/cloud-frontend/src/pages/login/` (app-auth OAuth is served by the cloud-frontend, not a `/api` route)
+- `packages/ui/src/cloud/public-pages/pages/login/` and `packages/ui/src/cloud/public-pages/pages/app-auth/` (app-auth OAuth login is served by the consolidated app's public pages, not a `/api` route)

--- a/packages/skills/skills/eliza-cloud/references/cloud-backend-and-monetization.md
+++ b/packages/skills/skills/eliza-cloud/references/cloud-backend-and-monetization.md
@@ -132,7 +132,7 @@ proxy only forwards unexpired hostnames minted by the Cloud Worker.
 
 Prefer these implementation surfaces:
 
-- `packages/cloud/shared/src/db/schemas/app-billing.ts`
+- `packages/cloud/shared/src/db/schemas/payment-requests.ts`
 - `packages/cloud/shared/src/db/schemas/apps.ts`
 - `packages/cloud/shared/src/db/schemas/redeemable-earnings.ts`
 - `packages/cloud/shared/src/lib/services/app-charge-requests.ts`


### PR DESCRIPTION
# Relates to

Delivers verified finding 6 from the #19170 post-merge review of #18996 (see the consolidated review comment there for the original evidence). No dedicated issue: one-line documentation repair with the defect already publicly documented and verified on #19170.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` — **see Known gaps: delegated to PR CI per operator hardware constraint; doc-only diff.**
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] Full `bun run verify` — delegated to PR CI; see Known gaps.

# Risks

**Negligible — one line in a runtime-loaded skill reference doc.** No code.

# Background

## What does this PR do?

The eliza-cloud skill's "Source Of Truth When Docs Drift" list still pointed its app-auth login bullet at `packages/cloud-frontend/src/pages/login/` — a package deleted by the #18996 consolidation (`git ls-tree` finds no `packages/cloud-frontend/` anywhere at tip). #18996's own diff rewrote the two sibling bullets in the same list to their new `packages/ui` locations but missed this one, so a runtime-loaded skill doc sent agents to a nonexistent package for "where does app-auth OAuth login live". The bullet now points at the real, verified locations — `packages/ui/src/cloud/public-pages/pages/login/` and `packages/ui/src/cloud/public-pages/pages/app-auth/` — with the parenthetical updated to match (served by the consolidated app's public pages).

A follow-up existence sweep over every bullet in the same source-of-truth list found one more stale entry: `schemas/app-billing.ts` does not exist in the tree; the app charge and x402 payment-request rows the doc's billing sections describe live in `schemas/payment-requests.ts`, and the second commit repoints that bullet. All nine remaining bullets verified to exist on this head.

## What kind of change is this?

Documentation fix.

# Documentation changes needed?

This is the documentation change.

# Testing

## Where should a reviewer start?

```bash
git ls-tree HEAD --name-only packages/ui/src/cloud/public-pages/pages/login/
```

## Detailed testing steps

Both replacement paths exist at tip (`login-page.tsx`, `steward-login-section.tsx`, … and `app-auth/app-authorize-page.tsx`); `packages/cloud-frontend/` does not. `packages/skills` package tests: 101 pass / 0 fail.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:6bf171d5e58ff8290969077dba62712aa767a005 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - one-line skill reference doc change; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - same reason as the before row.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - one-line documentation diff with no executable or rendered behavior to walk through.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — `N/A - no code runs.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs — `N/A - no code runs.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent, action, provider, prompt, or model behavior changes; the doc is loaded as reference material, not a prompt contract under test.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — path existence proof on the exact head:

<details>
<summary>the stale path is gone; the replacement paths are real</summary>

```
$ git ls-tree -r HEAD --name-only | grep -c '^packages/cloud-frontend/'
0

$ git ls-tree HEAD --name-only packages/ui/src/cloud/public-pages/pages/login/ | head -4
packages/ui/src/cloud/public-pages/pages/login/login-page.a11y.test.tsx
packages/ui/src/cloud/public-pages/pages/login/login-page.handoff.test.tsx
packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
packages/ui/src/cloud/public-pages/pages/login/login-section-skeleton.tsx

$ git ls-tree HEAD --name-only packages/ui/src/cloud/public-pages/pages/app-auth/ | head -2
packages/ui/src/cloud/public-pages/pages/app-auth/app-authorize-page.test.tsx
packages/ui/src/cloud/public-pages/pages/app-auth/app-authorize-page.tsx

$ bun test ./test   # packages/skills
 101 pass
 0 fail
```
</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface in the diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent behavior changes.`

## Backend + frontend logs

`N/A - documentation-only diff.`

## Screenshots (before / after) + video walkthrough

`N/A - documentation-only diff.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

- Full `bun run verify` delegated to PR CI per the recorded operator hardware constraint; the diff is one documentation line, with path-existence proof and the owning package's tests above.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
