### PR TITLE
fix(cloud): stabilize managed login navigation

### DIFF
--- a/packages/app/public/sw.js
+++ b/packages/app/public/sw.js
@@ -20,7 +20,9 @@
  * git sha / build timestamp of THIS deploy. That makes `dist/sw.js` byte-change
  * on every deploy, so the browser's SW byte-diff detects a new worker and runs
  * install -> skipWaiting -> activate (drop-stale-caches + claim + navigate
- * windows) automatically. Before this, `public/sw.js` was copied verbatim and
+ * each ordinary window once) automatically. The worker is the only navigation
+ * owner; the page registration seam must never add a competing controllerchange
+ * reload. Before this, `public/sw.js` was copied verbatim and
  * was byte-identical across deploys, so the update machinery below was DEAD CODE
  * and users needed a manual clear-data ritual to pick up a new renderer. The
  * cache-name suffixes are derived from BUILD_REV too, so `activate`'s stale-cache

--- a/packages/app/src/sw-registration.test.ts
+++ b/packages/app/src/sw-registration.test.ts
@@ -1,97 +1,87 @@
 /**
- * Service-worker update reload wiring through deterministic registration and
- * container fakes. First installation must not replay an auth navigation;
- * replacement workers reload the stale renderer exactly once.
+ * Service-worker update activation wiring through deterministic registration
+ * and container fakes. The page may activate a replacement worker but never
+ * becomes a second navigation owner; the real worker owns the one safe refresh.
  */
 
 import { describe, expect, it, vi } from "vitest";
-import {
-  isAuthNavigationUrl,
-  wireServiceWorkerUpdateReload,
-} from "./sw-registration";
+import { wireServiceWorkerUpdateActivation } from "./sw-registration";
 
 interface ListenerStore {
   registration: Map<string, EventListener>;
-  container: Map<string, EventListener>;
+  worker: Map<string, EventListener>;
 }
 
