### PR TITLE
fix(cloud): backport protected gateway deployment path

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -60,6 +60,42 @@ the `pr.yaml` title check cover narrower contracts. None replaces the
   `pages-domains` Terraform plan. That root owns the exact provider-generated
   CNAME/TXT values as DNS-only records and imports existing records only by
   reviewed Cloudflare id.
+- `deploy-gateway-webhook.yml` is the protected Railway release path for the
+  multi-platform webhook gateway. Staging dispatches must select `develop` and
+  production dispatches must select `main`. The workflow validates the exact
+  protected Railway project, environment, service, and public URL; uploads the
+  exact dispatch SHA from the repository root with a byte-identical root copy
+  of the tracked service `railway.toml`; follows the returned deployment id to
+  success; proves that exact id remains active around the public probes; and
+  verifies the applied Dockerfile/health manifest, live health, and canonical
+  cloud/agent fallback routing pair. It also sends a headerless `GET` to the
+  dedicated `/ready/forwarder-auth/eliza-app` contract and requires the exact
+  enforced-gate 401 response before reasserting the active deployment. A
+  disabled secret or mismatched forwarded project produces a distinct non-401
+  readiness failure; the probe never enters provider or message handling and
+  refuses supplied forwarder-secret headers without comparing them. Configure
+  environment variables
+  `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT_ID`,
+  `RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK`, and
+  `ELIZA_APP_WEBHOOK_GATEWAY_URL`, with `RAILWAY_TOKEN` as an environment
+  secret. Existing sensitive service values stay in Railway and are checked by
+  name without being printed or rewritten, including the required
+  `ELIZA_APP_WEBHOOK_GATEWAY_SECRET` BFF-forwarding trust gate. Staging is
+  protected by the workflow's exact `develop` branch and environment-scoped
+  configuration gates but does not currently require a reviewer; production
+  retains its required-reviewer approval.
+
+  The dispatch choice and selected GitHub Environment use the same exact name;
+  Railway service names are separate targets:
+
+  | Dispatch / GitHub Environment | Source branch | Railway service |
+  | --- | --- | --- |
+  | `staging` | `develop` | `gateway-webhook-stg` |
+  | `production` | `main` | `gateway-webhook` |
+
+  The pinned Railway CLI is invoked without a relative path so its explicit
+  project selector archives the absolute current repository root. Passing `.`
+  with Railway CLI v5.38.0 fails its pre-upload archive-prefix check.
 - `voice-code-bench.yml` retains the bounded real-ASR benchmark.
 
 These workflows use `workflow_dispatch` and never run for pull requests.

