### PR TITLE
fix(voice): authenticate Railway browser roundtrip

### DIFF
--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -192,6 +192,7 @@ jobs:
       WHISPER_STT_URL: ${{ vars.ELIZA_VOICE_WHISPER_STT_URL }}
       WHISPER_STT_MODEL: ${{ vars.ELIZA_VOICE_WHISPER_STT_MODEL }}
       CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+      ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZACLOUD_API_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -206,11 +207,15 @@ jobs:
           docker system prune -af || true
           df -h /
 
-      - name: Require a live model credential
+      - name: Require live model and Cloud credentials
         run: |
           set -euo pipefail
           if [ -z "${CEREBRAS_API_KEY:-}" ]; then
             echo "::error::The web Railway voice lane requires the provisioned CEREBRAS_API_KEY live model credential."
+            exit 1
+          fi
+          if [ -z "${ELIZAOS_CLOUD_API_KEY:-}" ]; then
+            echo "::error::The web Railway voice lane requires ELIZACLOUD_API_KEY so the app's authenticated Cloud STT/TTS proxies can reach Railway."
             exit 1
           fi
 

--- a/packages/app-core/scripts/voice/__tests__/voice-matrix.test.ts
+++ b/packages/app-core/scripts/voice/__tests__/voice-matrix.test.ts
@@ -1,21 +1,23 @@
-// Exercises tests voice matrix.test automation behavior with deterministic script fixtures.
-import { describe, expect, test } from "vitest";
+/** Exercises voice-matrix CLI selection and gating with deterministic subprocess fixtures. */
+
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
 
 const scriptPath = fileURLToPath(
   new URL("../voice-matrix.mjs", import.meta.url),
 );
 const repoRoot = path.resolve(path.dirname(scriptPath), "..", "..", "..", "..");
 
-function runVoiceMatrix(args: string[]) {
+function runVoiceMatrix(args: string[], env: NodeJS.ProcessEnv = {}) {
   const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "voice-matrix-"));
   const result = spawnSync("node", [scriptPath, ...args, "--out", outDir], {
     cwd: repoRoot,
     encoding: "utf8",
+    env: { ...process.env, ...env },
   });
   const reportPath = path.join(outDir, "voice-matrix.json");
   const report = fs.existsSync(reportPath)
@@ -55,5 +57,44 @@ describe("voice matrix CLI", () => {
     });
     expect(report.cells).toHaveLength(1);
     expect(report.cells[0].id).toBe("ios.sim-or-device.voice-roundtrip");
+  });
+
+  test("isolates the live Railway browser test and requires both credentials", () => {
+    const missingCloud = runVoiceMatrix(
+      ["--platform", "web.live.railway-roundtrip"],
+      {
+        ELIZA_VOICE_LIVE_RAILWAY: "1",
+        CEREBRAS_API_KEY: "test-model-key",
+        ELIZAOS_CLOUD_API_KEY: "",
+      },
+    );
+
+    expect(missingCloud.result.status).toBe(0);
+    expect(missingCloud.report.cells[0].probe).toEqual({
+      available: false,
+      reason:
+        "ELIZAOS_CLOUD_API_KEY is required for the live Railway browser round-trip",
+    });
+
+    const provisioned = runVoiceMatrix(
+      ["--platform", "web.live.railway-roundtrip"],
+      {
+        ELIZA_VOICE_LIVE_RAILWAY: "1",
+        CEREBRAS_API_KEY: "test-model-key",
+        ELIZAOS_CLOUD_API_KEY: "test-cloud-key",
+      },
+    );
+
+    expect(provisioned.report.cells[0].command).toEqual([
+      "bun",
+      "run",
+      "--cwd",
+      "packages/app",
+      "test:e2e",
+      "test/ui-smoke/voice-realaudio.spec.ts",
+      "--grep",
+      "live cloud voice round-trip",
+    ]);
+    expect(provisioned.report.cells[0].probe.available).toBe(true);
   });
 });

--- a/packages/app-core/scripts/voice/__tests__/voice-matrix.test.ts
+++ b/packages/app-core/scripts/voice/__tests__/voice-matrix.test.ts
@@ -95,6 +95,10 @@ describe("voice matrix CLI", () => {
       "--grep",
       "live cloud voice round-trip",
     ]);
