### PR TITLE
fix(app-core): run SMS watcher test with Vitest

### DIFF
--- a/packages/app-core/scripts/watch-sms-gateway-readiness.test.mjs
+++ b/packages/app-core/scripts/watch-sms-gateway-readiness.test.mjs
@@ -2,12 +2,12 @@
  * Focused coverage for watch-sms-gateway-readiness --timeout / --interval:
  * parser contract plus real CLI rejection before any adb poll.
  */
-import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
 import {
   DEFAULT_INTERVAL_SECONDS,
   DEFAULT_TIMEOUT_SECONDS,


### PR DESCRIPTION
## Summary

- use the package's declared Vitest runner in the SMS gateway readiness suite
- restore the app-core and root test lanes, which could not resolve `bun:test` under Vitest

## Verification

- `bunx vitest run --config packages/app-core/vitest.config.ts packages/app-core/scripts/watch-sms-gateway-readiness.test.mjs` — 10/10
- `bun run --cwd packages/app-core test` — 223 files passed, 1 skipped; 1,815 tests passed, 20 skipped
- `bun run --cwd packages/app-core typecheck`
- `bun run verify` — 350/350 workspace tasks; all audits green; 8,087 test files scanned with zero focused/orphaned skips

## Context

Found while completing the workflow-experience closeout audit on current `develop`. This is a one-line test-runner contract correction; production behavior is unchanged.