### PR TITLE
fix(homepage): keep manual copy after message handoff

### DIFF
--- a/packages/homepage/src/i18n/locales/en.json
+++ b/packages/homepage/src/i18n/locales/en.json
@@ -9,6 +9,7 @@
   "homepage_eliza.common.skipToContent": "Skip to content",
   "homepage_eliza.common.loading": "Loading…",
   "homepage_eliza.common.redirecting": "Redirecting…",
+  "homepage_eliza.common.messageHandoff": "Opening Messages. If nothing happens, copy the number.",
   "homepage_eliza.common.year": "ElizaCloud Inc. {{year}}",
   "homepage_eliza.common.terms": "Terms",
   "homepage_eliza.common.privacy": "Privacy",

--- a/packages/homepage/src/i18n/locales/es.json
+++ b/packages/homepage/src/i18n/locales/es.json
@@ -9,6 +9,7 @@
   "homepage_eliza.common.skipToContent": "Saltar al contenido",
   "homepage_eliza.common.loading": "Cargando…",
   "homepage_eliza.common.redirecting": "Redirigiendo…",
+  "homepage_eliza.common.messageHandoff": "Abriendo Mensajes. Si no ocurre nada, copia el número.",
   "homepage_eliza.common.year": "ElizaCloud Inc. {{year}}",
   "homepage_eliza.common.terms": "Términos",
   "homepage_eliza.common.privacy": "Privacidad",

--- a/packages/homepage/src/i18n/locales/ja.json
+++ b/packages/homepage/src/i18n/locales/ja.json
@@ -9,6 +9,7 @@
   "homepage_eliza.common.skipToContent": "本文へスキップ",
   "homepage_eliza.common.loading": "読み込み中…",
   "homepage_eliza.common.redirecting": "リダイレクト中…",
+  "homepage_eliza.common.messageHandoff": "メッセージを開いています。開かない場合は電話番号をコピーしてください。",
   "homepage_eliza.common.year": "ElizaCloud Inc. {{year}}",
   "homepage_eliza.common.terms": "利用規約",
   "homepage_eliza.common.privacy": "プライバシー",

--- a/packages/homepage/src/i18n/locales/ko.json
+++ b/packages/homepage/src/i18n/locales/ko.json
@@ -9,6 +9,7 @@
   "homepage_eliza.common.skipToContent": "본문으로 건너뛰기",
   "homepage_eliza.common.loading": "불러오는 중…",
   "homepage_eliza.common.redirecting": "이동 중이에요…",
+  "homepage_eliza.common.messageHandoff": "메시지 앱을 여는 중입니다. 열리지 않으면 번호를 복사하세요.",
   "homepage_eliza.common.year": "ElizaCloud Inc. {{year}}",
   "homepage_eliza.common.terms": "이용약관",
   "homepage_eliza.common.privacy": "개인정보",

--- a/packages/homepage/src/i18n/locales/pt.json
+++ b/packages/homepage/src/i18n/locales/pt.json
@@ -9,6 +9,7 @@
   "homepage_eliza.common.skipToContent": "Pular para o conteúdo",
   "homepage_eliza.common.loading": "Carregando…",
   "homepage_eliza.common.redirecting": "Redirecionando…",
+  "homepage_eliza.common.messageHandoff": "Abrindo o Mensagens. Se nada acontecer, copie o número.",
   "homepage_eliza.common.year": "ElizaCloud Inc. {{year}}",
   "homepage_eliza.common.terms": "Termos",
   "homepage_eliza.common.privacy": "Privacidade",

--- a/packages/homepage/src/i18n/locales/tl.json
+++ b/packages/homepage/src/i18n/locales/tl.json
@@ -9,6 +9,7 @@
   "homepage_eliza.common.skipToContent": "Lumaktaw sa content",
   "homepage_eliza.common.loading": "Naglo-load…",
   "homepage_eliza.common.redirecting": "Inire-redirect…",
