### PR TITLE
fix(plugin-calendar): drop planner key-name debris at the detail chokepoint

### DIFF
--- a/plugins/plugin-calendar/src/internal/detail.ts
+++ b/plugins/plugin-calendar/src/internal/detail.ts
@@ -21,14 +21,42 @@ export function messageText(message: Memory): string {
   return typeof text === "string" ? text : "";
 }
 
+/**
+ * Small models on the native tool path emit key-name debris as field VALUES.
+ * Two shapes show up live:
+ *   a comma-led key fragment  — `",time_min:"`, `",label:"`, `",new_title:"`
+ *   the field's own name      — `side: "side"`, `grantId: "grantId"`
+ * Both type-check, so they flow into connector routing and event lookup as if
+ * they were real input: a plain "cancel the quibbleworth review" arrived with
+ * grantId="grantId", missed the built-in calendar, and the user was told
+ * "Google Calendar isn't connected" about an event in their own local calendar.
+ *
+ * A value that is only a key fragment, or only its own field name, carries no
+ * information in ANY calendar field — so it is dropped here, at the single
+ * chokepoint every field reads through, rather than at each call site.
+ */
+const KEY_DEBRIS_PATTERN = /^,\s*[A-Za-z_][A-Za-z0-9_-]*\s*:?$/;
+
+function echoesOwnKey(key: string, value: string): boolean {
+  const normalize = (raw: string) => raw.replace(/[\s_-]+/g, "").toLowerCase();
+  return normalize(value) === normalize(key);
+}
+
 export function detailString(
   details: Record<string, unknown> | undefined,
   key: string,
 ): string | undefined {
   const value = details?.[key];
-  return typeof value === "string" && value.trim().length > 0
-    ? value.trim()
-    : undefined;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (
+    trimmed.length === 0 ||
+    KEY_DEBRIS_PATTERN.test(trimmed) ||
+    echoesOwnKey(key, trimmed)
+  ) {
+    return undefined;
+  }
+  return trimmed;
 }
 
 export type PlannerCalendarWindow = {

--- a/plugins/plugin-calendar/test/detail.test.ts
+++ b/plugins/plugin-calendar/test/detail.test.ts
@@ -115,3 +115,37 @@ describe("normalizePlannerCalendarWindow (#18946)", () => {
     });
   });
 });
+
+describe("detailString drops planner key-name debris", () => {
+  // Live 2026-08-14: "cancel the quibbleworth review" arrived with
+  // side="side", grantId="grantId", mode="mode". Those type-check, so the junk
+  // grant reached connector routing, missed the built-in calendar, and the user
+  // was told "Google Calendar isn't connected" about a local event.
+  it("drops a value that is only its own key name", () => {
+    expect(detailString({ side: "side" }, "side")).toBeUndefined();
+    expect(detailString({ grantId: "grantId" }, "grantId")).toBeUndefined();
+    expect(detailString({ mode: "mode" }, "mode")).toBeUndefined();
+  });
+
+  it("drops a key echo across naming styles", () => {
+    expect(detailString({ grantId: "grant_id" }, "grantId")).toBeUndefined();
+    expect(
+      detailString({ calendar_id: "calendarId" }, "calendar_id"),
+    ).toBeUndefined();
+  });
+
+  it("drops a comma-led key fragment", () => {
+    expect(detailString({ title: ",time_min:" }, "title")).toBeUndefined();
+    expect(detailString({ label: ", new_title" }, "label")).toBeUndefined();
+  });
+
+  it("keeps a real value that merely contains the key name", () => {
+    expect(detailString({ side: "google" }, "side")).toBe("google");
+    expect(detailString({ title: "title fight tickets" }, "title")).toBe(
+      "title fight tickets",
+    );
+    expect(detailString({ query: "querying the db" }, "query")).toBe(
+      "querying the db",
+    );
+  });
+});


### PR DESCRIPTION
## What

Drops planner key-name debris at `detailString`, the single chokepoint every calendar field reads through.

Small models on the native tool path emit key-name debris as field **values**, in two shapes:

| shape | example |
| --- | --- |
| comma-led key fragment | `",time_min:"`, `",label:"`, `",new_title:"` |
| the field's own name | `side: "side"`, `grantId: "grantId"`, `mode: "mode"` |

Both type-check, so they flow into connector routing and event lookup as if they were real input.

