### PR TITLE
fix(ui): route cloud settings lists through SettingsStack/Group/Row

### DIFF
--- a/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
@@ -53,7 +53,9 @@ vi.mock("../../../cloud-ui", () => ({
 
 vi.mock("lucide-react", () => ({
   Camera: () => <span data-testid="icon-camera" />,
+  ChevronRight: () => <span data-testid="icon-chevron" />,
   Download: () => <span data-testid="icon-download" />,
+  KeyRound: () => <span data-testid="icon-key" />,
   Lock: () => <span data-testid="icon-lock" />,
   ScrollText: () => <span data-testid="icon-scroll-text" />,
   Trash2: () => <span data-testid="icon-trash" />,
@@ -78,6 +80,7 @@ vi.mock("sonner", () => ({
 }));
 
 import { ActiveSessionsPanel } from "./active-sessions-panel";
+import { ApiKeysLink } from "./api-keys-link";
 import { MfaPanel } from "./mfa-panel";
 import { RecentAuditEvents } from "./recent-audit-events";
 
@@ -141,6 +144,33 @@ describe("account-security panels", () => {
     ).toBeTruthy();
     expect(screen.queryByText(/Session listing is unavailable/i)).toBeNull();
     expect(apiMock).toHaveBeenCalledWith("/api/v1/sessions");
+  });
+
+  it("renders a ready session inventory as settings rows", async () => {
+    apiMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          id: "sess-1",
+          device: "MacBook Pro",
+          ip: "100.64.1.9",
+          last_seen: "2026-08-14T12:00:00.000Z",
+          current: true,
+        },
+      ],
+    });
+
+    render(<ActiveSessionsPanel />);
+
+    expect(await screen.findByText("MacBook Pro")).toBeTruthy();
+    expect(screen.getByText("current")).toBeTruthy();
+    expect(screen.queryByText(/No other active sessions found/i)).toBeNull();
+    expect(screen.queryByText(/Session listing is unavailable/i)).toBeNull();
+  });
+
+  it("routes the API keys nav row to the cloud-api-keys hash", () => {
+    render(<ApiKeysLink />);
+    const link = screen.getByRole("link", { name: "Manage keys" });
+    expect(link.getAttribute("href")).toBe("#cloud-api-keys");
   });
 
   it("renders malformed session DTOs as errors, not healthy empty state", async () => {

--- a/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
@@ -5,7 +5,11 @@
  */
 
 import { useEffect, useState } from "react";
-import { BrandCard, CornerBrackets } from "../../../cloud-ui";
+import {
+  SettingsGroup,
+  SettingsRow,
+  SettingsStack,
+} from "../../../components/settings/settings-layout";
 import { api } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 
@@ -71,81 +75,72 @@ export function ActiveSessionsPanel() {
   }, []);
 
   return (
-    <BrandCard className="relative">
-      <CornerBrackets size="sm" className="opacity-50" />
-      <div className="relative z-10 space-y-4">
-        <div>
-          <h3 className="text-lg font-bold text-txt-strong">
-            {t("cloud.activeSessions.title", {
-              defaultValue: "Active sessions",
-            })}
-          </h3>
-          <p className="text-sm text-muted">
-            {t("cloud.activeSessions.description", {
-              defaultValue:
-                "Devices and browsers currently signed in to your account.",
-            })}
-          </p>
-        </div>
+    <SettingsStack data-testid="cloud-active-sessions">
+      <SettingsGroup
+        title={t("cloud.activeSessions.title", {
+          defaultValue: "Active sessions",
+        })}
+        description={t("cloud.activeSessions.description", {
+          defaultValue:
+            "Devices and browsers currently signed in to your account.",
+        })}
+      >
         {state.kind === "loading" ? (
-          <p className="text-sm text-muted">
-            {t("cloud.activeSessions.loading", {
+          <SettingsRow
+            label={t("cloud.activeSessions.loading", {
               defaultValue: "Loading sessions...",
             })}
-          </p>
+          />
         ) : state.kind === "unavailable" ? (
-          <p className="text-sm text-muted">
-            {t("cloud.activeSessions.notAvailable", {
+          <SettingsRow
+            label={t("cloud.activeSessions.notAvailable", {
               reason: state.reason ?? "",
               defaultValue: "Session listing is unavailable on this server.",
             })}
-          </p>
+          />
         ) : state.kind === "error" ? (
-          <p className="text-sm text-red-600 dark:text-red-300">
-            {state.message}
-          </p>
+          <SettingsRow tone="danger" label={state.message} />
         ) : state.sessions.length === 0 ? (
-          <p className="text-sm text-muted">
-            {t("cloud.activeSessions.noOther", {
+          <SettingsRow
+            label={t("cloud.activeSessions.noOther", {
               defaultValue: "No other active sessions found.",
             })}
-          </p>
+          />
         ) : (
-          <ul className="divide-y divide-border">
-            {state.sessions.map((session) => (
-              <li
+          state.sessions.map((session) => {
+            const device =
+              session.device ??
+              t("cloud.activeSessions.unknownDevice", {
+                defaultValue: "Unknown device",
+              });
+            return (
+              <SettingsRow
                 key={session.id}
-                className="flex items-center justify-between gap-3 py-2 text-sm"
-              >
-                <div className="space-y-0.5">
-                  <p className="font-medium text-txt-strong">
-                    {session.device ??
-                      t("cloud.activeSessions.unknownDevice", {
-                        defaultValue: "Unknown device",
-                      })}
+                active={Boolean(session.current)}
+                label={
+                  <span className="flex min-w-0 flex-wrap items-center gap-2">
+                    <span>{device}</span>
                     {session.current ? (
-                      <span className="ml-2 rounded-sm border border-green-500/40 bg-green-500/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-green-700 dark:text-green-300">
+                      <span className="rounded-full border border-border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted">
                         {t("cloud.activeSessions.current", {
                           defaultValue: "current",
                         })}
                       </span>
                     ) : null}
-                  </p>
-                  <p className="font-mono text-[11px] text-muted">
-                    {t("cloud.activeSessions.ipLastSeen", {
-                      ip: session.ip ?? "-",
-                      lastSeen: session.last_seen
-                        ? new Date(session.last_seen).toLocaleString()
-                        : "-",
-                      defaultValue: "{{ip}} - last seen {{lastSeen}}",
-                    })}
-                  </p>
-                </div>
-              </li>
-            ))}
-          </ul>
+                  </span>
+                }
+                description={t("cloud.activeSessions.ipLastSeen", {
+                  ip: session.ip ?? "-",
+                  lastSeen: session.last_seen
+                    ? new Date(session.last_seen).toLocaleString()
+                    : "-",
+                  defaultValue: "{{ip}} - last seen {{lastSeen}}",
+                })}
+              />
+            );
+          })
         )}
-      </div>
-    </BrandCard>
+      </SettingsGroup>
+    </SettingsStack>
   );
 }

--- a/packages/ui/src/cloud/account-security/components/api-keys-link.tsx
+++ b/packages/ui/src/cloud/account-security/components/api-keys-link.tsx
@@ -4,39 +4,37 @@
  */
 
 import { KeyRound } from "lucide-react";
-import { BrandButton, BrandCard, CornerBrackets } from "../../../cloud-ui";
+import {
+  SettingsGroup,
+  SettingsRow,
+  SettingsStack,
+} from "../../../components/settings/settings-layout";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 
 export function ApiKeysLink() {
   const t = useCloudT();
   return (
-    <BrandCard className="relative">
-      <CornerBrackets size="sm" className="opacity-50" />
-      <div className="relative z-10 flex items-start justify-between gap-3">
-        <div className="flex items-start gap-3">
-          <div className="rounded-sm border border-border bg-muted p-2">
-            <KeyRound className="h-4 w-4 text-txt-strong" />
-          </div>
-          <div className="space-y-0.5">
-            <p className="text-sm font-medium text-txt-strong">
-              {t("cloud.apiKeysLink.title", { defaultValue: "API keys" })}
-            </p>
-            <p className="text-xs text-muted">
-              {t("cloud.apiKeysLink.description", {
-                defaultValue:
-                  "Manage long-lived keys, their scopes, and per-key audit history.",
+    <SettingsStack data-testid="cloud-api-keys-link">
+      <SettingsGroup>
+        <SettingsRow
+          icon={KeyRound}
+          label={t("cloud.apiKeysLink.title", { defaultValue: "API keys" })}
+          description={t("cloud.apiKeysLink.description", {
+            defaultValue:
+              "Manage long-lived keys, their scopes, and per-key audit history.",
+          })}
+          control={
+            <a
+              href="#cloud-api-keys"
+              className="text-sm font-medium text-accent underline-offset-2 hover:underline"
+            >
+              {t("cloud.apiKeysLink.manageKeys", {
+                defaultValue: "Manage keys",
               })}
-            </p>
-          </div>
-        </div>
-        {/* Plain anchor: an in-settings hash change fires `hashchange`,
-            which is what SettingsView listens to for section switches. */}
-        <a href="#cloud-api-keys">
-          <BrandButton variant="outline" size="sm">
-            {t("cloud.apiKeysLink.manageKeys", { defaultValue: "Manage keys" })}
-          </BrandButton>
-        </a>
-      </div>
-    </BrandCard>
+            </a>
+          }
+        />
+      </SettingsGroup>
+    </SettingsStack>
   );
 }

--- a/packages/ui/src/cloud/account-security/components/plugin-permissions-page-client.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/plugin-permissions-page-client.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Drives PluginPermissionsPageClient: loading, missing, empty, error, ready,
+ * and revoke. jsdom; API client is mocked.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PropsWithChildren } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiMock, apiFetchMock, emitAuditEvent, FakeApiError } = vi.hoisted(
+  () => {
+    class FakeApiError extends Error {
+      status: number;
+      constructor(status: number, message: string) {
+        super(message);
+        this.status = status;
+        this.name = "ApiError";
+      }
+    }
+    return {
+      apiMock: vi.fn(),
+      apiFetchMock: vi.fn(),
+      emitAuditEvent: vi.fn(),
+      FakeApiError,
+    };
+  },
+);
+
+vi.mock("../../lib/api-client", () => ({
+  api: apiMock,
+  apiFetch: apiFetchMock,
+  ApiError: FakeApiError,
+}));
+
+vi.mock("../../../cloud-ui", () => ({
+  DashboardPageContainer: ({ children }: PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  useSetPageHeader: () => undefined,
+}));
+
+vi.mock("../data/audit-client", () => ({
+  emitAuditEvent,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { PluginPermissionsPageClient } from "./plugin-permissions-page-client";
+
+afterEach(cleanup);
+
+describe("PluginPermissionsPageClient", () => {
+  beforeEach(() => {
+    apiMock.mockReset();
+    apiFetchMock.mockReset();
+    emitAuditEvent.mockReset();
+  });
+
+  it("keeps missing, empty, and error states distinct", async () => {
+    apiMock.mockRejectedValueOnce(new FakeApiError(404, "not found"));
+    const missing = render(<PluginPermissionsPageClient />);
+    expect(
+      await screen.findByText(/Plugin grant tracking isn't exposed/i),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText(/No plugin has any permission granted/i),
+    ).toBeNull();
+    missing.unmount();
+
+    apiMock.mockResolvedValueOnce({ grants: [] });
+    const empty = render(<PluginPermissionsPageClient />);
+    expect(
+      await screen.findByText(/No plugin has any permission granted/i),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText(/Plugin grant tracking isn't exposed/i),
+    ).toBeNull();
+    empty.unmount();
+
+    apiMock.mockRejectedValueOnce(new Error("grants route failed"));
+    render(<PluginPermissionsPageClient />);
+    expect(await screen.findByText("grants route failed")).toBeTruthy();
+    expect(
+      screen.queryByText(/No plugin has any permission granted/i),
+    ).toBeNull();
+  });
+
+  it("revokes a ready grant through the shipped DELETE path", async () => {
+    const user = userEvent.setup();
+    apiMock
+      .mockResolvedValueOnce({
+        grants: [
+          {
+            grant_id: "g-1",
+            plugin_id: "plugin-browser",
+            plugin_name: "Browser",
+            permission: "screen",
+            granted_at: "2026-08-01T00:00:00.000Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ grants: [] });
+    apiFetchMock.mockResolvedValueOnce({});
+
+    render(<PluginPermissionsPageClient />);
+    expect(await screen.findByText("Browser")).toBeTruthy();
+    await user.click(screen.getByTestId("revoke-g-1"));
+    expect(apiFetchMock).toHaveBeenCalledWith("/api/v1/me/plugin-grants/g-1", {
+      method: "DELETE",
+    });
+    expect(
+      await screen.findByText(/No plugin has any permission granted/i),
+    ).toBeTruthy();
+  });
+});

--- a/packages/ui/src/cloud/account-security/components/plugin-permissions-page-client.tsx
+++ b/packages/ui/src/cloud/account-security/components/plugin-permissions-page-client.tsx
@@ -9,13 +9,13 @@
 import { Puzzle } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { DashboardPageContainer, useSetPageHeader } from "../../../cloud-ui";
 import {
-  BrandButton,
-  BrandCard,
-  CornerBrackets,
-  DashboardPageContainer,
-  useSetPageHeader,
-} from "../../../cloud-ui";
+  SettingsGroup,
+  SettingsRow,
+  SettingsStack,
+} from "../../../components/settings/settings-layout";
+import { Button } from "../../../components/ui/button";
 import { ApiError, api, apiFetch } from "../../lib/api-client";
 import { emitAuditEvent } from "../data/audit-client";
 
@@ -101,50 +101,36 @@ export function PluginPermissionsPageClient() {
 
   return (
     <DashboardPageContainer>
-      <BrandCard className="relative">
-        <CornerBrackets size="sm" className="opacity-50" />
-        <div className="relative z-10 space-y-4">
-          <div className="flex items-center gap-2">
-            <Puzzle className="h-5 w-5 text-muted" />
-            <h3 className="text-lg font-bold text-txt-strong">Active grants</h3>
-          </div>
+      <SettingsStack data-testid="cloud-plugin-grants">
+        <SettingsGroup title="Active grants">
           {state.kind === "loading" ? (
-            <p className="text-sm text-muted">Loading…</p>
+            <SettingsRow label="Loading…" />
           ) : state.kind === "missing" ? (
-            <p className="text-sm text-muted">
-              Plugin grant tracking isn't exposed yet on this server. Grants
-              made from the desktop app will appear here once the backend is
-              wired.
-            </p>
+            <SettingsRow label="Plugin grant tracking isn't exposed yet on this server. Grants made from the desktop app will appear here once the backend is wired." />
           ) : state.kind === "error" ? (
-            <p className="text-sm text-red-300">{state.message}</p>
+            <SettingsRow tone="danger" label={state.message} />
           ) : state.grants.length === 0 ? (
-            <p className="text-sm text-muted">
-              No plugin has any permission granted on your account.
-            </p>
+            <SettingsRow label="No plugin has any permission granted on your account." />
           ) : (
-            <ul className="divide-y divide-border">
-              {state.grants.map((g) => (
-                <li
-                  key={g.grant_id}
-                  className="flex items-center justify-between gap-3 py-2 text-sm"
-                >
-                  <div className="space-y-0.5">
-                    <p className="font-medium text-txt-strong">
-                      {g.plugin_name ?? g.plugin_id}{" "}
-                      <span className="ml-1 rounded-sm border border-border bg-surface px-1.5 py-0.5 font-mono text-[10px] text-txt">
-                        {g.permission}
-                      </span>
-                    </p>
-                    <p className="font-mono text-[11px] text-muted">
-                      {g.scope ? `scope: ${g.scope} · ` : ""}granted{" "}
-                      {new Date(g.granted_at).toLocaleString()}
-                      {g.last_used
-                        ? ` · last used ${new Date(g.last_used).toLocaleString()}`
-                        : ""}
-                    </p>
-                  </div>
-                  <BrandButton
+            state.grants.map((g) => (
+              <SettingsRow
+                key={g.grant_id}
+                icon={Puzzle}
+                label={
+                  <span className="flex min-w-0 flex-wrap items-center gap-2">
+                    <span>{g.plugin_name ?? g.plugin_id}</span>
+                    <span className="rounded-full border border-border px-1.5 py-0.5 font-mono text-[10px] text-muted">
+                      {g.permission}
+                    </span>
+                  </span>
+                }
+                description={`${g.scope ? `scope: ${g.scope} · ` : ""}granted ${new Date(g.granted_at).toLocaleString()}${
+                  g.last_used
+                    ? ` · last used ${new Date(g.last_used).toLocaleString()}`
+                    : ""
+                }`}
+                control={
+                  <Button
                     size="sm"
                     variant="outline"
                     disabled={revoking === g.grant_id}
@@ -152,13 +138,13 @@ export function PluginPermissionsPageClient() {
                     data-testid={`revoke-${g.grant_id}`}
                   >
                     {revoking === g.grant_id ? "Revoking…" : "Revoke"}
-                  </BrandButton>
-                </li>
-              ))}
-            </ul>
+                  </Button>
+                }
+              />
+            ))
           )}
-        </div>
-      </BrandCard>
+        </SettingsGroup>
+      </SettingsStack>
     </DashboardPageContainer>
   );
 }

--- a/packages/ui/src/cloud/settings/applications-entry.tsx
+++ b/packages/ui/src/cloud/settings/applications-entry.tsx
@@ -1,0 +1,37 @@
+/**
+ * Settings → Cloud Applications entry: a single nav row that opens the
+ * standalone `/cloud/apps` developer surface.
+ */
+import { Grid3x3 } from "lucide-react";
+import {
+  SettingsGroup,
+  SettingsRow,
+  SettingsStack,
+} from "../../components/settings/settings-layout";
+import { useCloudT } from "../shell/CloudI18nProvider";
+
+export function ApplicationsEntry(): React.JSX.Element {
+  const t = useCloudT();
+  const open = () => {
+    if (typeof window !== "undefined") {
+      window.location.assign("/cloud/apps");
+    }
+  };
+  return (
+    <SettingsStack data-testid="cloud-applications-entry">
+      <SettingsGroup>
+        <SettingsRow
+          icon={Grid3x3}
+          label={t("cloud.applications.entryTitle", {
+            defaultValue: "Manage applications",
+          })}
+          description={t("cloud.applications.entryDescription", {
+            defaultValue:
+              "Cloud OAuth applications: monetization, earnings, domains, analytics, users.",
+          })}
+          onClick={open}
+        />
+      </SettingsGroup>
+    </SettingsStack>
+  );
+}

--- a/packages/ui/src/cloud/settings/sections.test.tsx
+++ b/packages/ui/src/cloud/settings/sections.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * Drives the Cloud Applications settings entry: the shipped nav row opens
+ * /cloud/apps. jsdom; i18n and the settings shell are mocked.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? _key,
+}));
+
+import { ApplicationsEntry } from "./applications-entry";
+
+afterEach(cleanup);
+
+describe("ApplicationsEntry", () => {
+  it("assigns /cloud/apps when the settings row is activated", async () => {
+    const user = userEvent.setup();
+    const assign = vi.fn();
+    const original = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...original, assign },
+    });
+
+    render(<ApplicationsEntry />);
+    await user.click(screen.getByText("Manage applications"));
+    expect(assign).toHaveBeenCalledWith("/cloud/apps");
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: original,
+    });
+  });
+});

--- a/packages/ui/src/cloud/settings/sections.tsx
+++ b/packages/ui/src/cloud/settings/sections.tsx
@@ -19,8 +19,6 @@
  *  - {@link CloudPluginGrantsSection}  → cloud/account-security (PermissionsSurface: plugin grants)
  */
 
-import { ExternalLink, Grid3x3 } from "lucide-react";
-import { Button } from "../../components/ui/button";
 import { AccountSurface } from "../account-security/AccountSurface";
 import { PermissionsSurface } from "../account-security/PermissionsSurface";
 import { SecuritySurface } from "../account-security/SecuritySurface";
@@ -28,7 +26,7 @@ import { ApiKeysSurface } from "../api-keys/ApiKeysSurface";
 import { BillingSectionBody } from "../billing/BillingSection";
 import { MonetizationView } from "../monetization/MonetizationSection";
 import { OrganizationSection } from "../organization/OrganizationSection";
-import { useCloudT } from "../shell/CloudI18nProvider";
+import { ApplicationsEntry } from "./applications-entry";
 import { CloudSettingsSectionShell } from "./CloudSettingsSectionShell";
 
 export function CloudAccountSection(): React.JSX.Element {
@@ -61,43 +59,7 @@ export function CloudApiKeysSection(): React.JSX.Element {
  * view (CloudRouterShell serves it on the web build). The cloud route registry
  * already registers the route at import time.
  */
-function ApplicationsEntry(): React.JSX.Element {
-  const t = useCloudT();
-  const open = () => {
-    if (typeof window !== "undefined") {
-      window.location.assign("/cloud/apps");
-    }
-  };
-  return (
-    <Button
-      variant="ghost"
-      type="button"
-      onClick={open}
-      className="group flex w-full items-center gap-3 rounded-lg border border-border bg-card px-4 py-4 text-left transition-colors hover:border-accent/40 hover:bg-surface   "
-    >
-      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-accent/12 text-accent  ">
-        <Grid3x3 className="h-[18px] w-[18px]" aria-hidden />
-      </span>
-      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="text-sm font-medium leading-5 text-txt-strong">
-          {t("cloud.applications.entryTitle", {
-            defaultValue: "Manage applications",
-          })}
-        </span>
-        <span className="text-xs leading-relaxed text-muted">
-          {t("cloud.applications.entryDescription", {
-            defaultValue:
-              "Cloud OAuth applications: monetization, earnings, domains, analytics, users.",
-          })}
-        </span>
-      </span>
-      <ExternalLink
-        className="h-4 w-4 shrink-0 text-muted transition-colors group-hover:text-accent"
-        aria-hidden
-      />
-    </Button>
-  );
-}
+export { ApplicationsEntry };
 
 export function CloudApplicationsSection(): React.JSX.Element {
   return (

--- a/packages/ui/src/components/settings/no-handrolled-section-layout.test.ts
+++ b/packages/ui/src/components/settings/no-handrolled-section-layout.test.ts
@@ -40,7 +40,7 @@ const SECTION_LAYOUT_ALLOWLIST = new Map<string, string>([
   ],
   [
     "../../cloud/settings/sections.tsx",
-    "cloud settings adapters; grouping lives in domain bodies",
+    "cloud settings adapters; ApplicationsEntry and domain bodies own grouping",
   ],
   [
     "../../cloud/mcps/McpsSection.tsx",


### PR DESCRIPTION
# Relates to

Closes #19480

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e2505b87c6610e2908a7150cc1eeb5a2f01b484b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` was not run for the whole monorepo in this turn.

# Risks

Low. Presentational list chrome only. MFA, billing, account, and organization
BrandCard forms are untouched. Session/grant load and revoke paths are
unchanged.

# Background

## What does this PR do?

Converts the Cloud BrandCard-**list** class to SettingsStack / SettingsGroup /
SettingsRow:

- Applications entry (opens `/cloud/apps`)
- Active sessions (loading / unavailable / empty / error / ready)
- Plugin grants (including Revoke)
- API keys nav row (`#cloud-api-keys` stays a real link)

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`applications-entry.tsx`, `active-sessions-panel.tsx`, `api-keys-link.tsx`,
`plugin-permissions-page-client.tsx`.

## Detailed testing steps

```bash
bun run --cwd packages/ui test -- src/cloud/account-security/components/account-security-panels.test.tsx src/cloud/account-security/components/plugin-permissions-page-client.test.tsx src/cloud/settings/sections.test.tsx src/components/settings/no-handrolled-section-layout.test.ts
```

40 tests passed.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:cdd7a4d36f6a358550e655de20cddb81c4fff2d4 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19482-brandcard-fullpage-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19482-brandcard-fullpage-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19482-brandcard-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or API path is changed.
<!-- evidence-row:frontend-logs -->
- [x] [19482-brandcard-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19482-brandcard-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, wallet, scheduled-task, or generated domain artifact is involved.
<!-- evidence-row:ocr-review -->
- [x] [19482-brandcard-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19482-brandcard-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Backend + frontend logs

Backend: N/A.

Frontend: capture console is attached.

## Screenshots (before / after) + video walkthrough

Isolated fixture of the four list/nav surfaces using real Settings layout
primitives. Desktop 1280×900 and mobile 390×844.

## Known gaps / failures

- `bun run verify` was not run for the whole monorepo.
- `packages/ui` typecheck still fails on develop-owned steward-login files.
- `audit:app` Settings captures remain blocked by `startupCoordinator.target`.
- DesktopWorkspaceSection compound rows are the next class, not this PR.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok-cli
Contribution skill revision: elizaOS/eliza@e2505b87c6610e2908a7150cc1eeb5a2f01b484b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-4.6]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-cli","skill_revision":"elizaOS/eliza@e2505b87c6610e2908a7150cc1eeb5a2f01b484b:packages/skills/skills/contribute-to-eliza"} -->

