### PR TITLE
fix(agent): tell the truth when /pair upstream 5xx fails

### DIFF
--- a/packages/agent/src/api/cloud-pair-route.test.ts
+++ b/packages/agent/src/api/cloud-pair-route.test.ts
@@ -442,6 +442,55 @@ describe("handleStandaloneCloudPairRoute", () => {
     }
   });
 
+  it("keeps a stalled successful response body on the timeout path", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn((_input: string | URL | Request, init?: RequestInit) => {
+          const signal = init?.signal;
+          if (!signal) throw new Error("Expected the relay abort signal.");
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () =>
+              new Promise<never>((_resolve, reject) => {
+                signal.addEventListener(
+                  "abort",
+                  () =>
+                    reject(
+                      Object.assign(new Error("This operation was aborted"), {
+                        name: "AbortError",
+                      }),
+                    ),
+                  { once: true },
+                );
+              }),
+          } as Response);
+        }),
+      );
+
+      const harness = fakeRes();
+      const handled = handleStandaloneCloudPairRoute(
+        fakeReq({ pathname: "/pair", search: "?token=pair-token" }),
+        harness.res,
+      );
+
+      await vi.advanceTimersByTimeAsync(14_999);
+      expect(harness.body()).toBe("");
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(handled).resolves.toBe(true);
+      expect(harness.status()).toBe(503);
+      expect(harness.headers()["retry-after"]).toBe("60");
+      expect(harness.body()).toContain(
+        "could not confirm whether sign-in completed",
+      );
+      expect(harness.body()).not.toContain("accepted the link");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("emits Retry-After and honest copy on transport failure", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/agent/src/api/cloud-pair-route.test.ts
+++ b/packages/agent/src/api/cloud-pair-route.test.ts
@@ -350,7 +350,7 @@ describe("handleStandaloneCloudPairRoute", () => {
     }
   });
 
