### PR TITLE
fix(ui): restore default Switch accent ON for cloud green ON-track overrides

### DIFF
--- a/packages/ui/src/cloud/__tests__/no-switch-green-track.test.ts
+++ b/packages/ui/src/cloud/__tests__/no-switch-green-track.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Source ratchet guarding the shared Switch primitive's default track on the
+ * three cloud call sites that previously forced a green ON / neutral OFF track
+ * and dead `data-slot=switch-thumb` selectors. The shared Switch already
+ * renders the correct accent-ON / input-OFF track, so these override strings
+ * must never return. Reads files off disk — no render. Matches the specific
+ * override strings, not a bare `bg-green-500`, so the legitimate non-Switch
+ * container backgrounds in app-monetization-settings do not trip the ratchet.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const cloudRoot = resolve(import.meta.dirname, "..");
+
+/** Files that render the shared Switch and must keep its default track. */
+const GUARDED_FILES = [
+  "applications/components/app-settings.tsx",
+  "applications/components/app-monetization-settings.tsx",
+  "instances/components/agent-card.tsx",
+] as const;
+
+/**
+ * Forbidden Switch override substrings. Each is a full override token so the
+ * container `bg-green-500/10`, `bg-green-500/5`, and `border-green-500/20`
+ * styling elsewhere in app-monetization-settings stays legitimate.
+ */
+const FORBIDDEN_SWITCH_OVERRIDES = [
+  "data-[state=checked]:bg-green-500",
+  "data-[state=unchecked]:bg-neutral-700",
+  "data-slot=switch-thumb",
+] as const;
+
+function findForbidden(source: string): string[] {
+  return FORBIDDEN_SWITCH_OVERRIDES.filter((needle) => source.includes(needle));
+}
+
+describe("cloud Switch call sites keep the shared default accent track", () => {
+  it.each(GUARDED_FILES)(
+    "%s contains no green ON / neutral OFF / switch-thumb Switch overrides",
+    (relPath) => {
+      const source = readFileSync(resolve(cloudRoot, relPath), "utf8");
+      const hits = findForbidden(source);
+      expect(
+        hits.length === 0,
+        hits.length > 0
+          ? `${relPath} reintroduced forbidden Switch override(s): ${hits.join(", ")}. ` +
+              `The shared Switch primitive already applies the default accent-ON / input-OFF track; ` +
+              `remove the override so it wins.`
+          : undefined,
+      ).toBe(true);
+    },
+  );
+
+  it("does not flag legitimate non-Switch green container backgrounds", () => {
+    const monetization = readFileSync(
+      resolve(
+        cloudRoot,
+        "applications/components/app-monetization-settings.tsx",
+      ),
+      "utf8",
+    );
+    // Container backgrounds exist and must remain untouched by this ratchet.
+    expect(monetization).toContain("bg-green-500/10");
+    expect(findForbidden(monetization)).toHaveLength(0);
+  });
+
+  it("detects a reintroduced green ON track override", () => {
+    const regressed = `<Switch className="data-[state=checked]:bg-green-500 data-[state=unchecked]:bg-neutral-700" />`;
+    expect(findForbidden(regressed)).toEqual([
+      "data-[state=checked]:bg-green-500",
+      "data-[state=unchecked]:bg-neutral-700",
+    ]);
+  });
+
+  it("detects a reintroduced switch-thumb selector override", () => {
+    const regressed = `<Switch className="[&_[data-slot=switch-thumb]]:data-[state=checked]:bg-green-500" />`;
+    expect(findForbidden(regressed)).toContain("data-slot=switch-thumb");
+  });
+});

--- a/packages/ui/src/cloud/applications/components/app-monetization-settings.tsx
+++ b/packages/ui/src/cloud/applications/components/app-monetization-settings.tsx
@@ -400,7 +400,6 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                       toggleMonetization(checked);
                     }
                   }}
-                  className="data-[state=checked]:bg-green-500 data-[state=unchecked]:bg-neutral-700"
                 />
               </div>
               <p className="text-xs text-neutral-500 mt-1">

