### PR TITLE
fix(release): promote robot-greeting removal to the production phone line (#19393 + #19432)

### DIFF
--- a/packages/cloud/api/v1/twilio/voice/inbound/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/inbound/route.ts
@@ -16,6 +16,7 @@ import { normalizePhoneNumber } from "@/lib/utils/phone-normalization";
 import { verifyTwilioSignature } from "@/lib/utils/twilio-api";
 import { recordVoiceSessionJti } from "@/lib/voice-session/jwt";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
+import { scheduleTwilioVoiceScopePrewarm } from "../lib/prewarm-voice-scope";
 import { resolveTwilioVoiceTarget } from "../lib/resolve-voice-target";
 import { mintTwilioStreamToken } from "../lib/twilio-stream-token";
 import {
@@ -114,6 +115,27 @@ app.post("/", async (c) => {
   }
 
   const id = randomUUID();
+  const conversationId = randomUUID();
+  try {
+    scheduleTwilioVoiceScopePrewarm({
+      agent: phoneNumber.agent,
+      env: c.env,
+      executionCtx: c.executionCtx,
+      claims: {
+        agentId: phoneNumber.agentId,
+        conversationId,
+        organizationId: phoneNumber.organizationId,
+        userId: phoneNumber.userId,
+      },
+    });
+  } catch (error) {
+    // error-policy:J7 local/test contexts can omit a Worker execution context;
+    // the media session remains the authoritative cold-hydration boundary.
+    logger.warn("[twilio-voice-inbound] early scope prewarm unavailable", {
+      agentId: phoneNumber.agentId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
   const [priorCall] = await dbRead
     .select({ id: twilioInboundCalls.id })
     .from(twilioInboundCalls)
@@ -157,7 +179,6 @@ app.post("/", async (c) => {
     agentId: phoneNumber?.agentId,
   });
 
-  const conversationId = randomUUID();
   const minted = await mintTwilioStreamToken(
     {
       accountSid: event.AccountSid,

--- a/packages/cloud/api/v1/twilio/voice/inbound/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/inbound/route.ts
@@ -4,9 +4,10 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
-import { dbWrite } from "@/db/helpers";
+import { dbRead, dbWrite } from "@/db/helpers";
 import { twilioInboundCalls } from "@/db/schemas";
 import { ObjectNamespaces } from "@/lib/storage/object-namespace";
 import { offloadJsonField } from "@/lib/storage/object-store";
@@ -113,6 +114,17 @@ app.post("/", async (c) => {
   }
 
   const id = randomUUID();
+  const [priorCall] = await dbRead
+    .select({ id: twilioInboundCalls.id })
+    .from(twilioInboundCalls)
+    .where(
+      and(
+        eq(twilioInboundCalls.from_number, normalizedFrom),
+        eq(twilioInboundCalls.to_number, normalizedTo),
+        eq(twilioInboundCalls.agent_id, phoneNumber.agentId),
+      ),
+    )
+    .limit(1);
   const rawPayload = await offloadJsonField<Record<string, string>>({
     namespace: ObjectNamespaces.TwilioInboundPayloads,
     organizationId: phoneNumber?.organizationId ?? "twilio",
@@ -155,6 +167,7 @@ app.post("/", async (c) => {
       agentId: phoneNumber.agentId,
       conversationId,
       calledNumber: normalizedTo,
+      returningCaller: Boolean(priorCall),
     },
     authToken,
   );
@@ -173,7 +186,6 @@ app.post("/", async (c) => {
       streamUrl: publicUrl.toString(),
       sessionId: minted.claims.sessionId,
       token: minted.token,
-      greeting: "Hi, you're connected to Eliza.",
     }),
     {
       headers: { "Content-Type": "text/xml" },

--- a/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.test.ts
@@ -1,0 +1,62 @@
+/** Proves inbound Twilio prewarm starts immediately and stays non-fatal. */
+
+import { describe, expect, mock, test } from "bun:test";
+import { scheduleTwilioVoiceScopePrewarm } from "./prewarm-voice-scope";
+
+const claims = {
+  agentId: "agent-voice",
+  conversationId: "conversation-voice",
+  organizationId: "org-voice",
+  userId: "user-voice",
+};
+const agent = {
+  id: claims.agentId,
+  organization_id: claims.organizationId,
+  user_id: claims.userId,
+  character_id: "character-voice",
+  agent_name: "Eliza",
+  agent_config: null,
+  execution_tier: "shared" as const,
+};
+
+describe("Twilio voice scope prewarm", () => {
+  test("registers and runs hydration without blocking the caller", async () => {
+    const waits: Promise<unknown>[] = [];
+    let releaseHydration: (() => void) | undefined;
+    const hydrateScope = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseHydration = resolve;
+        }),
+    );
+
+    const prewarm = scheduleTwilioVoiceScopePrewarm({
+      agent: agent as never,
+      claims,
+      env: {} as never,
+      executionCtx: { waitUntil: (promise) => waits.push(promise) },
+      hydrateScope,
+    });
+
+    await Promise.resolve();
+    expect(hydrateScope).toHaveBeenCalledWith({}, claims, agent);
+    expect(waits).toEqual([prewarm]);
+    releaseHydration?.();
+    await prewarm;
+  });
+
+  test("contains hydration failure for the media session fallback", async () => {
+    const waits: Promise<unknown>[] = [];
+    const prewarm = scheduleTwilioVoiceScopePrewarm({
+      claims,
+      env: {} as never,
+      executionCtx: { waitUntil: (promise) => waits.push(promise) },
+      hydrateScope: async () => {
+        throw new Error("database unavailable");
+      },
+    });
+
+    await expect(prewarm).resolves.toBeUndefined();
+    await expect(waits[0]).resolves.toBeUndefined();
+  });
+});

--- a/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.ts
@@ -1,0 +1,56 @@
+/**
+ * Starts shared-runtime cache hydration during the inbound Twilio webhook so
+ * cold database work overlaps call setup, the greeting, and caller speech.
+ */
+
+import type { AgentSandbox } from "@/db/repositories/agent-sandboxes";
+import { logger } from "@/lib/utils/logger";
+import type { Bindings } from "@/types/cloud-worker-env";
+import type { InternalElizaConversationFetchClaims } from "../../../voice/session/lib/internal-eliza-conversation-fetch";
+
+interface VoicePrewarmExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+type HydrateVoiceScope = (
+  env: Bindings,
+  claims: InternalElizaConversationFetchClaims,
+  preloadedAgent?: AgentSandbox,
+) => Promise<void>;
+
+interface ScheduleVoiceScopePrewarmOptions {
+  agent?: AgentSandbox;
+  claims: InternalElizaConversationFetchClaims;
+  env: Bindings;
+  executionCtx: VoicePrewarmExecutionContext;
+  hydrateScope?: HydrateVoiceScope;
+}
+
+/** Registers a safe background prewarm at the earliest authenticated call boundary. */
+export function scheduleTwilioVoiceScopePrewarm({
+  agent,
+  claims,
+  env,
+  executionCtx,
+  hydrateScope,
+}: ScheduleVoiceScopePrewarmOptions): Promise<void> {
+  const prewarm = Promise.resolve()
+    .then(async () => {
+      const hydrate =
+        hydrateScope ??
+        (await import("../../../voice/session/lib/voice-agent-scope-hydration"))
+          .hydrateVoiceSharedAgentScope;
+      await hydrate(env, claims, agent);
+    })
+    .catch((error) => {
+      // error-policy:J7 this is a latency hint; the media session retains its
+      // authoritative hydration and retry path if the early prewarm fails.
+      logger.warn("[twilio-voice-inbound] early scope prewarm failed", {
+        agentId: claims.agentId,
+        organizationId: claims.organizationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  executionCtx.waitUntil(prewarm);
+  return prewarm;
+}

--- a/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.test.ts
@@ -8,6 +8,22 @@ interface SandboxRow {
   id: string;
   organization_id: string;
   user_id: string;
+  character_id: string | null;
+  agent_name: string | null;
+  agent_config: Record<string, unknown> | null;
+  execution_tier: "shared";
+}
+
+function sandboxRow(id: string): SandboxRow {
+  return {
+    id,
+    organization_id: "org-public",
+    user_id: "user-public",
+    character_id: "character-public",
+    agent_name: "Eliza",
+    agent_config: null,
+    execution_tier: "shared",
+  };
 }
 
 const findById = mock(
@@ -42,15 +58,13 @@ beforeEach(() => {
 
 describe("resolveTwilioVoiceTarget", () => {
   test("resolves the exact public number to the configured sandbox", async () => {
-    findById.mockImplementation(async () => ({
-      id: DEFAULT_AGENT_ID,
-      organization_id: "org-public",
-      user_id: "user-public",
-    }));
+    const agent = sandboxRow(DEFAULT_AGENT_ID);
+    findById.mockImplementation(async () => agent);
 
     await expect(
       resolveTwilioVoiceTarget(publicEnv, PUBLIC_NUMBER),
     ).resolves.toEqual({
+      agent: agent as never,
       agentId: DEFAULT_AGENT_ID,
       organizationId: "org-public",
       userId: "user-public",
@@ -59,15 +73,13 @@ describe("resolveTwilioVoiceTarget", () => {
   });
 
   test("supports a legacy character id for the configured public agent", async () => {
-    findLatestByCharacterId.mockImplementation(async () => ({
-      id: "agent-from-character",
-      organization_id: "org-public",
-      user_id: "user-public",
-    }));
+    const agent = sandboxRow("agent-from-character");
+    findLatestByCharacterId.mockImplementation(async () => agent);
 
     await expect(
       resolveTwilioVoiceTarget(publicEnv, PUBLIC_NUMBER),
     ).resolves.toEqual({
+      agent: agent as never,
       agentId: "agent-from-character",
       organizationId: "org-public",
       userId: "user-public",

--- a/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.ts
@@ -2,9 +2,13 @@
  * Resolves only the exact public eliza.app Twilio line to its configured agent.
  */
 
-import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
+import {
+  type AgentSandbox,
+  agentSandboxesRepository,
+} from "@/db/repositories/agent-sandboxes";
 
 export interface TwilioVoiceTarget {
+  agent: AgentSandbox;
   agentId: string;
   organizationId: string;
   userId: string;
@@ -35,6 +39,7 @@ export async function resolveTwilioVoiceTarget(
     (await agentSandboxesRepository.findLatestByCharacterId(defaultAgentId));
   return sandbox
     ? {
+        agent: sandbox,
         agentId: sandbox.id,
         organizationId: sandbox.organization_id,
         userId: sandbox.user_id,

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.test.ts
@@ -14,6 +14,7 @@ const input = {
   agentId: "agent-1",
   conversationId: "11111111-1111-4111-8111-111111111111",
   calledNumber: "+14484080429",
+  returningCaller: true,
 };
 
 describe("Twilio stream token", () => {

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.ts
@@ -21,6 +21,7 @@ const ClaimsSchema = z.object({
   agentId: z.string().min(1),
   conversationId: z.string().uuid(),
   calledNumber: z.string().min(1),
+  returningCaller: z.boolean(),
 });
 
 const WireClaimsSchema = z.object({
@@ -35,6 +36,7 @@ const WireClaimsSchema = z.object({
   g: z.string().min(1),
   n: z.string().uuid(),
   p: z.string().min(1),
+  r: z.boolean(),
 });
 
 export type TwilioStreamTokenClaims = z.infer<typeof ClaimsSchema>;
@@ -95,6 +97,7 @@ export async function mintTwilioStreamToken(
         g: claims.agentId,
         n: claims.conversationId,
         p: claims.calledNumber,
+        r: claims.returningCaller,
       }),
     ),
   );
@@ -139,6 +142,7 @@ export async function verifyTwilioStreamToken(
       agentId: wire.data.g,
       conversationId: wire.data.n,
       calledNumber: wire.data.p,
+      returningCaller: wire.data.r,
     });
     if (!parsed.success) return null;
     const nowSeconds = Math.floor(now() / 1_000);

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.test.ts
@@ -12,11 +12,12 @@ describe("Twilio voice TwiML", () => {
       streamUrl: "wss://api.eliza.app/api/v1/twilio/voice/media",
       sessionId: "11111111-1111-4111-8111-111111111111",
       token: "signed",
-      greeting: "Hi, you're connected to Eliza.",
     });
 
-    expect(xml).toContain("<Say>Hi, you&apos;re connected to Eliza.</Say>");
-    expect(xml).toContain('<Connect><Stream url="wss://api.eliza.app/');
+    expect(xml).toContain(
+      '<Response><Connect><Stream url="wss://api.eliza.app/',
+    );
+    expect(xml).not.toContain("<Say>");
     expect(xml).toContain(
       'name="sessionId" value="11111111-1111-4111-8111-111111111111"',
     );
@@ -28,14 +29,12 @@ describe("Twilio voice TwiML", () => {
       streamUrl: "wss://example.test/a?x=1&y=<bad>",
       sessionId: '"session"',
       token: "token'one",
-      greeting: "A & B < C",
     });
 
     expect(xml).not.toContain("<bad>");
     expect(xml).toContain("x=1&amp;y=&lt;bad&gt;");
     expect(xml).toContain("&quot;session&quot;");
     expect(xml).toContain("token&apos;one");
-    expect(xml).toContain("A &amp; B &lt; C");
   });
 
   test("builds a terminal spoken response", () => {

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.ts
@@ -17,7 +17,6 @@ export function buildRealtimeVoiceTwiML(options: {
   streamUrl: string;
   sessionId: string;
   token: string;
-  greeting: string;
 }): string {
-  return `<?xml version="1.0" encoding="UTF-8"?><Response><Say>${escapeXml(options.greeting)}</Say><Connect><Stream url="${escapeXml(options.streamUrl)}"><Parameter name="sessionId" value="${escapeXml(options.sessionId)}"/><Parameter name="token" value="${escapeXml(options.token)}"/></Stream></Connect></Response>`;
+  return `<?xml version="1.0" encoding="UTF-8"?><Response><Connect><Stream url="${escapeXml(options.streamUrl)}"><Parameter name="sessionId" value="${escapeXml(options.sessionId)}"/><Parameter name="token" value="${escapeXml(options.token)}"/></Stream></Connect></Response>`;
 }

--- a/packages/cloud/api/v1/twilio/voice/media/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/media/route.ts
@@ -63,6 +63,8 @@ const app = new Hono<AppEnv>();
 // window instead of terminating ordinary first calls before setup completes.
 const MAX_PENDING_MEDIA_FRAMES = 512;
 const DEFAULT_MAX_CALL_SECONDS = 30 * 60;
+const FIRST_CALL_GREETING = "hello? who's this?";
+const RETURNING_CALLER_GREETING = "hey whats up";
 const bootstrapGate = new TwilioBootstrapGate();
 
 const TwilioStreamEventSchema = z.discriminatedUnion("event", [
@@ -397,6 +399,9 @@ app.get("/", async (c) => {
       elizaModel: resolveElizaModel(env),
       fetchImpl: elizaFetch,
       prewarmElizaContext: elizaFetch.prewarm,
+      openingGreeting: claims.returningCaller
+        ? RETURNING_CALLER_GREETING
+        : FIRST_CALL_GREETING,
       usageStore,
       usageLimits: resolveVoiceUsageLimits(env),
       isRevoked: (jti) =>

--- a/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts
@@ -97,6 +97,8 @@ test("real cache + canonical coordinator dispatch performs no response-path DB w
     },
     executionCtx,
   );
+  await fetchImpl.prewarm();
+  expect(background).toHaveLength(0);
   const response = await fetchImpl(
     `https://voice.internal/api/v1/eliza/agents/${AGENT_ID}/api/conversations/${CONVERSATION_ID}/messages/stream`,
     {

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -444,6 +444,7 @@ async function connectSession(opts: {
   client: FakeClientSocket;
   fetchImpl: typeof fetch;
   prewarmElizaContext?: () => Promise<void>;
+  openingGreeting?: string;
   cacheWarmingRetryDelaysMs?: readonly number[];
   fish?: {
     enabled?: boolean;
@@ -482,6 +483,9 @@ async function connectSession(opts: {
         fetchImpl: opts.fetchImpl,
         ...(opts.prewarmElizaContext
           ? { prewarmElizaContext: opts.prewarmElizaContext }
+          : {}),
+        ...(opts.openingGreeting
+          ? { openingGreeting: opts.openingGreeting }
           : {}),
         ...(opts.cacheWarmingRetryDelaysMs
           ? {
@@ -531,6 +535,30 @@ function pcmChunk(bytes: number): Uint8Array {
 // --- tests ----------------------------------------------------------------
 
 describe("voice-session WS lifecycle", () => {
+  test("speaks a live opening greeting while the agent context warms", async () => {
+    const client = new FakeClientSocket();
+    let responseRequests = 0;
+    await connectSession({
+      client,
+      openingGreeting: "hello? who's this?",
+      fetchImpl: (async () => {
+        responseRequests += 1;
+        return makeCanonicalChunkFetch(["unused"])("", {});
+      }) as unknown as typeof fetch,
+    });
+    await flush();
+
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    expect(cartesia.sentText()).toBe("hello? who's this?");
+    expect(client.audioFrames.length).toBeGreaterThan(0);
+    expect(client.controlTypes()).toContain("speaking_start");
+    expect(responseRequests).toBe(0);
+
+    cartesia.emitDone();
+    await flush();
+    expect(client.controlTypes()).toContain("speaking_end");
+  });
+
   test("stt_final posts the transcript to the canonical agent conversation stream with scoped identity", async () => {
     const requests: Array<{
       url: string;
@@ -1540,6 +1568,69 @@ describe("voice-session WS lifecycle", () => {
     // Flushing here proves no late frame leaks through after the barge-in.
     await flush();
     expect(client.audioFrames.length).toBe(framesAfterInterrupt);
+  });
+
+  test("acoustic activity interrupts only after Ink registers caller words", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch([
+        "I will keep speaking until you say something.",
+      ]),
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "please explain");
+    await flush();
+    await flush();
+
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    expect(client.controlTypes()).toContain("speaking_start");
+    expect(cartesia.closed).toBe(false);
+
+    // Acoustic turn-start and punctuation-only revisions can be background
+    // noise or echo. They must not clear audio or cancel the active response.
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.update", "...");
+    await flush();
+    expect(client.controlTypes()).not.toContain("interrupted");
+    expect(cartesia.closed).toBe(false);
+
+    // The first partial containing a letter/number is confirmed caller speech.
+    ink.emitTurn("turn.update", "wait");
+    await flush();
+    expect(client.controlFrames).toContainEqual(
+      expect.objectContaining({ t: "interrupted", reason: "acoustic" }),
+    );
+    expect(cartesia.closed).toBe(true);
+  });
+
+  test("a final-only caller transcript still interrupts the active response", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["The response is still in progress."]),
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "start talking");
+    await flush();
+    await flush();
+
+    const activeCartesia = FakeCartesiaSocket.instances.at(-1)!;
+    expect(client.controlTypes()).toContain("speaking_start");
+    expect(activeCartesia.closed).toBe(false);
+
+    // Ink may finalize a short utterance without sending an interim update.
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "stop");
+    await flush();
+    expect(client.controlFrames).toContainEqual(
+      expect.objectContaining({ t: "interrupted", reason: "acoustic" }),
+    );
+    expect(activeCartesia.closed).toBe(true);
   });
 
   test("interruption aborts the in-flight Eliza SSE fetch", async () => {

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -786,6 +786,44 @@ describe("voice-session WS lifecycle", () => {
     expect(prewarmCalls).toBe(1);
   });
 
+  test("first response joins prewarm and an interruption discards the obsolete turn", async () => {
+    let resolvePrewarm: () => void = () => {};
+    const prewarm = new Promise<void>((resolve) => {
+      resolvePrewarm = resolve;
+    });
+    const requestTexts: string[] = [];
+    const successFetch = makeSseFetch(["Replacement response."]);
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      prewarmElizaContext: () => prewarm,
+      fetchImpl: (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as { text: string };
+        requestTexts.push(body.text);
+        return successFetch(input, init);
+      }) as typeof fetch,
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+    const ttsBefore = FakeCartesiaSocket.instances.length;
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "obsolete first request");
+    await flush();
+    expect(FakeCartesiaSocket.instances.length).toBe(ttsBefore + 1);
+    expect(requestTexts).toEqual([]);
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "replacement request");
+    await flush();
+    expect(requestTexts).toEqual([]);
+
+    resolvePrewarm();
+    await flush();
+    await flush();
+    expect(requestTexts).toEqual(["replacement request"]);
+    expect(client.controlTypes()).toContain("llm_first_text");
+  });
+
   test("caps Cartesia server-side buffer delay for realtime voice", async () => {
     const client = new FakeClientSocket();
     await connectSession({

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -133,7 +133,13 @@ export function createInternalElizaConversationFetchFactory(
       await runWithCloudBindingsAsync(
         env as unknown as Record<string, unknown>,
         async () => {
-          if (!(await readCachedAgent())) scheduleHydration();
+          if (await readCachedAgent()) return;
+          scheduleHydration();
+          // Capture before awaiting: the hydration's finally block clears the
+          // shared slot. Joining this exact promise lets the first voice turn
+          // use the freshly cached scope without cache-miss polling/backoff.
+          const pendingHydration = hydrationPromise;
+          if (pendingHydration) await pendingHydration;
         },
       );
     };

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -13,9 +13,9 @@
  *     `CartesiaSonicTtsAdapter` (#15949). Phrase-aggregated deltas stream in;
  *     adapters' strict no-post-cancel guarantee makes barge-in correct.
  *
- * Interruption (contract §7.5): acoustic speech-start / Ink turn / explicit
- * `barge_in` -> under one `voiceTurnId`, cancel the active TTS stream (no
- * post-cancel frames), abort the Eliza SSE fetch, flush the downlink, drop pending phrase
+ * Interruption (contract §7.5): confirmed caller words / explicit `barge_in`
+ * -> under one `voiceTurnId`, cancel the active TTS stream (no post-cancel
+ * frames), abort the Eliza SSE fetch, flush the downlink, drop pending phrase
  * aggregation, emit `interrupted`, return to listening. Target <250ms.
  *
  * Metering (SEC-15): server-derived uplink duration only; the client is NEVER
@@ -105,6 +105,7 @@ const CACHE_WARMING_CODES = new Set([
   "shared_runtime_cache_warming",
   "conversation_cache_warming",
 ]);
+const SPOKEN_TRANSCRIPT_RE = /[\p{L}\p{N}]/u;
 
 // Cartesia's server buffers streamed transcript for up to 3000ms by default
 // before starting synthesis, which measured ~2.7s of the speaking_start gap on
@@ -144,6 +145,8 @@ export interface VoiceSessionConfig {
   fetchImpl?: typeof fetch;
   /** Session-start DB/tenancy warmup, injected only by the live Worker route. */
   prewarmElizaContext?: () => Promise<void>;
+  /** Optional provider-synthesized opener that runs while agent context warms. */
+  openingGreeting?: string;
   /** Deterministic test override; production uses bounded exponential backoff. */
   cacheWarmingRetryDelaysMs?: readonly number[];
 
@@ -320,6 +323,9 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     const sessionTrace = this.mintTraceId("session");
     this.currentTraceId = sessionTrace;
     this.send({ t: "ready", sessionId: this.sessionId, traceId: sessionTrace });
+    if (this.config.openingGreeting?.trim()) {
+      this.speakOpeningGreeting(this.config.openingGreeting.trim());
+    }
   }
 
   /**
@@ -480,23 +486,24 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         break;
       }
       case "start-of-turn": {
-        // A new user turn started. If the agent is mid-speech, this is a
-        // barge-in (acoustic speech-start via Ink's native turn detector).
-        if (this.state === "speaking" || this.state === "thinking") {
-          this.interrupt("acoustic");
-        }
+        // Ink's acoustic turn detector also fires for line noise, breathing,
+        // and speaker echo. Keep transcribing alongside the active response;
+        // only a non-empty transcript-update below proves caller speech and
+        // earns the right to cancel model/TTS work.
         this.resetSttPartialDelivery();
         this.activeSttTurn = true;
-        this.state = "transcribing";
+        if (!this.currentVoiceTurnId) this.state = "transcribing";
         break;
       }
       case "transcript-update": {
         if (this.activeSttTurn && event.transcript) {
+          this.interruptForConfirmedSpeech(event.transcript);
           this.queueSttPartial(event.transcript);
         }
         break;
       }
       case "eager-end-of-turn": {
+        this.interruptForConfirmedSpeech(event.transcript);
         this.flushSttPartial();
         this.send({
           t: "stt_eager_eot",
@@ -506,6 +513,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       }
       case "end-of-turn": {
         if (!this.activeSttTurn) return;
+        this.interruptForConfirmedSpeech(event.transcript);
         this.activeSttTurn = false;
         this.resetSttPartialDelivery();
         // A missing transcript commits as "" on purpose: commitTurn's empty-
@@ -532,6 +540,15 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         break;
       }
     }
+  }
+
+  /** Cancel an active response only after Ink has produced caller words. */
+  private interruptForConfirmedSpeech(transcript: string): void {
+    if (!this.currentVoiceTurnId || !SPOKEN_TRANSCRIPT_RE.test(transcript)) {
+      return;
+    }
+    this.interrupt("acoustic");
+    this.state = "transcribing";
   }
 
   /**
@@ -616,6 +633,63 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     void this.runResponseTurn(transcript, traceId);
   }
 
+  /** Speak a fixed live opener while the first agent context is warming. */
+  private speakOpeningGreeting(text: string): void {
+    if (this.closed || this.currentVoiceTurnId) return;
+    const traceId = this.mintTraceId("turn");
+    this.currentTraceId = traceId;
+    this.currentVoiceTurnId = traceId;
+    this.turnTtsChars = text.length;
+    this.firstLlmTextEmitted = false;
+
+    const stream = this.createTtsStream(traceId, {
+      onFirstAudio: () => {
+        if (this.currentVoiceTurnId !== traceId) return;
+        this.state = "speaking";
+        this.send({ t: "speaking_start", traceId });
+      },
+      onAudioFrame: (frame) => {
+        if (this.currentVoiceTurnId !== traceId) return;
+        this.config.downlink.sendAudio(frame.bytes);
+      },
+      onComplete: () => {
+        if (this.currentVoiceTurnId !== traceId) return;
+        this.send({ t: "speaking_end", traceId });
+        this.finishTurn(traceId);
+      },
+      onProviderError: (error) => {
+        if (this.currentVoiceTurnId !== traceId) return;
+        this.send({
+          t: "error",
+          code: error.code ?? "tts_error",
+          retryable: true,
+        });
+        this.finishTurn(traceId);
+      },
+    });
+    this.ttsStream = stream;
+    void stream.opened.catch(() => undefined);
+    stream.sendPhrase({ text, continueContext: false });
+  }
+
+  private createTtsStream(
+    traceId: string,
+    callbacks: RealtimeTtsStreamCallbacks,
+  ): RealtimeTtsStream {
+    const createCartesia = () =>
+      this.cartesiaAdapter.createStream(
+        { traceId, maxBufferDelayMs: VOICE_TTS_MAX_BUFFER_DELAY_MS },
+        callbacks,
+      );
+    if (!this.fishAudioAdapter) return createCartesia();
+    return new FishPrimaryRealtimeTtsStream({
+      traceId,
+      fishAudioAdapter: this.fishAudioAdapter,
+      createCartesia,
+      callbacks,
+    });
+  }
+
   private async runResponseTurn(
     transcript: string,
     traceId: string,
@@ -668,21 +742,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
           this.finishTurn(traceId);
         },
       };
-      const createCartesia = () =>
-        this.cartesiaAdapter.createStream(
-          { traceId, maxBufferDelayMs: VOICE_TTS_MAX_BUFFER_DELAY_MS },
-          callbacks,
-        );
-      if (this.fishAudioAdapter) {
-        tts = new FishPrimaryRealtimeTtsStream({
-          traceId,
-          fishAudioAdapter: this.fishAudioAdapter,
-          createCartesia,
-          callbacks,
-        });
-      } else {
-        tts = createCartesia();
-      }
+      tts = this.createTtsStream(traceId, callbacks);
       this.ttsStream = tts;
       return tts;
     };

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -213,6 +213,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   private lastSttPartialSentAtMs = Number.NEGATIVE_INFINITY;
   private sttPartialTimer: ReturnType<typeof setTimeout> | null = null;
   private llmAbort: AbortController | null = null;
+  private elizaPrewarm: Promise<void> | null = null;
   private phrase: PhraseAggregator | null = null;
   private turnSttMs = 0;
   private turnTtsChars = 0;
@@ -313,11 +314,17 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
     this.state = "listening";
     // Read immutable tenancy from cache while the user is beginning to speak.
-    // A miss only schedules authoritative hydration under the Worker lifetime;
-    // the first turn never joins that database work and reports retryable
-    // warming until a later cache read observes the completed fill.
+    // A miss schedules authoritative hydration under the Worker lifetime; the
+    // first turn joins that work so it does not burn time polling a cold cache.
     if (this.config.prewarmElizaContext) {
-      void this.config.prewarmElizaContext().catch(() => undefined);
+      this.elizaPrewarm = this.config.prewarmElizaContext().catch((error) => {
+        // error-policy:J7 prewarm is latency-only; the response path retains
+        // its typed cache-warming retry fallback and reports the failed hint.
+        logger.warn("[voice-session] Eliza context prewarm failed", {
+          sessionId: this.sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
     }
     // The session-level trace span id is stable until the first turn mints its own.
     const sessionTrace = this.mintTraceId("session");
@@ -758,6 +765,13 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       // turn does not await readiness because outbound phrases queue in the
       // adapter, so consume that designed rejection on fast teardown.
       void prewarmedTts.opened.catch(() => undefined);
+
+      const elizaPrewarm = this.elizaPrewarm;
+      if (elizaPrewarm) {
+        await elizaPrewarm;
+        if (this.elizaPrewarm === elizaPrewarm) this.elizaPrewarm = null;
+        if (abort.signal.aborted || this.currentVoiceTurnId !== traceId) return;
+      }
 
       const request = {
         endpoint: this.config.elizaEndpoint,

--- a/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
+++ b/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
@@ -6,7 +6,10 @@
  */
 
 import { runWithDbCacheAsync } from "@/db/client";
-import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
+import {
+  type AgentSandbox,
+  agentSandboxesRepository,
+} from "@/db/repositories/agent-sandboxes";
 import { userCharactersRepository } from "@/db/repositories/characters";
 import { cache } from "@/lib/cache/client";
 import { CacheKeys, CacheTTL } from "@/lib/cache/keys";
@@ -19,15 +22,18 @@ import type { InternalElizaConversationFetchClaims } from "./internal-eliza-conv
 export async function hydrateVoiceSharedAgentScope(
   env: Bindings,
   claims: InternalElizaConversationFetchClaims,
+  preloadedAgent?: AgentSandbox,
 ): Promise<void> {
   await runWithCloudBindingsAsync(
     env as unknown as Record<string, unknown>,
     () =>
       runWithDbCacheAsync(async () => {
-        const agent = await agentSandboxesRepository.findByIdAndOrg(
-          claims.agentId,
-          claims.organizationId,
-        );
+        const agent =
+          preloadedAgent ??
+          (await agentSandboxesRepository.findByIdAndOrg(
+            claims.agentId,
+            claims.organizationId,
+          ));
         if (
           !agent ||
           agent.id !== claims.agentId ||

--- a/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.test.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.test.ts
@@ -10,6 +10,10 @@ import {
   CARTESIA_INK_API_VERSION,
   CARTESIA_INK_CHUNK_BYTES,
   CARTESIA_INK_MODEL_ID,
+  CARTESIA_INK_TURN_EAGER_END_THRESHOLD,
+  CARTESIA_INK_TURN_END_THRESHOLD,
+  CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS,
+  CARTESIA_INK_TURN_START_THRESHOLD,
   CARTESIA_INK_WEBSOCKET_URL,
   CartesiaInkAudioChunkError,
   CartesiaInkConfigError,
@@ -108,6 +112,18 @@ describe("Cartesia Ink realtime adapter", () => {
     expect(url.searchParams.get("model")).toBe(CARTESIA_INK_MODEL_ID);
     expect(url.searchParams.get("encoding")).toBe("pcm_s16le");
     expect(url.searchParams.get("sample_rate")).toBe("16000");
+    expect(url.searchParams.get("turn_start_threshold")).toBe(
+      String(CARTESIA_INK_TURN_START_THRESHOLD),
+    );
+    expect(url.searchParams.get("turn_eager_end_threshold")).toBe(
+      String(CARTESIA_INK_TURN_EAGER_END_THRESHOLD),
+    );
+    expect(url.searchParams.get("turn_end_threshold")).toBe(
+      String(CARTESIA_INK_TURN_END_THRESHOLD),
+    );
+    expect(url.searchParams.get("turn_end_timeout_ms")).toBe(
+      String(CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS),
+    );
     expect(url.searchParams.get("cartesia_version")).toBe(
       CARTESIA_INK_API_VERSION,
     );

--- a/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.ts
@@ -13,6 +13,10 @@ export const CARTESIA_INK_SAMPLE_RATE = 16_000;
 export const CARTESIA_INK_AUDIO_ENCODING = "pcm_s16le";
 export const CARTESIA_INK_CHUNK_MILLISECONDS = 100;
 export const CARTESIA_INK_CHUNK_BYTES = 3_200;
+export const CARTESIA_INK_TURN_START_THRESHOLD = 0.8;
+export const CARTESIA_INK_TURN_EAGER_END_THRESHOLD = 0.5;
+export const CARTESIA_INK_TURN_END_THRESHOLD = 0.4;
+export const CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS = 1_200;
 
 const DEFAULT_CLOSE_CODE = 1000;
 
@@ -167,6 +171,22 @@ export function buildCartesiaInkUrl(config: CartesiaInkConfig): string {
   url.searchParams.set("encoding", CARTESIA_INK_AUDIO_ENCODING);
   url.searchParams.set("sample_rate", String(CARTESIA_INK_SAMPLE_RATE));
   url.searchParams.set("cartesia_version", CARTESIA_INK_API_VERSION);
+  url.searchParams.set(
+    "turn_start_threshold",
+    String(CARTESIA_INK_TURN_START_THRESHOLD),
+  );
+  url.searchParams.set(
+    "turn_eager_end_threshold",
+    String(CARTESIA_INK_TURN_EAGER_END_THRESHOLD),
+  );
+  url.searchParams.set(
+    "turn_end_threshold",
+    String(CARTESIA_INK_TURN_END_THRESHOLD),
+  );
+  url.searchParams.set(
+    "turn_end_timeout_ms",
+    String(CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS),
+  );
   return url.toString();
 }
 


### PR DESCRIPTION
# Relates to

Promotes the already-merged develop fixes #19393 and #19432 to `main` so the production phone line (808-788-1821) stops playing the Twilio `<Say>` robot greeting.

# Background

## What problem does this solve?

Production `main` still serves the original #19321 TwiML: `<Say>Hi, you're connected to Eliza.</Say>` before `<Connect><Stream>`. TwiML `<Say>` with no `voice` attribute is Twilio's default robotic TTS, so every caller hears a canned robot voice before the real Cartesia agent voice takes over. Phone QA on the prod line reproduces it on every call.

Develop already fixed this twice over:

- #19393 (merged 2026-08-14) removed the `<Say>` opener entirely and replaced it with a live Cartesia-voiced session greeting ("hello? who's this?" / "hey whats up") spoken in the agent's own voice, plus interruptibility fixes.
- #19432 (merged 2026-08-14) removed the cold first-turn stall the `<Say>` was masking, by prewarming scope/character/admission during the inbound webhook (cold TTFA ~6.5s down to ~4.2s, within ~0.5-1.0s of warm).

Neither promotion reached `main`, so prod still runs the robot greeting.

## What does this PR do?

Cherry-picks the two develop commits onto current `origin/main`, conflict-free:

- `3e88b13c13d` fix(cloud): make phone voice responsive and interruptible (#19393)
- `d9ed54afbe8` fix(cloud): remove cold first-turn voice stall (#19432)

`buildRealtimeVoiceTwiML` no longer takes a `greeting` and emits only `<Connect><Stream>`. The Cartesia session greeting in `media/route.ts` covers the first moments of the call in the brand voice. `buildTerminalVoiceTwiML` (error paths like NOT_CONFIGURED) intentionally keeps `<Say>`; robot voice is acceptable for terminal error prompts.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus`
<!-- attribution-row:client -->
- Agent tooling: `Sol (agent lane)`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Verification

- Focused suites on the cherry-picked head: `twilio/voice/lib` (twiml, stream-token, resolve-target, bootstrap-gate, media-codec, prewarm-scope) + `voice/session/__tests__/ws-lifecycle.test.ts`: **68 pass, 0 fail**.
- `twilio-voice-twiml.test.ts` asserts bidirectionally: realtime TwiML contains **no** `<Say>` and streams immediately; terminal TwiML still renders `<Say>` with XML escaping.
- `packages/cloud/api` typecheck + `wrangler deploy --env production --dry-run` worker bundle: **pass**.
- Both commits already carry Shaw's live carrier evidence on develop (recordings `REaa5e6b382fdf3bb13f0c65b06ba51f38`, `REa4c9a0b8632ea5b82d682ae163eda2c0`: "no Twilio canned intro", cold TTFA 4.24-4.78s).

# Risks

Low-medium. Both commits have been live on develop/staging since 2026-08-14 with recorded carrier proof. This is a selective promotion, not a wholesale develop merge. Merging deploys to production via the push-to-main workflow, so @lalalune should confirm timing since it is his Twilio rig.

Pre-existing failures not related to this change: `route-boundaries.test.ts` fails identically on unmodified `origin/main` (module resolution for `@elizaos/core` from `plugins/plugin-sql`); verified same failure on baseline.