--- a/.github/workflows/deploy-gateway-webhook.yml
+++ b/.github/workflows/deploy-gateway-webhook.yml
@@ -1,0 +1,530 @@
+name: Deploy Gateway Webhook
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Protected environment to deploy
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-gateway-webhook-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy gateway webhook (${{ inputs.environment }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    environment: ${{ inputs.environment }}
+    env:
+      TARGET_ENVIRONMENT: ${{ inputs.environment }}
+      DEPLOY_BRANCH: ${{ inputs.environment == 'production' && 'main' || 'develop' }}
+      EXPECTED_SERVICE_NAME: ${{ inputs.environment == 'production' && 'gateway-webhook' || 'gateway-webhook-stg' }}
+      EXPECTED_CLOUD_URL: ${{ inputs.environment == 'production' && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
+      EXPECTED_ROUTER_ORIGIN: ${{ inputs.environment == 'production' && 'eliza-production-1.eliza.app' || 'eliza-staging-1.eliza.app' }}
+      EXPECTED_AGENT_BASE_DOMAIN: ${{ inputs.environment == 'production' && 'cloud.eliza.app' || 'cloud-staging.eliza.app' }}
+      EXPECTED_GATEWAY_URL: ${{ inputs.environment == 'production' && 'https://gateway-webhook-production.up.railway.app' || 'https://gateway-webhook-stg-staging.up.railway.app' }}
+      GATEWAY_WEBHOOK_URL: ${{ vars.ELIZA_APP_WEBHOOK_GATEWAY_URL }}
+      RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+      RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK }}
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate protected canonical configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_settings=(
+            TARGET_ENVIRONMENT
+            DEPLOY_BRANCH
+            EXPECTED_SERVICE_NAME
+            EXPECTED_CLOUD_URL
+            EXPECTED_ROUTER_ORIGIN
+            EXPECTED_AGENT_BASE_DOMAIN
+            EXPECTED_GATEWAY_URL
+            GATEWAY_WEBHOOK_URL
+            RAILWAY_PROJECT_ID
+            RAILWAY_ENVIRONMENT_ID
+            RAILWAY_SERVICE_ID
+            RAILWAY_TOKEN
+          )
+          missing=()
+          for name in "${required_settings[@]}"; do
+            value="${!name:-}"
+            if [ -z "${value//[[:space:]]/}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required gateway-webhook setting name(s) on the protected $TARGET_ENVIRONMENT environment: ${missing[*]}"
+            exit 1
+          fi
+
+          case "$TARGET_ENVIRONMENT" in
+            staging | production) ;;
+            *)
+              echo "::error::Unsupported protected environment"
+              exit 1
+              ;;
+          esac
+
+          require_exact() {
+            local name="$1"
+            local actual="$2"
+            local expected="$3"
+            if [ "$actual" != "$expected" ]; then
+              echo "::error::$name does not match the canonical $TARGET_ENVIRONMENT gateway-webhook contract"
+              exit 1
+            fi
+          }
+
+          require_exact GITHUB_REF "$GITHUB_REF" "refs/heads/$DEPLOY_BRANCH"
+          require_exact GATEWAY_WEBHOOK_URL "$GATEWAY_WEBHOOK_URL" "$EXPECTED_GATEWAY_URL"
+          require_exact CHECKED_OUT_SHA "$(git rev-parse HEAD)" "$GITHUB_SHA"
+          if [ -n "$(git status --porcelain --untracked-files=all)" ]; then
+            echo "::error::The checkout is not an exact clean source tree"
+            exit 1
+          fi
+
+          for name in RAILWAY_PROJECT_ID RAILWAY_ENVIRONMENT_ID RAILWAY_SERVICE_ID; do
+            value="${!name}"
+            if [[ ! "$value" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+              echo "::error::$name must be a Railway UUID on the protected $TARGET_ENVIRONMENT environment"
+              exit 1
+            fi
+          done
+          echo "Canonical protected setting names, branch, and exact source SHA are valid; secret values were not printed."
+
+      - name: Install pinned Railway CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          cli_root="$RUNNER_TEMP/railway-cli"
+          archive="$RUNNER_TEMP/railway-v5.38.0.tar.gz"
+          mkdir -p "$cli_root"
+          curl \
+            --fail \
+            --location \
+            --silent \
+            --show-error \
+            --retry 3 \
+            --output "$archive" \
+            "https://github.com/railwayapp/cli/releases/download/v5.38.0/railway-v5.38.0-x86_64-unknown-linux-gnu.tar.gz"
+          printf '%s  %s\n' \
+            "72835c48a710c48c4542141bf12264823cf3a029b514f9e27994096c036c539e" \
+            "$archive" | sha256sum --check --status
+          tar -xzf "$archive" -C "$cli_root" railway
+          chmod 0755 "$cli_root/railway"
+          echo "$cli_root" >> "$GITHUB_PATH"
+          "$cli_root/railway" --version | grep -F "railway 5.38.0"
+
+      - name: Verify exact Railway target and public domain
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          status_path="$RUNNER_TEMP/gateway-webhook-railway-status.json"
+          domains_path="$RUNNER_TEMP/gateway-webhook-railway-domains.json"
+          railway status \
+            --project "$RAILWAY_PROJECT_ID" \
+            --environment "$RAILWAY_ENVIRONMENT_ID" \
+            --json > "$status_path"
+
+          jq -e --arg id "$RAILWAY_PROJECT_ID" '.id == $id' "$status_path" >/dev/null || {
+            echo "::error::RAILWAY_PROJECT_ID did not resolve to the selected project"
+            exit 1
+          }
+          jq -e \
+            --arg id "$RAILWAY_ENVIRONMENT_ID" \
+            --arg name "$TARGET_ENVIRONMENT" \
+            'any(.environments.edges[]; .node.id == $id and .node.name == $name)' \
+            "$status_path" >/dev/null || {
+            echo "::error::RAILWAY_ENVIRONMENT_ID is not the canonical $TARGET_ENVIRONMENT Railway environment"
+            exit 1
+          }
+          jq -e \
+            --arg id "$RAILWAY_SERVICE_ID" \
+            --arg name "$EXPECTED_SERVICE_NAME" \
+            'any(.services.edges[]; .node.id == $id and .node.name == $name)' \
+            "$status_path" >/dev/null || {
+            echo "::error::RAILWAY_SERVICE_ID is not the canonical $EXPECTED_SERVICE_NAME service"
+            exit 1
+          }
+
+          railway domain list \
+            --project "$RAILWAY_PROJECT_ID" \
+            --environment "$RAILWAY_ENVIRONMENT_ID" \
+            --service "$RAILWAY_SERVICE_ID" \
+            --json > "$domains_path"
+          gateway_host="${GATEWAY_WEBHOOK_URL#https://}"
+          jq -e --arg domain "$gateway_host" \
+            'any(.domains[]; .domain == $domain)' \
+            "$domains_path" >/dev/null || {
+            echo "::error::The selected service does not own the protected canonical gateway domain"
+            exit 1
+          }
+          echo "Railway project, environment, service, and public domain identities match."
+
+      - name: Verify canonical Railway variables and sensitive names
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          variables_raw_path="$RUNNER_TEMP/gateway-webhook-railway-variables-raw.json"
+          variables_path="$RUNNER_TEMP/gateway-webhook-railway-variable-inventory.json"
+          railway variable list \
+            --project "$RAILWAY_PROJECT_ID" \
+            --environment "$RAILWAY_ENVIRONMENT_ID" \
+            --service "$RAILWAY_SERVICE_ID" \
+            --json > "$variables_raw_path"
+          jq '{
+            canonical: {
+              ELIZA_CLOUD_URL: .ELIZA_CLOUD_URL,
+              AGENT_ROUTER_ORIGIN_HOST: .AGENT_ROUTER_ORIGIN_HOST,
+              ELIZA_CLOUD_AGENT_BASE_DOMAIN: .ELIZA_CLOUD_AGENT_BASE_DOMAIN
+            },
+            nonblank_sensitive_names: [
+              to_entries[] |
+              select(.value | type == "string" and length > 0) |
+              .key
+            ]
+          }' "$variables_raw_path" > "$variables_path"
+          shred -u "$variables_raw_path"
+
+          require_exact_variable() {
+            local name="$1"
+            local expected="$2"
+            if ! jq -e --arg name "$name" --arg expected "$expected" \
+              '.canonical[$name] == $expected' "$variables_path" >/dev/null; then
+              echo "::error::$name does not match the canonical $TARGET_ENVIRONMENT Railway value"
+              exit 1
+            fi
+          }
+          require_sensitive_name() {
+            local name="$1"
+            if ! jq -e --arg name "$name" \
+              '.nonblank_sensitive_names | index($name) != null' \
+              "$variables_path" >/dev/null; then
+              echo "::error::Required sensitive Railway variable name is absent or blank: $name"
+              exit 1
+            fi
+          }
+
+          require_exact_variable ELIZA_CLOUD_URL "$EXPECTED_CLOUD_URL"
+          require_exact_variable AGENT_ROUTER_ORIGIN_HOST "$EXPECTED_ROUTER_ORIGIN"
+          require_exact_variable ELIZA_CLOUD_AGENT_BASE_DOMAIN "$EXPECTED_AGENT_BASE_DOMAIN"
+          for name in \
+            GATEWAY_BOOTSTRAP_SECRET \
+            GATEWAY_INTERNAL_SECRET \
+            AGENT_SERVER_SHARED_SECRET \
+            ELIZA_APP_WEBHOOK_GATEWAY_SECRET; do
+            require_sensitive_name "$name"
+          done
+          if ! jq -e '.nonblank_sensitive_names as $names |
+            (($names | index("REDIS_URL")) != null or
+             ((($names | index("KV_REST_API_URL")) != null) and
+              (($names | index("KV_REST_API_TOKEN")) != null)))' \
+            "$variables_path" >/dev/null; then
+            echo "::error::Required sensitive Railway variable names must include REDIS_URL or the KV_REST_API_URL/KV_REST_API_TOKEN pair"
+            exit 1
+          fi
+          echo "Canonical routing values and required sensitive variable names are present; sensitive values were not printed or changed."
+
+      - name: Capture deployment baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          railway deployment list \
+            --project "$RAILWAY_PROJECT_ID" \
+            --environment "$RAILWAY_ENVIRONMENT_ID" \
+            --service "$RAILWAY_SERVICE_ID" \
+            --limit 50 \
+            --json > "$RUNNER_TEMP/gateway-webhook-deployment-baseline.json"
+
+      - name: Deploy exact gateway-webhook source
+        id: railway_deploy
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$(git rev-parse HEAD)" != "$GITHUB_SHA" ] || \
+            [ -n "$(git status --porcelain --untracked-files=all)" ]; then
+            echo "::error::Refusing to deploy anything other than the exact clean dispatch SHA"
+            exit 1
+          fi
+          git ls-files --error-unmatch \
+            packages/cloud/services/gateway-webhook/Dockerfile \
+            packages/cloud/services/gateway-webhook/railway.toml \
+            packages/cloud/services/gateway-webhook/src/index.ts >/dev/null
+          if [ -e railway.toml ] || [ -L railway.toml ]; then
+            echo "::error::The checkout root already contains an unexpected Railway config"
+            exit 1
+          fi
+          cp packages/cloud/services/gateway-webhook/railway.toml railway.toml
+          if ! cmp --silent \
+            packages/cloud/services/gateway-webhook/railway.toml \
+            railway.toml; then
+            echo "::error::The materialized root Railway config differs from the tracked service manifest"
+            exit 1
+          fi
+          if [ "$(git status --porcelain --untracked-files=all)" != "?? railway.toml" ]; then
+            echo "::error::Only the byte-identical root Railway config may differ from the exact dispatch SHA"
+            exit 1
+          fi
+          grep -Fx 'dockerfilePath = "packages/cloud/services/gateway-webhook/Dockerfile"' \
+            railway.toml >/dev/null
+          grep -Fx 'healthcheckPath = "/health"' \
+            railway.toml >/dev/null
+
+          umask 077
+          result_path="$RUNNER_TEMP/gateway-webhook-deployment-start.json"
+          railway up \
+            --project "$RAILWAY_PROJECT_ID" \
+            --environment "$RAILWAY_ENVIRONMENT_ID" \
+            --service "$RAILWAY_SERVICE_ID" \
+            --detach \
+            --yes \
+            --json \
+            --message "gateway-webhook $GITHUB_SHA ($TARGET_ENVIRONMENT)" > "$result_path"
+          deployment_id=$(jq -er '.deploymentId' "$result_path")
+          if [[ ! "$deployment_id" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+            echo "::error::Railway did not return a valid deployment id"
+            exit 1
+          fi
+          if jq -e --arg id "$deployment_id" \
+            'any(.[]; .id == $id)' "$RUNNER_TEMP/gateway-webhook-deployment-baseline.json" >/dev/null; then
+            echo "::error::Railway returned a deployment id that predates this exact-SHA upload"
+            exit 1
+          fi
+          echo "deployment_id=$deployment_id" >> "$GITHUB_OUTPUT"
+          echo "Railway accepted the exact clean dispatch SHA as deployment $deployment_id."
+
+      - name: Wait for the exact Railway deployment
+        shell: bash
+        env:
+          DEPLOYMENT_ID: ${{ steps.railway_deploy.outputs.deployment_id }}
+        run: |
+          set -euo pipefail
+          umask 077
+          deployments_path="$RUNNER_TEMP/gateway-webhook-deployments.json"
+          deployment_status=""
+          for _ in $(seq 1 90); do
+            railway deployment list \
+              --project "$RAILWAY_PROJECT_ID" \
+              --environment "$RAILWAY_ENVIRONMENT_ID" \
+              --service "$RAILWAY_SERVICE_ID" \
+              --limit 50 \
+              --json > "$deployments_path"
+            deployment_status=$(jq -r --arg id "$DEPLOYMENT_ID" \
+              '[.[] | select(.id == $id)] | if length == 1 then .[0].status else "" end' \
+              "$deployments_path")
+            case "$deployment_status" in
+              SUCCESS) break ;;
+              FAILED | CRASHED | REMOVED | REMOVING | SKIPPED | CANCELED | CANCELLED)
+                echo "::error::Exact Railway deployment entered terminal status $deployment_status"
+                exit 1
+                ;;
+              *) sleep 10 ;;
+            esac
+          done
+          if [ "$deployment_status" != "SUCCESS" ]; then
+            echo "::error::Exact Railway deployment did not reach SUCCESS before timeout"
+            exit 1
+          fi
+          echo "Exact Railway deployment $DEPLOYMENT_ID reached SUCCESS."
+
+      - name: Verify deployed health and canonical fallback configuration
+        shell: bash
+        env:
+          DEPLOYMENT_ID: ${{ steps.railway_deploy.outputs.deployment_id }}
+        run: |
+          set -euo pipefail
+          umask 077
+          deployment_meta_path="$RUNNER_TEMP/gateway-webhook-postdeploy-deployment.json"
+          railway deployment list \
+            --project "$RAILWAY_PROJECT_ID" \
+            --environment "$RAILWAY_ENVIRONMENT_ID" \
+            --service "$RAILWAY_SERVICE_ID" \
+            --limit 50 \
+            --json > "$deployment_meta_path"
+          jq -e --arg id "$DEPLOYMENT_ID" '
+            [.[] | select(.id == $id)] |
+            length == 1 and
+            .[0].status == "SUCCESS" and
+            .[0].meta.configFile == "/railway.toml" and
+            .[0].meta.fileServiceManifest.build.builder == "DOCKERFILE" and
+            .[0].meta.fileServiceManifest.build.dockerfilePath ==
+              "packages/cloud/services/gateway-webhook/Dockerfile" and
+            .[0].meta.fileServiceManifest.deploy.healthcheckPath == "/health" and
+            .[0].meta.fileServiceManifest.deploy.healthcheckTimeout == 30 and
+            .[0].meta.fileServiceManifest.deploy.restartPolicyType == "ON_FAILURE" and
+            .[0].meta.fileServiceManifest.deploy.restartPolicyMaxRetries == 10 and
+            .[0].meta.serviceManifest.build.builder == "DOCKERFILE" and
+            .[0].meta.serviceManifest.build.dockerfilePath ==
+              "packages/cloud/services/gateway-webhook/Dockerfile" and
+            .[0].meta.serviceManifest.deploy.healthcheckPath == "/health" and
+            .[0].meta.serviceManifest.deploy.healthcheckTimeout == 30 and
+            .[0].meta.serviceManifest.deploy.restartPolicyType == "ON_FAILURE" and
+            .[0].meta.serviceManifest.deploy.restartPolicyMaxRetries == 10
+          ' "$deployment_meta_path" >/dev/null || {
+            echo "::error::Exact deployment metadata does not prove the root config, Dockerfile, and health manifest"
+            exit 1
+          }
+
+          active_path="$RUNNER_TEMP/gateway-webhook-active-deployment.json"
+          assert_active_deployment() {
+            local phase="$1"
+            railway service status \
+              --project "$RAILWAY_PROJECT_ID" \
+              --environment "$RAILWAY_ENVIRONMENT_ID" \
+              --service "$RAILWAY_SERVICE_ID" \
+              --json > "$active_path"
+            jq -e \
+              --arg id "$DEPLOYMENT_ID" \
+              --arg service "$RAILWAY_SERVICE_ID" \
+              --arg name "$EXPECTED_SERVICE_NAME" \
+              '.id == $service and
+               .name == $name and
+               .deploymentId == $id and
+               .status == "SUCCESS" and
+               .stopped == false' \
+              "$active_path" >/dev/null || {
+              echo "::error::Exact deployment is not the active service deployment $phase public verification"
+              exit 1
+            }
+          }
+
+          assert_active_deployment before
+          health_path="$RUNNER_TEMP/gateway-webhook-health.json"
+          health_status=""
+          for _ in $(seq 1 60); do
+            health_status=$(curl \
+              --silent \
+              --show-error \
+              --max-time 15 \
+              --output "$health_path" \
+              --write-out '%{http_code}' \
+              "$GATEWAY_WEBHOOK_URL/health" || true)
+            if [ "$health_status" = "200" ] && \
+              jq -e '.status == "healthy"' "$health_path" >/dev/null 2>&1; then
+              break
+            fi
+            sleep 10
+          done
+          if [ "$health_status" != "200" ] || \
+            ! jq -e '.status == "healthy"' "$health_path" >/dev/null; then
+            echo "::error::Canonical gateway-webhook health did not become ready"
+            exit 1
+          fi
+
+          variables_raw_path="$RUNNER_TEMP/gateway-webhook-postdeploy-variables-raw.json"
+          variables_path="$RUNNER_TEMP/gateway-webhook-postdeploy-canonical.json"
+          railway variable list \
+            --project "$RAILWAY_PROJECT_ID" \
+            --environment "$RAILWAY_ENVIRONMENT_ID" \
+            --service "$RAILWAY_SERVICE_ID" \
+            --json > "$variables_raw_path"
+          jq '{
+            ELIZA_CLOUD_URL,
+            AGENT_ROUTER_ORIGIN_HOST,
+            ELIZA_CLOUD_AGENT_BASE_DOMAIN
+          }' "$variables_raw_path" > "$variables_path"
+          shred -u "$variables_raw_path"
+          jq -e \
+            --arg cloud "$EXPECTED_CLOUD_URL" \
+            --arg router "$EXPECTED_ROUTER_ORIGIN" \
+            --arg domain "$EXPECTED_AGENT_BASE_DOMAIN" \
+            '.ELIZA_CLOUD_URL == $cloud and
+             .AGENT_ROUTER_ORIGIN_HOST == $router and
+             .ELIZA_CLOUD_AGENT_BASE_DOMAIN == $domain' \
+            "$variables_path" >/dev/null || {
+            echo "::error::Postdeploy canonical cloud/fallback routing pair does not match the selected environment"
+            exit 1
+          }
+
+          forwarder_probe_path="$RUNNER_TEMP/gateway-webhook-forwarder-auth-readiness.json"
+          if ! forwarder_probe_status=$(curl \
+            --silent \
+            --show-error \
+            --max-time 15 \
+            --output "$forwarder_probe_path" \
+            --write-out '%{http_code}' \
+            "$GATEWAY_WEBHOOK_URL/ready/forwarder-auth/eliza-app"); then
+            echo "::error::Forwarder-auth readiness probe failed to complete"
+            exit 1
+          fi
+          if [ "$forwarder_probe_status" != "401" ] || \
+            ! jq -e \
+              'type == "object" and
+               keys == ["error", "project", "status"] and
+               .error == "unauthorized" and
+               .status == "enforced" and
+               .project == "eliza-app"' \
+              "$forwarder_probe_path" >/dev/null; then
+            echo "::error::Gateway did not prove the exact enforced eliza-app forwarder-auth contract"
+            exit 1
+          fi
+          assert_active_deployment after
+          echo "Exact manifest, active deployment identity, live health, canonical fallback, and forwarder-auth readiness passed."
+
+      - name: Write deployment summary
+        shell: bash
+        env:
+          DEPLOYMENT_ID: ${{ steps.railway_deploy.outputs.deployment_id }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Gateway webhook deployment"
+            echo
+            echo "- Environment: \`$TARGET_ENVIRONMENT\`"
+            echo "- Source SHA: \`$GITHUB_SHA\`"
+            echo "- Railway deployment: \`$DEPLOYMENT_ID\`"
+            echo "- Service: \`$EXPECTED_SERVICE_NAME\`"
+            echo "- Canonical health: passed"
+            echo "- Canonical fallback pair: verified"
+            echo "- Forwarder-auth readiness: enforced for eliza-app with exact headerless 401"
+            echo "- Root Railway manifest: verified"
+            echo "- Active deployment identity: verified before and after probes"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Remove temporary deployment files
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          for path in \
+            "$RUNNER_TEMP/gateway-webhook-railway-status.json" \
+            "$RUNNER_TEMP/gateway-webhook-railway-domains.json" \
+            "$RUNNER_TEMP/gateway-webhook-railway-variables-raw.json" \
+            "$RUNNER_TEMP/gateway-webhook-railway-variable-inventory.json" \
+            "$RUNNER_TEMP/gateway-webhook-deployment-baseline.json" \
+            "$RUNNER_TEMP/gateway-webhook-deployment-start.json" \
+            "$RUNNER_TEMP/gateway-webhook-deployments.json" \
+            "$RUNNER_TEMP/gateway-webhook-health.json" \
+            "$RUNNER_TEMP/gateway-webhook-postdeploy-deployment.json" \
+            "$RUNNER_TEMP/gateway-webhook-active-deployment.json" \
+            "$RUNNER_TEMP/gateway-webhook-forwarder-auth-readiness.json" \
+            "$RUNNER_TEMP/gateway-webhook-postdeploy-variables-raw.json" \
+            "$RUNNER_TEMP/gateway-webhook-postdeploy-canonical.json"; do
+            if [ -f "$path" ]; then
+              shred -u "$path"
+            fi
+          done
+          if [ -f railway.toml ]; then
+            shred -u railway.toml
+          fi

--- a/packages/cloud/infra/cloud/RAILWAY.md
+++ b/packages/cloud/infra/cloud/RAILWAY.md
@@ -23,7 +23,7 @@ config wins — fix this file.
 | Redis | **Railway managed Redis** (TCP, `REDIS_URL`) | n/a (managed service) | `REDIS_URL` Worker secret; in-Worker SocketRedis speaks RESP2 over `cloudflare:sockets` (`wrangler.toml` cache/queue notes). Upstash REST (`KV_REST_API_*`) is a **legacy fallback only** | Private |
 | Database migrations | GitHub Actions → Railway Postgres | `packages/cloud/shared/src/db/migrations/` | `cloud-cf-deploy.yml` `migrate-db` job (`bun run db:cloud:migrate`); every deploy job `needs: migrate-db` | n/a |
 | `gateway-discord` (multi-tenant Discord WS gateway) | Railway (Docker) | `packages/cloud/services/gateway-discord/` | `railway.toml` + `Dockerfile`; Railway auto-deploys on push — `cloud-gateway-discord.yml` runs tests only | Discord-facing; `/internal/*` shared-secret routes |
-| `gateway-webhook` (Telegram / Blooio / Twilio / WhatsApp) | Railway (Docker) | `packages/cloud/services/gateway-webhook/` | `railway.toml` + `Dockerfile`; `cloud-gateway-webhook.yml` runs tests only | Public webhook ingress |
+| `gateway-webhook` (Telegram / Blooio / Twilio / WhatsApp) | Railway (Docker) | `packages/cloud/services/gateway-webhook/` | protected `.github/workflows/deploy-gateway-webhook.yml` using `railway.toml` + `Dockerfile` | Public webhook ingress |
 | `voice-kokoro-tts` (free-cloud TTS) | Railway (Docker) | `packages/cloud/services/voice-kokoro-tts/` | `railway.toml`; its URL is injected at Worker deploy time as `KOKORO_TTS_URL` (GitHub var `ELIZA_VOICE_KOKORO_TTS_URL` in `cloud-cf-deploy.yml`) | **Private origin** behind the Worker's `POST /api/v1/voice/tts` — unauthenticated at the service boundary, so its URL must not be published |
 | `voice-whisper-stt` (free-cloud STT) | Railway (Docker) | `packages/cloud/services/voice-whisper-stt/` | `railway.toml`; consumed via the `WHISPER_STT_URL` env var | **Private origin** behind the Worker's `POST /api/v1/voice/stt` (same posture as Kokoro) |
 | `tunnel-proxy` (public HTTPS → tailnet bridge, customer-tunnel path) | Railway (Docker, Go) | `packages/cloud/services/tunnel-proxy/` | protected `.github/workflows/deploy-tunnel-proxy.yml` using `railway.toml` + `Dockerfile` | Public: `tunnel.eliza.app` (staging: `tunnel-staging.eliza.app`) |
@@ -138,12 +138,25 @@ was decommissioned on 2026-06-17.
 
 ### `gateway-discord` / `gateway-webhook`
 
-Docker/Bun services with `railway.toml` manifests; Railway auto-deploys on
-push to the watched branch. Their GitHub workflows
-(`cloud-gateway-discord.yml`, `cloud-gateway-webhook.yml`) run tests only —
-the AWS EKS/Terraform/Helm deploy jobs were removed with the AWS retirement
-([`AWS_RETIREMENT.md`](./AWS_RETIREMENT.md)). Required env vars are documented
-in each service's `railway.toml` header.
+Docker/Bun services with `railway.toml` manifests. `gateway-discord` retains
+its Railway watched-branch deployment and `cloud-gateway-discord.yml` runs its
+repository tests. `gateway-webhook` has no Railway repo trigger: the protected
+`deploy-gateway-webhook.yml` dispatcher is its only deployment authority. It
+binds staging to `develop` and production to `main`, validates the exact
+Railway identities and canonical routing variables, uploads the exact dispatch
+SHA from the repository root with a byte-identical root copy of the
+tracked service manifest, and verifies the returned deployment id, applied
+Dockerfile/health metadata, active-deployment identity around the public
+probes, live `/health`, and the dedicated headerless
+`/ready/forwarder-auth/eliza-app` contract. That read-only route returns its
+exact 401 only when the forwarding secret gate is active for `eliza-app`;
+disabled or project-mismatched configurations fail with distinct non-401
+states without entering provider handling. Required runtime variables are
+documented in each service's `railway.toml` header; the names-only sensitive
+inventory includes the mandatory `ELIZA_APP_WEBHOOK_GATEWAY_SECRET` forwarding
+trust gate. The old AWS EKS/Terraform/Helm deploy jobs were
+removed with the AWS retirement
+([`AWS_RETIREMENT.md`](./AWS_RETIREMENT.md)).
 
 ### `voice-kokoro-tts` / `voice-whisper-stt`
 

--- a/packages/cloud/services/gateway-webhook/AGENTS.md
+++ b/packages/cloud/services/gateway-webhook/AGENTS.md
@@ -13,6 +13,8 @@ system) from trusted in-cluster callers and forwards those to agents.
   the platform adapters, and registers routes:
   - `GET /health`, `GET /ready`, `POST /drain` — liveness / readiness /
     graceful-drain (KEDA / k8s lifecycle).
