### PR TITLE
fix(cloud): preserve managed voice bindings

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -13,6 +13,10 @@ compatibility_flags = ["nodejs_compat"]
 account_id = "23cf6feaeaa541f6a0675053c33da768"
 workers_dev = false
 minify = true
+# Voice routing/provider values are environment-managed plain-text bindings.
+# Preserve those bindings when publishing the committed vars block; without
+# this Wrangler deletes them and every configured Twilio line fails closed.
+keep_vars = true
 
 # -----------------------------------------------------------------------------
 # Bundle-time aliases — swap Node-only / forbidden-top-level-IO modules for

--- a/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
@@ -151,6 +151,7 @@ describe("Cloud CF realtime voice deploy contract", () => {
 
   test("keeps production wrangler vars and workflow env realtime-off with no dedicated-secret advertisement", () => {
     const wrangler = read("packages/cloud/api/wrangler.toml");
+    expect(wrangler).toMatch(/^keep_vars = true$/m);
     const stagingVars = wrangler.slice(
       wrangler.indexOf("[env.staging.vars]"),
       wrangler.indexOf("[env.production.vars]"),


### PR DESCRIPTION
## Summary
- preserve Cloudflare dashboard-managed voice bindings during Wrangler production deploys
- add a deployment contract test for `keep_vars = true`

## Root cause
A production publish supplied the committed `[env.production.vars]` block without `keep_vars`, so Wrangler deleted the environment-managed Twilio routing and Cartesia bindings. Inbound calls then failed closed with “this phone number is not configured for Eliza yet.”

## Verification
- `bun test ./packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts`
- `bunx wrangler deploy --env production --dry-run`
- restored live bindings and confirmed them on Worker version `93b37c6e-660f-4081-acd6-73a131d994e2`

Refs #19450