### PR TITLE
docs: point app catalog at registry source

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <a href="https://cloud.eliza.app">Eliza Cloud</a> ·
     <a href="https://os.eliza.app">elizaOS downloads</a> ·
     <a href="https://docs.elizaos.ai/">Documentation</a> ·
-    <a href="https://eliza.app">App catalog</a>
+    <a href="packages/registry">App catalog</a>
   </p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <a href="https://cloud.eliza.app">Eliza Cloud</a> ·
     <a href="https://os.eliza.app">elizaOS downloads</a> ·
     <a href="https://docs.elizaos.ai/">Documentation</a> ·
-    <a href="https://plugins.eliza.app">App catalog</a>
+    <a href="https://eliza.app">App catalog</a>
   </p>
 </div>
 


### PR DESCRIPTION
# Relates to

Supersedes #19636 while preserving its original contributor commit. The original patch fixed a dead hostname but pointed the catalog label at the marketing homepage; this replacement points it at the authoritative registry source.

Definition of Done: full standard in [`CONTRIBUTING.md`](CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code from the source-authority and validation evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes - original contribution plus independent root-cause review and repair
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: claude-code; codex-cli/0.147.0
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@83208ec5dcfdca0607a524a72c814bbec6fb3603:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop@7fe002360b732763c2c9f071a4b9bed5e97a13be`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. This changes one README hyperlink and no executable code. The only behavioral risk is sending readers to the wrong catalog surface; the target is the repository-owned, human-readable registry source, and the branch-rendered GitHub link was followed directly to the registry tree.

# Background

## What does this PR do?

Changes the README's “App catalog” link from the dead `https://plugins.eliza.app` host to the repository's authoritative catalog source, `packages/registry`.

The bare `https://eliza.app` URL proposed in #19636 is a marketing homepage, not a redirect to a catalog. The tempting `/apps` route is also wrong: current routing assigns it to the signed-in “My Apps” inventory/create/load surface, while the registry host intentionally serves only allowlisted machine-readable artifacts. `packages/registry` explicitly owns the community registry and curated first-party app/plugin/connector catalog, so its README is the stable human destination.

## What kind of change is this?

Documentation bug fix (non-breaking).

# Documentation changes needed?

This PR is the required documentation correction; no additional documentation surface is affected.

# Testing

## Where should a reviewer start?

Open the “App catalog” link in the README and confirm it resolves to `packages/registry/README.md`, which documents both registry formats and how catalog entries are maintained.

## Detailed testing steps

```text
$ curl -L -o /dev/null -w 'plugins status=%{http_code} final=%{url_effective}\n' https://plugins.eliza.app
plugins status=404 final=https://plugins.eliza.app/

$ curl -L -o /dev/null -w 'registry artifact status=%{http_code} type=%{content_type}\n' https://plugins.eliza.app/generated-registry.json
registry artifact status=200 type=application/json; charset=utf-8

$ test -f packages/registry/README.md
# exit 0

$ bun run check:agents-claude
[assert-agents-claude-identical] PASS: 153 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.

$ node scripts/check-markdown-links.mjs
[check-markdown-links] PASS: relative Markdown links resolve.

$ bun run verify
Tasks: 350 successful, 350 total
[anti-larp] clean — no focused tests, no untracked skips.
```

`git diff --check -- README.md` also passes.

# Evidence Gate

Evidence matches exact head `83208ec5dcfdca0607a524a72c814bbec6fb3603`.
<!-- evidence-head:83208ec5dcfdca0607a524a72c814bbec6fb3603 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - README hyperlink-only change; no rendered product UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - README hyperlink-only change; no rendered product UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive product flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code path changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime code or state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Source/live-host probes and a direct branch-rendered GitHub link check show the old human-facing root is dead, the registry artifact remains live, and `packages/registry` is the documented source of truth and resolves as the human catalog destination.

```text
registry root status=404 final=https://plugins.eliza.app/
registry artifact status=200 type=application/json; charset=utf-8
source authority=packages/registry/CLAUDE.md + packages/registry/README.md (community registry and curated first-party catalog)
rendered README anchor=GitHub rewrites packages/registry to the branch-relative registry tree; followed response=200
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text or UI changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no backend or frontend runtime path changed.

## Screenshots (before / after) + video walkthrough

N/A - README hyperlink-only change; the registry source contract and live artifact probe are the applicable artifacts.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

None. All required repository and documentation gates passed on the exact head; visual, runtime, model, and device artifacts are inapplicable to a README hyperlink correction.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex-cli/0.147.0
Contribution skill revision: elizaOS/eliza@83208ec5dcfdca0607a524a72c814bbec6fb3603:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-pr-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-cli/0.147.0","skill_revision":"elizaOS/eliza@83208ec5dcfdca0607a524a72c814bbec6fb3603:packages/skills/skills/contribute-to-eliza"} -->