### PR TITLE
fix(ui): split desktop workspace compound SettingsRows

### DIFF
--- a/packages/ui/src/components/settings/DesktopWorkspaceSection.test.ts
+++ b/packages/ui/src/components/settings/DesktopWorkspaceSection.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Source ratchet: DesktopWorkspaceSection must expose one SettingsRow per
+ * action instead of a multi-action grid inside a single SettingsRow.
+ * Reads the shipped file off disk.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "DesktopWorkspaceSection.tsx"),
+  "utf8",
+);
+
+const REQUIRED_AGENT_IDS = [
+  "desktop-refresh-diagnostics",
+  "desktop-open-settings-window",
+  "desktop-refresh-logs",
+  "desktop-copy-dev-stack",
+  "desktop-copy-diagnostics-bundle",
+  "desktop-console-refresh-tail",
+  "desktop-console-copy-tail",
+  "desktop-show-window",
+  "desktop-hide-window",
+  "desktop-focus-window",
+  "desktop-minimize-window",
+  "desktop-maximize-toggle",
+  "desktop-notify",
+  "desktop-restart-agent",
+  "desktop-relaunch-app",
+  "desktop-toggle-auto-launch",
+  "desktop-toggle-hidden-launch",
+  "desktop-open-file-dialog",
+  "desktop-open-folder-dialog",
+  "desktop-save-dialog",
+  "desktop-clipboard-read",
+  "desktop-clipboard-copy",
+  "desktop-clipboard-clear",
+];
+
+describe("DesktopWorkspaceSection compound-row ratchet", () => {
+  it("does not host a multi-action grid inside one SettingsRow", () => {
+    expect(source).not.toMatch(/grid gap-2 sm:grid-cols-2/);
+    expect(source).toContain("function WorkspaceActionRow");
+  });
+
+  it("keeps every existing desktop action agent id", () => {
+    for (const id of REQUIRED_AGENT_IDS) {
+      expect(source).toContain(`agentId="${id}"`);
+    }
+  });
+});

--- a/packages/ui/src/components/settings/DesktopWorkspaceSection.tsx
+++ b/packages/ui/src/components/settings/DesktopWorkspaceSection.tsx
@@ -39,6 +39,39 @@ import { useDesktopDiagnosticsText } from "./DesktopWorkspaceDisplay.hooks";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
 import { useDesktopWindowControls } from "./useDesktopWindowControls";
 
