### PR TITLE
fix(ui): keep Switch off-state thumb visible on the track

### DIFF
--- a/packages/ui/src/components/ui/switch.stories.tsx
+++ b/packages/ui/src/components/ui/switch.stories.tsx
@@ -24,6 +24,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+export const Off: Story = { args: { checked: false } };
 export const On: Story = { args: { defaultChecked: true } };
 export const Disabled: Story = { args: { disabled: true } };
 export const DisabledOn: Story = { args: { disabled: true, checked: true } };

--- a/packages/ui/src/components/ui/switch.test.tsx
+++ b/packages/ui/src/components/ui/switch.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Renders the shared Switch and pins off-state thumb contrast classes.
+ * jsdom, no visual capture.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Switch } from "./switch";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Switch", () => {
+  it("uses a text-token thumb when unchecked so it does not match the track", () => {
+    const { getByRole } = render(
+      <Switch checked={false} aria-label="Example setting" />,
+    );
+    const track = getByRole("switch");
+    const thumb = track.querySelector("[aria-hidden='true']");
+    expect(track.getAttribute("data-state")).toBe("unchecked");
+    expect(track.className).toContain("data-[state=unchecked]:bg-input");
+    expect(thumb?.className).toContain("data-[state=unchecked]:bg-txt");
+    expect(thumb?.className).not.toMatch(/data-\[state=unchecked\]:bg-card\b/);
+  });
+
+  it("keeps a card-token thumb on the accent track when checked", () => {
+    const { getByRole } = render(
+      <Switch checked aria-label="Example setting" />,
+    );
+    const track = getByRole("switch");
+    const thumb = track.querySelector("[aria-hidden='true']");
+    expect(track.getAttribute("data-state")).toBe("checked");
+    expect(track.className).toContain("data-[state=checked]:bg-accent");
+    expect(thumb?.className).toContain("data-[state=checked]:bg-card");
+  });
+});

--- a/packages/ui/src/components/ui/switch.tsx
+++ b/packages/ui/src/components/ui/switch.tsx
@@ -1,9 +1,11 @@
 /**
  * On/off switch rendered as a `<button role="switch">` (controlled or
  * uncontrolled) — a dependency-free toggle that does not pull in Radix, used
- * wherever a bare boolean switch is needed. On coarse pointers the button's
- * box expands to the 44px touch floor while background clipping preserves the
- * compact 44x24 visual track.
+ * wherever a bare boolean switch is needed. The off-state thumb uses the
+ * text token so it stays visible on the input track in both appearances;
+ * the on-state thumb stays on the card token against the accent track. On
+ * coarse pointers the button's box expands to the 44px touch floor while
+ * background clipping preserves the compact 44x24 visual track.
  */
 import * as React from "react";
 
@@ -70,7 +72,7 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
       >
         <span
           aria-hidden="true"
-          className="pointer-events-none block h-5 w-5 rounded-sm bg-card  transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+          className="pointer-events-none block h-5 w-5 rounded-sm bg-card transition-transform data-[state=checked]:translate-x-5 data-[state=checked]:bg-card data-[state=unchecked]:translate-x-0 data-[state=unchecked]:bg-txt"
           data-state={state}
         />
         {children}


### PR DESCRIPTION
# Relates to

Closes #19533

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, rebased onto latest `origin/develop`.
- [ ] `bun run verify` not run for the whole monorepo.
- [x] Reviewer can confirm from evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6b7a264ace00e0081f3dd61a6fea4f98fa627949:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop`.
- [ ] `bun run verify` not run for the whole monorepo.

# Risks

Low. Shared Switch thumb token only. No size, radius, or checked-state change.

# Background

## What does this PR do?

The unchecked Switch thumb used `bg-card` on a `bg-input` track. In dark appearance those tokens are nearly the same, so the knob disappeared on card surfaces (Advanced, settings rows, pay-as-you-go). Off thumbs now use `bg-txt`. On thumbs stay `bg-card` on the accent track.

## What kind of change is this?

Bug fixes

# Documentation changes needed?

No.

# Testing

```bash
bun run --cwd packages/ui test -- src/components/ui/switch.test.tsx
```

# Evidence Gate

<!-- evidence-head:0b94f8442cf2d8d3b11cdf1732e81cfc0d28e74a -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19534-switch-off-contrast-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19534-switch-off-contrast-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19534-switch-off-contrast-v2-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend contract change; Switch is a presentational control.
<!-- evidence-row:frontend-logs -->
- [x] [19534-switch-off-contrast-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19534-switch-off-contrast-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, wallet, scheduled-task, or generated domain artifact is involved.
<!-- evidence-row:ocr-review -->
- [x] [19534-switch-off-contrast-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19534-switch-off-contrast-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Known gaps / failures

- Full-repo verify not run.
- Isolated Playwright fixture of the real Switch primitive (audit:app still blocked by startupCoordinator.target).
- Light-mode input track still matches the card token; this PR only fixes thumb contrast.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok-cli
Contribution skill revision: elizaOS/eliza@6b7a264ace00e0081f3dd61a6fea4f98fa627949:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-4.6]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-cli","skill_revision":"elizaOS/eliza@6b7a264ace00e0081f3dd61a6fea4f98fa627949:packages/skills/skills/contribute-to-eliza"} -->
