### PR TITLE
fix(cloud/voice): room-lock watchdog so a dropped barge-in abort cannot wedge a phone call (draft, #19505)

### DIFF
--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -657,3 +657,91 @@ test("delete operation clears room storage and cancels the mirror-retry alarm", 
   });
   await Promise.all(background.splice(0));
 });
+
+test("room lock watchdog force-proceeds when a barge-in abort never releases the lock", async () => {
+  // Reproduces the phone-line wedge: turn 1 ok, turn 2 is a streamed turn whose
+  // caller barge-in aborts the LLM stream, but the abort -> body-cancel
+  // propagation is DROPPED (a Cloudflare DO stub-fetch abort gap), so the
+  // response body is neither drained to `done` nor `cancel`led and the room
+  // queue lock is never released the normal way. Without the watchdog, turn 3's
+  // `await previous` would hang forever ("responds 2-3 times then goes silent").
+  // With the watchdog, turn 3 force-proceeds.
+  repositoryReads = 0;
+  repositoryWrites = 0;
+  repositoryRow = [];
+  repositoryHistoryLengths.length = 0;
+  repositoryHistories.length = 0;
+  streamMergeGate = null;
+  resolveStreamMergeGate = () => {};
+  const data = new Map<string, unknown>([
+    [
+      "conversation",
+      {
+        agentId: AGENT_FIXTURE.id,
+        channelId: "room-1",
+        history: [],
+        dirty: false,
+        version: 1,
+      },
+    ],
+  ]);
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    {} as never,
+  );
+  // Shrink the watchdog so the force-proceed path is asserted without a 45s
+  // real-timer wait. Production keeps the module constant.
+  (object as unknown as { roomLockWaitMs: number }).roomLockWaitMs = 20;
+  const invoke = makeInvoke(object);
+
+  // Turn 1: a normal bridge turn releases its lock cleanly.
+  expect(await invoke("turn-one")).toMatchObject({
+    result: { historyLength: 1 },
+  });
+  await Promise.all(background.splice(0));
+
+  // Turn 2: a streamed turn. Read exactly one chunk, then abandon the body
+  // WITHOUT draining it to `done` and WITHOUT cancelling it — modelling the
+  // dropped abort -> body-cancel propagation. The lock stays held.
+  const streamed = await object.fetch(
+    new Request("https://shared-runtime.internal/stream", {
+      method: "POST",
+      body: JSON.stringify({
+        operation: "stream",
+        agent: AGENT_FIXTURE,
+        rpc: {
+          jsonrpc: "2.0",
+          id: "turn-two-wedged",
+          method: "message.send",
+          params: { text: "hi", roomId: "room-1" },
+        },
+      }),
+    }),
+  );
+  const reader = streamed.body!.getReader();
+  await reader.read(); // consume the first chunk, then leak the reader.
+
+  // Turn 3 must NOT hang. Guard with a race so a regression (missing watchdog)
+  // fails as a timeout instead of hanging the whole suite.
+  let thirdCompleted = false;
+  const third = invoke("turn-three").then((result) => {
+    thirdCompleted = true;
+    return result;
+  });
+  const guard = new Promise<"stuck">((resolve) =>
+    setTimeout(() => resolve("stuck"), 2_000),
+  );
+  const outcome = await Promise.race([
+    third.then(() => "done" as const),
+    guard,
+  ]);
+  expect(outcome).toBe("done");
+  expect(thirdCompleted).toBe(true);
+
+  const result = await third;
+  // History advanced past the wedged turn 2 (turn 1 + turn 3 both landed).
+  expect(result).toMatchObject({ result: { historyLength: 2 } });
+
+  await Promise.all(background.splice(0));
+});

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -42,6 +42,23 @@ const CONVERSATION_KEY = "conversation";
 const RETRY_DELAY_MS = 30_000;
 
 /**
+ * Upper bound on how long a queued turn waits for the previous turn's room
+ * lock to release before it force-proceeds. The room queue releases the lock
+ * when the prior turn's response body drains, is cancelled, or errors
+ * (`releaseWhenConsumed`). A caller barge-in aborts the LLM stream, and the
+ * abort is expected to propagate through the Durable Object stub-fetch to the
+ * response body's `cancel`, which releases the lock. If any link in that
+ * abort -> body-cancel chain fails to propagate (a Cloudflare DO stub-fetch
+ * abort-propagation gap, or a cancel finalizer rejecting), the lock would
+ * otherwise never release and every subsequent turn's `await previous` would
+ * hang forever — the observed "voice line responds 2-3 times then goes silent"
+ * signature. This watchdog bounds that wait so ordering degrades to at worst a
+ * slightly-out-of-order turn instead of a permanently wedged room. The window
+ * is generous relative to a real turn so it never fires on a healthy slow turn.
+ */
+const ROOM_LOCK_WAIT_MS = 45_000;
+
+/**
  * Durable claim ledger for client-keyed turns (#18045), stored as one bounded
  * value. The room queue fully serializes turns, so read-modify-write is safe.
  * Bounds keep the value under the storage limit; an evicted claim degrades to
@@ -116,6 +133,9 @@ export class SharedRuntimeConversation {
   private hydration: Promise<void> | undefined;
   private queue: Promise<void> = Promise.resolve();
   private mirrorQueue: Promise<void> = Promise.resolve();
+  // Room-lock watchdog window. Overridable only so unit tests can assert the
+  // force-proceed path without a 45s real-timer wait; production uses the const.
+  private roomLockWaitMs: number = ROOM_LOCK_WAIT_MS;
 
   constructor(state: DurableObjectState, env: AppEnv["Bindings"]) {
     this.state = state;
@@ -426,13 +446,59 @@ export class SharedRuntimeConversation {
     });
   }
 
+  /**
+   * Await the previous turn's lock with a watchdog. Resolves as soon as the
+   * prior turn releases; if that never happens within ROOM_LOCK_WAIT_MS (a
+   * dropped barge-in abort -> body-cancel propagation), it force-proceeds and
+   * logs the wedge so the gap is observable rather than silently permanent.
+   */
+  private async awaitPreviousTurn(previous: Promise<void>): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const watchdog = new Promise<"timeout">((resolve) => {
+      timer = setTimeout(() => resolve("timeout"), this.roomLockWaitMs);
+    });
+    try {
+      const outcome = await Promise.race([
+        previous.then(() => "released" as const),
+        watchdog,
+      ]);
+      if (outcome === "timeout") {
+        const { logger } = await import("@/lib/utils/logger");
+        logger.warn(
+          "[SharedRuntimeConversation] room lock watchdog fired; previous turn never released (suspected dropped abort->body-cancel propagation) — proceeding to avoid a wedged room",
+          { waitMs: this.roomLockWaitMs },
+        );
+      }
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
   async fetch(request: Request): Promise<Response> {
     const previous = this.queue;
-    let release = () => {};
+    // The lock is released by exactly one of three mutually exclusive paths:
+    // `handle` throwing (catch below), the response body draining/cancelling
+    // (`releaseWhenConsumed`), or the watchdog timing out `await previous`.
+    // Make release idempotent so a late body-cancel after a watchdog
+    // force-release (or vice versa) cannot resolve a stale, already-replaced
+    // queue promise and corrupt ordering for a later turn.
+    let released = false;
+    let resolveQueue = () => {};
     this.queue = new Promise<void>((resolve) => {
-      release = resolve;
+      resolveQueue = resolve;
     });
-    await previous;
+    const release = () => {
+      if (released) return;
+      released = true;
+      resolveQueue();
+    };
+
+    // Bound the wait for the previous turn's lock. A dropped abort -> body
+    // -cancel propagation on a prior barge-in would otherwise leave `previous`
+    // unresolved forever and wedge this room for the rest of the call. If the
+    // watchdog fires, we proceed anyway (ordering degrades gracefully) and log
+    // the wedge so the propagation gap is observable in Worker tail.
+    await this.awaitPreviousTurn(previous);
 
     try {
       const response = await this.handle(request);


### PR DESCRIPTION
# Relates to

Fixes #19505 (candidate #1). **DRAFT — starting point for @lalalune to take over** (barge-in surface, #19393/#19398/#19407 chain). Feel free to close/replace with a different shape.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [ ] `bun install` and `bun run verify` were run after sync — see **Known gaps / failures** (scoped to the one changed package's test).
- [x] A reviewer can confirm the change works from the evidence below (regression test proves the wedge and the fix).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `Sol`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched off the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` not run repo-wide (draft, scoped hotfix). Changed-package tests pass — see Known gaps.

# Risks

**Low.** Defensive-only. The change does not alter the healthy abort → cancel → release path; it only adds a fallback so a *dropped* release cannot wedge a room forever. Worst case if the watchdog ever fired on a genuinely healthy but very slow turn (>45s): one room turn could proceed slightly out of order, which is strictly better than a permanently silent call. The 45s window is far above a normal turn, so it should not fire in healthy operation.

# Background

## What does this PR do?

Adds a bounded watchdog to the shared-runtime conversation Durable Object's per-room turn queue, targeting candidate #1 in #19505.

The DO serializes turns per room by holding a queue lock that is released only when the prior turn's response body drains, cancels, or errors (`releaseWhenConsumed`). On a caller barge-in the phone path aborts the LLM stream (`session.ts` `interrupt()` → `llmAbort.abort()`) and relies on that abort propagating through the DO stub-fetch to the response body's `cancel` to release the lock. If any link in that abort → body-cancel chain fails to propagate (a Cloudflare DO stub-fetch abort gap, or a `cancel` finalizer rejecting), the lock never releases and every subsequent turn's `await previous` hangs forever — the "phone line responds 2-3 times then goes silent" signature, made frequent by the #19393/#19398/#19407 barge-in chain.

Changes, all in `packages/cloud/api/src/shared-runtime-conversation.ts`:
- `awaitPreviousTurn()` races the previous-turn lock against a `ROOM_LOCK_WAIT_MS` (45s) watchdog. If the lock never releases, the next turn force-proceeds and logs the wedge (`[SharedRuntimeConversation] room lock watchdog fired …`) so the propagation gap is observable in Worker tail instead of being silently permanent.
- The lock release is now an idempotent closure, so a late body-cancel after a watchdog force-proceed (or vice versa) cannot corrupt a later turn's ordering.
- Regression test in `shared-runtime-conversation.test.ts`: turn 1 ok → turn 2 stream body read once then abandoned WITHOUT drain/cancel (models the dropped abort propagation) → asserts turn 3 still completes via the watchdog. Verified the test **fails** (turn 3 hangs → "stuck") when the watchdog is effectively disabled, proving it exercises the fix.

## What kind of change is this?

Bug fix (non-breaking; defensive fallback).

## What is deliberately NOT addressed (left for @lalalune)

- **Candidate #2** — Ink STT `close` = hard call teardown (`session.ts` ~line 549). A reconnect-before-teardown touches the Cartesia Ink socket lifecycle + turn-state resync; too big/risky for this small defensive diff.
- **Candidate #3** — `activeSttTurn` turn-state wedge. STT state-machine surface.
- **Voice id / env / deploy** — untouched by design.
- No workflow files touched.

# Documentation changes needed?

My changes do not require a documentation change.

# Testing

## Where should a reviewer start?

`packages/cloud/api/src/shared-runtime-conversation.test.ts` — the new test `room lock watchdog force-proceeds when a barge-in abort never releases the lock`.

## Detailed testing steps

```bash
cd packages/cloud/api
bun test src/shared-runtime-conversation.test.ts
```

# Evidence Gate

<!-- evidence-head:413f4b0a3a0cfd4c4540452f031360d568f4f2bb -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend Durable Object lock logic; no UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual/user flow; failure is silence on a live PSTN call.
<!-- evidence-row:backend-logs -->
- [x] Regression test output below shows the lock-release path firing; the watchdog adds a `[SharedRuntimeConversation] room lock watchdog fired …` log on the wedge path.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - transport/lock deadlock, not model behavior; the test reproduces it deterministically without a model.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - in-memory DO queue state; no DB/memory artifact.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - this is a DO queue-lock deadlock, not agent/prompt/model behavior. The regression test deterministically reproduces the lock wedge and the fix without a live model.

## Backend + frontend logs

Regression test proof (changed package):

```
src/shared-runtime-conversation.test.ts:
(pass) warm coordinated turns use local history and mirror asynchronously
(pass) concurrent turns serialize through one room and retain both writes
(pass) stream body cancellation persists before the room queue releases
(pass) failed durable cancellation write is retryable on a later finalize
(pass) the Postgres mirror merges third-partyly written turns instead of erasing them
(pass) rate denial crosses the Durable Object boundary as a typed retryable 429
(pass) delete operation clears room storage and cancels the mirror-retry alarm
(pass) room lock watchdog force-proceeds when a barge-in abort never releases the lock
 9 pass  0 fail
```

Negative control: with the watchdog window forced to a large value (fix effectively disabled), the new test **fails** — turn 3 hangs and the guard resolves `"stuck"` — confirming the test genuinely exercises the fix, not a tautology.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - the fix is in the DO turn-queue transport layer, not the audio/TTS/STT round-trip. A live end-to-end phone recording confirming the full fix requires Cloudflare Worker tail access on the deployed cloud `api` Worker (this analysis/patch lane is read-only w.r.t. prod), which is part of why this is a DRAFT for @lalalune to validate against prod tail.

## Known gaps / failures

- `bun run verify` was not run repo-wide: this is a draft, scoped single-file hotfix. The changed package's targeted test suite passes (9/9 above). Left for the owner to run full verify on final shape.
- Live prod phone-call confirmation (candidate #1 firing end-to-end) requires Cloudflare Worker tail + `SHARED_RUNTIME_CONVERSATIONS` DO namespace access, unavailable to this lane. Flagged in #19505.
- Biome lint binary was not linked in the isolated worktree; the diff follows the file's existing style and typechecks clean.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: Sol
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [sol-voice-wedge-handoff]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"Sol","skill_revision":"N/A"} -->