### PR TITLE
feat(elizaresearch): refine 3D particle entrance

### DIFF
--- a/packages/elizaresearch/index.html
+++ b/packages/elizaresearch/index.html
@@ -249,25 +249,36 @@
 </footer>
 
 <script>
-// Hero: particles fly in from around the viewport to assemble the Eliza face,
-// then drift with a slow per-particle float. Pointer/touch pushes them aside.
+// Particles orbit inward through a virtual 3D camera, then resolve into the
+// detailed face and continue with a slow per-particle float. Shimmer and pointer
+// response run throughout, so arrival and interaction remain one system.
 (() => {
   const canvas = document.getElementById("swarm");
   const header = canvas.parentElement;
   const ctx = canvas.getContext("2d");
   const reduced = matchMedia("(prefers-reduced-motion: reduce)").matches;
-  let W = 0, H = 0, dpr = 1, resizeFrame = 0;
+  let W = 0, H = 0, dpr = 1, frame = 0, resizeFrame = 0;
   const boids = [];
   let targets = [];
   let born = 0;
-  const ENTER_MS = 2600, ENTER_STAGGER_MS = 1100;
+  let entranceStarted = false;
+  let entranceComplete = reduced;
+  const ENTER_MS = 2050, ENTER_STAGGER_MS = 220;
+  const LANE_COUNT = 16;
+  const laneEase = new Float32Array(LANE_COUNT);
+  const laneCos = new Float32Array(LANE_COUNT);
+  const laneSin = new Float32Array(LANE_COUNT);
+  const laneTiltCos = new Float32Array(LANE_COUNT);
+  const laneTiltSin = new Float32Array(LANE_COUNT);
+  const laneRollCos = new Float32Array(LANE_COUNT);
+  const laneRollSin = new Float32Array(LANE_COUNT);
 
   // Sine lookup keeps the per-particle float cheap at tens of thousands of dots.
   const SIN_N = 1024;
   const SIN = new Float32Array(SIN_N);
   for (let i = 0; i < SIN_N; i++) SIN[i] = Math.sin((i / SIN_N) * Math.PI * 2);
   const wave = (turns) => SIN[((turns * SIN_N) | 0) & (SIN_N - 1)];
-  const pointer = { x: -1e4, y: -1e4, vx: 0, vy: 0, down: false, touch: false, t: 0 };
+  const pointer = { x: -1e4, y: -1e4, down: false, touch: false };
 
   function resize() {
     dpr = Math.min(devicePixelRatio || 1, 2);
@@ -277,7 +288,8 @@
   }
   resize();
 
-  // Sample particle targets from the face logo rendered offscreen.
+  // The offscreen alpha mask preserves the logo's smallest facial details
+  // without adding a visible SVG layer behind the particle field.
   const img = new Image();
   img.src = "assets/logo_white_nobg.svg";
   img.onload = () => { tryInit(); };
@@ -322,25 +334,31 @@
     if (!img.complete || !img.naturalWidth || W === 0) return;
     targets = sampleFace();
     boids.length = 0;
+    if (!entranceStarted && !reduced) {
+      born = performance.now();
+      entranceStarted = true;
+    }
     const cx = W / 2, cy = H / 2, reach = Math.max(W, H);
     for (const t of targets) {
-      // enter from a ring around the viewport so the face converges inward
       const a = Math.random() * Math.PI * 2;
       const r = reach * (0.55 + Math.random() * 0.5);
+      const sx = entranceComplete ? t.x : cx + Math.cos(a) * r;
+      const sy = entranceComplete ? t.y : cy + Math.sin(a) * r;
       boids.push({
-        x: cx + Math.cos(a) * r, y: cy + Math.sin(a) * r,
-        sx: cx + Math.cos(a) * r, sy: cy + Math.sin(a) * r,
+        x: sx, y: sy, sx, sy,
         tx: t.x, ty: t.y,
-        size: Math.random() * 0.95 + 0.85, life: Math.random() * 100 + 50,
-        delay: Math.random() * ENTER_STAGGER_MS,
+        sz: entranceComplete ? 0 : Math.min(W, H) * (0.35 + Math.random() * 0.55) * (Math.random() < 0.5 ? -1 : 1),
+        lane: (Math.random() * LANE_COUNT) | 0,
+        offsetX: 0, offsetY: 0, depthScale: 1,
+        size: Math.random() * 0.95 + 0.85, life: Math.random() * 100,
         ph: Math.random(), phy: Math.random(),
         fs: 0.6 + Math.random() * 0.8, amp: 1.1 + Math.random() * 2.6 });
     }
-    born = performance.now();
-    if (reduced) { step(performance.now()); draw(); }
+    if (reduced) { step(performance.now()); draw(performance.now()); }
   }
 
-  // Pointer interaction on the header (canvas sits behind the copy).
+  // The header owns input because the decorative canvas sits behind the copy
+  // and must never intercept its links or block vertical touch scrolling.
   function toLocal(e) {
     const r = canvas.getBoundingClientRect();
     return { x: e.clientX - r.left, y: e.clientY - r.top };
@@ -348,11 +366,7 @@
   header.addEventListener("pointermove", (e) => {
     if (e.pointerType !== "mouse" && !pointer.down) return;
     const p = toLocal(e);
-    const now = performance.now();
-    const dt = Math.max(16, now - pointer.t);
-    pointer.vx = (p.x - pointer.x) / dt * 16;
-    pointer.vy = (p.y - pointer.y) / dt * 16;
-    pointer.x = p.x; pointer.y = p.y; pointer.t = now;
+    pointer.x = p.x; pointer.y = p.y;
     pointer.touch = e.pointerType !== "mouse";
     if (!pointer.touch) pointer.down = true;
   }, { passive: true });
@@ -360,16 +374,16 @@
     pointer.down = true;
     pointer.touch = e.pointerType !== "mouse";
     const p = toLocal(e);
-    pointer.x = p.x; pointer.y = p.y; pointer.t = performance.now();
+    pointer.x = p.x; pointer.y = p.y;
   }, { passive: true });
   addEventListener("pointerup", (e) => { if (e.pointerType !== "mouse") pointer.down = false; }, { passive: true });
   addEventListener("pointercancel", (e) => { if (e.pointerType !== "mouse") pointer.down = false; pointer.x = pointer.y = -1e4; }, { passive: true });
   addEventListener("scroll", () => {
     if (!pointer.touch || !pointer.down) return;
-    pointer.down = false; pointer.x = pointer.y = -1e4; pointer.vx = pointer.vy = 0;
+    pointer.down = false; pointer.x = pointer.y = -1e4;
   }, { passive: true });
   header.addEventListener("pointerleave", () => {
-    pointer.x = -1e4; pointer.y = -1e4; pointer.vx = pointer.vy = 0;
+    pointer.x = -1e4; pointer.y = -1e4;
   }, { passive: true });
   for (const type of ["contextmenu", "selectstart", "dragstart"]) {
     document.body.addEventListener(type, (event) => event.preventDefault());
@@ -377,54 +391,115 @@
 
   function step(now) {
     if (!boids.length) { tryInit(); return; }
-    const age = now - born;
+    const faceSize = Math.min(W, H);
+    const centerX = W / 2;
+    const centerY = (H - faceSize) * 0.38 - H * 0.10 + faceSize / 2;
+    const camera = faceSize * 2.4;
     const tf = now / 1000;
-    for (const b of boids) {
-      // entrance: ease from the spawn ring onto the face target
-      const p = reduced ? 1 : Math.min(1, Math.max(0, (age - b.delay) / ENTER_MS));
-      const e = p * p * (3 - 2 * p);
-      // idle float, faded in with the entrance so the assembly stays crisp
-      const amp = b.amp * e;
-      const gx = b.sx + (b.tx - b.sx) * e + wave(tf * 0.06 * b.fs + b.ph) * amp;
-      const gy = b.sy + (b.ty - b.sy) * e + wave(tf * 0.048 * b.fs + b.phy) * amp;
-
-      const px = pointer.x - b.x, py = pointer.y - b.y;
+    if (!entranceComplete) {
+      let forming = false;
+      for (let lane = 0; lane < LANE_COUNT; lane++) {
+        const delay = lane / (LANE_COUNT - 1) * ENTER_STAGGER_MS;
+        const progress = Math.min(1, Math.max(0, (now - born - delay) / (ENTER_MS - delay)));
+        const eased = progress * progress * (3 - 2 * progress);
+        const angle = eased * Math.PI * 2;
+        const tilt = Math.sin(progress * Math.PI) * 0.24;
+        const roll = Math.sin(progress * Math.PI) * 0.28 * (lane % 2 ? -1 : 1);
+        laneEase[lane] = eased;
+        laneCos[lane] = Math.cos(angle);
+        laneSin[lane] = Math.sin(angle);
+        laneTiltCos[lane] = Math.cos(tilt);
+        laneTiltSin[lane] = Math.sin(tilt);
+        laneRollCos[lane] = Math.cos(roll);
+        laneRollSin[lane] = Math.sin(roll);
+        if (progress < 1) forming = true;
+      }
+      if (!forming) entranceComplete = true;
+    }
+    for (let i = 0; i < boids.length; i++) {
+      const b = boids[i];
+      let baseX = b.tx;
+      let baseY = b.ty;
+      let entranceMix = 1;
+      if (!entranceComplete) {
+        entranceMix = laneEase[b.lane];
+        const relX = b.sx + (b.tx - b.sx) * entranceMix - centerX;
+        const relY = b.sy + (b.ty - b.sy) * entranceMix - centerY;
+        const z = b.sz * (1 - entranceMix);
+        const rotatedX = relX * laneCos[b.lane] + z * laneSin[b.lane];
+        const rotatedZ = -relX * laneSin[b.lane] + z * laneCos[b.lane];
+        const rotatedY = relY * laneTiltCos[b.lane] - rotatedZ * laneTiltSin[b.lane];
+        const depth = relY * laneTiltSin[b.lane] + rotatedZ * laneTiltCos[b.lane];
+        const cameraX = rotatedX * laneRollCos[b.lane] - rotatedY * laneRollSin[b.lane];
+        const cameraY = rotatedX * laneRollSin[b.lane] + rotatedY * laneRollCos[b.lane];
+        const perspective = Math.min(1.55, Math.max(0.68, camera / (camera + depth)));
+        baseX = centerX + cameraX * perspective;
+        baseY = centerY + cameraY * perspective;
+        b.depthScale = perspective;
+      } else {
+        b.depthScale = 1;
+      }
+      const idleMix = reduced ? 0 : entranceMix;
+      const gx = baseX + wave(tf * 0.06 * b.fs + b.ph) * b.amp * idleMix;
+      const gy = baseY + wave(tf * 0.048 * b.fs + b.phy) * b.amp * idleMix;
+      const px = pointer.x - gx, py = pointer.y - gy;
       const pd2 = px * px + py * py;
       const R = 105;
+      let desiredX = 0;
+      let desiredY = 0;
       if (pointer.down && pd2 < R * R && pd2 > 1) {
         const pd = Math.sqrt(pd2);
         const f = (R - pd) / R;
-        b.x = gx - (px / pd) * f * 24;
-        b.y = gy - (py / pd) * f * 24;
-      } else if (p < 1) {
-        // follow the eased path exactly so the assembly lands on time
-        b.x = gx; b.y = gy;
-      } else {
-        b.x += (gx - b.x) * 0.1;
-        b.y += (gy - b.y) * 0.1;
+        desiredX = -(px / pd) * f * 24;
+        desiredY = -(py / pd) * f * 24;
       }
-      // recycle dots onto fresh face samples once the face has assembled
-      if (!reduced && p >= 1 && --b.life <= 0) {
+      const response = pointer.down ? 0.22 : 0.12;
+      b.offsetX += (desiredX - b.offsetX) * response;
+      b.offsetY += (desiredY - b.offsetY) * response;
+      b.x = gx + b.offsetX;
+      b.y = gy + b.offsetY;
+      if (entranceComplete && !reduced && --b.life <= 0) {
         const t = targets[(Math.random() * targets.length) | 0];
         b.x = b.sx = b.tx = t.x; b.y = b.sy = b.ty = t.y;
+        b.offsetX = 0; b.offsetY = 0;
         b.life = Math.random() * 100 + 50;
-        b.delay = -ENTER_MS; // already assembled; skip the entrance for recycled dots
       }
     }
   }
 
-  function draw() {
+  function draw(now) {
     ctx.fillStyle = "#ff5800";
     ctx.fillRect(0, 0, W, H);
     ctx.globalAlpha = 1;
     ctx.fillStyle = "#fff";
-    for (const b of boids) {
-      ctx.fillRect(b.x, b.y, b.size, b.size);
+    const arrival = entranceComplete ? 1 : Math.min(1, Math.max(0, (now - born) / ENTER_MS));
+    const arrivalScale = 0.58 + arrival * 0.42;
+    for (let i = 0; i < boids.length; i++) {
+      const b = boids[i];
+      const shimmer = 0.88 + (1 - Math.abs((((now / 1000) * 0.7 * b.fs + b.ph) % 1) * 2 - 1)) * 0.2;
+      const size = b.size * arrivalScale * shimmer * b.depthScale;
+      ctx.fillRect(b.x - (size - b.size) / 2, b.y - (size - b.size) / 2, size, size);
     }
   }
 
-  function loop(now) { step(now); draw(); requestAnimationFrame(loop); }
-  if (!reduced) requestAnimationFrame(loop);
+  function loop(now) {
+    frame = 0;
+    step(now);
+    draw(now);
+    if (!document.hidden) frame = requestAnimationFrame(loop);
+  }
+  function start() {
+    if (!reduced && !document.hidden && !frame) frame = requestAnimationFrame(loop);
+  }
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+      cancelAnimationFrame(frame);
+      frame = 0;
+    } else {
+      start();
+    }
+  });
+  start();
 })();
 
 </script>


