### PR TITLE
fix(ui): recover cookie-only Steward auth

### DIFF
--- a/packages/app/test/ui-smoke/cloud-token-expiry-refresh.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-token-expiry-refresh.spec.ts
@@ -1,9 +1,7 @@
 /**
- * Renderer-level proof of the Steward JWT token-lifecycle: a session seeded
- * with a near-expiry JWT is silently renewed mid-suite so an authenticated
- * cloud connection never dies on `exp`. This is the contract-level expiry test
- * called for by issue #13691 ("Done when" #4) — it pins the refresh behavior
- * documented in packages/app/docs/TEST_AUTH.md rather than leaving it assumed.
+ * Renderer-level proof of the Steward JWT token lifecycle. It covers both a
+ * near-expiry readable token and a warm tab whose readable token disappeared
+ * while its HttpOnly cookie session remains authoritative.
  *
  * The real path under test lives in `useCloudState`'s token-lifecycle effect
  * (packages/ui/src/state/useCloudState.ts): while a stored Steward JWT is
@@ -12,10 +10,14 @@
  * back into localStorage via `writeStoredStewardToken`. The cloud API is faked
  * so the renderer drives the whole exchange.
  */
+
+import { STEWARD_SESSION_CHANGE_EVENT } from "@elizaos/shared/steward-session-client";
 import { expect, type Route, test } from "@playwright/test";
 import {
+  expectNoPageDiagnostics,
   installDefaultAppRoutes,
   openAppPath,
+  readLocalStorage,
   seedAppStorage,
 } from "./helpers";
 import {
@@ -130,4 +132,92 @@ test("cloud session survives a mid-suite JWT expiry by renewing the token", asyn
   await expect(page.getByText(/auth.*rejected|session expired/i)).toHaveCount(
     0,
   );
+});
+
+test("warm shared-cloud tab recovers its cookie-only session without dropping the binding", async ({
+  page,
+}) => {
+  const agentId = "19127000-0000-4000-8000-000000000001";
+  const apiBase = `https://api.eliza.app/api/v1/eliza/agents/${agentId}`;
+  const initialToken = createStewardSessionToken({
+    jwt: true,
+    subject: CLOUD_USER_ID,
+    userId: CLOUD_USER_ID,
+  });
+  const refreshedToken = createStewardSessionToken({
+    jwt: true,
+    subject: `${CLOUD_USER_ID}-refreshed`,
+    userId: CLOUD_USER_ID,
+  });
+  let refreshRequests = 0;
+
+  await page.route(STEWARD_REFRESH_ENDPOINT, async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+    refreshRequests += 1;
+    await fulfillJson(route, 200, { token: refreshedToken, expiresIn: 3_600 });
+  });
+  await installDefaultAppRoutes(page);
+  await seedAppStorage(page, {
+    [VOICE_PREFIX_DONE_STORAGE_KEY]: "1",
+    "eliza:mobile-runtime-mode": "cloud",
+    "elizaos:active-server": JSON.stringify({
+      id: `cloud:${agentId}`,
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase,
+      accessToken: "shared-agent-token",
+    }),
+    [STEWARD_SESSION_TOKEN_KEY]: initialToken,
+  });
+
+  await openAppPath(page, "/settings");
+  await expect
+    .poll(async () => {
+      const raw = await readLocalStorage(page, "elizaos:active-server");
+      return raw ? JSON.parse(raw) : null;
+    })
+    .toMatchObject({ id: `cloud:${agentId}`, apiBase });
+  await page
+    .context()
+    .addCookies([
+      { name: "steward-authed", value: "1", url: page.url(), sameSite: "Lax" },
+    ]);
+  await page.evaluate(
+    ({ eventName, tokenKey }) => {
+      localStorage.removeItem(tokenKey);
+      window.dispatchEvent(
+        new CustomEvent(eventName, { detail: { state: "present" } }),
+      );
+    },
+    {
+      eventName: STEWARD_SESSION_CHANGE_EVENT,
+      tokenKey: STEWARD_SESSION_TOKEN_KEY,
+    },
+  );
+  await expect
+    .poll(() => page.evaluate(() => document.cookie))
+    .toContain("steward-authed=1");
+
+  await expect.poll(() => refreshRequests).toBe(1);
+  await expect
+    .poll(() => readLocalStorage(page, STEWARD_SESSION_TOKEN_KEY))
+    .toBe(refreshedToken);
+  await expect
+    .poll(async () => {
+      const raw = await readLocalStorage(page, "elizaos:active-server");
+      return raw ? JSON.parse(raw) : null;
+    })
+    .toMatchObject({
+      id: `cloud:${agentId}`,
+      apiBase,
+      accessToken: "shared-agent-token",
+    });
+  await expect(page.getByTestId("settings-shell")).toBeVisible();
+  await expect(page.getByText(/auth.*rejected|session expired/i)).toHaveCount(
+    0,
+  );
+  await expectNoPageDiagnostics(page, "cookie-only warm shared-cloud auth");
 });

