### PR TITLE
fix(ui): use SettingsSwitchRow for Auto Top-Up enable

### DIFF
--- a/packages/ui/src/cloud/billing/components/auto-top-up-card.test.tsx
+++ b/packages/ui/src/cloud/billing/components/auto-top-up-card.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Renders AutoTopUpCard through SettingsSwitchRow and asserts load, draft
+ * toggle, and save persist. jsdom, mocked billing settings API.
+ */
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../lib/api-client", () => ({
+  api: apiMock,
+  ApiError: class ApiError extends Error {},
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? key,
+}));
+
+import { AutoTopUpCard } from "./auto-top-up-card";
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  apiMock.mockReset();
+});
+
+const loadedSettings = {
+  settings: {
+    autoTopUp: {
+      enabled: false,
+      amount: 25,
+      threshold: 10,
+      hasPaymentMethod: true,
+    },
+    limits: {
+      minAmount: 5,
+      maxAmount: 500,
+      minThreshold: 1,
+      maxThreshold: 200,
+    },
+  },
+};
+
+describe("AutoTopUpCard", () => {
+  it("loads the enable switch as SettingsSwitchRow inside the BrandCard editor", async () => {
+    apiMock.mockResolvedValueOnce(loadedSettings);
+
+    render(<AutoTopUpCard />);
+
+    expect(await screen.findByText("Auto Top-Up (Card)")).toBeTruthy();
+    expect(screen.getByText("Enable card auto top-up")).toBeTruthy();
+    const toggle = await screen.findByRole("switch");
+    expect(toggle.getAttribute("id")).toBe("cloud-billing-auto-top-up");
+    expect(
+      toggle.getAttribute("data-state") ?? toggle.getAttribute("aria-checked"),
+    ).toMatch(/unchecked|false/);
+    expect(apiMock).toHaveBeenCalledWith("/api/v1/billing/settings");
+    expect(screen.getByText("Top-up amount")).toBeTruthy();
+    expect(screen.getByText("Trigger threshold")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /save/i })).toBeTruthy();
+  });
+
+  it("keeps the toggle as draft until Save PUTs the autoTopUp payload", async () => {
+    apiMock
+      .mockResolvedValueOnce(loadedSettings)
+      .mockResolvedValueOnce(loadedSettings);
+
+    render(<AutoTopUpCard />);
+    const toggle = await screen.findByRole("switch");
+    fireEvent.click(toggle);
+
+    expect(apiMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(apiMock).toHaveBeenLastCalledWith("/api/v1/billing/settings", {
+        method: "PUT",
+        json: {
+          autoTopUp: {
+            enabled: true,
+            amount: 25,
+            threshold: 10,
+          },
+        },
+      });
+    });
+  });
+
+  it("disables the enable switch when no payment method is saved", async () => {
+    apiMock.mockResolvedValueOnce({
+      settings: {
+        autoTopUp: {
+          enabled: false,
+          amount: 25,
+          threshold: 10,
+          hasPaymentMethod: false,
+        },
+        limits: loadedSettings.settings.limits,
+      },
+    });
+
+    render(<AutoTopUpCard />);
+    const toggle = await screen.findByRole("switch");
+    expect(toggle).toHaveProperty("disabled", true);
+    expect(screen.getByText(/No saved payment method/i)).toBeTruthy();
+  });
+});

--- a/packages/ui/src/cloud/billing/components/auto-top-up-card.tsx
+++ b/packages/ui/src/cloud/billing/components/auto-top-up-card.tsx
@@ -6,21 +6,18 @@
  * auto-fund path — both can be enabled together. The earnings cron runs first so
  * card charges only happen if earnings can't cover.
  *
+ * The enable control is a SettingsSwitchRow (shared Switch chrome). Amount,
+ * threshold, and save stay on this BrandCard as a multi-field editor.
  * Reads/writes /api/v1/billing/settings.
  */
 
 "use client";
 
