### PR TITLE
feat(elizaresearch): blend slow and 3D particle entrance

### DIFF
--- a/packages/elizaresearch/index.html
+++ b/packages/elizaresearch/index.html
@@ -249,9 +249,9 @@
 </footer>
 
 <script>
-// Particles orbit inward through a virtual 3D camera, then resolve into the
-// detailed face and continue with a slow per-particle float. Shimmer and pointer
-// response run throughout, so arrival and interaction remain one system.
+// Particles take one calm orbit through a virtual 3D camera before resolving
+// into the detailed face. A deterministic entrance keeps the authored pace
+// consistent across reloads while shimmer and pointer response stay live.
 (() => {
   const canvas = document.getElementById("swarm");
   const header = canvas.parentElement;
@@ -263,7 +263,7 @@
   let born = 0;
   let entranceStarted = false;
   let entranceComplete = reduced;
-  const ENTER_MS = 2050, ENTER_STAGGER_MS = 220;
+  const ENTER_MS = 2800, ENTER_STAGGER_MS = 280;
   const LANE_COUNT = 16;
   const laneEase = new Float32Array(LANE_COUNT);
   const laneCos = new Float32Array(LANE_COUNT);
@@ -278,6 +278,15 @@
   const SIN = new Float32Array(SIN_N);
   for (let i = 0; i < SIN_N; i++) SIN[i] = Math.sin((i / SIN_N) * Math.PI * 2);
   const wave = (turns) => SIN[((turns * SIN_N) | 0) & (SIN_N - 1)];
+  const smootherstep = (progress) => progress * progress * progress * (progress * (progress * 6 - 15) + 10);
+  let entranceSeed = 0;
+  function entranceRandom() {
+    entranceSeed += 0x6d2b79f5;
+    let value = entranceSeed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  }
   const pointer = { x: -1e4, y: -1e4, down: false, touch: false };
 
   function resize() {
@@ -299,6 +308,7 @@
     resizeFrame = requestAnimationFrame(() => { resize(); tryInit(); });
   });
   function sampleFace() {
+    entranceSeed = (Math.imul(W, 73856093) ^ Math.imul(H, 19349663) ^ 0x9e3779b9) >>> 0;
     const scale = Math.min(W, H) * 1.0;
     const ow = Math.round(scale * (img.width / img.height)), oh = Math.round(scale);
     const off = document.createElement("canvas");
@@ -322,8 +332,8 @@
     );
     for (let i = 0; i < count; i++) {
       for (let attempt = 0; attempt < 100; attempt++) {
-        const x = Math.floor(Math.random() * ow);
-        const y = Math.floor(Math.random() * oh);
+        const x = Math.floor(entranceRandom() * ow);
+        const y = Math.floor(entranceRandom() * oh);
         if (solid(x, y)) { push(x, y); break; }
       }
     }
@@ -340,19 +350,19 @@
     }
     const cx = W / 2, cy = H / 2, reach = Math.max(W, H);
     for (const t of targets) {
-      const a = Math.random() * Math.PI * 2;
-      const r = reach * (0.55 + Math.random() * 0.5);
+      const a = entranceRandom() * Math.PI * 2;
+      const r = reach * (0.55 + entranceRandom() * 0.5);
       const sx = entranceComplete ? t.x : cx + Math.cos(a) * r;
       const sy = entranceComplete ? t.y : cy + Math.sin(a) * r;
       boids.push({
         x: sx, y: sy, sx, sy,
         tx: t.x, ty: t.y,
-        sz: entranceComplete ? 0 : Math.min(W, H) * (0.35 + Math.random() * 0.55) * (Math.random() < 0.5 ? -1 : 1),
-        lane: (Math.random() * LANE_COUNT) | 0,
+        sz: entranceComplete ? 0 : Math.min(W, H) * (0.35 + entranceRandom() * 0.55) * (entranceRandom() < 0.5 ? -1 : 1),
+        lane: (entranceRandom() * LANE_COUNT) | 0,
         offsetX: 0, offsetY: 0, depthScale: 1,
-        size: Math.random() * 0.95 + 0.85, life: Math.random() * 1000 + 500,
-        ph: Math.random(), phy: Math.random(),
-        fs: 0.6 + Math.random() * 0.8, amp: 1.1 + Math.random() * 2.6 });
+        size: entranceRandom() * 0.95 + 0.85, life: entranceRandom() * 100,
+        ph: entranceRandom(), phy: entranceRandom(),
+        fs: 0.6 + entranceRandom() * 0.8, amp: 1.1 + entranceRandom() * 2.6 });
     }
     if (reduced) { step(performance.now()); draw(performance.now()); }
   }
