### PR TITLE
test(app): share browser fixture stubs

### DIFF
--- a/packages/app/test/ui-smoke/cloud-pair-evidence.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-pair-evidence.spec.ts
@@ -24,11 +24,14 @@
  *   ELIZA_UI_SMOKE_REUSE_SERVER=1 bun x playwright test cloud-pair-evidence --config playwright.ui-smoke.config.ts
  */
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { builtinModules } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, type Page, test } from "@playwright/test";
-import { build, type Plugin as EsbuildPlugin, transform } from "esbuild";
+import { build, transform } from "esbuild";
+import {
+  stubElizaCore,
+  stubNodeBuiltins,
+} from "../../../ui/src/testing/e2e-runner/esbuild-stubs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // HERE = packages/app/test/ui-smoke → up 2 = packages/app
@@ -46,52 +49,6 @@ let evidenceBundlePromise: Promise<string> | null = null;
 function evidenceModulesBundle(): Promise<string> {
   evidenceBundlePromise ??= (async () => {
     const ui = join(REPO_ROOT, "packages", "ui", "src");
-    // Node-builtin imports reached through transitive dependency chains become
-    // inert proxies (mirrors the reviewed accounts-ui e2e bundler): the
-    // modules under test are browser storage/auth code and never call them.
-    const nodeBuiltins = new Set([
-      ...builtinModules,
-      ...builtinModules.map((name) => `node:${name}`),
-    ]);
-    // `@elizaos/core` is never imported by the modules under test (verified —
-    // it only enters transitively through i18n/api barrel collaterals), and
-    // its plugin-manager subtree is node-only, so the whole package becomes an
-    // inert proxy as well.
-    const stubElizaCore: EsbuildPlugin = {
-      name: "stub-eliza-core",
-      setup(b) {
-        b.onResolve({ filter: /^@elizaos\/core(\/.*)?$/ }, (args) => ({
-          path: args.path,
-          namespace: "eliza-core-stub",
-        }));
-        b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
-          contents:
-            "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
-          loader: "js",
-        }));
-      },
-    };
-    const stubNodeBuiltins: EsbuildPlugin = {
-      name: "stub-node-builtins",
-      setup(b) {
-        b.onResolve({ filter: /.*/ }, (args) => {
-          const bare = args.path.replace(/^node:/, "").split("/")[0] ?? "";
-          if (
-            args.path.startsWith("node:") ||
-            nodeBuiltins.has(args.path) ||
-            builtinModules.includes(bare)
-          ) {
-            return { path: args.path, namespace: "node-stub" };
-          }
-          return null;
-        });
-        b.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
-          contents:
-            "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
-          loader: "js",
-        }));
-      },
-    };
     const entry = [
       `export * as relay from ${JSON.stringify(join(ui, "components/auth/CloudPairRelay.tsx"))};`,
       `export * as tokenState from ${JSON.stringify(join(ui, "state/cloud-pair-token.ts"))};`,
@@ -124,7 +81,7 @@ function evidenceModulesBundle(): Promise<string> {
         ".woff": "empty",
         ".woff2": "empty",
       },
-      plugins: [stubElizaCore, stubNodeBuiltins],
+      plugins: [stubElizaCore(), stubNodeBuiltins()],
       absWorkingDir: REPO_ROOT,
       logLevel: "silent",
     });


### PR DESCRIPTION
# Relates to

Relates to #19307. Completes only the cloud-pair evidence-bundle harness failure; the separately reproduced first-run sandbox provisioning failure and the rest of the issue inventory remain open.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] The real browser path generates reviewable credential-lifecycle screenshots and storage dumps.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on `origin/develop@d1f678d57bcef9835014e457e80a9a85504932ed`; zero conflicts.
- [x] Exact-head `bun run verify` passes at `0f99c387afec559ca321fc82250d8930bef729d0`.

# Risks

Low. This changes only a Playwright evidence harness and removes its stale duplicate esbuild stubs. The harness now imports the shared, unit-tested stubs used by the UI evidence runner. No production bundle, timeout, catch, or fallback behavior changes.

# Background

## What does this PR do?

It makes the cloud-pair evidence spec use the shared browser bundle stubs. The local duplicate modeled `@elizaos/core` as a generic CommonJS proxy, so esbuild's ESM interop resolved `ElizaError` as undefined and crashed while evaluating `class CloudAgentWakeError extends ElizaError`. The shared stub exports a real `ElizaError` class and is already covered by its own contract test.

## What kind of change is this?

Test/evidence-harness repair (non-breaking).

# Testing

## Where should a reviewer start?

Run `bun run --cwd packages/app test:e2e test/ui-smoke/cloud-pair-evidence.spec.ts`, then inspect the attached lifecycle screenshots, manifest, and storage dumps.

## Detailed testing steps

- Before, on unmodified `develop`: the exact three-file reproduction was 3 passed / 3 failed. Both cloud-pair cases failed before injection with `evidence module bundle not injected`; the separate direct-sandbox first-run case failed with zero submissions.
- `bun install` completed with pinned Bun 1.3.14 and the required 971 MiB artifact sync.
- Shared stub unit contract: 2/2 passed.
- Exact cloud-pair Playwright contract: 2/2 passed and generated six lifecycle screenshots plus four storage dumps.
- `bun run verify`: 350/350 tasks plus all repository audits; anti-larp scanned 8,035 test files with zero focused or orphaned skips.
- `bun run --cwd packages/app audit:app`: pending while this draft preserves browser artifacts; the PR will not be marked ready until it passes.
- `git diff --check`: pending final audit/rebase check.

# Evidence Gate

<!-- evidence-head:0f99c387afec559ca321fc82250d8930bef729d0 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - the prior failure occurred during module evaluation before the browser harness could inject or render the evidence UI; the validation transcript records the exact failure
<!-- evidence-row:after-screenshots -->
- [x] Exact-head cloud-pair lifecycle screenshots attached below
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic harness test; the six ordered screenshots and storage manifest expose each state transition without an operator-only interaction
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend service changes; the harness deterministically models the cloud boundary
<!-- evidence-row:frontend-logs -->
- [x] Exact-head Playwright transcript attached below
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model invocation or agent behavior change
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head manifest and storage dumps attached below
<!-- evidence-row:ocr-review -->
- [ ] Pending exact-head app audit

# Evidence Details

Artifact links will be inserted by the repository evidence uploader before this PR is marked ready.

## Known gaps / failures

- The separately reproduced `direct-sandbox-first-run.spec.ts` failure (`submissions.length === 0`) is outside this focused harness repair and remains open under #19307.
- Other failures enumerated by #19307 remain open; this PR does not claim to close the parent issue.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
