### PR TITLE
fix(ui): restore default Switch accent ON on cloud green overrides

### DIFF
--- a/packages/ui/src/cloud/applications/components/app-monetization-settings.test.tsx
+++ b/packages/ui/src/cloud/applications/components/app-monetization-settings.test.tsx
@@ -275,9 +275,17 @@ describe("AppMonetizationSettings review gate", () => {
     renderMonetization(makeApp({ review_status: "approved" }));
 
     expect(await screen.findByText("Review approved")).toBeTruthy();
-    expect((screen.getByRole("switch") as HTMLButtonElement).disabled).toBe(
-      false,
+    const toggle = screen.getByRole("switch", {
+      name: "Enable Monetization",
+    }) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+    expect(toggle.getAttribute("aria-describedby")).toBe(
+      "monetization-enabled-hint",
     );
+    expect(toggle.className).not.toMatch(/bg-green-500/);
+    expect(toggle.className).not.toMatch(/bg-neutral-700/);
+    expect(toggle.className).toMatch(/data-\[state=checked\]:bg-accent/);
+    expect(toggle.className).toMatch(/data-\[state=unchecked\]:bg-input/);
     expect(
       screen.queryByRole("button", { name: "Submit for review" }),
     ).toBeNull();

--- a/packages/ui/src/cloud/applications/components/app-monetization-settings.tsx
+++ b/packages/ui/src/cloud/applications/components/app-monetization-settings.tsx
@@ -376,8 +376,11 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
               />
             </div>
             <div className="flex-1">
-              <div className="flex items-center justify-between">
-                <p className="text-sm font-medium text-txt">
+              <div className="flex items-center justify-between gap-3">
+                <label
+                  htmlFor="monetization-enabled"
+                  className="text-sm font-medium text-txt text-pretty"
+                >
                   {settings.monetizationEnabled
                     ? t("cloud.monetization.active", {
                         defaultValue: "Monetization Active",
@@ -385,12 +388,14 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                     : t("cloud.monetization.enableTitle", {
                         defaultValue: "Enable Monetization",
                       })}
-                </p>
+                </label>
                 <Switch
                   // The server always allows DISABLING; only ENABLING is
                   // review-gated. So the switch must stay interactive for a
                   // legacy enabled-but-unapproved row — otherwise it's trapped
                   // ON with no way to turn it off.
+                  id="monetization-enabled"
+                  aria-describedby="monetization-enabled-hint"
                   checked={settings.monetizationEnabled}
                   disabled={!reviewApproved && !settings.monetizationEnabled}
                   onCheckedChange={(checked) => {
@@ -400,10 +405,12 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                       toggleMonetization(checked);
                     }
                   }}
-                  className="data-[state=checked]:bg-green-500 data-[state=unchecked]:bg-neutral-700"
                 />
               </div>
-              <p className="text-xs text-neutral-500 mt-1">
+              <p
+                id="monetization-enabled-hint"
+                className="text-xs text-neutral-500 mt-1 text-pretty"
+              >
                 {settings.monetizationEnabled
                   ? t("cloud.monetization.activeDesc", {
                       defaultValue:

--- a/packages/ui/src/cloud/applications/components/app-settings.test.tsx
+++ b/packages/ui/src/cloud/applications/components/app-settings.test.tsx
@@ -1,0 +1,150 @@
+/** Verifies AppSettings active-status Switch through the package's configured test harness. */
+// @vitest-environment jsdom
+
+/**
+ * `AppSettings` active-status Switch: no custom green ON-track override, the
+ * visible "Active Status" label is the accessible name, and toggling updates
+ * the save payload. Query client, i18n, and app mutations are doubled; the
+ * form renders for real.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { App } from "../lib/apps";
+import { AppSettings } from "./app-settings";
+
+const updateAppMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../lib/apps", async () => {
+  const actual =
+    await vi.importActual<typeof import("../lib/apps")>("../lib/apps");
+  return {
+    ...actual,
+    updateApp: (...args: unknown[]) => updateAppMock(...args),
+    deleteApp: vi.fn(),
+    regenerateAppApiKey: vi.fn(),
+  };
+});
+
+vi.mock("../lib/one-time-app-api-key", () => ({
+  storeOneTimeAppApiKey: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../../shell/CloudI18nProvider", () => ({
+  useCloudT:
+    () =>
+    (
+      key: string,
+      options?: Record<string, unknown> & { defaultValue?: string },
+    ) =>
+      (options?.defaultValue ?? key).replace(/\{\{(\w+)\}\}/g, (_, name) =>
+        String(options?.[name] ?? ""),
+      ),
+}));
+
+function makeApp(overrides: Partial<App> = {}): App {
+  return {
+    id: "app_1",
+    name: "Draft App",
+    description: "Settings fixture",
+    slug: "draft-app",
+    organization_id: "org_1",
+    created_by_user_id: "user_1",
+    app_url: "https://draft.example.com",
+    allowed_origins: ["https://draft.example.com"],
+    api_key_id: null,
+    affiliate_code: null,
+    referral_bonus_credits: "0.00",
+    total_requests: 0,
+    total_users: 0,
+    total_credits_used: "0.00",
+    logo_url: null,
+    website_url: null,
+    contact_email: "ops@example.com",
+    metadata: {},
+    deployment_status: "draft",
+    production_url: null,
+    last_deployed_at: null,
+    github_repo: null,
+    linked_character_ids: [],
+    monetization_enabled: false,
+    inference_markup_percentage: 25,
+    purchase_share_percentage: 10,
+    platform_offset_amount: 1,
+    custom_pricing_enabled: false,
+    total_creator_earnings: "0.00",
+    total_platform_revenue: "0.00",
+    discord_automation: null,
+    telegram_automation: null,
+    twitter_automation: null,
+    promotional_assets: null,
+    user_database_status: "none",
+    user_database_uri: null,
+    user_database_region: null,
+    user_database_error: null,
+    email_notifications: true,
+    response_notifications: true,
+    is_active: true,
+    is_approved: true,
+    review_status: "approved",
+    review_content_hash: null,
+    reviewed_at: null,
+    created_at: "2026-07-03T12:00:00.000Z",
+    updated_at: "2026-07-03T12:00:00.000Z",
+    last_used_at: null,
+    ...overrides,
+  };
+}
+
+function renderSettings(app: App) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <AppSettings app={app} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  updateAppMock.mockReset();
+});
+
+describe("AppSettings active-status Switch", () => {
+  it("uses the default accent ON / input OFF track and the Active Status name", () => {
+    renderSettings(makeApp());
+
+    const toggle = screen.getByRole("switch", { name: "Active Status" });
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+    expect(toggle.getAttribute("aria-describedby")).toBe("is_active-hint");
+    expect(toggle.className).not.toMatch(/bg-green-500/);
+    expect(toggle.className).not.toMatch(/bg-neutral-700/);
+    expect(toggle.className).toMatch(/data-\[state=checked\]:bg-accent/);
+    expect(toggle.className).toMatch(/data-\[state=unchecked\]:bg-input/);
+  });
+
+  it("writes the toggled is_active value on save", async () => {
+    updateAppMock.mockResolvedValue(undefined);
+    const user = userEvent.setup({ delay: null });
+    renderSettings(makeApp({ is_active: true }));
+
+    await user.click(screen.getByRole("switch", { name: "Active Status" }));
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(updateAppMock).toHaveBeenCalledWith(
+      "app_1",
+      expect.objectContaining({ is_active: false }),
+    );
+  });
+});

--- a/packages/ui/src/cloud/applications/components/app-settings.tsx
+++ b/packages/ui/src/cloud/applications/components/app-settings.tsx
@@ -292,14 +292,20 @@ export function AppSettings({ app }: AppSettingsProps) {
             />
           </div>
 
-          <div className="flex items-center justify-between p-3 bg-surface rounded-sm border border-border">
+          <div className="flex items-center justify-between gap-3 p-3 bg-surface rounded-sm border border-border">
             <div>
-              <p className="text-sm font-medium text-txt">
+              <Label
+                htmlFor="is_active"
+                className="text-sm font-medium text-txt"
+              >
                 {t("cloud.appSettings.activeStatus", {
                   defaultValue: "Active Status",
                 })}
-              </p>
-              <p className="text-xs text-neutral-500 mt-0.5">
+              </Label>
+              <p
+                id="is_active-hint"
+                className="text-xs text-neutral-500 mt-0.5 text-pretty"
+              >
                 {t("cloud.appSettings.activeStatusHint", {
                   defaultValue: "Inactive apps cannot make API requests",
                 })}
@@ -307,11 +313,11 @@ export function AppSettings({ app }: AppSettingsProps) {
             </div>
             <Switch
               id="is_active"
+              aria-describedby="is_active-hint"
               checked={formData.is_active}
               onCheckedChange={(checked) =>
                 setFormData({ ...formData, is_active: checked })
               }
-              className="data-[state=checked]:bg-green-500 data-[state=unchecked]:bg-neutral-700"
             />
           </div>
         </div>

--- a/packages/ui/src/cloud/instances/components/agent-card.test.tsx
+++ b/packages/ui/src/cloud/instances/components/agent-card.test.tsx
@@ -1,0 +1,96 @@
+/** Verifies AgentCard share Switch through the package's configured test harness. */
+// @vitest-environment jsdom
+
+/**
+ * `AgentCard` public/private Switch: decorative (menu item is the control),
+ * no green ON-track or dead thumb selectors, Public/Private + Globe/Lock
+ * remain the non-color state. i18n, router, and toast are doubled.
+ */
+
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentCard } from "./agent-card";
+
+vi.mock("../lib/i18n", () => ({
+  useT:
+    () =>
+    (
+      key: string,
+      options?: Record<string, unknown> & { defaultValue?: string },
+    ) =>
+      (options?.defaultValue ?? key).replace(/\{\{(\w+)\}\}/g, (_, name) =>
+        String(options?.[name] ?? ""),
+      ),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+function renderCard(isPublic = false) {
+  return render(
+    <MemoryRouter>
+      <AgentCard
+        viewMode="list"
+        agent={{
+          id: "agent_1",
+          name: "Ada",
+          bio: "A fixture agent",
+          isOwned: true,
+          isPublic,
+        }}
+      />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AgentCard share Switch", () => {
+  it("keeps the share Switch decorative with default track colors", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderCard(false);
+
+    const openButtons = screen.getAllByRole("button");
+    const moreButton = openButtons.find(
+      (button) => button.getAttribute("aria-label") !== "Open agent: Ada",
+    );
+    expect(moreButton).toBeTruthy();
+    await user.click(moreButton as HTMLElement);
+
+    const menuItem = await screen.findByRole("menuitem", { name: /Private/ });
+    expect(within(menuItem).getByText("Private")).toBeTruthy();
+
+    const toggle = menuItem.querySelector('[role="switch"]');
+    expect(toggle).toBeTruthy();
+    expect(toggle?.getAttribute("aria-hidden")).toBe("true");
+    expect(toggle?.getAttribute("tabindex")).toBe("-1");
+    expect(toggle?.className).toContain("pointer-events-none");
+    expect(toggle?.className).not.toMatch(/bg-green-500/);
+    expect(toggle?.className).not.toMatch(/switch-thumb/);
+    expect(toggle?.className).toMatch(/data-\[state=checked\]:bg-accent/);
+    expect(toggle?.className).toMatch(/data-\[state=unchecked\]:bg-input/);
+  });
+
+  it("names the ON state Public with a Globe icon, not color alone", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderCard(true);
+
+    const openButtons = screen.getAllByRole("button");
+    const moreButton = openButtons.find(
+      (button) => button.getAttribute("aria-label") !== "Open agent: Ada",
+    );
+    await user.click(moreButton as HTMLElement);
+
+    const menuItem = await screen.findByRole("menuitem", { name: /Public/ });
+    expect(within(menuItem).getByText("Public")).toBeTruthy();
+    expect(menuItem.querySelector("svg")).toBeTruthy();
+    expect(
+      menuItem.querySelector('[role="switch"]')?.getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+});

--- a/packages/ui/src/cloud/instances/components/agent-card.tsx
+++ b/packages/ui/src/cloud/instances/components/agent-card.tsx
@@ -501,13 +501,13 @@ function AgentCardInner({
                     <DropdownMenuSeparator />
                     <DropdownMenuItem
                       onClick={handleToggleShare}
-                      className="cursor-pointer flex items-center justify-between"
+                      className="cursor-pointer flex items-center justify-between gap-3"
                     >
                       <span className="flex items-center">
                         {isPublic ? (
-                          <Globe className="h-4 w-4 mr-4 text-green-500" />
+                          <Globe className="h-4 w-4 mr-4" aria-hidden="true" />
                         ) : (
-                          <Lock className="h-4 w-4 mr-4" />
+                          <Lock className="h-4 w-4 mr-4" aria-hidden="true" />
                         )}
                         {isPublic
                           ? t("cloud.agentCard.public", {
@@ -517,9 +517,12 @@ function AgentCardInner({
                               defaultValue: "Private",
                             })}
                       </span>
+                      {/* Decorative: the menu item is the control. Public/Private + icon carry state. */}
                       <Switch
                         checked={isPublic}
-                        className="pointer-events-none data-[state=checked]:bg-green-500/20 [&_[data-slot=switch-thumb]]:data-[state=checked]:bg-green-500 [&_[data-slot=switch-thumb]]:data-[state=unchecked]:bg-white/40"
+                        tabIndex={-1}
+                        aria-hidden="true"
+                        className="pointer-events-none"
                       />
                     </DropdownMenuItem>
                     {isPublic && (
@@ -727,13 +730,13 @@ function AgentCardInner({
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={handleToggleShare}
-                  className="cursor-pointer flex items-center justify-between"
+                  className="cursor-pointer flex items-center justify-between gap-3"
                 >
                   <span className="flex items-center">
                     {isPublic ? (
-                      <Globe className="h-4 w-4 mr-4 text-green-500" />
+                      <Globe className="h-4 w-4 mr-4" aria-hidden="true" />
                     ) : (
-                      <Lock className="h-4 w-4 mr-4" />
+                      <Lock className="h-4 w-4 mr-4" aria-hidden="true" />
                     )}
                     {isPublic
                       ? t("cloud.agentCard.public", { defaultValue: "Public" })
@@ -741,9 +744,12 @@ function AgentCardInner({
                           defaultValue: "Private",
                         })}
                   </span>
+                  {/* Decorative: the menu item is the control. Public/Private + icon carry state. */}
                   <Switch
                     checked={isPublic}
-                    className="pointer-events-none data-[state=checked]:bg-green-500/20 [&_[data-slot=switch-thumb]]:data-[state=checked]:bg-green-500 [&_[data-slot=switch-thumb]]:data-[state=unchecked]:bg-white/40"
+                    tabIndex={-1}
+                    aria-hidden="true"
+                    className="pointer-events-none"
                   />
                 </DropdownMenuItem>
                 {isPublic && (

--- a/packages/ui/src/cloud/switch-green-on-color-ratchet.test.ts
+++ b/packages/ui/src/cloud/switch-green-on-color-ratchet.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Source ratchet for the three custom green ON-track Switch overrides.
+ * Reads those files only; fails if green checked tracks, forced unchecked
+ * neutrals, or dead `data-slot=switch-thumb` selectors return.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CLOUD_ROOT = import.meta.dirname;
+
+const GUARDED_FILES = [
+  "applications/components/app-settings.tsx",
+  "applications/components/app-monetization-settings.tsx",
+  "instances/components/agent-card.tsx",
+] as const;
+
+const FORBIDDEN = [
+  /data-\[state=checked\]:bg-green-500/,
+  /data-\[state=unchecked\]:bg-neutral-700/,
+  /data-slot=switch-thumb/,
+] as const;
+
+describe("cloud Switch green ON-track ratchet", () => {
+  it("keeps the guarded files free of custom green ON / forced-OFF Switch classes", () => {
+    const offenders: string[] = [];
+    for (const rel of GUARDED_FILES) {
+      const source = readFileSync(join(CLOUD_ROOT, rel), "utf8");
+      for (const pattern of FORBIDDEN) {
+        if (pattern.test(source)) {
+          offenders.push(`${rel} matches ${pattern}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("still guards the live Switch call sites (no stale paths)", () => {
+    for (const rel of GUARDED_FILES) {
+      const source = readFileSync(join(CLOUD_ROOT, rel), "utf8");
+      expect(source).toContain("<Switch");
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #19551

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun run verify` was not run for the whole monorepo; focused `@elizaos/ui` tests for the touched Switch call sites pass.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0e388e626e4d660ff24226ac71b38b78df1ed977:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` not run for the whole monorepo; focused UI tests pass.

# Risks

Low. Only three custom Switch `className` color overrides are removed. Persist, review-gate, and share-toggle behavior stay. No `Switch.tsx`, FieldSwitch, ConfigRenderer, or Auto Top-Up change.

# Background

## What does this PR do?

Restores the shared Switch default accent ON / input OFF track on the three cloud call sites that painted a custom green ON track (`data-[state=checked]:bg-green-500`) and a forced neutral OFF track. Agent-card also dropped dead `data-slot=switch-thumb` selectors the primitive does not expose. Labels already say Active / Enable / Public / Private; those remain the non-color state cue. A source ratchet fails if the green ON classes return on these files.

## What kind of change is this?

Bug fixes

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Isolated before/after screenshots (green ON vs orange ON), then the source ratchet and component tests.

## Detailed testing steps

```bash
bun run --cwd packages/ui test -- src/cloud/switch-green-on-color-ratchet.test.ts src/cloud/applications/components/app-settings.test.tsx src/cloud/applications/components/app-monetization-settings.test.tsx src/cloud/instances/components/agent-card.test.tsx
```

- As a cloud app owner, open App Settings → Active Status uses accent ON, not green.
- As a cloud app owner, open Monetization → Enable/Active uses accent ON; review gate is unchanged.
- As an agent owner, open the card menu → Public/Private still has Globe/Lock + label; the decorative switch uses the default track.

# Evidence Gate

<!-- evidence-head:6f3a667f259b4c8f23ba588ed24ab117d166f4ac -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19557-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19557-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19557-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend contract change; these Switches stay presentational or use existing persist paths
<!-- evidence-row:frontend-logs -->
- [x] [19557-frontend-logs-clean.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19557-frontend-logs-clean.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, wallet, scheduled-task, or generated domain artifact is involved
<!-- evidence-row:ocr-review -->
- [x] [19557-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19557-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Backend + frontend logs

Backend: N/A - no backend contract change; these Switches remain presentational/local draft or existing persist paths.

Frontend: focused `@elizaos/ui` test log attached via the evidence row.

## Screenshots (before / after) + video walkthrough

Isolated Playwright fixture of the three cloud Switch call sites: green ON / forced-neutral OFF versus accent orange ON / input OFF.

Desktop: ![before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19557-before-desktop.jpg) ![after desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19557-after-desktop.jpg)

Mobile: ![before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19557-before-mobile.jpg) ![after mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19557-after-mobile.jpg)

## Known gaps / failures

- Full-repo `bun run verify` not run.
- Isolated fixture of the three call-site Switch colors (audit:app still blocked by the full cloud app boot path).
- Did not convert these rows to SettingsSwitchRow, and did not touch FieldSwitch, ConfigRenderer, Auto Top-Up, or Switch.tsx.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok-cli
Contribution skill revision: elizaOS/eliza@0e388e626e4d660ff24226ac71b38b78df1ed977:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-4.6]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-cli","skill_revision":"elizaOS/eliza@0e388e626e4d660ff24226ac71b38b78df1ed977:packages/skills/skills/contribute-to-eliza"} -->