--- a/packages/ui/src/api/auth-client.ts
+++ b/packages/ui/src/api/auth-client.ts
@@ -12,6 +12,7 @@ import type { RoleGateRole } from "@elizaos/core";
 import { getElizaApiToken } from "@elizaos/shared";
 import {
   clearStoredStewardToken,
+  hasStewardAuthedCookie,
   readStoredStewardToken,
   writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
@@ -327,6 +328,19 @@ export async function authMe(): Promise<AuthMeResult> {
         normalizeCloudApiKeyToken(getBootConfig().apiToken) ??
           normalizeCloudApiKeyToken(getElizaApiToken()),
       );
+    if (!token && !hasNativeOwnerApiKey && hasStewardAuthedCookie()) {
+      try {
+        const refreshed = await refreshCloudStewardSession({
+          throwOnTransientHttpFailure: true,
+        });
+        token = refreshed?.token?.trim() || undefined;
+        if (token) writeStoredStewardToken(token);
+      } catch {
+        // error-policy:J1 a transport, throttle, or server outage is not
+        // authoritative logout; preserve the binding and expose unavailability.
+        return { ok: false, status: 503, reason: "server_error" };
+      }
+    }
     const secondsRemaining = token ? cloudTokenSecsRemaining(token) : null;
     if (
       token &&

--- a/packages/ui/src/api/auth-client.ts
+++ b/packages/ui/src/api/auth-client.ts
@@ -117,7 +117,8 @@ export type AuthMeResult =
       reason?:
         | "remote_auth_required"
         | "remote_password_not_configured"
-        | "server_error";
+        | "server_error"
+        | "cloud_unavailable";
       access?: AuthAccessInfo;
     };
 
@@ -338,7 +339,10 @@ export async function authMe(): Promise<AuthMeResult> {
       } catch {
         // error-policy:J1 a transport, throttle, or server outage is not
         // authoritative logout; preserve the binding and expose unavailability.
-        return { ok: false, status: 503, reason: "server_error" };
+        // "cloud_unavailable" (not "server_error") keeps this outcome out of
+        // the local-agent boot 503 retry budget so one transient refresh never
+        // becomes an amplified POST storm against a throttling endpoint.
+        return { ok: false, status: 503, reason: "cloud_unavailable" };
       }
     }
     const secondsRemaining = token ? cloudTokenSecsRemaining(token) : null;

--- a/packages/ui/src/api/client-cloud-steward-token.test.ts
+++ b/packages/ui/src/api/client-cloud-steward-token.test.ts
@@ -205,6 +205,26 @@ describe("refreshCloudStewardSession (web/fetch branch)", () => {
     expect(result).toBeNull();
   });
 