A plain **"cancel the quibbleworth review"** arrived with `grantId="grantId"`. The junk grant missed the built-in calendar, and the user was told:

> Google Calendar isn't connected, so I can't access or cancel anything.

— about an event sitting in their own local calendar.

A value that is only a key fragment, or only its own field name, carries no information in **any** calendar field, so both are dropped once at the chokepoint rather than teaching each call site to distrust its input. Real values that merely *contain* the key name survive: `title: "title fight tickets"` and `query: "querying the db"` both pass.

## Exact candidate

- Base: `90c2cd8de48eef5920746c78b9aa54e82ffdb48c`
- Head: `b7becdea79431430d408bda120236aa5058be35d`
- Paths: two under `plugins/plugin-calendar` (`src/internal/detail.ts`, `test/detail.test.ts`)

Additive only — grafted onto develop's current `detail.ts`, so #18946's `sanitizeCalendarId` and `normalizePlannerCalendarWindow` are untouched (verified present after the change).

## Evidence

<!-- evidence-head:b7becdea79431430d408bda120236aa5058be35d -->

<!-- evidence-row:before-screenshots -->
N/A - no UI surface; this is action-parameter coercion

<!-- evidence-row:after-screenshots -->
N/A - no UI surface; this is action-parameter coercion

<!-- evidence-row:walkthrough-video -->
N/A - no user-facing flow; a pure input-validation guard

<!-- evidence-row:backend-logs -->
<details><summary>live bot.log — the junk grant reaching connector routing</summary>
<pre>
WARN calendar mutation resolved side="side" grantId="grantId" mode="mode"
ERROR [calendar:action] Google Calendar is not connected. (subaction=search_events)
WARN user-visible reply: "Google Calendar isn't connected, so I can't access or cancel anything."
the event named in the request existed in the built-in eliza calendar the whole time;
only the planner-supplied grantId was junk, and nothing dropped it before routing.
</pre>
</details>

<!-- evidence-row:frontend-logs -->
N/A - no frontend code path touched

<!-- evidence-row:llm-trajectory -->
<details><summary>live trajectory tj-e76d46308ca42b — planner args carrying key-name debris</summary>
<pre>
{
 "provider": "cerebras",
 "model": "zai-glm-4.7",
 "messages": [
  {"role": "user", "content": "cancel the quibbleworth review"}
 ],
 "response": "CALENDAR subaction=search_events",
 "toolArgs": {
  "subaction": "search_events",
  "side": "side",
  "grantId": "grantId",
  "mode": "mode",
  "calendarId": "primary"
 },
 "result": {"success": false, "error": "Google Calendar is not connected."}
}
</pre>
</details>

<!-- evidence-row:domain-artifacts -->
The domain artifact is the coerced parameter set handed to CalendarService.
Printed from the real exported chokepoint at head `b7becdea79` — debris drops
to `undefined`, real values survive byte-identical:

<details>
<summary>detailString coercion, real values at PR head</summary>
<pre>
grantId    in="grantId"              -> undefined
side       in="side"                 -> undefined
new_title  in=",new_title:"          -> undefined
timeMin    in=",time_min:"           -> undefined
title      in="title fight tickets"  -> "title fight tickets"
query      in="querying the db"      -> "querying the db"
</pre>
</details>

<details>
<summary>plugins/plugin-calendar/test/detail.test.ts — 15 passed</summary>
<pre>
RUN  v4.1.5 /home/milady/.cal-wt
 ✓ sanitizeCalendarId (#18946) > drops planner placeholder tokens case-insensitively
 ✓ sanitizeCalendarId (#18946) > passes real calendar ids through trimmed
 ✓ normalizePlannerCalendarWindow (#18946) > canonicalizes an ordered offset-bearing pair
 ✓ detailString drops planner key-name debris > drops a value that is only its own key name
 ✓ detailString drops planner key-name debris > drops a key echo across naming styles
 ✓ detailString drops planner key-name debris > drops a comma-led key fragment
 ✓ detailString drops planner key-name debris > keeps a real value that merely contains the key name
 Test Files  1 passed (1)
      Tests  15 passed (15)
</pre>
</details>

<!-- evidence-row:ocr-review -->
N/A - no rendered text or imagery

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes - agent-authored under human direction, root-caused from a live trajectory
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored from live trajectory evidence, not the pinned contribute-to-eliza skill
<!-- attribution-row:status -->
- Attribution status: self-reported