--- a/packages/ui/src/cloud/applications/components/app-settings.tsx
+++ b/packages/ui/src/cloud/applications/components/app-settings.tsx
@@ -311,7 +311,6 @@ export function AppSettings({ app }: AppSettingsProps) {
               onCheckedChange={(checked) =>
                 setFormData({ ...formData, is_active: checked })
               }
-              className="data-[state=checked]:bg-green-500 data-[state=unchecked]:bg-neutral-700"
             />
           </div>
         </div>

--- a/packages/ui/src/cloud/instances/components/agent-card.tsx
+++ b/packages/ui/src/cloud/instances/components/agent-card.tsx
@@ -519,7 +519,7 @@ function AgentCardInner({
                       </span>
                       <Switch
                         checked={isPublic}
-                        className="pointer-events-none data-[state=checked]:bg-green-500/20 [&_[data-slot=switch-thumb]]:data-[state=checked]:bg-green-500 [&_[data-slot=switch-thumb]]:data-[state=unchecked]:bg-white/40"
+                        className="pointer-events-none"
                       />
                     </DropdownMenuItem>
                     {isPublic && (
@@ -741,10 +741,7 @@ function AgentCardInner({
                           defaultValue: "Private",
                         })}
                   </span>
-                  <Switch
-                    checked={isPublic}
-                    className="pointer-events-none data-[state=checked]:bg-green-500/20 [&_[data-slot=switch-thumb]]:data-[state=checked]:bg-green-500 [&_[data-slot=switch-thumb]]:data-[state=unchecked]:bg-white/40"
-                  />
+                  <Switch checked={isPublic} className="pointer-events-none" />
                 </DropdownMenuItem>
                 {isPublic && (
                   <DropdownMenuItem


### PR DESCRIPTION
# Relates to

Fixes #19551

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`HEAD..origin/develop` == 0 at push time).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker. — see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-6` (via pi coding-agent harness)
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts (branch based on `origin/develop`, `git rev-list --count HEAD..origin/develop` == 0).
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. This is a purely visual/cleanup change that removes non-standard per-call-site
Switch track override classes so the shared `Switch` primitive's default
`data-[state=checked]:bg-accent data-[state=unchecked]:bg-input` track wins.
No behavior, data, routing, or API surface changes. Non-Switch container green
backgrounds are intentionally left untouched.

# Background

## What does this PR do?

Three cloud call sites overrode the shared `Switch` primitive
(`packages/ui/src/components/ui/switch.tsx`) with a custom green ON track and a
forced neutral OFF track, plus dead `[&_[data-slot=switch-thumb]]:…` selectors
that the primitive does not expose. This introduced a second, conflicting visual
meaning (green) for the same control type. This PR removes those override classes
so the shared default accent-ON / input-OFF track renders consistently.

Files changed:

- `packages/ui/src/cloud/applications/components/app-settings.tsx` — removed
  `className="data-[state=checked]:bg-green-500 data-[state=unchecked]:bg-neutral-700"`
  from the `is_active` Switch.
- `packages/ui/src/cloud/applications/components/app-monetization-settings.tsx` —
  removed the same override from the `monetizationEnabled` Switch. The surrounding
  non-Switch container backgrounds (`bg-green-500/10`, `bg-green-500/5`,
  `border-green-500/20`) are card styling and were left untouched, per the issue's
  out-of-scope note.
- `packages/ui/src/cloud/instances/components/agent-card.tsx` — the two read-only
  decorative Public/Private display switches keep `pointer-events-none` but drop
  `data-[state=checked]:bg-green-500/20` and both `[&_[data-slot=switch-thumb]]:…`
  selectors, leaving `className="pointer-events-none"`.

Also adds a source ratchet:
`packages/ui/src/cloud/__tests__/no-switch-green-track.test.ts` reads the three
files and fails if `data-[state=checked]:bg-green-500`,
`data-[state=unchecked]:bg-neutral-700`, or `data-slot=switch-thumb` reappear.
The assertion matches the specific override tokens, so the legitimate container
`bg-green-500/*` backgrounds do not trip it (verified by an explicit case).

## What kind of change is this?

Improvements (misc. changes to existing features) — visual consistency cleanup.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/cloud/__tests__/no-switch-green-track.test.ts` and the three
diffs. Toggle any of the affected switches (App Settings "Active", App
Monetization "Enable", Agent Card Public/Private) and confirm the ON state now
renders the shared accent track instead of green.

## Detailed testing steps

Automated: the new ratchet test plus the existing `no-raw-switch.test.ts` pass;
the ui package typechecks; Biome check is clean on all four files.

Before → After (class-level):

| Switch | Before ON/OFF track | After |
| --- | --- | --- |
| app-settings `is_active` | `bg-green-500` ON / `bg-neutral-700` OFF | shared default `bg-accent` ON / `bg-input` OFF |
| app-monetization `monetizationEnabled` | `bg-green-500` ON / `bg-neutral-700` OFF | shared default |
| agent-card Public/Private (×2, read-only) | `bg-green-500/20` track + dead `switch-thumb` selectors | `pointer-events-none` only, shared default track |

# Evidence Gate

<!-- evidence-head:b90c8981933bf9a8907b66d05f077ea9c0010845 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots — `N/A - see Known gaps: app screenshot/browser capture is not runnable in this constrained headless worktree; class-level before/after is documented in the Testing table.`
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots — `N/A - see Known gaps (same constraint).`
<!-- evidence-row:walkthrough-video -->
- [ ] Video walkthrough — `N/A - see Known gaps (same constraint).`
<!-- evidence-row:backend-logs -->
- [ ] Backend logs — `N/A - no backend/server code path changes; UI class-only edit.`
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs — `N/A - no request/response or state-change behavior changed; purely CSS class removal.`
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory — `N/A - no agent/action/provider/prompt/model path touched.`
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts — `N/A - no DB/memory/scheduled-task/wallet/generated-file changes.`
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review — `N/A - see Known gaps; no rendered capture available in this environment. No text content changes (labels Active/Enable/Public/Private are unchanged).`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model path touched.`

## Backend + frontend logs

`N/A - UI class-only edit; no backend path and no changed frontend behavior.`

Passing checks instead (run from the ui package):

<details>
<summary>Typecheck — <code>tsc --noEmit -p tsconfig.json</code> (EXIT 0)</summary>

```
$ ./node_modules/.bin/tsc --noEmit -p tsconfig.json
EXIT: 0
```
</details>

<details>
<summary>Tests — new ratchet + no-raw-switch (57 passed)</summary>

```
 RUN  v4.1.5 packages/ui

 Test Files  2 passed (2)
      Tests  57 passed (57)
   Duration  594ms

Files: src/cloud/__tests__/no-switch-green-track.test.ts,
       src/components/settings/no-raw-switch.test.ts
```
</details>

<details>
<summary>Biome check (EXIT 0) + grep verification</summary>

```
$ biome check <4 changed files>
Checked 4 files in 49ms. No fixes applied.  # EXIT 0

$ grep -rn "bg-green-500|bg-neutral-700|switch-thumb" <3 source files>
app-monetization-settings.tsx:301:  reviewApproved ? "bg-green-500/10" : "bg-surface",
app-monetization-settings.tsx:358:  ? "bg-green-500/5 border-green-500/20"
app-monetization-settings.tsx:366:  settings.monetizationEnabled ? "bg-green-500/10" : "bg-surface",
# ^ only the intentional non-Switch container backgrounds remain
```
</details>

## Screenshots (before / after) + video walkthrough

### Before / ### After / ### Walkthrough video

`N/A - see Known gaps.` The behavioral change is class-level and is captured in
the Testing before/after table; the rendered before/after is: green ON track →
shared accent (orange) ON track.

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT/omnivoice changes.`

## Known gaps / failures

- **App screenshots / video / OCR (`N/A`):** This work was implemented in a
  constrained headless worktree without the app build + browser-capture stack
  runnable here. The `bun install` step is blocked on this machine by a global
  supply-chain policy (`minimumReleaseAge`) that rejects several recently
  published pinned deps; the ui package's `node_modules`, generated i18n files,
  and the `@elizaos/cloud-routing` `dist` were reused from an existing identical
  (byte-for-byte same `bun.lock`) local install so typecheck/tests/lint could run
  against **this** worktree's sources. Because of that, `bun run verify` and
  `audit:app` capture were not executed here. The change is a pure CSS-class
  removal that restores an existing shared primitive default, so the risk of the
  missing captures is low; a maintainer with the full app stack can confirm the
  rendered ON color in one toggle.

<!-- eliza.army footer -->
