### PR TITLE
fix(cloud): backport Telegram DM latency bound to production

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
@@ -1,6 +1,7 @@
 /** Exercises the real forwarding boundary with deterministic network responses. */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
+  __serverRouterTestHooks,
   forwardToServer,
   getCanonicalAgentFallbackBase,
   getCanonicalAgentFallbackTarget,
@@ -24,9 +25,36 @@ function domainWithLength(length: number): string {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  __serverRouterTestHooks.resetMessageForwardTimeoutMs();
 });
 
 describe("canonical agent forwarding fallback", () => {
+  test("does not replay a non-idempotent message after its response times out", async () => {
+    __serverRouterTestHooks.setMessageForwardTimeoutMs(10);
+    let requests = 0;
+    globalThis.fetch = mock(
+      async (_input: string | URL | Request, init?: RequestInit) => {
+        requests += 1;
+        return await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason);
+          });
+        });
+      },
+    ) as typeof fetch;
+
+    await expect(
+      forwardToServer(
+        "http://slow-agent.example/api",
+        "slow-agent",
+        AGENT_ID,
+        "user-1",
+        "hello once",
+      ),
+    ).rejects.toThrow("Agent forward timed out after 10ms");
+    expect(requests).toBe(1);
+  });
+
   test("derives a fixed-domain fallback only for UUID agent ids", () => {
     expect(getCanonicalAgentFallbackBase(AGENT_ID)).toBe(
       `https://${AGENT_ID}.elizacloud.ai/api`,

--- a/packages/cloud/services/gateway-webhook/__tests__/telegram-typing-refresh.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/telegram-typing-refresh.test.ts
@@ -1,0 +1,37 @@
+/** Proves Telegram typing remains visible for the whole in-flight agent turn. */
+import { describe, expect, mock, test } from "bun:test";
+import type {
+  ChatEvent,
+  PlatformAdapter,
+  WebhookConfig,
+} from "../src/adapters/types";
+import { startTypingRefreshLoop } from "../src/webhook-handler";
+
+describe("Telegram typing refresh", () => {
+  test("refreshes until stopped and never overlaps a slow send", async () => {
+    let calls = 0;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const adapter = {
+      platform: "telegram",
+      sendTypingIndicator: mock(async () => {
+        calls += 1;
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 12));
+        inFlight -= 1;
+      }),
+    } as unknown as PlatformAdapter;
+    const event = { platform: "telegram" } as ChatEvent;
+
+    const stop = startTypingRefreshLoop(adapter, {} as WebhookConfig, event, 5);
+    await new Promise((resolve) => setTimeout(resolve, 34));
+    stop();
+    const callsWhenStopped = calls;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(callsWhenStopped).toBeGreaterThanOrEqual(2);
+    expect(calls).toBe(callsWhenStopped);
+    expect(maxInFlight).toBe(1);
+  });
+});

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -7,6 +7,7 @@ import type { GatewayRedis } from "./redis";
 
 const KEDA_COOLDOWN_SECONDS = Number(process.env.KEDA_COOLDOWN_SECONDS ?? 900);
 const FORWARD_TIMEOUT_MS = 30_000;
+const MESSAGE_FORWARD_TIMEOUT_MS = 75_000;
 const RETRY_ATTEMPTS = 5;
 const RETRY_BASE_DELAY_MS = 2_000;
 const RETRY_INCREMENT_MS = 1_000;
@@ -388,6 +389,10 @@ export async function forwardToServer(
     `/agents/${agentId}/message`,
     JSON.stringify(body),
     getCanonicalAgentFallbackTarget(agentId),
+    {
+      timeoutMs: messageForwardTimeoutMs,
+      retryOnTimeout: false,
+    },
   );
   return parseAgentResponse(raw, agentId);
 }
@@ -456,8 +461,26 @@ type TargetResult =
       ok: false;
       error: Error;
       isConnectionError: boolean;
