### PR TITLE
fix(plugin-slack): harden date and permalink parsing

### DIFF
--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -185,7 +185,7 @@ describe("permalink build/parse round-trip", () => {
     expect(documented).toEqual({
       workspaceDomain: "ghostbusters",
       channelId: "C1H9RESGA",
-      messageTs: "1358546515.000080",
+      messageTs: "1358546515.000008",
     });
     expect(isValidMessageTs(documented?.messageTs ?? "")).toBe(true);
 
@@ -195,7 +195,7 @@ describe("permalink build/parse round-trip", () => {
     expect(threaded).toEqual({
       workspaceDomain: "ghostbusters",
       channelId: "C1H9RESGL",
-      messageTs: "1358546517.000230",
+      messageTs: "1358546517.000023",
     });
     expect(isValidMessageTs(threaded?.messageTs ?? "")).toBe(true);
   });
@@ -226,6 +226,11 @@ describe("permalink build/parse round-trip", () => {
         "https://acme.slack.com/archives/C0ABCDE/p1700000000123456evil",
       ),
     ).toBeNull(); // trailing garbage
+    expect(
+      parseSlackMessagePermalink(
+        "https://acme.slack.com/archives/C0ABCDE/p1700000000123456/evil",
+      ),
+    ).toBeNull();
   });
 });
 
@@ -273,7 +278,7 @@ describe("parseSlackMessageLink", () => {
     );
     expect(documented).toEqual({
       channelId: "C1H9RESGA",
-      messageTs: "1358546515.000080",
+      messageTs: "1358546515.000008",
     });
     expect(isValidMessageTs(documented?.messageTs ?? "")).toBe(true);
 
@@ -282,7 +287,7 @@ describe("parseSlackMessageLink", () => {
     );
     expect(threaded).toEqual({
       channelId: "C1H9RESGL",
-      messageTs: "1358546517.000230",
+      messageTs: "1358546517.000023",
     });
     expect(isValidMessageTs(threaded?.messageTs ?? "")).toBe(true);
   });
@@ -328,5 +333,15 @@ describe("parseSlackMessageLink", () => {
         "https://acme.slack.com/archives/C12345678/p1700000000123456evil",
       ),
     ).toBeNull(); // trailing garbage
+    expect(
+      parseSlackMessageLink(
+        "https://evil.example/archives/C12345678/p1700000000123456",
+      ),
+    ).toBeNull();
+    expect(
+      parseSlackMessageLink(
+        "https://acme.slack.com/archives/C12345678/p1700000000123456/evil",
+      ),
+    ).toBeNull();
   });
 });

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -233,31 +233,146 @@ describe("permalink build/parse round-trip", () => {
     ).toBeNull();
   });
 
