### PR TITLE
fix(scripts): fail closed on unhonorable timing flags (#19600)

### DIFF
--- a/packages/scripts/__tests__/dev-health-check.test.mjs
+++ b/packages/scripts/__tests__/dev-health-check.test.mjs
@@ -11,7 +11,10 @@ import { fileURLToPath } from "node:url";
 import {
   DEFAULT_API_PORT,
   DEFAULT_UI_PORT,
+  MAX_TIMER_MS,
   parseArgs,
+  parsePositiveIntMs,
+  parsePositiveIntSeconds,
   parseTcpPort,
   resolveApiPortFromEnv,
   resolveUiPortFromEnv,
@@ -73,6 +76,117 @@ describe("parseTcpPort", () => {
         /must be a TCP port integer from 1 to 65535/,
       );
     }
+  });
+});
+
+describe("parsePositiveIntMs", () => {
+  test("accepts positive integers through the timer ceiling", () => {
+    expect(parsePositiveIntMs("1", "--duration-ms")).toBe(1);
+    expect(parsePositiveIntMs("400", "--duration-ms")).toBe(400);
+    expect(parsePositiveIntMs(String(MAX_TIMER_MS), "--duration-ms")).toBe(
+      MAX_TIMER_MS,
+    );
+  });
+
+  test("rejects fractions, scientific notation, hex, and trailing garbage", () => {
+    for (const value of [
+      "0.4",
+      "1e20",
+      "1e3",
+      "0x10",
+      "20foo",
+      "1.5",
+      "+1",
+      " 5 ",
+      "NaN",
+      "Infinity",
+      "",
+    ]) {
+      expect(() => parsePositiveIntMs(value, "--duration-ms")).toThrow(
+        /--duration-ms must be a positive integer number of milliseconds from 1 to 2147483647/,
+      );
+    }
+  });
+
+  test("rejects zero, negatives, and values above the timer ceiling", () => {
+    for (const value of [
+      "0",
+      "-1",
+      String(MAX_TIMER_MS + 1),
+      "9007199254740992",
+      "9".repeat(400),
+    ]) {
+      expect(() => parsePositiveIntMs(value, "--duration-ms")).toThrow(
+        /--duration-ms must be a positive integer number of milliseconds from 1 to 2147483647/,
+      );
+    }
+  });
+});
+
+describe("parsePositiveIntSeconds", () => {
+  test("accepts positive integer seconds within the timer ceiling", () => {
+    expect(parsePositiveIntSeconds("1", "--seconds")).toBe(1);
+    expect(parsePositiveIntSeconds("90", "--seconds")).toBe(90);
+    // Largest whole-second window that still fits the 32-bit ms ceiling.
+    expect(parsePositiveIntSeconds("2147483", "--seconds")).toBe(2147483);
+  });
+
+  test("rejects fractional, scientific, zero, negative, and garbage input", () => {
+    for (const value of [
+      "0",
+      "0.4",
+      "1e20",
+      "1.5",
+      "0x10",
+      "20foo",
+      "-1",
+      "+1",
+      "",
+      "NaN",
+    ]) {
+      expect(() => parsePositiveIntSeconds(value, "--seconds")).toThrow(
+        /--seconds must be a positive integer number of seconds/,
+      );
+    }
+  });
+
+  test("rejects a whole-second window that overflows the timer ceiling", () => {
+    expect(() => parsePositiveIntSeconds("2147484", "--seconds")).toThrow(
+      /--seconds of 2147484 seconds exceeds the maximum observation window of 2147483647 milliseconds/,
+    );
+  });
+});
+
+describe("parseArgs duration wiring", () => {
+  test("--seconds keeps its integer value", () => {
+    expect(parseArgs(["--seconds=120"], {}).seconds).toBe(120);
+  });
+
+  test("--duration-ms converts to a seconds window that round-trips", () => {
+    // 400 ms must survive Math.round(seconds * 1000) instead of collapsing to 0.
+    const options = parseArgs(["--duration-ms=400"], {});
+    expect(Math.round(options.seconds * 1000)).toBe(400);
+    expect(Math.round(parseArgs(["--duration-ms=1"], {}).seconds * 1000)).toBe(
+      1,
+    );
+  });
+
+  test("rejects fractional, scientific, and over-ceiling timing flags", () => {
+    expect(() => parseArgs(["--duration-ms=0.4"], {})).toThrow(
+      /--duration-ms must be a positive integer number of milliseconds/,
+    );
+    expect(() => parseArgs(["--duration-ms=1e20"], {})).toThrow(
+      /--duration-ms must be a positive integer number of milliseconds/,
+    );
+    expect(() => parseArgs(["--seconds=1e20"], {})).toThrow(
+      /--seconds must be a positive integer number of seconds/,
+    );
+    expect(() => parseArgs(["--seconds=0"], {})).toThrow(
+      /--seconds must be a positive integer number of seconds/,
+    );
+    expect(() => parseArgs([`--duration-ms=${MAX_TIMER_MS + 1}`], {})).toThrow(
+      /--duration-ms must be a positive integer number of milliseconds from 1 to 2147483647/,
+    );
   });
 });
 
