### PR TITLE
fix(app): fail closed on mobile smoke timer and count env typos

### DIFF
--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -103,9 +103,13 @@ export const DEFAULT_ANDROID_LOCAL_INFERENCE_READY_ATTEMPTS = 180;
 export const DEFAULT_ANDROID_LOCAL_INFERENCE_READY_DELAY_MS = 2000;
 export const DEFAULT_ANDROID_SMOKE_MODEL_CONTEXT_SIZE = 4096;
 
-/** The bundled eliza-1 GGUF advertises a 128k context; anything above it is a
- * typo, and full width already OOMs a phone/simulator. */
-export const MAX_MODEL_CONTEXT_TOKENS = 131_072;
+/** Operational context ceiling for smoke devices. The bundled eliza-1 GGUF
+ * advertises 128k (131072), but that full width allocates a multi-GB KV cache
+ * and OOMs a phone/simulator — the format ceiling is a rejection case, not a
+ * bound. 32768 keeps the KV cache at ~1/4 of the known-OOM size while giving
+ * 8× headroom over the proven 4096 smoke width; tighten further if device
+ * measurements prove a lower safe cap. */
+export const MAX_MODEL_CONTEXT_TOKENS = 32_768;
 /** Retry/readiness/stability loops are dev-lane scale; five digits of attempts
  * is already three orders past any documented default. */
 export const MAX_LOOP_COUNT = 10_000;
@@ -139,10 +143,10 @@ function parseEnvInteger(raw, label, { min, max }) {
   return parsed;
 }
 
-function assertLoopBudget(attemptsName, attempts, delayName, delayMs) {
-  if (attempts * delayMs > MAX_LOOP_BUDGET_MS) {
+function assertLoopBudget(label, attempts, perAttemptMs) {
+  if (attempts * perAttemptMs > MAX_LOOP_BUDGET_MS) {
     throw new Error(
-      `Invalid ${attemptsName} × ${delayName}: ${attempts} × ${delayMs}ms exceeds the ${MAX_LOOP_BUDGET_MS}ms (24h) loop budget`,
+      `Invalid ${label}: ${attempts} × ${perAttemptMs}ms exceeds the ${MAX_LOOP_BUDGET_MS}ms (24h) loop budget`,
     );
   }
 }
@@ -249,23 +253,33 @@ export function resolveMobileSmokeNumericEnv(env = process.env) {
       `Invalid ANDROID_STABILITY_SAMPLES: ${resolved.androidStabilitySamples} exceeds ANDROID_STABILITY_ATTEMPTS ${resolved.androidStabilityAttempts}`,
     );
   }
+  // Composite budgets count the WORK an attempt can consume (probe timeouts,
+  // nested retries), not only the inter-attempt delay: 10000 attempts at
+  // delay 0 with a max probe timeout is centuries of wall clock, not zero.
+  const retryAttemptMs =
+    resolved.androidHealthProbeTimeoutMs +
+    resolved.androidTransientRetryDelayMs;
+  const retryBudgetMs = resolved.androidTransientRetryAttempts * retryAttemptMs;
   assertLoopBudget(
-    "ANDROID_TRANSIENT_RETRY_ATTEMPTS",
+    "ANDROID_TRANSIENT_RETRY_ATTEMPTS × (ANDROID_HEALTH_PROBE_TIMEOUT_MS + ANDROID_TRANSIENT_RETRY_DELAY_MS)",
     resolved.androidTransientRetryAttempts,
-    "ANDROID_TRANSIENT_RETRY_DELAY_MS",
-    resolved.androidTransientRetryDelayMs,
+    retryAttemptMs,
   );
   assertLoopBudget(
-    "ANDROID_STABILITY_ATTEMPTS",
+    "ANDROID_TRANSIENT_RETRY_ATTEMPTS × (ANDROID_FULL_TURN_TIMEOUT_MS + ANDROID_TRANSIENT_RETRY_DELAY_MS)",
+    resolved.androidTransientRetryAttempts,
+    resolved.androidFullTurnTimeoutMs + resolved.androidTransientRetryDelayMs,
+  );
+  assertLoopBudget(
+    "ANDROID_STABILITY_ATTEMPTS × (transient-retry budget + ANDROID_STABILITY_DELAY_MS)",
     resolved.androidStabilityAttempts,
-    "ANDROID_STABILITY_DELAY_MS",
-    resolved.androidStabilityDelayMs,
+    retryBudgetMs + resolved.androidStabilityDelayMs,
   );
   assertLoopBudget(
-    "ANDROID_LOCAL_INFERENCE_READY_ATTEMPTS",
+    "ANDROID_LOCAL_INFERENCE_READY_ATTEMPTS × (3 × ANDROID_HEALTH_PROBE_TIMEOUT_MS + ANDROID_LOCAL_INFERENCE_READY_DELAY_MS)",
     resolved.androidLocalInferenceReadyAttempts,
-    "ANDROID_LOCAL_INFERENCE_READY_DELAY_MS",
-    resolved.androidLocalInferenceReadyDelayMs,
+    3 * resolved.androidHealthProbeTimeoutMs +
+      resolved.androidLocalInferenceReadyDelayMs,
   );
   return resolved;
 }
