### PR TITLE
fix(cloud): retire reviewed Headscale legacy vhost

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -69,7 +69,8 @@ Representative examples:
   a separate explicit retirement operation. The latter validates the regular
   root-owned legacy-only two-listener contract, requires the exact SHA-256
   emitted by the reviewed inspection, backs up both nginx files, and
-  restores them on any ownership, SAN, nginx, reload, or public-health failure.
+  restores them on any ownership, SAN, nginx, reload, public-health, router,
+  environment-write, worker-restart, or final service-liveness failure.
   Production has no legacy-file cleanup path.
 - `deploy-tunnel-proxy.yml` is the protected Railway + Headscale convergence
   path for the customer tunnel proxy. It validates canonical staging/production

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -62,6 +62,15 @@ Representative examples:
   summary; it downloads by artifact id, decrypts only after every identity
   check, and never creates a replacement plan. Plaintext plan files are
   shredded on every plan/apply outcome.
+- `arm-headscale-control-plane.yml` is the protected Hetzner Headscale
+  convergence path. Its default operation converges the environment-fixed
+  canonical/legacy overlap. Staging additionally exposes a read-only inspection
+  of the exact reviewed `/etc/nginx/conf.d/headscale-staging.conf` artifact and
+  a separate explicit retirement operation. The latter validates the regular
+  root-owned legacy-only two-listener contract, requires the exact SHA-256
+  emitted by the reviewed inspection, backs up both nginx files, and
+  restores them on any ownership, SAN, nginx, reload, or public-health failure.
+  Production has no legacy-file cleanup path.
 - `deploy-tunnel-proxy.yml` is the protected Railway + Headscale convergence
   path for the customer tunnel proxy. It validates canonical staging/production
   hosts, rotates the reusable `tag:eliza-proxy` enrollment key without logging

--- a/.github/workflows/arm-headscale-control-plane.yml
+++ b/.github/workflows/arm-headscale-control-plane.yml
@@ -10,6 +10,20 @@ on:
         options:
           - staging
           - production
+      operation:
+        description: Inspect, converge, or retire the reviewed staging legacy vhost while converging
+        required: true
+        type: choice
+        default: converge
+        options:
+          - inspect-legacy-vhost
+          - converge
+          - retire-legacy-vhost-and-converge
+      reviewed_legacy_vhost_sha256:
+        description: Exact SHA-256 printed by the reviewed staging inspection (retirement only)
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -26,6 +40,8 @@ jobs:
     environment: ${{ inputs.environment }}
     env:
       TARGET_ENVIRONMENT: ${{ inputs.environment }}
+      TARGET_OPERATION: ${{ inputs.operation }}
+      TARGET_REVIEWED_LEGACY_VHOST_SHA256: ${{ inputs.reviewed_legacy_vhost_sha256 }}
       DEPLOY_HOST: ${{ secrets.ELIZA_PROVISIONING_HOST }}
       DEPLOY_SSH_KEY: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
       DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.ELIZA_PROVISIONING_SSH_KNOWN_HOSTS }}
@@ -50,6 +66,38 @@ jobs:
             echo "::error::$TARGET_ENVIRONMENT Headscale deploys must run from $expected_ref"
             exit 1
           fi
+          case "$TARGET_OPERATION" in
+            converge)
+              if [ -n "$TARGET_REVIEWED_LEGACY_VHOST_SHA256" ]; then
+                echo "::error::reviewed_legacy_vhost_sha256 is accepted only for retirement"
+                exit 1
+              fi
+              ;;
+            inspect-legacy-vhost)
+              if [ "$TARGET_ENVIRONMENT" != "staging" ]; then
+                echo "::error::$TARGET_OPERATION is registered only for the reviewed staging legacy vhost"
+                exit 1
+              fi
+              if [ -n "$TARGET_REVIEWED_LEGACY_VHOST_SHA256" ]; then
+                echo "::error::reviewed_legacy_vhost_sha256 is accepted only for retirement"
+                exit 1
+              fi
+              ;;
+            retire-legacy-vhost-and-converge)
+              if [ "$TARGET_ENVIRONMENT" != "staging" ]; then
+                echo "::error::$TARGET_OPERATION is registered only for the reviewed staging legacy vhost"
+                exit 1
+              fi
+              if ! [[ "$TARGET_REVIEWED_LEGACY_VHOST_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+                echo "::error::retirement requires the exact lowercase SHA-256 printed by the reviewed inspection"
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::Unsupported Headscale operation"
+              exit 1
+              ;;
+          esac
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -115,20 +163,35 @@ jobs:
           echo "path=$key_path" >> "$GITHUB_OUTPUT"
           echo "known_hosts_path=$known_hosts_path" >> "$GITHUB_OUTPUT"
 
-      - name: Converge Headscale, canonical TLS, and control-plane router
+      - name: Inspect or converge Headscale control plane
         shell: bash
         env:
           DEPLOY_SSH_KEY_PATH: ${{ steps.key.outputs.path }}
         run: |
           set -euo pipefail
-          node packages/cloud/scripts/admin/arm-headscale-control-plane.mjs \
-            --host "$DEPLOY_HOST" \
-            --ssh-key "$DEPLOY_SSH_KEY_PATH" \
-            --ssh-known-hosts "${{ steps.key.outputs.known_hosts_path }}" \
-            --headscale-public-url "$HEADSCALE_PUBLIC_URL" \
+          args=(
+            node packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+            --host "$DEPLOY_HOST"
+            --ssh-key "$DEPLOY_SSH_KEY_PATH"
+            --ssh-known-hosts "${{ steps.key.outputs.known_hosts_path }}"
+            --headscale-public-url "$HEADSCALE_PUBLIC_URL"
             --headscale-legacy-public-url "$resolved_legacy_public_url"
+          )
+          case "$TARGET_OPERATION" in
+            inspect-legacy-vhost)
+              args+=(--inspect-retirable-legacy-vhost)
+              ;;
+            retire-legacy-vhost-and-converge)
+              args+=(
+                --retire-retirable-legacy-vhost
+                --retirable-legacy-vhost-sha256 "$TARGET_REVIEWED_LEGACY_VHOST_SHA256"
+              )
+              ;;
+          esac
+          "${args[@]}"
 
       - name: Verify dual-SAN public identity and health
+        if: inputs.operation != 'inspect-legacy-vhost'
         shell: bash
         run: |
           set -euo pipefail

--- a/packages/cloud/infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud/infra/cloud/terraform/hetzner/control-plane/README.md
@@ -108,8 +108,13 @@ For the normal staging/prod path, use the idempotent workflow:
 
 ```bash
 gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza --ref main \
-  -f environment=production
+  -f environment=production -f operation=converge
 ```