+  it("surfaces a typed transient failure when the caller must preserve auth state", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 503 })),
+    );
+
+    await expect(
+      refreshCloudStewardSession({
+        endpoint: "https://api.elizacloud.ai/api/v1/auth/steward/refresh",
+        throwOnTransientHttpFailure: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "STEWARD_SESSION_REFRESH_TRANSIENT",
+      context: {
+        endpoint: "https://api.elizacloud.ai/api/v1/auth/steward/refresh",
+        status: 503,
+      },
+    });
+  });
+
   it("returns null when the response body is not parseable JSON (J3 fail-closed)", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/ui/src/api/client-cloud-steward-token.test.ts
+++ b/packages/ui/src/api/client-cloud-steward-token.test.ts
@@ -225,6 +225,48 @@ describe("refreshCloudStewardSession (web/fetch branch)", () => {
     });
   });
 
+  it("treats a malformed 2xx body as transient when the caller must preserve auth state", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError("Unexpected token");
+        },
+      })),
+    );
+
+    await expect(
+      refreshCloudStewardSession({
+        endpoint: "https://api.elizacloud.ai/api/v1/auth/steward/refresh",
+        throwOnTransientHttpFailure: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "STEWARD_SESSION_REFRESH_TRANSIENT",
+      context: {
+        endpoint: "https://api.elizacloud.ai/api/v1/auth/steward/refresh",
+        status: 200,
+      },
+    });
+  });
+
+  it("treats an empty 2xx body as transient when the caller must preserve auth state", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) })),
+    );
+
+    await expect(
+      refreshCloudStewardSession({
+        endpoint: "https://api.elizacloud.ai/api/v1/auth/steward/refresh",
+        throwOnTransientHttpFailure: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "STEWARD_SESSION_REFRESH_TRANSIENT",
+    });
+  });
+
   it("returns null when the response body is not parseable JSON (J3 fail-closed)", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -670,11 +670,24 @@ export async function refreshCloudStewardSession(opts?: {
       }
       return null;
     }
-    return parseDirectCloudJsonSafe(response.data) as {
+    const parsed = parseDirectCloudJsonSafe(response.data) as {
       token?: string;
       expiresAt?: number;
       expiresIn?: number;
     } | null;
+    if (opts?.throwOnTransientHttpFailure && !parsed?.token?.trim()) {
+      // A 2xx whose body carries no usable token is out of the endpoint's
+      // success contract (authoritative logout is a 401, never an empty 200):
+      // treat it as an outage artifact, not a signed-out state.
+      throw new ElizaError(
+        "Steward session refresh returned a success response without a token",
+        {
+          code: "STEWARD_SESSION_REFRESH_TRANSIENT",
+          context: { endpoint, status: response.status },
+        },
+      );
+    }
+    return parsed;
   }
 
   if (typeof fetch === "undefined") return null;
@@ -699,11 +712,25 @@ export async function refreshCloudStewardSession(opts?: {
   }
   // error-policy:J3 an unparseable refresh body reads as "no refreshed
   // session" (null) — callers keep/drop the stored token by its own expiry.
-  return (await response.json().catch(() => null)) as {
+  const parsed = (await response.json().catch(() => null)) as {
     token?: string;
     expiresAt?: number;
     expiresIn?: number;
   } | null;
+  if (opts?.throwOnTransientHttpFailure && !parsed?.token?.trim()) {
+    // A 2xx whose body carries no usable token is out of the endpoint's
+    // success contract (authoritative logout is a 401, never an empty 200):
+    // treat it as an outage artifact so cookie-only recovery preserves the
+    // shared-agent binding instead of tearing it down.
+    throw new ElizaError(
+      "Steward session refresh returned a success response without a token",
+      {
+        code: "STEWARD_SESSION_REFRESH_TRANSIENT",
+        context: { endpoint, status: response.status },
+      },
+    );
+  }
+  return parsed;
 }
 
 function isDirectCloudAuthMissing(client: ElizaClient): boolean {

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -634,6 +634,8 @@ export function cloudTokenSecsRemaining(token: string): number | null {
  */
 export async function refreshCloudStewardSession(opts?: {
   endpoint?: string;
+  /** Surface throttling/outage responses instead of treating them as logout. */
+  throwOnTransientHttpFailure?: boolean;
 }): Promise<{ token?: string; expiresAt?: number; expiresIn?: number } | null> {
   const endpoint = opts?.endpoint ?? STEWARD_REFRESH_ENDPOINT;
   if (shouldUseNativeStewardRefreshHttp(endpoint)) {
@@ -653,7 +655,21 @@ export async function refreshCloudStewardSession(opts?: {
       }),
       { method: "POST", url: endpoint },
     );
-    if (response.status < 200 || response.status >= 300) return null;
+    if (response.status < 200 || response.status >= 300) {
+      if (
+        opts?.throwOnTransientHttpFailure &&
+        (response.status === 429 || response.status >= 500)
+      ) {
+        throw new ElizaError(
+          "Steward session refresh is temporarily unavailable",
+          {
+            code: "STEWARD_SESSION_REFRESH_TRANSIENT",
+            context: { endpoint, status: response.status },
+          },
+        );
+      }
+      return null;
+    }
     return parseDirectCloudJsonSafe(response.data) as {
       token?: string;
       expiresAt?: number;
@@ -666,7 +682,21 @@ export async function refreshCloudStewardSession(opts?: {
     method: "POST",
     credentials: "include",
   });
-  if (!response.ok) return null;
+  if (!response.ok) {
+    if (
+      opts?.throwOnTransientHttpFailure &&
+      (response.status === 429 || response.status >= 500)
+    ) {
+      throw new ElizaError(
+        "Steward session refresh is temporarily unavailable",
+        {
+          code: "STEWARD_SESSION_REFRESH_TRANSIENT",
+          context: { endpoint, status: response.status },
+        },
+      );
+    }
+    return null;
+  }
   // error-policy:J3 an unparseable refresh body reads as "no refreshed
   // session" (null) — callers keep/drop the stored token by its own expiry.
   return (await response.json().catch(() => null)) as {

--- a/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
+++ b/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
@@ -14,6 +14,7 @@ import {
 } from "@elizaos/shared/steward-session-client";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { authMe } from "../api/auth-client";
 import { clearStaleStewardSession } from "../cloud/shell/StewardProviderShared";
 import { getBootConfig, setBootConfig } from "../config/boot-config-store";
 import {
@@ -55,6 +56,13 @@ function jsonResponse(status: number, body: unknown): Response {
   } as unknown as Response;
 }
 
+function setStewardAuthedCookie(present: boolean): void {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom has no Cookie Store API.
+  document.cookie = present
+    ? "steward-authed=1; Path=/"
+    : "steward-authed=; Max-Age=0; Path=/";
+}
+
 describe("primeAuthStatusProbe + activation reuse", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   const realFetch = globalThis.fetch;
@@ -63,6 +71,7 @@ describe("primeAuthStatusProbe + activation reuse", () => {
     delete (window as Window & { __electrobunWindowId?: number })
       .__electrobunWindowId;
     localStorage.clear();
+    setStewardAuthedCookie(false);
     setBootConfig({ branding: {} });
     __resetAuthStatusForTests();
     setBootConfig({ branding: {} });
@@ -82,6 +91,7 @@ describe("primeAuthStatusProbe + activation reuse", () => {
       await new Promise((resolve) => setImmediate(resolve));
     });
     globalThis.fetch = realFetch;
+    setStewardAuthedCookie(false);
     delete (window as Window & { __electrobunWindowId?: number })
       .__electrobunWindowId;
     vi.restoreAllMocks();
@@ -104,6 +114,98 @@ describe("primeAuthStatusProbe + activation reuse", () => {
       }),
     );
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("recovers a cookie-only Steward session before preserving the shared binding", async () => {
+    const apiBase = "https://api.eliza.app/api/v1/eliza/agents/shared-agent";
+    const refreshedToken = makeJwt(3600);
+    setBootConfig({ branding: {}, apiBase });
+    savePersistedActiveServer({
+      id: "cloud:shared-agent",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase,
+      accessToken: "shared-agent-token",
+    });
+    clearStoredStewardToken();
+    setStewardAuthedCookie(true);
+    fetchMock.mockResolvedValue(jsonResponse(200, { token: refreshedToken }));
+
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+
+    await waitFor(() =>
+      expect(result.current.state.phase).toBe("authenticated"),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+      "/api/auth/steward-refresh",
+    );
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      method: "POST",
+      credentials: "include",
+    });
+    expect(localStorage.getItem("steward_session_token")).toBe(refreshedToken);
+    expect(loadPersistedActiveServer()).toMatchObject({
+      id: "cloud:shared-agent",
+      apiBase,
+      accessToken: "shared-agent-token",
+    });
+    expect(getBootConfig().apiBase).toBe(apiBase);
+  });
+
+  it("clears a cookie-only shared binding once after authoritative refresh rejection", async () => {
+    const apiBase = "https://api.eliza.app/api/v1/eliza/agents/shared-agent";
+    setBootConfig({ branding: {}, apiBase });
+    savePersistedActiveServer({
+      id: "cloud:shared-agent",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase,
+      accessToken: "stale-token-mirror",
+    });
+    clearStoredStewardToken();
+    setStewardAuthedCookie(true);
+    fetchMock.mockResolvedValue(jsonResponse(401, {}));
+
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+
+    await waitFor(() =>
+      expect(result.current.state).toMatchObject({
+        phase: "unauthenticated",
+        reason: "remote_auth_required",
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(loadPersistedActiveServer()).toBeNull();
+    expect(getBootConfig().apiBase).toBeUndefined();
+  });
+
+  it("preserves a cookie-only shared binding when refresh is temporarily unavailable", async () => {
+    const apiBase = "https://api.eliza.app/api/v1/eliza/agents/shared-agent";
+    setBootConfig({ branding: {}, apiBase });
+    savePersistedActiveServer({
+      id: "cloud:shared-agent",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase,
+      accessToken: "shared-agent-token",
+    });
+    clearStoredStewardToken();
+    setStewardAuthedCookie(true);
+    fetchMock.mockResolvedValue(jsonResponse(503, {}));
+
+    await expect(authMe()).resolves.toEqual({
+      ok: false,
+      status: 503,
+      reason: "server_error",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(loadPersistedActiveServer()).toMatchObject({
+      id: "cloud:shared-agent",
+      apiBase,
+      accessToken: "shared-agent-token",
+    });
+    expect(getBootConfig().apiBase).toBe(apiBase);
   });
 
   it("preserves a native owner API-key session without a Steward JWT", async () => {

--- a/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
+++ b/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
@@ -197,7 +197,69 @@ describe("primeAuthStatusProbe + activation reuse", () => {
     await expect(authMe()).resolves.toEqual({
       ok: false,
       status: 503,
-      reason: "server_error",
+      reason: "cloud_unavailable",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(loadPersistedActiveServer()).toMatchObject({
+      id: "cloud:shared-agent",
+      apiBase,
+      accessToken: "shared-agent-token",
+    });
+    expect(getBootConfig().apiBase).toBe(apiBase);
+  });
+
+  // Regression for the review-found retry storm: the hook's 10×1s 503 retry
+  // budget exists for the local-agent boot race, and must not re-POST a
+  // throttling Steward refresh endpoint. Exactly one refresh request may
+  // leave the client before the hook settles on server_unavailable.
+  it.each([429, 503])(
+    "surfaces a persistent %d refresh as server_unavailable after exactly one POST",
+    async (status) => {
+      const apiBase = "https://api.eliza.app/api/v1/eliza/agents/shared-agent";
+      setBootConfig({ branding: {}, apiBase });
+      savePersistedActiveServer({
+        id: "cloud:shared-agent",
+        kind: "cloud",
+        label: "Eliza Cloud",
+        apiBase,
+        accessToken: "shared-agent-token",
+      });
+      clearStoredStewardToken();
+      setStewardAuthedCookie(true);
+      fetchMock.mockResolvedValue(jsonResponse(status, {}));
+
+      const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+
+      await waitFor(() =>
+        expect(result.current.state.phase).toBe("server_unavailable"),
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(loadPersistedActiveServer()).toMatchObject({
+        id: "cloud:shared-agent",
+        apiBase,
+        accessToken: "shared-agent-token",
+      });
+    },
+  );
+
+  it("preserves a cookie-only shared binding when refresh answers a malformed 200", async () => {
+    const apiBase = "https://api.eliza.app/api/v1/eliza/agents/shared-agent";
+    setBootConfig({ branding: {}, apiBase });
+    savePersistedActiveServer({
+      id: "cloud:shared-agent",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase,
+      accessToken: "shared-agent-token",
+    });
+    clearStoredStewardToken();
+    setStewardAuthedCookie(true);
+    fetchMock.mockResolvedValue(jsonResponse(200, {}));
+
+    await expect(authMe()).resolves.toEqual({
+      ok: false,
+      status: 503,
+      reason: "cloud_unavailable",
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(loadPersistedActiveServer()).toMatchObject({

--- a/packages/ui/src/hooks/useAuthStatus.ts
+++ b/packages/ui/src/hooks/useAuthStatus.ts
@@ -136,6 +136,13 @@ async function fetchAuthStatus(): Promise<void> {
         return;
       }
       if (result.status === 503) {
+        // A cloud Steward-refresh outage/throttle is not the local-agent boot
+        // race this retry budget exists for; each retry would re-POST the
+        // refresh endpoint and amplify a 429. Surface unavailability at once.
+        if (result.reason === "cloud_unavailable") {
+          publishAuthStatus({ phase: "server_unavailable" });
+          return;
+        }
         if (attempt < SERVER_UNAVAILABLE_RETRIES) {
           await new Promise((resolve) =>
             setTimeout(resolve, SERVER_UNAVAILABLE_RETRY_MS),


### PR DESCRIPTION
# Relates to

Closes #19127. Completes the cookie-only warm-tab residual identified after the earlier session-expiry fix.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the behavior from the evidence below without reading the code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@1fb83c8c3670a1071f39891f2e4a9a439a87c9cd`; zero conflicts.
- [x] Exact-head `bun run verify` passes at `7e0a4bcdc0115a6850ae253dcf5cc61492cf04f8`.

# Risks

Low and bounded to the managed shared-Cloud auth probe. A cookie marker with no JavaScript-readable token now invokes the existing canonical Steward refresh exactly once before teardown. A successful refresh restores the readable token and preserves the active shared-agent binding. An authoritative missing/401 response still clears state and returns 401. Opted-in 429/5xx responses become typed transient failures translated at the auth boundary to 503 while preserving state. No retry, timeout, catch-and-continue path, or synthetic authentication was added.

# Background

## What does this PR do?

The existing warm-tab expiry fix treated a missing JavaScript-readable Steward JWT as terminal logout even when `steward-authed=1` showed that an HttpOnly session could still be valid. That could erase the active shared server, profiles, and API base without asking the authoritative refresh endpoint.

This change aligns the live auth probe with startup recovery: cookie-only sessions get one canonical refresh. Success keeps the shared binding; terminal rejection clears it once; transient server failure remains visibly unavailable without destructive teardown.

## What kind of change is this?

Bug fix (non-breaking).

# Testing

## Where should a reviewer start?

Run the recorded Chromium test `packages/app/test/ui-smoke/cloud-token-expiry-refresh.spec.ts`. Its second journey opens the real settings shell with an active shared agent, removes only the readable JWT, leaves `steward-authed=1`, dispatches the canonical session event, and proves one refresh restores auth without dropping the binding.

## Detailed testing steps

- `bun install` — passed at exact head; 3,835 installs checked, no changes.
- Focused UI Vitest — passed, 2 files and 38/38 tests.
- `bun run --cwd packages/ui typecheck` — passed.
- `bun run --cwd packages/ui lint:check` — passed; eight pre-existing direct-cookie test warnings only.
- `bun run verify` — passed at exact head: 350/350 plus all repository audits; anti-larp scanned 8,026 files with zero focused/orphaned skips.
- Recorded Chromium journeys — passed 2/2 at exact head; the warm cookie-only path observed exactly one refresh and zero page diagnostics.
- `bun run --cwd packages/app audit:app` — passed 219/219 at content-identical pre-rebase head `bba6d3c9e594c6ad6eb49a9c0162ef2ee5c60762`: broken=0, needs-work=0, and all minimalism/ratchet/hover/density failure counts zero. Packaged OCR: 216 views, verified=200, broken=0. The subsequent base-only delta changed only `packages/homepage` and `packages/elizaresearch`; `packages/app` and `packages/ui` were byte-identical.
- Broad UI lane on the initial implementation revision — 10,100 passed, 33 failed, 7 skipped. All failures were unrelated current-base clusters (domain-host migration expectations, launcher fixtures, native mocks, and hosting); the changed auth suites passed. Exact final-head focused, type, lint, browser, and root gates are green.

# Evidence Gate

<!-- evidence-head:7e0a4bcdc0115a6850ae253dcf5cc61492cf04f8 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - this is an auth-state transition, not a visual redesign; the pre-fix destructive teardown is proven by the mutation-sensitive contract rather than a misleading static frame
<!-- evidence-row:after-screenshots -->
- [x] ![preserved settings shell after cookie-only refresh](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19127-warm-cookie-session-7e0a4b.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19127-warm-cookie-session-7e0a4b.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - the deterministic browser test intercepts the same-origin refresh boundary; no external backend was mutated
<!-- evidence-row:frontend-logs -->
- [x] [exact-head frontend diagnostics](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19127-frontend-diagnostics-7e0a4b-v2.json)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic authentication lifecycle; no model call
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - authentication state is not persisted as a domain record; the Playwright trace is linked in Evidence Details
<!-- evidence-row:ocr-review -->
- [x] [packaged OCR audit](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19127-app-audit-ocr-bba6d3c.json)

# Evidence Details

The screenshot and MP4 show the real settings shell and shared-agent composer remaining mounted after the readable token is removed and the canonical session event fires. The [Playwright trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19127-warm-cookie-session-trace-7e0a4b.zip) and diagnostics record one refresh, token restoration, unchanged active-server id/API base/access token, no expired-session surface, and no console errors, page errors, or failed HTTP responses.

The full validation transcript, including the exact SHA and the content-identical audit disclosure, is available at [19127-validation-7e0a4b.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19127-validation-7e0a4b.txt).

## Known gaps / failures

- No live production/staging session was mutated for this residual. The browser proof exercises the real renderer and storage/event path against a deterministic same-origin refresh response.
- The broad UI lane retains unrelated current-base failures listed above; focused auth tests, exact browser behavior, typecheck, lint, root verification, and the full visual audit are green.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->


## Final landing verification

Reviewed head `7f1571805942` is rebased onto `origin/develop@d28376846c61`; the final intervening develop changes were path-disjoint from this PR. Exact reviewed-head results: focused auth/refresh contracts 46/46; real Chromium token-expiry and cookie-only recovery scenarios 2/2; `packages/ui` and `packages/app` typecheck/lint passed; `bun run --cwd packages/app audit:app` passed 219/219 with broken=0 and needs-work=0, packaged OCR broken=0; root `bun run verify` passed 350/350 tasks plus all repository audits.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Attribution status: self-reported
— [codex]