### PR TITLE
fix(cloud): keep production voice enabled

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -478,15 +478,11 @@ jobs:
           VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
           VAST_BASE_URL: ${{ secrets.VAST_BASE_URL }}
           DEPLOY_ENVIRONMENT: ${{ steps.env.outputs.deploy_environment }}
-          VOICE_REALTIME_WS_ENABLED: ${{ steps.env.outputs.deploy_environment != 'production' && contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED) && 'true' || 'false' }}
-          # Keep this mirror locked to wrangler.toml's env.production value.
-          # The workflow contract test fails if they drift.
-          PRODUCTION_REALTIME_WS_ENABLED: "false"
-          # Production intentionally omits these runtime vars while realtime is
-          # off. Their mirrors are also contract-locked to wrangler.toml so a
-          # future enable cannot deploy a credential-complete but 503-only route.
-          PRODUCTION_REALTIME_CARTESIA_VOICE_ID: ""
-          PRODUCTION_REALTIME_ELIZA_ENDPOINT: ""
+          # Phone and app voice are production features. Staging remains an
+          # explicit repository-variable opt-in, while production is pinned on
+          # so a managed deploy cannot silently replace wrangler.toml's true
+          # value with a false command-line override.
+          VOICE_REALTIME_WS_ENABLED: ${{ (steps.env.outputs.deploy_environment == 'production' || contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED)) && 'true' || 'false' }}
           VOICE_REALTIME_ELIZA_AUTHORIZATION: ${{ secrets.VOICE_REALTIME_ELIZA_AUTHORIZATION }}
           # Staging may use its existing Cloud key for the Worker-to-gateway
           # voice bridge. Production MUST use the dedicated authorization and
@@ -549,25 +545,9 @@ jobs:
             export VOICE_REALTIME_ELIZA_AUTHORIZATION
           fi
 
-          # Production realtime is currently explicitly disabled. A stale
-          # Worker secret may therefore remain stored but is unreachable. If a
-          # future change enables the route, fail that deploy unless every
-          # provider and the dedicated bridge authorization is configured; the
-          # next publish then overwrites any legacy repository-key fallback.
-          # Production never constructs the staging repository-key fallback.
-          if [ "$DEPLOY_ENVIRONMENT" = "production" ] && \
-             is_truthy "$PRODUCTION_REALTIME_WS_ENABLED"; then
-            missing_voice_secrets=()
-            for name in CARTESIA_API_KEY VOICE_REALTIME_ELIZA_AUTHORIZATION PRODUCTION_REALTIME_CARTESIA_VOICE_ID PRODUCTION_REALTIME_ELIZA_ENDPOINT; do
-              if ! has_nonblank_value "${!name:-}"; then
-                missing_voice_secrets+=("$name")
-              fi
-            done
-            if [ "${#missing_voice_secrets[@]}" -gt 0 ]; then
-              echo "::error::Production realtime voice is enabled but required dedicated/provider secrets are missing: ${missing_voice_secrets[*]}"
-              exit 1
-            fi
-          fi
+          # Production provider and bridge values are managed Worker secrets,
+          # not GitHub secret material. keep_vars preserves them, and their
+          # binding names are verified against the live Worker before deploy.
 
           # Staging advertises realtime only when the repository variable
           # VOICE_REALTIME_WS_ENABLED is explicitly truthy. Refuse that opt-in
