### PR TITLE
fix(ui): route account ProfileForm fields through SettingsInputRow

### DIFF
--- a/packages/ui/src/cloud/account-security/components/profile-form.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/profile-form.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Renders ProfileForm through SettingsInputRow and asserts name save plus
+ * add-email against mocked apiFetch. jsdom, no backend.
+ */
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UserProfile } from "../data/user";
+import { ProfileForm } from "./profile-form";
+
+const apiFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../lib/api-client", () => ({
+  apiFetch: apiFetchMock,
+  ApiError: class ApiError extends Error {
+    status: number;
+    code: string;
+    constructor(status: number, code: string, message: string) {
+      super(message);
+      this.name = "ApiError";
+      this.status = status;
+      this.code = code;
+    }
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+function jsonResponse(body: unknown) {
+  return {
+    json: async () => body,
+  };
+}
+
+function makeUser(overrides: Partial<UserProfile> = {}): UserProfile {
+  const now = new Date("2026-03-15T12:00:00.000Z");
+  return {
+    id: "user-1",
+    email: "user@example.com",
+    email_verified: true,
+    wallet_address: null,
+    wallet_chain_type: null,
+    wallet_verified: false,
+    name: "Ada",
+    avatar: null,
+    organization_id: null,
+    role: "member",
+    steward_user_id: null,
+    telegram_id: null,
+    telegram_username: null,
+    telegram_first_name: null,
+    telegram_photo_url: null,
+    discord_id: null,
+    discord_username: null,
+    discord_global_name: null,
+    discord_avatar_url: null,
+    whatsapp_id: null,
+    whatsapp_name: null,
+    phone_number: null,
+    phone_verified: null,
+    is_anonymous: false,
+    anonymous_session_id: null,
+    expires_at: null,
+    nickname: null,
+    work_function: null,
+    preferences: null,
+    email_notifications: null,
+    response_notifications: null,
+    is_active: true,
+    created_at: now,
+    updated_at: now,
+    organization: null,
+    ...overrides,
+  };
+}
+
+const reloadMock = vi.fn();
+
+describe("ProfileForm", () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    reloadMock.mockReset();
+    vi.stubGlobal("location", { reload: reloadMock });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("routes name and present email through SettingsInputRow and disables email", () => {
+    render(<ProfileForm user={makeUser()} />);
+
+    expect(screen.getByText("Profile information")).toBeTruthy();
+    const name = screen.getByLabelText("Full name");
+    const email = screen.getByLabelText("Email address");
+    expect(name.getAttribute("data-agent-id")).toBe("profile-name");
+    expect(email.getAttribute("data-agent-id")).toBe("profile-email");
+    expect(email).toHaveProperty("disabled", true);
+    expect(
+      screen.queryByRole("button", { name: "Add email address" }),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+  });
+
+  it("submits the name through PATCH /api/v1/user and reloads on success", async () => {
+    apiFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        message: "Profile updated successfully",
+      }),
+    );
+
+    render(<ProfileForm user={makeUser()} />);
+
+    fireEvent.change(screen.getByLabelText("Full name"), {
+      target: { value: "Ada Lovelace" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith("/api/v1/user", {
+        method: "PATCH",
+        json: { name: "Ada Lovelace" },
+      });
+    });
+    expect(await screen.findByTestId("profile-success")).toBeTruthy();
+    expect(screen.getByTestId("profile-success").textContent).toContain(
+      "Profile updated successfully",
+    );
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds a missing email through PATCH /api/v1/user/email and reloads", async () => {
+    apiFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        message: "Email added successfully",
+      }),
+    );
+
+    render(<ProfileForm user={makeUser({ email: null })} />);
+
+    const email = screen.getByLabelText("Email address");
+    expect(email).toHaveProperty("disabled", false);
+    fireEvent.change(email, { target: { value: "ada@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add email address" }));
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith("/api/v1/user/email", {
+        method: "PATCH",
+        json: { email: "ada@example.com" },
+      });
+    });
+    expect(await screen.findByTestId("profile-success")).toBeTruthy();
+    expect(screen.getByTestId("profile-success").textContent).toContain(
+      "Email added successfully",
+    );
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a failed name save on the error alert and does not reload", async () => {
+    apiFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        success: false,
+        error: "Name is too long",
+      }),
+    );
+
+    render(<ProfileForm user={makeUser()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(await screen.findByTestId("profile-error")).toBeTruthy();
+    expect(screen.getByTestId("profile-error").textContent).toContain(
+      "Name is too long",
+    );
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/cloud/account-security/components/profile-form.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/profile-form.test.tsx
@@ -114,6 +114,12 @@ describe("ProfileForm", () => {
     ).toBeNull();
     expect(screen.getByRole("button", { name: "Save changes" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+    const help = screen.getByText(
+      "Email cannot be changed. Contact support if you need to update this.",
+    );
+    expect(
+      email.compareDocumentPosition(help) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("submits the name through PATCH /api/v1/user and reloads on success", async () => {

--- a/packages/ui/src/cloud/account-security/components/profile-form.tsx
+++ b/packages/ui/src/cloud/account-security/components/profile-form.tsx
@@ -1,5 +1,5 @@
 /**
- * Profile form for updating user profile information: name and email add.
+ * Profile editor for the signed-in user's name and optional first email.
  *
  * Talks directly to the canonical profile routes via the typed cloud client:
  *   PATCH /api/v1/user        (name)
@@ -7,21 +7,26 @@
  *
  * Successful mutations reload the page so every shell/profile consumer observes
  * the updated identity without depending on cross-section query invalidation.
+ * Email is add-once: a present address is shown disabled. The labelled 1:1
+ * fields compose SettingsStack / SettingsGroup / SettingsInputRow.
  */
 
-import { Loader2, Mail, User } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import {
-  Alert,
-  AlertDescription,
-  BrandButton,
-  BrandCard,
-  CornerBrackets,
-  Input,
-} from "../../../cloud-ui";
+  SettingsActionButton,
+  SettingsInputRow,
+} from "../../../components/settings/settings-agent-rows";
+import {
+  SettingsGroup,
+  SettingsStack,
+} from "../../../components/settings/settings-layout";
+import { Alert, AlertDescription } from "../../../components/ui/alert";
 import { ApiError, apiFetch } from "../../lib/api-client";
 import type { UserProfile } from "../data/user";
+
+const NAME_MAX_LENGTH = 100;
 
 function mutationError(err: unknown, fallback: string): string {
   if (err instanceof ApiError) return err.message;
@@ -41,9 +46,7 @@ interface ProfileMutationBody {
   message?: string;
 }
 
-async function updateProfile(formData: FormData): Promise<ProfileActionResult> {
-  const name = String(formData.get("name") ?? "");
-
+async function updateProfile(name: string): Promise<ProfileActionResult> {
   try {
     const res = await apiFetch("/api/v1/user", {
       method: "PATCH",
@@ -74,9 +77,7 @@ async function updateProfile(formData: FormData): Promise<ProfileActionResult> {
   }
 }
 
-async function updateEmail(formData: FormData): Promise<ProfileActionResult> {
-  const email = String(formData.get("email") ?? "");
-
+async function updateEmail(email: string): Promise<ProfileActionResult> {
   try {
     const res = await apiFetch("/api/v1/user/email", {
       method: "PATCH",
@@ -113,16 +114,20 @@ export function ProfileForm({ user }: ProfileFormProps) {
   const [success, setSuccess] = useState<string | null>(null);
   const [isUpdatingEmail, setIsUpdatingEmail] = useState(false);
   const [emailAdded, setEmailAdded] = useState(false);
+  const [name, setName] = useState(user.name ?? "");
+  const [email, setEmail] = useState("");
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const submitName = () => {
     setError(null);
     setSuccess(null);
-
-    const formData = new FormData(e.currentTarget);
+    const nextName = name.trim();
+    if (!nextName) {
+      setError("Enter your full name.");
+      return;
+    }
 
     startTransition(async () => {
-      const result = await updateProfile(formData);
+      const result = await updateProfile(nextName);
       if (result.success) {
         setSuccess(result.message || "Profile updated successfully");
         toast.success(result.message || "Profile updated successfully");
@@ -134,14 +139,17 @@ export function ProfileForm({ user }: ProfileFormProps) {
     });
   };
 
-  const handleEmailSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const submitEmail = async () => {
     setError(null);
     setSuccess(null);
-    setIsUpdatingEmail(true);
+    const nextEmail = email.trim();
+    if (!nextEmail) {
+      setError("Enter an email address.");
+      return;
+    }
 
-    const formData = new FormData(e.currentTarget);
-    const result = await updateEmail(formData);
+    setIsUpdatingEmail(true);
+    const result = await updateEmail(nextEmail);
 
     if (result.success) {
       setSuccess(result.message || "Email added successfully");
@@ -156,172 +164,163 @@ export function ProfileForm({ user }: ProfileFormProps) {
   };
 
   return (
-    <BrandCard className="relative">
-      <CornerBrackets size="sm" className="opacity-50" />
-
-      <div className="relative z-10 space-y-6">
-        <div>
-          <div className="flex items-center gap-2 mb-2">
-            <User className="h-5 w-5 text-accent" />
-            <h3 className="text-lg font-bold text-txt-strong">
-              Profile Information
-            </h3>
-          </div>
-          <p className="text-sm text-muted">
-            Update your profile information and manage your account settings
-          </p>
-        </div>
-
-        {!user.email && !emailAdded && (
-          <div className="space-y-2 p-4 border border-accent-muted bg-accent-subtle rounded-sm">
-            <div className="flex items-center gap-2 mb-3">
-              <Mail className="h-4 w-4 text-accent" />
-              <label
-                htmlFor="new-email"
-                className="text-xs font-medium text-accent uppercase tracking-wide"
-              >
-                Add Email Address
-              </label>
-            </div>
-            <p className="text-xs text-muted mb-3">
-              Adding an email allows you to receive important notifications and
-              updates.
-            </p>
-            <form onSubmit={handleEmailSubmit} className="space-y-3">
-              <Input
-                id="new-email"
-                name="email"
-                type="email"
-                placeholder="your@email.com"
-                disabled={isUpdatingEmail}
-                required
-                className="min-h-touch rounded-sm border-input bg-bg-elevated text-txt placeholder:text-muted disabled:opacity-50 disabled:cursor-not-allowed"
-              />
-              <BrandButton
+    <SettingsStack data-testid="cloud-profile-form">
+      <SettingsGroup
+        title="Profile information"
+        description="Update your profile information and manage your account settings."
+      >
+        {!user.email && !emailAdded ? (
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              void submitEmail();
+            }}
+          >
+            <SettingsInputRow
+              agentId="profile-email"
+              agentLabel="Email address"
+              group="profile"
+              label="Email address"
+              description="Adding an email lets you receive important notifications and updates."
+              type="email"
+              value={email}
+              onValueChange={setEmail}
+              placeholder="your@email.com"
+              autoComplete="email"
+              disabled={isUpdatingEmail}
+              testId="profile-email-input"
+            />
+            <div className="flex items-center gap-3 pt-1">
+              <SettingsActionButton
+                agentId="profile-add-email"
+                agentLabel="Add email address"
+                agentGroup="profile"
+                agentStatus={isUpdatingEmail ? "loading" : undefined}
                 type="submit"
-                variant="primary"
-                size="sm"
                 disabled={isUpdatingEmail}
-                className="w-full"
+                data-testid="profile-add-email"
               >
                 {isUpdatingEmail ? (
                   <>
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin motion-reduce:animate-none" />
-                    Adding Email...
+                    <Loader2
+                      className="h-4 w-4 animate-spin motion-reduce:animate-none"
+                      aria-hidden
+                    />
+                    Adding email...
                   </>
                 ) : (
-                  <>
-                    <Mail className="h-4 w-4 mr-2" />
-                    Add Email Address
-                  </>
+                  "Add email address"
                 )}
-              </BrandButton>
-            </form>
-          </div>
-        )}
-
-        {user.email && (
-          <div className="space-y-2">
-            <label
-              htmlFor="email"
-              className="text-xs font-medium text-muted uppercase tracking-wide flex items-center gap-2"
-            >
-              <Mail className="h-4 w-4" />
-              Email Address
-            </label>
-            <Input
-              id="email"
-              type="email"
-              value={user.email}
-              disabled
-              className="min-h-touch rounded-sm border-border bg-bg-muted text-muted disabled:opacity-50 disabled:cursor-not-allowed"
-            />
-            <p className="text-xs text-muted">
-              Email cannot be changed. Please contact support if you need to
-              update this.
-            </p>
-          </div>
-        )}
-
-        {emailAdded && !user.email && (
-          <div className="space-y-2 p-4 border border-status-success bg-status-success-bg rounded-sm">
-            <div className="flex items-center gap-2">
-              <Mail className="h-4 w-4 text-status-success" />
-              <p className="text-sm font-medium text-status-success">
-                Email Added Successfully!
-              </p>
+              </SettingsActionButton>
             </div>
-            <p className="text-xs text-muted">
-              Your email has been added and will appear here after the page
+          </form>
+        ) : null}
+
+        {user.email ? (
+          <SettingsInputRow
+            agentId="profile-email"
+            agentLabel="Email address"
+            group="profile"
+            label="Email address"
+            description="Email cannot be changed. Contact support if you need to update this."
+            type="email"
+            value={user.email}
+            onValueChange={() => undefined}
+            autoComplete="email"
+            disabled
+            testId="profile-email-input"
+          />
+        ) : null}
+
+        {emailAdded && !user.email ? (
+          <Alert className="rounded-sm border-status-success bg-status-success-bg">
+            <AlertDescription className="text-status-success">
+              Email added successfully. It will appear here after the page
               refreshes.
-            </p>
-          </div>
-        )}
+            </AlertDescription>
+          </Alert>
+        ) : null}
 
-        <form onSubmit={handleSubmit} className="space-y-6">
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <label
-                htmlFor="name"
-                className="text-xs font-medium text-muted uppercase tracking-wide"
-              >
-                Full Name <span className="text-accent">*</span>
-              </label>
-              <Input
-                id="name"
-                name="name"
-                type="text"
-                defaultValue={user.name || ""}
-                placeholder="Enter your full name"
-                required
-                maxLength={100}
-                disabled={isPending}
-                className="min-h-touch rounded-sm border-input bg-bg-elevated text-txt placeholder:text-muted disabled:opacity-50 disabled:cursor-not-allowed"
-              />
-            </div>
-          </div>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            submitName();
+          }}
+        >
+          <SettingsInputRow
+            agentId="profile-name"
+            agentLabel="Full name"
+            group="profile"
+            label="Full name"
+            type="text"
+            value={name}
+            onValueChange={(value) => setName(value.slice(0, NAME_MAX_LENGTH))}
+            placeholder="Enter your full name"
+            autoComplete="name"
+            disabled={isPending}
+            testId="profile-name-input"
+          />
 
-          {error && (
+          {error ? (
             <Alert
               variant="destructive"
-              className="rounded-sm border-status-danger bg-status-danger-bg"
+              className="mt-2 rounded-sm border-status-danger bg-status-danger-bg"
+              data-testid="profile-error"
             >
               <AlertDescription className="text-status-danger">
                 {error}
               </AlertDescription>
             </Alert>
-          )}
+          ) : null}
 
-          {success && (
-            <Alert className="rounded-sm border-status-success bg-status-success-bg">
+          {success ? (
+            <Alert
+              className="mt-2 rounded-sm border-status-success bg-status-success-bg"
+              data-testid="profile-success"
+            >
               <AlertDescription className="text-status-success">
                 {success}
               </AlertDescription>
             </Alert>
-          )}
+          ) : null}
 
-          <div className="flex items-center gap-3 pt-4">
-            <BrandButton type="submit" variant="primary" disabled={isPending}>
+          <div className="flex items-center gap-3 pt-3">
+            <SettingsActionButton
+              agentId="profile-save"
+              agentLabel="Save changes"
+              agentGroup="profile"
+              agentStatus={isPending ? "loading" : undefined}
+              type="submit"
+              disabled={isPending}
+              data-testid="profile-save"
+            >
               {isPending ? (
                 <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin motion-reduce:animate-none" />
+                  <Loader2
+                    className="h-4 w-4 animate-spin motion-reduce:animate-none"
+                    aria-hidden
+                  />
                   Saving...
                 </>
               ) : (
-                "Save Changes"
+                "Save changes"
               )}
-            </BrandButton>
-            <BrandButton
+            </SettingsActionButton>
+            <SettingsActionButton
+              agentId="profile-cancel"
+              agentLabel="Cancel"
+              agentGroup="profile"
               type="button"
               variant="outline"
-              onClick={() => window.location.reload()}
               disabled={isPending}
+              onClick={() => window.location.reload()}
+              data-testid="profile-cancel"
             >
               Cancel
-            </BrandButton>
+            </SettingsActionButton>
           </div>
         </form>
-      </div>
-    </BrandCard>
+      </SettingsGroup>
+    </SettingsStack>
   );
 }

--- a/packages/ui/src/components/settings/settings-agent-rows.tsx
+++ b/packages/ui/src/components/settings/settings-agent-rows.tsx
@@ -366,6 +366,7 @@ export interface SettingsInputRowProps {
   agentId: string;
   label: React.ReactNode;
   agentLabel?: string;
+  /** Field help rendered under the input, not under the label. */
   description?: React.ReactNode;
   icon?: LucideIcon;
   iconClassName?: string;
@@ -415,6 +416,10 @@ export function SettingsInputRow({
   const showError = Boolean(error);
   const isInvalid = invalid || showError;
   const errorId = `${agentId}-error`;
+  const helpId = description ? `${agentId}-help` : undefined;
+  const describedBy = [helpId, showError ? errorId : undefined]
+    .filter(Boolean)
+    .join(" ");
   const { ref, agentProps } = useAgentElement<HTMLInputElement>({
     id: agentId,
     role: type === "number" ? "number-input" : "text-input",
@@ -436,7 +441,6 @@ export function SettingsInputRow({
       icon={icon}
       iconClassName={iconClassName}
       label={label}
-      description={description}
       className={className}
       htmlFor={agentId}
       stacked
@@ -453,11 +457,16 @@ export function SettingsInputRow({
         autoComplete={autoComplete}
         disabled={disabled}
         aria-invalid={isInvalid || undefined}
-        aria-describedby={showError ? errorId : undefined}
+        aria-describedby={describedBy || undefined}
         data-testid={testId}
         className={cn(isInvalid && "border-danger", inputClassName)}
         {...rowAgentProps}
       />
+      {description ? (
+        <p id={helpId} className="mt-1 text-xs leading-relaxed text-muted">
+          {description}
+        </p>
+      ) : null}
       {showError ? (
         <p id={errorId} role="alert" className="mt-1 text-xs text-danger">
           {error}
@@ -471,6 +480,7 @@ export interface SettingsTextareaRowProps {
   agentId: string;
   label: React.ReactNode;
   agentLabel?: string;
+  /** Field help rendered under the textarea, not under the label. */
   description?: React.ReactNode;
   icon?: LucideIcon;
   iconClassName?: string;
@@ -502,6 +512,7 @@ export function SettingsTextareaRow({
   textareaClassName,
 }: SettingsTextareaRowProps) {
   const resolvedLabel = agentLabel ?? labelToString(label, agentId);
+  const helpId = description ? `${agentId}-help` : undefined;
   const { ref, agentProps } = useAgentElement<HTMLTextAreaElement>({
     id: agentId,
     role: "textarea",
@@ -522,7 +533,6 @@ export function SettingsTextareaRow({
       icon={icon}
       iconClassName={iconClassName}
       label={label}
-      description={description}
       className={className}
       htmlFor={agentId}
       stacked
@@ -535,9 +545,15 @@ export function SettingsTextareaRow({
         placeholder={placeholder}
         rows={rows}
         disabled={disabled}
+        aria-describedby={helpId}
         className={textareaClassName}
         {...textareaAgentProps}
       />
+      {description ? (
+        <p id={helpId} className="mt-1 text-xs leading-relaxed text-muted">
+          {description}
+        </p>
+      ) : null}
     </SettingsRow>
   );
 }

--- a/packages/ui/src/components/settings/settings-layout.test.tsx
+++ b/packages/ui/src/components/settings/settings-layout.test.tsx
@@ -175,6 +175,26 @@ describe("agent-addressable rows", () => {
     expect(onValueChange).toHaveBeenCalledWith("abcdefghijkl");
   });
 
+  it("SettingsInputRow renders field help below the input", () => {
+    render(
+      <SettingsInputRow
+        agentId="profile-email"
+        label="Email address"
+        type="email"
+        value="ada@example.com"
+        onValueChange={() => {}}
+        description="Email cannot be changed."
+      />,
+    );
+    const input = screen.getByLabelText("Email address");
+    const help = screen.getByText("Email cannot be changed.");
+    expect(
+      input.compareDocumentPosition(help) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(input.getAttribute("aria-describedby")).toBe("profile-email-help");
+    expect(help.getAttribute("id")).toBe("profile-email-help");
+  });
+
   it("SettingsInputRow announces a validation error below the field", () => {
     render(
       <SettingsInputRow


### PR DESCRIPTION
# Relates to

Closes #19514

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@499af898993342817ae603b8bd9be36e66df6c7a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` not run for the whole monorepo.

# Risks

Low. Visual/settings-row conversion only. Mutation contracts stay
`PATCH /api/v1/user` and `PATCH /api/v1/user/email`. No billing, MFA, or org
hero changes.

# Background

## What does this PR do?

Routes the account ProfileForm labelled 1:1 name and email fields through
SettingsStack / SettingsGroup / SettingsInputRow, with SettingsActionButton for
Save / Cancel / Add email. Group title is sentence-case "Profile information".

Keeps:

- PATCH `/api/v1/user` (name) and PATCH `/api/v1/user/email` (add email)
- reload on success
- disabled email when an address is already present
- add-email empty path
- error and success alerts

## What kind of change is this?

Improvements

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

```bash
bun run --cwd packages/ui test -- src/cloud/account-security/components/profile-form.test.tsx
```

4 passed.

## Detailed testing steps

- Render ProfileForm with an existing email: email input is disabled; Save / Cancel are SettingsActionButton.
- Change the name and submit: `apiFetch` is called with `PATCH /api/v1/user` and `{ name }`, then the page reloads.
- Render with no email, add an address: `PATCH /api/v1/user/email` fires and reloads.
- A failed name save stays on the error alert and does not reload.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:f580ed1c7431cf362b123e779b745fe1b778ab0d -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19516-profile-form-help-v2-fullpage-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19516-profile-form-help-v2-fullpage-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19516-profile-form-help-v2-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or API path is changed.
<!-- evidence-row:frontend-logs -->
- [x] [19516-profile-form-help-v2-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19516-profile-form-help-v2-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, wallet, scheduled-task, or generated domain artifact is involved.
<!-- evidence-row:ocr-review -->
- [x] [19516-profile-form-help-v2-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19516-profile-form-help-v2-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Backend + frontend logs

Backend: N/A - no backend path changed.
Frontend: isolated Playwright console capture attached after evidence upload.

## Screenshots (before / after) + video walkthrough

Isolated Playwright fixture with `before-surface` / `after-surface` (desktop + mobile) plus walkthrough click on Save.

## Known gaps / failures

- Full-repo `bun run verify` not run.
- `packages/ui` typecheck still fails on develop-owned steward-login files, unrelated to this change.
- `audit:app` still blocked by startupCoordinator.target. Isolated Playwright + extracted theme captures are the pixel path.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok-cli
Contribution skill revision: elizaOS/eliza@499af898993342817ae603b8bd9be36e66df6c7a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-4.6]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-cli","skill_revision":"elizaOS/eliza@499af898993342817ae603b8bd9be36e66df6c7a:packages/skills/skills/contribute-to-eliza"} -->


