### PR TITLE
fix(cloud): bound Telegram DM retry latency

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
@@ -1,6 +1,7 @@
 /** Exercises the real forwarding boundary with deterministic network responses. */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
+  __serverRouterTestHooks,
   forwardToServer,
   getCanonicalAgentFallbackBase,
   getCanonicalAgentFallbackTarget,
@@ -13,9 +14,36 @@ const originalFetch = globalThis.fetch;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  __serverRouterTestHooks.resetMessageForwardTimeoutMs();
 });
 
 describe("canonical agent forwarding fallback", () => {
+  test("does not replay a non-idempotent message after its response times out", async () => {
+    __serverRouterTestHooks.setMessageForwardTimeoutMs(10);
+    let requests = 0;
+    globalThis.fetch = mock(
+      async (_input: string | URL | Request, init?: RequestInit) => {
+        requests += 1;
+        return await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason);
+          });
+        });
+      },
+    ) as typeof fetch;
+
+    await expect(
+      forwardToServer(
+        "http://slow-agent.example/api",
+        "slow-agent",
+        AGENT_ID,
+        "user-1",
+        "hello once",
+      ),
+    ).rejects.toThrow("Agent forward timed out after 10ms");
+    expect(requests).toBe(1);
+  });
+
   test("derives a configured canonical fallback only for UUID agent ids", () => {
     const env = {
       AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.eliza.app",

--- a/packages/cloud/services/gateway-webhook/__tests__/telegram-typing-refresh.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/telegram-typing-refresh.test.ts
@@ -1,0 +1,37 @@
+/** Proves Telegram typing remains visible for the whole in-flight agent turn. */
+import { describe, expect, mock, test } from "bun:test";
+import type {
+  ChatEvent,
+  PlatformAdapter,
+  WebhookConfig,
+} from "../src/adapters/types";
+import { startTypingRefreshLoop } from "../src/webhook-handler";
+
+describe("Telegram typing refresh", () => {
+  test("refreshes until stopped and never overlaps a slow send", async () => {
+    let calls = 0;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const adapter = {
+      platform: "telegram",
+      sendTypingIndicator: mock(async () => {
+        calls += 1;
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 12));
+        inFlight -= 1;
+      }),
+    } as unknown as PlatformAdapter;
+    const event = { platform: "telegram" } as ChatEvent;
+
+    const stop = startTypingRefreshLoop(adapter, {} as WebhookConfig, event, 5);
+    await new Promise((resolve) => setTimeout(resolve, 34));
+    stop();
+    const callsWhenStopped = calls;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(callsWhenStopped).toBeGreaterThanOrEqual(2);
+    expect(calls).toBe(callsWhenStopped);
+    expect(maxInFlight).toBe(1);
+  });
+});

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -7,6 +7,7 @@ import type { GatewayRedis } from "./redis";
 
 const KEDA_COOLDOWN_SECONDS = Number(process.env.KEDA_COOLDOWN_SECONDS ?? 900);
 const FORWARD_TIMEOUT_MS = 30_000;
+const MESSAGE_FORWARD_TIMEOUT_MS = 75_000;
 const RETRY_ATTEMPTS = 5;
 const RETRY_BASE_DELAY_MS = 2_000;
 const RETRY_INCREMENT_MS = 1_000;
@@ -425,6 +426,10 @@ export async function forwardToServer(
     `/agents/${agentId}/message`,
     JSON.stringify(body),
     getCanonicalAgentFallbackTarget(agentId),
+    {
+      timeoutMs: messageForwardTimeoutMs,
+      retryOnTimeout: false,
+    },
   );
   return parseAgentResponse(raw, agentId);
 }
@@ -493,8 +498,26 @@ type TargetResult =
       ok: false;
       error: Error;
       isConnectionError: boolean;
+      timedOut: boolean;
       status?: number;
     };
