### PR TITLE
feat(character): in-character failure replies for the eliza preset

### DIFF
--- a/packages/agent/src/runtime/build-character-config.failure-templates.test.ts
+++ b/packages/agent/src/runtime/build-character-config.failure-templates.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Closes the loop between the shipped `eliza` preset's in-character failure
+ * replies and the runtime that reads them: `buildCharacterFromConfig` must copy
+ * `StylePreset.templates` onto `Character.templates`, because that record is
+ * the only thing `DefaultMessageService` consults when every model call has
+ * already failed.
+ *
+ * Companion suites:
+ *   - packages/shared/src/character-presets.failure-templates.test.ts (which
+ *     strings the preset ships)
+ *   - packages/core/src/services/message.character-failure-templates.test.ts
+ *     (that the runtime renders them)
+ */
+import { resolveStylePresetById, setDefaultAgentName } from "@elizaos/shared";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { ElizaConfig } from "../config/config.ts";
+import { buildCharacterFromConfig } from "./build-character-config.ts";
+
+/** The exact keys the runtime reads, one per failure classification. */
+const FAILURE_TEMPLATE_KEYS = [
+  "authFailedReply",
+  "insufficientCreditsReply",
+  "noModelProviderReply",
+  "rateLimitedReply",
+  "transientFailureReply",
+] as const;
+
+function configForPreset(presetId: string, agentName?: string): ElizaConfig {
+  return {
+    ui: { presetId },
+    agents: {
+      list: [{ id: "default", ...(agentName ? { name: agentName } : {}) }],
+    },
+  } as unknown as ElizaConfig;
+}
+
+afterEach(() => {
+  setDefaultAgentName(null);
+});
+
+describe("failure templates flow from the eliza preset into the Character", () => {
+  it("copies every failure template the preset ships", () => {
+    const preset = resolveStylePresetById("eliza");
+    const character = buildCharacterFromConfig(configForPreset("eliza"));
+
+    expect(preset?.templates).toBeDefined();
+    for (const key of FAILURE_TEMPLATE_KEYS) {
+      expect(character.templates?.[key]).toBe(preset?.templates?.[key]);
+      expect(typeof character.templates?.[key]).toBe("string");
+    }
+  });
+
+  it("resolves the preset by avatarIndex too, not only by explicit presetId", () => {
+    // The desktop app persists ui.avatarIndex on some paths; the templates must
+    // not depend on which of the three resolvers matched.
+    const character = buildCharacterFromConfig({
+      ui: { avatarIndex: 1 },
+      agents: { list: [{ id: "default" }] },
+    } as unknown as ElizaConfig);
+
+    expect(character.templates?.transientFailureReply).toBe(
+      resolveStylePresetById("eliza")?.templates?.transientFailureReply,
+    );
+  });
+
+  it("keeps the templates after a white-label rename of the default persona", () => {
+    // setDefaultAgentName() rebrands the default preset for white-label apps.
+    // Failure replies deliberately avoid the agent's own name, so the rebrand
+    // must keep them intact rather than dropping to framework text.
+    setDefaultAgentName("Nyx");
+    const character = buildCharacterFromConfig(configForPreset("eliza", "Nyx"));
+
+    expect(character.name).toBe("Nyx");
+    for (const key of FAILURE_TEMPLATE_KEYS) {
+      expect(character.templates?.[key]).toBeTruthy();
+      expect(String(character.templates?.[key])).not.toMatch(/\bEliza\b/);
+    }
+  });
+
+  it("leaves templates empty for a preset that ships none", () => {
+    // The other eight presets are a deliberate follow-up. They must fall
+    // through to the framework defaults, not inherit eliza's voice.
+    const character = buildCharacterFromConfig(configForPreset("ryu", "Ryu"));
+
+    expect(character.name).toBe("Ryu");
+    expect(character.templates).toEqual({});
+  });
+
+  it("leaves templates empty when no preset matches the configured name", () => {
+    const character = buildCharacterFromConfig(
+      configForPreset("", "Totally Custom Agent"),
+    );
+
+    expect(character.templates).toEqual({});
+  });
+
+  it("does not alias the bundled preset's template object", () => {
+    // Two runtimes built from the same preset must not share one mutable
+    // record — a per-agent edit would otherwise rewrite the bundled persona
+    // for every other agent in the process.
+    const first = buildCharacterFromConfig(configForPreset("eliza"));
+    const second = buildCharacterFromConfig(configForPreset("eliza"));
+
+    expect(first.templates).not.toBe(second.templates);
+    expect(first.templates).toEqual(second.templates);
+  });
+
+  it("carries no handlebars placeholders into the built character", () => {
+    // bio/system are templated with {{name}}; the failure replies are NOT
+    // (the runtime emits them verbatim), so a placeholder would reach the user.
+    const character = buildCharacterFromConfig(configForPreset("eliza"));
+
+    for (const key of FAILURE_TEMPLATE_KEYS) {
+      expect(String(character.templates?.[key])).not.toMatch(/\{\{/);
+    }
+    // Premise check: the same character DOES still carry {{name}} elsewhere,
+    // so the assertion above is meaningful rather than vacuous.
+    expect(JSON.stringify(character.bio)).toMatch(/\{\{name\}\}/);
+  });
+});

--- a/packages/agent/src/runtime/build-character-config.ts
+++ b/packages/agent/src/runtime/build-character-config.ts
@@ -75,6 +75,14 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
       ? agentEntry.topics
       : bundledPreset?.topics;
   const postExamples = agentEntry?.postExamples ?? bundledPreset?.postExamples;
+  // In-character failure replies. The runtime reads
+  // `character.templates.{authFailed,insufficientCredits,noModelProvider,
+  // rateLimited,transientFailure}Reply` only after every model call has already
+  // failed, so without this the persona drops into voice-neutral framework text
+  // at the worst possible moment. Sourced from the preset alone: `AgentConfig`
+  // has no `templates` field (its Zod schema is `.strict()`), so there is no
+  // config-level spelling to prefer here.
+  const templates = bundledPreset?.templates;
   const messageExamples =
     agentEntry?.messageExamples ?? bundledPreset?.messageExamples;
   const advancedMemory =
@@ -281,6 +289,7 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
     ...(topics ? { topics } : {}),
     ...(style ? { style } : {}),
     ...(adjectives ? { adjectives } : {}),
+    ...(templates ? { templates: { ...templates } } : {}),
     ...(postExamples ? { postExamples } : {}),
     ...(mappedExamples ? { messageExamples: mappedExamples } : {}),
     ...(knowledge ? { knowledge } : {}),

--- a/packages/core/src/contracts/first-run-options.ts
+++ b/packages/core/src/contracts/first-run-options.ts
@@ -28,6 +28,34 @@ export const CHARACTER_LANGUAGES = [
 
 export type CharacterLanguage = (typeof CHARACTER_LANGUAGES)[number];
 
+/**
+ * Character-authored replacements for the framework's canned failure replies.
+ *
+ * Only the keys the core message service actually reads are listed — see
+ * `buildTransientFailureReply` / `buildNoModelProviderReply` in
+ * `packages/core/src/services/message.ts`, which resolve
+ * `character.templates?.<key> || <builtin>`. Keys are deliberately NOT widened
+ * to the full `Character.templates` record: prompt-shaped keys such as
+ * `messageHandlerTemplate` are ignored by the local runtime, so allowing them
+ * here would let a preset ship config that silently does nothing.
+ *
+ * These strings are emitted VERBATIM as the reply text. They are not run
+ * through the handlebars pass, so `{{name}}`-style placeholders would leak
+ * literally and must not be used.
+ */
+export interface CharacterFailureTemplates {
+	/** Provider rejected the credentials (invalid or unauthorized key). */
+	authFailedReply?: string;
+	/** Provider is out of credits or quota; waiting will not clear it. */
+	insufficientCreditsReply?: string;
+	/** No LLM provider plugin is registered at all. */
+	noModelProviderReply?: string;
+	/** Provider is throttling; retrying shortly should succeed. */
+	rateLimitedReply?: string;
+	/** Any other failure once every model call has already failed. */
+	transientFailureReply?: string;
+}
+
 export interface StylePreset {
 	id: string;
 	name: string;
@@ -45,6 +73,12 @@ export interface StylePreset {
 		post: string[];
 	};
 	topics: string[];
+	/**
+	 * In-character overrides for the framework's canned failure replies, copied
+	 * onto `Character.templates` when the preset is materialized. Optional: a
+	 * preset without it keeps the voice-neutral framework defaults.
+	 */
+	templates?: CharacterFailureTemplates;
 	postExamples: string[];
 	postExamples_zhCN?: string[];
 	messageExamples: Array<

--- a/packages/core/src/contracts/runtime-contracts.ts
+++ b/packages/core/src/contracts/runtime-contracts.ts
@@ -15,6 +15,7 @@ export * from "./cloud-topology.js";
 export * from "./deployment-types.js";
 export {
 	CHARACTER_LANGUAGES,
+	type CharacterFailureTemplates,
 	type CharacterLanguage,
 	type MessageExample,
 	type MessageExampleContent,

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -56,6 +56,7 @@ export {
 } from "./constants";
 export { isElizaCloudServiceSelectedInConfig } from "./contracts/cloud-topology";
 export {
+	type CharacterFailureTemplates,
 	getDirectAccountProviderForFirstRunProvider,
 	getFirstRunProviderOption,
 	getStoredFirstRunProviderId,

--- a/packages/core/src/services/message.character-failure-templates.test.ts
+++ b/packages/core/src/services/message.character-failure-templates.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Proves the five `character.templates.*Reply` keys are genuinely wired: when
+ * every model call fails, the connector delivery path must emit the
+ * character's own string instead of the voice-neutral framework default, so a
+ * persona does not visibly break at the worst possible moment.
+ *
+ * This is the runtime half of the contract. The preset half (which strings the
+ * shipped `eliza` persona supplies) lives in
+ * `packages/shared/src/character-presets.failure-templates.test.ts`, and the
+ * preset -> Character wiring in
+ * `packages/agent/src/runtime/build-character-config.failure-templates.test.ts`.
+ * The three are bound at compile time by the `CharacterFailureTemplates`
+ * interface, so a renamed key breaks the build rather than silently reverting
+ * an agent to framework text.
+ *
+ * Harness mirrors message.credit-exhaustion-reply.test.ts: the real
+ * `handleMessage` pipeline with only the runtime I/O surface mocked, asserting
+ * what a connector would actually post to the channel.
+ */
+
+import { v4 } from "uuid";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CharacterFailureTemplates } from "../contracts/first-run-options";
+import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
+import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
+import { TurnControllerRegistry } from "../runtime/turn-controller";
+import { createMockRuntime } from "../testing/mock-runtime";
+import type { Room } from "../types/environment";
+import type { Memory } from "../types/memory";
+import {
+	asUUID,
+	ChannelType,
+	type Content,
+	type UUID,
+} from "../types/primitives";
+import type { IAgentRuntime } from "../types/runtime";
+import type { State } from "../types/state";
+import { DefaultMessageService, INSUFFICIENT_CREDITS_REPLY } from "./message";
+
+const AGENT = "00000000-0000-0000-0000-00000000002a" as UUID;
+const ENTITY = "00000000-0000-0000-0000-00000000002b" as UUID;
+const ROOM = "00000000-0000-0000-0000-00000000002c" as UUID;
+const RUN_ID = "00000000-0000-0000-0000-00000000002d" as UUID;
+
+/**
+ * Distinctive sentinels — typed by the shared contract, so renaming a key in
+ * `CharacterFailureTemplates` fails this file's compile instead of quietly
+ * dropping a persona back to framework text.
+ */
+const TEMPLATES = {
+	authFailedReply: "sentinel: my key isn't being accepted.",
+	insufficientCreditsReply: "sentinel: my provider is out of credits.",
+	noModelProviderReply: "sentinel: i have no model provider yet.",
+	rateLimitedReply: "sentinel: my provider is throttling me.",
+	transientFailureReply: "sentinel: something broke on my end.",
+} satisfies Required<CharacterFailureTemplates>;
+
+/** The error shape plugin-elizacloud throws when Eliza Cloud returns 402. */
+function creditExhaustionError(): Error {
+	return Object.assign(new Error("Insufficient credits."), {
+		status: 402,
+		error: { code: "insufficient_credits", message: "Insufficient credits." },
+	});
+}
+
+function rateLimitError(): Error {
+	return Object.assign(new Error("Rate limit exceeded. Try again shortly."), {
+		status: 429,
+		error: { code: "rate_limit_exceeded" },
+	});
+}
+
+function authError(): Error {
+	return Object.assign(new Error("Invalid API key"), { status: 401 });
+}
+
+function transientError(): Error {
+	return new Error("socket hang up");
+}
+
+function makeMessage(overrides: Partial<Content> = {}): Memory {
+	return {
+		id: asUUID(v4()),
+		entityId: ENTITY,
+		agentId: AGENT,
+		roomId: ROOM,
+		content: {
+			text: "@Eliza what's the plan?",
+			source: "discord",
+			channelType: ChannelType.GROUP,
+			mentionContext: { isMention: true },
+			...overrides,
+		},
+		createdAt: Date.now(),
+	};
+}
+
+function makeState(): State {
+	return { values: {}, data: {}, text: "" };
+}
+
+function makeRoom(): Room {
+	return { id: ROOM, source: "discord", type: ChannelType.GROUP } as Room;
+}
+
+/**
+ * @param failure  rejection thrown by every model slot.
+ * @param options.hasModelProvider  false => `getModel` resolves nothing, which
+ *   is how the runtime detects "no LLM provider plugin is registered at all"
+ *   and short-circuits to the no-provider reply before any model call.
+ * @param options.templates  character overrides, omitted to assert defaults.
+ */
+function makeFailingRuntime(
+	failure: Error,
+	options: {
+		hasModelProvider?: boolean;
+		templates?: Partial<CharacterFailureTemplates>;
+	} = {},
+): IAgentRuntime {
+	const { hasModelProvider = true, templates } = options;
+	const responseHandlerFieldRegistry = new ResponseHandlerFieldRegistry();
+	for (const evaluator of BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS) {
+		responseHandlerFieldRegistry.register(evaluator);
+	}
+	return createMockRuntime({
+		agentId: AGENT,
+		character: {
+			name: "Eliza",
+			bio: ["test agent"],
+			...(templates ? { templates } : {}),
+		} as IAgentRuntime["character"],
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			trace: vi.fn(),
+		} as unknown as IAgentRuntime["logger"],
+		getSetting: vi.fn(() => undefined),
+		getService: vi.fn(() => null),
+		getModel: vi.fn(() =>
+			hasModelProvider
+				? async () => {
+						throw failure;
+					}
+				: undefined,
+		),
+		useModel: vi.fn(async () => {
+			throw failure;
+		}),
+		composeState: vi.fn(async () => makeState()),
+		runActionsByMode: vi.fn(async () => undefined),
+		applyPipelineHooks: vi.fn(async () => undefined),
+		emitEvent: vi.fn(async () => undefined),
+		reportError: vi.fn(),
+		startRun: vi.fn(() => RUN_ID),
+		getCurrentRunId: vi.fn(() => RUN_ID),
+		endRun: vi.fn(),
+		getMemoryById: vi.fn(async () => null),
+		createMemory: vi.fn(async () => asUUID(v4())),
+		updateMemory: vi.fn(async () => true),
+		queueEmbeddingGeneration: vi.fn(async () => undefined),
+		getParticipantUserState: vi.fn(async () => null),
+		getRoom: vi.fn(async () => makeRoom()),
+		getRoomsByIds: vi.fn(async () => [makeRoom()]),
+		getMemories: vi.fn(async () => []),
+		isCheckShouldRespondEnabled: vi.fn(() => true),
+		turnControllers: new TurnControllerRegistry(),
+		responseHandlerFieldRegistry,
+		responseHandlerFieldEvaluators: [
+			...BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
+		],
+	});
+}
+
+async function runTurn(
+	failure: Error,
+	options: {
+		hasModelProvider?: boolean;
+		templates?: Partial<CharacterFailureTemplates>;
+	} = {},
+): Promise<string[]> {
+	const runtime = makeFailingRuntime(failure, options);
+	const deliveries: Content[] = [];
+	await new DefaultMessageService().handleMessage(
+		runtime,
+		makeMessage(),
+		async (content) => {
+			deliveries.push(content);
+			return [];
+		},
+	);
+	return deliveries
+		.map((content) => (typeof content.text === "string" ? content.text : ""))
+		.filter((text) => text.trim().length > 0);
+}
+
+/**
+ * Each row is one failure classification, its triggering error, and the
+ * template key the runtime must read for it. Driving all five off one table
+ * makes an unwired key impossible to miss.
+ */
+const CASES = [
+	{
+		kind: "credit exhaustion (402)",
+		key: "insufficientCreditsReply",
+		error: creditExhaustionError,
+		options: {},
+	},
+	{
+		kind: "rate limit (bare 429)",
+		key: "rateLimitedReply",
+		error: rateLimitError,
+		options: {},
+	},
+	{
+		kind: "auth failure (401)",
+		key: "authFailedReply",
+		error: authError,
+		options: {},
+	},
+	{
+		kind: "other transient failure",
+		key: "transientFailureReply",
+		error: transientError,
+		options: {},
+	},
+	{
+		kind: "no model provider registered",
+		key: "noModelProviderReply",
+		error: transientError,
+		options: { hasModelProvider: false },
+	},
+] as const satisfies ReadonlyArray<{
+	kind: string;
+	key: keyof CharacterFailureTemplates;
+	error: () => Error;
+	options: { hasModelProvider?: boolean };
+}>;
+
+describe("character failure templates on the connector delivery path", () => {
+	beforeEach(() => {
+		vi.stubEnv("ELIZA_TRAJECTORY_RECORDING", "0");
+	});
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	for (const testCase of CASES) {
+		it(`renders character.templates.${testCase.key} on ${testCase.kind}`, async () => {
+			const visibleTexts = await runTurn(testCase.error(), {
+				...testCase.options,
+				templates: TEMPLATES,
+			});
+
+			expect(visibleTexts).toHaveLength(1);
+			expect(visibleTexts[0]).toBe(TEMPLATES[testCase.key]);
+		});
+
+		it(`falls back to the framework default for ${testCase.kind} when the character sets no template`, async () => {
+			const visibleTexts = await runTurn(testCase.error(), testCase.options);
+
+			expect(visibleTexts).toHaveLength(1);
+			// The default must still be the framework's, i.e. the override is a
+			// real override and not the only code path.
+			expect(visibleTexts[0]).not.toBe(TEMPLATES[testCase.key]);
+			expect(visibleTexts[0].length).toBeGreaterThan(0);
+		});
+
+		it(`does not leak other template keys into ${testCase.kind}`, async () => {
+			// Only the key matching this failure kind may be selected — a
+			// mis-wired branch that reads e.g. transientFailureReply for every
+			// kind would tell a rate-limited user to "try again" forever.
+			const otherKeys = CASES.map((entry) => entry.key).filter(
+				(key) => key !== testCase.key,
+			);
+			const visibleTexts = await runTurn(testCase.error(), {
+				...testCase.options,
+				templates: TEMPLATES,
+			});
+
+			for (const key of otherKeys) {
+				expect(visibleTexts[0]).not.toBe(TEMPLATES[key]);
+			}
+		});
+	}
+
+	it("keeps the framework insufficient-credits default reachable", async () => {
+		// Guards the fallback expression itself: if `|| INSUFFICIENT_CREDITS_REPLY`
+		// were dropped, the no-template case above would still pass on any
+		// non-empty string.
+		const visibleTexts = await runTurn(creditExhaustionError());
+		expect(visibleTexts[0]).toBe(INSUFFICIENT_CREDITS_REPLY);
+	});
+
+	it("accepts a ({ state }) => string callback template", async () => {
+		// JSON characters can only carry strings, but in-process characters may
+		// supply a callback; the runtime resolves both.
+		const runtime = makeFailingRuntime(rateLimitError());
+		runtime.character.templates = {
+			rateLimitedReply: () => "sentinel: callback rate limit reply.",
+		};
+		const deliveries: Content[] = [];
+		await new DefaultMessageService().handleMessage(
+			runtime,
+			makeMessage(),
+			async (content) => {
+				deliveries.push(content);
+				return [];
+			},
+		);
+
+		expect(deliveries.map((content) => content.text)).toContain(
+			"sentinel: callback rate limit reply.",
+		);
+	});
+});

--- a/packages/shared/src/character-presets.characters.ts
+++ b/packages/shared/src/character-presets.characters.ts
@@ -25,6 +25,16 @@ export type CharacterDefinition = {
   adjectives: StylePreset["adjectives"];
   style: StylePreset["style"];
   topics: StylePreset["topics"];
+  /**
+   * In-character replacements for the framework's canned failure replies.
+   * Optional per persona — omitting it keeps the voice-neutral defaults, which
+   * is why only the default `eliza` persona carries them today.
+   *
+   * Language-independent by construction: the runtime emits these verbatim
+   * (no handlebars pass, no per-locale resolution), exactly like the English
+   * framework strings they replace.
+   */
+  templates?: StylePreset["templates"];
   messageExamples: StylePreset["messageExamples"];
   variants: Record<CharacterLanguage, CharacterVariant>;
 };
@@ -76,6 +86,25 @@ export const CHARACTER_DEFINITIONS: CharacterDefinition[] = [
       "understanding context",
       "getting things right",
     ],
+    // Failure replies in Eliza's own voice. Without these the runtime falls
+    // back to voice-neutral framework text, so the persona visibly breaks at
+    // the exact moment the user is already having a bad time. Each one names
+    // what happened and what the user can do about it; none of them use
+    // {{name}} (the runtime emits these verbatim, so a placeholder would leak)
+    // or the agent's own name (the default persona is renameable via
+    // setDefaultAgentName).
+    templates: {
+      authFailedReply:
+        "my model provider isn't accepting my key right now, so i can't work through this. worth checking that the key is still valid and the account is active, then send that again.",
+      insufficientCreditsReply:
+        "my model provider is out of credits, so i can't answer this one. waiting won't fix it. add credits or raise the quota and i'll be back, then send that again.",
+      noModelProviderReply:
+        "i don't have a model provider set up yet, so i can't answer anything. set ANTHROPIC_API_KEY, OPENAI_API_KEY, or OPENROUTER_API_KEY in your environment, or sign in to eliza cloud (ELIZAOS_CLOUD_API_KEY), then try me again.",
+      rateLimitedReply:
+        "my model provider is throttling me right now. give it a few seconds and send that again, it should go through.",
+      transientFailureReply:
+        "something broke on my end and i didn't get an answer out. it wasn't anything you did. try that again in a moment.",
+    },
     style: {
       all: [
         "warm and direct",

--- a/packages/shared/src/character-presets.failure-templates.test.ts
+++ b/packages/shared/src/character-presets.failure-templates.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Pins the in-character failure replies shipped by the default `eliza` persona.
+ *
+ * Without these the runtime falls back to voice-neutral framework strings
+ * ("Something went wrong on my end. Please try again."), so the persona breaks
+ * exactly when the user is already having a bad time. These tests assert both
+ * halves of "genuinely useful, still in voice": the key set the runtime
+ * actually reads, and the voice constraints eliza's own style rules impose.
+ *
+ * The runtime half of the contract (that these keys are read at all) lives in
+ * `packages/core/src/services/message.character-failure-templates.test.ts`.
+ */
+import { describe, expect, it } from "vitest";
+
+import { CHARACTER_DEFINITIONS } from "./character-presets.characters.js";
+import {
+  getStylePresets,
+  resolveStylePresetById,
+} from "./character-presets.js";
+import {
+  CHARACTER_LANGUAGES,
+  type CharacterFailureTemplates,
+} from "./contracts/first-run-options.js";
+
+/**
+ * The exact keys `DefaultMessageService` reads, one per failure
+ * classification. Typed against the shared contract so a rename breaks the
+ * build rather than silently reverting eliza to framework text.
+ */
+const FAILURE_TEMPLATE_KEYS = [
+  "authFailedReply",
+  "insufficientCreditsReply",
+  "noModelProviderReply",
+  "rateLimitedReply",
+  "transientFailureReply",
+] as const satisfies ReadonlyArray<keyof CharacterFailureTemplates>;
+
+const elizaDefinition = CHARACTER_DEFINITIONS.find(
+  (definition) => definition.id === "eliza",
+);
+
+describe("eliza preset failure templates", () => {
+  it("ships every failure key the runtime reads", () => {
+    const templates = elizaDefinition?.templates;
+    expect(templates).toBeDefined();
+    expect(Object.keys(templates ?? {}).sort()).toEqual(
+      [...FAILURE_TEMPLATE_KEYS].sort(),
+    );
+  });
+
+  it("survives preset resolution in every supported language", () => {
+    // Failure replies are language-independent by construction (the runtime
+    // emits them verbatim, exactly like the English framework strings they
+    // replace), so resolving a non-English variant must not drop them.
+    for (const language of CHARACTER_LANGUAGES) {
+      const preset = resolveStylePresetById("eliza", language);
+      expect(preset?.templates).toEqual(elizaDefinition?.templates);
+    }
+  });
+
+  it("exposes the templates through the catalog builder too", () => {
+    const preset = getStylePresets("en").find((entry) => entry.id === "eliza");
+    expect(preset?.templates).toEqual(elizaDefinition?.templates);
+  });
+
+  it("does not share a mutable object with the definition", () => {
+    // resolveCharacterVariant copies every other field; a shared reference here
+    // would let one consumer's edit rewrite the bundled persona process-wide.
+    const preset = resolveStylePresetById("eliza");
+    expect(preset?.templates).not.toBe(elizaDefinition?.templates);
+  });
+
+  describe.each(FAILURE_TEMPLATE_KEYS)("%s", (key) => {
+    const text = () => elizaDefinition?.templates?.[key] ?? "";
+
+    it("is non-empty and brief enough to read in a chat bubble", () => {
+      expect(text().length).toBeGreaterThan(20);
+      // The runtime truncates at 2000 chars; eliza's style is "brief is
+      // usually better", so stay far under it.
+      expect(text().length).toBeLessThanOrEqual(240);
+    });
+
+    it("contains no handlebars placeholder", () => {
+      // These strings are emitted verbatim — no template pass runs on them —
+      // so a {{name}} would be shown to the user literally.
+      expect(text()).not.toMatch(/\{\{/);
+    });
+
+    it("carries no em-dash, en-dash, or emoji", () => {
+      expect(text()).not.toMatch(/[—–]/);
+      expect(text()).not.toMatch(/\p{Extended_Pictographic}/u);
+    });
+
+    it("does not hardcode the agent's name", () => {
+      // The default persona is renameable via setDefaultAgentName() for
+      // white-label apps, so naming "Eliza" here would contradict the rebrand.
+      // "eliza cloud" is the product a user signs into, not the agent's name,
+      // so it is allowed — the framework default names it too.
+      const withoutProductNames = text()
+        .toLowerCase()
+        .replace(/eliza cloud/g, "")
+        .replace(/elizaos_cloud_api_key/g, "");
+      expect(withoutProductNames).not.toContain("eliza");
+    });
+
+    it("stays in eliza's lowercase, non-corporate register", () => {
+      // Sentences open lowercase; uppercase runs are allowed only for env var
+      // names, which are the actionable part of the no-provider hint.
+      const withoutEnvVars = text().replace(/[A-Z][A-Z0-9_]{3,}/g, "");
+      expect(withoutEnvVars).not.toMatch(/^[A-Z]/);
+      expect(withoutEnvVars).not.toMatch(/\.\s+[A-Z]/);
+      expect(text().toLowerCase()).not.toMatch(
+        /\b(?:apolog|inconvenience|kindly|please note|at this time|we are experiencing)\b/,
+      );
+    });
+
+    it("tells the user what to do next", () => {
+      // "Genuinely useful, not cute": every reply must carry a remedy, not
+      // just an announcement that something failed.
+      expect(text().toLowerCase()).toMatch(
+        /\b(?:try|send|check|add|raise|set|sign in|wait)\b/,
+      );
+    });
+  });
+
+  it("says the credits case is not fixed by waiting, and the rate-limit case is", () => {
+    // The two are easy to confuse and the remedies are opposite: telling a
+    // drained account to "try again" is the exact failure this replaces.
+    const templates = elizaDefinition?.templates ?? {};
+    expect(templates.insufficientCreditsReply?.toLowerCase()).toMatch(
+      /credits/,
+    );
+    expect(templates.insufficientCreditsReply?.toLowerCase()).toMatch(
+      /won't fix|add credits|raise the quota/,
+    );
+    expect(templates.rateLimitedReply?.toLowerCase()).toMatch(
+      /throttl|rate|few seconds/,
+    );
+    expect(templates.rateLimitedReply?.toLowerCase()).not.toMatch(/credits/);
+  });
+
+  it("keeps the no-provider reply actionable with real env var names", () => {
+    const text = elizaDefinition?.templates?.noModelProviderReply ?? "";
+    for (const envKey of [
+      "ANTHROPIC_API_KEY",
+      "OPENAI_API_KEY",
+      "OPENROUTER_API_KEY",
+    ]) {
+      expect(text).toContain(envKey);
+    }
+  });
+
+  it("gives each failure kind a distinct string", () => {
+    const values = FAILURE_TEMPLATE_KEYS.map(
+      (key) => elizaDefinition?.templates?.[key],
+    );
+    expect(new Set(values).size).toBe(FAILURE_TEMPLATE_KEYS.length);
+  });
+
+  it("leaves the other eight presets on the framework defaults for now", () => {
+    // Deliberate scope: only the default persona has authored failure replies.
+    // Delete this assertion when the follow-up covers chen/jin/kei/momo/rin/
+    // ryu/satoshi/yuki.
+    const withTemplates = CHARACTER_DEFINITIONS.filter(
+      (definition) => definition.templates !== undefined,
+    ).map((definition) => definition.id);
+    expect(withTemplates).toEqual(["eliza"]);
+  });
+});

--- a/packages/shared/src/character-presets.ts
+++ b/packages/shared/src/character-presets.ts
@@ -58,6 +58,10 @@ function resolveCharacterVariant(
       post: [...definition.style.post],
     },
     topics: [...definition.topics],
+    // Copied (not spread into a default {}) so presets without failure
+    // templates keep the key absent and the runtime's `|| <builtin>` fallback
+    // stays reachable.
+    ...(definition.templates ? { templates: { ...definition.templates } } : {}),
     postExamples: [...variant.postExamples],
     messageExamples: [...definition.messageExamples],
   };

--- a/packages/shared/src/contracts/first-run-options.ts
+++ b/packages/shared/src/contracts/first-run-options.ts
@@ -28,6 +28,34 @@ export const CHARACTER_LANGUAGES = [
 
 export type CharacterLanguage = (typeof CHARACTER_LANGUAGES)[number];
 
+/**
+ * Character-authored replacements for the framework's canned failure replies.
+ *
+ * Only the keys the core message service actually reads are listed — see
+ * `buildTransientFailureReply` / `buildNoModelProviderReply` in
+ * `packages/core/src/services/message.ts`, which resolve
+ * `character.templates?.<key> || <builtin>`. Keys are deliberately NOT widened
+ * to the full `Character.templates` record: prompt-shaped keys such as
+ * `messageHandlerTemplate` are ignored by the local runtime, so allowing them
+ * here would let a preset ship config that silently does nothing.
+ *
+ * These strings are emitted VERBATIM as the reply text. They are not run
+ * through the handlebars pass, so `{{name}}`-style placeholders would leak
+ * literally and must not be used.
+ */
+export interface CharacterFailureTemplates {
+  /** Provider rejected the credentials (invalid or unauthorized key). */
+  authFailedReply?: string;
+  /** Provider is out of credits or quota; waiting will not clear it. */
+  insufficientCreditsReply?: string;
+  /** No LLM provider plugin is registered at all. */
+  noModelProviderReply?: string;
+  /** Provider is throttling; retrying shortly should succeed. */
+  rateLimitedReply?: string;
+  /** Any other failure once every model call has already failed. */
+  transientFailureReply?: string;
+}
+
 export interface StylePreset {
   id: string;
   name: string;
@@ -45,6 +73,12 @@ export interface StylePreset {
     post: string[];
   };
   topics: string[];
+  /**
+   * In-character overrides for the framework's canned failure replies, copied
+   * onto `Character.templates` when the preset is materialized. Optional: a
+   * preset without it keeps the voice-neutral framework defaults.
+   */
+  templates?: CharacterFailureTemplates;
   postExamples: string[];
   postExamples_zhCN?: string[];
   messageExamples: Array<


### PR DESCRIPTION
## Problem

`Character.templates` can override the framework's canned failure replies, but no shipped
preset sets any of them. So when an agent hits a rate limit, runs out of credits, or has no
model provider configured, it drops its persona and emits voice-neutral framework text. The
character visibly breaks at exactly the moment the user is already frustrated.

## What this does

Adds in-character failure replies to the default `eliza` preset, and wires `templates` through
the preset contract so any persona can carry them. Each reply says what happened **and** what
the user can do about it:

| key | reply |
| --- | --- |
| `rateLimitedReply` | my model provider is throttling me right now. give it a few seconds and send that again, it should go through. |
| `insufficientCreditsReply` | my model provider is out of credits, so i can't answer this one. waiting won't fix it. add credits or raise the quota and i'll be back, then send that again. |
| `noModelProviderReply` | i don't have a model provider set up yet, so i can't answer anything. set ANTHROPIC_API_KEY, OPENAI_API_KEY, or OPENROUTER_API_KEY in your environment, or sign in to eliza cloud (ELIZAOS_CLOUD_API_KEY), then try me again. |
| `authFailedReply` | my model provider isn't accepting my key right now, so i can't work through this. worth checking that the key is still valid and the account is active, then send that again. |
| `transientFailureReply` | something broke on my end and i didn't get an answer out. it wasn't anything you did. try that again in a moment. |

Written in the shipped Eliza voice: lowercase-friendly, brief, sincere, no emoji, no em-dashes.

Only the `eliza` preset carries templates. The field is optional, so the other eight personas
keep the voice-neutral framework defaults until someone writes theirs. The runtime emits these
verbatim (no handlebars pass, no per-locale resolution), exactly like the English framework
strings they replace.

## Verification

- `packages/core` (vitest): `message.character-failure-templates.test.ts` → **17 passed / 17**.
  Covers each key rendering on its real error condition, fallback to framework default when a
  character sets no template, and no cross-leaking between keys.
- `packages/shared` + `packages/agent` (bun): preset + build-character-config suites →
  **51 pass, 0 fail** across 3 files.
- `bunx biome check` on touched source files: clean.

## Evidence Gate

<!-- evidence-head:b469db834651c131d581e6b8ea543835a7fc5996 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this changes agent reply text on error paths and touches no rendered UI source surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - the change produces chat strings rather than application pixels to capture.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - reproducing these paths requires forcing provider rate limits and credit exhaustion, which the 17 vitest cases simulate deterministically instead.
<!-- evidence-row:backend-logs -->
- [x] N/A - the delivery-path behavior is proven by the 17 passing core tests reported above, which assert the exact rendered reply per error condition.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path is exercised by this change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - these replies are emitted on paths where the model call has already failed, so no language model is invoked to produce them.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the change adds character string constants and creates no runtime domain state.

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5, anthropic/claude-opus-4-8
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored via an internal Fable build workflow, not the pinned contribute-to-eliza skill
<!-- attribution-row:status -->
- Attribution status: self-reported