+  "homepage_eliza.common.messageHandoff": "Binubuksan ang Messages. Kung walang mangyari, kopyahin ang numero.",
   "homepage_eliza.common.year": "ElizaCloud Inc. {{year}}",
   "homepage_eliza.common.terms": "Mga Tuntunin",
   "homepage_eliza.common.privacy": "Privacy",

--- a/packages/homepage/src/i18n/locales/vi.json
+++ b/packages/homepage/src/i18n/locales/vi.json
@@ -9,6 +9,7 @@
   "homepage_eliza.common.skipToContent": "Bỏ qua, vào nội dung",
   "homepage_eliza.common.loading": "Đang tải…",
   "homepage_eliza.common.redirecting": "Đang chuyển hướng…",
+  "homepage_eliza.common.messageHandoff": "Đang mở Tin nhắn. Nếu không có gì xảy ra, hãy sao chép số.",
   "homepage_eliza.common.year": "ElizaCloud Inc. {{year}}",
   "homepage_eliza.common.terms": "Điều khoản",
   "homepage_eliza.common.privacy": "Quyền riêng tư",

--- a/packages/homepage/src/i18n/locales/zh-CN.json
+++ b/packages/homepage/src/i18n/locales/zh-CN.json
@@ -9,6 +9,7 @@
   "homepage_eliza.common.skipToContent": "跳到正文",
   "homepage_eliza.common.loading": "加载中…",
   "homepage_eliza.common.redirecting": "正在跳转…",
+  "homepage_eliza.common.messageHandoff": "正在打开“信息”。如果没有反应，请复制号码。",
   "homepage_eliza.common.year": "ElizaCloud Inc. {{year}}",
   "homepage_eliza.common.terms": "条款",
   "homepage_eliza.common.privacy": "隐私",

--- a/packages/homepage/src/index.css
+++ b/packages/homepage/src/index.css
@@ -1457,6 +1457,22 @@ body {
   transform: translateX(-50%);
 }
 
+.landing-copy-notice-action {
+  min-height: 2.75rem;
+  margin-left: 0.75rem;
+  border: 0;
+  background: transparent;
+  color: currentColor;
+  font: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  cursor: pointer;
+}
+
+.landing-copy-notice--handoff {
+  color: #404040;
+}
+
 .landing-copy-notice--error {
   color: #991b1b;
 }

