### PR TITLE
fix(voice): recover realtime STT transport

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -61,9 +61,13 @@ class FakeInkSocket implements CartesiaInkWebSocket {
   closed = false;
   private listeners = new Map<string, Set<(e: unknown) => void>>();
 
-  constructor() {
+  constructor(opts?: { autoOpen?: boolean }) {
     FakeInkSocket.instances.push(this);
-    queueMicrotask(() => this.fire("open", {}));
+    if (opts?.autoOpen === false) {
+      this.readyState = 0;
+    } else {
+      queueMicrotask(() => this.fire("open", {}));
+    }
   }
   send(data: string | ArrayBuffer | ArrayBufferView) {
     if (typeof data === "string") return; // CloseStream control.
@@ -88,8 +92,15 @@ class FakeInkSocket implements CartesiaInkWebSocket {
       data: JSON.stringify({ type: event, transcript }),
     });
   }
+  emitMalformedMessage() {
+    this.fire("message", { data: "{not json" });
+  }
   emitConnectedHandshake() {
     this.fire("message", { data: JSON.stringify({ type: "connected" }) });
+  }
+  emitOpen() {
+    this.readyState = 1;
+    this.fire("open", {});
   }
   emitTransportError() {
     this.fire("error", new Event("error"));
@@ -443,6 +454,8 @@ const CLAIMS = {
 async function connectSession(opts: {
   client: FakeClientSocket;
   fetchImpl: typeof fetch;
+  inkSocketFactory?: () => CartesiaInkWebSocket;
+  sttReconnectDelaysMs?: readonly number[];
   prewarmElizaContext?: () => Promise<void>;
   openingGreeting?: string;
   cacheWarmingRetryDelaysMs?: readonly number[];
@@ -467,7 +480,8 @@ async function connectSession(opts: {
         agentId: claims.agentId,
         conversationId: claims.conversationId,
         tokenExpSeconds,
-        cartesiaInkWebSocketFactory: () => new FakeInkSocket(),
+        cartesiaInkWebSocketFactory:
+          opts.inkSocketFactory ?? (() => new FakeInkSocket()),
         cartesiaApiKey: "ct-key",
         cartesiaVoiceId: "db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
         cartesiaWebSocketFactory: () => new FakeCartesiaSocket(),
@@ -492,6 +506,9 @@ async function connectSession(opts: {
           ? {
               cacheWarmingRetryDelaysMs: opts.cacheWarmingRetryDelaysMs,
             }
+          : {}),
+        ...(opts.sttReconnectDelaysMs
+          ? { sttReconnectDelaysMs: opts.sttReconnectDelaysMs }
           : {}),
         usageStore,
         usageLimits: { organizationDailyMinutes: 600, userDailyMinutes: 120 },
@@ -1812,7 +1829,7 @@ describe("voice-session WS lifecycle", () => {
     expect(ink.sentChunks).toHaveLength(0);
   });
 
-  test("provider transport error and close surface fatal session errors", async () => {
+  test("provider transport error replaces Ink and the call keeps transcribing", async () => {
     const errored = new FakeClientSocket();
     await connectSession({ client: errored, fetchImpl: makeSseFetch(["ok."]) });
     const errorInk = FakeInkSocket.instances.at(-1)!;
@@ -1822,20 +1839,106 @@ describe("voice-session WS lifecycle", () => {
       expect.objectContaining({
         t: "error",
         code: "transport_error",
+        retryable: true,
+      }),
+    );
+    expect(errorInk.closed).toBe(true);
+    expect(errored.closedWith).toBeNull();
+    const replacement = FakeInkSocket.instances.at(-1)!;
+    expect(replacement).not.toBe(errorInk);
+    replacement.emitTurn("turn.start");
+    replacement.emitTurn("turn.end", "after reconnect");
+    await flush();
+    await flush();
+    expect(errored.controlFrames).toContainEqual(
+      expect.objectContaining({ t: "stt_final", text: "after reconnect" }),
+    );
+  });
+
+  test("provider protocol error clears the active STT turn", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({ client, fetchImpl: makeSseFetch(["ok."]) });
+    const ink = FakeInkSocket.instances.at(-1)!;
+
+    ink.emitTurn("turn.start");
+    ink.emitMalformedMessage();
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "fresh turn");
+    await flush();
+    await flush();
+
+    expect(client.controlFrames).toContainEqual(
+      expect.objectContaining({
+        t: "error",
+        code: "malformed_event",
         retryable: false,
       }),
     );
-    expect(errored.closedWith).toBeNull();
+    expect(client.controlFrames).toContainEqual(
+      expect.objectContaining({ t: "stt_final", text: "fresh turn" }),
+    );
+  });
 
+  test("unexpected Ink close buffers audio until the replacement is connected", async () => {
     const closed = new FakeClientSocket();
-    await connectSession({ client: closed, fetchImpl: makeSseFetch(["ok."]) });
+    let socketCount = 0;
+    let replacement: FakeInkSocket | null = null;
+    await connectSession({
+      client: closed,
+      fetchImpl: makeSseFetch(["ok."]),
+      inkSocketFactory: () => {
+        socketCount += 1;
+        if (socketCount === 1) return new FakeInkSocket();
+        replacement = new FakeInkSocket({ autoOpen: false });
+        return replacement;
+      },
+    });
     const closeInk = FakeInkSocket.instances.at(-1)!;
     closeInk.close(1006, "provider gone");
     await flush();
     expect(closed.controlFrames).toContainEqual(
+      expect.objectContaining({
+        t: "error",
+        code: "stt_reconnecting",
+        retryable: true,
+      }),
+    );
+    expect(closed.closedWith).toBeNull();
+    expect(replacement).not.toBeNull();
+
+    closed.clientSend(pcmChunk(3200));
+    await flush();
+    expect(replacement!.sentChunks).toHaveLength(0);
+    replacement!.emitOpen();
+    await flush();
+    expect(replacement!.sentChunks).toHaveLength(1);
+  });
+
+  test("Ink reconnect exhaustion fails the call closed", async () => {
+    const client = new FakeClientSocket();
+    let first: FakeInkSocket | null = null;
+    let attempts = 0;
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["ok."]),
+      sttReconnectDelaysMs: [0],
+      inkSocketFactory: () => {
+        attempts += 1;
+        if (attempts === 1) {
+          first = new FakeInkSocket();
+          return first;
+        }
+        throw new Error("Ink unavailable");
+      },
+    });
+    first!.close(1006, "provider gone");
+    await flush();
+
+    expect(attempts).toBe(2);
+    expect(client.closedWith).toEqual({ code: 1000, reason: "error" });
+    expect(client.controlFrames).toContainEqual(
       expect.objectContaining({ t: "error", code: "error", retryable: true }),
     );
-    expect(closed.closedWith).toEqual({ code: 1000, reason: "error" });
   });
 
   test("hello-first is enforced: a binary frame before hello closes the socket", async () => {

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -100,6 +100,8 @@ const STT_PARTIAL_EMIT_INTERVAL_MS = 40;
  * land, while keeping the total first-turn penalty bounded below eight seconds.
  */
 const CACHE_WARMING_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000] as const;
+/** Replace a failed realtime recognizer without dropping the live phone call. */
+const STT_RECONNECT_DELAYS_MS = [0, 250, 1_000] as const;
 const CACHE_WARMING_CODES = new Set([
   "agent_cache_warming",
   "shared_runtime_cache_warming",
@@ -149,6 +151,8 @@ export interface VoiceSessionConfig {
   openingGreeting?: string;
   /** Deterministic test override; production uses bounded exponential backoff. */
   cacheWarmingRetryDelaysMs?: readonly number[];
+  /** Deterministic test override for the bounded Ink reconnect schedule. */
+  sttReconnectDelaysMs?: readonly number[];
 
   // Metering (SEC-15). Server-derived only.
   usageStore: VoiceUsageStore;
@@ -194,6 +198,9 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
   private stt: CartesiaInkRealtimeSession | null = null;
   private sttReady = false;
+  private sttGeneration = 0;
+  private sttReconnectAttempts = 0;
+  private sttReconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly providerPendingFrames: ArrayBuffer[] = [];
   private readonly cartesiaAdapter: CartesiaSonicTtsAdapter;
   private readonly fishAudioAdapter: FishAudioTtsAdapter | null = null;
@@ -273,11 +280,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     if (this.started || this.closed) return;
     this.started = true;
 
-    this.stt = createCartesiaInkRealtimeSession({
-      cartesiaApiKey: this.config.cartesiaApiKey,
-      webSocketFactory: this.config.cartesiaInkWebSocketFactory,
-      onEvent: (event) => this.onSttEvent(event),
-    });
+    this.openSttSession();
 
     this.registry.register(this);
 
@@ -340,7 +343,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
    * meters server-derived seconds. Silently drops if the session is torn down.
    */
   pushUplinkAudio(bytes: Uint8Array): void {
-    if (this.closed || !this.stt || this.meteredExhausted) return;
+    if (this.closed || this.meteredExhausted) return;
 
     // Fail-closed admission (SEC-15): NO audio is forwarded to the paid provider
     // until an initial quota check has PASSED. Frames that arrive before the
@@ -389,8 +392,8 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
   /** Queue audio until Ink is ready, then preserve its original frame order. */
   private forwardSttFrame(frame: ArrayBuffer): boolean {
-    if (this.closed || !this.stt) return false;
-    if (!this.sttReady) {
+    if (this.closed) return false;
+    if (!this.stt || !this.sttReady) {
       this.providerPendingFrames.push(frame);
       if (this.providerPendingFrames.length <= MAX_PROVIDER_PENDING_FRAMES) {
         return true;
@@ -481,12 +484,26 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
   // --- STT event handling ---------------------------------------------------
 
-  private onSttEvent(event: CartesiaInkRealtimeEvent): void {
-    if (this.closed) return;
+  private openSttSession(): void {
+    const generation = ++this.sttGeneration;
+    this.sttReady = false;
+    this.stt = createCartesiaInkRealtimeSession({
+      cartesiaApiKey: this.config.cartesiaApiKey,
+      webSocketFactory: this.config.cartesiaInkWebSocketFactory,
+      onEvent: (event) => this.onSttEvent(event, generation),
+    });
+  }
+
+  private onSttEvent(
+    event: CartesiaInkRealtimeEvent,
+    generation: number,
+  ): void {
+    if (this.closed || generation !== this.sttGeneration) return;
     switch (event.type) {
       case "connected": {
         // Provider readiness is transport metadata; the client-facing session
         // has already emitted its own authenticated `ready` frame.
+        this.sttReconnectAttempts = 0;
         this.sttReady = true;
         const buffered = this.providerPendingFrames.splice(0);
         for (const frame of buffered) if (!this.forwardSttFrame(frame)) break;
@@ -541,17 +558,82 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       case "error": {
         // Provider/protocol failures are explicit and terminate the current
         // turn; malformed input must not be reinterpreted as speech.
+        this.activeSttTurn = false;
         this.resetSttPartialDelivery();
+        if (event.code === "transport_error") {
+          this.send({ t: "error", code: event.code, retryable: true });
+          this.recoverSttTransport("transport_error", generation);
+          break;
+        }
         this.send({ t: "error", code: event.code, retryable: false });
         break;
       }
       case "close": {
-        // Provider closed. If we were mid-session and not already tearing down,
-        // this is fatal for the turn; end the session so the client re-mints.
-        if (!this.closed) this.teardown("error");
+        this.send({ t: "error", code: "stt_reconnecting", retryable: true });
+        this.recoverSttTransport(`close:${event.code}`, generation);
         break;
       }
     }
+  }
+
+  /**
+   * Replace a failed Ink socket while preserving the authenticated call.
+   *
+   * The generation fence makes the old socket's recursive close callback a
+   * no-op. Any incomplete transcript is discarded because a new recognizer
+   * cannot safely resume provider turn state; newly metered audio remains in
+   * the bounded provider queue until the replacement emits `connected`.
+   */
+  private recoverSttTransport(reason: string, generation: number): void {
+    if (this.closed || generation !== this.sttGeneration) return;
+    const failed = this.stt;
+    this.stt = null;
+    this.sttReady = false;
+    this.activeSttTurn = false;
+    this.resetSttPartialDelivery();
+    this.sttGeneration += 1;
+    if (failed) {
+      try {
+        failed.cancel(`recover:${reason}`);
+      } catch {
+        // error-policy:J6 best-effort teardown of the failed recognizer; the
+        // generation fence already prevents it from reaching session state.
+      }
+    }
+    this.scheduleSttReconnect(reason);
+  }
+
+  private scheduleSttReconnect(reason: string): void {
+    if (this.closed || this.sttReconnectTimer !== null) return;
+    const delays = this.config.sttReconnectDelaysMs ?? STT_RECONNECT_DELAYS_MS;
+    const delay = delays[this.sttReconnectAttempts];
+    if (delay === undefined) {
+      logger.warn("[voice-session] Ink reconnect attempts exhausted", {
+        sessionId: this.sessionId,
+        reason,
+        attempts: this.sttReconnectAttempts,
+      });
+      this.teardown("error");
+      return;
+    }
+    this.sttReconnectAttempts += 1;
+    this.sttReconnectTimer = setTimeout(() => {
+      this.sttReconnectTimer = null;
+      if (this.closed) return;
+      try {
+        this.openSttSession();
+      } catch (error) {
+        // error-policy:J4 a replacement transport that cannot be constructed
+        // stays visibly retrying, then fails the call closed at the bound.
+        logger.warn("[voice-session] Ink reconnect failed", {
+          sessionId: this.sessionId,
+          reason,
+          attempt: this.sttReconnectAttempts,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        this.scheduleSttReconnect(reason);
+      }
+    }, delay);
   }
 
   /** Cancel an active response only after Ink has produced caller words. */
@@ -1082,6 +1164,11 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     // Invalidate any live turn so racing callbacks are dropped.
     this.currentVoiceTurnId = null;
     this.resetSttPartialDelivery();
+    this.sttGeneration += 1;
+    if (this.sttReconnectTimer !== null) {
+      clearTimeout(this.sttReconnectTimer);
+      this.sttReconnectTimer = null;
+    }
 
     if (this.ttsStream) {
       try {


### PR DESCRIPTION
## Summary

- keep an authenticated voice call alive when Cartesia Ink emits a transport error or closes unexpectedly
- reconnect with a bounded `0ms / 250ms / 1s` schedule, buffer already-metered PCM during replacement, and fail the call closed after exhaustion
- generation-fence stale callbacks and reset incomplete STT turn state so a failed recognizer cannot wedge or corrupt the next utterance
- clear active turn state after non-transport provider/protocol errors

Closes the remaining STT lifecycle candidates #2 and #3 from #19505. The DO cancellation/queue-lock candidate was fixed separately in #19537.

## Review findings addressed

Before this change, `case "close"` immediately tore down the whole phone call. A transport `error` stayed nonfatal but did not replace the dead socket, and a protocol error could leave `activeSttTurn` latched. The replacement lifecycle is bounded by the existing ~12.8s PCM queue cap and by three reconnect attempts.

## Verification

- `bun run verify` — 350/350 workspace tasks; all repository audits; anti-larp scanned 8,048 tests with no focused/orphaned skips
- `bun --config=.tmp/bunfig-no-coverage.toml test packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts` — 55/55
- `bun --config=.tmp/bunfig-no-coverage.toml test packages/cloud/api/v1/voice/stt/providers/cartesia-ink.test.ts packages/cloud/api/v1/voice/stt/route.test.ts packages/cloud/api/v1/voice/session/__tests__/uplink-reframer.test.ts` — 84 passed, 1 explicitly gated live Railway test skipped
- `bun run --cwd packages/cloud/api typecheck` — pass, including production Worker bundle dry-run
- `bunx biome check packages/cloud/api/v1/voice/session/lib/session.ts packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts` — pass

The lifecycle tests run the production session and real Cartesia Ink adapter behind an injected WebSocket transport. They prove transport-error replacement, post-reconnect transcription, audio buffering until readiness, bounded exhaustion teardown, and recovery from a malformed provider event.

## Evidence matrix

- UI screenshots / MP4: N/A — audio-only backend transport change; no UI pixels changed
- Backend behavior: deterministic production-path WebSocket lifecycle tests above
- Real-model trajectory: N/A — provider transport/state-machine behavior, independent of model output
- Live PSTN call: pending post-deploy production validation; not represented as completed by this PR

AI assistance: OpenAI Codex
