### PR TITLE
fix(scripts): fail closed on non-canonical integer and port flags

### DIFF
--- a/packages/scripts/__tests__/cli-numbers.test.mjs
+++ b/packages/scripts/__tests__/cli-numbers.test.mjs
@@ -1,0 +1,64 @@
+/**
+ * Contract coverage for the shared fail-closed numeric parsers in
+ * lib/cli-numbers.mjs. The harness is deterministic and pure: every case is
+ * an input/throw table over parseCanonicalInt and parseTcpPort, pinning the
+ * coercions that motivated the module (issue #19601): Number()/parseInt
+ * silently turning "1e4", "0x10", "080", and "8abc" into different valid
+ * numbers at port/limit/concurrency call sites.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { parseCanonicalInt, parseTcpPort } from "../lib/cli-numbers.mjs";
+
+describe("parseCanonicalInt", () => {
+  test("accepts canonical decimals inside the bounds", () => {
+    expect(parseCanonicalInt("1", "flag")).toBe(1);
+    expect(parseCanonicalInt("31337", "flag")).toBe(31337);
+    expect(parseCanonicalInt(8, "flag")).toBe(8);
+    expect(parseCanonicalInt(" 42 ", "flag")).toBe(42);
+    expect(parseCanonicalInt("7", "flag", { min: 7, max: 7 })).toBe(7);
+  });
+
+  test("rejects every coercible non-canonical form", () => {
+    for (const value of [
+      "1e4",
+      "0x10",
+      "080",
+      "8abc",
+      "abc",
+      "3.9",
+      "-3",
+      "+3",
+      "",
+      " ",
+      undefined,
+      null,
+      "Infinity",
+      "NaN",
+      String(Number.MAX_SAFE_INTEGER + 1),
+    ]) {
+      expect(() => parseCanonicalInt(value, "flag")).toThrow(/flag must be/);
+    }
+  });
+
+  test("enforces the caller's bounds and names the flag in the error", () => {
+    expect(() => parseCanonicalInt("0", "workers")).toThrow(/workers must be/);
+    expect(() =>
+      parseCanonicalInt("33", "workers", { min: 1, max: 32 }),
+    ).toThrow(/workers must be a whole decimal integer from 1 to 32/);
+  });
+});
+
+describe("parseTcpPort", () => {
+  test("accepts real ports and rejects the port coercions from #19601", () => {
+    expect(parseTcpPort("31338", "ELIZA_TEST_CONSOLE_PORT")).toBe(31338);
+    expect(parseTcpPort("1", "p")).toBe(1);
+    expect(parseTcpPort("65535", "p")).toBe(65535);
+    // "0" logged ":0" then bound an ephemeral port; "1e4" silently bound
+    // 10000; "080" printed an unusable URL while probes dialed 80.
+    for (const value of ["0", "1e4", "080", "65536", "abc", "", "8080x"]) {
+      expect(() => parseTcpPort(value, "p")).toThrow(/p must be/);
+    }
+  });
+});

--- a/packages/scripts/__tests__/cli-numbers.test.mjs
+++ b/packages/scripts/__tests__/cli-numbers.test.mjs
@@ -16,7 +16,6 @@ describe("parseCanonicalInt", () => {
     expect(parseCanonicalInt("1", "flag")).toBe(1);
     expect(parseCanonicalInt("31337", "flag")).toBe(31337);
     expect(parseCanonicalInt(8, "flag")).toBe(8);
-    expect(parseCanonicalInt(" 42 ", "flag")).toBe(42);
     expect(parseCanonicalInt("7", "flag", { min: 7, max: 7 })).toBe(7);
   });
 
@@ -36,6 +35,7 @@ describe("parseCanonicalInt", () => {
       null,
       "Infinity",
       "NaN",
+      " 42 ",
       String(Number.MAX_SAFE_INTEGER + 1),
     ]) {
       expect(() => parseCanonicalInt(value, "flag")).toThrow(/flag must be/);

--- a/packages/scripts/__tests__/dev-all-service-startup-timeout.test.mjs
+++ b/packages/scripts/__tests__/dev-all-service-startup-timeout.test.mjs
@@ -144,4 +144,20 @@ describe("dev-all CLI boundary", () => {
     const combined = `${result.stdout}${result.stderr}`;
     expect(combined).toContain("[dev:all] local stack");
   });
+
+  test("rejects malformed port configuration through a bounded usage error", () => {
+    for (const [key, value] of [
+      ["DEV_ALL_AGENT_API_PORT", "1e4"],
+      ["DEV_ALL_FRONTEND_PORT", "abc"],
+      ["DEV_ALL_CLOUD_API_PORT", "080"],
+      ["DEV_ALL_CLOUD_DB_PORT", "0"],
+    ]) {
+      const result = runCli(["--dry-run", "--no-prepare"], { [key]: value });
+      expect(result.status).toBe(2);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain(`[dev:all] ${key} must be`);
+      expect(result.stderr).not.toContain("at parseCanonicalInt");
+      expect(result.stderr).not.toContain("Bun v");
+    }
+  });
 });

--- a/packages/scripts/__tests__/dev-all-service-startup-timeout.test.mjs
+++ b/packages/scripts/__tests__/dev-all-service-startup-timeout.test.mjs
@@ -151,6 +151,10 @@ describe("dev-all CLI boundary", () => {
       ["DEV_ALL_FRONTEND_PORT", "abc"],
       ["DEV_ALL_CLOUD_API_PORT", "080"],
       ["DEV_ALL_CLOUD_DB_PORT", "0"],
+      // envDefault's trim used to normalize these before the canonical
+      // parser saw them, so " 4242 " completed a dry-run with exit 0.
+      ["DEV_ALL_FRONTEND_PORT", " 4242 "],
+      ["DEV_ALL_AGENT_API_PORT", "\t31337"],
     ]) {
       const result = runCli(["--dry-run", "--no-prepare"], { [key]: value });
       expect(result.status).toBe(2);
@@ -159,5 +163,13 @@ describe("dev-all CLI boundary", () => {
       expect(result.stderr).not.toContain("at parseCanonicalInt");
       expect(result.stderr).not.toContain("Bun v");
     }
+  });
+
+  test("blank port envs keep defaults while whitespace-padded values fail", () => {
+    const result = runCli(["--dry-run", "--no-prepare"], {
+      DEV_ALL_FRONTEND_PORT: "   ",
+    });
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toContain("localhost:2138");
   });
 });

--- a/packages/scripts/__tests__/run-all-tests-concurrency-usage.test.ts
+++ b/packages/scripts/__tests__/run-all-tests-concurrency-usage.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Spawned-CLI boundary coverage for run-all-tests concurrency validation: a
+ * present-but-malformed --concurrency (including an explicitly empty
+ * `--concurrency=`) must exit through the repository's named usage error with
+ * exit 2 and no stack trace, never degrade to serial execution. The harness is
+ * real — each case spawns the actual script in plan mode with a filter that
+ * matches nothing, so no tasks run.
+ */
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "../lib/spawn-sync-captured.mjs";
+
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "run-all-tests.mjs",
+);
+
+function runPlan(extraArgs: string[], env: Record<string, string> = {}) {
+  return spawnSync(
+    process.execPath,
+    [
+      SCRIPT,
+      "--plan=text",
+      "--no-cloud",
+      "--filter=^definitely-no-task$",
+      ...extraArgs,
+    ],
+    {
+      encoding: "utf8",
+      env: { ...process.env, TEST_CONCURRENCY: undefined, ...env },
+      timeout: 60_000,
+    },
+  );
+}
+
+describe("run-all-tests --concurrency usage boundary", () => {
+  test("explicitly empty --concurrency= fails usage instead of running serial", () => {
+    const result = runPlan(["--concurrency="]);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain(
+      "[eliza-test] ERROR --concurrency requires a value",
+    );
+    expect(result.stderr).not.toMatch(/\n\s+at /);
+    expect(result.stdout).not.toContain("concurrency=1");
+  });
+
+  test("missing and malformed --concurrency values fail with exit 2, not a stack", () => {
+    for (const args of [
+      ["--concurrency"],
+      ["--concurrency", "--no-cloud"],
+      ["--concurrency=1e3"],
+      ["--concurrency=8abc"],
+      ["--concurrency=0"],
+      ["--concurrency=999999"],
+    ]) {
+      const result = runPlan(args);
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain("[eliza-test] ERROR");
+      expect(result.stderr).toContain("concurrency");
+      expect(result.stderr).not.toMatch(/\n\s+at /);
+    }
+  });
+
+  test("valid --concurrency still plans and an empty env stays unset", () => {
+    const valid = runPlan(["--concurrency=3"]);
+    expect(valid.status).toBe(0);
+    expect(valid.stdout).toContain("concurrency=3");
+
+    for (const value of ["", "   "]) {
+      const emptyEnv = runPlan([], { TEST_CONCURRENCY: value });
+      expect(emptyEnv.status).toBe(0);
+      expect(emptyEnv.stdout).toContain("concurrency=1");
+    }
+  });
+
+  test("malformed TEST_CONCURRENCY env fails usage the same way", () => {
+    const result = runPlan([], { TEST_CONCURRENCY: "1e3" });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("[eliza-test] ERROR");
+    expect(result.stderr).not.toMatch(/\n\s+at /);
+  });
+});

