### PR TITLE
test(workflow): close chat action coverage gap

### DIFF
--- a/plugins/plugin-workflow/AGENTS.md
+++ b/plugins/plugin-workflow/AGENTS.md
@@ -4,7 +4,7 @@ Native Smithers workflow authoring and execution for elizaOS. This package owns 
 
 ## Architecture
 
-A persisted workflow is a TypeScript or TSX module that imports public APIs from `smthrs` and default-exports a workflow built with `smithers(...)`. The artifact also carries an input JSON Schema, a visual step manifest, optional schedule metadata, and props-driven widget manifests. There is one workflow format; foreign node graphs and translation layers are not supported.
+A persisted workflow is a TypeScript or TSX module that imports the authoring API from `smthrs/create` and default-exports a workflow built with `smithers(...)`. The artifact also carries an input JSON Schema, a visual step manifest, optional schedule metadata, and props-driven widget manifests. There is one workflow format; foreign node graphs and translation layers are not supported.
 
 elizaOS owns authentication, tenancy, definitions, revisions, run summaries, scheduling, HTTP routes, chat routing, and live product events. Smithers owns workflow evaluation. Runs execute in an isolated Bun child process and native Smithers progress is copied into the owning elizaOS run record. There is no Smithers Gateway, Gateway protocol, or Smithers HTTP sidecar.
 

--- a/plugins/plugin-workflow/AGENTS.md
+++ b/plugins/plugin-workflow/AGENTS.md
@@ -14,7 +14,7 @@ Every Smithers `Task` must use `globalThis.__elizaSmithers.agent`. The runner in
 
 ```tsx
 /** @jsxImportSource smthrs */
-import { createSmithers } from "smthrs";
+import { createSmithers } from "smthrs/create";
 import { z } from "zod";
 
 const { Workflow, Task, smithers, outputs } = createSmithers(

--- a/plugins/plugin-workflow/CLAUDE.md
+++ b/plugins/plugin-workflow/CLAUDE.md
@@ -4,7 +4,7 @@ Native Smithers workflow authoring and execution for elizaOS. This package owns 
 
 ## Architecture
 
-A persisted workflow is a TypeScript or TSX module that imports public APIs from `smthrs` and default-exports a workflow built with `smithers(...)`. The artifact also carries an input JSON Schema, a visual step manifest, optional schedule metadata, and props-driven widget manifests. There is one workflow format; foreign node graphs and translation layers are not supported.
+A persisted workflow is a TypeScript or TSX module that imports the authoring API from `smthrs/create` and default-exports a workflow built with `smithers(...)`. The artifact also carries an input JSON Schema, a visual step manifest, optional schedule metadata, and props-driven widget manifests. There is one workflow format; foreign node graphs and translation layers are not supported.
 
 elizaOS owns authentication, tenancy, definitions, revisions, run summaries, scheduling, HTTP routes, chat routing, and live product events. Smithers owns workflow evaluation. Runs execute in an isolated Bun child process and native Smithers progress is copied into the owning elizaOS run record. There is no Smithers Gateway, Gateway protocol, or Smithers HTTP sidecar.
 

--- a/plugins/plugin-workflow/CLAUDE.md
+++ b/plugins/plugin-workflow/CLAUDE.md
@@ -14,7 +14,7 @@ Every Smithers `Task` must use `globalThis.__elizaSmithers.agent`. The runner in
 
 ```tsx
 /** @jsxImportSource smthrs */
