### PR TITLE
fix(core): fail fast on malformed planner budget env vars (#19622)

### DIFF
--- a/packages/core/src/runtime/planner-loop-budget-env-validation.test.ts
+++ b/packages/core/src/runtime/planner-loop-budget-env-validation.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Pins the fail-fast contract for the planner's four operator-facing budget
+ * env knobs (issue #19622): a set-but-non-canonical value throws a fatal typed
+ * ElizaError naming the setting instead of silently coercing or falling back to
+ * a default, while unset/empty preserves the historical default and a canonical
+ * value keeps its exact configured meaning (no silent floor/truncation).
+ * Deterministic parser test over the exported resolvers; no runtime boot.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ElizaError, isElizaError } from "../errors";
+import {
+	resolveCodingMaxRequiredToolMisses,
+	resolveCodingMaxToolCalls,
+	resolvePositivePlannerInt,
+} from "./planner-loop";
+
+// The full rejection matrix from the work order: malformed suffix, exponent,
+// decimal, leading space, leading zero, negative, and the JS-truthy "Infinity"
+// literal. None is a canonical positive decimal integer.
+const REJECTED_VALUES = [
+	"80oops",
+	"1e2",
+	"3.9",
+	" 80",
+	"080",
+	"-5",
+	"Infinity",
+] as const;
+
+describe("resolvePositivePlannerInt (planner budget env fail-fast)", () => {
+	it("returns the default for an unset value", () => {
+		expect(resolvePositivePlannerInt("ELIZA_TEST_BUDGET", undefined, 42)).toBe(
+			42,
+		);
+	});
+
+	it("returns the default for an empty string (preserving unset⇒default)", () => {
+		expect(resolvePositivePlannerInt("ELIZA_TEST_BUDGET", "", 42)).toBe(42);
+	});
+
+	it("passes a canonical positive integer through with no floor/truncation", () => {
+		expect(resolvePositivePlannerInt("ELIZA_TEST_BUDGET", "80", 42)).toBe(80);
+		expect(resolvePositivePlannerInt("ELIZA_TEST_BUDGET", "16384", 42)).toBe(
+			16384,
+		);
+		expect(resolvePositivePlannerInt("ELIZA_TEST_BUDGET", "1", 42)).toBe(1);
+	});
+
+	it.each(REJECTED_VALUES)(
+		"throws a fatal ElizaError naming the setting for %j",
+		(value) => {
+			let thrown: unknown;
+			try {
+				resolvePositivePlannerInt("ELIZA_TEST_BUDGET", value, 42);
+			} catch (error) {
+				thrown = error;
+			}
+			expect(isElizaError(thrown)).toBe(true);
+			const err = thrown as ElizaError;
+			expect(err.code).toBe("PLANNER_BUDGET_ENV_INVALID");
+			expect(err.severity).toBe("fatal");
+			expect(err.message).toContain("ELIZA_TEST_BUDGET");
+			expect(err.message).toContain(value);
+			expect(err.context).toMatchObject({
+				setting: "ELIZA_TEST_BUDGET",
+				received: value,
+			});
+		},
+	);
+
+	it("rejects '0' (a positive integer knob cannot be zero)", () => {
+		expect(() =>
+			resolvePositivePlannerInt("ELIZA_TEST_BUDGET", "0", 42),
+		).toThrow(ElizaError);
+	});
+});
+
+describe("resolveCodingMaxToolCalls (ELIZA_CODING_MAX_TOOL_CALLS)", () => {
+	const KEY = "ELIZA_CODING_MAX_TOOL_CALLS";
+	let original: string | undefined;
+
+	beforeEach(() => {
+		original = process.env[KEY];
+	});
+
+	afterEach(() => {
+		if (original === undefined) {
+			delete process.env[KEY];
+		} else {
+			process.env[KEY] = original;
+		}
+	});
+
+	it("defaults to 80 when unset", () => {
+		delete process.env[KEY];
+		expect(resolveCodingMaxToolCalls()).toBe(80);
+	});
+
+	it("honors a canonical override exactly", () => {
+		process.env[KEY] = "120";
+		expect(resolveCodingMaxToolCalls()).toBe(120);
+	});
+
+	it.each(REJECTED_VALUES)("throws for the malformed value %j", (value) => {
+		process.env[KEY] = value;
+		let thrown: unknown;
+		try {
+			resolveCodingMaxToolCalls();
+		} catch (error) {
+			thrown = error;
+		}
+		expect(isElizaError(thrown)).toBe(true);
+		expect((thrown as ElizaError).message).toContain(KEY);
+	});
+});
+
+describe("resolveCodingMaxRequiredToolMisses (ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES)", () => {
+	const KEY = "ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES";
+	let original: string | undefined;
+
+	beforeEach(() => {
+		original = process.env[KEY];
+	});
+
+	afterEach(() => {
+		if (original === undefined) {
+			delete process.env[KEY];
+		} else {
+			process.env[KEY] = original;
+		}
+	});
+
+	it("defaults to 8 when unset", () => {
+		delete process.env[KEY];
+		expect(resolveCodingMaxRequiredToolMisses()).toBe(8);
+	});
+
+	it("honors a canonical override exactly", () => {
+		process.env[KEY] = "16";
+		expect(resolveCodingMaxRequiredToolMisses()).toBe(16);
+	});
+
+	it.each(REJECTED_VALUES)("throws for the malformed value %j", (value) => {
+		process.env[KEY] = value;
+		let thrown: unknown;
+		try {
+			resolveCodingMaxRequiredToolMisses();
+		} catch (error) {
+			thrown = error;
+		}
+		expect(isElizaError(thrown)).toBe(true);
+		expect((thrown as ElizaError).message).toContain(KEY);
+	});
+});

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -10,6 +10,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { promotedParentRoutingHint } from "../actions/promote-subactions";
+import { ElizaError } from "../errors";
 import { computeCallCostUsd } from "../features/trajectories/pricing";
 import { logger } from "../logger";
 import { parseInteractionBlocks } from "../messaging/interactions/parse";
@@ -178,22 +179,93 @@ function isCodingFullSurfaceMode(): boolean {
 const DEFAULT_CODING_PLANNER_MAX_TOKENS = 16384;
 
 /**
+ * Canonical form for an operator-facing positive-integer budget knob: a
+ * positive decimal integer with no sign, whitespace, leading zero, decimal
+ * point, or exponent. Matches the fail-fast precedent for numeric env config
+ * (issues #19148, #19295) so a misconfigured budget surfaces instead of
+ * silently coercing (`"1e2"` → 100, `"3.9"` → 3) or falling back to a default
+ * (`"80oops"` → NaN → default) — the exact error each ceiling exists to catch.
+ */
+const CANONICAL_POSITIVE_INTEGER = /^[1-9][0-9]*$/;
+
+/**
+ * Resolve one operator-facing positive-integer budget setting. An unset or
+ * empty value keeps `defaultValue` (preserving the historical "unset ⇒ default"
+ * behavior). Any other value must be a canonical positive decimal integer
+ * ({@link CANONICAL_POSITIVE_INTEGER}); anything else throws a fatal typed
+ * {@link ElizaError} naming the setting, the received value, and the accepted
+ * range, so a runaway-planner ceiling can never silently degrade to a default.
+ */
+export function resolvePositivePlannerInt(
+	envVarName: string,
+	rawValue: string | undefined,
+	defaultValue: number,
+): number {
+	if (rawValue === undefined || rawValue === "") {
+		return defaultValue;
+	}
+	if (!CANONICAL_POSITIVE_INTEGER.test(rawValue)) {
+		throw new ElizaError(
+			`${envVarName} must be a positive decimal integer (e.g. "80"), got: ${JSON.stringify(
+				rawValue,
+			)}`,
+			{
+				code: "PLANNER_BUDGET_ENV_INVALID",
+				severity: "fatal",
+				context: { setting: envVarName, received: rawValue },
+			},
+		);
+	}
+	return Number(rawValue);
+}
+
+/**
  * Resolve the planner's per-call `maxTokens`: the small chat default, or — in
  * coding/full-surface mode — a budget large enough to emit a full file in one
  * tool call ({@link DEFAULT_CODING_PLANNER_MAX_TOKENS}, overridable via
- * `ELIZA_CODING_PLANNER_MAX_TOKENS`).
+ * `ELIZA_CODING_PLANNER_MAX_TOKENS`). A set-but-malformed override throws via
+ * {@link resolvePositivePlannerInt} rather than silently defaulting.
  */
 function resolvePlannerMaxTokens(): number {
 	if (!isCodingFullSurfaceMode()) {
-		const chatRaw = Number(process.env.ELIZA_PLANNER_MAX_TOKENS);
-		return Number.isFinite(chatRaw) && chatRaw > 0
-			? Math.floor(chatRaw)
-			: DEFAULT_PLANNER_MAX_TOKENS;
+		return resolvePositivePlannerInt(
+			"ELIZA_PLANNER_MAX_TOKENS",
+			process.env.ELIZA_PLANNER_MAX_TOKENS,
+			DEFAULT_PLANNER_MAX_TOKENS,
+		);
 	}
-	const raw = Number(process.env.ELIZA_CODING_PLANNER_MAX_TOKENS);
-	return Number.isFinite(raw) && raw > 0
-		? Math.floor(raw)
-		: DEFAULT_CODING_PLANNER_MAX_TOKENS;
+	return resolvePositivePlannerInt(
+		"ELIZA_CODING_PLANNER_MAX_TOKENS",
+		process.env.ELIZA_CODING_PLANNER_MAX_TOKENS,
+		DEFAULT_CODING_PLANNER_MAX_TOKENS,
+	);
+}
+
+/**
+ * Coding-mode tool-call ceiling (default 80): the max number of tool calls a
+ * coding build may make before the loop terminates. Overridable via
+ * `ELIZA_CODING_MAX_TOOL_CALLS`; a set-but-malformed value throws.
+ */
+export function resolveCodingMaxToolCalls(): number {
+	return resolvePositivePlannerInt(
+		"ELIZA_CODING_MAX_TOOL_CALLS",
+		process.env.ELIZA_CODING_MAX_TOOL_CALLS,
+		80,
+	);
+}
+
+/**
+ * Coding-mode required-tool miss budget (default 8): how many times a coding
+ * build may answer with a terminal REPLY instead of acting before the loop
+ * gives up. Overridable via `ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES`; a
+ * set-but-malformed value throws.
+ */
+export function resolveCodingMaxRequiredToolMisses(): number {
+	return resolvePositivePlannerInt(
+		"ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES",
+		process.env.ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES,
+		8,
+	);
 }
 
 interface RawPlannerOutput {
@@ -265,20 +337,14 @@ async function runPlannerLoopIterations(
 	// Raise the ceiling for coding builds (still bounded). Overridable via
 	// ELIZA_CODING_MAX_TOOL_CALLS.
 	const codingMode = isCodingFullSurfaceMode();
-	const codingMaxToolCalls = ((): number => {
-		const raw = Number(process.env.ELIZA_CODING_MAX_TOOL_CALLS);
-		return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 80;
-	})();
+	const codingMaxToolCalls = resolveCodingMaxToolCalls();
 	// Weak coding models (e.g. Cerebras glm-4.7) sometimes answer a trivial build
 	// with a terminal REPLY ("Creating the app now…") instead of calling FILE.
 	// The action-first gate below re-prompts that, but the chat default of 3
 	// misses gives up too soon to convert a stubborn narrator — give coding
 	// builds more attempts to actually act. Overridable via
 	// ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES.
-	const codingMaxRequiredToolMisses = ((): number => {
-		const raw = Number(process.env.ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES);
-		return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 8;
-	})();
+	const codingMaxRequiredToolMisses = resolveCodingMaxRequiredToolMisses();
 	const config = ((): ChainingLoopConfig => {
 		const merged = mergeChainingLoopConfig(params.config);
 		return codingMode


### PR DESCRIPTION
# Relates to

Closes #19622

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. `bun run verify` (full repo gate) not run on this constrained device; the owning-package gates (core test, typecheck, lint) were run and pass — see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the before/after reproduction and test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a8a8b8d3e0dc2b3df23921c9259ba30ee5011bd3:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`a8a8b8d3e0`); zero conflicts.
- [ ] `bun run verify` passes post-sync — not run in full (see **Known gaps / failures**); the scoped core gates pass.

# Risks

Low. The change is confined to `packages/core/src/runtime/planner-loop.ts` resolution logic for four env knobs plus a new test file. Behavior for **valid canonical values and for unset/empty is unchanged**; only previously-silent malformed input now throws a fatal typed error at resolution time. An operator who was relying on a malformed value being silently ignored will now see a fatal `ElizaError` — which is the intended, documented fix.

# Background

## What does this PR do?

`packages/core/src/runtime/planner-loop.ts` resolved four operator-facing budget knobs with permissive `Number()` coercion, so malformed input silently fell back to a default (or was silently accepted/truncated) instead of surfacing the misconfiguration. These knobs bound how much tool work a runaway planner can do, so silent fallback hides exactly the error the knob exists to prevent.

Affected settings: `ELIZA_PLANNER_MAX_TOKENS`, `ELIZA_CODING_PLANNER_MAX_TOKENS`, `ELIZA_CODING_MAX_TOOL_CALLS`, `ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES`.

This PR:
- Adds one shared exported helper `resolvePositivePlannerInt(envVarName, rawValue, defaultValue)`. Unset/empty keeps the existing default; any set value must be a **canonical positive decimal integer** (`/^[1-9][0-9]*$/` — no sign, whitespace, leading zero, decimal, or exponent), else it throws a **fatal typed `ElizaError`** (`code: "PLANNER_BUDGET_ENV_INVALID"`) naming the setting, the received value, and the accepted range.
- Refactors `resolvePlannerMaxTokens()` to use the helper for both token knobs.
- Promotes the two inline IIFEs to named exported resolvers `resolveCodingMaxToolCalls()` and `resolveCodingMaxRequiredToolMisses()`, called from `runPlannerLoopIterations()` with their defaults (80, 8) and surrounding `Math.max(...)` merge logic unchanged.

Matches the repository's established fail-fast precedent for operator-facing numeric config (issues #19148, #19295).

## What kind of change is this?

Bug fix (non-breaking for valid/unset config; a previously-silent misconfiguration now fails fast as designed).

# Documentation changes needed?

No documentation change required — the env knobs already existed; this only hardens their validation.

# Testing

## Where should a reviewer start?

`packages/core/src/runtime/planner-loop-budget-env-validation.test.ts` — it pins the full rejection matrix and the accepted-value passthrough directly against the exported resolvers, no runtime boot.

## Detailed testing steps

From `packages/core`:

```
node ../scripts/run-vitest.mjs run src/runtime/planner-loop-budget-env-validation.test.ts
node ../scripts/run-vitest.mjs run src/runtime/__tests__/planner-loop.test.ts src/runtime/__tests__/planner-loop-honest-failure.test.ts src/runtime/__tests__/planner-loop-terminal-finish-without-message.test.ts
bun run typecheck
bunx @biomejs/biome check ./src/runtime/planner-loop.ts ./src/runtime/planner-loop-budget-env-validation.test.ts
```

### Before / after reproduction (real output)

```
ELIZA_CODING_MAX_TOOL_CALLS=80oops -> THROWS (ElizaError=true): ELIZA_CODING_MAX_TOOL_CALLS must be a positive decimal integer (e.g. "80"), got: "80oops"
ELIZA_PLANNER_MAX_TOKENS=1e5     -> THROWS (ElizaError=true): ELIZA_PLANNER_MAX_TOKENS must be a positive decimal integer (e.g. "80"), got: "1e5"
canonical "16384" -> 16384        (unchanged, no silent floor/truncation)
unset -> default -> 4096          (unchanged)
```

Before this PR: `80oops` → `NaN` → silently 80; `1e5` → silently 100000; `3.9` → silently floored to 3. All now throw a fatal typed error naming the setting.

# Evidence Gate

<!-- evidence-head:0532da41141df6f3f86df69fc4d4a403a4a5b60a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core runtime env-validation change; no UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - core runtime env-validation change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - non-interactive core parser change; reproduction and test output are inline in the PR body.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no server process; behavior is shown by the inline before/after reproduction and the passing unit suites in the PR body.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface touched.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic env-config validation with no model call; no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB rows, memories, scheduled tasks, or generated files; the produced artifact is a thrown typed ElizaError, shown in the reproduction.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic env-config validation, no model call.

## Backend + frontend logs

Frontend: N/A - no frontend surface.

Backend — new focused suite (rejection matrix + accepted-value passthrough), no runtime boot:

<details>
<summary>vitest — planner-loop-budget-env-validation.test.ts</summary>

```
 RUN  v4.1.5 packages/core

 Test Files  1 passed (1)
      Tests  29 passed (29)
```
</details>

<details>
<summary>vitest — existing planner-loop regression suites (no regression)</summary>

```
 Test Files  3 passed (3)
      Tests  133 passed (133)
 (planner-loop.test.ts, planner-loop-honest-failure.test.ts, planner-loop-terminal-finish-without-message.test.ts)
```
</details>

<details>
<summary>typecheck + lint</summary>

```
$ tsc --noEmit -p ./tsconfig.json    EXIT: 0
$ biome check ./src/runtime/planner-loop.ts ./src/runtime/planner-loop-budget-env-validation.test.ts
Checked 2 files in 142ms. No fixes applied.   EXIT: 0
```
</details>

## Screenshots (before / after) + video walkthrough

N/A - core runtime env-validation change, no rendered surface.

### Before
N/A
### After
N/A
### Walkthrough video
N/A - non-interactive parser change.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT path touched.

## Known gaps / failures

- `bun run verify` (the full repo parity/dependency/lint/audit gate) was **not** run end-to-end on this constrained device (Raspberry Pi). The owning-package gates were run and pass: core `typecheck` (exit 0), Biome `check` on both changed files (exit 0), the new focused suite (29/29), and three existing planner-loop suites (133/133). The diff is limited to `packages/core/src/runtime/planner-loop.ts` and one new sibling test file, so no cross-package surface changed.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@a8a8b8d3e0dc2b3df23921c9259ba30ee5011bd3:packages/skills/skills/contribute-to-eliza"} -->

