### PR TITLE
fix(ui): route cloud labelled status readouts through SettingsRow

### DIFF
--- a/packages/ui/src/cloud/account-security/components/account-details.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-details.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Renders AccountDetails through SettingsRow and asserts labelled 1:1
+ * readouts, verification badge, and omitted optional rows. jsdom, no backend.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { UserProfile } from "../data/user";
+import { AccountDetails } from "./account-details";
+
+vi.mock("../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? _key,
+}));
+
+function makeUser(overrides: Partial<UserProfile> = {}): UserProfile {
+  const now = new Date("2026-03-15T12:00:00.000Z");
+  return {
+    id: "user-1",
+    email: "user@example.com",
+    email_verified: true,
+    wallet_address: null,
+    wallet_chain_type: null,
+    wallet_verified: false,
+    name: null,
+    avatar: null,
+    organization_id: null,
+    role: "member",
+    steward_user_id: null,
+    telegram_id: null,
+    telegram_username: null,
+    telegram_first_name: null,
+    telegram_photo_url: null,
+    discord_id: null,
+    discord_username: null,
+    discord_global_name: null,
+    discord_avatar_url: null,
+    whatsapp_id: null,
+    whatsapp_name: null,
+    phone_number: null,
+    phone_verified: null,
+    is_anonymous: false,
+    anonymous_session_id: null,
+    expires_at: null,
+    nickname: null,
+    work_function: null,
+    preferences: null,
+    email_notifications: null,
+    response_notifications: null,
+    is_active: true,
+    created_at: now,
+    updated_at: now,
+    organization: {
+      id: "org-1",
+      name: "Example Org",
+      slug: "example-org",
+      billing_email: null,
+      credit_balance: "0",
+      is_active: true,
+      created_at: now,
+      updated_at: now,
+    },
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AccountDetails", () => {
+  it("renders labelled account id, verified email, and member since", () => {
+    render(<AccountDetails user={makeUser()} />);
+
+    expect(screen.getByText("Account details")).toBeTruthy();
+    expect(screen.getByText("Account ID")).toBeTruthy();
+    expect(screen.getByText("user-1")).toBeTruthy();
+    expect(screen.getByText("Email")).toBeTruthy();
+    expect(screen.getByText("user@example.com")).toBeTruthy();
+    expect(screen.getByText("Verified")).toBeTruthy();
+    expect(screen.getByText("Member since")).toBeTruthy();
+    expect(screen.queryByText("Unverified")).toBeNull();
+  });
+
+  it("shows unverified when email is present but not verified", () => {
+    render(<AccountDetails user={makeUser({ email_verified: false })} />);
+
+    expect(screen.getByText("Unverified")).toBeTruthy();
+    expect(screen.queryByText("Verified")).toBeNull();
+  });
+
+  it("omits the email row when the account has no email", () => {
+    render(<AccountDetails user={makeUser({ email: null })} />);
+
+    expect(screen.getByText("Account ID")).toBeTruthy();
+    expect(screen.queryByText("Email")).toBeNull();
+    expect(screen.queryByText("Verified")).toBeNull();
+    expect(screen.queryByText("Unverified")).toBeNull();
+  });
+});

--- a/packages/ui/src/cloud/account-security/components/account-details.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-details.tsx
@@ -1,9 +1,15 @@
 /**
  * Read-only account details: account id, email + verification, and join date.
+ * These are labelled 1:1 status rows, not the ProfileForm editor, so they
+ * compose SettingsStack / SettingsGroup / SettingsRow.
  */
 
-import { CheckCircle2, Info, XCircle } from "lucide-react";
-import { BrandCard, CornerBrackets } from "../../../cloud-ui";
+import {
+  SettingsGroup,
+  SettingsRow,
+  SettingsStack,
+} from "../../../components/settings/settings-layout";
+import { StatusBadge } from "../../../components/ui/status-badge";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import type { UserProfile } from "../data/user";
 
