### PR TITLE
fix(cloud): precompile Pages Functions artifact

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -1310,13 +1310,25 @@ jobs:
       - name: Verify frontend chunk safety
         run: bun run --cwd packages/app verify:chunks
 
+      - name: Build self-contained Pages Functions bundle
+        working-directory: packages/app
+        run: |
+          set -euo pipefail
+          functions_bundle="$RUNNER_TEMP/pages-functions-bundle"
+          bunx wrangler@4.100.0 pages functions build functions \
+            --outdir "$functions_bundle" \
+            --project-directory . \
+            --build-output-directory dist
+          test -s "$functions_bundle/index.js"
+          install -m 0644 "$functions_bundle/index.js" dist/_worker.js
+          node --check dist/_worker.js
+
       - name: Upload consolidated frontend artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: pages-app-${{ steps.pages-artifact.outputs.run_id }}-${{ steps.pages-artifact.outputs.run_attempt }}
           path: |
             packages/app/dist
-            packages/app/functions
             packages/app/wrangler.toml
           if-no-files-found: error
           retention-days: 1
@@ -1484,6 +1496,13 @@ jobs:
         with:
           name: ${{ steps.pages-artifact.outputs.name }}
           path: ${{ env.CHECKOUT_DIR }}/packages/app
+
+      - name: Verify immutable Pages Functions bundle
+        working-directory: ${{ env.CHECKOUT_DIR }}/packages/app
+        run: |
+          set -euo pipefail
+          test -s dist/_worker.js
+          node --check dist/_worker.js
 
       - name: Legacy inline fallback - install dependencies
         if: ${{ vars.CLOUD_CF_LEGACY_INLINE_BUILD == 'true' }}

--- a/packages/app/test/pages-deploy-workflow.test.ts
+++ b/packages/app/test/pages-deploy-workflow.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Deployment contract for the immutable Pages artifact and its precompiled
+ * Functions worker, exercised without production credentials.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const workflow = readFileSync(
+  join(import.meta.dir, "../../../.github/workflows/cloud-cf-release.yml"),
+  "utf8",
+);
+
+describe("Pages deployment artifact", () => {
+  test("compiles workspace imports before publishing the immutable artifact", () => {
+    expect(workflow).toContain("Build self-contained Pages Functions bundle");
+    expect(workflow).toContain(
+      "bunx wrangler@4.100.0 pages functions build functions",
+    );
+    expect(workflow).toContain(
+      'install -m 0644 "$functions_bundle/index.js" dist/_worker.js',
+    );
+    expect(workflow).toContain("node --check dist/_worker.js");
+  });
+
+  test("uploads and verifies the compiled worker instead of mutable function sources", () => {
+    const uploadStart = workflow.indexOf(
+      "- name: Upload consolidated frontend artifact",
+    );
+    const deployStart = workflow.indexOf("  deploy-app:", uploadStart);
+    expect(uploadStart).toBeGreaterThan(-1);
+    expect(deployStart).toBeGreaterThan(uploadStart);
+
+    const artifactProducer = workflow.slice(uploadStart, deployStart);
+    expect(artifactProducer).toContain("packages/app/dist");
+    expect(artifactProducer).not.toContain("packages/app/functions");
+
+    const artifactConsumer = workflow.slice(deployStart);
+    expect(artifactConsumer).toContain(
+      "Verify immutable Pages Functions bundle",
+    );
+    expect(artifactConsumer).toContain("test -s dist/_worker.js");
+  });
+});


### PR DESCRIPTION
Fixes #19642 and keeps develop aligned with production hotfix #19643.

The immutable Pages producer compiles raw Functions source while the frozen workspace dependencies exist, installs a self-contained advanced-mode `dist/_worker.js`, and publishes only deployable bytes. The consumer validates the Worker rather than recompiling source without `@elizaos/shared`.

Evidence:
- Focused workflow test 2/2.
- actionlint, Biome, and diff-check pass on current develop.
- Real Wrangler compile/dev proof is recorded in #19643: actual Functions + shared contract compiled, then served static `/` as 200 without workspace packages and preserved designed no-binding API 503.

No UI pixels, API Worker code, DNS, payout, wallet, or production runtime state are changed.