### PR TITLE
fix(ui): wrap pay-as-you-go switch in SettingsStack

### DIFF
--- a/packages/ui/src/cloud/billing/components/pay-as-you-go-card.test.tsx
+++ b/packages/ui/src/cloud/billing/components/pay-as-you-go-card.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Renders PayAsYouGoCard through SettingsSwitchRow and asserts load plus
+ * toggle persist. jsdom, mocked billing settings API.
+ */
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../lib/api-client", () => ({
+  api: apiMock,
+  ApiError: class ApiError extends Error {},
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { PayAsYouGoCard } from "./pay-as-you-go-card";
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  apiMock.mockReset();
+});
+
+describe("PayAsYouGoCard", () => {
+  it("loads the existing switch without BrandCard chrome", async () => {
+    apiMock.mockResolvedValueOnce({
+      settings: { payAsYouGoFromEarnings: true },
+    });
+
+    render(<PayAsYouGoCard />);
+
+    expect(screen.getByText("Pay hosting from earnings")).toBeTruthy();
+    expect(
+      screen.getByText("Use my app earnings to pay container hosting"),
+    ).toBeTruthy();
+    const toggle = await screen.findByRole("switch");
+    expect(
+      toggle.getAttribute("data-state") ?? toggle.getAttribute("aria-checked"),
+    ).toMatch(/checked|true/);
+    expect(apiMock).toHaveBeenCalledWith("/api/v1/billing/settings");
+  });
+
+  it("PUTs the next value when the switch is toggled", async () => {
+    apiMock
+      .mockResolvedValueOnce({ settings: { payAsYouGoFromEarnings: true } })
+      .mockResolvedValueOnce({});
+
+    render(<PayAsYouGoCard />);
+    const toggle = await screen.findByRole("switch");
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(apiMock).toHaveBeenLastCalledWith("/api/v1/billing/settings", {
+        method: "PUT",
+        json: { payAsYouGoFromEarnings: false },
+      });
+    });
+  });
+});

--- a/packages/ui/src/cloud/billing/components/pay-as-you-go-card.tsx
+++ b/packages/ui/src/cloud/billing/components/pay-as-you-go-card.tsx
@@ -5,17 +5,21 @@
  * earnings stay untouched for token cashout.
  *
  * Reads/writes /api/v1/billing/settings (the same endpoint that handles
- * auto-top-up).
+ * auto-top-up). The toggle is a SettingsSwitchRow hosted in SettingsStack /
+ * SettingsGroup.
  */
 
 "use client";
 
