### PR TITLE
test(homepage): guard shipped-asset allowlist against drift; bundle phone-mockup avatar

### DIFF
--- a/packages/app/scripts/sync-homepage-assets.mjs
+++ b/packages/app/scripts/sync-homepage-assets.mjs
@@ -18,6 +18,7 @@ export const HOMEPAGE_PUBLIC_ASSETS = [
   ".well-known/apple-app-site-association",
   ".well-known/assetlinks.json",
   "eliza-logo.webp",
+  "eliza-app-profile-image.webp",
   "elizapfp.webp",
   "elizawallpaper.webp",
   "geist-sans-latin-ext.woff2",

--- a/packages/homepage/tests/smoke.node.test.mjs
+++ b/packages/homepage/tests/smoke.node.test.mjs
@@ -6,10 +6,10 @@
  */
 
 import assert from "node:assert/strict";
-import { readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageJsonPath = resolve(__dirname, "../package.json");
@@ -195,4 +195,62 @@ test("clean builds resolve bare shared imports to language-only source", () => {
   assert.deepEqual(tsconfig.compilerOptions.paths["@elizaos/shared"], [
     "../shared/src/i18n/language.ts",
   ]);
+});
+
+// The deployable frontend is packages/app. A homepage `src="/…"` asset ships
+// only if the app allowlists it (HOMEPAGE_PUBLIC_ASSETS in
+// packages/app/scripts/sync-homepage-assets.mjs) or already owns a copy under
+// packages/app/public. A reference that ships through neither 404s in the
+// deployed app and is served the SPA index.html fallback: HTTP 200,
+// text/html, so the image silently renders blank at naturalWidth 0 with zero
+// build or CI errors. That class shipped /eliza-logotext.svg blank in
+// production (2026-08-14); the per-instance fix bundled that one wordmark.
+// This test is the standing guard for the whole class. Bundler imports
+// (`import x from "@/assets/…"`) are exempt by construction: they ship with
+// whatever build consumes the source.
+const homepageSrcRoot = resolve(__dirname, "../src");
+const appPublicRoot = resolve(__dirname, "../../app/public");
+
+function collectSourceFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(full));
+    } else if (/\.(tsx?|jsx?|css|html)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+test("every url-referenced homepage public asset ships with the deployed app", async () => {
+  const { HOMEPAGE_PUBLIC_ASSETS } = await import(
+    pathToFileURL(appAssetSyncPath).href
+  );
+  const allowlisted = new Set(HOMEPAGE_PUBLIC_ASSETS);
+  const assetUrl =
+    /(?:src|href)=(?:"|')(\/[^"'?#]+\.(?:svg|png|webp|jpe?g|gif|ico|woff2?|ttf|otf))(?:"|')/g;
+
+  const offenders = [];
+  for (const file of collectSourceFiles(homepageSrcRoot)) {
+    const source = readFileSync(file, "utf8");
+    for (const match of source.matchAll(assetUrl)) {
+      const rel = match[1].replace(/^\//, "");
+      if (allowlisted.has(rel)) continue;
+      if (existsSync(resolve(appPublicRoot, rel))) continue;
+      offenders.push(`${file.slice(homepageSrcRoot.length + 1)} -> /${rel}`);
+    }
+  }
+
+  assert.deepEqual(
+    offenders.sort(),
+    [],
+    `homepage sources reference public assets the deployed app does not ship ` +
+      `(they 404 into the SPA fallback and render blank with zero errors): ` +
+      `${offenders.join(", ")}. Add each path to HOMEPAGE_PUBLIC_ASSETS in ` +
+      `packages/app/scripts/sync-homepage-assets.mjs, place a copy under ` +
+      `packages/app/public, or import it through the bundler ` +
+      `(import x from "@/assets/…").`,
+  );
 });


### PR DESCRIPTION
## The bug class

The deployable frontend is `packages/app`, which ships `homepage/public` assets **only** through the hardcoded `HOMEPAGE_PUBLIC_ASSETS` allowlist in `packages/app/scripts/sync-homepage-assets.mjs`. A homepage `<img src="/…">` that references a public asset **missing** from that allowlist 404s in the deployed app and is served the SPA `index.html` fallback: **HTTP 200, content-type `text/html`** — so the image silently decodes at `naturalWidth 0`, rendering blank with **zero build/CI/health errors**.

This is the class that shipped `/eliza-logotext.svg` blank in prod + staging (logo incident 2026-08-14). curl/health/CI were all green; only a rendered browser caught it. Shaw's `abe29639050` fixed *that one instance* by switching the wordmark to a bundler import ("ships with whatever build consumes the source and cannot drift again"). **This PR generalizes that pattern into a standing guard** and clears the latent instances the guard exposes.

## What this does

- **New `node:test` guard** in `packages/homepage/tests/smoke.node.test.mjs`: enumerates every homepage source file and asserts each url-referenced public asset (`svg/png/webp/jpe?g/gif/ico/woff2?/ttf/otf`) is present in `HOMEPAGE_PUBLIC_ASSETS`. Bundler imports (`import x from "@/assets/…"`) are exempt — they ship with whatever build consumes the source. Runs in the existing smoke suite that `quality.yml` ("Validate homepage source contracts") already gates on `packages/homepage/**` + `packages/app/**` changes — **no workflow wiring added**.
- **Bundle the small brand marks** the guard flagged, mirroring `abe29639050` exactly (`import … from "@/assets/*.svg"` + `src={url}`):
  - landing phone-mockup avatar `logo_white_orangebg.svg`
  - marketing header + footer wordmarks `eliza_wordmark_black.svg` / `eliza_wordmark_white.svg`
  - login wordmark `eliza_wordmark_black.svg`
  - `public/` copies are **kept intact** — they back the `packages/shared` brand-path contracts (`brand/index.ts`, `brand-classic/index.ts`); only the homepage `<img>` usages move to the bundler.
- **Add `eliza-app-profile-image.webp`** (connected page media) to `HOMEPAGE_PUBLIC_ASSETS`. Large media legitimately stays in `public/` + allowlist — that is what the allowlist is for; the guard just enforces it can't be referenced *without* being listed.

## Bidirectional proof

Guard **FAILS on unmodified develop**, flagging all five latent url-referenced assets:
```
pages/connected.tsx → /eliza-app-profile-image.webp
pages/landing.tsx    → /brand/logos/logo_white_orangebg.svg
pages/login.tsx      → /brand/logos/eliza_wordmark_black.svg
pages/marketing.tsx  → /brand/logos/eliza_wordmark_black.svg
pages/marketing.tsx  → /brand/logos/eliza_wordmark_white.svg
```
Guard **PASSES with the conversions** in this PR.

## Testing

- `bun --conditions=eliza-source test tests/smoke.node.test.mjs`: **10 pass, 0 fail** (guard included)
- homepage `tsc -b` typecheck: **passed**
- `biome check` on all edited files: **clean** (one pre-existing `biome-ignore` warning in `landing.tsx`, unrelated)

## Risks

Low. Adds a source-contract test and swaps four `<img src="/…">` public paths for byte-identical bundled assets (same files, hashed at build). No layout, copy, or public-path contract changes.

## Reference

Generalizes @shaw's `abe29639050` ("fix(app): no boot splash on marketing hosts; bundle the wordmark") from a per-instance fix into a class guard.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-4-8
<!-- attribution-row:client -->
- Agent tooling: Sol
<!-- attribution-row:status -->
- Provenance status: self-reported