-function makeHarness(
-  hasController: boolean,
-  currentUrl = "https://staging.eliza.app/chat",
-) {
+function makeHarness({
+  hasController,
+  waiting = false,
+}: {
+  hasController: boolean;
+  waiting?: boolean;
+}) {
   const listeners: ListenerStore = {
     registration: new Map(),
-    container: new Map(),
+    worker: new Map(),
   };
+  const messages: unknown[] = [];
+  const worker = {
+    state: "installing",
+    postMessage(message: unknown) {
+      messages.push(message);
+    },
+    addEventListener(type: string, listener: EventListener) {
+      listeners.worker.set(type, listener);
+    },
+  } as unknown as ServiceWorker;
   const registration = {
-    waiting: null,
-    installing: null,
+    waiting: waiting ? worker : null,
+    installing: worker,
     addEventListener(type: string, listener: EventListener) {
       listeners.registration.set(type, listener);
     },
   } as unknown as ServiceWorkerRegistration;
   const serviceWorkers = {
     controller: hasController ? ({} as ServiceWorker) : null,
-    addEventListener(type: string, listener: EventListener) {
-      listeners.container.set(type, listener);
-    },
+    addEventListener: vi.fn(),
   } as unknown as ServiceWorkerContainer;
-  const reload = vi.fn();
 
-  wireServiceWorkerUpdateReload(
-    registration,
-    serviceWorkers,
-    reload,
-    () => currentUrl,
-  );
+  wireServiceWorkerUpdateActivation(registration, serviceWorkers);
 
-  return { listeners, reload };
+  return { listeners, messages, registration, serviceWorkers, worker };
 }
 
-describe("service-worker controller-change reload", () => {
-  it("does not reload when the first worker claims an uncontrolled page", () => {
-    const { listeners, reload } = makeHarness(false);
+describe("service-worker update activation", () => {
+  it("does not activate an installing worker on its first installation", () => {
+    const { listeners, messages, worker } = makeHarness({
+      hasController: false,
+    });
+    listeners.registration.get("updatefound")?.(new Event("updatefound"));
+    Object.assign(worker, { state: "installed" });
+    listeners.worker.get("statechange")?.(new Event("statechange"));
 
-    listeners.container.get("controllerchange")?.(
-      new Event("controllerchange"),
-    );
-
-    expect(reload).not.toHaveBeenCalled();
+    expect(messages).toEqual([]);
   });
 
-  it("reloads exactly once when a replacement worker takes control", () => {
-    const { listeners, reload } = makeHarness(true);
-    const controllerChange = listeners.container.get("controllerchange");
+  it("activates a newly installed replacement worker", () => {
+    const { listeners, messages, worker } = makeHarness({
+      hasController: true,
+    });
+    listeners.registration.get("updatefound")?.(new Event("updatefound"));
+    Object.assign(worker, { state: "installed" });
+    listeners.worker.get("statechange")?.(new Event("statechange"));
 
-    controllerChange?.(new Event("controllerchange"));
-    controllerChange?.(new Event("controllerchange"));
-
-    expect(reload).toHaveBeenCalledTimes(1);
+    expect(messages).toEqual([{ type: "SKIP_WAITING" }]);
   });
 
-  it.each([
-    "https://staging.eliza.app/auth/bridge?state=state",
-    "https://staging.eliza.app/login?code=one-time-code",
-    "https://staging.eliza.app/oidc/continue?rid=eoq_request",
-  ])("does not replay an auth-sensitive update navigation: %s", (url) => {
-    const { listeners, reload } = makeHarness(true, url);
+  it("activates a replacement worker that was already waiting", () => {
+    const { messages } = makeHarness({ hasController: true, waiting: true });
 
-    listeners.container.get("controllerchange")?.(
-      new Event("controllerchange"),
-    );
-
-    expect(reload).not.toHaveBeenCalled();
+    expect(messages).toEqual([{ type: "SKIP_WAITING" }]);
   });
-});
 
-describe("service-worker auth navigation classification", () => {
-  it("matches exact auth route families without blocking ordinary app pages", () => {
-    expect(isAuthNavigationUrl("https://eliza.app/login")).toBe(true);
-    expect(isAuthNavigationUrl("https://eliza.app/auth/email-callback")).toBe(
-      true,
-    );
-    expect(isAuthNavigationUrl("https://eliza.app/oidc/continue")).toBe(true);
-    expect(isAuthNavigationUrl("https://eliza.app/chat")).toBe(false);
-    expect(isAuthNavigationUrl("https://eliza.app/login-history")).toBe(false);
+  it("never subscribes to controllerchange, leaving navigation to the worker", () => {
+    const { serviceWorkers } = makeHarness({ hasController: true });
+
+    expect(serviceWorkers.addEventListener).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/sw-registration.ts
+++ b/packages/app/src/sw-registration.ts
@@ -36,53 +36,26 @@ function isElectrobunHost(): boolean {
   );
 }
 
-const AUTH_NAVIGATION_PATH_RE =
-  /^\/(?:login(?:\/|$)|auth(?:\/|$)|oidc\/continue(?:\/|$))/;
-
-/** Auth callbacks and bridges are one-time navigations that updates must not replay. */
-export function isAuthNavigationUrl(rawUrl: string): boolean {
-  try {
-    return AUTH_NAVIGATION_PATH_RE.test(new URL(rawUrl).pathname);
-  } catch {
-    // error-policy:J3 an unparseable current URL is treated as auth-sensitive;
-    // skipping an update reload is safer than replaying an unknown navigation.
-    return true;
-  }
-}
-
 /**
  * When a NEW service worker reaches `installed` while an existing controller is
- * present, a fresh renderer was just deployed. The new SW's own `activate`
- * already skips-waiting + claims + navigates windows, but wiring the client side
- * of the update makes the transition immediate and observable: tell the waiting
- * worker to take over (SKIP_WAITING), then reload once it becomes the controller.
- * Guarded so the FIRST install (no prior controller) does NOT reload — that is a
- * normal first paint, not an update (CONVERSATIONS-500-2026-07-22 fix #1).
+ * present, a fresh renderer was just deployed. Tell the waiting worker to take
+ * over; its `activate` handler is the SINGLE navigation owner: it claims clients,
+ * skips auth routes, and navigates each ordinary window once. A second page-side
+ * `controllerchange` reload races that navigation and can refresh the same login
+ * journey twice, so this registration seam deliberately never reloads a page.
  */
-export function wireServiceWorkerUpdateReload(
+export function wireServiceWorkerUpdateActivation(
   registration: ServiceWorkerRegistration,
   serviceWorkers: ServiceWorkerContainer = navigator.serviceWorker,
-  reload: () => void = () => globalThis.location.reload(),
-  currentUrl: () => string = () => globalThis.location.href,
 ): void {
-  // Snapshot before `controllerchange`: first-install claim changes this from
-  // null to the new worker, while an update already has the previous worker.
-  // Only the latter represents a stale renderer that needs a reload.
   const isUpdate = Boolean(serviceWorkers.controller);
-  let reloading = false;
-  const reloadOnControllerChange = () => {
-    if (!isUpdate || reloading || isAuthNavigationUrl(currentUrl())) return;
-    reloading = true;
-    // The new worker is now controlling this page → load the new renderer.
-    reload();
-  };
 
   const trackInstalling = (worker: ServiceWorker | null) => {
     if (!worker) return;
     worker.addEventListener("statechange", () => {
       // A worker reaching `installed` with an existing controller = an UPDATE
       // (not the first install). Ask it to activate immediately.
-      if (worker.state === "installed" && serviceWorkers.controller) {
+      if (worker.state === "installed" && isUpdate) {
         try {
           worker.postMessage({ type: "SKIP_WAITING" });
         } catch {
@@ -104,9 +77,6 @@ export function wireServiceWorkerUpdateReload(
   registration.addEventListener("updatefound", () => {
     trackInstalling(registration.installing);
   });
-
-  // On an update, reload exactly once when control passes to the new worker.
-  serviceWorkers.addEventListener("controllerchange", reloadOnControllerChange);
 }
 
 /**
@@ -128,9 +98,9 @@ export function registerViewServiceWorker(): void {
       // `.scope` off it would throw and masquerade as a registration error.
       if (!registration) return;
       console.info("[SW] Registered, scope:", registration.scope);
-      // Auto-reload into a new renderer when a deploy ships a new worker
-      // (the per-deploy build rev makes sw.js byte-change so this actually fires).
-      wireServiceWorkerUpdateReload(registration);
+      // Activate a new worker immediately; its activation owns the one safe
+      // renderer navigation for each non-auth window.
+      wireServiceWorkerUpdateActivation(registration);
     })
     // error-policy:J4 the service worker is a PWA enhancement — the app
     // works without it; the failure is logged for triage

--- a/packages/app/test/service-worker-cache-strategies.test.ts
+++ b/packages/app/test/service-worker-cache-strategies.test.ts
@@ -7,7 +7,8 @@
  * Covers the cold-start wins added for the installed iOS PWA:
  *  - navigation preload is enabled on activate (feature-detected)
  *  - first install claims but never navigates an in-flight auth bridge
- *  - replacement workers navigate existing windows to the fresh renderer
+ *  - replacement workers are the single owner that navigates each ordinary
+ *    window once while preserving auth routes
  *  - a navigation consumes event.preloadResponse instead of a second fetch
  *  - immutable /assets/<hash>.{js,css,...} are served cache-first and cached
  *  - the immutable asset cache is bounded (oldest entries evicted past the cap)

--- a/packages/app/test/ui-smoke/managed-login-stability.spec.ts
+++ b/packages/app/test/ui-smoke/managed-login-stability.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Real-browser regression for the managed Cloud login's navigation ownership.
+ * The fixture proxies the local renderer behind the canonical app hostname so
+ * production hostname gates run unchanged while all application bytes remain
+ * exact-head and local; network-bound auth provider discovery is deterministic.
+ */
+
+import { writeFile } from "node:fs/promises";
+import { expect, type Page, test } from "@playwright/test";
+
+const PROVIDERS = {
+  passkey: false,
+  email: true,
+  sms: false,
+  siwe: true,
+  siws: true,
+  google: true,
+  discord: true,
+  github: true,
+  twitter: false,
+  oauth: [],
+};
+
+const STABILITY_WINDOW_MS = 5_500;
+const SURFACES = [
+  { name: "desktop", viewport: { width: 1440, height: 900 } },
+  { name: "mobile", viewport: { width: 390, height: 844 } },
+] as const;
+
+async function installManagedOriginProxy(
+  page: Page,
+  localBaseUrl: string,
+): Promise<string> {
+  const local = new URL(localBaseUrl);
+  const managed = new URL(localBaseUrl);
+  managed.hostname = "cloud.eliza.app";
+
+  await page.route(`${managed.origin}/**`, async (route) => {
+    const target = new URL(route.request().url());
+    target.protocol = local.protocol;
+    target.hostname = local.hostname;
+    target.port = local.port;
+    const response = await route.fetch({ url: target.toString() });
+    await route.fulfill({ response });
+  });
+  await page.route("**/auth/providers", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(PROVIDERS),
+    });
+  });
+
+  return managed.origin;
+}
+
+for (const surface of SURFACES) {
+  for (const entryPath of ["/", "/login?intent=launch"] as const) {
+    test(`signed-out managed entry ${entryPath} settles on one login document (${surface.name})`, async ({
+      page,
+      baseURL,
+    }, testInfo) => {
+      if (!baseURL) throw new Error("Playwright baseURL is required");
+      await page.setViewportSize(surface.viewport);
+      const managedOrigin = await installManagedOriginProxy(page, baseURL);
+      const documentRequests: string[] = [];
+      const failures: string[] = [];
+      const consoleMessages: Array<{ type: string; text: string }> = [];
+
+      page.on("request", (request) => {
+        if (
+          request.isNavigationRequest() &&
+          request.frame() === page.mainFrame()
+        ) {
+          documentRequests.push(request.url());
+        }
+      });
+      page.on("pageerror", (error) => failures.push(error.message));
+      page.on("console", (message) => {
+        consoleMessages.push({ type: message.type(), text: message.text() });
+      });
+      page.on("requestfailed", (request) => {
+        failures.push(
+          `${request.method()} ${request.url()} ${request.failure()?.errorText ?? "unknown"}`,
+        );
+      });
+
+      await page.goto(`${managedOrigin}${entryPath}`);
+      const heading = page.getByRole("heading", { name: "Sign in to Eliza" });
+      await expect(heading).toBeVisible();
+      await expect(page.getByText("Taking you to Eliza sign in")).toHaveCount(
+        0,
+      );
+      const stableHeading = await heading.elementHandle();
+      if (!stableHeading) throw new Error("Login heading did not mount");
+      await stableHeading.evaluate((element) => {
+        element.setAttribute("data-login-stability-probe", "mounted");
+      });
+
+      // This spans the managed handoff fallback deadline. The former path
+      // remounted after five seconds even when no bridgeable session existed.
+      await page.waitForTimeout(STABILITY_WINDOW_MS);
+
+      await expect(heading).toHaveAttribute(
+        "data-login-stability-probe",
+        "mounted",
+      );
+      expect(
+        await stableHeading.evaluate((element) => element.isConnected),
+      ).toBe(true);
+      expect(new URL(page.url()).hostname).toBe("cloud.eliza.app");
+      expect(new URL(page.url()).pathname).toBe("/login");
+      expect(
+        documentRequests.map((url) => new URL(url).hostname),
+        "the signed-out path must never load an auth-bridge document",
+      ).toEqual(["cloud.eliza.app"]);
+      expect(failures).toEqual([]);
+
+      if (process.env.E2E_RECORD === "1") {
+        await page.screenshot({
+          path: testInfo.outputPath(`${surface.name}-stable-login.png`),
+          fullPage: true,
+        });
+        await writeFile(
+          testInfo.outputPath(`${surface.name}-frontend-observations.json`),
+          `${JSON.stringify(
+            {
+              head: process.env.GITHUB_SHA ?? "local-exact-head",
+              entryPath,
+              finalUrl: page.url(),
+              documentRequests,
+              failures,
+              consoleMessages,
+              stabilityWindowMs: STABILITY_WINDOW_MS,
+              stableHeadingConnected: await stableHeading.evaluate(
+                (element) => element.isConnected,
+              ),
+            },
+            null,
+            2,
+          )}\n`,
+        );
+      }
+    });
+  }
+}

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.handoff.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.handoff.test.tsx
@@ -13,13 +13,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const bridge = vi.hoisted(() => ({
   redirect: vi.fn<() => Promise<boolean>>(),
-  shouldAttempt: vi.fn<() => boolean>(),
+  shouldAutoBridge: vi.fn<() => boolean>(),
 }));
 
 vi.mock("../../../sso-bridge/sso-bridge", () => ({
   redirectToSsoBridge: bridge.redirect,
   sanitizeBridgeReturnTo: (value: string | null) => value ?? "/",
-  shouldAttemptSsoBridge: bridge.shouldAttempt,
+  shouldAutoBridgeToSso: bridge.shouldAutoBridge,
 }));
 
 vi.mock("./steward-login-section", () => ({
@@ -52,8 +52,8 @@ async function renderLogin(): Promise<void> {
 beforeEach(() => {
   vi.useFakeTimers();
   bridge.redirect.mockReset();
-  bridge.shouldAttempt.mockReset();
-  bridge.shouldAttempt.mockReturnValue(true);
+  bridge.shouldAutoBridge.mockReset();
+  bridge.shouldAutoBridge.mockReturnValue(true);
 });
 
 afterEach(() => {
@@ -62,15 +62,26 @@ afterEach(() => {
 });
 
 describe("managed-cloud login handoff", () => {
-  it("uses the redirect-loop guard before starting another bridge", async () => {
-    bridge.shouldAttempt.mockReturnValue(false);
+  it("renders one stable local sign-in surface when there is no auth-origin session to bridge", async () => {
+    bridge.shouldAutoBridge.mockReturnValue(false);
 
     await renderLogin();
 
     expect(bridge.redirect).not.toHaveBeenCalled();
+    expect(screen.queryByText("Taking you to Eliza sign in")).toBeNull();
     expect(
       screen.getByRole("heading", { name: "Sign in to Eliza" }),
     ).toBeTruthy();
+  });
+
+  it("starts one handoff under StrictMode when an existing session is bridgeable", async () => {
+    bridge.redirect.mockResolvedValue(true);
+
+    await renderLogin();
+
+    expect(bridge.shouldAutoBridge).toHaveBeenCalledTimes(2);
+    expect(bridge.redirect).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Taking you to Eliza sign in")).toBeTruthy();
   });
 
   it("falls back when bridge initiation rejects", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
@@ -17,7 +17,7 @@ import { useCloudT } from "../../../shell/CloudI18nProvider";
 import {
   redirectToSsoBridge,
   sanitizeBridgeReturnTo,
-  shouldAttemptSsoBridge,
+  shouldAutoBridgeToSso,
 } from "../../../sso-bridge/sso-bridge";
 import { usePageTitle } from "../../lib/use-page-title";
 import { LoginOptionsSkeleton } from "./login-section-skeleton";
@@ -95,17 +95,15 @@ function sessionIdFromLoginReturnTo(returnTo: string | null): string | null {
 
 function ManagedCloudLoginHandoff(): React.JSX.Element {
   const [searchParams] = useSearchParams();
+  const [handoffRequired] = useState(() => shouldAutoBridgeToSso());
   const [failed, setFailed] = useState(false);
   const attemptRef = useRef<Promise<boolean> | null>(null);
   const returnTo = sanitizeBridgeReturnTo(searchParams.get("returnTo"));
 
   useEffect(() => {
+    if (!handoffRequired) return;
     let attempt = attemptRef.current;
     if (!attempt) {
-      if (!shouldAttemptSsoBridge()) {
-        setFailed(true);
-        return;
-      }
       attempt = redirectToSsoBridge(returnTo);
       attemptRef.current = attempt;
     }
@@ -131,9 +129,9 @@ function ManagedCloudLoginHandoff(): React.JSX.Element {
       active = false;
       window.clearTimeout(timeout);
     };
-  }, [returnTo]);
+  }, [handoffRequired, returnTo]);
 
-  if (failed) return <PublicLoginPage />;
+  if (!handoffRequired || failed) return <PublicLoginPage />;
   return (
     <LoginBackground>
       <p className="text-center font-mono text-[11px] uppercase tracking-[0.32em] text-muted">


### PR DESCRIPTION
# Relates to

Closes #19654.

- [x] This PR targets `develop`, was rebased onto `49b0b26963085afe9a8114d4d41361f0feb1188a`, and remains conflict-free with the current `origin/develop`.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the changed login-navigation contract from the desktop/mobile captures, videos, and request logs below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@49b0b26963085afe9a8114d4d41361f0feb1188a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop` `49b0b26963085afe9a8114d4d41361f0feb1188a`; zero conflicts. Current develop `54709beab15dbc913bff379feb9ab1da4e683a6a` adds only two Cloud verification-script paths, has zero touched-path intersection, and produces a clean merge tree (`740ac43078dcd1080ebed0755fb781bbabd174bf`).
- [x] Final PR head is `31fb977ea205a6338bfee19fb92b14bc2b783670`.
- [x] Full `bun install --frozen-lockfile` completed with 3,822 installs checked and no dependency changes.
- [x] Exact-head `bun run verify` passed: 350/350 Turbo tasks plus all repository audits. The immediately preceding patch-equivalent head also passed 350/350 with 0 cache hits.

# Risks

Medium. This changes two navigation ownership boundaries: managed-login SSO initiation and service-worker update activation. Existing bridgeable sessions still take the signed, state/PKCE-bound SSO path once; signed-out browsers now render the local Steward form immediately. Replacement service workers still activate immediately and refresh ordinary app windows once, but the page registration seam no longer issues a competing `controllerchange` reload. No API, schema, migration, provider, secret, or infrastructure contract changes.

# Background

## What does this PR do?

It removes two independent sources of login bouncing and remounting:

- `ManagedCloudLoginHandoff` now uses the same strict `shouldAutoBridgeToSso` decision as app entry. A fresh signed-out browser without the domain-wide authenticated-session marker no longer leaves `cloud.eliza.app`, flashes the handoff screen, or waits five seconds before remounting the local login form.
- The bridge decision is snapshotted for the mount, and StrictMode shares one redirect promise, so a genuinely bridgeable session initiates exactly one handoff.
- Service-worker registration only asks a replacement worker to activate. The worker's existing activation handler remains the single navigation owner, skips `/login`, `/auth/*`, and `/oidc/continue`, and navigates each ordinary window once. The former page-side `controllerchange` reload could race that worker navigation and refresh the same page twice.
- A real Chromium regression proxies exact local renderer bytes behind the canonical `cloud.eliza.app` hostname. It covers `/` and `/login?intent=launch` on desktop and mobile, asserts exactly one main document, zero handoff text, zero browser failures, and the same connected login heading after the former five-second fallback deadline.

## What kind of change is this?

Bug fix (non-breaking login and renderer-update lifecycle correction).

# Documentation changes needed?

No public documentation change is required. The relevant code headers and tests now document the single-owner navigation invariant.

# Testing

## Where should a reviewer start?

Review `login-page.handoff.test.tsx`, `sw-registration.test.ts`, and `managed-login-stability.spec.ts`, then compare the live-production before logs/videos to the exact-head after artifacts.

## Detailed testing steps

- `bun run --cwd packages/ui test -- src/cloud/public-pages/pages/login/login-page.handoff.test.tsx src/cloud/sso-bridge/sso-bridge.test.ts` — passed, 2 files / 39 tests.
- `bun run --cwd packages/app test -- src/sw-registration.test.ts test/service-worker-cache-strategies.test.ts test/service-worker-auth-bypass.test.ts test/service-worker-runtime.test.ts` — passed, 4 focused files / 39 tests after 781 app script tests (1 platform skip).
- `(cd packages/app && GITHUB_SHA=31fb977... E2E_RECORD=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=chromium test/ui-smoke/managed-login-stability.spec.ts)` — passed, 4/4 desktop/mobile exact-host tests.
- `bun run --cwd packages/ui typecheck` — passed.
- `bun run --cwd packages/app build:web` — passed: 9,050 modules, chunk-safety and viewport checks green, SW stamped with the patch head.
- `bun run --cwd packages/app audit:app` — passed, 219/219 captures; broken=0, needs-work=0, hover-probe-failures=0, density-probe-failures=0; OCR verified 200 with 16 normal human-review candidates and zero broken views.
- `git diff --check origin/develop...HEAD` — passed.
- `TURBO_FORCE=1 bun run verify` — passed on the patch: 350/350 tasks, 0 cached, all follow-on audits. After the final conflict-free rebase, exact-head `bun run verify` passed again: 350/350 plus all audits.

# Evidence Gate

<!-- evidence-head:31fb977ea205a6338bfee19fb92b14bc2b783670 -->

<!-- evidence-row:before-screenshots -->
- [x] Current live-production login after the cross-origin bounce: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-before-desktop.jpg) and [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-before-mobile.jpg).
<!-- evidence-row:after-screenshots -->
- [x] Exact-head stable managed-host login: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-after-31fb-desktop.jpg) and [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-after-31fb-mobile.jpg).
<!-- evidence-row:walkthrough-video -->
- [x] H.264 walkthroughs: before [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-before-desktop.mp4) / [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-before-mobile.mp4), and after [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-after-31fb-desktop.mp4) / [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-after-31fb-mobile.mp4).
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend route or server behavior changed; auth/provider requests are deterministic fixtures in the exact renderer test.
<!-- evidence-row:frontend-logs -->
- [x] Sanitized browser observations: before [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-before-desktop-observations.json) / [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-before-mobile-observations.json), after [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-after-31fb-desktop-observations.json) / [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-after-31fb-mobile-observations.json), and exact-head Playwright traces [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-after-31fb-desktop-trace.zip) / [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-after-31fb-mobile-trace.zip).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, model, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] The affected machine-readable artifact is the [navigation ownership report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-navigation-ownership-31fb.json): live 3→ exact-head 1 main document on both viewports, stable-node proof, and single service-worker owner.
<!-- evidence-row:ocr-review -->
- [x] OCR review output: before [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-before-desktop-ocr.txt) / [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-before-mobile-ocr.txt), after [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-after-31fb-desktop-ocr.txt) / [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19662-login-stability-after-31fb-mobile-ocr.txt).

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changes.

## Backend + frontend logs

The before capture uses a fresh, unsigned Chromium context against deployed `https://cloud.eliza.app/login?intent=launch`. It records three main documents (`cloud.eliza.app/login` → `eliza.app/auth/bridge` → `eliza.app/login`) and a final host switch, with nonce/challenge values excluded from the uploaded report. The after fixture executes exact-head local bytes behind the canonical managed hostname and records one main document, a final managed `/login` URL, zero browser/request failures, and the same connected heading after 5.5 seconds.

## Screenshots (before / after) + video walkthrough

The screenshots show the rendered login surface on desktop and mobile. The important visual/behavioral distinction is recorded in the paired videos and machine logs: the current deployed version rebuilds the document twice and ends on a different origin, while the patch mounts the form once on `cloud.eliza.app` and remains stable.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

No authenticated provider was exercised because the defect occurs before credential entry and reproduces in a fresh signed-out context; external login would also mutate account/session state. Existing-session bridge behavior is covered by the StrictMode component regression and the existing state/PKCE bridge suite. The full app audit was captured on a rendered-equivalent patch head. Subsequent base-only changes touched app scripts/tests/tsconfig and a connector barrel comment, not rendered login code; exact-head browser evidence, focused tests, production build, and root verification were renewed at `31fb977`.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@49b0b26963085afe9a8114d4d41361f0feb1188a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@49b0b26963085afe9a8114d4d41361f0feb1188a:packages/skills/skills/contribute-to-eliza"} -->