-  it("rejects a non-Slack origin that carries .slack.com in the path", () => {
-    // A workspace label excluding only `.` let the authority end at the first
-    // `/`, so these parsed and reported the attacker origin as the workspace.
-    expect(
-      parseSlackMessagePermalink(
+  // Both exports resolve the origin through the same WHATWG `URL` boundary, so
+  // every case here is asserted against both. Textual patterns kept admitting
+  // whichever delimiter had not been banned yet: excluding `.` left `/` open,
+  // and excluding `/` too still left `?`, `#`, and `\`. Each entry below is a
+  // string a regex over the raw link reads as Slack while `new URL(...)`
+  // resolves it to a non-Slack host.
+  describe.each([
+    ["parseSlackMessagePermalink", parseSlackMessagePermalink],
+    ["parseSlackMessageLink", parseSlackMessageLink],
+  ])("%s host boundary", (_name, parse) => {
+    it.each([
+      // Delimiters that terminate the authority before the `.slack.com` text.
+      [
+        "query delimiter",
+        "https://attacker?x=.slack.com/archives/C12345678/p1700000000123456",
+      ],
+      [
+        "fragment delimiter",
+        "https://attacker#x=.slack.com/archives/C12345678/p1700000000123456",
+      ],
+      [
+        "WHATWG backslash delimiter",
+        "https://attacker\\redirect.slack.com/archives/C12345678/p1700000000123456",
+      ],
+      [
+        "path delimiter",
         "https://attacker/redirect.slack.com/archives/C12345678/p1700000000123456",
-      ),
-    ).toBeNull();
-    expect(
-      parseSlackMessagePermalink(
+      ],
+      [
+        "path delimiter on a hyphenated host",
         "https://evil-host/a.slack.com/archives/C12345678/p1700000000123456",
-      ),
-    ).toBeNull();
+      ],
+      // `user@evil.slack.com` reached a real Slack host, but reported the
+      // attacker-controlled userinfo as the workspace domain, which then
+      // round-trips back out through `buildSlackMessagePermalink`.
+      [
+        "userinfo",
+        "https://user@evil.slack.com/archives/C12345678/p1700000000123456",
+      ],
+      [
+        "userinfo with password",
+        "https://user:pw@acme.slack.com/archives/C12345678/p1700000000123456",
+      ],
+      [
+        "port",
+        "https://acme.slack.com:8080/archives/C12345678/p1700000000123456",
+      ],
+      // Percent-encoded separators must not be decoded back into structure.
+      [
+        "encoded host delimiter",
+        "https://attacker%2F.slack.com/archives/C12345678/p1700000000123456",
+      ],
+      [
+        "encoded path delimiter in the channel segment",
+        "https://acme.slack.com/archives/C12345678%2Fx/p1700000000123456",
+      ],
+      // Lookalike hosts: the suffix has to be the end of the host, and the
+      // workspace has to be a real label in front of it.
+      [
+        "suffix continues into another domain",
+        "https://acme.slack.com.evil.com/archives/C12345678/p1700000000123456",
+      ],
+      [
+        "slack.com without a workspace label",
+        "https://slack.com/archives/C12345678/p1700000000123456",
+      ],
+      [
+        "empty workspace label",
+        "https://.slack.com/archives/C12345678/p1700000000123456",
+      ],
+      [
+        "lookalike registrable domain",
+        "https://acme.slack.com.co/archives/C12345678/p1700000000123456",
+      ],
+      [
+        "unrelated host",
+        "https://evil.example/archives/C12345678/p1700000000123456",
+      ],
+      // Non-HTTP schemes never carry an `/archives/` permalink.
+      [
+        "non-HTTP scheme",
+        "javascript:alert(1)//acme.slack.com/archives/C12345678/p1700000000123456",
+      ],
+      [
+        "file scheme",
+        "file://acme.slack.com/archives/C12345678/p1700000000123456",
+      ],
+    ])("rejects %s", (_case, link) => {
+      expect(parse(link)).toBeNull();
+    });
+  });
+
+  // Consequences of resolving with `URL` rather than matching the raw string.
+  // Both inputs name a genuine `acme.slack.com` message and every real client
+  // resolves them to it, so they are accepted deliberately, not incidentally.
+  it("resolves links the way a URL parser does once the host is genuinely Slack", () => {
     expect(
       parseSlackMessagePermalink(
-        "https://evil.example/archives/C12345678/p1700000000123456",
+        "https://acme.slack.com\\archives\\C12345678\\p1700000000123456",
       ),
-    ).toBeNull();
-    // The same shape is already rejected by the sibling parser; pin both so the
-    // two helpers cannot drift apart again.
+    ).toEqual({
+      workspaceDomain: "acme",
+      channelId: "C12345678",
+      messageTs: "1700000000.123456",
+    });
     expect(
-      parseSlackMessageLink(
-        "https://attacker/redirect.slack.com/archives/C12345678/p1700000000123456",
+      parseSlackMessagePermalink(
+        "https://acme.slack.com/x/../archives/C12345678/p1700000000123456",
       ),
-    ).toBeNull();
+    ).toEqual({
+      workspaceDomain: "acme",
+      channelId: "C12345678",
+      messageTs: "1700000000.123456",
+    });
+  });
+
+  it("normalizes host case and accepts hyphenated workspace labels", () => {
+    expect(
+      parseSlackMessagePermalink(
+        "https://My-Team.SLACK.COM/archives/C12345678/p1700000000123456",
+      ),
+    ).toEqual({
+      workspaceDomain: "my-team",
+      channelId: "C12345678",
+      messageTs: "1700000000.123456",
+    });
+  });
+
+  it("keeps the channel contracts the two parsers actually need", () => {
+    // The permalink form is used for display and round-tripping, so it accepts
+    // any ID shape; the link form feeds conversation APIs and so requires a
+    // conversation ID.
+    const userChannel =
+      "https://acme.slack.com/archives/U1234567/p1700000000123456";
+    expect(parseSlackMessagePermalink(userChannel)).toEqual({
+      workspaceDomain: "acme",
+      channelId: "U1234567",
+      messageTs: "1700000000.123456",
+    });
+    expect(parseSlackMessageLink(userChannel)).toBeNull();
   });
 });
 

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -232,6 +232,33 @@ describe("permalink build/parse round-trip", () => {
       ),
     ).toBeNull();
   });
