### PR TITLE
fix(chat): contain malformed interaction markers

### DIFF
--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -773,4 +773,55 @@ describe("normalize", () => {
 			"Hi",
 		);
 	});
+
+	it("removes terminal unclaimed machinery before outbound delivery", () => {
+		const content: Content = {
+			text: "Done.\n[ FOLLOWUPS ]\nreply:Again=Again",
+		};
+		expect(normalizeContentInteractions(content)).toEqual({ text: "Done." });
+	});
+});
+
+describe("interaction marker residue", () => {
+	it("parses spaced CRLF blocks, including TASK whitespace before the bracket", () => {
+		const taskId = "0123abcd-1234-5678-9abc-deadbeefcafe";
+		const text = [
+			"Done.",
+			"[ FOLLOWUPS ]\r\nreply:More=More\r\n[ / FOLLOWUPS ]",
+			"[ CHOICE: pick ]\r\nyes=Yes\r\n[ / CHOICE ]",
+			`[ TASK: ${taskId} ]Ship it[ / TASK ]`,
+		].join("\r\n");
+		const { blocks, cleanedText } = parseInteractionBlocks(text);
+		expect(blocks.map((block) => block.kind)).toEqual([
+			"followups",
+			"choice",
+			"task",
+		]);
+		expect(cleanedText).toBe("Done.");
+	});
+
+	it("strips a terminal half-open block across blanks and malformed close rows", () => {
+		const { blocks, cleanedText } = parseInteractionBlocks(
+			"Here you go.\r\n[ FOLLOWUPS ]\r\nreply:More=More\r\n\r\nprompt:Again=Again\r\n[ /FOLLOWUP ]",
+		);
+		expect(blocks).toEqual([]);
+		expect(cleanedText).toBe("Here you go.");
+	});
+
+	it("preserves malformed marker prose when ordinary prose follows it", () => {
+		const text =
+			"[ FOLLOWUPS ]\nreply:More=More\nThis paragraph explains the malformed example.";
+		expect(parseInteractionBlocks(text).cleanedText).toBe(text);
+	});
+
+	it("preserves marker examples inside fenced Markdown", () => {
+		const text = "Example:\n```text\n[ FOLLOWUPS ]\nreply:More=More\n```";
+		expect(parseInteractionBlocks(text).cleanedText).toBe(text);
+	});
+
+	it("preserves invalid FORM data", () => {
+		const text =
+			'[ FORM ]\r\n{"fields":[{"name":"constructor","type":"text"}]}\r\n[ / FORM ]';
+		expect(parseInteractionBlocks(text).cleanedText).toBe(text);
+	});
 });

--- a/packages/core/src/messaging/interactions/normalize.ts
+++ b/packages/core/src/messaging/interactions/normalize.ts
@@ -13,7 +13,10 @@
  */
 
 import type { Content } from "../../types/primitives";
-import { parseInteractionBlocks } from "./parse";
+import {
+	parseInteractionBlocks,
+	stripUnclaimedInteractionMarkup,
+} from "./parse";
 
 /** Message text with every interaction marker removed and whitespace tidied. */
 export function stripInteractionMarkers(text: string): string {
@@ -22,16 +25,19 @@ export function stripInteractionMarkers(text: string): string {
 
 /**
  * Attach parsed interaction blocks to `content.interactions`. Idempotent and
- * non-destructive: returns the same reference when there's nothing to do, and
- * never mutates `content.text`.
+ * non-destructive for human prose and valid markers; terminal unclaimed
+ * machinery is removed before any delivery surface receives the content.
  */
 export function normalizeContentInteractions(content: Content): Content {
 	if (typeof content.text !== "string" || content.text.length === 0)
 		return content;
+	const text = stripUnclaimedInteractionMarkup(content.text);
 	if (Array.isArray(content.interactions) && content.interactions.length > 0) {
-		return content;
+		return text === content.text ? content : { ...content, text };
 	}
-	const { blocks } = parseInteractionBlocks(content.text);
-	if (blocks.length === 0) return content;
-	return { ...content, interactions: blocks };
+	const { blocks } = parseInteractionBlocks(text);
+	if (blocks.length === 0) {
+		return text === content.text ? content : { ...content, text };
+	}
+	return { ...content, text, interactions: blocks };
 }

--- a/packages/core/src/messaging/interactions/parse.ts
+++ b/packages/core/src/messaging/interactions/parse.ts
@@ -33,11 +33,14 @@ export const MAX_FOLLOWUPS = 4;
 export const MAX_TASK_TITLE_LEN = 200;
 
 // Group 2 captures the header attributes (`id=…`, `allow_custom`) in any order.
-const CHOICE_RE = /\[CHOICE:([\w-]+)([^\]]*)\]\n([\s\S]*?)\n\[\/CHOICE\]/g;
+const CHOICE_RE =
+	/\[[ \t]*CHOICE[ \t]*:[ \t]*([\w-]+)([^\]]*)\][ \t]*\r?\n([\s\S]*?)\r?\n\[[ \t]*\/[ \t]*CHOICE[ \t]*\]/g;
 const FOLLOWUPS_RE =