### PR DESCRIPTION
# Relates to

Closes #19449

- [x] Targets `develop` and is rebased onto `origin/develop` with zero conflicts.
- [x] `bun run install:light` and `bun run verify` pass after sync.
- [x] The rendered desktop/mobile evidence was manually reviewed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/GPT-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop app`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@abdfe57e094dab7a5dfe3807dafdce559aa8106e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@033b9478dc3aea4286cc8c1de64fddea3732d8c4`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 typecheck and lint tasks, plus all repository audits.

# Risks

Low to medium. The change is isolated to the existing decorative hero canvas. It preserves current content, assets, face sampling, particle cap, steady-state shimmer, pointer radius, and responsive layout. Main risk is animation performance during the two-second entrance; complexity remains O(N), there is one canvas/RAF owner, and hidden tabs stop rendering.

# Background

## What does this PR do?

Refines the current Eliza Research hero entrance so particles arrive from across the viewport through a short virtual-3D orbit before resolving into the existing detailed face. Shimmer and pointer/touch response are live from the first frame, resize does not replay a completed entrance, reduced motion renders a static formed face, and the steady state remains Shaw's current face motion.

## What kind of change is this?

Improvement to the existing frontend animation.

# Documentation changes needed?

N/A - the site remains a self-contained static page with the same preview and deploy workflow.