+  - `GET /ready/forwarder-auth/:project` — read-only forwarder-gate readiness;
+    a headerless 401 is reserved for an enforced gate on that project.
   - `POST /internal/event` — internal event delivery (auth via
     `X-Internal-Secret`).
   - `GET /webhook/:project/whatsapp[/:agentId]` — WhatsApp `hub.challenge`
@@ -36,7 +38,9 @@ system) from trusted in-cluster callers and forwards those to agents.
   `GATEWAY_BOOTSTRAP_SECRET` and auto-refreshes it; `getAuthHeader()` supplies
   the `Authorization` header for cloud calls.
 - `src/internal-auth.ts` — constant-time `X-Internal-Secret` validation for
-  `/internal/event`.
+  `/internal/event` and shared BFF-forwarder gate state/enforcement.
+- `src/forwarder-auth-readiness.ts` — non-mutating forwarder-gate readiness
+  route; it never accepts a secret or enters provider/message handling.
 - `src/internal-event-handler.ts` — zod-validated internal event ingestion
   (64KB cap), then background forward.
 - `src/webhook-config.ts` / `src/project-config.ts` — per-agent webhook config
@@ -72,18 +76,47 @@ service depends on the `@elizaos/cloud-services-common` workspace package, and
 
 ```bash
 docker build -f packages/cloud/services/gateway-webhook/Dockerfile .
-railway up            # run from the repository root
 ```
 
 The deps stage writes a pruned workspace root containing only this service and
 the package it needs, so the install resolves the workspace link without pulling
 the whole monorepo (32 packages, not several thousand).
 