+    expect(provisioned.report.cells[0].env).toMatchObject({
+      ELIZA_UI_SMOKE_CLOUD_LIVE: "1",
+      ELIZA_UI_SMOKE_SKIP_BUILD: "1",
+    });
     expect(provisioned.report.cells[0].probe.available).toBe(true);
   });
 });

--- a/packages/app-core/scripts/voice/voice-matrix.mjs
+++ b/packages/app-core/scripts/voice/voice-matrix.mjs
@@ -96,6 +96,8 @@ const CELLS = [
       "packages/app",
       "test:e2e",
       "test/ui-smoke/voice-realaudio.spec.ts",
+      "--grep",
+      "live cloud voice round-trip",
     ],
     env: UI_SMOKE_MATRIX_ENV,
     evidence: ["packages/app/test-results", "e2e-recordings/app/test-results"],
@@ -390,7 +392,10 @@ const CELLS = [
       voices: "multi-speaker",
     },
     class: "wakeword-device-gap",
-    command: ["node", "packages/app-core/scripts/voice/voice-openwakeword-eval.mjs"],
+    command: [
+      "node",
+      "packages/app-core/scripts/voice/voice-openwakeword-eval.mjs",
+    ],
     evidence: [
       "$ELIZA_VOICE_MATRIX_OUT/wake.openwakeword.real-head/openwakeword-eval.json",
       "$ELIZA_VOICE_OPENWAKEWORD_REPORT",
@@ -698,6 +703,14 @@ function probeCell(cell) {
           reason:
             "set ELIZA_VOICE_LIVE_RAILWAY=1 with reachable Railway STT/TTS + a live LLM key",
         };
+      }
+      for (const key of ["CEREBRAS_API_KEY", "ELIZAOS_CLOUD_API_KEY"]) {
+        if (!process.env[key]?.trim()) {
+          return {
+            available: false,
+            reason: `${key} is required for the live Railway browser round-trip`,
+          };
+        }
       }
       return {
         available: true,

--- a/packages/app-core/scripts/voice/voice-matrix.mjs
+++ b/packages/app-core/scripts/voice/voice-matrix.mjs
@@ -99,7 +99,12 @@ const CELLS = [
       "--grep",
       "live cloud voice round-trip",
     ],
-    env: UI_SMOKE_MATRIX_ENV,
+    env: {
+      ...UI_SMOKE_MATRIX_ENV,
+      // createLiveRuntimeChildEnv preserves the Cloud media credential beside
+      // the isolated Cerebras brain only for an explicitly Cloud-live lane.
+      ELIZA_UI_SMOKE_CLOUD_LIVE: "1",
+    },
     evidence: ["packages/app/test-results", "e2e-recordings/app/test-results"],
     probe: "webLiveRailway",
   },

--- a/packages/app/test/ui-smoke/voice-realaudio.spec.ts
+++ b/packages/app/test/ui-smoke/voice-realaudio.spec.ts
@@ -923,7 +923,11 @@ test.describe("live cloud voice round-trip (Railway path)", () => {
     }
 
     const asrResponsePromise = page.waitForResponse(
-      (response) => response.url().includes("/api/asr/cloud"),
+      // The product client deliberately retries the deferred runtime's
+      // `feature_starting` 503. Observe the settled request rather than
+      // treating the first readiness probe as the transcription result.
+      (response) =>
+        response.url().includes("/api/asr/cloud") && response.status() !== 503,
       { timeout: 60_000 },
     );
 

--- a/packages/app/test/ui-smoke/voice-realaudio.spec.ts
+++ b/packages/app/test/ui-smoke/voice-realaudio.spec.ts
@@ -21,7 +21,7 @@
  *
  *   bun run --cwd packages/app test:e2e test/ui-smoke/voice-realaudio.spec.ts
  */
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Page, type Response, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,
   openAppPath,
@@ -635,6 +635,27 @@ async function installCloudVoiceConfig(page: Page): Promise<void> {
   });
 }
 
