### PR TITLE
fix(plugin-calendar): reject impossible ISO calendar dates with Z or explicit offset

### DIFF
--- a/plugins/plugin-calendar/src/internal/calendar-normalize.test.ts
+++ b/plugins/plugin-calendar/src/internal/calendar-normalize.test.ts
@@ -81,6 +81,24 @@ describe("normalizeCalendarDateTimeInTimeZone — Z/offset path", () => {
     expectInvalidDate("2026-04-31T09:00:00-05:00", "startAt");
   });
 
+  it("rejects Feb 30 with compact positive offset (#19222)", () => {
+    expectInvalidDate("2026-02-30T09:00:00+0000", "startAt");
+  });
+
+  it("rejects Feb 30 with compact negative offset (#19222)", () => {
+    expectInvalidDate("2026-02-30T09:00:00-0500", "startAt");
+  });
+
+  it("accepts a valid compact offset datetime", () => {
+    expect(
+      normalizeCalendarDateTimeInTimeZone(
+        "2026-06-15T09:00:00+0200",
+        "startAt",
+        "UTC",
+      ),
+    ).toBe("2026-06-15T07:00:00.000Z");
+  });
+
   it("rejects an impossible month", () => {
     expectInvalidDate("2026-13-15T09:00:00Z", "startAt");
   });

--- a/plugins/plugin-calendar/src/internal/calendar-normalize.test.ts
+++ b/plugins/plugin-calendar/src/internal/calendar-normalize.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for the Z/offset path of `normalizeCalendarDateTimeInTimeZone`.
+ * JavaScript's `Date.parse` silently rolls over impossible dates like
+ * 2026-02-30 to March 2; the helper must reject those before they reach the
+ * pipeline (#19222).
+ */
+import { describe, expect, it } from "vitest";
+import { normalizeCalendarDateTimeInTimeZone } from "./calendar-normalize.js";
+import { CalendarServiceError } from "./errors.js";
+
+const expectInvalidDate = (
+  text: string,
+  field: string,
+): CalendarServiceError => {
+  try {
+    normalizeCalendarDateTimeInTimeZone(text, field, "UTC");
+  } catch (error) {
+    expect(error).toBeInstanceOf(CalendarServiceError);
+    expect((error as CalendarServiceError).status).toBe(400);
+    return error as CalendarServiceError;
+  }
+  throw new Error(
+    `normalizeCalendarDateTimeInTimeZone(${JSON.stringify(text)}) should have failed`,
+  );
+};
+
+describe("normalizeCalendarDateTimeInTimeZone — Z/offset path", () => {
+  it("accepts a valid UTC ISO datetime", () => {
+    expect(
+      normalizeCalendarDateTimeInTimeZone(
+        "2026-06-15T09:00:00Z",
+        "startAt",
+        "UTC",
+      ),
+    ).toBe("2026-06-15T09:00:00.000Z");
+  });
+
+  it("accepts a valid UTC ISO datetime with milliseconds", () => {
+    expect(
+      normalizeCalendarDateTimeInTimeZone(
+        "2026-06-15T09:00:00.123Z",
+        "startAt",
+        "UTC",
+      ),
+    ).toBe("2026-06-15T09:00:00.123Z");
+  });
+
+  it("accepts a valid offset ISO datetime", () => {
+    expect(
+      normalizeCalendarDateTimeInTimeZone(
+        "2026-06-15T11:00:00+02:00",
+        "startAt",
+        "UTC",
+      ),
+    ).toBe("2026-06-15T09:00:00.000Z");
+  });
+
+  it("rejects an impossible Feb 30 with Z suffix (#19222)", () => {
+    expectInvalidDate("2026-02-30T09:00:00Z", "startAt");
+  });
+
+  it("rejects Feb 30 with explicit offset (#19222)", () => {
+    expectInvalidDate("2026-02-30T09:00:00+00:00", "startAt");
+  });
+
+  it("rejects non-leap-year Feb 29 (#19222)", () => {
+    expectInvalidDate("2026-02-29T09:00:00Z", "startAt");
+  });
+
+  it("accepts Feb 29 in a leap year", () => {
+    expect(
+      normalizeCalendarDateTimeInTimeZone(
+        "2024-02-29T09:00:00Z",
+        "startAt",
+        "UTC",
+      ),
+    ).toBe("2024-02-29T09:00:00.000Z");
+  });
+
+  it("rejects April 31 with offset (#19222)", () => {
+    expectInvalidDate("2026-04-31T09:00:00-05:00", "startAt");
+  });
+
+  it("rejects an impossible month", () => {
+    expectInvalidDate("2026-13-15T09:00:00Z", "startAt");
+  });
+
+  it("rejects an impossible day-of-month (day 32)", () => {
+    expectInvalidDate("2026-01-32T09:00:00Z", "startAt");
+  });
+});


### PR DESCRIPTION
## Summary

`normalizeCalendarDateTimeInTimeZone` passed `Z`/explicit-offset inputs straight to `normalizeIsoString`, which uses `Date.parse()`. JavaScript silently rolls over impossible dates — `2026-02-30T09:00:00Z` becomes `2026-03-02T09:00:00.000Z` — so create/update requests could write a different date than the operator specified.

## Fix

Add a `validateCalendarDate` guard that rejects impossible month/day/leap-day combinations on the `Z`/offset path before they reach the pipeline. Scoped to that path so existing local-date (`YYYY-MM-DD` without offset) and historical behaviour is preserved.

## Reproduction (before)

```
normalizeCalendarDateTimeInTimeZone("2026-02-30T09:00:00Z", "startAt", "UTC")
// => "2026-03-02T09:00:00.000Z"  (silent rollover)
```

## After

```
// => CalendarServiceError(400) "startAt must be a valid calendar date"
```

## Tests

Added `calendar-normalize.test.ts` — 10 cases covering valid UTC/offset/leap-year and invalid Feb 30 (Z + offset), non-leap Feb 29, April 31, month 13, day 32.

## Verification

- `vitest run src/internal/calendar-normalize.test.ts` — 10/10 pass
- `tsc --noEmit` — clean

Closes #19222

<!-- evidence-head:d5dd3e420a095756d01eadbf8d351b4ef8ee66a6 -->

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic offline unit tests; vitest 13/13 shown in PR checks

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI change; pure date-normalization logic

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI change; pure date-normalization logic

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI change; pure date-normalization logic

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path touched

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/agent/prompt behavior change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain state change


---

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `z.ai/glm-5.2`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [sharkwon]


