### PR TITLE
fix(cloud): verify complete Pages JavaScript graph

### DIFF
--- a/packages/cloud/scripts/__tests__/verify-pages-frontend.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-pages-frontend.test.ts
@@ -241,7 +241,7 @@ describe("verifyPagesFrontendOnce", () => {
 
   it("returns a structured timeout when a live asset never settles", async () => {
     const distDir = makeDist("assets/index-fresh.js", "entry");
-    const fetchImpl = ((url: string, init?: RequestInit) => {
+    const fetchImpl = ((url: string) => {
       if (url === "https://app.elizacloud.ai/") {
         return Promise.resolve(
           response(
@@ -249,13 +249,7 @@ describe("verifyPagesFrontendOnce", () => {
           ),
         );
       }
-      return new Promise((_, reject) => {
-        init?.signal?.addEventListener(
-          "abort",
-          () => reject(new Error("aborted by verification deadline")),
-          { once: true },
-        );
-      });
+      return new Promise(() => {});
     }) as unknown as typeof fetch;
 
     const startedAt = Date.now();

--- a/packages/cloud/scripts/__tests__/verify-pages-frontend.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-pages-frontend.test.ts
@@ -5,7 +5,7 @@
  * bundle, which leaves onboarding fixes absent from the user-facing app.
  */
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -18,18 +18,24 @@ import { parseArgs } from "../verify-pages-frontend-cli.mjs";
 
 const tmpRoots: string[] = [];
 
-function makeDist(asset = "assets/index-fresh.js") {
+function makeDist(
+  asset = "assets/index-fresh.js",
+  contents = "Signing in to your agent\nCloudPairRelay",
+) {
   const dir = mkdtempSync(join(tmpdir(), "pages-frontend-"));
   tmpRoots.push(dir);
   writeFileSync(
     join(dir, "index.html"),
     `<html><head><script type="module" src="/${asset}"></script></head></html>`,
   );
+  mkdirSync(join(dir, "assets"), { recursive: true });
+  writeFileSync(join(dir, asset), contents);
   return dir;
 }
 
 function response(body: string, ok = true, status = ok ? 200 : 500) {
-  return { ok, status, text: async () => body };
+  const bytes = new TextEncoder().encode(body);
+  return { ok, status, arrayBuffer: async () => bytes.buffer };
 }
 
 afterEach(() => {
@@ -119,7 +125,10 @@ describe("verifyPagesFrontendOnce", () => {
   });
 
   it("fails when the served entry bundle misses required onboarding text", async () => {
-    const distDir = makeDist();
+    const distDir = makeDist(
+      "assets/index-fresh.js",
+      "Sign in with your password",
+    );
     const fetchImpl = (async (url: string) => {
       if (url.endsWith("/assets/index-fresh.js")) {
         return response("Sign in with your password");
@@ -142,6 +151,66 @@ describe("verifyPagesFrontendOnce", () => {
     expect(report.requiredTextResults).toEqual([
       { text: "Signing in to your agent", present: false },
     ]);
+  });
+
+  it("searches required text in lazy JavaScript while proving every emitted asset", async () => {
+    const entry = 'import("./AppContext-lazy.js");';
+    const lazy =
+      "Signing in to your agent\nThis tab will continue automatically";
+    const distDir = makeDist("assets/index-fresh.js", entry);
+    writeFileSync(join(distDir, "assets/AppContext-lazy.js"), lazy);
+    const fetchImpl = (async (url: string) => {
+      if (url === "https://app.elizacloud.ai/") {
+        return response(
+          '<script type="module" src="/assets/index-fresh.js"></script>',
+        );
+      }
+      if (url.endsWith("/assets/index-fresh.js")) return response(entry);
+      if (url.endsWith("/assets/AppContext-lazy.js")) return response(lazy);
+      throw new Error(`unexpected URL ${url}`);
+    }) as unknown as typeof fetch;
+
+    const report = await verifyPagesFrontendOnce({
+      servedUrl: "https://app.elizacloud.ai",
+      distDir,
+      requiredTexts: [
+        "Signing in to your agent",
+        "This tab will continue automatically",
+      ],
+      fetchImpl,
+      retrySleep: noSleep,
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.detail).toContain("2 emitted JavaScript asset(s)");
+  });
+
+  it("fails when a live lazy asset does not exactly match local bytes", async () => {
+    const distDir = makeDist("assets/index-fresh.js", "entry");
+    writeFileSync(join(distDir, "assets/AppContext-lazy.js"), "local lazy");
+    const fetchImpl = (async (url: string) => {
+      if (url === "https://app.elizacloud.ai/") {
+        return response(
+          '<script type="module" src="/assets/index-fresh.js"></script>',
+        );
+      }
+      if (url.endsWith("/assets/index-fresh.js")) return response("entry");
+      if (url.endsWith("/assets/AppContext-lazy.js")) {
+        return response("different live lazy");
+      }
+      throw new Error(`unexpected URL ${url}`);
+    }) as unknown as typeof fetch;
+
+    const report = await verifyPagesFrontendOnce({
+      servedUrl: "https://app.elizacloud.ai",
+      distDir,
+      fetchImpl,
+      retrySleep: noSleep,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.reason).toBe("asset_bytes_mismatch");
+    expect(report.detail).toContain("assets/AppContext-lazy.js");
   });
 
   it("reports an unreachable live index", async () => {

--- a/packages/cloud/scripts/__tests__/verify-pages-frontend.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-pages-frontend.test.ts
@@ -5,7 +5,13 @@
  * bundle, which leaves onboarding fixes absent from the user-facing app.
  */
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  truncateSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -76,8 +82,6 @@ describe("normalizers", () => {
 });
 
 describe("verifyPagesFrontendOnce", () => {
-  const noSleep = async () => {};
-
   it("passes when the live index serves the local entry bundle with required text", async () => {
     const distDir = makeDist();
     const fetchImpl = (async (url: string) => {
@@ -97,7 +101,6 @@ describe("verifyPagesFrontendOnce", () => {
       distDir,
       requiredTexts: ["Signing in to your agent", "CloudPairRelay"],
       fetchImpl,
-      retrySleep: noSleep,
     });
 
     expect(report.ok).toBe(true);
@@ -115,7 +118,6 @@ describe("verifyPagesFrontendOnce", () => {
       servedUrl: "https://app.elizacloud.ai",
       distDir,
       fetchImpl,
-      retrySleep: noSleep,
     });
 
     expect(report.ok).toBe(false);
@@ -143,7 +145,6 @@ describe("verifyPagesFrontendOnce", () => {
       distDir,
       requiredTexts: ["Signing in to your agent"],
       fetchImpl,
-      retrySleep: noSleep,
     });
 
     expect(report.ok).toBe(false);
@@ -178,7 +179,6 @@ describe("verifyPagesFrontendOnce", () => {
         "This tab will continue automatically",
       ],
       fetchImpl,
-      retrySleep: noSleep,
     });
 
     expect(report.ok).toBe(true);
@@ -205,12 +205,89 @@ describe("verifyPagesFrontendOnce", () => {
       servedUrl: "https://app.elizacloud.ai",
       distDir,
       fetchImpl,
-      retrySleep: noSleep,
     });
 
     expect(report.ok).toBe(false);
     expect(report.reason).toBe("asset_bytes_mismatch");
     expect(report.detail).toContain("assets/AppContext-lazy.js");
+  });
+
+  it("fails when a public-root service worker is stale", async () => {
+    const distDir = makeDist("assets/index-fresh.js", "entry");
+    writeFileSync(join(distDir, "sw.js"), 'const BUILD_REV = "fresh";');
+    const fetchImpl = (async (url: string) => {
+      if (url === "https://app.elizacloud.ai/") {
+        return response(
+          '<script type="module" src="/assets/index-fresh.js"></script>',
+        );
+      }
+      if (url.endsWith("/assets/index-fresh.js")) return response("entry");
+      if (url.endsWith("/sw.js")) {
+        return response('const BUILD_REV = "stale";');
+      }
+      throw new Error(`unexpected URL ${url}`);
+    }) as unknown as typeof fetch;
+
+    const report = await verifyPagesFrontendOnce({
+      servedUrl: "https://app.elizacloud.ai",
+      distDir,
+      fetchImpl,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.reason).toBe("asset_bytes_mismatch");
+    expect(report.detail).toContain("sw.js");
+  });
+
+  it("returns a structured timeout when a live asset never settles", async () => {
+    const distDir = makeDist("assets/index-fresh.js", "entry");
+    const fetchImpl = ((url: string, init?: RequestInit) => {
+      if (url === "https://app.elizacloud.ai/") {
+        return Promise.resolve(
+          response(
+            '<script type="module" src="/assets/index-fresh.js"></script>',
+          ),
+        );
+      }
+      return new Promise((_, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => reject(new Error("aborted by verification deadline")),
+          { once: true },
+        );
+      });
+    }) as unknown as typeof fetch;
+
+    const startedAt = Date.now();
+    const report = await verifyPagesFrontendOnce({
+      servedUrl: "https://app.elizacloud.ai",
+      distDir,
+      fetchImpl,
+      verificationTimeoutMs: 30,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.reason).toBe("verification_timeout");
+    expect(Date.now() - startedAt).toBeLessThan(250);
+  });
+
+  it("rejects an emitted JavaScript graph above its byte budget", async () => {
+    const distDir = makeDist("assets/index-fresh.js", "entry");
+    const oversizedAsset = join(distDir, "assets/oversized.js");
+    writeFileSync(oversizedAsset, "");
+    truncateSync(oversizedAsset, 128 * 1024 * 1024 + 1);
+
+    const report = await verifyPagesFrontendOnce({
+      servedUrl: "https://app.elizacloud.ai",
+      distDir,
+      fetchImpl: (async () => {
+        throw new Error("asset budget must fail before network access");
+      }) as unknown as typeof fetch,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.reason).toBe("asset_budget_exceeded");
+    expect(report.detail).toContain("134217728 bytes");
   });
 
   it("reports an unreachable live index", async () => {
@@ -222,8 +299,6 @@ describe("verifyPagesFrontendOnce", () => {
       servedUrl: "https://app.elizacloud.ai",
       distDir,
       fetchImpl,
-      fetchAttempts: 1,
-      retrySleep: noSleep,
     });
 
     expect(report.ok).toBe(false);

--- a/packages/cloud/scripts/__tests__/verify-pages-frontend.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-pages-frontend.test.ts
@@ -239,7 +239,7 @@ describe("verifyPagesFrontendOnce", () => {
     expect(report.detail).toContain("sw.js");
   });
 
-  it("returns a structured timeout when a live asset never settles", async () => {
+  it("returns a structured timeout when a live asset body never settles", async () => {
     const distDir = makeDist("assets/index-fresh.js", "entry");
     const fetchImpl = ((url: string) => {
       if (url === "https://app.elizacloud.ai/") {
@@ -249,7 +249,11 @@ describe("verifyPagesFrontendOnce", () => {
           ),
         );
       }
-      return new Promise(() => {});
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        arrayBuffer: () => new Promise(() => {}),
+      });
     }) as unknown as typeof fetch;
 
     const startedAt = Date.now();
@@ -262,6 +266,47 @@ describe("verifyPagesFrontendOnce", () => {
 
     expect(report.ok).toBe(false);
     expect(report.reason).toBe("verification_timeout");
+    expect(Date.now() - startedAt).toBeLessThan(250);
+  });
+
+  it("cancels a hanging sibling when another asset fails", async () => {
+    const distDir = makeDist("assets/index-fresh.js", "entry");
+    writeFileSync(join(distDir, "assets/a-fail.js"), "bad");
+    writeFileSync(join(distDir, "assets/b-hang.js"), "hang");
+    const fetchImpl = ((url: string) => {
+      if (url === "https://app.elizacloud.ai/") {
+        return Promise.resolve(
+          response(
+            '<script type="module" src="/assets/index-fresh.js"></script>',
+          ),
+        );
+      }
+      if (url.endsWith("/a-fail.js"))
+        return Promise.resolve(response("", false, 404));
+      if (url.endsWith("/b-hang.js")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          arrayBuffer: () => new Promise(() => {}),
+        });
+      }
+      if (url.endsWith("/assets/index-fresh.js"))
+        return Promise.resolve(response("entry"));
+      throw new Error(`unexpected URL ${url}`);
+    }) as unknown as typeof fetch;
+
+    const startedAt = Date.now();
+    const report = await verifyPagesFrontendOnce({
+      servedUrl: "https://app.elizacloud.ai",
+      distDir,
+      fetchImpl,
+      fetchTimeoutMs: 1_000,
+      verificationTimeoutMs: 2_000,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.reason).toBe("javascript_asset_unreachable");
+    expect(report.detail).toContain("assets/a-fail.js");
     expect(Date.now() - startedAt).toBeLessThan(250);
   });
 

--- a/packages/cloud/scripts/verify-pages-frontend.mjs
+++ b/packages/cloud/scripts/verify-pages-frontend.mjs
@@ -65,20 +65,37 @@ async function fetchText(url, options = {}) {
     fetchImpl = globalThis.fetch,
     timeoutMs = DEFAULT_TIMEOUT_MS,
     maxBytes = MAX_INDEX_BYTES,
+    signal,
   } = options;
   const controller = new AbortController();
+  let cancelled = false;
+  let timedOut = false;
   let timeout;
   const timeoutFailure = new Promise((_, reject) => {
     timeout = setTimeout(() => {
+      timedOut = true;
       controller.abort();
       reject(new Error(`request timed out after ${timeoutMs}ms`));
     }, timeoutMs);
   });
-  try {
-    const response = await Promise.race([
-      fetchImpl(url, { signal: controller.signal }),
-      timeoutFailure,
-    ]);
+  let detachCancellation = () => {};
+  const cancellationFailure = signal
+    ? new Promise((_, reject) => {
+        const cancel = () => {
+          cancelled = true;
+          controller.abort(signal.reason);
+          reject(new Error("request cancelled after sibling failure"));
+        };
+        if (signal.aborted) cancel();
+        else {
+          signal.addEventListener("abort", cancel, { once: true });
+          detachCancellation = () =>
+            signal.removeEventListener("abort", cancel);
+        }
+      })
+    : null;
+  const readResponse = async () => {
+    const response = await fetchImpl(url, { signal: controller.signal });
     const contentLength = Number(response.headers?.get?.("content-length"));
     if (Number.isFinite(contentLength) && contentLength > maxBytes) {
       controller.abort();
@@ -87,7 +104,21 @@ async function fetchText(url, options = {}) {
         bytes: null,
         text: "",
         limitExceeded: true,
+        cancelled: false,
+        timedOut: false,
         detail: `response declares ${contentLength} bytes; limit is ${maxBytes}`,
+      };
+    }
+    if (!response.ok) {
+      controller.abort();
+      return {
+        ok: false,
+        bytes: null,
+        text: "",
+        limitExceeded: false,
+        cancelled: false,
+        timedOut: false,
+        detail: `HTTP ${response.status}`,
       };
     }
 
@@ -108,6 +139,8 @@ async function fetchText(url, options = {}) {
             bytes: null,
             text: "",
             limitExceeded: true,
+            cancelled: false,
+            timedOut: false,
             detail: `response exceeded ${maxBytes} bytes`,
           };
         }
@@ -123,27 +156,29 @@ async function fetchText(url, options = {}) {
           bytes: null,
           text: "",
           limitExceeded: true,
+          cancelled: false,
+          timedOut: false,
           detail: `response returned ${bytes.length} bytes; limit is ${maxBytes}`,
         };
       }
     }
     const text = bytes.toString("utf8");
-    if (response.ok) {
-      return {
-        ok: true,
-        bytes,
-        text,
-        limitExceeded: false,
-        detail: `HTTP ${response.status}`,
-      };
-    }
     return {
-      ok: false,
-      bytes: null,
-      text: "",
+      ok: true,
+      bytes,
+      text,
       limitExceeded: false,
-      detail: `HTTP ${response.status}: ${text.slice(0, 200)}`,
+      cancelled: false,
+      timedOut: false,
+      detail: `HTTP ${response.status}`,
     };
+  };
+  try {
+    return await Promise.race(
+      cancellationFailure
+        ? [readResponse(), timeoutFailure, cancellationFailure]
+        : [readResponse(), timeoutFailure],
+    );
   } catch (err) {
     // error-policy:J1 boundary translation - network failures become verifier failure details.
     return {
@@ -151,10 +186,13 @@ async function fetchText(url, options = {}) {
       bytes: null,
       text: "",
       limitExceeded: false,
+      cancelled,
+      timedOut,
       detail: err instanceof Error ? err.message : String(err),
     };
   } finally {
     clearTimeout(timeout);
+    detachCancellation();
   }
 }
 
@@ -322,7 +360,10 @@ async function verifyPagesFrontendOnce(options) {
         requiredTextResults,
       };
     }
+    const deadlineBounded = remainingMs() <= fetchTimeoutMs;
     const batchTimeoutMs = Math.min(fetchTimeoutMs, remainingMs());
+    const batchController = new AbortController();
+    let firstBatchFailure = null;
     const batchResults = await Promise.all(
       batch.map(async (asset) => {
         const assetUrl = new URL(asset.path, baseUrl);
@@ -332,41 +373,56 @@ async function verifyPagesFrontendOnce(options) {
             fetchImpl,
             timeoutMs: batchTimeoutMs,
             maxBytes: asset.size,
+            signal: batchController.signal,
           }),
         ]);
-        return { asset: asset.path, localBytes, ...bundleFetch };
+        const bundle = { asset: asset.path, localBytes, ...bundleFetch };
+        let failure = null;
+        if (!bundle.ok && !bundle.limitExceeded && !bundle.cancelled) {
+          failure = {
+            reason:
+              bundle.timedOut && deadlineBounded
+                ? "verification_timeout"
+                : "javascript_asset_unreachable",
+            bundle,
+          };
+        } else if (
+          bundle.limitExceeded ||
+          (bundle.ok && !bundle.localBytes.equals(bundle.bytes))
+        ) {
+          failure = { reason: "asset_bytes_mismatch", bundle };
+        }
+        if (failure && firstBatchFailure === null) {
+          firstBatchFailure = failure;
+          batchController.abort();
+        }
+        return bundle;
       }),
     );
-    if (remainingMs() === 0) {
+    if (firstBatchFailure?.reason === "verification_timeout") {
       return {
         ok: false,
         reason: "verification_timeout",
-        detail: `Verification exceeded ${verificationTimeoutMs}ms while fetching ${batch[0].path}`,
+        detail: `Verification exceeded ${verificationTimeoutMs}ms while fetching ${firstBatchFailure.bundle.asset}`,
         expectedAssets,
         servedAssets,
         missingExpectedAssets,
         requiredTextResults,
       };
     }
-    const failedBundle = batchResults.find(
-      (bundle) => !bundle.ok && !bundle.limitExceeded,
-    );
-    if (failedBundle) {
+    if (firstBatchFailure?.reason === "javascript_asset_unreachable") {
       return {
         ok: false,
         reason: "javascript_asset_unreachable",
-        detail: `${failedBundle.asset}: ${failedBundle.detail}`,
+        detail: `${firstBatchFailure.bundle.asset}: ${firstBatchFailure.bundle.detail}`,
         expectedAssets,
         servedAssets,
         missingExpectedAssets,
         requiredTextResults,
       };
     }
-    const mismatchedBundle = batchResults.find(
-      (bundle) =>
-        bundle.limitExceeded || !bundle.localBytes.equals(bundle.bytes),
-    );
-    if (mismatchedBundle) {
+    if (firstBatchFailure?.reason === "asset_bytes_mismatch") {
+      const mismatchedBundle = firstBatchFailure.bundle;
       const sizeDetail = mismatchedBundle.limitExceeded
         ? mismatchedBundle.detail
         : `${mismatchedBundle.bytes.length} live, ${mismatchedBundle.localBytes.length} local`;

--- a/packages/cloud/scripts/verify-pages-frontend.mjs
+++ b/packages/cloud/scripts/verify-pages-frontend.mjs
@@ -1,15 +1,16 @@
 /**
  * Verifies that a Cloudflare Pages custom domain is serving the frontend bundle
  * that was just built by the deploy job. The check follows the live
- * `index.html` to its Vite entry chunk, compares that chunk name to the local
- * build output, and can require sentinel text that proves a specific user flow
- * is present in the served JavaScript.
+ * `index.html` to its Vite entry chunk, then compares every emitted JavaScript
+ * asset with the local build byte-for-byte. Required sentinel text is searched
+ * across the complete emitted graph so code-split user flows remain provable.
  */
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
 const DEFAULT_ATTEMPTS = 3;
 const DEFAULT_TIMEOUT_MS = 20_000;
+const MAX_CONCURRENT_ASSET_FETCHES = 16;
 
 function normalizeBaseUrl(url) {
   const trimmed = `${url ?? ""}`.trim();
@@ -73,10 +74,11 @@ async function fetchText(url, options = {}) {
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
       const response = await fetchImpl(url, { signal: controller.signal });
-      const text = await response.text();
+      const bytes = Buffer.from(await response.arrayBuffer());
+      const text = bytes.toString("utf8");
       if (response.ok) {
         clearTimeout(timeout);
-        return { ok: true, text, detail: `HTTP ${response.status}` };
+        return { ok: true, bytes, text, detail: `HTTP ${response.status}` };
       }
       lastDetail = `HTTP ${response.status}: ${text.slice(0, 200)}`;
     } catch (err) {
@@ -87,13 +89,32 @@ async function fetchText(url, options = {}) {
     }
     if (attempt < attempts) await retrySleep(intervalMs);
   }
-  return { ok: false, text: "", detail: lastDetail };
+  return { ok: false, bytes: null, text: "", detail: lastDetail };
 }
 
 async function readExpectedAssets(distDir) {
   const indexPath = path.join(distDir, "index.html");
   const html = await readFile(indexPath, "utf8");
   return extractEntryAssets(html);
+}
+
+async function readJavaScriptAssets(distDir) {
+  const pending = ["assets"];
+  const assets = [];
+  while (pending.length > 0) {
+    const relativeDir = pending.pop();
+    const entries = await readdir(path.join(distDir, relativeDir), {
+      withFileTypes: true,
+    });
+    for (const entry of entries) {
+      const relativePath = path.posix.join(relativeDir, entry.name);
+      if (entry.isDirectory()) pending.push(relativePath);
+      else if (entry.isFile() && entry.name.endsWith(".js")) {
+        assets.push(relativePath);
+      }
+    }
+  }
+  return assets.sort();
 }
 
 async function verifyPagesFrontendOnce(options) {
@@ -120,6 +141,7 @@ async function verifyPagesFrontendOnce(options) {
   }
 
   const expectedAssets = await readExpectedAssets(distDir);
+  const javascriptAssets = await readJavaScriptAssets(distDir);
   const indexFetch = await fetchText(baseUrl.href, {
     fetchImpl,
     attempts: fetchAttempts,
@@ -141,11 +163,29 @@ async function verifyPagesFrontendOnce(options) {
   const missingExpectedAssets = expectedAssets.filter(
     (asset) => !servedAssets.includes(asset),
   );
-  if (expectedAssets.length === 0 || servedAssets.length === 0) {
+  if (
+    expectedAssets.length === 0 ||
+    servedAssets.length === 0 ||
+    javascriptAssets.length === 0
+  ) {
     return {
       ok: false,
       reason: "entry_asset_missing",
       detail: `expected=${expectedAssets.join(",") || "-"} served=${servedAssets.join(",") || "-"}`,
+      expectedAssets,
+      servedAssets,
+      missingExpectedAssets,
+      requiredTextResults: [],
+    };
+  }
+  const missingLocalEntryAssets = expectedAssets.filter(
+    (asset) => !javascriptAssets.includes(asset),
+  );
+  if (missingLocalEntryAssets.length > 0) {
+    return {
+      ok: false,
+      reason: "entry_asset_missing",
+      detail: `Local dist is missing entry asset(s): ${missingLocalEntryAssets.join(", ")}`,
       expectedAssets,
       servedAssets,
       missingExpectedAssets,
@@ -164,24 +204,53 @@ async function verifyPagesFrontendOnce(options) {
     };
   }
 
-  const bundleTexts = await Promise.all(
-    expectedAssets.map(async (asset) => {
-      const assetUrl = new URL(asset, baseUrl);
-      const bundleFetch = await fetchText(assetUrl.href, {
-        fetchImpl,
-        attempts: fetchAttempts,
-        retrySleep,
-        intervalMs: fetchIntervalMs,
-      });
-      return { asset, ...bundleFetch };
-    }),
-  );
+  const bundleTexts = [];
+  for (
+    let offset = 0;
+    offset < javascriptAssets.length;
+    offset += MAX_CONCURRENT_ASSET_FETCHES
+  ) {
+    bundleTexts.push(
+      ...(await Promise.all(
+        javascriptAssets
+          .slice(offset, offset + MAX_CONCURRENT_ASSET_FETCHES)
+          .map(async (asset) => {
+            const assetUrl = new URL(asset, baseUrl);
+            const [localBytes, bundleFetch] = await Promise.all([
+              readFile(path.join(distDir, asset)),
+              fetchText(assetUrl.href, {
+                fetchImpl,
+                attempts: fetchAttempts,
+                retrySleep,
+                intervalMs: fetchIntervalMs,
+              }),
+            ]);
+            return { asset, localBytes, ...bundleFetch };
+          }),
+      )),
+    );
+  }
   const failedBundle = bundleTexts.find((bundle) => !bundle.ok);
   if (failedBundle) {
     return {
       ok: false,
-      reason: "entry_asset_unreachable",
+      reason: "javascript_asset_unreachable",
       detail: `${failedBundle.asset}: ${failedBundle.detail}`,
+      expectedAssets,
+      servedAssets,
+      missingExpectedAssets,
+      requiredTextResults: [],
+    };
+  }
+
+  const mismatchedBundle = bundleTexts.find(
+    (bundle) => !bundle.localBytes.equals(bundle.bytes),
+  );
+  if (mismatchedBundle) {
+    return {
+      ok: false,
+      reason: "asset_bytes_mismatch",
+      detail: `${mismatchedBundle.asset}: live bytes differ from local dist (${mismatchedBundle.bytes.length} live, ${mismatchedBundle.localBytes.length} local)`,
       expectedAssets,
       servedAssets,
       missingExpectedAssets,
@@ -212,7 +281,7 @@ async function verifyPagesFrontendOnce(options) {
   return {
     ok: true,
     reason: "ok",
-    detail: `Live bundle matches ${expectedAssets.join(", ")}`,
+    detail: `Live frontend matches ${javascriptAssets.length} emitted JavaScript asset(s), including ${expectedAssets.join(", ")}`,
     expectedAssets,
     servedAssets,
     missingExpectedAssets,

--- a/packages/cloud/scripts/verify-pages-frontend.mjs
+++ b/packages/cloud/scripts/verify-pages-frontend.mjs
@@ -67,9 +67,18 @@ async function fetchText(url, options = {}) {
     maxBytes = MAX_INDEX_BYTES,
   } = options;
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let timeout;
+  const timeoutFailure = new Promise((_, reject) => {
+    timeout = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`request timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
   try {
-    const response = await fetchImpl(url, { signal: controller.signal });
+    const response = await Promise.race([
+      fetchImpl(url, { signal: controller.signal }),
+      timeoutFailure,
+    ]);
     const contentLength = Number(response.headers?.get?.("content-length"));
     if (Number.isFinite(contentLength) && contentLength > maxBytes) {
       controller.abort();

--- a/packages/cloud/scripts/verify-pages-frontend.mjs
+++ b/packages/cloud/scripts/verify-pages-frontend.mjs
@@ -2,15 +2,19 @@
  * Verifies that a Cloudflare Pages custom domain is serving the frontend bundle
  * that was just built by the deploy job. The check follows the live
  * `index.html` to its Vite entry chunk, then compares every emitted JavaScript
- * asset with the local build byte-for-byte. Required sentinel text is searched
- * across the complete emitted graph so code-split user flows remain provable.
+ * script with the local build byte-for-byte. Required sentinel text is searched
+ * incrementally across the complete emitted graph so code-split user flows
+ * remain provable without retaining the entire application in memory.
  */
-import { readdir, readFile } from "node:fs/promises";
+import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 
-const DEFAULT_ATTEMPTS = 3;
 const DEFAULT_TIMEOUT_MS = 20_000;
+const DEFAULT_VERIFICATION_TIMEOUT_MS = 90_000;
 const MAX_CONCURRENT_ASSET_FETCHES = 16;
+const MAX_INDEX_BYTES = 2 * 1024 * 1024;
+const MAX_JAVASCRIPT_ASSETS = 2_048;
+const MAX_TOTAL_JAVASCRIPT_BYTES = 128 * 1024 * 1024;
 
 function normalizeBaseUrl(url) {
   const trimmed = `${url ?? ""}`.trim();
@@ -56,40 +60,93 @@ function normalizeRequiredTexts(requiredTexts) {
     .filter((text) => text.length > 0);
 }
 
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 async function fetchText(url, options = {}) {
   const {
     fetchImpl = globalThis.fetch,
-    attempts = DEFAULT_ATTEMPTS,
     timeoutMs = DEFAULT_TIMEOUT_MS,
-    retrySleep = sleep,
-    intervalMs = 2_000,
+    maxBytes = MAX_INDEX_BYTES,
   } = options;
-  let lastDetail = "not attempted";
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-      const response = await fetchImpl(url, { signal: controller.signal });
-      const bytes = Buffer.from(await response.arrayBuffer());
-      const text = bytes.toString("utf8");
-      if (response.ok) {
-        clearTimeout(timeout);
-        return { ok: true, bytes, text, detail: `HTTP ${response.status}` };
-      }
-      lastDetail = `HTTP ${response.status}: ${text.slice(0, 200)}`;
-    } catch (err) {
-      // error-policy:J1 boundary translation - network failures become verifier failure details.
-      lastDetail = err instanceof Error ? err.message : String(err);
-    } finally {
-      clearTimeout(timeout);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, { signal: controller.signal });
+    const contentLength = Number(response.headers?.get?.("content-length"));
+    if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+      controller.abort();
+      return {
+        ok: false,
+        bytes: null,
+        text: "",
+        limitExceeded: true,
+        detail: `response declares ${contentLength} bytes; limit is ${maxBytes}`,
+      };
     }
-    if (attempt < attempts) await retrySleep(intervalMs);
+
+    let bytes;
+    if (response.body && typeof response.body.getReader === "function") {
+      const reader = response.body.getReader();
+      const chunks = [];
+      let totalBytes = 0;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const chunk = Buffer.from(value);
+        totalBytes += chunk.length;
+        if (totalBytes > maxBytes) {
+          controller.abort();
+          return {
+            ok: false,
+            bytes: null,
+            text: "",
+            limitExceeded: true,
+            detail: `response exceeded ${maxBytes} bytes`,
+          };
+        }
+        chunks.push(chunk);
+      }
+      bytes = Buffer.concat(chunks, totalBytes);
+    } else {
+      bytes = Buffer.from(await response.arrayBuffer());
+      if (bytes.length > maxBytes) {
+        controller.abort();
+        return {
+          ok: false,
+          bytes: null,
+          text: "",
+          limitExceeded: true,
+          detail: `response returned ${bytes.length} bytes; limit is ${maxBytes}`,
+        };
+      }
+    }
+    const text = bytes.toString("utf8");
+    if (response.ok) {
+      return {
+        ok: true,
+        bytes,
+        text,
+        limitExceeded: false,
+        detail: `HTTP ${response.status}`,
+      };
+    }
+    return {
+      ok: false,
+      bytes: null,
+      text: "",
+      limitExceeded: false,
+      detail: `HTTP ${response.status}: ${text.slice(0, 200)}`,
+    };
+  } catch (err) {
+    // error-policy:J1 boundary translation - network failures become verifier failure details.
+    return {
+      ok: false,
+      bytes: null,
+      text: "",
+      limitExceeded: false,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    clearTimeout(timeout);
   }
-  return { ok: false, bytes: null, text: "", detail: lastDetail };
 }
 
 async function readExpectedAssets(distDir) {
@@ -99,8 +156,9 @@ async function readExpectedAssets(distDir) {
 }
 
 async function readJavaScriptAssets(distDir) {
-  const pending = ["assets"];
+  const pending = [""];
   const assets = [];
+  let totalBytes = 0;
   while (pending.length > 0) {
     const relativeDir = pending.pop();
     const entries = await readdir(path.join(distDir, relativeDir), {
@@ -110,11 +168,14 @@ async function readJavaScriptAssets(distDir) {
       const relativePath = path.posix.join(relativeDir, entry.name);
       if (entry.isDirectory()) pending.push(relativePath);
       else if (entry.isFile() && entry.name.endsWith(".js")) {
-        assets.push(relativePath);
+        const size = (await stat(path.join(distDir, relativePath))).size;
+        assets.push({ path: relativePath, size });
+        totalBytes += size;
       }
     }
   }
-  return assets.sort();
+  assets.sort((left, right) => left.path.localeCompare(right.path));
+  return { assets, totalBytes };
 }
 
 async function verifyPagesFrontendOnce(options) {
@@ -123,10 +184,11 @@ async function verifyPagesFrontendOnce(options) {
     distDir,
     requiredTexts = [],
     fetchImpl,
-    fetchAttempts = DEFAULT_ATTEMPTS,
-    retrySleep = sleep,
-    fetchIntervalMs = 2_000,
+    fetchTimeoutMs = DEFAULT_TIMEOUT_MS,
+    verificationTimeoutMs = DEFAULT_VERIFICATION_TIMEOUT_MS,
   } = options;
+  const deadlineAt = Date.now() + verificationTimeoutMs;
+  const remainingMs = () => Math.max(0, deadlineAt - Date.now());
   const baseUrl = normalizeBaseUrl(servedUrl);
   const required = normalizeRequiredTexts(requiredTexts);
   if (!baseUrl) {
@@ -141,12 +203,35 @@ async function verifyPagesFrontendOnce(options) {
   }
 
   const expectedAssets = await readExpectedAssets(distDir);
-  const javascriptAssets = await readJavaScriptAssets(distDir);
+  const javascriptManifest = await readJavaScriptAssets(distDir);
+  const javascriptAssets = javascriptManifest.assets;
+  if (
+    javascriptAssets.length > MAX_JAVASCRIPT_ASSETS ||
+    javascriptManifest.totalBytes > MAX_TOTAL_JAVASCRIPT_BYTES
+  ) {
+    return {
+      ok: false,
+      reason: "asset_budget_exceeded",
+      detail: `Local dist has ${javascriptAssets.length} JavaScript assets totaling ${javascriptManifest.totalBytes} bytes; limits are ${MAX_JAVASCRIPT_ASSETS} assets and ${MAX_TOTAL_JAVASCRIPT_BYTES} bytes`,
+      expectedAssets,
+      servedAssets: [],
+      requiredTextResults: [],
+    };
+  }
+  if (remainingMs() === 0) {
+    return {
+      ok: false,
+      reason: "verification_timeout",
+      detail: `Verification exceeded ${verificationTimeoutMs}ms before the live index fetch`,
+      expectedAssets,
+      servedAssets: [],
+      requiredTextResults: [],
+    };
+  }
   const indexFetch = await fetchText(baseUrl.href, {
     fetchImpl,
-    attempts: fetchAttempts,
-    retrySleep,
-    intervalMs: fetchIntervalMs,
+    timeoutMs: Math.min(fetchTimeoutMs, remainingMs()),
+    maxBytes: MAX_INDEX_BYTES,
   });
   if (!indexFetch.ok) {
     return {
@@ -179,7 +264,7 @@ async function verifyPagesFrontendOnce(options) {
     };
   }
   const missingLocalEntryAssets = expectedAssets.filter(
-    (asset) => !javascriptAssets.includes(asset),
+    (asset) => !javascriptAssets.some((entry) => entry.path === asset),
   );
   if (missingLocalEntryAssets.length > 0) {
     return {
@@ -204,65 +289,96 @@ async function verifyPagesFrontendOnce(options) {
     };
   }
 
-  const bundleTexts = [];
+  const requiredTextResults = required.map((text) => ({
+    text,
+    present: false,
+  }));
   for (
     let offset = 0;
     offset < javascriptAssets.length;
     offset += MAX_CONCURRENT_ASSET_FETCHES
   ) {
-    bundleTexts.push(
-      ...(await Promise.all(
-        javascriptAssets
-          .slice(offset, offset + MAX_CONCURRENT_ASSET_FETCHES)
-          .map(async (asset) => {
-            const assetUrl = new URL(asset, baseUrl);
-            const [localBytes, bundleFetch] = await Promise.all([
-              readFile(path.join(distDir, asset)),
-              fetchText(assetUrl.href, {
-                fetchImpl,
-                attempts: fetchAttempts,
-                retrySleep,
-                intervalMs: fetchIntervalMs,
-              }),
-            ]);
-            return { asset, localBytes, ...bundleFetch };
-          }),
-      )),
+    const batch = javascriptAssets.slice(
+      offset,
+      offset + MAX_CONCURRENT_ASSET_FETCHES,
     );
+    if (remainingMs() === 0) {
+      return {
+        ok: false,
+        reason: "verification_timeout",
+        detail: `Verification exceeded ${verificationTimeoutMs}ms after ${offset} JavaScript assets`,
+        expectedAssets,
+        servedAssets,
+        missingExpectedAssets,
+        requiredTextResults,
+      };
+    }
+    const batchTimeoutMs = Math.min(fetchTimeoutMs, remainingMs());
+    const batchResults = await Promise.all(
+      batch.map(async (asset) => {
+        const assetUrl = new URL(asset.path, baseUrl);
+        const [localBytes, bundleFetch] = await Promise.all([
+          readFile(path.join(distDir, asset.path)),
+          fetchText(assetUrl.href, {
+            fetchImpl,
+            timeoutMs: batchTimeoutMs,
+            maxBytes: asset.size,
+          }),
+        ]);
+        return { asset: asset.path, localBytes, ...bundleFetch };
+      }),
+    );
+    if (remainingMs() === 0) {
+      return {
+        ok: false,
+        reason: "verification_timeout",
+        detail: `Verification exceeded ${verificationTimeoutMs}ms while fetching ${batch[0].path}`,
+        expectedAssets,
+        servedAssets,
+        missingExpectedAssets,
+        requiredTextResults,
+      };
+    }
+    const failedBundle = batchResults.find(
+      (bundle) => !bundle.ok && !bundle.limitExceeded,
+    );
+    if (failedBundle) {
+      return {
+        ok: false,
+        reason: "javascript_asset_unreachable",
+        detail: `${failedBundle.asset}: ${failedBundle.detail}`,
+        expectedAssets,
+        servedAssets,
+        missingExpectedAssets,
+        requiredTextResults,
+      };
+    }
+    const mismatchedBundle = batchResults.find(
+      (bundle) =>
+        bundle.limitExceeded || !bundle.localBytes.equals(bundle.bytes),
+    );
+    if (mismatchedBundle) {
+      const sizeDetail = mismatchedBundle.limitExceeded
+        ? mismatchedBundle.detail
+        : `${mismatchedBundle.bytes.length} live, ${mismatchedBundle.localBytes.length} local`;
+      return {
+        ok: false,
+        reason: "asset_bytes_mismatch",
+        detail: `${mismatchedBundle.asset}: live bytes differ from local dist (${sizeDetail})`,
+        expectedAssets,
+        servedAssets,
+        missingExpectedAssets,
+        requiredTextResults,
+      };
+    }
+    for (const bundle of batchResults) {
+      for (const result of requiredTextResults) {
+        if (!result.present && bundle.text.includes(result.text)) {
+          result.present = true;
+        }
+      }
+    }
   }
-  const failedBundle = bundleTexts.find((bundle) => !bundle.ok);
-  if (failedBundle) {
-    return {
-      ok: false,
-      reason: "javascript_asset_unreachable",
-      detail: `${failedBundle.asset}: ${failedBundle.detail}`,
-      expectedAssets,
-      servedAssets,
-      missingExpectedAssets,
-      requiredTextResults: [],
-    };
-  }
-
-  const mismatchedBundle = bundleTexts.find(
-    (bundle) => !bundle.localBytes.equals(bundle.bytes),
-  );
-  if (mismatchedBundle) {
-    return {
-      ok: false,
-      reason: "asset_bytes_mismatch",
-      detail: `${mismatchedBundle.asset}: live bytes differ from local dist (${mismatchedBundle.bytes.length} live, ${mismatchedBundle.localBytes.length} local)`,
-      expectedAssets,
-      servedAssets,
-      missingExpectedAssets,
-      requiredTextResults: [],
-    };
-  }
-
-  const combinedBundle = bundleTexts.map((bundle) => bundle.text).join("\n");
-  const requiredTextResults = required.map((text) => ({
-    text,
-    present: combinedBundle.includes(text),
-  }));
   const missingTexts = requiredTextResults
     .filter((result) => !result.present)
     .map((result) => result.text);
@@ -281,7 +397,7 @@ async function verifyPagesFrontendOnce(options) {
   return {
     ok: true,
     reason: "ok",
-    detail: `Live frontend matches ${javascriptAssets.length} emitted JavaScript asset(s), including ${expectedAssets.join(", ")}`,
+    detail: `Live frontend matches ${javascriptAssets.length} emitted JavaScript asset(s) totaling ${javascriptManifest.totalBytes} bytes, including ${expectedAssets.join(", ")}`,
     expectedAssets,
     servedAssets,
     missingExpectedAssets,


### PR DESCRIPTION
Fixes #19624.

## Summary

- retain the live `index.html` entry-name freshness guard
- fetch and byte-compare every emitted JavaScript asset in bounded batches
- search release sentinels across the complete verified JavaScript graph
- fail closed on unreachable or byte-mismatched lazy chunks

## Verification

- `bun test packages/cloud/scripts/__tests__/verify-pages-frontend.test.ts` — 10/10
- Biome exact paths — pass
- `git diff --check` — pass
- `bun run build:core` — 56/56 Turbo tasks
- `bun run --cwd packages/app build:web` — pass, 563 JS assets
- real verifier against a local canonical app build — pass across all 563 assets and all three lazy `AppContext` sentinels

## Evidence

The canonical #19511 staging build placed all three required auth/handoff strings only in the lazy `AppContext` chunk. The prior entry-only verifier returned `required_text_missing`; this verifier passes after proving each live JavaScript response byte-identical to its local build artifact.