--- a/packages/homepage/src/lib/contact.ts
+++ b/packages/homepage/src/lib/contact.ts
@@ -74,10 +74,10 @@ export function canOpenElizaSmsLink(navigatorValue: MessageNavigator): boolean {
 export async function openOrCopyElizaMessage(
   windowValue: MessageWindow,
   message: string = IMESSAGE_GREETING,
-): Promise<"opened" | "copied"> {
+): Promise<"handoff" | "copied"> {
   if (canOpenElizaSmsLink(windowValue.navigator)) {
     windowValue.location.href = buildElizaSmsHref(message);
-    return "opened";
+    return "handoff";
   }
 
   if (!windowValue.navigator.clipboard) {

--- a/packages/homepage/src/pages/connected.tsx
+++ b/packages/homepage/src/pages/connected.tsx
@@ -90,7 +90,7 @@ export default function ConnectedPage() {
   const { user, organization, isAuthenticated, isLoading, logout, linkPhone } =
     useAuth();
   const [phoneCopyState, setPhoneCopyState] = useState<
-    "idle" | "copied" | "error"
+    "idle" | "handoff" | "copied" | "error"
   >("idle");
   const [copiedTelegram, setCopiedTelegram] = useState(false);
   const [copiedWhatsApp, setCopiedWhatsApp] = useState(false);
@@ -203,7 +203,7 @@ export default function ConnectedPage() {
   const handleOpenMessages = async () => {
     try {
       const outcome = await openOrCopyElizaMessage(window);
-      if (outcome === "copied") setPhoneCopyState("copied");
+      setPhoneCopyState(outcome);
     } catch {
       // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
       setPhoneCopyState("error");
@@ -263,18 +263,30 @@ export default function ConnectedPage() {
       {phoneCopyState !== "idle" && (
         <div
           className={`fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-full bg-white px-4 py-2 text-sm font-medium shadow-lg ${
-            phoneCopyState === "copied" ? "text-green-700" : "text-red-700"
+            phoneCopyState === "copied"
+              ? "text-green-700"
+              : phoneCopyState === "error"
+                ? "text-red-700"
+                : "text-neutral-700"
           }`}
-          role={phoneCopyState === "error" ? "alert" : "status"}
-          aria-live="polite"
         >
-          {phoneCopyState === "copied"
-            ? t("homepage_eliza.connected.phoneCopied", {
-                defaultValue: "Phone number copied",
-              })
-            : t("homepage_eliza.connected.phoneCopyFailed", {
-                defaultValue: "Couldn't copy the phone number",
-              })}
+          <span
+            role={phoneCopyState === "error" ? "alert" : "status"}
+            aria-live="polite"
+          >
+            {phoneCopyState === "copied"
+              ? t("homepage_eliza.connected.phoneCopied", {
+                  defaultValue: "Phone number copied",
+                })
+              : phoneCopyState === "handoff"
+                ? t("homepage_eliza.common.messageHandoff", {
+                    defaultValue:
+                      "Opening Messages. If nothing happens, copy the number.",
+                  })
+                : t("homepage_eliza.connected.phoneCopyFailed", {
+                    defaultValue: "Couldn't copy the phone number",
+                  })}
+          </span>
         </div>
       )}
       <header className="absolute top-0 inset-x-0 z-10 p-4 flex items-center justify-between pointer-events-none">

--- a/packages/homepage/src/pages/connected.tsx
+++ b/packages/homepage/src/pages/connected.tsx
@@ -16,7 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@elizaos/ui/dropdown-menu";
 import { Check, Copy, Info, LogOut } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { ElizaLogo } from "@/components/brand/eliza-logo";
 import {
@@ -92,6 +92,7 @@ export default function ConnectedPage() {
   const [phoneCopyState, setPhoneCopyState] = useState<
     "idle" | "handoff" | "copied" | "error"
   >("idle");
+  const phoneCopyOperation = useRef(0);
   const [copiedTelegram, setCopiedTelegram] = useState(false);
   const [copiedWhatsApp, setCopiedWhatsApp] = useState(false);
 
@@ -161,12 +162,13 @@ export default function ConnectedPage() {
   }, [isAuthenticated, isLoading, navigate]);
 
   const handleCopyPhone = async () => {
+    const operation = ++phoneCopyOperation.current;
     try {
       await navigator.clipboard.writeText(ELIZA_PHONE_NUMBER);
-      setPhoneCopyState("copied");
+      if (operation === phoneCopyOperation.current) setPhoneCopyState("copied");
     } catch {
       // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
-      setPhoneCopyState("error");
+      if (operation === phoneCopyOperation.current) setPhoneCopyState("error");
     }
   };
 
@@ -201,12 +203,13 @@ export default function ConnectedPage() {
   };
 
   const handleOpenMessages = async () => {
+    const operation = ++phoneCopyOperation.current;
     try {
       const outcome = await openOrCopyElizaMessage(window);
-      setPhoneCopyState(outcome);
+      if (operation === phoneCopyOperation.current) setPhoneCopyState(outcome);
     } catch {
       // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
-      setPhoneCopyState("error");
+      if (operation === phoneCopyOperation.current) setPhoneCopyState("error");
     }
   };
 

--- a/packages/homepage/src/pages/get-started.tsx
+++ b/packages/homepage/src/pages/get-started.tsx
@@ -709,6 +709,7 @@ export default function GetStartedPage() {
   const [messageNotice, setMessageNotice] = useState<
     "idle" | "handoff" | "copied" | "error"
   >("idle");
+  const messageNoticeOperation = useRef(0);
   const [showContent, setShowContent] = useState(false);
 
   useEffect(() => {
@@ -1290,22 +1291,28 @@ export default function GetStartedPage() {
   }, [handleDiscordAuthSubmit]);
 
   const handleOpenMessages = async () => {
+    const operation = ++messageNoticeOperation.current;
     try {
       const outcome = await openOrCopyElizaMessage(window);
-      setMessageNotice(outcome);
+      if (operation === messageNoticeOperation.current)
+        setMessageNotice(outcome);
     } catch {
       // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
-      setMessageNotice("error");
+      if (operation === messageNoticeOperation.current)
+        setMessageNotice("error");
     }
   };
 
   const handleCopyMessageNumber = async () => {
+    const operation = ++messageNoticeOperation.current;
     try {
       await navigator.clipboard.writeText(ELIZA_PHONE_NUMBER);
-      setMessageNotice("copied");
+      if (operation === messageNoticeOperation.current)
+        setMessageNotice("copied");
     } catch {
       // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
-      setMessageNotice("error");
+      if (operation === messageNoticeOperation.current)
+        setMessageNotice("error");
     }
   };
 

--- a/packages/homepage/src/pages/get-started.tsx
+++ b/packages/homepage/src/pages/get-started.tsx
@@ -43,6 +43,7 @@ const ShaderBackground = lazy(
 import { elizacloudAuthFetch } from "@/lib/api/client";
 import {
   buildElizaTelegramHref,
+  ELIZA_PHONE_NUMBER,
   getDiscordBotApplicationId,
   getTelegramBotId,
   getTelegramBotUsername,
@@ -706,7 +707,7 @@ export default function GetStartedPage() {
 
   const [suppressRedirect, setSuppressRedirect] = useState(false);
   const [messageNotice, setMessageNotice] = useState<
-    "idle" | "copied" | "error"
+    "idle" | "handoff" | "copied" | "error"
   >("idle");
   const [showContent, setShowContent] = useState(false);
 
@@ -1291,7 +1292,17 @@ export default function GetStartedPage() {
   const handleOpenMessages = async () => {
     try {
       const outcome = await openOrCopyElizaMessage(window);
-      setMessageNotice(outcome === "copied" ? "copied" : "idle");
+      setMessageNotice(outcome);
+    } catch {
+      // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
+      setMessageNotice("error");
+    }
+  };
+
+  const handleCopyMessageNumber = async () => {
+    try {
+      await navigator.clipboard.writeText(ELIZA_PHONE_NUMBER);
+      setMessageNotice("copied");
     } catch {
       // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
       setMessageNotice("error");
@@ -1809,17 +1820,37 @@ export default function GetStartedPage() {
                   className={`mt-3 text-center text-sm font-medium ${
                     messageNotice === "copied"
                       ? "text-green-700"
-                      : "text-red-700"
+                      : messageNotice === "error"
+                        ? "text-red-700"
+                        : "text-neutral-700"
                   }`}
                 >
                   {messageNotice === "copied"
                     ? t("homepage_eliza.getStarted.phoneCopied", {
                         defaultValue: "Phone number copied",
                       })
-                    : t("homepage_eliza.getStarted.phoneCopyFailed", {
-                        defaultValue: "Couldn't copy the phone number",
-                      })}
+                    : messageNotice === "handoff"
+                      ? t("homepage_eliza.common.messageHandoff", {
+                          defaultValue:
+                            "Opening Messages. If nothing happens, copy the number.",
+                        })
+                      : t("homepage_eliza.getStarted.phoneCopyFailed", {
+                          defaultValue: "Couldn't copy the phone number",
+                        })}
                 </p>
+              )}
+
+              {messageNotice === "handoff" && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void handleCopyMessageNumber()}
+                  className="mt-3 h-11 w-full rounded-full"
+                >
+                  {t("homepage_eliza.connected.copyPhoneAria", {
+                    defaultValue: "Copy phone number",
+                  })}
+                </Button>
               )}
 
               <button

--- a/packages/homepage/src/pages/landing.tsx
+++ b/packages/homepage/src/pages/landing.tsx
@@ -580,6 +580,7 @@ export default function LandingPage() {
   const [phoneCopyState, setPhoneCopyState] = useState<
     "idle" | "handoff" | "copied" | "error"
   >("idle");
+  const phoneCopyOperation = useRef(0);
   const browserWindow = typeof window === "undefined" ? null : window;
   const signedIn =
     browserWindow !== null &&
@@ -626,22 +627,24 @@ export default function LandingPage() {
   ];
 
   const handleMessageEliza = async () => {
+    const operation = ++phoneCopyOperation.current;
     try {
       const outcome = await openOrCopyElizaMessage(window);
-      setPhoneCopyState(outcome);
+      if (operation === phoneCopyOperation.current) setPhoneCopyState(outcome);
     } catch {
       // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
-      setPhoneCopyState("error");
+      if (operation === phoneCopyOperation.current) setPhoneCopyState("error");
     }
   };
 
   const handleCopyPhone = async () => {
+    const operation = ++phoneCopyOperation.current;
     try {
       await navigator.clipboard.writeText(ELIZA_PHONE_NUMBER);
-      setPhoneCopyState("copied");
+      if (operation === phoneCopyOperation.current) setPhoneCopyState("copied");
     } catch {
       // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
-      setPhoneCopyState("error");
+      if (operation === phoneCopyOperation.current) setPhoneCopyState("error");
     }
   };
 

--- a/packages/homepage/src/pages/landing.tsx
+++ b/packages/homepage/src/pages/landing.tsx
@@ -578,7 +578,7 @@ function ContactSheet({
 export default function LandingPage() {
   const t = useT();
   const [phoneCopyState, setPhoneCopyState] = useState<
-    "idle" | "copied" | "error"
+    "idle" | "handoff" | "copied" | "error"
   >("idle");
   const browserWindow = typeof window === "undefined" ? null : window;
   const signedIn =
@@ -628,7 +628,17 @@ export default function LandingPage() {
   const handleMessageEliza = async () => {
     try {
       const outcome = await openOrCopyElizaMessage(window);
-      setPhoneCopyState(outcome === "copied" ? "copied" : "idle");
+      setPhoneCopyState(outcome);
+    } catch {
+      // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
+      setPhoneCopyState("error");
+    }
+  };
+
+  const handleCopyPhone = async () => {
+    try {
+      await navigator.clipboard.writeText(ELIZA_PHONE_NUMBER);
+      setPhoneCopyState("copied");
     } catch {
       // error-policy:J4 Clipboard rejection stays visible as a distinct UI error.
       setPhoneCopyState("error");
@@ -640,9 +650,14 @@ export default function LandingPage() {
       ? t("homepage_eliza.landing.phoneCopied", {
           defaultValue: "Phone number copied",
         })
-      : t("homepage_eliza.landing.phoneCopyFailed", {
-          defaultValue: "Couldn't copy the phone number",
-        });
+      : phoneCopyState === "handoff"
+        ? t("homepage_eliza.common.messageHandoff", {
+            defaultValue:
+              "Opening Messages. If nothing happens, copy the number.",
+          })
+        : t("homepage_eliza.landing.phoneCopyFailed", {
+            defaultValue: "Couldn't copy the phone number",
+          });
   return (
     <div className="landing-page theme-app">
       <Suspense fallback={null}>
@@ -725,10 +740,24 @@ export default function LandingPage() {
           {phoneCopyState !== "idle" && (
             <div
               className={`landing-copy-notice landing-copy-notice--${phoneCopyState}`}
-              role={phoneCopyState === "error" ? "alert" : "status"}
-              aria-live="polite"
             >
-              {phoneCopyLabel}
+              <span
+                role={phoneCopyState === "error" ? "alert" : "status"}
+                aria-live="polite"
+              >
+                {phoneCopyLabel}
+              </span>
+              {phoneCopyState === "handoff" && (
+                <button
+                  type="button"
+                  className="landing-copy-notice-action"
+                  onClick={() => void handleCopyPhone()}
+                >
+                  {t("homepage_eliza.connected.copyPhoneAria", {
+                    defaultValue: "Copy phone number",
+                  })}
+                </button>
+              )}
             </div>
           )}
         </div>

--- a/packages/homepage/tests/contact.test.ts
+++ b/packages/homepage/tests/contact.test.ts
@@ -82,7 +82,7 @@ describe("Eliza contact links", () => {
           },
         },
       }),
-    ).resolves.toBe("opened");
+    ).resolves.toBe("handoff");
     expect(location.href).toBe(buildElizaSmsHref());
     expect(clipboardWrites).toEqual([]);
   });

--- a/packages/homepage/tests/e2e/app-routes-flow.spec.ts
+++ b/packages/homepage/tests/e2e/app-routes-flow.spec.ts
@@ -281,11 +281,11 @@ test("get-started covers Discord callback errors and setup guide", async ({
   await expect(
     page.getByRole("heading", { name: "Discord Setup Guide" }),
   ).toBeVisible();
-  await expect(page.getByText("Add Eliza to your server")).toBeVisible();
+  await expect(page.getByText("Install Eliza for your account")).toBeVisible();
   await expect(page.getByText("Send a direct message")).toBeVisible();
   await expect(page.getByText("Start chatting")).toBeVisible();
   await expect(
-    page.getByRole("button", { name: "Invite to Server" }),
+    page.getByRole("button", { name: "Install for DMs" }),
   ).toBeVisible();
   await expect(page.getByRole("button", { name: "Open DM" })).toBeVisible();
 
@@ -482,7 +482,7 @@ test("supported-platform messaging keeps a manual copy recovery visible", async 
   await page.goto("/");
   await waitForLandingIntro(page);
 
-  await page.getByRole("button", { name: "Message Eliza" }).click();
+  await page.getByRole("button", { name: "Text" }).click();
   await expect(page.getByRole("status")).toHaveText(
     "Opening Messages. If nothing happens, copy the number.",
   );
@@ -590,7 +590,7 @@ test("the latest manual-copy attempt owns the visible result", async ({
 
   await page.goto("/");
   await waitForLandingIntro(page);
-  await page.getByRole("button", { name: "Message Eliza" }).click();
+  await page.getByRole("button", { name: "Text" }).click();
   const copyButton = page.getByRole("button", { name: "Copy phone number" });
   await copyButton.click();
   await copyButton.click();
@@ -603,7 +603,7 @@ test("the latest manual-copy attempt owns the visible result", async ({
 
   await page.reload();
   await waitForLandingIntro(page);
-  await page.getByRole("button", { name: "Message Eliza" }).click();
+  await page.getByRole("button", { name: "Text" }).click();
   await copyButton.click();
   await copyButton.click();
   await expect.poll(attempts).toBe(2);

--- a/packages/homepage/tests/e2e/app-routes-flow.spec.ts
+++ b/packages/homepage/tests/e2e/app-routes-flow.spec.ts
@@ -528,3 +528,92 @@ test("supported-platform messaging keeps a manual copy recovery visible", async 
   await page.getByRole("button", { name: "Copy phone number" }).click();
   await expect(page.getByRole("status")).toHaveText("Phone number copied");
 });
+
+test("the latest manual-copy attempt owns the visible result", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      value: "MacIntel",
+    });
+    Object.defineProperty(navigator, "userAgentData", {
+      configurable: true,
+      value: { platform: "macOS" },
+    });
+    const attempts: Array<{
+      reject: () => void;
+      resolve: () => void;
+    }> = [];
+    Object.defineProperty(window, "__homepageCopyAttempts", {
+      configurable: true,
+      value: attempts,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: () =>
+          new Promise<void>((resolve, reject) => {
+            attempts.push({ resolve, reject });
+          }),
+      },
+    });
+  });
+
+  const attempts = () =>
+    page.evaluate(() => {
+      const controls = (
+        window as unknown as {
+          __homepageCopyAttempts: Array<{
+            reject: () => void;
+            resolve: () => void;
+          }>;
+        }
+      ).__homepageCopyAttempts;
+      return controls.length;
+    });
+  const settle = (index: number, outcome: "resolve" | "reject") =>
+    page.evaluate(
+      ({ attemptIndex, attemptOutcome }) => {
+        const controls = (
+          window as unknown as {
+            __homepageCopyAttempts: Array<{
+              reject: () => void;
+              resolve: () => void;
+            }>;
+          }
+        ).__homepageCopyAttempts;
+        controls[attemptIndex]?.[attemptOutcome]();
+      },
+      { attemptIndex: index, attemptOutcome: outcome },
+    );
+
+  await page.goto("/");
+  await waitForLandingIntro(page);
+  await page.getByRole("button", { name: "Message Eliza" }).click();
+  const copyButton = page.getByRole("button", { name: "Copy phone number" });
+  await copyButton.click();
+  await copyButton.click();
+  await expect.poll(attempts).toBe(2);
+
+  await settle(1, "resolve");
+  await expect(page.getByRole("status")).toHaveText("Phone number copied");
+  await settle(0, "reject");
+  await expect(page.getByRole("status")).toHaveText("Phone number copied");
+
+  await page.reload();
+  await waitForLandingIntro(page);
+  await page.getByRole("button", { name: "Message Eliza" }).click();
+  await copyButton.click();
+  await copyButton.click();
+  await expect.poll(attempts).toBe(2);
+
+  await settle(1, "reject");
+  await expect(page.getByRole("alert")).toHaveText(
+    "Couldn't copy the phone number",
+  );
+  await settle(0, "resolve");
+  await expect(page.getByRole("alert")).toHaveText(
+    "Couldn't copy the phone number",
+  );
+});

--- a/packages/homepage/tests/e2e/app-routes-flow.spec.ts
+++ b/packages/homepage/tests/e2e/app-routes-flow.spec.ts
@@ -463,3 +463,68 @@ test("landing keeps clipboard rejection visible", async ({ page }) => {
     "Couldn't copy the phone number",
   );
 });
+
+test("supported-platform messaging keeps a manual copy recovery visible", async ({
+  context,
+  page,
+}) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      value: "MacIntel",
+    });
+    Object.defineProperty(navigator, "userAgentData", {
+      configurable: true,
+      value: { platform: "macOS" },
+    });
+  });
+  await page.goto("/");
+  await waitForLandingIntro(page);
+
+  await page.getByRole("button", { name: "Message Eliza" }).click();
+  await expect(page.getByRole("status")).toHaveText(
+    "Opening Messages. If nothing happens, copy the number.",
+  );
+
+  const copyButton = page.getByRole("button", { name: "Copy phone number" });
+  await expect(copyButton).toBeVisible();
+  await copyButton.click();
+  await expect(page.getByRole("status")).toHaveText("Phone number copied");
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe("+18087881821");
+  await expect(page.getByText("+1 (808) 788-1821")).toHaveCount(0);
+
+  await page.goto("/get-started");
+  await page.getByRole("button", { name: /^iMessage$/ }).click();
+  await page.getByRole("button", { name: "Message Eliza" }).click();
+  await expect(page.getByRole("status")).toHaveText(
+    "Opening Messages. If nothing happens, copy the number.",
+  );
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: () =>
+          Promise.reject(new DOMException("denied", "NotAllowedError")),
+      },
+    });
+  });
+  await page.getByRole("button", { name: "Copy phone number" }).click();
+  await expect(page.getByRole("alert")).toHaveText(
+    "Couldn't copy the phone number",
+  );
+
+  await seedAuthenticatedSession(page);
+  await page.goto("/connected");
+  await page.getByRole("button", { name: /^iMessage$/ }).click();
+  await page.getByLabel("Phone number").fill("416 555 0123");
+  await page.getByRole("button", { name: "Link Phone" }).click();
+  await page.getByRole("button", { name: /^iMessage$/ }).click();
+  await expect(page.getByRole("status")).toHaveText(
+    "Opening Messages. If nothing happens, copy the number.",
+  );
+  await page.getByRole("button", { name: "Copy phone number" }).click();
+  await expect(page.getByRole("status")).toHaveText("Phone number copied");
+});


### PR DESCRIPTION
# Relates to

Closes #19388. Follow-up to #19397, #19411, and #19425.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change from the evidence below without reading the code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@83040db085837af52befe5bc5a2dd4d849462224`; zero conflicts.
- [x] Exact-head `bun run verify` passes.

# Risks

Low. This changes only homepage feedback after the existing native `sms:` handoff. SMS URL construction, platform selection, unsupported-platform clipboard fallback, and the production sender gate are unchanged. The manual copy action writes the existing E.164 constant and exposes rejection as an alert.

# Background

## What does this PR do?

The earlier fixes removed the public sender number and made copied/error feedback durable, but a supported-platform browser with no registered `sms:` handler could still remain on the page with no recovery action. Browser JavaScript cannot observe whether an external protocol handler actually opened.

This PR makes that boundary honest. The helper returns `handoff`, not `opened`; Landing and Get Started retain a conditional “If nothing happens” status with an explicit **Copy phone number** recovery action. Connected retains its existing copy icon and now shows the same honest handoff status. Copy success and rejection remain durable, no timeout is introduced, and the phone number remains absent from visible text. The status is localized in all eight homepage locales.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This completes the behavior already specified by #19388.

# Testing

## Where should a reviewer start?

On macOS/iOS/Android, open `/` or `/get-started`, activate the **Text** or **Message Eliza** action, and verify that the conditional handoff status and manual-copy action remain available if Messages does not open. On `/connected`, verify the handoff status and existing labelled copy icon.

## Detailed testing steps

- `bun install` — passed at exact head; 3,835 installs checked, workspace links and artifact bundle current.
- `bun run verify` — passed at exact head: 350/350 tasks plus all repository audits; anti-larp scanned 8,045 test files with zero focused/orphaned skips.
- `bun run --cwd packages/homepage test` — passed, 145/145.
- `bun run --cwd packages/homepage typecheck` — passed.
- `bun run --cwd packages/homepage lint:check` — passed, 101 files.
- `bun run --cwd packages/homepage test:e2e tests/e2e/app-routes-flow.spec.ts` — passed, 11/11.
- Recorded Chromium desktop/mobile handoff proof — passed, 1/1; zero console errors, page errors, or failed HTTP responses.
- `bun run --cwd packages/app audit:app` — passed: 219/219, broken=0, needs-work=0; packaged OCR reviewed 216 views with broken=0.

# Evidence Gate

<!-- evidence-head:d6facd9d18cd25b4eb7fb9d1234fb4d32a76ca92 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19459-19388-before-desktop-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19459-19388-after-desktop-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19459-19388-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - browser clipboard and external-protocol actions do not invoke a backend route
<!-- evidence-row:frontend-logs -->
- [x] [19459-19388-frontend-console-network-v2.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19459-19388-frontend-console-network-v2.json)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic homepage UI behavior; no model call
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain state is created by the CTA
<!-- evidence-row:ocr-review -->
- [x] [19459-19388-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19459-19388-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic homepage UI behavior; no model call.

## Backend + frontend logs

Backend: N/A - the browser clipboard and external-protocol actions do not invoke a backend route.

The recorded Chromium path asserts zero console errors, zero page errors, and zero failed HTTP responses while exercising both affected surfaces.

## Screenshots (before / after) + video walkthrough

The before artifact comes from the prior issue evidence and shows the pre-recovery state. The exact-head after montage and MP4 show desktop Landing and mobile Get Started retaining the conditional handoff status and explicit manual-copy action.

## Audio / voice walkthrough

N/A - no audio or voice behavior changes.

## Known gaps / failures

- A browser cannot report whether the operating system found or launched an external `sms:` handler. The UI therefore exposes a persistent manual recovery instead of fabricating launch success.
- Backend, LLM, domain, and audio evidence are inapplicable for this deterministic browser-only correction, as described above.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->




