### PR TITLE
fix(cloud): unblock canonical wildcard certificate plan

### DIFF
--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/.terraform.lock.hcl
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
   constraints = "~> 5.0"
   hashes = [
     "h1:gNF1Sro3G9nXhtdkitXwDVKxI1jpBAf8KPv+Y4kAJwk=",
+    "h1:hU72otEs26Wx6tcJD9igX6I/BQtVgeRuaIe3s/hn6bQ=",
     "zh:049719425b8be43d9d4f0c208217aca0baa22374f061d7ff92f02563490f649c",
     "zh:0a8a3c1b26680b437fe9e7910ca81e532d36f8efacfb14f45690b6a779856993",
     "zh:32b61f80892243f7ab8e453fa038c1f3e2aac733ccb98307c2cfe798b2793b32",


### PR DESCRIPTION
Production backport of #19630 for #19627.

## Scope
- one missing linux_amd64 Cloudflare provider checksum
- no application code
- no unrelated develop commits
- no old-domain rollback or certificate removal

## Why this is production-critical
`*.cloud.eliza.app` is the canonical dedicated-agent domain and already resolves through Cloudflare, but TLS fails because its declared Advanced Certificate pack was never applied. The protected Terraform workflow previously failed during provider initialization because this Linux checksum was absent.

## Verification
- fresh Linux-capable lock regeneration produced exactly this one h1 entry
- fresh `terraform init -backend=false -lockfile=readonly`: pass
- `terraform validate`: pass
- `terraform fmt -check`: pass
- main-baseline Terraform static tests: 14/14 pass
- develop-baseline Terraform static tests: 16/16 pass
- full `bun run verify` on the identical patch against develop: pass, 350/350 Turbo tasks and all repository audits
- clean worktree and `git diff --check`

## Evidence
- frontend screenshots/video: N/A, provider lock metadata only
- real-model trajectory: N/A, no model behavior change
- production proof: exact reviewed Terraform plan/apply plus live TLS handshake will be attached to #19627 after merge
- payouts/wallets: N/A and untouched