### PR TITLE
chore: remove dead GitPOAP badge from vendored OZ fixture

### DIFF
--- a/packages/app-core/test/contracts/lib/openzeppelin-contracts/README.md
+++ b/packages/app-core/test/contracts/lib/openzeppelin-contracts/README.md
@@ -3,7 +3,6 @@
 [![Github Release](https://img.shields.io/github/v/tag/OpenZeppelin/openzeppelin-contracts.svg?filter=v*&sort=semver&label=github)](https://github.com/OpenZeppelin/openzeppelin-contracts/releases/latest)
 [![NPM Package](https://img.shields.io/npm/v/@openzeppelin/contracts.svg)](https://www.npmjs.org/package/@openzeppelin/contracts)
 [![Coverage Status](https://codecov.io/gh/OpenZeppelin/openzeppelin-contracts/graph/badge.svg)](https://codecov.io/gh/OpenZeppelin/openzeppelin-contracts)
-[![GitPOAPs](https://public-api.gitpoap.io/v1/repo/OpenZeppelin/openzeppelin-contracts/badge)](https://www.gitpoap.io/gh/OpenZeppelin/openzeppelin-contracts)
 [![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-yellow)](https://docs.openzeppelin.com/contracts)
 [![Forum](https://img.shields.io/badge/forum-%F0%9F%92%AC-yellow)](https://forum.openzeppelin.com/)
 


### PR DESCRIPTION
# Relates to — Self-found — vendored OZ README dead GitPOAP badge (public-api.gitpoap.io)

Scope of this PR is `packages/app-core/test/contracts/lib/openzeppelin-contracts/README.md:6` — `[![GitPOAPs](https://public-api.gitpoap.io/...)]` (domain defunct). Parallels eow #9340a7f8 `fixes gitpoap dead link` which merged. No staging QA claimed.

Definition of Done: full standard in [CONTRIBUTING.md](../CONTRIBUTING.md).

- [x] This PR targets develop and is rebased onto the latest origin/develop with zero conflicts (git fetch origin && git rebase origin/develop).
- [ ] bun install and bun run verify were run after sync, or any failure is recorded below with the exact unrelated blocker. → focused docs hygiene gate; see Known gaps / failures.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto origin/develop at 883fb83; zero conflicts.
- [ ] bun run verify passes post-sync → not run in this worktree; 1-line docs hygiene; `grep` + `curl -I` is the gate (see Evidence). May be closed as `wontfix — vendored` and that's acceptable.

# Risks

Low. Single badge line removed from `packages/app-core/test/contracts/lib/openzeppelin-contracts/README.md:6`:

```diff
- [![GitPOAPs](https://public-api.gitpoap.io/v1/repo/OpenZeppelin/openzeppelin-contracts/badge)](https://www.gitpoap.io/gh/OpenZeppelin/openzeppelin-contracts)
```

No code, no runtime, no build. File is vendored OZ copy (9137B → 8979B, -158B). Upstream `public-api.gitpoap.io` is defunct (DNS/404), so badge never renders. If maintainers prefer to keep vendored verbatim, close as `wontfix` — no harm. Alternative is `knip.json` ignore or `.assetsignore`, but deletion matches eow precedent that merged.

# Background

## What does this PR do?

Removes dead `GitPOAPs` badge that points to `https://public-api.gitpoap.io/v1/repo/OpenZeppelin/openzeppelin-contracts/badge` — same defunct domain removed in `ethereum-org-website` `9340a7f8`. `packages/app-core/test/contracts/lib/` is a vendored copy, so the badge is upstream's but now dead. 1-line deletion, docs-only.

## What kind of change is this?

Docs/hygiene (non-breaking). May be considered `chore`.

# Documentation changes needed?

No — this is the hygiene fix.

# Testing

## Where should a reviewer start?

- `packages/app-core/test/contracts/lib/openzeppelin-contracts/README.md:6` (removed)

## Detailed testing steps

```bash
grep -rn "public-api.gitpoap.io" packages/app-core/
# before: 1 hit on README.md:6
# after: 0 hits

curl -I https://public-api.gitpoap.io/v1/repo/OpenZeppelin/openzeppelin-contracts/badge
# fails (defunct domain) — badge never loads

grep -n "GitPOAP" packages/app-core/test/contracts/lib/openzeppelin-contracts/README.md
# after: 0
```

# Evidence Gate

Evidence matches exact head `f62083056f74eb979b6b1eb196139f43408c2e61`.
<!-- evidence-head:f62083056f74eb979b6b1eb196139f43408c2e61 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - docs badge only.
<!-- evidence-row:after-screenshots -->
- [x] N/A
<!-- evidence-row:walkthrough-video -->
- [x] N/A
<!-- evidence-row:backend-logs -->
- [x] N/A
<!-- evidence-row:frontend-logs -->
- [x] N/A
<!-- evidence-row:llm-trajectory -->
- [x] N/A
<!-- evidence-row:domain-artifacts -->
- [x] `grep` after = 0; file size 9137 → 8979.

```
$ grep -rn "public-api.gitpoap.io" packages/app-core/
(no output)

$ grep -n "GitPOAP" packages/app-core/test/contracts/lib/openzeppelin-contracts/README.md
(no output)
```

<!-- evidence-row:ocr-review -->
- [x] N/A

# Known gaps / failures

- `bun run verify` not run; 1-line vendored README badge removal — `grep` is the gate. File is vendored; maintainers may prefer `wontfix` and that's expected.