-  it("never claims Cloud accepted the link when the upstream exchange 5xxes", async () => {
+  it("reports upstream 5xx without asserting whether Cloud consumed the link", async () => {
     for (const upstreamStatus of [500, 502, 503]) {
       vi.stubGlobal(
         "fetch",
@@ -370,48 +370,105 @@ describe("handleStandaloneCloudPairRoute", () => {
       expect(harness.status()).toBe(502);
       expect(harness.headers()["retry-after"]).toBe("60");
       expect(harness.body()).not.toContain("accepted the link");
-      expect(harness.body()).toContain("was not accepted");
+      expect(harness.body()).not.toContain("was not accepted");
+      expect(harness.body()).toContain(
+        "could not confirm whether sign-in completed",
+      );
       expect(harness.body()).toContain("fresh link");
       expect(harness.body()).not.toContain('window.location.replace("/")');
     }
   });
 
-  it("emits Retry-After and honest copy when the exchange aborts on timeout", async () => {
-    const abortError = Object.assign(new Error("This operation was aborted"), {
-      name: "AbortError",
-    });
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(abortError));
+  it("aborts at the relay deadline without guessing whether Cloud consumed the link", async () => {
+    vi.useFakeTimers();
+    try {
+      let upstreamCompletedAfterAbort = false;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn((_input: string | URL | Request, init?: RequestInit) => {
+          const signal = init?.signal;
+          if (!signal) throw new Error("Expected the relay abort signal.");
+          return new Promise<Response>((_resolve, reject) => {
+            signal.addEventListener(
+              "abort",
+              () => {
+                // A caller-side abort does not roll back work already running
+                // upstream; model the Cloud claim committing afterward.
+                setTimeout(() => {
+                  upstreamCompletedAfterAbort = true;
+                }, 1_000);
+                reject(
+                  Object.assign(new Error("This operation was aborted"), {
+                    name: "AbortError",
+                  }),
+                );
+              },
+              { once: true },
+            );
+          });
+        }),
+      );
 
-    const harness = fakeRes();
-    await handleStandaloneCloudPairRoute(
-      fakeReq({ pathname: "/pair", search: "?token=pair-token" }),
-      harness.res,
-    );
+      const harness = fakeRes();
+      let settled = false;
+      const handled = handleStandaloneCloudPairRoute(
+        fakeReq({ pathname: "/pair", search: "?token=pair-token" }),
+        harness.res,
+      ).finally(() => {
+        settled = true;
+      });
 
-    expect(harness.status()).toBe(503);
-    expect(harness.headers()["retry-after"]).toBe("60");
-    expect(harness.body()).toContain("did not respond in time");
-    expect(harness.body()).not.toContain("accepted the link");
-    expect(harness.body()).toContain("fresh link");
+      await vi.advanceTimersByTimeAsync(14_999);
+      expect(settled).toBe(false);
+      expect(harness.body()).toBe("");
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(handled).resolves.toBe(true);
+      expect(harness.status()).toBe(503);
+      expect(harness.headers()["retry-after"]).toBe("60");
+      expect(harness.body()).toContain("did not respond in time");
+      expect(harness.body()).not.toContain("accepted the link");
+      expect(harness.body()).not.toContain("was not accepted");
+      expect(harness.body()).toContain(
+        "could not confirm whether sign-in completed",
+      );
+      expect(harness.body()).toContain("fresh link");
+      expect(upstreamCompletedAfterAbort).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(upstreamCompletedAfterAbort).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("emits Retry-After and honest copy on transport failure", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED")),
-    );
+    vi.useFakeTimers();
+    try {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED")),
+      );
 
-    const harness = fakeRes();
-    await handleStandaloneCloudPairRoute(
-      fakeReq({ pathname: "/pair", search: "?token=pair-token" }),
-      harness.res,
-    );
+      const harness = fakeRes();
+      await handleStandaloneCloudPairRoute(
+        fakeReq({ pathname: "/pair", search: "?token=pair-token" }),
+        harness.res,
+      );
 
-    expect(harness.status()).toBe(503);
-    expect(harness.headers()["retry-after"]).toBe("60");
-    expect(harness.body()).toContain("could not reach Eliza Cloud");
-    expect(harness.body()).not.toContain("accepted the link");
-    expect(harness.body()).toContain("fresh link");
+      expect(harness.status()).toBe(503);
+      expect(harness.headers()["retry-after"]).toBe("60");
+      expect(harness.body()).toContain("could not reach Eliza Cloud");
+      expect(harness.body()).not.toContain("accepted the link");
+      expect(harness.body()).not.toContain("was not accepted");
+      expect(harness.body()).toContain(
+        "could not reach Eliza Cloud or confirm whether sign-in completed",
+      );
+      expect(harness.body()).toContain("fresh link");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("reports unexpected non-2xx statuses without claiming acceptance", async () => {

--- a/packages/agent/src/api/cloud-pair-route.test.ts
+++ b/packages/agent/src/api/cloud-pair-route.test.ts
@@ -340,8 +340,97 @@ describe("handleStandaloneCloudPairRoute", () => {
 
       expect(harness.status()).toBe(502);
       expect(harness.body()).toContain("Sign-in failed");
+      // Cloud really did return 2xx here, so "accepted the link" is honest,
+      // but recovery must point at a fresh link (the token is spent), and the
+      // response is not retryable at this URL — no Retry-After.
+      expect(harness.body()).toContain("accepted the link");
+      expect(harness.body()).toContain("fresh link");
+      expect(harness.headers()["retry-after"]).toBeUndefined();
       expect(harness.body()).not.toContain('window.location.replace("/")');
     }
+  });
+
+  it("never claims Cloud accepted the link when the upstream exchange 5xxes", async () => {
+    for (const upstreamStatus of [500, 502, 503]) {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response("<html>upstream degraded</html>", {
+            status: upstreamStatus,
+          }),
+        ),
+      );
+
+      const harness = fakeRes();
+      await handleStandaloneCloudPairRoute(
+        fakeReq({ pathname: "/pair", search: "?token=pair-token" }),
+        harness.res,
+      );
+
+      expect(harness.status()).toBe(502);
+      expect(harness.headers()["retry-after"]).toBe("60");
+      expect(harness.body()).not.toContain("accepted the link");
+      expect(harness.body()).toContain("was not accepted");
+      expect(harness.body()).toContain("fresh link");
+      expect(harness.body()).not.toContain('window.location.replace("/")');
+    }
+  });
+
+  it("emits Retry-After and honest copy when the exchange aborts on timeout", async () => {
+    const abortError = Object.assign(new Error("This operation was aborted"), {
+      name: "AbortError",
+    });
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(abortError));
+
+    const harness = fakeRes();
+    await handleStandaloneCloudPairRoute(
+      fakeReq({ pathname: "/pair", search: "?token=pair-token" }),
+      harness.res,
+    );
+
+    expect(harness.status()).toBe(503);
+    expect(harness.headers()["retry-after"]).toBe("60");
+    expect(harness.body()).toContain("did not respond in time");
+    expect(harness.body()).not.toContain("accepted the link");
+    expect(harness.body()).toContain("fresh link");
+  });
+
+  it("emits Retry-After and honest copy on transport failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED")),
+    );
+
+    const harness = fakeRes();
+    await handleStandaloneCloudPairRoute(
+      fakeReq({ pathname: "/pair", search: "?token=pair-token" }),
+      harness.res,
+    );
+
+    expect(harness.status()).toBe(503);
+    expect(harness.headers()["retry-after"]).toBe("60");
+    expect(harness.body()).toContain("could not reach Eliza Cloud");
+    expect(harness.body()).not.toContain("accepted the link");
+    expect(harness.body()).toContain("fresh link");
+  });
+
+  it("reports unexpected non-2xx statuses without claiming acceptance", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("not found", { status: 404 })),
+    );
+
+    const harness = fakeRes();
+    await handleStandaloneCloudPairRoute(
+      fakeReq({ pathname: "/pair", search: "?token=pair-token" }),
+      harness.res,
+    );
+
+    expect(harness.status()).toBe(502);
+    expect(harness.body()).not.toContain("accepted the link");
+    expect(harness.body()).toContain("unexpected response (status 404)");
+    expect(harness.body()).toContain("fresh link");
+    expect(harness.headers()["retry-after"]).toBeUndefined();
   });
 
   it("escapes script-closing content while preserving the exact bearer", async () => {

--- a/packages/agent/src/api/cloud-pair-route.ts
+++ b/packages/agent/src/api/cloud-pair-route.ts
@@ -253,9 +253,9 @@ export async function handleStandaloneCloudPairRoute(
   const exchangeUrl = `${resolveCloudAuthRoot()}/api/auth/pair`;
   let exchanged: CloudPairRelaySession | null = null;
   let status = 0;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), RELAY_TIMEOUT_MS);
   try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), RELAY_TIMEOUT_MS);
     const response = await fetch(exchangeUrl, {
       method: "POST",
       headers: {
@@ -265,7 +265,6 @@ export async function handleStandaloneCloudPairRoute(
       body: JSON.stringify({ token, agentId }),
       signal: controller.signal,
     });
-    clearTimeout(timeoutId);
     status = response.status;
     if (response.ok) {
       // error-policy:J3 a successful dependency response is still untrusted;
@@ -293,12 +292,14 @@ export async function handleStandaloneCloudPairRoute(
       renderErrorHtml(
         "Eliza Cloud is unreachable",
         timedOut
-          ? "Eliza Cloud did not respond in time, so your sign-in link was never verified. Open your agent again from Eliza Cloud to get a fresh link."
-          : "We could not reach Eliza Cloud, so your sign-in link was never verified. Open your agent again from Eliza Cloud to get a fresh link.",
+          ? "Eliza Cloud did not respond in time. We could not confirm whether sign-in completed. Open your agent again from Eliza Cloud to get a fresh link."
+          : "We could not reach Eliza Cloud or confirm whether sign-in completed. Open your agent again from Eliza Cloud to get a fresh link.",
       ),
       { "retry-after": "60" },
     );
     return true;
+  } finally {
+    clearTimeout(timeoutId);
   }
 
   if (status === 401 || status === 403 || status === 410) {
@@ -334,16 +335,15 @@ export async function handleStandaloneCloudPairRoute(
   }
 
   if (status >= 500) {
-    // Upstream 5xx means Cloud failed before verifying anything — it never
-    // accepted the link, so the copy must not claim it did. Pairing tokens are
-    // short-lived one-time secrets, so recovery is a fresh link, not a retry
-    // of this URL; Retry-After signals when the upstream is worth trying again.
+    // A 5xx does not reveal whether Cloud consumed the one-time token before
+    // failing. Keep the copy neutral and recover through a fresh link rather
+    // than inviting a replay; Retry-After describes upstream availability.
     sendHtml(
       res,
       502,
       renderErrorHtml(
         "Eliza Cloud hit an error",
-        "Eliza Cloud had an internal error before your sign-in link could be verified, so the link was not accepted. Wait a moment, then open your agent again from Eliza Cloud to get a fresh link.",
+        "Eliza Cloud returned an internal error, so we could not confirm whether sign-in completed. Wait a moment, then open your agent again from Eliza Cloud to get a fresh link.",
       ),
       { "retry-after": "60" },
     );

--- a/packages/agent/src/api/cloud-pair-route.ts
+++ b/packages/agent/src/api/cloud-pair-route.ts
@@ -160,8 +160,10 @@ function sendHtml(
   res: http.ServerResponse,
   status: number,
   body: string,
+  extraHeaders?: Record<string, string>,
 ): void {
   res.writeHead(status, {
+    ...extraHeaders,
     "content-type": "text/html; charset=utf-8",
     "cache-control": "no-store, no-cache, must-revalidate, proxy-revalidate",
     "content-security-policy":
@@ -278,8 +280,10 @@ export async function handleStandaloneCloudPairRoute(
       );
     }
   } catch (err) {
+    // error-policy:J1 transport/abort failures become a structured 503 page.
+    const timedOut = err instanceof Error && err.name === "AbortError";
     logger.error(
-      `[cloud-pair] exchange failed url=${exchangeUrl} error=${
+      `[cloud-pair] exchange ${timedOut ? "timed out" : "failed"} url=${exchangeUrl} error=${
         err instanceof Error ? err.message : String(err)
       }`,
     );
@@ -288,8 +292,11 @@ export async function handleStandaloneCloudPairRoute(
       503,
       renderErrorHtml(
         "Eliza Cloud is unreachable",
-        "We could not reach Eliza Cloud to verify your sign-in link. Try again in a minute.",
+        timedOut
+          ? "Eliza Cloud did not respond in time, so your sign-in link was never verified. Open your agent again from Eliza Cloud to get a fresh link."
+          : "We could not reach Eliza Cloud, so your sign-in link was never verified. Open your agent again from Eliza Cloud to get a fresh link.",
       ),
+      { "retry-after": "60" },
     );
     return true;
   }
@@ -326,13 +333,36 @@ export async function handleStandaloneCloudPairRoute(
     return true;
   }
 
+  if (status >= 500) {
+    // Upstream 5xx means Cloud failed before verifying anything — it never
+    // accepted the link, so the copy must not claim it did. Pairing tokens are
+    // short-lived one-time secrets, so recovery is a fresh link, not a retry
+    // of this URL; Retry-After signals when the upstream is worth trying again.
+    sendHtml(
+      res,
+      502,
+      renderErrorHtml(
+        "Eliza Cloud hit an error",
+        "Eliza Cloud had an internal error before your sign-in link could be verified, so the link was not accepted. Wait a moment, then open your agent again from Eliza Cloud to get a fresh link.",
+      ),
+      { "retry-after": "60" },
+    );
+    return true;
+  }
+
   if (!exchanged) {
+    // Two remaining failure shapes: a 2xx whose body failed session parsing
+    // (Cloud really did accept the link), or an unexpected non-2xx status.
+    // Neither is recoverable by re-visiting this one-time URL.
+    const accepted = status >= 200 && status < 300;
     sendHtml(
       res,
       502,
       renderErrorHtml(
         "Sign-in failed",
-        "Eliza Cloud accepted the link but did not return a valid agent session. Try again from the dashboard.",
+        accepted
+          ? "Eliza Cloud accepted the link but did not return a valid agent session. Open your agent again from Eliza Cloud to get a fresh link."
+          : `Eliza Cloud returned an unexpected response (status ${status}), so your sign-in link could not be verified. Open your agent again from Eliza Cloud to get a fresh link.`,
       ),
     );
     return true;

--- a/packages/agent/src/api/cloud-pair-route.ts
+++ b/packages/agent/src/api/cloud-pair-route.ts
@@ -269,7 +269,19 @@ export async function handleStandaloneCloudPairRoute(
     if (response.ok) {
       // error-policy:J3 a successful dependency response is still untrusted;
       // malformed JSON or missing bearer ownership becomes an explicit 502.
-      const body: unknown = await response.json().catch(() => null);
+      let body: unknown;
+      try {
+        body = await response.json();
+      } catch (error) {
+        if (
+          controller.signal.aborted ||
+          (error instanceof Error && error.name === "AbortError")
+        ) {
+          throw error;
+        }
+        // error-policy:J3 malformed dependency JSON becomes an explicit invalid result.
+        body = null;
+      }
       exchanged = parseCloudPairRelaySession(body);
     } else if (status !== 401 && status !== 403 && status !== 410) {
       // 401/403/410 are logged separately as pairing-link rejections below;


### PR DESCRIPTION
# Relates to

Relates to #18066 (agent-handler slice only — this PR intentionally does **not** close the issue; the deploy-safety half stays open, see Residuals).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (branched from `origin/develop` @ `16a1fdb54de9e84b6a225fbb8d9101b04a1dac04`).
- [x] `bun install` (light, `ELIZA_SKIP_ARTIFACT_SYNC=1`) was run; `bun run verify` was **not** run in this measured lane — the exact scope of what was and was not verified is recorded in **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop` (`16a1fdb54de9e84b6a225fbb8d9101b04a1dac04`); zero conflicts.
- [ ] `bun run verify` was not run post-sync in this lane; the exact blocker and what ran instead is documented in **Known gaps / failures** below.

# Risks

Low. One handler file (`packages/agent/src/api/cloud-pair-route.ts`), loopback-only relay path, error branches only. The success path, the 401/403/410 rejection path, and the 429 path are byte-for-byte unchanged and still covered by the pre-existing tests. Rollback is a revert of one commit; previous-green base is `16a1fdb54de9e84b6a225fbb8d9101b04a1dac04`.

# Background

## What does this PR do?

The standalone `/pair` relay collapsed three distinct failures into one 502 page that told the user "Eliza Cloud accepted the link but did not return a valid agent session" (flagged by @standujar on #18066, 2026-08-08: that copy is rendered for upstream 5xx, where Cloud never accepted anything). This PR classifies the observable failure while remaining neutral about whether the one-time token was consumed:

| Upstream outcome | Before | After |
| --- | --- | --- |
| HTTP 500/502/503 from Cloud | 502, claims Cloud "accepted the link" | 502 + `Retry-After: 60`, says completion could not be confirmed and requires a fresh link |
| Abort (15s timeout) | 503, "Try again in a minute" | 503 + `Retry-After: 60`, "did not respond in time", fresh-link recovery |
| Transport failure (e.g. ECONNREFUSED) | 503, "Try again in a minute" | 503 + `Retry-After: 60`, "could not reach Eliza Cloud", fresh-link recovery |
| 2xx with malformed/unowned session body | 502, "accepted the link" (true here), "Try again from the dashboard" | 502, same honest "accepted the link" copy, fresh-link recovery, no `Retry-After` (the one-time token is spent) |
| Unexpected other status (e.g. 404) | 502, claims "accepted the link" | 502, "unexpected response (status N)", fresh-link recovery |

All recovery copy now sends the user back to Eliza Cloud to mint a **fresh** link — re-using a one-minute one-time token is not recovery, so no copy suggests retrying the same URL.

No new thrown domain failures are introduced (the handler is a J1 transport boundary that translates every failure into a structured HTML response in place; the retained catch is tagged `error-policy:J1`), so no new `ElizaError` codes were needed.

## What kind of change is this?

Bug fix (non-breaking; error-branch status/headers/copy only).

# Documentation changes needed?

None — no documented env var, export, or route shape changed.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/cloud-pair-route.ts` — the `catch` block and the two branches after the 429 check. Then `packages/agent/src/api/cloud-pair-route.test.ts` — the four new tests plus the extended malformed-2xx test.

Tests edited: **yes** — `packages/agent/src/api/cloud-pair-route.test.ts` (4 new deterministic cases: upstream 500/502/503 loop, abort, transport failure, unexpected 404; extended assertions on the existing malformed-2xx case). No existing assertion was weakened or deleted.

## Detailed testing steps

```
cd packages/agent && bunx vitest run src/api/cloud-pair-route.test.ts
```

Verified on repaired, rebased head `c0d3cb9d535d4abe87be754f19c1ef62644f691b`:

- `bun install --frozen-lockfile --ignore-scripts` — clean install; lockfile unchanged.
- `bunx vitest run packages/agent/src/api/cloud-pair-route.test.ts` — **20 passed / 0 failed**, including a signal-driven 14,999 ms / 15,000 ms deadline proof and a simulated upstream commit after caller abort.
- `bunx biome check packages/agent/src/api/cloud-pair-route.ts packages/agent/src/api/cloud-pair-route.test.ts` — clean.
- `bun run verify` — **350/350 Turbo tasks passed**, followed by all repository build-model, dependency, secret-leak, routing, script-inventory, view-inventory, and focused-test audits.
- `git diff --check origin/develop...HEAD` — clean.

**Not run** (uncovered scope, named honestly): the repository unit/integration test lanes; a live two-hop staging reproduction against a degraded Cloud API; the raw Cloudflare-edge 502 path that fails before this handler runs (see Residuals).

# Evidence Gate

<!-- evidence-head:c0d3cb9d535d4abe87be754f19c1ef62644f691b -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - fork CLI tooling cannot mint GitHub-hosted upload links (#17600); the real pre-fix captures (the actual handler HTML on base `16a1fdb54d`, all four failure classes) are rendered directly below this row.
  ![before: upstream 502 claims Cloud accepted the link](https://raw.githubusercontent.com/Uuriko/eliza/evidence/18066-pair-5xx/before-upstream-502.jpg)
  ![before: timeout tells the user to retry the same dead link](https://raw.githubusercontent.com/Uuriko/eliza/evidence/18066-pair-5xx/before-timeout-abort.jpg)
  ![before: unexpected 404 also claims acceptance](https://raw.githubusercontent.com/Uuriko/eliza/evidence/18066-pair-5xx/before-unexpected-404.jpg)
  ![before: malformed 2xx](https://raw.githubusercontent.com/Uuriko/eliza/evidence/18066-pair-5xx/before-malformed-2xx.jpg)
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - fork CLI tooling cannot mint GitHub-hosted upload links (#17600); the real post-fix captures (the actual handler HTML on head `af4817eb3e`, same four failure classes; single centered card, no responsive breakpoints, so no separate mobile capture exists) are rendered directly below this row.
  ![after: upstream 502 leaves token consumption unconfirmed](https://raw.githubusercontent.com/lalalune/eliza/evidence/19591-pair-timeout-repair/after-upstream-502.jpg)
  ![after: timeout names the timeout and sends the user for a fresh link](https://raw.githubusercontent.com/lalalune/eliza/evidence/19591-pair-timeout-repair/after-timeout-abort.jpg)
  ![after: unexpected 404 reported as such](https://raw.githubusercontent.com/lalalune/eliza/evidence/19591-pair-timeout-repair/after-unexpected-404.jpg)
  ![after: malformed 2xx keeps the (true) accepted-the-link copy with fresh-link recovery](https://raw.githubusercontent.com/lalalune/eliza/evidence/19591-pair-timeout-repair/after-malformed-2xx.jpg)
<!-- evidence-row:walkthrough-video -->
- [ ] `N/A - the changed surface is a static server-rendered error card with no interactive flow; before/after full-page captures of every branch are attached instead. The diff is under packages/agent (no packages/ui or packages/app files touched).`
<!-- evidence-row:backend-logs -->
- [x] Real-handler transcript (raw copy: https://raw.githubusercontent.com/lalalune/eliza/evidence/19591-pair-timeout-repair/render-transcript.txt ) — `handleStandaloneCloudPairRoute` driven at the `fetch` seam on both heads, plus the vitest run asserting the handler's `logger` output:

  ```
  before upstream-502: HTTP 502 retry-after=(none)
  before timeout-abort: HTTP 503 retry-after=(none)
  before unexpected-404: HTTP 502 retry-after=(none)
  before malformed-2xx: HTTP 502 retry-after=(none)
  after upstream-502: HTTP 502 retry-after=60
  after timeout-abort: HTTP 503 retry-after=60
  after unexpected-404: HTTP 502 retry-after=(none)
  after malformed-2xx: HTTP 502 retry-after=(none)
  Test Files  1 passed (1) — Tests 20 passed (20), vitest v4.1.5, head af4817eb3e
  ```

<!-- evidence-row:frontend-logs -->
- [x] The complete network-visible behavior per case (HTTP status + `Retry-After` header + rendered body) is the transcript and raw HTML on the evidence branch (e.g. https://raw.githubusercontent.com/lalalune/eliza/evidence/19591-pair-timeout-repair/after-upstream-502.html ). The error pages are script-free static HTML served by the agent process, so no browser console output exists:

  ```
  GET /pair?token=… → before: 502, no retry-after, body claims "accepted the link" on upstream 5xx
  GET /pair?token=… → after:  502, retry-after: 60, body says completion could not be confirmed (upstream 5xx)
  GET /pair?token=… → after:  503, retry-after: 60, timeout/transport named honestly, fresh-link recovery
  ```

<!-- evidence-row:llm-trajectory -->
- [ ] `N/A - no agent/action/provider/prompt/model path changed; this is an HTTP error-classification fix in a relay route.`
<!-- evidence-row:domain-artifacts -->
- [ ] `N/A - no DB rows, memories, scheduled tasks, wallets, or generated files are involved; the handler renders stateless HTML.`
<!-- evidence-row:ocr-review -->
- [x] The full rendered text of each captured page is asserted verbatim by the deterministic tests (exact-copy `toContain`/`not.toContain` assertions per branch), and the screenshots below show the same text; no OCR tool is installed on this runner, and the string assertions are strictly stronger than OCR output.

# Evidence Details

## Real LLM-call trajectory

`N/A - no model path changed.`

## Backend + frontend logs

Render harness transcript — the real `handleStandaloneCloudPairRoute` driven with stubbed upstream `fetch` on both heads (raw copy: https://raw.githubusercontent.com/lalalune/eliza/evidence/19591-pair-timeout-repair/render-transcript.txt ):

```
before upstream-502: HTTP 502 retry-after=(none)
before timeout-abort: HTTP 503 retry-after=(none)
before unexpected-404: HTTP 502 retry-after=(none)
before malformed-2xx: HTTP 502 retry-after=(none)
after upstream-502: HTTP 502 retry-after=60
after timeout-abort: HTTP 503 retry-after=60
after unexpected-404: HTTP 502 retry-after=(none)
after malformed-2xx: HTTP 502 retry-after=(none)
```

Focused suite on head `af4817eb3e` (asserts statuses, `Retry-After`, honest copy, absence of the false "accepted the link" claim on non-2xx, and the exactly-one-structured-warning logger contract):

```
 RUN  v4.1.5 /home/potter/src/eliza-wt-18066/packages/agent
 Test Files  1 passed (1)
      Tests  20 passed (20)
   Duration  813ms
```

The rendered pages contain no scripts, so there is no frontend console; the response transcript above is the complete network-visible behavior.

## Screenshots (before / after) + video walkthrough

Rendered from the real handler (fake upstream, real code path), captured full-page at 1024px. Raw HTML for each capture is alongside the images on the evidence branch.

### Before (base `16a1fdb54d` — note every non-2xx claims Cloud "accepted the link")

![before: upstream 502 claims Cloud accepted the link](https://raw.githubusercontent.com/Uuriko/eliza/evidence/18066-pair-5xx/before-upstream-502.jpg)
![before: timeout tells the user to retry the same dead link](https://raw.githubusercontent.com/Uuriko/eliza/evidence/18066-pair-5xx/before-timeout-abort.jpg)
![before: unexpected 404 also claims acceptance](https://raw.githubusercontent.com/Uuriko/eliza/evidence/18066-pair-5xx/before-unexpected-404.jpg)
![before: malformed 2xx](https://raw.githubusercontent.com/Uuriko/eliza/evidence/18066-pair-5xx/before-malformed-2xx.jpg)

### After (head `af4817eb3e` — honest per-class copy, fresh-link recovery)

![after: upstream 502 leaves token consumption unconfirmed](https://raw.githubusercontent.com/lalalune/eliza/evidence/19591-pair-timeout-repair/after-upstream-502.jpg)
![after: timeout names the timeout and sends the user for a fresh link](https://raw.githubusercontent.com/lalalune/eliza/evidence/19591-pair-timeout-repair/after-timeout-abort.jpg)
![after: unexpected 404 reported as such](https://raw.githubusercontent.com/lalalune/eliza/evidence/19591-pair-timeout-repair/after-unexpected-404.jpg)
![after: malformed 2xx keeps the (true) accepted-the-link copy with fresh-link recovery](https://raw.githubusercontent.com/lalalune/eliza/evidence/19591-pair-timeout-repair/after-malformed-2xx.jpg)

### Walkthrough video

`N/A - static error card, no interactive flow; every branch is captured above.`

## Audio / voice walkthrough

`N/A - no voice surface.`

## Known gaps / failures

- Exact-head `bun run verify` passed all 350 Turbo tasks and every trailing repository audit after a frozen install.
- No live staging reproduction against a genuinely degraded Cloud API (the issue's original trigger); the upstream statuses are simulated at the `fetch` boundary, which is the exact seam the handler consumes.
- `Retry-After: 60` is a fixed hint, not derived from upstream headers; the upstream body is not consulted.

## Residuals (why this PR must NOT close #18066)

Out of scope here, still open on #18066:

- Raw Cloudflare/edge 502s served **before** `handleStandaloneCloudPairRoute` runs — nothing in this handler can classify those.
- Router restart / blue-green deploy safety on the serving side (the deploy-safety half of the issue).
- Hetzner restart residuals / host log correlation.
- Two-hop staging synthetic reproduction.
- Dashboard-side fresh-token mint UX.

---

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [claude-18066]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01M003Z59QCXEW0K1HF2X2HBXX","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-14T12:29:22.103Z","completed_at":"2026-08-14T12:36:22.528Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA1wup-TpOQbidV6XOR-nWj5-01vmuc1Uuv5emKqsM8iA","device_key_id":"dbd0806ed31cfab14a18eeb4990c66497a5ce64fdb0d37d3c878b8f5e6227484","device_signature":"3qt0XbE2jT1qIqVJigdJcvT_0dS24MV70j1EyZZgVj82_b0tXfEa-twtyfNGNkgPNE01shuV-GvqA6059tBlAQ"}} -->

## Maintainer repair

The exact head was rebased onto `develop@75b83886e585a80ab8a47b2024673832a4d3941e`. The repair replaces unobservable token-consumption claims with neutral copy, moves timeout cleanup into a `finally` boundary, proves the real 15-second abort signal, and models Cloud completing after caller abort. The two affected HTML/JPG captures and the transcript were regenerated from the exact repaired code; malformed-2xx and unexpected-status behavior remain unchanged. This is a substantive repair and still requires independent exact-head approval plus terminal hosted checks.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza"} -->