@@ -2046,12 +2060,15 @@ async function requestTextResponse(
 }
 
 async function requestOptionalJson(method, pathname, baseUrl, authToken) {
+  // Every readiness probe carries the bounded probe timeout: an un-timed
+  // fetch here could stay pending forever regardless of any loop budget.
   const { response, data, text } = await requestJsonResponse(
     method,
     pathname,
     undefined,
     baseUrl,
     authToken,
+    { timeoutMs: ANDROID_HEALTH_PROBE_TIMEOUT_MS },
   );
   if (response.status === 404) return null;
   if (!response.ok) {

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -103,11 +103,30 @@ export const DEFAULT_ANDROID_LOCAL_INFERENCE_READY_ATTEMPTS = 180;
 export const DEFAULT_ANDROID_LOCAL_INFERENCE_READY_DELAY_MS = 2000;
 export const DEFAULT_ANDROID_SMOKE_MODEL_CONTEXT_SIZE = 4096;
 
+/** The bundled eliza-1 GGUF advertises a 128k context; anything above it is a
+ * typo, and full width already OOMs a phone/simulator. */
+export const MAX_MODEL_CONTEXT_TOKENS = 131_072;
+/** Retry/readiness/stability loops are dev-lane scale; five digits of attempts
+ * is already three orders past any documented default. */
+export const MAX_LOOP_COUNT = 10_000;
+/** No single polling loop may be configured past 24h of wall clock — a lane
+ * that needs longer is broken, not patient. Checked as attempts × delay. */
+export const MAX_LOOP_BUDGET_MS = 86_400_000;
+/** Model bundles are single-digit GiB; a size override past 1 TiB is a typo. */
+export const MAX_MODEL_SIZE_BYTES = 1_099_511_627_776;
+
 function isBlankEnv(value) {
   return value === undefined || value === null || String(value).trim() === "";
 }
 
 function parseEnvInteger(raw, label, { min, max }) {
+  // Canonical decimal spelling only: the shared helpers accept /^\d+$/, which
+  // lets "0008" pass as 8. A leading zero is a typo, not a smaller number.
+  if (!/^(?:0|[1-9]\d*)$/.test(raw)) {
+    throw new Error(
+      `Invalid ${label}: expected a canonical decimal integer (no leading zeros); received ${JSON.stringify(raw)}`,
+    );
+  }
   if (min === 0) {
     return parseNonNegativeSafeInteger(raw, label, { max });
   }
@@ -118,6 +137,14 @@ function parseEnvInteger(raw, label, { min, max }) {
     );
   }
   return parsed;
+}
+
+function assertLoopBudget(attemptsName, attempts, delayName, delayMs) {
+  if (attempts * delayMs > MAX_LOOP_BUDGET_MS) {
+    throw new Error(
+      `Invalid ${attemptsName} × ${delayName}: ${attempts} × ${delayMs}ms exceeds the ${MAX_LOOP_BUDGET_MS}ms (24h) loop budget`,
+    );
+  }
 }
 
 function readEnvInteger(env, name, fallback, bounds) {
@@ -135,13 +162,14 @@ function readEnvInteger(env, name, fallback, bounds) {
 export function resolveMobileSmokeNumericEnv(env = process.env) {
   const timer = { min: 1, max: MAX_TIMER_DELAY_MS };
   const delay = { min: 0, max: MAX_TIMER_DELAY_MS };
-  const count = { min: 1, max: Number.MAX_SAFE_INTEGER };
-  return {
+  const count = { min: 1, max: MAX_LOOP_COUNT };
+  const context = { min: 1, max: MAX_MODEL_CONTEXT_TOKENS };
+  const resolved = {
     iosFullBunSmokeContextSize: readEnvInteger(
       env,
       "IOS_FULL_BUN_SMOKE_CONTEXT_SIZE",
       DEFAULT_IOS_FULL_BUN_SMOKE_CONTEXT_SIZE,
-      count,
+      context,
     ),
     androidFullTurnTimeoutMs: readEnvInteger(
       env,
@@ -201,7 +229,7 @@ export function resolveMobileSmokeNumericEnv(env = process.env) {
       env,
       "ANDROID_SMOKE_MODEL_CONTEXT_SIZE",
       DEFAULT_ANDROID_SMOKE_MODEL_CONTEXT_SIZE,
-      count,
+      context,
     ),
     androidSmokeModelSizeBytesOverride: isBlankEnv(
       env.ANDROID_SMOKE_MODEL_SIZE_BYTES,
@@ -210,9 +238,36 @@ export function resolveMobileSmokeNumericEnv(env = process.env) {
       : parseEnvInteger(
           String(env.ANDROID_SMOKE_MODEL_SIZE_BYTES).trim(),
           "ANDROID_SMOKE_MODEL_SIZE_BYTES",
-          { min: 1, max: Number.MAX_SAFE_INTEGER },
+          { min: 1, max: MAX_MODEL_SIZE_BYTES },
         ),
   };
+  // Per-loop execution budgets: a syntactically valid pair may still describe
+  // a lane that polls for months. Reject over-budget combinations before any
+  // device work, and keep the stability window self-consistent.
+  if (resolved.androidStabilitySamples > resolved.androidStabilityAttempts) {
+    throw new Error(
+      `Invalid ANDROID_STABILITY_SAMPLES: ${resolved.androidStabilitySamples} exceeds ANDROID_STABILITY_ATTEMPTS ${resolved.androidStabilityAttempts}`,
+    );
+  }
+  assertLoopBudget(
+    "ANDROID_TRANSIENT_RETRY_ATTEMPTS",
+    resolved.androidTransientRetryAttempts,
+    "ANDROID_TRANSIENT_RETRY_DELAY_MS",
+    resolved.androidTransientRetryDelayMs,
+  );
+  assertLoopBudget(
+    "ANDROID_STABILITY_ATTEMPTS",
+    resolved.androidStabilityAttempts,
+    "ANDROID_STABILITY_DELAY_MS",
+    resolved.androidStabilityDelayMs,
+  );
+  assertLoopBudget(
+    "ANDROID_LOCAL_INFERENCE_READY_ATTEMPTS",
+    resolved.androidLocalInferenceReadyAttempts,
+    "ANDROID_LOCAL_INFERENCE_READY_DELAY_MS",
+    resolved.androidLocalInferenceReadyDelayMs,
+  );
+  return resolved;
 }
 
 const smokeNumbers = resolveMobileSmokeNumericEnv();
@@ -220,8 +275,7 @@ const smokeNumbers = resolveMobileSmokeNumericEnv();
 // max context; loading it at full width allocates a multi-GB KV cache that is
 // impractically slow (and OOMs) on a phone/simulator, so the first reply never
 // lands. 4096 mirrors the Android smoke and keeps model load + generation fast.
-const IOS_FULL_BUN_SMOKE_CONTEXT_SIZE =
-  smokeNumbers.iosFullBunSmokeContextSize;
+const IOS_FULL_BUN_SMOKE_CONTEXT_SIZE = smokeNumbers.iosFullBunSmokeContextSize;
 const IOS_FULL_BUN_SMOKE_ATTEMPTS = 180;
 const IOS_FULL_BUN_SMOKE_DELAY_MS = 2000;
 // ANDROID_FULL_TURN_FAILURE_RE comes from the checked-in failure-string source
@@ -2751,7 +2805,6 @@ async function main() {
 }
 
 export {
-  MAX_TIMER_DELAY_MS,
   androidBackgroundServicesReady,
   androidDeviceSerial,
   androidRunAs,
@@ -2767,6 +2820,7 @@ export {
   launchAndroidEmulatorApp,
   launchIosSimulatorApp,
   localInferenceSummary,
+  MAX_TIMER_DELAY_MS,
   main,
   parseSseEvents,
   preseedAndroidLocalRuntime,

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -2,6 +2,11 @@
 /**
  * Command-line helper for the Mobile Local Chat Smoke app packaging, mobile,
  * or Playwright automation lane.
+ *
+ * Numeric env overrides (timeouts, retries, stability samples, context size)
+ * fail closed: unset/empty keep documented defaults, and any other token exits
+ * before device or API work. Timer knobs are bounded by Node's 32-bit
+ * `setTimeout` ceiling so an overflow cannot clamp to 1 ms.
  */
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -16,7 +21,12 @@ import {
   assertMarkerSurvivedRelaunch,
   buildRelaunchMarker,
 } from "./lib/chat-history-persistence.mjs";
-import { startDeviceE2eHostAgent } from "./lib/host-agent.mjs";
+import {
+  MAX_TIMER_DELAY_MS,
+  parseNonNegativeSafeInteger,
+  parsePositiveSafeInteger,
+  startDeviceE2eHostAgent,
+} from "./lib/host-agent.mjs";
 import {
   assertIosFullBunSmokeSuccess,
   iosFullBunSmokeResultTimeMs,
@@ -81,71 +91,170 @@ const ANDROID_LOCAL_AGENT_IPC_BASE = IOS_LOCAL_AGENT_IPC_BASE;
 const IOS_FULL_BUN_SMOKE_MODEL_ID = "eliza-1-2b";
 const IOS_FULL_BUN_SMOKE_MODEL_RELATIVE_PATH =
   "models/eliza-1-2b.bundle/text/eliza-1-2b-128k.gguf";
+export const DEFAULT_IOS_FULL_BUN_SMOKE_CONTEXT_SIZE = 4096;
+export const DEFAULT_ANDROID_FULL_TURN_TIMEOUT_MS = 10 * 60_000;
+export const DEFAULT_ANDROID_HEALTH_PROBE_TIMEOUT_MS = 30_000;
+export const DEFAULT_ANDROID_TRANSIENT_RETRY_ATTEMPTS = 5;
+export const DEFAULT_ANDROID_TRANSIENT_RETRY_DELAY_MS = 2000;
+export const DEFAULT_ANDROID_STABILITY_SAMPLES = 3;
+export const DEFAULT_ANDROID_STABILITY_DELAY_MS = 2000;
+export const DEFAULT_ANDROID_STABILITY_ATTEMPTS = 60;
+export const DEFAULT_ANDROID_LOCAL_INFERENCE_READY_ATTEMPTS = 180;
+export const DEFAULT_ANDROID_LOCAL_INFERENCE_READY_DELAY_MS = 2000;
+export const DEFAULT_ANDROID_SMOKE_MODEL_CONTEXT_SIZE = 4096;
+
+function isBlankEnv(value) {
+  return value === undefined || value === null || String(value).trim() === "";
+}
+
+function parseEnvInteger(raw, label, { min, max }) {
+  if (min === 0) {
+    return parseNonNegativeSafeInteger(raw, label, { max });
+  }
+  const parsed = parsePositiveSafeInteger(raw, label);
+  if (parsed > max) {
+    throw new Error(
+      `Invalid ${label}: expected a non-negative safe integer no greater than ${max}; received ${JSON.stringify(raw)}`,
+    );
+  }
+  return parsed;
+}
+
+function readEnvInteger(env, name, fallback, bounds) {
+  const raw = env[name];
+  if (isBlankEnv(raw)) return fallback;
+  return parseEnvInteger(String(raw).trim(), name, bounds);
+}
+
+/**
+ * Resolve smoke timing and count knobs from env. Unset/empty keep defaults.
+ * Any other token fails closed so `1e3` cannot become 1 ms and `abc` cannot
+ * skip the AbortController timeout gate.
+ * @param {NodeJS.ProcessEnv} [env]
+ */
+export function resolveMobileSmokeNumericEnv(env = process.env) {
+  const timer = { min: 1, max: MAX_TIMER_DELAY_MS };
+  const delay = { min: 0, max: MAX_TIMER_DELAY_MS };
+  const count = { min: 1, max: Number.MAX_SAFE_INTEGER };
+  return {
+    iosFullBunSmokeContextSize: readEnvInteger(
+      env,
+      "IOS_FULL_BUN_SMOKE_CONTEXT_SIZE",
+      DEFAULT_IOS_FULL_BUN_SMOKE_CONTEXT_SIZE,
+      count,
+    ),
+    androidFullTurnTimeoutMs: readEnvInteger(
+      env,
+      "ANDROID_FULL_TURN_TIMEOUT_MS",
+      DEFAULT_ANDROID_FULL_TURN_TIMEOUT_MS,
+      timer,
+    ),
+    androidHealthProbeTimeoutMs: readEnvInteger(
+      env,
+      "ANDROID_HEALTH_PROBE_TIMEOUT_MS",
+      DEFAULT_ANDROID_HEALTH_PROBE_TIMEOUT_MS,
+      timer,
+    ),
+    androidTransientRetryAttempts: readEnvInteger(
+      env,
+      "ANDROID_TRANSIENT_RETRY_ATTEMPTS",
+      DEFAULT_ANDROID_TRANSIENT_RETRY_ATTEMPTS,
+      count,
+    ),
+    androidTransientRetryDelayMs: readEnvInteger(
+      env,
+      "ANDROID_TRANSIENT_RETRY_DELAY_MS",
+      DEFAULT_ANDROID_TRANSIENT_RETRY_DELAY_MS,
+      delay,
+    ),
+    androidStabilitySamples: readEnvInteger(
+      env,
+      "ANDROID_STABILITY_SAMPLES",
+      DEFAULT_ANDROID_STABILITY_SAMPLES,
+      count,
+    ),
+    androidStabilityDelayMs: readEnvInteger(
+      env,
+      "ANDROID_STABILITY_DELAY_MS",
+      DEFAULT_ANDROID_STABILITY_DELAY_MS,
+      delay,
+    ),
+    androidStabilityAttempts: readEnvInteger(
+      env,
+      "ANDROID_STABILITY_ATTEMPTS",
+      DEFAULT_ANDROID_STABILITY_ATTEMPTS,
+      count,
+    ),
+    androidLocalInferenceReadyAttempts: readEnvInteger(
+      env,
+      "ANDROID_LOCAL_INFERENCE_READY_ATTEMPTS",
+      DEFAULT_ANDROID_LOCAL_INFERENCE_READY_ATTEMPTS,
+      count,
+    ),
+    androidLocalInferenceReadyDelayMs: readEnvInteger(
+      env,
+      "ANDROID_LOCAL_INFERENCE_READY_DELAY_MS",
+      DEFAULT_ANDROID_LOCAL_INFERENCE_READY_DELAY_MS,
+      delay,
+    ),
+    androidSmokeModelContextSize: readEnvInteger(
+      env,
+      "ANDROID_SMOKE_MODEL_CONTEXT_SIZE",
+      DEFAULT_ANDROID_SMOKE_MODEL_CONTEXT_SIZE,
+      count,
+    ),
+    androidSmokeModelSizeBytesOverride: isBlankEnv(
+      env.ANDROID_SMOKE_MODEL_SIZE_BYTES,
+    )
+      ? null
+      : parseEnvInteger(
+          String(env.ANDROID_SMOKE_MODEL_SIZE_BYTES).trim(),
+          "ANDROID_SMOKE_MODEL_SIZE_BYTES",
+          { min: 1, max: Number.MAX_SAFE_INTEGER },
+        ),
+  };
+}
+
+const smokeNumbers = resolveMobileSmokeNumericEnv();
 // Cap the on-device context window. The bundled eliza-1 GGUF advertises a 128k
 // max context; loading it at full width allocates a multi-GB KV cache that is
 // impractically slow (and OOMs) on a phone/simulator, so the first reply never
 // lands. 4096 mirrors the Android smoke and keeps model load + generation fast.
-const IOS_FULL_BUN_SMOKE_CONTEXT_SIZE = Number.parseInt(
-  process.env.IOS_FULL_BUN_SMOKE_CONTEXT_SIZE?.trim() || "4096",
-  10,
-);
+const IOS_FULL_BUN_SMOKE_CONTEXT_SIZE =
+  smokeNumbers.iosFullBunSmokeContextSize;
 const IOS_FULL_BUN_SMOKE_ATTEMPTS = 180;
 const IOS_FULL_BUN_SMOKE_DELAY_MS = 2000;
 // ANDROID_FULL_TURN_FAILURE_RE comes from the checked-in failure-string source
 // shared with the on-device XCUITest verifier (issue #13687).
 const ANDROID_HEALTH_ATTEMPTS = 240;
-const ANDROID_FULL_TURN_TIMEOUT_MS = Number.parseInt(
-  process.env.ANDROID_FULL_TURN_TIMEOUT_MS?.trim() || String(10 * 60_000),
-  10,
-);
+const ANDROID_FULL_TURN_TIMEOUT_MS = smokeNumbers.androidFullTurnTimeoutMs;
 // In-process CPU-only decode on a phone is slow (~0.2 tok/s generate, observed
 // ~41s end-to-end for a short reply). A single slow/blip read must not abort
 // the turn, so the per-request HTTP timeout sits well above that envelope.
-const ANDROID_HEALTH_PROBE_TIMEOUT_MS = Number.parseInt(
-  process.env.ANDROID_HEALTH_PROBE_TIMEOUT_MS?.trim() || String(30_000),
-  10,
-);
+const ANDROID_HEALTH_PROBE_TIMEOUT_MS =
+  smokeNumbers.androidHealthProbeTimeoutMs;
 // Bounded transient retry for accepted-but-empty / reset / 5xx / timeout reads
 // against the forwarded local-agent API. The boot/restart window briefly
 // accepts the socket and closes it with an empty body; retry rides that out.
-const ANDROID_TRANSIENT_RETRY_ATTEMPTS = Number.parseInt(
-  process.env.ANDROID_TRANSIENT_RETRY_ATTEMPTS?.trim() || "5",
-  10,
-);
-const ANDROID_TRANSIENT_RETRY_DELAY_MS = Number.parseInt(
-  process.env.ANDROID_TRANSIENT_RETRY_DELAY_MS?.trim() || "2000",
-  10,
-);
+const ANDROID_TRANSIENT_RETRY_ATTEMPTS =
+  smokeNumbers.androidTransientRetryAttempts;
+const ANDROID_TRANSIENT_RETRY_DELAY_MS =
+  smokeNumbers.androidTransientRetryDelayMs;
 // Process-stability gate: require monotonic uptime across N consecutive
 // /api/health samples (agentState==running, startup.attempt not climbing)
 // before exercising, so a turn is never fired mid-restart.
-const ANDROID_STABILITY_SAMPLES = Number.parseInt(
-  process.env.ANDROID_STABILITY_SAMPLES?.trim() || "3",
-  10,
-);
-const ANDROID_STABILITY_DELAY_MS = Number.parseInt(
-  process.env.ANDROID_STABILITY_DELAY_MS?.trim() || "2000",
-  10,
-);
-const ANDROID_STABILITY_ATTEMPTS = Number.parseInt(
-  process.env.ANDROID_STABILITY_ATTEMPTS?.trim() || "60",
-  10,
-);
-const ANDROID_LOCAL_INFERENCE_READY_ATTEMPTS = Number.parseInt(
-  process.env.ANDROID_LOCAL_INFERENCE_READY_ATTEMPTS?.trim() || "180",
-  10,
-);
-const ANDROID_LOCAL_INFERENCE_READY_DELAY_MS = Number.parseInt(
-  process.env.ANDROID_LOCAL_INFERENCE_READY_DELAY_MS?.trim() || "2000",
-  10,
-);
+const ANDROID_STABILITY_SAMPLES = smokeNumbers.androidStabilitySamples;
+const ANDROID_STABILITY_DELAY_MS = smokeNumbers.androidStabilityDelayMs;
+const ANDROID_STABILITY_ATTEMPTS = smokeNumbers.androidStabilityAttempts;
+const ANDROID_LOCAL_INFERENCE_READY_ATTEMPTS =
+  smokeNumbers.androidLocalInferenceReadyAttempts;
+const ANDROID_LOCAL_INFERENCE_READY_DELAY_MS =
+  smokeNumbers.androidLocalInferenceReadyDelayMs;
 const ANDROID_FULL_TURN_PROMPT =
   "Reply with exactly these four words: android smoke model works.";
 const ANDROID_FULL_TURN_EXPECTED_REPLY = "android smoke model works";
-const ANDROID_SMOKE_MODEL_CONTEXT_SIZE = Number.parseInt(
-  process.env.ANDROID_SMOKE_MODEL_CONTEXT_SIZE?.trim() || "4096",
-  10,
-);
+const ANDROID_SMOKE_MODEL_CONTEXT_SIZE =
+  smokeNumbers.androidSmokeModelContextSize;
 const ANDROID_SMOKE_MODEL_ID =
   process.env.ANDROID_SMOKE_MODEL_ID?.trim() || "eliza-1-2b";
 const DEFAULT_ANDROID_SMOKE_MODEL = {
@@ -159,15 +268,14 @@ const ANDROID_SMOKE_MODEL_RELATIVE_PATH =
 const ANDROID_SMOKE_MODEL_FILE =
   process.env.ANDROID_SMOKE_MODEL_FILE?.trim() ||
   DEFAULT_ANDROID_SMOKE_MODEL.file;
-const androidSmokeModelSizeOverride =
-  process.env.ANDROID_SMOKE_MODEL_SIZE_BYTES?.trim();
-const ANDROID_SMOKE_MODEL_SIZE_BYTES = androidSmokeModelSizeOverride
-  ? Number.parseInt(androidSmokeModelSizeOverride, 10)
-  : ANDROID_SMOKE_MODEL_RELATIVE_PATH ===
-        DEFAULT_ANDROID_SMOKE_MODEL.relativePath &&
-      ANDROID_SMOKE_MODEL_FILE === DEFAULT_ANDROID_SMOKE_MODEL.file
-    ? DEFAULT_ANDROID_SMOKE_MODEL.sizeBytes
-    : Number.NaN;
+const ANDROID_SMOKE_MODEL_SIZE_BYTES =
+  smokeNumbers.androidSmokeModelSizeBytesOverride !== null
+    ? smokeNumbers.androidSmokeModelSizeBytesOverride
+    : ANDROID_SMOKE_MODEL_RELATIVE_PATH ===
+          DEFAULT_ANDROID_SMOKE_MODEL.relativePath &&
+        ANDROID_SMOKE_MODEL_FILE === DEFAULT_ANDROID_SMOKE_MODEL.file
+      ? DEFAULT_ANDROID_SMOKE_MODEL.sizeBytes
+      : Number.NaN;
 const ANDROID_SMOKE_MODEL_SHA256 =
   process.env.ANDROID_SMOKE_MODEL_SHA256?.trim() || "";
 const ANDROID_SMOKE_MODEL_URL =
@@ -2643,6 +2751,7 @@ async function main() {
 }
 
 export {
+  MAX_TIMER_DELAY_MS,
   androidBackgroundServicesReady,
   androidDeviceSerial,
   androidRunAs,

--- a/packages/app/scripts/mobile-local-chat-smoke.test.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.test.mjs
@@ -597,14 +597,14 @@ describe("resolveMobileSmokeNumericEnv", () => {
   it("accepts canonical timer and count overrides through the Node ceiling", () => {
     const parsed = smoke.resolveMobileSmokeNumericEnv({
       ANDROID_FULL_TURN_TIMEOUT_MS: "800",
-      ANDROID_HEALTH_PROBE_TIMEOUT_MS: String(smoke.MAX_TIMER_DELAY_MS),
+      ANDROID_HEALTH_PROBE_TIMEOUT_MS: "60000",
       ANDROID_TRANSIENT_RETRY_ATTEMPTS: "1",
       ANDROID_STABILITY_DELAY_MS: "0",
       ANDROID_SMOKE_MODEL_CONTEXT_SIZE: "4096",
       ANDROID_SMOKE_MODEL_SIZE_BYTES: "4",
     });
     expect(parsed.androidFullTurnTimeoutMs).toBe(800);
-    expect(parsed.androidHealthProbeTimeoutMs).toBe(smoke.MAX_TIMER_DELAY_MS);
+    expect(parsed.androidHealthProbeTimeoutMs).toBe(60000);
     expect(parsed.androidTransientRetryAttempts).toBe(1);
     expect(parsed.androidStabilityDelayMs).toBe(0);
     expect(parsed.androidSmokeModelContextSize).toBe(4096);
@@ -660,7 +660,7 @@ describe("resolveMobileSmokeNumericEnv", () => {
     ).toBe(0);
   });
 
-  it("bounds context sizes at the model's advertised 128k", () => {
+  it("bounds context sizes at the operational cap, rejecting the known-OOM full width", () => {
     for (const name of [
       "IOS_FULL_BUN_SMOKE_CONTEXT_SIZE",
       "ANDROID_SMOKE_MODEL_CONTEXT_SIZE",
@@ -670,8 +670,11 @@ describe("resolveMobileSmokeNumericEnv", () => {
           [name]: String(smoke.MAX_MODEL_CONTEXT_TOKENS),
         }),
       ).toBeTruthy();
+      // 131072 is the model's format ceiling AND the documented phone OOM
+      // width — it must be a rejection case, not the bound.
       for (const value of [
         String(smoke.MAX_MODEL_CONTEXT_TOKENS + 1),
+        "131072",
         String(Number.MAX_SAFE_INTEGER),
       ]) {
         expect(() =>
@@ -704,6 +707,30 @@ describe("resolveMobileSmokeNumericEnv", () => {
     ).toThrow(/ANDROID_SMOKE_MODEL_SIZE_BYTES/);
   });
 
+  it("budgets count per-attempt work, not only delay (review counterexamples)", () => {
+    // 10000 attempts at delay 0 with a max probe timeout asserted a zero
+    // delay-budget but could consume ~680 years of probe work.
+    expect(() =>
+      smoke.resolveMobileSmokeNumericEnv({
+        ANDROID_TRANSIENT_RETRY_ATTEMPTS: String(smoke.MAX_LOOP_COUNT),
+        ANDROID_TRANSIENT_RETRY_DELAY_MS: "0",
+        ANDROID_HEALTH_PROBE_TIMEOUT_MS: String(smoke.MAX_TIMER_DELAY_MS),
+      }),
+    ).toThrow(/loop budget/);
+    // A max probe or full-turn timeout alone now exceeds the composite
+    // stability/retry budgets at the documented default attempt counts.
+    expect(() =>
+      smoke.resolveMobileSmokeNumericEnv({
+        ANDROID_HEALTH_PROBE_TIMEOUT_MS: String(smoke.MAX_TIMER_DELAY_MS),
+      }),
+    ).toThrow(/loop budget/);
+    expect(() =>
+      smoke.resolveMobileSmokeNumericEnv({
+        ANDROID_FULL_TURN_TIMEOUT_MS: String(smoke.MAX_TIMER_DELAY_MS),
+      }),
+    ).toThrow(/loop budget/);
+  });
+
   it("rejects over-budget loop combinations and inconsistent stability windows", () => {
     // 10_000 attempts × 8_640_001ms ≈ 2.7 years — each value alone is legal.
     expect(() =>
@@ -726,6 +753,31 @@ describe("resolveMobileSmokeNumericEnv", () => {
     ).toThrow(/ANDROID_STABILITY_SAMPLES.*exceeds ANDROID_STABILITY_ATTEMPTS/);
     // The documented defaults stay well inside every budget.
     expect(smoke.resolveMobileSmokeNumericEnv({})).toBeTruthy();
+  });
+});
+
+describe("readiness request timeout boundary", () => {
+  it("a never-settling readiness fetch rejects within the probe timeout", async () => {
+    // requestOptionalJson used to issue an un-timed fetch, so one hung
+    // readiness endpoint outlived any loop budget. Harness probe timeout is
+    // 50ms (module preamble), so the hang must reject fast.
+    const hang = Bun.serve({
+      port: 0,
+      fetch: () => new Promise(() => {}),
+    });
+    try {
+      const startedAt = Date.now();
+      await expect(
+        smoke.requestOptionalJson(
+          "GET",
+          "/api/local-inference/hub",
+          `http://127.0.0.1:${hang.port}`,
+        ),
+      ).rejects.toThrow();
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+    } finally {
+      hang.stop(true);
+    }
   });
 });
 

--- a/packages/app/scripts/mobile-local-chat-smoke.test.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.test.mjs
@@ -1,10 +1,14 @@
 /**
  * Exercises the mobile smoke CLI's host-side protocol, parsing, retry, and filesystem boundaries.
+ * Also covers fail-closed numeric env overrides so a typo cannot become a 1 ms
+ * timer or skip the AbortController timeout gate.
  */
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const fakeDirectory = fs.mkdtempSync(
   path.join(os.tmpdir(), "eliza-mobile-tools-"),
@@ -542,5 +546,123 @@ describe("mobile smoke failure states", () => {
       diagnostics.keys["eliza:ios-full-bun-smoke:request"].defaultsValue,
     ).toBeNull();
     await smoke.main();
+  });
+});
+
+const SMOKE_SCRIPT = fileURLToPath(
+  new URL("./mobile-local-chat-smoke.mjs", import.meta.url),
+);
+
+function runSmokeCli(envOverrides) {
+  return spawnSync(process.execPath, [SMOKE_SCRIPT, "--platform", "skip"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...envOverrides,
+    },
+    timeout: 8_000,
+  });
+}
+
+describe("resolveMobileSmokeNumericEnv", () => {
+  it("keeps documented defaults when knobs are unset or empty", () => {
+    expect(smoke.resolveMobileSmokeNumericEnv({})).toMatchObject({
+      androidFullTurnTimeoutMs: smoke.DEFAULT_ANDROID_FULL_TURN_TIMEOUT_MS,
+      androidHealthProbeTimeoutMs:
+        smoke.DEFAULT_ANDROID_HEALTH_PROBE_TIMEOUT_MS,
+      androidTransientRetryAttempts:
+        smoke.DEFAULT_ANDROID_TRANSIENT_RETRY_ATTEMPTS,
+      androidSmokeModelContextSize:
+        smoke.DEFAULT_ANDROID_SMOKE_MODEL_CONTEXT_SIZE,
+      androidSmokeModelSizeBytesOverride: null,
+    });
+    expect(
+      smoke.resolveMobileSmokeNumericEnv({
+        ANDROID_FULL_TURN_TIMEOUT_MS: "",
+        ANDROID_HEALTH_PROBE_TIMEOUT_MS: "   ",
+      }).androidFullTurnTimeoutMs,
+    ).toBe(smoke.DEFAULT_ANDROID_FULL_TURN_TIMEOUT_MS);
+  });
+
+  it("accepts canonical timer and count overrides through the Node ceiling", () => {
+    const parsed = smoke.resolveMobileSmokeNumericEnv({
+      ANDROID_FULL_TURN_TIMEOUT_MS: "800",
+      ANDROID_HEALTH_PROBE_TIMEOUT_MS: String(smoke.MAX_TIMER_DELAY_MS),
+      ANDROID_TRANSIENT_RETRY_ATTEMPTS: "1",
+      ANDROID_STABILITY_DELAY_MS: "0",
+      ANDROID_SMOKE_MODEL_CONTEXT_SIZE: "4096",
+      ANDROID_SMOKE_MODEL_SIZE_BYTES: "4",
+    });
+    expect(parsed.androidFullTurnTimeoutMs).toBe(800);
+    expect(parsed.androidHealthProbeTimeoutMs).toBe(smoke.MAX_TIMER_DELAY_MS);
+    expect(parsed.androidTransientRetryAttempts).toBe(1);
+    expect(parsed.androidStabilityDelayMs).toBe(0);
+    expect(parsed.androidSmokeModelContextSize).toBe(4096);
+    expect(parsed.androidSmokeModelSizeBytesOverride).toBe(4);
+  });
+
+  it("rejects scientific notation, partial tokens, and timer overflow", () => {
+    for (const value of [
+      "1e3",
+      "8abc",
+      "0x10",
+      "0.4",
+      "abc",
+      "-1",
+      "0",
+      String(smoke.MAX_TIMER_DELAY_MS + 1),
+    ]) {
+      expect(() =>
+        smoke.resolveMobileSmokeNumericEnv({
+          ANDROID_FULL_TURN_TIMEOUT_MS: value,
+        }),
+      ).toThrow(/ANDROID_FULL_TURN_TIMEOUT_MS/);
+    }
+    expect(() =>
+      smoke.resolveMobileSmokeNumericEnv({
+        ANDROID_HEALTH_PROBE_TIMEOUT_MS: "abc",
+      }),
+    ).toThrow(/ANDROID_HEALTH_PROBE_TIMEOUT_MS/);
+    expect(() =>
+      smoke.resolveMobileSmokeNumericEnv({
+        ANDROID_TRANSIENT_RETRY_ATTEMPTS: "1e3",
+      }),
+    ).toThrow(/ANDROID_TRANSIENT_RETRY_ATTEMPTS/);
+    expect(() =>
+      smoke.resolveMobileSmokeNumericEnv({
+        ANDROID_SMOKE_MODEL_CONTEXT_SIZE: "8abc",
+      }),
+    ).toThrow(/ANDROID_SMOKE_MODEL_CONTEXT_SIZE/);
+  });
+});
+
+describe("mobile smoke numeric env CLI boundary", () => {
+  it("rejects ANDROID_FULL_TURN_TIMEOUT_MS=1e3 before device or API work", () => {
+    const result = runSmokeCli({ ANDROID_FULL_TURN_TIMEOUT_MS: "1e3" });
+    expect(result.status).not.toBe(0);
+    const combined = `${result.stdout}${result.stderr}`;
+    expect(combined).toMatch(/ANDROID_FULL_TURN_TIMEOUT_MS/);
+    expect(combined).not.toContain("timed out after 1ms");
+    expect(combined).not.toContain("TimeoutOverflowWarning");
+    expect(combined).not.toContain("[local-chat-smoke]");
+  });
+
+  it("rejects overflowing and partial timeout tokens before spawn work", () => {
+    for (const value of ["8abc", "2147483648", "0.4"]) {
+      const result = runSmokeCli({ ANDROID_FULL_TURN_TIMEOUT_MS: value });
+      expect(result.status).not.toBe(0);
+      const combined = `${result.stdout}${result.stderr}`;
+      expect(combined).toMatch(/ANDROID_FULL_TURN_TIMEOUT_MS/);
+      expect(combined).not.toContain("TimeoutOverflowWarning");
+      expect(combined).not.toContain("[local-chat-smoke]");
+    }
+  });
+
+  it("rejects ANDROID_HEALTH_PROBE_TIMEOUT_MS=abc instead of hanging without a timer", () => {
+    const result = runSmokeCli({ ANDROID_HEALTH_PROBE_TIMEOUT_MS: "abc" });
+    expect(result.status).not.toBe(0);
+    const combined = `${result.stdout}${result.stderr}`;
+    expect(combined).toMatch(/ANDROID_HEALTH_PROBE_TIMEOUT_MS/);
+    expect(combined).not.toContain("[local-chat-smoke]");
   });
 });

--- a/packages/app/scripts/mobile-local-chat-smoke.test.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.test.mjs
@@ -565,13 +565,23 @@ function runSmokeCli(envOverrides) {
 }
 
 describe("resolveMobileSmokeNumericEnv", () => {
-  it("keeps documented defaults when knobs are unset or empty", () => {
-    expect(smoke.resolveMobileSmokeNumericEnv({})).toMatchObject({
+  it("keeps every documented default when knobs are unset or empty", () => {
+    expect(smoke.resolveMobileSmokeNumericEnv({})).toEqual({
+      iosFullBunSmokeContextSize: smoke.DEFAULT_IOS_FULL_BUN_SMOKE_CONTEXT_SIZE,
       androidFullTurnTimeoutMs: smoke.DEFAULT_ANDROID_FULL_TURN_TIMEOUT_MS,
       androidHealthProbeTimeoutMs:
         smoke.DEFAULT_ANDROID_HEALTH_PROBE_TIMEOUT_MS,
       androidTransientRetryAttempts:
         smoke.DEFAULT_ANDROID_TRANSIENT_RETRY_ATTEMPTS,
+      androidTransientRetryDelayMs:
+        smoke.DEFAULT_ANDROID_TRANSIENT_RETRY_DELAY_MS,
+      androidStabilitySamples: smoke.DEFAULT_ANDROID_STABILITY_SAMPLES,
+      androidStabilityDelayMs: smoke.DEFAULT_ANDROID_STABILITY_DELAY_MS,
+      androidStabilityAttempts: smoke.DEFAULT_ANDROID_STABILITY_ATTEMPTS,
+      androidLocalInferenceReadyAttempts:
+        smoke.DEFAULT_ANDROID_LOCAL_INFERENCE_READY_ATTEMPTS,
+      androidLocalInferenceReadyDelayMs:
+        smoke.DEFAULT_ANDROID_LOCAL_INFERENCE_READY_DELAY_MS,
       androidSmokeModelContextSize:
         smoke.DEFAULT_ANDROID_SMOKE_MODEL_CONTEXT_SIZE,
       androidSmokeModelSizeBytesOverride: null,
@@ -633,6 +643,89 @@ describe("resolveMobileSmokeNumericEnv", () => {
         ANDROID_SMOKE_MODEL_CONTEXT_SIZE: "8abc",
       }),
     ).toThrow(/ANDROID_SMOKE_MODEL_CONTEXT_SIZE/);
+  });
+
+  it("rejects leading-zero spellings the shared helpers would accept", () => {
+    expect(() =>
+      smoke.resolveMobileSmokeNumericEnv({
+        ANDROID_TRANSIENT_RETRY_ATTEMPTS: "0008",
+      }),
+    ).toThrow(/ANDROID_TRANSIENT_RETRY_ATTEMPTS.*leading zeros/);
+    expect(() =>
+      smoke.resolveMobileSmokeNumericEnv({ ANDROID_STABILITY_DELAY_MS: "00" }),
+    ).toThrow(/ANDROID_STABILITY_DELAY_MS.*leading zeros/);
+    expect(
+      smoke.resolveMobileSmokeNumericEnv({ ANDROID_STABILITY_DELAY_MS: "0" })
+        .androidStabilityDelayMs,
+    ).toBe(0);
+  });
+
+  it("bounds context sizes at the model's advertised 128k", () => {
+    for (const name of [
+      "IOS_FULL_BUN_SMOKE_CONTEXT_SIZE",
+      "ANDROID_SMOKE_MODEL_CONTEXT_SIZE",
+    ]) {
+      expect(
+        smoke.resolveMobileSmokeNumericEnv({
+          [name]: String(smoke.MAX_MODEL_CONTEXT_TOKENS),
+        }),
+      ).toBeTruthy();
+      for (const value of [
+        String(smoke.MAX_MODEL_CONTEXT_TOKENS + 1),
+        String(Number.MAX_SAFE_INTEGER),
+      ]) {
+        expect(() =>
+          smoke.resolveMobileSmokeNumericEnv({ [name]: value }),
+        ).toThrow(new RegExp(name));
+      }
+    }
+  });
+
+  it("bounds count knobs at the operational loop maximum", () => {
+    for (const name of [
+      "ANDROID_TRANSIENT_RETRY_ATTEMPTS",
+      "ANDROID_STABILITY_SAMPLES",
+      "ANDROID_STABILITY_ATTEMPTS",
+      "ANDROID_LOCAL_INFERENCE_READY_ATTEMPTS",
+    ]) {
+      for (const value of [
+        String(smoke.MAX_LOOP_COUNT + 1),
+        String(Number.MAX_SAFE_INTEGER),
+      ]) {
+        expect(() =>
+          smoke.resolveMobileSmokeNumericEnv({ [name]: value }),
+        ).toThrow(new RegExp(name));
+      }
+    }
+    expect(() =>
+      smoke.resolveMobileSmokeNumericEnv({
+        ANDROID_SMOKE_MODEL_SIZE_BYTES: String(smoke.MAX_MODEL_SIZE_BYTES + 1),
+      }),
+    ).toThrow(/ANDROID_SMOKE_MODEL_SIZE_BYTES/);
+  });
+
+  it("rejects over-budget loop combinations and inconsistent stability windows", () => {
+    // 10_000 attempts × 8_640_001ms ≈ 2.7 years — each value alone is legal.
+    expect(() =>
+      smoke.resolveMobileSmokeNumericEnv({
+        ANDROID_LOCAL_INFERENCE_READY_ATTEMPTS: String(smoke.MAX_LOOP_COUNT),
+        ANDROID_LOCAL_INFERENCE_READY_DELAY_MS: "8640001",
+      }),
+    ).toThrow(/loop budget/);
+    expect(() =>
+      smoke.resolveMobileSmokeNumericEnv({
+        ANDROID_TRANSIENT_RETRY_ATTEMPTS: "100",
+        ANDROID_TRANSIENT_RETRY_DELAY_MS: "864001",
+      }),
+    ).toThrow(/ANDROID_TRANSIENT_RETRY_ATTEMPTS.*loop budget/s);
+    expect(() =>
+      smoke.resolveMobileSmokeNumericEnv({
+        ANDROID_STABILITY_SAMPLES: "10",
+        ANDROID_STABILITY_ATTEMPTS: "5",
+      }),
+    ).toThrow(/ANDROID_STABILITY_SAMPLES.*exceeds ANDROID_STABILITY_ATTEMPTS/);
+    // The documented defaults stay well inside every budget.
+    expect(smoke.resolveMobileSmokeNumericEnv({})).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
# Relates to

Same defect family as #19600/#19601 (fail-open numeric CLI/env parsing in repo scripts); this PR covers the `packages/app/scripts` mobile smoke lane. Filed PR-direct with the full defect evidence below rather than as a separate issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop` (`75b83886e5`) with zero conflicts.
- [x] `bun install` was run; focused gates below. Root `bun run verify` was not run end-to-end in this environment — recorded in **Known gaps / failures** with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6 (defect reproductions and implementation in a local Grok Build lane, committed as ss251); anthropic/claude-fable-5 (independent review, fail-proof verification, publish)
<!-- attribution-row:client -->
- Agent tooling: Grok Build CLI; Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from the latest `origin/develop` (`75b83886e5`); zero conflicts on cherry-pick.
- [x] Focused gates pass post-sync; the root `bun run verify` blocker (pre-existing, unrelated) is documented in **Known gaps / failures**.

# Risks

Low. The diff touches one operator smoke script and its new test file. Behavior changes to weigh (revised per review — counts and context sizes now carry per-consumer operational maxima rather than `Number.MAX_SAFE_INTEGER`):

- All numeric env knobs now resolve once at module load through `resolveMobileSmokeNumericEnv()`; a malformed value fails the script immediately — including invocations that would only print usage — instead of running a device lane with a silently wrong timeout. For a smoke lane that bills device/CI minutes, failing before any work is the intended direction.
- Unset/empty values keep the exact documented defaults (pinned by tests); valid explicit values are unchanged.

# Background

## What does this PR do?

`packages/app/scripts/mobile-local-chat-smoke.mjs` parsed every timing/count env knob with bare `Number.parseInt`, so malformed values silently became different valid numbers. Confirmed live reproductions (mock `/api/health` + hub-ready + hanging `/messages/stream`):

- `ANDROID_FULL_TURN_TIMEOUT_MS=1e3` → "timed out after 1ms" in 0.12s (`parseInt("1e3")===1`); control `800` behaved correctly. `8abc` → 8ms. `2147483648` → `TimeoutOverflowWarning`, Node clamps the timer to 1ms while the message still claims 2147483648ms.
- `ANDROID_HEALTH_PROBE_TIMEOUT_MS=abc` → NaN fails the `timeoutMs > 0` gate, so the AbortController is never armed and the probe fetch hung until an external SIGKILL — a typo disabled the timeout entirely.
- The same unguarded parse covered `ANDROID_TRANSIENT_RETRY_*`, `ANDROID_STABILITY_*`, `ANDROID_LOCAL_INFERENCE_READY_*`, `ANDROID_SMOKE_MODEL_CONTEXT_SIZE`, and `IOS_FULL_BUN_SMOKE_CONTEXT_SIZE`.

The fix reuses the script directory's existing fail-closed helpers (`parsePositiveSafeInteger` / `parseNonNegativeSafeInteger` / `MAX_TIMER_DELAY_MS` from `lib/host-agent.mjs`): one exported resolver returns all knobs, timer knobs are bounded `1..2147483647`, delays allow `0`, counts require `≥1`, unset/empty keep the documented defaults, and any other token throws naming the variable before any device or API work.

## What kind of change is this?

Bug fix (non-breaking for valid input; malformed input now fails loudly before spending device/CI time).

# Documentation changes needed?

My changes do not require a change to the project documentation. The file header documents the fail-closed contract.

# Testing

## Where should a reviewer start?

`resolveMobileSmokeNumericEnv()` in `packages/app/scripts/mobile-local-chat-smoke.mjs`, then `mobile-local-chat-smoke.test.mjs` (co-located, matching the directory's existing `*.test.mjs` convention).

## Detailed testing steps

1. `bun test packages/app/scripts/mobile-local-chat-smoke.test.mjs` — 27 pass / 0 fail at this head: every documented default pinned exactly (all eleven knobs plus the null size override), each coercion rejected (`1e3`, `8abc`, `2147483648`, `abc`, fractions, hex, and canonical-spelling rejections like `0008`), and per-knob operational bounds enforced: context sizes ≤ 32768 (the 131072 format ceiling is the documented phone OOM width and is an explicit rejection case), counts ≤ 10000, size override ≤ 1 TiB, plus relational and composite work-inclusive budgets (stability samples ≤ attempts; each loop's attempts × per-attempt work-plus-delay ≤ 24h, with the stability budget nesting the full transient-retry budget and readiness fetches carrying the bounded probe timeout).
2. Fail-proof: restore only the production file to `origin/develop` and rerun — the suite fails on the rejection assertions (the old parser accepts the coercions); restore, 27 pass / 0 fail.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:61cefec30a874c7a1091f13a0c9d7735cb334b50 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - operator CLI smoke script; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - operator CLI smoke script; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user flow; behavior is env parsing at module load.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no server code path; the reproduction transcripts are inline below.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code path.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - deterministic env parsing; no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: reproduction and suite transcripts inline:

```
$ ANDROID_FULL_TURN_TIMEOUT_MS=1e3 ANDROID_STABILITY_SAMPLES=1 ANDROID_TRANSIENT_RETRY_ATTEMPTS=1 \
    node packages/app/scripts/mobile-local-chat-smoke.mjs --platform skip --api-base http://127.0.0.1:$PORT
[before, at origin/develop] timed out after 1ms   (wall clock 0.12s; control with 800 -> "timed out after 800ms" in 0.91s)
[before] ANDROID_FULL_TURN_TIMEOUT_MS=2147483648 -> TimeoutOverflowWarning: 2147483648 does not fit into a 32-bit signed integer; died in 0.10s
[before] ANDROID_HEALTH_PROBE_TIMEOUT_MS=abc against a hang-on-health local endpoint -> AbortController never armed, fetch hung until SIGKILL at 4s

$ bun test packages/app/scripts/mobile-local-chat-smoke.test.mjs   # at this head 61cefec30a
 27 pass
 0 fail
Ran 27 tests across 1 file.

$ git checkout origin/develop -- packages/app/scripts/mobile-local-chat-smoke.mjs && bun test packages/app/scripts/mobile-local-chat-smoke.test.mjs
error: expect(received).not.toBe(expected)   # rejection assertions fail against the old parser

$ git checkout HEAD -- packages/app/scripts/mobile-local-chat-smoke.mjs && bun test packages/app/scripts/mobile-local-chat-smoke.test.mjs
 27 pass
 0 fail
```
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic env parsing; no agent behavior involved.

## Backend + frontend logs

N/A - operator smoke script; the mocked-API reproduction transcripts above show the real code path (env parse → timer arming → probe abort) end to end.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

### Before

N/A - see reproduction transcript above.

### After

N/A - see suite transcript above.

### Walkthrough video

N/A - no user flow.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

- Root `bun run verify` was not run end-to-end in this environment; the pre-existing, unrelated blocker in this checkout is `packages/scripts/__tests__/e2e-coverage.test.ts` failing on `Cannot find module '@elizaos/core'` from an unbuilt workspace — identical without this diff, which touches only `packages/app/scripts/`. CI's required lanes run the same suites on a fully built tree.
- Biome on both touched files: clean.
- The full smoke lane against a real device/simulator was not run (no device in this environment); the reproductions used the script's own mocked-API path and the change is confined to env resolution ahead of the device flow.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-eliza"} -->