@@ -401,7 +411,7 @@
       for (let lane = 0; lane < LANE_COUNT; lane++) {
         const delay = lane / (LANE_COUNT - 1) * ENTER_STAGGER_MS;
         const progress = Math.min(1, Math.max(0, (now - born - delay) / (ENTER_MS - delay)));
-        const eased = progress * progress * (3 - 2 * progress);
+        const eased = smootherstep(progress);
         const angle = eased * Math.PI * 2;
         const tilt = Math.sin(progress * Math.PI) * 0.24;
         const roll = Math.sin(progress * Math.PI) * 0.28 * (lane % 2 ? -1 : 1);
@@ -420,13 +430,15 @@
     const breathe = reduced ? 1 : 1 + wave(tf * 0.07) * 0.03;
     for (let i = 0; i < boids.length; i++) {
       const b = boids[i];
-      let baseX = centerX + (b.tx - centerX) * breathe;
-      let baseY = centerY + (b.ty - centerY) * breathe;
+      const targetX = centerX + (b.tx - centerX) * breathe;
+      const targetY = centerY + (b.ty - centerY) * breathe;
+      let baseX = targetX;
+      let baseY = targetY;
       let entranceMix = 1;
       if (!entranceComplete) {
         entranceMix = laneEase[b.lane];
-        const relX = b.sx + (b.tx - b.sx) * entranceMix - centerX;
-        const relY = b.sy + (b.ty - b.sy) * entranceMix - centerY;
+        const relX = b.sx + (targetX - b.sx) * entranceMix - centerX;
+        const relY = b.sy + (targetY - b.sy) * entranceMix - centerY;
         const z = b.sz * (1 - entranceMix);
         const rotatedX = relX * laneCos[b.lane] + z * laneSin[b.lane];
         const rotatedZ = -relX * laneSin[b.lane] + z * laneCos[b.lane];
@@ -464,7 +476,7 @@
         const t = targets[(Math.random() * targets.length) | 0];
         b.x = b.sx = b.tx = t.x; b.y = b.sy = b.ty = t.y;
         b.offsetX = 0; b.offsetY = 0;
-        b.life = Math.random() * 1000 + 500;
+        b.life = Math.random() * 150 + 90;
       }
     }
   }
@@ -474,11 +486,11 @@
     ctx.fillRect(0, 0, W, H);
     ctx.globalAlpha = 1;
     ctx.fillStyle = "#fff";
-    const arrival = entranceComplete ? 1 : Math.min(1, Math.max(0, (now - born) / ENTER_MS));
-    const arrivalScale = 0.58 + arrival * 0.42;
+    const arrivalProgress = entranceComplete ? 1 : Math.min(1, Math.max(0, (now - born) / ENTER_MS));
+    const arrivalScale = 0.64 + smootherstep(arrivalProgress) * 0.36;
     for (let i = 0; i < boids.length; i++) {
       const b = boids[i];
-      const shimmer = 0.88 + (1 - Math.abs((((now / 1000) * 0.09 * b.fs + b.ph) % 1) * 2 - 1)) * 0.2;
+      const shimmer = 0.88 + (1 - Math.abs((((now / 1000) * 0.28 * b.fs + b.ph) % 1) * 2 - 1)) * 0.2;
       const size = b.size * arrivalScale * shimmer * b.depthScale;
       ctx.fillRect(b.x - (size - b.size) / 2, b.y - (size - b.size) / 2, size, size);
     }


### PR DESCRIPTION
# Relates to

