### PR TITLE
fix(ui): fail closed on join cleanup results

### DIFF
--- a/packages/app/test/ui-smoke/join-cta-contrast.spec.ts
+++ b/packages/app/test/ui-smoke/join-cta-contrast.spec.ts
@@ -1,0 +1,362 @@
+/**
+ * Browser contrast regression for the JoinPage primary recovery controls. The
+ * real renderer runs in desktop and coarse-pointer mobile contexts while Cloud
+ * responses deterministically expose cleanup-failure and credit-gate states;
+ * computed rest and hover colors must retain WCAG AA contrast in both.
+ */
+import { writeFile } from "node:fs/promises";
+import {
+  type CDPSession,
+  devices,
+  expect,
+  type Locator,
+  type Page,
+  type Route,
+  test,
+} from "@playwright/test";
+import { installDefaultAppRoutes } from "./helpers";
+import { seedStewardSession } from "./helpers/test-auth";
+
+const AGENT_ID = "11111111-2222-4333-8444-555555555555";
+const CREATED_AT = "2026-08-14T11:00:00.000Z";
+const JOB_ID = "provision-job-contrast";
+
+const SURFACES = [
+  {
+    name: "desktop",
+    context: {
+      ...devices["Desktop Chrome"],
+      viewport: { width: 1440, height: 900 },
+    },
+    coarsePointer: false,
+    hoverCapable: true,
+  },
+  {
+    name: "mobile-layout-hover",
+    context: {
+      ...devices["Pixel 7"],
+      // Chromium otherwise hard-wires `(hover: none)` for touch contexts and
+      // ignores CDP's hybrid coarse-pointer hover media override.
+      hasTouch: false,
+      viewport: { width: 390, height: 844 },
+    },
+    coarsePointer: false,
+    hoverCapable: true,
+  },
+  {
+    name: "mobile-touch",
+    context: {
+      ...devices["Pixel 7"],
+      viewport: { width: 390, height: 844 },
+    },
+    coarsePointer: true,
+    hoverCapable: false,
+  },
+] as const;
+
+type ContrastSample = {
+  backgroundColor: string;
+  className: string;
+  color: string;
+  expectedForeground: string;
+  ratio: number;
+};
+
+type FixtureMode = "cleanup-failure" | "credit-gate";
+type JoinRouteState = {
+  conditionalDeleteBodies: Record<string, unknown>[];
+  jobPolls: number;
+};
+
+async function fulfillJson(
+  route: Route,
+  status: number,
+  body: Record<string, unknown>,
+): Promise<void> {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function installJoinRoutes(
+  page: Page,
+  readMode: () => FixtureMode,
+  state: JoinRouteState,
+): Promise<void> {
+  await installDefaultAppRoutes(page);
+
+  await page.route("**/api/auth/steward-session", async (route) => {
+    await fulfillJson(route, 200, { success: true });
+  });
+
+  await page.route("**/api/cloud/compat/agents", async (route) => {
+    const request = route.request();
+    if (request.method() === "GET") {
+      if (readMode() === "credit-gate") {
+        await fulfillJson(route, 402, {
+          success: false,
+          code: "insufficient_credits",
+          error: "Insufficient credits. Add funds to start an agent.",
+          currentBalance: 0,
+          requiredBalance: 0.1,
+        });
+        return;
+      }
+      await fulfillJson(route, 200, { success: true, data: [] });
+      return;
+    }
+    if (request.method() === "POST") {
+      await fulfillJson(route, 200, {
+        success: true,
+        created: true,
+        data: {
+          agentId: AGENT_ID,
+          agentName: "Eliza",
+          status: "provisioning",
+          jobId: JOB_ID,
+          createdAt: CREATED_AT,
+          executionTier: "dedicated-always",
+        },
+      });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.route("**/api/cloud/compat/jobs/*", async (route) => {
+    state.jobPolls += 1;
+    await fulfillJson(route, 200, {
+      success: true,
+      data: {
+        jobId: JOB_ID,
+        status: "pending",
+        state: "pending",
+      },
+    });
+  });
+
+  await page.route("**/api/cloud/compat/agents/*", async (route) => {
+    if (route.request().method() !== "DELETE") {
+      await route.fallback();
+      return;
+    }
+    state.conditionalDeleteBodies.push(
+      (route.request().postDataJSON() ?? {}) as Record<string, unknown>,
+    );
+    await fulfillJson(route, 409, {
+      success: false,
+      error: "Conditional cleanup was rejected in the contrast probe",
+    });
+  });
+}
+
+async function readContrast(locator: Locator): Promise<ContrastSample> {
+  return locator.evaluate((element) => {
+    type Rgba = { r: number; g: number; b: number; a: number };
+    const parseColor = (value: string): Rgba => {
+      const canvas = document.createElement("canvas");
+      canvas.width = 1;
+      canvas.height = 1;
+      const context = canvas.getContext("2d", { willReadFrequently: true });
+      if (!context) throw new Error("Canvas 2D is unavailable");
+      context.clearRect(0, 0, 1, 1);
+      context.fillStyle = value;
+      context.fillRect(0, 0, 1, 1);
+      const [r, g, b, a] = context.getImageData(0, 0, 1, 1).data;
+      return { r: r / 255, g: g / 255, b: b / 255, a: a / 255 };
+    };
+    const composite = (foreground: Rgba, background: Rgba): Rgba => ({
+      r: foreground.r * foreground.a + background.r * (1 - foreground.a),
+      g: foreground.g * foreground.a + background.g * (1 - foreground.a),
+      b: foreground.b * foreground.a + background.b * (1 - foreground.a),
+      a: 1,
+    });
+    const luminance = (color: Rgba): number => {
+      const channel = (value: number) =>
+        value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+      return (
+        0.2126 * channel(color.r) +
+        0.7152 * channel(color.g) +
+        0.0722 * channel(color.b)
+      );
+    };
+
+    const style = getComputedStyle(element);
+    const theme = element.closest<HTMLElement>(".theme-cloud");
+    if (!theme) throw new Error("Join CTA is missing its theme-cloud owner");
+    const themeBackground = parseColor(getComputedStyle(theme).backgroundColor);
+    const background = composite(
+      parseColor(style.backgroundColor),
+      themeBackground,
+    );
+    const foreground = composite(parseColor(style.color), background);
+    const light = Math.max(luminance(background), luminance(foreground));
+    const dark = Math.min(luminance(background), luminance(foreground));
+
+    const probe = document.createElement("span");
+    probe.style.color = "var(--bg)";
+    theme.appendChild(probe);
+    const expectedForeground = getComputedStyle(probe).color;
+    probe.remove();
+
+    return {
+      backgroundColor: style.backgroundColor,
+      className: element.className,
+      color: style.color,
+      expectedForeground,
+      ratio: (light + 0.05) / (dark + 0.05),
+    };
+  });
+}
+
+async function assertStableContrast(
+  cdp: CDPSession,
+  page: Page,
+  button: Locator,
+  hoverCapable: boolean,
+): Promise<{ rest: ContrastSample; hover: ContrastSample }> {
+  await page.mouse.move(0, 0);
+  await page.waitForTimeout(200);
+  const rest = await readContrast(button);
+  expect(rest.color).toBe(rest.expectedForeground);
+  expect(rest.ratio).toBeGreaterThanOrEqual(4.5);
+
+  const box = await button.boundingBox();
+  if (!box) throw new Error("Join CTA has no rendered bounding box");
+  const node = await cdp.send("DOM.getNodeForLocation", {
+    x: Math.floor(box.x + box.width / 2),
+    y: Math.floor(box.y + box.height / 2),
+    includeUserAgentShadowDOM: true,
+  });
+  await cdp.send("DOM.getDocument", { depth: -1, pierce: true });
+  const { nodeIds } = await cdp.send("DOM.pushNodesByBackendIdsToFrontend", {
+    backendNodeIds: [node.backendNodeId],
+  });
+  const nodeId = nodeIds[0];
+  if (!nodeId) throw new Error("Join CTA could not be resolved in the DOM");
+  await cdp.send("CSS.forcePseudoState", {
+    nodeId,
+    forcedPseudoClasses: ["hover"],
+  });
+  await page.waitForTimeout(200);
+  const hover = await readContrast(button);
+  if (hoverCapable) {
+    expect(hover.backgroundColor).not.toBe(rest.backgroundColor);
+  } else {
+    expect(hover.backgroundColor).toBe(rest.backgroundColor);
+  }
+  expect(hover.color).toBe(rest.color);
+  expect(hover.color).toBe(hover.expectedForeground);
+  expect(hover.ratio).toBeGreaterThanOrEqual(4.5);
+  await cdp.send("CSS.forcePseudoState", {
+    nodeId,
+    forcedPseudoClasses: [],
+  });
+  return { rest, hover };
+}
+
+test("Join recovery CTAs preserve computed contrast on desktop, mobile-hover, and touch profiles", async ({
+  browser,
+  baseURL,
+}, testInfo) => {
+  const report: Record<string, unknown> = {
+    head: process.env.GITHUB_SHA ?? "local-exact-head",
+    surfaces: {},
+  };
+
+  for (const surface of SURFACES) {
+    const videoDir = testInfo.outputPath(`${surface.name}-video`);
+    const context = await browser.newContext({
+      ...surface.context,
+      baseURL,
+      serviceWorkers: "block",
+      ...(process.env.E2E_RECORD === "1"
+        ? { recordVideo: { dir: videoDir } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const cdp = await context.newCDPSession(page);
+    await cdp.send("DOM.enable");
+    await cdp.send("CSS.enable");
+    await cdp.send("DOM.getDocument", { depth: -1, pierce: true });
+    await cdp.send("Emulation.setEmulatedMedia", {
+      media: "screen",
+      features: [
+        { name: "hover", value: surface.hoverCapable ? "hover" : "none" },
+      ],
+    });
+    expect(
+      await page.evaluate(() => matchMedia("(hover: hover)").matches),
+    ).toBe(surface.hoverCapable);
+    let mode: FixtureMode = "cleanup-failure";
+    const routeState: JoinRouteState = {
+      conditionalDeleteBodies: [],
+      jobPolls: 0,
+    };
+    await seedStewardSession(page, { jwt: true });
+    await installJoinRoutes(page, () => mode, routeState);
+
+    await page.goto("/join");
+    const signOut = page.getByRole("button", { name: "Sign out" });
+    await expect(signOut).toBeVisible();
+    await expect.poll(() => routeState.jobPolls).toBeGreaterThan(0);
+    await signOut.click();
+    const retry = page.getByRole("button", { name: "Try again" });
+    await expect(retry).toBeVisible();
+    await expect.poll(() => routeState.conditionalDeleteBodies.length).toBe(1);
+    expect(routeState.conditionalDeleteBodies[0]).toEqual({
+      expectedAgentName: "Eliza",
+      expectedCreatedAt: CREATED_AT,
+      expectedExecutionTier: "dedicated-always",
+    });
+    const cleanupContrast = await assertStableContrast(
+      cdp,
+      page,
+      retry,
+      surface.hoverCapable,
+    );
+    await page.screenshot({
+      path: testInfo.outputPath(`${surface.name}-cleanup-hover.png`),
+      fullPage: true,
+    });
+
+    mode = "credit-gate";
+    await page.goto("/join");
+    const addFunds = page.getByRole("button", { name: "Add funds" });
+    await expect(addFunds).toBeVisible();
+    const creditContrast = await assertStableContrast(
+      cdp,
+      page,
+      addFunds,
+      surface.hoverCapable,
+    );
+    await page.screenshot({
+      path: testInfo.outputPath(`${surface.name}-credit-hover.png`),
+      fullPage: true,
+    });
+
+    const coarsePointer = await page.evaluate(
+      () => matchMedia("(pointer: coarse)").matches,
+    );
+    expect(coarsePointer).toBe(surface.coarsePointer);
+    report.surfaces = {
+      ...(report.surfaces as Record<string, unknown>),
+      [surface.name]: {
+        coarsePointer,
+        cleanupContrast,
+        creditContrast,
+        conditionalDeleteBody: routeState.conditionalDeleteBodies[0],
+      },
+    };
+    await context.close();
+  }
+
+  const reportPath = testInfo.outputPath("join-cta-computed-contrast.json");
+  await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  await testInfo.attach("join-cta-computed-contrast", {
+    path: reportPath,
+    contentType: "application/json",
+  });
+});

--- a/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
@@ -216,10 +216,20 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
     expect(res.status).toBe(202);
     const json = (await res.json()) as {
       success: boolean;
-      data: { jobId: string };
+      data: {
+        jobId: string;
+        agentName: string;
+        createdAt: string;
+        executionTier: string;
+      };
     };
     expect(json.success).toBe(true);
     expect(json.data.jobId).toBe("job-1");
+    expect(json.data).toMatchObject({
+      agentName: "alpha",
+      createdAt: "2026-06-24T00:00:00.000Z",
+      executionTier: "custom",
+    });
     expect(enqueueAgentProvision).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -667,6 +667,7 @@ app.post("/", async (c) => {
                   id: claimed.id,
                   agentName: claimed.agent_name,
                   status: "provisioning",
+                  createdAt: claimed.created_at,
                   executionTier: claimed.execution_tier,
                 },
               },
@@ -683,6 +684,7 @@ app.post("/", async (c) => {
                 status: "running",
                 bridgeUrl: claimed.bridge_url,
                 healthUrl: claimed.health_url,
+                createdAt: claimed.created_at,
                 executionTier: claimed.execution_tier,
               },
             },
@@ -827,6 +829,7 @@ app.post("/", async (c) => {
           status: job.status,
           jobId: job.id,
           estimatedCompletionAt: job.estimated_completion_at,
+          createdAt: agent.created_at,
           executionTier: agent.execution_tier,
         },
         polling: {

--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -433,6 +433,8 @@ describe("ElizaClient direct Cloud auth on native", () => {
           agentName: "My Agent",
           status: "provisioning",
           jobId: "job-async-1",
+          createdAt: "2026-08-14T12:00:00.000Z",
+          executionTier: "dedicated-always",
         },
       },
     });
@@ -448,6 +450,8 @@ describe("ElizaClient direct Cloud auth on native", () => {
         data: expect.objectContaining({
           agentId: "agent-async-1",
           status: "provisioning",
+          createdAt: "2026-08-14T12:00:00.000Z",
+          executionTier: "dedicated-always",
         }),
       }),
     );

--- a/packages/ui/src/api/client-cloud-direct-methods.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-methods.test.ts
@@ -36,12 +36,15 @@ function jsonResponse(status: number, body: unknown) {
 }
 
 function routeFetch(
-  routes: Record<string, (input: string) => Response | Promise<Response>>,
+  routes: Record<
+    string,
+    (input: string, init?: RequestInit) => Response | Promise<Response>
+  >,
 ) {
-  return vi.fn(async (input: RequestInfo | URL) => {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
     for (const [suffix, handler] of Object.entries(routes)) {
-      if (url.endsWith(suffix)) return handler(url);
+      if (url.endsWith(suffix)) return handler(url, init);
     }
     throw new Error(`unexpected fetch ${url}`);
   });
@@ -201,19 +204,36 @@ describe("direct-cloud prototype methods (Steward session bound)", () => {
   });
 
   it("deleteCloudCompatAgent: normalizes an async (jobId) delete response", async () => {
+    const request = vi.fn((_url: string, _init?: RequestInit) =>
+      jsonResponse(202, { success: true, data: { jobId: "job-1" } }),
+    );
     vi.stubGlobal(
       "fetch",
       routeFetch({
-        "/api/v1/eliza/agents/agent-1": () =>
-          jsonResponse(202, { success: true, data: { jobId: "job-1" } }),
+        "/api/v1/eliza/agents/agent-1": request,
       }),
     );
-    const result = await client.deleteCloudCompatAgent("agent-1");
+    const result = await client.deleteCloudCompatAgent("agent-1", {
+      expectedAgentName: "Eliza",
+      expectedCreatedAt: "2026-08-14T12:00:00.000Z",
+      expectedExecutionTier: "dedicated-always",
+    });
     expect(result.success).toBe(true);
     expect(result.data).toMatchObject({
       jobId: "job-1",
       status: "deleted",
     });
+    expect(request).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        method: "DELETE",
+        body: JSON.stringify({
+          expectedAgentName: "Eliza",
+          expectedCreatedAt: "2026-08-14T12:00:00.000Z",
+          expectedExecutionTier: "dedicated-always",
+        }),
+      }),
+    );
   });
 
   it("provisionCloudCompatAgent: normalizes a direct provision response", async () => {

--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -575,6 +575,47 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(result.agentId).toBe("agent-forced-new");
   });
 
+  it("returns the exact create identity when cancellation arrives after acceptance", async () => {
+    const controller = new AbortController();
+    const { client, getCloudCompatAgents, createCloudCompatAgent } =
+      fakeClient();
+    getCloudCompatAgents.mockResolvedValue({ success: true, data: [] });
+    createCloudCompatAgent.mockImplementation(async () => {
+      controller.abort(new DOMException("signed out", "AbortError"));
+      return {
+        success: true,
+        created: true,
+        data: {
+          agentId: "agent-cancelled",
+          agentName: "Authoritative Eliza",
+          jobId: "provision-job",
+          status: "provisioning",
+          nodeId: null,
+          message: "accepted",
+          createdAt: "2026-08-14T12:00:00.000Z",
+          executionTier: "dedicated-always" as const,
+        },
+      };
+    });
+
+    const result = await client.selectOrProvisionCloudAgent({
+      ...BASE_OPTS,
+      signal: controller.signal,
+    });
+
+    expect(result).toMatchObject({
+      agentId: "agent-cancelled",
+      created: true,
+      cleanupReceipt: {
+        deleteCondition: {
+          expectedAgentName: "Authoritative Eliza",
+          expectedCreatedAt: "2026-08-14T12:00:00.000Z",
+          expectedExecutionTier: "dedicated-always",
+        },
+      },
+    });
+  });
+
   it("rejects an existing-agent response to forceCreate without binding or inspecting that agent", async () => {
     const { client, createCloudCompatAgent, getCloudCompatAgent } =
       fakeClient();

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -144,7 +144,25 @@ type DirectCloudAgentCreateData = {
   agentName: string;
   status: string;
   jobId: string | null;
+  createdAt: string | null;
+  executionTier: CloudAgentExecutionTier | null;
 };
+
+type CloudAgentExecutionTier =
+  | "shared"
+  | "dedicated-lazy"
+  | "dedicated-always"
+  | "custom";
+
+interface CloudAgentDeleteCondition {
+  expectedAgentName: string;
+  expectedCreatedAt: string;
+  expectedExecutionTier: CloudAgentExecutionTier;
+}
+
+interface CloudAgentCleanupReceipt {
+  deleteCondition: CloudAgentDeleteCondition;
+}
 
 function requireConfirmedFreshCloudAgentCreate(
   forceCreate: boolean | undefined,
@@ -1000,7 +1018,25 @@ function parseDirectCloudAgentCreateData(
     jobId:
       firstString(data.jobId, data.job_id, job?.jobId, job?.job_id, job?.id) ??
       null,
+    createdAt: firstString(data.createdAt, data.created_at),
+    executionTier: parseCloudAgentExecutionTier(
+      firstString(data.executionTier, data.execution_tier),
+    ),
   };
+}
+
+function parseCloudAgentExecutionTier(
+  value: string | null,
+): CloudAgentExecutionTier | null {
+  switch (value) {
+    case "shared":
+    case "dedicated-lazy":
+    case "dedicated-always":
+    case "custom":
+      return value;
+    default:
+      return null;
+  }
 }
 
 function toCloudCompatAgent(input: DirectCloudAgent): CloudCompatAgent {
@@ -1369,6 +1405,9 @@ declare module "./client-base" {
         status: string;
         nodeId: string | null;
         message: string;
+        /** Authoritative create identity used only for conditional compensation. */
+        createdAt: string | null;
+        executionTier: CloudAgentExecutionTier | null;
       };
     }>;
     ensureCloudCompatManagedDiscordAgent(): Promise<{
@@ -1476,7 +1515,10 @@ declare module "./client-base" {
         githubUsername: string;
       };
     }>;
-    deleteCloudCompatAgent(agentId: string): Promise<{
+    deleteCloudCompatAgent(
+      agentId: string,
+      condition?: CloudAgentDeleteCondition,
+    ): Promise<{
       success: boolean;
       error?: string;
       data: { jobId: string; status: string; message: string };
@@ -1654,6 +1696,8 @@ declare module "./client-base" {
        */
       requiresAgentPairing?: boolean;
       executionTier?: string | null;
+      /** Exact fresh-create identity; absent for reused or legacy responses. */
+      cleanupReceipt?: CloudAgentCleanupReceipt;
     }>;
     /**
      * Background shared→personal handoff for a freshly provisioned cloud agent:
@@ -2164,6 +2208,8 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
         status: data.status,
         nodeId: null,
         message: direct.success ? "Agent created" : (direct.error ?? ""),
+        createdAt: data.createdAt,
+        executionTier: data.executionTier,
       },
     };
   }
@@ -2178,6 +2224,8 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
         status: "error",
         nodeId: null,
         message: directCloudAuthMissingMessage(),
+        createdAt: null,
+        executionTier: null,
       },
     };
   }
@@ -2222,6 +2270,8 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
         status: data.status,
         nodeId: null,
         message: response.success ? "Agent created" : (response.error ?? ""),
+        createdAt: data.createdAt,
+        executionTier: data.executionTier,
       },
     };
   }
@@ -2539,6 +2589,7 @@ ElizaClient.prototype.getCloudCompatAgentGithubToken = async function (
 ElizaClient.prototype.deleteCloudCompatAgent = async function (
   this: ElizaClient,
   agentId,
+  condition,
 ) {
   const normalizeDelete = (response: {
     success?: boolean;
@@ -2548,9 +2599,10 @@ ElizaClient.prototype.deleteCloudCompatAgent = async function (
     success: response.success === true,
     ...(response.error ? { error: response.error } : {}),
     data: {
-      // A 202 async delete carries a jobId the caller can poll
-      // (`/api/v1/jobs/<id>`) to learn whether the teardown actually
-      // completed. A synchronous delete returns no jobId.
+      // A 202 async delete carries the durable jobId. Management surfaces may
+      // poll it for eventual teardown state; join cancellation only needs the
+      // accepted receipt because the server already owns recovery and billing.
+      // A synchronous delete returns no jobId.
       jobId: response.data?.jobId ?? "",
       status:
         response.data?.status ??
@@ -2569,6 +2621,7 @@ ElizaClient.prototype.deleteCloudCompatAgent = async function (
     error?: string;
   }>(this, `/api/v1/eliza/agents/${encodeURIComponent(agentId)}`, {
     method: "DELETE",
+    ...(condition ? { body: JSON.stringify(condition) } : {}),
   });
   if (direct) return normalizeDelete(direct);
 
@@ -2591,7 +2644,10 @@ ElizaClient.prototype.deleteCloudCompatAgent = async function (
       error?: string;
     }>(
       `/api/v1/eliza/agents/${encodeURIComponent(agentId)}`,
-      { method: "DELETE" },
+      {
+        method: "DELETE",
+        ...(condition ? { body: JSON.stringify(condition) } : {}),
+      },
       { allowNonOk: true },
     );
     return normalizeDelete(response);
@@ -2599,6 +2655,7 @@ ElizaClient.prototype.deleteCloudCompatAgent = async function (
 
   return this.fetch(`/api/cloud/compat/agents/${encodeURIComponent(agentId)}`, {
     method: "DELETE",
+    ...(condition ? { body: JSON.stringify(condition) } : {}),
   });
 };
 
@@ -4165,6 +4222,16 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   }
   requireConfirmedFreshCloudAgentCreate(mustForceCreate, created.created);
   const agentId = created.data.agentId;
+  const cleanupReceipt =
+    created.data.createdAt && created.data.executionTier
+      ? {
+          deleteCondition: {
+            expectedAgentName: created.data.agentName || name,
+            expectedCreatedAt: created.data.createdAt,
+            expectedExecutionTier: created.data.executionTier,
+          },
+        }
+      : undefined;
   const cancellationReceipt = () => ({
     agentId,
     agentName: created.data.agentName || name,
@@ -4173,6 +4240,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     created: created.created !== false,
     requiresAgentPairing: false,
     executionTier: preferSharedTier ? ("shared" as const) : null,
+    ...(cleanupReceipt ? { cleanupReceipt } : {}),
   });
   // Once create is accepted, callers need the authoritative id even if the
   // remaining wait is cancelled so they can compensate the external mutation.
@@ -4274,6 +4342,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     created: created.created !== false,
     requiresAgentPairing: false,
     executionTier: detailAgent?.execution_tier ?? null,
+    ...(cleanupReceipt ? { cleanupReceipt } : {}),
   };
 };
 

--- a/packages/ui/src/cloud/join/JoinPage.credit-gate.test.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.credit-gate.test.tsx
@@ -101,6 +101,8 @@ describe("JoinPage credit-gate (402) surface", () => {
     expect(screen.queryByText("Couldn't connect to your agent")).toBeNull();
 
     const cta = screen.getByRole("button", { name: "Add funds" });
+    expect(cta.className).toContain("text-bg");
+    expect(cta.className).toContain("hover:!text-bg");
     act(() => {
       cta.click();
     });

--- a/packages/ui/src/cloud/join/JoinPage.sign-out-cleanup.test.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.sign-out-cleanup.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Verifies JoinPage retains auth until fresh-agent compensation is owned. The
+ * page-level sign-out owner must await the active join controller. A
+ * successful compensation permits SSO destruction; an AggregateError means
+ * cleanup is unowned, keeps the user signed in, and exposes an explicit
+ * sign-out-anyway decision. All network and navigation seams are deterministic.
+ */
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runJoinFlowMock = vi.hoisted(() => vi.fn());
+const signOutMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const replaceMock = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router-dom", () => ({ Navigate: () => null }));
+vi.mock("../../api", () => ({ client: {} }));
+vi.mock("../../config/boot-config-store", () => ({
+  getBootConfig: () => ({}),
+}));
+vi.mock("../../state/persistence", () => ({
+  clearPersistedActiveServer: vi.fn(),
+  savePersistedActiveServer: vi.fn(),
+  savePersistedFirstRunComplete: vi.fn(),
+}));
+vi.mock("../app-mode/app-mode", () => ({
+  appModeNavigation: { assign: vi.fn(), replace: replaceMock },
+}));
+vi.mock("../billing-console", () => ({
+  openCloudBillingConsole: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? _key,
+}));
+vi.mock("../sso-bridge/sso-bridge", () => ({
+  clearSsoLoggedOut: vi.fn(),
+  redirectToSsoBridge: vi.fn(() => Promise.resolve(false)),
+  shouldAutoBridgeToSso: vi.fn(() => false),
+  signOutFromSsoBridgedHost: signOutMock,
+}));
+vi.mock("./lib/apex-app-handoff", () => ({
+  resolveApexJoinHandoff: () => null,
+}));
+vi.mock("./lib/resolve-cloud-connection", () => ({
+  resolveJoinAuthToken: () => "steward-token",
+  resolveJoinCloudApiBase: () => "https://api.eliza.app",
+}));
+vi.mock("./lib/run-join-flow", () => ({
+  runJoinFlow: (...args: unknown[]) => runJoinFlowMock(...args),
+}));
+vi.mock("./lib/use-join-session", () => ({
+  useJoinSessionAuth: () => ({ ready: true, authenticated: true }),
+}));
+
+import JoinPage from "./JoinPage";
+
+function connectedResult() {
+  return {
+    agentId: "agent-new",
+    agentName: "Eliza",
+    apiBase: "https://agent-new.cloud.eliza.app",
+    created: true,
+    dedicated: true,
+  };
+}
+
+describe("JoinPage sign-out cleanup ownership", () => {
+  beforeEach(() => {
+    runJoinFlowMock.mockReset();
+    signOutMock.mockClear();
+    replaceMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("waits for the active join to settle before destroying the SSO session", async () => {
+    let finishJoin:
+      | ((value: ReturnType<typeof connectedResult>) => void)
+      | null = null;
+    runJoinFlowMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishJoin = resolve;
+        }),
+    );
+    render(<JoinPage />);
+    await waitFor(() => expect(runJoinFlowMock).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+    expect(signOutMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalledWith("/login");
+
+    await act(async () => {
+      finishJoin?.(connectedResult());
+    });
+    await waitFor(() => expect(signOutMock).toHaveBeenCalledTimes(1));
+    expect(replaceMock).toHaveBeenCalledWith("/login");
+  });
+
+  it("keeps auth on cleanup failure and requires an explicit sign-out-anyway action", async () => {
+    runJoinFlowMock.mockImplementation(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              reject(
+                new AggregateError(
+                  [signal.reason, new Error("delete job failed")],
+                  "Join was cancelled after create, and compensating deletion failed",
+                ),
+              );
+            },
+            { once: true },
+          );
+        }),
+    );
+    render(<JoinPage />);
+    await waitFor(() => expect(runJoinFlowMock).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+
+    expect(
+      await screen.findByText(
+        /couldn't finish removing the newly created agent/i,
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText(/delete job failed/i)).toBeTruthy();
+    const retry = screen.getByRole("button", { name: "Try again" });
+    expect(retry.className).toContain("text-bg");
+    expect(retry.className).toContain("hover:!text-bg");
+    expect(signOutMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalledWith("/login");
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign out anyway" }));
+    await waitFor(() => expect(signOutMock).toHaveBeenCalledTimes(1));
+    expect(replaceMock).toHaveBeenCalledWith("/login");
+  });
+});

--- a/packages/ui/src/cloud/join/JoinPage.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.tsx
@@ -75,6 +75,16 @@ function describeJoinError(err: unknown): string {
   return "Could not connect to your agent. Try again.";
 }
 
+function describeJoinCleanupError(
+  err: AggregateError,
+  abortReason: unknown,
+): string {
+  const cleanupError = err.errors.find(
+    (candidate) => candidate !== abortReason,
+  );
+  return `We couldn't finish removing the newly created agent: ${describeJoinError(cleanupError)} You are still signed in so you can retry safely.`;
+}
+
 export default function JoinPage(): React.JSX.Element {
   const t = useCloudT();
   const session = useJoinSessionAuth();
@@ -82,6 +92,7 @@ export default function JoinPage(): React.JSX.Element {
   const [detail, setDetail] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
   const [signingOut, setSigningOut] = useState(false);
+  const [cleanupBlockedSignOut, setCleanupBlockedSignOut] = useState(false);
   const [creditGateWithheldReason, setCreditGateWithheldReason] = useState<
     "ip_daily_cap" | "count_unavailable" | null
   >(null);
@@ -105,12 +116,24 @@ export default function JoinPage(): React.JSX.Element {
       // No session — the auth gate below redirects to login; bail quietly.
       return;
     }
+    const previous = activeAttemptRef.current;
+    if (previous) {
+      previous.controller.abort(
+        new DOMException("Join attempt superseded", "AbortError"),
+      );
+      try {
+        await previous.promise;
+      } catch {
+        // error-policy:J5 the previous attempt surfaced its cleanup failure in
+        // the join error state; refusing to start another selection prevents a
+        // newly adopted row from racing the previous conditional deletion.
+        return;
+      }
+    }
     setPhase("connecting");
     setError(null);
+    setCleanupBlockedSignOut(false);
     setCreditGateWithheldReason(null);
-    activeAttemptRef.current?.controller.abort(
-      new DOMException("Join attempt superseded", "AbortError"),
-    );
     const controller = new AbortController();
     const attempt = (async () => {
       try {
@@ -140,7 +163,13 @@ export default function JoinPage(): React.JSX.Element {
         void result;
         if (typeof window !== "undefined") appModeNavigation.assign("/");
       } catch (err) {
-        if (controller.signal.aborted) return;
+        if (controller.signal.aborted) {
+          if (!(err instanceof AggregateError)) return;
+          setError(describeJoinCleanupError(err, controller.signal.reason));
+          setCleanupBlockedSignOut(true);
+          setPhase("error");
+          throw err;
+        }
         // The Cloud's credit gate (402) is a payment state, not a connection
         // failure: retry can never succeed, so render the server's explanation
         // (e.g. the welcome bonus withheld by the per-IP daily free-credit cap
@@ -162,9 +191,16 @@ export default function JoinPage(): React.JSX.Element {
       }
     })();
     activeAttemptRef.current = { controller, promise: attempt };
-    await attempt;
-    if (activeAttemptRef.current?.controller === controller) {
-      activeAttemptRef.current = null;
+    try {
+      await attempt;
+    } catch {
+      // error-policy:J5 the attempt's catch above rendered the cleanup failure;
+      // the abort initiator also awaits the same rejected promise before it may
+      // sign out or supersede this attempt.
+    } finally {
+      if (activeAttemptRef.current?.controller === controller) {
+        activeAttemptRef.current = null;
+      }
     }
   }, []);
 
@@ -217,7 +253,17 @@ export default function JoinPage(): React.JSX.Element {
     active?.controller.abort(
       new DOMException("User signed out during join", "AbortError"),
     );
-    await active?.promise.catch(() => undefined);
+    if (active) {
+      try {
+        await active.promise;
+      } catch {
+        // error-policy:J4 the attempt rendered the cleanup failure and kept the Steward
+        // session. A second, explicitly labelled action lets the user choose
+        // to abandon that recoverable state instead of doing so silently.
+        setSigningOut(false);
+        return;
+      }
+    }
     const { signOutFromSsoBridgedHost } = await import(
       "../sso-bridge/sso-bridge"
     );
@@ -235,7 +281,9 @@ export default function JoinPage(): React.JSX.Element {
     >
       {signingOut
         ? t("cloud.join.signingOut", { defaultValue: "Signing out..." })
-        : t("cloud.join.signOut", { defaultValue: "Sign out" })}
+        : cleanupBlockedSignOut
+          ? t("cloud.join.signOutAnyway", { defaultValue: "Sign out anyway" })
+          : t("cloud.join.signOut", { defaultValue: "Sign out" })}
     </Button>
   );
 
@@ -291,7 +339,7 @@ export default function JoinPage(): React.JSX.Element {
               onClick={() => {
                 void openCloudBillingConsole();
               }}
-              className="bg-txt px-6 py-2.5 font-semibold text-bg transition-colors hover:bg-txt/90"
+              className="bg-txt px-6 py-2.5 font-semibold text-bg transition-colors hover:bg-txt/90 hover:!text-bg"
             >
               {t("cloud.join.creditGateCta", { defaultValue: "Add funds" })}
             </Button>
@@ -324,7 +372,7 @@ export default function JoinPage(): React.JSX.Element {
               variant="ghost"
               type="button"
               onClick={handleRetry}
-              className="bg-txt px-6 py-2.5 font-semibold text-bg transition-colors hover:bg-txt/90"
+              className="bg-txt px-6 py-2.5 font-semibold text-bg transition-colors hover:bg-txt/90 hover:!text-bg"
             >
               {t("cloud.join.retry", { defaultValue: "Try again" })}
             </Button>

--- a/packages/ui/src/cloud/join/lib/run-join-flow.test.ts
+++ b/packages/ui/src/cloud/join/lib/run-join-flow.test.ts
@@ -12,6 +12,22 @@ import {
 
 const CLOUD_API_BASE = "https://api.eliza.app";
 const SHARED_BASE = "https://api.eliza.app/api/v1/eliza/agents/agent-123";
+const DELETE_CONDITION = {
+  expectedAgentName: "Eliza",
+  expectedCreatedAt: "2026-08-14T12:00:00.000Z",
+  expectedExecutionTier: "dedicated-always" as const,
+};
+
+function freshSelection() {
+  return {
+    agentId: "agent-created",
+    agentName: "Eliza",
+    apiBase: SHARED_BASE,
+    bridgeUrl: null,
+    created: true,
+    cleanupReceipt: { deleteCondition: DELETE_CONDITION },
+  };
+}
 
 function makeClient(
   selectResult: Awaited<
@@ -376,16 +392,13 @@ describe("runJoinFlow", () => {
     expect(select).not.toHaveBeenCalled();
   });
 
-  test("deletes a newly created agent when cancellation arrives after selection", async () => {
+  test("conditionally deletes a newly created agent when cancellation arrives after selection", async () => {
     const controller = new AbortController();
-    const deleteAgent = vi.fn().mockResolvedValue(undefined);
-    const { client } = makeClient({
-      agentId: "agent-created",
-      agentName: "Eliza",
-      apiBase: SHARED_BASE,
-      bridgeUrl: null,
-      created: true,
+    const deleteAgent = vi.fn().mockResolvedValue({
+      success: true,
+      data: { jobId: "", status: "deleted", message: "deleted" },
     });
+    const { client } = makeClient(freshSelection());
     client.deleteCloudCompatAgent = deleteAgent;
     const select = client.selectOrProvisionCloudAgent;
     client.selectOrProvisionCloudAgent = vi.fn(async (options) => {
@@ -405,13 +418,16 @@ describe("runJoinFlow", () => {
         signal: controller.signal,
       }),
     ).rejects.toThrow(/signed out/i);
-    expect(deleteAgent).toHaveBeenCalledWith("agent-created");
+    expect(deleteAgent).toHaveBeenCalledWith("agent-created", DELETE_CONDITION);
     expect(saveServer).not.toHaveBeenCalled();
   });
 
   test("does not delete a reused agent when cancellation arrives after selection", async () => {
     const controller = new AbortController();
-    const deleteAgent = vi.fn().mockResolvedValue(undefined);
+    const deleteAgent = vi.fn().mockResolvedValue({
+      success: true,
+      data: { jobId: "", status: "deleted", message: "deleted" },
+    });
     const { client } = makeClient({
       agentId: "agent-reused",
       agentName: "Eliza",
@@ -444,13 +460,7 @@ describe("runJoinFlow", () => {
   test("reports both cancellation and compensating deletion failure", async () => {
     const controller = new AbortController();
     const cleanupError = new Error("delete failed");
-    const { client } = makeClient({
-      agentId: "agent-created",
-      agentName: "Eliza",
-      apiBase: SHARED_BASE,
-      bridgeUrl: null,
-      created: true,
-    });
+    const { client } = makeClient(freshSelection());
     client.deleteCloudCompatAgent = vi.fn().mockRejectedValue(cleanupError);
     const select = client.selectOrProvisionCloudAgent;
     client.selectOrProvisionCloudAgent = vi.fn(async (options) => {
@@ -474,5 +484,167 @@ describe("runJoinFlow", () => {
     expect((failure as AggregateError).errors).toContain(
       controller.signal.reason,
     );
+  });
+
+  test("fails closed on a resolved conditional-identity mismatch", async () => {
+    const controller = new AbortController();
+    const { client } = makeClient(freshSelection());
+    client.deleteCloudCompatAgent = vi.fn().mockResolvedValue({
+      success: false,
+      error: "agent identity no longer matches cleanup condition",
+      data: { jobId: "", status: "error", message: "denied" },
+    });
+    const select = client.selectOrProvisionCloudAgent;
+    client.selectOrProvisionCloudAgent = vi.fn(async (options) => {
+      const result = await select(options);
+      controller.abort(new DOMException("signed out", "AbortError"));
+      return result;
+    });
+    const { effects } = makeEffects();
+
+    const failure = await runJoinFlow({
+      client,
+      effects,
+      cloudApiBase: CLOUD_API_BASE,
+      authToken: "tok",
+      agentName: "Eliza",
+      signal: controller.signal,
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).errors).toContain(
+      controller.signal.reason,
+    );
+    expect((failure as AggregateError).errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: "agent identity no longer matches cleanup condition",
+        }),
+      ]),
+    );
+  });
+
+  test("treats an accepted async conditional delete as durable compensation", async () => {
+    const controller = new AbortController();
+    const { client } = makeClient(freshSelection());
+    const deleteAgent = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        jobId: "delete-job",
+        status: "pending",
+        message: "queued",
+      },
+    });
+    client.deleteCloudCompatAgent = deleteAgent;
+    const select = client.selectOrProvisionCloudAgent;
+    client.selectOrProvisionCloudAgent = vi.fn(async (options) => {
+      const result = await select(options);
+      controller.abort(new DOMException("signed out", "AbortError"));
+      return result;
+    });
+
+    await expect(
+      runJoinFlow({
+        client,
+        effects: makeEffects().effects,
+        cloudApiBase: CLOUD_API_BASE,
+        authToken: "tok",
+        agentName: "Eliza",
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(/signed out/i);
+
+    expect(deleteAgent).toHaveBeenCalledWith("agent-created", DELETE_CONDITION);
+  });
+
+  test("fails closed on a malformed successful delete without durable receipt", async () => {
+    const controller = new AbortController();
+    const { client } = makeClient(freshSelection());
+    client.deleteCloudCompatAgent = vi.fn().mockResolvedValue({
+      success: true,
+      data: { jobId: "", status: "pending", message: "ambiguous" },
+    });
+    const select = client.selectOrProvisionCloudAgent;
+    client.selectOrProvisionCloudAgent = vi.fn(async (options) => {
+      const result = await select(options);
+      controller.abort(new DOMException("signed out", "AbortError"));
+      return result;
+    });
+
+    const failure = await runJoinFlow({
+      client,
+      effects: makeEffects().effects,
+      cloudApiBase: CLOUD_API_BASE,
+      authToken: "tok",
+      agentName: "Eliza",
+      signal: controller.signal,
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message:
+            "Eliza Cloud did not return a durable agent deletion receipt",
+        }),
+      ]),
+    );
+  });
+
+  test("fails closed when the authoritative create identity is missing", async () => {
+    const controller = new AbortController();
+    const { client } = makeClient({
+      ...freshSelection(),
+      cleanupReceipt: undefined,
+    });
+    const deleteAgent = vi.fn();
+    client.deleteCloudCompatAgent = deleteAgent;
+    const select = client.selectOrProvisionCloudAgent;
+    client.selectOrProvisionCloudAgent = vi.fn(async (options) => {
+      const result = await select(options);
+      controller.abort(new DOMException("signed out", "AbortError"));
+      return result;
+    });
+
+    const failure = await runJoinFlow({
+      client,
+      effects: makeEffects().effects,
+      cloudApiBase: CLOUD_API_BASE,
+      authToken: "tok",
+      agentName: "Eliza",
+      signal: controller.signal,
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect(deleteAgent).not.toHaveBeenCalled();
+  });
+
+  test("runs compensation exactly once when cancellation is requested twice", async () => {
+    const controller = new AbortController();
+    const { client } = makeClient(freshSelection());
+    const deleteAgent = vi.fn().mockResolvedValue({
+      success: true,
+      data: { jobId: "", status: "deleted", message: "deleted" },
+    });
+    client.deleteCloudCompatAgent = deleteAgent;
+    const select = client.selectOrProvisionCloudAgent;
+    client.selectOrProvisionCloudAgent = vi.fn(async (options) => {
+      const result = await select(options);
+      controller.abort(new DOMException("signed out", "AbortError"));
+      controller.abort(new DOMException("superseded", "AbortError"));
+      return result;
+    });
+
+    await expect(
+      runJoinFlow({
+        client,
+        effects: makeEffects().effects,
+        cloudApiBase: CLOUD_API_BASE,
+        authToken: "tok",
+        agentName: "Eliza",
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(/signed out/i);
+    expect(deleteAgent).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/cloud/join/lib/run-join-flow.ts
+++ b/packages/ui/src/cloud/join/lib/run-join-flow.ts
@@ -33,6 +33,22 @@ import {
   ELIZA_CLOUD_CONTROL_PLANE_HOSTS,
 } from "../../../utils/cloud-agent-base";
 
+type CloudAgentExecutionTier =
+  | "shared"
+  | "dedicated-lazy"
+  | "dedicated-always"
+  | "custom";
+
+interface CloudAgentDeleteCondition {
+  expectedAgentName: string;
+  expectedCreatedAt: string;
+  expectedExecutionTier: CloudAgentExecutionTier;
+}
+
+interface CloudAgentCleanupReceipt {
+  deleteCondition: CloudAgentDeleteCondition;
+}
+
 /** The slice of `ElizaClient` the join flow drives. */
 export interface JoinFlowClient {
   selectOrProvisionCloudAgent(options: {
@@ -51,10 +67,18 @@ export interface JoinFlowClient {
     apiBase: string;
     bridgeUrl: string | null;
     created: boolean;
+    cleanupReceipt?: CloudAgentCleanupReceipt;
   }>;
   setBaseUrl(baseUrl: string | null): void;
   setToken(token: string | null): void;
-  deleteCloudCompatAgent?(agentId: string): Promise<unknown>;
+  deleteCloudCompatAgent?(
+    agentId: string,
+    condition?: CloudAgentDeleteCondition,
+  ): Promise<{
+    success: boolean;
+    error?: string;
+    data?: { jobId?: string; status?: string; message?: string };
+  }>;
 }
 
 /** Persistence + lifecycle seams, injected so the controller stays testable. */
@@ -99,6 +123,43 @@ export interface JoinFlowResult {
   created: boolean;
   /** True when the dedicated container subdomain was selected. */
   dedicated: boolean;
+}
+
+async function compensateCreatedAgent(
+  client: JoinFlowClient,
+  selected: Awaited<ReturnType<JoinFlowClient["selectOrProvisionCloudAgent"]>>,
+): Promise<void> {
+  if (!client.deleteCloudCompatAgent) {
+    throw new Error("Join client cannot compensate a created agent");
+  }
+  if (!selected.cleanupReceipt) {
+    throw new Error(
+      "Eliza Cloud did not return the authoritative create identity required for cleanup",
+    );
+  }
+  // Conditional DELETE is the server-owned delete-wins transaction: it accepts
+  // an exact provisioning identity, retires conflicting lifecycle work,
+  // suspends billing, frees quota, and queues recoverable teardown atomically.
+  // Its durable acceptance—not eventual infrastructure teardown—is the browser
+  // compensation boundary, so sign-out never waits on background cleanup.
+  const cleanup = await client.deleteCloudCompatAgent(
+    selected.agentId,
+    selected.cleanupReceipt.deleteCondition,
+  );
+  if (!cleanup.success) {
+    throw new Error(
+      cleanup.error ??
+        cleanup.data?.message ??
+        "Compensating cloud agent deletion failed",
+    );
+  }
+  const jobId = cleanup.data?.jobId?.trim() ?? "";
+  const status = cleanup.data?.status?.trim().toLowerCase() ?? "";
+  if (!jobId && status !== "deleted") {
+    throw new Error(
+      "Eliza Cloud did not return a durable agent deletion receipt",
+    );
+  }
 }
 
 /**
@@ -190,11 +251,10 @@ export async function runJoinFlow(
   if (signal?.aborted) {
     if (selected.created && selected.agentId) {
       try {
-        if (!client.deleteCloudCompatAgent) {
-          throw new Error("Join client cannot compensate a created agent");
-        }
-        await client.deleteCloudCompatAgent(selected.agentId);
+        await compensateCreatedAgent(client, selected);
       } catch (cleanupError) {
+        // error-policy:J2 preserve both the user's cancellation and the
+        // compensation failure so the page can refuse to destroy auth.
         throw new AggregateError(
           [signal.reason, cleanupError],
           "Join was cancelled after create, and compensating deletion failed",

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -8217,6 +8217,7 @@
   "cloud.join.retry": "Try again",
   "cloud.join.signingOut": "Signing out...",
   "cloud.join.signOut": "Sign out",
+  "cloud.join.signOutAnyway": "Sign out anyway",
   "cloud.login.back": "Back",
   "cloud.login.callback.codeRejected": "That sign-in link expired or was already used. Please sign in again below.",
   "cloud.login.callback.invalidLink": "We couldn't verify that sign-in link. Request a new one. If it keeps happening, contact support.",


### PR DESCRIPTION
# Relates to

Closes #19535.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the changed cancellation contract from the current desktop/mobile evidence and focused route/client tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d1466e483f5953a26afa053e4ca4a145f5fc8147:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop` `d1466e483f5953a26afa053e4ca4a145f5fc8147`; zero conflicts.
- [x] Final PR head is `243755c088540da035328a83dc23da5332086482`.
- [x] `bun install` completed with no dependency changes.
- [x] Exact-head `bun run verify` passed: 350/350 Turbo tasks, 0 cached, plus all repository audits.

# Risks

Medium. This changes the cancellation/sign-out lifecycle at the Cloud create/delete boundary, adds authoritative create identity fields to the compatible create response, and sends an exact conditional DELETE body. A malformed or rejected cleanup now deliberately retains the authenticated session instead of silently navigating away. There is no schema, migration, infrastructure, or deployment-variable change.

# Background

## What does this PR do?

It makes cancellation after a fresh dedicated Cloud-agent allocation fail closed and assigns cleanup ownership at the correct boundary:

- The create route/client carries the authoritative `createdAt` and `executionTier` identity alongside the new agent id/name.
- If the join is cancelled after that fresh allocation, the client immediately sends a conditional DELETE with the exact name, creation timestamp, and tier. It does not wait for the provisioning job first.
- A synchronous `status: "deleted"` response, or an accepted asynchronous response with a non-empty durable delete `jobId`, means the server owns compensation. The server transaction has already validated identity, suspended billing, freed quota, marked deletion pending, and persisted recovery-owned work, so the foreground does not poll teardown to completion.
- A rejected request, `{ success: false }`, missing cleanup identity, or malformed success without an authoritative deleted/accepted receipt preserves both the cancellation and cleanup error in an `AggregateError`.
- `JoinPage` does not swallow that aggregate. It retains authentication, explains that the fresh agent could not be removed, and offers **Try again** plus an explicit **Sign out anyway** escape hatch. Superseding starts wait for prior cleanup ownership before selecting another agent.
- Both primary Join recovery CTAs (**Try again** and **Add funds**) retain the explicit dark foreground through hover. The real renderer measures 20.19:1 at rest and 16.09:1 at hover on desktop and the mobile layout; the coarse-touch profile remains 20.19:1.

## What kind of change is this?

Bug fix (non-breaking compatible response/request additions).

# Documentation changes needed?

No public documentation change is required. This corrects an internal join lifecycle and compatibility-client contract. The user-facing failure copy is registered in the canonical English catalog.

# Testing

## Where should a reviewer start?

Review `run-join-flow.test.ts`, `JoinPage.sign-out-cleanup.test.tsx`, the Cloud create/delete route tests, then open the desktop/mobile walkthroughs. The failure fixture exercises the current real renderer and client call sequence while deliberately rejecting the exact conditional DELETE so auth-retention behavior is visible without creating billable external Cloud state.

## Detailed testing steps

- `bun run --cwd packages/ui test -- src/api/client-cloud-direct-auth.test.ts src/api/client-cloud-direct-methods.test.ts src/api/client-cloud-select-or-provision.test.ts src/cloud/join/JoinPage.credit-gate.test.tsx src/cloud/join/JoinPage.sign-out-cleanup.test.tsx src/cloud/join/lib/run-join-flow.test.ts src/i18n/messages.test.ts` — passed, 7 files / 92 tests.
- `bun test packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts` — passed, 13 tests / 56 assertions.
- `bun test packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts` — passed, 6 tests / 22 assertions, including conditional delete during provisioning.
- `bun run --cwd packages/ui typecheck` — passed.
- `bun run --cwd packages/ui lint:check` — passed with the eight existing warning-only `noDocumentCookie` diagnostics.
- `bun run --cwd packages/cloud/api build` — passed.
- `bun run --cwd packages/cloud/api lint:check` — passed.
- `GITHUB_SHA=243755c... node packages/app/scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/join-cta-contrast.spec.ts --project=chromium` — passed against the exact renderer across desktop, 390px mobile-hover, and Pixel coarse-touch profiles.
- `bun run --cwd packages/app audit:app` — passed, 219/219 captures; broken=0, needs-work=0, hover-probe-failures=0, density-probe-failures=0; OCR verified 200 and marked 16 for normal human review.
- `git diff --check origin/develop...HEAD` — passed.
- `bun run verify` — passed at the exact head/base: 350/350 Turbo tasks, 0 cached; compiler model, dependency graph, secret-leak, routing, script, view-bundle, and focused-test audits all passed.

# Evidence Gate

<!-- evidence-head:243755c088540da035328a83dc23da5332086482 -->

<!-- evidence-row:before-screenshots -->
- [x] Before cancellation on the exact final renderer: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19544-pr19544-243755c-before-desktop.png) and [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19544-pr19544-243755c-before-mobile.png).
<!-- evidence-row:after-screenshots -->
- [x] After the deliberate conditional-cleanup rejection with the contrast-safe hover state: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19544-pr19544-243755c-after-desktop-hover.png) and [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19544-pr19544-243755c-after-mobile-hover.png). The sibling Add-funds CTA is also captured at hover on [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19544-pr19544-243755c-credit-desktop-hover.png) and [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19544-pr19544-243755c-credit-mobile-hover.png).
<!-- evidence-row:walkthrough-video -->
- [x] Complete current-renderer flow: [desktop MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19544-pr19544-243755c-desktop-walkthrough.mp4) and [mobile MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19544-pr19544-243755c-mobile-walkthrough.mp4).
<!-- evidence-row:backend-logs -->
- [x] Exact create/delete route, UI, and renderer-gate results: [focused contract log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19544-pr19544-243755c-focused-contracts.log).
<!-- evidence-row:frontend-logs -->
- [x] Current-renderer request/response and computed browser assertions: [frontend observations](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19544-pr19544-243755c-frontend-observations.json), with the full console/DOM/screenshot timeline in the [Playwright trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19544-pr19544-243755c-browser-trace.zip).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, model, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] The affected artifacts are the durable conditional-delete receipt/ownership contract and rendered contrast: [machine-readable ownership artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19544-pr19544-243755c-cleanup-ownership-contract.json) and [computed contrast report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19544-pr19544-243755c-computed-contrast.json). No live billable Cloud row was created for evidence.
<!-- evidence-row:ocr-review -->
- [x] Apple Vision OCR text readout for all four exact-renderer screenshots: [OCR JSONL](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19544-pr19544-243755c-ocr.jsonl).

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changes.

## Backend + frontend logs

The deterministic browser fixture exercises the current real `JoinPage` renderer and compatibility client call sequence. It records GET empty agents, POST create with the authoritative receipt, provisioning status, the exact conditional DELETE body, the deliberate 409 response, retained-auth UI state, and computed rest/hover colors. The linked route test log independently exercises the real Cloud create and delete route contracts. The only browser console error is the expected failed-resource line for that deliberate 409.

## Screenshots (before / after) + video walkthrough

The “before” captures are frames from the exact-head recordings immediately before cancellation while the newly accepted agent is provisioning. The “after” captures show the unowned-cleanup state after DELETE rejection, including the retained-session explanation, **Try again**, and **Sign out anyway**, with the forced hover state visibly retaining dark text. Both states are full-page desktop and mobile captures; both complete flows are linked as MP4s. The machine report proves the same contract for **Add funds** and actual coarse-touch media.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

No live Cloud agent was allocated or deleted for visual evidence because doing so would mutate billable external state. That does not leave the protocol untested: the exact create and conditional-delete routes have focused contract coverage, and the current browser renderer/client sequence is captured with deterministic response fixtures. There are no known validation failures. UI lint retains eight unrelated warning-only cookie diagnostics.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@d1466e483f5953a26afa053e4ca4a145f5fc8147:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@d1466e483f5953a26afa053e4ca4a145f5fc8147:packages/skills/skills/contribute-to-eliza"} -->
