### PR TITLE
fix(prompts): stop telling the default character to answer in JSON

### DIFF
--- a/packages/agent/src/runtime/build-character-config.test.ts
+++ b/packages/agent/src/runtime/build-character-config.test.ts
@@ -89,6 +89,30 @@ describe("Matrix connector secret/settings boundary", () => {
   });
 });
 
+describe("last-resort character system prompt", () => {
+  // An agent whose name matches no bundled preset and whose entry supplies no
+  // `system` falls through to defaultCharacterSystemTemplate. That template is a
+  // persona for ordinary conversation, so a structured-output directive in it
+  // makes a self-hoster's agent answer every message with a JSON object.
+  it("carries no output-format directive", () => {
+    const character = buildCharacterFromConfig({
+      agents: { list: [{ name: "Zzyzx Quorra" }] },
+    } as ElizaConfig);
+
+    const system = character.system ?? "";
+    expect(system.length).toBeGreaterThan(0);
+    for (const directive of [
+      "JSON only",
+      "Return one JSON object",
+      "No prose",
+      "fences",
+      "markdown",
+    ]) {
+      expect(system).not.toContain(directive);
+    }
+  });
+});
+
 describe("agent entry character passthrough", () => {
   it("keeps runtime capability hints idempotent across config rebuilds", () => {
     const workflowHint =

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -210,16 +210,7 @@ JSON only. Return one JSON object. No prose, fences, thinking, or markdown.
 
 export const CUSTOM_ACTION_GENERATE_TEMPLATE = customActionGenerateTemplate;
 
-/**
- * Last-resort persona for an agent whose character supplies no `system` and
- * whose name matches no bundled preset. This is conversational output, not a
- * structured-response prompt: it must never carry output-format directives.
- */
-export const defaultCharacterSystemTemplate = `You are {{name}}, an AI agent built on elizaOS.
-
-Be useful first. Answer plainly, in as few words as the question needs.
-Say "I don't know" rather than guessing, and say when you could not do
-something instead of implying you did.
+export const defaultCharacterSystemTemplate = `You are {{name}}, an autonomous AI agent powered by elizaOS.
 `;
 
 export const DEFAULT_CHARACTER_SYSTEM_TEMPLATE = defaultCharacterSystemTemplate;

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -210,9 +210,16 @@ JSON only. Return one JSON object. No prose, fences, thinking, or markdown.
 
 export const CUSTOM_ACTION_GENERATE_TEMPLATE = customActionGenerateTemplate;
 
-export const defaultCharacterSystemTemplate = `You are {{name}}, an autonomous AI agent powered by elizaOS.
+/**
+ * Last-resort persona for an agent whose character supplies no `system` and
+ * whose name matches no bundled preset. This is conversational output, not a
+ * structured-response prompt: it must never carry output-format directives.
+ */
+export const defaultCharacterSystemTemplate = `You are {{name}}, an AI agent built on elizaOS.
 
-JSON only. Return one JSON object. No prose, fences, thinking, or markdown.
+Be useful first. Answer plainly, in as few words as the question needs.
+Say "I don't know" rather than guessing, and say when you could not do
+something instead of implying you did.
 `;
 
 export const DEFAULT_CHARACTER_SYSTEM_TEMPLATE = defaultCharacterSystemTemplate;


### PR DESCRIPTION
## The bug

`defaultCharacterSystemTemplate` is the last fallback in `buildCharacterFromConfig`:

```ts
const systemPrompt =
  agentEntry?.system ?? bundledPreset?.system ?? defaultCharacterSystemTemplate;
```

So it is what a self-hoster gets when their agent supplies no `system` and its name matches no bundled preset. It contained:

> JSON only. Return one JSON object. No prose, fences, thinking, or markdown.

That is a structured-response directive in a conversational persona. The agent is being told to answer every message with a JSON object.

The line looks like collateral from a sweep that added the directive across `packages/prompts`, where nearly every other export genuinely is a JSON-producing prompt. This one is a character persona and should never have received it.

## Evidence

Exercised through the real consumer, an agent named so it matches no preset:

```
BEFORE (develop)
You are {{name}}, an autonomous AI agent powered by elizaOS.

JSON only. Return one JSON object. No prose, fences, thinking, or markdown.
  contains "JSON only": true

AFTER (this branch)
You are {{name}}, an AI agent built on elizaOS.
Be useful first. Answer plainly, in as few words as the question needs.
Say "I don't know" rather than guessing, and say when you could not do
something instead of implying you did.
  contains "JSON only": false
```

No test pinned the old string, and `DEFAULT_CHARACTER_SYSTEM_TEMPLATE` has no consumer beyond the alias itself, so nothing depended on the directive.

## Evidence Gate

<!-- evidence-head:2952e775d0ca3c41bd60b88b98a53fbe0aed147c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - prompt template constant, no rendered surface is changed
<!-- evidence-row:after-screenshots -->
- [x] N/A - prompt template constant, no rendered surface is changed
<!-- evidence-row:walkthrough-video -->
- [x] N/A - single string constant with no interactive flow
<!-- evidence-row:backend-logs -->
- [x] Before/after through the real consumer `buildCharacterFromConfig`:
```
BEFORE: "JSON only. Return one JSON object. No prose, fences, thinking, or markdown."
        contains "JSON only": true
AFTER:  "Be useful first. Answer plainly, in as few words as the question needs."
        contains "JSON only": false
        contains "Return one JSON object": false
        contains "No prose": false
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser reachable code is touched by this change
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this removes a directive from a prompt; no model call is required to show the string changed
<!-- evidence-row:domain-artifacts -->
- [x] The rendered system prompt is the artifact, shown before and after above:
```
fallback path: agentEntry.system -> bundledPreset.system -> defaultCharacterSystemTemplate
agent name "Zzyzx Quorra" matches no preset, so the fallback is exercised
regression test added at packages/agent/src/runtime/build-character-config.test.ts
```

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- ai-assistance: yes
<!-- attribution-row:models -->
- models: anthropic/claude-opus-4-8
<!-- attribution-row:client -->
- client: Claude Code
<!-- attribution-row:skill-revision -->
- skill-revision: N/A - no packaged skill governed this change
<!-- attribution-row:status -->
- status: self-reported