--- a/packages/scripts/__tests__/seed-message-corpus.test.mjs
+++ b/packages/scripts/__tests__/seed-message-corpus.test.mjs
@@ -123,8 +123,10 @@ describe("parseArgs canonical integer flags", () => {
     for (const argv of [
       ["--seed=0x10"],
       ["--seed=1e2"],
+      ["--seed= 42 "],
       ["--seed= 7 8"],
       ["--conversations=1e2"],
+      ["--conversations= 12 "],
       ["--conversations=010"],
       ["--conversations=12abc"],
       ["--messages=3.5"],

--- a/packages/scripts/__tests__/seed-message-corpus.test.mjs
+++ b/packages/scripts/__tests__/seed-message-corpus.test.mjs
@@ -107,6 +107,35 @@ describe("parseArgs port wiring", () => {
   });
 });
 
+describe("parseArgs canonical integer flags", () => {
+  test("accepts canonical decimal counts and seeds", () => {
+    const options = parseArgs(
+      ["--conversations=24", "--seed=99", "--api-port=31337"],
+      {},
+    );
+    expect(options.body.conversations).toBe(24);
+    expect(options.body.seed).toBe(99);
+  });
+
+  test("rejects coercible non-canonical forms the same way --api-port already does", () => {
+    // Number("0x10") is 16 and Number("1e2") is 100, so a hex seed or a
+    // scientific count used to silently seed with a different valid value.
+    for (const argv of [
+      ["--seed=0x10"],
+      ["--seed=1e2"],
+      ["--seed= 7 8"],
+      ["--conversations=1e2"],
+      ["--conversations=010"],
+      ["--conversations=12abc"],
+      ["--messages=3.5"],
+      ["--span-months=0x2"],
+      ["--facts=1e1"],
+    ]) {
+      expect(() => parseArgs(argv, {})).toThrow(/must be/);
+    }
+  });
+});
+
 describe("seed-message-corpus CLI boundary", () => {
   test("--help prints usage and exits 0", () => {
     const result = runCli(["--help"]);

--- a/packages/scripts/__tests__/seed-message-corpus.test.mjs
+++ b/packages/scripts/__tests__/seed-message-corpus.test.mjs
@@ -158,7 +158,7 @@ describe("seed-message-corpus CLI boundary", () => {
       "1.5",
     ]) {
       const result = runCli([`--api-port=${value}`]);
-      expect(result.status).not.toBe(0);
+      expect(result.status).toBe(2);
       const combined = `${result.stdout}${result.stderr}`;
       expect(combined).toMatch(
         /--api-port must be a TCP port integer from 1 to 65535/,
@@ -170,7 +170,7 @@ describe("seed-message-corpus CLI boundary", () => {
   test("rejects invalid ELIZA_API_PORT before any seed request", () => {
     for (const value of ["0", "notaport", "31337junk", " 31337 ", "99999"]) {
       const result = runCli([], { ELIZA_API_PORT: value });
-      expect(result.status).not.toBe(0);
+      expect(result.status).toBe(2);
       const combined = `${result.stdout}${result.stderr}`;
       expect(combined).toMatch(
         /ELIZA_API_PORT must be a TCP port integer from 1 to 65535/,
@@ -184,7 +184,7 @@ describe("seed-message-corpus CLI boundary", () => {
       ELIZA_API_PORT: "notaport",
     });
     const combined = `${result.stdout}${result.stderr}`;
-    expect(result.status).not.toBe(0);
+    expect(result.status).toBe(2);
     expect(combined).toContain("--messages must be an integer");
     expect(combined).not.toContain("ELIZA_API_PORT must be");
     expect(combined).not.toContain("Seeding backdated message corpus");

--- a/packages/scripts/__tests__/test-task-pool.test.ts
+++ b/packages/scripts/__tests__/test-task-pool.test.ts
@@ -5,6 +5,7 @@ import { spawnSync } from "../lib/spawn-sync-captured.mjs";
 
 import {
   isParallelSafeTask,
+  MAX_TASK_CONCURRENCY,
   normalizeConcurrency,
   parseShardSpec,
   partitionTasks,
@@ -163,16 +164,39 @@ describe("runPool", () => {
 });
 
 describe("normalizeConcurrency", () => {
-  test("defaults to 1 (fully serial) for empty/invalid input", () => {
-    for (const value of [undefined, null, "", "abc", "0", "-3", 0, -1]) {
+  test("defaults to 1 (fully serial) only when the value is absent", () => {
+    for (const value of [undefined, null, ""]) {
       expect(normalizeConcurrency(value)).toBe(1);
     }
   });
 
-  test("parses positive integers from string or number", () => {
+  test("parses canonical positive integers from string or number", () => {
     expect(normalizeConcurrency("4")).toBe(4);
     expect(normalizeConcurrency(8)).toBe(8);
-    expect(normalizeConcurrency("3.9")).toBe(3);
+    expect(normalizeConcurrency(String(MAX_TASK_CONCURRENCY))).toBe(
+      MAX_TASK_CONCURRENCY,
+    );
+  });
+
+  test("throws on present-but-malformed values instead of degrading to serial", () => {
+    // "1e3" and "8abc" used to silently become 1 and 8 via parseInt; "3.9"
+    // used to truncate; zero/negative/overflow used to fall back to 1.
+    for (const value of [
+      "abc",
+      "0",
+      "-3",
+      0,
+      -1,
+      "1e3",
+      "8abc",
+      "3.9",
+      "08",
+      "0x10",
+      String(MAX_TASK_CONCURRENCY + 1),
+      "999999",
+    ]) {
+      expect(() => normalizeConcurrency(value)).toThrow(/concurrency/);
+    }
   });
 });
 

--- a/packages/scripts/__tests__/test-task-pool.test.ts
+++ b/packages/scripts/__tests__/test-task-pool.test.ts
@@ -191,6 +191,7 @@ describe("normalizeConcurrency", () => {
       "8abc",
       "3.9",
       "08",
+      " 4 ",
       "0x10",
       String(MAX_TASK_CONCURRENCY + 1),
       "999999",
@@ -333,6 +334,7 @@ describe("run-all-tests plan mode", () => {
         TEST_SCRIPT_FILTER: "",
         TEST_SHARD: "",
         TEST_START_AT: "",
+        TEST_CONCURRENCY: "",
         ...env,
       },
     });

--- a/packages/scripts/__tests__/trajectory-list.test.ts
+++ b/packages/scripts/__tests__/trajectory-list.test.ts
@@ -145,7 +145,7 @@ describe("trajectory list", () => {
       // "flag omitted"), so both used to succeed with the wrong row count.
       for (const bad of ["1e3", "abc", "20foo", "-5", "0x10", "0", " 2 "]) {
         const result = runList(directory, ["--limit", bad]);
-        expect(result.status).not.toBe(0);
+        expect(result.status).toBe(2);
         expect(result.stderr).toContain("--limit");
         expect(result.stdout).not.toContain("row-");
       }
@@ -165,7 +165,7 @@ describe("trajectory list", () => {
         ["--limit="],
       ]) {
         const result = runList(directory, args);
-        expect(result.status).not.toBe(0);
+        expect(result.status).toBe(2);
         expect(result.stderr).toContain("--limit requires a value");
         expect(result.stdout).not.toContain("must-not-list");
       }

--- a/packages/scripts/__tests__/trajectory-list.test.ts
+++ b/packages/scripts/__tests__/trajectory-list.test.ts
@@ -143,11 +143,31 @@ describe("trajectory list", () => {
 
       // parseInt("1e3") is 1 and parseInt("abc") is NaN (treated as
       // "flag omitted"), so both used to succeed with the wrong row count.
-      for (const bad of ["1e3", "abc", "20foo", "-5", "0x10", "0"]) {
+      for (const bad of ["1e3", "abc", "20foo", "-5", "0x10", "0", " 2 "]) {
         const result = runList(directory, ["--limit", bad]);
         expect(result.status).not.toBe(0);
         expect(result.stderr).toContain("--limit");
         expect(result.stdout).not.toContain("row-");
+      }
+    }));
+
+  test("a present --limit without a value fails before listing", () =>
+    withFixture((directory) => {
+      writeTrajectory(directory, {
+        id: "must-not-list",
+        agent: "target-agent",
+        mtimeMs: BASE_TIME_MS,
+      });
+
+      for (const args of [
+        ["--limit"],
+        ["--limit", "--agent", "target-agent"],
+        ["--limit="],
+      ]) {
+        const result = runList(directory, args);
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain("--limit requires a value");
+        expect(result.stdout).not.toContain("must-not-list");
       }
     }));
 

--- a/packages/scripts/__tests__/trajectory-list.test.ts
+++ b/packages/scripts/__tests__/trajectory-list.test.ts
@@ -131,6 +131,26 @@ describe("trajectory list", () => {
       expect(result.stdout).not.toContain("match-old");
     }));
 
+  test("non-canonical --limit values fail closed instead of listing the wrong count", () =>
+    withFixture((directory) => {
+      for (let index = 1; index <= 5; index++) {
+        writeTrajectory(directory, {
+          id: `row-${index}`,
+          agent: "target-agent",
+          mtimeMs: BASE_TIME_MS + index * 1_000,
+        });
+      }
+
+      // parseInt("1e3") is 1 and parseInt("abc") is NaN (treated as
+      // "flag omitted"), so both used to succeed with the wrong row count.
+      for (const bad of ["1e3", "abc", "20foo", "-5", "0x10", "0"]) {
+        const result = runList(directory, ["--limit", bad]);
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain("--limit");
+        expect(result.stdout).not.toContain("row-");
+      }
+    }));
+
   test("malformed and since-filtered files do not consume the result limit", () =>
     withFixture((directory) => {
       writeTrajectory(directory, {

--- a/packages/scripts/dev-all.mjs
+++ b/packages/scripts/dev-all.mjs
@@ -111,28 +111,23 @@ export function resolveServiceStartupTimeoutMs(env = process.env) {
   );
 }
 
+// Ports must not reuse envDefault: its trim would normalize " 4242 " before
+// the canonical parser could reject it. Unset/blank keeps the default; any
+// present value reaches parseTcpPort exactly as the operator wrote it.
+function portEnv(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "")
+    return parseTcpPort(fallback, name);
+  return parseTcpPort(raw, name);
+}
+
 function resolvePorts() {
   return {
-    agentApi: parseTcpPort(
-      envDefault("DEV_ALL_AGENT_API_PORT", "31337"),
-      "DEV_ALL_AGENT_API_PORT",
-    ),
-    frontend: parseTcpPort(
-      envDefault("DEV_ALL_FRONTEND_PORT", "2138"),
-      "DEV_ALL_FRONTEND_PORT",
-    ),
-    cloudWeb: parseTcpPort(
-      envDefault("DEV_ALL_CLOUD_WEB_PORT", "3000"),
-      "DEV_ALL_CLOUD_WEB_PORT",
-    ),
-    cloudApi: parseTcpPort(
-      envDefault("DEV_ALL_CLOUD_API_PORT", "8787"),
-      "DEV_ALL_CLOUD_API_PORT",
-    ),
-    cloudDb: parseTcpPort(
-      envDefault("DEV_ALL_CLOUD_DB_PORT", "55432"),
-      "DEV_ALL_CLOUD_DB_PORT",
-    ),
+    agentApi: portEnv("DEV_ALL_AGENT_API_PORT", "31337"),
+    frontend: portEnv("DEV_ALL_FRONTEND_PORT", "2138"),
+    cloudWeb: portEnv("DEV_ALL_CLOUD_WEB_PORT", "3000"),
+    cloudApi: portEnv("DEV_ALL_CLOUD_API_PORT", "8787"),
+    cloudDb: portEnv("DEV_ALL_CLOUD_DB_PORT", "55432"),
   };
 }
 

--- a/packages/scripts/dev-all.mjs
+++ b/packages/scripts/dev-all.mjs
@@ -15,6 +15,7 @@ import net from "node:net";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
+import { parseTcpPort } from "./lib/cli-numbers.mjs";
 import { resolveDevAllSkipPlugins } from "./lib/script-metadata.mjs";
 
 /** Default wall-clock budget for each service readiness wait (ms). */
@@ -106,11 +107,26 @@ export function resolveServiceStartupTimeoutMs(env = process.env) {
 }
 
 const ports = {
-  agentApi: envDefault("DEV_ALL_AGENT_API_PORT", "31337"),
-  frontend: envDefault("DEV_ALL_FRONTEND_PORT", "2138"),
-  cloudWeb: envDefault("DEV_ALL_CLOUD_WEB_PORT", "3000"),
-  cloudApi: envDefault("DEV_ALL_CLOUD_API_PORT", "8787"),
-  cloudDb: envDefault("DEV_ALL_CLOUD_DB_PORT", "55432"),
+  agentApi: parseTcpPort(
+    envDefault("DEV_ALL_AGENT_API_PORT", "31337"),
+    "DEV_ALL_AGENT_API_PORT",
+  ),
+  frontend: parseTcpPort(
+    envDefault("DEV_ALL_FRONTEND_PORT", "2138"),
+    "DEV_ALL_FRONTEND_PORT",
+  ),
+  cloudWeb: parseTcpPort(
+    envDefault("DEV_ALL_CLOUD_WEB_PORT", "3000"),
+    "DEV_ALL_CLOUD_WEB_PORT",
+  ),
+  cloudApi: parseTcpPort(
+    envDefault("DEV_ALL_CLOUD_API_PORT", "8787"),
+    "DEV_ALL_CLOUD_API_PORT",
+  ),
+  cloudDb: parseTcpPort(
+    envDefault("DEV_ALL_CLOUD_DB_PORT", "55432"),
+    "DEV_ALL_CLOUD_DB_PORT",
+  ),
 };
 
 const urls = {

--- a/packages/scripts/dev-all.mjs
+++ b/packages/scripts/dev-all.mjs
@@ -21,6 +21,11 @@ import { resolveDevAllSkipPlugins } from "./lib/script-metadata.mjs";
 /** Default wall-clock budget for each service readiness wait (ms). */
 export const DEFAULT_SERVICE_STARTUP_TIMEOUT_MS = 120_000;
 
+const isDirectRun =
+  import.meta.main === true ||
+  (typeof process.argv[1] === "string" &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href);
+
 const args = new Set(process.argv.slice(2));
 const dryRun = args.has("--dry-run");
 const fullPrepare =
@@ -106,28 +111,44 @@ export function resolveServiceStartupTimeoutMs(env = process.env) {
   );
 }
 
-const ports = {
-  agentApi: parseTcpPort(
-    envDefault("DEV_ALL_AGENT_API_PORT", "31337"),
-    "DEV_ALL_AGENT_API_PORT",
-  ),
-  frontend: parseTcpPort(
-    envDefault("DEV_ALL_FRONTEND_PORT", "2138"),
-    "DEV_ALL_FRONTEND_PORT",
-  ),
-  cloudWeb: parseTcpPort(
-    envDefault("DEV_ALL_CLOUD_WEB_PORT", "3000"),
-    "DEV_ALL_CLOUD_WEB_PORT",
-  ),
-  cloudApi: parseTcpPort(
-    envDefault("DEV_ALL_CLOUD_API_PORT", "8787"),
-    "DEV_ALL_CLOUD_API_PORT",
-  ),
-  cloudDb: parseTcpPort(
-    envDefault("DEV_ALL_CLOUD_DB_PORT", "55432"),
-    "DEV_ALL_CLOUD_DB_PORT",
-  ),
-};
+function resolvePorts() {
+  return {
+    agentApi: parseTcpPort(
+      envDefault("DEV_ALL_AGENT_API_PORT", "31337"),
+      "DEV_ALL_AGENT_API_PORT",
+    ),
+    frontend: parseTcpPort(
+      envDefault("DEV_ALL_FRONTEND_PORT", "2138"),
+      "DEV_ALL_FRONTEND_PORT",
+    ),
+    cloudWeb: parseTcpPort(
+      envDefault("DEV_ALL_CLOUD_WEB_PORT", "3000"),
+      "DEV_ALL_CLOUD_WEB_PORT",
+    ),
+    cloudApi: parseTcpPort(
+      envDefault("DEV_ALL_CLOUD_API_PORT", "8787"),
+      "DEV_ALL_CLOUD_API_PORT",
+    ),
+    cloudDb: parseTcpPort(
+      envDefault("DEV_ALL_CLOUD_DB_PORT", "55432"),
+      "DEV_ALL_CLOUD_DB_PORT",
+    ),
+  };
+}
+
+function resolvePortsAtCliBoundary() {
+  try {
+    return resolvePorts();
+  } catch (error) {
+    // error-policy:J1 Startup configuration errors become bounded usage failures.
+    console.error(
+      `[dev:all] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(2);
+  }
+}
+
+const ports = isDirectRun ? resolvePortsAtCliBoundary() : resolvePorts();
 
 const urls = {
   agentApi: `http://127.0.0.1:${ports.agentApi}`,
@@ -662,11 +683,6 @@ async function main() {
     });
   }
 }
-
-const isDirectRun =
-  import.meta.main === true ||
-  (typeof process.argv[1] === "string" &&
-    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href);
 
 if (isDirectRun) {
   main().catch((error) => {

--- a/packages/scripts/lib/cli-numbers.mjs
+++ b/packages/scripts/lib/cli-numbers.mjs
@@ -1,0 +1,53 @@
+/**
+ * Fail-closed parsing for numeric CLI flags and environment overrides. A
+ * malformed value must never coerce into a different valid number: callers
+ * receive exactly the integer the operator wrote, or a thrown Error naming
+ * the flag. Canonical form is a complete decimal integer — no hex, no
+ * scientific notation, no leading zeros, no fraction, no trailing garbage —
+ * so inputs like "1e4", "0x10", "080", and "8abc" are rejected instead of
+ * silently becoming 1, 16, 80, and 8 under Number()/parseInt coercion.
+ */
+
+/**
+ * Parse a canonical non-negative decimal integer within [min, max].
+ * Throws on any other input, including values that Number()/parseInt would
+ * happily coerce. Bounds default to a positive safe integer.
+ *
+ * @param {string | number | undefined | null} value
+ * @param {string} label flag or env-var name used in the error message
+ * @param {{ min?: number, max?: number }} [bounds]
+ * @returns {number}
+ */
+export function parseCanonicalInt(value, label, bounds = {}) {
+  const { min = 1, max = Number.MAX_SAFE_INTEGER } = bounds;
+  const raw = String(value ?? "").trim();
+  const fail = () => {
+    throw new Error(
+      `${label} must be a whole decimal integer from ${min} to ${max} (received ${JSON.stringify(String(value ?? ""))})`,
+    );
+  };
+  if (!/^\d+$/.test(raw)) fail();
+  const parsed = Number.parseInt(raw, 10);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    String(parsed) !== raw ||
+    parsed < min ||
+    parsed > max
+  ) {
+    fail();
+  }
+  return parsed;
+}
+
+/**
+ * Parse a canonical TCP port (1..65535). Same rejection rules as
+ * parseCanonicalInt; exists so port call sites read as ports and share one
+ * bounds definition.
+ *
+ * @param {string | number | undefined | null} value
+ * @param {string} label
+ * @returns {number}
+ */
+export function parseTcpPort(value, label) {
+  return parseCanonicalInt(value, label, { min: 1, max: 65535 });
+}

--- a/packages/scripts/lib/cli-numbers.mjs
+++ b/packages/scripts/lib/cli-numbers.mjs
@@ -20,7 +20,7 @@
  */
 export function parseCanonicalInt(value, label, bounds = {}) {
   const { min = 1, max = Number.MAX_SAFE_INTEGER } = bounds;
-  const raw = String(value ?? "").trim();
+  const raw = String(value ?? "");
   const fail = () => {
     throw new Error(
       `${label} must be a whole decimal integer from ${min} to ${max} (received ${JSON.stringify(String(value ?? ""))})`,

--- a/packages/scripts/lib/test-task-pool.mjs
+++ b/packages/scripts/lib/test-task-pool.mjs
@@ -34,6 +34,8 @@
  */
 
 import crypto from "node:crypto";
+
+import { parseCanonicalInt } from "./cli-numbers.mjs";
 import { resolveTestSerialPackages } from "./script-metadata.mjs";
 
 /**
@@ -126,9 +128,15 @@ export async function runPool(items, worker, concurrency) {
   return results;
 }
 
+/** Upper bound for --concurrency / TEST_CONCURRENCY; matches the widest task
+ * fan-out any repository lane benefits from before workers starve each other. */
+export const MAX_TASK_CONCURRENCY = 32;
+
 /**
  * Normalise a requested concurrency value (CLI flag or env var) into a positive
- * integer, defaulting to 1 (fully serial — the historical behaviour).
+ * integer, defaulting to 1 (fully serial — the historical behaviour) only when
+ * the value is absent. A present-but-malformed value throws instead of
+ * degrading to serial: "1e3" and "8abc" used to silently become 1 and 8.
  *
  * @param {string | number | undefined | null} value
  * @returns {number}
@@ -137,12 +145,10 @@ export function normalizeConcurrency(value) {
   if (value === undefined || value === null || value === "") {
     return 1;
   }
-  const parsed =
-    typeof value === "number" ? value : Number.parseInt(String(value), 10);
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    return 1;
-  }
-  return Math.trunc(parsed);
+  return parseCanonicalInt(value, "concurrency", {
+    min: 1,
+    max: MAX_TASK_CONCURRENCY,
+  });
 }
 
 /**

--- a/packages/scripts/run-all-tests.mjs
+++ b/packages/scripts/run-all-tests.mjs
@@ -112,8 +112,8 @@ function parseFlag(name) {
 function parseFlagValue(prefix) {
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
-    if (arg === prefix && i + 1 < argv.length) {
-      if (argv[i + 1].startsWith("--")) {
+    if (arg === prefix) {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("--")) {
         throw new Error(`${prefix} requires a value`);
       }
       const value = argv[i + 1];
@@ -122,6 +122,9 @@ function parseFlagValue(prefix) {
     }
     if (arg.startsWith(`${prefix}=`)) {
       const value = arg.slice(prefix.length + 1);
+      if (!value) {
+        throw new Error(`${prefix} requires a value`);
+      }
       argv.splice(i, 1);
       return value;
     }
@@ -171,6 +174,7 @@ let onlyFlag;
 let laneFilterFlag;
 let excludeFlags;
 let concurrencyFlag;
+let concurrency;
 let planFlag;
 let minTasksFlag;
 try {
@@ -183,6 +187,7 @@ try {
   planFlag = parseFlagValue("--plan");
   minTasksFlag = parseFlagValue("--min-tasks");
 } catch (error) {
+  // error-policy:J1 CLI parsing failures become a bounded usage error.
   failUsage(error.message);
 }
 
@@ -275,17 +280,25 @@ if (argv.length > 0) {
   failUsage(`unknown argument(s): ${argv.join(" ")}`);
 }
 
+try {
+  const concurrencyEnv = process.env.TEST_CONCURRENCY;
+  const concurrencyInput =
+    concurrencyFlag ??
+    (concurrencyEnv === undefined || concurrencyEnv.trim() === ""
+      ? undefined
+      : concurrencyEnv);
+  concurrency = normalizeConcurrency(concurrencyInput);
+} catch (error) {
+  // error-policy:J1 CLI and environment validation share the exit-2 boundary.
+  failUsage(error.message);
+}
+
 // ---------------------------------------------------------------------------
 // Environment / lane configuration
 // ---------------------------------------------------------------------------
 
 const TEST_LANE = process.env.TEST_LANE || "pr"; // "pr" | "post-merge"
 const TEST_SHARD = process.env.TEST_SHARD || ""; // "N/M"
-// Bounded worker-pool size for the parallel-safe `test` tasks. Default 1 keeps
-// the historical fully-serial behaviour; only an explicit opt-in parallelises.
-const concurrency = normalizeConcurrency(
-  concurrencyFlag ?? process.env.TEST_CONCURRENCY,
-);
 
 // Parse TEST_SHARD into { index, total } or null (parseShardSpec is pure; warn
 // here when a non-empty spec is malformed).

--- a/packages/scripts/seed-message-corpus.mjs
+++ b/packages/scripts/seed-message-corpus.mjs
@@ -215,7 +215,17 @@ function iso(ms) {
 }
 
 async function main() {
-  const options = parseArgs(process.argv.slice(2));
+  let options;
+  try {
+    options = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    // error-policy:J1 CLI usage boundary — malformed flags exit 2 per the
+    // #19601 contract; runtime/network failures below keep exit 1.
+    process.stderr.write(
+      `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(2);
+  }
   const base = `http://${options.host}:${options.apiPort}`;
 
   process.stdout.write(`Seeding backdated message corpus via ${base} ...\n`);

--- a/packages/scripts/seed-message-corpus.mjs
+++ b/packages/scripts/seed-message-corpus.mjs
@@ -127,7 +127,7 @@ export function parseTcpPort(value, label) {
 function parseIntStrict(value, flag) {
   // Canonical decimal only: Number() accepted "0x10" and "1e2" here, so a
   // hex seed or scientific count silently became a different valid integer.
-  const raw = String(value ?? "").trim();
+  const raw = String(value ?? "");
   const n = Number.parseInt(raw, 10);
   if (!/^-?\d+$/.test(raw) || !Number.isSafeInteger(n) || String(n) !== raw) {
     throw new Error(`${flag} must be an integer`);

--- a/packages/scripts/seed-message-corpus.mjs
+++ b/packages/scripts/seed-message-corpus.mjs
@@ -125,8 +125,13 @@ export function parseTcpPort(value, label) {
 }
 
 function parseIntStrict(value, flag) {
-  const n = Number(value);
-  if (!Number.isSafeInteger(n)) throw new Error(`${flag} must be an integer`);
+  // Canonical decimal only: Number() accepted "0x10" and "1e2" here, so a
+  // hex seed or scientific count silently became a different valid integer.
+  const raw = String(value ?? "").trim();
+  const n = Number.parseInt(raw, 10);
+  if (!/^-?\d+$/.test(raw) || !Number.isSafeInteger(n) || String(n) !== raw) {
+    throw new Error(`${flag} must be an integer`);
+  }
   return n;
 }
 

--- a/packages/scripts/test-console/__tests__/console-lib.test.ts
+++ b/packages/scripts/test-console/__tests__/console-lib.test.ts
@@ -9,11 +9,13 @@ import { beforeAll, describe, expect, mock, test } from "bun:test";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 import fs from "node:fs";
+import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 
+import { spawnSync } from "../../lib/spawn-sync-captured.mjs";
 import {
   classifyResult,
   countStatuses,
@@ -21,6 +23,23 @@ import {
 } from "../lib/runner.mjs";
 
 const LABEL = "@elizaos/logger (packages/logger)#test";
+
+async function allocateLoopbackPort(): Promise<number> {
+  const probe = createServer();
+  await new Promise<void>((resolve, reject) => {
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", resolve);
+  });
+  const address = probe.address();
+  if (!address || typeof address === "string") {
+    probe.close();
+    throw new Error("failed to allocate a loopback TCP port");
+  }
+  await new Promise<void>((resolve, reject) => {
+    probe.close((error) => (error ? reject(error) : resolve()));
+  });
+  return address.port;
+}
 
 describe("classifyResult", () => {
   test("FAIL line wins even with exit 0", () => {
@@ -228,12 +247,13 @@ describe("server entrypoint", () => {
       fileURLToPath(new URL("../server.mjs", import.meta.url)),
       linkedServer,
     );
+    const port = await allocateLoopbackPort();
 
     const child = spawn("node", [linkedServer], {
       env: {
         ...process.env,
         ELIZA_TEST_CONSOLE_DIR: path.join(tempDir, "state"),
-        ELIZA_TEST_CONSOLE_PORT: "0",
+        ELIZA_TEST_CONSOLE_PORT: String(port),
       },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -279,6 +299,7 @@ describe("server entrypoint", () => {
         }),
       ]);
       expect(child.exitCode).toBeNull();
+      expect(stdout).toContain(`http://127.0.0.1:${port}`);
     } finally {
       if (startupTimer) clearTimeout(startupTimer);
       if (child.exitCode === null) {
@@ -288,6 +309,25 @@ describe("server entrypoint", () => {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   }, 10_000);
+
+  test("rejects an invalid configured port through the startup boundary", () => {
+    const serverPath = fileURLToPath(new URL("../server.mjs", import.meta.url));
+    const result = spawnSync("node", [serverPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ELIZA_TEST_CONSOLE_PORT: "1e4",
+      },
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(
+      "[TestConsole] ELIZA_TEST_CONSOLE_PORT must be a whole decimal integer from 1 to 65535",
+    );
+    expect(result.stderr).not.toContain("at parseCanonicalInt");
+    expect(result.stderr).not.toContain("Node.js v");
+  });
 });
 
 describe("route: POST /api/run rejects invalid concurrency before live-lane side effects", () => {

--- a/packages/scripts/test-console/__tests__/console-lib.test.ts
+++ b/packages/scripts/test-console/__tests__/console-lib.test.ts
@@ -312,21 +312,25 @@ describe("server entrypoint", () => {
 
   test("rejects an invalid configured port through the startup boundary", () => {
     const serverPath = fileURLToPath(new URL("../server.mjs", import.meta.url));
-    const result = spawnSync("node", [serverPath], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        ELIZA_TEST_CONSOLE_PORT: "1e4",
-      },
-    });
+    // " 65431 " is here because a pre-parse trim used to normalize it and the
+    // server started listening on 65431 instead of failing usage.
+    for (const value of ["1e4", " 65431 ", "\t31338"]) {
+      const result = spawnSync("node", [serverPath], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ELIZA_TEST_CONSOLE_PORT: value,
+        },
+      });
 
-    expect(result.status).toBe(2);
-    expect(result.stdout).toBe("");
-    expect(result.stderr).toContain(
-      "[TestConsole] ELIZA_TEST_CONSOLE_PORT must be a whole decimal integer from 1 to 65535",
-    );
-    expect(result.stderr).not.toContain("at parseCanonicalInt");
-    expect(result.stderr).not.toContain("Node.js v");
+      expect(result.status).toBe(2);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain(
+        "[TestConsole] ELIZA_TEST_CONSOLE_PORT must be a whole decimal integer from 1 to 65535",
+      );
+      expect(result.stderr).not.toContain("at parseCanonicalInt");
+      expect(result.stderr).not.toContain("Node.js v");
+    }
   });
 });
 

--- a/packages/scripts/test-console/server.mjs
+++ b/packages/scripts/test-console/server.mjs
@@ -59,8 +59,11 @@ const DEFAULT_PORT = 31338;
 const HOST = "127.0.0.1";
 
 function resolveConsolePort(env = process.env) {
-  const raw = env.ELIZA_TEST_CONSOLE_PORT?.trim();
-  return raw ? parseTcpPort(raw, "ELIZA_TEST_CONSOLE_PORT") : DEFAULT_PORT;
+  const raw = env.ELIZA_TEST_CONSOLE_PORT;
+  // Trim decides only present-vs-blank; the raw value reaches the canonical
+  // parser untouched so " 65431 " is rejected instead of silently accepted.
+  if (raw === undefined || raw.trim() === "") return DEFAULT_PORT;
+  return parseTcpPort(raw, "ELIZA_TEST_CONSOLE_PORT");
 }
 
 export const runManager = new RunManager();

--- a/packages/scripts/test-console/server.mjs
+++ b/packages/scripts/test-console/server.mjs
@@ -55,11 +55,13 @@ import {
 import { verifyConnection } from "./lib/verify.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-const rawConsolePort = process.env.ELIZA_TEST_CONSOLE_PORT?.trim();
-const PORT = rawConsolePort
-  ? parseTcpPort(rawConsolePort, "ELIZA_TEST_CONSOLE_PORT")
-  : 31338;
+const DEFAULT_PORT = 31338;
 const HOST = "127.0.0.1";
+
+function resolveConsolePort(env = process.env) {
+  const raw = env.ELIZA_TEST_CONSOLE_PORT?.trim();
+  return raw ? parseTcpPort(raw, "ELIZA_TEST_CONSOLE_PORT") : DEFAULT_PORT;
+}
 
 export const runManager = new RunManager();
 const sseClients = new Set();
@@ -365,8 +367,17 @@ const server = http.createServer(async (req, res) => {
 // Keep route imports side-effect free while preserving startup through
 // canonical, symlinked, and URL-escaped entrypoint paths.
 if (import.meta.main) {
-  server.listen(PORT, HOST, () => {
-    console.log(`[TestConsole] listening on http://${HOST}:${PORT}`);
-    console.log(`[TestConsole] state dir: ${consoleDir()}`);
-  });
+  try {
+    const port = resolveConsolePort();
+    server.listen(port, HOST, () => {
+      console.log(`[TestConsole] listening on http://${HOST}:${port}`);
+      console.log(`[TestConsole] state dir: ${consoleDir()}`);
+    });
+  } catch (error) {
+    // error-policy:J1 Startup configuration errors become bounded usage failures.
+    console.error(
+      `[TestConsole] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 2;
+  }
 }

--- a/packages/scripts/test-console/server.mjs
+++ b/packages/scripts/test-console/server.mjs
@@ -27,6 +27,7 @@ import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { parseTcpPort } from "../lib/cli-numbers.mjs";
 import { connectionById, connectionStatus } from "./lib/connections.mjs";
 import {
   completeGoogleFlow,
@@ -54,7 +55,10 @@ import {
 import { verifyConnection } from "./lib/verify.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-const PORT = Number(process.env.ELIZA_TEST_CONSOLE_PORT || 31338);
+const rawConsolePort = process.env.ELIZA_TEST_CONSOLE_PORT?.trim();
+const PORT = rawConsolePort
+  ? parseTcpPort(rawConsolePort, "ELIZA_TEST_CONSOLE_PORT")
+  : 31338;
 const HOST = "127.0.0.1";
 
 export const runManager = new RunManager();

--- a/packages/scripts/trajectory.ts
+++ b/packages/scripts/trajectory.ts
@@ -1260,8 +1260,21 @@ function flagInt(
 ): number | undefined {
   const v = flagString(flags, key);
   if (v === undefined) return undefined;
-  const n = Number.parseInt(v, 10);
-  return Number.isFinite(n) ? n : undefined;
+  // Fail closed on non-canonical input: parseInt("1e3") is 1 and NaN used to
+  // mean "flag omitted", so typos silently listed the wrong number of rows.
+  const raw = v.trim();
+  const n = Number.parseInt(raw, 10);
+  if (
+    !/^\d+$/.test(raw) ||
+    !Number.isSafeInteger(n) ||
+    String(n) !== raw ||
+    n < 1
+  ) {
+    throw new Error(
+      `--${key} must be a positive whole decimal integer (received ${JSON.stringify(v)})`,
+    );
+  }
+  return n;
 }
 
 function flagDate(

--- a/packages/scripts/trajectory.ts
+++ b/packages/scripts/trajectory.ts
@@ -1254,6 +1254,8 @@ function flagString(
   return typeof v === "string" ? v : undefined;
 }
 
+class UsageError extends Error {}
+
 function flagInt(
   flags: Map<string, string | true>,
   key: string,
@@ -1261,7 +1263,7 @@ function flagInt(
   if (!flags.has(key)) return undefined;
   const v = flags.get(key);
   if (typeof v !== "string" || v.length === 0) {
-    throw new Error(`--${key} requires a value`);
+    throw new UsageError(`--${key} requires a value`);
   }
   // Fail closed on non-canonical input: parseInt("1e3") is 1 and NaN used to
   // mean "flag omitted", so typos silently listed the wrong number of rows.
@@ -1273,7 +1275,7 @@ function flagInt(
     String(n) !== raw ||
     n < 1
   ) {
-    throw new Error(
+    throw new UsageError(
       `--${key} must be a positive whole decimal integer (received ${JSON.stringify(v)})`,
     );
   }
@@ -1449,5 +1451,7 @@ async function main(): Promise<void> {
 
 main().catch((err) => {
   console.error(c.red(`error: ${(err as Error).message}`));
-  process.exitCode = 1;
+  // Usage errors (malformed or missing flag values) exit 2 per the #19601
+  // contract; genuine execution failures keep exit 1.
+  process.exitCode = err instanceof UsageError ? 2 : 1;
 });

--- a/packages/scripts/trajectory.ts
+++ b/packages/scripts/trajectory.ts
@@ -1258,11 +1258,14 @@ function flagInt(
   flags: Map<string, string | true>,
   key: string,
 ): number | undefined {
-  const v = flagString(flags, key);
-  if (v === undefined) return undefined;
+  if (!flags.has(key)) return undefined;
+  const v = flags.get(key);
+  if (typeof v !== "string" || v.length === 0) {
+    throw new Error(`--${key} requires a value`);
+  }
   // Fail closed on non-canonical input: parseInt("1e3") is 1 and NaN used to
   // mean "flag omitted", so typos silently listed the wrong number of rows.
-  const raw = v.trim();
+  const raw = v;
   const n = Number.parseInt(raw, 10);
   if (
     !/^\d+$/.test(raw) ||


### PR DESCRIPTION
# Relates to

Fixes #19601.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

# Review outcome

This head contains the contributor's implementation plus maintainer repairs for every blocker found during exact-head review. It is rebased directly onto current `develop@1c65e80f05520256c48a775ab9cc1d8a35c84a35` and is ready for independent exact-head re-review. It must not merge until the hosted gates and a fresh approval are terminal on this head.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5 and xai/grok-4.6 (issue, initial implementation, initial tests); openai/gpt-5.6-sol (maintainer audit, repair, expanded tests, verification)
<!-- attribution-row:client -->
- Agent tooling: Claude Code; Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-eliza

The maintainer repair commit (`27b6a085c7`, Shaw) was produced under elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza; recorded here as prose because the machine row above must carry one canonical revision.
<!-- attribution-row:status -->
- Provenance status: self-reported

# What changed

The implementation closes five fail-open numeric parsing paths under `packages/scripts`:

| Surface | Before | Exact-head behavior |
| --- | --- | --- |
| Test-console port | `0` logged `:0` while binding an unrelated ephemeral port; `1e4` bound 10000 | canonical TCP port `1..65535`; invalid startup exits 2 with a bounded named error |
| `dev-all` ports | `abc`, `1e4`, and `080` reached URLs/probes as different values | all five port envs share the canonical port parser and fail before plan/prepare output |
| `trajectory list --limit` | partial values changed the row count; bare/missing values silently used 20 | positive canonical decimal only; empty, terminal-bare, and next-flag forms fail before listing |
| `run-all-tests --concurrency` / `TEST_CONCURRENCY` | partial values changed worker count; explicit empty degraded to serial; malformed values leaked a stack | canonical `1..32`; missing/empty CLI values and malformed flag/env values use the controlled exit-2 usage boundary; empty env remains unset |
| Message corpus counts/seeds | hex/scientific/leading-zero values were coerced | complete safe decimal integer grammar, retaining signed seeds and each field's existing bounds |

The shared `lib/cli-numbers.mjs` parser rejects hex, exponent, fraction, leading-zero, surrounding-whitespace, trailing-garbage, unsafe, and out-of-range forms. Valid `--concurrency=3` remains covered because `.github/workflows/develop-pr.yml` invokes that exact form.

# Review repairs

- Distinguished an absent concurrency flag from `--concurrency=` and from a missing separate value.
- Routed malformed CLI and environment concurrency through `failUsage()` (exit 2, no stack).
- Rejected `trajectory list --limit`, `--limit --agent ...`, and `--limit=` instead of folding them into omission.
- Moved test-console port parsing to the direct startup boundary so route imports remain side-effect free.
- Repaired the owning test-console entrypoint test, which the submitted focused lane missed: it now allocates a real valid loopback port instead of relying on forbidden production port `0`.
- Added bounded startup errors for malformed `dev-all` and test-console port configuration.
- Retained and expanded the contributor's concurrent spawned-CLI regression suite, with co-authorship recorded in the repair commit.

# Verification

Exact head: `ce7a2bf1f5468256c9d864f4d657155a7a763a5c` (rebased onto develop@1c65e80f05; identical diff)

- `bun test` over the seven focused suites (cli-numbers, test-task-pool, seed-message-corpus, trajectory-list, dev-all, console-lib, run-all-tests concurrency usage) — **82 pass / 0 fail** at this head.
- `bun run verify` — **exit 0 at this head** (full gate: guide parity, dependency, type, lint, secret-leak, scripts/inventory/view-bundle audits, and the focused-test anti-larp scan reporting clean over 8,057 test files). The earlier 350/350 figure in this section was measured on the parent maintainer-repair head `27b6a085c7` and is superseded by this current-head run.
- Pinned Biome (2.5.7) on all touched files: only the pre-existing `noUnusedFunctionParameters`/`noUndeclaredEnvVars` warnings.
- Negative controls from the review history remain closed at this head: `--concurrency=` and malformed concurrency exit 2 through the named usage boundary; bare `--limit` fails before listing; whitespace-padded port envs are rejected at both entrypoints.
- `git diff --check origin/develop...HEAD` passed; the branch is a direct child of current `develop`.

# Risks

Low-to-medium, operator tooling only. Valid canonical values and documented defaults are preserved. Deliberately malformed values now fail before work begins. The concurrency cap is `1..32`; empty `TEST_CONCURRENCY` remains equivalent to unset for CI templating, while an explicit empty CLI flag is invalid.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:ce7a2bf1f5468256c9d864f4d657155a7a763a5c -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A — CLI/operator scripts only; the before artifacts are the exact negative-control transcripts summarized above and in #19601.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A — no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A — deterministic startup/argument parsing with no user flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A — no deployed backend path; real spawned-process exit/status/stderr assertions are included in the 82-test focused lane.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A — no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A — deterministic parser behavior; `trajectory.ts` is the read-only inspector CLI, not model/runtime behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A — argument/startup parsing does not generate a domain artifact; exact-head spawned CLI assertions cover valid, malformed, empty, missing, environment, port-startup, and symlinked-entrypoint paths.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A — no visual surface.

## Known gaps / failures

- Hosted checks and a new independent approval are pending on this repaired head. No local verification gap remains.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza"} -->