-This service has **no repo trigger on Railway** — nothing deploys it on push, so
-merging a change to it does not ship it. Until that is wired, a release is a
-manual `railway up` from the repository root, and the running image is whatever
-was last built. `__tests__/dockerfile-workspace-context.test.ts` guards the
-workspace-resolution half of this; nothing yet guards the deploy half.
+This service has **no Railway repo trigger** — merging a change does not ship
+it. Deploy staging or production only through the protected
+`.github/workflows/deploy-gateway-webhook.yml` dispatcher. The workflow accepts
+`develop` for staging and `main` for production, checks out and uploads the
+exact dispatch SHA from the repository root, validates the protected Railway
+project/environment/service ids and public URL, materializes the tracked
+service manifest byte-for-byte at the root config path Railway expects, and
+waits for that exact deployment id before proving its applied manifest and
+active identity around live health and canonical fallback checks.
+It then proves the dedicated headerless `/ready/forwarder-auth/eliza-app`
+contract returns the exact enforced-gate 401 and reasserts the exact active
+deployment. The route returns distinct non-401 states when the secret is
+disabled or the configured forwarded project does not match, never enters
+provider/message handling, and rejects any supplied forwarder-secret header
+without comparing it.
+The pinned Railway CLI is invoked with no path argument from the repository
+root; do not change this to relative `.` because v5.38.0 cannot strip its
+absolute archive prefix from that relative project path when `--project` is
+explicit.
+
+Each protected GitHub Environment supplies `RAILWAY_PROJECT_ID`,
+`RAILWAY_ENVIRONMENT_ID`, `RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK`, and
+`ELIZA_APP_WEBHOOK_GATEWAY_URL` as variables plus `RAILWAY_TOKEN` as a secret.
+The workflow validates the existing Railway variable names and canonical
+non-secret values without printing or rewriting sensitive values. Keep runtime
+secrets in Railway; do not copy their values into workflow YAML or logs. The
+names-only inventory requires `ELIZA_APP_WEBHOOK_GATEWAY_SECRET`, which keeps
+the cloud BFF forwarding trust gate enabled. Staging is branch/configuration
+gated but currently has no required reviewer; production retains reviewer
+approval.
+
+`__tests__/dockerfile-workspace-context.test.ts` guards the workspace build
+context. The repository-level
+`packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts` guards the
+protected deploy contract.
 
 ## Environment
 
@@ -92,6 +125,12 @@ Required (the process throws on startup if these are missing):
 - `ELIZA_CLOUD_URL` — base URL of the cloud API (identity resolve, webhook
   config, onboarding chat, auth token endpoints).
 - `GATEWAY_BOOTSTRAP_SECRET` — bootstrap secret used to acquire the gateway JWT.
+
+Required production forwarding trust (the protected deploy fails closed when
+this Railway variable is absent or blank):
+
+- `ELIZA_APP_WEBHOOK_GATEWAY_SECRET` — shared trust secret required on cloud
+  BFF forwards; it must match the Cloud Worker secret of the same name.
 
 Redis (at least one of these must resolve, or `createRedis()` throws):
 

--- a/packages/cloud/services/gateway-webhook/CLAUDE.md
+++ b/packages/cloud/services/gateway-webhook/CLAUDE.md
@@ -13,6 +13,8 @@ system) from trusted in-cluster callers and forwards those to agents.
   the platform adapters, and registers routes:
   - `GET /health`, `GET /ready`, `POST /drain` — liveness / readiness /
     graceful-drain (KEDA / k8s lifecycle).
+  - `GET /ready/forwarder-auth/:project` — read-only forwarder-gate readiness;
+    a headerless 401 is reserved for an enforced gate on that project.
   - `POST /internal/event` — internal event delivery (auth via
     `X-Internal-Secret`).
   - `GET /webhook/:project/whatsapp[/:agentId]` — WhatsApp `hub.challenge`
@@ -36,7 +38,9 @@ system) from trusted in-cluster callers and forwards those to agents.
   `GATEWAY_BOOTSTRAP_SECRET` and auto-refreshes it; `getAuthHeader()` supplies
   the `Authorization` header for cloud calls.
 - `src/internal-auth.ts` — constant-time `X-Internal-Secret` validation for
-  `/internal/event`.
+  `/internal/event` and shared BFF-forwarder gate state/enforcement.
+- `src/forwarder-auth-readiness.ts` — non-mutating forwarder-gate readiness
+  route; it never accepts a secret or enters provider/message handling.
 - `src/internal-event-handler.ts` — zod-validated internal event ingestion
   (64KB cap), then background forward.
 - `src/webhook-config.ts` / `src/project-config.ts` — per-agent webhook config
@@ -72,18 +76,47 @@ service depends on the `@elizaos/cloud-services-common` workspace package, and
 
 ```bash
 docker build -f packages/cloud/services/gateway-webhook/Dockerfile .
-railway up            # run from the repository root
 ```
 
 The deps stage writes a pruned workspace root containing only this service and
 the package it needs, so the install resolves the workspace link without pulling
 the whole monorepo (32 packages, not several thousand).
 