+      timedOut: boolean;
       status?: number;
     };
+
+interface ForwardAttemptPolicy {
+  timeoutMs: number;
+  retryOnTimeout: boolean;
+}
+
+let messageForwardTimeoutMs = MESSAGE_FORWARD_TIMEOUT_MS;
+
+/** Test-only seam for proving timeout behavior without a production-length wait. */
+export const __serverRouterTestHooks = {
+  setMessageForwardTimeoutMs(timeoutMs: number): void {
+    messageForwardTimeoutMs = timeoutMs;
+  },
+  resetMessageForwardTimeoutMs(): void {
+    messageForwardTimeoutMs = MESSAGE_FORWARD_TIMEOUT_MS;
+  },
+} as const;
 
 const RUNTIME_AGENT_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -512,12 +535,14 @@ async function tryCanonicalTarget(
   canonicalTarget: CanonicalAgentFallbackTarget,
   endpointPath: string,
   body: string,
+  policy: ForwardAttemptPolicy,
 ): Promise<TargetResult> {
   const direct = await tryTarget(
     canonicalTarget.baseUrl,
     endpointPath,
     body,
     canonicalTarget.forwardedHost,
+    policy.timeoutMs,
   );
   if (direct.ok || direct.status !== 404) return direct;
 
@@ -532,6 +557,7 @@ async function tryCanonicalTarget(
     `/agents/${encodeURIComponent(runtimeAgentId)}/${match[1]}`,
     body,
     canonicalTarget.forwardedHost,
+    policy.timeoutMs,
   );
 }
 
@@ -548,6 +574,10 @@ async function forwardWithRetry(
   endpointPath: string,
   body: string,
   connectionFallback?: CanonicalAgentFallbackTarget | null,
+  policy: ForwardAttemptPolicy = {
+    timeoutMs: FORWARD_TIMEOUT_MS,
+    retryOnTimeout: true,
+  },
 ): Promise<string> {
   let lastError: Error | null = null;
   let woken = false;
@@ -572,8 +602,17 @@ async function forwardWithRetry(
       continue;
     }
 
-    const result = await tryTarget(targets[0], endpointPath, body);
+    const result = await tryTarget(
+      targets[0],
+      endpointPath,
+      body,
+      undefined,
+      policy.timeoutMs,
+    );
     if (result.ok) return result.response;
+    if (result.timedOut && !policy.retryOnTimeout) {
+      throw result.error;
+    }
 
     // Dedicated sandboxes can remain healthy behind their canonical hostname
     // while an old direct host:port is still being refreshed into Redis. Only
@@ -589,15 +628,28 @@ async function forwardWithRetry(
         connectionFallback,
         endpointPath,
         body,
+        policy,
       );
       if (canonical.ok) return canonical.response;
+      if (canonical.timedOut && !policy.retryOnTimeout) {
+        throw canonical.error;
+      }
       lastError = canonical.error;
     }
 
     if (targets.length > 1) {
       await refreshHashRing(serverUrl);
-      const fallback = await tryTarget(targets[1], endpointPath, body);
+      const fallback = await tryTarget(
+        targets[1],
+        endpointPath,
+        body,
+        undefined,
+        policy.timeoutMs,
+      );
       if (fallback.ok) return fallback.response;
+      if (fallback.timedOut && !policy.retryOnTimeout) {
+        throw fallback.error;
+      }
     }
 
     lastError = result.error;
