### PR TITLE
fix(infra): parse Hetzner firewall action lists

### DIFF
--- a/packages/cloud/scripts/admin/slophub-cutover.test.ts
+++ b/packages/cloud/scripts/admin/slophub-cutover.test.ts
@@ -25,6 +25,7 @@ interface HarnessOptions {
   dnsRecords?: Record<string, unknown>[];
   firewallActionStatus?: "error" | "running" | "success";
   firewallPollStatus?: "error" | "success";
+  firewallSetRuleActions?: unknown[];
   firewalls?: Record<string, unknown>[];
   reverseFirewallRulesAfterSet?: boolean;
   servers?: Record<string, unknown>[];
@@ -157,7 +158,9 @@ function harness(options: HarnessOptions = {}) {
           : retainedRules,
       };
       return Response.json({
-        action: { id: 100, status: options.firewallActionStatus ?? "success" },
+        actions: options.firewallSetRuleActions ?? [
+          { id: 100, status: options.firewallActionStatus ?? "success" },
+        ],
       });
     }
     if (
@@ -478,6 +481,31 @@ describe("SlopHub cutover apply", () => {
       ),
     ).toBe(true);
     expect(droppedRule.state.dnsRecords).toEqual([]);
+  });
+
+  test("rejects missing or ambiguous Hetzner action lists before DNS", async () => {
+    for (const firewallSetRuleActions of [
+      [],
+      [
+        { id: 100, status: "success" },
+        { id: 101, status: "success" },
+      ],
+    ]) {
+      const provider = harness({ firewallSetRuleActions });
+      const reviewed = await buildSlopHubCutoverPlan(
+        environment,
+        provider.request,
+      );
+      await expect(
+        applySlopHubCutoverPlan(reviewed, environment, provider.request),
+      ).rejects.toThrow(/exactly one action/);
+      expect(
+        provider.mutations.every(
+          ({ url }) => !url.includes("api.cloudflare.com"),
+        ),
+      ).toBe(true);
+      expect(provider.state.dnsRecords).toEqual([]);
+    }
   });
 
   test("waits for an asynchronous Hetzner action and ignores provider rule ordering", async () => {

--- a/packages/cloud/scripts/admin/slophub-cutover.ts
+++ b/packages/cloud/scripts/admin/slophub-cutover.ts
@@ -510,7 +510,11 @@ async function waitForHetznerAction(
   environment: Required<Environment>,
   request: Request,
 ): Promise<void> {
-  let action = object(initialResponse.action, "Hetzner action");
+  const actions = array(initialResponse.actions, "Hetzner actions");
+  if (actions.length !== 1) {
+    throw new Error("Hetzner set_rules must return exactly one action");
+  }
+  let action = object(actions[0], "Hetzner action");
   const actionId = integer(action.id, "Hetzner action id");
   for (let poll = 0; poll <= MAX_ACTION_POLLS; poll += 1) {
     const status = string(action.status, "Hetzner action status");


### PR DESCRIPTION
Backports production hotfix #19650 to `develop`.

Closes #19649.

Verified locally: operator tests 11/11, focused Biome, diff check. The production apply that revealed the contract mismatch failed before DNS and will not be rerun; a fresh read-only plan is required.