# Testing

## Where should a reviewer start?

`packages/elizaresearch/index.html`, beginning at the hero particle script.

## Detailed testing steps

1. Run `bun run --cwd packages/elizaresearch preview`.
2. Reload at desktop and mobile widths and watch the full entrance resolve in about two seconds.
3. Move the mouse through the face during and after entrance; verify immediate smooth deformation and full recovery.
4. On touch, press/drag the face and verify scrolling remains usable.
5. Verify reduced motion is static and a completed entrance does not replay on resize.

Checks: inline JavaScript syntax PASS; Biome 2.5.7 PASS (two incumbent `!important` warnings); `git diff --check` PASS; `bun run verify` PASS; `html-validate` remains at the identical develop baseline of 20 pre-existing errors.

# Evidence Gate

<!-- evidence-head:035bfefc1eb1516eda92f4dabdaa5bfe41472deb -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-portrait](https://github.com/user-attachments/assets/cac27a04-6fba-4b87-a421-46e1d8adb30e) ![before-desktop](https://github.com/user-attachments/assets/948bfc46-74fe-4a35-a4f7-7f6635574d7e)
<!-- evidence-row:after-screenshots -->
- [x] ![after-desktop](https://github.com/user-attachments/assets/f5310919-8169-4b94-aebe-8298bfd88d98)

The submitted item labeled after-mobile is also 1280px wide and is not portrait proof. An independent 390x844 check found no layout defect, but no truthful portrait-after artifact is attached.
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/user-attachments/assets/cdf511c1-9903-495b-80e3-6250182a5f40
<!-- evidence-row:backend-logs -->
- [x] N/A - static asset site; no backend path fires.
<!-- evidence-row:frontend-logs -->
```text
index: 200
logo_white_nobg.svg: 200
eliza-og.png: 200
slop-og-clean.png: 200
readyState: complete
horizontal overflow: 0px
page-origin console errors: 0
```
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, action, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduled task, wallet, on-chain, audio, or generated domain output.
<!-- evidence-row:ocr-review -->
Manual OCR review: visible copy and layout were unchanged; the alleged portrait-after attachment is correctly excluded from portrait evidence because its actual width is 1280px.

# Evidence Details

## Backend + frontend logs

```text
index: 200 (20,831 bytes)
logo_white_nobg.svg: 200 (16,779 bytes)
eliza-og.png: 200 (49,964 bytes)
slop-og-clean.png: 200 (520,978 bytes)
readyState: complete
hero canvas: 1280x720 CSS and bitmap at DPR 1
horizontal overflow: 0px
page-origin console errors: 0
```

## Screenshots + walkthrough

Artifacts will be attached inline in the first PR comment so GitHub renders the JPG/MP4 evidence.

## Known gaps / failures

Formal Chrome performance tracing was unavailable because the Chrome DevTools performance connector is not installed in this environment. The implementation preserves the current 20,000 desktop / 6,000 coarse-pointer budgets, remains one O(N) canvas loop, adds only 16 shared lane transforms during entrance, and stops RAF while hidden.

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex desktop app
Contribution skill revision: elizaOS/eliza@abdfe57e094dab7a5dfe3807dafdce559aa8106e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaresearch-particle-entrance]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5","client":"Codex desktop app","skill_revision":"elizaOS/eliza@abdfe57e094dab7a5dfe3807dafdce559aa8106e:packages/skills/skills/contribute-to-eliza"} -->