### PR TITLE
fix(cloud): ignore Pages worker in freshness verification

### DIFF
--- a/packages/cloud/scripts/__tests__/verify-pages-frontend.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-pages-frontend.test.ts
@@ -185,6 +185,34 @@ describe("verifyPagesFrontendOnce", () => {
     expect(report.detail).toContain("2 emitted JavaScript asset(s)");
   });
 
+  it("ignores the reserved Pages _worker.js executable", async () => {
+    const distDir = makeDist("assets/index-fresh.js", "entry");
+    writeFileSync(
+      join(distDir, "_worker.js"),
+      "export default { fetch: () => new Response('middleware') };",
+    );
+    const fetchImpl = (async (url: string) => {
+      if (url === "https://app.elizacloud.ai/") {
+        return response(
+          '<script type="module" src="/assets/index-fresh.js"></script>',
+        );
+      }
+      if (url.endsWith("/assets/index-fresh.js")) return response("entry");
+      throw new Error(
+        `reserved worker must not be fetched as an asset: ${url}`,
+      );
+    }) as unknown as typeof fetch;
+
+    const report = await verifyPagesFrontendOnce({
+      servedUrl: "https://app.elizacloud.ai",
+      distDir,
+      fetchImpl,
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.detail).toContain("1 emitted JavaScript asset(s)");
+  });
+
   it("fails when a live lazy asset does not exactly match local bytes", async () => {
     const distDir = makeDist("assets/index-fresh.js", "entry");
     writeFileSync(join(distDir, "assets/AppContext-lazy.js"), "local lazy");

--- a/packages/cloud/scripts/verify-pages-frontend.mjs
+++ b/packages/cloud/scripts/verify-pages-frontend.mjs
@@ -1,10 +1,12 @@
 /**
  * Verifies that a Cloudflare Pages custom domain is serving the frontend bundle
  * that was just built by the deploy job. The check follows the live
- * `index.html` to its Vite entry chunk, then compares every emitted JavaScript
- * script with the local build byte-for-byte. Required sentinel text is searched
- * incrementally across the complete emitted graph so code-split user flows
- * remain provable without retaining the entire application in memory.
+ * `index.html` to its Vite entry chunk, then compares every public emitted
+ * JavaScript asset with the local build byte-for-byte. Required sentinel text
+ * is searched incrementally across the complete public graph so code-split
+ * user flows remain provable without retaining the entire application in
+ * memory. Cloudflare's reserved `_worker.js` is executable deployment input,
+ * not a public asset, and is deliberately excluded from that graph.
  */
 import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
@@ -15,6 +17,7 @@ const MAX_CONCURRENT_ASSET_FETCHES = 16;
 const MAX_INDEX_BYTES = 2 * 1024 * 1024;
 const MAX_JAVASCRIPT_ASSETS = 2_048;
 const MAX_TOTAL_JAVASCRIPT_BYTES = 128 * 1024 * 1024;
+const CLOUDFLARE_PAGES_EXECUTABLE_FILES = new Set(["_worker.js"]);
 
 function normalizeBaseUrl(url) {
   const trimmed = `${url ?? ""}`.trim();
@@ -214,7 +217,11 @@ async function readJavaScriptAssets(distDir) {
     for (const entry of entries) {
       const relativePath = path.posix.join(relativeDir, entry.name);
       if (entry.isDirectory()) pending.push(relativePath);
-      else if (entry.isFile() && entry.name.endsWith(".js")) {
+      else if (
+        entry.isFile() &&
+        entry.name.endsWith(".js") &&
+        !CLOUDFLARE_PAGES_EXECUTABLE_FILES.has(relativePath)
+      ) {
         const size = (await stat(path.join(distDir, relativePath))).size;
         assets.push({ path: relativePath, size });
         totalBytes += size;


### PR DESCRIPTION
Closes #19661

## Summary

- excludes Cloudflare Pages' reserved root `_worker.js` from the public JavaScript asset graph
- continues byte-verifying `sw.js`, the Vite entry, and every public lazy chunk
- adds a regression test proving the verifier never requests the executable Worker as a static asset

## Root cause

Wrangler places the Pages middleware bundle at `dist/_worker.js`. Cloudflare executes that reserved file instead of serving it. A request to `/_worker.js` therefore receives the SPA fallback `index.html`, which made the post-deploy verifier deterministically fail with a byte mismatch after successful production deployments.

## Verification

- Focused suite: 15/15 PASS
- `bun run verify`: 350/350 tasks PASS; all repository audits PASS
- Live `https://eliza.app`: 566/566 public JavaScript assets matched, all required login/onboarding sentinels present
- Live `https://cloud.eliza.app`: 566/566 public JavaScript assets matched, all required login/onboarding sentinels present
- Live renderer manifests on both domains report commit `ae645bebdd9e3095186167eff4d3e6f9543840ee`

## Evidence

- Screenshots: N/A — release verifier only; no rendered UI changed
- Video: N/A — no interaction changed
- Frontend logs: Live verifier output reports exact byte equality for 566 public assets on each production domain
- Backend logs: N/A — no backend runtime path changed

## Contribution provenance

| Field | Value |
| --- | --- |
| AI provider | OpenAI |
| Model | GPT-5 |
| Client / agent tooling | Codex desktop |
| Skill revision | elizaOS/eliza@49b0b26963085afe9a8114d4d41361f0feb1188a:packages/skills/skills/contribute-to-eliza |
| Attribution status | self-reported |

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@49b0b26963085afe9a8114d4d41361f0feb1188a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-desktop]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex-desktop","skill_revision":"elizaOS/eliza@49b0b26963085afe9a8114d4d41361f0feb1188a:packages/skills/skills/contribute-to-eliza"} -->