### PR TITLE
fix(cloud): repair missing personal DM conversation

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -67,6 +67,21 @@ const bridge = mock(
     result: { text: "hello from Dedicated" },
   }),
 );
+const importCanonicalConversation = mock(async () => ({
+  complete: true as const,
+  sourceMessageCount: 2,
+  inserted: 2,
+  skipped: 0,
+}));
+const coordinateSharedHistory = mock(async () => [
+  { id: "source-1", role: "user" as const, content: "before", createdAt: 100 },
+  {
+    id: "source-2",
+    role: "assistant" as const,
+    content: "after",
+    createdAt: 101,
+  },
+]);
 const namespace = {
   getByName: mock(() => ({ fetch: mock(async () => new Response()) })),
 };
@@ -98,7 +113,10 @@ mock.module("@/lib/services/provisioning-jobs", () => ({
   },
 }));
 mock.module("@/lib/services/eliza-sandbox", () => ({
-  elizaSandboxService: { bridge },
+  elizaSandboxService: { bridge, importCanonicalConversation },
+}));
+mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
+  coordinateSharedHistory,
 }));
 mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
   resolveSharedRuntimeWorkerRequestContext: () => ({
@@ -151,6 +169,8 @@ describe("personal Shared messaging deliveries", () => {
     sharedRestMessageSend.mockClear();
     runOnboardingChat.mockClear();
     bridge.mockClear();
+    importCanonicalConversation.mockClear();
+    coordinateSharedHistory.mockClear();
     enqueueAgentResumeOnce.mockClear();
     enqueueAgentWakeOnce.mockClear();
     triggerImmediate.mockClear();
@@ -432,6 +452,53 @@ describe("personal Shared messaging deliveries", () => {
     expect(await response.json()).toMatchObject({
       code: "service_unavailable",
     });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("repairs a missing cutover conversation from authoritative Shared history", async () => {
+    activeTarget = {
+      id: "00000000-0000-4000-8000-000000000020",
+      status: "running",
+    };
+    bridge
+      .mockImplementationOnce(async () => ({
+        jsonrpc: "2.0" as const,
+        id: "telegram:eliza:42",
+        error: { code: -32_000, message: "Bridge returned HTTP 404" },
+      }))
+      .mockImplementationOnce(async () => ({
+        jsonrpc: "2.0" as const,
+        id: "telegram:eliza:42",
+        result: { text: "repaired Dedicated reply" },
+      }));
+
+    const response = await request(valid);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: { reply: "repaired Dedicated reply" },
+    });
+    expect(coordinateSharedHistory).toHaveBeenCalledWith(
+      expect.stringMatching(/^personal:/),
+      expect.stringMatching(/^personal:/),
+      { namespace },
+    );
+    expect(importCanonicalConversation).toHaveBeenCalledWith(
+      "00000000-0000-4000-8000-000000000020",
+      "00000000-0000-4000-8000-000000000001",
+      expect.stringMatching(/^personal:/),
+      [
+        { sourceId: "source-1", role: "user", text: "before", timestamp: 100 },
+        {
+          sourceId: "source-2",
+          role: "assistant",
+          text: "after",
+          timestamp: 101,
+        },
+      ],
+    );
+    expect(bridge).toHaveBeenCalledTimes(2);
     expect(sharedRestMessageSend).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -9,6 +9,7 @@ import { elizaAppUserService } from "@/lib/services/eliza-app";
 import { runOnboardingChat } from "@/lib/services/eliza-app/onboarding-chat";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { preparePersonalDedicatedDelivery } from "@/lib/services/personal-dedicated-delivery";
+import { coordinateSharedHistory } from "@/lib/services/shared-runtime/conversation-coordinator";
 import { personalSharedAgent } from "@/lib/services/shared-runtime/personal-shared-agent";
 import { resolveSharedRuntimeWorkerRequestContext } from "@/lib/services/shared-runtime/resolve-shared-agent";
 import { sharedRestMessageSend } from "@/lib/services/shared-runtime/shared-rest-adapter";
@@ -200,31 +201,67 @@ app.post("/", async (c) => {
             : undefined,
         );
       }
-      const response = await elizaSandboxService.bridge(
+      const bridgeRequest = {
+        jsonrpc: "2.0" as const,
+        id: parsed.data.messageId,
+        method: "message.send",
+        params: {
+          text: parsed.data.message,
+          roomId: agent.id,
+          conversationId: agent.id,
+          canonicalBridgeBase: dedicated.bridge_url,
+          userId: account.user.id,
+          clientMessageId: parsed.data.messageId,
+          platformName: parsed.data.platform,
+          source: parsed.data.platform,
+          ...(parsed.data.platform === "telegram"
+            ? {
+                senderName:
+                  parsed.data.displayName ?? parsed.data.telegramUsername,
+              }
+            : {}),
+        },
+      };
+      let response = await elizaSandboxService.bridge(
         dedicated.id,
         account.organization.id,
-        {
-          jsonrpc: "2.0",
-          id: parsed.data.messageId,
-          method: "message.send",
-          params: {
-            text: parsed.data.message,
-            roomId: agent.id,
-            conversationId: agent.id,
-            canonicalBridgeBase: dedicated.bridge_url,
-            userId: account.user.id,
-            clientMessageId: parsed.data.messageId,
-            platformName: parsed.data.platform,
-            source: parsed.data.platform,
-            ...(parsed.data.platform === "telegram"
-              ? {
-                  senderName:
-                    parsed.data.displayName ?? parsed.data.telegramUsername,
-                }
-              : {}),
-          },
-        },
+        bridgeRequest,
       );
+      if (response.error?.message === "Bridge returned HTTP 404") {
+        const history = await coordinateSharedHistory(agent.id, agent.id, {
+          namespace: worker.namespace,
+        });
+        const importMessages = history.flatMap((message) =>
+          message.id
+            ? [
+                {
+                  sourceId: message.id,
+                  role: message.role,
+                  text: message.content,
+                  ...(typeof message.createdAt === "number"
+                    ? { timestamp: message.createdAt }
+                    : {}),
+                },
+              ]
+            : [],
+        );
+        const receipt =
+          importMessages.length === history.length
+            ? await elizaSandboxService.importCanonicalConversation(
+                dedicated.id,
+                account.organization.id,
+                agent.id,
+                importMessages,
+              )
+            : null;
+        if (receipt) {
+          response = await elizaSandboxService.bridge(
+            dedicated.id,
+            account.organization.id,
+            bridgeRequest,
+          );
+        }
+      }
       if (response.error) {
         return jsonError(
           c,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-agent-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-agent-router.test.ts
@@ -30,6 +30,22 @@ type AgentRecord = typeof sandbox;
 
 type AgentRouterHarness = {
   fetchAgentApi(rec: AgentRecord, path: string, init?: RequestInit): Promise<Response>;
+  importCanonicalConversation(
+    agentId: string,
+    orgId: string,
+    conversationId: string,
+    messages: Array<{
+      sourceId: string;
+      role: "user" | "assistant";
+      text: string;
+      timestamp?: number;
+    }>,
+  ): Promise<{
+    complete: true;
+    sourceMessageCount: number;
+    inserted: number;
+    skipped: number;
+  } | null>;
   ensureRuntimeAgentStarted(rec: AgentRecord): Promise<{
     id?: string;
     name?: string;
@@ -189,6 +205,58 @@ describe("ElizaSandboxService Worker agent-router fetch", () => {
       "x-forwarded-proto": "https",
     });
     expect(requests[0]?.redirect).toBe("manual");
+  });
+
+  test("reimports a missing canonical conversation through the Worker router", async () => {
+    enterWorkerRuntime();
+    const findRunning = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
+      sandbox as never,
+    );
+    const requests: Array<{ url: string; headers: Headers; body: string }> = [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({
+        url: typeof input === "string" ? input : input.toString(),
+        headers: new Headers(init?.headers),
+        body: String(init?.body ?? ""),
+      });
+      return Response.json({
+        complete: true,
+        sourceMessageCount: 1,
+        inserted: 1,
+        skipped: 0,
+      });
+    });
+
+    try {
+      const receipt = await runWithCloudBindings(
+        {
+          ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
+          AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.elizacloud.ai",
+        },
+        () =>
+          service().importCanonicalConversation(sandbox.id, "org-1", "personal:user-1", [
+            { sourceId: "source-1", role: "user", text: "hello", timestamp: 123 },
+          ]),
+      );
+
+      expect(receipt).toEqual({
+        complete: true,
+        sourceMessageCount: 1,
+        inserted: 1,
+        skipped: 0,
+      });
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.url).toBe(
+        "https://eliza-production-1.elizacloud.ai/api/conversations/personal%3Auser-1/import",
+      );
+      expect(requests[0]?.headers.get("authorization")).toBe("Bearer agent-token");
+      expect(requests[0]?.headers.get("x-forwarded-host")).toBe(`${sandbox.id}.elizacloud.ai`);
+      expect(JSON.parse(requests[0]!.body)).toEqual({
+        messages: [{ sourceId: "source-1", role: "user", text: "hello", timestamp: 123 }],
+      });
+    } finally {
+      findRunning.mockRestore();
+    }
   });
 
   test("fails closed before fetch when the agent credential is missing", async () => {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -5523,6 +5523,67 @@ export class ElizaSandboxService {
     };
   }
 
+  /**
+   * Recreates an authoritative cutover conversation after a Dedicated runtime
+   * loses its local conversation index during relocation or fresh boot. Exact
+   * source ids make concurrent repairs idempotent at the runtime boundary.
+   */
+  async importCanonicalConversation(
+    agentId: string,
+    orgId: string,
+    conversationId: string,
+    messages: Array<{
+      sourceId: string;
+      role: "user" | "assistant";
+      text: string;
+      timestamp?: number;
+    }>,
+  ): Promise<{
+    complete: true;
+    sourceMessageCount: number;
+    inserted: number;
+    skipped: number;
+  } | null> {
+    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
+    if (!rec) return null;
+
+    const res = await this.fetchCanonicalConversationApi(
+      rec,
+      `/api/conversations/${encodeURIComponent(conversationId)}/import`,
+      {
+        method: "POST",
+        body: JSON.stringify({ messages }),
+        signal: AbortSignal.timeout(20_000),
+      },
+      rec.bridge_url,
+    );
+    if (!res.ok) return null;
+
+    // error-policy:J3 an unreadable import receipt is explicitly invalid and
+    // cannot authorize the connector retry.
+    const body = (await res.json().catch(() => null)) as {
+      complete?: unknown;
+      sourceMessageCount?: unknown;
+      inserted?: unknown;
+      skipped?: unknown;
+    } | null;
+    if (
+      body?.complete !== true ||
+      body.sourceMessageCount !== messages.length ||
+      typeof body.inserted !== "number" ||
+      typeof body.skipped !== "number" ||
+      body.inserted + body.skipped !== messages.length
+    ) {
+      return null;
+    }
+    return {
+      complete: true,
+      sourceMessageCount: body.sourceMessageCount,
+      inserted: body.inserted,
+      skipped: body.skipped,
+    };
+  }
+
   private async bridgeMessagingSessionSend(
     rec: AgentSandbox,
     rpc: BridgeRequest,


### PR DESCRIPTION
## Summary

- detect a missing canonical personal conversation after Dedicated relocation or fresh boot
- re-import the authoritative Shared history with exact source ids through the canonical agent router
- retry the same idempotent connector turn only after a complete import receipt
- keep every other Dedicated failure fail-closed without reopening Shared

Related to #19519.

## Production diagnosis

The live Telegram webhook reached the correct Dedicated agent but returned 503 because its canonical personal conversation returned HTTP 404 after a canary relocation. A one-time canonical import restored service, and a real Telegram webhook then completed in 11.071 seconds. This change makes that recovery automatic and preserves the original history.

## Verification

- personal Shared message route tests: 15 pass, 0 fail
- Worker agent-router tests: 11 pass, 0 fail
- `bun run --cwd packages/cloud/shared typecheck`: pass
- `bun run --cwd packages/cloud/api build`: pass
- Biome on all four changed files: pass

## Evidence matrix

- Desktop/mobile screenshots: N/A - backend-only connector recovery
- UI walkthrough video: N/A - no UI surface changed
- Browser console/network logs: N/A - Telegram webhook path
- Backend logs: live webhook completion and exact 404 diagnosis reviewed during incident response
- Live model trajectory: exact-response production probe only; no prompt/model behavior changed
- Domain artifacts: N/A - no artifact output

## Contribution provenance

- AI provider/model: OpenAI / gpt-5
- Client / agent tooling: Codex desktop
- Contribution skill revision: elizaOS/eliza@404fd6cd53a6ec101fe9288fdd44885fe7601f2a:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only connector behavior; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only connector behavior; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Telegram webhook path has no repository UI surface

<!-- evidence-row:backend-logs -->
- [ ] N/A - live production timing is recorded above; no secret-bearing raw log bundle is attached

<!-- evidence-row:frontend-logs -->
- [ ] N/A - Telegram webhook path has no browser frontend

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model prompt, response policy, or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no image, audio, PDF, or domain artifact is produced

— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@404fd6cd53a6ec101fe9288fdd44885fe7601f2a:packages/skills/skills/contribute-to-eliza"} -->
