### PR TITLE
fix(ui): route My Runtimes list through SettingsStack/Group/Row

### DIFF
--- a/packages/ui/src/components/cockpit/MyRuntimesContainer.tsx
+++ b/packages/ui/src/components/cockpit/MyRuntimesContainer.tsx
@@ -5,7 +5,6 @@
 import { useCallback, useState } from "react";
 
 import { isStoreBuild } from "../../build-variant";
-import { cn } from "../../lib/utils";
 import { isAndroidCloudBuild } from "../../platform/android-runtime";
 import {
   addAgentProfile,
@@ -13,6 +12,7 @@ import {
   switchRuntimeNonDestructive,
 } from "../../state";
 import { isTrustedRestoreApiBaseUrl } from "../../state/runtime-url-trust";
+import { SettingsStack } from "../settings/settings-layout";
 import { MyRuntimesSection } from "./MyRuntimesSection";
 
 export interface MyRuntimesContainerProps {
@@ -123,7 +123,7 @@ export function MyRuntimesContainer({ className }: MyRuntimesContainerProps) {
   );
 
   return (
-    <div className={cn("flex flex-col gap-2", className)}>
+    <SettingsStack className={className}>
       {error ? (
         <div
           role="alert"
@@ -140,6 +140,6 @@ export function MyRuntimesContainer({ className }: MyRuntimesContainerProps) {
         onAddRemote={onAddRemote}
         busy={busy}
       />
-    </div>
+    </SettingsStack>
   );
 }

--- a/packages/ui/src/components/cockpit/MyRuntimesSection.test.tsx
+++ b/packages/ui/src/components/cockpit/MyRuntimesSection.test.tsx
@@ -79,6 +79,27 @@ describe("MyRuntimesSection", () => {
     expect(screen.queryByTestId("add-remote-runtime")).toBeNull();
   });
 
+  it("lays the list and add form out with SettingsGroup", () => {
+    render(
+      <MyRuntimesSection
+        runtimes={RUNTIMES}
+        activeId="local-1"
+        onSwitch={vi.fn()}
+        onAddRemote={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("My Runtimes")).toBeTruthy();
+    expect(screen.getByText("Add a VPS / remote runtime")).toBeTruthy();
+    expect(screen.getByLabelText("Label")).toBeTruthy();
+    expect(screen.getByLabelText("URL")).toBeTruthy();
+    expect(screen.getByLabelText("Access token")).toBeTruthy();
+    expect(
+      screen
+        .getByTestId("runtime-local-1")
+        .querySelector("[aria-current='true']"),
+    ).toBeTruthy();
+  });
+
   it("adding a remote requires a label + url, then emits the entry", async () => {
     const user = userEvent.setup();
     const onAddRemote = vi.fn();

--- a/packages/ui/src/components/cockpit/MyRuntimesSection.tsx
+++ b/packages/ui/src/components/cockpit/MyRuntimesSection.tsx
@@ -2,12 +2,25 @@
  * Renders the prop-driven runtime switcher used by Settings and the coding
  * cockpit to show local, cloud, and remote Eliza agent runtimes.
  */
-import { Check, Cloud, HardDrive, Server } from "lucide-react";
+import {
+  Check,
+  Cloud,
+  HardDrive,
+  KeyRound,
+  Link2,
+  Server,
+  Tag,
+} from "lucide-react";
 import { useState } from "react";
 import { cn } from "../../lib/utils";
 import type { AgentProfile } from "../../state/agent-profile-types";
+import { SettingsInputRow } from "../settings/settings-agent-rows";
+import {
+  SettingsGroup,
+  SettingsRow,
+  SettingsStack,
+} from "../settings/settings-layout";
 import { Button } from "../ui/button";
-import { Input } from "../ui/input";
 
 type RuntimeKind = AgentProfile["kind"];
 
@@ -92,32 +105,20 @@ export function MyRuntimesSection({
   };
 
   return (
-    <section
-      data-testid="my-runtimes"
-      className={cn("flex flex-col gap-3", className)}
-    >
-      <h2 className="text-sm font-semibold text-txt">My Runtimes</h2>
-
-      <ul className="flex flex-col gap-2">
+    <SettingsStack data-testid="my-runtimes" className={className}>
+      <SettingsGroup title="My Runtimes">
         {sorted.map((rt) => {
           const meta = KIND_META[rt.kind];
           const Icon = meta.icon;
           const isActive = rt.id === activeId;
           return (
-            <li key={rt.id}>
-              <div
-                data-testid={`runtime-${rt.id}`}
-                className={cn(
-                  "flex items-center gap-3 rounded-md border px-3 py-2.5",
-                  isActive ? "border-accent bg-accent-subtle" : "border-border",
-                )}
-              >
-                <Icon className="h-4 w-4 shrink-0 text-muted" />
-                <span className="flex min-w-0 flex-col">
-                  <span className="flex items-center gap-2">
-                    <span className="truncate text-sm font-semibold text-txt">
-                      {rt.label}
-                    </span>
+            <div key={rt.id} data-testid={`runtime-${rt.id}`}>
+              <SettingsRow
+                icon={Icon}
+                active={isActive}
+                label={
+                  <span className="flex min-w-0 items-center gap-2">
+                    <span className="truncate">{rt.label}</span>
                     <span
                       className={cn(
                         "shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
@@ -127,80 +128,94 @@ export function MyRuntimesSection({
                       {meta.label}
                     </span>
                   </span>
-                  {rt.apiBase ? (
-                    <span className="truncate text-xs text-muted">
-                      {rt.apiBase}
+                }
+                description={rt.apiBase}
+                control={
+                  isActive ? (
+                    <span
+                      data-testid={`runtime-${rt.id}-active`}
+                      className="flex shrink-0 items-center gap-1 text-xs font-semibold text-accent"
+                    >
+                      <Check className="h-3.5 w-3.5" aria-hidden /> Active
                     </span>
-                  ) : null}
-                </span>
-                {isActive ? (
-                  <span
-                    data-testid={`runtime-${rt.id}-active`}
-                    className="ml-auto flex shrink-0 items-center gap-1 text-xs font-semibold text-accent"
-                  >
-                    <Check className="h-3.5 w-3.5" /> Active
-                  </span>
-                ) : (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    data-testid={`runtime-${rt.id}-use`}
-                    disabled={busy}
-                    onClick={() => onSwitch(rt.id)}
-                    className="ml-auto shrink-0"
-                  >
-                    Use
-                  </Button>
-                )}
-              </div>
-            </li>
+                  ) : (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      data-testid={`runtime-${rt.id}-use`}
+                      disabled={busy}
+                      onClick={() => onSwitch(rt.id)}
+                    >
+                      Use
+                    </Button>
+                  )
+                }
+              />
+            </div>
           );
         })}
-      </ul>
+      </SettingsGroup>
 
       {onAddRemote ? (
         <form
           data-testid="add-remote-runtime"
-          className="flex flex-col gap-2 rounded-md border border-border p-3"
-          onSubmit={(e) => {
-            e.preventDefault();
+          onSubmit={(event) => {
+            event.preventDefault();
             submitRemote();
           }}
         >
-          <span className="text-xs font-semibold text-muted">
-            Add a VPS / remote runtime
-          </span>
-          <Input
-            data-testid="add-remote-label"
-            value={label}
-            onChange={(e) => setLabel(e.target.value)}
-            placeholder="Label (e.g. my VPS)"
-          />
-          <Input
-            data-testid="add-remote-url"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            placeholder="https://… or http://100.x.y.z:port (tailscale)"
-            inputMode="url"
-          />
-          <Input
-            data-testid="add-remote-token"
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            placeholder="Access token (optional)"
-            type="password"
-          />
-          <Button
-            type="submit"
-            size="sm"
-            data-testid="add-remote-submit"
-            disabled={!canAdd}
-          >
-            Add runtime
-          </Button>
+          <SettingsGroup title="Add a VPS / remote runtime">
+            <SettingsInputRow
+              agentId="my-runtimes-add-label"
+              group="my-runtimes-add"
+              icon={Tag}
+              label="Label"
+              value={label}
+              onValueChange={setLabel}
+              placeholder="e.g. my VPS"
+              testId="add-remote-label"
+              autoComplete="off"
+            />
+            <SettingsInputRow
+              agentId="my-runtimes-add-url"
+              group="my-runtimes-add"
+              icon={Link2}
+              label="URL"
+              type="url"
+              inputMode="url"
+              value={url}
+              onValueChange={setUrl}
+              placeholder="https://… or http://100.x.y.z:port (tailscale)"
+              testId="add-remote-url"
+              autoComplete="off"
+            />
+            <SettingsInputRow
+              agentId="my-runtimes-add-token"
+              group="my-runtimes-add"
+              icon={KeyRound}
+              label="Access token"
+              description="Optional. Leave blank when the runtime does not require one."
+              type="password"
+              value={token}
+              onValueChange={setToken}
+              placeholder="Access token (optional)"
+              testId="add-remote-token"
+              autoComplete="new-password"
+            />
+            <div className="pt-1">
+              <Button
+                type="submit"
+                size="sm"
+                data-testid="add-remote-submit"
+                disabled={!canAdd}
+              >
+                Add runtime
+              </Button>
+            </div>
+          </SettingsGroup>
         </form>
       ) : null}
-    </section>
+    </SettingsStack>
   );
 }

--- a/packages/ui/src/components/settings/no-handrolled-section-layout.test.ts
+++ b/packages/ui/src/components/settings/no-handrolled-section-layout.test.ts
@@ -35,10 +35,6 @@ const SECTION_LAYOUT_ALLOWLIST = new Map<string, string>([
   ],
   ["VoiceSectionMount.tsx", "lazy mount wrapper, not a section body"],
   [
-    "../cockpit/MyRuntimesContainer.tsx",
-    "cockpit runtime switcher mount; grouping lives in MyRuntimesSection",
-  ],
-  [
     "../../cloud/connectors/index.ts",
     "cloud connectors adapter; grouping lives in CloudConnectorsSettingsBody",
   ],

--- a/packages/ui/src/components/settings/settings-layout.test.tsx
+++ b/packages/ui/src/components/settings/settings-layout.test.tsx
@@ -51,6 +51,17 @@ describe("SettingsRow", () => {
     );
     expect(screen.getByTestId("wide")).toBeTruthy();
   });
+
+  it("marks a static row current when active", () => {
+    render(
+      <SettingsRow label="This device" active control={<span>Active</span>} />,
+    );
+    const row = screen
+      .getByText("This device")
+      .closest("[aria-current='true']");
+    expect(row).toBeTruthy();
+    expect(row?.className).toContain("bg-accent/10");
+  });
 });
 
 describe("SettingsGroup", () => {

--- a/packages/ui/src/components/settings/settings-layout.tsx
+++ b/packages/ui/src/components/settings/settings-layout.tsx
@@ -247,8 +247,10 @@ export function SettingsRow({
 
   return (
     <div
+      aria-current={active ? "true" : undefined}
       className={cn(
         "flex min-h-[3rem] flex-col justify-center py-2.5",
+        active && "rounded-lg bg-accent/10",
         className,
       )}
     >


### PR DESCRIPTION
# Relates to

Closes #19471

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d5f48ce311a482148b907b535a6cdd8799cd4491:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` was not run for the whole monorepo in this turn.

# Risks

Low. Presentational reuse of existing Settings layout primitives. Switch and
add-remote callbacks, trust gates, and testids are unchanged.

# Background

## What does this PR do?

First slice of the **settings layout** class: the My Runtimes switcher was a
hand-rolled heading + bordered cards. It now uses `SettingsStack` /
`SettingsGroup` / `SettingsRow`, matching Cloud Agents. The add-remote form is
a second group of labelled `SettingsInputRow`s. Static `SettingsRow` honors
`active`. `MyRuntimesContainer` leaves `SECTION_LAYOUT_ALLOWLIST`.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/cockpit/MyRuntimesSection.tsx`

## Detailed testing steps

```bash
bun run --cwd packages/ui test -- src/components/cockpit/MyRuntimesSection.test.tsx src/components/cockpit/MyRuntimesContainer.test.tsx src/components/settings/settings-layout.test.tsx src/components/settings/no-handrolled-section-layout.test.ts src/components/settings/no-raw-labelled-input.test.ts
```

108 tests passed.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:89fd6aabb223e94614fc43443222ea7cf29884f3 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19474-runtimes-fullpage-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19474-runtimes-fullpage-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19474-runtimes-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or API path is changed.
<!-- evidence-row:frontend-logs -->
- [x] [19474-runtimes-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19474-runtimes-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, wallet, scheduled-task, or generated domain artifact is involved.
<!-- evidence-row:ocr-review -->
- [x] [19474-runtimes-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19474-runtimes-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Backend + frontend logs

Backend: N/A - no server path is changed.

Frontend: capture console is attached.

## Screenshots (before / after) + video walkthrough

Isolated My Runtimes before (hand-rolled cards) and after (SettingsStack /
Group / Row) using the real layout primitives and extracted theme. Desktop
1280×900 and mobile 390×844, plus an MP4 of Use + filling the add form.

## Known gaps / failures

- `bun run verify` was not run for the whole monorepo in this turn.
- `packages/ui` typecheck still fails on develop-owned steward-login files,
  unrelated to this diff.
- Full-page `audit:app` Settings captures are still blocked by the
  `startupCoordinator.target` fixture crash.
- Later layout slices: cloud BrandCard lists (ApplicationsEntry, sessions,
  plugin grants) and DesktopWorkspaceSection compound rows.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok-cli
Contribution skill revision: elizaOS/eliza@d5f48ce311a482148b907b535a6cdd8799cd4491:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-4.6]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-cli","skill_revision":"elizaOS/eliza@d5f48ce311a482148b907b535a6cdd8799cd4491:packages/skills/skills/contribute-to-eliza"} -->