+
+Staging legacy-vhost retirement is a separate two-run operation documented in
+`packages/cloud/services/headscale/DEPLOY.md`. The retirement dispatch must
+include the exact lowercase SHA-256 printed by its preceding read-only
+inspection; do not retire against an unbound or stale review.
 
 That workflow installs the committed ACL, converges `server_url` and the fixed
 environment-specific loopback `listen_addr`, ensures the `agent`/`tunnel`

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -379,12 +379,42 @@ validate_retirable_legacy_vhost() {
     echo "legacy Headscale vhost bytes changed after inspection; refusing retirement"
     return 1
   fi
+  ambiguous_legacy_lines=$(printf '%s\\n' "$legacy_vhost_source" | awk '
+    {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      sub(/[[:space:]]+$/, "", line)
+      if (line == "" || line ~ /^#/) next
+      if (index(line, "#") > 0) {
+        printf "line %d: hash token in active syntax\\n", NR
+        next
+      }
+      semicolons = gsub(/;/, ";", line)
+      opens = gsub(/[{]/, "{", line)
+      closes = gsub(/[}]/, "}", line)
+      if (semicolons > 1) {
+        printf "line %d: multiple semicolon-terminated directives\\n", NR
+      } else if (semicolons == 1 && (line !~ /;$/ || opens > 0 || closes > 0)) {
+        printf "line %d: mixed block and directive syntax\\n", NR
+      } else if (opens > 1 || closes > 1 || (opens > 0 && closes > 0)) {
+        printf "line %d: multiple block boundaries\\n", NR
+      } else if (opens == 1 && line !~ /[{]$/) {
+        printf "line %d: content follows an opening block boundary\\n", NR
+      } else if (closes == 1 && line != "}") {
+        printf "line %d: content shares a closing block boundary\\n", NR
+      }
+    }
+  ')
+  if [ -n "$ambiguous_legacy_lines" ]; then
+    echo "legacy Headscale vhost uses unsupported dense directive syntax:"
+    printf '%s\\n' "$ambiguous_legacy_lines"
+    return 1
+  fi
   legacy_vhost_directives=$(printf '%s\\n' "$legacy_vhost_source" | awk '
     {
       line = $0
-      sub(/[[:space:]]*#.*/, "", line)
       sub(/^[[:space:]]+/, "", line)
-      if (line == "" || line ~ /^[{}]/) next
+      if (line == "" || line ~ /^#/ || line ~ /^[{}]/) next
       split(line, fields, /[[:space:]]+/)
       directive = fields[1]
       sub(/;.*$/, "", directive)

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -650,6 +650,19 @@ rollback_headscale_vhosts() {
     rm -f "$HS_RETIRABLE_LEGACY_VHOST_BACKUP"
   fi
 }
+
+commit_headscale_vhosts() {
+  # Disable rollback only after the complete remote convergence has passed.
+  # Any failure before this call must restore both reviewed nginx files.
+  trap - EXIT
+  rm -f "$HS_VHOST_BACKUP" "$HS_VHOST_STAGE"
+  if [ -n "$HS_RETIRABLE_LEGACY_VHOST_BACKUP" ]; then
+    rm -f "$HS_RETIRABLE_LEGACY_VHOST_BACKUP"
+  fi
+  if [ "$HS_RETIRABLE_LEGACY_VHOST_EXISTED" = "true" ]; then
+    echo "Retired validated legacy Headscale vhost $HS_RETIRABLE_LEGACY_VHOST"
+  fi
+}
 trap rollback_headscale_vhosts EXIT
 
 tee "$HS_VHOST_STAGE" >/dev/null <<NGINX
@@ -856,15 +869,6 @@ for public_host in "$HS_HOST" "$HS_LEGACY_HOST"; do
   fi
 done
 echo "public Headscale overlap is healthy on one exact dual-SAN leaf"
-
-rm -f "$HS_VHOST_BACKUP" "$HS_VHOST_STAGE"
-if [ -n "$HS_RETIRABLE_LEGACY_VHOST_BACKUP" ]; then
-  rm -f "$HS_RETIRABLE_LEGACY_VHOST_BACKUP"
-fi
-if [ "$HS_RETIRABLE_LEGACY_VHOST_EXISTED" = "true" ]; then
-  echo "Retired validated legacy Headscale vhost $HS_RETIRABLE_LEGACY_VHOST"
-fi
-trap - EXIT
 `;
 
 // ── CP self-enrollment as a tailscale node (cp-<env>-router) ─────────────────
@@ -936,10 +940,7 @@ sudo stat -c 'type=%F owner=%U group=%G mode=%a bytes=%s path=%n' \\
 echo "reviewed-sha256=$legacy_vhost_sha256"
 echo "--- reviewed nginx directive-name inventory (values withheld) ---"
 printf '%s\\n' "$legacy_vhost_directives" | sort | uniq -c
-echo "--- reviewed public routing/TLS directives ---"
-sudo grep -En \\
-  '^[[:space:]]*(listen|server_name|location|root|return|proxy_pass|ssl_certificate|ssl_certificate_key|include)[[:space:]]' \\
-  "$HS_RETIRABLE_LEGACY_VHOST" || true
+echo "reviewed-shape=server-blocks:$legacy_server_block_count server-names:$legacy_server_name_count exact-host:$HS_LEGACY_HOST"
 echo "Legacy Headscale vhost passed the read-only retirement preflight"
 `;
 
@@ -1083,6 +1084,7 @@ sudo systemctl restart ${SYSTEMD_UNIT}
 sleep 2
 systemctl is-active headscale
 systemctl is-active ${SYSTEMD_UNIT}
+commit_headscale_vhosts
 `;
 
 const remote = inspectRetirableLegacyVhost

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -44,6 +44,7 @@ const HEADSCALE_ENVIRONMENT_BY_CANONICAL_HOST = new Map([
       legacyHostname: "headscale.elizacloud.ai",
       apiUrl: "http://127.0.0.1:8081",
       listenAddr: "127.0.0.1:8081",
+      retirableLegacyVhost: undefined,
     },
   ],
   [
@@ -52,6 +53,7 @@ const HEADSCALE_ENVIRONMENT_BY_CANONICAL_HOST = new Map([
       legacyHostname: "headscale-staging.elizacloud.ai",
       apiUrl: "http://127.0.0.1:8080",
       listenAddr: "127.0.0.1:8080",
+      retirableLegacyVhost: "/etc/nginx/conf.d/headscale-staging.conf",
     },
   ],
 ]);
@@ -70,6 +72,8 @@ const BOOL_FLAGS = new Set([
   "dry-run",
   "help",
   "h",
+  "inspect-retirable-legacy-vhost",
+  "retire-retirable-legacy-vhost",
   "skip-nginx-cert",
   "skip-cp-router",
 ]);
@@ -163,6 +167,12 @@ Optional:
                                        by the 'tunnel' headscale user.
   --certbot-email <email>              Email for the Let's Encrypt account / expiry
                                        notices (default ops@elizalabs.ai).
+  --inspect-retirable-legacy-vhost     Read-only validation/report for the exact
+                                       environment-derived legacy nginx file.
+  --retire-retirable-legacy-vhost      Retire that reviewed file transactionally
+                                       while installing the canonical vhost.
+  --retirable-legacy-vhost-sha256 <h>  Exact lowercase SHA-256 emitted by the
+                                       read-only inspection; required to retire.
   --skip-nginx-cert                    Skip the nginx vhost + LE cert step.
   --skip-cp-router                     Skip the CP self-enrollment step.
   --agent-token-private-key-pem <pem>  Upsert daemon env when already generated.
@@ -214,6 +224,14 @@ const cpRouterHostnameArg = readArg(
 );
 const skipNginxCert = args["skip-nginx-cert"] === true;
 const skipCpRouter = args["skip-cp-router"] === true;
+const inspectRetirableLegacyVhost =
+  args["inspect-retirable-legacy-vhost"] === true;
+const retireRetirableLegacyVhost =
+  args["retire-retirable-legacy-vhost"] === true;
+const reviewedLegacyVhostSha256 = readArg(
+  args,
+  "retirable-legacy-vhost-sha256",
+);
 
 if (!host) die("--host or DEPLOY_HOST is required");
 if (!sshKey) die("--ssh-key or DEPLOY_SSH_KEY is required");
@@ -251,7 +269,31 @@ const {
   legacyHostname: expectedLegacyHostname,
   apiUrl,
   listenAddr,
+  retirableLegacyVhost,
 } = environmentConfig;
+if (inspectRetirableLegacyVhost && retireRetirableLegacyVhost) {
+  die("legacy vhost inspection and retirement modes are mutually exclusive");
+}
+if (retireRetirableLegacyVhost && skipNginxCert) {
+  die("legacy vhost retirement cannot be combined with --skip-nginx-cert");
+}
+if (
+  retireRetirableLegacyVhost &&
+  !/^[0-9a-f]{64}$/.test(reviewedLegacyVhostSha256 ?? "")
+) {
+  die(
+    "--retirable-legacy-vhost-sha256 must be the exact lowercase SHA-256 from inspection",
+  );
+}
+if (!retireRetirableLegacyVhost && reviewedLegacyVhostSha256) {
+  die("--retirable-legacy-vhost-sha256 is accepted only with retirement mode");
+}
+if (
+  (inspectRetirableLegacyVhost || retireRetirableLegacyVhost) &&
+  !retirableLegacyVhost
+) {
+  die(`no reviewed legacy nginx vhost is registered for ${headscaleHostname}`);
+}
 const legacyHeadscaleHostname = parsedLegacyPublicUrl.hostname;
 if (legacyHeadscaleHostname !== expectedLegacyHostname) {
   die(
@@ -306,6 +348,145 @@ const upserts = Object.entries(daemonEnv)
   })
   .join("\n");
 
+const legacyVhostValidationFunction = `
+validate_retirable_legacy_vhost() {
+  if [ -z "$HS_RETIRABLE_LEGACY_VHOST" ] \\
+      || ! sudo test -e "$HS_RETIRABLE_LEGACY_VHOST"; then
+    if [ "\${HS_REQUIRE_RETIRABLE_LEGACY_VHOST:-false}" = "true" ]; then
+      echo "reviewed legacy Headscale vhost is absent; refusing retirement"
+      return 1
+    fi
+    return 0
+  fi
+  if sudo test -L "$HS_RETIRABLE_LEGACY_VHOST" \\
+      || ! sudo test -f "$HS_RETIRABLE_LEGACY_VHOST"; then
+    echo "refusing to inspect or retire a non-regular legacy Headscale vhost: $HS_RETIRABLE_LEGACY_VHOST"
+    return 1
+  fi
+  legacy_vhost_owner=$(sudo stat -c '%U:%G' "$HS_RETIRABLE_LEGACY_VHOST")
+  if [ "$legacy_vhost_owner" != "root:root" ] \\
+      || sudo find "$HS_RETIRABLE_LEGACY_VHOST" -maxdepth 0 -perm /022 \\
+        -print -quit | grep -q .; then
+    echo "legacy Headscale vhost must be root-owned and not group/world writable"
+    return 1
+  fi
+
+  legacy_vhost_source=$(sudo cat -- "$HS_RETIRABLE_LEGACY_VHOST")
+  legacy_vhost_sha256=$(sudo sha256sum -- "$HS_RETIRABLE_LEGACY_VHOST" \\
+    | awk '{print $1}')
+  if [ -n "\${HS_REVIEWED_LEGACY_VHOST_SHA256:-}" ] \\
+      && [ "$legacy_vhost_sha256" != "$HS_REVIEWED_LEGACY_VHOST_SHA256" ]; then
+    echo "legacy Headscale vhost bytes changed after inspection; refusing retirement"
+    return 1
+  fi
+  legacy_vhost_directives=$(printf '%s\\n' "$legacy_vhost_source" | awk '
+    {
+      line = $0
+      sub(/[[:space:]]*#.*/, "", line)
+      sub(/^[[:space:]]+/, "", line)
+      if (line == "" || line ~ /^[{}]/) next
+      split(line, fields, /[[:space:]]+/)
+      directive = fields[1]
+      sub(/;.*$/, "", directive)
+      if (directive ~ /^[[:alpha:]_][[:alnum:]_]*$/) print directive
+    }
+  ')
+  unexpected_legacy_directives=$(printf '%s\\n' "$legacy_vhost_directives" \\
+    | awk '$0 !~ /^(server|listen|server_name|location|root|default_type|try_files|return|ssl_certificate|ssl_certificate_key|proxy_pass|proxy_http_version|proxy_set_header|proxy_buffering|proxy_read_timeout|proxy_send_timeout)$/ { print }')
+  if [ "\${HS_ENFORCE_LEGACY_VHOST_DIRECTIVE_ALLOWLIST:-false}" = "true" ] \\
+      && [ -n "$unexpected_legacy_directives" ]; then
+    echo "legacy Headscale vhost contains directives outside the reviewed retirement allowlist:"
+    printf '%s\\n' "$unexpected_legacy_directives"
+    return 1
+  fi
+  legacy_server_block_count=$(printf '%s\\n' "$legacy_vhost_source" \\
+    | awk '/^[[:space:]]*server[[:space:]]*\\{/ { count += 1 } END { print count + 0 }')
+  legacy_server_names=$(printf '%s\\n' "$legacy_vhost_source" | awk '
+    function inspect_names(text, fields, count, i, name) {
+      count = split(text, fields, /[[:space:]]+/)
+      for (i = 1; i <= count; i += 1) {
+        name = fields[i]
+        if (name == "") continue
+        if (name ~ /;$/) collecting = 0
+        sub(/;$/, "", name)
+        gsub(/^"|"$/, "", name)
+        if (name != "") print name
+      }
+    }
+    {
+      line = $0
+      sub(/[[:space:]]*#.*/, "", line)
+      if (collecting) {
+        inspect_names(line)
+        next
+      }
+      if (line ~ /^[[:space:]]*server_name[[:space:]]+/) {
+        sub(/^[[:space:]]*server_name[[:space:]]+/, "", line)
+        collecting = 1
+        inspect_names(line)
+      }
+    }
+  ')
+  legacy_server_name_count=$(printf '%s\\n' "$legacy_server_names" \\
+    | awk 'NF { count += 1 } END { print count + 0 }')
+  unexpected_legacy_server_names=$(printf '%s\\n' "$legacy_server_names" \\
+    | awk -v expected="$HS_LEGACY_HOST" 'NF && $0 != expected { print }')
+  if [ "$legacy_server_block_count" -ne 2 ] \\
+      || [ "$legacy_server_name_count" -ne 2 ] \\
+      || [ -n "$unexpected_legacy_server_names" ]; then
+    echo "legacy Headscale vhost does not contain exactly two expected legacy-only server blocks"
+    return 1
+  fi
+
+  loaded_legacy_owners=$(sudo nginx -T 2>&1 | awk \\
+    -v target="$HS_RETIRABLE_LEGACY_VHOST" \\
+    -v canonical="$HS_HOST" \\
+    -v legacy="$HS_LEGACY_HOST" '
+    function inspect_names(text, fields, count, i, name) {
+      count = split(text, fields, /[[:space:]]+/)
+      for (i = 1; i <= count; i += 1) {
+        name = fields[i]
+        if (name == "") continue
+        if (name ~ /;$/) collecting = 0
+        sub(/;$/, "", name)
+        gsub(/^"|"$/, "", name)
+        if (config_file == target && (name == canonical || name == legacy)) {
+          print name
+        }
+      }
+    }
+    /^# configuration file / {
+      config_file = $0
+      sub(/^# configuration file /, "", config_file)
+      sub(/:$/, "", config_file)
+      collecting = 0
+      next
+    }
+    {
+      line = $0
+      sub(/[[:space:]]*#.*/, "", line)
+      if (collecting) {
+        inspect_names(line)
+        next
+      }
+      if (line ~ /^[[:space:]]*server_name[[:space:]]+/) {
+        sub(/^[[:space:]]*server_name[[:space:]]+/, "", line)
+        collecting = 1
+        inspect_names(line)
+      }
+    }
+  ')
+  loaded_legacy_count=$(printf '%s\\n' "$loaded_legacy_owners" \\
+    | awk -v host="$HS_LEGACY_HOST" '$0 == host { count += 1 } END { print count + 0 }')
+  loaded_canonical_count=$(printf '%s\\n' "$loaded_legacy_owners" \\
+    | awk -v host="$HS_HOST" '$0 == host { count += 1 } END { print count + 0 }')
+  if [ "$loaded_legacy_count" -ne 2 ] || [ "$loaded_canonical_count" -ne 0 ]; then
+    echo "legacy Headscale vhost ownership no longer matches the reviewed two-listener contract"
+    return 1
+  fi
+}
+`;
+
 // ── nginx vhost + Let's Encrypt migration-overlap certificate ────────────────
 // The canonical hostname owns Headscale identity and daemon configuration. The
 // legacy exact hostname remains an additive TLS/vhost alias only while clients
@@ -325,6 +506,13 @@ echo "--- nginx vhost + Let's Encrypt cert for ${headscaleHostname} and ${legacy
 HS_HOST=${shellQuote(headscaleHostname)}
 HS_LEGACY_HOST=${shellQuote(legacyHeadscaleHostname)}
 HS_PORT=${shellQuote(headscalePort)}
+HS_RETIRABLE_LEGACY_VHOST=${shellQuote(retirableLegacyVhost ?? "")}
+HS_RETIRE_REVIEWED_LEGACY_VHOST=${shellQuote(
+      retireRetirableLegacyVhost ? "true" : "false",
+    )}
+HS_REQUIRE_RETIRABLE_LEGACY_VHOST=$HS_RETIRE_REVIEWED_LEGACY_VHOST
+HS_ENFORCE_LEGACY_VHOST_DIRECTIVE_ALLOWLIST=$HS_RETIRE_REVIEWED_LEGACY_VHOST
+HS_REVIEWED_LEGACY_VHOST_SHA256=${shellQuote(reviewedLegacyVhostSha256 ?? "")}
 CERTBOT_EMAIL=${shellQuote(certbotEmail)}
 HS_VHOST=/etc/nginx/conf.d/headscale.conf
 HS_ACME_VHOST=/etc/nginx/conf.d/00-headscale-acme.conf
@@ -349,6 +537,9 @@ certificate_covers_overlap() {
   certificate_has_exact_san "$HS_HOST" \\
     && certificate_has_exact_san "$HS_LEGACY_HOST"
 }
+
+${legacyVhostValidationFunction}
+validate_retirable_legacy_vhost
 
 if certificate_covers_overlap; then
   echo "LE cert already covers canonical and legacy Headscale hosts; skipping issuance"
@@ -421,17 +612,33 @@ fi
 HS_VHOST_BACKUP=$(mktemp)
 HS_VHOST_STAGE=$(mktemp)
 HS_VHOST_EXISTED=false
+HS_RETIRABLE_LEGACY_VHOST_BACKUP=""
+HS_RETIRABLE_LEGACY_VHOST_EXISTED=false
+HS_RETIRABLE_LEGACY_VHOST_MODE=""
 if sudo test -f "$HS_VHOST"; then
   sudo cp "$HS_VHOST" "$HS_VHOST_BACKUP"
   HS_VHOST_EXISTED=true
 fi
+if [ "$HS_RETIRE_REVIEWED_LEGACY_VHOST" = "true" ] \\
+    && sudo test -f "$HS_RETIRABLE_LEGACY_VHOST"; then
+  HS_RETIRABLE_LEGACY_VHOST_BACKUP=$(mktemp)
+  HS_RETIRABLE_LEGACY_VHOST_MODE=$(sudo stat -c '%a' \\
+    "$HS_RETIRABLE_LEGACY_VHOST")
+  sudo cp -- "$HS_RETIRABLE_LEGACY_VHOST" \\
+    "$HS_RETIRABLE_LEGACY_VHOST_BACKUP"
+  HS_RETIRABLE_LEGACY_VHOST_EXISTED=true
+fi
 
-rollback_headscale_vhost() {
+rollback_headscale_vhosts() {
   trap - EXIT
   if [ "$HS_VHOST_EXISTED" = "true" ]; then
     sudo cp "$HS_VHOST_BACKUP" "$HS_VHOST"
   else
     sudo rm -f "$HS_VHOST"
+  fi
+  if [ "$HS_RETIRABLE_LEGACY_VHOST_EXISTED" = "true" ]; then
+    sudo install -o root -g root -m "$HS_RETIRABLE_LEGACY_VHOST_MODE" \\
+      "$HS_RETIRABLE_LEGACY_VHOST_BACKUP" "$HS_RETIRABLE_LEGACY_VHOST"
   fi
   if sudo nginx -t; then
     sudo systemctl reload nginx
@@ -439,8 +646,11 @@ rollback_headscale_vhost() {
     echo "rollback restored the previous Headscale vhost bytes, but nginx validation failed"
   fi
   rm -f "$HS_VHOST_BACKUP" "$HS_VHOST_STAGE"
+  if [ -n "$HS_RETIRABLE_LEGACY_VHOST_BACKUP" ]; then
+    rm -f "$HS_RETIRABLE_LEGACY_VHOST_BACKUP"
+  fi
 }
-trap rollback_headscale_vhost EXIT
+trap rollback_headscale_vhosts EXIT
 
 tee "$HS_VHOST_STAGE" >/dev/null <<NGINX
 # headscale control-protocol (TS2021/noise) needs the Upgrade header passed
@@ -484,6 +694,10 @@ server {
 }
 NGINX
 sudo install -o root -g root -m 0644 "$HS_VHOST_STAGE" "$HS_VHOST"
+if [ "$HS_RETIRABLE_LEGACY_VHOST_EXISTED" = "true" ]; then
+  validate_retirable_legacy_vhost
+  sudo rm -f -- "$HS_RETIRABLE_LEGACY_VHOST"
+fi
 sudo nginx -t
 
 effective_nginx_config=$(sudo nginx -T 2>&1)
@@ -549,9 +763,6 @@ certificate_has_exact_san "$HS_HOST"
 certificate_has_exact_san "$HS_LEGACY_HOST"
 sudo systemctl reload nginx
 
-rm -f "$HS_VHOST_BACKUP" "$HS_VHOST_STAGE"
-trap - EXIT
-
 # Certbot's webroot renewal updates the certificate files in place. Install a
 # deploy hook on every arm, including no-op certificate runs, so nginx adopts
 # only a leaf that still covers both migration-overlap names. The hook is
@@ -596,6 +807,64 @@ sudo systemctl enable --now certbot.timer
 sudo systemctl is-enabled --quiet certbot.timer
 sudo systemctl is-active --quiet certbot.timer
 echo "certbot.timer active (auto-renewal wired)"
+
+# Keep the rollback transaction active through the public edge proof. Local
+# certificate files and nginx ownership are necessary but not sufficient when
+# another listener or stale SNI route can still win externally.
+expected_public_fingerprint=""
+for public_host in "$HS_HOST" "$HS_LEGACY_HOST"; do
+  public_healthy=false
+  for _ in $(seq 1 30); do
+    if curl --fail --silent --show-error --max-time 10 \\
+        "https://$public_host/health" >/dev/null; then
+      public_healthy=true
+      break
+    fi
+    sleep 5
+  done
+  if [ "$public_healthy" != "true" ]; then
+    echo "public Headscale health did not become ready at https://$public_host"
+    exit 1
+  fi
+
+  public_leaf=$(openssl s_client \\
+    -connect "$public_host:443" \\
+    -servername "$public_host" \\
+    -verify_hostname "$public_host" \\
+    -verify_return_error \\
+    -showcerts </dev/null 2>/dev/null \\
+    | openssl x509 -outform PEM)
+  for required_host in "$HS_HOST" "$HS_LEGACY_HOST"; do
+    if ! printf '%s\\n' "$public_leaf" \\
+      | openssl x509 -noout -ext subjectAltName \\
+      | tr ',' '\\n' \\
+      | sed -n 's/^[[:space:]]*DNS://p' \\
+      | grep -Fx -- "$required_host" >/dev/null; then
+      echo "$public_host did not serve a leaf with exact SAN $required_host"
+      exit 1
+    fi
+  done
+  public_fingerprint=$(printf '%s\\n' "$public_leaf" \\
+    | openssl x509 -outform DER \\
+    | openssl dgst -sha256 -r \\
+    | awk '{print $1}')
+  if [ -z "$expected_public_fingerprint" ]; then
+    expected_public_fingerprint="$public_fingerprint"
+  elif [ "$public_fingerprint" != "$expected_public_fingerprint" ]; then
+    echo "canonical and legacy Headscale SNI served different certificate leaves"
+    exit 1
+  fi
+done
+echo "public Headscale overlap is healthy on one exact dual-SAN leaf"
+
+rm -f "$HS_VHOST_BACKUP" "$HS_VHOST_STAGE"
+if [ -n "$HS_RETIRABLE_LEGACY_VHOST_BACKUP" ]; then
+  rm -f "$HS_RETIRABLE_LEGACY_VHOST_BACKUP"
+fi
+if [ "$HS_RETIRABLE_LEGACY_VHOST_EXISTED" = "true" ]; then
+  echo "Retired validated legacy Headscale vhost $HS_RETIRABLE_LEGACY_VHOST"
+fi
+trap - EXIT
 `;
 
 // ── CP self-enrollment as a tailscale node (cp-<env>-router) ─────────────────
@@ -645,7 +914,36 @@ sudo tailscale status 2>/dev/null | grep -F "$CP_ROUTER_HOST" \\
   || echo "WARN: $CP_ROUTER_HOST not visible in tailscale status yet"
 `;
 
-const remote = `
+const legacyVhostInspectionRemote = `
+set -euo pipefail
+HS_HOST=${shellQuote(headscaleHostname)}
+HS_LEGACY_HOST=${shellQuote(legacyHeadscaleHostname)}
+HS_RETIRABLE_LEGACY_VHOST=${shellQuote(retirableLegacyVhost ?? "")}
+HS_REQUIRE_RETIRABLE_LEGACY_VHOST=true
+HS_ENFORCE_LEGACY_VHOST_DIRECTIVE_ALLOWLIST=false
+HS_REVIEWED_LEGACY_VHOST_SHA256=""
+
+if [ -z "$HS_RETIRABLE_LEGACY_VHOST" ] \\
+    || ! sudo test -e "$HS_RETIRABLE_LEGACY_VHOST"; then
+  echo "reviewed legacy Headscale vhost is not present"
+  exit 1
+fi
+
+${legacyVhostValidationFunction}
+validate_retirable_legacy_vhost
+sudo stat -c 'type=%F owner=%U group=%G mode=%a bytes=%s path=%n' \\
+  "$HS_RETIRABLE_LEGACY_VHOST"
+echo "reviewed-sha256=$legacy_vhost_sha256"
+echo "--- reviewed nginx directive-name inventory (values withheld) ---"
+printf '%s\\n' "$legacy_vhost_directives" | sort | uniq -c
+echo "--- reviewed public routing/TLS directives ---"
+sudo grep -En \\
+  '^[[:space:]]*(listen|server_name|location|root|return|proxy_pass|ssl_certificate|ssl_certificate_key|include)[[:space:]]' \\
+  "$HS_RETIRABLE_LEGACY_VHOST" || true
+echo "Legacy Headscale vhost passed the read-only retirement preflight"
+`;
+
+const convergeRemote = `
 set -euo pipefail
 PUBLIC_URL=${shellQuote(publicUrl)}
 API_URL=${shellQuote(apiUrl)}
@@ -787,6 +1085,10 @@ systemctl is-active headscale
 systemctl is-active ${SYSTEMD_UNIT}
 `;
 
+const remote = inspectRetirableLegacyVhost
+  ? legacyVhostInspectionRemote
+  : convergeRemote;
+
 if (args["dry-run"]) {
   console.log("# DRY RUN - remote script that WOULD run on", host, ":\n");
   console.log(remote);
@@ -817,6 +1119,10 @@ const result = spawnSync(
 if (result.status !== 0)
   die(`remote Headscale arm failed (exit ${result.status})`);
 
-console.log(
-  "\nHeadscale armed. Next: set matching Worker secrets, then run one provision E2E.",
-);
+if (inspectRetirableLegacyVhost) {
+  console.log("\nReviewed legacy Headscale vhost inspection passed.");
+} else {
+  console.log(
+    "\nHeadscale armed. Next: set matching Worker secrets, then run one provision E2E.",
+  );
+}

--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -98,9 +98,10 @@ gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza \
 The inspection requires a regular, root-owned, non-group/world-writable file,
 exactly two server blocks that name only `headscale-staging.elizacloud.ai`, and
 exactly two loaded nginx owners from that path. It reports file metadata,
-SHA-256, and the public routing/TLS directives for review. Only after that run
-is reviewed may an operator select the retirement operation and supply that
-exact lowercase digest:
+SHA-256, directive-name counts, and the validated server-block/name shape for
+review without printing directive literal values. Only after that run is
+reviewed may an operator select the retirement operation and supply that exact
+lowercase digest:
 
 ```bash
 gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza \
@@ -113,9 +114,11 @@ The digest makes the reviewed bytes the retirement authority; any intervening
 file change fails closed. The arm backs up the exact file,
 installs the canonical dual-name vhost, removes the legacy file only after the
 rollback trap is active, then validates ownership, SANs, nginx, and public
-health. Any failure restores both prior files and reloads the previous valid
-configuration. Production has no registered cleanup path and rejects both
-legacy-file operations.
+health before converging router enrollment, environment writes, the worker
+restart, and final service liveness. Any failure before all remote convergence
+passes restores both prior files and reloads the previous valid configuration.
+Production has no registered cleanup path and rejects both legacy-file
+operations.
 
 The matching Cloudflare Worker secrets still need to be set through the normal
 Worker secret path. Keep host and Worker values identical for

--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -41,7 +41,7 @@ from the selected environment. Operators do not provide or override that alias.
 
 ```bash
 gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza --ref main \
-  -f environment=production
+  -f environment=production -f operation=converge
 ```
 
 > `workflow_dispatch` runs the copy of the workflow on the dispatched ref, so
@@ -84,6 +84,38 @@ files untouched, and fails the workflow. Review the explicit conflict path and
 land a separate targeted cleanup; do not add a generic config deletion rule.
 Certificate expansion can succeed before a later vhost ownership failure, but
 the prior active vhost is still restored.
+
+Staging has one separately reviewed retirement path for the legacy manual
+vhost discovered by the fail-closed ownership audit:
+`/etc/nginx/conf.d/headscale-staging.conf`. Inspect it first without changing
+the host:
+
+```bash
+gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza \
+  --ref develop -f environment=staging -f operation=inspect-legacy-vhost
+```
+
+The inspection requires a regular, root-owned, non-group/world-writable file,
+exactly two server blocks that name only `headscale-staging.elizacloud.ai`, and
+exactly two loaded nginx owners from that path. It reports file metadata,
+SHA-256, and the public routing/TLS directives for review. Only after that run
+is reviewed may an operator select the retirement operation and supply that
+exact lowercase digest:
+
+```bash
+gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza \
+  --ref develop -f environment=staging \
+  -f operation=retire-legacy-vhost-and-converge \
+  -f reviewed_legacy_vhost_sha256=<LOWERCASE_SHA256_FROM_INSPECTION>
+```
+
+The digest makes the reviewed bytes the retirement authority; any intervening
+file change fails closed. The arm backs up the exact file,
+installs the canonical dual-name vhost, removes the legacy file only after the
+rollback trap is active, then validates ownership, SANs, nginx, and public
+health. Any failure restores both prior files and reloads the previous valid
+configuration. Production has no registered cleanup path and rejects both
+legacy-file operations.
 
 The matching Cloudflare Worker secrets still need to be set through the normal
 Worker secret path. Keep host and Worker values identical for

--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -86,6 +86,7 @@ function runDryArm(
   publicUrl: string,
   legacyPublicUrl: string,
   extraArgs: string[] = [],
+  skipCpRouter = true,
 ) {
   const fixtureDir = mkdtempSync(join(tmpdir(), "headscale-arm-test-"));
   const sshKey = join(fixtureDir, "deploy-key");
@@ -110,7 +111,7 @@ function runDryArm(
         legacyPublicUrl,
         "--headscale-api-key",
         "test-only-api-key",
-        "--skip-cp-router",
+        ...(skipCpRouter ? ["--skip-cp-router"] : []),
         ...extraArgs,
         "--dry-run",
       ],
@@ -121,6 +122,92 @@ function runDryArm(
         },
       },
     );
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
+}
+
+function shellFunction(remoteScript: string, name: string) {
+  const startMarker = `${name}() {\n`;
+  const start = remoteScript.indexOf(startMarker);
+  if (start === -1) throw new Error(`Missing shell function ${name}`);
+  const end = remoteScript.indexOf("\n}\n", start);
+  if (end === -1) throw new Error(`Missing shell function end for ${name}`);
+  return remoteScript.slice(start, end + 2);
+}
+
+function runVhostRollbackAfterFailure(failureStage: string) {
+  const dry = runDryArm(
+    "https://headscale-staging.eliza.app",
+    "https://headscale-staging.elizacloud.ai",
+    [
+      "--retire-retirable-legacy-vhost",
+      "--retirable-legacy-vhost-sha256",
+      reviewedLegacyVhostSha256,
+    ],
+    false,
+  );
+  expect(dry.status).toBe(0);
+  const rollback = shellFunction(dry.stdout, "rollback_headscale_vhosts");
+  const fixtureDir = mkdtempSync(join(tmpdir(), "headscale-rollback-test-"));
+  const vhost = join(fixtureDir, "headscale.conf");
+  const vhostBackup = join(fixtureDir, "headscale.conf.backup");
+  const vhostStage = join(fixtureDir, "headscale.conf.stage");
+  const legacyVhost = join(fixtureDir, "headscale-staging.conf");
+  const legacyBackup = join(fixtureDir, "headscale-staging.conf.backup");
+  const commandLog = join(fixtureDir, "commands.log");
+  writeFileSync(vhost, "new canonical bytes\n");
+  writeFileSync(vhostBackup, "old canonical bytes\n");
+  writeFileSync(vhostStage, "staged canonical bytes\n");
+  writeFileSync(legacyBackup, "old legacy bytes\n");
+  writeFileSync(commandLog, "");
+
+  const harness = `
+set -euo pipefail
+HS_VHOST=${JSON.stringify(vhost)}
+HS_VHOST_BACKUP=${JSON.stringify(vhostBackup)}
+HS_VHOST_STAGE=${JSON.stringify(vhostStage)}
+HS_VHOST_EXISTED=true
+HS_RETIRABLE_LEGACY_VHOST=${JSON.stringify(legacyVhost)}
+HS_RETIRABLE_LEGACY_VHOST_BACKUP=${JSON.stringify(legacyBackup)}
+HS_RETIRABLE_LEGACY_VHOST_EXISTED=true
+HS_RETIRABLE_LEGACY_VHOST_MODE=0644
+COMMAND_LOG=${JSON.stringify(commandLog)}
+sudo() {
+  case "$1" in
+    cp) command cp "$2" "$3" ;;
+    rm) shift; command rm "$@" ;;
+    install)
+      command cp "\${@: -2:1}" "\${@: -1}"
+      ;;
+    nginx) return 0 ;;
+    systemctl)
+      shift
+      printf 'systemctl %s\\n' "$*" >> "$COMMAND_LOG"
+      ;;
+    *) "$@" ;;
+  esac
+}
+${rollback}
+trap rollback_headscale_vhosts EXIT
+for stage in cp-router env-write worker-restart final-liveness; do
+  if [ "$stage" = ${JSON.stringify(failureStage)} ]; then
+    false
+  fi
+done
+`;
+
+  try {
+    const result = spawnSync("bash", ["-c", harness], {
+      encoding: "utf8",
+      env: { PATH: process.env.PATH ?? "" },
+    });
+    return {
+      ...result,
+      canonical: readFileSync(vhost, "utf8"),
+      legacy: readFileSync(legacyVhost, "utf8"),
+      commandLog: readFileSync(commandLog, "utf8"),
+    };
   } finally {
     rmSync(fixtureDir, { recursive: true, force: true });
   }
@@ -215,6 +302,56 @@ validate_retirable_legacy_vhost
         TEST_FILE_OWNER: options.owner ?? "root:root",
         TEST_FILE_WRITABLE: options.writable ? "true" : "false",
         TEST_NGINX_CONFIG: (options.loadedConfig ?? "").replaceAll(
+          "REPLACE_LEGACY_PATH",
+          legacyVhost,
+        ),
+      },
+    });
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
+}
+
+function runLegacyVhostInspection(source: string, loadedConfig: string) {
+  const dry = runDryArm(
+    "https://headscale-staging.eliza.app",
+    "https://headscale-staging.elizacloud.ai",
+    ["--inspect-retirable-legacy-vhost"],
+  );
+  expect(dry.status).toBe(0);
+  const fixtureDir = mkdtempSync(
+    join(tmpdir(), "headscale-legacy-inspection-test-"),
+  );
+  const legacyVhost = join(fixtureDir, "headscale-staging.conf");
+  writeFileSync(legacyVhost, source, { mode: 0o644 });
+  const remoteScript = dry.stdout.replaceAll(
+    "/etc/nginx/conf.d/headscale-staging.conf",
+    legacyVhost,
+  );
+  const harness = `
+sudo() {
+  case "$1" in
+    stat)
+      if [ "$2" = "-c" ] && [ "$3" = "%U:%G" ]; then
+        printf 'root:root\\n'
+      else
+        printf 'type=regular-file owner=root group=root mode=644 bytes=reviewed path=%s\\n' ${JSON.stringify(legacyVhost)}
+      fi
+      ;;
+    find) return 0 ;;
+    nginx) printf '%s\\n' "$TEST_NGINX_CONFIG" ;;
+    *) "$@" ;;
+  esac
+}
+${remoteScript}
+`;
+
+  try {
+    return spawnSync("bash", ["-c", harness], {
+      encoding: "utf8",
+      env: {
+        PATH: process.env.PATH ?? "",
+        TEST_NGINX_CONFIG: loadedConfig.replaceAll(
           "REPLACE_LEGACY_PATH",
           legacyVhost,
         ),
@@ -568,6 +705,7 @@ server_name headscale-staging.elizacloud.ai;
         "--retirable-legacy-vhost-sha256",
         reviewedLegacyVhostSha256,
       ],
+      false,
     );
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
@@ -607,7 +745,19 @@ server_name headscale-staging.elizacloud.ai;
       '-servername "$public_host"',
       publicHealthProof,
     );
-    const transactionCommit = result.stdout.lastIndexOf("trap - EXIT");
+    const cpRouter = result.stdout.indexOf("--- CP self-enrollment:");
+    const envWrite = result.stdout.indexOf("sudo sed -i", cpRouter);
+    const workerRestart = result.stdout.indexOf(
+      "sudo systemctl restart eliza-provisioning-worker.service",
+      envWrite,
+    );
+    const finalServiceLiveness = result.stdout.indexOf(
+      "systemctl is-active eliza-provisioning-worker.service",
+      workerRestart,
+    );
+    const transactionCommit = result.stdout.lastIndexOf(
+      "commit_headscale_vhosts",
+    );
     expect(validation).toBeGreaterThan(-1);
     expect(trap).toBeGreaterThan(validation);
     expect(install).toBeGreaterThan(trap);
@@ -618,6 +768,11 @@ server_name headscale-staging.elizacloud.ai;
     expect(timerProof).toBeGreaterThan(ownership);
     expect(publicHealthProof).toBeGreaterThan(timerProof);
     expect(publicSniProof).toBeGreaterThan(publicHealthProof);
+    expect(cpRouter).toBeGreaterThan(publicSniProof);
+    expect(envWrite).toBeGreaterThan(cpRouter);
+    expect(workerRestart).toBeGreaterThan(envWrite);
+    expect(finalServiceLiveness).toBeGreaterThan(workerRestart);
+    expect(transactionCommit).toBeGreaterThan(finalServiceLiveness);
     expect(transactionCommit).toBeGreaterThan(publicSniProof);
     expect(transactionCommit).toBeGreaterThan(timerProof);
     expect(result.stdout).toContain(
@@ -625,6 +780,17 @@ server_name headscale-staging.elizacloud.ai;
     );
     expectBashSyntax(result.stdout);
   });
+
+  test.each(["cp-router", "env-write", "worker-restart", "final-liveness"])(
+    "restores both reviewed vhosts when %s convergence fails",
+    (failureStage) => {
+      const result = runVhostRollbackAfterFailure(failureStage);
+      expect(result.status).not.toBe(0);
+      expect(result.canonical).toBe("old canonical bytes\n");
+      expect(result.legacy).toBe("old legacy bytes\n");
+      expect(result.commandLog).toBe("systemctl reload nginx\n");
+    },
+  );
 
   test("inspects only the exact reviewed staging file without generating convergence", () => {
     const result = runDryArm(
@@ -641,16 +807,45 @@ server_name headscale-staging.elizacloud.ai;
     expect(result.stdout).toContain(
       "directive-name inventory (values withheld)",
     );
-    const publicDirectiveReport = result.stdout.slice(
-      result.stdout.indexOf("--- reviewed public routing/TLS directives ---"),
-      result.stdout.indexOf(
-        "Legacy Headscale vhost passed the read-only retirement preflight",
-      ),
+    expect(result.stdout).toContain("reviewed-shape=server-blocks:");
+    expect(result.stdout).not.toContain(
+      "reviewed public routing/TLS directives",
     );
-    expect(publicDirectiveReport).not.toContain("proxy_set_header");
+    expect(result.stdout).not.toContain("sudo grep -En");
     expect(result.stdout).not.toContain("sudo systemctl restart headscale");
     expect(result.stdout).not.toContain("sudo rm -f --");
     expectBashSyntax(result.stdout);
+  });
+
+  test("withholds every reviewed directive literal from inspection output", () => {
+    const signedRedirect = "https://redirect.invalid/canary-signed-query";
+    const embeddedCredential =
+      "http://canary-user:canary-password@127.0.0.1:8080";
+    const privateInclude = "/etc/nginx/canary-private-include.conf";
+    const source = `server {
+  listen 80;
+  listen [::]:80;
+  server_name headscale-staging.elizacloud.ai;
+  return 301 ${signedRedirect};
+}
+server {
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  server_name headscale-staging.elizacloud.ai;
+  proxy_pass ${embeddedCredential};
+  include ${privateInclude};
+}
+`;
+    const result = runLegacyVhostInspection(source, expectedLoadedConfig);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("reviewed-sha256=");
+    expect(result.stdout).toContain("reviewed-shape=server-blocks:2");
+    expect(result.stdout).toContain("proxy_pass");
+    expect(result.stdout).toContain("include");
+    expect(result.stdout).not.toContain(signedRedirect);
+    expect(result.stdout).not.toContain(embeddedCredential);
+    expect(result.stdout).not.toContain(privateInclude);
   });
 
   test("rejects inspection or retirement for production without a reviewed path", () => {

--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -9,6 +9,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -46,6 +47,7 @@ const scriptPath = fileURLToPath(
 );
 
 interface WorkflowStep {
+  if?: string;
   name?: string;
   run?: string;
   uses?: string;
@@ -63,6 +65,7 @@ interface Workflow {
 
 const workflow = Bun.YAML.parse(workflowSource) as Workflow;
 const arm = workflow.jobs?.arm;
+const reviewedLegacyVhostSha256 = "a".repeat(64);
 
 function step(name: string): WorkflowStep {
   const found = arm?.steps?.find((candidate) => candidate.name === name);
@@ -79,7 +82,11 @@ function expectBashSyntax(source: string) {
   expect(syntax.stderr).toBe("");
 }
 
-function runDryArm(publicUrl: string, legacyPublicUrl: string) {
+function runDryArm(
+  publicUrl: string,
+  legacyPublicUrl: string,
+  extraArgs: string[] = [],
+) {
   const fixtureDir = mkdtempSync(join(tmpdir(), "headscale-arm-test-"));
   const sshKey = join(fixtureDir, "deploy-key");
   const knownHosts = join(fixtureDir, "known-hosts");
@@ -104,6 +111,7 @@ function runDryArm(publicUrl: string, legacyPublicUrl: string) {
         "--headscale-api-key",
         "test-only-api-key",
         "--skip-cp-router",
+        ...extraArgs,
         "--dry-run",
       ],
       {
@@ -120,12 +128,101 @@ function runDryArm(publicUrl: string, legacyPublicUrl: string) {
 
 function ownershipAwkProgram(remoteScript: string) {
   const startMarker = '-v legacy="$HS_LEGACY_HOST" \'\n';
-  const start = remoteScript.indexOf(startMarker);
+  const start = remoteScript.lastIndexOf(startMarker);
   if (start === -1) throw new Error("Missing Headscale ownership awk start");
   const bodyStart = start + startMarker.length;
   const end = remoteScript.indexOf("\n')", bodyStart);
   if (end === -1) throw new Error("Missing Headscale ownership awk end");
   return remoteScript.slice(bodyStart, end);
+}
+
+function legacyVhostValidationFunction(remoteScript: string) {
+  const startMarker = "validate_retirable_legacy_vhost() {\n";
+  const start = remoteScript.indexOf(startMarker);
+  if (start === -1) throw new Error("Missing legacy vhost validator start");
+  const endMarker = "\n}\n\nvalidate_retirable_legacy_vhost";
+  const end = remoteScript.indexOf(endMarker, start);
+  if (end === -1) throw new Error("Missing legacy vhost validator end");
+  return remoteScript.slice(start, end + 2);
+}
+
+function runLegacyVhostValidation(options: {
+  source?: string;
+  loadedConfig?: string;
+  owner?: string;
+  symlink?: boolean;
+  writable?: boolean;
+  reviewedSha256?: string;
+  requireFile?: boolean;
+  enforceDirectiveAllowlist?: boolean;
+}) {
+  const dry = runDryArm(
+    "https://headscale-staging.eliza.app",
+    "https://headscale-staging.elizacloud.ai",
+    [
+      "--retire-retirable-legacy-vhost",
+      "--retirable-legacy-vhost-sha256",
+      reviewedLegacyVhostSha256,
+    ],
+  );
+  expect(dry.status).toBe(0);
+  const fixtureDir = mkdtempSync(
+    join(tmpdir(), "headscale-legacy-vhost-test-"),
+  );
+  const legacyVhost = join(fixtureDir, "headscale-staging.conf");
+  const target = join(fixtureDir, "target.conf");
+  if (options.source !== undefined) {
+    if (options.symlink) {
+      writeFileSync(target, options.source, { mode: 0o644 });
+      symlinkSync(target, legacyVhost);
+    } else {
+      writeFileSync(legacyVhost, options.source, { mode: 0o644 });
+    }
+  }
+  const validator = legacyVhostValidationFunction(dry.stdout).replaceAll(
+    "/etc/nginx/conf.d/headscale-staging.conf",
+    legacyVhost,
+  );
+  const harness = `
+set -euo pipefail
+HS_HOST=headscale-staging.eliza.app
+HS_LEGACY_HOST=headscale-staging.elizacloud.ai
+HS_RETIRABLE_LEGACY_VHOST=${JSON.stringify(legacyVhost)}
+HS_REVIEWED_LEGACY_VHOST_SHA256=${JSON.stringify(options.reviewedSha256 ?? "")}
+HS_REQUIRE_RETIRABLE_LEGACY_VHOST=${options.requireFile ? "true" : "false"}
+HS_ENFORCE_LEGACY_VHOST_DIRECTIVE_ALLOWLIST=${options.enforceDirectiveAllowlist ? "true" : "false"}
+sudo() {
+  case "$1" in
+    stat) printf '%s\\n' "$TEST_FILE_OWNER" ;;
+    find)
+      if [ "$TEST_FILE_WRITABLE" = "true" ]; then
+        printf '%s\\n' "$HS_RETIRABLE_LEGACY_VHOST"
+      fi
+      ;;
+    *) "$@" ;;
+  esac
+}
+nginx() { printf '%s\\n' "$TEST_NGINX_CONFIG"; }
+${validator}
+validate_retirable_legacy_vhost
+`;
+
+  try {
+    return spawnSync("bash", ["-c", harness], {
+      encoding: "utf8",
+      env: {
+        PATH: process.env.PATH ?? "",
+        TEST_FILE_OWNER: options.owner ?? "root:root",
+        TEST_FILE_WRITABLE: options.writable ? "true" : "false",
+        TEST_NGINX_CONFIG: (options.loadedConfig ?? "").replaceAll(
+          "REPLACE_LEGACY_PATH",
+          legacyVhost,
+        ),
+      },
+    });
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
 }
 
 function renewalHookScript(remoteScript: string) {
@@ -201,9 +298,7 @@ describe("protected Headscale arm workflow", () => {
     expect(install).toContain("printf '%s\\n' \"$DEPLOY_SSH_KNOWN_HOSTS\"");
     expect(install).toContain('ssh-keygen -F "$DEPLOY_HOST"');
 
-    const converge = step(
-      "Converge Headscale, canonical TLS, and control-plane router",
-    ).run;
+    const converge = step("Inspect or converge Headscale control plane").run;
     expect(converge).toContain("--ssh-known-hosts");
   });
 
@@ -256,18 +351,31 @@ describe("protected Headscale arm workflow", () => {
       "resolved_legacy_public_url=$expected_legacy_public_url",
     );
 
-    const converge = step(
-      "Converge Headscale, canonical TLS, and control-plane router",
-    ).run;
+    const converge = step("Inspect or converge Headscale control plane").run;
     expect(converge).toContain("--headscale-legacy-public-url");
     expect(converge).toContain('"$resolved_legacy_public_url"');
-    expect(
-      converge
-        ?.trimEnd()
-        .endsWith(
-          '--headscale-legacy-public-url "$resolved_legacy_public_url"',
-        ),
-    ).toBe(true);
+    expect(converge).toContain("--inspect-retirable-legacy-vhost");
+    expect(converge).toContain("--retire-retirable-legacy-vhost");
+    expect(converge).toContain("--retirable-legacy-vhost-sha256");
+    expect(converge).toContain('"$' + '{args[@]}"');
+  });
+
+  test("separates read-only inspection from explicit staging retirement", () => {
+    expect(workflowSource).toContain("inspect-legacy-vhost");
+    expect(workflowSource).toContain("retire-legacy-vhost-and-converge");
+    expect(workflowSource).toContain("reviewed_legacy_vhost_sha256");
+    const sourceGate = step("Validate protected deploy source").run;
+    expect(sourceGate).toContain('if [ "$TARGET_ENVIRONMENT" != "staging" ]');
+    expect(sourceGate).toContain(
+      "is registered only for the reviewed staging legacy vhost",
+    );
+    expect(sourceGate).toContain("^[0-9a-f]{64}$");
+    expect(sourceGate).toContain(
+      "retirement requires the exact lowercase SHA-256",
+    );
+    expect(step("Verify dual-SAN public identity and health").if).toContain(
+      "inputs.operation != 'inspect-legacy-vhost'",
+    );
   });
 
   test("does not accept dispatch overrides for loopback API or listen addresses", () => {
@@ -351,6 +459,27 @@ describe("protected Headscale arm workflow", () => {
 });
 
 describe("Headscale migration-overlap remote script", () => {
+  const expectedLegacySource = `server {
+  listen 80;
+  listen [::]:80;
+  server_name headscale-staging.elizacloud.ai;
+  return 301 https://$host$request_uri;
+}
+server {
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  server_name headscale-staging.elizacloud.ai;
+  proxy_pass http://127.0.0.1:8080;
+}
+`;
+  const expectedLoadedConfig = `# configuration file /etc/nginx/conf.d/headscale.conf:
+server_name headscale-staging.eliza.app headscale-staging.elizacloud.ai;
+server_name headscale-staging.eliza.app headscale-staging.elizacloud.ai;
+# configuration file REPLACE_LEGACY_PATH:
+server_name headscale-staging.elizacloud.ai;
+server_name headscale-staging.elizacloud.ai;
+`;
+
   test.each([
     [
       "production",
@@ -386,7 +515,7 @@ describe("Headscale migration-overlap remote script", () => {
       expect(result.stdout).toContain(
         "Leaving unknown nginx configs untouched and restoring the prior $HS_VHOST",
       );
-      expect(result.stdout).toContain("rollback_headscale_vhost()");
+      expect(result.stdout).toContain("rollback_headscale_vhosts()");
       const acmeTrap = result.stdout.indexOf("trap restore_acme_vhost EXIT");
       const acmeInstall = result.stdout.indexOf(
         'sudo install -o root -g root -m 0644 "$HS_ACME_STAGE" "$HS_ACME_VHOST"',
@@ -396,7 +525,7 @@ describe("Headscale migration-overlap remote script", () => {
       expect(acmeTrap).toBeLessThan(acmeInstall);
 
       const finalTrap = result.stdout.indexOf(
-        "trap rollback_headscale_vhost EXIT",
+        "trap rollback_headscale_vhosts EXIT",
       );
       const finalInstall = result.stdout.indexOf(
         'sudo install -o root -g root -m 0644 "$HS_VHOST_STAGE" "$HS_VHOST"',
@@ -429,6 +558,213 @@ describe("Headscale migration-overlap remote script", () => {
       expectBashSyntax(result.stdout);
     },
   );
+
+  test("retires the reviewed staging file only inside the rollback transaction", () => {
+    const result = runDryArm(
+      "https://headscale-staging.eliza.app",
+      "https://headscale-staging.elizacloud.ai",
+      [
+        "--retire-retirable-legacy-vhost",
+        "--retirable-legacy-vhost-sha256",
+        reviewedLegacyVhostSha256,
+      ],
+    );
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(
+      "HS_RETIRABLE_LEGACY_VHOST='/etc/nginx/conf.d/headscale-staging.conf'",
+    );
+    expect(result.stdout).toContain("HS_RETIRE_REVIEWED_LEGACY_VHOST='true'");
+    expect(result.stdout).toContain(
+      `HS_REVIEWED_LEGACY_VHOST_SHA256='${reviewedLegacyVhostSha256}'`,
+    );
+    const validation = result.stdout.indexOf(
+      "validate_retirable_legacy_vhost\n",
+    );
+    const trap = result.stdout.indexOf("trap rollback_headscale_vhosts EXIT");
+    const install = result.stdout.indexOf(
+      'sudo install -o root -g root -m 0644 "$HS_VHOST_STAGE" "$HS_VHOST"',
+    );
+    const removal = result.stdout.indexOf(
+      'sudo rm -f -- "$HS_RETIRABLE_LEGACY_VHOST"',
+    );
+    const finalValidation = result.stdout.lastIndexOf(
+      "validate_retirable_legacy_vhost",
+      removal,
+    );
+    const ownership = result.stdout.indexOf(
+      "effective_nginx_config=$(sudo nginx -T 2>&1)",
+      removal,
+    );
+    const timerProof = result.stdout.indexOf(
+      "sudo systemctl is-active --quiet certbot.timer",
+    );
+    const publicHealthProof = result.stdout.indexOf(
+      '"https://$public_host/health"',
+      timerProof,
+    );
+    const publicSniProof = result.stdout.indexOf(
+      '-servername "$public_host"',
+      publicHealthProof,
+    );
+    const transactionCommit = result.stdout.lastIndexOf("trap - EXIT");
+    expect(validation).toBeGreaterThan(-1);
+    expect(trap).toBeGreaterThan(validation);
+    expect(install).toBeGreaterThan(trap);
+    expect(removal).toBeGreaterThan(install);
+    expect(finalValidation).toBeGreaterThan(install);
+    expect(finalValidation).toBeLessThan(removal);
+    expect(ownership).toBeGreaterThan(removal);
+    expect(timerProof).toBeGreaterThan(ownership);
+    expect(publicHealthProof).toBeGreaterThan(timerProof);
+    expect(publicSniProof).toBeGreaterThan(publicHealthProof);
+    expect(transactionCommit).toBeGreaterThan(publicSniProof);
+    expect(transactionCommit).toBeGreaterThan(timerProof);
+    expect(result.stdout).toContain(
+      'sudo install -o root -g root -m "$HS_RETIRABLE_LEGACY_VHOST_MODE"',
+    );
+    expectBashSyntax(result.stdout);
+  });
+
+  test("inspects only the exact reviewed staging file without generating convergence", () => {
+    const result = runDryArm(
+      "https://headscale-staging.eliza.app",
+      "https://headscale-staging.elizacloud.ai",
+      ["--inspect-retirable-legacy-vhost"],
+    );
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(
+      "Legacy Headscale vhost passed the read-only retirement preflight",
+    );
+    expect(result.stdout).toContain("reviewed-sha256=$legacy_vhost_sha256");
+    expect(result.stdout).toContain(
+      "directive-name inventory (values withheld)",
+    );
+    const publicDirectiveReport = result.stdout.slice(
+      result.stdout.indexOf("--- reviewed public routing/TLS directives ---"),
+      result.stdout.indexOf(
+        "Legacy Headscale vhost passed the read-only retirement preflight",
+      ),
+    );
+    expect(publicDirectiveReport).not.toContain("proxy_set_header");
+    expect(result.stdout).not.toContain("sudo systemctl restart headscale");
+    expect(result.stdout).not.toContain("sudo rm -f --");
+    expectBashSyntax(result.stdout);
+  });
+
+  test("rejects inspection or retirement for production without a reviewed path", () => {
+    const result = runDryArm(
+      "https://headscale.eliza.app",
+      "https://headscale.elizacloud.ai",
+      ["--inspect-retirable-legacy-vhost"],
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "no reviewed legacy nginx vhost is registered for headscale.eliza.app",
+    );
+  });
+
+  test("requires retirement to bind the exact inspected file digest", () => {
+    const missing = runDryArm(
+      "https://headscale-staging.eliza.app",
+      "https://headscale-staging.elizacloud.ai",
+      ["--retire-retirable-legacy-vhost"],
+    );
+    expect(missing.status).toBe(1);
+    expect(missing.stderr).toContain(
+      "must be the exact lowercase SHA-256 from inspection",
+    );
+
+    const changed = runLegacyVhostValidation({
+      source: expectedLegacySource,
+      loadedConfig: expectedLoadedConfig,
+      reviewedSha256: reviewedLegacyVhostSha256,
+    });
+    expect(changed.status).toBe(1);
+    expect(changed.stdout).toContain("bytes changed after inspection");
+
+    const absent = runLegacyVhostValidation({ requireFile: true });
+    expect(absent.status).toBe(1);
+    expect(absent.stdout).toContain("is absent; refusing retirement");
+
+    const unrelatedDirective = runLegacyVhostValidation({
+      source: expectedLegacySource.replace(
+        "  return 301",
+        "  auth_basic off;\n  return 301",
+      ),
+      loadedConfig: expectedLoadedConfig,
+      enforceDirectiveAllowlist: true,
+    });
+    expect(unrelatedDirective.status).toBe(1);
+    expect(unrelatedDirective.stdout).toContain(
+      "directives outside the reviewed retirement allowlist",
+    );
+  });
+
+  test("accepts only the reviewed regular legacy-only two-listener contract", () => {
+    const valid = runLegacyVhostValidation({
+      source: expectedLegacySource,
+      loadedConfig: expectedLoadedConfig,
+    });
+    expect(valid.status).toBe(0);
+    expect(valid.stderr).toBe("");
+
+    const absent = runLegacyVhostValidation({});
+    expect(absent.status).toBe(0);
+
+    const symlink = runLegacyVhostValidation({
+      source: expectedLegacySource,
+      loadedConfig: "",
+      symlink: true,
+    });
+    expect(symlink.status).not.toBe(0);
+    expect(symlink.stdout).toContain("non-regular legacy Headscale vhost");
+
+    const unexpectedHost = runLegacyVhostValidation({
+      source: expectedLegacySource.replace(
+        "headscale-staging.elizacloud.ai;",
+        "unrelated.example.com;",
+      ),
+      loadedConfig: "",
+    });
+    expect(unexpectedHost.status).not.toBe(0);
+    expect(unexpectedHost.stdout).toContain(
+      "exactly two expected legacy-only server blocks",
+    );
+
+    const wrongOwner = runLegacyVhostValidation({
+      source: expectedLegacySource,
+      loadedConfig: expectedLoadedConfig,
+      owner: "deploy:deploy",
+    });
+    expect(wrongOwner.status).not.toBe(0);
+    expect(wrongOwner.stdout).toContain(
+      "must be root-owned and not group/world writable",
+    );
+
+    const writable = runLegacyVhostValidation({
+      source: expectedLegacySource,
+      loadedConfig: expectedLoadedConfig,
+      writable: true,
+    });
+    expect(writable.status).not.toBe(0);
+    expect(writable.stdout).toContain(
+      "must be root-owned and not group/world writable",
+    );
+
+    const missingLoadedOwner = runLegacyVhostValidation({
+      source: expectedLegacySource,
+      loadedConfig: expectedLoadedConfig.replace(
+        "# configuration file REPLACE_LEGACY_PATH:",
+        "# configuration file /tmp/not-the-reviewed-vhost:",
+      ),
+    });
+    expect(missingLoadedOwner.status).not.toBe(0);
+    expect(missingLoadedOwner.stdout).toContain(
+      "ownership no longer matches the reviewed two-listener contract",
+    );
+  });
 
   test("enumerates multiline exact hostname owners by loaded nginx config", () => {
     const result = runDryArm(

--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -848,6 +848,45 @@ server {
     expect(result.stdout).not.toContain(privateInclude);
   });
 
+  test("rejects multiple directives on one physical line without echoing values", () => {
+    const privateInclude = "/etc/nginx/canary-private-include.conf";
+    const quotedHashRedirect = "https://redirect.invalid/#canary-fragment";
+    const allowedDenseSource = expectedLegacySource.replace(
+      "  proxy_pass http://127.0.0.1:8080;",
+      "  proxy_pass http://127.0.0.1:8080; proxy_read_timeout 30s;",
+    );
+    const unexpectedDenseSource = expectedLegacySource.replace(
+      "  proxy_pass http://127.0.0.1:8080;",
+      `  proxy_pass http://127.0.0.1:8080; include ${privateInclude};`,
+    );
+    const quotedHashDenseSource = expectedLegacySource.replace(
+      "  return 301 https://$host$request_uri;",
+      `  return 302 "${quotedHashRedirect}"; include ${privateInclude};`,
+    );
+
+    for (const source of [
+      allowedDenseSource,
+      unexpectedDenseSource,
+      quotedHashDenseSource,
+    ]) {
+      const inspection = runLegacyVhostInspection(source, expectedLoadedConfig);
+      expect(inspection.status).not.toBe(0);
+      expect(inspection.stdout).toContain("unsupported dense directive syntax");
+      expect(inspection.stdout).not.toContain(privateInclude);
+      expect(inspection.stdout).not.toContain(quotedHashRedirect);
+
+      const retirement = runLegacyVhostValidation({
+        source,
+        loadedConfig: expectedLoadedConfig,
+        enforceDirectiveAllowlist: true,
+      });
+      expect(retirement.status).not.toBe(0);
+      expect(retirement.stdout).toContain("unsupported dense directive syntax");
+      expect(retirement.stdout).not.toContain(privateInclude);
+      expect(retirement.stdout).not.toContain(quotedHashRedirect);
+    }
+  });
+
   test("rejects inspection or retirement for production without a reviewed path", () => {
     const result = runDryArm(
       "https://headscale.eliza.app",


### PR DESCRIPTION
# Relates to

Closes #19568.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] The full frozen install (including artifact sync) and forced root verification completed successfully; later base advances changed no manifest or lockfile.
- [x] Generated remote-shell and workflow contracts make the destructive boundary reviewable without touching staging.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b8939d678d885f79473be58f82d493da6e29aa2d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@b8939d678d885f79473be58f82d493da6e29aa2d`; zero conflicts.
- [x] Forced root verify passes at exact head `3d9f7ab27394f3e5c949f5e444325dd6bcd66cc6`.

# Risks

Medium operational risk, fail-closed. Retirement can remove one loaded nginx file, but only the hard-coded staging path after exact file-type, ownership, mode, inspected SHA-256, directive allowlist, one-directive-per-line syntax, server-block, hostname, and effective `nginx -T` ownership checks. Active nginx lines containing `#` are rejected rather than guessed at, so quoted fragments cannot hide a second directive. The file is revalidated immediately before removal. Backup/rollback is active before mutation and remains active through nginx ownership/SAN/reload, renewal hook and timer health, public dual-SAN/SNI proof, CP router enrollment, environment writes, provisioning-worker restart, and final service liveness. Production and arbitrary paths are rejected.

# Background

## What does this PR do?

The protected Headscale arm correctly stopped when it found a second, manually provisioned staging vhost at `/etc/nginx/conf.d/headscale-staging.conf`. This PR adds a two-step operator flow:

1. `inspect-legacy-vhost` validates and reports that exact file without changing the host. It emits metadata, a digest, directive-name counts, and the validated shape only; literal directive values never enter Actions logs.
2. After review, `retire-legacy-vhost-and-converge` requires the exact lowercase SHA-256 from inspection, then transactionally backs up and removes only those reviewed bytes while installing the canonical dual-SAN vhost. Any mismatch or later remote-convergence failure restores both prior files and reloads the restored nginx configuration.

The normal `converge` mode retains the existing unknown-owner fail-closed behavior. Inspection and retirement are registered only for staging; production cannot select them.

## What kind of change is this?

Bug fix and operational hardening.

# Documentation changes needed?

Updated the workflow inventory, Headscale deploy runbook, and Terraform control-plane runbook with the exact inspect/review/retire order and rollback contract.

# Testing

## Where should a reviewer start?

- `packages/cloud/scripts/admin/arm-headscale-control-plane.mjs`
- `packages/scripts/__tests__/headscale-arm-workflow.test.ts`
- `.github/workflows/arm-headscale-control-plane.yml`

## Detailed testing steps

- `bun test packages/scripts/__tests__/headscale-arm-workflow.test.ts` — 29/29 tests, 295 expectations.
  - Four executable downstream failure injections prove byte-identical canonical + legacy vhost restoration and nginx reload for CP-router, env-write, worker-restart, and final-liveness failures.
  - Inspection canaries prove signed redirects, embedded credentials, and private include paths never appear in output.
  - Dense-syntax canaries prove both allowed and unexpected same-line directives are rejected, including a quoted `#` fragment followed by a private include, without leaking either literal.
- Actionlint on `.github/workflows/arm-headscale-control-plane.yml`.
- Node syntax, touched-file Biome, guide parity, and `git diff --check`.
- Full `bun install --frozen-lockfile` including repository artifact sync; subsequent rebases changed no dependency manifest or lockfile.
- Exact-head `bun run verify:cloud` — 78/78 Cloud workspace tasks passed.
- Exact-head `TURBO_FORCE=1 bun run verify` — 350/350 workspace tasks, 0 cached, and all repository audits passed; anti-larp scanned 8,055 test files with zero focused or orphaned skips.

No staging mutation was performed while preparing this PR. After merge, the first protected run must use `inspect-legacy-vhost`; retirement is permitted only after its full output/hash is reviewed.

# Evidence Gate

<!-- evidence-head:3d9f7ab27394f3e5c949f5e444325dd6bcd66cc6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - protected infrastructure workflow and remote shell only; no UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - the real staging inspect is intentionally deferred until reviewed code is merged; this PR performs no provider mutation.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, model, provider, or action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no live artifact is produced before the protected read-only inspection; executable generated-shell contracts are documented in Testing.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Known gaps / failures

- This PR deliberately does not delete the live legacy file during review. The protected read-only inspection and separately approved retirement/convergence runs are the post-merge acceptance evidence.
- The inspection prints the exact path, stat/mode, SHA-256, a value-free directive-name inventory, validated server-block/name counts, and effective nginx ownership. Retirement accepts only that exact digest, rejects unexpected directive classes, and never broadens cleanup to other files.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@b8939d678d885f79473be58f82d493da6e29aa2d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@b8939d678d885f79473be58f82d493da6e29aa2d:packages/skills/skills/contribute-to-eliza"} -->
