### PR TITLE
fix(cloud): route dedicated DMs through canonical ingress first

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
@@ -100,7 +100,7 @@ describe("canonical agent forwarding fallback", () => {
     ).toBeNull();
   });
 
-  test("sends the canonical agent hostname to the router origin", async () => {
+  test("sends dedicated sandboxes to the canonical router before their blocked public port", async () => {
     const requests: Array<{ url: string; forwardedHost: string | null }> = [];
     const previousOrigin = process.env.AGENT_ROUTER_ORIGIN_HOST;
     const previousDomain = process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN;
@@ -113,9 +113,6 @@ describe("canonical agent forwarding fallback", () => {
           url,
           forwardedHost: new Headers(init?.headers).get("x-forwarded-host"),
         });
-        if (url.startsWith("http://stale-sandbox.example")) {
-          throw new TypeError("connection timed out");
-        }
         return new Response(JSON.stringify({ response: "agent is live" }), {
           status: 200,
         });
@@ -146,10 +143,6 @@ describe("canonical agent forwarding fallback", () => {
     }
 
     expect(requests).toEqual([
-      {
-        url: `http://stale-sandbox.example/api/agents/${AGENT_ID}/message`,
-        forwardedHost: null,
-      },
       {
         url: `https://eliza-production-1.eliza.app/api/agents/${AGENT_ID}/message`,
         forwardedHost: `${AGENT_ID}.cloud.eliza.app`,
@@ -210,9 +203,6 @@ describe("canonical agent forwarding fallback", () => {
     globalThis.fetch = mock(async (input: string | URL | Request) => {
       const url = input instanceof Request ? input.url : String(input);
       requests.push(url);
-      if (url.startsWith("http://stale-sandbox.example")) {
-        throw new TypeError("connection timed out");
-      }
       if (url.endsWith(`/agents/${AGENT_ID}/message`)) {
         return new Response(JSON.stringify({ error: "Agent not found" }), {
           status: 404,
@@ -257,7 +247,6 @@ describe("canonical agent forwarding fallback", () => {
     }
 
     expect(requests).toEqual([
-      `http://stale-sandbox.example/api/agents/${AGENT_ID}/message`,
       `https://eliza-production-1.eliza.app/api/agents/${AGENT_ID}/message`,
       "https://eliza-production-1.eliza.app/api/agents",
       `https://eliza-production-1.eliza.app/api/agents/${RUNTIME_AGENT_ID}/message`,

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -618,6 +618,28 @@ async function forwardWithRetry(
 ): Promise<string> {
   let lastError: Error | null = null;
   let woken = false;
+  let canonicalAttempted = false;
+
+  // Dedicated Docker sandboxes self-register a public host:port in Redis for
+  // compatibility, but production node firewalls intentionally do not expose
+  // those high ports to Railway. Their supported ingress is the canonical
+  // control-plane router over HTTPS. Prefer it before the Redis target so a
+  // normal Telegram/DM turn does not spend its entire non-replay timeout on a
+  // transport that cannot be reached from this service.
+  if (connectionFallback && serverName.startsWith("sandbox-")) {
+    canonicalAttempted = true;
+    const canonical = await tryCanonicalTarget(
+      connectionFallback,
+      endpointPath,
+      body,
+      policy,
+    );
+    if (canonical.ok) return canonical.response;
+    if (canonical.timedOut && !policy.retryOnTimeout) {
+      throw canonical.error;
+    }
+    lastError = canonical.error;
+  }
 
   for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt++) {
     if (attempt > 0) {
@@ -658,9 +680,11 @@ async function forwardWithRetry(
     if (
       result.isConnectionError &&
       connectionFallback &&
+      !canonicalAttempted &&
       targets[0].replace(/\/$/, "") !==
         connectionFallback.baseUrl.replace(/\/$/, "")
     ) {
+      canonicalAttempted = true;
       const canonical = await tryCanonicalTarget(
         connectionFallback,
         endpointPath,


### PR DESCRIPTION
## Summary

- send dedicated Docker sandboxes through the canonical HTTPS control-plane router before their firewall-blocked Redis public port
- retain direct routing as a compatibility fallback when canonical ingress fails without timing out
- preserve the no-replay rule for non-idempotent message timeouts
- discover and address the sole running runtime when its runtime id differs from the cloud sandbox id

Related to #19519.

## Production diagnosis

The production agent's canonical health route returned ready with runtime and database OK. A real canonical message call returned `TELEGRAM_ROUTER_OK` in 7.860s. The same gateway first tried the Redis-advertised Hetzner high port and exhausted the full 75-second non-replay deadline, so the canonical fallback was never reached.

## Verification

- `bun run --cwd packages/cloud/services/gateway-webhook test`: 119 pass, 0 fail
- `bun run --cwd packages/cloud/services/gateway-webhook typecheck`: pass
- `bun run --cwd packages/cloud/services/gateway-webhook lint:check`: pass
- `bun run --cwd packages/cloud/services/gateway-webhook build`: pass

## Evidence matrix

- Desktop/mobile screenshots: N/A - backend-only connector routing
- UI walkthrough video: N/A - no UI surface changed
- Browser console/network logs: N/A - Telegram webhook path
- Backend logs: live canonical health and message timing reviewed during incident response
- Live model trajectory: N/A - no prompt/model behavior changed; exact-response probe only
- Domain artifacts: N/A - no artifact output

## Contribution provenance

- AI provider/model: OpenAI / gpt-5
- Client / agent tooling: Codex desktop
- Contribution skill revision: elizaOS/eliza@404fd6cd53a6ec101fe9288fdd44885fe7601f2a:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only gateway behavior; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only gateway behavior; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Telegram webhook path has no repository UI surface

<!-- evidence-row:backend-logs -->
- [ ] N/A - live production timing is recorded in this PR body; no secret-bearing raw log bundle is attached

<!-- evidence-row:frontend-logs -->
- [ ] N/A - Telegram webhook path has no browser frontend

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model prompt, response policy, or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no image, audio, PDF, or domain artifact is produced

— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@404fd6cd53a6ec101fe9288fdd44885fe7601f2a:packages/skills/skills/contribute-to-eliza"} -->