-This service has **no repo trigger on Railway** — nothing deploys it on push, so
-merging a change to it does not ship it. Until that is wired, a release is a
-manual `railway up` from the repository root, and the running image is whatever
-was last built. `__tests__/dockerfile-workspace-context.test.ts` guards the
-workspace-resolution half of this; nothing yet guards the deploy half.
+This service has **no Railway repo trigger** — merging a change does not ship
+it. Deploy staging or production only through the protected
+`.github/workflows/deploy-gateway-webhook.yml` dispatcher. The workflow accepts
+`develop` for staging and `main` for production, checks out and uploads the
+exact dispatch SHA from the repository root, validates the protected Railway
+project/environment/service ids and public URL, materializes the tracked
+service manifest byte-for-byte at the root config path Railway expects, and
+waits for that exact deployment id before proving its applied manifest and
+active identity around live health and canonical fallback checks.
+It then proves the dedicated headerless `/ready/forwarder-auth/eliza-app`
+contract returns the exact enforced-gate 401 and reasserts the exact active
+deployment. The route returns distinct non-401 states when the secret is
+disabled or the configured forwarded project does not match, never enters
+provider/message handling, and rejects any supplied forwarder-secret header
+without comparing it.
+The pinned Railway CLI is invoked with no path argument from the repository
+root; do not change this to relative `.` because v5.38.0 cannot strip its
+absolute archive prefix from that relative project path when `--project` is
+explicit.
+
+Each protected GitHub Environment supplies `RAILWAY_PROJECT_ID`,
+`RAILWAY_ENVIRONMENT_ID`, `RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK`, and
+`ELIZA_APP_WEBHOOK_GATEWAY_URL` as variables plus `RAILWAY_TOKEN` as a secret.
+The workflow validates the existing Railway variable names and canonical
+non-secret values without printing or rewriting sensitive values. Keep runtime
+secrets in Railway; do not copy their values into workflow YAML or logs. The
+names-only inventory requires `ELIZA_APP_WEBHOOK_GATEWAY_SECRET`, which keeps
+the cloud BFF forwarding trust gate enabled. Staging is branch/configuration
+gated but currently has no required reviewer; production retains reviewer
+approval.
+
+`__tests__/dockerfile-workspace-context.test.ts` guards the workspace build
+context. The repository-level
+`packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts` guards the
+protected deploy contract.
 
 ## Environment
 
@@ -92,6 +125,12 @@ Required (the process throws on startup if these are missing):
 - `ELIZA_CLOUD_URL` — base URL of the cloud API (identity resolve, webhook
   config, onboarding chat, auth token endpoints).
 - `GATEWAY_BOOTSTRAP_SECRET` — bootstrap secret used to acquire the gateway JWT.
+
+Required production forwarding trust (the protected deploy fails closed when
+this Railway variable is absent or blank):
+
+- `ELIZA_APP_WEBHOOK_GATEWAY_SECRET` — shared trust secret required on cloud
+  BFF forwards; it must match the Cloud Worker secret of the same name.
 
 Redis (at least one of these must resolve, or `createRedis()` throws):
 

