### PR TITLE
fix(ui): route incident report textarea through SettingsTextareaRow

### DIFF
--- a/packages/ui/src/cloud/account-security/components/incident-report-panel.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/incident-report-panel.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Drives IncidentReportPanel submit: empty toast, successful POST clear, and
+ * 404 mailto fallback. jsdom with apiFetch/ApiError/sonner mocked.
+ */
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiFetchMock, ApiError } = vi.hoisted(() => {
+  class ApiError extends Error {
+    constructor(
+      public readonly status: number,
+      public readonly code: string,
+      message: string,
+    ) {
+      super(message);
+      this.name = "ApiError";
+    }
+  }
+  return { apiFetchMock: vi.fn(), ApiError };
+});
+
+vi.mock("../../lib/api-client", () => ({
+  apiFetch: apiFetchMock,
+  ApiError,
+}));
+
+vi.mock("../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? _key,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import { toast } from "sonner";
+import { IncidentReportPanel } from "./incident-report-panel";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PANEL_SOURCE = path.join(HERE, "incident-report-panel.tsx");
+const SECURITY_EMAIL = "security@elizaos.ai";
+
+describe("IncidentReportPanel", () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    vi.mocked(toast.error).mockReset();
+    vi.mocked(toast.success).mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("composes SettingsTextareaRow instead of BrandCard", () => {
+    const source = readFileSync(PANEL_SOURCE, "utf8");
+    expect(source).toContain("SettingsStack");
+    expect(source).toContain("SettingsGroup");
+    expect(source).toContain("SettingsTextareaRow");
+    expect(source).toContain("SettingsActionButton");
+    expect(source).not.toContain("BrandCard");
+    expect(source).not.toContain("BrandButton");
+  });
+
+  it("toasts and does not POST when details are empty", () => {
+    render(<IncidentReportPanel />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Submit incident report" }),
+    );
+
+    expect(toast.error).toHaveBeenCalledWith("Please describe what happened.");
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("toasts and does not POST when details are only whitespace", () => {
+    render(<IncidentReportPanel />);
+
+    fireEvent.change(screen.getByLabelText("Incident details"), {
+      target: { value: "   \n\t  " },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Submit incident report" }),
+    );
+
+    expect(toast.error).toHaveBeenCalledWith("Please describe what happened.");
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("POSTs the trimmed details, toasts success, and clears the textarea", async () => {
+    apiFetchMock.mockResolvedValueOnce({});
+    render(<IncidentReportPanel />);
+
+    const field = screen.getByLabelText("Incident details");
+    fireEvent.change(field, {
+      target: { value: "  Phishing email at https://example.com  " },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Submit incident report" }),
+    );
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith("/api/v1/security/incident", {
+        method: "POST",
+        json: { details: "Phishing email at https://example.com" },
+      });
+    });
+    expect(toast.success).toHaveBeenCalledWith(
+      "Incident report submitted. We'll follow up by email.",
+    );
+    expect((field as HTMLTextAreaElement).value).toBe("");
+  });
+
+  it("assigns the security mailto fallback when the endpoint returns 404", async () => {
+    const location = { href: "https://eliza.example/settings#cloud-security" };
+    vi.stubGlobal("location", location);
+    apiFetchMock.mockRejectedValueOnce(
+      new ApiError(404, "not_found", "Not Found"),
+    );
+
+    render(<IncidentReportPanel />);
+    fireEvent.change(screen.getByLabelText("Incident details"), {
+      target: { value: "Unexpected token leak in the billing invoice PDF." },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Submit incident report" }),
+    );
+
+    const expectedMailto = `mailto:${SECURITY_EMAIL}?subject=${encodeURIComponent(
+      "Security incident report",
+    )}&body=${encodeURIComponent(
+      "Unexpected token leak in the billing invoice PDF.",
+    )}`;
+    await waitFor(() => {
+      expect(location.href).toBe(expectedMailto);
+    });
+    expect(toast.success).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it("disables the field and submit while the POST is in flight", async () => {
+    let resolveFetch: (value: unknown) => void = () => {};
+    apiFetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    render(<IncidentReportPanel />);
+    const field = screen.getByLabelText("Incident details");
+    fireEvent.change(field, {
+      target: { value: "Compromised session token." },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Submit incident report" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        (
+          screen.getByRole("button", {
+            name: "Submitting…",
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(true);
+    });
+    expect((field as HTMLTextAreaElement).disabled).toBe(true);
+
+    resolveFetch({});
+    await waitFor(() => {
+      expect(
+        (
+          screen.getByRole("button", {
+            name: "Submit incident report",
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(false);
+    });
+  });
+
+  it("keeps the mailto link in the group description", () => {
+    render(<IncidentReportPanel />);
+    const link = screen.getByRole("link", { name: SECURITY_EMAIL });
+    expect(link.getAttribute("href")).toBe(`mailto:${SECURITY_EMAIL}`);
+    expect(screen.getByText("Report a security incident")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/cloud/account-security/components/incident-report-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/incident-report-panel.tsx
@@ -1,16 +1,19 @@
 /**
- * Report a security incident: POST /api/v1/security/incident, falling back to a
- * mailto: when the endpoint isn't built yet.
+ * Security incident report form. POSTs /api/v1/security/incident and falls
+ * back to mailto:security@elizaos.ai when that route is not shipped. Mounted
+ * on the cloud-security settings section as a labelled SettingsTextareaRow.
  */
 
 import { useState } from "react";
 import { toast } from "sonner";
 import {
-  BrandButton,
-  BrandCard,
-  CornerBrackets,
-  Textarea,
-} from "../../../cloud-ui";
+  SettingsActionButton,
+  SettingsTextareaRow,
+} from "../../../components/settings/settings-agent-rows";
+import {
+  SettingsGroup,
+  SettingsStack,
+} from "../../../components/settings/settings-layout";
 import { ApiError, apiFetch } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 
@@ -20,6 +23,13 @@ export function IncidentReportPanel() {
   const t = useCloudT();
   const [details, setDetails] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const submitLabel = submitting
+    ? t("cloud.incidentReport.submitting", {
+        defaultValue: "Submitting…",
+      })
+    : t("cloud.incidentReport.submit", {
+        defaultValue: "Submit incident report",
+      });
 
   const submit = async () => {
     if (!details.trim()) {
@@ -44,13 +54,14 @@ export function IncidentReportPanel() {
       setDetails("");
     } catch (err) {
       if (err instanceof ApiError && err.status === 404) {
-        // Server endpoint not built yet — fall back to mailto.
+        // error-policy:J4 endpoint not shipped; open mailto instead of a fake success
         const mailto = `mailto:${SECURITY_EMAIL}?subject=${encodeURIComponent(
           "Security incident report",
         )}&body=${encodeURIComponent(details.trim())}`;
         window.location.href = mailto;
         return;
       }
+      // error-policy:J4 surface submit failure as a toast, not a fabricated success
       const message = err instanceof Error ? err.message : String(err);
       toast.error(
         t("cloud.incidentReport.failedToSubmit", {
@@ -64,16 +75,13 @@ export function IncidentReportPanel() {
   };
 
   return (
-    <BrandCard className="relative">
-      <CornerBrackets size="sm" className="opacity-50" />
-      <div className="relative z-10 space-y-3">
-        <div>
-          <h3 className="text-lg font-bold text-txt-strong">
-            {t("cloud.incidentReport.title", {
-              defaultValue: "Report a security incident",
-            })}
-          </h3>
-          <p className="text-sm text-muted">
+    <SettingsStack data-testid="cloud-incident-report">
+      <SettingsGroup
+        title={t("cloud.incidentReport.title", {
+          defaultValue: "Report a security incident",
+        })}
+        description={
+          <>
             {t("cloud.incidentReport.emailPre", { defaultValue: "Email" })}{" "}
             <a
               href={`mailto:${SECURITY_EMAIL}`}
@@ -85,33 +93,40 @@ export function IncidentReportPanel() {
               defaultValue:
                 "or submit details below. Encrypted disclosures welcomed.",
             })}
-          </p>
-        </div>
-        <Textarea
+          </>
+        }
+      >
+        <SettingsTextareaRow
+          agentId="cloud-incident-details"
+          group="cloud-incident"
+          label={t("cloud.incidentReport.detailsLabel", {
+            defaultValue: "Incident details",
+          })}
           value={details}
-          onChange={(e) => setDetails(e.target.value)}
+          onValueChange={setDetails}
           placeholder={t("cloud.incidentReport.placeholder", {
             defaultValue:
               "What happened? Include affected URLs, timestamps, and steps to reproduce.",
           })}
           rows={5}
           disabled={submitting}
+          textareaClassName="block w-full resize-y font-sans text-sm text-txt"
         />
-        <BrandButton
-          size="sm"
-          variant="primary"
-          onClick={() => void submit()}
-          disabled={submitting}
-        >
-          {submitting
-            ? t("cloud.incidentReport.submitting", {
-                defaultValue: "Submitting…",
-              })
-            : t("cloud.incidentReport.submit", {
-                defaultValue: "Submit incident report",
-              })}
-        </BrandButton>
-      </div>
-    </BrandCard>
+        <div className="pt-1">
+          <SettingsActionButton
+            agentId="cloud-incident-submit"
+            agentGroup="cloud-incident"
+            agentLabel={submitLabel}
+            type="button"
+            variant="default"
+            disabled={submitting}
+            onClick={() => void submit()}
+            className="h-11 w-full rounded-md px-4 text-sm sm:w-fit"
+          >
+            {submitLabel}
+          </SettingsActionButton>
+        </div>
+      </SettingsGroup>
+    </SettingsStack>
   );
 }

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -7851,6 +7851,7 @@
   "cloud.incidentReport.describeWhatHappened": "Please describe what happened.",
   "cloud.incidentReport.submittedSuccess": "Incident report submitted. We'll follow up by email.",
   "cloud.incidentReport.failedToSubmit": "Failed to submit: {{message}}",
+  "cloud.incidentReport.detailsLabel": "Incident details",
   "cloud.incidentReport.title": "Report a security incident",
   "cloud.incidentReport.emailPre": "Email",
   "cloud.incidentReport.emailPost": "or submit details below. Encrypted disclosures welcomed.",


### PR DESCRIPTION
# Relates to

Closes #19513

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@499af898993342817ae603b8bd9be36e66df6c7a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` not run for the whole monorepo.

# Risks

Low. One settings leftover conversion. Submit still POSTs `/api/v1/security/incident`, still falls back to `mailto:security@elizaos.ai` on 404, and still refuses empty details.

# Background

## What does this PR do?

Routes the security incident report leftover from BrandCard + unlabeled Textarea + BrandButton onto SettingsStack / SettingsGroup / SettingsTextareaRow + SettingsActionButton.

Preserved behavior:

- `POST /api/v1/security/incident`
- 404 mailto fallback to `security@elizaos.ai`
- empty-details toast
- success toast + textarea clear
- submitting disabled state
- mailto link in the group description
- sentence-case title "Report a security incident"

## What kind of change is this?

Improvements

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

```bash
bun run --cwd packages/ui test -- src/cloud/account-security/components/incident-report-panel.test.tsx
```

7 tests passed.

## Detailed testing steps

- Empty submit toasts and does not POST.
- Successful POST clears the textarea.
- 404 assigns `window.location` to the security mailto.

# Evidence Gate

<!-- evidence-head:5aa4dc273f9c75438c588ee301748caa2c80f54f -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19515-incident-textarea-fullpage-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19515-incident-textarea-fullpage-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19515-incident-textarea-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend route or Worker handler is changed; the client still POSTs /api/v1/security/incident.
<!-- evidence-row:frontend-logs -->
- [x] [19515-incident-textarea-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19515-incident-textarea-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, wallet, scheduled-task, or generated domain artifact is involved.
<!-- evidence-row:ocr-review -->
- [x] [19515-incident-textarea-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19515-incident-textarea-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Backend + frontend logs

Backend: N/A - no backend route is changed.
Frontend: attached after isolated Playwright capture.

## Screenshots (before / after) + video walkthrough

Isolated Playwright capture of the incident report leftover. `audit:app` remains blocked by startupCoordinator.target on this checkout.

### Before

### After

### Walkthrough video

## Known gaps / failures

- Full-repo `bun run verify` not run.
- Isolated Playwright + extracted theme captures are the pixel path.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok-cli
Contribution skill revision: elizaOS/eliza@499af898993342817ae603b8bd9be36e66df6c7a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-4.6]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-cli","skill_revision":"elizaOS/eliza@499af898993342817ae603b8bd9be36e66df6c7a:packages/skills/skills/contribute-to-eliza"} -->
