### PR TITLE
fix(research): retire synthetic fallback explicitly

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -19,6 +19,13 @@ bun run test
 
 See `package.json` for `build`, `lint`, and other scripts.
 
+## Research tasks
+
+`ResearchTaskExecutor` requires a provider registered for
+`ModelType.RESEARCH`. Provider absence, rejection, or an empty report returns an
+unsuccessful `TaskResult` with a stable `errorCode`; it never falls back to
+ordinary `TEXT_LARGE` synthesis and labels that output as research.
+
 ## Approval-bound plugin installation
 
 `installPlugin` always installs the canonical npm package declared by the

--- a/packages/agent/src/services/research-task-executor.test.ts
+++ b/packages/agent/src/services/research-task-executor.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Exercises the research task boundary with a deterministic runtime stub. The
+ * suite proves that only the real RESEARCH slot can produce successful research.
+ */
+import { type IAgentRuntime, ModelType } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { ResearchTaskExecutor } from "./research-task-executor.ts";
+
+const spec = {
+  id: "research-1",
+  type: "research",
+  description: "Research current browser security guidance",
+};
+
+function runtimeWith(useModel: unknown): IAgentRuntime {
+  return { useModel } as IAgentRuntime;
+}
+
+describe("ResearchTaskExecutor", () => {
+  it("returns the real RESEARCH provider report", async () => {
+    const useModel = vi.fn(
+      async (_modelType: string, _params: unknown) => "Cited research report",
+    );
+
+    const result = await new ResearchTaskExecutor().execute(
+      spec,
+      runtimeWith(useModel),
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      output: "Cited research report",
+    });
+    expect(useModel).toHaveBeenCalledTimes(1);
+    expect(useModel).toHaveBeenCalledWith(
+      ModelType.RESEARCH,
+      expect.objectContaining({ input: spec.description }),
+    );
+  });
+
+  it("exposes provider rejection and never falls back to TEXT_LARGE", async () => {
+    const useModel = vi.fn(async (_modelType: string, _params: unknown) => {
+      throw new Error("no RESEARCH model registered");
+    });
+
+    const result = await new ResearchTaskExecutor().execute(
+      spec,
+      runtimeWith(useModel),
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: "RESEARCH_PROVIDER_FAILED",
+      error:
+        "The configured research provider failed: no RESEARCH model registered",
+    });
+    expect(useModel).toHaveBeenCalledTimes(1);
+    expect(useModel.mock.calls[0]?.[0]).toBe(ModelType.RESEARCH);
+  });
+
+  it("rejects an empty provider response as an explicit failure", async () => {
+    const useModel = vi.fn(
+      async (_modelType: string, _params: unknown) => "   ",
+    );
+
+    const result = await new ResearchTaskExecutor().execute(
+      spec,
+      runtimeWith(useModel),
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: "RESEARCH_EMPTY_RESULT",
+      error: "The research provider returned no report",
+    });
+    expect(useModel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent/src/services/research-task-executor.ts
+++ b/packages/agent/src/services/research-task-executor.ts
@@ -1,18 +1,19 @@
 /**
- * TaskExecutor for research-shaped work. Routes matching task specs through the
- * runtime's RESEARCH model when one is available, otherwise decomposes the question
- * into sub-questions, answers each via TEXT_LARGE, and synthesizes a final report.
+ * TaskExecutor for research-shaped work. It requires a real RESEARCH model and
+ * translates provider failures into an explicit task failure at the executor boundary.
  */
-import { type IAgentRuntime, ModelType } from "@elizaos/core";
+import {
+  ElizaError,
+  type IAgentRuntime,
+  isElizaError,
+  ModelType,
+} from "@elizaos/core";
 import type { TaskExecutor, TaskResult, TaskSpec } from "./task-executor.ts";
 
 const RESEARCH_PATTERNS =
   /\b(research|investigate|analyze|find out|look into|explore|summarize|compare|evaluate|review|study|assess)\b/i;
 
-/**
- * Decomposes research questions into sub-questions, answers each via the
- * runtime's LLM, and synthesizes a final report.
- */
+/** Executes research only through a provider that implements the RESEARCH contract. */
 export class ResearchTaskExecutor implements TaskExecutor {
   readonly type = "research";
   readonly description =
@@ -26,8 +27,14 @@ export class ResearchTaskExecutor implements TaskExecutor {
   async execute(spec: TaskSpec, runtime: IAgentRuntime): Promise<TaskResult> {
     const startTime = Date.now();
     try {
+      let researchResult:
+        | {
+            text?: string;
+            annotations?: Array<{ url?: string; title?: string }>;
+          }
+        | string;
       try {
-        const researchResult = (await runtime.useModel(ModelType.RESEARCH, {
+        researchResult = (await runtime.useModel(ModelType.RESEARCH, {
           input: spec.description,
           tools: [{ type: "web_search_preview" }],
           background: true,
@@ -38,119 +45,53 @@ export class ResearchTaskExecutor implements TaskExecutor {
               annotations?: Array<{ url?: string; title?: string }>;
             }
           | string;
-
-        const output =
-          typeof researchResult === "string"
-            ? researchResult
-            : (researchResult.text ?? "");
-        if (output.trim().length > 0) {
-          return {
-            taskId: spec.id,
-            success: true,
-            output,
-            durationMs: Date.now() - startTime,
-          };
-        }
-      } catch {
-        // Fall through to the sequential synthesis path when the runtime
-        // does not expose a RESEARCH model or the provider rejects it.
+      } catch (cause) {
+        // error-policy:J2 provider errors gain a stable research-task code and
+        // preserve their cause before the executor boundary translates them.
+        const detail = cause instanceof Error ? cause.message : String(cause);
+        throw new ElizaError(
+          `The configured research provider failed: ${detail}`,
+          {
+            code: "RESEARCH_PROVIDER_FAILED",
+            cause,
+            context: { taskId: spec.id },
+            severity: "ephemeral",
+          },
+        );
       }
 
-      // Step 1: Decompose the research question into sub-questions
-      const decomposition = await runtime.useModel(ModelType.TEXT_LARGE, {
-        prompt: [
-          "Decompose this research question into 3-5 focused sub-questions",
-          "that can be answered independently:",
-          "",
-          spec.description,
-          "",
-          "Return each sub-question on its own line, one per line. No numbering, no bullets, no prose.",
-        ].join("\n"),
-      });
-
-      let subQuestions: string[];
-      try {
-        // Parse line-delimited questions from the response.
-        // Strip markdown fences and numbering if the model adds them.
-        let raw: string =
-          typeof decomposition === "string"
-            ? decomposition
-            : String(decomposition);
-        const fenceMatch = raw.match(/```(?:\w+)?\s*\n?([\s\S]*?)\n?\s*```/);
-        if (fenceMatch) raw = fenceMatch[1];
-
-        // Try line-based parsing first (preferred)
-        const lines = raw
-          .split(/\r?\n/)
-          .map((line) =>
-            line
-              .replace(
-                /^\s{0,32}(?:\d{1,8}[.)]\s{0,32}|-\s{0,32}|\*\s{0,32})/,
-                "",
-              )
-              .trim(),
-          )
-          .filter((line) => line.length > 0);
-
-        if (lines.length >= 2) {
-          subQuestions = lines;
-        } else {
-          subQuestions = [spec.description];
-        }
-        if (subQuestions.length === 0) subQuestions = [spec.description];
-      } catch {
-        subQuestions = [spec.description];
-      }
-
-      // Step 2: Answer each sub-question
-      const answers: Array<{ question: string; answer: string }> = [];
-      for (const question of subQuestions) {
-        const answer = await runtime.useModel(ModelType.TEXT_LARGE, {
-          prompt: [
-            "Answer this research question concisely but thoroughly:",
-            "",
-            question,
-            "",
-            `Context: This is part of a larger research task: "${spec.description}"`,
-          ].join("\n"),
-        });
-        answers.push({
-          question,
-          answer: typeof answer === "string" ? answer : String(answer),
+      const output =
+        typeof researchResult === "string"
+          ? researchResult
+          : (researchResult.text ?? "");
+      if (output.trim().length === 0) {
+        throw new ElizaError("The research provider returned no report", {
+          code: "RESEARCH_EMPTY_RESULT",
+          context: { taskId: spec.id },
         });
       }
-
-      // Step 3: Synthesize into a final report
-      const findingsBlock = answers
-        .map((a, i) => `${i + 1}. Q: ${a.question}\n   A: ${a.answer}`)
-        .join("\n\n");
-
-      const synthesis = await runtime.useModel(ModelType.TEXT_LARGE, {
-        prompt: [
-          "Synthesize these research findings into a coherent report:",
-          "",
-          `Original question: ${spec.description}`,
-          "",
-          `Findings:\n${findingsBlock}`,
-          "",
-          "Provide a structured summary with key findings, conclusions, and any caveats.",
-        ].join("\n"),
-      });
-
-      const report =
-        typeof synthesis === "string" ? synthesis : String(synthesis);
 
       return {
         taskId: spec.id,
         success: true,
-        output: report,
+        output,
         durationMs: Date.now() - startTime,
       };
     } catch (error) {
+      // error-policy:J1 TaskExecutor is the result boundary consumed by the
+      // orchestrator, so typed failures become an explicit unsuccessful result.
+      const failure = isElizaError(error)
+        ? error
+        : new ElizaError("Research execution failed", {
+            code: "RESEARCH_EXECUTION_FAILED",
+            cause: error,
+            context: { taskId: spec.id },
+          });
       return {
         taskId: spec.id,
         success: false,
-        error: error instanceof Error ? error.message : String(error),
+        errorCode: failure.code,
+        error: failure.message,
         durationMs: Date.now() - startTime,
       };
     }

--- a/packages/agent/src/services/task-executor.ts
+++ b/packages/agent/src/services/task-executor.ts
@@ -21,6 +21,8 @@ export interface TaskResult {
   success: boolean;
   output?: string;
   artifacts?: Array<{ name: string; path: string; type: string }>;
+  /** Stable machine-readable classification for a failed task. */
+  errorCode?: string;
   error?: string;
   durationMs?: number;
 }

--- a/plugins/plugin-elizacloud/README.md
+++ b/plugins/plugin-elizacloud/README.md
@@ -163,6 +163,18 @@ const transcript = await runtime.useModel(ModelType.TRANSCRIPTION, audioBuffer);
 
 ```
 
+### Research retirement
+
+Eliza Cloud does not register `ModelType.RESEARCH`. Use a provider that
+implements the real research contract, including its search tools and citation
+output, and call it through `runtime.useModel(ModelType.RESEARCH, ...)`.
+
+The previously published `models/research` handler, `models/index` barrel
+export, and `getResearchModel` config export remain as deprecated compatibility
+shims. They throw `ELIZA_CLOUD_RESEARCH_UNAVAILABLE`; they never substitute a
+`TEXT_LARGE` model or return ordinary synthesis as research. These shims will
+remain through the 2.x line and may be removed in 3.0.0.
+
 ## Adding Cloud Calls
 
 1. Prefer an existing high-level SDK method when one exists.

--- a/plugins/plugin-elizacloud/__tests__/unit/research-retirement.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/research-retirement.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Proves the retired Cloud research imports remain resolvable under source
+ * conditions and fail with an explicit typed-unavailable contract.
+ */
+import { getResearchModel } from "@elizaos/plugin-elizacloud/endpoint-config";
+import { handleResearch as handleResearchFromBarrel } from "@elizaos/plugin-elizacloud/models/index";
+import { handleResearch } from "@elizaos/plugin-elizacloud/models/research";
+import { describe, expect, it } from "vitest";
+
+describe("retired Cloud research compatibility", () => {
+  it.each([handleResearch, handleResearchFromBarrel])(
+    "keeps the handler import but rejects with a typed unavailable error",
+    async (handler) => {
+      await expect(handler({} as never, {} as never)).rejects.toMatchObject({
+        code: "ELIZA_CLOUD_RESEARCH_UNAVAILABLE",
+      });
+    }
+  );
+
+  it("keeps the legacy model getter but refuses to select an ordinary text model", () => {
+    expect(() => getResearchModel({} as never)).toThrowError(
+      expect.objectContaining({
+        code: "ELIZA_CLOUD_RESEARCH_UNAVAILABLE",
+      })
+    );
+  });
+});

--- a/plugins/plugin-elizacloud/scripts/verify-built-package.mjs
+++ b/plugins/plugin-elizacloud/scripts/verify-built-package.mjs
@@ -19,6 +19,23 @@ const probe = `
   if (module.default?.name !== "elizaOSCloud") {
     throw new Error("built plugin export is missing or malformed");
   }
+  const directResearch = await import("@elizaos/plugin-elizacloud/models/research");
+  const modelBarrel = await import("@elizaos/plugin-elizacloud/models/index");
+  const endpointConfig = await import("@elizaos/plugin-elizacloud/endpoint-config");
+  for (const handler of [directResearch.handleResearch, modelBarrel.handleResearch]) {
+    try {
+      await handler({}, {});
+      throw new Error("retired research handler returned fabricated success");
+    } catch (error) {
+      if (error?.code !== "ELIZA_CLOUD_RESEARCH_UNAVAILABLE") throw error;
+    }
+  }
+  try {
+    endpointConfig.getResearchModel({});
+    throw new Error("retired research getter returned a text model");
+  } catch (error) {
+    if (error?.code !== "ELIZA_CLOUD_RESEARCH_UNAVAILABLE") throw error;
+  }
 `;
 
 export function verifyBuiltPackage({

--- a/plugins/plugin-elizacloud/src/models/index.ts
+++ b/plugins/plugin-elizacloud/src/models/index.ts
@@ -1,3 +1,6 @@
+/** Exposes the Cloud model handlers and compatibility errors used by callers. */
+import { handleResearch as retiredHandleResearch } from "./research";
+
 export type { BatchEmbeddingResult } from "./embeddings";
 export { handleBatchTextEmbedding, handleTextEmbedding } from "./embeddings";
 export { handleImageDescription, handleImageGeneration } from "./image";
@@ -18,3 +21,9 @@ export {
   type CloudTranscriptionInput,
   handleTranscription,
 } from "./transcription";
+
+/**
+ * @deprecated Eliza Cloud research was retired. Install a provider that
+ * registers `ModelType.RESEARCH` and call it through `runtime.useModel`.
+ */
+export const handleResearch = retiredHandleResearch;

--- a/plugins/plugin-elizacloud/src/models/research.ts
+++ b/plugins/plugin-elizacloud/src/models/research.ts
@@ -1,0 +1,32 @@
+/**
+ * Preserves the published Cloud research import while making its retirement
+ * explicit. Real research must be supplied by a provider that registers RESEARCH.
+ */
+import {
+  ElizaError,
+  type IAgentRuntime,
+  type ResearchParams,
+  type ResearchResult,
+} from "@elizaos/core";
+
+/** Builds the stable typed failure returned by the compatibility handler. */
+function unavailableResearchError(): ElizaError {
+  return new ElizaError(
+    "Eliza Cloud no longer provides a RESEARCH model; install a research-capable provider",
+    {
+      code: "ELIZA_CLOUD_RESEARCH_UNAVAILABLE",
+      severity: "fatal",
+    },
+  );
+}
+
+/**
+ * @deprecated Eliza Cloud research was retired. Install a provider that
+ * registers `ModelType.RESEARCH` and call it through `runtime.useModel`.
+ */
+export async function handleResearch(
+  _runtime: IAgentRuntime,
+  _params: ResearchParams,
+): Promise<ResearchResult> {
+  throw unavailableResearchError();
+}

--- a/plugins/plugin-elizacloud/src/utils/config.ts
+++ b/plugins/plugin-elizacloud/src/utils/config.ts
@@ -1,5 +1,6 @@
+/** Resolves Cloud model and endpoint settings from runtime and environment state. */
 import type { IAgentRuntime } from "@elizaos/core";
-import { logger, resolveSetting } from "@elizaos/core";
+import { ElizaError, logger, resolveSetting } from "@elizaos/core";
 import {
   DEFAULT_ELIZA_CLOUD_LARGE_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
@@ -233,6 +234,20 @@ export function getResponseModel(runtime: IAgentRuntime): string {
     getSetting(runtime, "ELIZAOS_CLOUD_RESPONSE_MODEL") ??
     getSetting(runtime, "RESPONSE_MODEL") ??
     getLargeModel(runtime)
+  );
+}
+
+/**
+ * @deprecated Eliza Cloud research was retired. This compatibility export
+ * fails explicitly instead of selecting a text model that cannot do research.
+ */
+export function getResearchModel(_runtime: IAgentRuntime): never {
+  throw new ElizaError(
+    "Eliza Cloud no longer provides a RESEARCH model; install a research-capable provider",
+    {
+      code: "ELIZA_CLOUD_RESEARCH_UNAVAILABLE",
+      severity: "fatal",
+    },
   );
 }
 


### PR DESCRIPTION
# Relates to

Closes #19178.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Maintainer direction was recorded on the issue before the compatibility source change.
- [x] This PR targets `develop` and was rebased onto current `origin/develop` before opening.
- [x] `bun install` and exact-head `bun run verify` passed after sync.
- [x] Default and `eliza-source` public import contracts are exercised.
- [x] The executor never fabricates research through `TEXT_LARGE`.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on `origin/develop@16a1fdb54de9e84b6a225fbb8d9101b04a1dac04`; zero conflicts.
- [x] Exact-head `bun run verify` passes at `d63d49085917816304bbe8c6a11e6004d23fac43`.

# Risks

Low and intentionally fail-fast. Callers that were already broken by the removed Cloud handler regain resolvable compatibility imports, but those shims explicitly throw `ELIZA_CLOUD_RESEARCH_UNAVAILABLE`. Research tasks now fail visibly when no genuine research provider exists instead of returning mislabeled ordinary text.

# Background

## What does this PR do?

It implements the issue's recommended explicit-retirement direction:

- removes the executor's broad catch and sequential `TEXT_LARGE` decomposition/synthesis fallback;
- returns stable `RESEARCH_PROVIDER_FAILED` and `RESEARCH_EMPTY_RESULT` task failures;
- restores deprecated direct, barrel, and config compatibility exports that throw one typed unavailable error;
- proves `eliza-source` package imports in Vitest and default-condition dist imports in a clean Node child process;
- documents the 2.x deprecation window and possible 3.0.0 removal.

## What kind of change is this?

Bug fix and compatibility retirement (non-breaking import restoration; behavioral correction from fabricated success to explicit failure).

# Testing

## Detailed testing steps

- `bun install` — passed with pinned Bun 1.3.14; 3,822 installs checked, no changes.
- Agent focused executor contract — 3/3 passed.
- Cloud source-condition compatibility and probe tests — 5/5 passed.
- Cloud typecheck — passed.
- Cloud lint — 59 files checked, no fixes.
- Cloud production build — Node/browser/CJS/subpaths/declarations/views passed; default-condition dist child import passed.
- `bun run verify` — 350/350 plus all audits; anti-larp scanned 8,053 tests with zero focused or orphaned skips.
- `git diff --check` — passed.

# Evidence Gate

<!-- evidence-head:e9ce89cac1fa9ff3b4748888c66b80045584e54f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend task execution and package import contract; no UI surface exists
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend task execution and package import contract; no UI surface exists
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or visual workflow changed
<!-- evidence-row:backend-logs -->
- [x] [19581-19178-backend-d63d4908.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19581-19178-backend-d63d4908.txt)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser behavior changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - this removes synthetic LLM fallback; no live model behavior is introduced
<!-- evidence-row:domain-artifacts -->
- [x] [19581-19178-domain-import-d63d4908.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19581-19178-domain-import-d63d4908.txt)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or visual text changed

# Evidence Details

The validation artifact records the exact revision, real built package import probe, deterministic task-result behavior, package gates, and root repository gate. No screenshot, recording, frontend log, OCR, or live-model trajectory can add evidence for this non-visual contract change.

## Known gaps / failures

- None in the changed scope. Independent review and hosted checks remain reviewer/CI-owned gates.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->


