### PR TITLE
fix(ci): stop skipping the PR Pages producer behind a dispatch-only need

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -280,7 +280,12 @@ jobs:
 
   build-pages:
     name: Build Pages artifacts
-    needs: [validate-deploy-source, resolve-pages-preview-config]
+    # PR-only producer. It must not need validate-deploy-source: that job is
+    # skipped outside workflow_dispatch, and an `if` without a status-check
+    # function implies success() of every needed job, so GitHub skipped this
+    # upload on every pull request and cloud-cf-pr-preview-deploy.yml failed
+    # with "Artifact not found for name: pages-app-<run>-<attempt>".
+    needs: [resolve-pages-preview-config]
     if: ${{ github.event_name == 'pull_request' && needs.resolve-pages-preview-config.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
@@ -169,10 +169,11 @@ describe("Cloud CF PR preview workflow contract", () => {
 
   test("keeps PR builds reachable and gates canonical Pages on the API", () => {
     const buildJob = producer.jobs?.["build-pages"];
-    expect(buildJob?.needs).toEqual([
-      "validate-deploy-source",
-      "resolve-pages-preview-config",
-    ]);
+    // build-pages must never need the dispatch-only validate-deploy-source
+    // job: with a plain `if` (no status-check function), a skipped need
+    // skips the producer and PR preview consumers 404 on the Pages artifact.
+    expect(buildJob?.needs).toEqual(["resolve-pages-preview-config"]);
+    expect(buildJob?.needs).not.toContain("validate-deploy-source");
     expect(buildJob?.if).toBe(
       "$" +
         "{{ github.event_name == 'pull_request' && needs.resolve-pages-preview-config.result == 'success' }}",


### PR DESCRIPTION
# Relates to

Fixes #19596

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` (`d1466e483f`) with zero conflicts.
- [x] `bun install` was run; focused gates below. Root `bun run verify` was not run end-to-end in this environment — recorded in **Known gaps / failures** with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5 (verification, fix, tests, PR); xai/grok-4.6 (initial CI-log triage in a read-only diagnosis lane)
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from the latest `origin/develop` (`d1466e483f`); zero conflicts.
- [x] Focused package gates pass post-sync; the root `bun run verify` blocker (pre-existing, unrelated) is documented in **Known gaps / failures**.

# Risks

Low. The diff touches one `needs:` list in `.github/workflows/cloud-cf-deploy.yml` and the contract test that pins it. `validate-deploy-source` only ever runs on `workflow_dispatch`, and `build-pages` only ever runs on `pull_request` — the two jobs can never execute in the same run, so dropping the need removes a dead edge, not a real ordering constraint. Dispatch and push behavior is unchanged (`build-pages` remains PR-only via its `if`). The blast radius is the PR preview lane, which is currently 100% broken.

# Background

## What does this PR do?

Makes the `build-pages` producer actually run on pull requests again, so `Cloud CF PR Preview Deploy` stops failing closed with `Artifact not found for name: pages-app-<run-id>-<attempt>`.

`build-pages` declared `needs: [validate-deploy-source, resolve-pages-preview-config]`, but `validate-deploy-source` is `if: github.event_name == 'workflow_dispatch'` and is therefore **skipped** on every `pull_request` event. Because the `build-pages` `if` expression contains no status-check function, GitHub applies the implicit `success()` rule to its needs — and a skipped need is not a success — so the job was skipped on every PR while the run still concluded `success`. The green producer then triggered the preview consumer, which 404'd on the never-uploaded artifact.

Regressed in `12b833896b`, which rewrote the previous `!cancelled()`-based expression while adding the dispatch-only need. This PR drops the unused need (the smaller, harder-to-rebreak change versus re-adding a status-check function) and updates `packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts` to pin the corrected shape, including an explicit `not.toContain("validate-deploy-source")` so the coupling cannot silently return.

## What kind of change is this?

Bug fix (non-breaking; repairs the broken PR preview deploy lane).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`.github/workflows/cloud-cf-deploy.yml` (`build-pages` job) and `packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts`.

## Detailed testing steps

1. `bun test packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts` — passes at this head (5 pass / 0 fail).
2. Fail-proof: revert only the workflow file and rerun — `keeps PR builds reachable and gates canonical Pages on the API` fails (4 pass / 1 fail), proving the test pins the fix.
3. Live proof after merge: the first PR touching cloud frontend paths should show `Build Pages artifacts` executing (not skipped) in its `Cloud CF Deploy` run, and the triggered `Cloud CF PR Preview Deploy` run should get past `Download immutable untrusted Pages artifact`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:3477d75c9617681385d327db66ae89ce367e3ca3 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - CI workflow configuration change; no UI surface. The "before" is the run-log evidence in Evidence Details.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - CI workflow configuration change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user flow; the behavior is a GitHub Actions `needs`-graph evaluation.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no server code path; the equivalent artifact is the CI run logs quoted in Evidence Details.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code path.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: contract-test transcript inline:

```
# at head 3477d75c96
bun test packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
 5 pass / 4 skip / 0 fail (32 expect() calls)

# with only .github/workflows/cloud-cf-deploy.yml reverted to develop
(fail) Cloud CF PR preview workflow contract > keeps PR builds reachable and gates canonical Pages on the API
 4 pass / 1 fail
```
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - CI configuration defect; no agent behavior involved.

## Backend + frontend logs

Consumer failure (`gh run view 31788519978 --log-failed`, same shape on 31785968294):

```
Unable to download artifact(s): Artifact not found for name: pages-app-31779593252-1
Please ensure that your artifact is not expired and the artifact does exist
```

Producer runs 31779593252, 31777760592, 31788763696, 31788323437, 31788121565 (all `pull_request`, all conclusion `success`) each show `Build Pages artifacts: skipped` with `Resolve Pages preview configuration: success` — the skip is systematic, not flaky.

## Screenshots (before / after) + video walkthrough

N/A - no UI change; `packages/app` audit not applicable to a workflow-YAML diff.

### Before

N/A - see CI run logs above.

### After

N/A - see contract-test transcript below.

### Walkthrough video

N/A - no user flow.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

- Root `bun run verify` was not run end-to-end here. `bun test packages/scripts/__tests__/` in this checkout reports 924 pass / 1 fail, where the single failure is `e2e-coverage.test.ts` dying on `Cannot find module '@elizaos/core' from plugins/plugin-commands/...` — an unbuilt-workspace resolution issue in this environment that exists identically without this diff (the diff touches only a workflow `needs:` list and its contract test). CI's required lanes will exercise the same suite on a fully built tree.
- The "after" state cannot be demonstrated pre-merge: `pull_request` runs of `Cloud CF Deploy` from a fork branch evaluate the base repo's workflow graph only after this change lands. The fail-proof contract-test transcript is the strongest pre-merge evidence available:

```
# at head 3477d75c96
bun test packages/scripts/__tests__/cloud-cf-pages-branch-workflow.test.ts
 5 pass / 4 skip / 0 fail (32 expect() calls)

# with only .github/workflows/cloud-cf-deploy.yml reverted to develop
(fail) Cloud CF PR preview workflow contract > keeps PR builds reachable and gates canonical Pages on the API
 4 pass / 1 fail
```

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-eliza"} -->