@@ -22,67 +28,56 @@ export function AccountDetails({ user }: AccountDetailsProps) {
     : null;
 
   return (
-    <BrandCard className="relative">
-      <CornerBrackets size="sm" className="opacity-50" />
+    <SettingsStack data-testid="cloud-account-details">
+      <SettingsGroup
+        title={t("cloud.accountDetails.title", {
+          defaultValue: "Account details",
+        })}
+      >
+        <SettingsRow
+          label={t("cloud.accountDetails.accountId", {
+            defaultValue: "Account ID",
+          })}
+          description={
+            <span className="break-all font-mono text-txt-strong">
+              {user.id}
+            </span>
+          }
+        />
 
-      <div className="relative z-10 space-y-6">
-        <div className="flex items-center gap-2">
-          <Info className="h-5 w-5 text-muted" />
-          <h3 className="text-lg font-bold text-txt-strong">
-            {t("cloud.accountDetails.title", {
-              defaultValue: "Account details",
+        {user.email ? (
+          <SettingsRow
+            label={t("cloud.accountDetails.email", { defaultValue: "Email" })}
+            description={
+              <span className="break-all text-txt-strong">{user.email}</span>
+            }
+            control={
+              <StatusBadge
+                withDot
+                variant={user.email_verified ? "success" : "muted"}
+                label={
+                  user.email_verified
+                    ? t("cloud.accountDetails.verified", {
+                        defaultValue: "Verified",
+                      })
+                    : t("cloud.accountDetails.notVerified", {
+                        defaultValue: "Unverified",
+                      })
+                }
+              />
+            }
+          />
+        ) : null}
+
+        {created ? (
+          <SettingsRow
+            label={t("cloud.accountDetails.accountCreated", {
+              defaultValue: "Member since",
             })}
-          </h3>
-        </div>
-
-        <div className="space-y-4">
-          <div className="space-y-1">
-            <p className="text-xs text-muted uppercase tracking-wide">
-              {t("cloud.accountDetails.accountId", {
-                defaultValue: "Account ID",
-              })}
-            </p>
-            <p className="font-mono text-xs text-txt">{user.id}</p>
-          </div>
-
-          {user.email && (
-            <div className="space-y-1">
-              <p className="text-xs text-muted uppercase tracking-wide">
-                {t("cloud.accountDetails.email", { defaultValue: "Email" })}
-              </p>
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="text-sm text-txt-strong">{user.email}</span>
-                {user.email_verified ? (
-                  <span className="inline-flex items-center gap-1 rounded-sm border border-green-500/40 bg-green-500/10 px-2 py-0.5 text-xs text-green-400">
-                    <CheckCircle2 className="h-3 w-3" />
-                    {t("cloud.accountDetails.verified", {
-                      defaultValue: "Verified",
-                    })}
-                  </span>
-                ) : (
-                  <span className="inline-flex items-center gap-1 rounded-sm border border-border bg-muted px-2 py-0.5 text-xs text-txt-strong">
-                    <XCircle className="h-3 w-3" />
-                    {t("cloud.accountDetails.notVerified", {
-                      defaultValue: "Unverified",
-                    })}
-                  </span>
-                )}
-              </div>
-            </div>
-          )}
-
-          {created && (
-            <div className="space-y-1">
-              <p className="text-xs text-muted uppercase tracking-wide">
-                {t("cloud.accountDetails.accountCreated", {
-                  defaultValue: "Member since",
-                })}
-              </p>
-              <p className="text-sm text-txt-strong">{created}</p>
-            </div>
-          )}
-        </div>
-      </div>
-    </BrandCard>
+            description={<span className="text-txt-strong">{created}</span>}
+          />
+        ) : null}
+      </SettingsGroup>
+    </SettingsStack>
   );
 }

--- a/packages/ui/src/cloud/organization/organization-general-tab.test.tsx
+++ b/packages/ui/src/cloud/organization/organization-general-tab.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Renders OrganizationGeneralTab through SettingsRow and asserts labelled
+ * status fields, inactive badge, and omitted billing email. jsdom, no backend.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OrganizationDto } from "./data/cloud-org-types";
+import { OrganizationGeneralTab } from "./organization-general-tab";
+
+function makeOrg(overrides: Partial<OrganizationDto> = {}): OrganizationDto {
+  return {
+    id: "org-1",
+    name: "Sol's Organization",
+    slug: "sols-org",
+    credit_balance: "1250",
+    billing_email: "billing@example.com",
+    is_active: true,
+    created_at: "2026-03-15T12:00:00.000Z",
+    updated_at: "2026-03-15T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("OrganizationGeneralTab", () => {
+  it("renders labelled organization and billing readouts", () => {
+    render(<OrganizationGeneralTab organization={makeOrg()} />);
+
+    expect(screen.getByText("Organization details")).toBeTruthy();
+    expect(screen.getByText("Organization name")).toBeTruthy();
+    expect(screen.getByText("Sol's Organization")).toBeTruthy();
+    expect(screen.getByText("Organization slug")).toBeTruthy();
+    expect(screen.getByText("sols-org")).toBeTruthy();
+    expect(screen.getByText("Status")).toBeTruthy();
+    expect(screen.getByText("Active")).toBeTruthy();
+    expect(screen.getByText("Created")).toBeTruthy();
+    expect(screen.getByText("Mar 15, 2026")).toBeTruthy();
+    expect(screen.getByText("Billing information")).toBeTruthy();
+    expect(screen.getByText("Credit balance")).toBeTruthy();
+    expect(screen.getByText("1,250 credits")).toBeTruthy();
+    expect(screen.getByText("Billing email")).toBeTruthy();
+    expect(screen.getByText("billing@example.com")).toBeTruthy();
+  });
+
+  it("shows Inactive and omits billing email when those fields are empty", () => {
+    render(
+      <OrganizationGeneralTab
+        organization={makeOrg({ is_active: false, billing_email: null })}
+      />,
+    );
+
+    expect(screen.getByText("Inactive")).toBeTruthy();
+    expect(screen.queryByText("Active")).toBeNull();
+    expect(screen.queryByText("Billing email")).toBeNull();
+    expect(screen.getByText("Credit balance")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/cloud/organization/organization-general-tab.tsx
+++ b/packages/ui/src/cloud/organization/organization-general-tab.tsx
@@ -1,15 +1,18 @@
 /**
  * Organization general tab — read-only organization details + billing summary.
  * Intentionally read-only: Eliza Cloud has no organization-rename flow, so this
- * surface displays name/slug/status/balance but never edits them.
- *
- * @param props - Organization general tab configuration
- * @param props.organization - Organization data to display
+ * surface displays name/slug/status/balance but never edits them. Labelled
+ * status fields compose SettingsStack / SettingsGroup / SettingsRow.
  */
 
 import { format } from "date-fns";
 import { Calendar } from "lucide-react";
-import { BrandCard, CornerBrackets } from "../../cloud-ui";
+import {
+  SettingsGroup,
+  SettingsRow,
+  SettingsStack,
+} from "../../components/settings/settings-layout";
+import { StatusBadge } from "../../components/ui/status-badge";
 import type { OrganizationDto } from "./data/cloud-org-types";
 
 interface OrganizationGeneralTabProps {
@@ -20,99 +23,71 @@ export function OrganizationGeneralTab({
   organization,
 }: OrganizationGeneralTabProps) {
   return (
-    <div className="space-y-4 md:space-y-6">
-      <BrandCard className="relative">
-        <CornerBrackets size="sm" className="opacity-50" />
-        <div className="relative z-10 space-y-4">
-          <div>
-            <div className="flex items-center gap-2 mb-2">
-              <div className="w-2 h-2 rounded-full bg-muted" />
-              <h3 className="text-sm md:text-base font-mono text-txt uppercase">
-                Organization Details
-              </h3>
-            </div>
-            <p className="text-xs md:text-sm font-mono text-muted">
-              Basic information about your organization
-            </p>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <p className="text-xs font-mono font-medium text-muted uppercase tracking-wide">
-                Organization Name
-              </p>
-              <p className="mt-1 text-sm font-mono font-semibold text-txt-strong">
-                {organization.name}
-              </p>
-            </div>
-            <div>
-              <p className="text-xs font-mono font-medium text-muted uppercase tracking-wide">
-                Organization Slug
-              </p>
-              <p className="mt-1 text-sm font-mono text-txt-strong">
-                {organization.slug}
-              </p>
-            </div>
-            <div>
-              <p className="text-xs font-mono font-medium text-muted uppercase tracking-wide">
-                Status
-              </p>
-              <div className="mt-1">
-                <span
-                  className={`px-2 py-1 text-xs font-mono font-bold uppercase tracking-wide border ${organization.is_active ? "bg-green-500/20 text-green-400 border-green-500/40" : "bg-red-500/20 text-red-400 border-red-500/40"}`}
-                >
-                  {organization.is_active ? "Active" : "Inactive"}
-                </span>
-              </div>
-            </div>
-            <div>
-              <p className="text-xs font-mono font-medium text-muted uppercase tracking-wide">
-                Created
-              </p>
-              <p className="mt-1 text-sm font-mono flex items-center gap-1.5 text-txt-strong">
-                <Calendar className="h-3.5 w-3.5 text-muted" />
-                {format(new Date(organization.created_at), "MMM d, yyyy")}
-              </p>
-            </div>
-          </div>
-        </div>
-      </BrandCard>
+    <SettingsStack data-testid="cloud-organization-general">
+      <SettingsGroup
+        title="Organization details"
+        description="Basic information about your organization"
+      >
+        <SettingsRow
+          label="Organization name"
+          description={
+            <span className="break-words font-medium text-txt-strong">
+              {organization.name}
+            </span>
+          }
+        />
+        <SettingsRow
+          label="Organization slug"
+          description={
+            <span className="break-all font-mono text-txt-strong">
+              {organization.slug}
+            </span>
+          }
+        />
+        <SettingsRow
+          label="Status"
+          control={
+            <StatusBadge
+              withDot
+              variant={organization.is_active ? "success" : "danger"}
+              label={organization.is_active ? "Active" : "Inactive"}
+            />
+          }
+        />
+        <SettingsRow
+          icon={Calendar}
+          label="Created"
+          description={
+            <span className="text-txt-strong">
+              {format(new Date(organization.created_at), "MMM d, yyyy")}
+            </span>
+          }
+        />
+      </SettingsGroup>
 
-      <BrandCard className="relative">
-        <CornerBrackets size="sm" className="opacity-50" />
-        <div className="relative z-10 space-y-4">
-          <div>
-            <div className="flex items-center gap-2 mb-2">
-              <div className="w-2 h-2 rounded-full bg-muted" />
-              <h3 className="text-sm md:text-base font-mono text-txt uppercase">
-                Billing Information
-              </h3>
-            </div>
-            <p className="text-xs md:text-sm font-mono text-muted">
-              Credit balance and billing details
-            </p>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <p className="text-xs font-mono font-medium text-muted uppercase tracking-wide">
-                Credit Balance
-              </p>
-              <p className="mt-1 text-xl md:text-2xl font-mono font-bold text-txt-strong">
-                {Number(organization.credit_balance).toLocaleString()} credits
-              </p>
-            </div>
-            {organization.billing_email && (
-              <div>
-                <p className="text-xs font-mono font-medium text-muted uppercase tracking-wide">
-                  Billing Email
-                </p>
-                <p className="mt-1 text-sm font-mono text-txt-strong break-all">
-                  {organization.billing_email}
-                </p>
-              </div>
-            )}
-          </div>
-        </div>
-      </BrandCard>
-    </div>
+      <SettingsGroup
+        title="Billing information"
+        description="Credit balance and billing details"
+      >
+        <SettingsRow
+          label="Credit balance"
+          description={
+            <span className="tabular-nums text-txt-strong">
+              {Number(organization.credit_balance).toLocaleString()} credits
+            </span>
+          }
+        />
+        {organization.billing_email ? (
+          <SettingsRow
+            label="Billing email"
+            description={
+              <span className="break-all font-mono text-txt-strong">
+                {organization.billing_email}
+              </span>
+            }
+          />
+        ) : null}
+      </SettingsGroup>
+    </SettingsStack>
   );
 }

--- a/packages/ui/src/components/settings/cloud-labelled-status-readouts.test.ts
+++ b/packages/ui/src/components/settings/cloud-labelled-status-readouts.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Source ratchet: cloud labelled status readouts must compose SettingsRow
+ * rather than BrandCard key/value shells. Reads shipped files off disk.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const settingsRoot = dirname(fileURLToPath(import.meta.url));
+const uiSrc = join(settingsRoot, "../..");
+
+function read(rel: string): string {
+  return readFileSync(join(uiSrc, rel), "utf8");
+}
+
+describe("cloud labelled status readouts use SettingsRow", () => {
+  it("account details labelled fields are SettingsRows", () => {
+    const source = read(
+      "cloud/account-security/components/account-details.tsx",
+    );
+    expect(source).toContain("<SettingsStack");
+    expect(source).toContain("<SettingsGroup");
+    expect(source).toContain("<SettingsRow");
+    expect(source).toContain("Account ID");
+    expect(source).toContain("Member since");
+    expect(source).not.toContain("BrandCard");
+    expect(source).not.toContain("CornerBrackets");
+  });
+
+  it("organization general labelled fields are SettingsRows", () => {
+    const source = read("cloud/organization/organization-general-tab.tsx");
+    expect(source).toContain("<SettingsStack");
+    expect(source).toContain("<SettingsGroup");
+    expect(source).toContain("<SettingsRow");
+    expect(source).toContain("Organization name");
+    expect(source).toContain("Credit balance");
+    expect(source).not.toContain("BrandCard");
+    expect(source).not.toContain("grid grid-cols-1 md:grid-cols-2");
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #19491

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, rebased onto latest `origin/develop`.
- [ ] `bun run verify` not run for the whole monorepo.
- [x] Reviewer can confirm from evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b6d73a186ceba6c50351f88852950410b35b4e2a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop`.
- [ ] `bun run verify` not run for the whole monorepo.

# Risks

Low. Read-only labelled fields only. No form submit, rename, or credential paths.

# Background

## What does this PR do?

Independent scan found leftover labelled 1:1 status fields still on BrandCard shells. This PR routes them through SettingsStack / SettingsGroup / SettingsRow:

- Account details: Account ID, Email + verification, Member since
- Organization general: name / slug / status / created, credit balance / billing email

## What kind of change is this?

Improvements

# Documentation changes needed?

No.

# Testing

```bash
bun run --cwd packages/ui test -- src/cloud/account-security/components/account-details.test.tsx src/cloud/organization/organization-general-tab.test.tsx src/components/settings/cloud-labelled-status-readouts.test.ts
```

# Evidence Gate

<!-- evidence-head:d3763ab4564c05d2542ddc555c25cc04b25dc1c3 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19492-status-readouts-fullpage-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19492-status-readouts-fullpage-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19492-status-readouts-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or API path is changed.
<!-- evidence-row:frontend-logs -->
- [x] [19492-status-readouts-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19492-status-readouts-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, wallet, scheduled-task, or generated domain artifact is involved.
<!-- evidence-row:ocr-review -->
- [x] [19492-status-readouts-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19492-status-readouts-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Known gaps / failures

- Full-repo verify not run.
- packages/ui typecheck still fails on develop-owned steward-login files.
- audit:app still blocked by startupCoordinator.target. Isolated Playwright + extracted theme captures are the pixel path.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok-cli
Contribution skill revision: elizaOS/eliza@b6d73a186ceba6c50351f88852950410b35b4e2a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-4.6]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-cli","skill_revision":"elizaOS/eliza@b6d73a186ceba6c50351f88852950410b35b4e2a:packages/skills/skills/contribute-to-eliza"} -->
