### PR TITLE
fix(agent): retain bounded trajectory provider completeness

### DIFF
--- a/packages/agent/src/runtime/trajectory-bridge.test.ts
+++ b/packages/agent/src/runtime/trajectory-bridge.test.ts
@@ -1481,4 +1481,30 @@ describe("budgeted provider capture completeness", () => {
     expect(normalized?.params.data).toEqual({ text: "ok", success: true });
     expect(normalized?.params.purpose).toBe("action");
   });
+
+  it("retains required provider fields through logger flush and SQL serialization", async () => {
+    const { runtime, logger, execute } = makeRuntime();
+    await installDatabaseTrajectoryLogger(runtime);
+    await logger.startTrajectory?.("provider-budget-persistence", {
+      agentId: runtime.agentId,
+      source: "test",
+    });
+    await flushTrajectoryWrites(runtime);
+    execute.mockClear();
+
+    logger.logProviderAccess({
+      stepId: "provider-budget-persistence",
+      providerName: "KNOWLEDGE",
+      data: oversizedProviderData(),
+      purpose: "Provider KNOWLEDGE accessed for context",
+    });
+    await logger.flushWriteQueue?.("provider-budget-persistence");
+
+    const serialized = trajectoryPersistenceSql(execute).join("\n");
+    expect(serialized).toContain('"providerName":"KNOWLEDGE"');
+    expect(serialized).toContain(
+      '"purpose":"Provider KNOWLEDGE accessed for context"',
+    );
+    expect(serialized).toContain('"data":');
+  });
 });

--- a/packages/agent/src/runtime/trajectory-bridge.test.ts
+++ b/packages/agent/src/runtime/trajectory-bridge.test.ts
@@ -15,6 +15,7 @@ import {
   enqueueStepWrite,
   ensureTrajectoriesTable,
   normalizeLlmCallPayload,
+  normalizeProviderAccessPayload,
 } from "./trajectory-internals.ts";
 import { installDatabaseTrajectoryLogger } from "./trajectory-persistence.ts";
 import { loadPersistedTrajectoryRows } from "./trajectory-query.ts";
@@ -1412,5 +1413,72 @@ describe("budgeted LLM capture completeness", () => {
     ]);
 
     expect(normalized?.params.response).toBe("ok");
+  });
+});
+
+describe("budgeted provider capture completeness", () => {
+  // The canonical producer shape (TrajectoriesService.logProviderAccess) emits
+  // `data` before the required `purpose` string, so a context-heavy provider
+  // payload exhausted the shared row budget first and `purpose` was bounded
+  // into a truncation marker. Re-validating that snapshot then discarded the
+  // whole provider access, which is the opposite of what the record is for.
+  const oversizedProviderData = () =>
+    Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [
+        `chunk-${index}`,
+        "x".repeat(70_000),
+      ]),
+    );
+
+  it("retains required fields when data exhausts the global row budget", () => {
+    const normalized = normalizeProviderAccessPayload([
+      {
+        stepId: "step-provider-budget",
+        providerName: "KNOWLEDGE",
+        data: oversizedProviderData(),
+        purpose: "Provider KNOWLEDGE accessed for context",
+      },
+    ]);
+
+    expect(normalized?.params).toMatchObject({
+      providerName: "KNOWLEDGE",
+      purpose: "Provider KNOWLEDGE accessed for context",
+    });
+    // `data` stays an object so the capture keeps its shape while degrading.
+    expect(normalized?.params.data).toBeTypeOf("object");
+    expect(
+      new TextEncoder().encode(JSON.stringify(normalized?.params)).byteLength,
+    ).toBeLessThanOrEqual(1024 * 1024);
+  });
+
+  it("retains required fields through the (stepId, details) overload", () => {
+    const normalized = normalizeProviderAccessPayload([
+      "step-provider-budget-positional",
+      {
+        providerName: "KNOWLEDGE",
+        data: oversizedProviderData(),
+        purpose: "Provider KNOWLEDGE accessed for context",
+      },
+    ]);
+
+    expect(normalized?.stepId).toBe("step-provider-budget-positional");
+    expect(normalized?.params).toMatchObject({
+      providerName: "KNOWLEDGE",
+      purpose: "Provider KNOWLEDGE accessed for context",
+    });
+  });
+
+  it("leaves a small provider payload byte-identical", () => {
+    const normalized = normalizeProviderAccessPayload([
+      {
+        stepId: "step-provider-small",
+        providerName: "KNOWLEDGE",
+        data: { text: "ok", success: true },
+        purpose: "action",
+      },
+    ]);
+
+    expect(normalized?.params.data).toEqual({ text: "ok", success: true });
+    expect(normalized?.params.purpose).toBe("action");
   });
 });

--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -3582,6 +3582,28 @@ function normalizeStepForPersistence(
     }
     return bounded;
   };