+
+  it("rejects a non-Slack origin that carries .slack.com in the path", () => {
+    // A workspace label excluding only `.` let the authority end at the first
+    // `/`, so these parsed and reported the attacker origin as the workspace.
+    expect(
+      parseSlackMessagePermalink(
+        "https://attacker/redirect.slack.com/archives/C12345678/p1700000000123456",
+      ),
+    ).toBeNull();
+    expect(
+      parseSlackMessagePermalink(
+        "https://evil-host/a.slack.com/archives/C12345678/p1700000000123456",
+      ),
+    ).toBeNull();
+    expect(
+      parseSlackMessagePermalink(
+        "https://evil.example/archives/C12345678/p1700000000123456",
+      ),
+    ).toBeNull();
+    // The same shape is already rejected by the sibling parser; pin both so the
+    // two helpers cannot drift apart again.
+    expect(
+      parseSlackMessageLink(
+        "https://attacker/redirect.slack.com/archives/C12345678/p1700000000123456",
+      ),
+    ).toBeNull();
+  });
 });
 
 describe("formatSlackDate", () => {

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -1,8 +1,9 @@
 /**
  * Slack mrkdwn formatting helpers. Escaping &, <, > is required so user text
  * can't forge Slack control sequences (mentions/links); the mention/link
- * builders and their extractors must round-trip; and markdown→mrkdwn must use
- * Slack's *bold* / _italic_ syntax rather than the markdown originals.
+ * builders and their extractors must round-trip; date and permalink helpers
+ * must reject malformed boundary values; and markdown→mrkdwn must use Slack's
+ * *bold* / _italic_ syntax rather than the markdown originals.
  */
 import { describe, expect, it } from "vitest";
 import {
@@ -13,6 +14,7 @@ import {
   extractUrlFromSlackLink,
   extractUserIdFromMention,
   formatSlackChannelMention,
+  formatSlackDate,
   formatSlackLink,
   formatSlackSpecialMention,
   formatSlackUserGroupMention,
@@ -22,6 +24,7 @@ import {
   stripSlackFormatting,
   truncateText,
 } from "./formatting.ts";
+import { isValidMessageTs, parseSlackMessageLink } from "./types.ts";
 
 describe("escapeSlackMrkdwn", () => {
   it("escapes the three Slack control chars, leaves clean text untouched", () => {
@@ -154,32 +157,119 @@ describe("permalink build/parse round-trip", () => {
   });
 
   it("parses user DM channel permalinks and non-fractional 10-digit timestamps", () => {
-    expect(
-      parseSlackMessagePermalink(
-        "https://acme.slack.com/archives/U1234567/p1700000000123456",
-      ),
-    ).toEqual({
+    const parsed16 = parseSlackMessagePermalink(
+      "https://acme.slack.com/archives/U1234567/p1700000000123456",
+    );
+    expect(parsed16).toEqual({
       workspaceDomain: "acme",
       channelId: "U1234567",
       messageTs: "1700000000.123456",
     });
+    expect(isValidMessageTs(parsed16?.messageTs ?? "")).toBe(true);
 
-    expect(
-      parseSlackMessagePermalink(
-        "https://acme.slack.com/archives/C0ABCDE/p1700000000",
-      ),
-    ).toEqual({
+    const parsed10 = parseSlackMessagePermalink(
+      "https://acme.slack.com/archives/C0ABCDE/p1700000000",
+    );
+    expect(parsed10).toEqual({
       workspaceDomain: "acme",
       channelId: "C0ABCDE",
-      messageTs: "1700000000",
+      messageTs: "1700000000.000000",
     });
+    expect(isValidMessageTs(parsed10?.messageTs ?? "")).toBe(true);
   });
 
-  it("returns null for malformed short timestamps", () => {
+  it("returns null for malformed timestamps, wrong lengths, or trailing garbage", () => {
     expect(
       parseSlackMessagePermalink(
         "https://acme.slack.com/archives/C0ABCDE/p12345",
       ),
     ).toBeNull();
+    expect(
+      parseSlackMessagePermalink(
+        "https://acme.slack.com/archives/C0ABCDE/p17000000001",
+      ),
+    ).toBeNull(); // 11 digits
+    expect(
+      parseSlackMessagePermalink(
+        "https://acme.slack.com/archives/C0ABCDE/p170000000012345",
+      ),
+    ).toBeNull(); // 15 digits
+    expect(
+      parseSlackMessagePermalink(
+        "https://acme.slack.com/archives/C0ABCDE/p17000000001234567",
+      ),
+    ).toBeNull(); // 17 digits
+    expect(
+      parseSlackMessagePermalink(
+        "https://acme.slack.com/archives/C0ABCDE/p1700000000123456evil",
+      ),
+    ).toBeNull(); // trailing garbage
+  });
+});
+
+describe("formatSlackDate", () => {
+  it("formats valid Date or timestamp into Slack <!date...>", () => {
+    const d = new Date(1700000000000);
+    expect(formatSlackDate(d)).toBe(
+      "<!date^1700000000^{date_short_pretty} at {time}|2023-11-14T22:13:20.000Z>",
+    );
+  });
+
+  it("degrades instead of throwing on unrepresentable timestamps", () => {
+    // Previously `new Date(NaN).toISOString()` threw RangeError out of a
+    // formatting helper; out-of-range epoch millis are the same failure.
+    expect(formatSlackDate(new Date("invalid"))).toBe("Invalid date");
+    expect(formatSlackDate(Infinity)).toBe("Invalid date");
+    expect(formatSlackDate(8_640_000_000_000_001, "{date}", "Fallback")).toBe(
+      "Fallback",
+    );
+  });
+});
+
+describe("parseSlackMessageLink", () => {
+  it("parses valid archives links and normalizes messageTs to satisfy isValidMessageTs", () => {
+    const res16 = parseSlackMessageLink(
+      "https://acme.slack.com/archives/C12345678/p1700000000123456",
+    );
+    expect(res16).toEqual({
+      channelId: "C12345678",
+      messageTs: "1700000000.123456",
+    });
+    expect(isValidMessageTs(res16?.messageTs ?? "")).toBe(true);
+
+    const res10 = parseSlackMessageLink(
+      "https://acme.slack.com/archives/C12345678/p1700000000",
+    );
+    expect(res10).toEqual({
+      channelId: "C12345678",
+      messageTs: "1700000000.000000",
+    });
+    expect(isValidMessageTs(res10?.messageTs ?? "")).toBe(true);
+  });
+
+  it("returns null for malformed lengths, invalid digits, or trailing garbage", () => {
+    expect(
+      parseSlackMessageLink("https://acme.slack.com/archives/C12345678/p123"),
+    ).toBeNull();
+    expect(
+      parseSlackMessageLink(
+        "https://acme.slack.com/archives/C12345678/p17000000001",
+      ),
+    ).toBeNull(); // 11 digits
+    expect(
+      parseSlackMessageLink(
+        "https://acme.slack.com/archives/C12345678/p170000000012345",
+      ),
+    ).toBeNull(); // 15 digits
+    expect(
+      parseSlackMessageLink(
+        "https://acme.slack.com/archives/C12345678/p17000000001234567",
+      ),
+    ).toBeNull(); // 17 digits
+    expect(
+      parseSlackMessageLink(
+        "https://acme.slack.com/archives/C12345678/p1700000000123456evil",
+      ),
+    ).toBeNull(); // trailing garbage
   });
 });

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -287,6 +287,23 @@ describe("parseSlackMessageLink", () => {
     expect(isValidMessageTs(threaded?.messageTs ?? "")).toBe(true);
   });
 
+  it("requires a bare permalink, and round-trips the mrkdwn-wrapped form via extractUrlFromSlackLink", () => {
+    const bare = "https://acme.slack.com/archives/C12345678/p1700000000123456";
+    // parseSlackMessageLink substring-matched before anchoring, so these three
+    // used to parse; parseSlackMessagePermalink was already start-anchored and
+    // is pinned here so both helpers now agree on rejecting a non-bare link.
+    expect(parseSlackMessageLink(`<${bare}|jump to message>`)).toBeNull();
+    expect(parseSlackMessageLink(`see ${bare} for context`)).toBeNull();
+    expect(parseSlackMessagePermalink(`<${bare}>`)).toBeNull();
+
+    const extracted = extractUrlFromSlackLink(`<${bare}|jump to message>`);
+    expect(extracted).toBe(bare);
+    expect(parseSlackMessageLink(extracted ?? "")).toEqual({
+      channelId: "C12345678",
+      messageTs: "1700000000.123456",
+    });
+  });
+
   it("returns null for malformed lengths, invalid digits, or trailing garbage", () => {
     expect(
       parseSlackMessageLink("https://acme.slack.com/archives/C12345678/p123"),

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -178,6 +178,28 @@ describe("permalink build/parse round-trip", () => {
     expect(isValidMessageTs(parsed10?.messageTs ?? "")).toBe(true);
   });
 
+  it("normalizes Slack's documented 15-digit chat.getPermalink examples", () => {
+    const documented = parseSlackMessagePermalink(
+      "https://ghostbusters.slack.com/archives/C1H9RESGA/p135854651500008",
+    );
+    expect(documented).toEqual({
+      workspaceDomain: "ghostbusters",
+      channelId: "C1H9RESGA",
+      messageTs: "1358546515.000080",
+    });
+    expect(isValidMessageTs(documented?.messageTs ?? "")).toBe(true);
+
+    const threaded = parseSlackMessagePermalink(
+      "https://ghostbusters.slack.com/archives/C1H9RESGL/p135854651700023?thread_ts=1358546515.000008&cid=C1H9RESGL",
+    );
+    expect(threaded).toEqual({
+      workspaceDomain: "ghostbusters",
+      channelId: "C1H9RESGL",
+      messageTs: "1358546517.000230",
+    });
+    expect(isValidMessageTs(threaded?.messageTs ?? "")).toBe(true);
+  });
+
   it("returns null for malformed timestamps, wrong lengths, or trailing garbage", () => {
     expect(
       parseSlackMessagePermalink(
@@ -191,9 +213,9 @@ describe("permalink build/parse round-trip", () => {
     ).toBeNull(); // 11 digits
     expect(
       parseSlackMessagePermalink(
-        "https://acme.slack.com/archives/C0ABCDE/p170000000012345",
+        "https://acme.slack.com/archives/C0ABCDE/p17000000001234",
       ),
-    ).toBeNull(); // 15 digits
+    ).toBeNull(); // 14 digits
     expect(
       parseSlackMessagePermalink(
         "https://acme.slack.com/archives/C0ABCDE/p17000000001234567",
@@ -245,6 +267,24 @@ describe("parseSlackMessageLink", () => {
       messageTs: "1700000000.000000",
     });
     expect(isValidMessageTs(res10?.messageTs ?? "")).toBe(true);
+
+    const documented = parseSlackMessageLink(
+      "https://ghostbusters.slack.com/archives/C1H9RESGA/p135854651500008",
+    );
+    expect(documented).toEqual({
+      channelId: "C1H9RESGA",
+      messageTs: "1358546515.000080",
+    });
+    expect(isValidMessageTs(documented?.messageTs ?? "")).toBe(true);
+
+    const threaded = parseSlackMessageLink(
+      "https://ghostbusters.slack.com/archives/C1H9RESGL/p135854651700023?thread_ts=1358546515.000008&cid=C1H9RESGL",
+    );
+    expect(threaded).toEqual({
+      channelId: "C1H9RESGL",
+      messageTs: "1358546517.000230",
+    });
+    expect(isValidMessageTs(threaded?.messageTs ?? "")).toBe(true);
   });
 
   it("returns null for malformed lengths, invalid digits, or trailing garbage", () => {
@@ -258,9 +298,9 @@ describe("parseSlackMessageLink", () => {
     ).toBeNull(); // 11 digits
     expect(
       parseSlackMessageLink(
-        "https://acme.slack.com/archives/C12345678/p170000000012345",
+        "https://acme.slack.com/archives/C12345678/p17000000001234",
       ),
-    ).toBeNull(); // 15 digits
+    ).toBeNull(); // 14 digits
     expect(
       parseSlackMessageLink(
         "https://acme.slack.com/archives/C12345678/p17000000001234567",

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -488,7 +488,7 @@ export function parseSlackMessagePermalink(
   link: string,
 ): { workspaceDomain: string; channelId: string; messageTs: string } | null {
   const match = link.match(
-    /^https?:\/\/([^.]+)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d{16}|\d{15}|\d{10})(?:[/?#].*)?$/i,
+    /^https?:\/\/([^.]+)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d{16}|\d{15}|\d{10})\/?(?:[?#].*)?$/i,
   );
   if (!match) {
     return null;

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -479,7 +479,10 @@ export function buildSlackMessagePermalink(
 }
 
 /**
- * Parses a Slack message permalink
+ * Parses a Slack message permalink.
+ *
+ * The match is anchored at both ends, so prose-embedded or mrkdwn-wrapped
+ * links must be extracted before they are passed in.
  */
 export function parseSlackMessagePermalink(
   link: string,

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -317,10 +317,21 @@ export function formatSlackDate(
   format: string = "{date_short_pretty} at {time}",
   fallbackText?: string,
 ): string {
-  const unix = Math.floor(
-    (typeof timestamp === "number" ? timestamp : timestamp.getTime()) / 1000,
-  );
-  const fallback = fallbackText || new Date(unix * 1000).toISOString();
+  const timeMs =
+    typeof timestamp === "number" ? timestamp : timestamp.getTime();
+  const date = new Date(timeMs);
+  if (!Number.isFinite(date.getTime())) {
+    return fallbackText || "Invalid date";
+  }
+  const unix = Math.floor(timeMs / 1000);
+  let fallback = fallbackText;
+  if (!fallback) {
+    try {
+      fallback = date.toISOString();
+    } catch {
+      return fallbackText || "Invalid date";
+    }
+  }
   return `<!date^${unix}^${format}|${fallback}>`;
 }
 
@@ -477,21 +488,15 @@ export function parseSlackMessagePermalink(
   link: string,
 ): { workspaceDomain: string; channelId: string; messageTs: string } | null {
   const match = link.match(
-    /^https?:\/\/([^.]+)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d+)/i,
+    /^https?:\/\/([^.]+)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d{10}|\d{16})(?:[/?#].*)?$/i,
   );
   if (!match) {
     return null;
   }
 
   const ts = match[3];
-  if (ts.length < 10) {
-    return null;
-  }
-
-  const fractional = ts.slice(10);
-  const messageTs = fractional
-    ? `${ts.slice(0, 10)}.${fractional}`
-    : ts.slice(0, 10);
+  const messageTs =
+    ts.length === 16 ? `${ts.slice(0, 10)}.${ts.slice(10)}` : `${ts}.000000`;
 
   return {
     workspaceDomain: match[1],

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -9,7 +9,7 @@
  * paths and re-exported from `index.ts`.
  */
 import {
-  normalizeSlackPermalinkTimestamp,
+  parseSlackArchivesUrl,
   type SlackChannel,
   type SlackUser,
 } from "./types";
@@ -481,33 +481,16 @@ export function buildSlackMessagePermalink(
 /**
  * Parses a Slack message permalink.
  *
- * The match is anchored at both ends, so prose-embedded or mrkdwn-wrapped
- * links must be extracted before they are passed in.
+ * Prose-embedded or mrkdwn-wrapped links must be extracted before they are
+ * passed in. The origin is established by `parseSlackArchivesUrl`, which both
+ * this helper and `parseSlackMessageLink` share so the two cannot drift into
+ * disagreeing about what counts as a Slack host.
  *
- * The workspace label excludes `/` as well as `.`, so `.slack.com` has to sit
- * in the authority rather than the path. Excluding only `.` still admitted
- * `https://attacker/redirect.slack.com/archives/...`, which reports a non-Slack
- * origin as the workspace domain. `parseSlackMessageLink` enforces the same
- * boundary.
+ * The returned `workspaceDomain` is a bare DNS label and so is safe to feed
+ * back through `buildSlackMessagePermalink`.
  */
 export function parseSlackMessagePermalink(
   link: string,
 ): { workspaceDomain: string; channelId: string; messageTs: string } | null {
-  const match = link.match(
-    /^https?:\/\/([^./]+)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d{16}|\d{15}|\d{10})\/?(?:[?#].*)?$/i,
-  );
-  if (!match) {
-    return null;
-  }
-
-  const messageTs = normalizeSlackPermalinkTimestamp(match[3]);
-  if (!messageTs) {
-    return null;
-  }
-
-  return {
-    workspaceDomain: match[1],
-    channelId: match[2],
-    messageTs,
-  };
+  return parseSlackArchivesUrl(link);
 }

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -8,7 +8,11 @@
  * channel-type / display-name helpers. Used by `service.ts` on the send/receive
  * paths and re-exported from `index.ts`.
  */
-import type { SlackChannel, SlackUser } from "./types";
+import {
+  normalizeSlackPermalinkTimestamp,
+  type SlackChannel,
+  type SlackUser,
+} from "./types";
 
 /**
  * Escape special characters for Slack mrkdwn format
@@ -488,15 +492,16 @@ export function parseSlackMessagePermalink(
   link: string,
 ): { workspaceDomain: string; channelId: string; messageTs: string } | null {
   const match = link.match(
-    /^https?:\/\/([^.]+)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d{10}|\d{16})(?:[/?#].*)?$/i,
+    /^https?:\/\/([^.]+)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d{16}|\d{15}|\d{10})(?:[/?#].*)?$/i,
   );
   if (!match) {
     return null;
   }
 
-  const ts = match[3];
-  const messageTs =
-    ts.length === 16 ? `${ts.slice(0, 10)}.${ts.slice(10)}` : `${ts}.000000`;
+  const messageTs = normalizeSlackPermalinkTimestamp(match[3]);
+  if (!messageTs) {
+    return null;
+  }
 
   return {
     workspaceDomain: match[1],

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -483,12 +483,18 @@ export function buildSlackMessagePermalink(
  *
  * The match is anchored at both ends, so prose-embedded or mrkdwn-wrapped
  * links must be extracted before they are passed in.
+ *
+ * The workspace label excludes `/` as well as `.`, so `.slack.com` has to sit
+ * in the authority rather than the path. Excluding only `.` still admitted
+ * `https://attacker/redirect.slack.com/archives/...`, which reports a non-Slack
+ * origin as the workspace domain. `parseSlackMessageLink` enforces the same
+ * boundary.
  */
 export function parseSlackMessagePermalink(
   link: string,
 ): { workspaceDomain: string; channelId: string; messageTs: string } | null {
   const match = link.match(
-    /^https?:\/\/([^.]+)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d{16}|\d{15}|\d{10})\/?(?:[?#].*)?$/i,
+    /^https?:\/\/([^./]+)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d{16}|\d{15}|\d{10})\/?(?:[?#].*)?$/i,
   );
   if (!match) {
     return null;

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -328,14 +328,7 @@ export function formatSlackDate(
     return fallbackText || "Invalid date";
   }
   const unix = Math.floor(timeMs / 1000);
-  let fallback = fallbackText;
-  if (!fallback) {
-    try {
-      fallback = date.toISOString();
-    } catch {
-      return fallbackText || "Invalid date";
-    }
-  }
+  const fallback = fallbackText || date.toISOString();
   return `<!date^${unix}^${format}|${fallback}>`;
 }
 

--- a/plugins/plugin-slack/src/types.ts
+++ b/plugins/plugin-slack/src/types.ts
@@ -384,8 +384,16 @@ export function isValidMessageTs(ts: string): boolean {
 /**
  * Normalizes a Slack permalink path timestamp (`p` digits with the decimal
  * removed) to the `seconds.microseconds` form `isValidMessageTs` accepts.
- * Official `chat.getPermalink` examples use 15 digits; current links use 16;
- * seconds-only links use 10. Other widths stay rejected.
+ * Current links use 16 digits, seconds-only links use 10, and the documented
+ * `chat.getPermalink` examples use 15. Other widths stay rejected.
+ *
+ * The 15-digit width is padded on the right (`00008` -> `000080`), which is an
+ * assumption the published documentation cannot settle: that page's own
+ * `message_ts` argument example is the dot-less `135854651500008`, so its
+ * 15-digit permalink may equally be a truncated 16-digit value needing a left
+ * pad (`000008`). Both decodings satisfy `isValidMessageTs`, and the previous
+ * code emitted a value this package's own contract rejected, so the ambiguity
+ * is confined here: an API-verified correction changes only this function.
  */
 export function normalizeSlackPermalinkTimestamp(
   digits: string,
@@ -397,7 +405,12 @@ export function normalizeSlackPermalinkTimestamp(
 }
 
 /**
- * Parses a Slack message link to extract channel and message IDs
+ * Parses a Slack message link to extract channel and message IDs.
+ *
+ * The match is anchored, so the argument must be a bare permalink: a link
+ * embedded in surrounding prose or wrapped in mrkdwn (`<https://…|label>`)
+ * returns `null`. Callers holding message text extract the URL first, with
+ * `extractUrlFromSlackLink` for the mrkdwn form.
  */
 export function parseSlackMessageLink(
   link: string,

--- a/plugins/plugin-slack/src/types.ts
+++ b/plugins/plugin-slack/src/types.ts
@@ -401,27 +401,111 @@ export function normalizeSlackPermalinkTimestamp(
   return `${digits.slice(0, 10)}.${digits.slice(10).padStart(6, "0")}`;
 }
 
+/** One DNS label, so a nested `.slack.com` cannot be spelled inside it. */
+const SLACK_WORKSPACE_LABEL_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+/**
+ * Resolves a Slack `/archives/` permalink through the WHATWG URL parser and
+ * returns its parts, or `null` if the input is not one.
+ *
+ * The origin is established by `URL`, not by a pattern over the raw string.
+ * Textual matching cannot decide which characters end the authority: `?`, `#`,
+ * and (for special schemes) `\` all terminate the host before a later
+ * `.slack.com` suffix, so `https://attacker?x=.slack.com/archives/…` reads as
+ * Slack to a regex while every real client resolves it to `attacker`. Banning
+ * each delimiter as it is discovered leaves the next one open, so the host is
+ * taken from `url.hostname` and the segments from `url.pathname`.
+ *
+ * Credentials and ports are rejected rather than ignored: `https://user@…`
+ * would otherwise surface `user@workspace` as the workspace domain, which
+ * round-trips back out through `buildSlackMessagePermalink`. Query and fragment
+ * tails stay allowed — Slack's own threaded permalinks carry `?thread_ts=…`.
+ */
+export function parseSlackArchivesUrl(link: string): {
+  workspaceDomain: string;
+  channelId: string;
+  messageTs: string;
+} | null {
+  let url: URL;
+  try {
+    url = new URL(link);
+  } catch {
+    // error-policy:J3 an unparseable link is not a permalink; the explicit
+    // invalid result is `null`, never a partially-trusted default.
+    return null;
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return null;
+  }
+  if (url.username !== "" || url.password !== "" || url.port !== "") {
+    return null;
+  }
+
+  // `url.hostname` is already lowercased and IDNA-normalized.
+  const host = url.hostname;
+  const suffix = ".slack.com";
+  if (!host.endsWith(suffix)) {
+    return null;
+  }
+  const workspaceDomain = host.slice(0, -suffix.length);
+  if (!SLACK_WORKSPACE_LABEL_RE.test(workspaceDomain)) {
+    return null;
+  }
+
+  // Percent-encoded separators survive in `pathname`, so a segment carrying
+  // `%2F` fails the character classes below instead of splitting into two.
+  const segments = url.pathname.split("/");
+  if (segments[segments.length - 1] === "") {
+    segments.pop(); // one optional trailing slash
+  }
+  if (
+    segments.length !== 4 ||
+    segments[0] !== "" ||
+    segments[1] !== "archives"
+  ) {
+    return null;
+  }
+
+  const channelId = segments[2];
+  if (!/^[A-Z0-9]+$/i.test(channelId)) {
+    return null;
+  }
+
+  const tsMatch = /^p(\d+)$/.exec(segments[3]);
+  if (!tsMatch) {
+    return null;
+  }
+  const messageTs = normalizeSlackPermalinkTimestamp(tsMatch[1]);
+  if (!messageTs) {
+    return null;
+  }
+
+  return { workspaceDomain, channelId, messageTs };
+}
+
 /**
  * Parses a Slack message link to extract channel and message IDs.
  *
- * The match is anchored, so the argument must be a bare permalink: a link
- * embedded in surrounding prose or wrapped in mrkdwn (`<https://…|label>`)
- * returns `null`. Callers holding message text extract the URL first, with
- * `extractUrlFromSlackLink` for the mrkdwn form.
+ * Accepts only a bare permalink: a link embedded in surrounding prose or
+ * wrapped in mrkdwn (`<https://…|label>`) returns `null`. Callers holding
+ * message text extract the URL first, with `extractUrlFromSlackLink` for the
+ * mrkdwn form.
+ *
+ * Narrower than `parseSlackMessagePermalink` on the channel only: this helper
+ * feeds conversation APIs and so requires a conversation ID (`C`/`G`/`D`).
  */
 export function parseSlackMessageLink(
   link: string,
 ): { channelId: string; messageTs: string } | null {
   // Format: https://workspace.slack.com/archives/C12345678/p1234567890123456
-  const match = link.match(
-    /^https?:\/\/[^./]+\.slack\.com\/archives\/([CGD][A-Z0-9]+)\/p(\d{16}|\d{15}|\d{10})\/?(?:[?#].*)?$/i,
-  );
-  if (!match) return null;
+  const parsed = parseSlackArchivesUrl(link);
+  if (!parsed) return null;
 
-  const messageTs = normalizeSlackPermalinkTimestamp(match[2]);
-  if (!messageTs) return null;
+  const { channelId, messageTs } = parsed;
+  if (!/^[CGD][A-Z0-9]+$/i.test(channelId)) return null;
 
-  return { channelId: match[1], messageTs };
+  return { channelId, messageTs };
 }
 
 /**

--- a/plugins/plugin-slack/src/types.ts
+++ b/plugins/plugin-slack/src/types.ts
@@ -388,13 +388,15 @@ export function parseSlackMessageLink(
   link: string,
 ): { channelId: string; messageTs: string } | null {
   // Format: https://workspace.slack.com/archives/C12345678/p1234567890123456
-  const match = link.match(/\/archives\/([CGD][A-Z0-9]+)\/p(\d+)/i);
+  const match = link.match(
+    /^https?:\/\/[^/]+\/archives\/([CGD][A-Z0-9]+)\/p(\d{10}|\d{16})(?:[/?#].*)?$/i,
+  );
   if (!match) return null;
 
   const channelId = match[1];
   const ts = match[2];
-  // Convert the timestamp: p1234567890123456 -> 1234567890.123456
-  const messageTs = `${ts.slice(0, 10)}.${ts.slice(10)}`;
+  const messageTs =
+    ts.length === 16 ? `${ts.slice(0, 10)}.${ts.slice(10)}` : `${ts}.000000`;
 
   return { channelId, messageTs };
 }

--- a/plugins/plugin-slack/src/types.ts
+++ b/plugins/plugin-slack/src/types.ts
@@ -382,6 +382,21 @@ export function isValidMessageTs(ts: string): boolean {
 }
 
 /**
+ * Normalizes a Slack permalink path timestamp (`p` digits with the decimal
+ * removed) to the `seconds.microseconds` form `isValidMessageTs` accepts.
+ * Official `chat.getPermalink` examples use 15 digits; current links use 16;
+ * seconds-only links use 10. Other widths stay rejected.
+ */
+export function normalizeSlackPermalinkTimestamp(
+  digits: string,
+): string | null {
+  if (!/^(?:\d{16}|\d{15}|\d{10})$/.test(digits)) {
+    return null;
+  }
+  return `${digits.slice(0, 10)}.${digits.slice(10).padEnd(6, "0")}`;
+}
+
+/**
  * Parses a Slack message link to extract channel and message IDs
  */
 export function parseSlackMessageLink(
@@ -389,16 +404,14 @@ export function parseSlackMessageLink(
 ): { channelId: string; messageTs: string } | null {
   // Format: https://workspace.slack.com/archives/C12345678/p1234567890123456
   const match = link.match(
-    /^https?:\/\/[^/]+\/archives\/([CGD][A-Z0-9]+)\/p(\d{10}|\d{16})(?:[/?#].*)?$/i,
+    /^https?:\/\/[^/]+\/archives\/([CGD][A-Z0-9]+)\/p(\d{16}|\d{15}|\d{10})(?:[/?#].*)?$/i,
   );
   if (!match) return null;
 
-  const channelId = match[1];
-  const ts = match[2];
-  const messageTs =
-    ts.length === 16 ? `${ts.slice(0, 10)}.${ts.slice(10)}` : `${ts}.000000`;
+  const messageTs = normalizeSlackPermalinkTimestamp(match[2]);
+  if (!messageTs) return null;
 
-  return { channelId, messageTs };
+  return { channelId: match[1], messageTs };
 }
 
 /**

--- a/plugins/plugin-slack/src/types.ts
+++ b/plugins/plugin-slack/src/types.ts
@@ -387,13 +387,10 @@ export function isValidMessageTs(ts: string): boolean {
  * Current links use 16 digits, seconds-only links use 10, and the documented
  * `chat.getPermalink` examples use 15. Other widths stay rejected.
  *
- * The 15-digit width is padded on the right (`00008` -> `000080`), which is an
- * assumption the published documentation cannot settle: that page's own
- * `message_ts` argument example is the dot-less `135854651500008`, so its
- * 15-digit permalink may equally be a truncated 16-digit value needing a left
- * pad (`000008`). Both decodings satisfy `isValidMessageTs`, and the previous
- * code emitted a value this package's own contract rejected, so the ambiguity
- * is confined here: an API-verified correction changes only this function.
+ * The documented 15-digit examples omit a leading zero from the six-digit
+ * fractional field. Slack's threaded example exposes the corresponding
+ * six-decimal `thread_ts`, so left-padding restores the canonical value instead
+ * of shifting the message timestamp by a decimal place.
  */
 export function normalizeSlackPermalinkTimestamp(
   digits: string,
@@ -401,7 +398,7 @@ export function normalizeSlackPermalinkTimestamp(
   if (!/^(?:\d{16}|\d{15}|\d{10})$/.test(digits)) {
     return null;
   }
-  return `${digits.slice(0, 10)}.${digits.slice(10).padEnd(6, "0")}`;
+  return `${digits.slice(0, 10)}.${digits.slice(10).padStart(6, "0")}`;
 }
 
 /**
@@ -417,7 +414,7 @@ export function parseSlackMessageLink(
 ): { channelId: string; messageTs: string } | null {
   // Format: https://workspace.slack.com/archives/C12345678/p1234567890123456
   const match = link.match(
-    /^https?:\/\/[^/]+\/archives\/([CGD][A-Z0-9]+)\/p(\d{16}|\d{15}|\d{10})(?:[/?#].*)?$/i,
+    /^https?:\/\/[^./]+\.slack\.com\/archives\/([CGD][A-Z0-9]+)\/p(\d{16}|\d{15}|\d{10})\/?(?:[?#].*)?$/i,
   );
   if (!match) return null;
 


### PR DESCRIPTION
# Relates to

Supersedes #19196 with its review fixes preserved.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Owning plugin tests, typecheck, lint, and build pass on the exact head.
- [x] A reviewer can verify the normalization matrix and fail-closed boundaries below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.6-flash`, `xai/grok-4.6`, `anthropic/claude-opus-5`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`, `Grok`, `Claude Code`, `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8b67d4b6e35f53785d06bd0bbe532b6a03ddb8ec:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@8b67d4b6e35f53785d06bd0bbe532b6a03ddb8ec`; zero conflicts.
- [x] The four original contributor commits and all three reviewed correction commits are patch-identical after replay.

# Risks

Moderate and explicit. The public permalink parsers now require a bare Slack-hosted permalink instead of substring-matching arbitrary prose or hosts. Callers with Slack mrkdwn must first use `extractUrlFromSlackLink`. Invalid or out-of-range dates now return the supplied fallback (or `Invalid date`) instead of throwing. Canonical 16-digit, shortened documented 15-digit, and seconds-only 10-digit permalink timestamps normalize to six fractional digits; all other widths fail closed.

# Background

## What does this PR do?

- Makes `formatSlackDate` safely reject invalid and unrepresentable dates.
- Anchors both Slack permalink parsers and rejects unrelated hosts, extra path segments, malformed widths, invalid digits, and trailing garbage.
- Normalizes canonical 16-digit and seconds-only 10-digit permalink timestamps.
- Supports Slack's documented 15-digit examples by left-padding the five-digit fractional field. The official threaded example exposes a six-decimal `thread_ts`, confirming that the omitted digit is a leading fractional zero: https://docs.slack.dev/reference/methods/chat.getPermalink/
- Documents the deliberate bare-link contract and the mrkdwn extraction path.

## What kind of change is this?

Bug fix and public parser hardening.

# Documentation changes needed?

The caller-facing contract is documented at the exported helpers; no separate user documentation is required.

# Testing

```bash
bun run --cwd plugins/plugin-slack test
bun run --cwd plugins/plugin-slack typecheck
bun run --cwd plugins/plugin-slack lint:check
bun run --cwd plugins/plugin-slack build
bunx @biomejs/biome check plugins/plugin-slack/src/formatting.ts plugins/plugin-slack/src/types.ts plugins/plugin-slack/src/formatting.test.ts
bun run check:agents-claude
git diff --check
```

Exact-head results at `f367b47cb0d`: 5 files / 83 tests passed; typecheck, lint (22 files), build, changed-file Biome, and diff checks passed.

The added regression was proven non-vacuous: reverting only the workspace-label
character class and rerunning the suite fails exactly the new case
(`expected { …(3) } to be null`, 1 failed / 46 passed), then passes again once
the fix is restored.

# Evidence Gate

<!-- evidence-head:f367b47cb0deaba2aa9ad28d01d274697da4eb8d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - pure Slack formatting/parser utilities; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - pure Slack formatting/parser utilities; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head isolated plugin transcript:

<details>
<summary>Slack plugin verification</summary>

```text
Test Files  5 passed (5)
Tests       83 passed (83)
Typecheck, lint (22 files), build, changed-file Biome, and git diff --check passed.

Regression proof (workspace-label fix reverted):
  x rejects a non-Slack origin that carries .slack.com in the path
  AssertionError: expected { …(3) } to be null
  Tests  1 failed | 46 passed (47)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or inference behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Normalization matrix pinned by tests:

```text
p1700000000123456 -> 1700000000.123456
p1700000000       -> 1700000000.000000
p135854651500008  -> 1358546515.000008
p135854651700023  -> 1358546517.000023
```

Host-boundary matrix (both exported parsers now agree):

```text
https://acme.slack.com/archives/C12345678/p1700000000123456
  -> workspaceDomain "acme"                              accepted
https://attacker/redirect.slack.com/archives/C12345678/p1700000000123456
  -> was workspaceDomain "attacker/redirect"             now rejected
https://evil-host/a.slack.com/archives/C12345678/p1700000000123456
  -> was workspaceDomain "evil-host/a"                   now rejected
https://evil.example/archives/C12345678/p1700000000123456
  -> rejected
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text.

# Evidence Details

## Known gaps / warnings

- No live workspace API call was needed because parsing is deterministic and the documented response examples are the protocol artifacts under test.
- Hosted exact-head gates remain required before merge.

Original contributor attribution remains recorded in the four contributor commits (`e5b53ad`, `d78a3b9`, `bf69d9e`, `12eeddb`) with their original model, client, and skill revisions.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@8b67d4b6e35f53785d06bd0bbe532b6a03ddb8ec:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@8b67d4b6e35f53785d06bd0bbe532b6a03ddb8ec:packages/skills/skills/contribute-to-eliza"} -->