+
+interface ForwardAttemptPolicy {
+  timeoutMs: number;
+  retryOnTimeout: boolean;
+}
+
+let messageForwardTimeoutMs = MESSAGE_FORWARD_TIMEOUT_MS;
+
+/** Test-only seam for proving timeout behavior without a production-length wait. */
+export const __serverRouterTestHooks = {
+  setMessageForwardTimeoutMs(timeoutMs: number): void {
+    messageForwardTimeoutMs = timeoutMs;
+  },
+  resetMessageForwardTimeoutMs(): void {
+    messageForwardTimeoutMs = MESSAGE_FORWARD_TIMEOUT_MS;
+  },
+} as const;
 
 const RUNTIME_AGENT_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -549,12 +572,14 @@ async function tryCanonicalTarget(
   canonicalTarget: CanonicalAgentFallbackTarget,
   endpointPath: string,
   body: string,
+  policy: ForwardAttemptPolicy,
 ): Promise<TargetResult> {
   const direct = await tryTarget(
     canonicalTarget.baseUrl,
     endpointPath,
     body,
     canonicalTarget.forwardedHost,
+    policy.timeoutMs,
   );
   if (direct.ok || direct.status !== 404) return direct;
 
@@ -569,6 +594,7 @@ async function tryCanonicalTarget(
     `/agents/${encodeURIComponent(runtimeAgentId)}/${match[1]}`,
     body,
     canonicalTarget.forwardedHost,
+    policy.timeoutMs,
   );
 }
 
@@ -585,6 +611,10 @@ async function forwardWithRetry(
   endpointPath: string,
   body: string,
   connectionFallback?: CanonicalAgentFallbackTarget | null,
+  policy: ForwardAttemptPolicy = {
+    timeoutMs: FORWARD_TIMEOUT_MS,
+    retryOnTimeout: true,
+  },
 ): Promise<string> {
   let lastError: Error | null = null;
   let woken = false;
@@ -609,8 +639,17 @@ async function forwardWithRetry(
       continue;
     }
 
-    const result = await tryTarget(targets[0], endpointPath, body);
+    const result = await tryTarget(
+      targets[0],
+      endpointPath,
+      body,
+      undefined,
+      policy.timeoutMs,
+    );
     if (result.ok) return result.response;
+    if (result.timedOut && !policy.retryOnTimeout) {
+      throw result.error;
+    }
 
     // Dedicated sandboxes can remain healthy behind their canonical hostname
     // while an old direct host:port is still being refreshed into Redis. Only
@@ -626,15 +665,28 @@ async function forwardWithRetry(
         connectionFallback,
         endpointPath,
         body,
+        policy,
       );
       if (canonical.ok) return canonical.response;
+      if (canonical.timedOut && !policy.retryOnTimeout) {
+        throw canonical.error;
+      }
       lastError = canonical.error;
     }
 
     if (targets.length > 1) {
       await refreshHashRing(serverUrl);
-      const fallback = await tryTarget(targets[1], endpointPath, body);
+      const fallback = await tryTarget(
+        targets[1],
+        endpointPath,
+        body,
+        undefined,
+        policy.timeoutMs,
+      );
       if (fallback.ok) return fallback.response;
+      if (fallback.timedOut && !policy.retryOnTimeout) {
+        throw fallback.error;
+      }
     }
 
     lastError = result.error;
