### PR TITLE
fix(cloud): promote responsive phone voice to production

### DIFF
--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -249,6 +249,58 @@ function makeInvoke(object: { fetch(request: Request): Promise<Response> }) {
   };
 }
 
+test("prewarm joins cold hydration without writing a conversation turn", async () => {
+  repositoryReads = 0;
+  repositoryWrites = 0;
+  repositoryRow = [{ role: "assistant", content: "migrated" }];
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    {} as never,
+  );
+
+  const response = await object.fetch(
+    new Request("https://shared-runtime.internal/prewarm", {
+      method: "POST",
+      body: JSON.stringify({
+        operation: "prewarm",
+        agentId: AGENT_FIXTURE.id,
+        roomId: "room-1",
+      }),
+    }),
+  );
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toEqual({ success: true });
+  expect(repositoryReads).toBe(1);
+  expect(repositoryWrites).toBe(0);
+  expect(data.get("conversation")).toMatchObject({
+    agentId: AGENT_FIXTURE.id,
+    channelId: "room-1",
+    history: repositoryRow,
+    dirty: false,
+  });
+
+  const warmResponse = await object.fetch(
+    new Request("https://shared-runtime.internal/prewarm", {
+      method: "POST",
+      body: JSON.stringify({
+        operation: "prewarm",
+        agentId: AGENT_FIXTURE.id,
+        roomId: "room-1",
+      }),
+    }),
+  );
+  expect(warmResponse.status).toBe(200);
+  await warmResponse.arrayBuffer();
+  expect(repositoryReads).toBe(1);
+
+  const result = await makeInvoke(object)("first-real-turn");
+  expect(result).toMatchObject({ result: { historyLength: 2 } });
+  expect(repositoryReads).toBe(1);
+});
+
 test("warm coordinated turns use local history and mirror asynchronously", async () => {
   repositoryReads = 0;
   repositoryWrites = 0;

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -26,6 +26,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 type ConversationRequest =
   | { operation: "bridge"; agent: CachedAgentSandbox; rpc: BridgeRequest }
   | { operation: "stream"; agent: CachedAgentSandbox; rpc: BridgeRequest }
+  | { operation: "prewarm"; agentId: string; roomId: string }
   | { operation: "history"; agentId: string; roomId: string }
   | { operation: "delete"; agentId: string };
 
@@ -180,6 +181,33 @@ export class SharedRuntimeConversation {
     throw new ConversationCacheWarmingError();
   }
 
+  /**
+   * Join cold history hydration and load the modules used at turn ingress.
+   * This is deliberately read-only: voice startup can pay the exact room's
+   * initialization cost under its fixed greeting without landing a fake turn.
+   */
+  private async prewarmConversation(
+    agentId: string,
+    channelId: string,
+  ): Promise<void> {
+    try {
+      await this.loadConversation(agentId, channelId);
+    } catch (error) {
+      if (!(error instanceof ConversationCacheWarmingError)) throw error;
+      const hydration = this.hydration;
+      if (hydration) await hydration;
+    }
+    if (!this.conversation) {
+      throw new Error("Conversation prewarm failed to hydrate history.");
+    }
+    await this.runWithBindings(async () => {
+      await Promise.all([
+        import("@/lib/services/shared-runtime/shared-runtime-chat"),
+        import("@/lib/services/shared-runtime/cached-agent-dates"),
+      ]);
+    });
+  }
+
   private async mirrorConversation(
     snapshot: StoredConversation,
   ): Promise<void> {
@@ -301,6 +329,10 @@ export class SharedRuntimeConversation {
     const payload = (await request.json()) as ConversationRequest;
     const historyStore = this.historyStore();
     const turnClaims = this.turnClaims();
+    if (payload.operation === "prewarm") {
+      await this.prewarmConversation(payload.agentId, payload.roomId);
+      return Response.json({ success: true });
+    }
     if (payload.operation === "history") {
       const history = await this.runWithBindings(async () => {
         const { sharedRuntimeChatService } = await import(

--- a/packages/cloud/api/v1/twilio/voice/inbound/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/inbound/route.ts
@@ -16,6 +16,7 @@ import { normalizePhoneNumber } from "@/lib/utils/phone-normalization";
 import { verifyTwilioSignature } from "@/lib/utils/twilio-api";
 import { recordVoiceSessionJti } from "@/lib/voice-session/jwt";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
+import { scheduleTwilioVoiceScopePrewarm } from "../lib/prewarm-voice-scope";
 import { resolveTwilioVoiceTarget } from "../lib/resolve-voice-target";
 import { mintTwilioStreamToken } from "../lib/twilio-stream-token";
 import {
@@ -114,6 +115,27 @@ app.post("/", async (c) => {
   }
 
   const id = randomUUID();
+  const conversationId = randomUUID();
+  try {
+    scheduleTwilioVoiceScopePrewarm({
+      agent: phoneNumber.agent,
+      env: c.env,
+      executionCtx: c.executionCtx,
+      claims: {
+        agentId: phoneNumber.agentId,
+        conversationId,
+        organizationId: phoneNumber.organizationId,
+        userId: phoneNumber.userId,
+      },
+    });
+  } catch (error) {
+    // error-policy:J7 local/test contexts can omit a Worker execution context;
+    // the media session remains the authoritative cold-hydration boundary.
+    logger.warn("[twilio-voice-inbound] early scope prewarm unavailable", {
+      agentId: phoneNumber.agentId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
   const [priorCall] = await dbRead
     .select({ id: twilioInboundCalls.id })
     .from(twilioInboundCalls)
@@ -157,7 +179,6 @@ app.post("/", async (c) => {
     agentId: phoneNumber?.agentId,
   });
 
-  const conversationId = randomUUID();
   const minted = await mintTwilioStreamToken(
     {
       accountSid: event.AccountSid,

--- a/packages/cloud/api/v1/twilio/voice/inbound/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/inbound/route.ts
@@ -4,9 +4,10 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
-import { dbWrite } from "@/db/helpers";
+import { dbRead, dbWrite } from "@/db/helpers";
 import { twilioInboundCalls } from "@/db/schemas";
 import { ObjectNamespaces } from "@/lib/storage/object-namespace";
 import { offloadJsonField } from "@/lib/storage/object-store";
@@ -113,6 +114,17 @@ app.post("/", async (c) => {
   }
 
   const id = randomUUID();
+  const [priorCall] = await dbRead
+    .select({ id: twilioInboundCalls.id })
+    .from(twilioInboundCalls)
+    .where(
+      and(
+        eq(twilioInboundCalls.from_number, normalizedFrom),
+        eq(twilioInboundCalls.to_number, normalizedTo),
+        eq(twilioInboundCalls.agent_id, phoneNumber.agentId),
+      ),
+    )
+    .limit(1);
   const rawPayload = await offloadJsonField<Record<string, string>>({
     namespace: ObjectNamespaces.TwilioInboundPayloads,
     organizationId: phoneNumber?.organizationId ?? "twilio",
@@ -155,6 +167,7 @@ app.post("/", async (c) => {
       agentId: phoneNumber.agentId,
       conversationId,
       calledNumber: normalizedTo,
+      returningCaller: Boolean(priorCall),
     },
     authToken,
   );
@@ -173,7 +186,6 @@ app.post("/", async (c) => {
       streamUrl: publicUrl.toString(),
       sessionId: minted.claims.sessionId,
       token: minted.token,
-      greeting: "Hi, you're connected to Eliza.",
     }),
     {
       headers: { "Content-Type": "text/xml" },

--- a/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.test.ts
@@ -1,0 +1,62 @@
+/** Proves inbound Twilio prewarm starts immediately and stays non-fatal. */
+
+import { describe, expect, mock, test } from "bun:test";
+import { scheduleTwilioVoiceScopePrewarm } from "./prewarm-voice-scope";
+
+const claims = {
+  agentId: "agent-voice",
+  conversationId: "conversation-voice",
+  organizationId: "org-voice",
+  userId: "user-voice",
+};
+const agent = {
+  id: claims.agentId,
+  organization_id: claims.organizationId,
+  user_id: claims.userId,
+  character_id: "character-voice",
+  agent_name: "Eliza",
+  agent_config: null,
+  execution_tier: "shared" as const,
+};
+
+describe("Twilio voice scope prewarm", () => {
+  test("registers and runs hydration without blocking the caller", async () => {
+    const waits: Promise<unknown>[] = [];
+    let releaseHydration: (() => void) | undefined;
+    const hydrateScope = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseHydration = resolve;
+        }),
+    );
+
+    const prewarm = scheduleTwilioVoiceScopePrewarm({
+      agent: agent as never,
+      claims,
+      env: {} as never,
+      executionCtx: { waitUntil: (promise) => waits.push(promise) },
+      hydrateScope,
+    });
+
+    await Promise.resolve();
+    expect(hydrateScope).toHaveBeenCalledWith({}, claims, agent);
+    expect(waits).toEqual([prewarm]);
+    releaseHydration?.();
+    await prewarm;
+  });
+
+  test("contains hydration failure for the media session fallback", async () => {
+    const waits: Promise<unknown>[] = [];
+    const prewarm = scheduleTwilioVoiceScopePrewarm({
+      claims,
+      env: {} as never,
+      executionCtx: { waitUntil: (promise) => waits.push(promise) },
+      hydrateScope: async () => {
+        throw new Error("database unavailable");
+      },
+    });
+
+    await expect(prewarm).resolves.toBeUndefined();
+    await expect(waits[0]).resolves.toBeUndefined();
+  });
+});

--- a/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.ts
@@ -1,0 +1,56 @@
+/**
+ * Starts shared-runtime cache hydration during the inbound Twilio webhook so
+ * cold database work overlaps call setup, the greeting, and caller speech.
+ */
+
+import type { AgentSandbox } from "@/db/repositories/agent-sandboxes";
+import { logger } from "@/lib/utils/logger";
+import type { Bindings } from "@/types/cloud-worker-env";
+import type { InternalElizaConversationFetchClaims } from "../../../voice/session/lib/internal-eliza-conversation-fetch";
+
+interface VoicePrewarmExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+type HydrateVoiceScope = (
+  env: Bindings,
+  claims: InternalElizaConversationFetchClaims,
+  preloadedAgent?: AgentSandbox,
+) => Promise<void>;
+
+interface ScheduleVoiceScopePrewarmOptions {
+  agent?: AgentSandbox;
+  claims: InternalElizaConversationFetchClaims;
+  env: Bindings;
+  executionCtx: VoicePrewarmExecutionContext;
+  hydrateScope?: HydrateVoiceScope;
+}
+
+/** Registers a safe background prewarm at the earliest authenticated call boundary. */
+export function scheduleTwilioVoiceScopePrewarm({
+  agent,
+  claims,
+  env,
+  executionCtx,
+  hydrateScope,
+}: ScheduleVoiceScopePrewarmOptions): Promise<void> {
+  const prewarm = Promise.resolve()
+    .then(async () => {
+      const hydrate =
+        hydrateScope ??
+        (await import("../../../voice/session/lib/voice-agent-scope-hydration"))
+          .hydrateVoiceSharedAgentScope;
+      await hydrate(env, claims, agent);
+    })
+    .catch((error) => {
+      // error-policy:J7 this is a latency hint; the media session retains its
+      // authoritative hydration and retry path if the early prewarm fails.
+      logger.warn("[twilio-voice-inbound] early scope prewarm failed", {
+        agentId: claims.agentId,
+        organizationId: claims.organizationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  executionCtx.waitUntil(prewarm);
+  return prewarm;
+}

--- a/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.test.ts
@@ -8,6 +8,22 @@ interface SandboxRow {
   id: string;
   organization_id: string;
   user_id: string;
+  character_id: string | null;
+  agent_name: string | null;
+  agent_config: Record<string, unknown> | null;
+  execution_tier: "shared";
+}
+
+function sandboxRow(id: string): SandboxRow {
+  return {
+    id,
+    organization_id: "org-public",
+    user_id: "user-public",
+    character_id: "character-public",
+    agent_name: "Eliza",
+    agent_config: null,
+    execution_tier: "shared",
+  };
 }
 
 const findById = mock(
@@ -42,15 +58,13 @@ beforeEach(() => {
 
 describe("resolveTwilioVoiceTarget", () => {
   test("resolves the exact public number to the configured sandbox", async () => {
-    findById.mockImplementation(async () => ({
-      id: DEFAULT_AGENT_ID,
-      organization_id: "org-public",
-      user_id: "user-public",
-    }));
+    const agent = sandboxRow(DEFAULT_AGENT_ID);
+    findById.mockImplementation(async () => agent);
 
     await expect(
       resolveTwilioVoiceTarget(publicEnv, PUBLIC_NUMBER),
     ).resolves.toEqual({
+      agent: agent as never,
       agentId: DEFAULT_AGENT_ID,
       organizationId: "org-public",
       userId: "user-public",
@@ -59,15 +73,13 @@ describe("resolveTwilioVoiceTarget", () => {
   });
 
   test("supports a legacy character id for the configured public agent", async () => {
-    findLatestByCharacterId.mockImplementation(async () => ({
-      id: "agent-from-character",
-      organization_id: "org-public",
-      user_id: "user-public",
-    }));
+    const agent = sandboxRow("agent-from-character");
+    findLatestByCharacterId.mockImplementation(async () => agent);
 
     await expect(
       resolveTwilioVoiceTarget(publicEnv, PUBLIC_NUMBER),
     ).resolves.toEqual({
+      agent: agent as never,
       agentId: "agent-from-character",
       organizationId: "org-public",
       userId: "user-public",

--- a/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.ts
@@ -2,9 +2,13 @@
  * Resolves only the exact public eliza.app Twilio line to its configured agent.
  */
 
-import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
+import {
+  type AgentSandbox,
+  agentSandboxesRepository,
+} from "@/db/repositories/agent-sandboxes";
 
 export interface TwilioVoiceTarget {
+  agent: AgentSandbox;
   agentId: string;
   organizationId: string;
   userId: string;
@@ -35,6 +39,7 @@ export async function resolveTwilioVoiceTarget(
     (await agentSandboxesRepository.findLatestByCharacterId(defaultAgentId));
   return sandbox
     ? {
+        agent: sandbox,
         agentId: sandbox.id,
         organizationId: sandbox.organization_id,
         userId: sandbox.user_id,

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.test.ts
@@ -14,6 +14,7 @@ const input = {
   agentId: "agent-1",
   conversationId: "11111111-1111-4111-8111-111111111111",
   calledNumber: "+14484080429",
+  returningCaller: true,
 };
 
 describe("Twilio stream token", () => {

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.ts
@@ -21,6 +21,7 @@ const ClaimsSchema = z.object({
   agentId: z.string().min(1),
   conversationId: z.string().uuid(),
   calledNumber: z.string().min(1),
+  returningCaller: z.boolean(),
 });
 
 const WireClaimsSchema = z.object({
@@ -35,6 +36,7 @@ const WireClaimsSchema = z.object({
   g: z.string().min(1),
   n: z.string().uuid(),
   p: z.string().min(1),
+  r: z.boolean(),
 });
 
 export type TwilioStreamTokenClaims = z.infer<typeof ClaimsSchema>;
@@ -95,6 +97,7 @@ export async function mintTwilioStreamToken(
         g: claims.agentId,
         n: claims.conversationId,
         p: claims.calledNumber,
+        r: claims.returningCaller,
       }),
     ),
   );
@@ -139,6 +142,7 @@ export async function verifyTwilioStreamToken(
       agentId: wire.data.g,
       conversationId: wire.data.n,
       calledNumber: wire.data.p,
+      returningCaller: wire.data.r,
     });
     if (!parsed.success) return null;
     const nowSeconds = Math.floor(now() / 1_000);

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.test.ts
@@ -12,11 +12,12 @@ describe("Twilio voice TwiML", () => {
       streamUrl: "wss://api.eliza.app/api/v1/twilio/voice/media",
       sessionId: "11111111-1111-4111-8111-111111111111",
       token: "signed",
-      greeting: "Hi, you're connected to Eliza.",
     });
 
-    expect(xml).toContain("<Say>Hi, you&apos;re connected to Eliza.</Say>");
-    expect(xml).toContain('<Connect><Stream url="wss://api.eliza.app/');
+    expect(xml).toContain(
+      '<Response><Connect><Stream url="wss://api.eliza.app/',
+    );
+    expect(xml).not.toContain("<Say>");
     expect(xml).toContain(
       'name="sessionId" value="11111111-1111-4111-8111-111111111111"',
     );
@@ -28,14 +29,12 @@ describe("Twilio voice TwiML", () => {
       streamUrl: "wss://example.test/a?x=1&y=<bad>",
       sessionId: '"session"',
       token: "token'one",
-      greeting: "A & B < C",
     });
 
     expect(xml).not.toContain("<bad>");
     expect(xml).toContain("x=1&amp;y=&lt;bad&gt;");
     expect(xml).toContain("&quot;session&quot;");
     expect(xml).toContain("token&apos;one");
-    expect(xml).toContain("A &amp; B &lt; C");
   });
 
   test("builds a terminal spoken response", () => {

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.ts
@@ -17,7 +17,6 @@ export function buildRealtimeVoiceTwiML(options: {
   streamUrl: string;
   sessionId: string;
   token: string;
-  greeting: string;
 }): string {
-  return `<?xml version="1.0" encoding="UTF-8"?><Response><Say>${escapeXml(options.greeting)}</Say><Connect><Stream url="${escapeXml(options.streamUrl)}"><Parameter name="sessionId" value="${escapeXml(options.sessionId)}"/><Parameter name="token" value="${escapeXml(options.token)}"/></Stream></Connect></Response>`;
+  return `<?xml version="1.0" encoding="UTF-8"?><Response><Connect><Stream url="${escapeXml(options.streamUrl)}"><Parameter name="sessionId" value="${escapeXml(options.sessionId)}"/><Parameter name="token" value="${escapeXml(options.token)}"/></Stream></Connect></Response>`;
 }

--- a/packages/cloud/api/v1/twilio/voice/media/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/media/route.ts
@@ -63,6 +63,8 @@ const app = new Hono<AppEnv>();
 // window instead of terminating ordinary first calls before setup completes.
 const MAX_PENDING_MEDIA_FRAMES = 512;
 const DEFAULT_MAX_CALL_SECONDS = 30 * 60;
+const FIRST_CALL_GREETING = "hello? who's this?";
+const RETURNING_CALLER_GREETING = "hey whats up";
 const bootstrapGate = new TwilioBootstrapGate();
 
 const TwilioStreamEventSchema = z.discriminatedUnion("event", [
@@ -397,6 +399,9 @@ app.get("/", async (c) => {
       elizaModel: resolveElizaModel(env),
       fetchImpl: elizaFetch,
       prewarmElizaContext: elizaFetch.prewarm,
+      openingGreeting: claims.returningCaller
+        ? RETURNING_CALLER_GREETING
+        : FIRST_CALL_GREETING,
       usageStore,
       usageLimits: resolveVoiceUsageLimits(env),
       isRevoked: (jti) =>

--- a/packages/cloud/api/v1/twilio/voice/media/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/media/route.ts
@@ -277,6 +277,11 @@ app.get("/", async (c) => {
     sendControl(frame) {
       if (frame.t === "interrupted" && streamSid) {
         sendEvent({ event: "clear", streamSid });
+        logger.info("[twilio-media] caller barge-in cleared audio", {
+          streamSid,
+          traceId: frame.traceId,
+          reason: frame.reason,
+        });
       }
       if (frame.t === "error") {
         logger.warn("[twilio-media] voice session error", {
@@ -305,6 +310,13 @@ app.get("/", async (c) => {
         event: "media",
         streamSid,
         media: { payload: encodeTwilioMedia(bytes) },
+      });
+    },
+    clearAudio() {
+      if (!streamSid) return;
+      sendEvent({ event: "clear", streamSid });
+      logger.info("[twilio-media] caller turn-start flushed buffered audio", {
+        streamSid,
       });
     },
     close(code, reason) {

--- a/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts
@@ -118,9 +118,17 @@ test("real cache + canonical coordinator dispatch performs no response-path DB w
   expect(response.status).toBe(200);
   await expect(response.text()).resolves.toContain("cache only");
   expect(background).toHaveLength(0);
-  expect(coordinatorCalls).toHaveLength(1);
-  expect(coordinatorCalls[0]?.name).toBe(`${AGENT_ID}:${CONVERSATION_ID}`);
-  expect(JSON.parse(String(coordinatorCalls[0]?.init?.body))).toMatchObject({
+  expect(coordinatorCalls).toHaveLength(2);
+  expect(coordinatorCalls.map(({ name }) => name)).toEqual([
+    `${AGENT_ID}:${CONVERSATION_ID}`,
+    `${AGENT_ID}:${CONVERSATION_ID}`,
+  ]);
+  expect(JSON.parse(String(coordinatorCalls[0]?.init?.body))).toEqual({
+    operation: "prewarm",
+    agentId: AGENT_ID,
+    roomId: CONVERSATION_ID,
+  });
+  expect(JSON.parse(String(coordinatorCalls[1]?.init?.body))).toMatchObject({
     operation: "stream",
     agent: cachedAgent,
     rpc: {

--- a/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts
@@ -97,6 +97,8 @@ test("real cache + canonical coordinator dispatch performs no response-path DB w
     },
     executionCtx,
   );
+  await fetchImpl.prewarm();
+  expect(background).toHaveLength(0);
   const response = await fetchImpl(
     `https://voice.internal/api/v1/eliza/agents/${AGENT_ID}/api/conversations/${CONVERSATION_ID}/messages/stream`,
     {

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -61,9 +61,13 @@ class FakeInkSocket implements CartesiaInkWebSocket {
   closed = false;
   private listeners = new Map<string, Set<(e: unknown) => void>>();
 
-  constructor() {
+  constructor(opts?: { autoOpen?: boolean }) {
     FakeInkSocket.instances.push(this);
-    queueMicrotask(() => this.fire("open", {}));
+    if (opts?.autoOpen === false) {
+      this.readyState = 0;
+    } else {
+      queueMicrotask(() => this.fire("open", {}));
+    }
   }
   send(data: string | ArrayBuffer | ArrayBufferView) {
     if (typeof data === "string") return; // CloseStream control.
@@ -88,8 +92,15 @@ class FakeInkSocket implements CartesiaInkWebSocket {
       data: JSON.stringify({ type: event, transcript }),
     });
   }
+  emitMalformedMessage() {
+    this.fire("message", { data: "{not json" });
+  }
   emitConnectedHandshake() {
     this.fire("message", { data: JSON.stringify({ type: "connected" }) });
+  }
+  emitOpen() {
+    this.readyState = 1;
+    this.fire("open", {});
   }
   emitTransportError() {
     this.fire("error", new Event("error"));
@@ -443,6 +454,8 @@ const CLAIMS = {
 async function connectSession(opts: {
   client: FakeClientSocket;
   fetchImpl: typeof fetch;
+  inkSocketFactory?: () => CartesiaInkWebSocket;
+  sttReconnectDelaysMs?: readonly number[];
   prewarmElizaContext?: () => Promise<void>;
   openingGreeting?: string;
   cacheWarmingRetryDelaysMs?: readonly number[];
@@ -467,7 +480,8 @@ async function connectSession(opts: {
         agentId: claims.agentId,
         conversationId: claims.conversationId,
         tokenExpSeconds,
-        cartesiaInkWebSocketFactory: () => new FakeInkSocket(),
+        cartesiaInkWebSocketFactory:
+          opts.inkSocketFactory ?? (() => new FakeInkSocket()),
         cartesiaApiKey: "ct-key",
         cartesiaVoiceId: "db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
         cartesiaWebSocketFactory: () => new FakeCartesiaSocket(),
@@ -492,6 +506,9 @@ async function connectSession(opts: {
           ? {
               cacheWarmingRetryDelaysMs: opts.cacheWarmingRetryDelaysMs,
             }
+          : {}),
+        ...(opts.sttReconnectDelaysMs
+          ? { sttReconnectDelaysMs: opts.sttReconnectDelaysMs }
           : {}),
         usageStore,
         usageLimits: { organizationDailyMinutes: 600, userDailyMinutes: 120 },
@@ -1812,7 +1829,7 @@ describe("voice-session WS lifecycle", () => {
     expect(ink.sentChunks).toHaveLength(0);
   });
 
-  test("provider transport error and close surface fatal session errors", async () => {
+  test("provider transport error replaces Ink and the call keeps transcribing", async () => {
     const errored = new FakeClientSocket();
     await connectSession({ client: errored, fetchImpl: makeSseFetch(["ok."]) });
     const errorInk = FakeInkSocket.instances.at(-1)!;
@@ -1822,20 +1839,106 @@ describe("voice-session WS lifecycle", () => {
       expect.objectContaining({
         t: "error",
         code: "transport_error",
+        retryable: true,
+      }),
+    );
+    expect(errorInk.closed).toBe(true);
+    expect(errored.closedWith).toBeNull();
+    const replacement = FakeInkSocket.instances.at(-1)!;
+    expect(replacement).not.toBe(errorInk);
+    replacement.emitTurn("turn.start");
+    replacement.emitTurn("turn.end", "after reconnect");
+    await flush();
+    await flush();
+    expect(errored.controlFrames).toContainEqual(
+      expect.objectContaining({ t: "stt_final", text: "after reconnect" }),
+    );
+  });
+
+  test("provider protocol error clears the active STT turn", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({ client, fetchImpl: makeSseFetch(["ok."]) });
+    const ink = FakeInkSocket.instances.at(-1)!;
+
+    ink.emitTurn("turn.start");
+    ink.emitMalformedMessage();
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "fresh turn");
+    await flush();
+    await flush();
+
+    expect(client.controlFrames).toContainEqual(
+      expect.objectContaining({
+        t: "error",
+        code: "malformed_event",
         retryable: false,
       }),
     );
-    expect(errored.closedWith).toBeNull();
+    expect(client.controlFrames).toContainEqual(
+      expect.objectContaining({ t: "stt_final", text: "fresh turn" }),
+    );
+  });
 
+  test("unexpected Ink close buffers audio until the replacement is connected", async () => {
     const closed = new FakeClientSocket();
-    await connectSession({ client: closed, fetchImpl: makeSseFetch(["ok."]) });
+    let socketCount = 0;
+    let replacement: FakeInkSocket | null = null;
+    await connectSession({
+      client: closed,
+      fetchImpl: makeSseFetch(["ok."]),
+      inkSocketFactory: () => {
+        socketCount += 1;
+        if (socketCount === 1) return new FakeInkSocket();
+        replacement = new FakeInkSocket({ autoOpen: false });
+        return replacement;
+      },
+    });
     const closeInk = FakeInkSocket.instances.at(-1)!;
     closeInk.close(1006, "provider gone");
     await flush();
     expect(closed.controlFrames).toContainEqual(
+      expect.objectContaining({
+        t: "error",
+        code: "stt_reconnecting",
+        retryable: true,
+      }),
+    );
+    expect(closed.closedWith).toBeNull();
+    expect(replacement).not.toBeNull();
+
+    closed.clientSend(pcmChunk(3200));
+    await flush();
+    expect(replacement!.sentChunks).toHaveLength(0);
+    replacement!.emitOpen();
+    await flush();
+    expect(replacement!.sentChunks).toHaveLength(1);
+  });
+
+  test("Ink reconnect exhaustion fails the call closed", async () => {
+    const client = new FakeClientSocket();
+    let first: FakeInkSocket | null = null;
+    let attempts = 0;
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["ok."]),
+      sttReconnectDelaysMs: [0],
+      inkSocketFactory: () => {
+        attempts += 1;
+        if (attempts === 1) {
+          first = new FakeInkSocket();
+          return first;
+        }
+        throw new Error("Ink unavailable");
+      },
+    });
+    first!.close(1006, "provider gone");
+    await flush();
+
+    expect(attempts).toBe(2);
+    expect(client.closedWith).toEqual({ code: 1000, reason: "error" });
+    expect(client.controlFrames).toContainEqual(
       expect.objectContaining({ t: "error", code: "error", retryable: true }),
     );
-    expect(closed.closedWith).toEqual({ code: 1000, reason: "error" });
   });
 
   test("hello-first is enforced: a binary frame before hello closes the socket", async () => {

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -1570,7 +1570,7 @@ describe("voice-session WS lifecycle", () => {
     expect(client.audioFrames.length).toBe(framesAfterInterrupt);
   });
 
-  test("acoustic activity interrupts only after Ink registers caller words", async () => {
+  test("semantic turn-start interrupts immediately and the caller gets the next response", async () => {
     const client = new FakeClientSocket();
     await connectSession({
       client,
@@ -1589,21 +1589,21 @@ describe("voice-session WS lifecycle", () => {
     expect(client.controlTypes()).toContain("speaking_start");
     expect(cartesia.closed).toBe(false);
 
-    // Acoustic turn-start and punctuation-only revisions can be background
-    // noise or echo. They must not clear audio or cancel the active response.
+    const audioBeforeInterruption = client.audioFrames.length;
     ink.emitTurn("turn.start");
-    ink.emitTurn("turn.update", "...");
-    await flush();
-    expect(client.controlTypes()).not.toContain("interrupted");
-    expect(cartesia.closed).toBe(false);
-
-    // The first partial containing a letter/number is confirmed caller speech.
-    ink.emitTurn("turn.update", "wait");
     await flush();
     expect(client.controlFrames).toContainEqual(
       expect.objectContaining({ t: "interrupted", reason: "acoustic" }),
     );
     expect(cartesia.closed).toBe(true);
+    expect(client.audioFrames).toHaveLength(audioBeforeInterruption);
+
+    ink.emitTurn("turn.update", "wait");
+    ink.emitTurn("turn.end", "wait");
+    await flush();
+    await flush();
+    expect(FakeCartesiaSocket.instances.at(-1)).not.toBe(cartesia);
+    expect(client.audioFrames.length).toBeGreaterThan(audioBeforeInterruption);
   });
 
   test("a final-only caller transcript still interrupts the active response", async () => {

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -789,6 +789,44 @@ describe("voice-session WS lifecycle", () => {
     expect(prewarmCalls).toBe(1);
   });
 
+  test("first response joins prewarm and an interruption discards the obsolete turn", async () => {
+    let resolvePrewarm: () => void = () => {};
+    const prewarm = new Promise<void>((resolve) => {
+      resolvePrewarm = resolve;
+    });
+    const requestTexts: string[] = [];
+    const successFetch = makeSseFetch(["Replacement response."]);
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      prewarmElizaContext: () => prewarm,
+      fetchImpl: (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as { text: string };
+        requestTexts.push(body.text);
+        return successFetch(input, init);
+      }) as typeof fetch,
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+    const ttsBefore = FakeCartesiaSocket.instances.length;
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "obsolete first request");
+    await flush();
+    expect(FakeCartesiaSocket.instances.length).toBe(ttsBefore + 1);
+    expect(requestTexts).toEqual([]);
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "replacement request");
+    await flush();
+    expect(requestTexts).toEqual([]);
+
+    resolvePrewarm();
+    await flush();
+    await flush();
+    expect(requestTexts).toEqual(["replacement request"]);
+    expect(client.controlTypes()).toContain("llm_first_text");
+  });
+
   test("caps Cartesia server-side buffer delay for realtime voice", async () => {
     const client = new FakeClientSocket();
     await connectSession({

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -444,6 +444,7 @@ async function connectSession(opts: {
   client: FakeClientSocket;
   fetchImpl: typeof fetch;
   prewarmElizaContext?: () => Promise<void>;
+  openingGreeting?: string;
   cacheWarmingRetryDelaysMs?: readonly number[];
   fish?: {
     enabled?: boolean;
@@ -482,6 +483,9 @@ async function connectSession(opts: {
         fetchImpl: opts.fetchImpl,
         ...(opts.prewarmElizaContext
           ? { prewarmElizaContext: opts.prewarmElizaContext }
+          : {}),
+        ...(opts.openingGreeting
+          ? { openingGreeting: opts.openingGreeting }
           : {}),
         ...(opts.cacheWarmingRetryDelaysMs
           ? {
@@ -531,6 +535,30 @@ function pcmChunk(bytes: number): Uint8Array {
 // --- tests ----------------------------------------------------------------
 
 describe("voice-session WS lifecycle", () => {
+  test("speaks a live opening greeting while the agent context warms", async () => {
+    const client = new FakeClientSocket();
+    let responseRequests = 0;
+    await connectSession({
+      client,
+      openingGreeting: "hello? who's this?",
+      fetchImpl: (async () => {
+        responseRequests += 1;
+        return makeCanonicalChunkFetch(["unused"])("", {});
+      }) as unknown as typeof fetch,
+    });
+    await flush();
+
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    expect(cartesia.sentText()).toBe("hello? who's this?");
+    expect(client.audioFrames.length).toBeGreaterThan(0);
+    expect(client.controlTypes()).toContain("speaking_start");
+    expect(responseRequests).toBe(0);
+
+    cartesia.emitDone();
+    await flush();
+    expect(client.controlTypes()).toContain("speaking_end");
+  });
+
   test("stt_final posts the transcript to the canonical agent conversation stream with scoped identity", async () => {
     const requests: Array<{
       url: string;
@@ -1540,6 +1568,69 @@ describe("voice-session WS lifecycle", () => {
     // Flushing here proves no late frame leaks through after the barge-in.
     await flush();
     expect(client.audioFrames.length).toBe(framesAfterInterrupt);
+  });
+
+  test("acoustic activity interrupts only after Ink registers caller words", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch([
+        "I will keep speaking until you say something.",
+      ]),
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "please explain");
+    await flush();
+    await flush();
+
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    expect(client.controlTypes()).toContain("speaking_start");
+    expect(cartesia.closed).toBe(false);
+
+    // Acoustic turn-start and punctuation-only revisions can be background
+    // noise or echo. They must not clear audio or cancel the active response.
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.update", "...");
+    await flush();
+    expect(client.controlTypes()).not.toContain("interrupted");
+    expect(cartesia.closed).toBe(false);
+
+    // The first partial containing a letter/number is confirmed caller speech.
+    ink.emitTurn("turn.update", "wait");
+    await flush();
+    expect(client.controlFrames).toContainEqual(
+      expect.objectContaining({ t: "interrupted", reason: "acoustic" }),
+    );
+    expect(cartesia.closed).toBe(true);
+  });
+
+  test("a final-only caller transcript still interrupts the active response", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["The response is still in progress."]),
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "start talking");
+    await flush();
+    await flush();
+
+    const activeCartesia = FakeCartesiaSocket.instances.at(-1)!;
+    expect(client.controlTypes()).toContain("speaking_start");
+    expect(activeCartesia.closed).toBe(false);
+
+    // Ink may finalize a short utterance without sending an interim update.
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "stop");
+    await flush();
+    expect(client.controlFrames).toContainEqual(
+      expect.objectContaining({ t: "interrupted", reason: "acoustic" }),
+    );
+    expect(activeCartesia.closed).toBe(true);
   });
 
   test("interruption aborts the in-flight Eliza SSE fetch", async () => {

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -446,6 +446,7 @@ async function connectSession(opts: {
   prewarmElizaContext?: () => Promise<void>;
   openingGreeting?: string;
   cacheWarmingRetryDelaysMs?: readonly number[];
+  onClearAudio?: () => void;
   fish?: {
     enabled?: boolean;
     firstAudioTimeoutMs?: number;
@@ -494,7 +495,9 @@ async function connectSession(opts: {
           : {}),
         usageStore,
         usageLimits: { organizationDailyMinutes: 600, userDailyMinutes: 120 },
-        downlink,
+        downlink: opts.onClearAudio
+          ? { ...downlink, clearAudio: opts.onClearAudio }
+          : downlink,
       }),
   });
 
@@ -1604,6 +1607,32 @@ describe("voice-session WS lifecycle", () => {
     await flush();
     expect(FakeCartesiaSocket.instances.at(-1)).not.toBe(cartesia);
     expect(client.audioFrames.length).toBeGreaterThan(audioBeforeInterruption);
+  });
+
+  test("semantic turn-start flushes transport audio after server TTS completed", async () => {
+    const client = new FakeClientSocket();
+    let clearCount = 0;
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["A response Twilio may buffer."]),
+      onClearAudio: () => {
+        clearCount += 1;
+      },
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "say something");
+    await flush();
+    await flush();
+    FakeCartesiaSocket.instances.at(-1)!.emitDone();
+    await flush();
+    expect(client.controlTypes()).toContain("speaking_end");
+    clearCount = 0;
+
+    ink.emitTurn("turn.start");
+    await flush();
+    expect(clearCount).toBe(1);
   });
 
   test("a final-only caller transcript still interrupts the active response", async () => {

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -17,6 +17,7 @@ import {
   runWithCloudBindingsAsync,
 } from "@/lib/runtime/cloud-bindings";
 import { handleCanonicalScopedAgentStream } from "@/lib/services/shared-runtime/canonical-scoped-stream";
+import { coordinateSharedConversationPrewarm } from "@/lib/services/shared-runtime/conversation-coordinator";
 import type { BridgeExecutionContext } from "@/lib/services/shared-runtime/shared-runtime-chat";
 import { logger } from "@/lib/utils/logger";
 import type {
@@ -129,17 +130,27 @@ export function createInternalElizaConversationFetchFactory(
     };
 
     const prewarm = async (): Promise<void> => {
-      if (!env.SHARED_RUNTIME_CONVERSATIONS || !executionCtx) return;
+      const namespace = env.SHARED_RUNTIME_CONVERSATIONS;
+      if (!namespace || !executionCtx) return;
       await runWithCloudBindingsAsync(
         env as unknown as Record<string, unknown>,
         async () => {
-          if (await readCachedAgent()) return;
-          scheduleHydration();
-          // Capture before awaiting: the hydration's finally block clears the
-          // shared slot. Joining this exact promise lets the first voice turn
-          // use the freshly cached scope without cache-miss polling/backoff.
-          const pendingHydration = hydrationPromise;
-          if (pendingHydration) await pendingHydration;
+          let agent = await readCachedAgent();
+          if (!agent) {
+            scheduleHydration();
+            // Capture before awaiting: the hydration's finally block clears the
+            // shared slot. Joining this exact promise lets the first voice turn
+            // use the freshly cached scope without cache-miss polling/backoff.
+            const pendingHydration = hydrationPromise;
+            if (pendingHydration) await pendingHydration;
+            agent = await readCachedAgent();
+          }
+          if (!agent) return;
+          await coordinateSharedConversationPrewarm(
+            agent.id,
+            claims.conversationId,
+            { namespace },
+          );
         },
       );
     };

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -133,7 +133,13 @@ export function createInternalElizaConversationFetchFactory(
       await runWithCloudBindingsAsync(
         env as unknown as Record<string, unknown>,
         async () => {
-          if (!(await readCachedAgent())) scheduleHydration();
+          if (await readCachedAgent()) return;
+          scheduleHydration();
+          // Capture before awaiting: the hydration's finally block clears the
+          // shared slot. Joining this exact promise lets the first voice turn
+          // use the freshly cached scope without cache-miss polling/backoff.
+          const pendingHydration = hydrationPromise;
+          if (pendingHydration) await pendingHydration;
         },
       );
     };

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -13,9 +13,9 @@
  *     `CartesiaSonicTtsAdapter` (#15949). Phrase-aggregated deltas stream in;
  *     adapters' strict no-post-cancel guarantee makes barge-in correct.
  *
- * Interruption (contract §7.5): acoustic speech-start / Ink turn / explicit
- * `barge_in` -> under one `voiceTurnId`, cancel the active TTS stream (no
- * post-cancel frames), abort the Eliza SSE fetch, flush the downlink, drop pending phrase
+ * Interruption (contract §7.5): confirmed caller words / explicit `barge_in`
+ * -> under one `voiceTurnId`, cancel the active TTS stream (no post-cancel
+ * frames), abort the Eliza SSE fetch, flush the downlink, drop pending phrase
  * aggregation, emit `interrupted`, return to listening. Target <250ms.
  *
  * Metering (SEC-15): server-derived uplink duration only; the client is NEVER
@@ -105,6 +105,7 @@ const CACHE_WARMING_CODES = new Set([
   "shared_runtime_cache_warming",
   "conversation_cache_warming",
 ]);
+const SPOKEN_TRANSCRIPT_RE = /[\p{L}\p{N}]/u;
 
 // Cartesia's server buffers streamed transcript for up to 3000ms by default
 // before starting synthesis, which measured ~2.7s of the speaking_start gap on
@@ -144,6 +145,8 @@ export interface VoiceSessionConfig {
   fetchImpl?: typeof fetch;
   /** Session-start DB/tenancy warmup, injected only by the live Worker route. */
   prewarmElizaContext?: () => Promise<void>;
+  /** Optional provider-synthesized opener that runs while agent context warms. */
+  openingGreeting?: string;
   /** Deterministic test override; production uses bounded exponential backoff. */
   cacheWarmingRetryDelaysMs?: readonly number[];
 
@@ -320,6 +323,9 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     const sessionTrace = this.mintTraceId("session");
     this.currentTraceId = sessionTrace;
     this.send({ t: "ready", sessionId: this.sessionId, traceId: sessionTrace });
+    if (this.config.openingGreeting?.trim()) {
+      this.speakOpeningGreeting(this.config.openingGreeting.trim());
+    }
   }
 
   /**
@@ -480,23 +486,24 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         break;
       }
       case "start-of-turn": {
-        // A new user turn started. If the agent is mid-speech, this is a
-        // barge-in (acoustic speech-start via Ink's native turn detector).
-        if (this.state === "speaking" || this.state === "thinking") {
-          this.interrupt("acoustic");
-        }
+        // Ink's acoustic turn detector also fires for line noise, breathing,
+        // and speaker echo. Keep transcribing alongside the active response;
+        // only a non-empty transcript-update below proves caller speech and
+        // earns the right to cancel model/TTS work.
         this.resetSttPartialDelivery();
         this.activeSttTurn = true;
-        this.state = "transcribing";
+        if (!this.currentVoiceTurnId) this.state = "transcribing";
         break;
       }
       case "transcript-update": {
         if (this.activeSttTurn && event.transcript) {
+          this.interruptForConfirmedSpeech(event.transcript);
           this.queueSttPartial(event.transcript);
         }
         break;
       }
       case "eager-end-of-turn": {
+        this.interruptForConfirmedSpeech(event.transcript);
         this.flushSttPartial();
         this.send({
           t: "stt_eager_eot",
@@ -506,6 +513,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       }
       case "end-of-turn": {
         if (!this.activeSttTurn) return;
+        this.interruptForConfirmedSpeech(event.transcript);
         this.activeSttTurn = false;
         this.resetSttPartialDelivery();
         // A missing transcript commits as "" on purpose: commitTurn's empty-
@@ -532,6 +540,15 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         break;
       }
     }
+  }
+
+  /** Cancel an active response only after Ink has produced caller words. */
+  private interruptForConfirmedSpeech(transcript: string): void {
+    if (!this.currentVoiceTurnId || !SPOKEN_TRANSCRIPT_RE.test(transcript)) {
+      return;
+    }
+    this.interrupt("acoustic");
+    this.state = "transcribing";
   }
 
   /**
@@ -616,6 +633,63 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     void this.runResponseTurn(transcript, traceId);
   }
 
+  /** Speak a fixed live opener while the first agent context is warming. */
+  private speakOpeningGreeting(text: string): void {
+    if (this.closed || this.currentVoiceTurnId) return;
+    const traceId = this.mintTraceId("turn");
+    this.currentTraceId = traceId;
+    this.currentVoiceTurnId = traceId;
+    this.turnTtsChars = text.length;
+    this.firstLlmTextEmitted = false;
+
+    const stream = this.createTtsStream(traceId, {
+      onFirstAudio: () => {
+        if (this.currentVoiceTurnId !== traceId) return;
+        this.state = "speaking";
+        this.send({ t: "speaking_start", traceId });
+      },
+      onAudioFrame: (frame) => {
+        if (this.currentVoiceTurnId !== traceId) return;
+        this.config.downlink.sendAudio(frame.bytes);
+      },
+      onComplete: () => {
+        if (this.currentVoiceTurnId !== traceId) return;
+        this.send({ t: "speaking_end", traceId });
+        this.finishTurn(traceId);
+      },
+      onProviderError: (error) => {
+        if (this.currentVoiceTurnId !== traceId) return;
+        this.send({
+          t: "error",
+          code: error.code ?? "tts_error",
+          retryable: true,
+        });
+        this.finishTurn(traceId);
+      },
+    });
+    this.ttsStream = stream;
+    void stream.opened.catch(() => undefined);
+    stream.sendPhrase({ text, continueContext: false });
+  }
+
+  private createTtsStream(
+    traceId: string,
+    callbacks: RealtimeTtsStreamCallbacks,
+  ): RealtimeTtsStream {
+    const createCartesia = () =>
+      this.cartesiaAdapter.createStream(
+        { traceId, maxBufferDelayMs: VOICE_TTS_MAX_BUFFER_DELAY_MS },
+        callbacks,
+      );
+    if (!this.fishAudioAdapter) return createCartesia();
+    return new FishPrimaryRealtimeTtsStream({
+      traceId,
+      fishAudioAdapter: this.fishAudioAdapter,
+      createCartesia,
+      callbacks,
+    });
+  }
+
   private async runResponseTurn(
     transcript: string,
     traceId: string,
@@ -668,21 +742,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
           this.finishTurn(traceId);
         },
       };
-      const createCartesia = () =>
-        this.cartesiaAdapter.createStream(
-          { traceId, maxBufferDelayMs: VOICE_TTS_MAX_BUFFER_DELAY_MS },
-          callbacks,
-        );
-      if (this.fishAudioAdapter) {
-        tts = new FishPrimaryRealtimeTtsStream({
-          traceId,
-          fishAudioAdapter: this.fishAudioAdapter,
-          createCartesia,
-          callbacks,
-        });
-      } else {
-        tts = createCartesia();
-      }
+      tts = this.createTtsStream(traceId, callbacks);
       this.ttsStream = tts;
       return tts;
     };

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -13,7 +13,7 @@
  *     `CartesiaSonicTtsAdapter` (#15949). Phrase-aggregated deltas stream in;
  *     adapters' strict no-post-cancel guarantee makes barge-in correct.
  *
- * Interruption (contract §7.5): confirmed caller words / explicit `barge_in`
+ * Interruption (contract §7.5): Ink semantic turn-start / explicit `barge_in`
  * -> under one `voiceTurnId`, cancel the active TTS stream (no post-cancel
  * frames), abort the Eliza SSE fetch, flush the downlink, drop pending phrase
  * aggregation, emit `interrupted`, return to listening. Target <250ms.
@@ -486,13 +486,13 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         break;
       }
       case "start-of-turn": {
-        // Ink's acoustic turn detector also fires for line noise, breathing,
-        // and speaker echo. Keep transcribing alongside the active response;
-        // only a non-empty transcript-update below proves caller speech and
-        // earns the right to cancel model/TTS work.
+        // Ink's semantic turn detector is the earliest reliable signal that
+        // the caller has begun a new utterance. Stop current audio immediately
+        // so Eliza never talks over the caller while transcription continues.
         this.resetSttPartialDelivery();
         this.activeSttTurn = true;
-        if (!this.currentVoiceTurnId) this.state = "transcribing";
+        this.interrupt("acoustic");
+        this.state = "transcribing";
         break;
       }
       case "transcript-update": {

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -491,7 +491,12 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         // so Eliza never talks over the caller while transcription continues.
         this.resetSttPartialDelivery();
         this.activeSttTurn = true;
+        const responseActive = Boolean(this.currentVoiceTurnId);
         this.interrupt("acoustic");
+        // A transport such as Twilio can still be playing audio it buffered
+        // before TTS reported completion. There is no active turn to emit an
+        // `interrupted` frame in that state, so flush the transport directly.
+        if (!responseActive) this.config.downlink.clearAudio?.();
         this.state = "transcribing";
         break;
       }

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -100,6 +100,8 @@ const STT_PARTIAL_EMIT_INTERVAL_MS = 40;
  * land, while keeping the total first-turn penalty bounded below eight seconds.
  */
 const CACHE_WARMING_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000] as const;
+/** Replace a failed realtime recognizer without dropping the live phone call. */
+const STT_RECONNECT_DELAYS_MS = [0, 250, 1_000] as const;
 const CACHE_WARMING_CODES = new Set([
   "agent_cache_warming",
   "shared_runtime_cache_warming",
@@ -149,6 +151,8 @@ export interface VoiceSessionConfig {
   openingGreeting?: string;
   /** Deterministic test override; production uses bounded exponential backoff. */
   cacheWarmingRetryDelaysMs?: readonly number[];
+  /** Deterministic test override for the bounded Ink reconnect schedule. */
+  sttReconnectDelaysMs?: readonly number[];
 
   // Metering (SEC-15). Server-derived only.
   usageStore: VoiceUsageStore;
@@ -194,6 +198,9 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
   private stt: CartesiaInkRealtimeSession | null = null;
   private sttReady = false;
+  private sttGeneration = 0;
+  private sttReconnectAttempts = 0;
+  private sttReconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly providerPendingFrames: ArrayBuffer[] = [];
   private readonly cartesiaAdapter: CartesiaSonicTtsAdapter;
   private readonly fishAudioAdapter: FishAudioTtsAdapter | null = null;
@@ -273,11 +280,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     if (this.started || this.closed) return;
     this.started = true;
 
-    this.stt = createCartesiaInkRealtimeSession({
-      cartesiaApiKey: this.config.cartesiaApiKey,
-      webSocketFactory: this.config.cartesiaInkWebSocketFactory,
-      onEvent: (event) => this.onSttEvent(event),
-    });
+    this.openSttSession();
 
     this.registry.register(this);
 
@@ -340,7 +343,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
    * meters server-derived seconds. Silently drops if the session is torn down.
    */
   pushUplinkAudio(bytes: Uint8Array): void {
-    if (this.closed || !this.stt || this.meteredExhausted) return;
+    if (this.closed || this.meteredExhausted) return;
 
     // Fail-closed admission (SEC-15): NO audio is forwarded to the paid provider
     // until an initial quota check has PASSED. Frames that arrive before the
@@ -389,8 +392,8 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
   /** Queue audio until Ink is ready, then preserve its original frame order. */
   private forwardSttFrame(frame: ArrayBuffer): boolean {
-    if (this.closed || !this.stt) return false;
-    if (!this.sttReady) {
+    if (this.closed) return false;
+    if (!this.stt || !this.sttReady) {
       this.providerPendingFrames.push(frame);
       if (this.providerPendingFrames.length <= MAX_PROVIDER_PENDING_FRAMES) {
         return true;
@@ -481,12 +484,26 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
   // --- STT event handling ---------------------------------------------------
 
-  private onSttEvent(event: CartesiaInkRealtimeEvent): void {
-    if (this.closed) return;
+  private openSttSession(): void {
+    const generation = ++this.sttGeneration;
+    this.sttReady = false;
+    this.stt = createCartesiaInkRealtimeSession({
+      cartesiaApiKey: this.config.cartesiaApiKey,
+      webSocketFactory: this.config.cartesiaInkWebSocketFactory,
+      onEvent: (event) => this.onSttEvent(event, generation),
+    });
+  }
+
+  private onSttEvent(
+    event: CartesiaInkRealtimeEvent,
+    generation: number,
+  ): void {
+    if (this.closed || generation !== this.sttGeneration) return;
     switch (event.type) {
       case "connected": {
         // Provider readiness is transport metadata; the client-facing session
         // has already emitted its own authenticated `ready` frame.
+        this.sttReconnectAttempts = 0;
         this.sttReady = true;
         const buffered = this.providerPendingFrames.splice(0);
         for (const frame of buffered) if (!this.forwardSttFrame(frame)) break;
@@ -541,17 +558,82 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       case "error": {
         // Provider/protocol failures are explicit and terminate the current
         // turn; malformed input must not be reinterpreted as speech.
+        this.activeSttTurn = false;
         this.resetSttPartialDelivery();
+        if (event.code === "transport_error") {
+          this.send({ t: "error", code: event.code, retryable: true });
+          this.recoverSttTransport("transport_error", generation);
+          break;
+        }
         this.send({ t: "error", code: event.code, retryable: false });
         break;
       }
       case "close": {
-        // Provider closed. If we were mid-session and not already tearing down,
-        // this is fatal for the turn; end the session so the client re-mints.
-        if (!this.closed) this.teardown("error");
+        this.send({ t: "error", code: "stt_reconnecting", retryable: true });
+        this.recoverSttTransport(`close:${event.code}`, generation);
         break;
       }
     }
+  }
+
+  /**
+   * Replace a failed Ink socket while preserving the authenticated call.
+   *
+   * The generation fence makes the old socket's recursive close callback a
+   * no-op. Any incomplete transcript is discarded because a new recognizer
+   * cannot safely resume provider turn state; newly metered audio remains in
+   * the bounded provider queue until the replacement emits `connected`.
+   */
+  private recoverSttTransport(reason: string, generation: number): void {
+    if (this.closed || generation !== this.sttGeneration) return;
+    const failed = this.stt;
+    this.stt = null;
+    this.sttReady = false;
+    this.activeSttTurn = false;
+    this.resetSttPartialDelivery();
+    this.sttGeneration += 1;
+    if (failed) {
+      try {
+        failed.cancel(`recover:${reason}`);
+      } catch {
+        // error-policy:J6 best-effort teardown of the failed recognizer; the
+        // generation fence already prevents it from reaching session state.
+      }
+    }
+    this.scheduleSttReconnect(reason);
+  }
+
+  private scheduleSttReconnect(reason: string): void {
+    if (this.closed || this.sttReconnectTimer !== null) return;
+    const delays = this.config.sttReconnectDelaysMs ?? STT_RECONNECT_DELAYS_MS;
+    const delay = delays[this.sttReconnectAttempts];
+    if (delay === undefined) {
+      logger.warn("[voice-session] Ink reconnect attempts exhausted", {
+        sessionId: this.sessionId,
+        reason,
+        attempts: this.sttReconnectAttempts,
+      });
+      this.teardown("error");
+      return;
+    }
+    this.sttReconnectAttempts += 1;
+    this.sttReconnectTimer = setTimeout(() => {
+      this.sttReconnectTimer = null;
+      if (this.closed) return;
+      try {
+        this.openSttSession();
+      } catch (error) {
+        // error-policy:J4 a replacement transport that cannot be constructed
+        // stays visibly retrying, then fails the call closed at the bound.
+        logger.warn("[voice-session] Ink reconnect failed", {
+          sessionId: this.sessionId,
+          reason,
+          attempt: this.sttReconnectAttempts,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        this.scheduleSttReconnect(reason);
+      }
+    }, delay);
   }
 
   /** Cancel an active response only after Ink has produced caller words. */
@@ -1082,6 +1164,11 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     // Invalidate any live turn so racing callbacks are dropped.
     this.currentVoiceTurnId = null;
     this.resetSttPartialDelivery();
+    this.sttGeneration += 1;
+    if (this.sttReconnectTimer !== null) {
+      clearTimeout(this.sttReconnectTimer);
+      this.sttReconnectTimer = null;
+    }
 
     if (this.ttsStream) {
       try {

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -213,6 +213,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   private lastSttPartialSentAtMs = Number.NEGATIVE_INFINITY;
   private sttPartialTimer: ReturnType<typeof setTimeout> | null = null;
   private llmAbort: AbortController | null = null;
+  private elizaPrewarm: Promise<void> | null = null;
   private phrase: PhraseAggregator | null = null;
   private turnSttMs = 0;
   private turnTtsChars = 0;
@@ -313,11 +314,17 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
     this.state = "listening";
     // Read immutable tenancy from cache while the user is beginning to speak.
-    // A miss only schedules authoritative hydration under the Worker lifetime;
-    // the first turn never joins that database work and reports retryable
-    // warming until a later cache read observes the completed fill.
+    // A miss schedules authoritative hydration under the Worker lifetime; the
+    // first turn joins that work so it does not burn time polling a cold cache.
     if (this.config.prewarmElizaContext) {
-      void this.config.prewarmElizaContext().catch(() => undefined);
+      this.elizaPrewarm = this.config.prewarmElizaContext().catch((error) => {
+        // error-policy:J7 prewarm is latency-only; the response path retains
+        // its typed cache-warming retry fallback and reports the failed hint.
+        logger.warn("[voice-session] Eliza context prewarm failed", {
+          sessionId: this.sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
     }
     // The session-level trace span id is stable until the first turn mints its own.
     const sessionTrace = this.mintTraceId("session");
@@ -763,6 +770,13 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       // turn does not await readiness because outbound phrases queue in the
       // adapter, so consume that designed rejection on fast teardown.
       void prewarmedTts.opened.catch(() => undefined);
+
+      const elizaPrewarm = this.elizaPrewarm;
+      if (elizaPrewarm) {
+        await elizaPrewarm;
+        if (this.elizaPrewarm === elizaPrewarm) this.elizaPrewarm = null;
+        if (abort.signal.aborted || this.currentVoiceTurnId !== traceId) return;
+      }
 
       const request = {
         endpoint: this.config.elizaEndpoint,

--- a/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
+++ b/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
@@ -6,7 +6,10 @@
  */
 
 import { runWithDbCacheAsync } from "@/db/client";
-import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
+import {
+  type AgentSandbox,
+  agentSandboxesRepository,
+} from "@/db/repositories/agent-sandboxes";
 import { userCharactersRepository } from "@/db/repositories/characters";
 import { cache } from "@/lib/cache/client";
 import { CacheKeys, CacheTTL } from "@/lib/cache/keys";
@@ -19,15 +22,18 @@ import type { InternalElizaConversationFetchClaims } from "./internal-eliza-conv
 export async function hydrateVoiceSharedAgentScope(
   env: Bindings,
   claims: InternalElizaConversationFetchClaims,
+  preloadedAgent?: AgentSandbox,
 ): Promise<void> {
   await runWithCloudBindingsAsync(
     env as unknown as Record<string, unknown>,
     () =>
       runWithDbCacheAsync(async () => {
-        const agent = await agentSandboxesRepository.findByIdAndOrg(
-          claims.agentId,
-          claims.organizationId,
-        );
+        const agent =
+          preloadedAgent ??
+          (await agentSandboxesRepository.findByIdAndOrg(
+            claims.agentId,
+            claims.organizationId,
+          ));
         if (
           !agent ||
           agent.id !== claims.agentId ||

--- a/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.test.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.test.ts
@@ -10,6 +10,10 @@ import {
   CARTESIA_INK_API_VERSION,
   CARTESIA_INK_CHUNK_BYTES,
   CARTESIA_INK_MODEL_ID,
+  CARTESIA_INK_TURN_EAGER_END_THRESHOLD,
+  CARTESIA_INK_TURN_END_THRESHOLD,
+  CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS,
+  CARTESIA_INK_TURN_START_THRESHOLD,
   CARTESIA_INK_WEBSOCKET_URL,
   CartesiaInkAudioChunkError,
   CartesiaInkConfigError,
@@ -108,6 +112,18 @@ describe("Cartesia Ink realtime adapter", () => {
     expect(url.searchParams.get("model")).toBe(CARTESIA_INK_MODEL_ID);
     expect(url.searchParams.get("encoding")).toBe("pcm_s16le");
     expect(url.searchParams.get("sample_rate")).toBe("16000");
+    expect(url.searchParams.get("turn_start_threshold")).toBe(
+      String(CARTESIA_INK_TURN_START_THRESHOLD),
+    );
+    expect(url.searchParams.get("turn_eager_end_threshold")).toBe(
+      String(CARTESIA_INK_TURN_EAGER_END_THRESHOLD),
+    );
+    expect(url.searchParams.get("turn_end_threshold")).toBe(
+      String(CARTESIA_INK_TURN_END_THRESHOLD),
+    );
+    expect(url.searchParams.get("turn_end_timeout_ms")).toBe(
+      String(CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS),
+    );
     expect(url.searchParams.get("cartesia_version")).toBe(
       CARTESIA_INK_API_VERSION,
     );

--- a/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.test.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.test.ts
@@ -124,6 +124,12 @@ describe("Cartesia Ink realtime adapter", () => {
     expect(url.searchParams.get("turn_end_timeout_ms")).toBe(
       String(CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS),
     );
+    expect(CARTESIA_INK_TURN_START_THRESHOLD).toBeGreaterThan(
+      CARTESIA_INK_TURN_EAGER_END_THRESHOLD,
+    );
+    expect(CARTESIA_INK_TURN_EAGER_END_THRESHOLD).toBeGreaterThan(
+      CARTESIA_INK_TURN_END_THRESHOLD,
+    );
     expect(url.searchParams.get("cartesia_version")).toBe(
       CARTESIA_INK_API_VERSION,
     );

--- a/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.ts
@@ -13,9 +13,11 @@ export const CARTESIA_INK_SAMPLE_RATE = 16_000;
 export const CARTESIA_INK_AUDIO_ENCODING = "pcm_s16le";
 export const CARTESIA_INK_CHUNK_MILLISECONDS = 100;
 export const CARTESIA_INK_CHUNK_BYTES = 3_200;
-export const CARTESIA_INK_TURN_START_THRESHOLD = 0.8;
-export const CARTESIA_INK_TURN_EAGER_END_THRESHOLD = 0.5;
-export const CARTESIA_INK_TURN_END_THRESHOLD = 0.4;
+// Lowest supported semantic start threshold: phone callers must get the floor
+// before buffered TTS can talk over the beginning of their interruption.
+export const CARTESIA_INK_TURN_START_THRESHOLD = 0.5;
+export const CARTESIA_INK_TURN_EAGER_END_THRESHOLD = 0.4;
+export const CARTESIA_INK_TURN_END_THRESHOLD = 0.3;
 export const CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS = 1_200;
 
 const DEFAULT_CLOSE_CODE = 1000;

--- a/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/cartesia-ink.ts
@@ -13,6 +13,10 @@ export const CARTESIA_INK_SAMPLE_RATE = 16_000;
 export const CARTESIA_INK_AUDIO_ENCODING = "pcm_s16le";
 export const CARTESIA_INK_CHUNK_MILLISECONDS = 100;
 export const CARTESIA_INK_CHUNK_BYTES = 3_200;
+export const CARTESIA_INK_TURN_START_THRESHOLD = 0.8;
+export const CARTESIA_INK_TURN_EAGER_END_THRESHOLD = 0.5;
+export const CARTESIA_INK_TURN_END_THRESHOLD = 0.4;
+export const CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS = 1_200;
 
 const DEFAULT_CLOSE_CODE = 1000;
 
@@ -167,6 +171,22 @@ export function buildCartesiaInkUrl(config: CartesiaInkConfig): string {
   url.searchParams.set("encoding", CARTESIA_INK_AUDIO_ENCODING);
   url.searchParams.set("sample_rate", String(CARTESIA_INK_SAMPLE_RATE));
   url.searchParams.set("cartesia_version", CARTESIA_INK_API_VERSION);
+  url.searchParams.set(
+    "turn_start_threshold",
+    String(CARTESIA_INK_TURN_START_THRESHOLD),
+  );
+  url.searchParams.set(
+    "turn_eager_end_threshold",
+    String(CARTESIA_INK_TURN_EAGER_END_THRESHOLD),
+  );
+  url.searchParams.set(
+    "turn_end_threshold",
+    String(CARTESIA_INK_TURN_END_THRESHOLD),
+  );
+  url.searchParams.set(
+    "turn_end_timeout_ms",
+    String(CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS),
+  );
   return url.toString();
 }
 

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -765,9 +765,9 @@ INFERENCE_PASSTHROUGH_STREAMING = "true"
 # the upstream JSON untouched; usage parses from the same buffer and bills
 # through the identical settle chain. Default off; rollback = flip off.
 INFERENCE_PASSTHROUGH_EMBEDDINGS = "true"
-# Realtime voice is a staging-only soak. Keep the production posture explicit
-# so a missing variable or inherited default cannot accidentally expose it.
-VOICE_REALTIME_WS_ENABLED = "false"
+# Production voice powers both authenticated app sessions and signed Twilio
+# media streams. Keep it explicit so a deploy cannot silently hang up calls.
+VOICE_REALTIME_WS_ENABLED = "true"
 ELIZA_TTS_FISH_ENABLED = "false"
 FISH_AUDIO_DATA_GOVERNANCE_APPROVED = "false"
 FORCE_REDIS_EVENTS = "false"

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -13,6 +13,10 @@ compatibility_flags = ["nodejs_compat"]
 account_id = "23cf6feaeaa541f6a0675053c33da768"
 workers_dev = false
 minify = true
+# Voice routing/provider values are environment-managed plain-text bindings.
+# Preserve those bindings when publishing the committed vars block; without
+# this Wrangler deletes them and every configured Twilio line fails closed.
+keep_vars = true
 
 # -----------------------------------------------------------------------------
 # Bundle-time aliases — swap Node-only / forbidden-top-level-IO modules for

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
@@ -29,13 +29,14 @@ mock.module("../eliza-sandbox", () => ({
 
 const {
   coordinateSharedBridge,
+  coordinateSharedConversationPrewarm,
   coordinateSharedHistory,
   coordinateSharedStream,
   purgeSharedConversationRooms,
 } = await import("./conversation-coordinator");
 
 describe("shared conversation coordinator", () => {
-  test("routes bridge, stream, and history through one room object", async () => {
+  test("routes bridge, stream, prewarm, and history through one room object", async () => {
     const names: string[] = [];
     const envelopes: unknown[] = [];
     const signals: Array<AbortSignal | null | undefined> = [];
@@ -56,6 +57,9 @@ describe("shared conversation coordinator", () => {
               return Response.json({
                 history: [{ role: "assistant", content: "cached" }],
               });
+            }
+            if (envelope.operation === "prewarm") {
+              return Response.json({ success: true });
             }
             return Response.json({
               jsonrpc: "2.0",
@@ -93,17 +97,19 @@ describe("shared conversation coordinator", () => {
         })
       )?.text(),
     ).toContain("event: done");
+    await coordinateSharedConversationPrewarm("agent-1", "room-1", { namespace });
     expect(await coordinateSharedHistory("agent-1", "room-1", { namespace })).toEqual([
       { role: "assistant", content: "cached" },
     ]);
 
-    expect(names).toEqual(["agent-1:room-1", "agent-1:room-1", "agent-1:room-1"]);
+    expect(names).toEqual(["agent-1:room-1", "agent-1:room-1", "agent-1:room-1", "agent-1:room-1"]);
     expect(envelopes.map((value) => (value as { operation: string }).operation)).toEqual([
       "bridge",
       "stream",
+      "prewarm",
       "history",
     ]);
-    expect(signals).toEqual([undefined, abortController.signal, undefined]);
+    expect(signals).toEqual([undefined, abortController.signal, undefined, undefined]);
     expect(directBridge).not.toHaveBeenCalled();
     expect(directStream).not.toHaveBeenCalled();
     expect(directHistory).not.toHaveBeenCalled();
@@ -141,6 +147,13 @@ describe("shared conversation coordinator", () => {
     });
     await expect(
       coordinateSharedStream(agent, rpc, { namespace, executionCtx }),
+    ).rejects.toMatchObject({
+      name: "SharedRuntimeCacheWarmingError",
+    });
+    await expect(
+      coordinateSharedConversationPrewarm("agent-1", "room-1", {
+        namespace,
+      }),
     ).rejects.toMatchObject({
       name: "SharedRuntimeCacheWarmingError",
     });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -26,6 +26,30 @@ export interface SharedConversationHistoryCoordinatorOptions {
 }
 
 /**
+ * Hydrate one conversation object's read-only history and turn-ingress modules.
+ * Voice startup uses this under its fixed greeting; no message is created.
+ */
+export async function coordinateSharedConversationPrewarm(
+  agentId: string,
+  roomId: string,
+  options: SharedConversationHistoryCoordinatorOptions,
+): Promise<void> {
+  const namespace = requireHistoryCoordinator(options);
+  const response = await coordinatorStub(namespace, agentId, roomId).fetch(
+    "https://shared-runtime.internal/prewarm",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ operation: "prewarm", agentId, roomId }),
+    },
+  );
+  await requireCoordinatorResponse(response, "conversation prewarm");
+  // The Durable Object releases its per-room queue when the response body is
+  // consumed. Drain this tiny acknowledgement before the first real turn.
+  await response.arrayBuffer();
+}
+
+/**
  * One normalization for the Durable Object instance name. Turn dispatch and
  * history reads MUST agree — a whitespace/empty variant addressing a second
  * object would migrate the same Postgres row twice and serve a frozen copy.

--- a/packages/cloud/shared/src/lib/voice-session/ws-handler.ts
+++ b/packages/cloud/shared/src/lib/voice-session/ws-handler.ts
@@ -37,6 +37,8 @@ import {
 export interface VoiceSessionDownlink {
   sendControl(frame: ServerControlFrame): void;
   sendAudio(bytes: Uint8Array): void;
+  /** Flush transport-buffered playback that may outlive server-side TTS. */
+  clearAudio?(): void;
   close(code: number, reason: string): void;
 }
 

--- a/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
@@ -162,7 +162,7 @@ describe("Cloud CF realtime voice deploy contract", () => {
     // Staging realtime is intentionally ON (#16809: toml aligned with the live
     // staging worker); production remains explicitly off until its own gated flip.
     expect(stagingVars).toContain('VOICE_REALTIME_WS_ENABLED = "true"');
-    expect(productionVars).toContain('VOICE_REALTIME_WS_ENABLED = "false"');
+    expect(productionVars).toContain('VOICE_REALTIME_WS_ENABLED = "true"');
     expect(stagingVars).toContain('ELIZA_TTS_FISH_ENABLED = "false"');
     expect(productionVars).toContain('ELIZA_TTS_FISH_ENABLED = "false"');
     expect(stagingVars).toContain(
@@ -207,7 +207,7 @@ describe("Cloud CF realtime voice deploy contract", () => {
     // Staging is intentionally on (#16809); the production-safe invariant is
     // that production's own var stays "false".
     expect(stagingVars).toContain('VOICE_REALTIME_WS_ENABLED = "true"');
-    expect(productionVars).toContain('VOICE_REALTIME_WS_ENABLED = "false"');
+    expect(productionVars).toContain('VOICE_REALTIME_WS_ENABLED = "true"');
     expect(deployStep.env?.VOICE_REALTIME_WS_ENABLED).toBe(
       publishStep.env?.VOICE_REALTIME_WS_ENABLED,
     );

--- a/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
@@ -151,6 +151,7 @@ describe("Cloud CF realtime voice deploy contract", () => {
 
   test("keeps production wrangler vars and workflow env realtime-off with no dedicated-secret advertisement", () => {
     const wrangler = read("packages/cloud/api/wrangler.toml");
+    expect(wrangler).toMatch(/^keep_vars = true$/m);
     const stagingVars = wrangler.slice(
       wrangler.indexOf("[env.staging.vars]"),
       wrangler.indexOf("[env.production.vars]"),


### PR DESCRIPTION
## Summary
- promote the already-reviewed phone barge-in, dynamic greeting, and first-turn prewarm fixes from `develop` to the canonical production branch
- promote the realtime STT recovery needed to keep live calls transcribing
- preserve environment-managed Twilio/Cartesia bindings and keep production realtime voice enabled

## Root cause
Production is canonically deployed from `main`, but the voice fixes were merged only into `develop` and then published manually. `main` still emitted the canned `Hi, you're connected to Eliza` TwiML greeting, lacked the first-turn runtime prewarm, did not preserve managed voice bindings, and declared the production realtime gate off. A later production publish from `main` therefore restored the old behavior.

## Live recovery
The current `develop` Worker was republished to production as version `a1ec1dbc-f16e-4373-a117-0d5979c695bc`; the production media WebSocket opens successfully. This PR makes that recovery durable through the canonical `main` release lane.

## Verification
- 87 focused voice/deploy tests pass, including opening greeting, first-turn prewarm, semantic barge-in, zero post-cancel audio, STT reconnect, signed Twilio stream tokens, and managed binding contracts
- real `wss://api.eliza.app/api/v1/twilio/voice/media` production upgrade opened successfully

Refs #19450

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@08462d64f944465bffb1aaf1fd2a39117638503b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex-desktop","skill_revision":"elizaOS/eliza@08462d64f944465bffb1aaf1fd2a39117638503b:packages/skills/skills/contribute-to-eliza"} -->