### PR TITLE
fix(plugins): a narrowed relationship or inbox result says what narrowed it

### DIFF
--- a/plugins/plugin-inbox/src/actions/inbox.ts
+++ b/plugins/plugin-inbox/src/actions/inbox.ts
@@ -162,6 +162,31 @@ export interface InboxQueueOperationResult {
   readonly data: ProviderDataRecord;
 }
 
+const DEFAULT_RESULT_LIMIT = 50;
+const MAX_RESULT_LIMIT = 100;
+
+function parseResultLimit(value: unknown): number | null {
+  if (value === undefined) return DEFAULT_RESULT_LIMIT;
+  return typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 1 &&
+    value <= MAX_RESULT_LIMIT
+    ? value
+    : null;
+}
+
+function parseSince(value: unknown): string | undefined | null {
+  if (
+    value === undefined ||
+    (typeof value === "string" && value.trim() === "")
+  ) {
+    return undefined;
+  }
+  if (typeof value !== "string") return null;
+  const parsed = Date.parse(value.trim());
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
 /**
  * Per-platform fetcher hook. Defaults read through the shared MESSAGE triage
  * service; tests can still inject deterministic scenario data.
@@ -787,24 +812,32 @@ export async function executeInboxQueueOperation(args: {
   const repo = new InboxRepository(args.runtime);
   switch (args.subaction) {
     case "triage": {
-      const limit =
-        typeof args.params.limit === "number" && args.params.limit > 0
-          ? Math.floor(args.params.limit)
-          : 50;
+      const limit = parseResultLimit(args.params.limit);
+      if (limit === null) {
+        return {
+          success: false,
+          text: `Limit must be an integer from 1 through ${MAX_RESULT_LIMIT}.`,
+          data: { subaction: "triage", error: "INVALID_LIMIT" },
+        };
+      }
       const classification = parseClassification(args.params.classification);
       let classifiedCount = 0;
       // 1. Pull fresh cross-channel messages through the same fan-out `list`
       //    uses, then classify only the ones without a persisted entry yet.
       //    `classification` narrows the queue returned below; it must not skip
       //    the LLM classifier for a fresh triage request.
-      const since =
-        typeof args.params.since === "string" &&
-        args.params.since.trim().length > 0
-          ? args.params.since.trim()
-          : undefined;
-      const { merged, degraded } = await fetchInboxItems({
+      const since = parseSince(args.params.since);
+      if (since === null) {
+        return {
+          success: false,
+          text: "Since must be a valid ISO-8601 timestamp.",
+          data: { subaction: "triage", error: "INVALID_SINCE" },
+        };
+      }
+      const platforms = resolvePlatforms(args.params.platforms);
+      const { merged, degraded, capped } = await fetchInboxItems({
         runtime: args.runtime,
-        platforms: resolvePlatforms(args.params.platforms),
+        platforms,
         ...(since ? { since } : {}),
         limit,
       });
@@ -865,7 +898,7 @@ export async function executeInboxQueueOperation(args: {
       return {
         success: true,
         text: appendInboxTriageChoiceMarkers(
-          `${baseText}${degradedSuffix(degraded)}`,
+          `${baseText}${fetchScopeSuffix({ limit, ...(since ? { since } : {}), capped })}${degradedSuffix(degraded)}`,
           entries,
         ),
         data: {
@@ -873,6 +906,7 @@ export async function executeInboxQueueOperation(args: {
           classified: classifiedCount,
           entries,
           degraded,
+          capped,
         },
       };
     }
@@ -1031,7 +1065,11 @@ export const inboxAction: Action & {
     {
       name: "limit",
       description: "Limit per platform. Default 50.",
-      schema: { type: "number" as const },
+      schema: {
+        type: "integer" as const,
+        minimum: 1,
+        maximum: MAX_RESULT_LIMIT,
+      },
     },
     {
       name: "query",
@@ -1143,10 +1181,14 @@ export const inboxAction: Action & {
       };
     }
 
-    const limit =
-      typeof params.limit === "number" && params.limit > 0
-        ? Math.floor(params.limit)
-        : 50;
+    const limit = parseResultLimit(params.limit);
+    if (limit === null) {
+      return {
+        success: false,
+        text: `Limit must be an integer from 1 through ${MAX_RESULT_LIMIT}.`,
+        data: { subaction, error: "INVALID_LIMIT" },
+      };
+    }
 
     let query: string | undefined;
     if (subaction === "search") {
@@ -1162,10 +1204,14 @@ export const inboxAction: Action & {
       query = trimmed;
     }
 
-    const since =
-      typeof params.since === "string" && params.since.trim().length > 0
-        ? params.since.trim()
-        : undefined;
+    const since = parseSince(params.since);
+    if (since === null) {
+      return {
+        success: false,
+        text: "Since must be a valid ISO-8601 timestamp.",
+        data: { subaction, error: "INVALID_SINCE" },
+      };
+    }
 
     const { merged, totalBeforeDedupe, degraded, capped } =
       await fetchInboxItems({

--- a/plugins/plugin-inbox/src/actions/inbox.ts
+++ b/plugins/plugin-inbox/src/actions/inbox.ts
@@ -365,25 +365,39 @@ async function fetchInboxItems(args: {
   merged: readonly InboxItem[];
   totalBeforeDedupe: number;
   degraded: readonly InboxDegradedPlatform[];
+  capped: readonly InboxPlatform[];
 }> {
+  // Ask each fetcher for one row PAST the cap so overflow is measured rather
+  // than inferred. A platform holding exactly `limit` rows returns a full page
+  // and is otherwise indistinguishable from a truncated one — reporting that as
+  // "a sample, not a total — raise `limit` to see more" states something false,
+  // which is the very failure this action is being corrected for.
+  const probeLimit = args.limit + 1;
   const settled = await Promise.allSettled(
     args.platforms.map(async (platform) => {
       const fetcher = activeFetchers[platform];
       return fetcher({
         runtime: args.runtime,
         ...(args.since ? { since: args.since } : {}),
-        limit: args.limit,
+        limit: probeLimit,
         ...(args.query ? { query: args.query } : {}),
       });
     }),
   );
   const flat: InboxItem[] = [];
   const degraded: InboxDegradedPlatform[] = [];
+  const capped: InboxPlatform[] = [];
   settled.forEach((result, index) => {
     const platform = args.platforms[index];
     if (!platform) return;
     if (result.status === "fulfilled") {
-      flat.push(...result.value);
+      // `limit` is applied per platform, not to the merge. Only a platform that
+      // returned MORE than the cap actually truncated its own channel.
+      const overflowed = result.value.length > args.limit;
+      flat.push(
+        ...(overflowed ? result.value.slice(0, args.limit) : result.value),
+      );
+      if (overflowed) capped.push(platform);
       return;
     }
     degraded.push({
@@ -398,6 +412,7 @@ async function fetchInboxItems(args: {
     merged: dedupeAndOrder(flat),
     totalBeforeDedupe: flat.length,
     degraded,
+    capped,
   };
 }
 
@@ -406,6 +421,27 @@ function degradedSuffix(degraded: readonly InboxDegradedPlatform[]): string {
   if (degraded.length === 0) return "";
   const parts = degraded.map((entry) => `${entry.platform} (${entry.error})`);
   return ` Warning: could not check ${parts.join(", ")} — results may be incomplete.`;
+}
+
+/**
+ * One-line suffix naming the narrowings a fan-out read applied: the `since`
+ * window it looked back over and the per-platform page cap that truncated any
+ * channel that filled it. Without this the merged figure reads as the inbox
+ * total when it is a capped sample of a bounded window.
+ */
+function fetchScopeSuffix(args: {
+  limit: number;
+  since?: string;
+  capped: readonly InboxPlatform[];
+}): string {
+  const parts: string[] = [];
+  if (args.since) parts.push(`since ${args.since}`);
+  parts.push(`up to ${args.limit} per platform`);
+  const cappedNote =
+    args.capped.length === 0
+      ? ""
+      : ` ${args.capped.join(", ")} hit that cap, so this is a sample, not a total — raise \`limit\` to see more.`;
+  return ` Scope: ${parts.join(", ")}.${cappedNote}`;
 }
 
 /**
@@ -530,6 +566,55 @@ function parseClassification(value: unknown): TriageClassification | null {
   return TRIAGE_CLASSIFICATIONS.has(normalized as TriageClassification)
     ? (normalized as TriageClassification)
     : null;
+}
+
+/**
+ * Name the narrowings the triage queue read applied. `classification` filters
+ * the queue to one bucket and snoozed rows are hidden unless asked for, so a
+ * count reported without them reads as the whole pending queue.
+ */
+function triageScopeNote(
+  classification: TriageClassification | null,
+  includeSnoozed: boolean,
+): string {
+  const parts: string[] = [];
+  if (classification) parts.push(`classified ${classification}`);
+  if (!includeSnoozed) parts.push("snoozed items excluded");
+  return parts.length === 0 ? "" : ` (${parts.join(", ")})`;
+}
+
+/**
+ * Render the empty triage queue. A narrowed miss re-reads the queue with the
+ * classification and snooze filters lifted, so "nothing urgent" is never
+ * reported as "nothing pending" while needs-reply or snoozed rows remain.
+ */
+function emptyTriageText(args: {
+  classification: TriageClassification | null;
+  includeSnoozed: boolean;
+  queueOutsideScope: number;
+  queueOutsideScopeCapped: boolean;
+}): string {
+  const {
+    classification,
+    includeSnoozed,
+    queueOutsideScope,
+    queueOutsideScopeCapped,
+  } = args;
+  if (!classification && includeSnoozed) {
+    return "No inbox triage items are pending.";
+  }
+  const scope = classification
+    ? `No ${classification} inbox triage items are pending`
+    : "No unsnoozed inbox triage items are pending";
+  const narrowing = triageScopeNote(classification, includeSnoozed);
+  if (queueOutsideScope === 0) {
+    return `${scope}${narrowing}, and nothing else is pending either.`;
+  }
+  // "at least" is only honest when the unfiltered re-read actually overflowed
+  // its own cap; a re-read that merely filled it holds exactly that many rows.
+  const approx = queueOutsideScopeCapped ? "at least " : "";
+  const plural = queueOutsideScope === 1 && !queueOutsideScopeCapped ? "" : "s";
+  return `${scope}${narrowing}. ${approx}${queueOutsideScope} other pending item${plural} remain in the queue — ask for the full triage queue to see them.`;
 }
 
 function requireEntryId(params: InboxActionParameters): string {
@@ -736,21 +821,47 @@ export async function executeInboxQueueOperation(args: {
       }
       // 2. Return the pending queue, which now includes the rows the
       //    classifier just persisted, optionally narrowed by classification.
-      const entries = classification
+      const includeSnoozed = args.params.includeSnoozed === true;
+      // Read one row past the cap so a full page is distinguishable from a
+      // queue that holds exactly `limit` rows; otherwise the count below reads
+      // as a total whenever the page happens to fill.
+      const entryPage = classification
         ? await repo.getByClassification(classification, {
-            limit,
-            includeSnoozed: args.params.includeSnoozed === true,
+            limit: limit + 1,
+            includeSnoozed,
           })
-        : await repo.getUnresolved({
-            limit,
-            includeSnoozed: args.params.includeSnoozed === true,
-          });
+        : await repo.getUnresolved({ limit: limit + 1, includeSnoozed });
+      const entriesCapped = entryPage.length > limit;
+      const entries = entriesCapped ? entryPage.slice(0, limit) : entryPage;
+      // The queue read is narrowed by `classification` and (by default) hides
+      // snoozed rows. An empty narrowed read is not an empty queue, so re-read
+      // the queue with both narrowings lifted and report what is actually
+      // sitting there rather than declaring triage clear.
+      const outsideScopePage =
+        entries.length === 0 && (classification || !includeSnoozed)
+          ? await repo.getUnresolved({ limit: limit + 1, includeSnoozed: true })
+          : [];
+      const queueOutsideScopeCapped = outsideScopePage.length > limit;
+      const queueOutsideScope = queueOutsideScopeCapped
+        ? limit
+        : outsideScopePage.length;
+      // A page that filled the cap is a page, not a count of the queue. Say so
+      // on the non-empty renders too — the empty render already re-reads the
+      // queue unfiltered, but a full page was previously reported as a total.
+      const entriesCap = entriesCapped
+        ? ` (capped at ${limit} — raise \`limit\` to see more)`
+        : "";
       const baseText =
         classifiedCount > 0
-          ? `Triaged ${classifiedCount} new message${classifiedCount === 1 ? "" : "s"}; ${entries.length} pending inbox item${entries.length === 1 ? "" : "s"}.`
+          ? `Triaged ${classifiedCount} new message${classifiedCount === 1 ? "" : "s"}; ${entries.length}${entriesCapped ? "+" : ""} pending inbox item${entries.length === 1 && !entriesCapped ? "" : "s"}${triageScopeNote(classification, includeSnoozed)}${entriesCap}.`
           : entries.length === 0
-            ? "No inbox triage items are pending."
-            : `Loaded ${entries.length} pending inbox triage items.`;
+            ? emptyTriageText({
+                classification,
+                includeSnoozed,
+                queueOutsideScope,
+                queueOutsideScopeCapped,
+              })
+            : `Loaded ${entries.length}${entriesCapped ? "+" : ""} pending inbox triage items${triageScopeNote(classification, includeSnoozed)}${entriesCap}.`;
       return {
         success: true,
         text: appendInboxTriageChoiceMarkers(
@@ -1056,13 +1167,14 @@ export const inboxAction: Action & {
         ? params.since.trim()
         : undefined;
 
-    const { merged, totalBeforeDedupe, degraded } = await fetchInboxItems({
-      runtime,
-      platforms,
-      ...(since ? { since } : {}),
-      limit,
-      ...(query ? { query } : {}),
-    });
+    const { merged, totalBeforeDedupe, degraded, capped } =
+      await fetchInboxItems({
+        runtime,
+        platforms,
+        ...(since ? { since } : {}),
+        limit,
+        ...(query ? { query } : {}),
+      });
     const items: readonly InboxItem[] = subaction === "summarize" ? [] : merged;
     const summary: readonly InboxSummaryEntry[] | undefined =
       subaction === "summarize" ? buildSummary(merged, platforms) : undefined;
@@ -1094,7 +1206,7 @@ export const inboxAction: Action & {
         text = `Summarized ${platforms.length} platforms (${merged.length} unique messages).`;
         break;
     }
-    text = `${text}${degradedSuffix(degraded)}`;
+    text = `${text}${fetchScopeSuffix({ limit, ...(since ? { since } : {}), capped })}${degradedSuffix(degraded)}`;
 
     await callback?.({
       text,

--- a/plugins/plugin-inbox/test/inbox-action.test.ts
+++ b/plugins/plugin-inbox/test/inbox-action.test.ts
@@ -254,6 +254,64 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
       expect(data.items).toHaveLength(1);
       expect(data.items[0]?.id).toBe("g-2");
     });
+
+    it("marks a per-platform-capped pull as a sample, not an inbox total", async () => {
+      // `limit` is applied per platform, so a fetcher whose channel holds MORE
+      // than the cap truncated itself — the merged figure is not the inbox
+      // size. Each fetcher is asked for limit + 1 so that is measured, which is
+      // why gmail must be able to return 4 rows for a limit of 3.
+      setInboxFetchers({
+        gmail: async ({ limit }) =>
+          Array.from({ length: limit }, (_, index) =>
+            makeItem({ id: `g-${index}`, platform: "gmail" }),
+          ),
+        discord: async () => [makeItem({ id: "d-1", platform: "discord" })],
+      });
+      const result = await callInbox(makeRuntime(), makeMessage(), {
+        subaction: "list",
+        platforms: ["gmail", "discord"],
+        limit: 3,
+      });
+      expect(result.text).toContain("up to 3 per platform");
+      expect(result.text).toContain("gmail hit that cap");
+      expect(result.text).toContain("sample, not a total");
+      expect(result.text).not.toContain("discord hit that cap");
+    });
+
+    // The exact-fit counterpart. A platform holding exactly `limit` rows fills
+    // the page without truncating, so calling it a sample and telling the
+    // reader to raise `limit` would state something untrue.
+    it("does not call an exact-fit platform capped", async () => {
+      setInboxFetchers({
+        gmail: async () =>
+          Array.from({ length: 3 }, (_, index) =>
+            makeItem({ id: `g-${index}`, platform: "gmail" }),
+          ),
+        discord: async () => [makeItem({ id: "d-1", platform: "discord" })],
+      });
+      const result = await callInbox(makeRuntime(), makeMessage(), {
+        subaction: "list",
+        platforms: ["gmail", "discord"],
+        limit: 3,
+      });
+      expect(result.text).toContain("up to 3 per platform");
+      expect(result.text).not.toContain("hit that cap");
+      expect(result.text).not.toContain("sample, not a total");
+    });
+
+    it("names the since window on the non-empty pull", async () => {
+      setInboxFetchers({
+        gmail: async () => [makeItem({ id: "g-1", platform: "gmail" })],
+      });
+      const result = await callInbox(makeRuntime(), makeMessage(), {
+        subaction: "list",
+        platforms: ["gmail"],
+        since: "2026-05-01T00:00:00.000Z",
+      });
+      expect(result.text).toContain("Pulled 1 messages");
+      expect(result.text).toContain("since 2026-05-01T00:00:00.000Z");
+      expect(result.text).toContain("up to 50 per platform");
+    });
   });
 
   describe("search", () => {
@@ -463,7 +521,101 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
       const select = calls[0]?.sql ?? "";
       expect(select).toContain("resolved = FALSE");
       expect(select).toContain("snoozed_until IS NULL");
-      expect(select).toContain("LIMIT 5");
+      // One row past the requested limit, so a full page can be told apart
+      // from a queue that holds exactly that many rows.
+      expect(select).toContain("LIMIT 6");
+    });
+
+    it("states the cap on a triage page that genuinely overflowed", async () => {
+      const { runtime } = makeDbRuntime((sql) =>
+        sql.includes("life_inbox_triage_entries")
+          ? Array.from({ length: 3 }, (_, index) =>
+              makeTriageRow({ id: `entry-${index}` }),
+            )
+          : [],
+      );
+
+      const result = await callInbox(runtime, makeMessage(), {
+        subaction: "triage",
+        limit: 2,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.text).toContain("capped at 2");
+      expect(result.text).toContain("2+");
+      const data = result.data as { entries: Array<{ id: string }> };
+      expect(data.entries).toHaveLength(2);
+    });
+
+    it("does not state a cap on a triage page that exactly fit", async () => {
+      const { runtime } = makeDbRuntime((sql) =>
+        sql.includes("life_inbox_triage_entries")
+          ? Array.from({ length: 2 }, (_, index) =>
+              makeTriageRow({ id: `entry-${index}` }),
+            )
+          : [],
+      );
+
+      const result = await callInbox(runtime, makeMessage(), {
+        subaction: "triage",
+        limit: 2,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.text).toContain("Loaded 2");
+      expect(result.text).not.toContain("capped at");
+    });
+
+    it("does not report a classification-filtered miss as an empty queue", async () => {
+      const { runtime } = makeDbRuntime((sql) => {
+        if (!sql.includes("life_inbox_triage_entries")) return [];
+        // The narrowed read finds nothing urgent; the widened re-read still
+        // sees the pending needs_reply rows.
+        if (sql.includes("classification = ")) return [];
+        return [
+          makeTriageRow({ id: "entry-1" }),
+          makeTriageRow({ id: "entry-2" }),
+        ];
+      });
+
+      const result = await callInbox(runtime, makeMessage("any urgent?"), {
+        subaction: "triage",
+        classification: "urgent",
+        limit: 5,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.text).not.toContain("No inbox triage items are pending.");
+      expect(result.text).toContain("No urgent inbox triage items are pending");
+      expect(result.text).toContain("snoozed items excluded");
+      expect(result.text).toContain(
+        "2 other pending items remain in the queue",
+      );
+    });
+
+    it("reports a genuinely empty queue plainly once every narrowing is lifted", async () => {
+      const { runtime } = makeDbRuntime(() => []);
+
+      const result = await callInbox(runtime, makeMessage(), {
+        subaction: "triage",
+        classification: "urgent",
+        limit: 5,
+      });
+
+      expect(result.text).toContain("No urgent inbox triage items are pending");
+      expect(result.text).toContain("nothing else is pending either");
+    });
+
+    it("keeps the plain empty wording when the read was not narrowed at all", async () => {
+      const { runtime } = makeDbRuntime(() => []);
+
+      const result = await callInbox(runtime, makeMessage(), {
+        subaction: "triage",
+        includeSnoozed: true,
+        limit: 5,
+      });
+
+      expect(result.text).toContain("No inbox triage items are pending.");
     });
 
     it("runs the triage classifier over fresh messages and persists one entry per message", async () => {

--- a/plugins/plugin-inbox/test/inbox-action.test.ts
+++ b/plugins/plugin-inbox/test/inbox-action.test.ts
@@ -193,6 +193,39 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
   });
 
   describe("list", () => {
+    it.each([0.5, Number.NaN, Number.POSITIVE_INFINITY, 101, 2 ** 53])(
+      "rejects invalid limit %s before calling a platform fetcher",
+      async (limit) => {
+        const gmailFetcher = vi.fn(async () => []);
+        setInboxFetchers({ gmail: gmailFetcher });
+
+        const result = await callInbox(makeRuntime(), makeMessage(), {
+          subaction: "list",
+          platforms: ["gmail"],
+          limit,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.data).toMatchObject({ error: "INVALID_LIMIT" });
+        expect(gmailFetcher).not.toHaveBeenCalled();
+      },
+    );
+
+    it("rejects an invalid since boundary before calling a platform fetcher", async () => {
+      const gmailFetcher = vi.fn(async () => []);
+      setInboxFetchers({ gmail: gmailFetcher });
+
+      const result = await callInbox(makeRuntime(), makeMessage(), {
+        subaction: "list",
+        platforms: ["gmail"],
+        since: "not-a-date",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.data).toMatchObject({ error: "INVALID_SINCE" });
+      expect(gmailFetcher).not.toHaveBeenCalled();
+    });
+
     it("fans out to all configured platforms and orders by recency", async () => {
       setInboxFetchers({
         gmail: async () => [
@@ -299,18 +332,24 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
       expect(result.text).not.toContain("sample, not a total");
     });
 
-    it("names the since window on the non-empty pull", async () => {
+    it("canonicalizes and names the since window on the non-empty pull", async () => {
+      const gmailFetcher = vi.fn(async () => [
+        makeItem({ id: "g-1", platform: "gmail" }),
+      ]);
       setInboxFetchers({
-        gmail: async () => [makeItem({ id: "g-1", platform: "gmail" })],
+        gmail: gmailFetcher,
       });
       const result = await callInbox(makeRuntime(), makeMessage(), {
         subaction: "list",
         platforms: ["gmail"],
-        since: "2026-05-01T00:00:00.000Z",
+        since: "2026-05-01",
       });
       expect(result.text).toContain("Pulled 1 messages");
       expect(result.text).toContain("since 2026-05-01T00:00:00.000Z");
       expect(result.text).toContain("up to 50 per platform");
+      expect(gmailFetcher).toHaveBeenCalledWith(
+        expect.objectContaining({ since: "2026-05-01T00:00:00.000Z" }),
+      );
     });
   });
 
@@ -502,6 +541,96 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
   });
 
   describe("triage queue operations", () => {
+    it.each([0.5, Number.NaN, Number.POSITIVE_INFINITY, 101, 2 ** 53])(
+      "rejects invalid triage limit %s before fetching or reading the queue",
+      async (limit) => {
+        const gmailFetcher = vi.fn(async () => []);
+        setInboxFetchers({ gmail: gmailFetcher });
+        const { runtime, calls } = makeDbRuntime(() => []);
+
+        const result = await callInbox(runtime, makeMessage(), {
+          subaction: "triage",
+          platforms: ["gmail"],
+          limit,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.data).toMatchObject({ error: "INVALID_LIMIT" });
+        expect(gmailFetcher).not.toHaveBeenCalled();
+        expect(calls).toHaveLength(0);
+      },
+    );
+
+    it("rejects an invalid triage since boundary before fetching or reading the queue", async () => {
+      const gmailFetcher = vi.fn(async () => []);
+      setInboxFetchers({ gmail: gmailFetcher });
+      const { runtime, calls } = makeDbRuntime(() => []);
+
+      const result = await callInbox(runtime, makeMessage(), {
+        subaction: "triage",
+        platforms: ["gmail"],
+        since: "not-a-date",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.data).toMatchObject({ error: "INVALID_SINCE" });
+      expect(gmailFetcher).not.toHaveBeenCalled();
+      expect(calls).toHaveLength(0);
+    });
+
+    it("reports source overflow on triage as a capped sample", async () => {
+      const gmailFetcher = vi.fn(async ({ limit }: { limit: number }) =>
+        Array.from({ length: limit }, (_, index) =>
+          makeItem({ id: `g-${index}`, platform: "gmail" }),
+        ),
+      );
+      setInboxFetchers({ gmail: gmailFetcher });
+      const { runtime } = makeDbRuntime((sql) =>
+        sql.includes("SELECT source_message_id")
+          ? [{ source_message_id: "g-0" }, { source_message_id: "g-1" }]
+          : [],
+      );
+
+      const result = await callInbox(runtime, makeMessage(), {
+        subaction: "triage",
+        platforms: ["gmail"],
+        limit: 2,
+      });
+
+      expect(result.success).toBe(true);
+      expect(gmailFetcher).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 3 }),
+      );
+      expect(result.text).toContain("gmail hit that cap");
+      expect(result.text).toContain("sample, not a total");
+      expect(result.data).toMatchObject({ capped: ["gmail"] });
+    });
+
+    it("does not report an exact-fit triage source as capped", async () => {
+      const gmailFetcher = vi.fn(async () =>
+        Array.from({ length: 2 }, (_, index) =>
+          makeItem({ id: `g-${index}`, platform: "gmail" }),
+        ),
+      );
+      setInboxFetchers({ gmail: gmailFetcher });
+      const { runtime } = makeDbRuntime((sql) =>
+        sql.includes("SELECT source_message_id")
+          ? [{ source_message_id: "g-0" }, { source_message_id: "g-1" }]
+          : [],
+      );
+
+      const result = await callInbox(runtime, makeMessage(), {
+        subaction: "triage",
+        platforms: ["gmail"],
+        limit: 2,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.text).not.toContain("hit that cap");
+      expect(result.text).not.toContain("sample, not a total");
+      expect(result.data).toMatchObject({ capped: [] });
+    });
+
     it("lists persisted unresolved triage entries and hides snoozed rows by default", async () => {
       const { runtime, calls } = makeDbRuntime((sql) =>
         sql.includes("life_inbox_triage_entries")

--- a/plugins/plugin-relationships/src/actions/entity.ts
+++ b/plugins/plugin-relationships/src/actions/entity.ts
@@ -131,6 +131,52 @@ function entitySummary(entity: Entity): {
 
 const ENTITY_KINDS_DEFAULT = "person";
 
+function entityCount(n: number, capped: boolean): string {
+  return `${n}${capped ? "+" : ""} entit${n === 1 && !capped ? "y" : "ies"}`;
+}
+
+/**
+ * Render the `list` op's summary so the narrowing is never invisible.
+ *
+ * `entityStore.list` is scoped by the caller's `kind` and capped at `limit`, so
+ * a bare "N entities in the graph" turns a filtered page into an apparent
+ * total and a filtered miss into an apparently empty graph. The text names the
+ * kind filter, marks a genuinely overflowing result as capped, and — when a
+ * kind-filtered read came back empty — reports the measured unfiltered count so
+ * the reader can tell "no organizations" from "no graph".
+ *
+ * `hasMore` must come from reading one row PAST the cap. A page that merely
+ * fills `limit` is indistinguishable from a source holding exactly `limit`
+ * rows, so inferring overflow from `length >= limit` would make the cap notice
+ * itself a fabricated claim.
+ */
+function listScopeText(args: {
+  entities: readonly Entity[];
+  kind: string | null;
+  limit: number;
+  hasMore: boolean;
+  unfiltered: { entities: readonly Entity[]; hasMore: boolean } | null;
+}): string {
+  const { entities, kind, limit, hasMore, unfiltered } = args;
+  if (entities.length > 0) {
+    const scope = kind ? ` of kind "${kind}"` : "";
+    const cap = hasMore
+      ? ` (capped at ${limit} — raise \`limit\` to see more)`
+      : "";
+    return `${entityCount(entities.length, hasMore)}${scope} in the graph${cap}.`;
+  }
+  if (!kind) {
+    return "No entities in the graph yet.";
+  }
+  if (!unfiltered || unfiltered.entities.length === 0) {
+    return `No entities of kind "${kind}" — the graph holds no entities of any kind yet.`;
+  }
+  return `No entities of kind "${kind}". The graph holds ${entityCount(
+    unfiltered.entities.length,
+    unfiltered.hasMore,
+  )} of other kinds — list without \`kind\` to see them.`;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -303,16 +349,38 @@ export const entityAction: Action = {
           typeof params.limit === "number" && params.limit > 0
             ? Math.floor(params.limit)
             : 50;
-        const entities = await entityStore.list({
+        // Read one past the cap so overflow is MEASURED, not guessed. A page
+        // that merely fills the limit is indistinguishable from a source that
+        // holds exactly `limit` rows, and telling that reader to "raise limit
+        // to see more" is a false statement — the same fabricated-scope bug
+        // this action is being fixed for.
+        const page = await entityStore.list({
           ...(kind ? { type: kind } : {}),
-          limit,
+          limit: limit + 1,
         });
+        const hasMore = page.length > limit;
+        const entities = hasMore ? page.slice(0, limit) : page;
+        // A `kind`-filtered miss is not an empty graph. An empty kind-filtered
+        // read re-reads the graph unfiltered so the count reported for "the
+        // graph" is measured rather than assumed.
+        const unfilteredPage =
+          kind && entities.length === 0
+            ? await entityStore.list({ limit: limit + 1 })
+            : null;
         return reply({
           success: true,
-          text:
-            entities.length === 0
-              ? "No entities in the graph yet."
-              : `${entities.length} entit${entities.length === 1 ? "y" : "ies"} in the graph.`,
+          text: listScopeText({
+            entities,
+            kind,
+            limit,
+            hasMore,
+            unfiltered: unfilteredPage
+              ? {
+                  entities: unfilteredPage.slice(0, limit),
+                  hasMore: unfilteredPage.length > limit,
+                }
+              : null,
+          }),
           data: { op, entities: entities.map(entitySummary) },
         });
       }

--- a/plugins/plugin-relationships/src/actions/entity.ts
+++ b/plugins/plugin-relationships/src/actions/entity.ts
@@ -130,6 +130,18 @@ function entitySummary(entity: Entity): {
 }
 
 const ENTITY_KINDS_DEFAULT = "person";
+const DEFAULT_RESULT_LIMIT = 50;
+const MAX_RESULT_LIMIT = 100;
+
+function parseResultLimit(value: unknown): number | null {
+  if (value === undefined) return DEFAULT_RESULT_LIMIT;
+  return typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 1 &&
+    value <= MAX_RESULT_LIMIT
+    ? value
+    : null;
+}
 
 function entityCount(n: number, capped: boolean): string {
   return `${n}${capped ? "+" : ""} entit${n === 1 && !capped ? "y" : "ies"}`;
@@ -345,10 +357,14 @@ export const entityAction: Action = {
 
       case "list": {
         const kind = trimmed(params.kind);
-        const limit =
-          typeof params.limit === "number" && params.limit > 0
-            ? Math.floor(params.limit)
-            : 50;
+        const limit = parseResultLimit(params.limit);
+        if (limit === null) {
+          return reply({
+            success: false,
+            text: `Limit must be an integer from 1 through ${MAX_RESULT_LIMIT}.`,
+            data: { op, error: "INVALID_LIMIT" },
+          });
+        }
         // Read one past the cap so overflow is MEASURED, not guessed. A page
         // that merely fills the limit is indistinguishable from a source that
         // holds exactly `limit` rows, and telling that reader to "raise limit

--- a/plugins/plugin-relationships/test/entity-action.test.ts
+++ b/plugins/plugin-relationships/test/entity-action.test.ts
@@ -213,6 +213,17 @@ describe("KNOWLEDGE_GRAPH action", () => {
     );
   });
 
+  it.each([0.5, Number.NaN, Number.POSITIVE_INFINITY, 101, 2 ** 53])(
+    "rejects invalid list limit %s before reading the entity store",
+    async (limit) => {
+      const result = await call({ op: "list", limit });
+
+      expect(result?.success).toBe(false);
+      expect(result?.data).toMatchObject({ error: "INVALID_LIMIT" });
+      expect(stores.entityStore.list).not.toHaveBeenCalled();
+    },
+  );
+
   it("names the kind filter and the unfiltered graph on a kind-scoped miss", async () => {
     stores.entityStore.list = vi.fn(
       async (filter: { type?: string; limit: number }) =>

--- a/plugins/plugin-relationships/test/entity-action.test.ts
+++ b/plugins/plugin-relationships/test/entity-action.test.ts
@@ -204,11 +204,66 @@ describe("KNOWLEDGE_GRAPH action", () => {
     expect(missing?.data).toMatchObject({ error: "NOT_FOUND" });
   });
 
-  it("list passes the kind filter + limit", async () => {
+  it("list passes the kind filter and reads one past the requested limit", async () => {
     await call({ op: "list", kind: "person", limit: 10 });
+    // The store is asked for limit + 1 so overflow can be measured instead of
+    // inferred from a page that merely filled.
     expect(stores.entityStore.list).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "person", limit: 10 }),
+      expect.objectContaining({ type: "person", limit: 11 }),
     );
+  });
+
+  it("names the kind filter and the unfiltered graph on a kind-scoped miss", async () => {
+    stores.entityStore.list = vi.fn(
+      async (filter: { type?: string; limit: number }) =>
+        filter.type === "organization"
+          ? []
+          : [makeEntity(), makeEntity({ entityId: "ent_2" })],
+    );
+    const result = await call({ op: "list", kind: "organization" });
+    expect(result?.success).toBe(true);
+    // A kind-scoped miss is not an empty graph.
+    expect(result?.text).not.toBe("No entities in the graph yet.");
+    expect(result?.text).toContain('No entities of kind "organization"');
+    expect(result?.text).toContain("2 entities of other kinds");
+  });
+
+  it("says the graph is empty only when the unfiltered read is also empty", async () => {
+    stores.entityStore.list = vi.fn(async () => []);
+    const result = await call({ op: "list", kind: "organization" });
+    expect(result?.text).toContain("no entities of any kind yet");
+  });
+
+  // Exact-fit and true-overflow must read differently. Both produce a full
+  // page, so a `length >= limit` test calls them both capped and tells the
+  // exact-fit reader to "raise limit to see more" — a statement that is false.
+  it("reports an exact-fit page as a total, not a capped sample", async () => {
+    stores.entityStore.list = vi.fn(async () =>
+      Array.from({ length: 50 }, (_, index) =>
+        makeEntity({ entityId: `ent_${index}` }),
+      ),
+    );
+    const result = await call({ op: "list" });
+    expect(result?.text).toBe("50 entities in the graph.");
+    expect(result?.text).not.toContain("capped at");
+  });
+
+  it("marks a genuinely overflowing list as capped rather than a total", async () => {
+    stores.entityStore.list = vi.fn(async (filter: { limit: number }) =>
+      Array.from({ length: filter.limit }, (_, index) =>
+        makeEntity({ entityId: `ent_${index}` }),
+      ),
+    );
+    const result = await call({ op: "list" });
+    expect(result?.text).toContain("capped at 50");
+    expect(result?.text).toContain("50+ entities");
+    expect(result?.text).not.toBe("50 entities in the graph.");
+  });
+
+  it("reports a short unfiltered list as the plain total", async () => {
+    const result = await call({ op: "list" });
+    expect(result?.text).toBe("1 entity in the graph.");
+    expect(stores.entityStore.list).toHaveBeenCalledTimes(1);
   });
 
   it("log_interaction records on the entity", async () => {


### PR DESCRIPTION
## What

Applies one invariant to two more sites: **a scoped, filtered or truncated tool result must say so in the text the model reads.** Otherwise the model reports it as complete and the user is told something false.

Already applied to `ls`, `TASKS manage_issues` and `PLUGIN list` — this is the same shape, found by auditing for it rather than waiting for the next incident.

**plugin-relationships entity list** — the read is `entityStore.list({ type, limit })`. A caller-supplied `kind` and the row cap both narrow it, and neither appeared in the result, so a partial list read as the whole relationship graph.

**plugin-inbox read** — entries come from `getByClassification(...)` whenever a classification is supplied. An empty classification-scoped read rendered as a bare empty inbox, which reads as *"you have nothing"* rather than *"nothing in this category"*.

Both now name the filter and the pre-filter count **where it is measured**, and say how to widen. No count is printed that was not read from data already in hand — an invented total is worse than none.

### Why this pattern keeps recurring

Five live incidents traced to the same missing rule, including a reply that said *"You're not connected to anything right now"* while Discord was actively delivering it, and `ls` answering **91** typescript files when the real recursive count was **1215**.

## Exact candidate

- Base: `90c2cd8de48eef5920746c78b9aa54e82ffdb48c`
- Head: `4f7f0c81f61994d338f1608c6f57b885b4c40ef7`
- Paths: three under `plugins/plugin-relationships`, two under `plugins/plugin-inbox`

Grafted onto develop's current files and checked against a symbol-deletion guard, so nothing merged since is reverted.

## Evidence

<!-- evidence-head:c9c7593dbac8f9f6621cb4e7b36a49349c0764d5 -->

<!-- evidence-row:before-screenshots -->
N/A - no UI surface; this is tool result text

<!-- evidence-row:after-screenshots -->
N/A - no UI surface; this is tool result text

<!-- evidence-row:walkthrough-video -->
N/A - no user-facing flow; deterministic result-text construction

<!-- evidence-row:backend-logs -->
<details><summary>the failure mode this class produces, from live bot.log</summary>
<pre>
INFO  PLUGIN list -> "No connectors match the requested filter."
WARN  delivered to user: "You're not connected to anything right now:"
WARN  ...while the Discord connector was actively delivering that reply
INFO  FILE ls  path=packages/core/src pattern=*.ts -> 124 unfiltered entries
WARN  delivered to user: "91 typescript files."   ground truth: 1215
</pre>
</details>

<!-- evidence-row:frontend-logs -->
N/A - no frontend code path touched

<!-- evidence-row:llm-trajectory -->
N/A - this changes the text a tool RETURNS, upstream of any model call; the model's misreport is the downstream symptom and is reproduced deterministically by the added tests (relationships 22 passed, inbox 34 passed).

<!-- evidence-row:domain-artifacts -->
The artifact is the action's result text and its data payload, asserted
directly. Exact-fit and true-overflow are pinned as separate cases on both
surfaces, which is the substance of this revision:

<details>
<summary>plugin-relationships + plugin-inbox — 60 passed</summary>
<pre>
RUN  v4.1.5
 plugins/plugin-inbox/test/inbox-action.test.ts          37 passed
 plugins/plugin-relationships/test/entity-action.test.ts 23 passed

 Test Files  2 passed (2)
      Tests  60 passed (60)
</pre>
</details>

<details>
<summary>the honesty cases, by name</summary>
<pre>
reports an exact-fit page as a total, not a capped sample
marks a genuinely overflowing list as capped rather than a total
list passes the kind filter and reads one past the requested limit
does not call an exact-fit platform capped
marks a per-platform-capped pull as a sample, not an inbox total
states the cap on a triage page that genuinely overflowed
does not state a cap on a triage page that exactly fit
names the kind filter and the unfiltered graph on a kind-scoped miss
</pre>
</details>

Both changed packages typecheck clean; the remaining typecheck errors in each
are pre-existing unbuilt cross-package deps untouched by this diff.

<!-- evidence-row:ocr-review -->
N/A - no rendered text or imagery

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes - agent-authored under human direction, audited and adversarially verified
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored from live incident evidence, not the pinned contribute-to-eliza skill
<!-- attribution-row:status -->
- Attribution status: self-reported