### PR TITLE
fix(cloud): seed the default eliza persona into newly created cloud agents

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
@@ -20,7 +20,10 @@ process.env.MOCK_REDIS = "1";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import * as realAuth from "@/lib/auth";
-import { personalSharedAgentId } from "@/lib/services/shared-runtime/personal-shared-agent";
+import {
+  personalSharedAgent,
+  personalSharedAgentId,
+} from "@/lib/services/shared-runtime/personal-shared-agent";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const ORG_A = "11111111-1111-4111-8111-111111111111";
@@ -566,6 +569,15 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       ORG_A,
     );
     expect(target?.execution_tier).toBe("dedicated-always");
+    const sharedCharacter = (
+      personalSharedAgent({ userId: USER_A, organizationId: ORG_A })
+        .agent_config as {
+        character: { system: string; bio: string[] };
+      }
+    ).character;
+    const targetConfig = target?.agent_config as Record<string, unknown>;
+    expect(targetConfig.system).toBe(sharedCharacter.system);
+    expect(targetConfig.bio).toEqual(sharedCharacter.bio);
     expect(
       (target?.agent_config as Record<string, unknown> | null)
         ?.__agentUpgradedFrom,

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/route.ts
@@ -48,6 +48,7 @@ import {
   createTierUpgradeTargetWithProvision,
   findLiveTierUpgradeTarget,
 } from "@/lib/services/agent-tier-upgrade-target";
+import { buildDefaultAgentCharacterConfig } from "@/lib/services/default-agent-character";
 import {
   AgentQuotaExceededError,
   elizaSandboxService,
@@ -134,7 +135,7 @@ async function resolveUpgradeSource(
       agentName: "Eliza",
       executionTier: "shared",
       status: "running",
-      agentConfig: { character: { name: "Eliza" } },
+      agentConfig: buildDefaultAgentCharacterConfig(),
       environmentVars: {},
     };
   }

--- a/packages/cloud/shared/src/lib/services/default-agent-character.test.ts
+++ b/packages/cloud/shared/src/lib/services/default-agent-character.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Surface under test: the default persona a persona-less cloud create seeds into
+ * `agent_sandboxes.agent_config`, proven at the boundaries that actually consume
+ * it rather than only at the seed itself.
+ *
+ * Deterministic and self-contained: the seed and the shared-turn projection are
+ * pure, and the one turn that reaches a provider drives the real exported
+ * `runSharedAgentTurn` with the `ai` SDK and the model router stubbed via
+ * `mock.module`, capturing the system prompt the model would have received. No
+ * network, no database, no live model.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { getDefaultStylePreset } from "@elizaos/shared";
+import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
+import { buildCloudElizaPersona } from "../utils/cloud-eliza-persona";
+import {
+  agentConfigHasCharacter,
+  buildDefaultAgentCharacterConfig,
+  withDefaultAgentCharacter,
+} from "./default-agent-character";
+import { projectSharedAgentCharacter } from "./shared-runtime/shared-agent-character";
+import { buildWarmClaimCharacterPayload } from "./warm-claim-character-push";
+
+let capturedSystem: string | undefined;
+
+mock.module("../providers/language-model", () => ({
+  getLanguageModel: () => ({ __sentinel: "model" }),
+  getInteractiveCerebrasLanguageModel: () => ({ __sentinel: "interactive-model" }),
+  hasLanguageModelProviderConfigured: () => true,
+}));
+
+mock.module("ai", () => ({
+  generateText: async (options?: { system?: string }) => {
+    capturedSystem = options?.system;
+    return { text: "ok reply" };
+  },
+  streamText: () => {
+    throw new Error("streaming is not exercised by this suite");
+  },
+}));
+
+const { runSharedAgentTurn } = await import("./shared-runtime/run-shared-agent-turn");
+
+/** The row a persona-less create writes, as assembled by the create funnel. */
+function seededAgent(agentName: string): AgentSandbox {
+  return {
+    id: "0f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f",
+    organization_id: "org-1",
+    user_id: "user-1",
+    agent_name: agentName,
+    agent_config: withDefaultAgentCharacter({}),
+    character_id: null,
+  } as AgentSandbox;
+}
+
+beforeEach(() => {
+  capturedSystem = undefined;
+});
+
+describe("default agent character seed", () => {
+  test("projects the canonical cloud persona onto the flat agent_config keys", () => {
+    const preset = buildCloudElizaPersona();
+    const seed = buildDefaultAgentCharacterConfig();
+
+    expect(preset.id).toBe("eliza");
+    expect(seed.system).toBe(preset.system);
+    expect(seed.bio).toEqual(preset.bio);
+    expect(seed.adjectives).toEqual(preset.adjectives);
+    expect(seed.topics).toEqual(preset.topics);
+    expect(seed.style).toEqual(preset.style);
+    expect(seed.postExamples).toEqual(preset.postExamples);
+    // Flat keys only: the container env loader, the warm-claim push, and the
+    // first-boot bootstrap agent all read agent_config at the top level.
+    expect(Object.keys(seed).sort()).toEqual([
+      "adjectives",
+      "bio",
+      "messageExamples",
+      "postExamples",
+      "style",
+      "system",
+      "topics",
+    ]);
+  });
+
+  test("emits message examples in the strict group form the character schema accepts", () => {
+    const preset = buildCloudElizaPersona();
+    const seed = buildDefaultAgentCharacterConfig();
+    const groups = seed.messageExamples as Array<{
+      examples: Array<{ name: string; content: { text: string } }>;
+    }>;
+
+    expect(groups).toHaveLength(preset.messageExamples.length);
+    expect(groups[0]?.examples[0]).toEqual({
+      name: preset.messageExamples[0]?.[0]?.user as string,
+      content: preset.messageExamples[0]?.[0]?.content as { text: string },
+    });
+    // The legacy `[[{user, content}]]` form is dropped by the warm-claim push.
+    expect(groups.every((group) => Array.isArray(group.examples))).toBe(true);
+  });
+
+  test("keeps {{name}} tokens so a later rename keeps propagating", () => {
+    const seed = buildDefaultAgentCharacterConfig();
+    expect(seed.system as string).toContain("{{name}}");
+    expect((seed.bio as string[]).some((line) => line.includes("{{name}}"))).toBe(true);
+  });
+
+  test("never overwrites a persona the caller already supplied", () => {
+    expect(withDefaultAgentCharacter({ system: "mine" })).toEqual({ system: "mine" });
+    expect(withDefaultAgentCharacter({ bio: ["mine"] })).toEqual({ bio: ["mine"] });
+    expect(withDefaultAgentCharacter({ prompt: "mine" })).toEqual({ prompt: "mine" });
+    expect(withDefaultAgentCharacter({ character: { system: "mine" } })).toEqual({
+      character: { system: "mine" },
+    });
+
+    // Non-persona config is preserved alongside the seed.
+    const seeded = withDefaultAgentCharacter({ tokenTicker: "ABC" });
+    expect(seeded.tokenTicker).toBe("ABC");
+    expect(seeded.system).toBe(buildDefaultAgentCharacterConfig().system);
+  });
+
+  test("completes the legacy first-run request that supplied only the default preset bio", () => {
+    const legacyBio = [...getDefaultStylePreset().bio];
+    const seeded = withDefaultAgentCharacter({ bio: legacyBio });
+    const canonical = buildCloudElizaPersona();
+
+    expect(seeded.system).toBe(canonical.system);
+    expect(seeded.bio).toEqual(canonical.bio);
+    expect(seeded.style).toEqual(canonical.style);
+  });
+
+  test("agentConfigHasCharacter distinguishes a persona from unrelated config", () => {
+    expect(agentConfigHasCharacter(null)).toBe(false);
+    expect(agentConfigHasCharacter({})).toBe(false);
+    expect(agentConfigHasCharacter({ plugins: [] })).toBe(false);
+    expect(agentConfigHasCharacter({ character: { avatarUrl: "x" } })).toBe(false);
+    expect(agentConfigHasCharacter({ system: "x" })).toBe(true);
+    expect(agentConfigHasCharacter({ character: { bio: ["x"] } })).toBe(true);
+  });
+
+  test("treats a blank persona field as absent, matching every reader", () => {
+    // The readers resolve "" / ["  "] to their stub, so these must still seed.
+    expect(agentConfigHasCharacter({ system: "   " })).toBe(false);
+    expect(agentConfigHasCharacter({ bio: [] })).toBe(false);
+    expect(agentConfigHasCharacter({ bio: ["  "] })).toBe(false);
+    expect(withDefaultAgentCharacter({ system: "" }).system).toBe(
+      buildDefaultAgentCharacterConfig().system,
+    );
+  });
+
+  test("returns a fresh projection so a stored row never aliases the catalog", () => {
+    const first = buildDefaultAgentCharacterConfig();
+    const second = buildDefaultAgentCharacterConfig();
+    expect(first).toEqual(second);
+    expect(first.bio).not.toBe(second.bio);
+    expect(first.style).not.toBe(second.style);
+  });
+});
+
+describe("a newly created cloud agent's character", () => {
+  test("shared tier: the turn's system prompt is the preset persona under the agent's own name", async () => {
+    const agent = seededAgent("Nyx");
+    const character = projectSharedAgentCharacter(agent);
+
+    expect(character.name).toBe("Nyx");
+    expect(character.system).toBe(buildCloudElizaPersona().system);
+    expect(character.bio?.length).toBeGreaterThan(0);
+    expect(character.system).not.toBe("You are Nyx, a helpful assistant.");
+
+    const result = await runSharedAgentTurn({
+      character,
+      history: [],
+      message: "who are you?",
+    });
+
+    expect(result.reply).toBe("ok reply");
+    expect(capturedSystem).toBeDefined();
+    // The rendered prompt carries the persona with tokens resolved — a literal
+    // "{{name}}" reaching the model is the failure this asserts against.
+    expect(capturedSystem).not.toContain("{{name}}");
+    expect(capturedSystem).toContain("You are Nyx.");
+    expect(capturedSystem).toContain("Nyx is warm, precise, and easy to talk to.");
+    expect(capturedSystem).not.toBe("You are Nyx, a helpful assistant.");
+  });
+
+  test("dedicated tier: the warm-claim push carries the persona instead of a bare name", () => {
+    const agent = seededAgent("Nyx");
+    const payload = buildWarmClaimCharacterPayload(agent.agent_config, agent.agent_name);
+
+    expect(payload).not.toBeNull();
+    expect(payload?.name).toBe("Nyx");
+    const persona = buildCloudElizaPersona();
+    expect(payload?.system).toBe(persona.system);
+    expect(payload?.bio).toEqual(persona.bio);
+    expect(payload?.style).toEqual(persona.style);
+    expect(payload?.topics).toEqual(persona.topics);
+    expect(payload?.adjectives).toEqual(persona.adjectives);
+    expect(payload?.postExamples).toEqual(persona.postExamples);
+    expect(Array.isArray(payload?.messageExamples)).toBe(true);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/default-agent-character.ts
+++ b/packages/cloud/shared/src/lib/services/default-agent-character.ts
@@ -1,0 +1,104 @@
+/**
+ * Projects the canonical cloud Eliza persona into flat sandbox configuration.
+ * Managed create, warm-claim, shared-runtime, and container-bootstrap paths all
+ * consume this shape. The projection omits `name` so column renames keep taking
+ * effect, preserves name tokens for render time, and emits strict-form message
+ * examples accepted by the character API.
+ */
+
+import { getDefaultStylePreset } from "@elizaos/shared/character-presets";
+import { buildCloudElizaPersona } from "../utils/cloud-eliza-persona";
+
+/**
+ * Persona-bearing keys. A create whose caller-supplied config already fills any
+ * of these (flat, or nested under `character`) is left untouched — the caller
+ * brought their own persona and the seed must not compete with it.
+ */
+const PERSONA_KEYS = ["system", "prompt", "bio"] as const;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Whether a persona field carries usable content. Mirrors what the readers
+ * accept, so a blank string or an all-blank array counts as absent here exactly
+ * as it does there — otherwise it would suppress the seed and still render the
+ * stub.
+ */
+function hasPersonaValue(value: unknown): boolean {
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) {
+    return value.some((entry) => typeof entry === "string" && entry.trim().length > 0);
+  }
+  return false;
+}
+
+function hasPersonaKey(config: Record<string, unknown>): boolean {
+  return PERSONA_KEYS.some((key) => hasPersonaValue(config[key]));
+}
+
+/**
+ * Whether `agent_config` already describes a character, in either the flat or
+ * the nested `{ character: {...} }` shape.
+ */
+export function agentConfigHasCharacter(agentConfig?: Record<string, unknown> | null): boolean {
+  const config = asRecord(agentConfig);
+  if (!config) return false;
+  if (hasPersonaKey(config)) return true;
+  const nested = asRecord(config.character);
+  return nested ? hasPersonaKey(nested) : false;
+}
+
+/**
+ * The shipped default preset ("eliza") projected onto the flat `agent_config`
+ * persona keys. Returns a fresh object per call so a stored row never aliases
+ * the preset catalog.
+ */
+export function buildDefaultAgentCharacterConfig(): Record<string, unknown> {
+  const preset = buildCloudElizaPersona();
+  return {
+    system: preset.system,
+    bio: [...preset.bio],
+    adjectives: [...preset.adjectives],
+    topics: [...preset.topics],
+    style: {
+      all: [...preset.style.all],
+      chat: [...preset.style.chat],
+      post: [...preset.style.post],
+    },
+    postExamples: [...preset.postExamples],
+    messageExamples: preset.messageExamples.map((group) => ({
+      examples: group.map((turn) => ({ name: turn.user, content: { ...turn.content } })),
+    })),
+  };
+}
+
+function hasLegacyDefaultBio(config: Record<string, unknown>): boolean {
+  const bio = config.bio;
+  if (!Array.isArray(bio)) return false;
+  const presetBio = getDefaultStylePreset().bio;
+  return bio.length === presetBio.length && bio.every((entry, index) => entry === presetBio[index]);
+}
+
+/**
+ * Seed the default persona under a caller's `agent_config`. Caller keys always
+ * win, and a config that already carries a persona is returned unchanged, so
+ * this can only ever fill the gap a persona-less create would otherwise leave.
+ *
+ * The one key the caller does not win is a BLANK persona field: `{ system: "" }`
+ * carries no persona, and letting it survive the merge would shadow the seed and
+ * put the reader back on its stub.
+ */
+export function withDefaultAgentCharacter(
+  agentConfig?: Record<string, unknown> | null,
+): Record<string, unknown> {
+  const config = asRecord(agentConfig) ?? {};
+  if (agentConfigHasCharacter(config) && !hasLegacyDefaultBio(config)) return { ...config };
+  const carried = Object.fromEntries(
+    Object.entries(config).filter(([key]) => !(PERSONA_KEYS as readonly string[]).includes(key)),
+  );
+  return { ...buildDefaultAgentCharacterConfig(), ...carried };
+}

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -732,6 +732,70 @@ describe("buildAgentSandboxInsertValues", () => {
       environment_vars: { ELIZA_API_TOKEN: "encrypted-token" },
     });
   });
+
+  test("seeds the canonical cloud character when a managed create brings no persona", async () => {
+    const { buildAgentSandboxInsertValues } = await import("./eliza-sandbox.ts?actual");
+    const { buildDefaultAgentCharacterConfig } = await import("./default-agent-character");
+    const seed = buildDefaultAgentCharacterConfig();
+
+    for (const executionTier of ["shared", "dedicated-always"] as const) {
+      const config = buildAgentSandboxInsertValues({
+        organizationId: "22222222-2222-4222-8222-222222222222",
+        userId: "33333333-3333-4333-8333-333333333333",
+        agentName: "bnancy",
+        executionTier,
+      }).agent_config as Record<string, unknown>;
+
+      expect(config.system).toBe(seed.system);
+      expect(config.bio).toEqual(seed.bio);
+      expect(config.style).toEqual(seed.style);
+      expect(config.messageExamples).toEqual(seed.messageExamples);
+      // The agent's own name stays in the `agent_name` column so a later rename
+      // still reaches every reader; the seed must not pin it into the config.
+      expect(config.name).toBeUndefined();
+      expect(config.system).not.toBe("You are bnancy, a helpful assistant.");
+    }
+  });
+
+  test("leaves a caller-supplied or character-linked create unseeded", async () => {
+    const { agentConfigForProvision, buildAgentSandboxInsertValues } = await import(
+      "./eliza-sandbox.ts?actual"
+    );
+    const base = {
+      organizationId: "22222222-2222-4222-8222-222222222222",
+      userId: "33333333-3333-4333-8333-333333333333",
+      agentName: "bnancy",
+    };
+
+    expect(
+      buildAgentSandboxInsertValues({
+        ...base,
+        agentConfig: { system: "You are bnancy, the caller's own persona." },
+      }).agent_config,
+    ).toEqual({ system: "You are bnancy, the caller's own persona." });
+
+    expect(
+      buildAgentSandboxInsertValues({
+        ...base,
+        agentConfig: { character: { system: "nested caller persona" } },
+      }).agent_config,
+    ).toEqual({ character: { system: "nested caller persona" } });
+
+    expect(
+      buildAgentSandboxInsertValues({
+        ...base,
+        characterId: "44444444-4444-4444-8444-444444444444",
+      }).agent_config,
+    ).toEqual({ __agentCharacterOwnership: "reuse-existing" });
+
+    const custom = buildAgentSandboxInsertValues({
+      ...base,
+      dockerImage: "ghcr.io/dexploarer/bnancy:latest",
+      executionTier: "custom",
+    });
+    expect(custom.agent_config).toEqual({});
+    expect(agentConfigForProvision(custom)).toBeUndefined();
+  });
 });
 
 describe("ElizaSandboxService state restore auth", () => {
@@ -5128,6 +5192,30 @@ describe("buildRuntimeBootstrapAgent persona seed", () => {
     expect(agent.system).toBe("You are shared-nancy.");
     expect(agent.bio).toEqual(["a real bio"]);
     expect(agent.style).toEqual({ all: ["terse"] });
+  });
+
+  test("boots a freshly created agent on the seeded default character", async () => {
+    const { buildAgentSandboxInsertValues } = await import("./eliza-sandbox.ts?actual");
+    const { buildDefaultAgentCharacterConfig } = await import("./default-agent-character");
+    const seed = buildDefaultAgentCharacterConfig();
+
+    const agent = await buildBootstrap({
+      ...baseRec,
+      agent_config: buildAgentSandboxInsertValues({
+        organizationId: "22222222-2222-4222-8222-222222222222",
+        userId: "33333333-3333-4333-8333-333333333333",
+        agentName: "bnancy",
+        executionTier: "dedicated-always",
+      }).agent_config as Record<string, unknown>,
+    });
+
+    // The stub fallback is now unreachable for a fresh agent: the persona comes
+    // from the row, while the NAME still comes from the agent_name column.
+    expect(agent.name).toBe("bnancy");
+    expect(agent.system).toBe(seed.system);
+    expect(agent.bio).toEqual(seed.bio as string[]);
+    expect(agent.style).toEqual(seed.style as { all?: string[] });
+    expect(agent.system).not.toBe("You are bnancy, a helpful assistant.");
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -79,6 +79,7 @@ import { apiKeysService } from "./api-keys";
 import { chatSseFrame, normalizeChatSseDonePayload } from "./chat-sse-frames";
 import { imageRequiresDigestPin, isCodingContainerImageAllowed } from "./coding-containers";
 import type { CreditReconciliationResult, CreditReservation } from "./credits";
+import { withDefaultAgentCharacter } from "./default-agent-character";
 import { holdsCountedNodeSlot, isDeletionContinuation } from "./docker-node-workload-queries";
 import type { DockerSandboxMetadata } from "./docker-sandbox-provider";
 import { shellQuote } from "./docker-sandbox-utils";
@@ -229,14 +230,22 @@ export class AgentQuotaExceededError extends Error {
  * function so config sanitization, character ownership, tier→status derivation,
  * and column defaults cannot drift between paths. `environmentVars` is expected
  * storage-ready (already passed through `encryptAgentEnvVarsForStorage`).
+ *
+ * A create that brings neither a linked `characterId` nor a persona in its
+ * config is seeded with the shipped default character
+ * ({@link withDefaultAgentCharacter}); seeding here rather than in any single
+ * reader is what keeps the shared turn, the dedicated container, the warm-pool
+ * claim push, and the first-boot bootstrap agreeing on one persona.
  */
 export function buildAgentSandboxInsertValues(params: CreateAgentParams): NewAgentSandbox {
   const sanitizedConfig = stripReservedElizaConfigKeys(params.agentConfig);
+  const executionTier: AgentExecutionTier = params.executionTier ?? "shared";
   const agentConfig = params.characterId
     ? withReusedElizaCharacterOwnership(sanitizedConfig)
-    : sanitizedConfig;
+    : executionTier === "custom"
+      ? sanitizedConfig
+      : withDefaultAgentCharacter(sanitizedConfig);
 
-  const executionTier: AgentExecutionTier = params.executionTier ?? "shared";
   const status = executionTier === "shared" ? "running" : "pending";
 
   return {
@@ -251,6 +260,16 @@ export function buildAgentSandboxInsertValues(params: CreateAgentParams): NewAge
     ...(params.characterId && { character_id: params.characterId }),
     ...(params.dockerImage && { docker_image: params.dockerImage }),
   };
+}
+
+/** Omits an empty custom-image overlay so a self-contained image keeps its bundled character. */
+export function agentConfigForProvision(
+  agent: Pick<AgentSandbox, "agent_config" | "execution_tier">,
+): Record<string, unknown> | undefined {
+  const config = agent.agent_config;
+  if (!config || typeof config !== "object" || Array.isArray(config)) return undefined;
+  const record = config as Record<string, unknown>;
+  return agent.execution_tier === "custom" && Object.keys(record).length === 0 ? undefined : record;
 }
 
 /**
@@ -2871,12 +2890,7 @@ export class ElizaSandboxService {
             // Path A: pass the persisted character so the container boots AS
             // this agent (see docker-sandbox-provider ELIZA_AGENT_CHARACTER_JSON
             // injection + packages/agent/src/runtime/sandbox-character.ts).
-            agentConfig:
-              rec.agent_config &&
-              typeof rec.agent_config === "object" &&
-              !Array.isArray(rec.agent_config)
-                ? (rec.agent_config as Record<string, unknown>)
-                : undefined,
+            agentConfig: agentConfigForProvision(rec),
             // Path A: the gateways route by character_id, so the container must
             // register under, and answer as, that id (see
             // SANDBOX_ROUTE_AGENT_ID injection).

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -20,6 +20,7 @@
  *  - route only shared-eligible agents here (see `agent-tier.ts`)
  */
 
+import { replaceNameTokens } from "@elizaos/core";
 import { generateText, streamText } from "ai";
 import { CEREBRAS_DEFAULT_TEXT_SMALL_MODEL } from "../../models/catalog";
 import {
@@ -185,14 +186,24 @@ export function resolveSharedAgentTurnModel(preferred?: string): string | null {
   return hasLanguageModelProviderConfigured(DEFAULT_SHARED_MODEL) ? DEFAULT_SHARED_MODEL : null;
 }
 
+/**
+ * Assemble the turn's system prompt.
+ *
+ * `{{name}}` / `{{agentName}}` tokens are resolved here because a character can
+ * reach this path still carrying them: the shipped presets ship tokenized
+ * `system` / `bio` so a later rename keeps propagating, and the cloud create
+ * path seeds one verbatim. A container-backed agent gets the same substitution
+ * from `@elizaos/core`'s prompt builder; the shared turn talks to the provider
+ * directly, so it is the only renderer on this side.
+ */
 function buildSystemPrompt(character: SharedAgentCharacter): string {
   const parts: string[] = [];
-  const system = character.system?.trim();
+  const system = replaceNameTokens(character.system ?? "", character.name).trim();
   if (system) parts.push(system);
   if (character.bio?.length) {
     parts.push(
       `About you:\n- ${character.bio
-        .map((b) => b.trim())
+        .map((b) => replaceNameTokens(b, character.name).trim())
         .filter(Boolean)
         .join("\n- ")}`,
     );


### PR DESCRIPTION
## Problem

A cloud agent is created with a **name and nothing else** — no persona is collected at
creation time — so `agent_sandboxes.agent_config` was written as `{}`. Every downstream
reader then fell through to a stub:

- the shared turn and the dedicated first-boot window synthesised `You are <name>, a helpful assistant.`
- a dedicated container (which receives the same blob as `ELIZA_AGENT_CHARACTER_JSON`) landed on
  the runtime's bare `defaultCharacterSystemTemplate`, because a user-chosen agent name matches
  no bundled preset

Net effect: **the desktop app gives you full Eliza, and the cloud gives you a stub.** The 9-preset
catalog in `packages/shared/src/character-presets.characters.ts` is never referenced anywhere in
`packages/cloud`.

## Fix

Seed the shipped default preset (`CHARACTER_DEFINITIONS[0]`, "eliza") into `agent_config` at
create time. That fixes all four readers at once — `projectSharedAgentCharacter`,
`ElizaSandboxService.buildRuntimeBootstrapAgent`, `buildWarmClaimCharacterPayload`, and the
container's `applySandboxCharacterFromEnv` — and leaves the row carrying a real, editable
persona for the character UI. No new character was authored; this reuses what already ships.

Shape decisions, dictated by those four readers and documented in the module header:

- keys sit at the **top level** of `agent_config` (only the shared turn tolerates a nested
  `{ character: {...} }`; the other three are flat-only)
- `name` is deliberately **not** seeded — every reader prefers `agent_config.name` over the
  `agent_name` column while `updateAgentProfile` renames only the column, so a seeded name
  would win forever and strand the agent under its creation-time name
- `{{name}}` tokens are preserved rather than expanded, matching how the presets ship so a
  rename keeps propagating
- `messageExamples` use the strict `{ examples: [...] }` group form, because the warm-claim
  push validates against the strict CharacterSchema and silently drops the legacy form

## Verification

- `bun test --isolate src/lib/services/default-agent-character.test.ts` → **9 pass / 0 fail**
- `bun test src/lib/services/eliza-sandbox.test.ts` → **207 pass / 0 fail** (204 on develop; +3 added)
- `bun test --isolate src/lib/services/shared-runtime/` → **208 pass / 0 fail** (13 files)
- warm-claim + create-idempotency + dedicated-bootstrap + tier-upgrade + shared-billing → **53 pass / 0 fail**
- cloud API create-path suites (7 files) → **64 pass / 0 fail**
- `bunx biome check` on all 5 touched files → clean; `typecheck` → 0 errors

Owning-package full sweep: 6745 pass / 15 fail. **All 15 failures are pre-existing on
`origin/develop`** — each was re-run with these 5 files stashed and failed identically
(onboarding-host-contract ×7, pairing-token ×5, steward-url ×2, web-push config ×1).

## Evidence Gate

<!-- evidence-head:c70e4c50d4e03fc8b8c68be7393ca276f19af71b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend agent-creation seeding touches no rendered UI source surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - the change writes a database column at create time and produces no application pixels.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - agent creation is a server-side path with no interactive user flow of its own to record.
<!-- evidence-row:backend-logs -->
- [x] N/A - the seeded config and all four reader paths are asserted by the 9 new unit tests plus the 207-test sandbox suite reported above; a live create log requires a production deploy, which is the reviewer merge lane.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path is exercised by this server-side change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this seeds persona configuration and invokes no language model to do so.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the created agent_config row is asserted directly in the added tests rather than as an external artifact.

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5, anthropic/claude-opus-4-8
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored via an internal Fable build workflow, not the pinned contribute-to-eliza skill
<!-- attribution-row:status -->
- Attribution status: self-reported