@@ -643,6 +623,33 @@ jobs:
           if [ -z "$OPENROUTER_API_KEY" ] && [ -z "$CEREBRAS_API_KEY" ] && [ -z "$OPENAI_API_KEY" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
             echo "::error::No model provider key configured. Set OPENROUTER_API_KEY (backup) and/or a native key (CEREBRAS/OPENAI/ANTHROPIC) at https://github.com/elizaOS/eliza/settings/secrets/actions."
             exit 1
+          fi
+
+          if [ "$DEPLOY_ENVIRONMENT" = "production" ] && \
+             is_truthy "$VOICE_REALTIME_WS_ENABLED"; then
+            secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
+            printf '%s' "$secret_inventory" | node -e '
+              const fs = require("node:fs");
+              const parsed = JSON.parse(fs.readFileSync(0, "utf8"));
+              const entries = Array.isArray(parsed)
+                ? parsed
+                : Array.isArray(parsed?.result)
+                  ? parsed.result
+                  : [];
+              const present = new Set(entries.map((entry) => entry?.name).filter(Boolean));
+              const required = [
+                "CARTESIA_API_KEY",
+                "VOICE_REALTIME_CARTESIA_VOICE_ID",
+                "VOICE_REALTIME_ELIZA_AUTHORIZATION",
+                "VOICE_REALTIME_ELIZA_ENDPOINT",
+              ];
+              const missing = required.filter((name) => !present.has(name));
+              if (missing.length > 0) {
+                console.error(`::error::Production realtime voice is missing managed Worker secret binding name(s): ${missing.join(" ")}`);
+                process.exit(1);
+              }
+              console.log(`Verified ${required.length} managed production voice secret binding names; values were not read.`);
+            '
           fi
 
           publish_secret() {
@@ -831,7 +838,7 @@ jobs:
           DEPLOY_ENVIRONMENT: ${{ steps.env.outputs.deploy_environment }}
           STAGING_ONBOARDING_LOGIN_APP_URL: https://staging.eliza.app
           KOKORO_TTS_URL: ${{ vars.ELIZA_VOICE_KOKORO_TTS_URL }}
-          VOICE_REALTIME_WS_ENABLED: ${{ steps.env.outputs.deploy_environment != 'production' && contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED) && 'true' || 'false' }}
+          VOICE_REALTIME_WS_ENABLED: ${{ (steps.env.outputs.deploy_environment == 'production' || contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED)) && 'true' || 'false' }}
           ELIZA_TTS_FISH_ENABLED: ${{ steps.env.outputs.deploy_environment != 'production' && contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.ELIZA_TTS_FISH_ENABLED) && 'true' || 'false' }}
           FISH_AUDIO_DATA_GOVERNANCE_APPROVED: ${{ steps.env.outputs.deploy_environment != 'production' && contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.FISH_AUDIO_DATA_GOVERNANCE_APPROVED) && 'true' || 'false' }}
           FISH_AUDIO_MODEL: ${{ vars.FISH_AUDIO_MODEL || 's2.1-pro' }}
@@ -1303,7 +1310,7 @@ jobs:
           VITE_STEWARD_TENANT_ID: ${{ (inputs.target_environment == 'production') && 'elizacloud' || 'elizacloud-staging' }}
           NEXT_PUBLIC_STEWARD_TENANT_ID: ${{ (inputs.target_environment == 'production') && 'elizacloud' || 'elizacloud-staging' }}
           VITE_ENVIRONMENT: ${{ inputs.target_environment }}
-          VITE_VOICE_REALTIME_WS: ${{ !(inputs.target_environment == 'production') && contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED) && '1' || '0' }}
+          VITE_VOICE_REALTIME_WS: ${{ (inputs.target_environment == 'production' || contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED)) && '1' || '0' }}
           VITE_VOICE_REALTIME_FORCE: "0"
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
 
@@ -1579,7 +1586,7 @@ jobs:
           VITE_STEWARD_TENANT_ID: ${{ (inputs.target_environment == 'production') && 'elizacloud' || 'elizacloud-staging' }}
           NEXT_PUBLIC_STEWARD_TENANT_ID: ${{ (inputs.target_environment == 'production') && 'elizacloud' || 'elizacloud-staging' }}
           VITE_ENVIRONMENT: ${{ inputs.target_environment }}
-          VITE_VOICE_REALTIME_WS: ${{ !(inputs.target_environment == 'production') && contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED) && '1' || '0' }}
+          VITE_VOICE_REALTIME_WS: ${{ (inputs.target_environment == 'production' || contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED)) && '1' || '0' }}
           VITE_VOICE_REALTIME_FORCE: "0"
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
 

--- a/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
@@ -1,10 +1,8 @@
 /**
- * Fail-closed deployment contracts for the staging realtime-voice soak.
- * Provider and bridge credentials must exist before a Worker advertising the
- * feature can deploy, while production may never inherit the repository Cloud
- * key as an implicit service authorization. Production remains deployable
- * while realtime is explicitly off; enabling it requires dedicated/provider
- * secrets so a managed deploy overwrites any stale Worker value first.
+ * Fail-closed deployment contracts for realtime voice across staging and
+ * production. Staging requires explicit credentials when opted in; production
+ * stays enabled for phone and app voice while preserving and verifying the
+ * dedicated provider and bridge bindings already managed on the Worker.
  */
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -91,9 +89,6 @@ function runPreflight(env: Record<string, string>) {
       VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer dedicated-test",
       VOICE_REALTIME_WS_ENABLED: "false",
       STAGING_ELIZACLOUD_API_KEY: "",
-      PRODUCTION_REALTIME_WS_ENABLED: "false",
-      PRODUCTION_REALTIME_CARTESIA_VOICE_ID: "",
-      PRODUCTION_REALTIME_ELIZA_ENDPOINT: "",
       ...env,
     },
   });
@@ -162,7 +157,7 @@ describe("Cloud CF realtime voice deploy contract", () => {
     );
   });
 
