### PR TITLE
fix(plugin-app-control): a static app is not a failed worker spawn

### DIFF
--- a/plugins/plugin-app-control/src/services/__tests__/app-worker-host.test.ts
+++ b/plugins/plugin-app-control/src/services/__tests__/app-worker-host.test.ts
@@ -514,9 +514,23 @@ describe("AppWorkerHostService worker bridge", () => {
 			} as unknown as IAgentRuntime;
 		}
 
-		it("does not import a source file the package never declared", async () => {
-			// Declares an entry that is absent (unbuilt static app) but ships a
-			// src/index.ts a naive fallback would have imported.
+		function validPluginSource(name: string): string {
+			return `export default {
+	name: "${name}",
+	actions: [{
+		name: "SOURCE_PING",
+		description: "fixture",
+		similes: [],
+		validate: async () => true,
+		handler: async () => ({ success: true }),
+	}],
+};\n`;
+		}
+
+		it("classifies a source module with no plugin export as static", async () => {
+			// Local app loading deliberately falls back to source when the declared
+			// build is absent. Capability is decided from the loaded module, not file
+			// absence, so valid source plugins are not silently disabled.
 			const dir = mkdtempSync(path.join(tmpdir(), "app-static-"));
 			writeFileSync(
 				path.join(dir, "package.json"),
@@ -545,33 +559,77 @@ describe("AppWorkerHostService worker bridge", () => {
 			expect(result.reason).toContain("No worker plugin entry found");
 		});
 
-		it("still uses the conventional fallbacks when nothing is declared", async () => {
+		it("boots a valid source plugin when its declared build is absent", async () => {
 			const dir = mkdtempSync(path.join(tmpdir(), "app-undeclared-"));
 			writeFileSync(
 				path.join(dir, "package.json"),
-				JSON.stringify({ name: "undeclared-app" }),
+				JSON.stringify({ name: "source-plugin", main: "./dist/index.js" }),
 			);
 			mkdirSync(path.join(dir, "src"), { recursive: true });
-			writeFileSync(path.join(dir, "src", "index.ts"), "export default {};\n");
+			writeFileSync(
+				path.join(dir, "src", "index.ts"),
+				validPluginSource("source-plugin"),
+			);
 
 			const svc = new AppWorkerHostService(
 				makeRegistryRuntime({
-					slug: "undeclared-app",
+					slug: "source-plugin",
 					directory: dir,
 					isolation: "worker",
 				}),
 			);
-			// Resolution succeeds here, so the call proceeds to a real spawn — which
-			// may then reject because the fixture is not a plugin. Either way it got
-			// PAST classification, which is the only thing this pins.
-			const outcome = await svc
-				.startForRegisteredApp("undeclared-app")
-				.then((r) => (r.ok ? "ok" : r.kind))
-				.catch(() => "threw-during-spawn");
-			await svc.stop().catch(() => {});
+			const outcome = await svc.startForRegisteredApp("source-plugin");
+			await svc.stop();
 			rmSync(dir, { recursive: true, force: true });
 
-			expect(outcome).not.toBe("no-worker-surface");
+			expect(outcome.ok).toBe(true);
+		});
+
+		it("reports a missing declared worker artifact when no source fallback exists", async () => {
+			const dir = mkdtempSync(path.join(tmpdir(), "app-missing-worker-"));
+			writeFileSync(
+				path.join(dir, "package.json"),
+				JSON.stringify({ name: "missing-worker", main: "./dist/index.js" }),
+			);
+			const svc = new AppWorkerHostService(
+				makeRegistryRuntime({
+					slug: "missing-worker",
+					directory: dir,
+					isolation: "worker",
+				}),
+			);
+			const outcome = await svc.startForRegisteredApp("missing-worker");
+			rmSync(dir, { recursive: true, force: true });
+
+			expect(outcome.ok).toBe(false);
+			if (outcome.ok) return;
+			expect(outcome.kind).toBe("error");
+			expect(outcome.reason).toContain("No worker plugin entry found");
+		});
+
+		it("keeps the conventional source fallback for legacy packages with no entry", async () => {
+			const dir = mkdtempSync(path.join(tmpdir(), "app-legacy-worker-"));
+			writeFileSync(
+				path.join(dir, "package.json"),
+				JSON.stringify({ name: "legacy-worker" }),
+			);
+			mkdirSync(path.join(dir, "src"), { recursive: true });
+			writeFileSync(
+				path.join(dir, "src", "index.ts"),
+				validPluginSource("legacy-worker"),
+			);
+			const svc = new AppWorkerHostService(
+				makeRegistryRuntime({
+					slug: "legacy-worker",
+					directory: dir,
+					isolation: "worker",
+				}),
+			);
+			const outcome = await svc.startForRegisteredApp("legacy-worker");
+			await svc.stop();
+			rmSync(dir, { recursive: true, force: true });
+
+			expect(outcome.ok).toBe(true);
 		});
 	});
 });

--- a/plugins/plugin-app-control/src/services/__tests__/app-worker-host.test.ts
+++ b/plugins/plugin-app-control/src/services/__tests__/app-worker-host.test.ts
@@ -18,7 +18,7 @@
  * by the registry-to-worker end-to-end test.
  */
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import http from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -490,6 +490,88 @@ describe("AppWorkerHostService worker bridge", () => {
 			expect(reply.ok).toBe(false);
 			if (reply.ok) return;
 			expect(reply.reason).toContain("escapes the sandbox statePath");
+		});
+	});
+
+	// `trust: "external"` promotes EVERY registered app to isolation:"worker",
+	// including static frontend apps that ship no agent-side module. Those apps
+	// declare `main: "./dist/index.js"` for their bundler; the file is not a
+	// plugin and often is not built. Resolving through to some source file the
+	// package never pointed at made every one of them boot, import a React
+	// entry, and report "no plugin export found in module" — 20 warnings per
+	// boot on a real install, burying the spawns that actually broke.
+	describe("apps with no worker surface are classified, not failed", () => {
+		function makeRegistryRuntime(entry: Record<string, unknown>) {
+			return {
+				agentId: "00000000-0000-0000-0000-000000000001",
+				getService: (type: string) =>
+					type === "app-registry"
+						? {
+								list: async () => [entry],
+								getPermissionsView: async () => null,
+							}
+						: null,
+			} as unknown as IAgentRuntime;
+		}
+
+		it("does not import a source file the package never declared", async () => {
+			// Declares an entry that is absent (unbuilt static app) but ships a
+			// src/index.ts a naive fallback would have imported.
+			const dir = mkdtempSync(path.join(tmpdir(), "app-static-"));
+			writeFileSync(
+				path.join(dir, "package.json"),
+				JSON.stringify({ name: "static-app", main: "./dist/index.js" }),
+			);
+			mkdirSync(path.join(dir, "src"), { recursive: true });
+			writeFileSync(
+				path.join(dir, "src", "index.ts"),
+				"export const ui = 1;\n",
+			);
+
+			const svc = new AppWorkerHostService(
+				makeRegistryRuntime({
+					slug: "static-app",
+					directory: dir,
+					isolation: "worker",
+				}),
+			);
+			const result = await svc.startForRegisteredApp("static-app");
+			rmSync(dir, { recursive: true, force: true });
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			// Classified as "no surface", so the caller logs it at debug.
+			expect(result.kind).toBe("no-worker-surface");
+			expect(result.reason).toContain("No worker plugin entry found");
+		});
+
+		it("still uses the conventional fallbacks when nothing is declared", async () => {
+			const dir = mkdtempSync(path.join(tmpdir(), "app-undeclared-"));
+			writeFileSync(
+				path.join(dir, "package.json"),
+				JSON.stringify({ name: "undeclared-app" }),
+			);
+			mkdirSync(path.join(dir, "src"), { recursive: true });
+			writeFileSync(path.join(dir, "src", "index.ts"), "export default {};\n");
+
+			const svc = new AppWorkerHostService(
+				makeRegistryRuntime({
+					slug: "undeclared-app",
+					directory: dir,
+					isolation: "worker",
+				}),
+			);
+			// Resolution succeeds here, so the call proceeds to a real spawn — which
+			// may then reject because the fixture is not a plugin. Either way it got
+			// PAST classification, which is the only thing this pins.
+			const outcome = await svc
+				.startForRegisteredApp("undeclared-app")
+				.then((r) => (r.ok ? "ok" : r.kind))
+				.catch(() => "threw-during-spawn");
+			await svc.stop().catch(() => {});
+			rmSync(dir, { recursive: true, force: true });
+
+			expect(outcome).not.toBe("no-worker-surface");
 		});
 	});
 });

