### PR TITLE
fix(cloud): restore Linux Terraform provider verification

### DIFF
--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/.terraform.lock.hcl
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
   constraints = "~> 5.0"
   hashes = [
     "h1:gNF1Sro3G9nXhtdkitXwDVKxI1jpBAf8KPv+Y4kAJwk=",
+    "h1:hU72otEs26Wx6tcJD9igX6I/BQtVgeRuaIe3s/hn6bQ=",
     "zh:049719425b8be43d9d4f0c208217aca0baa22374f061d7ff92f02563490f649c",
     "zh:0a8a3c1b26680b437fe9e7910ca81e532d36f8efacfb14f45690b6a779856993",
     "zh:32b61f80892243f7ab8e453fa038c1f3e2aac733ccb98307c2cfe798b2793b32",


### PR DESCRIPTION
Refs #19627

## Summary
- add the missing linux_amd64 package checksum for cloudflare/cloudflare 5.21.1
- keep the existing darwin_arm64 checksum and signed zip checksums unchanged
- unblock the protected pages-domains Terraform plan that issues the additive `*.cloud.eliza.app` certificate

## Root cause
The canonical API URL is correct. `*.cloud.eliza.app` resolves through Cloudflare, but its intended Advanced Certificate pack has not been applied. The protected Terraform lane previously failed before planning because the cached Linux provider package did not match the platform hashes recorded in the lock file.

An isolated `terraform providers lock -platform=linux_amd64 -platform=darwin_arm64` produced exactly this one missing h1 entry.

## Verification
- `terraform init -backend=false -lockfile=readonly` on a fresh isolated copy: pass
- `terraform validate`: pass
- `terraform fmt -check`: pass
- `bun test packages/cloud/infra/tests/terraform-static.test.ts`: 16/16 pass
- `bun run verify`: pass, 350/350 Turbo tasks plus repository audits
- `git diff --check`: pass

## Evidence
- backend logs: protected Terraform plan/apply receipts will be attached after the reviewed production operation
- frontend screenshots/video: N/A, infrastructure certificate metadata only
- real-model trajectory: N/A, no agent/model behavior change
- payouts/wallets: N/A and untouched

The certificate operation remains additive. No API domain rollback, existing certificate removal, payout mutation, or wallet action is included.