### PR TITLE
fix(homepage): align readiness with Text Eliza

### DIFF
--- a/packages/app-core/scripts/check-homepage-public-readiness.mjs
+++ b/packages/app-core/scripts/check-homepage-public-readiness.mjs
@@ -17,6 +17,7 @@ const repo = "elizaOS/eliza";
 const defaultOrigin = "https://eliza.app";
 const expectedGatewayNumber = "+18087881821";
 const expectedFormattedNumber = "+1 (808) 788-1821";
+export const messageButtonAccessibleName = "Text Eliza";
 const rejectedWhatsAppNumbers = [
   "+14155238886",
   "+15551649988",
@@ -212,7 +213,10 @@ async function inspectPublicSurface(origin) {
             .filter((value) => typeof value === "string"),
         );
 
-    const messageButton = page.getByRole("button", { name: "Message Eliza" });
+    const messageButton = page.getByRole("button", {
+      name: messageButtonAccessibleName,
+      exact: true,
+    });
     const messageButtonCount = await messageButton.count();
     let copiedPhone = "";
     let copyNotice = "";

--- a/packages/app-core/scripts/check-homepage-public-readiness.test.mjs
+++ b/packages/app-core/scripts/check-homepage-public-readiness.test.mjs
@@ -5,6 +5,7 @@
 import { expect, test } from "vitest";
 import {
   evaluatePublicSurface,
+  messageButtonAccessibleName,
   resolveWhatsAppAdmission,
 } from "./check-homepage-public-readiness.mjs";
 
@@ -19,6 +20,10 @@ const healthySurface = {
   whatsAppHrefs: [],
   consoleErrors: [],
 };
+
+test("targets the shipped primary messaging action", () => {
+  expect(messageButtonAccessibleName).toBe("Text Eliza");
+});
 
 test("accepts the Cloudflare homepage with WhatsApp disabled", () => {
   for (const whatsAppNumber of ["", "+14159611510"]) {


### PR DESCRIPTION
Closes #19674.

The phone-first landing renamed the shipped messaging action to `Text Eliza`, while the public readiness checker still selected `Message Eliza`. This aligns the exact accessible-name selector and adds a contract assertion so the live Windows copy path is measured again.

Verified on exact head `cc65444e18ecb6c1e7c2cd5a1825f228f8a212ed`:

- pinned Bun 1.3.14 frozen install passed;
- focused readiness policy: 8/8 passed;
- Biome and `git diff --check` passed;
- full `bun run verify`: 350/350 tasks, repository audits, anti-larp 8,087 files;
- `https://staging.eliza.app`: all public checks passed, including clipboard `+18087881821` and `Copied!`;
- `https://eliza.app`: all public checks passed with the same exact result;
- WhatsApp remains fail-closed (`WHATSAPP_PUBLIC_ENABLED=false`) with no public CTA until Blooio provisions a real WhatsApp channel.

## Evidence Gate

<!-- evidence-head:cc65444e18ecb6c1e7c2cd5a1825f228f8a212ed -->

- before-screenshots: N/A — checker-only repair; no rendered pixels changed.
- after-screenshots: N/A — checker-only repair; no rendered pixels changed.
- walkthrough-video: N/A — no UI implementation changed.
- backend-logs: N/A — no backend changed.
- frontend-logs: PASS — live browser checks on staging and production reported zero console errors.
- llm-trajectory: N/A — no agent/model behavior changed.
- domain-artifacts: PASS — exact live clipboard, toast, tel target, hidden formatted number, and WhatsApp fail-closed assertions passed.