### PR TITLE
fix(homepage): align readiness admission policy

### DIFF
--- a/packages/app-core/scripts/check-homepage-public-readiness.mjs
+++ b/packages/app-core/scripts/check-homepage-public-readiness.mjs
@@ -84,12 +84,12 @@ function getRepoVariables() {
 }
 
 function normalizePhone(value) {
-  const trimmed = value?.trim() ?? "";
-  return /^\+[1-9]\d{7,14}$/.test(trimmed) ? trimmed : null;
+  const normalized = value ?? "";
+  return /^\+[1-9]\d{7,14}$/.test(normalized) ? normalized : null;
 }
 
 export function resolveWhatsAppAdmission(value) {
-  const normalized = value?.trim().toLowerCase() ?? "";
+  const normalized = value?.toLowerCase() ?? "";
   if (["", "0", "false", "no", "off"].includes(normalized)) {
     return { enabled: false, valid: true };
   }

--- a/packages/app-core/scripts/check-homepage-public-readiness.mjs
+++ b/packages/app-core/scripts/check-homepage-public-readiness.mjs
@@ -76,13 +76,27 @@ function run(command, args) {
   return result.stdout.trim();
 }
 
-function getRepoVariable(name) {
-  return run("gh", ["variable", "get", name, "--repo", repo]).trim();
+function getRepoVariables() {
+  const rows = JSON.parse(
+    run("gh", ["variable", "list", "--repo", repo, "--json", "name,value"]),
+  );
+  return Object.fromEntries(rows.map(({ name, value }) => [name, value]));
 }
 
 function normalizePhone(value) {
-  const trimmed = value.trim();
+  const trimmed = value?.trim() ?? "";
   return /^\+[1-9]\d{7,14}$/.test(trimmed) ? trimmed : null;
+}
+
+export function resolveWhatsAppAdmission(value) {
+  const normalized = value?.trim().toLowerCase() ?? "";
+  if (["", "0", "false", "no", "off"].includes(normalized)) {
+    return { enabled: false, valid: true };
+  }
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return { enabled: true, valid: true };
+  }
+  return { enabled: false, valid: false };
 }
 
 export function evaluatePublicSurface(surface, config) {
@@ -125,12 +139,14 @@ export function evaluatePublicSurface(surface, config) {
 
   const configuredWhatsApp = normalizePhone(config.whatsAppNumber);
   const configSafe =
-    configuredWhatsApp === expectedGatewayNumber &&
-    !rejectedWhatsAppNumbers.includes(configuredWhatsApp);
+    config.whatsAppAdmissionValid !== false &&
+    (!config.whatsAppEnabled ||
+      (configuredWhatsApp === expectedGatewayNumber &&
+        !rejectedWhatsAppNumbers.includes(configuredWhatsApp)));
   check(
     "whatsapp-sender-config",
     configSafe,
-    `configured=${configuredWhatsApp ?? "invalid"}`,
+    `enabled=${String(config.whatsAppEnabled)} admission=${config.whatsAppAdmissionValid === false ? "invalid" : "valid"} configured=${configuredWhatsApp ?? "unset"}`,
   );
 
   if (config.whatsAppEnabled) {
@@ -233,12 +249,17 @@ function writeEvidence(evidencePath, evidence) {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const whatsAppEnabled = getRepoVariable("WHATSAPP_PUBLIC_ENABLED") === "true";
-  const whatsAppNumber = getRepoVariable("VITE_WHATSAPP_PHONE_NUMBER");
+  const variables = getRepoVariables();
+  const whatsAppAdmission = resolveWhatsAppAdmission(
+    variables.WHATSAPP_PUBLIC_ENABLED,
+  );
+  const whatsAppEnabled = whatsAppAdmission.enabled;
+  const whatsAppNumber = variables.VITE_WHATSAPP_PHONE_NUMBER ?? "";
   const surface = await inspectPublicSurface(args.origin);
   const result = evaluatePublicSurface(surface, {
     origin: args.origin,
     whatsAppEnabled,
+    whatsAppAdmissionValid: whatsAppAdmission.valid,
     whatsAppNumber,
   });
 
@@ -254,6 +275,7 @@ async function main() {
     origin: args.origin,
     expectedGatewayNumber,
     whatsAppEnabled,
+    whatsAppAdmissionValid: whatsAppAdmission.valid,
     whatsAppNumber,
     checks: result.checks,
     surface: {

--- a/packages/app-core/scripts/check-homepage-public-readiness.test.mjs
+++ b/packages/app-core/scripts/check-homepage-public-readiness.test.mjs
@@ -3,7 +3,10 @@
  * fixtures; no network, browser, or provider account is used by this suite.
  */
 import { expect, test } from "vitest";
-import { evaluatePublicSurface } from "./check-homepage-public-readiness.mjs";
+import {
+  evaluatePublicSurface,
+  resolveWhatsAppAdmission,
+} from "./check-homepage-public-readiness.mjs";
 
 const healthySurface = {
   finalUrl: "https://eliza.app/",
@@ -18,11 +21,45 @@ const healthySurface = {
 };
 
 test("accepts the Cloudflare homepage with WhatsApp disabled", () => {
+  for (const whatsAppNumber of ["", "+14159611510"]) {
+    const result = evaluatePublicSurface(healthySurface, {
+      whatsAppEnabled: false,
+      whatsAppNumber,
+    });
+    expect(result.ok).toBe(true);
+  }
+});
+
+test("matches the deployment workflow's admission values", () => {
+  for (const value of [undefined, "", "0", "false", "no", "off"]) {
+    expect(resolveWhatsAppAdmission(value)).toEqual({
+      enabled: false,
+      valid: true,
+    });
+  }
+  for (const value of ["1", "true", "yes", "on", " TRUE "]) {
+    expect(resolveWhatsAppAdmission(value)).toEqual({
+      enabled: true,
+      valid: true,
+    });
+  }
+  expect(resolveWhatsAppAdmission("maybe")).toEqual({
+    enabled: false,
+    valid: false,
+  });
+});
+
+test("fails closed for an invalid admission flag", () => {
   const result = evaluatePublicSurface(healthySurface, {
     whatsAppEnabled: false,
-    whatsAppNumber: "+18087881821",
+    whatsAppAdmissionValid: false,
+    whatsAppNumber: "",
   });
-  expect(result.ok).toBe(true);
+  expect(result.ok).toBe(false);
+  expect(
+    result.checks.find((entry) => entry.name === "whatsapp-sender-config")
+      ?.passed,
+  ).toBe(false);
 });
 
 test("evaluates an explicitly selected public origin", () => {

--- a/packages/app-core/scripts/check-homepage-public-readiness.test.mjs
+++ b/packages/app-core/scripts/check-homepage-public-readiness.test.mjs
@@ -37,16 +37,18 @@ test("matches the deployment workflow's admission values", () => {
       valid: true,
     });
   }
-  for (const value of ["1", "true", "yes", "on", " TRUE "]) {
+  for (const value of ["1", "true", "yes", "on"]) {
     expect(resolveWhatsAppAdmission(value)).toEqual({
       enabled: true,
       valid: true,
     });
   }
-  expect(resolveWhatsAppAdmission("maybe")).toEqual({
-    enabled: false,
-    valid: false,
-  });
+  for (const value of ["maybe", " TRUE ", " off "]) {
+    expect(resolveWhatsAppAdmission(value)).toEqual({
+      enabled: false,
+      valid: false,
+    });
+  }
 });
 
 test("fails closed for an invalid admission flag", () => {
@@ -107,6 +109,17 @@ test("requires the same admitted Blooio number when WhatsApp is enabled", () => 
     { whatsAppEnabled: true, whatsAppNumber: "+14159611510" },
   );
   expect(formerNumber.ok).toBe(false);
+
+  for (const paddedNumber of [" +18087881821", "+18087881821 "]) {
+    const padded = evaluatePublicSurface(
+      {
+        ...healthySurface,
+        whatsAppHrefs: ["https://wa.me/18087881821"],
+      },
+      { whatsAppEnabled: true, whatsAppNumber: paddedNumber },
+    );
+    expect(padded.ok).toBe(false);
+  }
 });
 
 test("rejects visible phone copy and incorrect call targets", () => {


### PR DESCRIPTION
## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - repository contribution skill was not available in this session
<!-- attribution-row:status -->
- Provenance status: self-reported

## Summary

Closes #19522.

A post-merge review of #19532 found that the new readiness audit did not exactly match the deployment policy: it required the verified sender even while WhatsApp was disabled, and interpreted an invalid admission value as disabled. Both Cloudflare workflows allow a missing/dormant sender while disabled and reject an invalid boolean.

This follow-up reads repository variables in one authenticated operation, mirrors every workflow admission spelling, allows an unset or dormant sender only while disabled, requires the exact verified Blooio sender when enabled, and fails closed for malformed admission values.

## Exact-head validation

<!-- evidence-head:82c869ea89948f2d11f04c57e2dba3294bee7e48 -->

- `bun install --frozen-lockfile` - passed on rebased head.
- `bun test packages/app-core/scripts/check-homepage-public-readiness.test.mjs` - 7/7 passed, 27 assertions.
- `bun run --cwd packages/app-core lint` - passed, 339 files.
- `bun run --cwd packages/app-core typecheck` - passed through the authoritative dependency-ordered root gate.
- `bun run --cwd packages/app-core build` - passed.
- `bun run verify` - 350/350 tasks plus every repository audit passed.
- `node packages/app-core/scripts/check-homepage-public-readiness.mjs --no-evidence` - Cloudflare origin, canonical URL, clipboard fallback, call target, hidden phone copy, sender configuration, and browser console all passed; the command correctly exited 1 only because production still renders the retired `https://wa.me/14159611510` CTA while admission is disabled.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - policy/parser correction only; no rendered UI code changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - policy/parser correction only; no rendered UI code changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - read-only audit; no backend behavior changed.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - Read-only audit policy correction; no frontend runtime code changed, and the live browser console was clean.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No persistent domain data changed; the live readiness transcript is summarized in exact-head validation.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

## Known external gap

The code gate is complete. Production deployment remains intentionally uncertified until the consolidated current artifact removes the retired WhatsApp CTA; that external state is visible rather than fabricated as success.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - repository contribution skill was not available in this session
Attribution status: self-reported
— [codex-19522-postmerge]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - repository contribution skill was not available in this session"} -->