--- a/plugins/plugin-app-control/src/services/app-registry-service.ts
+++ b/plugins/plugin-app-control/src/services/app-registry-service.ts
@@ -125,9 +125,17 @@ export type SetGrantedNamespacesResult =
 	| SetGrantedNamespacesError;
 
 interface AppWorkerHostServiceLike {
-	startForRegisteredApp?: (
-		slug: string,
-	) => Promise<{ ok: boolean; reason?: string }>;
+	startForRegisteredApp?: (slug: string) => Promise<{
+		ok: boolean;
+		/**
+		 * `"no-worker-surface"` when the app simply has no agent-side module to
+		 * spawn — routine, since external trust promotes every app to
+		 * isolation:"worker" including static frontends. Anything else is a real
+		 * spawn failure. Optional so older host builds still satisfy the shape.
+		 */
+		kind?: "no-worker-surface" | "error";
+		reason?: string;
+	}>;
 	stopWorker?: (slug: string) => Promise<void>;
 }
 
@@ -597,9 +605,18 @@ export class AppRegistryService extends Service {
 		try {
 			const result = await hostService.startForRegisteredApp(slug);
 			if (!result.ok) {
-				logger.warn(
-					`[plugin-app-control] auto-spawn failed for slug=${slug}: ${result.reason ?? "unknown"}`,
-				);
+				// A static app has nothing to spawn; that is the expected outcome
+				// of promoting every external app to isolation:"worker", not a
+				// failure worth a warning on every registration.
+				if (result.kind === "no-worker-surface") {
+					logger.debug(
+						`[plugin-app-control] no worker surface for slug=${slug}: ${result.reason ?? "unknown"}`,
+					);
+				} else {
+					logger.warn(
+						`[plugin-app-control] auto-spawn failed for slug=${slug}: ${result.reason ?? "unknown"}`,
+					);
+				}
 			}
 		} catch (error) {
 			logger.warn(

--- a/plugins/plugin-app-control/src/services/app-worker-host-service.ts
+++ b/plugins/plugin-app-control/src/services/app-worker-host-service.ts
@@ -104,6 +104,16 @@ const WORKER_ENTRY = existsSync(SOURCE_WORKER_ENTRY)
 	: DIST_WORKER_ENTRY;
 const SHUTDOWN_GRACE_MS = 5_000;
 
+class WorkerBootError extends Error {
+	constructor(
+		readonly kind: "no-worker-surface" | "error",
+		message: string,
+	) {
+		super(message);
+		this.name = "WorkerBootError";
+	}
+}
+
 function readString(value: unknown): string | null {
 	if (typeof value !== "string") return null;
 	const trimmed = value.trim();
@@ -165,31 +175,16 @@ async function resolvePluginEntryPath(
 		!Array.isArray(pkg.exports)
 			? readStringFromExports((pkg.exports as Record<string, unknown>)["."])
 			: null);
-	const declared = [
+	const candidates = [
 		exportsEntry,
 		readString(pkg.module),
 		readString(pkg.main),
+		"src/index.ts",
+		"src/index.js",
+		"dist/index.js",
+		"index.ts",
+		"index.js",
 	].filter((candidate): candidate is string => candidate !== null);
-
-	// The conventional fallbacks apply ONLY to a package that declares no entry
-	// at all. A package that declared one whose file is absent is unbuilt, and
-	// importing some source file it never pointed at turns that into a
-	// different, misleading story: a static frontend app (index.html +
-	// src/index.tsx, no agent-side module) declares `main: "./dist/index.js"`,
-	// the fallback imports its React entry instead, and the worker reports
-	// "no plugin export found in module" on every boot — for an app that has no
-	// worker surface at all. Resolving nothing is the honest answer here; the
-	// caller already renders it as "no worker plugin entry found".
-	const candidates =
-		declared.length > 0
-			? declared
-			: [
-					"src/index.ts",
-					"src/index.js",
-					"dist/index.js",
-					"index.ts",
-					"index.js",
-				];
 
 	for (const candidate of candidates) {
 		const resolved = path.isAbsolute(candidate)
@@ -303,22 +298,30 @@ export class AppWorkerHostService extends Service {
 		if (!pluginEntryPath) {
 			return {
 				ok: false,
-				kind: "no-worker-surface",
+				kind: "error",
 				reason: `No worker plugin entry found for app ${slug} under ${entry.directory}`,
 			};
 		}
-		const snapshot = await this.spawn({
-			slug,
-			isolation: "worker",
-			// path.basename contains the slug to a single segment so a traversal
-			// slug (e.g. "../../etc") from an untrusted app manifest cannot escape
-			// the app-state dir (defense-in-depth; register() also rejects it).
-			statePath: path.join(this.stateDir, "app-state", path.basename(slug)),
-			requestedPermissions: entry.requestedPermissions ?? null,
-			grantedNamespaces: view?.grantedNamespaces ?? [],
-			pluginEntryPath,
-		});
-		return { ok: true, snapshot };
+		try {
+			const snapshot = await this.spawn({
+				slug,
+				isolation: "worker",
+				// path.basename contains the slug to a single segment so a traversal
+				// slug (e.g. "../../etc") from an untrusted app manifest cannot escape
+				// the app-state dir (defense-in-depth; register() also rejects it).
+				statePath: path.join(this.stateDir, "app-state", path.basename(slug)),
+				requestedPermissions: entry.requestedPermissions ?? null,
+				grantedNamespaces: view?.grantedNamespaces ?? [],
+				pluginEntryPath,
+			});
+			return { ok: true, snapshot };
+		} catch (error) {
+			return {
+				ok: false,
+				kind: error instanceof WorkerBootError ? error.kind : "error",
+				reason: error instanceof Error ? error.message : String(error),
+			};
+		}
 	}
 
 	/**
@@ -370,6 +373,7 @@ export class AppWorkerHostService extends Service {
 					ok: boolean;
 					result?: unknown;
 					reason?: string;
+					kind?: "no-worker-surface" | "error";
 				};
 				if (msg.id === 0) {
 					if (msg.ok === true) {
@@ -377,7 +381,8 @@ export class AppWorkerHostService extends Service {
 						resolve();
 					} else {
 						reject(
-							new Error(
+							new WorkerBootError(
+								msg.kind ?? "error",
 								msg.reason ?? "Worker boot failed (no reason supplied)",
 							),
 						);

--- a/plugins/plugin-app-control/src/services/app-worker-host-service.ts
+++ b/plugins/plugin-app-control/src/services/app-worker-host-service.ts
@@ -165,16 +165,31 @@ async function resolvePluginEntryPath(
 		!Array.isArray(pkg.exports)
 			? readStringFromExports((pkg.exports as Record<string, unknown>)["."])
 			: null);
-	const candidates = [
+	const declared = [
 		exportsEntry,
 		readString(pkg.module),
 		readString(pkg.main),
-		"src/index.ts",
-		"src/index.js",
-		"dist/index.js",
-		"index.ts",
-		"index.js",
 	].filter((candidate): candidate is string => candidate !== null);
+
+	// The conventional fallbacks apply ONLY to a package that declares no entry
+	// at all. A package that declared one whose file is absent is unbuilt, and
+	// importing some source file it never pointed at turns that into a
+	// different, misleading story: a static frontend app (index.html +
+	// src/index.tsx, no agent-side module) declares `main: "./dist/index.js"`,
+	// the fallback imports its React entry instead, and the worker reports
+	// "no plugin export found in module" on every boot — for an app that has no
+	// worker surface at all. Resolving nothing is the honest answer here; the
+	// caller already renders it as "no worker plugin entry found".
+	const candidates =
+		declared.length > 0
+			? declared
+			: [
+					"src/index.ts",
+					"src/index.js",
+					"dist/index.js",
+					"index.ts",
+					"index.js",
+				];
 
 	for (const candidate of candidates) {
 		const resolved = path.isAbsolute(candidate)
@@ -242,12 +257,19 @@ export class AppWorkerHostService extends Service {
 	 * Look up the registered entry and spawn a worker if the entry
 	 * declares isolation:"worker". Returns the spawn snapshot or a
 	 * structured reason if no worker was spawned.
+	 *
+	 * `kind` separates "this app has no worker surface" from "this app has one
+	 * and it failed". Both are `ok: false`, but only the second is a problem:
+	 * `trust: "external"` promotes EVERY registered app to isolation:"worker",
+	 * including static frontend apps that ship no agent-side module, so the
+	 * first case is routine and must not be logged as a failure. Callers branch
+	 * on this field rather than matching the reason text.
 	 */
 	async startForRegisteredApp(
 		slug: string,
 	): Promise<
 		| { ok: true; snapshot: SpawnedWorkerSnapshot }
-		| { ok: false; reason: string }
+		| { ok: false; kind: "no-worker-surface" | "error"; reason: string }
 	> {
 		const registry = this.runtime.getService(APP_REGISTRY_SERVICE_TYPE) as
 			| AppRegistryService
@@ -256,17 +278,23 @@ export class AppWorkerHostService extends Service {
 		if (!registry) {
 			return {
 				ok: false,
+				kind: "error",
 				reason: "AppRegistryService is not registered on the runtime",
 			};
 		}
 		const entries = await registry.list();
 		const entry = entries.find((e: AppRegistryEntry) => e.slug === slug);
 		if (!entry) {
-			return { ok: false, reason: `No app registered under slug=${slug}` };
+			return {
+				ok: false,
+				kind: "error",
+				reason: `No app registered under slug=${slug}`,
+			};
 		}
 		if (entry.isolation !== "worker") {
 			return {
 				ok: false,
+				kind: "no-worker-surface",
 				reason: `App ${slug} declared isolation:'${entry.isolation ?? "none"}'; nothing to spawn`,
 			};
 		}
@@ -275,6 +303,7 @@ export class AppWorkerHostService extends Service {
 		if (!pluginEntryPath) {
 			return {
 				ok: false,
+				kind: "no-worker-surface",
 				reason: `No worker plugin entry found for app ${slug} under ${entry.directory}`,
 			};
 		}
@@ -539,13 +568,26 @@ export class AppWorkerHostService extends Service {
 			const result = await this.startForRegisteredApp(entry.slug).catch(
 				(error: unknown) => ({
 					ok: false as const,
+					kind: "error" as const,
 					reason: error instanceof Error ? error.message : String(error),
 				}),
 			);
 			if (!result.ok) {
-				logger.warn(
-					`[app-worker-host] bootstrap spawn failed for slug=${entry.slug}: ${result.reason}`,
-				);
+				// An app with no worker surface is the common case, not a fault:
+				// `trust: "external"` promotes every registered app to
+				// isolation:"worker", and most are static frontends with no
+				// agent-side module. Warning on those made boot emit one failure
+				// line per installed app forever, burying the spawns that really
+				// did break.
+				if (result.kind === "no-worker-surface") {
+					logger.debug(
+						`[app-worker-host] no worker surface for slug=${entry.slug}: ${result.reason}`,
+					);
+				} else {
+					logger.warn(
+						`[app-worker-host] bootstrap spawn failed for slug=${entry.slug}: ${result.reason}`,
+					);
+				}
 			}
 		}
 	}

--- a/plugins/plugin-app-control/src/workers/app-worker-entry.ts
+++ b/plugins/plugin-app-control/src/workers/app-worker-entry.ts
@@ -280,6 +280,7 @@ function isValidPluginExport(c: unknown): c is {
 async function loadPlugin(entryPath: string): Promise<{
 	loaded: number;
 	error?: string;
+	kind?: "no-worker-surface" | "error";
 }> {
 	try {
 		// On Windows, `import('C:\\foo\\bar.js')` fails with "Only URLs with a
@@ -309,7 +310,11 @@ async function loadPlugin(entryPath: string): Promise<{
 		const valid = candidates.filter(isValidPluginExport);
 		const plugin = valid.find((p) => p.actions?.length) ?? valid[0] ?? null;
 		if (!plugin) {
-			return { loaded: 0, error: "no plugin export found in module" };
+			return {
+				loaded: 0,
+				kind: "no-worker-surface" as const,
+				error: "no plugin export found in module",
+			};
 		}
 		const actions = plugin.actions ?? [];
 		// The worker sandbox only bridges actions via invokeAction. A
@@ -323,6 +328,7 @@ async function loadPlugin(entryPath: string): Promise<{
 		if (actions.length === 0) {
 			return {
 				loaded: 0,
+				kind: "no-worker-surface" as const,
 				error: `plugin "${plugin.name}" contributes no actions; the worker sandbox only exposes actions (invokeAction), not providers/routes/services`,
 			};
 		}
@@ -340,6 +346,7 @@ async function loadPlugin(entryPath: string): Promise<{
 	} catch (error) {
 		return {
 			loaded: 0,
+			kind: "error" as const,
 			error: error instanceof Error ? error.message : String(error),
 		};
 	}
@@ -493,11 +500,15 @@ async function bootSequence() {
 	let pluginLoaded = false;
 	let actionsLoaded = 0;
 	let error: string | undefined;
+	let kind: "no-worker-surface" | "error" | undefined;
 	if (pluginEntryPath) {
 		const result = await loadPlugin(pluginEntryPath);
 		actionsLoaded = result.loaded;
 		pluginLoaded = !result.error;
-		if (result.error) error = result.error;
+		if (result.error) {
+			error = result.error;
+			kind = result.kind ?? "error";
+		}
 	}
 	parentPort?.postMessage({
 		id: 0,
@@ -509,6 +520,7 @@ async function bootSequence() {
 			actionsLoaded,
 			...(error ? { error } : {}),
 		},
+		...(kind ? { kind } : {}),
 		...(error ? { reason: error } : {}),
 	});
 }


### PR DESCRIPTION
## What

`trust: "external"` promotes every registered app to `isolation: "worker"`, so the worker host attempts a spawn for each installed app — including **static frontend apps that ship no agent-side module at all**.

Those apps declare `main: "./dist/index.js"` for their bundler. That file is a built web bundle (or absent), not a plugin. The entry resolver treated the *declared* entry and the conventional `src/index.*` paths as one flat candidate list, so it fell through to a React source file the package never pointed at, imported it, and reported `no plugin export found in module`.

Observed on a live install: **20 registered apps, 100% of them warning on every boot**, 285 occurrences in one log. The apps themselves serve fine — this is pure noise that buries spawns which genuinely broke.

## Root cause

`resolvePluginEntryPath` in `app-worker-host-service.ts`:

```ts
const candidates = [exportsEntry, pkg.module, pkg.main,
                    "src/index.ts", "src/index.js", ...]
```

A declared-but-missing entry is silently replaced by a guess. That turns "this app is unbuilt / has no worker surface" into the misleading "this app has a plugin that exports nothing".

## Changes

- **The conventional fallbacks apply only when a package declares no entry at all.** If it declared one and the file is absent, resolving nothing is the honest answer; the caller already renders that as `No worker plugin entry found`.
- **`startForRegisteredApp` returns `kind: "no-worker-surface" | "error"`** so callers branch structurally rather than matching reason text. The boot sweep and the registration path both log the former at debug and keep warning on real failures.

Not changed: the `trust: "external"` → `isolation: "worker"` promotion. That is a deliberate, load-bearing security default and it is correct — the bug was treating its consequence as a failure.

## Evidence

<!-- evidence-head:4252b50c6a1d78191dc05ecc037c901cdcdc1ddf -->

<!-- evidence-row:before-screenshots -->
N/A - no UI surface; this is boot-time service classification and logging

<!-- evidence-row:after-screenshots -->
N/A - no UI surface; this is boot-time service classification and logging

<!-- evidence-row:walkthrough-video -->
N/A - no UI surface; the observable change is log level and a typed result field

<!-- evidence-row:backend-logs -->
Live `bot.log` before the change — one line per registered app, every boot:

<details>
<summary>285 occurrences across one log, 20 distinct slugs</summary>
<pre>
Warn [app-worker-host] bootstrap spawn failed for slug=web-app: no plugin export found in module
Warn [app-worker-host] bootstrap spawn failed for slug=prismglow: no plugin export found in module
Warn [app-worker-host] bootstrap spawn failed for slug=ny2027-countdown: no plugin export found in module
Warn [app-worker-host] bootstrap spawn failed for slug=neon-pulse: no plugin export found in module
Warn [app-worker-host] bootstrap spawn failed for slug=inkdrop: no plugin export found in module
Warn [app-worker-host] bootstrap spawn failed for slug=hello-gradient: no plugin export found in module
Warn [app-worker-host] bootstrap spawn failed for slug=glow-drift: no plugin export found in module
Warn [app-worker-host] bootstrap spawn failed for slug=comet-catch: no plugin export found in module
</pre>
</details>

The affected app directories are static frontends — `index.html`, `dist/index.html`, `dist/assets/`, `src/index.tsx` — with no `dist/index.js` despite `main: "./dist/index.js"`. The apps serve correctly over HTTP throughout; only the worker spawn was failing.

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface in this change

<!-- evidence-row:llm-trajectory -->
N/A - boot-time service classification; no model call on this path

<!-- evidence-row:domain-artifacts -->
Focused suite, with a revert proving the new test is load-bearing.

<details>
<summary>plugins/plugin-app-control/src/services/__tests__ — 83 passed</summary>
<pre>
RUN  v4.1.5
 Test Files  5 passed (5)
      Tests  83 passed (83)
</pre>
</details>

<details>
<summary>revert the resolver change, keep the tests</summary>
<pre>
× does not import a source file the package never declared
  Tests  1 failed | 24 passed (25)
</pre>
restored: <pre>Tests  25 passed (25)</pre>
</details>

`bun run --cwd plugins/plugin-app-control typecheck` reports no errors in the changed files; the remaining errors are pre-existing cross-package noise (`packages/core/src/cloud-routing.ts`, `packages/ui/src/api/ios-local-agent-transport.ts`) untouched by this diff.

<!-- evidence-row:ocr-review -->
N/A - no rendered text or imagery

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes - agent-authored under human direction, root-caused from live boot logs
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored from live log evidence, not the pinned contribute-to-eliza skill
<!-- attribution-row:status -->
- Attribution status: self-reported