@@ -659,9 +711,16 @@ async function tryTarget(
   endpointPath: string,
   body: string,
   forwardedHost?: string,
+  timeoutMs = FORWARD_TIMEOUT_MS,
 ): Promise<TargetResult> {
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FORWARD_TIMEOUT_MS);
+  const timeoutId = setTimeout(
+    () =>
+      controller.abort(
+        new Error(`Agent forward timed out after ${timeoutMs}ms`),
+      ),
+    timeoutMs,
+  );
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -695,13 +754,21 @@ async function tryTarget(
       ok: false,
       error: new Error(`Server returned ${res.status}: ${await res.text()}`),
       isConnectionError: false,
+      timedOut: false,
       status: res.status,
     };
   } catch (err) {
+    const timedOut = controller.signal.aborted;
     return {
       ok: false,
-      error: err instanceof Error ? err : new Error(String(err)),
-      isConnectionError: true,
+      error:
+        timedOut && controller.signal.reason instanceof Error
+          ? controller.signal.reason
+          : err instanceof Error
+            ? err
+            : new Error(String(err)),
+      isConnectionError: !timedOut,
+      timedOut,
     };
   } finally {
     clearTimeout(timeoutId);

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -18,10 +18,14 @@ import {
 import { resolveWebhookConfig } from "./webhook-config";
 
 const DEDUP_TTL_SECONDS = 300;
-const PROCESSING_TTL_SECONDS = 60;
+// Must outlive the 75s non-idempotent message-forward budget plus Telegram
+// egress. Otherwise a provider retry can reclaim the update while the first
+// worker is still generating and execute the same user turn twice.
+const PROCESSING_TTL_SECONDS = 120;
 const TELEGRAM_DELIVERY_TTL_SECONDS = 30 * 24 * 60 * 60;
 const TELEGRAM_EGRESS_STARTED = "egress_started";
 const TELEGRAM_DELIVERED = "delivered";
+const TELEGRAM_TYPING_REFRESH_MS = 4_000;
 
 class TelegramEgressAlreadyClaimedError extends Error {
   override readonly name = "TelegramEgressAlreadyClaimedError";
@@ -240,6 +244,8 @@ async function processMessage(
   explicitAgentId?: string,
   beforeEgress?: () => Promise<void>,
 ): Promise<void> {
+  const startedAt = Date.now();
+  let stageStartedAt = startedAt;
   const { redis, cloudBaseUrl, getAuthHeader } = deps;
   const reauth = deps.reacquireAuthHeader ?? reacquireAuthHeader;
   const authHeader = getAuthHeader();
@@ -253,6 +259,8 @@ async function processMessage(
     event.senderName,
     reauth,
   );
+  const identityMs = Date.now() - stageStartedAt;
+  stageStartedAt = Date.now();
 
   if (!identity) {
     logger.info("Identity not linked; routing message to onboarding chat", {
@@ -289,6 +297,7 @@ async function processMessage(
   const server = agentId
     ? await resolveAgentServer(redis, agentId)
     : ({ kind: "unregistered" } as const);
+  const routingMs = Date.now() - stageStartedAt;
 
   if (!agentId || server.kind !== "ready") {
     if (explicitAgentId || server.kind === "unreachable") {
@@ -309,12 +318,18 @@ async function processMessage(
     return;
   }
 
-  adapter.sendTypingIndicator(config, event).catch((err) => {
-    logger.debug("sendTypingIndicator failed", {
-      platform: adapter.platform,
-      error: err instanceof Error ? err.message : String(err),
+  const stopTyping =
+    adapter.platform === "telegram"
+      ? startTypingRefreshLoop(adapter, config, event)
+      : () => undefined;
+  if (adapter.platform !== "telegram") {
+    adapter.sendTypingIndicator(config, event).catch((err) => {
+      logger.debug("sendTypingIndicator failed", {
+        platform: adapter.platform,
+        error: err instanceof Error ? err.message : String(err),
+      });
     });
-  });
+  }
   refreshKedaActivity(redis, server.serverName).catch((err) => {
     logger.warn("refreshKedaActivity failed", {
       serverName: server.serverName,
@@ -323,6 +338,7 @@ async function processMessage(
   });
 
   let responseText: string;
+  stageStartedAt = Date.now();
   try {
     responseText = await forwardToServer(
       server.serverUrl,
@@ -347,7 +363,10 @@ async function processMessage(
       agentId,
     });
     throw err;
+  } finally {
+    stopTyping();
   }
+  const forwardMs = Date.now() - stageStartedAt;
 
   // An empty responseText is a deliberate no-response from the agent (mute /
   // shouldRespond=no), not content: forwarding it would make platform adapters
@@ -364,8 +383,20 @@ async function processMessage(
   }
 
   try {
+    stageStartedAt = Date.now();
     await beforeEgress?.();
     await adapter.sendReply(config, event, responseText);
+    logger.info("Connector message completed", {
+      project,
+      platform: adapter.platform,
+      agentId,
+      messageId: event.messageId,
+      identityMs,
+      routingMs,
+      forwardMs,
+      egressMs: Date.now() - stageStartedAt,
+      totalMs: Date.now() - startedAt,
+    });
   } catch (err) {
     logger.error("Failed to send reply", {
       error: err instanceof Error ? err.message : String(err),
@@ -373,6 +404,45 @@ async function processMessage(
     });
     throw err;
   }
+}
+
+/**
+ * Telegram expires a `typing` action after roughly five seconds. Refresh it
+ * while the agent turn is in flight so a slow but healthy response never looks
+ * like a dead bot. The loop is presentation-only and never enters the egress
+ * dedupe boundary.
+ */
+export function startTypingRefreshLoop(
+  adapter: PlatformAdapter,
+  config: WebhookConfig,
+  event: ChatEvent,
+  intervalMs = TELEGRAM_TYPING_REFRESH_MS,
+): () => void {
+  let stopped = false;
+  let sending = false;
+
+  const send = async (): Promise<void> => {
+    if (stopped || sending) return;
+    sending = true;
+    try {
+      await adapter.sendTypingIndicator(config, event);
+    } catch (err) {
+      logger.debug("sendTypingIndicator failed", {
+        platform: adapter.platform,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      sending = false;
+    }
+  };
+
+  void send();
+  const timer = setInterval(() => void send(), intervalMs);
+  timer.unref?.();
+  return () => {
+    stopped = true;
+    clearInterval(timer);
+  };
 }
 
 async function sendOnboardingReply(


### PR DESCRIPTION
## Summary

- give non-idempotent connector messages a 75-second response budget and never replay them after a response timeout
- keep the Telegram processing claim alive beyond that budget to prevent provider retry races
- refresh Telegram typing every four seconds without overlapping sends
- log PII-free identity, routing, forwarding, egress, and total stage timings

Closes #19519

## Production baseline

Three real Telegram DM webhook probes through the production BFF, gateway, agent, and Telegram egress took 44.474s, 38.899s, and 39.283s. Each crossed the old 30-second gateway deadline, which replayed an already in-flight agent turn. The same production agent model endpoint answered directly in 1.241s.

Post-deploy timing is pending the protected staging deployment because gateway-webhook releases may only run from develop or main through deploy-gateway-webhook.yml.

## Verification

- bun run --cwd packages/cloud/services/gateway-webhook test: 117 pass, 0 fail
- bun run --cwd packages/cloud/services/gateway-webhook typecheck: pass
- bun run --cwd packages/cloud/services/gateway-webhook lint: pass
- bun run --cwd packages/cloud/services/gateway-webhook build: pass
- git diff origin/develop...HEAD --check: pass
- bun run verify: blocked by current develop failures in packages/test scenarios: missing Node process types and unresolved @elizaos/agent declarations; gateway tasks pass

## Evidence matrix

- Desktop/mobile screenshots: N/A, backend-only connector change
- UI walkthrough video: N/A, no UI surface changed
- Browser console/network logs: N/A, Telegram webhook path
- Backend evidence: production timing samples above; post-deploy canary pending protected release
- Live model trajectory: direct production model probe measured 1.241s; message-path timing is captured above

## Contribution provenance

- AI provider/model: OpenAI / gpt-5
- Client / agent tooling: Codex desktop
- Contribution skill revision: elizaOS/eliza@acb1b6cdc6113eb8a5437eb6c8568201cb807f79:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported

<!-- evidence-head:a3b0964d66d89b3a7ff5a50ecf5200a9e95aa398 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only gateway behavior; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only gateway behavior; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Telegram webhook path has no repository UI surface

<!-- evidence-row:backend-logs -->
- [x] [19524-telegram-gateway-production-baseline-structured.jsonl](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19524-telegram-gateway-production-baseline-structured.jsonl)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - Telegram webhook path has no browser frontend

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model prompt, response, or agent behavior changed; the direct model request was diagnostic timing only

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no image, audio, PDF, or domain artifact is produced by this connector change

— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@acb1b6cdc6113eb8a5437eb6c8568201cb807f79:packages/skills/skills/contribute-to-eliza"} -->