--- a/packages/cloud/services/gateway-webhook/__tests__/forwarder-auth-readiness.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/forwarder-auth-readiness.test.ts
@@ -1,0 +1,95 @@
+/** Exercises the registered forwarder-auth readiness route with real Hono requests and process configuration. */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { registerForwarderAuthReadinessRoute } from "../src/forwarder-auth-readiness";
+
+const app = new Hono();
+registerForwarderAuthReadinessRoute(app);
+
+const secretBeforeTests = process.env.ELIZA_APP_WEBHOOK_GATEWAY_SECRET;
+const projectBeforeTests = process.env.ELIZA_APP_WEBHOOK_PROJECT;
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+describe("forwarder-auth readiness route", () => {
+  beforeEach(() => {
+    process.env.ELIZA_APP_WEBHOOK_GATEWAY_SECRET = "integration-secret";
+    delete process.env.ELIZA_APP_WEBHOOK_PROJECT;
+  });
+
+  afterEach(() => {
+    restoreEnv("ELIZA_APP_WEBHOOK_GATEWAY_SECRET", secretBeforeTests);
+    restoreEnv("ELIZA_APP_WEBHOOK_PROJECT", projectBeforeTests);
+  });
+
+  test("reserves headerless 401 for an enforced eliza-app gate", async () => {
+    const response = await app.request(
+      "http://gateway.example/ready/forwarder-auth/eliza-app",
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({
+      error: "unauthorized",
+      status: "enforced",
+      project: "eliza-app",
+    });
+  });
+
+  test("returns distinct non-401 readiness failure when the secret is disabled", async () => {
+    delete process.env.ELIZA_APP_WEBHOOK_GATEWAY_SECRET;
+    const response = await app.request(
+      "http://gateway.example/ready/forwarder-auth/eliza-app",
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: "forwarder-auth-not-ready",
+      reason: "secret-disabled",
+      project: "eliza-app",
+    });
+  });
+
+  test("returns distinct non-401 readiness failure for a project mismatch", async () => {
+    process.env.ELIZA_APP_WEBHOOK_PROJECT = "another-project";
+    const response = await app.request(
+      "http://gateway.example/ready/forwarder-auth/eliza-app",
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: "forwarder-auth-not-ready",
+      reason: "project-mismatch",
+      project: "eliza-app",
+    });
+  });
+
+  test("rejects supplied forwarder headers without comparing their values", async () => {
+    const request = (value: string) =>
+      app.request("http://gateway.example/ready/forwarder-auth/eliza-app", {
+        headers: { "X-Eliza-Webhook-Forwarder-Secret": value },
+      });
+
+    for (const value of ["integration-secret", "wrong-secret"]) {
+      const response = await request(value);
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: "forwarder-auth-probe-must-omit-secret",
+      });
+    }
+  });
+
+  test("does not expose a POST surface that could enter provider handling", async () => {
+    const response = await app.request(
+      "http://gateway.example/ready/forwarder-auth/eliza-app",
+      { method: "POST", body: "{}" },
+    );
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/cloud/services/gateway-webhook/__tests__/internal-auth.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/internal-auth.test.ts
@@ -1,7 +1,8 @@
-// Exercises the gateway-webhook internal auth path with deterministic cloud service fixtures.
+/** Exercises gateway internal-auth boundaries with deterministic service fixtures. */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   enforceForwarderSecret,
+  getForwarderAuthReadiness,
   validateInternalSecret,
 } from "../src/internal-auth";
 
@@ -76,6 +77,7 @@ describe("validateInternalSecret", () => {
 // is configured; backward-compatible no-op when not.
 describe("enforceForwarderSecret", () => {
   const originalForwarder = process.env.ELIZA_APP_WEBHOOK_GATEWAY_SECRET;
+  const originalProject = process.env.ELIZA_APP_WEBHOOK_PROJECT;
   const originalInternal = process.env.GATEWAY_INTERNAL_SECRET;
 
   afterEach(() => {
@@ -83,6 +85,11 @@ describe("enforceForwarderSecret", () => {
       delete process.env.ELIZA_APP_WEBHOOK_GATEWAY_SECRET;
     } else {
       process.env.ELIZA_APP_WEBHOOK_GATEWAY_SECRET = originalForwarder;
+    }
+    if (originalProject === undefined) {
+      delete process.env.ELIZA_APP_WEBHOOK_PROJECT;
+    } else {
+      process.env.ELIZA_APP_WEBHOOK_PROJECT = originalProject;
     }
     if (originalInternal === undefined) {
       delete process.env.GATEWAY_INTERNAL_SECRET;
@@ -109,6 +116,9 @@ describe("enforceForwarderSecret", () => {
 
   test("no forwarder secret configured => gate is a no-op (allows traffic)", () => {
     delete process.env.ELIZA_APP_WEBHOOK_GATEWAY_SECRET;
+    expect(getForwarderAuthReadiness(FORWARDED_PROJECT)).toBe(
+      "secret-disabled",
+    );
     expect(enforceForwarderSecret(webhookRequest(), FORWARDED_PROJECT)).toBe(
       true,
     );
@@ -129,6 +139,7 @@ describe("enforceForwarderSecret", () => {
 
   test("forwarder secret configured + valid header => allowed", () => {
     process.env.ELIZA_APP_WEBHOOK_GATEWAY_SECRET = "bff-secret";
+    expect(getForwarderAuthReadiness(FORWARDED_PROJECT)).toBe("enforced");
     expect(
       enforceForwarderSecret(webhookRequest("bff-secret"), FORWARDED_PROJECT),
     ).toBe(true);
@@ -155,6 +166,24 @@ describe("enforceForwarderSecret", () => {
     // No forwarder header at all, but a non-forwarded project => allowed.
     expect(enforceForwarderSecret(webhookRequest(), "some-other-project")).toBe(
       true,
+    );
+  });
+
+  test("configured forwarded-project mismatch is distinct from an enabled gate", () => {
+    process.env.ELIZA_APP_WEBHOOK_GATEWAY_SECRET = "bff-secret";
+    process.env.ELIZA_APP_WEBHOOK_PROJECT = "different-project";
+    expect(getForwarderAuthReadiness(FORWARDED_PROJECT)).toBe(
+      "project-mismatch",
+    );
+    expect(enforceForwarderSecret(webhookRequest(), FORWARDED_PROJECT)).toBe(
+      true,
+    );
+  });
+
+  test("a blank dedicated secret reports disabled readiness", () => {
+    process.env.ELIZA_APP_WEBHOOK_GATEWAY_SECRET = "  \n";
+    expect(getForwarderAuthReadiness(FORWARDED_PROJECT)).toBe(
+      "secret-disabled",
     );
   });
 

--- a/packages/cloud/services/gateway-webhook/railway.toml
+++ b/packages/cloud/services/gateway-webhook/railway.toml
@@ -6,6 +6,7 @@
 # Required env vars / secrets:
 #   GATEWAY_INTERNAL_SECRET     Shared secret for internal routes from cloud-api.
 #   AGENT_SERVER_SHARED_SECRET  Shared secret for forwards to agent-server.
+#   ELIZA_APP_WEBHOOK_GATEWAY_SECRET  Shared secret required on BFF forwards.
 #   REDIS_URL                   Upstash Redis REST URL (or KV_REST_API_URL).
 #   KV_REST_API_TOKEN           Upstash Redis REST token.
 #

--- a/packages/cloud/services/gateway-webhook/src/forwarder-auth-readiness.ts
+++ b/packages/cloud/services/gateway-webhook/src/forwarder-auth-readiness.ts
@@ -1,0 +1,68 @@
+/** Exposes a non-mutating readiness contract for the eliza-app forwarder trust boundary. */
+import type { Hono } from "hono";
+import {
+  FORWARDER_SECRET_HEADER,
+  getForwarderAuthReadiness,
+} from "./internal-auth";
+
+const JSON_HEADERS = {
+  "cache-control": "no-store",
+  "content-type": "application/json",
+} as const;
+
+function jsonResponse(body: Record<string, string>, status: number): Response {
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+/**
+ * Reports the gate's configuration without accepting or comparing a secret.
+ * A headerless 401 is reserved for an active gate on the requested project;
+ * disabled and project-mismatch states are operational failures with distinct
+ * non-401 responses. Requests carrying the forwarder header are rejected
+ * before configuration inspection so this endpoint cannot validate guesses.
+ */
+export function handleForwarderAuthReadiness(
+  request: Request,
+  project: string,
+): Response {
+  if (request.headers.has(FORWARDER_SECRET_HEADER)) {
+    return jsonResponse(
+      { error: "forwarder-auth-probe-must-omit-secret" },
+      400,
+    );
+  }
+
+  const readiness = getForwarderAuthReadiness(project);
+  if (readiness === "secret-disabled") {
+    return jsonResponse(
+      {
+        error: "forwarder-auth-not-ready",
+        reason: "secret-disabled",
+        project,
+      },
+      503,
+    );
+  }
+  if (readiness === "project-mismatch") {
+    return jsonResponse(
+      {
+        error: "forwarder-auth-not-ready",
+        reason: "project-mismatch",
+        project,
+      },
+      409,
+    );
+  }
+
+  return jsonResponse(
+    { error: "unauthorized", status: "enforced", project },
+    401,
+  );
+}
+
+/** Registers the public read-only gate-readiness route on the service app. */
+export function registerForwarderAuthReadinessRoute(app: Hono): void {
+  app.get("/ready/forwarder-auth/:project", (context) =>
+    handleForwarderAuthReadiness(context.req.raw, context.req.param("project")),
+  );
+}

--- a/packages/cloud/services/gateway-webhook/src/index.ts
+++ b/packages/cloud/services/gateway-webhook/src/index.ts
@@ -1,4 +1,4 @@
-// Handles webhook gateway index behavior for authenticated connector fan-in.
+/** Assembles and starts the authenticated multi-platform webhook gateway. */
 import { Hono } from "hono";
 import { blooioAdapter } from "./adapters/blooio";
 import { telegramAdapter } from "./adapters/telegram";
@@ -6,6 +6,7 @@ import { twilioAdapter } from "./adapters/twilio";
 import type { Platform, PlatformAdapter } from "./adapters/types";
 import { whatsappAdapter } from "./adapters/whatsapp";
 import { getAuthHeader, initAuth, shutdownAuth } from "./auth";
+import { registerForwarderAuthReadinessRoute } from "./forwarder-auth-readiness";
 import { enforceForwarderSecret } from "./internal-auth";
 import { handleInternalEvent } from "./internal-event-handler";
 import { logger } from "./logger";
@@ -54,6 +55,7 @@ app.get("/ready", (c) => {
   if (draining) return c.json({ status: "draining" }, 503);
   return c.json({ status: "ready" });
 });
+registerForwarderAuthReadinessRoute(app);
 app.post("/drain", (c) => {
   draining = true;
   logger.info("Drain requested");

--- a/packages/cloud/services/gateway-webhook/src/internal-auth.ts
+++ b/packages/cloud/services/gateway-webhook/src/internal-auth.ts
@@ -1,4 +1,4 @@
-// Handles webhook gateway internal auth behavior for authenticated connector fan-in.
+/** Enforces internal-event and BFF-forwarder trust boundaries for gateway ingress. */
 import { timingSafeEqual } from "node:crypto";
 import { logger } from "./logger";
 
@@ -73,14 +73,41 @@ export function validateInternalSecret(request: Request): boolean {
  * so enabling the BFF-forwarder gate does NOT force every direct provider
  * webhook to present the internal-event secret.
  */
-const FORWARDER_SECRET_HEADER = "X-Eliza-Webhook-Forwarder-Secret";
+export const FORWARDER_SECRET_HEADER = "X-Eliza-Webhook-Forwarder-Secret";
 
 // The project the eliza-app BFF forwarder targets (matches the forwarder's
 // `ELIZA_APP_WEBHOOK_PROJECT`, default "eliza-app"). The forwarder secret gate
 // applies ONLY to this project, so other gateway tenants that post directly
 // with valid provider auth are never affected.
-const FORWARDED_PROJECT =
-  (process.env.ELIZA_APP_WEBHOOK_PROJECT ?? "eliza-app").trim() || "eliza-app";
+export type ForwarderAuthReadiness =
+  | "enforced"
+  | "secret-disabled"
+  | "project-mismatch";
+
+function resolveForwarderAuth(project: string): {
+  readiness: ForwarderAuthReadiness;
+  secret: string;
+} {
+  const secret = (process.env.ELIZA_APP_WEBHOOK_GATEWAY_SECRET ?? "").trim();
+  const forwardedProject =
+    (process.env.ELIZA_APP_WEBHOOK_PROJECT ?? "eliza-app").trim() ||
+    "eliza-app";
+
+  if (!secret) {
+    return { readiness: "secret-disabled", secret };
+  }
+  if (project !== forwardedProject) {
+    return { readiness: "project-mismatch", secret };
+  }
+  return { readiness: "enforced", secret };
+}
+
+/** Reports whether the dedicated forwarder gate applies to the named project. */
+export function getForwarderAuthReadiness(
+  project: string,
+): ForwarderAuthReadiness {
+  return resolveForwarderAuth(project).readiness;
+}
 
 /**
  * Optional BFF-forwarder gate for the public webhook routes (finding L3,
@@ -114,16 +141,11 @@ export function enforceForwarderSecret(
   request: Request,
   project: string,
 ): boolean {
-  // Trim to match the BFF forwarder, which stamps the trimmed env value
-  // (readStringEnv() -> value.trim()). Comparing the raw env here would 401
-  // every forward when the secret mount has a trailing newline/whitespace.
-  const secret = (process.env.ELIZA_APP_WEBHOOK_GATEWAY_SECRET ?? "").trim();
-  // No dedicated secret configured ⇒ feature off ⇒ do not break existing traffic.
-  if (!secret) {
-    return true;
-  }
-  // Only the forwarded project is gated; other tenants pass through untouched.
-  if (project !== FORWARDED_PROJECT) {
+  // Resolve the same state used by the public auth-readiness contract. A
+  // disabled secret or another project remains backward-compatible traffic;
+  // only the configured forwarded project enters the constant-time gate.
+  const { readiness, secret } = resolveForwarderAuth(project);
+  if (readiness !== "enforced") {
     return true;
   }
 

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -1,0 +1,497 @@
+/**
+ * Guards the protected gateway-webhook deploy workflow's exact source,
+ * Railway identity, canonical routing, secret-name, and live smoke contracts.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, relative, sep } from "node:path";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const workflowPath = new URL(
+  ".github/workflows/deploy-gateway-webhook.yml",
+  repoRoot,
+);
+const source = readFileSync(workflowPath, "utf8");
+const workflowReadme = readFileSync(
+  new URL(".github/workflows/README.md", repoRoot),
+  "utf8",
+);
+interface WorkflowStep {
+  env?: Record<string, string>;
+  id?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, string | number | boolean>;
+}
+
+interface WorkflowJob {
+  env?: Record<string, string>;
+  environment?: string;
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  concurrency?: {
+    "cancel-in-progress"?: boolean;
+    group?: string;
+  };
+  jobs?: Record<string, WorkflowJob>;
+  on?: {
+    workflow_dispatch?: {
+      inputs?: {
+        environment?: {
+          options?: string[];
+          required?: boolean;
+          type?: string;
+        };
+      };
+    };
+  };
+  permissions?: Record<string, string>;
+}
+
+const workflow = Bun.YAML.parse(source) as Workflow;
+const deploy = workflow.jobs?.deploy;
+const steps = deploy?.steps ?? [];
+
+function step(name: string): WorkflowStep {
+  const found = steps.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`Missing gateway-webhook workflow step: ${name}`);
+  return found;
+}
+
+function githubExpression(body: string): string {
+  return ["$", "{{ ", body, " }}"].join("");
+}
+
+const expectedJobEnvironment = {
+  TARGET_ENVIRONMENT: githubExpression("inputs.environment"),
+  DEPLOY_BRANCH: githubExpression(
+    "inputs.environment == 'production' && 'main' || 'develop'",
+  ),
+  EXPECTED_SERVICE_NAME: githubExpression(
+    "inputs.environment == 'production' && 'gateway-webhook' || 'gateway-webhook-stg'",
+  ),
+  EXPECTED_CLOUD_URL: githubExpression(
+    "inputs.environment == 'production' && 'https://api.eliza.app' || 'https://api-staging.eliza.app'",
+  ),
+  EXPECTED_ROUTER_ORIGIN: githubExpression(
+    "inputs.environment == 'production' && 'eliza-production-1.eliza.app' || 'eliza-staging-1.eliza.app'",
+  ),
+  EXPECTED_AGENT_BASE_DOMAIN: githubExpression(
+    "inputs.environment == 'production' && 'cloud.eliza.app' || 'cloud-staging.eliza.app'",
+  ),
+  EXPECTED_GATEWAY_URL: githubExpression(
+    "inputs.environment == 'production' && 'https://gateway-webhook-production.up.railway.app' || 'https://gateway-webhook-stg-staging.up.railway.app'",
+  ),
+  GATEWAY_WEBHOOK_URL: githubExpression("vars.ELIZA_APP_WEBHOOK_GATEWAY_URL"),
+  RAILWAY_PROJECT_ID: githubExpression("vars.RAILWAY_PROJECT_ID"),
+  RAILWAY_ENVIRONMENT_ID: githubExpression("vars.RAILWAY_ENVIRONMENT_ID"),
+  RAILWAY_SERVICE_ID: githubExpression(
+    "vars.RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK",
+  ),
+  RAILWAY_TOKEN: githubExpression("secrets.RAILWAY_TOKEN"),
+};
+
+function assertExactProtectedRouting(job: WorkflowJob | undefined): void {
+  if (job?.environment !== githubExpression("inputs.environment")) {
+    throw new Error("protected environment expression drifted");
+  }
+  for (const [name, expected] of Object.entries(expectedJobEnvironment)) {
+    if (job.env?.[name] !== expected) {
+      throw new Error(`${name} mapping drifted`);
+    }
+  }
+}
+
+function railwayUpPathArgument(run: string): string | undefined {
+  const normalized = run.replace(/\\\n/g, " ");
+  const invocation = normalized.match(/(?:^|\n)\s*railway up(?:\s+(\S+))?/);
+  if (!invocation) throw new Error("Missing Railway up invocation");
+  const firstArgument = invocation[1];
+  return firstArgument && !firstArgument.startsWith("-")
+    ? firstArgument
+    : undefined;
+}
+
+/**
+ * Reproduces Railway CLI v5.38.0's pre-upload path contract from
+ * `commands/up.rs::get_deploy_paths` and
+ * `controllers/upload.rs::create_deploy_tarball`.
+ */
+function pinnedRailwayV538ArchiveMembers(
+  cwd: string,
+  pathArgument: string | undefined,
+  relativeMembers: string[],
+): string[] {
+  const projectPath = pathArgument ?? cwd;
+  const archivePrefixPath = cwd;
+  return relativeMembers.map((member) => {
+    const walkedPath = join(projectPath, member);
+    if (isAbsolute(walkedPath) !== isAbsolute(archivePrefixPath)) {
+      throw new Error("prefix not found");
+    }
+    const stripped = relative(archivePrefixPath, walkedPath);
+    if (
+      stripped === ".." ||
+      stripped.startsWith(`..${sep}`) ||
+      isAbsolute(stripped)
+    ) {
+      throw new Error("prefix not found");
+    }
+    return stripped;
+  });
+}
+
+function assertExactForwarderAuthReadinessProbe(run: string): void {
+  const required = {
+    route: '"$GATEWAY_WEBHOOK_URL/ready/forwarder-auth/eliza-app"',
+    status: '"$forwarder_probe_status" != "401"',
+    keys: 'keys == ["error", "project", "status"]',
+    error: '.error == "unauthorized"',
+    readiness: '.status == "enforced"',
+    project: '.project == "eliza-app"',
+  } as const;
+  for (const [contract, fragment] of Object.entries(required)) {
+    if (!run.includes(fragment)) {
+      throw new Error(`forwarder readiness ${contract} contract drifted`);
+    }
+  }
+  for (const forbidden of [
+    "X-Eliza-Webhook-Forwarder-Secret",
+    "--request POST",
+    "--data '{}'",
+    "/webhook/eliza-app/telegram",
+  ]) {
+    if (run.includes(forbidden)) {
+      throw new Error("forwarder readiness probe entered a forbidden path");
+    }
+  }
+  if (
+    run.indexOf("assert_active_deployment after") < run.indexOf(required.route)
+  ) {
+    throw new Error("forwarder readiness active-deployment recheck drifted");
+  }
+}
+
+describe("protected gateway-webhook deployment workflow", () => {
+  test("is manual, least-privileged, protected, and serialized per environment", () => {
+    expect(Object.keys(workflow.on ?? {})).toEqual(["workflow_dispatch"]);
+    expect(workflow.on?.workflow_dispatch?.inputs?.environment).toEqual({
+      description: "Protected environment to deploy",
+      required: true,
+      type: "choice",
+      options: ["staging", "production"],
+    });
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(deploy?.environment).toBe(githubExpression("inputs.environment"));
+    expect(workflow.concurrency?.group).toContain("inputs.environment");
+    expect(workflow.concurrency?.["cancel-in-progress"]).toBe(false);
+
+    expect(deploy?.env).toEqual(expectedJobEnvironment);
+    expect(() => assertExactProtectedRouting(deploy)).not.toThrow();
+
+    expect(() =>
+      assertExactProtectedRouting({
+        ...deploy,
+        environment: `unsafe-${deploy?.environment}`,
+      }),
+    ).toThrow("protected environment expression drifted");
+
+    const reversedMappings = {
+      EXPECTED_CLOUD_URL: githubExpression(
+        "inputs.environment == 'production' && 'https://api-staging.eliza.app' || 'https://api.eliza.app'",
+      ),
+      EXPECTED_ROUTER_ORIGIN: githubExpression(
+        "inputs.environment == 'production' && 'eliza-staging-1.eliza.app' || 'eliza-production-1.eliza.app'",
+      ),
+      EXPECTED_AGENT_BASE_DOMAIN: githubExpression(
+        "inputs.environment == 'production' && 'cloud-staging.eliza.app' || 'cloud.eliza.app'",
+      ),
+      EXPECTED_GATEWAY_URL: githubExpression(
+        "inputs.environment == 'production' && 'https://gateway-webhook-stg-staging.up.railway.app' || 'https://gateway-webhook-production.up.railway.app'",
+      ),
+    };
+    for (const [name, reversed] of Object.entries(reversedMappings)) {
+      expect(() =>
+        assertExactProtectedRouting({
+          ...deploy,
+          env: { ...deploy?.env, [name]: reversed },
+        }),
+      ).toThrow(`${name} mapping drifted`);
+    }
+    expect(workflowReadme).toContain(
+      "| `staging` | `develop` | `gateway-webhook-stg` |",
+    );
+    expect(workflowReadme).toContain(
+      "| `production` | `main` | `gateway-webhook` |",
+    );
+
+    const checkout = steps.find((candidate) =>
+      candidate.uses?.startsWith("actions/checkout@"),
+    );
+    expect(checkout?.uses).toBe(
+      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+    );
+    expect(checkout?.with?.ref).toContain("github.sha");
+    expect(checkout?.with?.["persist-credentials"]).toBe(false);
+  });
+
+  test("fails closed on branch, exact SHA, canonical URLs, and protected ids", () => {
+    const preflight = step("Validate protected canonical configuration");
+    for (const name of [
+      "TARGET_ENVIRONMENT",
+      "DEPLOY_BRANCH",
+      "EXPECTED_CLOUD_URL",
+      "EXPECTED_ROUTER_ORIGIN",
+      "EXPECTED_AGENT_BASE_DOMAIN",
+      "EXPECTED_GATEWAY_URL",
+      "GATEWAY_WEBHOOK_URL",
+      "RAILWAY_PROJECT_ID",
+      "RAILWAY_ENVIRONMENT_ID",
+      "RAILWAY_SERVICE_ID",
+      "RAILWAY_TOKEN",
+    ]) {
+      expect(preflight.run).toContain(`\n  ${name}\n`);
+    }
+    expect(preflight.run).toContain('"refs/heads/$DEPLOY_BRANCH"');
+    expect(preflight.run).toContain('"$(git rev-parse HEAD)" "$GITHUB_SHA"');
+    expect(preflight.run).toContain(
+      "git status --porcelain --untracked-files=all",
+    );
+    expect(preflight.run).toContain("Unsupported protected environment");
+    expect(preflight.run).not.toContain('echo "$actual"');
+
+    for (const canonical of [
+      "https://api.eliza.app",
+      "https://api-staging.eliza.app",
+      "eliza-production-1.eliza.app",
+      "eliza-staging-1.eliza.app",
+      "cloud.eliza.app",
+      "cloud-staging.eliza.app",
+      "https://gateway-webhook-production.up.railway.app",
+      "https://gateway-webhook-stg-staging.up.railway.app",
+    ]) {
+      expect(source).toContain(canonical);
+    }
+  });
+
+  test("pins Railway and resolves the exact project, environment, service, and domain", () => {
+    const install = step("Install pinned Railway CLI");
+    expect(install.run).toContain("v5.38.0");
+    expect(install.run).toContain(
+      "72835c48a710c48c4542141bf12264823cf3a029b514f9e27994096c036c539e",
+    );
+    expect(install.run).toContain("sha256sum --check --status");
+
+    const target = step("Verify exact Railway target and public domain");
+    expect(target.run).toContain("railway status");
+    expect(target.run).toContain('--project "$RAILWAY_PROJECT_ID"');
+    expect(target.run).toContain('--environment "$RAILWAY_ENVIRONMENT_ID"');
+    expect(target.run).toContain(".node.id == $id and .node.name == $name");
+    expect(target.run).toContain("railway domain list");
+    expect(target.run).toContain('--service "$RAILWAY_SERVICE_ID"');
+    expect(target.run).toContain(".domain == $domain");
+  });
+
+  test("checks sensitive variable names through private files without publishing values", () => {
+    const variables = step(
+      "Verify canonical Railway variables and sensitive names",
+    );
+    expect(variables.run).toContain("umask 077");
+    expect(variables.run).toContain("railway variable list");
+    expect(variables.run).toContain("nonblank_sensitive_names");
+    expect(variables.run).toContain('shred -u "$variables_raw_path"');
+    expect(variables.run).toContain("GATEWAY_BOOTSTRAP_SECRET");
+    expect(variables.run).toContain("GATEWAY_INTERNAL_SECRET");
+    expect(variables.run).toContain("AGENT_SERVER_SHARED_SECRET");
+    expect(variables.run).toContain("ELIZA_APP_WEBHOOK_GATEWAY_SECRET");
+    expect(variables.run).toContain("REDIS_URL");
+    expect(variables.run).toContain("KV_REST_API_URL");
+    expect(variables.run).toContain("KV_REST_API_TOKEN");
+    expect(variables.run).toContain("AGENT_ROUTER_ORIGIN_HOST");
+    expect(variables.run).toContain("ELIZA_CLOUD_AGENT_BASE_DOMAIN");
+    expect(source).not.toContain("railway variable set");
+    expect(source).not.toContain('cat "$variables_path"');
+    expect(source).not.toContain('echo "$RAILWAY_TOKEN"');
+  });
+
+  test("binds the exact root source and manifest to its new deployment id", () => {
+    const exactSource = step("Deploy exact gateway-webhook source");
+    expect(exactSource.run).toContain(
+      '"$(git rev-parse HEAD)" != "$GITHUB_SHA"',
+    );
+    expect(exactSource.run).toContain(
+      "git status --porcelain --untracked-files=all",
+    );
+    expect(railwayUpPathArgument(exactSource.run ?? "")).toBeUndefined();
+    expect(exactSource.run).toContain(
+      "cp packages/cloud/services/gateway-webhook/railway.toml railway.toml",
+    );
+    expect(exactSource.run).toContain("cmp --silent");
+    expect(exactSource.run).toContain('!= "?? railway.toml"');
+    expect(exactSource.run).toContain('--project "$RAILWAY_PROJECT_ID"');
+    expect(exactSource.run).toContain(
+      '--environment "$RAILWAY_ENVIRONMENT_ID"',
+    );
+    expect(exactSource.run).toContain('--service "$RAILWAY_SERVICE_ID"');
+    expect(exactSource.run).toContain("--detach");
+    expect(exactSource.run).toContain("--yes");
+    expect(exactSource.run).toContain(
+      '--message "gateway-webhook $GITHUB_SHA ($TARGET_ENVIRONMENT)"',
+    );
+    expect(exactSource.run).toContain(
+      "gateway-webhook-deployment-baseline.json",
+    );
+    expect(exactSource.run).toContain("deployment_id=$deployment_id");
+
+    const fixtureRoot = mkdtempSync(
+      join(tmpdir(), "gateway-webhook-railway-v538-"),
+    );
+    try {
+      const dockerfilePath =
+        "packages/cloud/services/gateway-webhook/Dockerfile";
+      mkdirSync(join(fixtureRoot, "packages/cloud/services/gateway-webhook"), {
+        recursive: true,
+      });
+      writeFileSync(join(fixtureRoot, "railway.toml"), "[build]\n");
+      writeFileSync(join(fixtureRoot, dockerfilePath), "FROM scratch\n");
+
+      expect(() =>
+        pinnedRailwayV538ArchiveMembers(fixtureRoot, ".", [
+          "railway.toml",
+          dockerfilePath,
+        ]),
+      ).toThrow("prefix not found");
+
+      const archiveMembers = pinnedRailwayV538ArchiveMembers(
+        fixtureRoot,
+        railwayUpPathArgument(exactSource.run ?? ""),
+        ["railway.toml", dockerfilePath],
+      );
+      expect(archiveMembers).toEqual(["railway.toml", dockerfilePath]);
+
+      const archivePath = join(fixtureRoot, "gateway-webhook-source.tar.gz");
+      const createArchive = Bun.spawnSync([
+        "tar",
+        "-czf",
+        archivePath,
+        "-C",
+        fixtureRoot,
+        ...archiveMembers,
+      ]);
+      expect(createArchive.exitCode).toBe(0);
+      const listArchive = Bun.spawnSync(["tar", "-tzf", archivePath]);
+      expect(listArchive.exitCode).toBe(0);
+      const listed = listArchive.stdout.toString().trim().split("\n");
+      expect(listed).toContain("railway.toml");
+      expect(listed).toContain(dockerfilePath);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+
+    const wait = step("Wait for the exact Railway deployment");
+    expect(wait.env?.DEPLOYMENT_ID).toContain(
+      "steps.railway_deploy.outputs.deployment_id",
+    );
+    expect(wait.run).toContain("railway deployment list");
+    expect(wait.run).toContain(".id == $id");
+    expect(wait.run).toContain("SUCCESS");
+    expect(wait.run).toContain("FAILED | CRASHED | REMOVED");
+    expect(wait.run).toContain("CANCELED | CANCELLED");
+  });
+
+  test("proves live health and the startup-required canonical fallback pair", () => {
+    const verify = step(
+      "Verify deployed health and canonical fallback configuration",
+    );
+    expect(verify.env?.DEPLOYMENT_ID).toContain(
+      "steps.railway_deploy.outputs.deployment_id",
+    );
+    expect(verify.run).toContain('.meta.configFile == "/railway.toml"');
+    expect(verify.run).toContain(".meta.fileServiceManifest.build.builder");
+    expect(verify.run).toContain(".meta.serviceManifest.build.builder");
+    expect(verify.run).toContain(
+      "packages/cloud/services/gateway-webhook/Dockerfile",
+    );
+    expect(verify.run).toContain(
+      ".meta.fileServiceManifest.deploy.healthcheckPath",
+    );
+    expect(verify.run).toContain("railway service status");
+    expect(
+      verify.run?.match(/^assert_active_deployment (before|after)$/gm)?.length,
+    ).toBe(2);
+    expect(verify.run).toContain(".deploymentId == $id");
+    expect(verify.run).toContain('"$GATEWAY_WEBHOOK_URL/health"');
+    expect(verify.run).toContain('.status == "healthy"');
+    expect(verify.run).toContain("railway variable list");
+    expect(verify.run).toContain(".AGENT_ROUTER_ORIGIN_HOST == $router");
+    expect(verify.run).toContain(".ELIZA_CLOUD_AGENT_BASE_DOMAIN == $domain");
+    const verifyRun = verify.run ?? "";
+    expect(() =>
+      assertExactForwarderAuthReadinessProbe(verifyRun),
+    ).not.toThrow();
+    const readinessMutations = [
+      [
+        "/ready/forwarder-auth/eliza-app",
+        "/webhook/eliza-app/telegram",
+        "forwarder readiness route contract drifted",
+      ],
+      [
+        '"$forwarder_probe_status" != "401"',
+        '"$forwarder_probe_status" != "200"',
+        "forwarder readiness status contract drifted",
+      ],
+      [
+        '.status == "enforced"',
+        '.status == "ready"',
+        "forwarder readiness readiness contract drifted",
+      ],
+      [
+        '.project == "eliza-app"',
+        '.project == "another-project"',
+        "forwarder readiness project contract drifted",
+      ],
+    ] as const;
+    for (const [from, to, error] of readinessMutations) {
+      const mutated = verifyRun.replace(from, to);
+      expect(mutated).not.toBe(verifyRun);
+      expect(() => assertExactForwarderAuthReadinessProbe(mutated)).toThrow(
+        error,
+      );
+    }
+    expect(() =>
+      assertExactForwarderAuthReadinessProbe(
+        verifyRun.replace(
+          "--max-time 15",
+          "--max-time 15 --header X-Eliza-Webhook-Forwarder-Secret:guess",
+        ),
+      ),
+    ).toThrow("forwarder readiness probe entered a forbidden path");
+
+    const summary = step("Write deployment summary");
+    expect(summary.run).toContain("$GITHUB_SHA");
+    expect(summary.run).toContain("$DEPLOYMENT_ID");
+    expect(summary.run).toContain("Canonical fallback pair: verified");
+
+    const cleanup = step("Remove temporary deployment files");
+    expect(cleanup.run).toContain("shred -u");
+    expect(cleanup.run).toContain("shred -u railway.toml");
+    expect(cleanup.run).toContain("gateway-webhook-active-deployment.json");
+    expect(cleanup.run).toContain(
+      "gateway-webhook-forwarder-auth-readiness.json",
+    );
+    expect(cleanup.run).toContain("gateway-webhook-railway-variables-raw.json");
+    expect(cleanup.run).toContain(
+      "gateway-webhook-postdeploy-variables-raw.json",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Backport the already-merged protected gateway-webhook release path from develop so the production-only main branch can actually dispatch it.

- add the audited manual Railway workflow with exact branch, SHA, project, environment, service, domain, and source checks
- add fail-closed forwarder-auth readiness probing
- add workflow and readiness tests
- update deployment documentation and paired package guides

This unblocks the production release of #19525 without using an unguarded local Railway deployment.

Related to #19519 and #19524.

## Verification

- bun test packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts: 6 pass, 0 fail
- bun run --cwd packages/cloud/services/gateway-webhook test: 116 pass, 0 fail
- bun run --cwd packages/cloud/services/gateway-webhook typecheck: pass
- bun run --cwd packages/cloud/services/gateway-webhook lint: pass
- bun run --cwd packages/cloud/services/gateway-webhook build: pass
- bun run check:agents-claude: pass
- git diff origin/main...HEAD --check: pass

## Contribution provenance

- AI provider/model: OpenAI / gpt-5
- Client / agent tooling: Codex desktop
- Contribution skill revision: elizaOS/eliza@acb1b6cdc6113eb8a5437eb6c8568201cb807f79:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported

<!-- evidence-head:a25a7e0de5ca3a9624ef3097c09b626d29e1e904 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - deployment workflow and backend readiness route only

<!-- evidence-row:after-screenshots -->
- [ ] N/A - deployment workflow and backend readiness route only

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI or interactive surface changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - pre-deploy change; deterministic workflow and gateway suites are listed in Verification

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser frontend changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model prompt, response, or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no image, audio, PDF, or domain artifact is produced by this release workflow

— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@acb1b6cdc6113eb8a5437eb6c8568201cb807f79:packages/skills/skills/contribute-to-eliza"} -->
