### PR TITLE
fix(core): project tool-call diagnostics through composed redaction before every egress

### DIFF
--- a/packages/agent/src/runtime/trajectory-storage-diagnostics.test.ts
+++ b/packages/agent/src/runtime/trajectory-storage-diagnostics.test.ts
@@ -9,7 +9,10 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import type { TrajectoryActionAttempt } from "../types/trajectory.ts";
-import { projectSettledActionDiagnostics } from "./trajectory-storage.ts";
+import {
+  projectLlmCallDiagnostics,
+  projectSettledActionDiagnostics,
+} from "./trajectory-storage.ts";
 
 const RUNTIME_SECRET = "SYNTH-AGENT-RUNTIME-SECRET-CANARY-1111";
 const FLAG_CANARY = "SYNTH-AGENT-FLAG-CANARY-2222";
@@ -26,6 +29,7 @@ function makeAttempt(): TrajectoryActionAttempt {
     timestamp: 1_000,
     actionType: "CANARY_TOOL",
     actionName: "CANARY_TOOL",
+    llmCallId: "llm-call-identity-1",
     parameters: {
       command: `deploy --token=${FLAG_CANARY} ${RUNTIME_SECRET}`,
       target: `https://canary:${URI_CANARY}@synthetic.invalid/`,
@@ -35,6 +39,7 @@ function makeAttempt(): TrajectoryActionAttempt {
     success: false,
     result: { stderr: `auth failed for --token=${FLAG_CANARY}` },
     error: `rejected ${RUNTIME_SECRET}`,
+    reasoning: `Action failed with --token=${FLAG_CANARY} and ${RUNTIME_SECRET}`,
     immediateReward: -0.1,
   };
 }
@@ -53,6 +58,7 @@ describe("projectSettledActionDiagnostics", () => {
     expect(projected.attemptId).toBe("attempt-1");
     expect(projected.timestamp).toBe(1_000);
     expect(projected.actionName).toBe("CANARY_TOOL");
+    expect(projected.llmCallId).toBe("llm-call-identity-1");
     expect(projected.parameters.retries).toBe(4);
     expect(projected.parameters.dryRun).toBe(true);
     expect(projected.success).toBe(false);
@@ -64,5 +70,69 @@ describe("projectSettledActionDiagnostics", () => {
     projectSettledActionDiagnostics(runtime, attempt);
     expect(attempt.parameters.command).toContain(FLAG_CANARY);
     expect(attempt.error).toContain(RUNTIME_SECRET);
+    expect(attempt.reasoning).toContain(FLAG_CANARY);
+  });
+});
+
+describe("projectLlmCallDiagnostics", () => {
+  it("scrubs model messages/tool calls and invalidates changed message spans", () => {
+    const raw = {
+      callId: "call-identity-1",
+      runId: "run-identity-1",
+      roomId: "room-identity-1",
+      messageId: "message-identity-1",
+      executionTraceId: "trace-identity-1",
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "tool-call-1",
+              toolName: "CANARY_TOOL",
+              input: { command: `run --token=${FLAG_CANARY}` },
+            },
+          ],
+        },
+      ],
+      toolCalls: [
+        {
+          id: "tool-call-1",
+          name: "CANARY_TOOL",
+          args: { target: `https://user:${URI_CANARY}@synthetic.invalid/` },
+        },
+      ],
+      response: `failed with ${RUNTIME_SECRET}`,
+      providerAttributions: [
+        {
+          providerName: "CHARACTER",
+          sha256: "a".repeat(64),
+          spanStart: 2,
+          spanEnd: 18,
+          tokenCount: 4,
+        },
+      ],
+    };
+
+    const projected = projectLlmCallDiagnostics(runtime, raw);
+    const serialized = JSON.stringify(projected);
+    expect(serialized).not.toContain(RUNTIME_SECRET);
+    expect(serialized).not.toContain(FLAG_CANARY);
+    expect(serialized).not.toContain(URI_CANARY);
+    expect(projected.callId).toBe("call-identity-1");
+    expect(projected.runId).toBe("run-identity-1");
+    expect(projected.roomId).toBe("room-identity-1");
+    expect(projected.messageId).toBe("message-identity-1");
+    expect(projected.executionTraceId).toBe("trace-identity-1");
+    expect(projected.providerAttributions).toEqual([
+      expect.objectContaining({
+        providerName: "CHARACTER",
+        tokenCountEstimated: true,
+      }),
+    ]);
+    expect(projected.providerAttributions).not.toEqual([
+      expect.objectContaining({ spanStart: 2, spanEnd: 18 }),
+    ]);
+    expect(raw.messages[0]?.content[0]?.input.command).toContain(FLAG_CANARY);
   });
 });

--- a/packages/agent/src/runtime/trajectory-storage-diagnostics.test.ts
+++ b/packages/agent/src/runtime/trajectory-storage-diagnostics.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit coverage for the agent DB bridge's final-persistence diagnostic
+ * projection: every settlement written by the patched `completeStep` funnel
+ * composes runtime-known-secret redaction with the shared tool-shape
+ * patterns over parameters and result/failure metadata while preserving
+ * identity, numeric, and boolean fields. Deterministic; the runtime is a
+ * minimal stub and every credential-shaped value is a synthetic canary.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import type { TrajectoryActionAttempt } from "../types/trajectory.ts";
+import { projectSettledActionDiagnostics } from "./trajectory-storage.ts";
+
+const RUNTIME_SECRET = "SYNTH-AGENT-RUNTIME-SECRET-CANARY-1111";
+const FLAG_CANARY = "SYNTH-AGENT-FLAG-CANARY-2222";
+const URI_CANARY = "SYNTH-AGENT-URI-CANARY-3333";
+
+const runtime = {
+  redactSecrets: (text: string) =>
+    text.split(RUNTIME_SECRET).join("[REDACTED:AGENT_CANARY]"),
+} as unknown as IAgentRuntime;
+
+function makeAttempt(): TrajectoryActionAttempt {
+  return {
+    attemptId: "attempt-1",
+    timestamp: 1_000,
+    actionType: "CANARY_TOOL",
+    actionName: "CANARY_TOOL",
+    parameters: {
+      command: `deploy --token=${FLAG_CANARY} ${RUNTIME_SECRET}`,
+      target: `https://canary:${URI_CANARY}@synthetic.invalid/`,
+      retries: 4,
+      dryRun: true,
+    },
+    success: false,
+    result: { stderr: `auth failed for --token=${FLAG_CANARY}` },
+    error: `rejected ${RUNTIME_SECRET}`,
+    immediateReward: -0.1,
+  };
+}
+
+describe("projectSettledActionDiagnostics", () => {
+  it("excludes every canary from the persisted settlement", () => {
+    const projected = projectSettledActionDiagnostics(runtime, makeAttempt());
+    const serialized = JSON.stringify(projected);
+    expect(serialized).not.toContain(RUNTIME_SECRET);
+    expect(serialized).not.toContain(FLAG_CANARY);
+    expect(serialized).not.toContain(URI_CANARY);
+  });
+
+  it("preserves identity, numbers, and booleans for correlation", () => {
+    const projected = projectSettledActionDiagnostics(runtime, makeAttempt());
+    expect(projected.attemptId).toBe("attempt-1");
+    expect(projected.timestamp).toBe(1_000);
+    expect(projected.actionName).toBe("CANARY_TOOL");
+    expect(projected.parameters.retries).toBe(4);
+    expect(projected.parameters.dryRun).toBe(true);
+    expect(projected.success).toBe(false);
+    expect(projected.immediateReward).toBe(-0.1);
+  });
+
+  it("does not mutate the settlement it was given", () => {
+    const attempt = makeAttempt();
+    projectSettledActionDiagnostics(runtime, attempt);
+    expect(attempt.parameters.command).toContain(FLAG_CANARY);
+    expect(attempt.error).toContain(RUNTIME_SECRET);
+  });
+});

--- a/packages/agent/src/runtime/trajectory-storage.ts
+++ b/packages/agent/src/runtime/trajectory-storage.ts
@@ -8,10 +8,12 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import {
+  composeToolDiagnosticRedactor,
   logger as coreLogger,
   ElizaError,
   type IAgentRuntime,
   type JsonValue,
+  projectToolDiagnosticValue,
   Service,
   sanitizeTrajectoryJsonObject,
 } from "@elizaos/core";
@@ -516,6 +518,38 @@ function startChildTrajectoryStep(
   return stepId;
 }
 
+/**
+ * Final persistence boundary for the agent DB bridge: every patched
+ * `completeStep` caller funnels through here, so tool-call parameters and
+ * result/failure metadata are projected through the composed runtime-known +
+ * tool-shape redaction before the row is written. Identity, numeric, and
+ * boolean fields survive untouched for correlation.
+ */
+export function projectSettledActionDiagnostics(
+  runtime: IAgentRuntime,
+  action: TrajectoryActionAttempt,
+): TrajectoryActionAttempt {
+  const redactDiagnosticText = composeToolDiagnosticRedactor(runtime);
+  return {
+    ...action,
+    parameters: projectToolDiagnosticValue(
+      action.parameters,
+      redactDiagnosticText,
+    ) as TrajectoryActionAttempt["parameters"],
+    ...(action.result !== undefined
+      ? {
+          result: projectToolDiagnosticValue(
+            action.result,
+            redactDiagnosticText,
+          ) as TrajectoryActionAttempt["result"],
+        }
+      : {}),
+    ...(typeof action.error === "string"
+      ? { error: redactDiagnosticText(action.error) }
+      : {}),
+  };
+}
+
 function completeTrajectoryAction(
   runtime: IAgentRuntime,
   trajectoryId: string,
@@ -537,7 +571,10 @@ function completeTrajectoryAction(
     );
   }
   rememberTrajectoryStep(runtime, normalizedTrajectoryId, normalizedStepId);
-  const action = normalizeSettledAction(actionValue, rewardInfo);
+  const action = projectSettledActionDiagnostics(
+    runtime,
+    normalizeSettledAction(actionValue, rewardInfo),
+  );
   const rewardComponentsValue = asRecord(rewardInfo)?.components;
   const rewardComponents =
     rewardComponentsValue === undefined