+  const normalizeProviderRecord = (
+    access: PersistedProviderAccess,
+    index: number,
+  ): PersistedProviderAccess => {
+    const bounded = snapshotCaptureParams(
+      {
+        providerId: access.providerId,
+        providerName: access.providerName,
+        timestamp: access.timestamp,
+        purpose: access.purpose,
+        data: access.data,
+        ...access,
+      },
+      step.stepId,
+    );
+    return parsePersistedProviderAccess(
+      bounded,
+      trajectoryId,
+      step.stepId,
+      index,
+    );
+  };
 
   return {
     ...(boundedScalars as unknown as PersistedStep),
@@ -3592,14 +3614,7 @@ function normalizeStepForPersistence(
       (call, index) =>
         normalizeRecord(call, "llmCalls", index) as unknown as PersistedLlmCall,
     ),
-    providerAccesses: providerAccesses.map(
-      (access, index) =>
-        normalizeRecord(
-          access,
-          "providerAccesses",
-          index,
-        ) as unknown as PersistedProviderAccess,
-    ),
+    providerAccesses: providerAccesses.map(normalizeProviderRecord),
     ...(childSteps !== undefined ? { childSteps: [...childSteps] } : {}),
     ...(usedSkills !== undefined ? { usedSkills: [...usedSkills] } : {}),
     ...(skillInvocations !== undefined

--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -1840,6 +1840,34 @@ function validateLlmCapture(
   }
 }
 
+/**
+ * Snapshot a provider capture with its completeness fields first in the shared
+ * byte budget, mirroring {@link snapshotLlmCaptureParams}.
+ *
+ * `data` carries the provider's rendered output and routinely dominates the
+ * row budget, and the canonical producer shape emits it BEFORE the required
+ * `purpose` string. Bounding in producer order therefore starved `purpose`
+ * into a truncation marker, and re-validating the deliberately lossy snapshot
+ * against the same completeness contract discarded the ENTIRE provider access
+ * — on exactly the context-heavy turns the record exists to explain. Reserving
+ * the small required strings first keeps the record complete and lets `data`
+ * degrade to a bounded object instead.
+ */
+function snapshotProviderCaptureParams(
+  params: Record<string, unknown>,
+  stepId: string,
+): Record<string, unknown> {
+  return snapshotCaptureParams(
+    {
+      providerName: params.providerName,
+      purpose: params.purpose,
+      data: params.data,
+      ...params,
+    },
+    stepId,
+  );
+}
+
 export function normalizeProviderAccessPayload(
   args: unknown[],
 ): { stepId: string; params: Record<string, unknown> } | null {
@@ -1863,7 +1891,7 @@ export function normalizeProviderAccessPayload(
       stepId,
     };
     validateProviderCapture(params, stepId);
-    const snapshot = snapshotCaptureParams(params, stepId);
+    const snapshot = snapshotProviderCaptureParams(params, stepId);
     validateProviderCapture(snapshot, stepId);
     return {
       stepId,
@@ -1888,7 +1916,7 @@ export function normalizeProviderAccessPayload(
   const normalizedParams =
     params.stepId === stepId ? params : { ...params, stepId };
   validateProviderCapture(normalizedParams, stepId);
-  const snapshot = snapshotCaptureParams(normalizedParams, stepId);
+  const snapshot = snapshotProviderCaptureParams(normalizedParams, stepId);
   validateProviderCapture(snapshot, stepId);
   return {
     stepId,


### PR DESCRIPTION
## What

The trajectory row-size budget's provider half discarded the **entire provider access record** on exactly the context-heavy turns the record exists to explain.

## Root cause

`boundProviderAccess` in `packages/agent/src/runtime/trajectory-internals.ts` budgeted fields in the canonical producer order, which emits `data` before the required `purpose` string. A context-heavy provider payload exhausted the shared budget first, `purpose` was bounded into a truncation marker, and the re-validation step — which checks the deliberately lossy snapshot against the **full** completeness contract — rejected the whole snapshot. Result: the biggest provider payloads are precisely the ones that vanish from the trajectory.

## Change

Hoist the required strings ahead of `data` in the budget, mirroring what `snapshotLlmCaptureParams` already does for the LLM half, so `data` degrades to a bounded object instead of starving the fields that make the record readable. No contract change; the bounded snapshot now always retains `purpose` and its peers.

## Evidence

<!-- evidence-head:2658c36c0abe59ed733b014abbf2e4de7b914c67 -->

<!-- evidence-row:before-screenshots -->
N/A - no UI surface; this changes trajectory persistence internals

<!-- evidence-row:after-screenshots -->
N/A - no UI surface; this changes trajectory persistence internals

<!-- evidence-row:walkthrough-video -->
N/A - no UI surface

<!-- evidence-row:backend-logs -->
N/A - the failure is silent by construction: the discarded provider access leaves no log line, only an absent row. The reproducing test below is the observable form.

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface in this change

<!-- evidence-row:llm-trajectory -->
N/A - this changes how trajectories are persisted, not any model call; no live model runs on the changed path

<!-- evidence-row:domain-artifacts -->
New tests in `trajectory-bridge.test.ts` drive the real budget + re-validation seam with a context-heavy provider payload and assert the bounded snapshot retains `purpose` (and is accepted) instead of being discarded.

<details>
<summary>with the fix</summary>
<pre>
 Test Files  1 passed (1)
      Tests  26 passed (26)
</pre>
</details>

The new cases fail on the parent commit (budget in producer order): the bounded snapshot loses `purpose` to a truncation marker and re-validation rejects it, reproducing the silent drop.

<!-- evidence-row:ocr-review -->
N/A - no rendered text or imagery

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes - agent-authored under human direction
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5, anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored from runtime-code evidence, not the pinned contribute-to-eliza skill
<!-- attribution-row:status -->
- Attribution status: self-reported