-	/\[FOLLOWUPS(?:\s+id=(\S+))?\]\n([\s\S]*?)\n\[\/FOLLOWUPS\]/g;
-const FORM_RE = /\[FORM\]\n([\s\S]*?)\n\[\/FORM\]/g;
-const TASK_RE = /\[TASK:([a-f0-9-]{8,64})\]([\s\S]*?)\[\/TASK\]/g;
+	/\[[ \t]*FOLLOWUPS(?:[ \t]+id=([^\s\]]+))?[ \t]*\][ \t]*\r?\n([\s\S]*?)\r?\n\[[ \t]*\/[ \t]*FOLLOWUPS[ \t]*\]/g;
+const FORM_RE =
+	/\[[ \t]*FORM[ \t]*\][ \t]*\r?\n([\s\S]*?)\r?\n\[[ \t]*\/[ \t]*FORM[ \t]*\]/g;
+const TASK_RE =
+	/\[[ \t]*TASK[ \t]*:[ \t]*([a-f0-9-]{8,64})[ \t]*\]([\s\S]*?)\[[ \t]*\/[ \t]*TASK[ \t]*\]/g;
 
 const FIELD_TYPES: ReadonlySet<InteractionFieldType> = new Set([
 	"text",
@@ -290,6 +293,93 @@ export interface ParsedInteractions {
 	cleanedText: string;
 }
 
+const UNCLAIMED_BLOCK_OPEN_RE =
+	/^[ \t]*\[[ \t]*(?:FOLLOWUPS|CHOICE)\b[^\]]*\][ \t]*\r?$/i;
+const UNCLAIMED_TASK_RE = /^[ \t]*\[[ \t]*TASK\b[^\]]*\][^\r\n]*\r?$/i;
+const UNCLAIMED_MARKER_RE =
+	/^[ \t]*\[[ \t]*\/?[ \t]*[A-Z][A-Z_-]*(?:\s*:[^\]]*)?[ \t]*\][ \t]*\r?$/;
+const UNCLAIMED_OPTION_RE =
+	/^[ \t]*(?:(?:reply|navigate|prompt|value|action|url)[ \t]*:)?[^=\r\n]{1,256}=.+\r?$/i;
+
+interface SourceLine {
+	start: number;
+	end: number;
+	text: string;
+	inFence: boolean;
+}
+
+function sourceLines(text: string): SourceLine[] {
+	const lines: SourceLine[] = [];
+	const lineRe = /[^\n]*(?:\n|$)/g;
+	let fence: "`" | "~" | null = null;
+	let match: RegExpExecArray | null = lineRe.exec(text);
+	while (match !== null && match[0].length > 0) {
+		const line = match[0].endsWith("\n") ? match[0].slice(0, -1) : match[0];
+		const fenceMatch = line.match(/^[ \t]*(`{3,}|~{3,})/);
+		const marker = fenceMatch?.[1]?.[0] as "`" | "~" | undefined;
+		const inFence = fence !== null || marker !== undefined;
+		lines.push({
+			start: match.index,
+			end: match.index + match[0].length,
+			text: line,
+			inFence,
+		});
+		if (marker !== undefined) {
+			fence = fence === null ? marker : fence === marker ? null : fence;
+		}
+		match = lineRe.exec(text);
+	}
+	return lines;
+}
+
+/**
+ * Remove only a terminal, unclaimed interaction suffix from model output.
+ * Valid blocks remain untouched for renderers, FORM residue is preserved
+ * because it can contain user data, and fenced examples are never rewritten.
+ */
+function stripUnclaimedInteractionMarkupTail(text: string): string {
+	if (!/\[[ \t]*(?:FOLLOWUPS|CHOICE|TASK)\b/i.test(text)) return text;
+	const lines = sourceLines(text);
+	let suffixStart = lines.length;
+	for (let index = lines.length - 1; index >= 0; index -= 1) {
+		const line = lines[index];
+		if (line.inFence) break;
+		if (
+			line.text.trim().length === 0 ||
+			UNCLAIMED_OPTION_RE.test(line.text) ||
+			UNCLAIMED_MARKER_RE.test(line.text)
+		) {
+			suffixStart = index;
+			continue;
+		}
+		break;
+	}
+	if (suffixStart >= lines.length) return text;
+	let opening = -1;
+	for (let index = suffixStart; index < lines.length; index += 1) {
+		const line = lines[index];
+		if (
+			!line.inFence &&
+			(UNCLAIMED_BLOCK_OPEN_RE.test(line.text) ||
+				UNCLAIMED_TASK_RE.test(line.text))
+		) {
+			opening = index;
+			break;
+		}
+	}
+	if (opening < 0) return text;
+	return text.slice(0, lines[opening].start).trimEnd();
+}
+
+/** Preserve claimable controls while removing a terminal unclaimed suffix. */
+export function stripUnclaimedInteractionMarkup(text: string): string {
+	if (!/\[[ \t]*(?:FOLLOWUPS|CHOICE|TASK)\b/i.test(text)) return text;
+	const terminalClaim = findInteractionRegions(text).some(
+		(region) => text.slice(region.end).trim().length === 0,
+	);
+	return terminalClaim ? text : stripUnclaimedInteractionMarkupTail(text);
+}
+
 /**
  * Parse `text` into its interaction blocks plus the human-readable text with
  * the markers stripped. The cleaned text is what a connector shows above the
@@ -297,7 +387,9 @@ export interface ParsedInteractions {
  */
 export function parseInteractionBlocks(text: string): ParsedInteractions {
 	const regions = findInteractionRegions(text);
-	if (regions.length === 0) return { blocks: [], cleanedText: text };
+	if (regions.length === 0) {
+		return { blocks: [], cleanedText: stripUnclaimedInteractionMarkup(text) };
+	}
 	const blocks: InteractionBlock[] = [];
 	const parts: string[] = [];
 	let cursor = 0;
@@ -307,8 +399,7 @@ export function parseInteractionBlocks(text: string): ParsedInteractions {
 		cursor = r.end;
 	}
 	if (cursor < text.length) parts.push(text.slice(cursor));
-	const cleanedText = parts
-		.join("")
+	const cleanedText = stripUnclaimedInteractionMarkup(parts.join(""))
 		.replace(/\n{3,}/g, "\n\n")
 		.trim();
 	return { blocks, cleanedText };

--- a/packages/ui/src/components/chat/InlineWidgetText.tsx
+++ b/packages/ui/src/components/chat/InlineWidgetText.tsx
@@ -4,6 +4,7 @@
  * affordances stay consistent with the full chat view.
  */
 
+import { stripUnclaimedInteractionMarkup } from "@elizaos/core";
 import type { ReactNode } from "react";
 import { useAppSelectorShallow } from "../../state";
 import { useChatComposer } from "../../state/ChatComposerContext.hooks";
@@ -39,7 +40,10 @@ export function InlineWidgetText({ content }: { content: string }): ReactNode {
   // non-analysis mode — hidden reasoning/tool tags are stripped, not leaked.
   // Incremental prefix-cached parse so a streaming overlay bubble re-parses only
   // its changed tail (#15280); byte-identical to parseSegments.
-  const segments = useParsedSegments(content, false);
+  const segments = useParsedSegments(
+    stripUnclaimedInteractionMarkup(content),
+    false,
+  );
 
   // Fast path: a single plain-text segment (most replies) renders as-is.
   if (segments.length === 1 && segments[0].kind === "text") {

--- a/packages/ui/src/components/chat/MessageContent.interactions.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.interactions.test.tsx
@@ -105,6 +105,38 @@ describe("MessageContent non-bytes interaction rendering", () => {
     expect(container.textContent ?? "").toContain("Run again");
   });
 
+  it("renders spaced CRLF followups without exposing wire markup", () => {
+    const { container } = withApp(
+      <MessageContent
+        message={assistant({
+          text: "Done.\r\n[ FOLLOWUPS ]\r\nreply:Again=Again\r\n[ / FOLLOWUPS ]",
+        })}
+      />,
+    );
+    expect(container.textContent ?? "").toContain("Again");
+    expect(container.textContent ?? "").not.toContain("FOLLOWUPS");
+    expect(container.textContent ?? "").not.toContain("reply:");
+  });
+
+  it("strips terminal unclaimed markers only from assistant messages", () => {
+    const assistantView = withApp(
+      <MessageContent
+        message={assistant({
+          text: "Done.\n[ FOLLOWUPS ]\nreply:Again=Again",
+        })}
+      />,
+    );
+    expect(assistantView.container.textContent ?? "").toBe("Done.");
+    assistantView.unmount();
+
+    const userMessage = assistant({
+      role: "user",
+      text: "Example:\n[ FOLLOWUPS ]\nreply:Again=Again",
+    });
+    const userView = withApp(<MessageContent message={userMessage} />);
+    expect(userView.container.textContent ?? "").toContain("FOLLOWUPS");
+  });
+
   it("renders a choice picker from a [CHOICE] block", () => {
     const { container } = withApp(
       <MessageContent

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -13,6 +13,8 @@
  * `MessageUiSpecBlock`, `SensitiveRequestBlock`, and `MessagePermissionCard`
  * exports here drive their own mutations through the typed `ElizaClient`.
  */
+
+import { stripUnclaimedInteractionMarkup } from "@elizaos/core";
 import {
   type FormEvent,
   memo,
@@ -1310,7 +1312,11 @@ export function MessageContent({
   // Incremental prefix-cached parse: a streaming turn re-parses only its changed
   // tail instead of the whole buffer every rAF flush (#15280). Byte-identical to
   // parseSegments; falls back to raw text if the markup is malformed.
-  const segments = useParsedSegments(message.text, analysisMode);
+  const displayText =
+    message.role === "assistant"
+      ? stripUnclaimedInteractionMarkup(message.text)
+      : message.text;
+  const segments = useParsedSegments(displayText, analysisMode);
 
   // Handlers handed to every inline widget at render: the SAME shared contract
   // the overlay surface (InlineWidgetText) uses, so a CHOICE pick / FOLLOWUPS

--- a/packages/ui/src/components/chat/message-choice-parser.ts
+++ b/packages/ui/src/components/chat/message-choice-parser.ts
@@ -10,7 +10,7 @@ import type { ChoiceOption } from "./widgets/ChoiceWidget";
 // Header attributes (`id=…`, `allow_custom`) are captured as a single string in
 // group 2 and parsed below, so they can appear in any order.
 export const CHOICE_RE =
-  /\[CHOICE:([\w-]+)(?:\s+([^\]]*))?\]\n([\s\S]*?)\n\[\/CHOICE\]/g;
+  /\[[ \t]*CHOICE[ \t]*:[ \t]*([\w-]+)(?:[ \t]+([^\]]*))?\][ \t]*\r?\n([\s\S]*?)\r?\n\[[ \t]*\/[ \t]*CHOICE[ \t]*\]/g;
 
 export function generateChoiceId(): string {
   if (

--- a/packages/ui/src/components/chat/message-followups-parser.ts
+++ b/packages/ui/src/components/chat/message-followups-parser.ts
@@ -31,7 +31,7 @@ export const MAX_FOLLOWUPS = 4;
 const FOLLOWUP_KINDS = new Set<FollowupKind>(["reply", "navigate", "prompt"]);
 
 export const FOLLOWUPS_RE =
-  /\[FOLLOWUPS(?:\s+id=(\S+))?\]\n([\s\S]*?)\n\[\/FOLLOWUPS\]/g;
+  /\[[ \t]*FOLLOWUPS(?:[ \t]+id=([^\s\]]+))?[ \t]*\][ \t]*\r?\n([\s\S]*?)\r?\n\[[ \t]*\/[ \t]*FOLLOWUPS[ \t]*\]/g;
 
 export function generateFollowupsId(): string {
   if (

--- a/packages/ui/src/components/chat/message-form-parser.ts
+++ b/packages/ui/src/components/chat/message-form-parser.ts
@@ -91,7 +91,8 @@ const UNSAFE_OBJECT_FIELD_NAMES = new Set([
   "valueOf",
 ]);
 
-export const FORM_RE = /\[FORM\]\n([\s\S]*?)\n\[\/FORM\]/g;
+export const FORM_RE =
+  /\[[ \t]*FORM[ \t]*\][ \t]*\r?\n([\s\S]*?)\r?\n\[[ \t]*\/[ \t]*FORM[ \t]*\]/g;
 
 export function generateFormId(): string {
   if (

--- a/packages/ui/src/components/chat/message-parser-edge.test.ts
+++ b/packages/ui/src/components/chat/message-parser-edge.test.ts
@@ -39,6 +39,26 @@ describe("inline widget parser edge cases", () => {
     ]);
   });
 
+  it("parses spaced CRLF markers identically across widget types", () => {
+    const taskId = "0123abcd-1234-5678-9abc-deadbeefcafe";
+    expect(
+      findChoiceRegions("[ CHOICE: approval ]\r\nyes=Yes\r\n[ / CHOICE ]"),
+    ).toHaveLength(1);
+    expect(
+      findFollowupsRegions(
+        "[ FOLLOWUPS ]\r\nreply:Again=Again\r\n[ / FOLLOWUPS ]",
+      ),
+    ).toHaveLength(1);
+    expect(
+      findFormRegions(
+        '[ FORM ]\r\n{"fields":[{"name":"when","type":"text"}]}\r\n[ / FORM ]',
+      ),
+    ).toHaveLength(1);
+    expect(findTaskRegions(`[ TASK: ${taskId} ]Ship[ / TASK ]`)).toHaveLength(
+      1,
+    );
+  });
+
   it("keeps duplicate ids as separate parser regions", () => {
     const text =
       "[CHOICE:approval id=dup]\nyes=Yes\n[/CHOICE]\n[CHOICE:approval id=dup]\nno=No\n[/CHOICE]";

--- a/packages/ui/src/components/chat/message-task-parser.ts
+++ b/packages/ui/src/components/chat/message-task-parser.ts
@@ -22,7 +22,8 @@
  *     ignored entirely (no half-rendered widget).
  */
 
-const TASK_BLOCK_RE = /\[TASK:([a-f0-9-]{8,64})\]([\s\S]*?)\[\/TASK\]/g;
+const TASK_BLOCK_RE =
+  /\[[ \t]*TASK[ \t]*:[ \t]*([a-f0-9-]{8,64})[ \t]*\]([\s\S]*?)\[[ \t]*\/[ \t]*TASK[ \t]*\]/g;
 
 /** Hard cap on the inline preview title — keeps a runaway template safe. */
 export const MAX_TASK_TITLE_LEN = 200;

--- a/plugins/plugin-discord/__tests__/interactions.test.ts
+++ b/plugins/plugin-discord/__tests__/interactions.test.ts
@@ -24,6 +24,22 @@ describe("renderDiscordInteractions", () => {
 		expect(out.components).toHaveLength(0);
 	});
 
+	it("does not ship an unclaimed terminal marker when no controls parse", () => {
+		const out = renderDiscordInteractions({
+			text: "Done.\r\n[ FOLLOWUPS ]\r\nreply:More=More",
+		} as Content);
+		expect(out.text).toBe("Done.");
+		expect(out.components).toEqual([]);
+	});
+
+	it("renders spaced CRLF followups as native controls", () => {
+		const out = renderDiscordInteractions({
+			text: "Done.\r\n[ FOLLOWUPS ]\r\nreply:More=More\r\n[ / FOLLOWUPS ]",
+		} as Content);
+		expect(out.text).toBe("Done.");
+		expect(out.components[0]?.components[0]?.label).toBe("More");
+	});
+
 	it("renders a choice block as a button action row and strips the marker", () => {
 		const content: Content = {
 			text: "Approve?\n[CHOICE:approve id=c1]\nyes=Yes, ship it\nno=Cancel\n[/CHOICE]",

--- a/plugins/plugin-discord/interactions.ts
+++ b/plugins/plugin-discord/interactions.ts
@@ -81,7 +81,7 @@ export function renderDiscordInteractions(
 	const { blocks, cleanedText } = parseInteractionBlocks(content.text ?? "");
 	if (blocks.length === 0) {
 		return {
-			text: content.text ?? "",
+			text: cleanedText,
 			components: [],
 			needsFreeTextReply: false,
 		};

--- a/plugins/plugin-telegram/src/interactions.test.ts
+++ b/plugins/plugin-telegram/src/interactions.test.ts
@@ -23,6 +23,22 @@ describe("renderTelegramInteractions", () => {
     expect(out.needsFreeTextReply).toBe(false);
   });
 
+  it("does not ship an unclaimed terminal marker when no controls parse", () => {
+    const out = renderTelegramInteractions({
+      text: "Done.\r\n[ FOLLOWUPS ]\r\nreply:More=More",
+    } as Content);
+    expect(out.text).toBe("Done.");
+    expect(out.keyboardRows).toEqual([]);
+  });
+
+  it("renders spaced CRLF followups as native controls", () => {
+    const out = renderTelegramInteractions({
+      text: "Done.\r\n[ FOLLOWUPS ]\r\nreply:More=More\r\n[ / FOLLOWUPS ]",
+    } as Content);
+    expect(out.text).toBe("Done.");
+    expect(out.keyboardRows[0]?.[0]).toMatchObject({ text: "More" });
+  });
+
   it("renders a choice block as callback buttons and strips the marker", () => {
     const content: Content = {
       text: "Approve the deploy?\n[CHOICE:approve id=c1]\nyes=Yes, ship it\nno=Cancel\n[/CHOICE]",

--- a/plugins/plugin-telegram/src/interactions.ts
+++ b/plugins/plugin-telegram/src/interactions.ts
@@ -61,7 +61,7 @@ export function renderTelegramInteractions(
   const { blocks, cleanedText } = parseInteractionBlocks(content.text ?? "");
   if (blocks.length === 0) {
     return {
-      text: content.text ?? "",
+      text: cleanedText,
       keyboardRows: [],
       needsFreeTextReply: false,
     };


### PR DESCRIPTION
Closes #19472. Supersedes the incomplete helper-only fix in #19429.

## What

- accepts harmless bracket whitespace and LF/CRLF for CHOICE, FOLLOWUPS, FORM, and TASK markers
- removes only terminal unclaimed CHOICE/FOLLOWUPS/TASK machinery
- preserves invalid FORM data, ordinary/nonterminal prose, fenced Markdown examples, and user-authored messages
- makes Discord and Telegram use cleaned text even when no native control parses
- applies the same assistant-only boundary to ChatView and ChatOverlay
- adds core, connector, parser-parity, rendered UI, and incremental-parser regressions

## Validation

- core interaction contract: 54 pass
- Discord interaction renderer: 15 pass
- Telegram interaction renderer: 8 pass
- UI parser/render/streaming focus: 193 pass
- core, Discord, Telegram, and UI typechecks: pass
- targeted Biome and diff check: pass
- full Telegram and Discord package tests: pass
- full UI suite: 10,130 pass / 7 skipped; five unrelated current baseline failures (legacy Cloud URL expectations, incomplete Electrobun test mock, and two load-sensitive 5s timeouts)
- root `bun run verify`: pass on the exact refreshed tree after merging current develop

## Evidence

<!-- evidence-head:dfe90852b418de438b55f281199e2674552032a4 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19476-before-desktop-mobile.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19476-after-desktop-mobile.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19476-walkthrough.mp4

<!-- evidence-row:backend-logs -->
N/A - no backend request or state mutation; this is deterministic post-model-output parsing and connector projection.

<!-- evidence-row:frontend-logs -->
- [x] [19476-frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19476-frontend.log)

<!-- evidence-row:llm-trajectory -->
N/A - no model call changes; the parser consumes already-produced text and the exact leaked payload is pinned deterministically.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no external domain state or artifact; the delivered-text boundary is proven by core, connector, rendered UI, and incremental-parser tests

<!-- evidence-row:ocr-review -->
- [x] [19476-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19476-ocr-review.txt)

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Models: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Client / agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Contribution skill revision: elizaOS/eliza@75dfd30f81c395100add458d0690f1fc2f44ed48:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

AI provider/model: openai/gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@75dfd30f81c395100add458d0690f1fc2f44ed48:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [nubs-interaction-marker-parity]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@75dfd30f81c395100add458d0690f1fc2f44ed48:packages/skills/skills/contribute-to-eliza"} -->


