### PR TITLE
fix(cloud): promote protected SlopHub cutover

### DIFF
--- a/.github/workflows/slophub-cutover.yml
+++ b/.github/workflows/slophub-cutover.yml
@@ -1,0 +1,198 @@
+# The SlopHub cutover is two fixed mutations behind one reviewed-plan boundary.
+# A plan reads production state and publishes an attempt-scoped artifact. Apply
+# accepts only that exact successful artifact, executes its source SHA, rechecks
+# drift, and leaves GitHub's protected production approval in front of secrets.
+name: SlopHub Cutover
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Plan or apply the fixed SlopHub cutover
+        required: true
+        default: plan
+        type: choice
+        options: [plan, apply]
+      plan_run_id:
+        description: Successful SlopHub Cutover plan run id required for apply
+        required: false
+        type: string
+      plan_run_attempt:
+        description: Exact attempt that produced the reviewed plan
+        required: false
+        type: string
+      plan_artifact_id:
+        description: Exact GitHub artifact id shown by the plan run
+        required: false
+        type: string
+      plan_artifact_digest:
+        description: Exact sha256 artifact digest shown by the plan run
+        required: false
+        type: string
+
+concurrency:
+  group: slophub-production-cutover
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  validate-source:
+    name: Validate canonical source
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - name: Require production main
+        shell: bash
+        env:
+          SOURCE_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [ "$SOURCE_REF" != "refs/heads/main" ]; then
+            echo "::error::SlopHub production cutover must run from refs/heads/main"
+            exit 1
+          fi
+
+  cutover:
+    name: ${{ inputs.operation }} SlopHub production cutover
+    needs: validate-source
+    runs-on: ubuntu-24.04
+    environment: production
+    timeout-minutes: 15
+    steps:
+      - name: Validate reviewed plan run
+        if: inputs.operation == 'apply'
+        id: reviewed-run
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PLAN_RUN_ID: ${{ inputs.plan_run_id }}
+          PLAN_RUN_ATTEMPT: ${{ inputs.plan_run_attempt }}
+        run: |
+          set -euo pipefail
+          [[ "$PLAN_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo "::error::apply requires a numeric plan_run_id"; exit 1; }
+          [[ "$PLAN_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || { echo "::error::apply requires a numeric plan_run_attempt"; exit 1; }
+          run_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PLAN_RUN_ID")
+          RUN_JSON="$run_json" EXPECTED_ATTEMPT="$PLAN_RUN_ATTEMPT" node - <<'NODE'
+          const run = JSON.parse(process.env.RUN_JSON);
+          const failures = [];
+          if (run.name !== "SlopHub Cutover") failures.push("workflow name");
+          if (run.path !== ".github/workflows/slophub-cutover.yml") failures.push("workflow path");
+          if (run.event !== "workflow_dispatch") failures.push("event");
+          if (run.status !== "completed" || run.conclusion !== "success") failures.push("successful conclusion");
+          if (run.head_branch !== "main") failures.push("canonical source branch");
+          if (String(run.run_attempt) !== process.env.EXPECTED_ATTEMPT) failures.push("run attempt");
+          if (failures.length > 0) {
+            console.error(`::error::Reviewed SlopHub plan run failed verification: ${failures.join(", ")}`);
+            process.exit(1);
+          }
+          console.log("Reviewed plan run identity verified; plan contents remain unprinted.");
+          NODE
+          source_sha=$(printf '%s' "$run_json" | jq -r '.head_sha')
+          [[ "$source_sha" =~ ^[a-f0-9]{40}$ ]] || { echo "::error::Reviewed plan source SHA is invalid"; exit 1; }
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve reviewed plan artifact
+        if: inputs.operation == 'apply'
+        shell: bash
+        env:
+          EXPECTED_ARTIFACT_ID: ${{ inputs.plan_artifact_id }}
+          EXPECTED_ARTIFACT_DIGEST: ${{ inputs.plan_artifact_digest }}
+          EXPECTED_RUN_ID: ${{ inputs.plan_run_id }}
+          EXPECTED_RUN_ATTEMPT: ${{ inputs.plan_run_attempt }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || { echo "::error::apply requires a numeric plan_artifact_id"; exit 1; }
+          [[ "$EXPECTED_ARTIFACT_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] || { echo "::error::apply requires the exact sha256 artifact digest"; exit 1; }
+          artifact_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$EXPECTED_ARTIFACT_ID")
+          ARTIFACT_JSON="$artifact_json" node - <<'NODE'
+          const artifact = JSON.parse(process.env.ARTIFACT_JSON);
+          const expectedName = `slophub-cutover-plan-${process.env.EXPECTED_RUN_ID}-${process.env.EXPECTED_RUN_ATTEMPT}`;
+          const failures = [];
+          if (String(artifact.id) !== process.env.EXPECTED_ARTIFACT_ID) failures.push("artifact id");
+          if (artifact.name !== expectedName) failures.push("attempt-scoped artifact name");
+          if (artifact.digest !== process.env.EXPECTED_ARTIFACT_DIGEST) failures.push("GitHub artifact digest");
+          if (artifact.expired !== false) failures.push("unexpired artifact");
+          if (String(artifact.workflow_run?.id) !== process.env.EXPECTED_RUN_ID) failures.push("workflow run id");
+          if (failures.length > 0) {
+            console.error(`::error::Reviewed SlopHub artifact failed verification: ${failures.join(", ")}`);
+            process.exit(1);
+          }
+          console.log("Reviewed artifact identity and service digest verified.");
+          NODE
+
+      - name: Download reviewed plan artifact
+        if: inputs.operation == 'apply'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          artifact-ids: ${{ inputs.plan_artifact_id }}
+          path: ${{ runner.temp }}/reviewed-slophub-plan
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.plan_run_id }}
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.operation == 'apply' && steps.reviewed-run.outputs.source_sha || github.sha }}
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
+      - name: Plan fixed cutover
+        if: inputs.operation == 'plan'
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          SLOPHUB_SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          install -d -m 0700 "$RUNNER_TEMP/slophub-plan"
+          bun packages/cloud/scripts/admin/slophub-cutover.ts plan \
+            --output "$RUNNER_TEMP/slophub-plan/plan.json"
+
+      - name: Upload reviewed plan artifact
+        if: inputs.operation == 'plan'
+        id: upload-plan
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: slophub-cutover-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/slophub-plan/plan.json
+          if-no-files-found: error
+          retention-days: 3
+
+      - name: Summarize reviewed plan identity
+        if: inputs.operation == 'plan' && success()
+        shell: bash
+        env:
+          ARTIFACT_ID: ${{ steps.upload-plan.outputs.artifact-id }}
+          ARTIFACT_DIGEST: ${{ steps.upload-plan.outputs.artifact-digest }}
+        run: |
+          {
+            echo "### SlopHub production cutover plan"
+            echo "- Run id: $GITHUB_RUN_ID"
+            echo "- Run attempt: $GITHUB_RUN_ATTEMPT"
+            echo "- Artifact id: $ARTIFACT_ID"
+            echo "- Artifact digest: sha256:$ARTIFACT_DIGEST"
+            echo ""
+            echo "Review the plan job and supply all four exact values to apply."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Apply reviewed cutover
+        if: inputs.operation == 'apply'
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          SLOPHUB_SOURCE_SHA: ${{ steps.reviewed-run.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          plan="$RUNNER_TEMP/reviewed-slophub-plan/plan.json"
+          [ -f "$plan" ] || { echo "::error::Reviewed artifact has no plan.json"; exit 1; }
+          bun packages/cloud/scripts/admin/slophub-cutover.ts apply --plan "$plan"

--- a/packages/cloud/api/__tests__/oidc-provider.test.ts
+++ b/packages/cloud/api/__tests__/oidc-provider.test.ts
@@ -47,6 +47,8 @@ const ISSUER = "https://api.elizacloud.test";
 const CONSOLE_ORIGIN = "https://console.elizacloud.test";
 const FORGEJO_REDIRECT =
   "https://hub.elizacloud.test/user/oauth2/elizacloud/callback";
+const SLOPHUB_REDIRECT =
+  "https://git.slop.cash/user/oauth2/elizacloud/callback";
 const FORGEJO_CLIENT_ID = "elizahub-forgejo";
 const FORGEJO_SECRET = "forgejo-client-secret-value-0123456789";
 const LOWTRUST_CLIENT_ID = "lowtrust-app";
@@ -754,6 +756,87 @@ describe("discovery document", () => {
 });
 
 describe("authorize — validation that must never redirect", () => {
+  test("an additive callback works only for its existing registered client", async () => {
+    const aliasEnvironment = {
+      ...ENV,
+      OIDC_REDIRECT_URI_ALIASES: JSON.stringify({
+        [FORGEJO_CLIENT_ID]: [SLOPHUB_REDIRECT],
+      }),
+    };
+    await seedUser({ stewardUserId: "u-slophub-alias" });
+    const accepted = await harness.request(
+      `${ISSUER}${authorizeUrl({ redirect_uri: SLOPHUB_REDIRECT })}`,
+      {
+        headers: {
+          cookie: await sessionCookie("u-slophub-alias"),
+          "x-forwarded-for": "10.8.7.6",
+        },
+        redirect: "manual",
+      },
+      aliasEnvironment,
+    );
+    expect(accepted.status).toBe(302);
+    const acceptedLocation = new URL(
+      accepted.headers.get("location") as string,
+    );
+    expect(acceptedLocation.origin + acceptedLocation.pathname).toBe(
+      SLOPHUB_REDIRECT,
+    );
+    const code = acceptedLocation.searchParams.get("code");
+    expect(code).not.toBeNull();
+    const aliasTokenForm = form({
+      grant_type: "authorization_code",
+      code: code as string,
+      redirect_uri: SLOPHUB_REDIRECT,
+    });
+    const redeemed = await harness.request(
+      `${ISSUER}/api/oidc/token`,
+      {
+        method: "POST",
+        body: aliasTokenForm.body,
+        headers: {
+          ...aliasTokenForm.headers,
+          authorization: basicAuth(FORGEJO_CLIENT_ID, FORGEJO_SECRET),
+          "x-forwarded-for": "10.8.7.4",
+        },
+      },
+      aliasEnvironment,
+    );
+    expect(redeemed.status).toBe(200);
+
+    await seedUser({ stewardUserId: "u-slophub-primary" });
+    const primary = await harness.request(
+      `${ISSUER}${authorizeUrl()}`,
+      {
+        headers: {
+          cookie: await sessionCookie("u-slophub-primary"),
+          "x-forwarded-for": "10.8.7.3",
+        },
+        redirect: "manual",
+      },
+      aliasEnvironment,
+    );
+    expect(primary.status).toBe(302);
+    const primaryLocation = new URL(primary.headers.get("location") as string);
+    expect(primaryLocation.origin + primaryLocation.pathname).toBe(
+      FORGEJO_REDIRECT,
+    );
+    expect(primaryLocation.searchParams.get("code")).not.toBeNull();
+
+    for (const [clientId, redirectUri, ip] of [
+      [CONSOLE_CLIENT_ID, SLOPHUB_REDIRECT, "10.8.7.5"],
+      [FORGEJO_CLIENT_ID, `${SLOPHUB_REDIRECT}/`, "10.8.7.2"],
+    ] as const) {
+      const refused = await harness.request(
+        `${ISSUER}${authorizeUrl({ client_id: clientId, redirect_uri: redirectUri })}`,
+        { headers: { "x-forwarded-for": ip }, redirect: "manual" },
+        aliasEnvironment,
+      );
+      expect(refused.status).toBe(400);
+      expect(refused.headers.get("location")).toBeNull();
+    }
+  });
+
   test("an unknown client renders an error page with NO Location header", async () => {
     const cookie = await sessionCookie("u-unknown-client");
     await seedUser({ stewardUserId: "u-unknown-client" });

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -340,9 +340,14 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 #                                      Generate with packages/cloud/scripts/admin/generate-oidc-keys.ts.
 #   OIDC_CLIENTS                       OIDC relying-party registry: JSON array; client
 #                                      secrets stored as sha256 hex only.
-#                                      NOTE: both are SECRETS on purpose — a wiped secret
-#                                      makes SSO fail closed (503) rather than serve an
-#                                      empty registry. OIDC_ENABLED / OIDC_ISSUER_URL are
+#                                      OIDC_SIGNING_JWKS and OIDC_CLIENTS are
+#                                      SECRETS on purpose: losing either makes
+#                                      SSO fail closed instead of serving an
+#                                      empty registry.
+#   OIDC_REDIRECT_URI_ALIASES          Public JSON object of client_id to additive
+#                                      exact HTTPS callbacks. It cannot create a
+#                                      client or change any protected registration.
+#                                      OIDC_ENABLED / OIDC_ISSUER_URL are
 #                                      committed [vars] below for the same reason inverted:
 #                                      losing them must not silently change the issuer.
 #                                      OIDC_WALLET_EMAIL_DOMAIN is a var for that same
@@ -681,6 +686,7 @@ ELIZA_FRONTEND_HOST_SUFFIX = "sites.eliza.app"
 # relying-party account link.
 OIDC_ENABLED = "true"
 OIDC_ISSUER_URL = "https://api.eliza.app"
+OIDC_REDIRECT_URI_ALIASES = '{"elizahub":["https://git.slop.cash/user/oauth2/elizacloud/callback"]}'
 # Pin the prod Steward tenant explicitly instead of leaning on the implicit
 # DEFAULT_STEWARD_TENANT_ID ("elizacloud") in steward-tenant-config.ts. That
 # implicit fallback is what the prod magic-link bug hinged on — make it explicit

--- a/packages/cloud/scripts/admin/slophub-cutover.test.ts
+++ b/packages/cloud/scripts/admin/slophub-cutover.test.ts
@@ -1,0 +1,505 @@
+/**
+ * Exercises the SlopHub cutover operator against stateful provider HTTP
+ * boundaries. The harness records every mutation and updates its in-memory
+ * provider state, so apply must prove the same post-mutation reads production
+ * will perform rather than passing on mocked return values alone.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  applySlopHubCutoverPlan,
+  buildSlopHubCutoverPlan,
+} from "./slophub-cutover";
+
+const SOURCE_SHA = "a".repeat(40);
+const environment = {
+  CLOUDFLARE_ACCOUNT_ID: "account-1",
+  CLOUDFLARE_API_TOKEN: "cloudflare-secret",
+  HCLOUD_TOKEN: "hetzner-secret",
+  SLOPHUB_SOURCE_SHA: SOURCE_SHA,
+};
+
+interface HarnessOptions {
+  dropUnrelatedFirewallRulesAfterSet?: boolean;
+  dnsRecords?: Record<string, unknown>[];
+  firewallActionStatus?: "error" | "running" | "success";
+  firewallPollStatus?: "error" | "success";
+  firewalls?: Record<string, unknown>[];
+  reverseFirewallRulesAfterSet?: boolean;
+  servers?: Record<string, unknown>[];
+  zoneAccountId?: string;
+}
+
+function harness(options: HarnessOptions = {}) {
+  const state = {
+    dnsRecords: structuredClone(options.dnsRecords ?? []),
+    firewalls: structuredClone(
+      options.firewalls ?? [
+        {
+          id: 90,
+          name: "eliza-hub",
+          applied_to: [{ type: "server", server: { id: 80 } }],
+          rules: [
+            {
+              direction: "in",
+              protocol: "tcp",
+              port: "443",
+              source_ips: ["0.0.0.0/0", "::/0"],
+              description: "HTTPS",
+            },
+          ],
+        },
+      ],
+    ),
+    servers: structuredClone(
+      options.servers ?? [
+        {
+          id: 80,
+          name: "eliza-hub",
+          public_net: { ipv4: { ip: "5.78.151.202" } },
+        },
+      ],
+    ),
+  };
+  const mutations: Array<{ method: string; url: string; body: unknown }> = [];
+
+  const request = async (
+    input: string | URL | Request,
+    init: RequestInit = {},
+  ) => {
+    const url = new URL(
+      typeof input === "string" || input instanceof URL ? input : input.url,
+    );
+    const method = init.method ?? "GET";
+    const body = init.body ? (JSON.parse(String(init.body)) as unknown) : null;
+    const headers = new Headers(init.headers);
+    const expectedAuthorization =
+      url.hostname === "api.cloudflare.com"
+        ? "Bearer cloudflare-secret"
+        : "Bearer hetzner-secret";
+    expect(headers.get("authorization")).toBe(expectedAuthorization);
+
+    if (
+      url.hostname === "api.cloudflare.com" &&
+      url.pathname === "/client/v4/zones"
+    ) {
+      return Response.json({
+        success: true,
+        result: [
+          {
+            id: "zone-1",
+            name: "slop.cash",
+            account: { id: options.zoneAccountId ?? "account-1" },
+          },
+        ],
+      });
+    }
+    if (
+      url.hostname === "api.cloudflare.com" &&
+      url.pathname === "/client/v4/zones/zone-1/dns_records" &&
+      method === "GET"
+    ) {
+      return Response.json({ success: true, result: state.dnsRecords });
+    }
+    if (
+      url.hostname === "api.cloudflare.com" &&
+      url.pathname === "/client/v4/zones/zone-1/dns_records" &&
+      method === "POST"
+    ) {
+      mutations.push({ method, url: url.href, body });
+      state.dnsRecords = [{ id: "record-1", ...(body as object) }];
+      return Response.json({ success: true, result: state.dnsRecords[0] });
+    }
+    if (
+      url.hostname === "api.cloudflare.com" &&
+      url.pathname === "/client/v4/zones/zone-1/dns_records/record-1" &&
+      method === "PATCH"
+    ) {
+      mutations.push({ method, url: url.href, body });
+      state.dnsRecords[0] = { ...state.dnsRecords[0], ...(body as object) };
+      return Response.json({ success: true, result: state.dnsRecords[0] });
+    }
+    if (
+      url.hostname === "api.hetzner.cloud" &&
+      url.pathname === "/v1/servers"
+    ) {
+      return Response.json({
+        servers: state.servers,
+        meta: { pagination: { last_page: 1 } },
+      });
+    }
+    if (
+      url.hostname === "api.hetzner.cloud" &&
+      url.pathname === "/v1/firewalls"
+    ) {
+      return Response.json({
+        firewalls: state.firewalls,
+        meta: { pagination: { last_page: 1 } },
+      });
+    }
+    if (
+      url.hostname === "api.hetzner.cloud" &&
+      url.pathname === "/v1/firewalls/90/actions/set_rules" &&
+      method === "POST"
+    ) {
+      mutations.push({ method, url: url.href, body });
+      const requestedRules = (body as { rules: unknown[] }).rules;
+      const retainedRules = options.dropUnrelatedFirewallRulesAfterSet
+        ? requestedRules.filter(
+            (rule) => (rule as { port?: string }).port === "2222",
+          )
+        : requestedRules;
+      state.firewalls[0] = {
+        ...state.firewalls[0],
+        rules: options.reverseFirewallRulesAfterSet
+          ? retainedRules.toReversed()
+          : retainedRules,
+      };
+      return Response.json({
+        action: { id: 100, status: options.firewallActionStatus ?? "success" },
+      });
+    }
+    if (
+      url.hostname === "api.hetzner.cloud" &&
+      url.pathname === "/v1/actions/100"
+    ) {
+      return Response.json({
+        action: { id: 100, status: options.firewallPollStatus ?? "success" },
+      });
+    }
+    return new Response("not found", { status: 404 });
+  };
+
+  return { state, mutations, request: request as typeof fetch };
+}
+
+function desiredRecord() {
+  return {
+    id: "record-1",
+    type: "A",
+    name: "git.slop.cash",
+    content: "5.78.151.202",
+    proxied: false,
+    ttl: 1,
+  };
+}
+
+function desiredSshRule() {
+  return {
+    direction: "in",
+    protocol: "tcp",
+    port: "2222",
+    source_ips: ["0.0.0.0/0", "::/0"],
+    description: "Public SlopHub Forgejo SSH",
+  };
+}
+
+describe("SlopHub cutover plan", () => {
+  test("plans only the missing DNS record and SSH rule without exposing credentials", async () => {
+    const provider = harness();
+    const plan = await buildSlopHubCutoverPlan(environment, provider.request);
+
+    expect(plan.cloudflare.action).toBe("create");
+    expect(plan.hetzner.action).toBe("add-rule");
+    expect(plan.hetzner.nextRules).toEqual([
+      ...plan.hetzner.beforeRules,
+      desiredSshRule(),
+    ]);
+    expect(JSON.stringify(plan)).not.toContain("cloudflare-secret");
+    expect(JSON.stringify(plan)).not.toContain("hetzner-secret");
+    expect(provider.mutations).toEqual([]);
+  });
+
+  test("reports a complete no-op when both providers already match", async () => {
+    const provider = harness({
+      dnsRecords: [desiredRecord()],
+      firewalls: [
+        {
+          id: 90,
+          name: "eliza-hub",
+          applied_to: [{ type: "server", server: { id: 80 } }],
+          rules: [desiredSshRule()],
+        },
+      ],
+    });
+    const plan = await buildSlopHubCutoverPlan(environment, provider.request);
+    expect(plan.cloudflare.action).toBe("noop");
+    expect(plan.hetzner.action).toBe("noop");
+  });
+
+  test("fails closed on DNS conflicts, account mismatch, server ambiguity, or firewall ambiguity", async () => {
+    const cases = [
+      harness({
+        dnsRecords: [desiredRecord(), { ...desiredRecord(), id: "record-2" }],
+      }),
+      harness({
+        dnsRecords: [
+          { ...desiredRecord(), type: "CNAME", content: "wrong.example" },
+        ],
+      }),
+      harness({
+        dnsRecords: [{ ...desiredRecord(), name: "other.slop.cash" }],
+      }),
+      harness({ zoneAccountId: "other-account" }),
+      harness({
+        servers: [
+          { id: 80, name: "one", public_net: { ipv4: { ip: "5.78.151.202" } } },
+          { id: 81, name: "two", public_net: { ipv4: { ip: "5.78.151.202" } } },
+        ],
+      }),
+      harness({
+        firewalls: [
+          {
+            id: 90,
+            name: "one",
+            applied_to: [{ type: "server", server: { id: 80 } }],
+            rules: [],
+          },
+          {
+            id: 91,
+            name: "two",
+            applied_to: [{ type: "server", server: { id: 80 } }],
+            rules: [],
+          },
+        ],
+      }),
+      harness({
+        firewalls: [
+          {
+            id: 90,
+            name: "shared",
+            applied_to: [
+              { type: "server", server: { id: 80 } },
+              { type: "server", server: { id: 81 } },
+            ],
+            rules: [],
+          },
+        ],
+      }),
+      harness({
+        firewalls: [
+          {
+            id: 90,
+            name: "selector",
+            applied_to: [
+              {
+                type: "label_selector",
+                label_selector: { selector: "role=git" },
+              },
+            ],
+            rules: [],
+          },
+        ],
+      }),
+    ];
+    for (const provider of cases) {
+      await expect(
+        buildSlopHubCutoverPlan(environment, provider.request),
+      ).rejects.toThrow();
+      expect(provider.mutations).toEqual([]);
+    }
+  });
+});
+
+describe("SlopHub cutover apply", () => {
+  test("applies the exact reviewed changes, preserves unrelated rules, and proves convergence", async () => {
+    const provider = harness();
+    const reviewed = await buildSlopHubCutoverPlan(
+      environment,
+      provider.request,
+    );
+    const verified = await applySlopHubCutoverPlan(
+      reviewed,
+      environment,
+      provider.request,
+    );
+
+    expect(verified.cloudflare.action).toBe("noop");
+    expect(verified.hetzner.action).toBe("noop");
+    expect(provider.mutations.map(({ method }) => method)).toEqual([
+      "POST",
+      "POST",
+    ]);
+    expect(provider.mutations.map(({ url }) => new URL(url).hostname)).toEqual([
+      "api.hetzner.cloud",
+      "api.cloudflare.com",
+    ]);
+    expect(provider.state.firewalls[0]?.rules).toEqual([
+      reviewed.hetzner.beforeRules[0],
+      desiredSshRule(),
+    ]);
+  });
+
+  test("continues idempotently when one reviewed leg was already applied", async () => {
+    const provider = harness();
+    const reviewed = await buildSlopHubCutoverPlan(
+      environment,
+      provider.request,
+    );
+    provider.state.dnsRecords = [desiredRecord()];
+
+    const verified = await applySlopHubCutoverPlan(
+      reviewed,
+      environment,
+      provider.request,
+    );
+    expect(verified.cloudflare.action).toBe("noop");
+    expect(verified.hetzner.action).toBe("noop");
+    expect(provider.mutations.map(({ url }) => url)).toEqual([
+      "https://api.hetzner.cloud/v1/firewalls/90/actions/set_rules",
+    ]);
+  });
+
+  test("rejects source mismatch and live drift before any mutation", async () => {
+    const provider = harness({
+      dnsRecords: [{ ...desiredRecord(), content: "5.78.151.201" }],
+    });
+    const reviewed = await buildSlopHubCutoverPlan(
+      environment,
+      provider.request,
+    );
+
+    await expect(
+      applySlopHubCutoverPlan(
+        reviewed,
+        { ...environment, SLOPHUB_SOURCE_SHA: "b".repeat(40) },
+        provider.request,
+      ),
+    ).rejects.toThrow(/source validation/);
+    provider.state.dnsRecords[0] = {
+      ...desiredRecord(),
+      content: "5.78.151.200",
+    };
+    await expect(
+      applySlopHubCutoverPlan(reviewed, environment, provider.request),
+    ).rejects.toThrow(/drifted/);
+    expect(provider.mutations).toEqual([]);
+  });
+
+  test("rejects when a reviewed no-op drifts into a mutation", async () => {
+    const provider = harness({
+      dnsRecords: [desiredRecord()],
+      firewalls: [
+        {
+          id: 90,
+          name: "eliza-hub",
+          applied_to: [{ type: "server", server: { id: 80 } }],
+          rules: [desiredSshRule()],
+        },
+      ],
+    });
+    const reviewed = await buildSlopHubCutoverPlan(
+      environment,
+      provider.request,
+    );
+    provider.state.dnsRecords[0] = {
+      ...desiredRecord(),
+      content: "5.78.151.201",
+    };
+
+    await expect(
+      applySlopHubCutoverPlan(reviewed, environment, provider.request),
+    ).rejects.toThrow(/drifted/);
+    expect(provider.mutations).toEqual([]);
+  });
+
+  test("patches one existing A record without deleting its identity or unrelated firewall rules", async () => {
+    const provider = harness({
+      dnsRecords: [
+        {
+          ...desiredRecord(),
+          content: "5.78.151.201",
+          proxied: true,
+          ttl: 300,
+        },
+      ],
+      firewalls: [
+        {
+          id: 90,
+          name: "eliza-hub",
+          applied_to: [{ type: "server", server: { id: 80 } }],
+          rules: [desiredSshRule()],
+        },
+      ],
+    });
+    const reviewed = await buildSlopHubCutoverPlan(
+      environment,
+      provider.request,
+    );
+    const verified = await applySlopHubCutoverPlan(
+      reviewed,
+      environment,
+      provider.request,
+    );
+    expect(verified.cloudflare.recordId).toBe("record-1");
+    expect(provider.mutations).toHaveLength(1);
+    expect(provider.mutations[0]).toMatchObject({
+      method: "PATCH",
+      body: { content: "5.78.151.202", proxied: false },
+    });
+    expect(provider.state.dnsRecords[0]?.ttl).toBe(300);
+  });
+
+  test("fails when Hetzner reports an action error or drops an unrelated rule", async () => {
+    const actionError = harness({ firewallActionStatus: "error" });
+    const actionErrorPlan = await buildSlopHubCutoverPlan(
+      environment,
+      actionError.request,
+    );
+    await expect(
+      applySlopHubCutoverPlan(
+        actionErrorPlan,
+        environment,
+        actionError.request,
+      ),
+    ).rejects.toThrow();
+    expect(
+      actionError.mutations.every(
+        ({ url }) => !url.includes("api.cloudflare.com"),
+      ),
+    ).toBe(true);
+
+    const droppedRule = harness({ dropUnrelatedFirewallRulesAfterSet: true });
+    const droppedRulePlan = await buildSlopHubCutoverPlan(
+      environment,
+      droppedRule.request,
+    );
+    await expect(
+      applySlopHubCutoverPlan(
+        droppedRulePlan,
+        environment,
+        droppedRule.request,
+      ),
+    ).rejects.toThrow(/ingress did not match/);
+    expect(
+      droppedRule.mutations.every(
+        ({ url }) => !url.includes("api.cloudflare.com"),
+      ),
+    ).toBe(true);
+    expect(droppedRule.state.dnsRecords).toEqual([]);
+  });
+
+  test("waits for an asynchronous Hetzner action and ignores provider rule ordering", async () => {
+    const provider = harness({
+      firewallActionStatus: "running",
+      firewallPollStatus: "success",
+      reverseFirewallRulesAfterSet: true,
+    });
+    const reviewed = await buildSlopHubCutoverPlan(
+      environment,
+      provider.request,
+    );
+    const verified = await applySlopHubCutoverPlan(
+      reviewed,
+      environment,
+      provider.request,
+    );
+    expect(verified.cloudflare.action).toBe("noop");
+    expect(verified.hetzner.action).toBe("noop");
+    expect(provider.state.firewalls[0]?.rules).toEqual([
+      desiredSshRule(),
+      reviewed.hetzner.beforeRules[0],
+    ]);
+  });
+});

--- a/packages/cloud/scripts/admin/slophub-cutover.ts
+++ b/packages/cloud/scripts/admin/slophub-cutover.ts
@@ -1,0 +1,703 @@
+/**
+ * Plans and applies the two external mutations required for the SlopHub
+ * canonical-domain cutover. Targets are compiled into this operator so a
+ * workflow input cannot widen its authority. Apply consumes a reviewed plan,
+ * re-reads both providers, refuses drift, preserves unrelated firewall rules,
+ * and proves the desired state after mutation.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+
+const TARGET = Object.freeze({
+  dnsName: "git.slop.cash",
+  dnsType: "A",
+  ipv4: "5.78.151.202",
+  sshPort: "2222",
+  zoneName: "slop.cash",
+  sourceCidrs: ["0.0.0.0/0", "::/0"] as const,
+});
+const SOURCE_SHA = /^[a-f0-9]{40}$/;
+const MAX_PROVIDER_PAGES = 10;
+const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
+const MAX_ACTION_POLLS = 30;
+const ACTION_POLL_DELAY_MS = 2_000;
+
+type Request = typeof fetch;
+type JsonObject = Record<string, unknown>;
+
+interface Environment {
+  CLOUDFLARE_ACCOUNT_ID?: string;
+  CLOUDFLARE_API_TOKEN?: string;
+  HCLOUD_TOKEN?: string;
+  SLOPHUB_SOURCE_SHA?: string;
+}
+
+interface DnsRecord {
+  id: string;
+  type: string;
+  name: string;
+  content: string;
+  proxied: boolean;
+  ttl: number;
+}
+
+interface FirewallRule {
+  direction: string;
+  protocol: string;
+  port?: string | null;
+  source_ips?: string[];
+  destination_ips?: string[];
+  description?: string | null;
+}
+
+export interface SlopHubCutoverPlan {
+  schemaVersion: 1;
+  sourceSha: string;
+  target: typeof TARGET;
+  cloudflare: {
+    accountId: string;
+    zoneId: string;
+    recordId: string | null;
+    before: DnsRecord | null;
+    action: "create" | "patch" | "noop";
+  };
+  hetzner: {
+    serverId: number;
+    serverName: string;
+    firewallId: number;
+    firewallName: string;
+    beforeRules: FirewallRule[];
+    beforeRulesSha256: string;
+    nextRules: FirewallRule[];
+    action: "add-rule" | "noop";
+  };
+}
+
+function object(value: unknown, field: string): JsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${field} must be an object`);
+  }
+  return value as JsonObject;
+}
+
+function array(value: unknown, field: string): unknown[] {
+  if (!Array.isArray(value)) throw new TypeError(`${field} must be an array`);
+  return value;
+}
+
+function string(value: unknown, field: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new TypeError(`${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function integer(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    throw new TypeError(`${field} must be a positive safe integer`);
+  }
+  return value as number;
+}
+
+function requiredEnvironment(environment: Environment): Required<Environment> {
+  const resolved = {
+    CLOUDFLARE_ACCOUNT_ID: string(
+      environment.CLOUDFLARE_ACCOUNT_ID,
+      "CLOUDFLARE_ACCOUNT_ID",
+    ),
+    CLOUDFLARE_API_TOKEN: string(
+      environment.CLOUDFLARE_API_TOKEN,
+      "CLOUDFLARE_API_TOKEN",
+    ),
+    HCLOUD_TOKEN: string(environment.HCLOUD_TOKEN, "HCLOUD_TOKEN"),
+    SLOPHUB_SOURCE_SHA: string(
+      environment.SLOPHUB_SOURCE_SHA,
+      "SLOPHUB_SOURCE_SHA",
+    ),
+  };
+  if (!SOURCE_SHA.test(resolved.SLOPHUB_SOURCE_SHA)) {
+    throw new TypeError(
+      "SLOPHUB_SOURCE_SHA must be a full lowercase commit SHA",
+    );
+  }
+  return resolved;
+}
+
+async function jsonResponse(
+  response: Response,
+  boundary: string,
+): Promise<JsonObject> {
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.byteLength > MAX_RESPONSE_BYTES) {
+    throw new RangeError(`${boundary} response exceeds its byte limit`);
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — provider bodies are untrusted and
+    // may contain credentials or internal detail, so never echo them.
+    throw new Error(`${boundary} returned invalid JSON`, { cause: error });
+  }
+  if (!response.ok)
+    throw new Error(`${boundary} returned HTTP ${response.status}`);
+  return object(value, `${boundary} response`);
+}
+
+async function cloudflareRequest(
+  path: string,
+  environment: Required<Environment>,
+  request: Request,
+  init: RequestInit = {},
+): Promise<unknown> {
+  // The shared application helper owns normal API calls. This operator keeps a
+  // separate injected-fetch boundary because plans must be statefully tested,
+  // provider responses are byte-bounded, and errors must never echo bodies.
+  const response = await request(
+    `https://api.cloudflare.com/client/v4${path}`,
+    {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${environment.CLOUDFLARE_API_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+    },
+  );
+  const envelope = await jsonResponse(response, "Cloudflare API");
+  if (envelope.success !== true)
+    throw new Error("Cloudflare API reported failure");
+  return envelope.result;
+}
+
+async function hetznerRequest(
+  path: string,
+  environment: Required<Environment>,
+  request: Request,
+  init: RequestInit = {},
+): Promise<JsonObject> {
+  const response = await request(`https://api.hetzner.cloud/v1${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${environment.HCLOUD_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+  });
+  return jsonResponse(response, "Hetzner API");
+}
+
+async function listHetzner(
+  path: string,
+  field: string,
+  environment: Required<Environment>,
+  request: Request,
+): Promise<unknown[]> {
+  const values: unknown[] = [];
+  for (let page = 1; page <= MAX_PROVIDER_PAGES; page += 1) {
+    const separator = path.includes("?") ? "&" : "?";
+    const response = await hetznerRequest(
+      `${path}${separator}page=${page}&per_page=50`,
+      environment,
+      request,
+    );
+    values.push(...array(response[field], `Hetzner ${field}`));
+    const pagination = object(
+      object(response.meta, "Hetzner meta").pagination,
+      "pagination",
+    );
+    const lastPage = integer(pagination.last_page, "pagination.last_page");
+    if (lastPage > MAX_PROVIDER_PAGES) {
+      throw new RangeError(`Hetzner ${field} exceeds the page limit`);
+    }
+    if (page >= lastPage) return values;
+  }
+  throw new RangeError(`Hetzner ${field} pagination did not terminate`);
+}
+
+function parseDnsRecord(value: unknown): DnsRecord {
+  const record = object(value, "Cloudflare DNS record");
+  const proxied = record.proxied;
+  const ttl = record.ttl;
+  if (
+    typeof proxied !== "boolean" ||
+    !Number.isSafeInteger(ttl) ||
+    (ttl as number) < 1
+  ) {
+    throw new TypeError(
+      "Cloudflare DNS record has invalid proxied or ttl fields",
+    );
+  }
+  return {
+    id: string(record.id, "DNS record id"),
+    type: string(record.type, "DNS record type"),
+    name: string(record.name, "DNS record name"),
+    content: string(record.content, "DNS record content"),
+    proxied,
+    ttl: ttl as number,
+  };
+}
+
+function parseFirewallRule(value: unknown): FirewallRule {
+  const rule = object(value, "Hetzner firewall rule");
+  const parsed: FirewallRule = {
+    direction: string(rule.direction, "firewall rule direction"),
+    protocol: string(rule.protocol, "firewall rule protocol"),
+  };
+  if (rule.port !== undefined && rule.port !== null) {
+    parsed.port = string(rule.port, "firewall rule port");
+  }
+  for (const field of ["source_ips", "destination_ips"] as const) {
+    if (rule[field] !== undefined) {
+      parsed[field] = array(rule[field], `firewall rule ${field}`).map(
+        (value) => string(value, `firewall rule ${field} entry`),
+      );
+    }
+  }
+  if (rule.description !== undefined && rule.description !== null) {
+    parsed.description = string(rule.description, "firewall rule description");
+  }
+  return parsed;
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as JsonObject)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value: unknown): string {
+  return createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+function firewallRulesSha256(rules: FirewallRule[]): string {
+  return sha256(rules.map(canonicalJson).sort());
+}
+
+function desiredSshRule(): FirewallRule {
+  return {
+    direction: "in",
+    protocol: "tcp",
+    port: TARGET.sshPort,
+    source_ips: [...TARGET.sourceCidrs],
+    description: "Public SlopHub Forgejo SSH",
+  };
+}
+
+function isDesiredSshRule(rule: FirewallRule): boolean {
+  return (
+    rule.direction === "in" &&
+    rule.protocol === "tcp" &&
+    rule.port === TARGET.sshPort &&
+    canonicalJson([...(rule.source_ips ?? [])].sort()) ===
+      canonicalJson([...TARGET.sourceCidrs].sort())
+  );
+}
+
+export async function buildSlopHubCutoverPlan(
+  rawEnvironment: Environment,
+  request: Request = fetch,
+): Promise<SlopHubCutoverPlan> {
+  const environment = requiredEnvironment(rawEnvironment);
+  const zones = array(
+    await cloudflareRequest(
+      `/zones?name=${encodeURIComponent(TARGET.zoneName)}&status=active&per_page=50`,
+      environment,
+      request,
+    ),
+    "Cloudflare zones",
+  )
+    .map((value) => object(value, "Cloudflare zone"))
+    .filter(
+      (zone) =>
+        zone.name === TARGET.zoneName &&
+        object(zone.account, "Cloudflare zone account").id ===
+          environment.CLOUDFLARE_ACCOUNT_ID,
+    );
+  if (zones.length !== 1) {
+    throw new Error(
+      `Expected exactly one active ${TARGET.zoneName} zone in the configured account`,
+    );
+  }
+  const zoneId = string(zones[0]?.id, "Cloudflare zone id");
+  const records = array(
+    await cloudflareRequest(
+      `/zones/${encodeURIComponent(zoneId)}/dns_records?name.exact=${encodeURIComponent(TARGET.dnsName)}&per_page=100`,
+      environment,
+      request,
+    ),
+    "Cloudflare DNS records",
+  ).map(parseDnsRecord);
+  if (
+    records.length > 1 ||
+    records.some(
+      (record) =>
+        record.type !== TARGET.dnsType || record.name !== TARGET.dnsName,
+    )
+  ) {
+    throw new Error(
+      `Expected zero or one A record and no conflicting record at ${TARGET.dnsName}`,
+    );
+  }
+  const record = records[0] ?? null;
+  const dnsAction = !record
+    ? "create"
+    : record.content === TARGET.ipv4 && record.proxied === false
+      ? "noop"
+      : "patch";
+
+  const servers = (
+    await listHetzner("/servers", "servers", environment, request)
+  )
+    .map((value) => object(value, "Hetzner server"))
+    .filter((server) => {
+      const publicNet = object(server.public_net, "Hetzner server public_net");
+      const ipv4 = object(publicNet.ipv4, "Hetzner server IPv4");
+      return ipv4.ip === TARGET.ipv4;
+    });
+  if (servers.length !== 1) {
+    throw new Error(
+      `Expected exactly one Hetzner server with IPv4 ${TARGET.ipv4}`,
+    );
+  }
+  const server = servers[0] as JsonObject;
+  const serverId = integer(server.id, "Hetzner server id");
+  const firewalls = (
+    await listHetzner("/firewalls", "firewalls", environment, request)
+  )
+    .map((value) => object(value, "Hetzner firewall"))
+    .filter((firewall) => {
+      const targets = array(firewall.applied_to, "Hetzner firewall applied_to");
+      if (targets.length !== 1) return false;
+      const applied = object(targets[0], "Hetzner firewall target");
+      return (
+        applied.type === "server" &&
+        integer(
+          object(applied.server, "Hetzner firewall server").id,
+          "firewall server id",
+        ) === serverId
+      );
+    });
+  if (firewalls.length !== 1) {
+    throw new Error(
+      `Expected exactly one Hetzner firewall applied to server ${serverId}`,
+    );
+  }
+  const firewall = firewalls[0] as JsonObject;
+  const beforeRules = array(firewall.rules, "Hetzner firewall rules").map(
+    parseFirewallRule,
+  );
+  const hasSshRule = beforeRules.some(isDesiredSshRule);
+  const nextRules = hasSshRule
+    ? beforeRules
+    : [...beforeRules, desiredSshRule()];
+
+  return {
+    schemaVersion: 1,
+    sourceSha: environment.SLOPHUB_SOURCE_SHA,
+    target: TARGET,
+    cloudflare: {
+      accountId: environment.CLOUDFLARE_ACCOUNT_ID,
+      zoneId,
+      recordId: record?.id ?? null,
+      before: record,
+      action: dnsAction,
+    },
+    hetzner: {
+      serverId,
+      serverName: string(server.name, "Hetzner server name"),
+      firewallId: integer(firewall.id, "Hetzner firewall id"),
+      firewallName: string(firewall.name, "Hetzner firewall name"),
+      beforeRules,
+      beforeRulesSha256: firewallRulesSha256(beforeRules),
+      nextRules,
+      action: hasSshRule ? "noop" : "add-rule",
+    },
+  };
+}
+
+function validateReviewedPlan(
+  value: unknown,
+  expectedSourceSha: string,
+): SlopHubCutoverPlan {
+  const plan = object(
+    value,
+    "reviewed SlopHub plan",
+  ) as unknown as SlopHubCutoverPlan;
+  const beforeRules = array(
+    plan.hetzner?.beforeRules,
+    "reviewed beforeRules",
+  ).map(parseFirewallRule);
+  const nextRules = array(plan.hetzner?.nextRules, "reviewed nextRules").map(
+    parseFirewallRule,
+  );
+  const action = plan.hetzner?.action;
+  const rulesAreValid =
+    plan.hetzner.beforeRulesSha256 === firewallRulesSha256(beforeRules) &&
+    (action === "add-rule"
+      ? firewallRulesSha256(nextRules) ===
+        firewallRulesSha256([...beforeRules, desiredSshRule()])
+      : action === "noop" &&
+        beforeRules.some(isDesiredSshRule) &&
+        firewallRulesSha256(nextRules) === firewallRulesSha256(beforeRules));
+  if (
+    plan.schemaVersion !== 1 ||
+    plan.sourceSha !== expectedSourceSha ||
+    canonicalJson(plan.target) !== canonicalJson(TARGET) ||
+    !["create", "patch", "noop"].includes(plan.cloudflare?.action) ||
+    !["add-rule", "noop"].includes(action) ||
+    !rulesAreValid
+  ) {
+    throw new Error("Reviewed SlopHub plan failed schema or source validation");
+  }
+  return plan;
+}
+
+function assertNoDrift(
+  reviewed: SlopHubCutoverPlan,
+  current: SlopHubCutoverPlan,
+): void {
+  if (canonicalJson(reviewed.target) !== canonicalJson(current.target)) {
+    throw new Error("SlopHub target changed after plan review");
+  }
+  if (current.cloudflare.action !== "noop") {
+    if (
+      reviewed.cloudflare.action !== current.cloudflare.action ||
+      reviewed.cloudflare.zoneId !== current.cloudflare.zoneId ||
+      reviewed.cloudflare.recordId !== current.cloudflare.recordId ||
+      canonicalJson(reviewed.cloudflare.before) !==
+        canonicalJson(current.cloudflare.before)
+    ) {
+      throw new Error("Cloudflare DNS state drifted after plan review");
+    }
+  }
+  if (current.hetzner.action !== "noop") {
+    if (
+      reviewed.hetzner.action !== current.hetzner.action ||
+      reviewed.hetzner.serverId !== current.hetzner.serverId ||
+      reviewed.hetzner.firewallId !== current.hetzner.firewallId ||
+      reviewed.hetzner.beforeRulesSha256 !== current.hetzner.beforeRulesSha256
+    ) {
+      throw new Error("Hetzner firewall state drifted after plan review");
+    }
+  }
+}
+
+function validateDnsMutation(
+  value: unknown,
+  expectedRecordId: string | null,
+): void {
+  const record = parseDnsRecord(value);
+  if (
+    record.type !== TARGET.dnsType ||
+    record.name !== TARGET.dnsName ||
+    record.content !== TARGET.ipv4 ||
+    record.proxied !== false ||
+    (expectedRecordId !== null && record.id !== expectedRecordId)
+  ) {
+    throw new Error("Cloudflare DNS mutation returned an unexpected record");
+  }
+}
+
+async function waitForHetznerAction(
+  initialResponse: JsonObject,
+  environment: Required<Environment>,
+  request: Request,
+): Promise<void> {
+  let action = object(initialResponse.action, "Hetzner action");
+  const actionId = integer(action.id, "Hetzner action id");
+  for (let poll = 0; poll <= MAX_ACTION_POLLS; poll += 1) {
+    const status = string(action.status, "Hetzner action status");
+    if (status === "success") return;
+    if (status === "error")
+      throw new Error(`Hetzner action ${actionId} failed`);
+    if (status !== "running") {
+      throw new Error(
+        `Hetzner action ${actionId} returned an unsupported status`,
+      );
+    }
+    if (poll === MAX_ACTION_POLLS) {
+      throw new Error(
+        `Hetzner action ${actionId} did not finish before the poll limit`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, ACTION_POLL_DELAY_MS));
+    const response = await hetznerRequest(
+      `/actions/${actionId}`,
+      environment,
+      request,
+    );
+    action = object(response.action, "Hetzner action");
+    if (integer(action.id, "Hetzner action id") !== actionId) {
+      throw new Error("Hetzner action identity changed while polling");
+    }
+  }
+}
+
+export async function applySlopHubCutoverPlan(
+  rawPlan: unknown,
+  rawEnvironment: Environment,
+  request: Request = fetch,
+): Promise<SlopHubCutoverPlan> {
+  const environment = requiredEnvironment(rawEnvironment);
+  const reviewed = validateReviewedPlan(
+    rawPlan,
+    environment.SLOPHUB_SOURCE_SHA,
+  );
+  const current = await buildSlopHubCutoverPlan(environment, request);
+  assertNoDrift(reviewed, current);
+
+  // Ingress must be proven ready before the public hostname can expose it.
+  if (current.hetzner.action === "add-rule") {
+    const action = await hetznerRequest(
+      `/firewalls/${current.hetzner.firewallId}/actions/set_rules`,
+      environment,
+      request,
+      {
+        method: "POST",
+        body: JSON.stringify({ rules: current.hetzner.nextRules }),
+      },
+    );
+    await waitForHetznerAction(action, environment, request);
+
+    const ingressVerified = await buildSlopHubCutoverPlan(environment, request);
+    if (
+      ingressVerified.hetzner.action !== "noop" ||
+      ingressVerified.hetzner.serverId !== current.hetzner.serverId ||
+      ingressVerified.hetzner.firewallId !== current.hetzner.firewallId ||
+      ingressVerified.hetzner.beforeRulesSha256 !==
+        firewallRulesSha256(current.hetzner.nextRules) ||
+      ingressVerified.cloudflare.action !== current.cloudflare.action ||
+      ingressVerified.cloudflare.zoneId !== current.cloudflare.zoneId ||
+      ingressVerified.cloudflare.recordId !== current.cloudflare.recordId ||
+      canonicalJson(ingressVerified.cloudflare.before) !==
+        canonicalJson(current.cloudflare.before)
+    ) {
+      throw new Error(
+        "SlopHub ingress did not match the reviewed state before DNS cutover",
+      );
+    }
+  }
+
+  if (current.cloudflare.action === "create") {
+    const created = await cloudflareRequest(
+      `/zones/${encodeURIComponent(current.cloudflare.zoneId)}/dns_records`,
+      environment,
+      request,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          type: TARGET.dnsType,
+          name: TARGET.dnsName,
+          content: TARGET.ipv4,
+          proxied: false,
+          ttl: 1,
+        }),
+      },
+    );
+    validateDnsMutation(created, null);
+  } else if (current.cloudflare.action === "patch") {
+    const patched = await cloudflareRequest(
+      `/zones/${encodeURIComponent(current.cloudflare.zoneId)}/dns_records/${encodeURIComponent(
+        string(current.cloudflare.recordId, "Cloudflare record id"),
+      )}`,
+      environment,
+      request,
+      {
+        method: "PATCH",
+        body: JSON.stringify({ content: TARGET.ipv4, proxied: false }),
+      },
+    );
+    validateDnsMutation(patched, current.cloudflare.recordId);
+  }
+
+  const verified = await buildSlopHubCutoverPlan(environment, request);
+  if (
+    verified.cloudflare.action !== "noop" ||
+    verified.hetzner.action !== "noop" ||
+    verified.cloudflare.zoneId !== current.cloudflare.zoneId ||
+    verified.hetzner.serverId !== current.hetzner.serverId ||
+    verified.hetzner.firewallId !== current.hetzner.firewallId ||
+    verified.hetzner.beforeRulesSha256 !==
+      firewallRulesSha256(current.hetzner.nextRules)
+  ) {
+    throw new Error(
+      "SlopHub cutover apply did not converge to the reviewed desired state",
+    );
+  }
+  return verified;
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArgs({
+    allowPositionals: true,
+    options: {
+      output: { type: "string" },
+      plan: { type: "string" },
+    },
+  });
+  const action = parsed.positionals[0];
+  if (
+    parsed.positionals.length !== 1 ||
+    (action !== "plan" && action !== "apply")
+  ) {
+    throw new Error(
+      "usage: slophub-cutover.ts plan --output <path> | apply --plan <path>",
+    );
+  }
+  if (action === "plan") {
+    if (!parsed.values.output || parsed.values.plan) {
+      throw new Error("plan requires --output and rejects --plan");
+    }
+    const plan = await buildSlopHubCutoverPlan(process.env);
+    writeFileSync(parsed.values.output, `${JSON.stringify(plan, null, 2)}\n`, {
+      flag: "wx",
+    });
+    console.log(
+      JSON.stringify({
+        action: "plan",
+        dns: plan.cloudflare.action,
+        firewall: plan.hetzner.action,
+        zoneId: plan.cloudflare.zoneId,
+        serverId: plan.hetzner.serverId,
+        firewallId: plan.hetzner.firewallId,
+      }),
+    );
+    return;
+  }
+  if (!parsed.values.plan || parsed.values.output) {
+    throw new Error("apply requires --plan and rejects --output");
+  }
+  const reviewed = JSON.parse(
+    readFileSync(parsed.values.plan, "utf8"),
+  ) as unknown;
+  const verified = await applySlopHubCutoverPlan(reviewed, process.env);
+  console.log(
+    JSON.stringify({
+      action: "apply",
+      dns: verified.cloudflare.action,
+      firewall: verified.hetzner.action,
+      zoneId: verified.cloudflare.zoneId,
+      recordId: verified.cloudflare.recordId,
+      serverId: verified.hetzner.serverId,
+      firewallId: verified.hetzner.firewallId,
+    }),
+  );
+}
+
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    // error-policy:J1 CLI boundary translation — one redacted message and a
+    // non-zero exit are the complete operator failure contract.
+    console.error(
+      error instanceof Error ? error.message : "SlopHub cutover failed",
+    );
+    process.exitCode = 1;
+  });
+}

--- a/packages/cloud/shared/src/lib/oidc/clients.test.ts
+++ b/packages/cloud/shared/src/lib/oidc/clients.test.ts
@@ -40,6 +40,7 @@ function loadRegistry(entries: Record<string, unknown>[]): void {
 
 afterEach(() => {
   delete process.env.OIDC_CLIENTS;
+  delete process.env.OIDC_REDIRECT_URI_ALIASES;
   _resetOidcClientCacheForTests();
 });
 
@@ -62,6 +63,95 @@ describe("defaults", () => {
     expect(
       parseOidcClientEntry(entry({ wallet_email_fallback: "true" })).wallet_email_fallback,
     ).toBe(false);
+  });
+});
+
+describe("redirect URI aliases", () => {
+  test("adds an exact HTTPS callback to an existing client without changing its policy", () => {
+    process.env.OIDC_CLIENTS = JSON.stringify([entry({ client_id: "elizahub" })]);
+    process.env.OIDC_REDIRECT_URI_ALIASES = JSON.stringify({
+      elizahub: ["https://git.slop.cash/user/oauth2/elizacloud/callback"],
+    });
+
+    const client = getOidcClient("elizahub");
+    expect(client?.redirect_uris).toEqual([
+      "https://hub.example/user/oauth2/elizacloud/callback",
+      "https://git.slop.cash/user/oauth2/elizacloud/callback",
+    ]);
+    expect(client?.secret_hashes).toEqual([SECRET_HASH]);
+    expect(client?.allowed_scopes).toEqual(["openid", "email", "profile", "groups"]);
+  });
+
+  test("an unset overlay leaves every registered client byte-for-byte unchanged", () => {
+    process.env.OIDC_CLIENTS = JSON.stringify([entry()]);
+    expect(getOidcClient("elizahub-forgejo")?.redirect_uris).toEqual([
+      "https://hub.example/user/oauth2/elizacloud/callback",
+    ]);
+  });
+
+  test("changing only the overlay invalidates the isolate cache", () => {
+    process.env.OIDC_CLIENTS = JSON.stringify([entry({ client_id: "elizahub" })]);
+    process.env.OIDC_REDIRECT_URI_ALIASES = JSON.stringify({
+      elizahub: ["https://git.slop.cash/user/oauth2/elizacloud/callback"],
+    });
+    expect(getOidcClient("elizahub")?.redirect_uris.at(-1)).toBe(
+      "https://git.slop.cash/user/oauth2/elizacloud/callback",
+    );
+
+    process.env.OIDC_REDIRECT_URI_ALIASES = JSON.stringify({
+      elizahub: ["https://next.slop.cash/user/oauth2/elizacloud/callback"],
+    });
+    expect(getOidcClient("elizahub")?.redirect_uris.at(-1)).toBe(
+      "https://next.slop.cash/user/oauth2/elizacloud/callback",
+    );
+  });
+
+  test("malformed, empty, array, and oversized overlay sources fail closed", () => {
+    process.env.OIDC_CLIENTS = JSON.stringify([entry()]);
+    for (const source of ["{", "{}", "[]", `{"x":"${"x".repeat(16_384)}"}`]) {
+      process.env.OIDC_REDIRECT_URI_ALIASES = source;
+      _resetOidcClientCacheForTests();
+      expect(() => getOidcClient("elizahub-forgejo")).toThrow(/OIDC_REDIRECT_URI_ALIASES/);
+    }
+  });
+
+  test("an alias cannot create a client or collide with any primary callback", () => {
+    process.env.OIDC_CLIENTS = JSON.stringify([
+      entry(),
+      entry({ client_id: "other-app", redirect_uris: ["https://other.example/callback"] }),
+    ]);
+    for (const aliases of [
+      { missing: ["https://missing.example/callback"] },
+      { "other-app": ["https://hub.example/user/oauth2/elizacloud/callback"] },
+      { "elizahub-forgejo": ["https://hub.example/user/oauth2/elizacloud/callback"] },
+    ]) {
+      process.env.OIDC_REDIRECT_URI_ALIASES = JSON.stringify(aliases);
+      _resetOidcClientCacheForTests();
+      expect(() => getOidcClient("elizahub-forgejo")).toThrow(
+        /unregistered client_id|already registered/,
+      );
+    }
+  });
+
+  test("aliases reject insecure, credentialed, fragmented, duplicate, and empty callbacks", () => {
+    process.env.OIDC_CLIENTS = JSON.stringify([entry()]);
+    const invalidAliases = [
+      ["http://git.slop.cash/callback"],
+      ["https:git.slop.cash/callback"],
+      ["https://user:secret@git.slop.cash/callback"],
+      ["https://git.slop.cash/callback#fragment"],
+      ["https://git.slop.cash/callback", "https://git.slop.cash/callback"],
+      [],
+    ];
+    for (const aliases of invalidAliases) {
+      process.env.OIDC_REDIRECT_URI_ALIASES = JSON.stringify({
+        "elizahub-forgejo": aliases,
+      });
+      _resetOidcClientCacheForTests();
+      expect(() => getOidcClient("elizahub-forgejo")).toThrow(
+        /HTTPS|already registered|between 1 and/,
+      );
+    }
   });
 });
 

--- a/packages/cloud/shared/src/lib/oidc/clients.ts
+++ b/packages/cloud/shared/src/lib/oidc/clients.ts
@@ -32,6 +32,13 @@
  * resource server behind the audience a token its client already holds. It is
  * refused across the whole registry, not per entry.
  *
+ * Canonical-domain migrations use the separate public
+ * `OIDC_REDIRECT_URI_ALIASES` variable. It can add exact HTTPS callbacks to an
+ * existing registered client, but cannot create a client or change its secret,
+ * scopes, claims, or primary callbacks. Keeping that overlay outside the
+ * monolithic secret lets an operator migrate one relying party without reading
+ * or reconstructing every protected registration.
+ *
  * `wallet_email_fallback` defaults FALSE and is the only knob that changes what
  * the `email` claim can hold. It widens the `require_verified_email` gate rather
  * than replacing it, so the two must be set together: with the requirement OFF
@@ -124,6 +131,10 @@ const DEFAULT_SCOPES = ["openid", "email", "profile", "groups"];
 const DEFAULT_TTL_SECONDS = 300;
 const MIN_TTL_SECONDS = 60;
 const MAX_TTL_SECONDS = 3600;
+const MAX_REDIRECT_ALIAS_SOURCE_BYTES = 16_384;
+const MAX_REDIRECT_ALIAS_CLIENTS = 32;
+const MAX_REDIRECT_ALIASES_PER_CLIENT = 8;
+const MAX_REDIRECT_URI_BYTES = 2_048;
 const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
 const CLAIM_NAME_RE = /^[a-zA-Z][a-zA-Z0-9_.-]{0,63}$/;
 
@@ -170,9 +181,15 @@ const NATIVE_ROLE_VALUES = new Set<string>(OIDC_ROLE_VALUES);
 
 let cachedClients: Map<string, OidcClient> | null = null;
 let cachedClientsSource: string | null = null;
+let cachedRedirectAliasesSource: string | null = null;
 
 function readSource(): string | undefined {
   const raw = getCloudAwareEnv().OIDC_CLIENTS;
+  return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
+}
+
+function readRedirectAliasesSource(): string | undefined {
+  const raw = getCloudAwareEnv().OIDC_REDIRECT_URI_ALIASES;
   return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
 }
 
@@ -247,6 +264,97 @@ function parseRedirectUris(raw: Record<string, unknown>, clientId: string): stri
     }
   }
   return uris;
+}
+
+function parseRedirectAliases(source: string | undefined, clients: Map<string, OidcClient>): void {
+  if (!source) return;
+  if (Buffer.byteLength(source, "utf8") > MAX_REDIRECT_ALIAS_SOURCE_BYTES) {
+    throw new Error("OIDC_REDIRECT_URI_ALIASES exceeds its byte limit");
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(source) as unknown;
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — the public overlay is named but
+    // its raw contents are never copied into logs or error messages.
+    throw new Error("OIDC_REDIRECT_URI_ALIASES is not valid JSON", { cause: error });
+  }
+  if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) {
+    throw new Error("OIDC_REDIRECT_URI_ALIASES must be an object keyed by client_id");
+  }
+
+  const entries = Object.entries(decoded as Record<string, unknown>);
+  if (entries.length === 0 || entries.length > MAX_REDIRECT_ALIAS_CLIENTS) {
+    throw new Error(
+      `OIDC_REDIRECT_URI_ALIASES must contain between 1 and ${MAX_REDIRECT_ALIAS_CLIENTS} clients`,
+    );
+  }
+
+  const redirectOwners = new Map<string, string | null>();
+  for (const client of clients.values()) {
+    for (const redirectUri of client.redirect_uris) {
+      const owner = redirectOwners.get(redirectUri);
+      redirectOwners.set(
+        redirectUri,
+        owner !== undefined && owner !== client.client_id ? null : client.client_id,
+      );
+    }
+  }
+
+  for (const [rawClientId, rawAliases] of entries) {
+    const clientId = rawClientId.trim();
+    if (!clientId || clientId !== rawClientId) {
+      throw new Error("OIDC_REDIRECT_URI_ALIASES contains an invalid client_id key");
+    }
+    const client = clients.get(clientId);
+    if (!client) {
+      throw new Error(`OIDC_REDIRECT_URI_ALIASES references unregistered client_id "${clientId}"`);
+    }
+    const aliases = stringList(rawAliases, "redirect_uri_aliases", clientId);
+    if (aliases.length === 0 || aliases.length > MAX_REDIRECT_ALIASES_PER_CLIENT) {
+      throw new Error(
+        `OIDC_REDIRECT_URI_ALIASES[${clientId}] must contain between 1 and ${MAX_REDIRECT_ALIASES_PER_CLIENT} callbacks`,
+      );
+    }
+
+    for (const alias of aliases) {
+      if (Buffer.byteLength(alias, "utf8") > MAX_REDIRECT_URI_BYTES) {
+        throw new Error(`OIDC_REDIRECT_URI_ALIASES[${clientId}] callback exceeds its byte limit`);
+      }
+      let parsed: URL;
+      try {
+        parsed = new URL(alias);
+      } catch (error) {
+        // error-policy:J2 context-adding rethrow — aliases must pass the same
+        // parse boundary as primary redirects before exact matching.
+        throw new Error(`OIDC_REDIRECT_URI_ALIASES[${clientId}] has an invalid callback`, {
+          cause: error,
+        });
+      }
+      if (
+        parsed.protocol !== "https:" ||
+        parsed.href !== alias ||
+        parsed.username ||
+        parsed.password ||
+        parsed.hash ||
+        !parsed.hostname
+      ) {
+        throw new Error(
+          `OIDC_REDIRECT_URI_ALIASES[${clientId}] callbacks must be credential-free HTTPS URLs without fragments`,
+        );
+      }
+
+      const owner = redirectOwners.get(alias);
+      if (owner !== undefined) {
+        throw new Error(
+          `OIDC_REDIRECT_URI_ALIASES[${clientId}] callback is already registered${owner ? ` to "${owner}"` : " to multiple clients"}`,
+        );
+      }
+      redirectOwners.set(alias, clientId);
+      client.redirect_uris.push(alias);
+    }
+  }
 }
 
 function parseClaimsPolicy(value: unknown): OidcClaimsPolicy {
@@ -498,7 +606,14 @@ function loadClients(): Map<string, OidcClient> {
   if (!source) {
     throw new Error("OIDC_CLIENTS is not configured");
   }
-  if (cachedClients && cachedClientsSource === source) return cachedClients;
+  const redirectAliasesSource = readRedirectAliasesSource();
+  if (
+    cachedClients &&
+    cachedClientsSource === source &&
+    cachedRedirectAliasesSource === (redirectAliasesSource ?? null)
+  ) {
+    return cachedClients;
+  }
 
   let decoded: unknown;
   try {
@@ -522,9 +637,11 @@ function loadClients(): Map<string, OidcClient> {
     throw new Error("OIDC_CLIENTS must register at least one client");
   }
   assertNoAudienceCollisions(map);
+  parseRedirectAliases(redirectAliasesSource, map);
 
   cachedClients = map;
   cachedClientsSource = source;
+  cachedRedirectAliasesSource = redirectAliasesSource ?? null;
   return map;
 }
 
@@ -574,4 +691,5 @@ export function intersectScopes(client: OidcClient, requested: string[]): string
 export function _resetOidcClientCacheForTests(): void {
   cachedClients = null;
   cachedClientsSource = null;
+  cachedRedirectAliasesSource = null;
 }

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -310,6 +310,12 @@ export interface Bindings {
    */
   OIDC_CLIENTS?: string;
   /**
+   * Public JSON object of client_id → additional exact HTTPS callbacks used
+   * during canonical-domain migrations. The client must already exist in
+   * OIDC_CLIENTS; this overlay cannot create or otherwise modify a client.
+   */
+  OIDC_REDIRECT_URI_ALIASES?: string;
+  /**
    * Domain that wallet-derived no-reply identities are minted on, for relying
    * parties registered with `wallet_email_fallback`. Defaults to
    * `users.noreply.<OIDC_ISSUER_URL hostname>` and is normally left unset.

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -16,11 +16,14 @@ interface WorkflowStep {
   id?: string;
   name?: string;
   run?: string;
-  with?: { script?: string };
+  uses?: string;
+  with?: Record<string, string>;
 }
 
 interface WorkflowJob {
   env?: Record<string, string>;
+  environment?: string;
+  needs?: string | string[];
   steps?: WorkflowStep[];
 }
 
@@ -45,8 +48,11 @@ function step(workflow: Workflow, jobId: string, name: string): WorkflowStep {
 // `cloud-cf-release.yml` it calls, so the mutation contracts are read there.
 const cloudSource = read(".github/workflows/cloud-cf-release.yml");
 const cloud = parse(".github/workflows/cloud-cf-release.yml");
+const cloudApiWranglerSource = read("packages/cloud/api/wrangler.toml");
 const infraSource = read(".github/workflows/infra.yml");
 const infra = parse(".github/workflows/infra.yml");
+const slopHubSource = read(".github/workflows/slophub-cutover.yml");
+const slopHub = parse(".github/workflows/slophub-cutover.yml");
 const provisioning = parse(
   ".github/workflows/deploy-eliza-provisioning-worker.yml",
 );
@@ -76,6 +82,82 @@ const requiredAuthWorkerSecretNames = [
 ] as const;
 
 describe("canonical cloud deployment environment contract", () => {
+  test("keeps the fixed SlopHub cutover behind a reviewed production plan", () => {
+    const triggerBlock = slopHubSource.slice(
+      slopHubSource.indexOf("on:"),
+      slopHubSource.indexOf("\nconcurrency:"),
+    );
+    expect(triggerBlock).toContain("workflow_dispatch:");
+    expect(triggerBlock).toContain("default: plan");
+    for (const forbiddenTrigger of ["push:", "pull_request:", "schedule:"]) {
+      expect(triggerBlock).not.toContain(forbiddenTrigger);
+    }
+    for (const forbiddenTargetInput of [
+      "dns_name:",
+      "zone_name:",
+      "server_id:",
+      "firewall_id:",
+      "target_ipv4:",
+    ]) {
+      expect(triggerBlock).not.toContain(forbiddenTargetInput);
+    }
+
+    expect(slopHub.jobs?.cutover?.needs).toBe("validate-source");
+    expect(slopHub.jobs?.cutover?.environment).toBe("production");
+    expect(slopHub.jobs?.cutover?.env).toBeUndefined();
+    expect(
+      step(slopHub, "validate-source", "Require production main").run,
+    ).toContain('"refs/heads/main"');
+    const reviewedRun = step(slopHub, "cutover", "Validate reviewed plan run");
+    expect(reviewedRun.run).toContain(
+      'run.path !== ".github/workflows/slophub-cutover.yml"',
+    );
+    expect(reviewedRun.run).toContain("run.run_attempt");
+    const artifact = step(slopHub, "cutover", "Resolve reviewed plan artifact");
+    expect(artifact.run).toContain("artifact.digest");
+    expect(artifact.run).toContain("artifact.workflow_run?.id");
+    expect(artifact.run).toContain("EXPECTED_RUN_ATTEMPT");
+    const checkout = slopHub.jobs?.cutover?.steps?.find((candidate) =>
+      candidate.uses?.startsWith("actions/checkout@"),
+    );
+    expect(checkout?.with?.ref).toContain(
+      "steps.reviewed-run.outputs.source_sha",
+    );
+    for (const name of ["Plan fixed cutover", "Apply reviewed cutover"]) {
+      const operator = step(slopHub, "cutover", name);
+      expect(operator.env?.CLOUDFLARE_ACCOUNT_ID).toContain(
+        "secrets.CLOUDFLARE_ACCOUNT_ID",
+      );
+      expect(operator.env?.CLOUDFLARE_API_TOKEN).toContain(
+        "secrets.CLOUDFLARE_API_TOKEN",
+      );
+      expect(operator.env?.HCLOUD_TOKEN).toContain("secrets.HCLOUD_TOKEN");
+    }
+    for (const action of slopHub.jobs?.cutover?.steps?.filter(
+      (candidate) => candidate.uses,
+    ) ?? []) {
+      expect(action.env?.CLOUDFLARE_API_TOKEN).toBeUndefined();
+      expect(action.env?.HCLOUD_TOKEN).toBeUndefined();
+    }
+    expect(slopHubSource).toContain(
+      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+    );
+    expect(slopHubSource).toContain(
+      "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+    );
+    expect(slopHubSource).toContain(
+      "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    );
+    expect(slopHubSource).not.toMatch(/wallet|payment|payout|settlement/i);
+    expect(cloudApiWranglerSource).toContain(
+      `OIDC_REDIRECT_URI_ALIASES = '{"elizahub":["https://git.slop.cash/user/oauth2/elizacloud/callback"]}'`,
+    );
+    expect(requiredAuthWorkerSecretNames).toContain("OIDC_CLIENTS");
+    expect([...requiredAuthWorkerSecretNames]).not.toContain(
+      "OIDC_REDIRECT_URI_ALIASES",
+    );
+    expect(cloudSource).not.toContain("secrets.OIDC_REDIRECT_URI_ALIASES");
+  });
   test("derives Terraform deploy branches from the selected environment", () => {
     const deployBranch = infra.jobs?.terraform?.env?.TF_VAR_deploy_branch;
     expect(deployBranch).toContain("inputs.environment == 'production'");


### PR DESCRIPTION
## Summary

Narrow production backport of merged develop PR #19589 (`d1466e483f5953a26afa053e4ca4a145f5fc8147`).

- add the exact `git.slop.cash` OIDC callback alias without replacing the protected client registry
- add the fixed-target SlopHub DNS/SSH cutover operator and manual production-protected plan/apply workflow
- preserve `git.eliza.army` compatibility
- leave wallet, payout, reward-cycle, and settlement paths untouched

Part of #19578.

## Exact-head verification

Candidate `dd307efaab428409d36c5de02a0d8b87ca82d071`, directly atop `main` `89ad9b506ecee8b20b783fe07bca8f7f58f0be3b`.

- `bun run verify`: pass, 350/350 Turbo tasks plus all repository audits
- focused OIDC, cutover, and main workflow contract suites: 61 tests / 458 assertions, pass
- real OIDC authorize+redeem route: 1 test / 11 assertions, pass
- `packages/cloud/shared` and `packages/cloud/api` typechecks: pass
- production Wrangler dry-run: pass
- focused Biome and `git diff --check`: pass

The only cherry-pick conflict was the main/develop contract-test inventory. Resolution keeps the SlopHub production contract and excludes two unrelated develop-only Terraform tests.

## Evidence

- No frontend surface changed, so screenshots/video are N/A.
- No DNS, firewall, Worker, Forgejo, or other production mutation has occurred from this PR.
- After merge, the new workflow must first create a reviewed, source-bound plan artifact. Apply remains a separately protected operation.
- Payouts remain disabled.