Closes #19475.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/GPT-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop app`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@75dfd30f81c395100add458d0690f1fc2f44ed48:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@e2505b87c6610e2908a7150cc1eeb5a2f01b484b`; zero conflicts.
- [x] `bun run verify` passes post-sync. The Research package did not change in the final upstream advance; focused checks were rerun after the rebase.

# Risks

Low. The change is confined to the existing static Eliza Research canvas animation. Primary risks are visual handoff continuity, animation performance, mobile layout, and reduced-motion behavior. The implementation remains one O(N) Canvas2D loop with no new dependencies or DOM surfaces.

# Background

## What does this PR do?

It combines the current slow Eliza Research face breathe and sparkle with a deterministic 2.8-second 3D entrance. Particles approach from the full canvas in opposing orbit lanes, remain interactive during the entrance, and transition continuously into the settled face. The settled breathe target is now used throughout the approach, removing the end-of-entrance snap. Sparkle lifetimes and size modulation begin immediately so the face stays visibly alive without extra orbiting particles.

## What kind of change is this?

Improvement and bug fix to an existing frontend animation.

# Documentation changes needed?

No documentation change is required. The public content, routes, deployment configuration, and operating procedure are unchanged.

# Testing

## Where should a reviewer start?

Open the attached desktop/mobile walkthrough evidence, then run `bun run preview` from `packages/elizaresearch` and reload `/`.

## Detailed testing steps

1. Reload the page and confirm particles begin across the canvas, orbit toward the face, and settle without a final snap.
2. Move the pointer over the forming face and confirm hover deformation works during the entrance.
3. Wait after formation and confirm continuous breathe and visible one-color sparkle.
4. Repeat at 390x844 and 844x390; confirm no horizontal overflow.
5. Enable reduced motion; confirm the face renders formed and remains static.

# Evidence Gate

<!-- evidence-head:74ae0f8f2f05db139ad725f5b63d0162fbbfd704 -->

<!-- evidence-row:before-screenshots -->
- [x] [Before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19481-before-desktop.jpg) and [before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19481-before-mobile.jpg).
<!-- evidence-row:after-screenshots -->
- [x] [After desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19481-after-desktop.jpg) and [after mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19481-after-mobile.jpg).
<!-- evidence-row:walkthrough-video -->
- [x] [Desktop MP4 walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19481-slow-spin-walkthrough.mp4).
<!-- evidence-row:backend-logs -->
- [x] N/A - this is a static asset-only site with no backend request path.
<!-- evidence-row:frontend-logs -->
- [x] [Frontend console/network/layout results](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19481-frontend-network.log).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the source PR produces no DB, memory, scheduled-task, wallet, or on-chain artifacts; the deployment version receipt will be posted after merge.
<!-- evidence-row:ocr-review -->
- [x] [Manual OCR/visual-text review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19481-ocr-review.txt); all visible copy is unchanged and legible in the attached desktop/mobile captures.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

Backend: N/A - static asset-only Worker.

Frontend QA:

```text
Desktop 1280x720: no page-origin console errors; assets loaded; no horizontal overflow.
Mobile 390x844: no page-origin console errors; no horizontal overflow.
Short landscape 844x390: no page-origin console errors; no horizontal overflow.
Reduced motion: canvas output remained byte-stable across the observation window.
Pointer input: hover/touch deformation remained active during entrance and recovered cleanly.
```

## Screenshots (before / after) + video walkthrough

Attached inline in the evidence comment immediately below the PR body.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changes.

## Known gaps / failures

None. Biome reports only the two incumbent `!important` reduced-motion cascade warnings in the unchanged CSS rule.

# Deploy Notes

Deploy the merged `develop` commit from `packages/elizaresearch` using its pinned Wrangler script. Post the Cloudflare Worker version, production SHA-256 match, and rollback version after verification.

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex desktop app
Contribution skill revision: elizaOS/eliza@75dfd30f81c395100add458d0690f1fc2f44ed48:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [root/elizaresearch-spin-slow-local]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5","client":"Codex desktop app","skill_revision":"elizaOS/eliza@75dfd30f81c395100add458d0690f1fc2f44ed48:packages/skills/skills/contribute-to-eliza"} -->