--- a/packages/agent/src/runtime/trajectory-storage.ts
+++ b/packages/agent/src/runtime/trajectory-storage.ts
@@ -8,11 +8,14 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import {
+  canonicalPromptForModelCall,
   composeToolDiagnosticRedactor,
   logger as coreLogger,
   ElizaError,
   type IAgentRuntime,
   type JsonValue,
+  omitUnvalidatedProviderSpans,
+  projectModelCallDiagnosticValue,
   projectToolDiagnosticValue,
   Service,
   sanitizeTrajectoryJsonObject,
@@ -520,32 +523,99 @@ function startChildTrajectoryStep(
 
 /**
  * Final persistence boundary for the agent DB bridge: every patched
- * `completeStep` caller funnels through here, so tool-call parameters and
- * result/failure metadata are projected through the composed runtime-known +
- * tool-shape redaction before the row is written. Identity, numeric, and
- * boolean fields survive untouched for correlation.
+ * `completeStep` caller funnels through here, so the complete settlement,
+ * including interceptor reasoning and future text fields, is projected through
+ * composed runtime-known + tool-shape redaction before the row is written.
+ * Identity, numeric, and boolean fields survive untouched for correlation.
  */
 export function projectSettledActionDiagnostics(
   runtime: IAgentRuntime,
   action: TrajectoryActionAttempt,
 ): TrajectoryActionAttempt {
   const redactDiagnosticText = composeToolDiagnosticRedactor(runtime);
+  const projected = projectToolDiagnosticValue(
+    action,
+    redactDiagnosticText,
+  ) as TrajectoryActionAttempt;
   return {
-    ...action,
-    parameters: projectToolDiagnosticValue(
-      action.parameters,
-      redactDiagnosticText,
-    ) as TrajectoryActionAttempt["parameters"],
-    ...(action.result !== undefined
-      ? {
-          result: projectToolDiagnosticValue(
-            action.result,
-            redactDiagnosticText,
-          ) as TrajectoryActionAttempt["result"],
-        }
+    ...projected,
+    attemptId: action.attemptId,
+    timestamp: action.timestamp,
+    actionType: action.actionType,
+    actionName: action.actionName,
+    ...(typeof action.llmCallId === "string"
+      ? { llmCallId: action.llmCallId }
       : {}),
-    ...(typeof action.error === "string"
-      ? { error: redactDiagnosticText(action.error) }
+  };
+}
+
+/**
+ * Final-persistence projection for an agent-bridge LLM capture. Correlation
+ * identity remains exact; diagnostic payloads are scrubbed structurally, and
+ * message-indexed provider spans are dropped whenever message text changes.
+ */
+export function projectLlmCallDiagnostics(
+  runtime: IAgentRuntime,
+  rawParams: Record<string, unknown>,
+): Record<string, unknown> {
+  const redactDiagnosticText = composeToolDiagnosticRedactor(runtime);
+  const projectedParams = projectModelCallDiagnosticValue(
+    rawParams,
+    redactDiagnosticText,
+  );
+  const projectedPrompt =
+    typeof (
+      projectedParams.prompt ??
+      projectedParams.userPrompt ??
+      projectedParams.input
+    ) === "string"
+      ? ((projectedParams.prompt ??
+          projectedParams.userPrompt ??
+          projectedParams.input) as string)
+      : undefined;
+  const rawPrompt =
+    typeof (rawParams.prompt ?? rawParams.userPrompt ?? rawParams.input) ===
+    "string"
+      ? ((rawParams.prompt ??
+          rawParams.userPrompt ??
+          rawParams.input) as string)
+      : undefined;
+  const attributionInputChanged =
+    canonicalPromptForModelCall({
+      messages: Array.isArray(projectedParams.messages)
+        ? projectedParams.messages
+        : undefined,
+      prompt: projectedPrompt,
+    }) !==
+    canonicalPromptForModelCall({
+      messages: Array.isArray(rawParams.messages)
+        ? rawParams.messages
+        : undefined,
+      prompt: rawPrompt,
+    });
+  return {
+    ...projectedParams,
+    ...(typeof rawParams.callId === "string"
+      ? { callId: rawParams.callId }
+      : {}),
+    ...(typeof rawParams.runId === "string" ? { runId: rawParams.runId } : {}),
+    ...(typeof rawParams.roomId === "string"
+      ? { roomId: rawParams.roomId }
+      : {}),
+    ...(typeof rawParams.messageId === "string"
+      ? { messageId: rawParams.messageId }
+      : {}),
+    ...(typeof rawParams.executionTraceId === "string"
+      ? { executionTraceId: rawParams.executionTraceId }
+      : {}),
+    ...(attributionInputChanged
+      ? {
+          providerAttributions: omitUnvalidatedProviderSpans(
+            projectedParams.providerAttributions as Parameters<
+              typeof omitUnvalidatedProviderSpans
+            >[0],
+          ),
+        }
       : {}),
   };
 }
@@ -726,10 +796,12 @@ async function appendLlmCall(
   runtime: IAgentRuntime,
   trajectoryId: string,
   stepId: string,
-  params: Record<string, unknown>,
+  rawParams: Record<string, unknown>,
   retryState?: ActiveCaptureRetryState,
 ): Promise<void> {
-  if (shouldSuppressNoInputEmbeddingCall(params)) return;
+  if (shouldSuppressNoInputEmbeddingCall(rawParams)) return;
+
+  const params = projectLlmCallDiagnostics(runtime, rawParams);
 
   const now =
     retryState?.timestamp ??

--- a/packages/core/src/features/trajectories/TrajectoriesService.test.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.test.ts
@@ -91,8 +91,15 @@ describe("TrajectoriesService", () => {
 	it("persists LLM calls with bounded JSON-safe payloads", async () => {
 		const trajectoryId = "00000000-0000-4000-8000-000000000010";
 		const stepId = "00000000-0000-4000-8000-000000000011";
+		const runtimeSecret = "SYNTH-CORE-DB-RUNTIME-SECRET-1111";
+		const flagCanary = "SYNTH-CORE-DB-FLAG-CANARY-2222";
+		const uriCanary = "SYNTH-CORE-DB-URI-CANARY-3333";
 		const row = makeTrajectoryRow(trajectoryId, stepId);
-		const service = new TrajectoriesService(createRuntimeWithoutSql());
+		const service = new TrajectoriesService({
+			...createRuntimeWithoutSql(),
+			redactSecrets: (text: string) =>
+				text.split(runtimeSecret).join("[REDACTED:DB_CANARY]"),
+		} as IAgentRuntime);
 		const serviceInternals = service as unknown as {
 			stepToTrajectory: Map<string, string>;
 			executeRawSql: (
@@ -129,12 +136,31 @@ describe("TrajectoriesService", () => {
 			model: "gpt-oss-120b",
 			modelType: "RESPONSE_HANDLER",
 			provider: "cerebras",
+			runId: "run-identity-1",
+			roomId: "room-identity-1",
+			messageId: "message-identity-1",
+			executionTraceId: "trace-identity-1",
 			systemPrompt: "system",
 			userPrompt: "user",
-			messages: [{ role: "user", content: "m".repeat(120_000), circular }],
+			messages: [
+				{
+					role: "assistant",
+					content: `--token=${flagCanary} ${runtimeSecret} ${"m".repeat(120_000)}`,
+					circular,
+				},
+			],
 			tools: { circular },
+			toolCalls: [
+				{
+					id: "call-1",
+					name: "CANARY_TOOL",
+					args: {
+						target: `https://user:${uriCanary}@synthetic.invalid/`,
+					},
+				},
+			],
 			providerMetadata: circular,
-			response: "ok",
+			response: `ok ${runtimeSecret}`,
 			temperature: 0,
 			maxTokens: 1024,
 			purpose: "action",
@@ -159,19 +185,91 @@ describe("TrajectoriesService", () => {
 		expect(updates[0].length).toBeLessThan(350_000);
 
 		const persisted = JSON.parse(row.steps_json);
+		const persistedJson = JSON.stringify(persisted);
+		expect(persistedJson).not.toContain(runtimeSecret);
+		expect(persistedJson).not.toContain(flagCanary);
+		expect(persistedJson).not.toContain(uriCanary);
 		const call = persisted[0].llmCalls[0];
 		expect(call.messages[0].content).toMatch(/\.{3}\[truncated\]$/);
-		expect(call.tools.circular.self).toBe("[Circular]");
+		expect(call.tools.circular.self).toBe("[REDACTED]");
 		expect(call.tools.circular.fn).toBe("[Function toolHandler]");
-		expect(call.providerMetadata.self).toBe("[Circular]");
+		expect(call.providerMetadata.self).toBe("[REDACTED]");
 		expect(call.providerOrder).toEqual(["CHARACTER"]);
+		expect(call.runId).toBe("run-identity-1");
+		expect(call.roomId).toBe("room-identity-1");
+		expect(call.messageId).toBe("message-identity-1");
+		expect(call.executionTraceId).toBe("trace-identity-1");
 		expect(call.providerAttributions[0]).toMatchObject({
 			providerName: "CHARACTER",
 			tokenCount: 8,
 			position: 0,
-			spanStart: 5,
-			spanEnd: 19,
+			tokenCountEstimated: true,
 		});
+		expect(call.providerAttributions[0].spanStart).toBeUndefined();
+		expect(call.providerAttributions[0].spanEnd).toBeUndefined();
+	});
+
+	it("projects the complete action settlement including interceptor reasoning", async () => {
+		const trajectoryId = "00000000-0000-4000-8000-000000000012";
+		const stepId = "00000000-0000-4000-8000-000000000013";
+		const runtimeSecret = "SYNTH-SETTLEMENT-RUNTIME-SECRET-4444";
+		const flagCanary = "SYNTH-SETTLEMENT-FLAG-CANARY-5555";
+		const row = makeTrajectoryRow(trajectoryId, stepId);
+		const runtime = {
+			...createRuntimeWithoutSql(),
+			redactSecrets: (text: string) =>
+				text.split(runtimeSecret).join("[REDACTED:SETTLEMENT]"),
+		} as IAgentRuntime;
+		const service = new TrajectoriesService(runtime);
+		const serviceInternals = service as unknown as {
+			stepToTrajectory: Map<string, string>;
+			executeRawSql: (
+				sqlText: string,
+			) => Promise<{ rows: Array<Record<string, unknown>>; columns: string[] }>;
+			executeRawSqlTransaction: <T>(
+				work: (
+					execute: (sqlText: string) => Promise<{
+						rows: Array<Record<string, unknown>>;
+						columns: string[];
+					}>,
+				) => Promise<T>,
+			) => Promise<T>;
+		};
+
+		serviceInternals.stepToTrajectory.set(stepId, trajectoryId);
+		serviceInternals.executeRawSql = async (sqlText: string) => {
+			if (sqlText.includes("SELECT * FROM trajectories")) {
+				return { rows: [row], columns: Object.keys(row) };
+			}
+			if (sqlText.includes("UPDATE trajectories SET")) {
+				const stepsJson = extractSqlStringAssignment(sqlText, "steps_json");
+				if (stepsJson) row.steps_json = stepsJson;
+			}
+			return { rows: [], columns: [] };
+		};
+		serviceInternals.executeRawSqlTransaction = (work) =>
+			work(serviceInternals.executeRawSql);
+
+		service.completeStep(trajectoryId, stepId, {
+			actionType: "CANARY_TOOL",
+			actionName: "CANARY_TOOL",
+			parameters: { command: `run --token=${flagCanary}`, retries: 2 },
+			llmCallId: "llm-call-identity-1",
+			success: false,
+			result: { error: `rejected ${runtimeSecret}` },
+			error: `rejected ${runtimeSecret}`,
+			reasoning: `Action CANARY_TOOL failed with --token=${flagCanary}`,
+		});
+		await service.flushWriteQueue(trajectoryId);
+
+		const persisted = JSON.parse(row.steps_json)[0].action;
+		const serialized = JSON.stringify(persisted);
+		expect(serialized).not.toContain(runtimeSecret);
+		expect(serialized).not.toContain(flagCanary);
+		expect(persisted.actionName).toBe("CANARY_TOOL");
+		expect(persisted.llmCallId).toBe("llm-call-identity-1");
+		expect(persisted.parameters.retries).toBe(2);
+		expect(persisted.reasoning).toContain("Action CANARY_TOOL failed");
 	});
 
 	it("keeps empty step objects parseable across queued step writes", async () => {

--- a/packages/core/src/features/trajectories/TrajectoriesService.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.ts
@@ -22,6 +22,10 @@ import type {
 /** Public alias for {@link CanonicalTrajectoryExportOptions} (canonical type lives in services). */
 export type TrajectoryExportOptions = CanonicalTrajectoryExportOptions;
 
+import {
+	composeToolDiagnosticRedactor,
+	projectToolDiagnosticValue,
+} from "../../security/tool-diagnostics";
 import type { TrajectoryRuntimeLlmCallParams } from "../../trajectory-utils";
 import type { IAgentRuntime } from "../../types";
 import { Service } from "../../types/service";
@@ -2590,10 +2594,33 @@ export class TrajectoriesService extends Service {
 				if (!stepId) return;
 
 				const step = await this.ensureStepExists(trajectory, stepId, execute);
+				// Final persistence boundary for every completeStep caller (planner
+				// executor, action/provider interceptors, generic wrappers): tool-call
+				// parameters and result/failure metadata are projected through the
+				// composed diagnostic redaction before they reach steps_json. Raw
+				// values never persist, regardless of which call site produced them.
+				const redactDiagnosticText = composeToolDiagnosticRedactor(
+					this.runtime,
+				);
 				step.action = {
 					attemptId: uuidv4(),
 					timestamp: Date.now(),
 					...action,
+					parameters: projectToolDiagnosticValue(
+						action.parameters,
+						redactDiagnosticText,
+					) as typeof action.parameters,
+					...(action.result !== undefined
+						? {
+								result: projectToolDiagnosticValue(
+									action.result,
+									redactDiagnosticText,
+								) as typeof action.result,
+							}
+						: {}),
+					...(typeof action.error === "string"
+						? { error: redactDiagnosticText(action.error) }
+						: {}),
 				};
 				step.done = true;
 

--- a/packages/core/src/features/trajectories/TrajectoriesService.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.ts
@@ -23,7 +23,12 @@ import type {
 export type TrajectoryExportOptions = CanonicalTrajectoryExportOptions;
 
 import {
+	canonicalPromptForModelCall,
+	omitUnvalidatedProviderSpans,
+} from "../../runtime/trajectory-provider-attribution";
+import {
 	composeToolDiagnosticRedactor,
+	projectModelCallDiagnosticValue,
 	projectToolDiagnosticValue,
 } from "../../security/tool-diagnostics";
 import type { TrajectoryRuntimeLlmCallParams } from "../../trajectory-utils";
@@ -1948,8 +1953,39 @@ export class TrajectoriesService extends Service {
 
 	private async _persistLlmCall(
 		trajectoryId: string,
-		params: TrajectoryRuntimeLlmCallParams,
+		rawParams: TrajectoryRuntimeLlmCallParams,
 	): Promise<void> {
+		const redactDiagnosticText = composeToolDiagnosticRedactor(this.runtime);
+		const projectedParams = projectModelCallDiagnosticValue(
+			rawParams as TrajectoryRuntimeLlmCallParams & Record<string, unknown>,
+			redactDiagnosticText,
+		) as TrajectoryRuntimeLlmCallParams;
+		const attributionInputChanged =
+			canonicalPromptForModelCall({
+				messages: projectedParams.messages,
+				prompt: projectedParams.prompt ?? projectedParams.userPrompt,
+			}) !==
+			canonicalPromptForModelCall({
+				messages: rawParams.messages,
+				prompt: rawParams.prompt ?? rawParams.userPrompt,
+			});
+		const params: TrajectoryRuntimeLlmCallParams = {
+			...projectedParams,
+			// The routing identity is operational rather than diagnostic and must
+			// stay byte-exact even when a configured secret happens to overlap it.
+			stepId: rawParams.stepId,
+			runId: rawParams.runId,
+			roomId: rawParams.roomId,
+			messageId: rawParams.messageId,
+			executionTraceId: rawParams.executionTraceId,
+			...(attributionInputChanged
+				? {
+						providerAttributions: omitUnvalidatedProviderSpans(
+							projectedParams.providerAttributions,
+						),
+					}
+				: {}),
+		};
 		await this.withTrajectoryWriteLock(trajectoryId, async () => {
 			const trajectory = await this.getTrajectoryById(trajectoryId);
 			if (!trajectory) return;
@@ -2595,31 +2631,25 @@ export class TrajectoriesService extends Service {
 
 				const step = await this.ensureStepExists(trajectory, stepId, execute);
 				// Final persistence boundary for every completeStep caller (planner
-				// executor, action/provider interceptors, generic wrappers): tool-call
-				// parameters and result/failure metadata are projected through the
-				// composed diagnostic redaction before they reach steps_json. Raw
-				// values never persist, regardless of which call site produced them.
+				// executor, action/provider interceptors, generic wrappers): the full
+				// settlement, including reasoning and future text fields, is projected
+				// before it reaches steps_json. Raw values never persist, regardless
+				// of which call site produced them.
 				const redactDiagnosticText = composeToolDiagnosticRedactor(
 					this.runtime,
 				);
+				const diagnosticAction = projectToolDiagnosticValue(
+					action,
+					redactDiagnosticText,
+				) as typeof action;
 				step.action = {
 					attemptId: uuidv4(),
 					timestamp: Date.now(),
-					...action,
-					parameters: projectToolDiagnosticValue(
-						action.parameters,
-						redactDiagnosticText,
-					) as typeof action.parameters,
-					...(action.result !== undefined
-						? {
-								result: projectToolDiagnosticValue(
-									action.result,
-									redactDiagnosticText,
-								) as typeof action.result,
-							}
-						: {}),
-					...(typeof action.error === "string"
-						? { error: redactDiagnosticText(action.error) }
+					...diagnosticAction,
+					actionType: action.actionType,
+					actionName: action.actionName,
+					...(typeof action.llmCallId === "string"
+						? { llmCallId: action.llmCallId }
 						: {}),
 				};
 				step.done = true;

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -296,6 +296,7 @@ export * from "./runtime/sub-planner";
 export * from "./runtime/system-prompt";
 export * from "./runtime/trace-correlation";
 export * from "./runtime/trajectory-gate";
+export * from "./runtime/trajectory-provider-attribution";
 export * from "./runtime/trajectory-recorder";
 export * from "./runtime/trajectory-usage-rollup";
 export * from "./runtime/turn-controller";

--- a/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
+++ b/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
@@ -1070,8 +1070,14 @@ describe("executePlannedToolCall", () => {
 			expect(bounded.long).toMatch(/\.\.\.\[truncated\]$/);
 			expect(bounded.items).toHaveLength(251);
 			expect(bounded.items[250]).toEqual({ __truncatedItems: 50 });
-			expect(JSON.stringify(bounded.deep)).toContain("[MaxDepth]");
 		}
+		// Parameters and result cross the diagnostic projection before the JSON
+		// sanitizer, so over-deep subtrees collapse to the projection's mask at
+		// its (shallower) depth bound rather than the sanitizer's [MaxDepth].
+		expect(JSON.stringify(settlement.parameters.payload.deep)).toContain(
+			"[REDACTED]",
+		);
+		expect(JSON.stringify(settlement.result.data.deep)).toContain("[REDACTED]");
 		expect(settlement.success).toBe(true);
 	});
 

--- a/packages/core/src/runtime/__tests__/planner-loop-honest-failure.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-honest-failure.test.ts
@@ -633,8 +633,10 @@ describe("rescue synthesis from successful tool results (2026-08-11 sub-agent re
 	});
 
 	it("rescues archived successes: mid-turn compaction must not blind the rescue to completed work", async () => {
+		const runtimeSecret = "SYNTH-RESCUE-RUNTIME-SECRET-1111";
+		const flagCanary = "SYNTH-RESCUE-FLAG-CANARY-2222";
 		const searchResultA =
-			"search results A: archived-fact-alpha — the fleet release shipped with twelve plugins. " +
+			`search results A: archived-fact-alpha --token=${flagCanary} ${runtimeSecret} — the fleet release shipped with twelve plugins. ` +
 			"padding ".repeat(400);
 		const searchResultB =
 			"search results B: archived-fact-beta — the shipwright tail closed out last week. " +
@@ -715,7 +717,11 @@ describe("rescue synthesis from successful tool results (2026-08-11 sub-agent re
 			});
 
 		const result = await runPlannerLoop({
-			runtime: { useModel },
+			runtime: {
+				useModel,
+				redactSecrets: (text: string) =>
+					text.split(runtimeSecret).join("[REDACTED:RESCUE]"),
+			},
 			context: { id: "ctx" },
 			tools: [
 				{ name: "WEB_SEARCH", description: "Search the web." },
@@ -762,6 +768,8 @@ describe("rescue synthesis from successful tool results (2026-08-11 sub-agent re
 			.join("\n");
 		expect(rescueText).toContain("archived-fact-alpha");
 		expect(rescueText).toContain("archived-fact-beta");
+		expect(rescueText).not.toContain(runtimeSecret);
+		expect(rescueText).not.toContain(flagCanary);
 	});
 
 	it("never ships the handled-step placeholder as a rescue: a canned synthesis falls through to the honest failure", async () => {

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -1705,7 +1705,7 @@ describe("v5 planner loop skeleton", () => {
 		expect(synthesisInput).toContain("SAFE_READ_OBSERVATION");
 		expect(synthesisInput).toContain("Updated the secret safely.");
 		expect(synthesisInput).toContain(
-			"receipt outcome=applied operation=vault.secret.update-5 resource=vault.secret:secret-5",
+			"receipt outcome=applied operation=vault.secret.update-5 resource_kind=vault.secret resource_id=secret-5",
 		);
 		expect(synthesisInput).not.toContain(mutationSecret);
 		expect(synthesisInput).not.toContain("planner-parameter-secret");
@@ -2991,9 +2991,13 @@ describe("v5 planner loop skeleton", () => {
 
 	it("compacts old assistant/tool suffixes when the planner input crosses the budget threshold", async () => {
 		const capturedMessages: ChatMessage[][] = [];
-		const longPayload = `generated file content: ${"x".repeat(20_000)}`;
+		const runtimeSecret = "SYNTH-COMPACTION-RUNTIME-SECRET-1111";
+		const flagCanary = "SYNTH-COMPACTION-FLAG-CANARY-2222";
+		const longPayload = `generated --token=${flagCanary} ${runtimeSecret}: ${"x".repeat(20_000)}`;
 		let plannerCallCount = 0;
 		const runtime = {
+			redactSecrets: (text: string) =>
+				text.split(runtimeSecret).join("[REDACTED:COMPACTION]"),
 			useModel: vi.fn(async (_modelType: unknown, params: unknown) => {
 				const messages =
 					(params as { messages?: ChatMessage[] }).messages ?? [];
@@ -3055,10 +3059,17 @@ describe("v5 planner loop skeleton", () => {
 		expect(secondPayload).toContain("compaction");
 		expect(secondPayload).toContain("GENERATE success");
 		expect(secondPayload).not.toContain("x".repeat(1_000));
+		expect(secondPayload).not.toContain(runtimeSecret);
+		expect(secondPayload).not.toContain(flagCanary);
 
 		const recordedKinds = recordStage.mock.calls.map((call) => call[1]?.kind);
 		expect(recordedKinds).toContain("compaction");
 		expect(recordedKinds).toContain("planner");
+		const compactionStage = recordStage.mock.calls.find(
+			(call) => call[1]?.kind === "compaction",
+		)?.[1];
+		expect(JSON.stringify(compactionStage)).not.toContain(runtimeSecret);
+		expect(JSON.stringify(compactionStage)).not.toContain(flagCanary);
 	});
 });
 

--- a/packages/core/src/runtime/__tests__/sub-planner.test.ts
+++ b/packages/core/src/runtime/__tests__/sub-planner.test.ts
@@ -360,6 +360,22 @@ describe("sub-planner helpers", () => {
 		});
 	});
 
+	it("keeps replay correlation stable without embedding raw parameters", () => {
+		const canary = "SYNTH-SUBPLANNER-TOKEN-CANARY-3333";
+		const first = subPlannerCallDigest({
+			name: "GOOGLE_CALENDAR",
+			params: { nested: { count: 2, token: canary }, calendar: "primary" },
+		});
+		const reordered = subPlannerCallDigest({
+			name: "GOOGLE_CALENDAR",
+			params: { calendar: "primary", nested: { token: canary, count: 2 } },
+		});
+
+		expect(first).toBe(reordered);
+		expect(first).not.toContain(canary);
+		expect(first).toMatch(/^GOOGLECALENDAR\|[a-f0-9]{64}$/);
+	});
+
 	it("passes child actions to the model as native tool definitions", async () => {
 		const childA = makeAction({
 			name: "CHILD_A",

--- a/packages/core/src/runtime/__tests__/tool-diagnostic-projection.canary.test.ts
+++ b/packages/core/src/runtime/__tests__/tool-diagnostic-projection.canary.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Deterministic synthetic-canary harness for the tool-call diagnostic
+ * projection (#19175). Proves the two halves of the contract at once: the
+ * action handler receives the exact raw validated arguments (raw sentinel,
+ * CLI --token form, URI userinfo, runtime-known secret), while JSON
+ * serialization of every diagnostic egress surface — streaming onToolCall /
+ * onToolResult payloads, ACTION_COMPLETED event content, trajectory
+ * settlement parameters, planner queue/context/events, and the persisted
+ * file-recorder trajectory — excludes those values. Stub runtime with vitest
+ * mocks plus the real JSON-file recorder writing to a temp dir; no live
+ * model. Every credential-shaped value is an obviously synthetic canary.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runWithStreamingContext } from "../../streaming-context";
+import { runWithTrajectoryContext } from "../../trajectory-context";
+import type { Action, IAgentRuntime, Memory } from "../../types";
+import { EventType } from "../../types";
+import { executePlannedToolCall } from "../execute-planned-tool-call";
+import { runPlannerLoop } from "../planner-loop";
+import { createJsonFileTrajectoryRecorder } from "../trajectory-recorder";
+
+const RAW_SENTINEL = "SYNTHETIC-CANARY-RAW-SENTINEL-000000";
+const RUNTIME_SECRET = "SYNTHETIC-CANARY-RUNTIME-SECRET-111111";
+const FLAG_CANARY = "SYNTHETIC-CANARY-FLAG-222222";
+const URI_CANARY = "SYNTHETIC-CANARY-URI-333333";
+
+const CANARY_PARAMS = {
+	command: `deploy --token=${FLAG_CANARY} ${RUNTIME_SECRET}`,
+	target: `https://canary-user:${URI_CANARY}@synthetic.invalid/path`,
+	note: RAW_SENTINEL,
+	retries: 3,
+	dryRun: false,
+};
+
+const CANARIES = [RUNTIME_SECRET, FLAG_CANARY, URI_CANARY] as const;
+
+function expectNoCanaries(serialized: string): void {
+	for (const canary of CANARIES) {
+		expect(serialized).not.toContain(canary);
+	}
+}
+
+function makeMessage(): Memory {
+	return {
+		id: "message-id",
+		entityId: "entity-id",
+		roomId: "room-id",
+		content: { text: "run the canary" },
+	} as Memory;
+}
+
+/** Runtime-known-secret redaction stub mirroring AgentRuntime.redactSecrets. */
+function redactRuntimeSecrets(text: string): string {
+	return text.split(RUNTIME_SECRET).join("[REDACTED:CANARY_SECRET]");
+}
+
+describe("tool-call diagnostic projection canaries", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("delivers exact raw arguments to the handler while every executor egress surface excludes the canaries", async () => {
+		const seenParameters: unknown[] = [];
+		const action: Action = {
+			name: "CANARY_TOOL",
+			description: "Records the exact parameters it receives",
+			parameters: [
+				{
+					name: "command",
+					description: "Command line",
+					required: true,
+					schema: { type: "string" },
+				},
+				{
+					name: "target",
+					description: "Target URL",
+					required: true,
+					schema: { type: "string" },
+				},
+				{
+					name: "note",
+					description: "Free-form note",
+					required: true,
+					schema: { type: "string" },
+				},
+				{
+					name: "retries",
+					description: "Retry count",
+					required: false,
+					schema: { type: "number" },
+				},
+				{
+					name: "dryRun",
+					description: "Dry-run switch",
+					required: false,
+					schema: { type: "boolean" },
+				},
+			],
+			validate: async () => true,
+			handler: async (_runtime, _message, _state, options) => {
+				seenParameters.push(options?.parameters);
+				return {
+					success: true,
+					text: `ran ${CANARY_PARAMS.command} against ${CANARY_PARAMS.target}`,
+					data: { echoedCommand: CANARY_PARAMS.command, exitCode: 0 },
+				};
+			},
+		};
+
+		const emittedEvents: Array<{ event: string; payload: unknown }> = [];
+		const trajectoryLogger = {
+			isEnabled: vi.fn(() => true),
+			startStep: vi.fn(() => "canary-step"),
+			completeStep: vi.fn(),
+			flushWriteQueue: vi.fn(async () => {}),
+			annotateStep: vi.fn(async () => {}),
+		};
+		const completeStep = trajectoryLogger.completeStep;
+		const runtime = {
+			actions: [action],
+			redactSecrets: redactRuntimeSecrets,
+			emitEvent: vi.fn(async (event: string, payload: unknown) => {
+				emittedEvents.push({ event, payload });
+			}),
+			getRoom: vi.fn(async () => null),
+			getService: vi.fn((serviceType: string) =>
+				serviceType === "trajectories" ? trajectoryLogger : undefined,
+			),
+			getServicesByType: vi.fn(() => []),
+			reportError: vi.fn(),
+			logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		} as unknown as IAgentRuntime;
+
+		const toolResults: unknown[] = [];
+		const result = await runWithTrajectoryContext(
+			{ trajectoryId: "canary-trajectory", trajectoryStepId: "canary-parent" },
+			() =>
+				runWithStreamingContext(
+					{
+						onStreamChunk: vi.fn(),
+						onToolResult: vi.fn(async (payload: unknown) => {
+							toolResults.push(payload);
+						}),
+					},
+					() =>
+						executePlannedToolCall(
+							runtime,
+							{ message: makeMessage() },
+							{ id: "call-77", name: "CANARY_TOOL", params: CANARY_PARAMS },
+						),
+				),
+		);
+		expect(result.success).toBe(true);
+
+		// The handler received the exact raw values — including the runtime-known
+		// secret, the --token form, and the URI userinfo — untouched.
+		expect(seenParameters).toHaveLength(1);
+		expect(seenParameters[0]).toEqual(CANARY_PARAMS);
+		const rawReceived = seenParameters[0] as typeof CANARY_PARAMS;
+		expect(rawReceived.command).toBe(CANARY_PARAMS.command);
+		expect(rawReceived.target).toBe(CANARY_PARAMS.target);
+		expect(rawReceived.note).toBe(RAW_SENTINEL);
+
+		// Streaming observer payload: no canaries, raw call identity preserved,
+		// non-sensitive scalars intact.
+		expect(toolResults).toHaveLength(1);
+		const streamed = toolResults[0] as {
+			toolCall: { id: string; arguments: Record<string, unknown> };
+			toolCallId: string;
+		};
+		expectNoCanaries(JSON.stringify(streamed));
+		expect(streamed.toolCall.id).toBe("call-77");
+		expect(streamed.toolCallId).toBe("call-77");
+		expect(streamed.toolCall.arguments.retries).toBe(3);
+		expect(streamed.toolCall.arguments.dryRun).toBe(false);
+		expect(streamed.toolCall.arguments.note).toBe(RAW_SENTINEL);
+
+		// Lifecycle events (ACTION_STARTED / ACTION_COMPLETED): no canaries.
+		expect(emittedEvents.map((entry) => entry.event)).toEqual([
+			EventType.ACTION_STARTED,
+			EventType.ACTION_COMPLETED,
+		]);
+		expectNoCanaries(JSON.stringify(emittedEvents));
+
+		// Trajectory settlement (the completeStep funnel): no canaries, scalar
+		// parameters preserved exactly.
+		expect(completeStep).toHaveBeenCalledTimes(1);
+		const settlement = completeStep.mock.calls[0]?.[2] as {
+			parameters: Record<string, unknown>;
+		};
+		expectNoCanaries(JSON.stringify(completeStep.mock.calls[0]));
+		expect(settlement.parameters.retries).toBe(3);
+		expect(settlement.parameters.dryRun).toBe(false);
+		expect(settlement.parameters.note).toBe(RAW_SENTINEL);
+	});
+
+	it("keeps planner queue/context/events and the persisted file trajectory canary-free while the executor sees raw params", async () => {
+		const trajectoryRoot = await fs.mkdtemp(
+			path.join(os.tmpdir(), "eliza-canary-trajectories-"),
+		);
+		const recorder = createJsonFileTrajectoryRecorder({
+			enabled: true,
+			rootDir: trajectoryRoot,
+			redactSecrets: redactRuntimeSecrets,
+		});
+		const trajectoryId = recorder.startTrajectory({
+			agentId: "canary-agent",
+			rootMessage: { id: "root-msg", text: "run the canary" },
+		});
+
+		let plannerCall = 0;
+		const runtime = {
+			redactSecrets: redactRuntimeSecrets,
+			useModel: vi.fn(async () => {
+				plannerCall += 1;
+				if (plannerCall === 1) {
+					return {
+						text: "",
+						toolCalls: [
+							{ id: "call-1", name: "CANARY_TOOL", arguments: CANARY_PARAMS },
+						],
+					};
+				}
+				return { text: "", toolCalls: [] };
+			}),
+		};
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: `ran ${CANARY_PARAMS.command}`,
+			data: { echoedTarget: CANARY_PARAMS.target },
+		}));
+		const evaluate = vi.fn(async () => ({
+			success: true,
+			decision: "FINISH" as const,
+			thought: "Done.",
+			messageToUser: "Done.",
+		}));
+
+		const streamedToolCalls: unknown[] = [];
+		const loopResult = await runWithStreamingContext(
+			{
+				onStreamChunk: vi.fn(),
+				onToolCall: vi.fn(async (payload: unknown) => {
+					streamedToolCalls.push(payload);
+				}),
+			},
+			() =>
+				runPlannerLoop({
+					runtime,
+					context: {
+						id: "ctx",
+						events: [
+							{
+								id: "msg",
+								type: "message",
+								message: { role: "user", content: { text: "run the canary" } },
+							},
+						],
+					},
+					executeToolCall,
+					evaluate,
+					recorder,
+					trajectoryId,
+				}),
+		);
+		await recorder.endTrajectory(trajectoryId, "finished");
+
+		// The execution path received the exact raw call, id included.
+		expect(executeToolCall).toHaveBeenCalledWith(
+			{ id: "call-1", name: "CANARY_TOOL", params: CANARY_PARAMS },
+			expect.objectContaining({ iteration: 1 }),
+		);
+		expect(loopResult.status).toBe("finished");
+
+		// Streaming onToolCall (pending phase): projected, identity preserved.
+		expect(streamedToolCalls).toHaveLength(1);
+		const pending = streamedToolCalls[0] as {
+			toolCall: { id: string; arguments: Record<string, unknown> };
+		};
+		expectNoCanaries(JSON.stringify(pending));
+		expect(pending.toolCall.id).toBe("call-1");
+		expect(pending.toolCall.arguments.retries).toBe(3);
+
+		// Planner queue and context events: diagnostic copies exclude canaries;
+		// the raw sentinel and scalars survive for correlation and debugging.
+		const contextSerialized = JSON.stringify(loopResult.trajectory.context);
+		expectNoCanaries(contextSerialized);
+		expect(contextSerialized).toContain(RAW_SENTINEL);
+		const queueEntry = loopResult.trajectory.context.plannedQueue?.[0] as {
+			id?: string;
+			args: string;
+		};
+		expect(queueEntry.id).toBe("call-1");
+		expectNoCanaries(queueEntry.args);
+		expect(queueEntry.args).toContain('"retries": 3');
+
+		// The planner's own in-memory step kept the raw call for the ephemeral
+		// path (result correlation, retry signatures).
+		expect(
+			loopResult.trajectory.steps.find((step) => step.toolCall)?.toolCall
+				?.params,
+		).toEqual(CANARY_PARAMS);
+
+		// Persisted file trajectory (final persistence boundary): the on-disk
+		// JSON — planner-stage toolCalls args, tool-stage args, and captured
+		// tool I/O included — excludes every canary.
+		const persistedPath = path.join(
+			trajectoryRoot,
+			"canary-agent",
+			`${trajectoryId}.json`,
+		);
+		const persisted = await fs.readFile(persistedPath, "utf8");
+		expectNoCanaries(persisted);
+		expect(persisted).toContain("CANARY_TOOL");
+		expect(persisted).toContain(RAW_SENTINEL);
+
+		await fs.rm(trajectoryRoot, { recursive: true, force: true });
+	});
+});

--- a/packages/core/src/runtime/__tests__/tool-diagnostic-projection.canary.test.ts
+++ b/packages/core/src/runtime/__tests__/tool-diagnostic-projection.canary.test.ts
@@ -19,7 +19,10 @@ import { runWithTrajectoryContext } from "../../trajectory-context";
 import type { Action, IAgentRuntime, Memory } from "../../types";
 import { EventType } from "../../types";
 import { executePlannedToolCall } from "../execute-planned-tool-call";
-import { runPlannerLoop } from "../planner-loop";
+import {
+	runPlannerLoop,
+	summarizeActionResultForPlanner,
+} from "../planner-loop";
 import { createJsonFileTrajectoryRecorder } from "../trajectory-recorder";
 
 const RAW_SENTINEL = "SYNTHETIC-CANARY-RAW-SENTINEL-000000";
@@ -212,9 +215,11 @@ describe("tool-call diagnostic projection canaries", () => {
 		});
 
 		let plannerCall = 0;
+		const modelInputs: unknown[] = [];
 		const runtime = {
 			redactSecrets: redactRuntimeSecrets,
-			useModel: vi.fn(async () => {
+			useModel: vi.fn(async (_modelType: unknown, input: unknown) => {
+				modelInputs.push(input);
 				plannerCall += 1;
 				if (plannerCall === 1) {
 					return {
@@ -224,7 +229,10 @@ describe("tool-call diagnostic projection canaries", () => {
 						],
 					};
 				}
-				return { text: "", toolCalls: [] };
+				return {
+					text: '{"thought":"Done.","messageToUser":"Done.","toolCalls":[]}',
+					toolCalls: [],
+				};
 			}),
 		};
 		const executeToolCall = vi.fn(async () => ({
@@ -232,14 +240,22 @@ describe("tool-call diagnostic projection canaries", () => {
 			text: `ran ${CANARY_PARAMS.command}`,
 			data: { echoedTarget: CANARY_PARAMS.target },
 		}));
-		const evaluate = vi.fn(async () => ({
-			success: true,
-			decision: "FINISH" as const,
-			thought: "Done.",
-			messageToUser: "Done.",
-		}));
+		const evaluate = vi
+			.fn()
+			.mockResolvedValueOnce({
+				success: true,
+				decision: "CONTINUE" as const,
+				thought: `Continue without ${RUNTIME_SECRET}.`,
+			})
+			.mockResolvedValue({
+				success: true,
+				decision: "FINISH" as const,
+				thought: `Finish without ${RUNTIME_SECRET}.`,
+				messageToUser: "Done.",
+			});
 
 		const streamedToolCalls: unknown[] = [];
+		const enqueuedToolCalls: unknown[] = [];
 		const loopResult = await runWithStreamingContext(
 			{
 				onStreamChunk: vi.fn(),
@@ -262,6 +278,9 @@ describe("tool-call diagnostic projection canaries", () => {
 					},
 					executeToolCall,
 					evaluate,
+					onToolCallEnqueued: (toolCall) => {
+						enqueuedToolCalls.push(toolCall);
+					},
 					recorder,
 					trajectoryId,
 				}),
@@ -283,6 +302,17 @@ describe("tool-call diagnostic projection canaries", () => {
 		expectNoCanaries(JSON.stringify(pending));
 		expect(pending.toolCall.id).toBe("call-1");
 		expect(pending.toolCall.arguments.retries).toBe(3);
+		expectNoCanaries(JSON.stringify(enqueuedToolCalls));
+		expect(enqueuedToolCalls).toHaveLength(1);
+
+		// The second planner request receives native assistant/tool history, but
+		// both the prior call arguments and its result are diagnostic projections.
+		const secondModelInput = modelInputs[1];
+		if (!secondModelInput) throw new Error("Expected a second planner input");
+		const secondModelSurface = JSON.stringify(secondModelInput);
+		expectNoCanaries(secondModelSurface);
+		expect(secondModelSurface).toContain(RAW_SENTINEL);
+		expect(secondModelSurface).toContain('"retries":3');
 
 		// Planner queue and context events: diagnostic copies exclude canaries;
 		// the raw sentinel and scalars survive for correlation and debugging.
@@ -318,5 +348,23 @@ describe("tool-call diagnostic projection canaries", () => {
 		expect(persisted).toContain(RAW_SENTINEL);
 
 		await fs.rm(trajectoryRoot, { recursive: true, force: true });
+	});
+
+	it("projects action-owned summaries before they can become model or user diagnostics", () => {
+		const summary = summarizeActionResultForPlanner(
+			{
+				summarize: (_result, params) =>
+					`ran ${String(params.command)} against ${String(params.target)}`,
+			},
+			{
+				success: true,
+				text: `result contains ${RUNTIME_SECRET}`,
+			},
+			CANARY_PARAMS,
+			{ redactSecrets: redactRuntimeSecrets },
+		);
+		if (!summary) throw new Error("Expected an action summary");
+		expectNoCanaries(summary);
+		expect(summary).toContain("ran");
 	});
 });

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -8,6 +8,11 @@ import { ElizaError } from "../errors";
 import { computeCallCostUsd } from "../features/trajectories/pricing";
 import { evaluatorSchema, evaluatorTemplate } from "../prompts/evaluator";
 import {
+	composeToolDiagnosticRedactor,
+	projectToolDiagnosticValue,
+	type ToolDiagnosticTextRedactor,
+} from "../security/tool-diagnostics";
+import {
 	emitStreamingHook,
 	getStreamingContext,
 	runWithStreamingContext,
@@ -94,11 +99,13 @@ export async function runEvaluator(
 	params: RunEvaluatorParams,
 ): Promise<EvaluatorOutput> {
 	const streamingContext = getStreamingContext();
+	const redactDiagnosticText = composeToolDiagnosticRedactor(params.runtime);
 	const EVALUATOR_MIN_TOOL_RESULT_CHARS = 2_000;
 	let toolResultCap = DEFAULT_MAX_KEPT_STEP_CHARS;
 	let renderedInput = renderEvaluatorModelInput({
 		context: params.context,
 		trajectory: params.trajectory,
+		redactText: redactDiagnosticText,
 	});
 	let modelInputBudget = buildModelInputBudget({
 		messages: renderedInput.messages,
@@ -123,6 +130,7 @@ export async function runEvaluator(
 			context: params.context,
 			trajectory: params.trajectory,
 			maxToolResultChars: toolResultCap,
+			redactText: redactDiagnosticText,
 		});
 		modelInputBudget = buildModelInputBudget({
 			messages: renderedInput.messages,
@@ -264,7 +272,10 @@ export async function runEvaluator(
 		),
 	);
 	await emitStreamingHook(streamingContext, "onEvaluation", {
-		evaluation: output,
+		evaluation: projectToolDiagnosticValue(
+			output,
+			redactDiagnosticText,
+		) as EvaluatorOutput,
 		messageId: streamingContext?.messageId,
 	});
 	await applyEvaluatorEffects(output, params.effects);
@@ -433,6 +444,7 @@ function renderEvaluatorModelInput(params: {
 	context: ContextObject;
 	trajectory: PlannerTrajectory;
 	template?: string;
+	redactText: ToolDiagnosticTextRedactor;
 	/**
 	 * Per-tool-result render cap (chars) applied via
 	 * `trajectoryStepsToMessages`. Defaults to `DEFAULT_MAX_KEPT_STEP_CHARS`
@@ -454,6 +466,7 @@ function renderEvaluatorModelInput(params: {
 	const stepMessages = trajectoryStepsToMessages(params.trajectory.steps, {
 		maxToolResultChars:
 			params.maxToolResultChars ?? DEFAULT_MAX_KEPT_STEP_CHARS,
+		redactText: params.redactText,
 	});
 	// Mirrors planner-loop: the evaluator stage instructions are template-derived
 	// (`evaluatorTemplate`) and structurally identical across calls. Marking

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -10,6 +10,12 @@ import { evaluateConnectorAccountPolicies } from "../connectors/account-manager"
 import { ElizaError } from "../errors";
 import { checkSenderRole } from "../roles";
 import {
+	composeToolDiagnosticRedactor,
+	projectToolDiagnosticArgs,
+	projectToolDiagnosticValue,
+	type ToolDiagnosticTextRedactor,
+} from "../security/tool-diagnostics";
+import {
 	authorizeOwnerExclusiveDisclosure,
 	PRIVACY_DENIED_TEXT,
 	revalidateOwnerExclusiveDisclosure,
@@ -341,12 +347,17 @@ export async function executePlannedToolCall(
 	options: ExecutePlannedToolCallOptions = {},
 ): Promise<ActionResult> {
 	options.abortSignal?.throwIfAborted();
+	// Diagnostic projection for every copy of the arguments that leaves the
+	// execution path (streaming observers, lifecycle events, trajectories).
+	// The handler itself receives the exact validated values.
+	const redactDiagnosticText = composeToolDiagnosticRedactor(runtime);
 	const action = (options.actions ?? runtime.actions).find(
 		(candidate) => candidate.name === toolCall.name,
 	);
 	if (!action) {
 		return emitToolResult(
 			toolCall,
+			redactDiagnosticText,
 			failureResult(toolCall.name, `Action not found: ${toolCall.name}`),
 		);
 	}
@@ -354,7 +365,11 @@ export async function executePlannedToolCall(
 	const executorCtx = await withResolvedUserRoles(runtime, ctx);
 	const gateFailure = actionGateFailure(action, executorCtx);
 	if (gateFailure) {
-		return emitToolResult(toolCall, failureResult(action.name, gateFailure));
+		return emitToolResult(
+			toolCall,
+			redactDiagnosticText,
+			failureResult(action.name, gateFailure),
+		);
 	}
 	if (action.disclosureGate?.require === "owner_exclusive") {
 		const disclosure = await authorizeOwnerExclusiveDisclosure(
@@ -364,6 +379,7 @@ export async function executePlannedToolCall(
 		if (!disclosure.allowed) {
 			return emitToolResult(
 				toolCall,
+				redactDiagnosticText,
 				failureResult(
 					action.name,
 					`Owner-private disclosure denied: ${disclosure.reason}`,
@@ -392,6 +408,7 @@ export async function executePlannedToolCall(
 		const invalidParameterNames = validation.invalidParameterNames ?? [];
 		return emitToolResult(
 			toolCall,
+			redactDiagnosticText,
 			failureResult(
 				action.name,
 				validation.errors.join("; ") ||
@@ -442,12 +459,14 @@ export async function executePlannedToolCall(
 			// planner-visible failed tool result with the original error attached.
 			return emitToolResult(
 				toolCall,
+				redactDiagnosticText,
 				failureResult(action.name, stringifyError(error), { error }),
 			);
 		}
 		if (!valid) {
 			return emitToolResult(
 				toolCall,
+				redactDiagnosticText,
 				failureResult(
 					action.name,
 					`Action ${action.name} is not available for the current state`,
@@ -467,6 +486,7 @@ export async function executePlannedToolCall(
 	if (!accountPolicy.allowed) {
 		return emitToolResult(
 			toolCall,
+			redactDiagnosticText,
 			failureResult(
 				action.name,
 				accountPolicy.reason ??
@@ -599,6 +619,9 @@ export async function executePlannedToolCall(
 						},
 					}),
 				{
+					// Raw here by design: completeActionTrajectoryStep owns the
+					// diagnostic projection for every settlement, so the handler-adjacent
+					// copy stays exact and the egress copy is projected once.
 					parameters: isContentRecord(validation.args) ? validation.args : {},
 					projectResult: (result) =>
 						projectSettledResultForObserver(action, result),
@@ -633,16 +656,21 @@ export async function executePlannedToolCall(
 				roomId,
 				world: worldId,
 				content: {
-					text: resultForEvent.text ?? `Action ${action.name} completed`,
+					text: redactDiagnosticText(
+						resultForEvent.text ?? `Action ${action.name} completed`,
+					),
 					actions: [action.name],
 					actionStatus: resultForEvent.success ? "completed" : "failed",
-					actionResult: actionResultToContentRecord(resultForEvent, {
-						suppressData: suppressActionResult,
-					}),
+					actionResult: projectToolDiagnosticValue(
+						actionResultToContentRecord(resultForEvent, {
+							suppressData: suppressActionResult,
+						}),
+						redactDiagnosticText,
+					) as Record<string, ContentValue>,
 					source: executorCtx.message.content.source,
 					error:
 						typeof resultForEvent.error === "string"
-							? resultForEvent.error
+							? redactDiagnosticText(resultForEvent.error)
 							: undefined,
 				},
 			})
@@ -676,13 +704,14 @@ export async function executePlannedToolCall(
 			});
 		}
 	}
-	return emitToolResult(toolCall, resultForEvent, {
+	return emitToolResult(toolCall, redactDiagnosticText, resultForEvent, {
 		suppressData: suppressActionResult,
 	});
 }
 
 async function emitToolResult(
 	toolCall: PlannerToolCall | PlannedToolCall,
+	redactDiagnosticText: ToolDiagnosticTextRedactor,
 	result: ActionResult,
 	options: { suppressData?: boolean } = {},
 ): Promise<ActionResult> {
@@ -691,8 +720,12 @@ async function emitToolResult(
 	const streamingToolCall = plannedToolCallToStreamingToolCall(
 		toolCall,
 		status,
+		redactDiagnosticText,
 	);
-	streamingToolCall.result = actionResultToStreamingResult(result, options);
+	streamingToolCall.result = projectToolDiagnosticValue(
+		actionResultToStreamingResult(result, options),
+		redactDiagnosticText,
+	) as ToolCall["result"];
 	await emitStreamingHook(streamingContext, "onToolResult", {
 		toolCall: streamingToolCall,
 		toolCallId: streamingToolCall.id,
@@ -756,11 +789,18 @@ async function resolveToolCallUserRoles(
 function plannedToolCallToStreamingToolCall(
 	toolCall: PlannerToolCall | PlannedToolCall,
 	status: "completed" | "failed",
+	redactDiagnosticText: ToolDiagnosticTextRedactor,
 ): ToolCall {
+	// The raw call id/name survive for correlation with the pending-phase
+	// stream event; argument values are projected because stream observers are
+	// a diagnostic surface, not the execution path.
 	return {
 		id: toolCall.id ?? toolCall.name,
 		name: toolCall.name,
-		arguments: normalizeToolArgs(toolCall) as ToolCall["arguments"],
+		arguments: (projectToolDiagnosticArgs(
+			normalizeToolArgs(toolCall),
+			redactDiagnosticText,
+		) ?? {}) as ToolCall["arguments"],
 		status,
 	};
 }

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -54,7 +54,11 @@ import {
 import { resolveStateDir } from "../utils/state-dir";
 import { isPlainObject } from "../utils/type-guards";
 import { tailWellFormed, truncateWellFormed } from "../utils/well-formed";
-import { computePrefixHashes, stableJsonStringify } from "./context-hash";
+import {
+	computePrefixHashes,
+	hashString,
+	stableJsonStringify,
+} from "./context-hash";
 import { appendContextEvent } from "./context-object";
 import {
 	buildStageChatMessages,
@@ -681,11 +685,17 @@ async function runPlannerLoopIterations(
 						trajectory,
 						iteration,
 					);
-					trajectory.evaluatorOutputs.push(evaluator);
+					trajectory.evaluatorOutputs.push(
+						projectToolDiagnosticValue(
+							evaluator,
+							redactDiagnosticText,
+						) as EvaluatorOutput,
+					);
 					trajectory.context = appendEvaluationEvent({
 						context: trajectory.context,
 						iteration,
 						evaluator,
+						redactDiagnosticText,
 					});
 					const protocolFailureRelay =
 						deterministicEvaluatorProtocolFailureRelay(evaluator, trajectory);
@@ -945,11 +955,17 @@ async function runPlannerLoopIterations(
 				// — the happy path tests assert this.
 				const shouldRecordTerminalEvaluation =
 					trajectory.evaluatorOutputs.length > 0;
-				trajectory.evaluatorOutputs.push(terminalEvaluator);
+				trajectory.evaluatorOutputs.push(
+					projectToolDiagnosticValue(
+						terminalEvaluator,
+						redactDiagnosticText,
+					) as EvaluatorOutput,
+				);
 				trajectory.context = appendEvaluationEvent({
 					context: trajectory.context,
 					iteration,
 					evaluator: terminalEvaluator,
+					redactDiagnosticText,
 				});
 				if (shouldRecordTerminalEvaluation) {
 					const terminalEvalStartedAt = Date.now();
@@ -1238,11 +1254,17 @@ async function runPlannerLoopIterations(
 		});
 		if (gatedDecision) {
 			const { output: gated, reason } = gatedDecision;
-			trajectory.evaluatorOutputs.push(gated);
+			trajectory.evaluatorOutputs.push(
+				projectToolDiagnosticValue(
+					gated,
+					redactDiagnosticText,
+				) as EvaluatorOutput,
+			);
 			trajectory.context = appendEvaluationEvent({
 				context: trajectory.context,
 				iteration,
 				evaluator: gated,
+				redactDiagnosticText,
 			});
 			await recordGatedEvaluationStage({
 				runtime: params.runtime,
@@ -1317,8 +1339,18 @@ async function runPlannerLoopIterations(
 				),
 			};
 		}
-		trajectory.evaluatorOutputs.push(evaluator);
-		appendEvaluatorContextEvent(trajectory, evaluator, iteration);
+		trajectory.evaluatorOutputs.push(
+			projectToolDiagnosticValue(
+				evaluator,
+				redactDiagnosticText,
+			) as EvaluatorOutput,
+		);
+		appendEvaluatorContextEvent(
+			trajectory,
+			evaluator,
+			iteration,
+			redactDiagnosticText,
+		);
 		const protocolFailureRelay = deterministicEvaluatorProtocolFailureRelay(
 			evaluator,
 			trajectory,
@@ -1434,6 +1466,7 @@ function renderPlannerModelInput(params: {
 	).trim();
 	const stepMessages = trajectoryStepsToMessages(params.trajectory.steps, {
 		maxToolResultChars: params.maxToolResultChars,
+		redactText: composeToolDiagnosticRedactor(params.runtime),
 	});
 	// Action names + parameter schemas now ride directly on the tools array
 	// (each Action is exposed as its own native tool), so there is no separate
@@ -2383,9 +2416,20 @@ function summarizePlannerStep(
 				)}`
 			: "";
 	const result = step.result
-		? ` result=${compactText(toolMessageContent(step.result), 360)}`
+		? ` result=${compactText(
+				toolMessageContent(
+					projectToolDiagnosticValue(
+						step.result,
+						redactDiagnosticText,
+					) as PlannerToolResult,
+				),
+				360,
+			)}`
 		: step.terminalMessage
-			? ` message=${compactText(step.terminalMessage, 240)}`
+			? ` message=${compactText(
+					redactDiagnosticText(step.terminalMessage),
+					240,
+				)}`
 			: "";
 	return `iter ${step.iteration} ${name} ${status}${args}${result}`;
 }
@@ -2704,8 +2748,13 @@ function appendEvaluationEvent(args: {
 	context: ContextObject;
 	iteration: number;
 	evaluator: EvaluatorOutput;
+	redactDiagnosticText?: ToolDiagnosticTextRedactor;
 }): ContextObject {
 	const createdAt = Date.now();
+	const evaluator = projectToolDiagnosticValue(
+		args.evaluator,
+		args.redactDiagnosticText ?? composeToolDiagnosticRedactor(),
+	) as EvaluatorOutput;
 	return appendContextEvent(args.context, {
 		id: `evaluation:${args.iteration}:${createdAt}`,
 		type: "evaluation",
@@ -2713,13 +2762,13 @@ function appendEvaluationEvent(args: {
 		createdAt,
 		metadata: {
 			iteration: args.iteration,
-			success: args.evaluator.success,
-			decision: args.evaluator.decision,
-			thought: args.evaluator.thought,
-			messageToUser: args.evaluator.messageToUser,
-			recommendedToolCallId: args.evaluator.recommendedToolCallId,
-			protocolFailure: args.evaluator.protocolFailure,
-			parseError: args.evaluator.parseError,
+			success: evaluator.success,
+			decision: evaluator.decision,
+			thought: evaluator.thought,
+			messageToUser: evaluator.messageToUser,
+			recommendedToolCallId: evaluator.recommendedToolCallId,
+			protocolFailure: evaluator.protocolFailure,
+			parseError: evaluator.parseError,
 		},
 	});
 }
@@ -2728,11 +2777,13 @@ function appendEvaluatorContextEvent(
 	trajectory: PlannerTrajectory,
 	evaluator: EvaluatorOutput,
 	iteration: number,
+	redactDiagnosticText?: ToolDiagnosticTextRedactor,
 ): void {
 	trajectory.context = appendEvaluationEvent({
 		context: trajectory.context,
 		iteration,
 		evaluator,
+		redactDiagnosticText,
 	});
 }
 
@@ -2917,9 +2968,20 @@ async function executeQueuedToolCall(params: {
 		metadata: { iteration: params.iteration },
 	});
 
-	await params.params.onToolCallEnqueued?.(params.toolCall, {
-		iteration: params.iteration,
-	});
+	await params.params.onToolCallEnqueued?.(
+		{
+			...params.toolCall,
+			...(params.toolCall.params !== undefined
+				? {
+						params: projectToolDiagnosticArgs(
+							params.toolCall.params,
+							redactDiagnosticText,
+						),
+					}
+				: {}),
+		},
+		{ iteration: params.iteration },
+	);
 
 	const startedAt = Date.now();
 	let result: PlannerToolResult;
@@ -2954,12 +3016,13 @@ async function executeQueuedToolCall(params: {
 	const isParameterValidationFailure = Array.isArray(
 		(result.data as { parameterErrors?: unknown } | undefined)?.parameterErrors,
 	);
+	const failureError = isParameterValidationFailure
+		? "parameter_validation_failed"
+		: (result.error ?? diagnosticFailureReason(result));
 	const failure = {
 		toolName: params.toolCall.name,
 		success: result.success,
-		error: isParameterValidationFailure
-			? "parameter_validation_failed"
-			: (result.error ?? diagnosticFailureReason(result)),
+		error: projectToolDiagnosticValue(failureError, redactDiagnosticText),
 		repeatKey: isParameterValidationFailure
 			? "parameter_validation"
 			: toolFailureRepeatKey(params.toolCall),
@@ -3850,7 +3913,7 @@ function synthesisReceiptSummary(
 			const operation = compactText(receipt.operation, 120);
 			const resourceKind = compactText(receipt.resource.kind, 80);
 			const resourceId = compactText(receipt.resource.id, 160);
-			return `receipt outcome=${receipt.outcome} operation=${operation} resource=${resourceKind}:${resourceId}`;
+			return `receipt outcome=${receipt.outcome} operation=${operation} resource_kind=${resourceKind} resource_id=${resourceId}`;
 		})
 		.join("\n");
 }
@@ -4262,13 +4325,18 @@ async function rescueReplyFromSuccessfulResults(
 	params: PlannerLoopParams,
 	trajectory: PlannerTrajectory,
 ): Promise<string | undefined> {
+	const redactDiagnosticText = composeToolDiagnosticRedactor(params.runtime);
 	const successfulExcerpts: string[] = [];
 	for (const step of [...trajectory.archivedSteps, ...trajectory.steps]) {
 		if (!step.toolCall || isTerminalToolCall(step.toolCall)) continue;
 		if (step.result?.success !== true) continue;
+		const diagnosticResult = projectToolDiagnosticValue(
+			step.result,
+			redactDiagnosticText,
+		) as PlannerToolResult;
 		const text =
-			getNonEmptyString(step.result.userFacingText) ??
-			getNonEmptyString(step.result.text);
+			getNonEmptyString(diagnosticResult.userFacingText) ??
+			getNonEmptyString(diagnosticResult.text);
 		if (!text) continue;
 		successfulExcerpts.push(
 			[
@@ -4284,7 +4352,8 @@ async function rescueReplyFromSuccessfulResults(
 		latestUnresolvedFailedNonTerminalToolStep(trajectory) ??
 		latestFailedToolStep(trajectory);
 	const failedCause = failedStep
-		? failedStepCauseForPrompt(failedStep)
+		? redactDiagnosticText(failedStepCauseForPrompt(failedStep) ?? "") ||
+			undefined
 		: undefined;
 	const instructions = [
 		"You are finishing a chat turn. Compose the final reply to the user from the tool results in the next message.",
@@ -4937,7 +5006,9 @@ function splitUnavailableToolCalls(
 }
 
 function toolFailureRepeatKey(toolCall: PlannerToolCall): string {
-	return `${toolCall.name}:${stringifyForModel(toolCall.params ?? {})}`;
+	return `${toolCall.name}:${hashString(
+		stableJsonStringify(toolCall.params ?? {}),
+	)}`;
 }
 
 /**
@@ -5611,12 +5682,20 @@ export function summarizeActionResultForPlanner(
 	action: Pick<Action, "summarize"> | undefined,
 	result: ActionResult,
 	params: Record<string, unknown> = {},
+	runtime?: Pick<PlannerRuntime, "redactSecrets">,
 ): string | undefined {
 	if (result.success !== true || typeof action?.summarize !== "function") {
 		return undefined;
 	}
-	const summary = action.summarize(result, params)?.trim();
-	return summary || undefined;
+	const redactDiagnosticText = composeToolDiagnosticRedactor(runtime);
+	const diagnosticResult = projectToolDiagnosticValue(
+		result,
+		redactDiagnosticText,
+	) as ActionResult;
+	const diagnosticParams =
+		projectToolDiagnosticArgs(params, redactDiagnosticText) ?? {};
+	const summary = action.summarize(diagnosticResult, diagnosticParams)?.trim();
+	return summary ? redactDiagnosticText(summary) : undefined;
 }
 
 function getNonEmptyString(value: unknown): string | undefined {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -15,6 +15,12 @@ import { computeCallCostUsd } from "../features/trajectories/pricing";
 import { logger } from "../logger";
 import { parseInteractionBlocks } from "../messaging/interactions/parse";
 import { plannerSchema, plannerTemplate } from "../prompts/planner";
+import {
+	composeToolDiagnosticRedactor,
+	projectToolDiagnosticArgs,
+	projectToolDiagnosticValue,
+	type ToolDiagnosticTextRedactor,
+} from "../security/tool-diagnostics";
 import { resolveOptimizedPromptForRuntime } from "../services/optimized-prompt-resolver";
 import {
 	emitStreamingHook,
@@ -329,6 +335,10 @@ async function runPlannerLoopIterations(
 	params: PlannerLoopParams,
 ): Promise<PlannerLoopResult> {
 	const plannerContext = normalizePlannerContext(params.context);
+	// Diagnostic projection for every context/event copy of tool-call
+	// arguments: runtime-known secrets composed with the shared tool-shape
+	// patterns. The raw calls stay on `trajectory.plannedQueue` for execution.
+	const redactDiagnosticText = composeToolDiagnosticRedactor(params.runtime);
 	// Coding/full-surface mode (the eliza-code sub-agent sets
 	// ELIZA_PLANNER_FULL_ACTION_SURFACE): a real build legitimately makes many
 	// tool calls (read several files, write several, run tests). The chat default
@@ -1096,6 +1106,8 @@ async function runPlannerLoopIterations(
 			}
 			repeatedNonTerminalToolCalls = 0;
 			trajectory.plannedQueue.push(...validNonTerminalCalls);
+			// The queue keeps the exact raw calls for the handler path; the context
+			// copies below are diagnostics and carry the redacted projection only.
 			trajectory.context = {
 				...trajectory.context,
 				plannedQueue: [
@@ -1103,7 +1115,10 @@ async function runPlannerLoopIterations(
 					...validNonTerminalCalls.map((toolCall) => ({
 						id: toolCall.id,
 						name: toolCall.name,
-						args: stringifyForModel(toolCall.params ?? {}),
+						args: stringifyToolArgsForDiagnostics(
+							toolCall.params,
+							redactDiagnosticText,
+						),
 						status: "queued" as const,
 						sourceStageId: `planner:${iteration}`,
 					})),
@@ -1119,7 +1134,10 @@ async function runPlannerLoopIterations(
 						iteration,
 						toolCallId: toolCall.id,
 						name: toolCall.name,
-						params: stringifyForModel(toolCall.params ?? {}),
+						params: stringifyToolArgsForDiagnostics(
+							toolCall.params,
+							redactDiagnosticText,
+						),
 						status: "queued",
 					},
 				});
@@ -2228,6 +2246,7 @@ async function maybeCompactPlannerTrajectory(args: {
 		compactedSteps,
 		keptSteps,
 		budget: args.budget,
+		redactDiagnosticText: composeToolDiagnosticRedactor(args.runtime),
 	});
 	args.trajectory.archivedSteps.push(...compactedSteps);
 	args.trajectory.steps = keptSteps;
@@ -2326,6 +2345,7 @@ function buildCompactionSummary(args: {
 	compactedSteps: readonly PlannerStep[];
 	keptSteps: readonly PlannerStep[];
 	budget: ModelInputBudget;
+	redactDiagnosticText: ToolDiagnosticTextRedactor;
 }): string {
 	const lines = [
 		"Compacted prior planner trajectory steps because estimated input approached the model context window.",
@@ -2337,12 +2357,15 @@ function buildCompactionSummary(args: {
 		"Compacted step summaries:",
 	];
 	for (const step of args.compactedSteps) {
-		lines.push(`- ${summarizePlannerStep(step)}`);
+		lines.push(`- ${summarizePlannerStep(step, args.redactDiagnosticText)}`);
 	}
 	return lines.join("\n").trim();
 }
 
-function summarizePlannerStep(step: PlannerStep): string {
+function summarizePlannerStep(
+	step: PlannerStep,
+	redactDiagnosticText: ToolDiagnosticTextRedactor,
+): string {
 	const name = step.toolCall?.name ?? (step.terminalOnly ? "terminal" : "step");
 	const status = step.result
 		? step.result.success
@@ -2351,7 +2374,13 @@ function summarizePlannerStep(step: PlannerStep): string {
 		: "no_result";
 	const args =
 		step.toolCall?.params && Object.keys(step.toolCall.params).length > 0
-			? ` args=${compactText(stringifyForModel(step.toolCall.params), 180)}`
+			? ` args=${compactText(
+					stringifyToolArgsForDiagnostics(
+						step.toolCall.params,
+						redactDiagnosticText,
+					),
+					180,
+				)}`
 			: "";
 	const result = step.result
 		? ` result=${compactText(toolMessageContent(step.result), 360)}`
@@ -2874,8 +2903,15 @@ async function executeQueuedToolCall(params: {
 		params.trajectory.context,
 		params.toolCall,
 	);
+	const redactDiagnosticText = composeToolDiagnosticRedactor(
+		params.params.runtime,
+	);
 	await emitStreamingHook(streamingContext, "onToolCall", {
-		toolCall: plannerToolCallToStreamingToolCall(params.toolCall, "pending"),
+		toolCall: plannerToolCallToStreamingToolCall(
+			params.toolCall,
+			"pending",
+			redactDiagnosticText,
+		),
 		contextEvent,
 		messageId: streamingContext?.messageId,
 		metadata: { iteration: params.iteration },
@@ -2963,8 +2999,13 @@ async function executeQueuedToolCall(params: {
 			iteration: params.iteration,
 			toolCallId: params.toolCall.id,
 			name: params.toolCall.name,
-			params: stringifyForModel(params.toolCall.params ?? {}),
-			result: stringifyForModel(result),
+			params: stringifyToolArgsForDiagnostics(
+				params.toolCall.params,
+				redactDiagnosticText,
+			),
+			result: stringifyForModel(
+				projectToolDiagnosticValue(result, redactDiagnosticText),
+			),
 			status: result.success ? "completed" : "failed",
 		},
 	});
@@ -3044,13 +3085,33 @@ async function recordToolStage(args: {
 function plannerToolCallToStreamingToolCall(
 	toolCall: PlannerToolCall,
 	status: "pending" | "completed" | "failed",
+	redactDiagnosticText: ToolDiagnosticTextRedactor,
 ): ToolCall {
+	// Streaming observers are a diagnostic surface: keep the raw call identity
+	// for correlation, project the argument values.
 	return {
 		id: toolCall.id ?? toolCall.name,
 		name: toolCall.name,
-		arguments: (toolCall.params ?? {}) as ToolCall["arguments"],
+		arguments: (projectToolDiagnosticArgs(
+			toolCall.params ?? {},
+			redactDiagnosticText,
+		) ?? {}) as ToolCall["arguments"],
 		status,
 	};
+}
+
+/**
+ * Serialize tool-call arguments for a diagnostic context/event copy: project
+ * through the composed redaction first, then stringify. Never used for the
+ * execution path, which reads the raw call from the planned queue.
+ */
+function stringifyToolArgsForDiagnostics(
+	params: Record<string, unknown> | undefined,
+	redactDiagnosticText: ToolDiagnosticTextRedactor,
+): string {
+	return stringifyForModel(
+		projectToolDiagnosticArgs(params ?? {}, redactDiagnosticText) ?? {},
+	);
 }
 
 function findToolContextEvent(

--- a/packages/core/src/runtime/planner-rendering.ts
+++ b/packages/core/src/runtime/planner-rendering.ts
@@ -4,6 +4,13 @@
  * call, shaping everything append-only so the prompt prefix stays byte-stable
  * for provider prompt caching. Also re-exports the provider cache-plan helpers.
  */
+
+import {
+	composeToolDiagnosticRedactor,
+	projectToolDiagnosticArgs,
+	projectToolDiagnosticValue,
+	type ToolDiagnosticTextRedactor,
+} from "../security/tool-diagnostics";
 import type { ChatMessage, ChatMessageContentPart } from "../types/model";
 import type { JsonValue } from "../types/primitives.ts";
 import { tailWellFormed, truncateWellFormed } from "../utils/well-formed";
@@ -20,6 +27,11 @@ import {
  * Options for {@link trajectoryStepsToMessages}.
  */
 export interface TrajectoryStepsToMessagesOptions {
+	/**
+	 * Runtime-aware diagnostic redactor for model-bound tool history. When
+	 * omitted, the shared credential-shape pass still runs.
+	 */
+	redactText?: ToolDiagnosticTextRedactor;
 	/**
 	 * When set, caps each rendered tool-result string to this many characters.
 	 *
@@ -122,6 +134,7 @@ export function trajectoryStepsToMessages(
 	options: TrajectoryStepsToMessagesOptions = {},
 ): ChatMessage[] {
 	const messages: ChatMessage[] = [];
+	const redactText = options.redactText ?? composeToolDiagnosticRedactor();
 	for (const step of steps) {
 		if (!step.toolCall || !step.result) {
 			continue;
@@ -129,7 +142,7 @@ export function trajectoryStepsToMessages(
 		const toolCallId = stableToolCallId(step);
 
 		const assistantContent: ChatMessageContentPart[] = [];
-		const thought = (step.thought ?? "").trim();
+		const thought = redactText((step.thought ?? "").trim());
 		if (thought) {
 			assistantContent.push({ type: "text", text: thought });
 		}
@@ -137,14 +150,17 @@ export function trajectoryStepsToMessages(
 			type: "tool-call",
 			toolCallId,
 			toolName: step.toolCall.name,
-			input: (step.toolCall.params ?? {}) as Record<string, unknown>,
+			input:
+				projectToolDiagnosticArgs(step.toolCall.params ?? {}, redactText) ?? {},
 		});
 		messages.push({
 			role: "assistant",
 			content: assistantContent,
 		});
 
-		const rawResultText = toolMessageContent(step.result);
+		const rawResultText = toolMessageContent(
+			projectToolDiagnosticValue(step.result, redactText) as PlannerToolResult,
+		);
 		const renderedResultText = truncateToolResultText(
 			rawResultText,
 			options.maxToolResultChars,

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -35,6 +35,8 @@ export interface EvaluatorRuntime {
 		error: unknown,
 		context?: Record<string, unknown>,
 	): void;
+	/** Runtime-known-secret redaction composed into model-bound tool history. */
+	redactSecrets?(text: string): string;
 	useModel(
 		modelType: TextGenerationModelType,
 		params: {

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -76,6 +76,12 @@ export interface PlannerRuntime {
 		error: unknown,
 		context?: Record<string, unknown>,
 	): void;
+	/**
+	 * Runtime-known-secret redaction (character-configured values). Composed
+	 * with the shared tool-shape patterns for every diagnostic projection of
+	 * tool-call arguments; when absent the shape pass still applies.
+	 */
+	redactSecrets?(text: string): string;
 	useModel(
 		modelType: TextGenerationModelType,
 		params: {

--- a/packages/core/src/runtime/sub-planner.ts
+++ b/packages/core/src/runtime/sub-planner.ts
@@ -16,6 +16,7 @@ import type { Action, ActionResult, IAgentRuntime } from "../types";
 import type { ContextEvent, ContextObject } from "../types/context-object";
 import type { JSONSchema, ToolDefinition } from "../types/model";
 import { canActionRun } from "./action-gate";
+import { hashString, stableJsonStringify } from "./context-hash";
 import {
 	type ExecutePlannedToolCallContext,
 	type ExecutePlannedToolCallOptions,
@@ -165,16 +166,8 @@ export type SubPlannerExecute = (
 ) => Promise<ActionResult> | ActionResult;
 
 export function subPlannerCallDigest(toolCall: PlannerToolCall): string {
-	const canonical = JSON.stringify(toolCall.params ?? {}, (_key, value) =>
-		value && typeof value === "object" && !Array.isArray(value)
-			? Object.fromEntries(
-					Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
-						a.localeCompare(b),
-					),
-				)
-			: value,
-	);
-	return `${normalizeSubPlannerActionIdentifier(toolCall.name)}|${canonical}`;
+	const canonical = stableJsonStringify(toolCall.params ?? {});
+	return `${normalizeSubPlannerActionIdentifier(toolCall.name)}|${hashString(canonical)}`;
 }
 
 function priorNonRetryableSubstep(
@@ -369,6 +362,7 @@ export async function runSubPlanner(
 					resolvedChildAction,
 					result,
 					toolCall.params,
+					params.runtime,
 				),
 			});
 		},

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -46,7 +46,10 @@ import {
 } from "./trace-correlation";
 import { resolveTrajectoryGate } from "./trajectory-gate";
 import type { TrajectoryProviderAttribution } from "./trajectory-provider-attribution";
-import { omitUnvalidatedProviderSpans } from "./trajectory-provider-attribution";
+import {
+	canonicalPromptForModelCall,
+	omitUnvalidatedProviderSpans,
+} from "./trajectory-provider-attribution";
 
 // ---------------------------------------------------------------------------
 // Schema (mirrors PLAN.md §18.1)
@@ -1190,10 +1193,10 @@ export function annotateStageCost(
  * handler, and any future generic caller) is protected here rather than at
  * its own call site: tool arguments, tool result/error, captured tool I/O,
  * and model-stage tool-call arguments are projected through the composed
- * redaction before the stage reaches disk. Mutates the (already cloned)
- * stage in place. Model prompt/message text is deliberately untouched:
- * provider attributions index into the flattened persisted messages by span,
- * so rewriting that text would corrupt attribution provenance.
+ * redaction before the stage reaches disk. Mutates the (already cloned) stage
+ * in place. Model prompt/message text is projected as well; when message bytes
+ * change, provider-attribution offsets are dropped through the canonical
+ * fallback so they never index text different from the persisted messages.
  */
 export function projectRecordedStageToolDiagnostics(
 	stage: RecordedStage,
@@ -1220,6 +1223,10 @@ export function projectRecordedStageToolDiagnostics(
 		}
 	}
 	if (stage.model) {
+		const attributionInputBefore = canonicalPromptForModelCall({
+			messages: stage.model.messages,
+			prompt: stage.model.prompt,
+		});
 		if (stage.model.toolCalls?.length) {
 			stage.model.toolCalls = stage.model.toolCalls.map((toolCall) => ({
 				...toolCall,
@@ -1235,7 +1242,10 @@ export function projectRecordedStageToolDiagnostics(
 		// no longer provable against the persisted prompt — drop the offsets via
 		// the canonical fallback and keep contribution identity.
 		if (typeof stage.model.prompt === "string") {
-			stage.model.prompt = redactText(stage.model.prompt);
+			const projectedPrompt = redactText(stage.model.prompt);
+			if (projectedPrompt !== stage.model.prompt) {
+				stage.model.prompt = projectedPrompt;
+			}
 		}
 		stage.model.response = redactText(stage.model.response);
 		if (Array.isArray(stage.model.messages)) {
@@ -1245,12 +1255,19 @@ export function projectRecordedStageToolDiagnostics(
 			) as RecordedModelCall["messages"];
 			if (projectedMessages !== stage.model.messages) {
 				stage.model.messages = projectedMessages;
-				if (stage.model.providerAttributions?.length) {
-					stage.model.providerAttributions = omitUnvalidatedProviderSpans(
-						stage.model.providerAttributions,
-					);
-				}
 			}
+		}
+		const attributionInputAfter = canonicalPromptForModelCall({
+			messages: stage.model.messages,
+			prompt: stage.model.prompt,
+		});
+		if (
+			attributionInputAfter !== attributionInputBefore &&
+			stage.model.providerAttributions?.length
+		) {
+			stage.model.providerAttributions = omitUnvalidatedProviderSpans(
+				stage.model.providerAttributions,
+			);
 		}
 	}
 	if (stage.evaluation) {

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -29,6 +29,12 @@ import {
 	computeCallCostUsd,
 	PRICE_TABLE_ID,
 } from "../features/trajectories/pricing";
+import {
+	composeToolDiagnosticRedactor,
+	projectToolDiagnosticArgs,
+	projectToolDiagnosticValue,
+	type ToolDiagnosticTextRedactor,
+} from "../security/tool-diagnostics";
 import type { EvaluationResult } from "../types/components";
 import type { ChatMessage, ToolChoice } from "../types/model";
 import { readEnv } from "../utils/read-env";
@@ -40,6 +46,7 @@ import {
 } from "./trace-correlation";
 import { resolveTrajectoryGate } from "./trajectory-gate";
 import type { TrajectoryProviderAttribution } from "./trajectory-provider-attribution";
+import { omitUnvalidatedProviderSpans } from "./trajectory-provider-attribution";
 
 // ---------------------------------------------------------------------------
 // Schema (mirrors PLAN.md §18.1)
@@ -1177,6 +1184,83 @@ export function annotateStageCost(
 	}
 }
 
+/**
+ * Final-persistence projection of tool-call diagnostics for one recorded
+ * stage. Every recordStage caller (planner, sub-planner, evaluator, message
+ * handler, and any future generic caller) is protected here rather than at
+ * its own call site: tool arguments, tool result/error, captured tool I/O,
+ * and model-stage tool-call arguments are projected through the composed
+ * redaction before the stage reaches disk. Mutates the (already cloned)
+ * stage in place. Model prompt/message text is deliberately untouched:
+ * provider attributions index into the flattened persisted messages by span,
+ * so rewriting that text would corrupt attribution provenance.
+ */
+export function projectRecordedStageToolDiagnostics(
+	stage: RecordedStage,
+	redactText: ToolDiagnosticTextRedactor,
+): void {
+	if (stage.tool) {
+		stage.tool.args =
+			projectToolDiagnosticArgs(stage.tool.args, redactText) ?? {};
+		stage.tool.result = projectToolDiagnosticValue(
+			stage.tool.result,
+			redactText,
+		);
+		if (typeof stage.tool.error === "string") {
+			stage.tool.error = redactText(stage.tool.error);
+		}
+		if (stage.tool.input !== undefined) {
+			stage.tool.input = redactText(stage.tool.input);
+		}
+		if (stage.tool.output !== undefined) {
+			stage.tool.output = redactText(stage.tool.output);
+		}
+		if (stage.tool.errorText !== undefined) {
+			stage.tool.errorText = redactText(stage.tool.errorText);
+		}
+	}
+	if (stage.model) {
+		if (stage.model.toolCalls?.length) {
+			stage.model.toolCalls = stage.model.toolCalls.map((toolCall) => ({
+				...toolCall,
+				...(toolCall.args !== undefined
+					? { args: projectToolDiagnosticArgs(toolCall.args, redactText) }
+					: {}),
+			}));
+		}
+		// Prompt/messages/response carry rendered tool-call arguments and tool
+		// output (assistant tool-call turns, tool-result turns, evaluator
+		// trajectory renderings), so the persisted copies are projected too.
+		// When the messages text changes, provider-attribution span offsets are
+		// no longer provable against the persisted prompt — drop the offsets via
+		// the canonical fallback and keep contribution identity.
+		if (typeof stage.model.prompt === "string") {
+			stage.model.prompt = redactText(stage.model.prompt);
+		}
+		stage.model.response = redactText(stage.model.response);
+		if (Array.isArray(stage.model.messages)) {
+			const projectedMessages = projectToolDiagnosticValue(
+				stage.model.messages,
+				redactText,
+			) as RecordedModelCall["messages"];
+			if (projectedMessages !== stage.model.messages) {
+				stage.model.messages = projectedMessages;
+				if (stage.model.providerAttributions?.length) {
+					stage.model.providerAttributions = omitUnvalidatedProviderSpans(
+						stage.model.providerAttributions,
+					);
+				}
+			}
+		}
+	}
+	if (stage.evaluation) {
+		stage.evaluation = projectToolDiagnosticValue(
+			stage.evaluation,
+			redactText,
+		) as RecordedEvaluationStage;
+	}
+}
+
 // ---------------------------------------------------------------------------
 // JsonFileTrajectoryRecorder
 // ---------------------------------------------------------------------------
@@ -1190,6 +1274,15 @@ export interface CreateJsonFileRecorderOptions {
 		error: unknown,
 		context?: Record<string, unknown>,
 	) => void;
+	/**
+	 * Runtime-known-secret redaction (e.g. `runtime.redactSecrets`) composed
+	 * into the recorder's final-persistence diagnostic projection (see
+	 * {@link projectRecordedStageToolDiagnostics}). The shared tool-shape
+	 * pattern pass always runs regardless — the option only ADDS
+	 * character-configured secret masking, so a recorder constructed without a
+	 * runtime still never persists raw credential-shaped argument values.
+	 */
+	redactSecrets?: (text: string) => string;
 }
 
 interface MutableTrajectory extends RecordedTrajectory {}
@@ -1201,6 +1294,7 @@ class JsonFileTrajectoryRecorder implements TrajectoryRecorder {
 	private readonly reportError?: CreateJsonFileRecorderOptions["reportError"];
 	private readonly enabled: boolean;
 	private readonly markdownEnabled: boolean;
+	private readonly redactText: ToolDiagnosticTextRedactor;
 	private readonly active = new Map<string, MutableTrajectory>();
 	private readonly flushQueues = new Map<string, Promise<void>>();
 
@@ -1209,6 +1303,9 @@ class JsonFileTrajectoryRecorder implements TrajectoryRecorder {
 		this.markdownDir = resolveTrajectoryMarkdownDir(this.rootDir);
 		this.logger = opts.logger;
 		this.reportError = opts.reportError;
+		this.redactText = composeToolDiagnosticRedactor({
+			redactSecrets: opts.redactSecrets,
+		});
 		this.enabled =
 			opts.enabled !== undefined
 				? opts.enabled
@@ -1296,6 +1393,7 @@ class JsonFileTrajectoryRecorder implements TrajectoryRecorder {
 		}
 
 		const recordedStage = cloneForRecord(stage);
+		projectRecordedStageToolDiagnostics(recordedStage, this.redactText);
 		annotateStageCost(recordedStage, this.logger);
 		trajectory.stages.push(recordedStage);
 		applyMetricsForStage(trajectory.metrics, recordedStage);

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -151,6 +151,13 @@ export {
 	sanitizeSpawnEnv,
 } from "./spawn-env-policy.js";
 export {
+	composeToolDiagnosticRedactor,
+	projectToolDiagnosticArgs,
+	projectToolDiagnosticValue,
+	TOOL_DIAGNOSTIC_MASK,
+	type ToolDiagnosticTextRedactor,
+} from "./tool-diagnostics.js";
+export {
 	attestAuthenticatedApiDeliveryAudience,
 	attestDeliveryAudienceFromCanonicalRoom,
 	authorizeOwnerExclusiveDisclosure,

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -152,6 +152,7 @@ export {
 } from "./spawn-env-policy.js";
 export {
 	composeToolDiagnosticRedactor,
+	projectModelCallDiagnosticValue,
 	projectToolDiagnosticArgs,
 	projectToolDiagnosticValue,
 	TOOL_DIAGNOSTIC_MASK,

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -297,10 +297,22 @@ describe("isSensitiveKeyName", () => {
 		}
 	});
 
-	it("does not flag benign keys, including tokenId", () => {
-		for (const key of ["userId", "count", "tokenId", "name", "url", "status"]) {
+	it("does not flag benign keys, including exact token telemetry fields", () => {
+		for (const key of [
+			"userId",
+			"count",
+			"tokenId",
+			"tokenCount",
+			"max_tokens",
+			"promptTokens",
+			"cacheReadInputTokens",
+			"name",
+			"url",
+			"status",
+		]) {
 			expect(isSensitiveKeyName(key)).toBe(false);
 		}
+		expect(isSensitiveKeyName("accessTokens")).toBe(true);
 	});
 });
 

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -102,6 +102,30 @@ const SENSITIVE_KEY_SUBSTRINGS: readonly string[] = [
 	"authorization",
 ];
 
+// Exact telemetry/schema controls whose names contain "token" but whose
+// values are counts, budgets, or correlation identifiers rather than
+// credentials. Keep this list deliberately closed: broad suffix rules would
+// accidentally exempt credential collections such as `accessTokens`.
+const NON_SECRET_TOKEN_METADATA_KEYS = new Set([
+	"cachecreationinputtokens",
+	"cachereadinputtokens",
+	"completiontokens",
+	"compactionthresholdtokens",
+	"contextwindowtokens",
+	"estimatedinputtokens",
+	"inputtokens",
+	"maxtokens",
+	"maxtokensomitted",
+	"outputtokens",
+	"prompttokens",
+	"reasoningtokens",
+	"reservetokens",
+	"tokencount",
+	"tokencountestimated",
+	"tokenid",
+	"totaltokens",
+]);
+
 /**
  * Whether an object key names a credential and its value must be fully masked.
  * Matches the substrings in {@link SENSITIVE_KEY_SUBSTRINGS} plus `token`
@@ -110,6 +134,10 @@ const SENSITIVE_KEY_SUBSTRINGS: readonly string[] = [
  */
 export function isSensitiveKeyName(key: string): boolean {
 	const lower = key.toLowerCase();
+	const normalized = lower.replace(/[_-]/g, "");
+	if (NON_SECRET_TOKEN_METADATA_KEYS.has(normalized)) {
+		return false;
+	}
 	if (SENSITIVE_KEY_SUBSTRINGS.some((needle) => lower.includes(needle))) {
 		return true;
 	}

--- a/packages/core/src/security/tool-diagnostics.test.ts
+++ b/packages/core/src/security/tool-diagnostics.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit coverage for the tool-call diagnostic projection: composed
+ * runtime-known + shape redaction, key-based masking, primitive
+ * preservation, non-mutation, structural sharing, and cycle/depth bounds.
+ * Deterministic and fully synthetic — every credential-shaped value is an
+ * obviously fake canary, never a real secret.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	composeToolDiagnosticRedactor,
+	projectToolDiagnosticArgs,
+	projectToolDiagnosticValue,
+	TOOL_DIAGNOSTIC_MASK,
+} from "./tool-diagnostics";
+
+const RUNTIME_SECRET_CANARY = "SYNTH-RUNTIME-SECRET-CANARY-0000";
+const FLAG_CANARY = "SYNTH-FLAG-CANARY-1111";
+const USERINFO_CANARY = "SYNTH-URI-CANARY-2222";
+
+const redactor = composeToolDiagnosticRedactor({
+	redactSecrets: (text) =>
+		text.split(RUNTIME_SECRET_CANARY).join("[REDACTED:CANARY]"),
+});
+
+describe("composeToolDiagnosticRedactor", () => {
+	it("applies runtime-known-secret redaction before shape patterns", () => {
+		const projected = redactor(
+			`run with ${RUNTIME_SECRET_CANARY} and --token=${FLAG_CANARY}`,
+		);
+		expect(projected).not.toContain(RUNTIME_SECRET_CANARY);
+		expect(projected).not.toContain(FLAG_CANARY);
+		expect(projected).toContain("[REDACTED:CANARY]");
+	});
+
+	it("keeps the shape pass when redactSecrets is identity", () => {
+		const identity = composeToolDiagnosticRedactor({
+			redactSecrets: (text) => text,
+		});
+		expect(identity(`--token=${FLAG_CANARY}`)).not.toContain(FLAG_CANARY);
+	});
+
+	it("masks URI userinfo credentials", () => {
+		const projected = redactor(
+			`https://user:${USERINFO_CANARY}@internal.example/path`,
+		);
+		expect(projected).not.toContain(USERINFO_CANARY);
+		expect(projected).toContain("https://***@internal.example/path");
+	});
+});
+
+describe("projectToolDiagnosticValue", () => {
+	it("preserves numbers, booleans, and null exactly", () => {
+		const args = {
+			retries: 3,
+			ratio: 0.25,
+			dryRun: false,
+			enabled: true,
+			cursor: null,
+		};
+		expect(projectToolDiagnosticValue(args, redactor)).toEqual(args);
+	});
+
+	it("fully masks values under credential-named keys", () => {
+		const projected = projectToolDiagnosticValue(
+			{ apiKey: "short", nested: { authorization: { deep: 1 } } },
+			redactor,
+		) as Record<string, unknown>;
+		expect(projected.apiKey).toBe(TOOL_DIAGNOSTIC_MASK);
+		expect((projected.nested as Record<string, unknown>).authorization).toBe(
+			TOOL_DIAGNOSTIC_MASK,
+		);
+	});
+
+	it("scrubs nested strings without mutating the input", () => {
+		const raw = {
+			command: `deploy --token=${FLAG_CANARY}`,
+			targets: [`https://ci:${USERINFO_CANARY}@ci.example/job`],
+		};
+		const projected = projectToolDiagnosticValue(raw, redactor) as typeof raw;
+		expect(projected).not.toBe(raw);
+		expect(JSON.stringify(projected)).not.toContain(FLAG_CANARY);
+		expect(JSON.stringify(projected)).not.toContain(USERINFO_CANARY);
+		expect(raw.command).toContain(FLAG_CANARY);
+		expect(raw.targets[0]).toContain(USERINFO_CANARY);
+	});
+
+	it("returns the same reference when nothing needs redaction", () => {
+		const raw = { path: "/tmp/file.txt", lines: [1, 2, 3], deep: { ok: true } };
+		expect(projectToolDiagnosticValue(raw, redactor)).toBe(raw);
+	});
+
+	it("collapses cycles to the mask instead of hanging", () => {
+		const raw: Record<string, unknown> = { name: "loop" };
+		raw.self = raw;
+		const projected = projectToolDiagnosticValue(raw, redactor) as Record<
+			string,
+			unknown
+		>;
+		expect(projected.self).toBe(TOOL_DIAGNOSTIC_MASK);
+		expect(projected.name).toBe("loop");
+	});
+
+	it("allows the same subtree on sibling paths (DAG, not cycle)", () => {
+		const shared = { ok: true };
+		const projected = projectToolDiagnosticValue(
+			{ a: shared, b: shared },
+			redactor,
+		) as Record<string, unknown>;
+		expect(projected.a).toEqual({ ok: true });
+		expect(projected.b).toEqual({ ok: true });
+	});
+
+	it("bounds depth", () => {
+		let deep: Record<string, unknown> = { leaf: `--token=${FLAG_CANARY}` };
+		for (let i = 0; i < 12; i += 1) {
+			deep = { child: deep };
+		}
+		const serialized = JSON.stringify(
+			projectToolDiagnosticValue(deep, redactor),
+		);
+		expect(serialized).not.toContain(FLAG_CANARY);
+		expect(serialized).toContain(TOOL_DIAGNOSTIC_MASK);
+	});
+
+	it("scrubs Error message and stack while preserving the shape", () => {
+		const raw = new Error(`refused --token=${FLAG_CANARY}`);
+		raw.name = "ToolFailure";
+		const projected = projectToolDiagnosticValue(raw, redactor) as Error;
+		expect(projected).toBeInstanceOf(Error);
+		expect(projected.name).toBe("ToolFailure");
+		expect(projected.message).not.toContain(FLAG_CANARY);
+		expect(projected.stack ?? "").not.toContain(FLAG_CANARY);
+	});
+});
+
+describe("projectToolDiagnosticArgs", () => {
+	it("passes undefined through", () => {
+		expect(projectToolDiagnosticArgs(undefined, redactor)).toBeUndefined();
+	});
+
+	it("projects a defined record", () => {
+		const projected = projectToolDiagnosticArgs(
+			{ token: FLAG_CANARY, count: 2 },
+			redactor,
+		);
+		expect(projected?.token).toBe(TOOL_DIAGNOSTIC_MASK);
+		expect(projected?.count).toBe(2);
+	});
+});

--- a/packages/core/src/security/tool-diagnostics.test.ts
+++ b/packages/core/src/security/tool-diagnostics.test.ts
@@ -123,6 +123,17 @@ describe("projectToolDiagnosticValue", () => {
 		expect(serialized).toContain(TOOL_DIAGNOSTIC_MASK);
 	});
 
+	it("passes Date values through untouched, valid or invalid", () => {
+		const valid = new Date("2026-01-02T03:04:05.000Z");
+		const invalid = new Date(Number.NaN);
+		const projected = projectToolDiagnosticValue(
+			{ at: valid, bad: invalid },
+			redactor,
+		) as { at: Date; bad: Date };
+		expect(projected.at).toBe(valid);
+		expect(projected.bad).toBe(invalid);
+	});
+
 	it("scrubs Error message and stack while preserving the shape", () => {
 		const raw = new Error(`refused --token=${FLAG_CANARY}`);
 		raw.name = "ToolFailure";

--- a/packages/core/src/security/tool-diagnostics.test.ts
+++ b/packages/core/src/security/tool-diagnostics.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	composeToolDiagnosticRedactor,
+	projectModelCallDiagnosticValue,
 	projectToolDiagnosticArgs,
 	projectToolDiagnosticValue,
 	TOOL_DIAGNOSTIC_MASK,
@@ -53,6 +54,8 @@ describe("projectToolDiagnosticValue", () => {
 	it("preserves numbers, booleans, and null exactly", () => {
 		const args = {
 			retries: 3,
+			tokenCount: 12,
+			maxTokens: 4096,
 			ratio: 0.25,
 			dryRun: false,
 			enabled: true,
@@ -63,10 +66,15 @@ describe("projectToolDiagnosticValue", () => {
 
 	it("fully masks values under credential-named keys", () => {
 		const projected = projectToolDiagnosticValue(
-			{ apiKey: "short", nested: { authorization: { deep: 1 } } },
+			{
+				apiKey: "short",
+				accessTokens: ["short"],
+				nested: { authorization: { deep: 1 } },
+			},
 			redactor,
 		) as Record<string, unknown>;
 		expect(projected.apiKey).toBe(TOOL_DIAGNOSTIC_MASK);
+		expect(projected.accessTokens).toBe(TOOL_DIAGNOSTIC_MASK);
 		expect((projected.nested as Record<string, unknown>).authorization).toBe(
 			TOOL_DIAGNOSTIC_MASK,
 		);
@@ -142,6 +150,78 @@ describe("projectToolDiagnosticValue", () => {
 		expect(projected.name).toBe("ToolFailure");
 		expect(projected.message).not.toContain(FLAG_CANARY);
 		expect(projected.stack ?? "").not.toContain(FLAG_CANARY);
+	});
+});
+
+describe("projectModelCallDiagnosticValue", () => {
+	it("preserves schema identifiers while scrubbing schema values and tool metadata", () => {
+		const raw = {
+			responseSchema: {
+				type: "object",
+				properties: {
+					apiKey: {
+						type: "string",
+						description: `Never echo --token=${FLAG_CANARY}`,
+					},
+					secret: { type: "string" },
+				},
+				required: ["apiKey", "secret"],
+				default: { apiKey: "short-canary" },
+			},
+			tools: [
+				{
+					name: "authenticate",
+					parameters: {
+						type: "object",
+						properties: {
+							token: { type: "string" },
+						},
+						required: ["token"],
+					},
+					metadata: { apiKey: "short-canary" },
+				},
+				{
+					type: "function",
+					function: {
+						name: "nested_authenticate",
+						parameters: {
+							type: "object",
+							properties: {
+								accessToken: { type: "string" },
+							},
+							required: ["accessToken"],
+						},
+					},
+				},
+			],
+			providerOptions: { apiKey: "short-canary" },
+		};
+
+		const projected = projectModelCallDiagnosticValue(
+			raw,
+			redactor,
+		) as typeof raw;
+		expect(projected.responseSchema.properties.apiKey).toEqual({
+			type: "string",
+			description: expect.not.stringContaining(FLAG_CANARY),
+		});
+		expect(projected.responseSchema.properties.secret).toEqual({
+			type: "string",
+		});
+		expect(projected.responseSchema.required).toEqual(["apiKey", "secret"]);
+		expect(projected.responseSchema.default.apiKey).toBe(TOOL_DIAGNOSTIC_MASK);
+		expect(projected.tools[0]?.parameters.properties.token).toEqual({
+			type: "string",
+		});
+		expect(projected.tools[0]?.parameters.required).toEqual(["token"]);
+		expect(projected.tools[0]?.metadata.apiKey).toBe(TOOL_DIAGNOSTIC_MASK);
+		expect(
+			projected.tools[1]?.function.parameters.properties.accessToken,
+		).toEqual({ type: "string" });
+		expect(projected.providerOptions.apiKey).toBe(TOOL_DIAGNOSTIC_MASK);
+		expect(raw.responseSchema.properties.apiKey.description).toContain(
+			FLAG_CANARY,
+		);
 	});
 });
 

--- a/packages/core/src/security/tool-diagnostics.ts
+++ b/packages/core/src/security/tool-diagnostics.ts
@@ -1,0 +1,153 @@
+/**
+ * Non-mutating diagnostic projection for validated tool-call arguments. The
+ * handler must receive the exact raw values, so redaction cannot happen where
+ * arguments are produced; instead every boundary where arguments leave the
+ * ephemeral execution path (planner queue/context/events, streaming and
+ * observer payloads, action summaries, result/failure metadata, persisted
+ * trajectories) projects them through this module before serialization.
+ *
+ * The projection composes runtime-known-secret redaction with the shared
+ * tool-shape patterns from redact.ts (CLI --token forms, URI userinfo, token
+ * prefixes), fully masks values under credential-named keys, preserves
+ * non-string primitives so numeric/boolean diagnostics stay exact, and bounds
+ * depth/cycles so a pathological argument graph cannot hang a diagnostic
+ * writer. Unchanged subtrees are returned by reference (structural sharing);
+ * callers must treat projected values as immutable.
+ */
+
+import {
+	isSensitiveKeyName,
+	type RedactSensitiveMode,
+	redactSensitiveText,
+} from "./redact";
+
+/** Replacement emitted for masked keys, cycles, and over-deep subtrees. */
+export const TOOL_DIAGNOSTIC_MASK = "[REDACTED]";
+
+/**
+ * Depth bound for the projection walk. Matches the log-sink redactor's bound
+ * so a diagnostic surface never preserves structure a log line would refuse.
+ */
+const MAX_TOOL_DIAGNOSTIC_DEPTH = 8;
+
+/** Scrubs one string for diagnostic output. */
+export type ToolDiagnosticTextRedactor = (text: string) => string;
+
+const TOOLS_MODE: { mode: RedactSensitiveMode } = { mode: "tools" };
+
+/**
+ * Composes runtime-known-secret redaction with shared tool-shape redaction —
+ * the established order from the action-output work: literal character
+ * secrets first, then pattern detection over whatever remains. Lightweight
+ * and test runtimes may stub `redactSecrets` as identity, so the pattern pass
+ * always runs.
+ */
+export function composeToolDiagnosticRedactor(runtime?: {
+	redactSecrets?(text: string): string;
+}): ToolDiagnosticTextRedactor {
+	const redactSecrets = runtime?.redactSecrets?.bind(runtime);
+	if (!redactSecrets) {
+		return (text) => redactSensitiveText(text, TOOLS_MODE);
+	}
+	return (text) => redactSensitiveText(redactSecrets(text), TOOLS_MODE);
+}
+
+function projectValue(
+	value: unknown,
+	redactText: ToolDiagnosticTextRedactor,
+	seen: WeakSet<object>,
+	depth: number,
+): unknown {
+	if (typeof value === "string") {
+		return redactText(value);
+	}
+	if (value === null || typeof value !== "object") {
+		// Numbers, booleans, bigints, undefined, functions, symbols: preserved.
+		// Non-serializable entries drop out at JSON.stringify time exactly as
+		// they would have for the raw value, so the projection never changes
+		// which fields a surface serializes — only what the strings contain.
+		return value;
+	}
+	if (depth >= MAX_TOOL_DIAGNOSTIC_DEPTH || seen.has(value)) {
+		return TOOL_DIAGNOSTIC_MASK;
+	}
+	seen.add(value);
+	try {
+		if (Array.isArray(value)) {
+			let changed = false;
+			const projected = value.map((item) => {
+				const next = projectValue(item, redactText, seen, depth + 1);
+				if (next !== item) {
+					changed = true;
+				}
+				return next;
+			});
+			return changed ? projected : value;
+		}
+		if (value instanceof Error) {
+			// Thrown values routinely interpolate the offending argument into
+			// their message; preserve the Error shape but scrub message/stack.
+			const projected = new Error(redactText(value.message));
+			projected.name = value.name;
+			projected.stack = value.stack ? redactText(value.stack) : undefined;
+			return projected;
+		}
+		let changed = false;
+		const projected: Record<string, unknown> = {};
+		for (const [key, entry] of Object.entries(value)) {
+			if (isSensitiveKeyName(key)) {
+				projected[key] = TOOL_DIAGNOSTIC_MASK;
+				changed = true;
+				continue;
+			}
+			const next = projectValue(entry, redactText, seen, depth + 1);
+			if (next !== entry) {
+				changed = true;
+			}
+			projected[key] = next;
+		}
+		// A non-plain prototype (class instance) still projects to a plain
+		// object: diagnostics serialize own enumerable state only.
+		if (!changed && Object.getPrototypeOf(value) === Object.prototype) {
+			return value;
+		}
+		return projected;
+	} finally {
+		// Re-entrant siblings may legitimately share a subtree; only a path
+		// back through an ancestor is a cycle.
+		seen.delete(value);
+	}
+}
+
+/**
+ * Projects one value for diagnostic egress. The input is never mutated; the
+ * result is safe to embed in planner context, events, stream payloads,
+ * summaries, and persisted trajectories. Strings are scrubbed with
+ * `redactText`, values under credential-named keys are fully masked,
+ * non-string primitives are preserved exactly, and cycles or nesting beyond
+ * the depth bound collapse to {@link TOOL_DIAGNOSTIC_MASK}.
+ */
+export function projectToolDiagnosticValue(
+	value: unknown,
+	redactText: ToolDiagnosticTextRedactor,
+): unknown {
+	return projectValue(value, redactText, new WeakSet<object>(), 0);
+}
+
+/**
+ * Projects a tool-call argument record for diagnostic egress. Returns the
+ * same reference when nothing needed redaction so unchanged calls stay
+ * identity-comparable across surfaces.
+ */
+export function projectToolDiagnosticArgs(
+	args: Record<string, unknown> | undefined,
+	redactText: ToolDiagnosticTextRedactor,
+): Record<string, unknown> | undefined {
+	if (args === undefined) {
+		return undefined;
+	}
+	return projectToolDiagnosticValue(args, redactText) as Record<
+		string,
+		unknown
+	>;
+}

--- a/packages/core/src/security/tool-diagnostics.ts
+++ b/packages/core/src/security/tool-diagnostics.ts
@@ -30,6 +30,48 @@ export const TOOL_DIAGNOSTIC_MASK = "[REDACTED]";
  */
 const MAX_TOOL_DIAGNOSTIC_DEPTH = 8;
 
+/** JSON Schema keys whose object keys are schema identifiers, not values. */
+const JSON_SCHEMA_DEFINITION_MAP_KEYS = new Set([
+	"$defs",
+	"definitions",
+	"dependencies",
+	"dependentSchemas",
+	"patternProperties",
+	"properties",
+]);
+
+/** JSON Schema keys containing one nested schema. */
+const JSON_SCHEMA_SINGLE_SCHEMA_KEYS = new Set([
+	"additionalProperties",
+	"contains",
+	"else",
+	"if",
+	"items",
+	"not",
+	"propertyNames",
+	"then",
+	"unevaluatedItems",
+	"unevaluatedProperties",
+]);
+
+/** JSON Schema keys containing an array of nested schemas. */
+const JSON_SCHEMA_SCHEMA_ARRAY_KEYS = new Set([
+	"allOf",
+	"anyOf",
+	"oneOf",
+	"prefixItems",
+]);
+
+/** Tool-definition fields whose values are JSON Schemas. */
+const TOOL_DEFINITION_SCHEMA_KEYS = new Set([
+	"inputSchema",
+	"input_schema",
+	"parameters",
+	"responseSchema",
+	"response_schema",
+	"schema",
+]);
+
 /** Scrubs one string for diagnostic output. */
 export type ToolDiagnosticTextRedactor = (text: string) => string;
 
@@ -126,6 +168,178 @@ function projectValue(
 	}
 }
 
+function projectJsonSchemaDefinitionMap(
+	value: unknown,
+	redactText: ToolDiagnosticTextRedactor,
+	seen: WeakSet<object>,
+	depth: number,
+): unknown {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return projectValue(value, redactText, seen, depth);
+	}
+	if (depth >= MAX_TOOL_DIAGNOSTIC_DEPTH || seen.has(value)) {
+		return TOOL_DIAGNOSTIC_MASK;
+	}
+	seen.add(value);
+	try {
+		let changed = false;
+		const projected: Record<string, unknown> = {};
+		for (const [propertyName, propertySchema] of Object.entries(value)) {
+			// Property/definition names are executable schema identifiers. Treating
+			// names such as `apiKey`, `token`, or `secret` as credential containers
+			// would replace their schema object and make the recorded request
+			// unreplayable. Values inside each schema still receive the full pass.
+			const next =
+				Array.isArray(propertySchema) &&
+				propertySchema.every((name) => typeof name === "string")
+					? propertySchema
+					: projectJsonSchemaNode(propertySchema, redactText, seen, depth + 1);
+			if (next !== propertySchema) changed = true;
+			projected[propertyName] = next;
+		}
+		return changed ? projected : value;
+	} finally {
+		seen.delete(value);
+	}
+}
+
+function projectJsonSchemaNode(
+	value: unknown,
+	redactText: ToolDiagnosticTextRedactor,
+	seen: WeakSet<object>,
+	depth: number,
+): unknown {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return projectValue(value, redactText, seen, depth);
+	}
+	if (depth >= MAX_TOOL_DIAGNOSTIC_DEPTH || seen.has(value)) {
+		return TOOL_DIAGNOSTIC_MASK;
+	}
+	seen.add(value);
+	try {
+		let changed = false;
+		const projected: Record<string, unknown> = {};
+		for (const [key, entry] of Object.entries(value)) {
+			let next: unknown;
+			if (JSON_SCHEMA_DEFINITION_MAP_KEYS.has(key)) {
+				next = projectJsonSchemaDefinitionMap(
+					entry,
+					redactText,
+					seen,
+					depth + 1,
+				);
+			} else if (JSON_SCHEMA_SINGLE_SCHEMA_KEYS.has(key)) {
+				if (key === "items" && Array.isArray(entry)) {
+					next = entry.map((item) =>
+						projectJsonSchemaNode(item, redactText, seen, depth + 1),
+					);
+				} else {
+					next = projectJsonSchemaNode(entry, redactText, seen, depth + 1);
+				}
+			} else if (
+				JSON_SCHEMA_SCHEMA_ARRAY_KEYS.has(key) &&
+				Array.isArray(entry)
+			) {
+				next = entry.map((item) =>
+					projectJsonSchemaNode(item, redactText, seen, depth + 1),
+				);
+			} else if (
+				key === "required" &&
+				Array.isArray(entry) &&
+				entry.every((propertyName) => typeof propertyName === "string")
+			) {
+				// Required entries are references to property identifiers. Preserve
+				// them byte-exact so they continue to match the property map above.
+				next = entry;
+			} else if (
+				key === "dependentRequired" &&
+				entry &&
+				typeof entry === "object" &&
+				!Array.isArray(entry) &&
+				Object.values(entry).every(
+					(propertyNames) =>
+						Array.isArray(propertyNames) &&
+						propertyNames.every(
+							(propertyName) => typeof propertyName === "string",
+						),
+				)
+			) {
+				// Both map keys and array values are schema property identifiers.
+				next = entry;
+			} else if (isSensitiveKeyName(key)) {
+				next = TOOL_DIAGNOSTIC_MASK;
+			} else {
+				next = projectValue(entry, redactText, seen, depth + 1);
+			}
+			if (next !== entry) changed = true;
+			projected[key] = next;
+		}
+		return changed ? projected : value;
+	} finally {
+		seen.delete(value);
+	}
+}
+
+function projectModelToolDefinition(
+	value: unknown,
+	redactText: ToolDiagnosticTextRedactor,
+	seen: WeakSet<object>,
+	depth: number,
+): unknown {
+	if (Array.isArray(value)) {
+		if (depth >= MAX_TOOL_DIAGNOSTIC_DEPTH || seen.has(value)) {
+			return TOOL_DIAGNOSTIC_MASK;
+		}
+		seen.add(value);
+		try {
+			let changed = false;
+			const projected = value.map((entry) => {
+				const next = projectModelToolDefinition(
+					entry,
+					redactText,
+					seen,
+					depth + 1,
+				);
+				if (next !== entry) changed = true;
+				return next;
+			});
+			return changed ? projected : value;
+		} finally {
+			seen.delete(value);
+		}
+	}
+	if (!value || typeof value !== "object") {
+		return projectValue(value, redactText, seen, depth);
+	}
+	if (depth >= MAX_TOOL_DIAGNOSTIC_DEPTH || seen.has(value)) {
+		return TOOL_DIAGNOSTIC_MASK;
+	}
+	seen.add(value);
+	try {
+		let changed = false;
+		const projected: Record<string, unknown> = {};
+		for (const [key, entry] of Object.entries(value)) {
+			let next: unknown;
+			if (TOOL_DEFINITION_SCHEMA_KEYS.has(key)) {
+				next = projectJsonSchemaNode(entry, redactText, seen, depth + 1);
+			} else if (key === "function") {
+				// OpenAI-style definitions nest name/description/parameters below a
+				// `function` object instead of exposing the neutral ToolDefinition.
+				next = projectModelToolDefinition(entry, redactText, seen, depth + 1);
+			} else if (isSensitiveKeyName(key)) {
+				next = TOOL_DIAGNOSTIC_MASK;
+			} else {
+				next = projectValue(entry, redactText, seen, depth + 1);
+			}
+			if (next !== entry) changed = true;
+			projected[key] = next;
+		}
+		return changed ? projected : value;
+	} finally {
+		seen.delete(value);
+	}
+}
+
 /**
  * Projects one value for diagnostic egress. The input is never mutated; the
  * result is safe to embed in planner context, events, stream payloads,
@@ -139,6 +353,51 @@ export function projectToolDiagnosticValue(
 	redactText: ToolDiagnosticTextRedactor,
 ): unknown {
 	return projectValue(value, redactText, new WeakSet<object>(), 0);
+}
+
+/**
+ * Projects a complete model-call record without corrupting its executable JSON
+ * Schemas. Model messages, responses, provider payloads, and tool-call values
+ * use the normal credential-key pass. Schema property/definition names remain
+ * exact identifiers, while descriptions, defaults, examples, and other schema
+ * values are still scrubbed. Both neutral and OpenAI-style tool definitions
+ * are supported.
+ */
+export function projectModelCallDiagnosticValue(
+	value: Record<string, unknown>,
+	redactText: ToolDiagnosticTextRedactor,
+): Record<string, unknown> {
+	const projected = projectToolDiagnosticValue(value, redactText) as Record<
+		string,
+		unknown
+	>;
+	let next = projected;
+	for (const schemaKey of ["responseSchema", "response_schema"] as const) {
+		if (!(schemaKey in value)) continue;
+		const projectedSchema = projectJsonSchemaNode(
+			value[schemaKey],
+			redactText,
+			new WeakSet<object>(),
+			0,
+		);
+		if (projectedSchema !== projected[schemaKey]) {
+			if (next === projected) next = { ...projected };
+			next[schemaKey] = projectedSchema;
+		}
+	}
+	if ("tools" in value) {
+		const projectedTools = projectModelToolDefinition(
+			value.tools,
+			redactText,
+			new WeakSet<object>(),
+			0,
+		);
+		if (projectedTools !== projected.tools) {
+			if (next === projected) next = { ...projected };
+			next.tools = projectedTools;
+		}
+	}
+	return next;
 }
 
 /**

--- a/packages/core/src/security/tool-diagnostics.ts
+++ b/packages/core/src/security/tool-diagnostics.ts
@@ -68,6 +68,13 @@ function projectValue(
 		// which fields a surface serializes — only what the strings contain.
 		return value;
 	}
+	if (value instanceof Date) {
+		// A Date carries no string payload to scrub. Pass it through untouched so
+		// downstream sanitizers keep their own Date semantics — in particular an
+		// invalid Date must keep failing normalization loudly instead of being
+		// flattened into a healthy-looking empty object.
+		return value;
+	}
 	if (depth >= MAX_TOOL_DIAGNOSTIC_DEPTH || seen.has(value)) {
 		return TOOL_DIAGNOSTIC_MASK;
 	}

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -7252,8 +7252,10 @@ export async function runV5MessageRuntimeStage1(args: {
 				reportError: args.runtime.reportError.bind(args.runtime),
 				// Final-persistence tool-diagnostic projection: the recorder always
 				// runs the shared tool-shape pattern pass; this adds the runtime's
-				// character-configured secret masking on top.
-				redactSecrets: (text) => args.runtime.redactSecrets(text),
+				// character-configured secret masking on top. Optional-bound because
+				// lightweight/test runtimes may not implement redactSecrets — the
+				// pattern pass must keep running for them.
+				redactSecrets: args.runtime.redactSecrets?.bind(args.runtime),
 			})
 		: undefined;
 	const trajectoryId = recorder

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6509,6 +6509,7 @@ async function executeV5PlannedToolCall(
 			action,
 			actionResult,
 			toolCall.params,
+			args.runtime,
 		),
 	});
 }

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -7250,6 +7250,10 @@ export async function runV5MessageRuntimeStage1(args: {
 					warn?: (context: unknown, message?: string) => void;
 				},
 				reportError: args.runtime.reportError.bind(args.runtime),
+				// Final-persistence tool-diagnostic projection: the recorder always
+				// runs the shared tool-shape pattern pass; this adds the runtime's
+				// character-configured secret masking on top.
+				redactSecrets: (text) => args.runtime.redactSecrets(text),
 			})
 		: undefined;
 	const trajectoryId = recorder

--- a/packages/core/src/trajectory-utils.ts
+++ b/packages/core/src/trajectory-utils.ts
@@ -31,6 +31,10 @@ import {
 } from "./features/trajectories/types";
 import { stringifyForDiagnostics } from "./runtime/json-output";
 import type { TrajectoryProviderAttribution } from "./runtime/trajectory-provider-attribution";
+import {
+	composeToolDiagnosticRedactor,
+	projectToolDiagnosticValue,
+} from "./security/tool-diagnostics";
 import { trackPostDeliveryTask } from "./services/post-delivery-task-tracker";
 import { sanitizeTrajectoryJsonObject } from "./services/trajectory-json";
 import type { TrajectorySkillInvocationRecord } from "./services/trajectory-types";
@@ -1576,9 +1580,23 @@ function completeActionTrajectoryStep<T extends ActionResult>(
 	let phase: "project" | "normalize" | "complete" = "project";
 	try {
 		const projectedResult = projectResult?.(result) ?? result;
+		// Diagnostic projection ahead of any logger implementation: whatever
+		// backend `completeStep` resolves to, the settlement it receives already
+		// composes runtime-known-secret redaction with the shared tool-shape
+		// patterns over parameters and result/failure metadata.
+		const redactDiagnosticText = composeToolDiagnosticRedactor(runtime);
+		const diagnosticParameters = projectToolDiagnosticValue(
+			parameters ?? {},
+			redactDiagnosticText,
+		);
+		const diagnosticResult = projectToolDiagnosticValue(
+			projectedResult,
+			redactDiagnosticText,
+		) as ActionResult;
 		phase = "normalize";
-		const normalizedParameters = sanitizeTrajectoryJsonObject(parameters ?? {});
-		const normalizedResult = sanitizeTrajectoryJsonObject(projectedResult);
+		const normalizedParameters =
+			sanitizeTrajectoryJsonObject(diagnosticParameters);
+		const normalizedResult = sanitizeTrajectoryJsonObject(diagnosticResult);
 		if (!normalizedParameters || !normalizedResult) {
 			throw new ElizaError("Action settlement is not JSON serializable", {
 				code: "TRAJECTORY_ACTION_SETTLEMENT_INVALID",
@@ -1593,8 +1611,8 @@ function completeActionTrajectoryStep<T extends ActionResult>(
 			parameters: normalizedParameters,
 			success: projectedResult.success,
 			result: normalizedResult,
-			...(typeof projectedResult.error === "string"
-				? { error: projectedResult.error }
+			...(typeof diagnosticResult.error === "string"
+				? { error: diagnosticResult.error }
 				: {}),
 		});
 	} catch (error) {


### PR DESCRIPTION
Closes #19175

# Outcome

Validated tool-call arguments still reach the selected handler byte-exact, but every diagnostic copy now passes through one composed, non-mutating projection before it reaches a model prompt, observer, context event, summary, or persistent trajectory.

The original contribution established the right primitive and covered several executor boundaries. Exact-head review found additional leaks in the next planner/evaluator model request, compaction, generic settlement reasoning, model-call persistence, summaries, rescue prompts, and repeat-correlation material. Those gaps are repaired on the contributor branch and the complete series is rebased onto current `develop`.

# Design

`packages/core/src/security/tool-diagnostics.ts` is the canonical boundary projector:

- `composeToolDiagnosticRedactor` applies runtime-known-secret redaction first, then the shared credential-shape pass for CLI credential flags, URI userinfo, authorization headers, PEM blocks, and provider-token formats.
- `projectToolDiagnosticValue` and `projectToolDiagnosticArgs` are non-mutating, cycle/depth bounded, fully mask credential-named values, preserve non-string primitives, and structurally share unchanged plain objects.
- `projectModelCallDiagnosticValue` applies the same policy to a complete model-call record without corrupting JSON Schema semantics. Schema property/definition identifiers such as `token`, `apiKey`, and `secret` remain exact so recorded requests stay replayable; descriptions, defaults, examples, tool metadata, provider options, messages, results, and actual arguments remain scrubbed.
- Operational correlation identity (`stepId`, call/run/room/message/trace ids, action identity, `llmCallId`) remains exact. Provider-attribution byte spans are dropped through the existing canonical fallback whenever projected prompt/message bytes change, so hashes and order survive without false offsets.
- Raw execution is deliberately unchanged: `trajectory.plannedQueue` retains the exact validated call and the handler receives the exact raw parameters. Redaction occurs only when a copy leaves that ephemeral execution path.

## Covered egress boundaries

| Surface | Boundary |
| --- | --- |
| Planner queue/context/event copies | projected at copy/emit in `planner-loop.ts` |
| Pending `onToolCallEnqueued` and streaming tool-call/tool-result observers | projected before callback/emit |
| Next planner and evaluator model history | projected structurally in `trajectoryStepsToMessages` |
| Compaction summaries and terminal messages | projected before rendering |
| Repeated-failure and sub-planner correlation | raw parameters replaced with stable SHA-256 digests |
| Action-owned summaries | projected inputs plus scrubbed summary output |
| Failure rescue/synthesis prompts | projected successful excerpts and scrubbed failed causes |
| Evaluator stream/context/stored output | projected before each egress |
| `ACTION_COMPLETED` and generic action settlement | complete payload projected, including `reasoning` and future text fields |
| Core SQL trajectory LLM/action funnels | final-write projection in `TrajectoriesService` |
| Agent SQL trajectory bridge | final-write projection in `trajectory-storage.ts` |
| JSON trajectory recorder | final-write projection for tool/model/evaluation stages |
| Provider attribution | spans invalidated whenever canonical persisted input changes |

# Exact-head proof

- Head: `09ab55809334fbde8889d308cb990e01a6e4463a`
- Base: `develop@5fde9ff885`
- `bun install --frozen-lockfile --ignore-scripts`: pass, no dependency changes.
- Eight focused Bun suites: **204 passed, 0 failed, 753 assertions**. These include the end-to-end canary harness, planner loop, compaction, honest-failure rescue, sub-planner correlation, both SQL persistence funnels, redaction primitives, and schema-fidelity coverage.
- Agent Vitest regression: **1 file, 4 tests passed**.
- `packages/core` typecheck: pass.
- `packages/agent` typecheck: pass.
- Biome on all 21 maintainer-touched files: pass.
- `git diff --check`: pass.
- Root `bun run verify`: **350/350 Turbo tasks passed**; guide parity, dependency contracts, typecheck, lint, build-model, script inventory, secret-leak, view inventory, and focused-test audits all passed.

The deterministic canary test proves all of the following in one real planner/recorder path:

1. the handler receives the original synthetic credential-shaped values;
2. the second model request excludes those values from assistant tool calls and tool-result messages;
3. forced compaction excludes them;
4. streaming callbacks, lifecycle events, planner context, summaries, settlements, and the on-disk trajectory exclude them; and
5. ids, numeric telemetry, booleans, token counts, and executable JSON Schema identifiers retain their semantics.

# Risk

This changes diagnostic representations only. Handler inputs and tool execution remain exact. Consumers may now see masks or hash digests where they previously received credential material; that is the intended security contract. The schema-aware model projector and explicit identity preservation avoid the two main over-redaction risks: corrupting replay schemas and breaking trajectory joins.

No UI, provider-selection, deployment, or production configuration path changes.

<!-- evidence-head:09ab55809334fbde8889d308cb990e01a6e4463a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - runtime diagnostic security change with no rendered UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - runtime diagnostic security change with no rendered UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive flow; the observable contract is serialized canary exclusion

<!-- evidence-row:backend-logs -->
- [x] Exact-head focused, typecheck, formatter, and repository-gate results summarized above

<!-- evidence-row:frontend-logs -->
- [ ] N/A - frontend code is unchanged; SSE tool rows consume the projected observer payload upstream

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - model decision behavior is unchanged; a deterministic synthetic-canary trajectory is the relevant security proof

<!-- evidence-row:domain-artifacts -->
- [x] Real JSON trajectory recorder and both SQL persistence funnels are asserted by exact-head canary tests

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual surface

## Contributor attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

## Maintainer repair attribution

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@d1466e483f5953a26afa053e4ca4a145f5fc8147:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@d1466e483f5953a26afa053e4ca4a145f5fc8147:packages/skills/skills/contribute-to-eliza"} -->
