### PR TITLE
fix(homepage): validate live Blooio readiness

### DIFF
--- a/packages/app-core/scripts/check-homepage-public-readiness.mjs
+++ b/packages/app-core/scripts/check-homepage-public-readiness.mjs
@@ -1,32 +1,27 @@
 #!/usr/bin/env node
 /**
- * Check whether the public eliza.app entry point is ready for the shared
- * Eliza Cloud phone gateway.
- *
- * This is intentionally read-only. It verifies the deploy target, DNS records,
- * and the published GitHub Pages bundle that users hit before texting the
- * shared gateway number.
+ * Validates the rendered public homepage against the admitted Cloudflare and
+ * Blooio messaging configuration. The check is read-only and writes evidence
+ * that distinguishes a disabled WhatsApp surface from a verified live sender.
  */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
 
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const scriptPath = fileURLToPath(import.meta.url);
+const scriptDir = path.dirname(scriptPath);
 const repoRoot = path.resolve(scriptDir, "..", "..", "..");
-const repo = "elizaOS/elizaos.github.io";
-const expectedDomain = "eliza.app";
-const expectedGatewayNumber = "+14159611510";
-const expectedFormattedNumber = "+1 (415) 961-1510";
-const disallowedNumbers = ["+14153024399", "4153024399", "415-302-4399"];
-const expectedApexRecords = new Set([
-  "185.199.108.153",
-  "185.199.109.153",
-  "185.199.110.153",
-  "185.199.111.153",
-]);
-const expectedWwwCname = "elizaos.github.io.";
-const registryRdapUrl = `https://pubapi.registry.google/rdap/domain/${expectedDomain}`;
+const repo = "elizaOS/eliza";
+const defaultOrigin = "https://eliza.app";
+const expectedGatewayNumber = "+18087881821";
+const expectedFormattedNumber = "+1 (808) 788-1821";
+const rejectedWhatsAppNumbers = [
+  "+14155238886",
+  "+15551649988",
+  "+14159611510",
+];
 const defaultEvidencePath = path.join(
   repoRoot,
   ".eliza-local",
@@ -38,15 +33,14 @@ function usage() {
     "Usage: node packages/app-core/scripts/check-homepage-public-readiness.mjs [options]",
     "",
     "Options:",
-    "  --evidence <path>  Write structured proof JSON. Defaults to .eliza-local/homepage-public-readiness-latest.json.",
+    "  --origin <url>     Public origin. Defaults to https://eliza.app.",
+    "  --evidence <path>  Write proof JSON. Defaults to .eliza-local/homepage-public-readiness-latest.json.",
     "  --no-evidence      Do not write a proof JSON file.",
   ].join("\n");
 }
 
 function parseArgs(argv) {
-  const args = {
-    evidencePath: defaultEvidencePath,
-  };
+  const args = { evidencePath: defaultEvidencePath, origin: defaultOrigin };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     const next = () => {
@@ -54,7 +48,8 @@ function parseArgs(argv) {
       if (!value) throw new Error(`${arg} requires a value`);
       return value;
     };
-    if (arg === "--evidence") args.evidencePath = path.resolve(next());
+    if (arg === "--origin") args.origin = new URL(next()).origin;
+    else if (arg === "--evidence") args.evidencePath = path.resolve(next());
     else if (arg === "--no-evidence") args.evidencePath = null;
     else if (arg === "--help" || arg === "-h") {
       console.log(usage());
@@ -71,302 +66,222 @@ function run(command, args) {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });
-  return {
-    status: result.status ?? (result.error ? 1 : 0),
-    stdout: result.stdout ?? "",
-    stderr: result.stderr ?? (result.error ? String(result.error) : ""),
-  };
-}
-
-function sleepSync(ms) {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-const evidenceChecks = [];
-
-function check(name, passed, detail) {
-  evidenceChecks.push({ name, passed, detail });
-  console.log(
-    `[homepage-public] ${passed ? "PASS" : "BLOCKED"} ${name}: ${detail}`,
-  );
-  return passed;
-}
-
-function ghJson(path, jq) {
-  const args = ["api", path];
-  if (jq) args.push("--jq", jq);
-  let lastResult = null;
-  for (let attempt = 1; attempt <= 3; attempt += 1) {
-    lastResult = run("gh", args);
-    if (lastResult.status === 0) return lastResult.stdout.trim();
-    if (attempt < 3) sleepSync(500 * attempt);
-  }
-  throw new Error(
-    lastResult?.stderr.trim() || lastResult?.stdout.trim() || "gh api failed",
-  );
-}
-
-function decodeGhContent(path) {
-  const content = ghJson(path, ".content");
-  return Buffer.from(content, "base64").toString("utf8");
-}
-
-function dig(name, type = null) {
-  const args = ["+short"];
-  if (type) args.push(type);
-  args.push(name);
-  const result = run("dig", args);
-  if (result.status !== 0) return [];
-  return result.stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
-}
-
-function fetchJson(url) {
-  const result = run("curl", ["-sS", "--max-time", "10", url]);
   if (result.status !== 0) {
     throw new Error(
-      result.stderr.trim() || result.stdout.trim() || "curl failed",
+      result.stderr?.trim() ||
+        result.stdout?.trim() ||
+        `${command} exited with ${result.status}`,
     );
   }
-  return JSON.parse(result.stdout);
+  return result.stdout.trim();
 }
 
-function setEquals(a, b) {
-  if (a.size !== b.size) return false;
-  for (const value of a) {
-    if (!b.has(value)) return false;
-  }
-  return true;
+function getRepoVariable(name) {
+  return run("gh", ["variable", "get", name, "--repo", repo]).trim();
 }
 
-function findJsAssets() {
-  const output = ghJson(
-    `repos/${repo}/git/trees/gh-pages?recursive=1`,
-    ".tree[].path",
+function normalizePhone(value) {
+  const trimmed = value.trim();
+  return /^\+[1-9]\d{7,14}$/.test(trimmed) ? trimmed : null;
+}
+
+export function evaluatePublicSurface(surface, config) {
+  const checks = [];
+  const check = (name, passed, detail) => {
+    checks.push({ name, passed, detail });
+  };
+  const expectedTelHref = `tel:${expectedGatewayNumber}`;
+  const expectedWhatsAppHref = `https://wa.me/${expectedGatewayNumber.slice(1)}`;
+
+  check(
+    "cloudflare-origin",
+    surface.server.toLowerCase() === "cloudflare",
+    `server=${surface.server || "missing"}`,
   );
-  return output
-    .split(/\r?\n/)
-    .filter((path) =>
-      /^assets\/(get-started|connected|contact)-.*\.js$/.test(path),
+  check(
+    "canonical-origin",
+    surface.finalUrl === `${config.origin ?? defaultOrigin}/`,
+    `url=${surface.finalUrl}`,
+  );
+  check(
+    "message-copy-fallback",
+    surface.messageButtonCount === 1 &&
+      surface.copiedPhone === expectedGatewayNumber &&
+      surface.copyNotice === "Phone number copied",
+    `buttons=${surface.messageButtonCount} clipboard=${surface.copiedPhone || "empty"} notice=${surface.copyNotice || "missing"}`,
+  );
+  check(
+    "call-target",
+    surface.telHrefs.includes(expectedTelHref),
+    surface.telHrefs.length ? surface.telHrefs.join(", ") : "missing",
+  );
+  check(
+    "phone-not-rendered",
+    !surface.bodyText.includes(expectedFormattedNumber),
+    surface.bodyText.includes(expectedFormattedNumber)
+      ? `visible text contains ${expectedFormattedNumber}`
+      : "formatted number absent from visible text",
+  );
+
+  const configuredWhatsApp = normalizePhone(config.whatsAppNumber);
+  const configSafe =
+    configuredWhatsApp === expectedGatewayNumber &&
+    !rejectedWhatsAppNumbers.includes(configuredWhatsApp);
+  check(
+    "whatsapp-sender-config",
+    configSafe,
+    `configured=${configuredWhatsApp ?? "invalid"}`,
+  );
+
+  if (config.whatsAppEnabled) {
+    check(
+      "whatsapp-public-admission",
+      surface.whatsAppHrefs.length === 1 &&
+        surface.whatsAppHrefs[0] === expectedWhatsAppHref,
+      surface.whatsAppHrefs.length
+        ? surface.whatsAppHrefs.join(", ")
+        : "enabled but rendered CTA is missing",
     );
+  } else {
+    check(
+      "whatsapp-fail-closed",
+      surface.whatsAppHrefs.length === 0,
+      surface.whatsAppHrefs.length
+        ? `disabled but rendered ${surface.whatsAppHrefs.join(", ")}`
+        : "disabled and no WhatsApp CTA rendered",
+    );
+  }
+
+  check(
+    "browser-console",
+    surface.consoleErrors.length === 0,
+    surface.consoleErrors.length
+      ? surface.consoleErrors.join(" | ")
+      : "no console errors",
+  );
+
+  return { ok: checks.every((entry) => entry.passed), checks };
 }
 
-function writeEvidence({ evidencePath, ok, next, details }) {
+async function inspectPublicSurface(origin) {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const context = await browser.newContext({
+      permissions: ["clipboard-read", "clipboard-write"],
+      userAgent:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/140.0.0.0 Safari/537.36",
+    });
+    const page = await context.newPage();
+    const consoleErrors = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") consoleErrors.push(message.text());
+    });
+    page.on("pageerror", (error) => consoleErrors.push(error.message));
+
+    const response = await page.goto(`${origin}/`, {
+      waitUntil: "domcontentloaded",
+      timeout: 30_000,
+    });
+    if (!response) throw new Error("homepage navigation returned no response");
+    await page.waitForSelector('a[href^="tel:"]', {
+      timeout: 20_000,
+    });
+
+    const collectHrefs = (selector) =>
+      page
+        .locator(selector)
+        .evaluateAll((elements) =>
+          elements
+            .map((element) => element.getAttribute("href"))
+            .filter((value) => typeof value === "string"),
+        );
+
+    const messageButton = page.getByRole("button", { name: "Message Eliza" });
+    const messageButtonCount = await messageButton.count();
+    let copiedPhone = "";
+    let copyNotice = "";
+    if (messageButtonCount === 1) {
+      await messageButton.click();
+      const status = page.getByRole("status");
+      await status.waitFor({ state: "visible", timeout: 5_000 });
+      copyNotice = await status.innerText();
+      copiedPhone = await page.evaluate(() => navigator.clipboard.readText());
+    }
+
+    return {
+      finalUrl: page.url(),
+      server: response.headers().server ?? "",
+      bodyText: await page.locator("body").innerText(),
+      messageButtonCount,
+      copiedPhone,
+      copyNotice,
+      telHrefs: await collectHrefs('a[href^="tel:"]'),
+      whatsAppHrefs: await collectHrefs('a[href^="https://wa.me/"]'),
+      consoleErrors,
+    };
+  } finally {
+    await browser.close();
+  }
+}
+
+function writeEvidence(evidencePath, evidence) {
   if (!evidencePath) return;
   fs.mkdirSync(path.dirname(evidencePath), { recursive: true });
-  const evidence = {
-    ok,
-    checkedAt: new Date().toISOString(),
-    domain: expectedDomain,
-    expectedGatewayNumber,
-    expectedFormattedNumber,
-    expectedApexRecords: [...expectedApexRecords],
-    expectedWwwCname,
-    checks: evidenceChecks,
-    next: next ?? null,
-    details,
-  };
   fs.writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`);
   console.log(`[homepage-public] evidence=${evidencePath}`);
 }
 
-function main() {
+async function main() {
   const args = parseArgs(process.argv.slice(2));
-  let allPassed = true;
-  let pagesSummary = null;
-  let assetSummary = null;
-
-  try {
-    const pages = JSON.parse(
-      ghJson(
-        `repos/${repo}/pages`,
-        "{status,cname,html_url,source,protected_domain_state,pending_domain_unverified_at}",
-      ),
-    );
-    allPassed =
-      check(
-        "pages-source",
-        pages.status === "built" &&
-          pages.cname === expectedDomain &&
-          pages.source?.branch === "gh-pages" &&
-          pages.source?.path === "/",
-        `status=${pages.status} cname=${pages.cname ?? "none"} source=${pages.source?.branch ?? "none"}:${pages.source?.path ?? "none"}`,
-      ) && allPassed;
-    pagesSummary = pages;
-  } catch (error) {
-    allPassed =
-      check(
-        "pages-source",
-        false,
-        error instanceof Error ? error.message : String(error),
-      ) && allPassed;
-  }
-
-  try {
-    const cname = decodeGhContent(
-      `repos/${repo}/contents/CNAME?ref=gh-pages`,
-    ).trim();
-    allPassed =
-      check(
-        "gh-pages-cname",
-        cname === expectedDomain,
-        `CNAME=${cname || "empty"}`,
-      ) && allPassed;
-  } catch (error) {
-    allPassed =
-      check(
-        "gh-pages-cname",
-        false,
-        error instanceof Error ? error.message : String(error),
-      ) && allPassed;
-  }
-
-  try {
-    const assets = findJsAssets();
-    if (!assets.some((asset) => /^assets\/get-started-.*\.js$/.test(asset))) {
-      throw new Error("no get-started asset found on gh-pages");
-    }
-    const bundle = assets
-      .map((asset) =>
-        decodeGhContent(`repos/${repo}/contents/${asset}?ref=gh-pages`),
-      )
-      .join("\n");
-    const hasGateway =
-      bundle.includes(expectedGatewayNumber) &&
-      bundle.includes(expectedFormattedNumber);
-    const hasPersonalNumber = disallowedNumbers.some((value) =>
-      bundle.includes(value),
-    );
-    assetSummary = {
-      count: assets.length,
-      assets,
-      hasGateway,
-      hasPersonalNumber,
-    };
-    allPassed =
-      check(
-        "homepage-bundle",
-        hasGateway && !hasPersonalNumber,
-        `${assets.length} js assets gateway=${hasGateway ? "yes" : "no"} personal-number=${hasPersonalNumber ? "yes" : "no"}`,
-      ) && allPassed;
-  } catch (error) {
-    allPassed =
-      check(
-        "homepage-bundle",
-        false,
-        error instanceof Error ? error.message : String(error),
-      ) && allPassed;
-  }
-
-  const delegatedNameservers = dig(expectedDomain, "NS");
-  let registryStatuses = [];
-  let registryNameservers = [];
-  try {
-    const rdap = fetchJson(registryRdapUrl);
-    registryStatuses = Array.isArray(rdap.status) ? rdap.status : [];
-    registryNameservers = Array.isArray(rdap.nameservers)
-      ? rdap.nameservers
-          .map((entry) =>
-            typeof entry?.ldhName === "string"
-              ? entry.ldhName.toLowerCase()
-              : "",
-          )
-          .filter(Boolean)
-      : [];
-    const clientHold = registryStatuses.includes("client hold");
-    allPassed =
-      check(
-        "registry-status",
-        !clientHold,
-        registryStatuses.length
-          ? registryStatuses.join(", ")
-          : "no status flags",
-      ) && allPassed;
-  } catch (error) {
-    allPassed =
-      check(
-        "registry-status",
-        false,
-        error instanceof Error ? error.message : String(error),
-      ) && allPassed;
-  }
-
-  allPassed =
-    check(
-      "domain-delegation",
-      delegatedNameservers.length > 0,
-      delegatedNameservers.length
-        ? delegatedNameservers.join(", ")
-        : registryNameservers.length
-          ? `registry lists ${registryNameservers.join(", ")} but delegation is withheld`
-          : "no delegated nameservers at .app registry",
-    ) && allPassed;
-
-  const apexRecords = new Set(dig(expectedDomain));
-  allPassed =
-    check(
-      "apex-dns",
-      setEquals(apexRecords, expectedApexRecords),
-      apexRecords.size ? [...apexRecords].join(", ") : "no A records",
-    ) && allPassed;
-
-  const wwwCnames = dig(`www.${expectedDomain}`, "CNAME");
-  allPassed =
-    check(
-      "www-dns",
-      wwwCnames.includes(expectedWwwCname),
-      wwwCnames.length ? wwwCnames.join(", ") : "no CNAME records",
-    ) && allPassed;
-
-  if (!allPassed) {
-    const dnsRecordInstructions =
-      `A ${expectedDomain} -> ${[...expectedApexRecords].join(", ")}; ` +
-      `CNAME www.${expectedDomain} -> ${expectedWwwCname}`;
-    const next = registryStatuses.includes("client hold")
-      ? `clear client hold at Porkbun/registrar, then add GitHub Pages DNS records (${dnsRecordInstructions}). With Porkbun API credentials, run: bun run --cwd packages/app-core sms-gateway:homepage:dns -- --apply. Then rerun this script.`
-      : `delegate eliza.app to DNS nameservers, add GitHub Pages DNS records (${dnsRecordInstructions}). With Porkbun API credentials, run: bun run --cwd packages/app-core sms-gateway:homepage:dns -- --apply. Then rerun this script.`;
-    console.error(`[homepage-public] next: ${next}`);
-    writeEvidence({
-      evidencePath: args.evidencePath,
-      ok: false,
-      next,
-      details: {
-        pages: pagesSummary,
-        assets: assetSummary,
-        registryStatuses,
-        registryNameservers,
-        delegatedNameservers,
-        apexRecords: [...apexRecords],
-        wwwCnames,
-      },
-    });
-    process.exitCode = 1;
-    return;
-  }
-
-  writeEvidence({
-    evidencePath: args.evidencePath,
-    ok: true,
-    next: null,
-    details: {
-      pages: pagesSummary,
-      assets: assetSummary,
-      registryStatuses,
-      registryNameservers,
-      delegatedNameservers,
-      apexRecords: [...apexRecords],
-      wwwCnames,
-    },
+  const whatsAppEnabled = getRepoVariable("WHATSAPP_PUBLIC_ENABLED") === "true";
+  const whatsAppNumber = getRepoVariable("VITE_WHATSAPP_PHONE_NUMBER");
+  const surface = await inspectPublicSurface(args.origin);
+  const result = evaluatePublicSurface(surface, {
+    origin: args.origin,
+    whatsAppEnabled,
+    whatsAppNumber,
   });
+
+  for (const entry of result.checks) {
+    console.log(
+      `[homepage-public] ${entry.passed ? "PASS" : "BLOCKED"} ${entry.name}: ${entry.detail}`,
+    );
+  }
+
+  const evidence = {
+    ok: result.ok,
+    checkedAt: new Date().toISOString(),
+    origin: args.origin,
+    expectedGatewayNumber,
+    whatsAppEnabled,
+    whatsAppNumber,
+    checks: result.checks,
+    surface: {
+      finalUrl: surface.finalUrl,
+      server: surface.server,
+      messageButtonCount: surface.messageButtonCount,
+      copiedPhone: surface.copiedPhone,
+      copyNotice: surface.copyNotice,
+      telHrefs: surface.telHrefs,
+      whatsAppHrefs: surface.whatsAppHrefs,
+      consoleErrors: surface.consoleErrors,
+    },
+  };
+  writeEvidence(args.evidencePath, evidence);
+
+  if (!result.ok) {
+    console.error(
+      "[homepage-public] next: deploy the current main Cloudflare Pages artifact; keep WHATSAPP_PUBLIC_ENABLED=false until Blooio exposes an active WhatsApp channel and a real handset inbound/reply round trip passes.",
+    );
+    process.exitCode = 1;
+  }
 }
 
-try {
-  main();
-} catch (error) {
-  console.error(
-    `[homepage-public] ${error instanceof Error ? error.message : String(error)}`,
-  );
-  process.exit(1);
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  main().catch((error) => {
+    console.error(
+      `[homepage-public] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  });
 }

--- a/packages/app-core/scripts/check-homepage-public-readiness.test.mjs
+++ b/packages/app-core/scripts/check-homepage-public-readiness.test.mjs
@@ -1,0 +1,91 @@
+/**
+ * Exercises the homepage readiness policy with deterministic rendered-surface
+ * fixtures; no network, browser, or provider account is used by this suite.
+ */
+import { expect, test } from "vitest";
+import { evaluatePublicSurface } from "./check-homepage-public-readiness.mjs";
+
+const healthySurface = {
+  finalUrl: "https://eliza.app/",
+  server: "cloudflare",
+  bodyText: "Four hours of your time back every week.",
+  messageButtonCount: 1,
+  copiedPhone: "+18087881821",
+  copyNotice: "Phone number copied",
+  telHrefs: ["tel:+18087881821"],
+  whatsAppHrefs: [],
+  consoleErrors: [],
+};
+
+test("accepts the Cloudflare homepage with WhatsApp disabled", () => {
+  const result = evaluatePublicSurface(healthySurface, {
+    whatsAppEnabled: false,
+    whatsAppNumber: "+18087881821",
+  });
+  expect(result.ok).toBe(true);
+});
+
+test("evaluates an explicitly selected public origin", () => {
+  const result = evaluatePublicSurface(
+    { ...healthySurface, finalUrl: "https://preview.eliza.app/" },
+    {
+      origin: "https://preview.eliza.app",
+      whatsAppEnabled: false,
+      whatsAppNumber: "+18087881821",
+    },
+  );
+  expect(result.ok).toBe(true);
+});
+
+test("rejects a stale WhatsApp CTA while admission is disabled", () => {
+  const result = evaluatePublicSurface(
+    {
+      ...healthySurface,
+      whatsAppHrefs: ["https://wa.me/14159611510"],
+    },
+    { whatsAppEnabled: false, whatsAppNumber: "+18087881821" },
+  );
+  expect(result.ok).toBe(false);
+  expect(
+    result.checks.find((entry) => entry.name === "whatsapp-fail-closed")
+      ?.passed,
+  ).toBe(false);
+});
+
+test("requires the same admitted Blooio number when WhatsApp is enabled", () => {
+  const admitted = evaluatePublicSurface(
+    {
+      ...healthySurface,
+      whatsAppHrefs: ["https://wa.me/18087881821"],
+    },
+    { whatsAppEnabled: true, whatsAppNumber: "+18087881821" },
+  );
+  expect(admitted.ok).toBe(true);
+
+  const formerNumber = evaluatePublicSurface(
+    {
+      ...healthySurface,
+      whatsAppHrefs: ["https://wa.me/14159611510"],
+    },
+    { whatsAppEnabled: true, whatsAppNumber: "+14159611510" },
+  );
+  expect(formerNumber.ok).toBe(false);
+});
+
+test("rejects visible phone copy and incorrect call targets", () => {
+  const result = evaluatePublicSurface(
+    {
+      ...healthySurface,
+      bodyText: "Call +1 (808) 788-1821",
+      telHrefs: ["tel:+14159611510"],
+    },
+    { whatsAppEnabled: false, whatsAppNumber: "+18087881821" },
+  );
+  expect(result.ok).toBe(false);
+  expect(
+    result.checks.find((entry) => entry.name === "phone-not-rendered")?.passed,
+  ).toBe(false);
+  expect(
+    result.checks.find((entry) => entry.name === "call-target")?.passed,
+  ).toBe(false);
+});

--- a/packages/homepage/AGENTS.md
+++ b/packages/homepage/AGENTS.md
@@ -125,7 +125,7 @@ isolated visual harness.
 | `VITE_TELEGRAM_BOT_ID` | `8931353359` | Optional numeric Telegram bot ID override |
 | `VITE_DISCORD_CLIENT_ID` | `1474591626759376967` | Optional Discord Application ID override |
 | `WHATSAPP_PUBLIC_ENABLED` | disabled | Deployment-only switch that admits the public WhatsApp CTA |
-| `VITE_WHATSAPP_PHONE_NUMBER` | — | Production WhatsApp Business sender (E.164); local/test code retains a fixture |
+| `VITE_WHATSAPP_PHONE_NUMBER` | — | Admitted Blooio WhatsApp sender (E.164); production uses the shared `+18087881821` number only after its WhatsApp channel passes live proof |
 
 Auth token is stored in `localStorage` under key `eliza_app_session`. The test signer hook is `window.__siwsTestSigner` (used by Playwright e2e to skip wallet interaction).
 

--- a/packages/homepage/CLAUDE.md
+++ b/packages/homepage/CLAUDE.md
@@ -125,7 +125,7 @@ isolated visual harness.
 | `VITE_TELEGRAM_BOT_ID` | `8931353359` | Optional numeric Telegram bot ID override |
 | `VITE_DISCORD_CLIENT_ID` | `1474591626759376967` | Optional Discord Application ID override |
 | `WHATSAPP_PUBLIC_ENABLED` | disabled | Deployment-only switch that admits the public WhatsApp CTA |
-| `VITE_WHATSAPP_PHONE_NUMBER` | — | Production WhatsApp Business sender (E.164); local/test code retains a fixture |
+| `VITE_WHATSAPP_PHONE_NUMBER` | — | Admitted Blooio WhatsApp sender (E.164); production uses the shared `+18087881821` number only after its WhatsApp channel passes live proof |
 
 Auth token is stored in `localStorage` under key `eliza_app_session`. The test signer hook is `window.__siwsTestSigner` (used by Playwright e2e to skip wallet interaction).
 

--- a/packages/homepage/README.md
+++ b/packages/homepage/README.md
@@ -25,7 +25,7 @@ cp .env.example .env.local
 | `VITE_TELEGRAM_BOT_ID` | Optional numeric Telegram bot ID override (default `8931353359`) |
 | `VITE_DISCORD_CLIENT_ID` | Optional Discord Application ID override (default `1474591626759376967`) |
 | `WHATSAPP_PUBLIC_ENABLED` | Deployment switch that must be true before the public WhatsApp CTA is built |
-| `VITE_WHATSAPP_PHONE_NUMBER` | Production WhatsApp Business sender in E.164 format; omitted by default |
+| `VITE_WHATSAPP_PHONE_NUMBER` | Admitted Blooio WhatsApp sender in E.164 format; set to the shared `+18087881821` number |
 
 OAuth provider callback configuration belongs to the unified Cloud auth routes
 and API deployment. Do not register a callback against this source package or
@@ -33,19 +33,21 @@ its optional test-harness port.
 
 ### WhatsApp production activation
 
-The homepage is provider-neutral: it opens the admitted Business sender with
-`wa.me`, while the gateway can receive and reply through either the direct Meta
-Cloud API adapter or the Twilio adapter. Leave `WHATSAPP_PUBLIC_ENABLED=false`
-until one provider owns a registered production sender and a real handset
-round trip has succeeded.
+The homepage opens the admitted Blooio WhatsApp sender with `wa.me`. A normal
+Blooio channel is not automatically a WhatsApp channel: it resolves outbound
+messages to iMessage, RCS, or SMS. Leave `WHATSAPP_PUBLIC_ENABLED=false` until
+Blooio exposes a separate active WhatsApp-capable channel for the shared number
+and a real handset round trip has succeeded.
 
-1. Register a production sender with Meta or Twilio and configure the matching
-   gateway credentials and webhook.
-2. Set the target GitHub environment's `VITE_WHATSAPP_PHONE_NUMBER` variable to
-   that exact sender.
-3. Set `WHATSAPP_PUBLIC_ENABLED=true` in the same environment and deploy the
+1. Ask Blooio to provision and expose an active WhatsApp channel for
+   `+18087881821`; verify it through `GET /v4/channels`.
+2. Confirm the gateway receives `message.received` with that exact channel id
+   and replies through the v4 channel-aware message endpoint.
+3. Set the repository `VITE_WHATSAPP_PHONE_NUMBER` variable to
+   `+18087881821`.
+4. Set `WHATSAPP_PUBLIC_ENABLED=true` and deploy the
    consolidated app.
-4. Verify the rendered `wa.me` target, receive a handset message through the
+5. Verify the rendered `wa.me` target, receive a handset message through the
    signed webhook, and confirm the agent reply reaches the same handset.
 
 The release workflow rejects the Twilio shared sandbox (`+14155238886`), the


### PR DESCRIPTION
## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI/GPT-5
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@acb1b6cdc6113eb8a5437eb6c8568201cb807f79:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

## Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passed post-sync: 350/350 tasks plus repository audits.

## Risks

Low. This changes an operational audit and documentation, not rendered UI or runtime messaging. The gate deliberately fails while production serves a disabled/stale WhatsApp CTA.

## Background

Closes #19522.

Replaces the retired GitHub Pages/old-number readiness check with a real Chromium audit of the Cloudflare-served homepage. It verifies the 808 call target, Windows clipboard fallback and notification, hidden formatted number, browser console, repository sender configuration, and fail-closed WhatsApp admission. Documentation now reflects Blooio v4 channel affinity and the requirement for a separately active WhatsApp channel.

## Testing

- `bun test packages/app-core/scripts/check-homepage-public-readiness.test.mjs` — 5/5
- `bun run --cwd packages/homepage test` — 101/101
- `bun run --cwd packages/homepage typecheck`
- `bun run --cwd packages/homepage lint`
- `bun run --cwd packages/app-core typecheck`
- `bun run --cwd packages/app-core lint`
- `bun run --cwd packages/app-core build`
- `bun run check:agents-claude` — 153 pairs identical
- `bun run verify` — 350/350
- `node packages/app-core/scripts/check-homepage-public-readiness.mjs --no-evidence` — live Cloudflare/call/copy/number/console checks pass; correctly blocks the stale `https://wa.me/14159611510` CTA while admission is false

## Evidence Gate

<!-- evidence-head:3ee450cd25b2f26991b8e77223f59809b4354bc8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — no rendered UI code changed; the audit reads the existing production surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no rendered UI code changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no rendered flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A — read-only browser/configuration audit; no backend path changed.
<!-- evidence-row:frontend-logs -->
- [x] Live headless Chromium audit observed no console errors and verified the copy interaction; command output is summarized above.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — no persistent domain data changed.
<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered visual surface changed.

## Audio / voice walkthrough

N/A — no TTS, STT, transcript, or voice code changed in this PR.

## Known gaps / failures

The live audit intentionally exits nonzero because production still serves the former WhatsApp CTA while `WHATSAPP_PUBLIC_ENABLED=false`. This is the production defect the new audit prevents from being certified; deploying the current main artifact is operational follow-up and is not hidden by this PR.

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@acb1b6cdc6113eb8a5437eb6c8568201cb807f79:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-homepage-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5","client":"codex-desktop","skill_revision":"elizaOS/eliza@acb1b6cdc6113eb8a5437eb6c8568201cb807f79:packages/skills/skills/contribute-to-eliza"} -->
