### PR TITLE
test(ui): restamp stale settings BrandCard leftover catalog

### DIFF
--- a/packages/ui/src/components/settings/settings-dashboard-leftovers.test.ts
+++ b/packages/ui/src/components/settings/settings-dashboard-leftovers.test.ts
@@ -34,24 +34,8 @@ const SETTINGS_MOUNTED_DIRS = [
  */
 const BRANDCARD_ALLOWLIST = new Map<string, string>([
   [
-    "cloud/account-security/components/profile-form.tsx",
-    "account name/email save-cancel form (next 1:1 SettingsInputRow class)",
-  ],
-  [
-    "cloud/account-security/components/incident-report-panel.tsx",
-    "incident textarea + submit + mailto form (next SettingsTextareaRow class)",
-  ],
-  [
-    "cloud/account-security/components/mfa-panel.tsx",
-    "pending #19497 status-only SettingsRow conversion",
-  ],
-  [
-    "cloud/account-security/components/recent-audit-events.tsx",
-    "pending #19497 unavailable SettingsRow conversion",
-  ],
-  [
     "cloud/billing/components/pay-as-you-go-card.tsx",
-    "pending #19497 SettingsStack wrapper around SettingsSwitchRow",
+    "BrandCard wrap around an already-converted SettingsSwitchRow",
   ],
   [
     "cloud/billing/components/auto-top-up-card.tsx",
@@ -67,7 +51,7 @@ const BRANDCARD_ALLOWLIST = new Map<string, string>([
   ],
   [
     "cloud/organization/organization-tab.tsx",
-    "org hero tile + tabs; empty state pending #19497",
+    "org hero tile + tabs; empty state already converted",
   ],
   [
     "cloud/monetization/affiliates/AffiliatesPageClient.tsx",


### PR DESCRIPTION
# Relates to

Closes #19526

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, rebased onto latest `origin/develop`.
- [ ] `bun run verify` not run for the whole monorepo.
- [x] Reviewer can confirm from the allowlist diff and the catalog test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d1f678d57bcef9835014e457e80a9a85504932ed:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop`.
- [ ] `bun run verify` not run for the whole monorepo.

# Risks

None. Test-only catalog restamp.

# Background

## What does this PR do?

Drops leftover-catalog allowlist rows for converted profile, incident, MFA, and audit surfaces. Remaining rows are payg wrap, billing multi-field/hero/table, org hero, monetization cards.

## What kind of change is this?

Updates

# Documentation changes needed?

No.

# Testing

```bash
bun run --cwd packages/ui test -- src/components/settings/settings-dashboard-leftovers.test.ts
```

# Evidence Gate

<!-- evidence-head:145e33a1dd736449682f268f58b6332590fe1b97 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only catalog, no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only catalog, no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only catalog, no rendered UI surface.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or API path is changed.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no rendered frontend surface.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, wallet, scheduled-task, or generated domain artifact is involved.
<!-- evidence-row:ocr-review -->
- [ ] N/A - test-only catalog, no rendered UI surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Known gaps / failures

- Full-repo verify not run.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok-cli
Contribution skill revision: elizaOS/eliza@d1f678d57bcef9835014e457e80a9a85504932ed:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-4.6]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-cli","skill_revision":"elizaOS/eliza@d1f678d57bcef9835014e457e80a9a85504932ed:packages/skills/skills/contribute-to-eliza"} -->


## Maintainer exact-head audit

Rebased patch-identically onto `develop@5a249cd99d76ed7c70cc23c7e89bc6aaabd39b1a`. Exact-head proof: focused catalog test 3/3, full UI typecheck, UI lint over 2,973 files (eight pre-existing cookie warnings only), changed-file Biome, guide parity (153 pairs), and `git diff --check` all pass. The change removes only stale test allowlist rows; no runtime or rendered source changes.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@5a249cd99d76ed7c70cc23c7e89bc6aaabd39b1a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@5a249cd99d76ed7c70cc23c7e89bc6aaabd39b1a:packages/skills/skills/contribute-to-eliza"} -->

