### PR TITLE
fix(test): restore scenario workspace resolution

### DIFF
--- a/packages/test/scenarios/tsconfig.json
+++ b/packages/test/scenarios/tsconfig.json
@@ -5,7 +5,9 @@
     "composite": false,
     "declaration": false,
     "declarationMap": false,
+    "types": ["node"],
     "paths": {
+      "@elizaos/agent": ["../../agent/src/index.ts"],
       "@elizaos/scenario-runner/scenario-assertions": [
         "../../scenario-runner/src/scenario-assertions.ts"
       ],


### PR DESCRIPTION
Closes #19663

## Summary

- declares Node types for the scenario corpus compiler boundary
- maps `@elizaos/agent` to its workspace source
- backports the configuration already proven during the develop-to-main promotion

## Verification

- `bun run --cwd packages/test typecheck` — PASS
- `bunx biome check packages/test/scenarios/tsconfig.json` — PASS
- Root `bun run verify` previously reached this lane and failed only on the missing declarations; the full gate will be rerun after this prerequisite lands and the release-verifier patch is rebased.

## Evidence

- Screenshots: N/A — compiler configuration only
- Video: N/A — no rendered UI
- Frontend logs: N/A — no frontend behavior
- Backend logs: N/A — no runtime behavior

## Contribution provenance

| Field | Value |
| --- | --- |
| AI provider | OpenAI |
| Model | GPT-5 |
| Client / agent tooling | Codex desktop |
| Skill revision | elizaOS/eliza@b3165aed2bb139deaa30cd81fdb295648fbd493e:packages/skills/skills/contribute-to-eliza |
| Attribution status | self-reported |

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@b3165aed2bb139deaa30cd81fdb295648fbd493e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-desktop]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex-desktop","skill_revision":"elizaOS/eliza@b3165aed2bb139deaa30cd81fdb295648fbd493e:packages/skills/skills/contribute-to-eliza"} -->