### PR TITLE
fix(ui): route affiliates copy-link rows through SettingsRow

### DIFF
--- a/packages/ui/src/cloud/monetization/affiliates/AffiliatesPageClient.test.tsx
+++ b/packages/ui/src/cloud/monetization/affiliates/AffiliatesPageClient.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * Renders AffiliatesPageClient copyable invite/affiliate URLs through
+ * SettingsRow + copy control. jsdom, mocked affiliates and referral APIs.
+ */
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMock = vi.hoisted(() => vi.fn());
+const copyMock = vi.hoisted(() => vi.fn(async () => true));
+const toastMock = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+const referralState = vi.hoisted(() => ({
+  referralMe: {
+    code: "FRIEND1",
+    total_referrals: 2,
+    is_active: true,
+  },
+  loadingReferral: false,
+  referralFetchFailed: false,
+  refetch: vi.fn(),
+}));
+
+vi.mock("../../lib/api-client", () => ({
+  api: apiMock,
+  ApiError: class ApiError extends Error {},
+}));
+
+vi.mock("sonner", () => ({
+  toast: toastMock,
+}));
+
+vi.mock("../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? key,
+}));
+
+vi.mock("../lib/clipboard", async () => {
+  const actual =
+    await vi.importActual<typeof import("../lib/clipboard")>(
+      "../lib/clipboard",
+    );
+  return {
+    ...actual,
+    copyTextToClipboard: copyMock,
+  };
+});
+
+vi.mock("./use-dashboard-referral-me", () => ({
+  useDashboardReferralMe: () => referralState,
+}));
+
+import { AffiliatesPageClient } from "./AffiliatesPageClient";
+
+const affiliatePayload = {
+  code: {
+    id: "aff-1",
+    code: "AFFCODE",
+    markup_percent: "20.00",
+    is_active: true,
+  },
+};
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AffiliatesPageClient />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  apiMock.mockReset();
+  copyMock.mockReset();
+  copyMock.mockResolvedValue(true);
+  toastMock.success.mockReset();
+  toastMock.error.mockReset();
+  referralState.referralMe = {
+    code: "FRIEND1",
+    total_referrals: 2,
+    is_active: true,
+  };
+  referralState.loadingReferral = false;
+  referralState.referralFetchFailed = false;
+  apiMock.mockResolvedValue(affiliatePayload);
+  vi.stubGlobal("location", {
+    ...window.location,
+    origin: "https://app.eliza.test",
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("AffiliatesPageClient copy rows", () => {
+  it("routes invite and affiliate URLs through labelled SettingsRows", async () => {
+    renderPage();
+
+    expect(await screen.findByText("Invite link")).toBeTruthy();
+    expect(screen.getByText("Affiliate link")).toBeTruthy();
+    expect(
+      screen.getByText("https://app.eliza.test/login?ref=FRIEND1"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("https://app.eliza.test/login?affiliate=AFFCODE"),
+    ).toBeTruthy();
+
+    const inviteCopy = screen.getByTestId("cloud-affiliates-copy-invite");
+    const affiliateCopy = screen.getByTestId("cloud-affiliates-copy-affiliate");
+    expect(inviteCopy.textContent).toMatch(/Copy link/);
+    expect(affiliateCopy.textContent).toMatch(/Copy link/);
+    expect(inviteCopy.getAttribute("aria-label")).toBe("Copy link (invite)");
+    expect(affiliateCopy.getAttribute("aria-label")).toBe(
+      "Copy link (affiliate)",
+    );
+    expect(screen.getByRole("button", { name: "Copy link (invite)" })).toBe(
+      inviteCopy,
+    );
+    expect(screen.getByRole("button", { name: "Copy link (affiliate)" })).toBe(
+      affiliateCopy,
+    );
+
+    const inviteUrl = screen.getByText(
+      "https://app.eliza.test/login?ref=FRIEND1",
+    );
+    expect(inviteUrl.className).toMatch(/break-all/);
+    expect(inviteUrl.className).not.toMatch(/whitespace-nowrap/);
+    expect(screen.getByTestId("cloud-affiliates-markup-percent")).toBeTruthy();
+    expect(screen.getByText("cURL Example")).toBeTruthy();
+    expect(screen.getByText("Affiliate Program")).toBeTruthy();
+  });
+
+  it("copies the invite URL and announces copied with icon plus text", async () => {
+    renderPage();
+    const inviteCopy = await screen.findByTestId(
+      "cloud-affiliates-copy-invite",
+    );
+
+    fireEvent.click(inviteCopy);
+
+    await waitFor(() => {
+      expect(copyMock).toHaveBeenCalledWith(
+        "https://app.eliza.test/login?ref=FRIEND1",
+      );
+    });
+    expect(toastMock.success).toHaveBeenCalledWith("Invite link copied");
+    expect(inviteCopy.textContent).toMatch(/Copied/);
+    expect(inviteCopy.getAttribute("aria-label")).toBe("Copied invite link");
+    expect(screen.getByRole("status").textContent).toBe("Invite link copied");
+  });
+
+  it("copies the affiliate URL and keeps the cURL snippet out of the row", async () => {
+    renderPage();
+    const affiliateCopy = await screen.findByTestId(
+      "cloud-affiliates-copy-affiliate",
+    );
+
+    fireEvent.click(affiliateCopy);
+
+    await waitFor(() => {
+      expect(copyMock).toHaveBeenCalledWith(
+        "https://app.eliza.test/login?affiliate=AFFCODE",
+      );
+    });
+    expect(toastMock.success).toHaveBeenCalledWith("Affiliate link copied");
+    expect(affiliateCopy.textContent).toMatch(/Copied/);
+    expect(screen.getByText("cURL Example")).toBeTruthy();
+  });
+
+  it("toasts when the clipboard write fails", async () => {
+    copyMock.mockResolvedValueOnce(false);
+    renderPage();
+    fireEvent.click(await screen.findByTestId("cloud-affiliates-copy-invite"));
+
+    await waitFor(() => {
+      expect(toastMock.error).toHaveBeenCalledWith(
+        "Could not copy to clipboard",
+      );
+    });
+    expect(
+      screen.getByRole("button", { name: "Copy link (invite)" }).textContent,
+    ).toMatch(/Copy link/);
+  });
+
+  it("does not show the invite copy row when the referral code is inactive", async () => {
+    referralState.referralMe = {
+      code: "FRIEND1",
+      total_referrals: 0,
+      is_active: false,
+    };
+    renderPage();
+
+    expect(await screen.findByText("Invite link inactive")).toBeTruthy();
+    expect(screen.queryByTestId("cloud-affiliates-copy-invite")).toBeNull();
+    expect(screen.getByTestId("cloud-affiliates-copy-affiliate")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/cloud/monetization/affiliates/AffiliatesPageClient.tsx
+++ b/packages/ui/src/cloud/monetization/affiliates/AffiliatesPageClient.tsx
@@ -3,8 +3,9 @@
  *
  * Data: GET `/api/v1/affiliates` (auto-create on first load via POST), POST/PUT
  * `/api/v1/affiliates` (markup), GET `/api/v1/referrals` (via
- * {@link useDashboardReferralMe}). Markup is a SettingsInputRow; the surrounding
- * BrandCard chrome and save button stay.
+ * {@link useDashboardReferralMe}). Invite and affiliate URLs are SettingsRows
+ * with a copy control. Markup is a SettingsInputRow. BrandCard chrome, save,
+ * cURL docs, and the marketing intro stay.
  */
 
 "use client";
@@ -26,6 +27,8 @@ import { toast } from "sonner";
 import { BrandCard } from "../../../cloud-ui/components/brand/brand-card";
 import { Button, Skeleton } from "../../../cloud-ui/components/primitives";
 import { SettingsInputRow } from "../../../components/settings/settings-agent-rows";
+import { SettingsRow } from "../../../components/settings/settings-layout";
+import { Button as SettingsButton } from "../../../components/ui/button";
 import { ApiError, api } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import {
@@ -60,6 +63,62 @@ function getAppUrl(): string {
   const url = configured || "http://localhost:3000";
   const base = url.startsWith("http") ? url : `https://${url}`;
   return base.replace(/\/$/, "");
+}
+
+function buildAffiliateLoginUrl(
+  origin: string,
+  code: string | undefined,
+): string {
+  return `${origin.replace(/\/$/, "")}/login?affiliate=${code ?? ""}`;
+}
+
+function AffiliateCopyControl({
+  copied,
+  onCopy,
+  kind,
+  testId,
+}: {
+  copied: boolean;
+  onCopy: () => void;
+  kind: "invite" | "affiliate";
+  testId: string;
+}) {
+  const t = useCloudT();
+  const visible = copied
+    ? t("cloud.affiliates.copied", { defaultValue: "Copied" })
+    : t("cloud.affiliates.copyLink", { defaultValue: "Copy link" });
+  const accessibleName = copied
+    ? kind === "invite"
+      ? t("cloud.affiliates.copiedInviteLinkAria", {
+          defaultValue: "Copied invite link",
+        })
+      : t("cloud.affiliates.copiedAffiliateLinkAria", {
+          defaultValue: "Copied affiliate link",
+        })
+    : kind === "invite"
+      ? t("cloud.affiliates.copyInviteLinkAria", {
+          defaultValue: "Copy link (invite)",
+        })
+      : t("cloud.affiliates.copyAffiliateLinkAria", {
+          defaultValue: "Copy link (affiliate)",
+        });
+  return (
+    <SettingsButton
+      type="button"
+      size="sm"
+      variant="outline"
+      onClick={onCopy}
+      aria-label={accessibleName}
+      data-testid={testId}
+    >
+      {copied ? (
+        <CheckCircle2 className="text-status-success" aria-hidden />
+      ) : (
+        <Copy aria-hidden />
+      )}
+      {visible}
+    </SettingsButton>
+  );
 }
 
 export function AffiliatesPageClient() {
@@ -118,15 +177,46 @@ export function AffiliatesPageClient() {
     fetchAffiliateData();
   }, [fetchAffiliateData]);
 
-  const handleCopyLink = async () => {
+  const pageOrigin =
+    typeof window !== "undefined" ? window.location.origin : getAppUrl();
+
+  const handleCopyInvite = async () => {
+    if (!pageOrigin) {
+      toast.error(
+        t("cloud.affiliates.couldNotBuildInvite", {
+          defaultValue: "Could not build invite link",
+        }),
+      );
+      return;
+    }
+    if (!referralMe) return;
+    const url = buildReferralInviteLoginUrl(pageOrigin, referralMe.code);
+    const ok = await copyTextToClipboard(url);
+    if (ok) {
+      markReferralCopied();
+      toast.success(
+        t("cloud.affiliates.inviteCopied", {
+          defaultValue: "Invite link copied",
+        }),
+      );
+    } else {
+      toast.error(
+        t("cloud.affiliates.couldNotCopy", {
+          defaultValue: "Could not copy to clipboard",
+        }),
+      );
+    }
+  };
+
+  const handleCopyAffiliate = async () => {
     if (!affiliateData) return;
-    const url = `${window.location.origin}/login?affiliate=${affiliateData.code}`;
+    const url = buildAffiliateLoginUrl(pageOrigin, affiliateData.code);
     const ok = await copyTextToClipboard(url);
     if (ok) {
       markAffiliateCopied();
       toast.success(
         t("cloud.affiliates.linkCopied", {
-          defaultValue: "Link copied to clipboard!",
+          defaultValue: "Affiliate link copied",
         }),
       );
     } else {
@@ -189,11 +279,30 @@ export function AffiliatesPageClient() {
     );
   }
 
-  const pageOrigin =
-    typeof window !== "undefined" ? window.location.origin : getAppUrl();
+  const inviteUrl = referralMe
+    ? buildReferralInviteLoginUrl(pageOrigin, referralMe.code)
+    : "";
+  const affiliateUrl = buildAffiliateLoginUrl(pageOrigin, affiliateData?.code);
+  const copyStatus =
+    referralCopied && copied
+      ? t("cloud.affiliates.bothLinksCopied", {
+          defaultValue: "Invite link copied. Affiliate link copied",
+        })
+      : referralCopied
+        ? t("cloud.affiliates.inviteCopied", {
+            defaultValue: "Invite link copied",
+          })
+        : copied
+          ? t("cloud.affiliates.linkCopied", {
+              defaultValue: "Affiliate link copied",
+            })
+          : "";
 
   return (
     <div className="flex flex-col gap-6 max-w-4xl mx-auto">
+      <p role="status" aria-live="polite" className="sr-only">
+        {copyStatus}
+      </p>
       {/* Introduction Banner */}
       <BrandCard className="relative" corners={false}>
         <div className="flex items-start gap-3">
@@ -318,56 +427,28 @@ export function AffiliatesPageClient() {
                         "{{count}} friends have joined with your link.",
                     })}
             </p>
-            <div className="flex items-center gap-3 bg-bg-hover border border-accent/20 rounded-sm p-3">
-              <LinkIcon className="h-5 w-5 text-accent/60 shrink-0" />
-              <div className="flex-1 font-mono text-txt overflow-hidden text-ellipsis whitespace-nowrap text-sm">
-                {buildReferralInviteLoginUrl(pageOrigin, referralMe.code)}
-              </div>
-              <Button
-                variant="secondary"
-                className="shrink-0"
-                onClick={() => {
-                  void (async () => {
-                    if (!pageOrigin) {
-                      toast.error(
-                        t("cloud.affiliates.couldNotBuildInvite", {
-                          defaultValue: "Could not build invite link",
-                        }),
-                      );
-                      return;
-                    }
-                    const url = buildReferralInviteLoginUrl(
-                      pageOrigin,
-                      referralMe.code,
-                    );
-                    const ok = await copyTextToClipboard(url);
-                    if (ok) {
-                      markReferralCopied();
-                      toast.success(
-                        t("cloud.affiliates.inviteCopied", {
-                          defaultValue: "Invite link copied!",
-                        }),
-                      );
-                    } else {
-                      toast.error(
-                        t("cloud.affiliates.couldNotCopy", {
-                          defaultValue: "Could not copy to clipboard",
-                        }),
-                      );
-                    }
-                  })();
-                }}
-              >
-                {referralCopied ? (
-                  <CheckCircle2 className="h-4 w-4 mr-2 text-status-success" />
-                ) : (
-                  <Copy className="h-4 w-4 mr-2" />
-                )}
-                {referralCopied
-                  ? t("cloud.affiliates.copied", { defaultValue: "Copied" })
-                  : t("cloud.affiliates.copy", { defaultValue: "Copy" })}
-              </Button>
-            </div>
+            <SettingsRow
+              icon={LinkIcon}
+              label={t("cloud.affiliates.inviteLinkLabel", {
+                defaultValue: "Invite link",
+              })}
+              description={
+                <span className="break-all font-mono text-txt-strong">
+                  {inviteUrl}
+                </span>
+              }
+              control={
+                <AffiliateCopyControl
+                  copied={referralCopied}
+                  onCopy={() => {
+                    void handleCopyInvite();
+                  }}
+                  kind="invite"
+                  testId="cloud-affiliates-copy-invite"
+                />
+              }
+              className="min-w-0 [&>div]:flex-wrap [&>div]:items-start"
+            />
           </>
         )}
       </BrandCard>
@@ -386,28 +467,28 @@ export function AffiliatesPageClient() {
           })}
         </p>
 
-        <div className="flex items-center gap-3 bg-bg-hover border border-border rounded-sm p-3">
-          <LinkIcon className="h-5 w-5 text-muted shrink-0" />
-          <div className="flex-1 font-mono text-txt overflow-hidden text-ellipsis whitespace-nowrap text-sm">
-            {typeof window !== "undefined"
-              ? `${window.location.origin}/login?affiliate=${affiliateData?.code}`
-              : `${getAppUrl()}/login?affiliate=${affiliateData?.code}`}
-          </div>
-          <Button
-            variant="secondary"
-            className="shrink-0"
-            onClick={handleCopyLink}
-          >
-            {copied ? (
-              <CheckCircle2 className="h-4 w-4 mr-2 text-status-success" />
-            ) : (
-              <Copy className="h-4 w-4 mr-2" />
-            )}
-            {copied
-              ? t("cloud.affiliates.copied", { defaultValue: "Copied" })
-              : t("cloud.affiliates.copy", { defaultValue: "Copy" })}
-          </Button>
-        </div>
+        <SettingsRow
+          icon={LinkIcon}
+          label={t("cloud.affiliates.affiliateLinkLabel", {
+            defaultValue: "Affiliate link",
+          })}
+          description={
+            <span className="break-all font-mono text-txt-strong">
+              {affiliateUrl}
+            </span>
+          }
+          control={
+            <AffiliateCopyControl
+              copied={copied}
+              onCopy={() => {
+                void handleCopyAffiliate();
+              }}
+              kind="affiliate"
+              testId="cloud-affiliates-copy-affiliate"
+            />
+          }
+          className="min-w-0 [&>div]:flex-wrap [&>div]:items-start"
+        />
       </BrandCard>
 
       {/* Markup Configuration */}

--- a/packages/ui/src/components/settings/cloud-affiliates-copy-rows.test.ts
+++ b/packages/ui/src/components/settings/cloud-affiliates-copy-rows.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Source ratchet: affiliates invite and affiliate URLs use SettingsRow + copy
+ * control. Markup stays SettingsInputRow. BrandCard chrome stays. Reads the
+ * shipped file.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const uiSrc = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function read(rel: string): string {
+  return readFileSync(join(uiSrc, rel), "utf8");
+}
+
+describe("affiliates copyable URL rows", () => {
+  it("routes invite and affiliate links through SettingsRow copy controls", () => {
+    const source = read(
+      "cloud/monetization/affiliates/AffiliatesPageClient.tsx",
+    );
+    expect(source).toContain("<SettingsRow");
+    expect(source).toContain('testId="cloud-affiliates-copy-invite"');
+    expect(source).toContain('testId="cloud-affiliates-copy-affiliate"');
+    expect(source).toContain("Copy link");
+    expect(source).toContain("break-all");
+    expect(source).not.toContain(
+      "overflow-hidden text-ellipsis whitespace-nowrap",
+    );
+    expect(source).toContain("<SettingsInputRow");
+    expect(source).toContain('agentId="cloud-affiliates-markup-percent"');
+    expect(source).toContain("BrandCard");
+    expect(source).toContain("cURL Example");
+    expect(source).toContain("Affiliate Program");
+  });
+});

--- a/packages/ui/src/components/settings/settings-dashboard-leftovers.test.ts
+++ b/packages/ui/src/components/settings/settings-dashboard-leftovers.test.ts
@@ -51,7 +51,7 @@ const BRANDCARD_ALLOWLIST = new Map<string, string>([
   ],
   [
     "cloud/monetization/affiliates/AffiliatesPageClient.tsx",
-    "affiliates dashboard cards/tables",
+    "affiliates dashboard cards; copy rows converted; markup SettingsInputRow",
   ],
   [
     "cloud/monetization/earnings/EarningsPageClient.tsx",


### PR DESCRIPTION
# Relates to

Closes #19558

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `grok-cli`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0e388e626e4d660ff24226ac71b38b78df1ed977:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` not run for the whole monorepo.

# Risks

Low. Clipboard persist paths unchanged. Only invite and affiliate copy-link chrome.

# Background

## What does this PR do?

Converts the affiliates invite-link and affiliate-link rows (label + URL + Copy) to `SettingsRow` plus a copy control. Applies better-* HIGH/MEDIUM on those rows: accessible name, wrap at 320px, sentence-case \"Copy link\", copied state is icon + text + live status. Markup stays `SettingsInputRow`. BrandCards, marketing intro, and the cURL docs card stay.

## What kind of change is this?

Bug fixes

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/ui/src/cloud/monetization/affiliates/AffiliatesPageClient.tsx`

## Detailed testing steps

```bash
bun run --cwd packages/ui test -- src/cloud/monetization/affiliates/AffiliatesPageClient.test.tsx src/components/settings/cloud-affiliates-copy-rows.test.ts src/components/settings/settings-dashboard-leftovers.test.ts
```

# Evidence Gate

<!-- evidence-head:054a5a27955a7570fd63fb4cfa8a29baf77114de -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19559-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19559-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19559-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - copy is client clipboard only; affiliates still GET/PUT /api/v1/affiliates and GET /api/v1/referrals.
<!-- evidence-row:frontend-logs -->
- [x] [19559-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19559-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or inference behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, wallet, scheduled-task, or generated domain artifact is involved.
<!-- evidence-row:ocr-review -->
- [x] [19559-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19559-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or inference behavior is changed.

## Known gaps / failures

- Full-repo verify not run.
- Isolated Playwright fixture of SettingsRow + copy control (audit:app still blocked by startupCoordinator.target).
- BrandCards, markup SettingsInputRow, intro, and cURL docs left on purpose.

AI provider/model: xai / grok-4.6
Client / agent tooling: grok-cli
Contribution skill revision: elizaOS/eliza@0e388e626e4d660ff24226ac71b38b78df1ed977:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-4.6]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok-cli","skill_revision":"elizaOS/eliza@0e388e626e4d660ff24226ac71b38b78df1ed977:packages/skills/skills/contribute-to-eliza"} -->
