### PR TITLE
fix(plugin-todos): reject invalid list limits before persistence

### DIFF
--- a/plugins/plugin-todos/src/actions/todo.test.ts
+++ b/plugins/plugin-todos/src/actions/todo.test.ts
@@ -8,9 +8,10 @@ import type {
   IAgentRuntime,
   Memory,
 } from "@elizaos/core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { currentTodosProvider } from "../providers/current-todos.js";
+import { TODO_LIST_LIMIT_ERROR_CODE, TodosService } from "../service.js";
 import { TODOS_SERVICE_TYPE } from "../types.js";
 import { todoAction } from "./todo.js";
 
@@ -40,6 +41,7 @@ class FakeTodosService {
   private nextId = 0;
   rows: StoredTodo[] = [];
   failOn: string | null = null;
+  listCallCount = 0;
 
   private throwIf(operation: string): void {
     if (this.failOn === operation) {
@@ -88,6 +90,7 @@ class FakeTodosService {
     includeCompleted?: boolean;
     limit?: number;
   }): Promise<StoredTodo[]> {
+    this.listCallCount++;
     this.throwIf("list");
     let results = this.rows.filter((r) => {
       if (r.entityId !== filter.entityId) return false;
@@ -101,7 +104,7 @@ class FakeTodosService {
       }
       return true;
     });
-    if (filter.limit && Number.isSafeInteger(filter.limit) && filter.limit > 0) {
+    if (filter.limit !== undefined) {
       results = results.slice(0, filter.limit);
     }
     return results;
@@ -633,7 +636,7 @@ describe("TODO action", () => {
     });
   });
 
-  describe("action=list with limit validation", () => {
+  describe("action=list limit validation", () => {
     beforeEach(async () => {
       // Create 5 todos for limit testing
       for (let i = 1; i <= 5; i++) {
@@ -655,72 +658,69 @@ describe("TODO action", () => {
       expect(data.todos.length).toBe(3);
     });
 
-    it("rejects limit=0 with invalid_param error", async () => {
-      const result = await invoke(runtime, {
-        action: "list",
-        limit: 0,
-      });
-      expect(result.success).toBe(false);
-      expect(result.text).toContain("invalid_param");
-      expect(result.text).toContain("positive integer");
-    });
-
-    it("rejects negative limit with invalid_param error", async () => {
-      const result = await invoke(runtime, {
-        action: "list",
-        limit: -5,
-      });
-      expect(result.success).toBe(false);
-      expect(result.text).toContain("invalid_param");
-    });
-
-    it("rejects fractional limit (2.5) with invalid_param error", async () => {
-      const result = await invoke(runtime, {
-        action: "list",
-        limit: 2.5,
-      });
-      expect(result.success).toBe(false);
-      expect(result.text).toContain("invalid_param");
-    });
-
-    it("treats NaN limit as undefined (readNumber filters it out)", async () => {
-      // readNumber returns undefined for NaN, so no validation error occurs
-      const result = await invoke(runtime, {
-        action: "list",
-        limit: Number.NaN,
-      });
-      expect(result.success).toBe(true);
-      const data = result.data as { todos: unknown[] };
-      expect(data.todos.length).toBe(5);
-    });
-
     it("omitted limit returns all results (unlimited)", async () => {
       const result = await invoke(runtime, { action: "list" });
       expect(result.success).toBe(true);
       const data = result.data as { todos: unknown[] };
       expect(data.todos.length).toBe(5);
+      expect(service.listCallCount).toBe(1);
     });
 
-    it("parses numeric string limit correctly", async () => {
-      const result = await invoke(runtime, {
-        action: "list",
-        limit: "3",
-      });
-      expect(result.success).toBe(true);
-      const data = result.data as { todos: unknown[] };
-      expect(data.todos.length).toBe(3);
-    });
+    it.each([
+      ["zero", 0],
+      ["negative", -5],
+      ["fraction", 2.5],
+      ["NaN", Number.NaN],
+      ["infinity", Number.POSITIVE_INFINITY],
+      ["unsafe integer", Number.MAX_SAFE_INTEGER + 1],
+      ["numeric string", "3"],
+      ["non-numeric string", "abc"],
+      ["null", null],
+      ["boolean", false],
+      ["explicit undefined", undefined],
+    ])(
+      "rejects a supplied %s before calling the service",
+      async (_name, limit) => {
+        const result = await invoke(runtime, {
+          action: "list",
+          limit,
+        });
+        expect(result.success).toBe(false);
+        expect(result.text).toContain("invalid_param");
+        expect(result.text).toContain("positive safe integer number");
+        expect(service.listCallCount).toBe(0);
+      },
+    );
+  });
 
-    it("treats non-numeric string limit as undefined (no limit applied)", async () => {
-      // readNumber("abc") returns undefined, so no validation occurs
-      const result = await invoke(runtime, {
-        action: "list",
-        limit: "abc",
-      });
-      expect(result.success).toBe(true);
-      const data = result.data as { todos: unknown[] };
-      expect(data.todos.length).toBe(5);
-    });
+  describe("TodosService.list limit validation", () => {
+    it.each([
+      ["zero", 0],
+      ["negative", -1],
+      ["fraction", 1.5],
+      ["NaN", Number.NaN],
+      ["numeric string", "2"],
+      ["explicit undefined", undefined],
+    ])(
+      "rejects a supplied %s before reading the database",
+      async (_name, limit) => {
+        const select = vi.fn();
+        const directService = new TodosService({
+          db: { select },
+        } as unknown as IAgentRuntime);
+
+        await expect(
+          directService.list({
+            entityId: ENTITY,
+            limit: limit as number,
+          }),
+        ).rejects.toMatchObject({
+          name: "ElizaError",
+          code: TODO_LIST_LIMIT_ERROR_CODE,
+        });
+        expect(select).not.toHaveBeenCalled();
+      },
+    );
   });
 
   describe("persistence failures", () => {

--- a/plugins/plugin-todos/src/actions/todo.test.ts
+++ b/plugins/plugin-todos/src/actions/todo.test.ts
@@ -666,6 +666,23 @@ describe("TODO action", () => {
       expect(service.listCallCount).toBe(1);
     });
 
+    it("reads a supplied limit once before validation and use", async () => {
+      let reads = 0;
+      const parameters = {
+        action: "list",
+        get limit() {
+          reads += 1;
+          return reads === 1 ? 1 : undefined;
+        },
+      };
+
+      const result = await invoke(runtime, parameters);
+
+      expect(result.success).toBe(true);
+      expect((result.data as { todos: unknown[] }).todos).toHaveLength(1);
+      expect(reads).toBe(1);
+    });
+
     it.each([
       ["zero", 0],
       ["negative", -5],
@@ -694,6 +711,30 @@ describe("TODO action", () => {
   });
 
   describe("TodosService.list limit validation", () => {
+    it("uses the same single-read limit value for the database query", async () => {
+      let reads = 0;
+      const limit = vi.fn(async () => []);
+      const orderBy = vi.fn(() => ({ limit }));
+      const where = vi.fn(() => ({ orderBy }));
+      const from = vi.fn(() => ({ where }));
+      const select = vi.fn(() => ({ from }));
+      const directService = new TodosService({
+        db: { select },
+      } as unknown as IAgentRuntime);
+      const filter = {
+        entityId: ENTITY,
+        get limit() {
+          reads += 1;
+          return reads === 1 ? 1 : undefined;
+        },
+      };
+
+      await directService.list(filter);
+
+      expect(reads).toBe(1);
+      expect(limit).toHaveBeenCalledWith(1);
+    });
+
     it.each([
       ["zero", 0],
       ["negative", -1],

--- a/plugins/plugin-todos/src/actions/todo.test.ts
+++ b/plugins/plugin-todos/src/actions/todo.test.ts
@@ -86,9 +86,10 @@ class FakeTodosService {
     agentId?: string;
     roomId?: string | null;
     includeCompleted?: boolean;
+    limit?: number;
   }): Promise<StoredTodo[]> {
     this.throwIf("list");
-    return this.rows.filter((r) => {
+    let results = this.rows.filter((r) => {
       if (r.entityId !== filter.entityId) return false;
       if (filter.agentId && r.agentId !== filter.agentId) return false;
       if (filter.roomId && r.roomId !== filter.roomId) return false;
@@ -100,6 +101,10 @@ class FakeTodosService {
       }
       return true;
     });
+    if (filter.limit && Number.isSafeInteger(filter.limit) && filter.limit > 0) {
+      results = results.slice(0, filter.limit);
+    }
+    return results;
   }
 
   async update(
@@ -625,6 +630,96 @@ describe("TODO action", () => {
       });
       expect(result.success).toBe(true);
       expect(result.data).toMatchObject({ action: "create", op: "create" });
+    });
+  });
+
+  describe("action=list with limit validation", () => {
+    beforeEach(async () => {
+      // Create 5 todos for limit testing
+      for (let i = 1; i <= 5; i++) {
+        await invoke(runtime, {
+          action: "create",
+          content: `task ${i}`,
+          status: "pending",
+        });
+      }
+    });
+
+    it("accepts positive integer limit and returns capped results", async () => {
+      const result = await invoke(runtime, {
+        action: "list",
+        limit: 3,
+      });
+      expect(result.success).toBe(true);
+      const data = result.data as { todos: unknown[] };
+      expect(data.todos.length).toBe(3);
+    });
+
+    it("rejects limit=0 with invalid_param error", async () => {
+      const result = await invoke(runtime, {
+        action: "list",
+        limit: 0,
+      });
+      expect(result.success).toBe(false);
+      expect(result.text).toContain("invalid_param");
+      expect(result.text).toContain("positive integer");
+    });
+
+    it("rejects negative limit with invalid_param error", async () => {
+      const result = await invoke(runtime, {
+        action: "list",
+        limit: -5,
+      });
+      expect(result.success).toBe(false);
+      expect(result.text).toContain("invalid_param");
+    });
+
+    it("rejects fractional limit (2.5) with invalid_param error", async () => {
+      const result = await invoke(runtime, {
+        action: "list",
+        limit: 2.5,
+      });
+      expect(result.success).toBe(false);
+      expect(result.text).toContain("invalid_param");
+    });
+
+    it("treats NaN limit as undefined (readNumber filters it out)", async () => {
+      // readNumber returns undefined for NaN, so no validation error occurs
+      const result = await invoke(runtime, {
+        action: "list",
+        limit: Number.NaN,
+      });
+      expect(result.success).toBe(true);
+      const data = result.data as { todos: unknown[] };
+      expect(data.todos.length).toBe(5);
+    });
+
+    it("omitted limit returns all results (unlimited)", async () => {
+      const result = await invoke(runtime, { action: "list" });
+      expect(result.success).toBe(true);
+      const data = result.data as { todos: unknown[] };
+      expect(data.todos.length).toBe(5);
+    });
+
+    it("parses numeric string limit correctly", async () => {
+      const result = await invoke(runtime, {
+        action: "list",
+        limit: "3",
+      });
+      expect(result.success).toBe(true);
+      const data = result.data as { todos: unknown[] };
+      expect(data.todos.length).toBe(3);
+    });
+
+    it("treats non-numeric string limit as undefined (no limit applied)", async () => {
+      // readNumber("abc") returns undefined, so no validation occurs
+      const result = await invoke(runtime, {
+        action: "list",
+        limit: "abc",
+      });
+      expect(result.success).toBe(true);
+      const data = result.data as { todos: unknown[] };
+      expect(data.todos.length).toBe(5);
     });
   });
 

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -417,6 +417,14 @@ async function actionList({
 }: ActionHandlerArgs): Promise<ActionResult> {
   const includeCompleted = readBoolean(params.includeCompleted) ?? false;
   const limit = readNumber(params.limit);
+  if (limit !== undefined) {
+    if (!Number.isSafeInteger(limit) || limit <= 0) {
+      return failure(
+        "invalid_param",
+        "limit must be a positive integer (omit for unlimited results)",
+      );
+    }
+  }
   const filter: Parameters<TodosService["list"]>[0] = {
     entityId: scope.entityId,
     agentId: scope.agentId,

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -409,7 +409,8 @@ async function actionList({
 }: ActionHandlerArgs): Promise<ActionResult> {
   const includeCompleted = readBoolean(params.includeCompleted) ?? false;
   const hasLimit = Object.hasOwn(params, "limit");
-  if (hasLimit && !isValidTodoListLimit(params.limit)) {
+  const rawLimit = hasLimit ? params.limit : undefined;
+  if (hasLimit && !isValidTodoListLimit(rawLimit)) {
     return failure(
       "invalid_param",
       "limit must be a positive safe integer number (omit for unlimited results)",
@@ -420,7 +421,7 @@ async function actionList({
     agentId: scope.agentId,
     includeCompleted,
   };
-  if (hasLimit) filter.limit = params.limit as number;
+  if (hasLimit) filter.limit = rawLimit as number;
   const todos = await service.list(filter);
   const text = renderMarkdown(todos);
   await emit(callback, text);

--- a/plugins/plugin-todos/src/actions/todo.ts
+++ b/plugins/plugin-todos/src/actions/todo.ts
@@ -26,6 +26,7 @@ import type {
 import {
   type CreateTodoInput,
   getTodosService,
+  isValidTodoListLimit,
   type TodosService,
   type UpdateTodoInput,
 } from "../service.js";
@@ -90,15 +91,6 @@ function readBoolean(value: unknown): boolean | undefined {
     const v = value.trim().toLowerCase();
     if (v === "true" || v === "1" || v === "yes") return true;
     if (v === "false" || v === "0" || v === "no") return false;
-  }
-  return undefined;
-}
-
-function readNumber(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string" && value.trim()) {
-    const n = Number(value);
-    if (Number.isFinite(n)) return n;
   }
   return undefined;
 }
@@ -416,21 +408,19 @@ async function actionList({
   callback,
 }: ActionHandlerArgs): Promise<ActionResult> {
   const includeCompleted = readBoolean(params.includeCompleted) ?? false;
-  const limit = readNumber(params.limit);
-  if (limit !== undefined) {
-    if (!Number.isSafeInteger(limit) || limit <= 0) {
-      return failure(
-        "invalid_param",
-        "limit must be a positive integer (omit for unlimited results)",
-      );
-    }
+  const hasLimit = Object.hasOwn(params, "limit");
+  if (hasLimit && !isValidTodoListLimit(params.limit)) {
+    return failure(
+      "invalid_param",
+      "limit must be a positive safe integer number (omit for unlimited results)",
+    );
   }
   const filter: Parameters<TodosService["list"]>[0] = {
     entityId: scope.entityId,
     agentId: scope.agentId,
     includeCompleted,
   };
-  if (limit !== undefined) filter.limit = limit;
+  if (hasLimit) filter.limit = params.limit as number;
   const todos = await service.list(filter);
   const text = renderMarkdown(todos);
   await emit(callback, text);
@@ -583,9 +573,10 @@ export const todoAction: Action = {
     },
     {
       name: "limit",
-      description: "Max rows to return for action=list.",
+      description:
+        "Positive safe integer maximum rows to return for action=list; omit for unlimited results.",
       required: false,
-      schema: { type: "number" as const },
+      schema: { type: "integer" as const, minimum: 1 },
     },
   ],
   validate: async (runtime: IAgentRuntime) => Boolean(getTodosService(runtime)),

--- a/plugins/plugin-todos/src/service.ts
+++ b/plugins/plugin-todos/src/service.ts
@@ -3,7 +3,13 @@
  * scoped by `(agentId, entityId)` with optional `roomId`/`worldId` narrowing.
  * Requires `runtime.db` from `@elizaos/plugin-sql`; throws if it is absent.
  */
-import { type IAgentRuntime, logger, Service, type UUID } from "@elizaos/core";
+import {
+  ElizaError,
+  type IAgentRuntime,
+  logger,
+  Service,
+  type UUID,
+} from "@elizaos/core";
 import { and, desc, eq, inArray } from "drizzle-orm";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 
@@ -43,6 +49,13 @@ export interface UpdateTodoInput {
   status?: TodoStatus;
   parentTodoId?: string | null;
   metadata?: Record<string, unknown>;
+}
+
+export const TODO_LIST_LIMIT_ERROR_CODE = "TODO_INVALID_LIST_LIMIT";
+
+/** Return true only for executable SQL limits accepted by the TODO contract. */
+export function isValidTodoListLimit(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
 }
 
 function rowToTodo(row: TodoRow): Todo {
@@ -127,6 +140,20 @@ export class TodosService extends Service {
   }
 
   async list(filter: TodoFilter): Promise<Todo[]> {
+    let limit: number | undefined;
+    if (Object.hasOwn(filter, "limit")) {
+      if (!isValidTodoListLimit(filter.limit)) {
+        throw new ElizaError(
+          `${TODOS_LOG_PREFIX} limit must be a positive safe integer`,
+          {
+            code: TODO_LIST_LIMIT_ERROR_CODE,
+            context: { receivedType: typeof filter.limit },
+          },
+        );
+      }
+      limit = filter.limit;
+    }
+
     const db = this.getDb();
     const conditions = [eq(todosTable.entityId, filter.entityId as UUID)];
     if (filter.agentId) {
@@ -146,21 +173,12 @@ export class TodosService extends Service {
       );
     }
 
-    // Validate limit before building query
-    if (filter.limit !== undefined) {
-      if (!Number.isSafeInteger(filter.limit) || filter.limit <= 0) {
-        throw new Error(
-          `${TODOS_LOG_PREFIX} limit must be a positive integer; received ${filter.limit}`,
-        );
-      }
-    }
-
     const query = db
       .select()
       .from(todosTable)
       .where(and(...conditions))
       .orderBy(desc(todosTable.updatedAt));
-    const rows = filter.limit ? await query.limit(filter.limit) : await query;
+    const rows = limit === undefined ? await query : await query.limit(limit);
     return rows.map(rowToTodo);
   }
 

--- a/plugins/plugin-todos/src/service.ts
+++ b/plugins/plugin-todos/src/service.ts
@@ -145,6 +145,16 @@ export class TodosService extends Service {
         inArray(todosTable.status, ["pending", "in_progress"] as TodoStatus[]),
       );
     }
+
+    // Validate limit before building query
+    if (filter.limit !== undefined) {
+      if (!Number.isSafeInteger(filter.limit) || filter.limit <= 0) {
+        throw new Error(
+          `${TODOS_LOG_PREFIX} limit must be a positive integer; received ${filter.limit}`,
+        );
+      }
+    }
+
     const query = db
       .select()
       .from(todosTable)

--- a/plugins/plugin-todos/src/service.ts
+++ b/plugins/plugin-todos/src/service.ts
@@ -142,16 +142,17 @@ export class TodosService extends Service {
   async list(filter: TodoFilter): Promise<Todo[]> {
     let limit: number | undefined;
     if (Object.hasOwn(filter, "limit")) {
-      if (!isValidTodoListLimit(filter.limit)) {
+      const rawLimit = filter.limit;
+      if (!isValidTodoListLimit(rawLimit)) {
         throw new ElizaError(
           `${TODOS_LOG_PREFIX} limit must be a positive safe integer`,
           {
             code: TODO_LIST_LIMIT_ERROR_CODE,
-            context: { receivedType: typeof filter.limit },
+            context: { receivedType: typeof rawLimit },
           },
         );
       }
-      limit = filter.limit;
+      limit = rawLimit;
     }
 
     const db = this.getDb();


### PR DESCRIPTION
# Relates to

Closes #19256.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebuilt on `origin/develop@75b83886e585a80ab8a47b2024673832a4d3941e` with zero conflicts.
- [x] Contains only the three TODO files authorized by #19256; unrelated Calendar and CI commits were removed from the submitted branch.
- [x] A reviewer can confirm the boundary behavior from the exact-head test and verification evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-haiku-4.5`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`, `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Background

## What does this PR do?

It gives `TODO action=list` one explicit limit contract:

- omitting `limit` is the only way to request unlimited results;
- a positive safe-integer number caps the result set;
- every supplied invalid value—including `0`, negatives, fractions, `NaN`, infinity, unsafe integers, numeric strings, other strings, booleans, `null`, and explicit `undefined`—returns `invalid_param` before the service is called;
- direct `TodosService.list` callers receive typed `ElizaError` code `TODO_INVALID_LIST_LIMIT` before database access.

The action and service share one raw-value predicate. `Object.hasOwn` distinguishes omission from an explicitly supplied invalid value, and the action schema now advertises an integer with `minimum: 1`. The service uses the validated local value rather than a truthiness check.

## Scope and history repair

The submitted head bundled unrelated Calendar and CI commits and duplicated other open PRs. The branch was rebuilt from current `develop` by replaying only the contributor's TODO commit, retaining its authorship, then applying the boundary repair. The final diff is limited to:

- `plugins/plugin-todos/src/actions/todo.ts`
- `plugins/plugin-todos/src/service.ts`
- `plugins/plugin-todos/src/actions/todo.test.ts`

# Testing

Verified on exact head `30d28e2bbdbc79b252b93301ad2e11a8e1400a73`:

- `bunx vitest run plugins/plugin-todos/src/actions/todo.test.ts` — **49 passed / 0 failed**.
- `bun run --cwd plugins/plugin-todos test` — **74 passed / 0 failed**, including the real-database suite.
- `bunx biome check plugins/plugin-todos/src/actions/todo.ts plugins/plugin-todos/src/actions/todo.test.ts plugins/plugin-todos/src/service.ts` — clean.
- `bun run verify` — **350/350 Turbo tasks passed**, followed by all repository audits.
- `git diff --check origin/develop...HEAD` — clean.

The invalid-value matrix asserts that the fake service is never called. A direct `TodosService` matrix injects a database spy and proves `select` is never called before the typed error is thrown.

# Evidence Gate

<!-- evidence-head:30d28e2bbdbc79b252b93301ad2e11a8e1400a73 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - action/service boundary change with no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - action/service boundary change with no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - deterministic parameter validation with no interactive frontend or device flow.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no live server path changed; exact action and real-database test results are recorded under Domain artifacts.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend files or network protocol changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no prompt, model, planner, provider, or model-driven behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — exact-head test and repository-gate transcript:
<details>
<summary>Focused, package, and repository proof</summary>

```text
focused action suite:          49 passed / 0 failed
plugin-todos full suite:       74 passed / 0 failed (4 files)
repository verify:           350 successful / 350 total
Biome changed-file check:      clean; no fixes applied
git diff --check:              clean; no whitespace errors
final diff:                    3 files (action, service, action tests)
invalid action inputs:         service call count remains 0
invalid direct service inputs: database select call count remains 0
```
</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface in the diff.`

# Known gaps / failures

- Hosted checks and an independent exact-head approval are still required before merge.
- No live production database was mutated; the plugin's real-database test harness and pre-database spy assertions cover the changed persistence boundary deterministically.

## Maintainer repair

The maintainer repair removes raw-value coercion, rejects explicit invalid values before service dispatch, moves defensive validation ahead of database acquisition, replaces the generic service error with a typed `ElizaError`, covers adversarial inputs at both boundaries, aligns the action schema, and strips every unrelated commit from the PR history. This is a substantive repair, so the maintainer will not self-approve it.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza"} -->