+async function describeVoiceRouteFailure(response: Response): Promise<string> {
+  // error-policy:J6 diagnostic capture — the live assertion remains the
+  // failure authority. Only structured error/message text is retained;
+  // arbitrary response bodies and credential-shaped values stay out of logs.
+  const body = (await response.json().catch(() => null)) as {
+    error?: unknown;
+    message?: unknown;
+  } | null;
+  const detail =
+    typeof body?.error === "string"
+      ? body.error
+      : typeof body?.message === "string"
+        ? body.message
+        : "<structured error body unavailable>";
+  const preview = detail
+    .replace(/\s+/g, " ")
+    .replace(/\b(?:eliza|sk)_[a-z0-9_-]{8,}\b/gi, "[REDACTED]")
+    .slice(0, 500);
+  return `${new URL(response.url()).pathname} HTTP ${response.status()}: ${preview}`;
+}
+
 /** Count POSTs to a client route (ignoring the `/status` probe siblings). */
 function countPosts(page: Page, needle: string): { get: () => number } {
   let n = 0;
@@ -901,27 +922,10 @@ test.describe("live cloud voice round-trip (Railway path)", () => {
       await page.unroute(r).catch(() => {});
     }
 
-    let asrTranscript = "";
-    let ttsBytes = 0;
-    let ttsContentType = "";
-    let ttsAudio: Buffer | null = null;
-    page.on("response", async (res) => {
-      const url = res.url();
-      if (url.includes("/api/asr/cloud") && res.ok()) {
-        // error-policy:J6 diagnostic capture — a failed body read must not mask
-        // the assertion below, which fails loudly on an empty transcript.
-        const json = (await res.json().catch(() => null)) as {
-          text?: unknown;
-        } | null;
-        if (typeof json?.text === "string") asrTranscript = json.text;
-      }
-      if (url.includes("/api/tts/cloud") && res.ok()) {
-        ttsContentType = res.headers()["content-type"] ?? "";
-        const body = await res.body().catch(() => Buffer.alloc(0));
-        ttsBytes = body.byteLength;
-        ttsAudio = body;
-      }
-    });
+    const asrResponsePromise = page.waitForResponse(
+      (response) => response.url().includes("/api/asr/cloud"),
+      { timeout: 60_000 },
+    );
 
     await openAppPath(page, "/chat");
     await expect(page.getByTestId("chat-overlay")).toBeVisible({
@@ -939,21 +943,33 @@ test.describe("live cloud voice round-trip (Railway path)", () => {
     await page.waitForTimeout(2500);
     await mic.click();
 
-    // Real cloud STT returned the injected phrase (the fixture speaks it).
-    await expect
-      .poll(() => asrTranscript.toLowerCase(), {
-        timeout: 60_000,
-        message: "cloud STT must transcribe the injected known phrase",
-      })
-      .toContain("time");
+    const asrResponse = await asrResponsePromise;
+    expect(asrResponse.ok(), await describeVoiceRouteFailure(asrResponse)).toBe(
+      true,
+    );
+    const asrJson = (await asrResponse.json()) as { text?: unknown };
+    const asrTranscript = typeof asrJson.text === "string" ? asrJson.text : "";
+    expect(
+      asrTranscript.toLowerCase(),
+      "cloud STT must transcribe the injected known phrase",
+    ).toContain("time");
 
     // Real cloud TTS returned decoded, non-silent audio that actually played.
-    await expect
-      .poll(() => ttsBytes, {
-        timeout: 60_000,
-        message: "cloud TTS must return a non-trivial audio body",
-      })
-      .toBeGreaterThan(2000);
+    const ttsResponsePromise = page.waitForResponse(
+      (response) => response.url().includes("/api/tts/cloud"),
+      { timeout: 120_000 },
+    );
+    const ttsResponse = await ttsResponsePromise;
+    expect(ttsResponse.ok(), await describeVoiceRouteFailure(ttsResponse)).toBe(
+      true,
+    );
+    const ttsContentType = ttsResponse.headers()["content-type"] ?? "";
+    const ttsAudio = await ttsResponse.body();
+    const ttsBytes = ttsAudio.byteLength;
+    expect(
+      ttsBytes,
+      "cloud TTS must return a non-trivial audio body",
+    ).toBeGreaterThan(2000);
     expect(ttsContentType).toContain("audio");
     await expect
       .poll(async () => (await readAudioProbe(page)).starts, {

--- a/packages/ui/src/voice/local-asr-transcribe.test.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.test.ts
@@ -277,6 +277,65 @@ describe("transcribeCloudWav", () => {
     expect(fetchWithCsrfMock).toHaveBeenCalledTimes(2);
   });
 
+  it("waits for a deferred cloud STT route that is still starting", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchWithCsrfMock
+        .mockResolvedValueOnce(
+          jsonResponse({ error: "feature_starting" }, false, 503),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({ error: "feature_starting" }, false, 503),
+        )
+        .mockResolvedValueOnce(jsonResponse({ text: "runtime ready" }));
+
+      const pending = transcribeCloudWav(new Uint8Array([1]));
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      await expect(pending).resolves.toBe("runtime ready");
+      expect(fetchWithCsrfMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops the startup wait immediately when the caller cancels", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchWithCsrfMock.mockResolvedValue(
+        jsonResponse({ error: "feature_starting" }, false, 503),
+      );
+      const controller = new AbortController();
+      const pending = transcribeCloudWav(new Uint8Array([1]), {
+        signal: controller.signal,
+      });
+      await Promise.resolve();
+      controller.abort();
+
+      await expect(pending).rejects.toThrow(/cancelled/);
+      expect(fetchWithCsrfMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails loud when deferred route startup exceeds the bounded window", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchWithCsrfMock.mockResolvedValue(
+        jsonResponse({ error: "feature_starting" }, false, 503),
+      );
+      const pending = transcribeCloudWav(new Uint8Array([1]));
+      const assertion = expect(pending).rejects.toThrow(/feature_starting/);
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await assertion;
+      expect(fetchWithCsrfMock).toHaveBeenCalledTimes(31);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does NOT retry a terminal 4xx client error (#voice-V4)", async () => {
     fetchWithCsrfMock.mockResolvedValue(
       jsonResponse({ error: "no api key" }, false, 401),

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -55,11 +55,18 @@ export interface TranscribeCloudWavOptions extends TranscribeWavOptions {
 export class CloudSttError extends Error {
   /** HTTP status when the failure was a response; `undefined` for transport/timeout. */
   readonly status?: number;
+  /** Machine-readable server error code when the response provides one. */
+  readonly code?: string;
   /** True when this failure class is safe to retry once (network/timeout/5xx/429). */
   readonly retryable: boolean;
   constructor(
     message: string,
-    opts: { status?: number; retryable: boolean; cause?: unknown },
+    opts: {
+      status?: number;
+      code?: string;
+      retryable: boolean;
+      cause?: unknown;
+    },
   ) {
     super(
       message,
@@ -67,8 +74,47 @@ export class CloudSttError extends Error {
     );
     this.name = "CloudSttError";
     this.status = opts.status;
+    this.code = opts.code;
     this.retryable = opts.retryable;
   }
+}
+
+const CLOUD_STT_STARTING_RETRY_LIMIT = 30;
+const CLOUD_STT_STARTING_RETRY_DELAY_MS = 1_000;
+
+function readCloudSttErrorCode(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body) as { code?: unknown; error?: unknown };
+    if (typeof parsed.code === "string") return parsed.code;
+    return typeof parsed.error === "string" ? parsed.error : undefined;
+  } catch {
+    // error-policy:J3 an unparseable diagnostic body has no machine-readable
+    // code; status-based retry classification remains authoritative.
+    return undefined;
+  }
+}
+
+async function waitForCloudSttStartup(signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    throw new CloudSttError("Cloud ASR request was cancelled", {
+      retryable: false,
+    });
+  }
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(
+        new CloudSttError("Cloud ASR request was cancelled", {
+          retryable: false,
+        }),
+      );
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, CLOUD_STT_STARTING_RETRY_DELAY_MS);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 /** HTTP statuses worth one automatic retry (transient upstream/transport). */
@@ -170,6 +216,9 @@ function bytesToBase64(bytes: Uint8Array): string {
  * failure (transport error, timeout, 5xx, 429) so a flaky-cellular STT doesn't
  * hard-fail the turn on the first hiccup. Terminal client errors (401/402/413)
  * and an empty transcript are NOT retried — retrying won't change the outcome.
+ * A dedicated runtime's explicit `feature_starting` response gets its own
+ * bounded 30-second readiness window so an immediate post-launch mic tap waits
+ * for deferred route registration instead of firing two back-to-back failures.
  * A caller-initiated abort (`options.signal`) is honored immediately and never
  * retried.
  */
@@ -271,7 +320,11 @@ export async function transcribeCloudWav(
         const body = await res.text().catch(() => "");
         throw new CloudSttError(
           `Cloud ASR ${res.status}: ${body.slice(0, 200)}`,
-          { status: res.status, retryable: isRetryableStatus(res.status) },
+          {
+            status: res.status,
+            code: readCloudSttErrorCode(body),
+            retryable: isRetryableStatus(res.status),
+          },
         );
       }
       // error-policy:J3 unparseable body falls through to the empty-transcript
@@ -323,18 +376,32 @@ export async function transcribeCloudWav(
     }
   };
 
-  try {
-    return await attempt();
-  } catch (err) {
-    // One auto-retry on a network-class failure, unless the caller cancelled.
-    if (
-      err instanceof CloudSttError &&
-      err.retryable &&
-      !callerSignal?.aborted
-    ) {
+  let transientRetries = 0;
+  let startingRetries = 0;
+  for (;;) {
+    try {
       return await attempt();
+    } catch (err) {
+      if (!(err instanceof CloudSttError)) throw err;
+      if (callerSignal?.aborted) {
+        throw new CloudSttError("Cloud ASR request was cancelled", {
+          retryable: false,
+          cause: err,
+        });
+      }
+      if (err.code === "feature_starting") {
+        if (startingRetries >= CLOUD_STT_STARTING_RETRY_LIMIT) throw err;
+        startingRetries++;
+        await waitForCloudSttStartup(callerSignal);
+        continue;
+      }
+      // One auto-retry on an ordinary network-class failure.
+      if (err.retryable && transientRetries < 1) {
+        transientRetries++;
+        continue;
+      }
+      throw err;
     }
-    throw err;
   }
 }
 

--- a/plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts
+++ b/plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts
@@ -7,10 +7,13 @@
  * `ELIZA_TTS_DEBUG` contract (phases observably emitted on the structured
  * logger when the flag is set, silent otherwise).
  */
-import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type http from "node:http";
 import { addLogListener, type LogEntry } from "@elizaos/core";
-import { handleCloudTtsPreviewRoute } from "./server-cloud-tts";
+import {
+  handleCloudSttRoute,
+  handleCloudTtsPreviewRoute,
+} from "./server-cloud-tts";
 
 // The logger freezes its level at module init and the repo test setup defaults
 // LOG_LEVEL to "error", which would gate the info-level tts lines (and their
@@ -22,6 +25,7 @@ vi.hoisted(() => {
 });
 
 const prevApiKey = process.env.ELIZAOS_CLOUD_API_KEY;
+const prevConfigPath = process.env.ELIZA_CONFIG_PATH;
 const prevTtsDebug = process.env.ELIZA_TTS_DEBUG;
 const realFetch = globalThis.fetch;
 
@@ -105,6 +109,7 @@ function fakeRes(): {
 
 beforeEach(() => {
   process.env.ELIZAOS_CLOUD_API_KEY = "test-cloud-key";
+  process.env.ELIZA_CONFIG_PATH = "/nonexistent/server-cloud-tts-test.json";
   upstream = [];
   upstreamResponse = () =>
     new Response(new Uint8Array([73, 68, 51]), {
@@ -118,7 +123,12 @@ beforeEach(() => {
     upstream.push({
       url: String(input),
       headers: (init?.headers ?? {}) as Record<string, string>,
-      body: init?.body ? JSON.parse(String(init.body)) : null,
+      body:
+        init?.body instanceof FormData
+          ? init.body
+          : init?.body
+            ? JSON.parse(String(init.body))
+            : null,
     });
     return upstreamResponse();
   }) as typeof fetch;
@@ -128,8 +138,14 @@ afterAll(() => {
   globalThis.fetch = realFetch;
   if (prevApiKey === undefined) delete process.env.ELIZAOS_CLOUD_API_KEY;
   else process.env.ELIZAOS_CLOUD_API_KEY = prevApiKey;
+  if (prevConfigPath === undefined) delete process.env.ELIZA_CONFIG_PATH;
+  else process.env.ELIZA_CONFIG_PATH = prevConfigPath;
   if (prevTtsDebug === undefined) delete process.env.ELIZA_TTS_DEBUG;
   else process.env.ELIZA_TTS_DEBUG = prevTtsDebug;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("handleCloudTtsPreviewRoute (/api/tts/cloud proxy)", () => {
@@ -236,6 +252,89 @@ describe("handleCloudTtsPreviewRoute (/api/tts/cloud proxy)", () => {
     expect(JSON.parse(String(state.body))).toMatchObject({
       error: "Insufficient credits",
     });
+  });
+
+  test("retries an explicit cache-warming 503 before returning audio", async () => {
+    let calls = 0;
+    upstreamResponse = () => {
+      calls++;
+      return calls === 1
+        ? new Response(
+            JSON.stringify({
+              code: "service_unavailable",
+              details: { retryable: true, retryAfterSeconds: 1 },
+            }),
+            { status: 503 },
+          )
+        : new Response(new Uint8Array([73, 68, 51]), {
+            status: 200,
+            headers: { "content-type": "audio/mpeg" },
+          });
+    };
+    vi.useFakeTimers();
+
+    const { res, state } = fakeRes();
+    const handled = handleCloudTtsPreviewRoute(
+      fakeReq(JSON.stringify({ text: "warm up" })),
+      res,
+    );
+    await vi.runAllTimersAsync();
+    await handled;
+
+    expect(state.statusCode).toBe(200);
+    expect(upstream).toHaveLength(2);
+  });
+});
+
+describe("handleCloudSttRoute (/api/asr/cloud proxy)", () => {
+  test("retries an explicit cache-warming 503 before returning a transcript", async () => {
+    let calls = 0;
+    upstreamResponse = () => {
+      calls++;
+      return calls === 1
+        ? new Response(
+            JSON.stringify({
+              code: "service_unavailable",
+              details: { retryable: true, retryAfterSeconds: 1 },
+            }),
+            { status: 503 },
+          )
+        : Response.json({ text: "The quick brown fox." });
+    };
+    vi.useFakeTimers();
+
+    const { res, state } = fakeRes();
+    const handled = handleCloudSttRoute(
+      fakeReq("RIFF-audio", { "content-type": "audio/wav" }),
+      res,
+    );
+    await vi.runAllTimersAsync();
+    await handled;
+
+    expect(state.statusCode).toBe(200);
+    expect(JSON.parse(String(state.body))).toEqual({
+      text: "The quick brown fox.",
+    });
+    expect(upstream).toHaveLength(2);
+    expect(upstream.every((request) => request.body instanceof FormData)).toBe(
+      true,
+    );
+  });
+
+  test("does not retry a non-warming 503", async () => {
+    upstreamResponse = () =>
+      new Response(JSON.stringify({ error: "Whisper unavailable" }), {
+        status: 503,
+      });
+    const { res, state } = fakeRes();
+
+    await handleCloudSttRoute(
+      fakeReq("RIFF-audio", { "content-type": "audio/wav" }),
+      res,
+    );
+
+    expect(state.statusCode).toBe(502);
+    expect(upstream).toHaveLength(1);
   });
 });
 

--- a/plugins/plugin-elizacloud/src/lib/server-cloud-tts.ts
+++ b/plugins/plugin-elizacloud/src/lib/server-cloud-tts.ts
@@ -22,6 +22,7 @@ import {
   ttsDebug,
   ttsDebugTextPreview,
 } from "@elizaos/shared";
+import { warmingRetryWaitSeconds } from "../utils/warming";
 
 export {
   __resetCloudBaseUrlCache,
@@ -238,23 +239,36 @@ export async function handleCloudTtsPreviewRoute(
       // instead of charging the same utterance a second time through this
       // fallback transport.
       const idempotencyKey = req.headers["idempotency-key"];
-      const attempt = await fetch(cloudUrl, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${cloudApiKey}`,
-          "x-api-key": cloudApiKey,
-          "Content-Type": "application/json",
-          Accept: "audio/mpeg",
-          ...(typeof idempotencyKey === "string" && idempotencyKey
-            ? { "Idempotency-Key": idempotencyKey }
-            : {}),
-        },
-        body: JSON.stringify({
-          text,
-          voiceId: cloudVoice,
-          modelId: cloudModel,
-        }),
-      });
+      let attempt: Response;
+      let warmingRetries = 0;
+      for (;;) {
+        attempt = await fetch(cloudUrl, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${cloudApiKey}`,
+            "x-api-key": cloudApiKey,
+            "Content-Type": "application/json",
+            Accept: "audio/mpeg",
+            ...(typeof idempotencyKey === "string" && idempotencyKey
+              ? { "Idempotency-Key": idempotencyKey }
+              : {}),
+          },
+          body: JSON.stringify({
+            text,
+            voiceId: cloudVoice,
+            modelId: cloudModel,
+          }),
+        });
+
+        if (attempt.ok || warmingRetries >= 2) break;
+        const waitSeconds = await warmingRetryWaitSeconds(attempt);
+        if (waitSeconds === null) break;
+        warmingRetries++;
+        logger.warn(
+          `[Cloud TTS] authorization cache warming (503), retry ${warmingRetries}/2 after ${waitSeconds}s`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, waitSeconds * 1000));
+      }
 
       if (attempt.ok) {
         cloudResponse = attempt;
@@ -405,20 +419,32 @@ export async function handleCloudSttRoute(
     for (let i = 0; i < cloudUrls.length; i++) {
       const cloudUrl = cloudUrls[i];
       if (cloudUrl === undefined) continue;
-      const form = new FormData();
-      form.append(
-        "audio",
-        new Blob([new Uint8Array(rawBody)], { type: mime }),
-        filename,
-      );
-      const attempt = await fetch(cloudUrl, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${cloudApiKey}`,
-          "x-api-key": cloudApiKey,
-        },
-        body: form,
-      });
+      let attempt: Response;
+      let warmingRetries = 0;
+      for (;;) {
+        const form = new FormData();
+        form.append(
+          "audio",
+          new Blob([new Uint8Array(rawBody)], { type: mime }),
+          filename,
+        );
+        attempt = await fetch(cloudUrl, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${cloudApiKey}`,
+            "x-api-key": cloudApiKey,
+          },
+          body: form,
+        });
+        if (attempt.ok || warmingRetries >= 2) break;
+        const waitSeconds = await warmingRetryWaitSeconds(attempt);
+        if (waitSeconds === null) break;
+        warmingRetries++;
+        logger.warn(
+          `[Cloud STT] authorization cache warming (503), retry ${warmingRetries}/2 after ${waitSeconds}s`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, waitSeconds * 1000));
+      }
       if (attempt.ok) {
         cloudResponse = attempt;
         break;


### PR DESCRIPTION
Closes #19454.

## What changed
- supplies the existing `ELIZACLOUD_API_KEY` repository secret to the app backend as canonical `ELIZAOS_CLOUD_API_KEY`
- fails closed before browser startup when either Cloud or Cerebras credentials are absent
- narrows `web.live.railway-roundtrip` to only its intended Playwright describe block
- captures bounded, structured, credential-redacted ASR/TTS failure diagnostics
- adds deterministic matrix selection/credential regression coverage

## Evidence so far
- root-pinned Bun 1.3.14
- app typecheck: pass
- app-core typecheck: pass
- voice-matrix focused tests: 3/3 pass
- Biome focused check: pass
- actionlint: pass
- Ruby YAML parse: pass
- missing Cloud credential + `--require-green`: exit 1 with explicit probe reason
- direct Railway Kokoro → Whisper contract: previously observed green on the same endpoints

The secret-backed exact browser cell will be dispatched on this PR head before merge.