@@ -201,7 +315,9 @@ describe("dev-health-check CLI boundary", () => {
       },
     );
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toMatch(/--seconds must be a positive number/);
+    expect(result.stderr).toMatch(
+      /--seconds must be a positive integer number of seconds/,
+    );
     expect(result.stderr).not.toMatch(/ELIZA_(?:UI|API)?_?PORT/);
     expect(result.stdout).not.toContain("[dev-health-check] starting:");
   });
@@ -224,6 +340,56 @@ describe("dev-health-check CLI boundary", () => {
       expect(paddedEnv.status).not.toBe(0);
       expect(paddedEnv.stderr).toMatch(/ELIZA_API_PORT must be a TCP port/);
       expect(existsSync(logDir)).toBe(false);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects invalid --duration-ms before log/output or dev startup", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "dev-health-dur-"));
+    const logDir = path.join(directory, "nested-logs");
+    try {
+      for (const value of [
+        "0",
+        "0.4",
+        "1e20",
+        "1e3",
+        "0x10",
+        "20foo",
+        "-5",
+        "2147483648",
+      ]) {
+        const result = runCli([
+          `--log-dir=${logDir}`,
+          `--duration-ms=${value}`,
+        ]);
+        expect(result.status).not.toBe(0);
+        const combined = `${result.stdout}${result.stderr}`;
+        expect(combined).toMatch(
+          /--duration-ms must be a positive integer number of milliseconds/,
+        );
+        expect(combined).not.toContain("[dev-health-check] starting:");
+        expect(existsSync(logDir)).toBe(false);
+      }
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects invalid --seconds before log/output or dev startup", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "dev-health-secs-"));
+    const logDir = path.join(directory, "nested-logs");
+    try {
+      for (const value of ["0", "0.4", "1e20", "0x10", "20foo", "-5"]) {
+        const result = runCli([`--log-dir=${logDir}`, `--seconds=${value}`]);
+        expect(result.status).not.toBe(0);
+        const combined = `${result.stdout}${result.stderr}`;
+        expect(combined).toMatch(
+          /--seconds must be a positive integer number of seconds/,
+        );
+        expect(combined).not.toContain("[dev-health-check] starting:");
+        expect(existsSync(logDir)).toBe(false);
+      }
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/packages/scripts/__tests__/run-live-test-with-artifacts.test.ts
+++ b/packages/scripts/__tests__/run-live-test-with-artifacts.test.ts
@@ -15,6 +15,11 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  MAX_TIMER_DELAY_MS,
+  parseArgs,
+  parseTimeoutMs,
+} from "../run-live-test-with-artifacts.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const RUNNER = path.resolve(
@@ -68,6 +73,137 @@ function processIsAlive(pid: number): boolean {
     return false;
   }
 }
+
+describe("parseTimeoutMs", () => {
+  test("accepts positive integers through the Node timer ceiling", () => {
+    expect(parseTimeoutMs("1")).toBe(1);
+    expect(parseTimeoutMs("800")).toBe(800);
+    expect(parseTimeoutMs(String(MAX_TIMER_DELAY_MS))).toBe(MAX_TIMER_DELAY_MS);
+  });
+
+  test("rejects zero, fractional, signed, scientific, and non-decimal forms", () => {
+    for (const value of [
+      "0",
+      "-5",
+      "+1",
+      "0.4",
+      "1.5",
+      "1e3",
+      "0x10",
+      "20foo",
+      "800ms",
+      "",
+      " ",
+      "NaN",
+      "Infinity",
+      "08",
+    ]) {
+      expect(() => parseTimeoutMs(value)).toThrow(
+        `--timeout-ms must be a positive decimal integer from 1 to ${MAX_TIMER_DELAY_MS}`,
+      );
+    }
+  });
+
+  test("rejects values Node would clamp to one millisecond", () => {
+    for (const value of [
+      String(MAX_TIMER_DELAY_MS + 1),
+      "9007199254740992",
+      "9".repeat(400),
+    ]) {
+      expect(() => parseTimeoutMs(value)).toThrow(
+        `--timeout-ms must be a positive decimal integer from 1 to ${MAX_TIMER_DELAY_MS}`,
+      );
+    }
+  });
+});
+
+describe("parseArgs", () => {
+  test("parses a valid timeout and command", () => {
+    const options = parseArgs([
+      "--label",
+      "ok",
+      "--timeout-ms",
+      "800",
+      "--",
+      "node",
+      "-e",
+      "0",
+    ]);
+    expect(options.timeoutMs).toBe(800);
+    expect(options.command).toEqual(["node", "-e", "0"]);
+  });
+
+  test("defaults to no deadline when --timeout-ms is omitted", () => {
+    expect(parseArgs(["--", "node", "-e", "0"]).timeoutMs).toBe(0);
+  });
+
+  test("rejects an over-ceiling, fractional, scientific, or zero timeout", () => {
+    for (const value of ["2147483648", "0.4", "1e3", "0", "-5", "abc"]) {
+      expect(() =>
+        parseArgs(["--timeout-ms", value, "--", "node", "-e", "0"]),
+      ).toThrow(
+        `--timeout-ms must be a positive decimal integer from 1 to ${MAX_TIMER_DELAY_MS}`,
+      );
+    }
+  });
+});
+
+describe("run-live-test-with-artifacts timeout CLI boundary", () => {
+  const cases = ["2147483648", "0.4", "1e3", "0", "-5", "abc"];
+  for (const value of cases) {
+    test(`rejects --timeout-ms ${value} before creating a run bundle`, () => {
+      const reportRoot = mkdtempSync(path.join(tmpdir(), "live-artifacts-"));
+      try {
+        const result = runWithArtifacts(reportRoot, [
+          "--label",
+          "bad-timeout",
+          "--timeout-ms",
+          value,
+          "--",
+          NODE_BIN,
+          "-e",
+          "process.exit(0)",
+        ]);
+        expect(result.status).toBe(2);
+        expect(result.stderr).toContain(
+          `--timeout-ms must be a positive decimal integer from 1 to ${MAX_TIMER_DELAY_MS}`,
+        );
+        // No run directory is created when argument parsing fails closed.
+        expect(
+          readdirSync(reportRoot, { withFileTypes: true }).filter((entry) =>
+            entry.isDirectory(),
+          ),
+        ).toHaveLength(0);
+      } finally {
+        rmSync(reportRoot, { recursive: true, force: true });
+      }
+    });
+  }
+
+  test("accepts a valid --timeout-ms and completes the run", () => {
+    const reportRoot = mkdtempSync(path.join(tmpdir(), "live-artifacts-"));
+    try {
+      const result = runWithArtifacts(reportRoot, [
+        "--label",
+        "valid-timeout",
+        "--timeout-ms",
+        "800",
+        "--",
+        NODE_BIN,
+        "-e",
+        'process.stdout.write("done");',
+      ]);
+      expect(result.status).toBe(0);
+      const runDirectory = onlyRunDirectory(reportRoot);
+      const report = readReport(runDirectory);
+      expect(report.timeoutMs).toBe(800);
+      expect(report.timedOut).toBe(false);
+      expect(report.exitCode).toBe(0);
+    } finally {
+      rmSync(reportRoot, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("run-live-test-with-artifacts", () => {
   test("preserves a completed child's exit and fully drained output", () => {

--- a/packages/scripts/dev-health-check.mjs
+++ b/packages/scripts/dev-health-check.mjs
@@ -35,6 +35,12 @@ import { pathToFileURL } from "node:url";
 const DEFAULT_SECONDS = 90;
 export const DEFAULT_UI_PORT = 2138;
 export const DEFAULT_API_PORT = 31337;
+/**
+ * Node clamps `setTimeout` delays above this 32-bit ceiling to 1 ms. Every
+ * millisecond window derived from a timing flag must fall within it so the
+ * observation loop can honor the requested duration literally.
+ */
+export const MAX_TIMER_MS = 2_147_483_647;
 const DEFAULT_INITIAL_PROBE_DELAY_MS = 8000;
 const POLL_INTERVAL_MS = 1000;
 const FETCH_TIMEOUT_MS = 10000;
@@ -78,15 +84,15 @@ export function parseArgs(argv, env = process.env) {
 
   for (const { key, value } of parsedArgs) {
     if (key === "--seconds") {
-      options.seconds = parsePositiveNumber(value, "--seconds");
+      options.seconds = parsePositiveIntSeconds(value, "--seconds");
     } else if (key === "--duration-ms") {
-      options.seconds = parsePositiveNumber(value, "--duration-ms") / 1000;
+      options.seconds = parsePositiveIntMs(value, "--duration-ms") / 1000;
     } else if (key === "--ui-port") {
       options.uiPort = parseTcpPort(value, "--ui-port");
     } else if (key === "--api-port") {
       options.apiPort = parseTcpPort(value, "--api-port");
     } else if (key === "--initial-probe-delay-ms") {
-      options.initialProbeDelayMs = parsePositiveNumber(
+      options.initialProbeDelayMs = parsePositiveIntMs(
         value,
         "--initial-probe-delay-ms",
       );
@@ -230,12 +236,52 @@ Environment:
   ELIZA_API_PORT              API probe port when --api-port is omitted`);
 }
 
-function parsePositiveNumber(value, label) {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    throw new Error(`${label} must be a positive number`);
+/**
+ * Parse a positive integer count of milliseconds bounded by Node's 32-bit
+ * timer ceiling. Rejects fractions, scientific notation, hex, trailing
+ * garbage, empty, negatives, and zero so a timing flag can never pass
+ * validation and then clamp to 1 ms or collapse to a 0 ms window.
+ * @param {string} value
+ * @param {string} label
+ */
+export function parsePositiveIntMs(value, label) {
+  const raw = String(value ?? "");
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(
+      `${label} must be a positive integer number of milliseconds from 1 to ${MAX_TIMER_MS}`,
+    );
   }
-  return parsed;
+  const ms = Number(raw);
+  if (!Number.isSafeInteger(ms) || ms < 1 || ms > MAX_TIMER_MS) {
+    throw new Error(
+      `${label} must be a positive integer number of milliseconds from 1 to ${MAX_TIMER_MS}`,
+    );
+  }
+  return ms;
+}
+
+/**
+ * Parse a positive integer count of seconds whose millisecond window stays
+ * within Node's timer ceiling. Mirrors {@link parsePositiveIntMs} so the
+ * observation window can never round to 0 ms or overflow to a 1 ms timer.
+ * @param {string} value
+ * @param {string} label
+ */
+export function parsePositiveIntSeconds(value, label) {
+  const raw = String(value ?? "");
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`${label} must be a positive integer number of seconds`);
+  }
+  const seconds = Number(raw);
+  if (!Number.isSafeInteger(seconds) || seconds < 1) {
+    throw new Error(`${label} must be a positive integer number of seconds`);
+  }
+  if (seconds * 1000 > MAX_TIMER_MS) {
+    throw new Error(
+      `${label} of ${seconds} seconds exceeds the maximum observation window of ${MAX_TIMER_MS} milliseconds`,
+    );
+  }
+  return seconds;
 }
 
 function stripAnsi(value) {

--- a/packages/scripts/run-live-test-with-artifacts.mjs
+++ b/packages/scripts/run-live-test-with-artifacts.mjs
@@ -9,7 +9,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -18,6 +18,40 @@ const REPO_ROOT = path.resolve(
 );
 const DEFAULT_REPORT_ROOT = path.join(REPO_ROOT, "reports", "live-test-runs");
 const TERMINATION_GRACE_MS = 5_000;
+
+/**
+ * Node clamps `setTimeout` delays above this 32-bit ceiling to 1 ms, which
+ * would kill the child almost immediately with `timedOut=true`. Reject such
+ * values at the boundary instead of letting the timer silently misfire.
+ */
+export const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+/**
+ * Parse `--timeout-ms` at the CLI boundary. Requires a positive decimal
+ * integer no greater than Node's timer ceiling so a value can never pass
+ * validation and then clamp to 1 ms (rejects fractions, scientific notation,
+ * hex, trailing garbage, empty, negatives, and zero).
+ * @param {string} raw
+ * @returns {number}
+ */
+export function parseTimeoutMs(raw) {
+  if (typeof raw !== "string" || !/^[1-9]\d*$/.test(raw)) {
+    throw new Error(
+      `--timeout-ms must be a positive decimal integer from 1 to ${MAX_TIMER_DELAY_MS}`,
+    );
+  }
+  const timeoutMs = Number(raw);
+  if (
+    !Number.isSafeInteger(timeoutMs) ||
+    timeoutMs < 1 ||
+    timeoutMs > MAX_TIMER_DELAY_MS
+  ) {
+    throw new Error(
+      `--timeout-ms must be a positive decimal integer from 1 to ${MAX_TIMER_DELAY_MS}`,
+    );
+  }
+  return timeoutMs;
+}
 
 function timestampId() {
   return new Date().toISOString().replace(/[:.]/g, "-");
@@ -31,7 +65,7 @@ function slug(value) {
     .slice(0, 80);
 }
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const options = {
     label: "",
     reportRoot: DEFAULT_REPORT_ROOT,
@@ -62,11 +96,7 @@ function parseArgs(argv) {
     if (arg === "--timeout-ms") {
       const next = argv[index + 1];
       if (!next) throw new Error("--timeout-ms requires a value");
-      const timeoutMs = Number(next);
-      if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
-        throw new Error("--timeout-ms must be a non-negative number");
-      }
-      options.timeoutMs = timeoutMs;
+      options.timeoutMs = parseTimeoutMs(next);
       index += 2;
       continue;
     }
@@ -450,7 +480,14 @@ async function main() {
   process.exit(exitCode);
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(2);
-});
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    // error-policy:J1 CLI boundary — invalid arguments or a fatal run failure
+    // surface as one diagnostic and a non-zero exit before/around the run.
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(2);
+  });
+}


### PR DESCRIPTION
# Relates to

Fixes #19600

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change is confined to two `packages/scripts` CLI entrypoints and their
argument validators. It only tightens input validation (fail closed on values
that were previously accepted and then silently misbehaved); it does not change
output formatting, public flag names, defaults, or any honored value. No runtime
or product surface is touched.

# Background

## What does this PR do?

Two timing flags in `packages/scripts` passed a bare `Number()` gate and then
silently did the opposite of what the operator asked (same defect family as
#18621 / PR #19287):

1. `run-live-test-with-artifacts.mjs` `--timeout-ms` was gated only by
   `Number(next)` + `Number.isFinite(timeoutMs) && timeoutMs >= 0`. Any value
   above the `2_147_483_647` `setTimeout` ceiling passed validation, Node emitted
   `TimeoutOverflowWarning` and set the timer to **1 ms**, so the child was killed
   almost immediately with `timedOut=true`. It also accepted fractions, scientific
   notation, and `0`.
2. `dev-health-check.mjs` `--duration-ms` and `--seconds` were parsed via a
   `parsePositiveNumber` helper using bare `Number()` + `> 0`. `--duration-ms=0.4`
   became `Math.round(0.0004 * 1000) = 0` ms — a **0 ms observation window** that
   skipped the probe loop entirely — and `--seconds=1e20` was accepted as an
   effectively infinite window.

The fix mirrors the validators already in the same directory
(`run-with-deadline.mjs`'s `parseDeadlineMs` and `test-cloud-run.mjs`'s
`parsePositiveDuration`): a `/^[1-9]\d*$/` regex, `Number.isSafeInteger`, and an
explicit `1..2_147_483_647` bound. Any value that cannot be honored literally now
throws a named error and exits non-zero. For `--seconds` the resulting
millisecond window is also validated against the ceiling and can never round to
0 ms. The parse helpers are exported and the `run-live-test` entrypoint is
guarded (`import.meta.url` check) so the validators are unit-testable without
invoking `main()`.

`--initial-probe-delay-ms` in the same file shared the identical weak helper and
is routed through the same integer-ms validator for consistency (it also feeds a
`setTimeout`).

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The scripts'
in-file usage/`--help` text already describes the flags as durations; only the
rejection of un-honorable values changed.

# Testing

## Where should a reviewer start?

`packages/scripts/run-live-test-with-artifacts.mjs` and
`packages/scripts/dev-health-check.mjs` (validators + wiring), then the extended
test files under `packages/scripts/__tests__/`.

## Detailed testing steps

From `packages/scripts` (repo is bun-pinned; the script tests use `bun:test`):

```bash
bun test __tests__/run-live-test-with-artifacts.test.ts __tests__/dev-health-check.test.mjs
```

Result: **51 pass / 0 fail, 354 expect() calls**. New coverage rejects
fractions, scientific notation, hex, trailing garbage, negatives, zero, and
over-ceiling values, and accepts the boundary values `1` and `2_147_483_647`
plus normal values.

# Evidence Gate

<!-- evidence-head:ca7f64366207575c80cef933839daed4b6227976 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. This change is CLI-only in `packages/scripts`
with no rendered surface, so UI/video/OCR rows are `N/A` with reasons below.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CLI-only argument validation in packages/scripts; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - CLI-only argument validation in packages/scripts; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - CLI-only; deterministic terminal transcripts are attached inline in the PR body.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no server runtime path; the real CLI path is shown via before/after terminal transcripts in the PR body.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic argument parsing; no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB/memory/scheduled-task/wallet/file domain state; behavior is exit code + stderr.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic CLI argument parsing; no live model involved.`

## Backend + frontend logs

Real CLI transcripts (this machine, Node v22.22.2). **Before** is the current
`develop` behavior (source files reverted via `git stash`); **After** is this PR.

<details>
<summary>BEFORE — `run-live-test-with-artifacts.mjs --timeout-ms 2147483648` clamps to 1 ms</summary>

```
$ node packages/scripts/run-live-test-with-artifacts.mjs --label repro --timeout-ms 2147483648 -- node -e 'setInterval(()=>{},1000)'
(node:4082391) TimeoutOverflowWarning: 2147483648 does not fit into a 32-bit signed integer.
[live-test-artifacts] viewer=.../reports/live-test-runs/...-repro/index.html
# child killed almost immediately (timedOut=true, timer clamped to 1ms)
```
</details>

<details>
<summary>BEFORE — `dev-health-check.mjs --duration-ms=0.4` collapses to a 0 ms window</summary>

```
$ node -e 'const s=Number("0.4")/1000; console.log("options.seconds=",s,"durationMs=Math.round(s*1000)=",Math.round(s*1000));'
options.seconds= 0.0004 durationMs=Math.round(s*1000)= 0   # => observation loop skipped
```
</details>

<details>
<summary>AFTER — `run-live-test-with-artifacts.mjs` fails closed on unhonorable --timeout-ms, still runs valid values</summary>

```
$ node packages/scripts/run-live-test-with-artifacts.mjs --label repro --timeout-ms 2147483648 -- node -e 'setInterval(()=>{},1000)'
--timeout-ms must be a positive decimal integer from 1 to 2147483647
exit=2

$ node packages/scripts/run-live-test-with-artifacts.mjs --label repro --timeout-ms 0.4 -- node -e '0'
--timeout-ms must be a positive decimal integer from 1 to 2147483647
exit=2

$ node packages/scripts/run-live-test-with-artifacts.mjs --label repro --timeout-ms 0 -- node -e '0'
--timeout-ms must be a positive decimal integer from 1 to 2147483647
exit=2

$ node packages/scripts/run-live-test-with-artifacts.mjs --label repro --timeout-ms 800 -- node -e 'process.stdout.write("ok")'
ok
[live-test-artifacts] viewer=.../reports/live-test-runs/...-repro/index.html
exit=0
```
</details>

<details>
<summary>AFTER — `dev-health-check.mjs` fails closed on --duration-ms / --seconds</summary>

```
$ node packages/scripts/dev-health-check.mjs --duration-ms=0.4
[dev-health-check] Error: --duration-ms must be a positive integer number of milliseconds from 1 to 2147483647
exit=1

$ node packages/scripts/dev-health-check.mjs --duration-ms=1e20
[dev-health-check] Error: --duration-ms must be a positive integer number of milliseconds from 1 to 2147483647
exit=1

$ node packages/scripts/dev-health-check.mjs --seconds=1e20
[dev-health-check] Error: --seconds must be a positive integer number of seconds
exit=1

$ node packages/scripts/dev-health-check.mjs --seconds=0
[dev-health-check] Error: --seconds must be a positive integer number of seconds
exit=1
```
</details>

<details>
<summary>Focused test run — 51 pass / 0 fail</summary>

```
$ bun test __tests__/run-live-test-with-artifacts.test.ts __tests__/dev-health-check.test.mjs
...
 51 pass
 0 fail
 354 expect() calls
Ran 51 tests across 2 files.
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - CLI-only argument validation in packages/scripts; no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/audio path involved.`

## Known gaps / failures

- `bun run verify` (full repository gate) was **not** run on this machine: a
  clean `bun install` cannot complete here because the environment enforces a
  `minimumReleaseAge` install policy that blocks recently published pinned
  dependencies (e.g. `ws@8.21.3`), which is unrelated to this change. The
  `packages/scripts` tests are self-contained (only Node built-ins plus sibling
  scripts) and were run directly with the repo-pinned `bun 1.3.14`; Biome
  `2.5.7` `check` passes on all four changed files (only pre-existing
  info-level `useTemplate` suggestions in untouched lines remain). A maintainer
  should confirm `bun run verify` on CI.
- The issue author (ss251) noted "Fix PR to follow" but no PR was filed for
  #19600 at authoring time. If a prior/duplicate effort surfaces, it should be
  reconciled with this one.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza"} -->

