### PR TITLE
fix(cloud): keep production voice realtime enabled

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -759,9 +759,9 @@ INFERENCE_PASSTHROUGH_STREAMING = "true"
 # the upstream JSON untouched; usage parses from the same buffer and bills
 # through the identical settle chain. Default off; rollback = flip off.
 INFERENCE_PASSTHROUGH_EMBEDDINGS = "true"
-# Realtime voice is a staging-only soak. Keep the production posture explicit
-# so a missing variable or inherited default cannot accidentally expose it.
-VOICE_REALTIME_WS_ENABLED = "false"
+# Production voice powers both authenticated app sessions and signed Twilio
+# media streams. Keep it explicit so a deploy cannot silently hang up calls.
+VOICE_REALTIME_WS_ENABLED = "true"
 ELIZA_TTS_FISH_ENABLED = "false"
 FISH_AUDIO_DATA_GOVERNANCE_APPROVED = "false"
 FORCE_REDIS_EVENTS = "false"

--- a/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
@@ -162,7 +162,7 @@ describe("Cloud CF realtime voice deploy contract", () => {
     // Staging realtime is intentionally ON (#16809: toml aligned with the live
     // staging worker); production remains explicitly off until its own gated flip.
     expect(stagingVars).toContain('VOICE_REALTIME_WS_ENABLED = "true"');
-    expect(productionVars).toContain('VOICE_REALTIME_WS_ENABLED = "false"');
+    expect(productionVars).toContain('VOICE_REALTIME_WS_ENABLED = "true"');
     expect(stagingVars).toContain('ELIZA_TTS_FISH_ENABLED = "false"');
     expect(productionVars).toContain('ELIZA_TTS_FISH_ENABLED = "false"');
     expect(stagingVars).toContain(
@@ -207,7 +207,7 @@ describe("Cloud CF realtime voice deploy contract", () => {
     // Staging is intentionally on (#16809); the production-safe invariant is
     // that production's own var stays "false".
     expect(stagingVars).toContain('VOICE_REALTIME_WS_ENABLED = "true"');
-    expect(productionVars).toContain('VOICE_REALTIME_WS_ENABLED = "false"');
+    expect(productionVars).toContain('VOICE_REALTIME_WS_ENABLED = "true"');
     expect(deployStep.env?.VOICE_REALTIME_WS_ENABLED).toBe(
       publishStep.env?.VOICE_REALTIME_WS_ENABLED,
     );


### PR DESCRIPTION
## Summary
- keep the production realtime voice gate enabled for signed Twilio Media Streams and authenticated app voice sessions
- update the deployment contract to prevent production from silently reverting the gate to false

## Root cause
The committed production Wrangler value was `false`, while the previously working Worker and repository production variable were both `true`. A manual publish applied the committed value, causing `/api/v1/twilio/voice/media` to reject Twilio WebSocket upgrades with 404 and end calls immediately.

## Verification
- `bun test ./packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts ./packages/cloud/api/v1/twilio/voice/route-boundaries.test.ts`
- `bunx biome check packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts`
- production Worker `6420e7c8-dc57-4b47-81b3-768e73de6449` verified with the gate enabled and all Twilio/Cartesia bindings present

Refs #19450

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@2356d9de0dcd4c92e1e8690f435b1e468d9803b6:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex-desktop","skill_revision":"elizaOS/eliza@2356d9de0dcd4c92e1e8690f435b1e468d9803b6:packages/skills/skills/contribute-to-eliza"} -->