### PR TITLE
fix(infra): allow absent Railway DNS handoff

### DIFF
--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/variables.tf
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/variables.tf
@@ -75,21 +75,23 @@ variable "railway_tunnel_dns_records" {
   default = {}
 
   validation {
-    condition = alltrue([
-      for required_role in [
-        "apex-routing",
-        "apex-verification",
-        "wildcard-routing",
-        "wildcard-certificate",
-        "wildcard-verification",
-        ] : length([
-          for record in values(var.railway_tunnel_dns_records) : record
-          if contains(record.roles, required_role)
-      ]) == 1
-      ]) && alltrue([
-      for key in keys(var.railway_tunnel_dns_records) :
-      can(regex("^[a-z0-9][a-z0-9-]*$", key))
-    ])
+    condition = length(var.railway_tunnel_dns_records) == 0 || (
+      alltrue([
+        for required_role in [
+          "apex-routing",
+          "apex-verification",
+          "wildcard-routing",
+          "wildcard-certificate",
+          "wildcard-verification",
+          ] : length([
+            for record in values(var.railway_tunnel_dns_records) : record
+            if contains(record.roles, required_role)
+        ]) == 1
+        ]) && alltrue([
+        for key in keys(var.railway_tunnel_dns_records) :
+        can(regex("^[a-z0-9][a-z0-9-]*$", key))
+      ])
+    )
     error_message = "railway_tunnel_dns_records must cover each documented apex/wildcard routing, verification, and certificate role exactly once; record keys must be stable lowercase kebab-case names"
   }
 

--- a/packages/cloud/infra/tests/terraform-static.test.ts
+++ b/packages/cloud/infra/tests/terraform-static.test.ts
@@ -284,6 +284,9 @@ describe("Cloudflare Pages domain durability", () => {
 
   test("owns reviewed Railway tunnel DNS as an imported DNS-only inventory", () => {
     expect(variables).toContain('variable "railway_tunnel_dns_records"');
+    expect(variables).toContain(
+      "length(var.railway_tunnel_dns_records) == 0 || (",
+    );
     expect(variables).toContain('"apex-routing"');
     expect(variables).toContain('"apex-verification"');
     expect(variables).toContain('"wildcard-routing"');


### PR DESCRIPTION
Develop parity for #19627 and production hotfix #19646.

The Railway tunnel DNS input now accepts either a genuinely absent inventory or the existing complete five-role provider-owned handoff. Partial, invented, or malformed inventories still fail. This preserves the tunnel workflow boundary while allowing unrelated canonical certificate resources to plan.

Evidence: Terraform fmt; fresh init/validate on main-equivalent bytes; 17/17 develop static tests; Biome and diff-check. Live Railway was inspected read-only and no domain/DNS state was changed.