### PR TITLE
test(ui): harden settings BrandCard catalog

### DIFF
--- a/packages/ui/src/components/settings/settings-dashboard-leftovers.test.ts
+++ b/packages/ui/src/components/settings/settings-dashboard-leftovers.test.ts
@@ -27,6 +27,14 @@ const SETTINGS_MOUNTED_DIRS = [
   "components/settings",
 ];
 
+const CONVERTED_BRANDCARD_HOSTS = [
+  "cloud/account-security/components/profile-form.tsx",
+  "cloud/account-security/components/incident-report-panel.tsx",
+  "cloud/account-security/components/mfa-panel.tsx",
+  "cloud/account-security/components/recent-audit-events.tsx",
+  "cloud/billing/components/pay-as-you-go-card.tsx",
+];
+
 /**
  * Remaining BrandCard hosts and why they are not a SettingsStack/Group/Row
  * leftover of the already-shipped classes. Remove a row when that file
@@ -35,7 +43,7 @@ const SETTINGS_MOUNTED_DIRS = [
 const BRANDCARD_ALLOWLIST = new Map<string, string>([
   [
     "cloud/billing/components/auto-top-up-card.tsx",
-    "billing multi-field editor (switch + amounts + save)",
+    "billing multi-field editor (amounts + payment method + save; switch already converted)",
   ],
   [
     "cloud/billing/components/billing-tab.tsx",
@@ -124,10 +132,17 @@ describe("settings-mounted BrandCard leftover catalog", () => {
     expect(stale).toEqual([]);
   });
 
-  it("prints the remaining catalog (not a gate)", () => {
-    const remaining = [...BRANDCARD_ALLOWLIST.entries()].map(
-      ([rel, reason]) => `${rel} — ${reason}`,
+  it("keeps converted BrandCard hosts out of the allowlist", () => {
+    const regressions = CONVERTED_BRANDCARD_HOSTS.filter((rel) =>
+      BRANDCARD_ALLOWLIST.has(rel),
     );
-    expect(remaining.length).toBeGreaterThan(0);
+    expect(regressions).toEqual([]);
+  });
+
+  it("records a non-empty kind reason for every remaining host", () => {
+    const missingReasons = [...BRANDCARD_ALLOWLIST.entries()]
+      .filter(([, reason]) => reason.trim().length === 0)
+      .map(([rel]) => rel);
+    expect(missingReasons).toEqual([]);
   });
 });


### PR DESCRIPTION
# Relates to

Closes #19526.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the catalog behavior from the deterministic tests and exact-head results below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `c614ea05e24511d4f7131469a3f4734088f780fe`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 tasks and all repository audits.

# Risks

Low. This changes only the source-based settings BrandCard catalog test. It does not change runtime code or rendered UI.

# Background

## What does this PR do?

- Restamps the auto-top-up leftover reason after its switch moved to `SettingsSwitchRow`.
- Explicitly ratchets the five converted BrandCard hosts out of the allowlist.
- Replaces the non-gating catalog print assertion with a gate that rejects missing kind reasons.

## What kind of change is this?

Test maintenance / regression hardening.

# Documentation changes needed?

No. This is an internal test catalog correction.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/settings/settings-dashboard-leftovers.test.ts`

## Detailed testing steps

1. Run `bun test packages/ui/src/components/settings/settings-dashboard-leftovers.test.ts` and confirm 4/4 pass.
2. Run `bun run --cwd packages/ui lint` and `bun run --cwd packages/ui build`.
3. Run `bun run verify` and confirm 350/350 tasks plus all audits pass.

# Evidence Gate

<!-- evidence-head:45346a8c62d703d16513f51cb1723dcec99696d1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only TypeScript change; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only TypeScript change; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow or runtime behavior changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime code or request/state behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain state or generated product artifact changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

Focused exact-head result:

```text
4 pass
0 fail
4 expect() calls
```

Package results:

```text
@elizaos/ui lint: 2983 files checked; no fixes applied (8 pre-existing document.cookie warnings)
@elizaos/ui build: verified 46 runtime exports
```

Root exact-head result:

```text
Tasks: 350 successful, 350 total
[audit-build-typecheck] passed
[audit-turbo-build-deps] passed
[audit-tee-secret-leak] passed
[hetzner-fleet-routing] verified 61 selectors across 16 workflows
[audit-scripts] passed
[anti-larp] scanned 8047 test files; clean
```

## Known gaps / failures

An isolated initial `packages/ui typecheck` invocation reported missing generated cross-workspace modules before root orchestration had generated/built them. The authoritative post-sync `bun run verify` then generated those dependencies and passed the UI typecheck as part of 350/350 tasks. No product evidence is applicable because the only changed file is a source-based test.

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - repository contribution skill is not available in this session"} -->
