### PR TITLE
fix(cloud): accept legacy DM import receipts (production)

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -67,12 +67,30 @@ const bridge = mock(
     result: { text: "hello from Dedicated" },
   }),
 );
-const importCanonicalConversation = mock(async () => ({
-  complete: true as const,
-  sourceMessageCount: 2,
-  inserted: 2,
-  skipped: 0,
-}));
+type ImportReceipt = {
+  complete: true;
+  sourceMessageCount: number;
+  inserted: number;
+  skipped: number;
+};
+const importCanonicalConversation = mock(
+  async (
+    _agentId: string,
+    _orgId: string,
+    _conversationId: string,
+    _messages: Array<{
+      sourceId: string;
+      role: "user" | "assistant";
+      text: string;
+      timestamp?: number;
+    }>,
+  ): Promise<ImportReceipt | null> => ({
+    complete: true,
+    sourceMessageCount: 2,
+    inserted: 2,
+    skipped: 0,
+  }),
+);
 const coordinateSharedHistory = mock(async () => [
   { id: "source-1", role: "user" as const, content: "before", createdAt: 100 },
   {
@@ -500,6 +518,43 @@ describe("personal Shared messaging deliveries", () => {
     );
     expect(bridge).toHaveBeenCalledTimes(2);
     expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("recreates an empty canonical conversation when history import is unavailable", async () => {
+    activeTarget = {
+      id: "00000000-0000-4000-8000-000000000020",
+      status: "running",
+    };
+    bridge
+      .mockImplementationOnce(async () => ({
+        jsonrpc: "2.0" as const,
+        id: "telegram:eliza:42",
+        error: { code: -32_000, message: "Bridge returned HTTP 404" },
+      }))
+      .mockImplementationOnce(async () => ({
+        jsonrpc: "2.0" as const,
+        id: "telegram:eliza:42",
+        result: { text: "available Dedicated reply" },
+      }));
+    importCanonicalConversation
+      .mockImplementationOnce(async () => null)
+      .mockImplementationOnce(async () => ({
+        complete: true as const,
+        sourceMessageCount: 0,
+        inserted: 0,
+        skipped: 0,
+      }));
+
+    const response = await request(valid);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: { reply: "available Dedicated reply" },
+    });
+    expect(importCanonicalConversation).toHaveBeenCalledTimes(2);
+    expect(importCanonicalConversation.mock.calls[1]?.[3]).toEqual([]);
+    expect(bridge).toHaveBeenCalledTimes(2);
   });
 
   test.each([

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -245,7 +245,7 @@ app.post("/", async (c) => {
               ]
             : [],
         );
-        const receipt =
+        let receipt =
           importMessages.length === history.length
             ? await elizaSandboxService.importCanonicalConversation(
                 dedicated.id,
@@ -254,6 +254,14 @@ app.post("/", async (c) => {
                 importMessages,
               )
             : null;
+        if (!receipt && importMessages.length > 0) {
+          receipt = await elizaSandboxService.importCanonicalConversation(
+            dedicated.id,
+            account.organization.id,
+            agent.id,
+            [],
+          );
+        }
         if (receipt) {
           response = await elizaSandboxService.bridge(
             dedicated.id,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-agent-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-agent-router.test.ts
@@ -220,8 +220,7 @@ describe("ElizaSandboxService Worker agent-router fetch", () => {
         body: String(init?.body ?? ""),
       });
       return Response.json({
-        complete: true,
-        sourceMessageCount: 1,
+        conversationId: "personal:user-1",
         inserted: 1,
         skipped: 0,
       });

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -5562,25 +5562,31 @@ export class ElizaSandboxService {
     // error-policy:J3 an unreadable import receipt is explicitly invalid and
     // cannot authorize the connector retry.
     const body = (await res.json().catch(() => null)) as {
+      conversationId?: unknown;
       complete?: unknown;
       sourceMessageCount?: unknown;
       inserted?: unknown;
       skipped?: unknown;
     } | null;
-    if (
-      body?.complete !== true ||
-      body.sourceMessageCount !== messages.length ||
-      typeof body.inserted !== "number" ||
-      typeof body.skipped !== "number" ||
-      body.inserted + body.skipped !== messages.length
-    ) {
+    if (!body || typeof body.inserted !== "number" || typeof body.skipped !== "number") {
+      return null;
+    }
+    const inserted = body.inserted;
+    const skipped = body.skipped;
+    const countsMatch = inserted + skipped === messages.length;
+    const modernReceipt = body?.complete === true && body.sourceMessageCount === messages.length;
+    const legacyReceipt =
+      body?.complete === undefined &&
+      body.sourceMessageCount === undefined &&
+      body.conversationId === conversationId;
+    if (!countsMatch || (!modernReceipt && !legacyReceipt)) {
       return null;
     }
     return {
       complete: true,
-      sourceMessageCount: body.sourceMessageCount,
-      inserted: body.inserted,
-      skipped: body.skipped,
+      sourceMessageCount: messages.length,
+      inserted,
+      skipped,
     };
   }
 


### PR DESCRIPTION
## Summary

- accept both modern and verified legacy Dedicated conversation import receipts
- preserve strict inserted-plus-skipped count validation and exact conversation identity
- recreate an empty canonical conversation only when the authoritative history import is unavailable
- retry the original idempotent connector turn after either successful recovery path

Follow-up to #19679 and #19519.

## Production diagnosis

The first live recovery correctly fetched authoritative Shared history, but the current Dedicated runtime returned its legacy import receipt without `complete` or `sourceMessageCount`. The strict new validator rejected that receipt and did not retry. This patch supports both deployed receipt versions and adds a tested availability fallback.

## Verification

- personal Shared message route tests: 16 pass, 0 fail
- Worker agent-router tests: 11 pass, 0 fail
- `bun run --cwd packages/cloud/shared typecheck`: pass
- `bun run --cwd packages/cloud/api build`: pass
- Biome on all changed files: pass

## Evidence matrix

- Desktop/mobile screenshots: N/A - backend-only connector recovery
- UI walkthrough video: N/A - no UI surface changed
- Browser console/network logs: N/A - Telegram webhook path
- Backend logs: live Worker tail confirmed Shared history fetch and the rejected legacy receipt path
- Live model trajectory: N/A - no prompt/model behavior changed
- Domain artifacts: N/A - no artifact output

## Contribution provenance

- AI provider/model: OpenAI / gpt-5
- Client / agent tooling: Codex desktop
- Contribution skill revision: elizaOS/eliza@404fd6cd53a6ec101fe9288fdd44885fe7601f2a:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only connector behavior; no rendered UI changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only connector behavior; no rendered UI changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Telegram webhook path has no repository UI surface
<!-- evidence-row:backend-logs -->
- [ ] N/A - live diagnosis is summarized above; no secret-bearing raw log bundle is attached
<!-- evidence-row:frontend-logs -->
- [ ] N/A - Telegram webhook path has no browser frontend
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model prompt, response policy, or agent behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no image, audio, PDF, or domain artifact is produced

— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@404fd6cd53a6ec101fe9288fdd44885fe7601f2a:packages/skills/skills/contribute-to-eliza"} -->