-import { createSmithers } from "smthrs";
+import { createSmithers } from "smthrs/create";
 import { z } from "zod";
 
 const { Workflow, Task, smithers, outputs } = createSmithers(

--- a/plugins/plugin-workflow/__tests__/unit/workflow-action.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-action.test.ts
@@ -39,6 +39,20 @@ const execution = {
   input: {},
 };
 
+const administrationMethods = [
+  'listWorkflows',
+  'searchWorkflows',
+  'getWorkflow',
+  'activateWorkflow',
+  'deactivateWorkflow',
+  'deleteWorkflow',
+  'cancelExecution',
+  'getWorkflowExecutions',
+  'getWorkflowRevisions',
+  'restoreWorkflowRevision',
+  'getWorkflowEvaluationSuite',
+] as const;
+
 function serviceHarness() {
   const service = {
     generateWorkflowDraft: mock(async () => workflow),
@@ -106,6 +120,11 @@ describe('WORKFLOW chat action', () => {
     });
     expect(await workflowAction.validate?.(runtimeFor(serviceHarness()), message)).toBe(true);
     expect(await workflowAction.validate?.(runtimeFor(null), message)).toBe(false);
+    expect(
+      await workflowAction.handler?.(runtimeFor(null), message, undefined, {
+        parameters: { action: 'list' },
+      } as HandlerOptions)
+    ).toEqual({ success: false, text: 'Workflow service is unavailable.' });
   });
 
   test('creates and modifies Smithers workflows for the canonical owner', async () => {
@@ -171,25 +190,111 @@ describe('WORKFLOW chat action', () => {
     );
   });
 
-  test('covers administration branches, bounded history, and explicit invalid input', async () => {
-    const service = serviceHarness();
-    for (const parameters of [
-      { action: 'list' },
-      { action: 'search', query: 'brief' },
-      { action: 'get', workflowId },
-      { action: 'activate', workflowId },
-      { action: 'deactivate', workflowId },
-      { action: 'delete', workflowId },
-      { action: 'cancel_run', executionId },
-      { action: 'executions', workflowId, limit: 999 },
-      { action: 'revisions', workflowId, limit: 0 },
-      { action: 'restore', workflowId, versionId: 'version-1' },
-      { action: 'eval_samples', workflowId },
-    ]) {
-      expect((await run(service, parameters)).success).toBe(true);
+  test('dispatches every administration operation with canonical ownership', async () => {
+    const cases = [
+      {
+        parameters: { action: 'list', limit: 1 },
+        method: 'listWorkflows',
+        args: [ownerId],
+        text: 'Found 1 workflow.',
+        data: { workflows: [workflow] },
+        metadata: { count: 1 },
+      },
+      {
+        parameters: { action: 'search', query: ' brief ' },
+        method: 'searchWorkflows',
+        args: ['brief', ownerId],
+        text: 'Found 1 workflow.',
+        data: { workflows: [workflow] },
+        metadata: { count: 1 },
+      },
+      {
+        parameters: { action: 'get', workflowId: ` ${workflowId} ` },
+        method: 'getWorkflow',
+        args: [workflowId, ownerId],
+        text: 'Loaded “Daily brief”.',
+        data: { workflow },
+      },
+      {
+        parameters: { action: 'activate', workflowId },
+        method: 'activateWorkflow',
+        args: [workflowId, ownerId],
+        text: 'Daily brief is now active.',
+        data: { workflow: { ...workflow, active: true } },
+      },
+      {
+        parameters: { action: 'deactivate', workflowId },
+        method: 'deactivateWorkflow',
+        args: [workflowId, ownerId],
+        text: 'Daily brief is now inactive.',
+        data: { workflow },
+      },
+      {
+        parameters: { action: 'delete', workflowId },
+        method: 'deleteWorkflow',
+        args: [workflowId, ownerId],
+        text: 'Workflow deleted.',
+        data: { workflowId },
+      },
+      {
+        parameters: { action: 'cancel_run', executionId: ` ${executionId} ` },
+        method: 'cancelExecution',
+        args: [executionId, ownerId],
+        text: `Cancellation requested for ${executionId}.`,
+        data: { execution: { ...execution, status: 'cancelled' } },
+      },
+      {
+        parameters: { action: 'executions', workflowId, limit: 999 },
+        method: 'getWorkflowExecutions',
+        args: [workflowId, 50, ownerId],
+        text: 'Found 1 run.',
+        data: { executions: [execution] },
+      },
+      {
+        parameters: { action: 'revisions', workflowId, limit: 0 },
+        method: 'getWorkflowRevisions',
+        args: [workflowId, 1, ownerId],
+        text: 'Found 1 revision.',
+        data: { revisions: [{ id: 'revision-1' }] },
+      },
+      {
+        parameters: { action: 'restore', workflowId, versionId: ' version-1 ' },
+        method: 'restoreWorkflowRevision',
+        args: [workflowId, 'version-1', ownerId],
+        text: 'Restored “Daily brief”.',
+        data: { workflow },
+      },
+      {
+        parameters: { action: 'eval_samples', workflowId, limit: '7' },
+        method: 'getWorkflowEvaluationSuite',
+        args: [workflowId, 7, ownerId],
+        text: 'Generated Smithers evaluation samples.',
+        data: { suite: { samples: [] } },
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const service = serviceHarness();
+      const callback = mock(async () => undefined);
+      const result = await run(service, testCase.parameters, callback);
+
+      expect(result).toEqual({ success: true, text: testCase.text, data: testCase.data });
+      expect(service[testCase.method]).toHaveBeenCalledTimes(1);
+      expect(service[testCase.method]).toHaveBeenCalledWith(...testCase.args);
+      for (const method of administrationMethods) {
+        if (method !== testCase.method) expect(service[method]).not.toHaveBeenCalled();
+      }
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith({
+        text: testCase.text,
+        action: 'WORKFLOW',
+        metadata: 'metadata' in testCase ? testCase.metadata : undefined,
+      });
     }
-    expect(service.getWorkflowExecutions).toHaveBeenCalledWith(workflowId, 50, ownerId);
-    expect(service.getWorkflowRevisions).toHaveBeenCalledWith(workflowId, 1, ownerId);
+  });
+
+  test('rejects invalid administration input and returns visible service failures', async () => {
+    const service = serviceHarness();
 
     expect((await run(service, {})).text).toContain('action is required');
     expect((await run(service, { action: 'get' })).text).toBe('workflowId is required.');

--- a/plugins/plugin-workflow/__tests__/unit/workflow-action.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-action.test.ts
@@ -1,0 +1,206 @@
+/** Exercises the chat WORKFLOW action against a deterministic service boundary, including authoring, execution widgets, administration, validation, and visible failures. */
+
+import { describe, expect, mock, test } from 'bun:test';
+import type {
+  ActionResult,
+  HandlerCallback,
+  HandlerOptions,
+  IAgentRuntime,
+  Memory,
+  UUID,
+} from '@elizaos/core';
+import { workflowAction } from '../../src/actions/workflow';
+import { WORKFLOW_SERVICE_TYPE, type WorkflowService } from '../../src/services/workflow-service';
+
+const ownerId = '00000000-0000-4000-8000-000000000010' as UUID;
+const workflowId = 'workflow-1';
+const executionId = 'execution-1';
+const workflow = {
+  id: workflowId,
+  name: 'Daily brief',
+  language: 'tsx' as const,
+  source: "import 'smthrs'; export default {};",
+  active: false,
+  steps: [{ id: 'collect', label: 'Collect', kind: 'task' }],
+  widgets: [{ id: 'summary', title: 'Summary', surface: 'status' as const }],
+  createdAt: '2026-08-14T00:00:00.000Z',
+  updatedAt: '2026-08-14T00:00:00.000Z',
+  versionId: 'version-1',
+};
+const execution = {
+  id: executionId,
+  workflowId,
+  workflowVersionId: 'version-1',
+  workflowName: workflow.name,
+  mode: 'chat' as const,
+  status: 'queued' as const,
+  finished: false,
+  startedAt: '2026-08-14T00:00:00.000Z',
+  input: {},
+};
+
+function serviceHarness() {
+  const service = {
+    generateWorkflowDraft: mock(async () => workflow),
+    modifyWorkflowDraft: mock(async () => ({ ...workflow, name: 'Edited brief' })),
+    deployWorkflow: mock(async () => ({
+      id: workflowId,
+      name: workflow.name,
+      active: false,
+      stepCount: 1,
+    })),
+    listWorkflows: mock(async () => [workflow]),
+    searchWorkflows: mock(async () => [workflow]),
+    getWorkflow: mock(async () => workflow),
+    updateWorkflow: mock(async (_id: string, update: typeof workflow) => update),
+    activateWorkflow: mock(async () => ({ ...workflow, active: true })),
+    deactivateWorkflow: mock(async () => workflow),
+    deleteWorkflow: mock(async () => undefined),
+    startWorkflow: mock(async () => execution),
+    cancelExecution: mock(async () => ({ ...execution, status: 'cancelled' as const })),
+    getWorkflowExecutions: mock(async () => [execution]),
+    getWorkflowRevisions: mock(async () => [{ id: 'revision-1' }]),
+    restoreWorkflowRevision: mock(async () => workflow),
+    getWorkflowEvaluationSuite: mock(async () => ({ samples: [] })),
+  };
+  return service as unknown as WorkflowService & typeof service;
+}
+
+function runtimeFor(service: WorkflowService | null): IAgentRuntime {
+  return {
+    agentId: '00000000-0000-4000-8000-000000000001' as UUID,
+    character: { name: 'Workflow action test' },
+    getSetting: (key: string) => (key === 'ELIZA_ADMIN_ENTITY_ID' ? ownerId : null),
+    getService: (type: string) => (type === WORKFLOW_SERVICE_TYPE ? service : null),
+  } as unknown as IAgentRuntime;
+}
+
+const message = {
+  id: '00000000-0000-4000-8000-000000000020' as UUID,
+  agentId: '00000000-0000-4000-8000-000000000001' as UUID,
+  entityId: '00000000-0000-4000-8000-000000000021' as UUID,
+  roomId: '00000000-0000-4000-8000-000000000022' as UUID,
+  content: { text: 'Create a daily brief' },
+  createdAt: 0,
+} satisfies Memory;
+
+async function run(
+  service: WorkflowService,
+  parameters: Record<string, unknown>,
+  callback?: HandlerCallback
+): Promise<ActionResult> {
+  return (await workflowAction.handler?.(
+    runtimeFor(service),
+    message,
+    undefined,
+    { parameters } as HandlerOptions,
+    callback
+  )) as ActionResult;
+}
+
+describe('WORKFLOW chat action', () => {
+  test('declares owner-only workflow routing and validates service availability', async () => {
+    expect(workflowAction.roleGate).toEqual({ minRole: 'OWNER' });
+    expect(workflowAction.contextGate).toEqual({
+      anyOf: ['general', 'automation', 'tasks', 'agent_internal'],
+    });
+    expect(await workflowAction.validate?.(runtimeFor(serviceHarness()), message)).toBe(true);
+    expect(await workflowAction.validate?.(runtimeFor(null), message)).toBe(false);
+  });
+
+  test('creates and modifies Smithers workflows for the canonical owner', async () => {
+    const service = serviceHarness();
+    const callback = mock(async () => undefined);
+    const created = await run(service, { action: 'create', seedPrompt: 'Daily brief' }, callback);
+
+    expect(created.success).toBe(true);
+    expect(service.generateWorkflowDraft).toHaveBeenCalledWith('Daily brief', { userId: ownerId });
+    expect(service.deployWorkflow).toHaveBeenCalledWith(workflow, ownerId, { activate: false });
+    expect(created.data).toEqual({
+      workflow,
+      widget: { type: 'workflow', workflowId },
+    });
+    expect(callback).toHaveBeenCalledWith({
+      text: 'Created “Daily brief” as an inactive Smithers workflow.',
+      action: 'WORKFLOW',
+      metadata: { workflowId },
+    });
+
+    const modified = await run(service, {
+      action: 'modify',
+      workflowId,
+      instruction: 'Add approval',
+    });
+    expect(modified.success).toBe(true);
+    expect(service.modifyWorkflowDraft).toHaveBeenCalledWith(workflow, 'Add approval', {
+      userId: ownerId,
+    });
+    expect(service.updateWorkflow).toHaveBeenCalledWith(
+      workflowId,
+      expect.objectContaining({ name: 'Edited brief', active: false }),
+      ownerId
+    );
+  });
+
+  test('starts chat runs with a hydratable visual widget', async () => {
+    const service = serviceHarness();
+    const callback = mock(async () => undefined);
+    const result = await run(
+      service,
+      { action: 'run', workflowId, input: { topic: 'release' } },
+      callback
+    );
+
+    expect(service.startWorkflow).toHaveBeenCalledWith(
+      workflowId,
+      { mode: 'chat', input: { topic: 'release' } },
+      ownerId
+    );
+    expect(result.success).toBe(true);
+    expect(result.text).toContain('[WORKFLOW]');
+    expect(result.text).toContain('"nodeId":"collect"');
+    expect(result.data).toEqual({
+      execution,
+      widget: { type: 'workflow-run', workflowId, runId: executionId },
+    });
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'WORKFLOW',
+        metadata: { workflowId, runId: executionId },
+      })
+    );
+  });
+
+  test('covers administration branches, bounded history, and explicit invalid input', async () => {
+    const service = serviceHarness();
+    for (const parameters of [
+      { action: 'list' },
+      { action: 'search', query: 'brief' },
+      { action: 'get', workflowId },
+      { action: 'activate', workflowId },
+      { action: 'deactivate', workflowId },
+      { action: 'delete', workflowId },
+      { action: 'cancel_run', executionId },
+      { action: 'executions', workflowId, limit: 999 },
+      { action: 'revisions', workflowId, limit: 0 },
+      { action: 'restore', workflowId, versionId: 'version-1' },
+      { action: 'eval_samples', workflowId },
+    ]) {
+      expect((await run(service, parameters)).success).toBe(true);
+    }
+    expect(service.getWorkflowExecutions).toHaveBeenCalledWith(workflowId, 50, ownerId);
+    expect(service.getWorkflowRevisions).toHaveBeenCalledWith(workflowId, 1, ownerId);
+
+    expect((await run(service, {})).text).toContain('action is required');
+    expect((await run(service, { action: 'get' })).text).toBe('workflowId is required.');
+    expect((await run(service, { action: 'cancel_run' })).text).toBe('executionId is required.');
+    expect((await run(service, { action: 'restore', workflowId })).text).toBe(
+      'versionId is required.'
+    );
+
+    service.getWorkflow = mock(async () => {
+      throw new Error('not found');
+    });
+    expect((await run(service, { action: 'get', workflowId })).text).toBe('not found');
+  });
+});


### PR DESCRIPTION
# Relates to

Relates to #16580.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` passed after sync.
- [x] A reviewer can confirm the change from the test evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` `b8320ff38d9afd3bb129106dde8b65daf08123e6`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 Turbo tasks plus all repository audits.

# Risks

Low. Production behavior is unchanged. The new deterministic suite exercises the existing chat action boundary, and the documentation fix points authors at the already-used public `smthrs/create` export.

# Background

## What does this PR do?

- Adds direct coverage for every WORKFLOW chat operation, including exact method, canonical owner, normalized arguments, incompatible-method silence, exact result/callback payloads, unavailable handlers, visual run widgets, bounded history, invalid parameters, and surfaced service errors.
- Includes mutation controls proving that wrong delete dispatch and a dropped cancellation owner both fail the suite.
- Corrects the maintained Smithers source example from `smthrs` to the `smthrs/create` subpath used by generated workflows, the editor, and the real runner.

## What kind of change is this?

Testing and documentation improvement.

# Documentation changes needed?

The package-local Smithers source contract is updated in both byte-identical guides.

# Testing

## Where should a reviewer start?

`plugins/plugin-workflow/__tests__/unit/workflow-action.test.ts`

## Detailed testing steps

- `bun run check:agents-claude` — 153/153 guide pairs identical.
- `bun run --cwd plugins/plugin-workflow typecheck` — passed.
- `bun run --cwd plugins/plugin-workflow lint:check` — 42 files clean.
- `bun run --cwd plugins/plugin-workflow test` — 14/14 isolated suites passed, including the real Smithers runner and the new 5-test/189-assertion chat suite.
- Workflow UI focused tests — 5 files, 34 tests passed.
- Workflow fixture browser journey — 2/2 passed (create, first trigger refresh, execute, inspect, reload).
- Real local-stack browser journey — 1/1 passed (create, message trigger, native Smithers completion/output, manual run, reload).
- `bun run verify` — passed, 350/350 Turbo tasks and all repository audits.

# Evidence Gate

<!-- evidence-head:1176aac5782a251c573223bdb2d3b1ae225c7e00 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI source changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI source changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this PR changes deterministic coverage and maintained documentation only; the unchanged real workflow journey was exercised locally.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend implementation changed; the real Smithers runner and local-stack journey passed
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend implementation changed; both Playwright workflow journeys passed without console/network failures.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or action implementation changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistence or domain implementation changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Known gaps / failures

None in this PR's scope. Initial fresh-checkout focused runs correctly stopped before test execution because core/shared generated exports had not yet been built; after running the owning builds, all focused, browser, and repository gates passed.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-workflow-closeout]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no repository contribution skill used","attribution_status":"self-reported","lane":"codex-workflow-closeout"} -->




