### PR TITLE
fix(cloud): backport canonical DM routing to production

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/server-router-fallback.test.ts
@@ -100,7 +100,7 @@ describe("canonical agent forwarding fallback", () => {
     ).toBeNull();
   });
 
-  test("sends the canonical agent hostname to the router origin", async () => {
+  test("sends dedicated sandboxes to the canonical router before their blocked public port", async () => {
     const requests: Array<{ url: string; forwardedHost: string | null }> = [];
     const previousOrigin = process.env.AGENT_ROUTER_ORIGIN_HOST;
     const previousDomain = process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN;
@@ -113,9 +113,6 @@ describe("canonical agent forwarding fallback", () => {
           url,
           forwardedHost: new Headers(init?.headers).get("x-forwarded-host"),
         });
-        if (url.startsWith("http://stale-sandbox.example")) {
-          throw new TypeError("connection timed out");
-        }
         return new Response(JSON.stringify({ response: "agent is live" }), {
           status: 200,
         });
@@ -146,10 +143,6 @@ describe("canonical agent forwarding fallback", () => {
     }
 
     expect(requests).toEqual([
-      {
-        url: `http://stale-sandbox.example/api/agents/${AGENT_ID}/message`,
-        forwardedHost: null,
-      },
       {
         url: `https://eliza-production-1.eliza.app/api/agents/${AGENT_ID}/message`,
         forwardedHost: `${AGENT_ID}.cloud.eliza.app`,
@@ -210,9 +203,6 @@ describe("canonical agent forwarding fallback", () => {
     globalThis.fetch = mock(async (input: string | URL | Request) => {
       const url = input instanceof Request ? input.url : String(input);
       requests.push(url);
-      if (url.startsWith("http://stale-sandbox.example")) {
-        throw new TypeError("connection timed out");
-      }
       if (url.endsWith(`/agents/${AGENT_ID}/message`)) {
         return new Response(JSON.stringify({ error: "Agent not found" }), {
           status: 404,
@@ -257,7 +247,6 @@ describe("canonical agent forwarding fallback", () => {
     }
 
     expect(requests).toEqual([
-      `http://stale-sandbox.example/api/agents/${AGENT_ID}/message`,
       `https://eliza-production-1.eliza.app/api/agents/${AGENT_ID}/message`,
       "https://eliza-production-1.eliza.app/api/agents",
       `https://eliza-production-1.eliza.app/api/agents/${RUNTIME_AGENT_ID}/message`,

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -618,6 +618,28 @@ async function forwardWithRetry(
 ): Promise<string> {
   let lastError: Error | null = null;
   let woken = false;
+  let canonicalAttempted = false;
+
+  // Dedicated Docker sandboxes self-register a public host:port in Redis for
+  // compatibility, but production node firewalls intentionally do not expose
+  // those high ports to Railway. Their supported ingress is the canonical
+  // control-plane router over HTTPS. Prefer it before the Redis target so a
+  // normal Telegram/DM turn does not spend its entire non-replay timeout on a
+  // transport that cannot be reached from this service.
+  if (connectionFallback && serverName.startsWith("sandbox-")) {
+    canonicalAttempted = true;
+    const canonical = await tryCanonicalTarget(
+      connectionFallback,
+      endpointPath,
+      body,
+      policy,
+    );
+    if (canonical.ok) return canonical.response;
+    if (canonical.timedOut && !policy.retryOnTimeout) {
+      throw canonical.error;
+    }
+    lastError = canonical.error;
+  }
 
   for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt++) {
     if (attempt > 0) {
@@ -658,9 +680,11 @@ async function forwardWithRetry(
     if (
       result.isConnectionError &&
       connectionFallback &&
+      !canonicalAttempted &&
       targets[0].replace(/\/$/, "") !==
         connectionFallback.baseUrl.replace(/\/$/, "")
     ) {
+      canonicalAttempted = true;
       const canonical = await tryCanonicalTarget(
         connectionFallback,
         endpointPath,


### PR DESCRIPTION
## Summary

Production hotfix backport of #19669, already merged to develop.

- route dedicated Docker sandboxes through canonical HTTPS ingress before their firewall-blocked public high port
- preserve direct compatibility fallback and non-idempotent timeout no-replay behavior
- discover the sole running runtime when its id differs from the cloud sandbox id

Related to #19519.

## Live diagnosis

The canonical production agent health route returned ready with runtime/database OK. A real canonical model turn returned `TELEGRAM_ROUTER_OK` in 7.860s; the old gateway ordering exhausted 75s against the unreachable high port before canonical fallback.

## Verification

- `bun run --cwd packages/cloud/services/gateway-webhook test`: 119 pass, 0 fail
- `bun run --cwd packages/cloud/services/gateway-webhook typecheck`: pass
- `bun run --cwd packages/cloud/services/gateway-webhook lint:check`: pass
- `bun run --cwd packages/cloud/services/gateway-webhook build`: pass
- `git diff --check origin/main...HEAD`: pass

## Contribution provenance

- AI provider/model: OpenAI / gpt-5
- Client / agent tooling: Codex desktop
- Contribution skill revision: elizaOS/eliza@24d8f5fe92206c1e136382c649f2f7070e6a0c63:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only gateway behavior; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only gateway behavior; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Telegram webhook path has no repository UI surface

<!-- evidence-row:backend-logs -->
- [ ] N/A - live production timing is summarized above; raw production logs may contain user metadata

<!-- evidence-row:frontend-logs -->
- [ ] N/A - Telegram webhook path has no browser frontend

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model prompt, response policy, or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no image, audio, PDF, or domain artifact is produced

— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@24d8f5fe92206c1e136382c649f2f7070e6a0c63:packages/skills/skills/contribute-to-eliza"} -->

