### PR TITLE
fix(infra): allow absent Railway DNS handoff

### DIFF
--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/variables.tf
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/variables.tf
@@ -75,21 +75,23 @@ variable "railway_tunnel_dns_records" {
   default = {}
 
   validation {
-    condition = alltrue([
-      for required_role in [
-        "apex-routing",
-        "apex-verification",
-        "wildcard-routing",
-        "wildcard-certificate",
-        "wildcard-verification",
-        ] : length([
-          for record in values(var.railway_tunnel_dns_records) : record
-          if contains(record.roles, required_role)
-      ]) == 1
-      ]) && alltrue([
-      for key in keys(var.railway_tunnel_dns_records) :
-      can(regex("^[a-z0-9][a-z0-9-]*$", key))
-    ])
+    condition = length(var.railway_tunnel_dns_records) == 0 || (
+      alltrue([
+        for required_role in [
+          "apex-routing",
+          "apex-verification",
+          "wildcard-routing",
+          "wildcard-certificate",
+          "wildcard-verification",
+          ] : length([
+            for record in values(var.railway_tunnel_dns_records) : record
+            if contains(record.roles, required_role)
+        ]) == 1
+        ]) && alltrue([
+        for key in keys(var.railway_tunnel_dns_records) :
+        can(regex("^[a-z0-9][a-z0-9-]*$", key))
+      ])
+    )
     error_message = "railway_tunnel_dns_records must cover each documented apex/wildcard routing, verification, and certificate role exactly once; record keys must be stable lowercase kebab-case names"
   }
 

--- a/packages/cloud/infra/tests/terraform-static.test.ts
+++ b/packages/cloud/infra/tests/terraform-static.test.ts
@@ -262,6 +262,9 @@ describe("Cloudflare Pages domain durability", () => {
 
   test("owns reviewed Railway tunnel DNS as an imported DNS-only inventory", () => {
     expect(variables).toContain('variable "railway_tunnel_dns_records"');
+    expect(variables).toContain(
+      "length(var.railway_tunnel_dns_records) == 0 || (",
+    );
     expect(variables).toContain('"apex-routing"');
     expect(variables).toContain('"apex-verification"');
     expect(variables).toContain('"wildcard-routing"');


### PR DESCRIPTION
Continues #19627 after replacement plan 31845454146 reached Terraform and failed safely.

The protected Railway inventory is currently `{}` because canonical `tunnel.eliza.app` domains have not been attached to Railway. That is a valid absent optional handoff for this root: the variable itself defaults to `{}` and its resources use `for_each`, while the separate tunnel deployment remains fail-closed until a complete five-role provider inventory exists.

The validation now accepts either:
1. no Railway handoff records, or
2. a complete, exact five-role inventory with the existing strict names/types/role checks.

It does not accept a partial inventory and does not invent Railway DNS targets. This unblocks the independent advanced-certificate plan for `*.cloud.eliza.app` and `*.sites.eliza.app`.

Evidence:
- `terraform fmt -check` — pass.
- Fresh `terraform init -backend=false` + `terraform validate` — pass with the empty default.
- `bun test packages/cloud/infra/tests/terraform-static.test.ts` — 15/15 pass.
- Biome and diff-check pass.
- Live read-only Railway inventory confirms production tunnel-proxy currently has only the working legacy `tunnel.elizacloud.ai` and `*.tunnel.elizacloud.ai` domains; no canonical domains were mutated or inferred.

No Terraform apply, Railway domain attachment, DNS, certificate, payout, wallet, or runtime mutation occurs in this PR.