-  test("keeps production wrangler vars and workflow env realtime-off with no dedicated-secret advertisement", () => {
+  test("keeps production realtime enabled and verifies managed secret bindings", () => {
     const wrangler = read("packages/cloud/api/wrangler.toml");
     expect(wrangler).toMatch(/^keep_vars = true$/m);
     const stagingVars = wrangler.slice(
@@ -172,8 +167,8 @@ describe("Cloud CF realtime voice deploy contract", () => {
     const productionVars = wrangler.slice(
       wrangler.indexOf("[env.production.vars]"),
     );
-    // Staging realtime is intentionally ON (#16809: toml aligned with the live
-    // staging worker); production remains explicitly off until its own gated flip.
+    // Both deployed environments intentionally serve realtime voice. Staging
+    // still requires its repository opt-in; production is pinned on.
     expect(stagingVars).toContain('VOICE_REALTIME_WS_ENABLED = "true"');
     expect(productionVars).toContain('VOICE_REALTIME_WS_ENABLED = "true"');
     expect(stagingVars).toContain('ELIZA_TTS_FISH_ENABLED = "false"');
@@ -187,11 +182,14 @@ describe("Cloud CF realtime voice deploy contract", () => {
     expect(publishStep.env?.VOICE_REALTIME_WS_ENABLED).toContain(
       "vars.VOICE_REALTIME_WS_ENABLED",
     );
-    expect(publishStep.env?.PRODUCTION_REALTIME_WS_ENABLED).toBe("false");
+    expect(publishStep.env?.VOICE_REALTIME_WS_ENABLED).toContain(
+      "deploy_environment == 'production'",
+    );
     expect(productionVars).not.toContain("VOICE_REALTIME_CARTESIA_VOICE_ID");
     expect(productionVars).not.toContain("VOICE_REALTIME_ELIZA_ENDPOINT");
-    expect(publishStep.env?.PRODUCTION_REALTIME_CARTESIA_VOICE_ID).toBe("");
-    expect(publishStep.env?.PRODUCTION_REALTIME_ELIZA_ENDPOINT).toBe("");
+    expect(publishStep.run).toContain('"VOICE_REALTIME_CARTESIA_VOICE_ID"');
+    expect(publishStep.run).toContain('"VOICE_REALTIME_ELIZA_ENDPOINT"');
+    expect(publishStep.run).toContain("managed Worker secret binding name(s)");
     expect(wrangler).not.toContain("VOICE_AMBIENT_ENABLED");
     expect(wrangler).not.toContain("VOICE_AMBIENT_PENDANT_BASE_URL");
   });
@@ -200,7 +198,7 @@ describe("Cloud CF realtime voice deploy contract", () => {
     const runtimeFlag = deployStep.env?.VOICE_REALTIME_WS_ENABLED;
     expect(runtimeFlag).toBe(publishStep.env?.VOICE_REALTIME_WS_ENABLED);
     expect(runtimeFlag).toContain("steps.env.outputs.deploy_environment");
-    expect(runtimeFlag).toContain("!= 'production'");
+    expect(runtimeFlag).toContain("== 'production'");
     expect(runtimeFlag).toContain("vars.VOICE_REALTIME_WS_ENABLED");
     expect(runtimeFlag).toContain("&& 'true' || 'false'");
     expect(deployStep.run).toContain(
@@ -208,7 +206,7 @@ describe("Cloud CF realtime voice deploy contract", () => {
     );
   });
 
-  test("runtime realtime override stays default-off and production-safe across Worker and frontend", () => {
+  test("runtime and frontend realtime stay enabled in production", () => {
     const wrangler = read("packages/cloud/api/wrangler.toml");
     const stagingVars = wrangler.slice(
       wrangler.indexOf("[env.staging.vars]"),
@@ -217,8 +215,7 @@ describe("Cloud CF realtime voice deploy contract", () => {
     const productionVars = wrangler.slice(
       wrangler.indexOf("[env.production.vars]"),
     );
-    // Staging is intentionally on (#16809); the production-safe invariant is
-    // that production's own var stays "false".
+    // Staging and production both intentionally serve realtime voice.
     expect(stagingVars).toContain('VOICE_REALTIME_WS_ENABLED = "true"');
     expect(productionVars).toContain('VOICE_REALTIME_WS_ENABLED = "true"');
     expect(deployStep.env?.VOICE_REALTIME_WS_ENABLED).toBe(
@@ -228,17 +225,15 @@ describe("Cloud CF realtime voice deploy contract", () => {
       "&& 'true' || 'false'",
     );
 
-    // Every frontend build in either workflow must resolve the realtime flag
-    // from the repository variable and must not be able to reach production
-    // with it on. The canonical release build carries the production guard in
-    // the expression itself; the pull-request preview build has no production
-    // path at all because its whole environment is pinned to staging.
+    // Canonical production builds pin the voice UI on. Staging and pull-request
+    // previews continue to use the repository variable.
     const flagPattern =
       /VITE_VOICE_REALTIME_WS: \$\{\{[^}]*vars\.VOICE_REALTIME_WS_ENABLED[^}]*&& '1' \|\| '0' \}\}/g;
     const releaseRealtimeFlags = workflowSource.match(flagPattern) ?? [];
     expect(releaseRealtimeFlags.length).toBeGreaterThanOrEqual(1);
     for (const flag of releaseRealtimeFlags) {
-      expect(flag).toContain("!(inputs.target_environment == 'production')");
+      expect(flag).toContain("inputs.target_environment == 'production'");
+      expect(flag).toContain("|| contains");
       expect(flag).toContain("vars.VOICE_REALTIME_WS_ENABLED");
     }
 
@@ -423,54 +418,6 @@ executedDescribe(
       });
       expect(empty.status).toBe(1);
       expect(empty.stdout).not.toContain("Bearer ");
-    });
-
-    test("keeps disabled production deployable but fails a future enable without dedicated secrets", () => {
-      const disabled = runPreflight({
-        DEPLOY_ENVIRONMENT: "production",
-        DEEPGRAM_API_KEY: "",
-        CARTESIA_API_KEY: "",
-        VOICE_REALTIME_ELIZA_AUTHORIZATION: "",
-        STAGING_ELIZACLOUD_API_KEY: "repo-key-must-not-be-used",
-      });
-      expect(disabled.status).toBe(0);
-      expect(disabled.stdout).not.toContain("Bearer repo-key-must-not-be-used");
-
-      const missingDedicated = runPreflight({
-        DEPLOY_ENVIRONMENT: "production",
-        PRODUCTION_REALTIME_WS_ENABLED: "true",
-        DEEPGRAM_API_KEY: "",
-        CARTESIA_API_KEY: "",
-        VOICE_REALTIME_ELIZA_AUTHORIZATION: "",
-        STAGING_ELIZACLOUD_API_KEY: "repo-key-must-not-be-used",
-      });
-      expect(missingDedicated.status).toBe(1);
-      expect(missingDedicated.stdout).toContain(
-        "Production realtime voice is enabled",
-      );
-      expect(missingDedicated.stdout).not.toContain("DEEPGRAM_API_KEY");
-      expect(missingDedicated.stdout).toContain("CARTESIA_API_KEY");
-      expect(missingDedicated.stdout).toContain(
-        "VOICE_REALTIME_ELIZA_AUTHORIZATION",
-      );
-      expect(missingDedicated.stdout).toContain(
-        "PRODUCTION_REALTIME_CARTESIA_VOICE_ID",
-      );
-      expect(missingDedicated.stdout).toContain(
-        "PRODUCTION_REALTIME_ELIZA_ENDPOINT",
-      );
-
-      const configured = runPreflight({
-        DEPLOY_ENVIRONMENT: "production",
-        PRODUCTION_REALTIME_WS_ENABLED: "true",
-        CARTESIA_API_KEY: "cartesia-production",
-        VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer production-dedicated",
-        PRODUCTION_REALTIME_CARTESIA_VOICE_ID: "production-voice-id",
-        PRODUCTION_REALTIME_ELIZA_ENDPOINT:
-          "https://api.elizacloud.ai/api/v1/chat/completions",
-        STAGING_ELIZACLOUD_API_KEY: "repo-key-must-not-be-used",
-      });
-      expect(configured.status).toBe(0);
     });
   },
 );


### PR DESCRIPTION
## Summary

- pin realtime voice on for production Worker deployments instead of overriding `wrangler.toml` to false
- pin the production voice UI on while preserving staging opt-in and production Fish-off posture
- verify `CARTESIA_API_KEY`, `VOICE_REALTIME_CARTESIA_VOICE_ID`, `VOICE_REALTIME_ELIZA_AUTHORIZATION`, and `VOICE_REALTIME_ELIZA_ENDPOINT` live binding names before production deploy, without reading values
- replace the obsolete production-off contract tests with production-on Worker/frontend and managed-binding assertions

Closes #19659

## Verification

- 30 focused workflow contract tests
- `bun run verify` (350/350 Turbo tasks and all repository audits)
- confirmed all four managed production voice binding names exist on the live Worker

## Attribution

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@e9fa709e11f2e93a57d04a14cd2f1c270192b91b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported

— [codex]

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex-desktop","skill_revision":"elizaOS/eliza@e9fa709e11f2e93a57d04a14cd2f1c270192b91b:packages/skills/skills/contribute-to-eliza"} -->