-import {
-  BrandCard,
-  Button,
-  CornerBrackets,
-  Label,
-  Switch,
-} from "@elizaos/ui/cloud-ui";
+import { BrandCard, Button, CornerBrackets } from "@elizaos/ui/cloud-ui";
 import { CreditCard, Info, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { SettingsSwitchRow } from "../../../components/settings/settings-agent-rows";
 import { ApiError, api } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import { NumericField } from "./numeric-field";
@@ -181,32 +178,22 @@ export function AutoTopUpCard() {
           </p>
         </div>
 
-        <div className="flex items-start justify-between gap-3">
-          <div className="space-y-1">
-            <Label className="text-txt-strong font-mono text-sm">
-              {t("cloud.autoTopUp.enableLabel", {
-                defaultValue: "Enable card auto top-up",
-              })}
-            </Label>
-            <p className="text-xs font-mono text-muted">
-              {settings?.enabled
-                ? t("cloud.autoTopUp.activeState", {
-                    defaultValue:
-                      "Active. Your saved card will be charged automatically.",
-                  })
-                : t("cloud.autoTopUp.offState", {
-                    defaultValue:
-                      "Currently off — card won't be charged automatically.",
-                  })}
-            </p>
-          </div>
-          <Switch
-            checked={enabled}
-            onCheckedChange={setEnabled}
-            disabled={saving || !!noPaymentMethod}
-            className="data-[state=checked]:bg-txt flex-shrink-0"
-          />
-        </div>
+        <SettingsSwitchRow
+          agentId="cloud-billing-auto-top-up"
+          group="cloud-billing"
+          icon={CreditCard}
+          label={t("cloud.autoTopUp.enableLabel", {
+            defaultValue: "Enable card auto top-up",
+          })}
+          description={t("cloud.autoTopUp.enableDescription", {
+            defaultValue:
+              "When on, your saved card is charged automatically when credits dip below the threshold. When off, the card is not charged automatically.",
+          })}
+          checked={enabled}
+          disabled={saving || !!noPaymentMethod}
+          onCheckedChange={setEnabled}
+          testId="cloud-billing-auto-top-up"
+        />
 
         {noPaymentMethod && (
           <div className="flex items-start gap-2 border border-yellow-500/30 bg-yellow-500/5 p-3">

--- a/packages/ui/src/components/settings/cloud-billing-switch-row.test.ts
+++ b/packages/ui/src/components/settings/cloud-billing-switch-row.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Source ratchet: the Auto Top-Up enable control is a SettingsSwitchRow, not
+ * a raw Switch with a custom ON color. The BrandCard editor around it stays.
+ * Reads the shipped file off disk.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const uiSrc = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+describe("cloud billing auto-top-up enable switch", () => {
+  const source = readFileSync(
+    join(uiSrc, "cloud/billing/components/auto-top-up-card.tsx"),
+    "utf8",
+  );
+
+  it("uses SettingsSwitchRow with the shared billing agent id", () => {
+    expect(source).toContain("<SettingsSwitchRow");
+    expect(source).toContain('agentId="cloud-billing-auto-top-up"');
+    expect(source).toContain('group="cloud-billing"');
+  });
+
+  it("does not keep a raw Switch or a text-token ON track", () => {
+    expect(source).not.toMatch(/<Switch[\s>]/);
+    expect(source).not.toContain("data-[state=checked]:bg-txt");
+  });
+
+  it("leaves the multi-field BrandCard editor in place", () => {
+    expect(source).toContain("BrandCard");
+    expect(source).toContain("CornerBrackets");
+    expect(source).toContain("<NumericField");
+    expect(source).toMatch(/Save/);
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #19539

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, rebased onto latest `origin/develop`.
- [ ] `bun run verify` not run for the whole monorepo.
- [x] Reviewer can confirm from evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6c121807e5cebded3c612d75569ffccea4c0f6e4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop`.
- [ ] `bun run verify` not run for the whole monorepo.

# Risks

Low. Only the Auto Top-Up enable control is rewired. Amounts, save, and persist path stay.

# Background

## What does this PR do?

Replaces the Auto Top-Up labelled raw Switch (`data-[state=checked]:bg-txt`) with `SettingsSwitchRow` so it matches pay-as-you-go on the same billing page. BrandCard editor, NumericField amounts, payment-method banner, and Save are unchanged. Toggle stays draft until Save.

## What kind of change is this?

Bug fixes

# Documentation changes needed?

No.

# Testing

```bash
bun run --cwd packages/ui test -- src/cloud/billing/components/auto-top-up-card.test.tsx src/components/settings/cloud-billing-switch-row.test.ts
```

# Evidence Gate

<!-- evidence-head:138621d9ba047e1a434595de0124ead7a124c32e -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19540-autotopup-switch-row-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19540-autotopup-switch-row-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19540-autotopup-switch-row-v2-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - persist path unchanged; still PUT /api/v1/billing/settings on Save.
<!-- evidence-row:frontend-logs -->
- [x] [19540-autotopup-switch-row-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19540-autotopup-switch-row-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, wallet, scheduled-task, or generated domain artifact is involved.
<!-- evidence-row:ocr-review -->
- [x] [19540-autotopup-switch-row-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19540-autotopup-switch-row-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Known gaps / failures

- Full-repo verify not run.
- Isolated Playwright fixture of the real Switch + SettingsRow composition (audit:app still blocked by startupCoordinator.target).
- Amounts/Save remain a multi-field BrandCard editor on purpose.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok-cli
Contribution skill revision: elizaOS/eliza@6c121807e5cebded3c612d75569ffccea4c0f6e4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-4.6]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-cli","skill_revision":"elizaOS/eliza@6c121807e5cebded3c612d75569ffccea4c0f6e4:packages/skills/skills/contribute-to-eliza"} -->