-import { BrandCard, CornerBrackets } from "@elizaos/ui/cloud-ui";
 import { Coins, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { SettingsSwitchRow } from "../../../components/settings/settings-agent-rows";
-import { SettingsRow } from "../../../components/settings/settings-layout";
+import {
+  SettingsGroup,
+  SettingsRow,
+  SettingsStack,
+} from "../../../components/settings/settings-layout";
 import { ApiError, api } from "../../lib/api-client";
 
 const ENDPOINT = "/api/v1/billing/settings";
@@ -60,17 +64,8 @@ export function PayAsYouGoCard() {
   };
 
   return (
-    <BrandCard className="relative">
-      <CornerBrackets size="sm" className="opacity-50" />
-
-      <div className="relative z-10 space-y-4">
-        <div className="flex items-center gap-2">
-          <div className="w-2 h-2 rounded-full bg-muted" />
-          <h3 className="text-base font-mono text-txt uppercase">
-            Pay Hosting From Earnings
-          </h3>
-        </div>
-
+    <SettingsStack data-testid="cloud-pay-as-you-go">
+      <SettingsGroup title="Pay hosting from earnings">
         {enabled === null ? (
           <SettingsRow
             icon={Coins}
@@ -92,7 +87,7 @@ export function PayAsYouGoCard() {
             onCheckedChange={(next) => void handleToggle(next)}
           />
         )}
-      </div>
-    </BrandCard>
+      </SettingsGroup>
+    </SettingsStack>
   );
 }

--- a/packages/ui/src/components/settings/settings-dashboard-leftovers.test.ts
+++ b/packages/ui/src/components/settings/settings-dashboard-leftovers.test.ts
@@ -34,24 +34,8 @@ const SETTINGS_MOUNTED_DIRS = [
  */
 const BRANDCARD_ALLOWLIST = new Map<string, string>([
   [
-    "cloud/account-security/components/profile-form.tsx",
-    "account name/email save-cancel form (next 1:1 SettingsInputRow class)",
-  ],
-  [
-    "cloud/account-security/components/incident-report-panel.tsx",
-    "incident textarea + submit + mailto form (next SettingsTextareaRow class)",
-  ],
-  [
-    "cloud/account-security/components/mfa-panel.tsx",
-    "pending #19497 status-only SettingsRow conversion",
-  ],
-  [
-    "cloud/account-security/components/recent-audit-events.tsx",
-    "pending #19497 unavailable SettingsRow conversion",
-  ],
-  [
     "cloud/billing/components/pay-as-you-go-card.tsx",
-    "pending #19497 SettingsStack wrapper around SettingsSwitchRow",
+    "BrandCard wrap around an already-converted SettingsSwitchRow",
   ],
   [
     "cloud/billing/components/auto-top-up-card.tsx",
@@ -67,7 +51,7 @@ const BRANDCARD_ALLOWLIST = new Map<string, string>([
   ],
   [
     "cloud/organization/organization-tab.tsx",
-    "org hero tile + tabs; empty state pending #19497",
+    "org hero tile + tabs; empty state already converted",
   ],
   [
     "cloud/monetization/affiliates/AffiliatesPageClient.tsx",

--- a/packages/ui/src/components/settings/settings-dashboard-leftovers.test.ts
+++ b/packages/ui/src/components/settings/settings-dashboard-leftovers.test.ts
@@ -34,10 +34,6 @@ const SETTINGS_MOUNTED_DIRS = [
  */
 const BRANDCARD_ALLOWLIST = new Map<string, string>([
   [
-    "cloud/billing/components/pay-as-you-go-card.tsx",
-    "BrandCard wrap around an already-converted SettingsSwitchRow",
-  ],
-  [
     "cloud/billing/components/auto-top-up-card.tsx",
     "billing multi-field editor (switch + amounts + save)",
   ],


### PR DESCRIPTION
# Relates to

Closes #19530

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, rebased onto latest `origin/develop`.
- [ ] `bun run verify` not run for the whole monorepo.
- [x] Reviewer can confirm from evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d1f678d57bcef9835014e457e80a9a85504932ed:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop`.
- [ ] `bun run verify` not run for the whole monorepo.

# Risks

Low. Toggle contract and agent id unchanged.

# Background

## What does this PR do?

Unwraps the BrandCard around the already-converted pay-as-you-go SettingsSwitchRow. SettingsStack / SettingsGroup only.

## What kind of change is this?

Improvements

# Documentation changes needed?

No.

# Testing

```bash
bun run --cwd packages/ui test -- src/cloud/billing/components/pay-as-you-go-card.test.tsx src/components/settings/settings-dashboard-leftovers.test.ts
```

# Evidence Gate

<!-- evidence-head:ab3e72ca86b1cd00eecdfd555bfa9513810a3310 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19531-payg-wrap-real-switch-fullpage-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19531-payg-wrap-real-switch-fullpage-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19531-payg-wrap-real-switch-v2-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend contract change; still PUT /api/v1/billing/settings.
<!-- evidence-row:frontend-logs -->
- [x] [19531-payg-wrap-real-switch-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19531-payg-wrap-real-switch-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, wallet, scheduled-task, or generated domain artifact is involved.
<!-- evidence-row:ocr-review -->
- [x] [19531-payg-wrap-real-switch-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19531-payg-wrap-real-switch-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Known gaps / failures

- Full-repo verify not run.
- audit:app still blocked by startupCoordinator.target.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok-cli
Contribution skill revision: elizaOS/eliza@d1f678d57bcef9835014e457e80a9a85504932ed:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-4.6]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-cli","skill_revision":"elizaOS/eliza@d1f678d57bcef9835014e457e80a9a85504932ed:packages/skills/skills/contribute-to-eliza"} -->


