### PR TITLE
fix(voice): isolate Cloud media from onboarding

### DIFF
--- a/packages/app-core/scripts/playwright-ui-live-stack.ts
+++ b/packages/app-core/scripts/playwright-ui-live-stack.ts
@@ -30,7 +30,10 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { WebSocket, WebSocketServer } from "ws";
 import { buildFirstRunRuntimeConfig } from "../src/first-run/first-run-config.ts";
-import { createLiveRuntimeChildEnv } from "../test/helpers/live-child-env.ts";
+import {
+  createLiveRuntimeChildEnv,
+  shouldSkipLiveStackAutoFirstRun,
+} from "../test/helpers/live-child-env.ts";
 import {
   getFirstRunProviderForLiveProvider,
   selectLiveProviderAsync,
@@ -1325,7 +1328,7 @@ async function startRealStack(): Promise<StartedStack> {
     // the spec can drive the real cloud onboarding (login -> provision) through the
     // UI against real Eliza Cloud. The default lane auto-completes a local first-run
     // so chat/view specs land on a ready agent.
-    const skipAutoFirstRun = process.env.ELIZA_UI_SMOKE_CLOUD_LIVE === "1";
+    const skipAutoFirstRun = shouldSkipLiveStackAutoFirstRun();
     if (!skipAutoFirstRun) {
       const onboardingStatus = await fetchJson<{ complete: boolean }>(
         `${apiBase}/api/first-run/status`,

--- a/packages/app-core/scripts/voice/__tests__/voice-matrix.test.ts
+++ b/packages/app-core/scripts/voice/__tests__/voice-matrix.test.ts
@@ -96,9 +96,12 @@ describe("voice matrix CLI", () => {
       "live cloud voice round-trip",
     ]);
     expect(provisioned.report.cells[0].env).toMatchObject({
-      ELIZA_UI_SMOKE_CLOUD_LIVE: "1",
+      ELIZA_UI_SMOKE_CLOUD_MEDIA_LIVE: "1",
       ELIZA_UI_SMOKE_SKIP_BUILD: "1",
     });
+    expect(provisioned.report.cells[0].env).not.toHaveProperty(
+      "ELIZA_UI_SMOKE_CLOUD_LIVE",
+    );
     expect(provisioned.report.cells[0].probe.available).toBe(true);
   });
 });

--- a/packages/app-core/scripts/voice/voice-matrix.mjs
+++ b/packages/app-core/scripts/voice/voice-matrix.mjs
@@ -101,9 +101,9 @@ const CELLS = [
     ],
     env: {
       ...UI_SMOKE_MATRIX_ENV,
-      // createLiveRuntimeChildEnv preserves the Cloud media credential beside
-      // the isolated Cerebras brain only for an explicitly Cloud-live lane.
-      ELIZA_UI_SMOKE_CLOUD_LIVE: "1",
+      // Preserve Cloud STT/TTS beside the isolated Cerebras brain without
+      // entering Cloud-onboarding mode, which deliberately skips first-run.
+      ELIZA_UI_SMOKE_CLOUD_MEDIA_LIVE: "1",
     },
     evidence: ["packages/app/test-results", "e2e-recordings/app/test-results"],
     probe: "webLiveRailway",

--- a/packages/app-core/test/helpers/live-child-env.test.ts
+++ b/packages/app-core/test/helpers/live-child-env.test.ts
@@ -1,6 +1,9 @@
 /** Exercises credential isolation for child processes used by live app-core tests. */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createLiveRuntimeChildEnv } from "./live-child-env.ts";