+function WorkspaceActionRow({
+  agentId,
+  label,
+  group,
+  disabled,
+  onClick,
+}: {
+  agentId: string;
+  label: string;
+  group: string;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <SettingsRow
+      label={label}
+      disabled={disabled}
+      control={
+        <WorkspaceActionButton
+          agentId={agentId}
+          label={label}
+          group={group}
+          disabled={disabled}
+          onClick={onClick}
+          className="min-h-11 shrink-0"
+        >
+          {label}
+        </WorkspaceActionButton>
+      }
+    />
+  );
+}
+
 function WorkspaceActionButton({
   agentId,
   label,
@@ -366,43 +399,57 @@ export function DesktopWorkspaceSection({
   return (
     <ContentLayout contentHeader={contentHeader}>
       <SettingsStack>
-        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
-          <WorkspaceActionButton
-            agentId="desktop-refresh-diagnostics"
+        <SettingsGroup
+          title={t("desktopworkspacesection.toolbar", {
+            defaultValue: "Desktop tools",
+          })}
+        >
+          <SettingsRow
+            icon={RefreshCw}
             label={t("desktopworkspacesection.RefreshDiagnostics")}
-            group="desktop-toolbar"
-            disabled={loading}
-            onClick={() => {
-              void refreshSnapshot();
-              void refreshDevDiagnostics();
-            }}
-          >
-            <RefreshCw
-              className={`mr-1 h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`}
-            />
-            {t("desktopworkspacesection.RefreshDiagnostics")}
-          </WorkspaceActionButton>
-          <WorkspaceActionButton
-            agentId="desktop-open-settings-window"
-            label={t("desktopworkspacesection.OpenDesktopSettingsWindow")}
-            group="desktop-toolbar"
-            variant="default"
-            disabled={busyAction === "desktop-open-settings-window"}
-            onClick={() =>
-              void runAction(
-                "desktop-open-settings-window",
-                async () => openDesktopSettingsWindow("desktop"),
-                t(
-                  "desktopworkspacesection.OpenedDetachedDesktopSettingsWindow",
-                ),
-                false,
-              )
+            control={
+              <WorkspaceActionButton
+                agentId="desktop-refresh-diagnostics"
+                label={t("desktopworkspacesection.RefreshDiagnostics")}
+                group="desktop-toolbar"
+                disabled={loading}
+                onClick={() => {
+                  void refreshSnapshot();
+                  void refreshDevDiagnostics();
+                }}
+                className="min-h-11"
+              >
+                {t("desktopworkspacesection.RefreshDiagnostics")}
+              </WorkspaceActionButton>
             }
-          >
-            <Monitor className="mr-1 h-3.5 w-3.5" />
-            {t("desktopworkspacesection.OpenDesktopSettingsWindow")}
-          </WorkspaceActionButton>
-        </div>
+          />
+          <SettingsRow
+            icon={Monitor}
+            label={t("desktopworkspacesection.OpenDesktopSettingsWindow")}
+            control={
+              <WorkspaceActionButton
+                agentId="desktop-open-settings-window"
+                label={t("desktopworkspacesection.OpenDesktopSettingsWindow")}
+                group="desktop-toolbar"
+                variant="default"
+                disabled={busyAction === "desktop-open-settings-window"}
+                onClick={() =>
+                  void runAction(
+                    "desktop-open-settings-window",
+                    async () => openDesktopSettingsWindow("desktop"),
+                    t(
+                      "desktopworkspacesection.OpenedDetachedDesktopSettingsWindow",
+                    ),
+                    false,
+                  )
+                }
+                className="min-h-11"
+              >
+                {t("desktopworkspacesection.OpenDesktopSettingsWindow")}
+              </WorkspaceActionButton>
+            }
+          />
+        </SettingsGroup>
 
         {(actionError || actionMessage) && (
           <div
@@ -429,51 +476,37 @@ export function DesktopWorkspaceSection({
                 "Live `/api/dev/stack` snapshot for the current desktop session.",
             })}
           >
+            <WorkspaceActionRow
+              agentId="desktop-refresh-logs"
+              label={t("desktopworkspacesection.devStack.refreshLogs", {
+                defaultValue: "Refresh Desktop Logs",
+              })}
+              group="desktop-dev-stack"
+              onClick={() => void refreshDevDiagnostics()}
+            />
+            <WorkspaceActionRow
+              agentId="desktop-copy-dev-stack"
+              label={t("desktopworkspacesection.devStack.copyStack", {
+                defaultValue: "Copy Dev Stack",
+              })}
+              group="desktop-dev-stack"
+              onClick={() => void copyTextToClipboard(devStackText)}
+            />
+            <WorkspaceActionRow
+              agentId="desktop-copy-diagnostics-bundle"
+              label={t("desktopworkspacesection.devStack.copyBundle", {
+                defaultValue: "Copy Full Diagnostics Bundle",
+              })}
+              group="desktop-dev-stack"
+              onClick={() => void copyDesktopDiagnosticsBundle()}
+            />
             <SettingsRow
-              label={t("desktopworkspacesection.devStack.title", {
-                defaultValue: "Desktop Dev Stack",
+              label={t("desktopworkspacesection.devStack.snapshot", {
+                defaultValue: "Current snapshot",
               })}
               stacked
             >
-              <div className="flex flex-wrap gap-2">
-                <WorkspaceActionButton
-                  agentId="desktop-refresh-logs"
-                  label={t("desktopworkspacesection.devStack.refreshLogs", {
-                    defaultValue: "Refresh Desktop Logs",
-                  })}
-                  group="desktop-dev-stack"
-                  onClick={() => void refreshDevDiagnostics()}
-                >
-                  {t("desktopworkspacesection.devStack.refreshLogs", {
-                    defaultValue: "Refresh Desktop Logs",
-                  })}
-                </WorkspaceActionButton>
-                <WorkspaceActionButton
-                  agentId="desktop-copy-dev-stack"
-                  label={t("desktopworkspacesection.devStack.copyStack", {
-                    defaultValue: "Copy Dev Stack",
-                  })}
-                  group="desktop-dev-stack"
-                  onClick={() => void copyTextToClipboard(devStackText)}
-                >
-                  {t("desktopworkspacesection.devStack.copyStack", {
-                    defaultValue: "Copy Dev Stack",
-                  })}
-                </WorkspaceActionButton>
-                <WorkspaceActionButton
-                  agentId="desktop-copy-diagnostics-bundle"
-                  label={t("desktopworkspacesection.devStack.copyBundle", {
-                    defaultValue: "Copy Full Diagnostics Bundle",
-                  })}
-                  group="desktop-dev-stack"
-                  onClick={() => void copyDesktopDiagnosticsBundle()}
-                >
-                  {t("desktopworkspacesection.devStack.copyBundle", {
-                    defaultValue: "Copy Full Diagnostics Bundle",
-                  })}
-                </WorkspaceActionButton>
-              </div>
-              <pre className="mt-3 max-h-72 overflow-auto break-all rounded-sm border border-border bg-bg px-3 py-3 text-xs-tight leading-5 text-txt">
+              <pre className="max-h-72 overflow-auto break-all rounded-sm border border-border bg-bg px-3 py-3 text-xs-tight leading-5 text-txt">
                 {devStackText}
               </pre>
             </SettingsRow>
@@ -485,34 +518,25 @@ export function DesktopWorkspaceSection({
               "desktopworkspacesection.DetachedSurfacesDescription",
             )}
           >
-            <SettingsRow
-              label={t("desktopworkspacesection.DetachedSurfaces")}
-              stacked
-            >
-              <div className="grid gap-2 sm:grid-cols-2">
-                {DESKTOP_WORKSPACE_SURFACES.map((surface) => (
-                  <WorkspaceActionButton
-                    key={surface.id}
-                    agentId={`desktop-surface-${surface.id}`}
-                    label={getSurfaceLabel(surface.id)}
-                    group="desktop-surfaces"
-                    disabled={busyAction === `desktop-surface-${surface.id}`}
-                    onClick={() =>
-                      void runAction(
-                        `desktop-surface-${surface.id}`,
-                        async () => openDesktopSurfaceWindow(surface.id),
-                        t("desktopworkspacesection.SurfaceOpened", {
-                          surface: getSurfaceLabel(surface.id),
-                        }),
-                        false,
-                      )
-                    }
-                  >
-                    {getSurfaceLabel(surface.id)}
-                  </WorkspaceActionButton>
-                ))}
-              </div>
-            </SettingsRow>
+            {DESKTOP_WORKSPACE_SURFACES.map((surface) => (
+              <WorkspaceActionRow
+                key={surface.id}
+                agentId={`desktop-surface-${surface.id}`}
+                label={getSurfaceLabel(surface.id)}
+                group="desktop-surfaces"
+                disabled={busyAction === `desktop-surface-${surface.id}`}
+                onClick={() =>
+                  void runAction(
+                    `desktop-surface-${surface.id}`,
+                    async () => openDesktopSurfaceWindow(surface.id),
+                    t("desktopworkspacesection.SurfaceOpened", {
+                      surface: getSurfaceLabel(surface.id),
+                    }),
+                    false,
+                  )
+                }
+              />
+            ))}
           </SettingsGroup>
         </div>
 
@@ -527,106 +551,73 @@ export function DesktopWorkspaceSection({
               "Live tail of the desktop console log: renderer, network, RPC, and main-process logs.",
           })}
         >
+          <WorkspaceActionRow
+            agentId="desktop-console-refresh-tail"
+            label={t("desktopworkspacesection.console.refreshTail", {
+              defaultValue: "Refresh Console Tail",
+            })}
+            group="desktop-console"
+            onClick={() => void refreshDevDiagnostics()}
+          />
+          <WorkspaceActionRow
+            agentId="desktop-console-copy-tail"
+            label={t("desktopworkspacesection.console.copyTail", {
+              defaultValue: "Copy Visible Console Tail",
+            })}
+            group="desktop-console"
+            onClick={() =>
+              void copyTextToClipboard(filteredDevConsoleText || devConsoleText)
+            }
+          />
           <SettingsRow
-            label={t("desktopworkspacesection.console.title", {
-              defaultValue: "Desktop Console Log",
+            label={t("desktopworkspacesection.console.filter", {
+              defaultValue: "Filter",
+            })}
+            description={`${t("desktopworkspacesection.console.total", {
+              count: devConsoleSummary.total,
+              defaultValue: "Total: {{count}}",
+            })} · ${t("desktopworkspacesection.console.errors", {
+              count: devConsoleSummary.errors,
+              defaultValue: "Errors: {{count}}",
+            })} · ${t("desktopworkspacesection.console.warnings", {
+              count: devConsoleSummary.warnings,
+              defaultValue: "Warnings: {{count}}",
+            })}`}
+            htmlFor="desktop-console-filter"
+            stacked
+          >
+            <SettingsTextarea
+              id="desktop-console-filter"
+              ref={consoleFilterRef}
+              value={devConsoleFilter}
+              onChange={(event) => setDevConsoleFilter(event.target.value)}
+              placeholder={t(
+                "desktopworkspacesection.console.filterPlaceholder",
+                {
+                  defaultValue:
+                    "Filter console lines (e.g. rpc, fetch, talkmode, 404)",
+                },
+              )}
+              className="min-h-[4rem]"
+              {...consoleFilterAgentProps}
+            />
+          </SettingsRow>
+          <SettingsRow
+            label={t("desktopworkspacesection.console.tail", {
+              defaultValue: "Console tail",
             })}
             stacked
           >
-            <div className="space-y-3">
-              <div className="flex flex-wrap gap-2">
-                <WorkspaceActionButton
-                  agentId="desktop-console-refresh-tail"
-                  label={t("desktopworkspacesection.console.refreshTail", {
-                    defaultValue: "Refresh Console Tail",
-                  })}
-                  group="desktop-console"
-                  onClick={() => void refreshDevDiagnostics()}
-                >
-                  {t("desktopworkspacesection.console.refreshTail", {
-                    defaultValue: "Refresh Console Tail",
-                  })}
-                </WorkspaceActionButton>
-                <WorkspaceActionButton
-                  agentId="desktop-console-copy-tail"
-                  label={t("desktopworkspacesection.console.copyTail", {
-                    defaultValue: "Copy Visible Console Tail",
-                  })}
-                  group="desktop-console"
-                  onClick={() =>
-                    void copyTextToClipboard(
-                      filteredDevConsoleText || devConsoleText,
-                    )
-                  }
-                >
-                  {t("desktopworkspacesection.console.copyTail", {
-                    defaultValue: "Copy Visible Console Tail",
-                  })}
-                </WorkspaceActionButton>
-              </div>
-              <div className="flex flex-wrap gap-2 text-xs text-muted">
-                <span>
-                  {t("desktopworkspacesection.console.total", {
-                    count: devConsoleSummary.total,
-                    defaultValue: "Total: {{count}}",
-                  })}
-                </span>
-                <span>
-                  {t("desktopworkspacesection.console.errors", {
-                    count: devConsoleSummary.errors,
-                    defaultValue: "Errors: {{count}}",
-                  })}
-                </span>
-                <span>
-                  {t("desktopworkspacesection.console.warnings", {
-                    count: devConsoleSummary.warnings,
-                    defaultValue: "Warnings: {{count}}",
-                  })}
-                </span>
-                <span>
-                  {t("desktopworkspacesection.console.rpc", {
-                    count: devConsoleSummary.rpc,
-                    defaultValue: "RPC: {{count}}",
-                  })}
-                </span>
-                <span>
-                  {t("desktopworkspacesection.console.fetch", {
-                    count: devConsoleSummary.fetch,
-                    defaultValue: "Fetch: {{count}}",
-                  })}
-                </span>
-                <span>
-                  {t("desktopworkspacesection.console.talkmode", {
-                    count: devConsoleSummary.talkmode,
-                    defaultValue: "TalkMode: {{count}}",
-                  })}
-                </span>
-              </div>
-              <SettingsTextarea
-                ref={consoleFilterRef}
-                value={devConsoleFilter}
-                onChange={(event) => setDevConsoleFilter(event.target.value)}
-                placeholder={t(
-                  "desktopworkspacesection.console.filterPlaceholder",
-                  {
-                    defaultValue:
-                      "Filter console lines (e.g. rpc, fetch, talkmode, 404)",
-                  },
-                )}
-                className="min-h-[4rem]"
-                {...consoleFilterAgentProps}
-              />
-              <SettingsTextarea
-                value={
-                  filteredDevConsoleText ||
-                  t("desktopworkspacesection.console.noMatch", {
-                    defaultValue: "No console lines match the current filter.",
-                  })
-                }
-                readOnly
-                className="min-h-[22rem] leading-5"
-              />
-            </div>
+            <SettingsTextarea
+              value={
+                filteredDevConsoleText ||
+                t("desktopworkspacesection.console.noMatch", {
+                  defaultValue: "No console lines match the current filter.",
+                })
+              }
+              readOnly
+              className="min-h-[22rem] leading-5"
+            />
           </SettingsRow>
         </SettingsGroup>
 
@@ -635,200 +626,158 @@ export function DesktopWorkspaceSection({
             title={t("desktopworkspacesection.WindowControls")}
             description={t("desktopworkspacesection.WindowControlsDescription")}
           >
-            <SettingsRow
-              label={t("desktopworkspacesection.WindowControls")}
-              stacked
-            >
-              <div className="grid gap-2 sm:grid-cols-2">
-                <WorkspaceActionButton
-                  agentId="desktop-show-window"
-                  label={t("gameview.ShowWindow")}
-                  group="desktop-window-controls"
-                  disabled={busyAction === "desktop-show-window"}
-                  onClick={() =>
-                    void runAction("desktop-show-window", windowControls.show)
-                  }
-                >
-                  {t("gameview.ShowWindow")}
-                </WorkspaceActionButton>
-                <WorkspaceActionButton
-                  agentId="desktop-hide-window"
-                  label={t("gameview.HideWindow")}
-                  group="desktop-window-controls"
-                  disabled={busyAction === "desktop-hide-window"}
-                  onClick={() =>
-                    void runAction("desktop-hide-window", windowControls.hide)
-                  }
-                >
-                  {t("gameview.HideWindow")}
-                </WorkspaceActionButton>
-                <WorkspaceActionButton
-                  agentId="desktop-focus-window"
-                  label={t("gameview.FocusWindow")}
-                  group="desktop-window-controls"
-                  disabled={busyAction === "desktop-focus-window"}
-                  onClick={() =>
-                    void runAction("desktop-focus-window", windowControls.focus)
-                  }
-                >
-                  {t("gameview.FocusWindow")}
-                </WorkspaceActionButton>
-                <WorkspaceActionButton
-                  agentId="desktop-minimize-window"
-                  label={
-                    snapshot?.window.minimized
-                      ? t("desktopworkspacesection.RestoreWindow")
-                      : t("desktopworkspacesection.MinimizeWindow")
-                  }
-                  group="desktop-window-controls"
-                  disabled={busyAction === "desktop-minimize-window"}
-                  onClick={() =>
-                    void runAction(
-                      "desktop-minimize-window",
-                      windowControls.toggleMinimize,
-                    )
-                  }
-                >
-                  {snapshot?.window.minimized
-                    ? t("desktopworkspacesection.RestoreWindow")
-                    : t("desktopworkspacesection.MinimizeWindow")}
-                </WorkspaceActionButton>
-                <WorkspaceActionButton
-                  agentId="desktop-maximize-toggle"
-                  label={
-                    snapshot?.window.maximized
-                      ? t("desktopworkspacesection.UnmaximizeWindow")
-                      : t("desktopworkspacesection.MaximizeWindow")
-                  }
-                  group="desktop-window-controls"
-                  className="sm:col-span-2 min-h-9 justify-start whitespace-normal text-left sm:min-h-10"
-                  disabled={busyAction === "desktop-maximize-toggle"}
-                  onClick={() =>
-                    void runAction(
-                      "desktop-maximize-toggle",
-                      windowControls.toggleMaximize,
-                    )
-                  }
-                >
-                  {snapshot?.window.maximized
-                    ? t("desktopworkspacesection.UnmaximizeWindow")
-                    : t("desktopworkspacesection.MaximizeWindow")}
-                </WorkspaceActionButton>
-              </div>
-            </SettingsRow>
+            <WorkspaceActionRow
+              agentId="desktop-show-window"
+              label={t("gameview.ShowWindow")}
+              group="desktop-window-controls"
+              disabled={busyAction === "desktop-show-window"}
+              onClick={() =>
+                void runAction("desktop-show-window", windowControls.show)
+              }
+            />
+            <WorkspaceActionRow
+              agentId="desktop-hide-window"
+              label={t("gameview.HideWindow")}
+              group="desktop-window-controls"
+              disabled={busyAction === "desktop-hide-window"}
+              onClick={() =>
+                void runAction("desktop-hide-window", windowControls.hide)
+              }
+            />
+            <WorkspaceActionRow
+              agentId="desktop-focus-window"
+              label={t("gameview.FocusWindow")}
+              group="desktop-window-controls"
+              disabled={busyAction === "desktop-focus-window"}
+              onClick={() =>
+                void runAction("desktop-focus-window", windowControls.focus)
+              }
+            />
+            <WorkspaceActionRow
+              agentId="desktop-minimize-window"
+              label={
+                snapshot?.window.minimized
+                  ? t("desktopworkspacesection.RestoreWindow")
+                  : t("desktopworkspacesection.MinimizeWindow")
+              }
+              group="desktop-window-controls"
+              disabled={busyAction === "desktop-minimize-window"}
+              onClick={() =>
+                void runAction(
+                  "desktop-minimize-window",
+                  windowControls.toggleMinimize,
+                )
+              }
+            />
+            <WorkspaceActionRow
+              agentId="desktop-maximize-toggle"
+              label={
+                snapshot?.window.maximized
+                  ? t("desktopworkspacesection.UnmaximizeWindow")
+                  : t("desktopworkspacesection.MaximizeWindow")
+              }
+              group="desktop-window-controls"
+              disabled={busyAction === "desktop-maximize-toggle"}
+              onClick={() =>
+                void runAction(
+                  "desktop-maximize-toggle",
+                  windowControls.toggleMaximize,
+                )
+              }
+            />
           </SettingsGroup>
 
           <SettingsGroup
             title={t("desktopworkspacesection.Lifecycle")}
             description={t("desktopworkspacesection.LifecycleDescription")}
           >
-            <SettingsRow label={t("desktopworkspacesection.Lifecycle")} stacked>
-              <div className="grid gap-2 sm:grid-cols-2">
-                <WorkspaceActionButton
-                  agentId="desktop-notify"
-                  label={t("desktopworkspacesection.SendTestNotification")}
-                  group="desktop-lifecycle"
-                  disabled={busyAction === "desktop-notify"}
-                  onClick={() =>
-                    void runAction(
-                      "desktop-notify",
-                      windowControls.notify,
-                      t("desktopworkspacesection.NotificationSent"),
-                      false,
-                    )
-                  }
-                >
-                  {t("desktopworkspacesection.SendTestNotification")}
-                </WorkspaceActionButton>
-                <WorkspaceActionButton
-                  agentId="desktop-restart-agent"
-                  label={t("finetuningview.RestartAgentTitle")}
-                  group="desktop-lifecycle"
-                  disabled={busyAction === "desktop-restart-agent"}
-                  onClick={() =>
-                    void runAction(
-                      "desktop-restart-agent",
-                      async () => restartBackend(),
-                      t("desktopworkspacesection.AgentRestartRequested"),
-                    )
-                  }
-                >
-                  {t("finetuningview.RestartAgentTitle")}
-                </WorkspaceActionButton>
-                <WorkspaceActionButton
-                  agentId="desktop-relaunch-app"
-                  label={t("desktopworkspacesection.Relaunch")}
-                  group="desktop-lifecycle"
-                  disabled={busyAction === "desktop-relaunch-app"}
-                  onClick={() =>
-                    void runAction(
-                      "desktop-relaunch-app",
-                      async () => relaunchDesktop(),
-                      t("desktopworkspacesection.DesktopRelaunchRequested"),
-                      false,
-                    )
-                  }
-                >
-                  {t("desktopworkspacesection.Relaunch")}
-                </WorkspaceActionButton>
-                <WorkspaceActionButton
-                  agentId="desktop-toggle-auto-launch"
-                  label={
-                    snapshot?.autoLaunch?.enabled
-                      ? t("desktopworkspacesection.DisableAutoLaunch")
-                      : t("desktopworkspacesection.EnableAutoLaunch")
-                  }
-                  group="desktop-lifecycle"
-                  disabled={busyAction === "desktop-toggle-auto-launch"}
-                  onClick={() =>
-                    void runAction("desktop-toggle-auto-launch", async () => {
-                      await invokeDesktopBridgeRequest<void>({
-                        rpcMethod: "desktopSetAutoLaunch",
-                        ipcChannel: "desktop:setAutoLaunch",
-                        params: {
-                          enabled: !(snapshot?.autoLaunch?.enabled ?? false),
-                          openAsHidden:
-                            snapshot?.autoLaunch?.openAsHidden ?? false,
-                        },
-                      });
-                    })
-                  }
-                >
-                  {snapshot?.autoLaunch?.enabled
-                    ? t("desktopworkspacesection.DisableAutoLaunch")
-                    : t("desktopworkspacesection.EnableAutoLaunch")}
-                </WorkspaceActionButton>
-                <WorkspaceActionButton
-                  agentId="desktop-toggle-hidden-launch"
-                  label={
-                    snapshot?.autoLaunch?.openAsHidden
-                      ? t("desktopworkspacesection.LaunchVisibleOnLogin")
-                      : t("desktopworkspacesection.LaunchHiddenOnLogin")
-                  }
-                  group="desktop-lifecycle"
-                  className="sm:col-span-2 min-h-9 justify-start whitespace-normal text-left sm:min-h-10"
-                  disabled={busyAction === "desktop-toggle-hidden-launch"}
-                  onClick={() =>
-                    void runAction("desktop-toggle-hidden-launch", async () => {
-                      await invokeDesktopBridgeRequest<void>({
-                        rpcMethod: "desktopSetAutoLaunch",
-                        ipcChannel: "desktop:setAutoLaunch",
-                        params: {
-                          enabled: snapshot?.autoLaunch?.enabled ?? false,
-                          openAsHidden: !(
-                            snapshot?.autoLaunch?.openAsHidden ?? false
-                          ),
-                        },
-                      });
-                    })
-                  }
-                >
-                  {snapshot?.autoLaunch?.openAsHidden
-                    ? t("desktopworkspacesection.LaunchVisibleOnLogin")
-                    : t("desktopworkspacesection.LaunchHiddenOnLogin")}
-                </WorkspaceActionButton>
-              </div>
-            </SettingsRow>
+            <WorkspaceActionRow
+              agentId="desktop-notify"
+              label={t("desktopworkspacesection.SendTestNotification")}
+              group="desktop-lifecycle"
+              disabled={busyAction === "desktop-notify"}
+              onClick={() =>
+                void runAction(
+                  "desktop-notify",
+                  windowControls.notify,
+                  t("desktopworkspacesection.NotificationSent"),
+                  false,
+                )
+              }
+            />
+            <WorkspaceActionRow
+              agentId="desktop-restart-agent"
+              label={t("finetuningview.RestartAgentTitle")}
+              group="desktop-lifecycle"
+              disabled={busyAction === "desktop-restart-agent"}
+              onClick={() =>
+                void runAction(
+                  "desktop-restart-agent",
+                  async () => restartBackend(),
+                  t("desktopworkspacesection.AgentRestartRequested"),
+                )
+              }
+            />
+            <WorkspaceActionRow
+              agentId="desktop-relaunch-app"
+              label={t("desktopworkspacesection.Relaunch")}
+              group="desktop-lifecycle"
+              disabled={busyAction === "desktop-relaunch-app"}
+              onClick={() =>
+                void runAction(
+                  "desktop-relaunch-app",
+                  async () => relaunchDesktop(),
+                  t("desktopworkspacesection.DesktopRelaunchRequested"),
+                  false,
+                )
+              }
+            />
+            <WorkspaceActionRow
+              agentId="desktop-toggle-auto-launch"
+              label={
+                snapshot?.autoLaunch?.enabled
+                  ? t("desktopworkspacesection.DisableAutoLaunch")
+                  : t("desktopworkspacesection.EnableAutoLaunch")
+              }
+              group="desktop-lifecycle"
+              disabled={busyAction === "desktop-toggle-auto-launch"}
+              onClick={() =>
+                void runAction("desktop-toggle-auto-launch", async () => {
+                  await invokeDesktopBridgeRequest<void>({
+                    rpcMethod: "desktopSetAutoLaunch",
+                    ipcChannel: "desktop:setAutoLaunch",
+                    params: {
+                      enabled: !(snapshot?.autoLaunch?.enabled ?? false),
+                      openAsHidden: snapshot?.autoLaunch?.openAsHidden ?? false,
+                    },
+                  });
+                })
+              }
+            />
+            <WorkspaceActionRow
+              agentId="desktop-toggle-hidden-launch"
+              label={
+                snapshot?.autoLaunch?.openAsHidden
+                  ? t("desktopworkspacesection.LaunchVisibleOnLogin")
+                  : t("desktopworkspacesection.LaunchHiddenOnLogin")
+              }
+              group="desktop-lifecycle"
+              disabled={busyAction === "desktop-toggle-hidden-launch"}
+              onClick={() =>
+                void runAction("desktop-toggle-hidden-launch", async () => {
+                  await invokeDesktopBridgeRequest<void>({
+                    rpcMethod: "desktopSetAutoLaunch",
+                    ipcChannel: "desktop:setAutoLaunch",
+                    params: {
+                      enabled: snapshot?.autoLaunch?.enabled ?? false,
+                      openAsHidden: !(
+                        snapshot?.autoLaunch?.openAsHidden ?? false
+                      ),
+                    },
+                  });
+                })
+              }
+            />
           </SettingsGroup>
         </div>
 
@@ -839,121 +788,99 @@ export function DesktopWorkspaceSection({
               "desktopworkspacesection.NativeFileDialogsDescription",
             )}
           >
+            <WorkspaceActionRow
+              agentId="desktop-open-file-dialog"
+              label={t("desktopworkspacesection.OpenFilesDialog")}
+              group="desktop-file-dialogs"
+              disabled={busyAction === "desktop-open-file-dialog"}
+              onClick={() =>
+                void runAction(
+                  "desktop-open-file-dialog",
+                  async () => {
+                    const result = await invokeDesktopBridgeRequest<{
+                      canceled: boolean;
+                      filePaths: string[];
+                    }>({
+                      rpcMethod: "desktopShowOpenDialog",
+                      ipcChannel: "desktop:showOpenDialog",
+                      params: {
+                        title: t("desktopworkspacesection.SelectFiles"),
+                        defaultPath: snapshot?.paths.downloads,
+                        canChooseFiles: true,
+                        allowsMultipleSelection: true,
+                      },
+                    });
+                    setOpenPaths(result?.filePaths ?? []);
+                  },
+                  t("desktopworkspacesection.FileDialogCompleted"),
+                  false,
+                )
+              }
+            />
+            <WorkspaceActionRow
+              agentId="desktop-open-folder-dialog"
+              label={t("desktopworkspacesection.OpenFolderDialog")}
+              group="desktop-file-dialogs"
+              disabled={busyAction === "desktop-open-folder-dialog"}
+              onClick={() =>
+                void runAction(
+                  "desktop-open-folder-dialog",
+                  async () => {
+                    const result = await invokeDesktopBridgeRequest<{
+                      canceled: boolean;
+                      filePaths: string[];
+                    }>({
+                      rpcMethod: "desktopShowOpenDialog",
+                      ipcChannel: "desktop:showOpenDialog",
+                      params: {
+                        title: t("desktopworkspacesection.SelectFolder"),
+                        defaultPath: snapshot?.paths.home,
+                        canChooseDirectory: true,
+                      },
+                    });
+                    setOpenPaths(result?.filePaths ?? []);
+                  },
+                  t("desktopworkspacesection.FolderDialogCompleted"),
+                  false,
+                )
+              }
+            />
+            <WorkspaceActionRow
+              agentId="desktop-save-dialog"
+              label={t("desktopworkspacesection.SaveFileDialog")}
+              group="desktop-file-dialogs"
+              disabled={busyAction === "desktop-save-dialog"}
+              onClick={() =>
+                void runAction(
+                  "desktop-save-dialog",
+                  async () => {
+                    const result = await invokeDesktopBridgeRequest<{
+                      canceled: boolean;
+                      filePaths: string[];
+                    }>({
+                      rpcMethod: "desktopShowSaveDialog",
+                      ipcChannel: "desktop:showSaveDialog",
+                      params: {
+                        title: t("desktopworkspacesection.SaveFile"),
+                        defaultPath: snapshot?.paths.documents,
+                        allowedFileTypes: "txt,md,json",
+                      },
+                    });
+                    setSavePaths(result?.filePaths ?? []);
+                  },
+                  t("desktopworkspacesection.SaveDialogCompleted"),
+                  false,
+                )
+              }
+            />
             <SettingsRow
-              label={t("desktopworkspacesection.NativeFileDialogs")}
-              stacked
-            >
-              <div className="space-y-3">
-                <div className="grid gap-2 sm:grid-cols-2">
-                  <WorkspaceActionButton
-                    agentId="desktop-open-file-dialog"
-                    label={t("desktopworkspacesection.OpenFilesDialog")}
-                    group="desktop-file-dialogs"
-                    disabled={busyAction === "desktop-open-file-dialog"}
-                    onClick={() =>
-                      void runAction(
-                        "desktop-open-file-dialog",
-                        async () => {
-                          const result = await invokeDesktopBridgeRequest<{
-                            canceled: boolean;
-                            filePaths: string[];
-                          }>({
-                            rpcMethod: "desktopShowOpenDialog",
-                            ipcChannel: "desktop:showOpenDialog",
-                            params: {
-                              title: t("desktopworkspacesection.SelectFiles"),
-                              defaultPath: snapshot?.paths.downloads,
-                              canChooseFiles: true,
-                              allowsMultipleSelection: true,
-                            },
-                          });
-                          setOpenPaths(result?.filePaths ?? []);
-                        },
-                        t("desktopworkspacesection.FileDialogCompleted"),
-                        false,
-                      )
-                    }
-                  >
-                    {t("desktopworkspacesection.OpenFilesDialog")}
-                  </WorkspaceActionButton>
-                  <WorkspaceActionButton
-                    agentId="desktop-open-folder-dialog"
-                    label={t("desktopworkspacesection.OpenFolderDialog")}
-                    group="desktop-file-dialogs"
-                    disabled={busyAction === "desktop-open-folder-dialog"}
-                    onClick={() =>
-                      void runAction(
-                        "desktop-open-folder-dialog",
-                        async () => {
-                          const result = await invokeDesktopBridgeRequest<{
-                            canceled: boolean;
-                            filePaths: string[];
-                          }>({
-                            rpcMethod: "desktopShowOpenDialog",
-                            ipcChannel: "desktop:showOpenDialog",
-                            params: {
-                              title: t("desktopworkspacesection.SelectFolder"),
-                              defaultPath: snapshot?.paths.home,
-                              canChooseDirectory: true,
-                            },
-                          });
-                          setOpenPaths(result?.filePaths ?? []);
-                        },
-                        t("desktopworkspacesection.FolderDialogCompleted"),
-                        false,
-                      )
-                    }
-                  >
-                    {t("desktopworkspacesection.OpenFolderDialog")}
-                  </WorkspaceActionButton>
-                  <WorkspaceActionButton
-                    agentId="desktop-save-dialog"
-                    label={t("desktopworkspacesection.SaveFileDialog")}
-                    group="desktop-file-dialogs"
-                    className="sm:col-span-2 min-h-9 justify-start whitespace-normal text-left sm:min-h-10"
-                    disabled={busyAction === "desktop-save-dialog"}
-                    onClick={() =>
-                      void runAction(
-                        "desktop-save-dialog",
-                        async () => {
-                          const result = await invokeDesktopBridgeRequest<{
-                            canceled: boolean;
-                            filePaths: string[];
-                          }>({
-                            rpcMethod: "desktopShowSaveDialog",
-                            ipcChannel: "desktop:showSaveDialog",
-                            params: {
-                              title: t("desktopworkspacesection.SaveFile"),
-                              defaultPath: snapshot?.paths.documents,
-                              allowedFileTypes: "txt,md,json",
-                            },
-                          });
-                          setSavePaths(result?.filePaths ?? []);
-                        },
-                        t("desktopworkspacesection.SaveDialogCompleted"),
-                        false,
-                      )
-                    }
-                  >
-                    {t("desktopworkspacesection.SaveFileDialog")}
-                  </WorkspaceActionButton>
-                </div>
-                <div className="space-y-2 rounded-sm border border-border bg-bg px-3 py-3 text-xs text-muted">
-                  <div>
-                    <div className="mb-1 font-semibold text-txt">
-                      {t("desktopworkspacesection.OpenDialogResult")}
-                    </div>
-                    {renderPathList(openPaths, t)}
-                  </div>
-                  <div>
-                    <div className="mb-1 font-semibold text-txt">
-                      {t("desktopworkspacesection.SaveDialogResult")}
-                    </div>
-                    {renderPathList(savePaths, t)}
-                  </div>
-                </div>
-              </div>
-            </SettingsRow>
+              label={t("desktopworkspacesection.OpenDialogResult")}
+              description={renderPathList(openPaths, t)}
+            />
+            <SettingsRow
+              label={t("desktopworkspacesection.SaveDialogResult")}
+              description={renderPathList(savePaths, t)}
+            />
           </SettingsGroup>
 
           <SettingsGroup
@@ -963,136 +890,118 @@ export function DesktopWorkspaceSection({
             )}
           >
             <SettingsRow
-              label={t("desktopworkspacesection.ClipboardAndPaths")}
+              label={t("desktopworkspacesection.ClipboardDraft")}
+              htmlFor="desktop-clipboard-draft"
               stacked
             >
-              <div className="space-y-3">
-                <SettingsTextarea
-                  ref={clipboardDraftRef}
-                  value={clipboardDraft}
-                  onChange={(event) => setClipboardDraft(event.target.value)}
-                  className="min-h-24 text-sm"
-                  placeholder={t("desktopworkspacesection.ClipboardDraft")}
-                  {...clipboardDraftAgentProps}
-                />
-                <div className="grid gap-2 sm:grid-cols-2">
-                  <WorkspaceActionButton
-                    agentId="desktop-clipboard-read"
-                    label={t("desktopworkspacesection.ReadClipboard")}
-                    group="desktop-clipboard"
-                    disabled={busyAction === "desktop-clipboard-read"}
-                    onClick={() =>
-                      void runAction("desktop-clipboard-read", async () => {
-                        const result = await invokeDesktopBridgeRequest<{
-                          text?: string;
-                        }>({
-                          rpcMethod: "desktopReadFromClipboard",
-                          ipcChannel: "desktop:readFromClipboard",
-                        });
-                        setClipboardDraft(result?.text ?? "");
-                      })
-                    }
-                  >
-                    {t("desktopworkspacesection.ReadClipboard")}
-                  </WorkspaceActionButton>
-                  <WorkspaceActionButton
-                    agentId="desktop-clipboard-copy"
-                    label={t("desktopworkspacesection.CopyDraft")}
-                    group="desktop-clipboard"
-                    disabled={busyAction === "desktop-clipboard-copy"}
-                    onClick={() =>
-                      void runAction("desktop-clipboard-copy", async () => {
-                        await copyTextToClipboard(clipboardDraft);
-                      })
-                    }
-                  >
-                    {t("desktopworkspacesection.CopyDraft")}
-                  </WorkspaceActionButton>
-                  <WorkspaceActionButton
-                    agentId="desktop-clipboard-clear"
-                    label={t("desktopworkspacesection.ClearClipboard")}
-                    group="desktop-clipboard"
-                    disabled={busyAction === "desktop-clipboard-clear"}
-                    onClick={() =>
-                      void runAction("desktop-clipboard-clear", async () => {
-                        await invokeDesktopBridgeRequest<void>({
-                          rpcMethod: "desktopClearClipboard",
-                          ipcChannel: "desktop:clearClipboard",
-                        });
-                        setClipboardDraft("");
-                      })
-                    }
-                  >
-                    {t("desktopworkspacesection.ClearClipboard")}
-                  </WorkspaceActionButton>
-                  {savePaths[0] && (
-                    <>
-                      <WorkspaceActionButton
-                        agentId="desktop-open-path"
-                        label={t("desktopworkspacesection.OpenSavedPath")}
-                        group="desktop-clipboard"
-                        disabled={busyAction === "desktop-open-path"}
-                        onClick={() =>
-                          void runAction(
-                            "desktop-open-path",
-                            async () => {
-                              await invokeDesktopBridgeRequest<void>({
-                                rpcMethod: "desktopOpenPath",
-                                ipcChannel: "desktop:openPath",
-                                params: { path: savePaths[0] },
-                              });
-                            },
-                            t("desktopworkspacesection.OpenedSavedPath"),
-                            false,
-                          )
-                        }
-                      >
-                        {t("desktopworkspacesection.OpenSavedPath")}
-                      </WorkspaceActionButton>
-                      <WorkspaceActionButton
-                        agentId="desktop-reveal-path"
-                        label={t("desktopworkspacesection.RevealSavedPath")}
-                        group="desktop-clipboard"
-                        disabled={busyAction === "desktop-reveal-path"}
-                        onClick={() =>
-                          void runAction(
-                            "desktop-reveal-path",
-                            async () => {
-                              await invokeDesktopBridgeRequest<void>({
-                                rpcMethod: "desktopShowItemInFolder",
-                                ipcChannel: "desktop:showItemInFolder",
-                                params: { path: savePaths[0] },
-                              });
-                            },
-                            t("desktopworkspacesection.RevealedSavedPath"),
-                            false,
-                          )
-                        }
-                      >
-                        {t("desktopworkspacesection.RevealSavedPath")}
-                      </WorkspaceActionButton>
-                    </>
-                  )}
-                </div>
-                <div className="rounded-sm border border-border bg-bg px-3 py-3 text-xs text-muted">
-                  {snapshot?.clipboard ? (
-                    <>
-                      <div className="font-semibold text-txt">
-                        {t("desktopworkspacesection.Formats")}{" "}
-                        {snapshot.clipboard.formats.join(", ") ||
-                          t("desktopworkspacesection.PlainText")}
-                      </div>
-                      <div className="mt-1 break-all">
-                        {snapshot.clipboard.text ||
-                          t("desktopworkspacesection.ClipboardTextUnavailable")}
-                      </div>
-                    </>
-                  ) : (
-                    t("desktopworkspacesection.ClipboardDetailsUnavailable")
-                  )}
-                </div>
-              </div>
+              <SettingsTextarea
+                id="desktop-clipboard-draft"
+                ref={clipboardDraftRef}
+                value={clipboardDraft}
+                onChange={(event) => setClipboardDraft(event.target.value)}
+                className="min-h-24 text-sm"
+                placeholder={t("desktopworkspacesection.ClipboardDraft")}
+                {...clipboardDraftAgentProps}
+              />
             </SettingsRow>
+            <WorkspaceActionRow
+              agentId="desktop-clipboard-read"
+              label={t("desktopworkspacesection.ReadClipboard")}
+              group="desktop-clipboard"
+              disabled={busyAction === "desktop-clipboard-read"}
+              onClick={() =>
+                void runAction("desktop-clipboard-read", async () => {
+                  const result = await invokeDesktopBridgeRequest<{
+                    text?: string;
+                  }>({
+                    rpcMethod: "desktopReadFromClipboard",
+                    ipcChannel: "desktop:readFromClipboard",
+                  });
+                  setClipboardDraft(result?.text ?? "");
+                })
+              }
+            />
+            <WorkspaceActionRow
+              agentId="desktop-clipboard-copy"
+              label={t("desktopworkspacesection.CopyDraft")}
+              group="desktop-clipboard"
+              disabled={busyAction === "desktop-clipboard-copy"}
+              onClick={() =>
+                void runAction("desktop-clipboard-copy", async () => {
+                  await copyTextToClipboard(clipboardDraft);
+                })
+              }
+            />
+            <WorkspaceActionRow
+              agentId="desktop-clipboard-clear"
+              label={t("desktopworkspacesection.ClearClipboard")}
+              group="desktop-clipboard"
+              disabled={busyAction === "desktop-clipboard-clear"}
+              onClick={() =>
+                void runAction("desktop-clipboard-clear", async () => {
+                  await invokeDesktopBridgeRequest<void>({
+                    rpcMethod: "desktopClearClipboard",
+                    ipcChannel: "desktop:clearClipboard",
+                  });
+                  setClipboardDraft("");
+                })
+              }
+            />
+            {savePaths[0] ? (
+              <>
+                <WorkspaceActionRow
+                  agentId="desktop-open-path"
+                  label={t("desktopworkspacesection.OpenSavedPath")}
+                  group="desktop-clipboard"
+                  disabled={busyAction === "desktop-open-path"}
+                  onClick={() =>
+                    void runAction(
+                      "desktop-open-path",
+                      async () => {
+                        await invokeDesktopBridgeRequest<void>({
+                          rpcMethod: "desktopOpenPath",
+                          ipcChannel: "desktop:openPath",
+                          params: { path: savePaths[0] },
+                        });
+                      },
+                      t("desktopworkspacesection.OpenedSavedPath"),
+                      false,
+                    )
+                  }
+                />
+                <WorkspaceActionRow
+                  agentId="desktop-reveal-path"
+                  label={t("desktopworkspacesection.RevealSavedPath")}
+                  group="desktop-clipboard"
+                  disabled={busyAction === "desktop-reveal-path"}
+                  onClick={() =>
+                    void runAction(
+                      "desktop-reveal-path",
+                      async () => {
+                        await invokeDesktopBridgeRequest<void>({
+                          rpcMethod: "desktopShowItemInFolder",
+                          ipcChannel: "desktop:showItemInFolder",
+                          params: { path: savePaths[0] },
+                        });
+                      },
+                      t("desktopworkspacesection.RevealedSavedPath"),
+                      false,
+                    )
+                  }
+                />
+              </>
+            ) : null}
+            <SettingsRow
+              label={t("desktopworkspacesection.Formats")}
+              description={
+                snapshot?.clipboard
+                  ? `${snapshot.clipboard.formats.join(", ") || t("desktopworkspacesection.PlainText")} · ${
+                      snapshot.clipboard.text ||
+                      t("desktopworkspacesection.ClipboardTextUnavailable")
+                    }`
+                  : t("desktopworkspacesection.ClipboardDetailsUnavailable")
+              }
+            />
           </SettingsGroup>
         </div>
       </SettingsStack>


### PR DESCRIPTION
# Relates to

Closes #19483

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e2505b87c6610e2908a7150cc1eeb5a2f01b484b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` was not run for the whole monorepo in this turn.

# Risks

Low. Same actions and agent-surface ids; only grouping changes from one
compound SettingsRow per group to one SettingsRow per action.

# Background

## What does this PR do?

Splits DesktopWorkspaceSection compound rows (button grids + logs stuffed
into one SettingsRow that repeated the group title) into one SettingsRow per
action. Logs, filters, dialog results, and the clipboard draft sit on
dedicated stacked rows.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/settings/DesktopWorkspaceSection.tsx`

## Detailed testing steps

```bash
bun run --cwd packages/ui test -- src/components/settings/DesktopWorkspaceSection.test.ts
```

# Evidence Gate

<!-- evidence-head:af5d3342eca9e2ace31883b9b078cbb9d55da6ea -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19484-desktop-fullpage-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19484-desktop-fullpage-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19484-desktop-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or API path is changed.
<!-- evidence-row:frontend-logs -->
- [x] [19484-desktop-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19484-desktop-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, wallet, scheduled-task, or generated domain artifact is involved.
<!-- evidence-row:ocr-review -->
- [x] [19484-desktop-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19484-desktop-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Backend + frontend logs

Backend: N/A.

## Screenshots (before / after) + video walkthrough

Isolated fixture of window-control and clipboard groups.

## Known gaps / failures

- `bun run verify` not run for the whole monorepo.
- `packages/ui` typecheck still fails on develop-owned steward-login files.
- `audit:app` still blocked by `startupCoordinator.target`.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok-cli
Contribution skill revision: elizaOS/eliza@e2505b87c6610e2908a7150cc1eeb5a2f01b484b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-4.6]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-cli","skill_revision":"elizaOS/eliza@e2505b87c6610e2908a7150cc1eeb5a2f01b484b:packages/skills/skills/contribute-to-eliza"} -->