@@ -622,9 +674,16 @@ async function tryTarget(
   endpointPath: string,
   body: string,
   forwardedHost?: string,
+  timeoutMs = FORWARD_TIMEOUT_MS,
 ): Promise<TargetResult> {
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FORWARD_TIMEOUT_MS);
+  const timeoutId = setTimeout(
+    () =>
+      controller.abort(
+        new Error(`Agent forward timed out after ${timeoutMs}ms`),
+      ),
+    timeoutMs,
+  );
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -658,13 +717,21 @@ async function tryTarget(
       ok: false,
       error: new Error(`Server returned ${res.status}: ${await res.text()}`),
       isConnectionError: false,
+      timedOut: false,
       status: res.status,
     };
   } catch (err) {
+    const timedOut = controller.signal.aborted;
     return {
       ok: false,
-      error: err instanceof Error ? err : new Error(String(err)),
-      isConnectionError: true,
+      error:
+        timedOut && controller.signal.reason instanceof Error
+          ? controller.signal.reason
+          : err instanceof Error
+            ? err
+            : new Error(String(err)),
+      isConnectionError: !timedOut,
+      timedOut,
     };
   } finally {
     clearTimeout(timeoutId);

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -18,10 +18,14 @@ import {
 import { resolveWebhookConfig } from "./webhook-config";
 
 const DEDUP_TTL_SECONDS = 300;
-const PROCESSING_TTL_SECONDS = 60;
+// Must outlive the 75s non-idempotent message-forward budget plus Telegram
+// egress. Otherwise a provider retry can reclaim the update while the first
+// worker is still generating and execute the same user turn twice.
+const PROCESSING_TTL_SECONDS = 120;
 const TELEGRAM_DELIVERY_TTL_SECONDS = 30 * 24 * 60 * 60;
 const TELEGRAM_EGRESS_STARTED = "egress_started";
 const TELEGRAM_DELIVERED = "delivered";
+const TELEGRAM_TYPING_REFRESH_MS = 4_000;
 
 class TelegramEgressAlreadyClaimedError extends Error {
   override readonly name = "TelegramEgressAlreadyClaimedError";
@@ -240,6 +244,8 @@ async function processMessage(
   explicitAgentId?: string,
   beforeEgress?: () => Promise<void>,
 ): Promise<void> {
+  const startedAt = Date.now();
+  let stageStartedAt = startedAt;
   const { redis, cloudBaseUrl, getAuthHeader } = deps;
   const reauth = deps.reacquireAuthHeader ?? reacquireAuthHeader;
   const authHeader = getAuthHeader();
@@ -253,6 +259,8 @@ async function processMessage(
     event.senderName,
     reauth,
   );
+  const identityMs = Date.now() - stageStartedAt;
+  stageStartedAt = Date.now();
 
   if (!identity) {
     logger.info("Identity not linked; routing message to onboarding chat", {
@@ -289,6 +297,7 @@ async function processMessage(
   const server = agentId
     ? await resolveAgentServer(redis, agentId)
     : ({ kind: "unregistered" } as const);
+  const routingMs = Date.now() - stageStartedAt;
 
   if (!agentId || server.kind !== "ready") {
     if (explicitAgentId || server.kind === "unreachable") {
@@ -309,12 +318,18 @@ async function processMessage(
     return;
   }
 
-  adapter.sendTypingIndicator(config, event).catch((err) => {
-    logger.debug("sendTypingIndicator failed", {
-      platform: adapter.platform,
-      error: err instanceof Error ? err.message : String(err),
+  const stopTyping =
+    adapter.platform === "telegram"
+      ? startTypingRefreshLoop(adapter, config, event)
+      : () => undefined;
+  if (adapter.platform !== "telegram") {
+    adapter.sendTypingIndicator(config, event).catch((err) => {
+      logger.debug("sendTypingIndicator failed", {
+        platform: adapter.platform,
+        error: err instanceof Error ? err.message : String(err),
+      });
     });
-  });
+  }
   refreshKedaActivity(redis, server.serverName).catch((err) => {
     logger.warn("refreshKedaActivity failed", {
       serverName: server.serverName,
@@ -323,6 +338,7 @@ async function processMessage(
   });
 
   let responseText: string;
+  stageStartedAt = Date.now();
   try {
     responseText = await forwardToServer(
       server.serverUrl,
@@ -347,7 +363,10 @@ async function processMessage(
       agentId,
     });
     throw err;
+  } finally {
+    stopTyping();
   }
+  const forwardMs = Date.now() - stageStartedAt;
 
   // An empty responseText is a deliberate no-response from the agent (mute /
   // shouldRespond=no), not content: forwarding it would make platform adapters
@@ -364,8 +383,20 @@ async function processMessage(
   }
 
   try {
+    stageStartedAt = Date.now();
     await beforeEgress?.();
     await adapter.sendReply(config, event, responseText);
+    logger.info("Connector message completed", {
+      project,
+      platform: adapter.platform,
+      agentId,
+      messageId: event.messageId,
+      identityMs,
+      routingMs,
+      forwardMs,
+      egressMs: Date.now() - stageStartedAt,
+      totalMs: Date.now() - startedAt,
+    });
   } catch (err) {
     logger.error("Failed to send reply", {
       error: err instanceof Error ? err.message : String(err),
@@ -373,6 +404,45 @@ async function processMessage(
     });
     throw err;
   }
+}
+
+/**
+ * Telegram expires a `typing` action after roughly five seconds. Refresh it
+ * while the agent turn is in flight so a slow but healthy response never looks
+ * like a dead bot. The loop is presentation-only and never enters the egress
+ * dedupe boundary.
+ */
+export function startTypingRefreshLoop(
+  adapter: PlatformAdapter,
+  config: WebhookConfig,
+  event: ChatEvent,
+  intervalMs = TELEGRAM_TYPING_REFRESH_MS,
+): () => void {
+  let stopped = false;
+  let sending = false;
+
+  const send = async (): Promise<void> => {
+    if (stopped || sending) return;
+    sending = true;
+    try {
+      await adapter.sendTypingIndicator(config, event);
+    } catch (err) {
+      logger.debug("sendTypingIndicator failed", {
+        platform: adapter.platform,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      sending = false;
+    }
+  };
+
+  void send();
+  const timer = setInterval(() => void send(), intervalMs);
+  timer.unref?.();
+  return () => {
+    stopped = true;
+    clearInterval(timer);
+  };
 }
 
 async function sendOnboardingReply(


### PR DESCRIPTION
## Summary

Production hotfix backport of #19524, already merged and validated on develop.

- stop replaying non-idempotent connector messages after response timeout
- extend the message forward and processing-claim budgets
- keep Telegram typing visible throughout the turn
- emit PII-free stage timing logs

Related to #19519.

## Why main

The protected gateway-webhook production workflow accepts only main. This backport contains exactly the four files from the merged develop fix and avoids releasing unrelated develop changes.

## Verification

- bun run --cwd packages/cloud/services/gateway-webhook test: 109 pass, 0 fail on main
- bun run --cwd packages/cloud/services/gateway-webhook typecheck: pass
- bun run --cwd packages/cloud/services/gateway-webhook lint: pass
- bun run --cwd packages/cloud/services/gateway-webhook build: pass
- git diff origin/main...HEAD --check: pass

## Contribution provenance

- AI provider/model: OpenAI / gpt-5
- Client / agent tooling: Codex desktop
- Contribution skill revision: elizaOS/eliza@acb1b6cdc6113eb8a5437eb6c8568201cb807f79:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported

<!-- evidence-head:c5be90cf9e82ca733ecb570da72153c9e925ca11 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only gateway behavior; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only gateway behavior; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Telegram webhook path has no repository UI surface

<!-- evidence-row:backend-logs -->
- [x] [19525-telegram-gateway-production-baseline-structured.jsonl](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19525-telegram-gateway-production-baseline-structured.jsonl)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - Telegram webhook path has no browser frontend

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model prompt, response, or agent behavior changed; the direct model request was diagnostic timing only

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no image, audio, PDF, or domain artifact is produced by this connector change

— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@acb1b6cdc6113eb8a5437eb6c8568201cb807f79:packages/skills/skills/contribute-to-eliza"} -->