+import {
+  createLiveRuntimeChildEnv,
+  shouldSkipLiveStackAutoFirstRun,
+} from "./live-child-env.ts";
 
 describe("createLiveRuntimeChildEnv", () => {
   afterEach(() => {
@@ -9,6 +12,7 @@ describe("createLiveRuntimeChildEnv", () => {
 
   it("blanks an ambient Cloud key when isolating a different live provider", () => {
     vi.stubEnv("ELIZA_UI_SMOKE_CLOUD_LIVE", "");
+    vi.stubEnv("ELIZA_UI_SMOKE_CLOUD_MEDIA_LIVE", "");
     vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "ambient-cloud-key");
 
     const childEnv = createLiveRuntimeChildEnv({
@@ -18,10 +22,12 @@ describe("createLiveRuntimeChildEnv", () => {
 
     expect(childEnv.OPENAI_API_KEY).toBe("selected-provider-key");
     expect(childEnv.ELIZAOS_CLOUD_API_KEY).toBe("");
+    expect(childEnv.ELIZAOS_CLOUD_USE_INFERENCE).toBeUndefined();
   });
 
-  it("preserves the ambient Cloud key only in Cloud-live mode", () => {
+  it("preserves the ambient Cloud key for Cloud onboarding without changing routing", () => {
     vi.stubEnv("ELIZA_UI_SMOKE_CLOUD_LIVE", "1");
+    vi.stubEnv("ELIZA_UI_SMOKE_CLOUD_MEDIA_LIVE", "");
     vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "cloud-live-key");
 
     const childEnv = createLiveRuntimeChildEnv({
@@ -31,13 +37,50 @@ describe("createLiveRuntimeChildEnv", () => {
 
     expect(childEnv.OPENAI_API_KEY).toBe("selected-provider-key");
     expect(childEnv.ELIZAOS_CLOUD_API_KEY).toBe("cloud-live-key");
+    expect(childEnv.ELIZAOS_CLOUD_USE_INFERENCE).toBeUndefined();
+    expect(childEnv.ELIZAOS_CLOUD_USE_STT).toBeUndefined();
+    expect(childEnv.ELIZAOS_CLOUD_USE_TTS).toBeUndefined();
+  });
+
+  it("preserves Cloud media while keeping the selected provider as text brain", () => {
+    vi.stubEnv("ELIZA_UI_SMOKE_CLOUD_LIVE", "");
+    vi.stubEnv("ELIZA_UI_SMOKE_CLOUD_MEDIA_LIVE", "1");
+    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "cloud-media-key");
+
+    const childEnv = createLiveRuntimeChildEnv({
+      CEREBRAS_API_KEY: "selected-provider-key",
+      ELIZA_STATE_DIR: undefined,
+    });
+
+    expect(childEnv.CEREBRAS_API_KEY).toBe("selected-provider-key");
+    expect(childEnv.ELIZAOS_CLOUD_API_KEY).toBe("cloud-media-key");
+    expect(childEnv.ELIZAOS_CLOUD_USE_INFERENCE).toBe("false");
+    expect(childEnv.ELIZAOS_CLOUD_USE_STT).toBe("true");
+    expect(childEnv.ELIZAOS_CLOUD_USE_TTS).toBe("true");
+    expect(shouldSkipLiveStackAutoFirstRun()).toBe(false);
+  });
+
+  it("leaves first-run incomplete only for the Cloud onboarding lane", () => {
+    expect(
+      shouldSkipLiveStackAutoFirstRun({
+        ELIZA_UI_SMOKE_CLOUD_LIVE: "1",
+        ELIZA_UI_SMOKE_CLOUD_MEDIA_LIVE: "",
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipLiveStackAutoFirstRun({
+        ELIZA_UI_SMOKE_CLOUD_LIVE: "",
+        ELIZA_UI_SMOKE_CLOUD_MEDIA_LIVE: "1",
+      }),
+    ).toBe(false);
   });
 
   it.each([
     ["missing", undefined],
     ["whitespace-only", " \t\n"],
-  ])("does not preserve a %s Cloud key in Cloud-live mode", (_, cloudKey) => {
-    vi.stubEnv("ELIZA_UI_SMOKE_CLOUD_LIVE", "1");
+  ])("does not preserve a %s Cloud key in media-live mode", (_, cloudKey) => {
+    vi.stubEnv("ELIZA_UI_SMOKE_CLOUD_LIVE", "");
+    vi.stubEnv("ELIZA_UI_SMOKE_CLOUD_MEDIA_LIVE", "1");
     if (cloudKey === undefined) {
       // Record the ambient value for `vi.unstubAllEnvs()`, then remove it.
       // `vi.stubEnv(key, undefined)` leaves an existing CI secret untouched.
@@ -53,5 +96,8 @@ describe("createLiveRuntimeChildEnv", () => {
     });
 
     expect(childEnv.ELIZAOS_CLOUD_API_KEY).toBe("");
+    expect(childEnv.ELIZAOS_CLOUD_USE_INFERENCE).toBeUndefined();
+    expect(childEnv.ELIZAOS_CLOUD_USE_STT).toBeUndefined();
+    expect(childEnv.ELIZAOS_CLOUD_USE_TTS).toBeUndefined();
   });
 });

--- a/packages/app-core/test/helpers/live-child-env.ts
+++ b/packages/app-core/test/helpers/live-child-env.ts
@@ -30,12 +30,21 @@ function ensureSelfControlTestHostsPath(env: NodeJS.ProcessEnv): string | null {
   return hostsFilePath;
 }
 
+/** Cloud onboarding owns the one live lane that must leave first-run incomplete. */
+export function shouldSkipLiveStackAutoFirstRun(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env.ELIZA_UI_SMOKE_CLOUD_LIVE === "1";
+}
+
 export function createLiveRuntimeChildEnv(
   overrides: Record<string, string | undefined>,
 ): NodeJS.ProcessEnv {
   const ambientCloudApiKey = process.env.ELIZAOS_CLOUD_API_KEY;
+  const cloudOnboardingLive = process.env.ELIZA_UI_SMOKE_CLOUD_LIVE === "1";
+  const cloudMediaLive = process.env.ELIZA_UI_SMOKE_CLOUD_MEDIA_LIVE === "1";
   const preserveAmbientCloudApiKey =
-    process.env.ELIZA_UI_SMOKE_CLOUD_LIVE === "1" &&
+    (cloudOnboardingLive || cloudMediaLive) &&
     hasNonWhitespaceValue(ambientCloudApiKey);
   const liveProviderOverrides = Object.fromEntries(
     Object.entries(overrides).filter(
@@ -50,10 +59,19 @@ export function createLiveRuntimeChildEnv(
       : { ...process.env };
 
   // Provider isolation deliberately blanks every unselected credential. The
-  // app Cloud-live lane is the sole exception: its onboarding runtime needs the
-  // workflow-validated Cloud bearer in addition to the selected model provider.
+  // Cloud onboarding and live-media lanes are the only exceptions: both need
+  // the workflow-validated Cloud bearer beside the selected model provider.
   if (preserveAmbientCloudApiKey) {
     env.ELIZAOS_CLOUD_API_KEY = ambientCloudApiKey;
+  }
+
+  // The live voice lane uses Cloud only for STT/TTS. Make that ownership
+  // explicit so preserving the bearer cannot also register Cloud's higher-
+  // priority text handlers over the provider selected by first-run.
+  if (cloudMediaLive && preserveAmbientCloudApiKey) {
+    env.ELIZAOS_CLOUD_USE_INFERENCE = "false";
+    env.ELIZAOS_CLOUD_USE_STT = "true";
+    env.ELIZAOS_CLOUD_USE_TTS = "true";
   }
 
   for (const key of Object.keys(env)) {


### PR DESCRIPTION
# Relates to

Fixes #19495. Follow-up to the post-merge audit of #19458.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was already current and `bun run verify` passed after sync.
- [x] A reviewer can confirm the real provisioned voice round trip and the exact corrective routing contract from the attached evidence.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@499af898993342817ae603b8bd9be36e66df6c7a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `499af898993342817ae603b8bd9be36e66df6c7a`; zero conflicts.
- [x] `bun run verify` passes post-sync (350/350 build and typecheck tasks plus all repository audits).

# Risks

Low. The diff changes only the live voice test launcher and its deterministic regression tests. The principal risk is accidentally changing Cloud onboarding semantics; dedicated tests prove onboarding remains the only mode that skips first-run.

# Background

## What does this PR do?

The merged #19458 reused `ELIZA_UI_SMOKE_CLOUD_LIVE=1` to retain Cloud STT/TTS credentials. The live-stack launcher also interprets that flag as "skip first-run," so the voice lane could start without configuring Cerebras. Retaining the Cloud key also left Cloud text inference eligible to compete with the explicitly selected Cerebras provider.

This change adds a separate `ELIZA_UI_SMOKE_CLOUD_MEDIA_LIVE=1` mode. It retains the Cloud credential for STT/TTS, explicitly disables Cloud text inference, enables Cloud STT/TTS, and still performs normal first-run setup for Cerebras. The Cloud onboarding lane keeps its existing behavior.

## What kind of change is this?

Bug fix and test-hardening improvement.

# Documentation changes needed?

No user-facing documentation change is needed; this is an internal live-test routing contract.

# Testing

## Where should a reviewer start?

- `packages/app-core/test/helpers/live-child-env.ts`
- `packages/app-core/scripts/playwright-ui-live-stack.ts`
- `packages/app-core/scripts/voice/voice-matrix.mjs`

## Detailed testing steps

- `bun run --cwd packages/app-core test -- test/helpers/live-child-env.test.ts scripts/voice/__tests__/voice-matrix.test.ts` — 9 passed.
- `bun run --cwd packages/app-core typecheck` — passed.
- `bun run --cwd packages/app-core build` — passed.
- `bun run --cwd packages/app-core lint:check` — passed.
- `bunx biome check` on all five touched files — passed.
- `bun run verify` — passed: 350/350 tasks and all repository audits.
- Exact-head provisioned `Voice Live E2E` rerun — dispatched at https://github.com/elizaOS/eliza/actions/runs/31789351777; capacity-queued, not failed.

The full app-core suite completed 1,792 passing tests, 20 skips, and one pre-existing failure outside this diff: the repository i18n contract lists nine missing UI translation keys. The two stale Cloud URL failures seen on the earlier base are fixed by current `develop`.

# Evidence Gate

<!-- evidence-head:4489e53d9ee62bca8aea5099e011b835e30241fb -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI or styling changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI or styling changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - non-rendered live-test launcher fix; the domain artifact records the applicable real browser audio playback proof
<!-- evidence-row:backend-logs -->
- [x] [19507-backend-v3.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19507-backend-v3.log)
<!-- evidence-row:frontend-logs -->
- [x] [19507-frontend-v3.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19507-frontend-v3.log)
<!-- evidence-row:llm-trajectory -->
- [x] [19507-trajectory-v3.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19507-trajectory-v3.json)
<!-- evidence-row:domain-artifacts -->
- [x] [19507-audio-v3.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19507-audio-v3.txt)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

# Evidence Details

## Real LLM-call trajectory

The attached structured trajectory records the maintainer-reviewed no-mock STT → Cerebras → Cloud TTS turn. The new exact-head hosted rerun remains capacity-queued.

## Backend + frontend logs

The attached backend and frontend artifacts record the reviewed transcript, provider completion, TTS bytes, decode, playback, and cache-warming recovery. The new exact-head hosted rerun remains capacity-queued.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changed.

## Audio / voice walkthrough

The attached audio manifest records the reviewed 35,153-byte audio/mpeg response and confirmed browser playback. The raw local audio was not retained; the new exact-head hosted rerun remains capacity-queued.

## Known gaps / failures

GitHub-hosted Ubuntu capacity has kept both the prior and new exact-head web jobs queued. This is not a test failure. Merge proof combines the reviewed real no-mock production round trip, nine exact-head routing regressions, the full app-core result above, package build/typecheck/lint, and two clean 350/350 repository verification runs. The one current-base i18n failure is unrelated to these five files.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@499af898993342817ae603b8bd9be36e66df6c7a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-desktop]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@499af898993342817ae603b8bd9be36e66df6c7a:packages/skills/skills/contribute-to-eliza"} -->







