### PR TITLE
fix(core): personality authorization keys on blast radius, not op name

### DIFF
--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts
@@ -375,3 +375,95 @@ describe("personalityAction — audit trail", () => {
 		expect(meta.personalityScope).toBe("user");
 	});
 });
+
+describe("personalityAction — authorization floors (blast radius, not op name)", () => {
+	test("a plain user personalises their own slot but cannot reconfigure the agent-wide one", async () => {
+		const fake = makeFakeRuntime();
+		await initStore(fake);
+
+		const own = await run(fake, "be terse with me", "set_trait", {
+			scope: "user",
+			trait: "verbosity",
+			value: "terse",
+		});
+		expect(own.result.success).toBe(true);
+
+		const global = await run(fake, "be terse with everyone", "set_trait", {
+			scope: "global",
+			trait: "verbosity",
+			value: "terse",
+		});
+		expect(global.result.success).toBe(false);
+		expect(global.result.values?.error).toBe("PERMISSION_DENIED");
+		expect(global.result.data).toMatchObject({
+			reach: "agent_wide",
+			requiredRole: "OWNER",
+		});
+		// The refusal changed nothing: the agent-wide slot is untouched.
+		expect(fake.store.getSlot(GLOBAL_PERSONALITY_SCOPE).verbosity).toBeNull();
+	});
+
+	test("a plain user cannot even inspect the agent-wide state", async () => {
+		const fake = makeFakeRuntime();
+		await initStore(fake);
+		const { result } = await run(fake, "show global settings", "show_state", {
+			scope: "global",
+		});
+		expect(result.success).toBe(false);
+		expect(result.data).toMatchObject({
+			reach: "agent_wide",
+			requiredRole: "ADMIN",
+		});
+	});
+
+	test("an admin may inspect agent-wide state but not reconfigure it", async () => {
+		const fake = makeFakeRuntime({ admins: [TEST_SENDER] });
+		await initStore(fake);
+
+		const inspect = await run(fake, "show global settings", "show_state", {
+			scope: "global",
+		});
+		expect(inspect.result.success).toBe(true);
+
+		const mutate = await run(fake, "everyone gets emojis", "set_trait", {
+			scope: "global",
+			trait: "tone",
+			value: "playful",
+		});
+		expect(mutate.result.success).toBe(false);
+		expect(mutate.result.data).toMatchObject({
+			reach: "agent_wide",
+			requiredRole: "OWNER",
+		});
+		expect(fake.store.getSlot(GLOBAL_PERSONALITY_SCOPE).tone).toBeNull();
+	});
+
+	test("load_profile is an agent-wide reconfiguration whatever its spelling", async () => {
+		// load_profile takes no scope parameter, yet it rewrites the agent-wide
+		// slot — the case an op-name allowlist misses and the shape table catches.
+		const fake = makeFakeRuntime({ admins: [TEST_SENDER] });
+		await initStore(fake);
+		const { result } = await run(fake, "load the weekend vibe", "load_profile", {
+			name: "weekend",
+		});
+		expect(result.success).toBe(false);
+		expect(result.data).toMatchObject({
+			reach: "agent_wide",
+			requiredRole: "OWNER",
+		});
+	});
+
+	test("the owner clears the agent-wide floor", async () => {
+		const fake = makeFakeRuntime({ owner: TEST_SENDER });
+		await initStore(fake);
+		const { result } = await run(fake, "be terse with everyone", "set_trait", {
+			scope: "global",
+			trait: "verbosity",
+			value: "terse",
+		});
+		expect(result.success).toBe(true);
+		expect(fake.store.getSlot(GLOBAL_PERSONALITY_SCOPE).verbosity).toBe(
+			"terse",
+		);
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/test-helpers.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/test-helpers.ts
@@ -59,6 +59,7 @@ export function makeFakeRuntime(options: FakeRuntimeOptions = {}): FakeRuntime {
 	const agentId = options.agentId ?? nextUuid();
 	const owner = options.owner ?? null;
 	const admins = new Set<UUID>(options.admins ?? []);
+	const worldId = nextUuid();
 
 	const character: Character = {
 		name: "TestAgent",
@@ -147,16 +148,39 @@ export function makeFakeRuntime(options: FakeRuntimeOptions = {}): FakeRuntime {
 				);
 			}
 		},
-		async getRoom(): Promise<null> {
-			return null;
+		// A world exists only when `admins` seeds explicit grants. With no world,
+		// resolveWorldForMessage returns null and hasRoleAccess falls back to its
+		// unresolved-sender floor (USER for these sourceless messages) — the
+		// ordinary-user case most tests want.
+		async getRoom(roomId: UUID): Promise<{ id: UUID; worldId: UUID } | null> {
+			return admins.size > 0 ? { id: roomId, worldId } : null;
+		},
+		async getWorld(
+			id: UUID,
+		): Promise<{ id: UUID; metadata: Record<string, unknown> } | null> {
+			if (admins.size === 0) return null;
+			return {
+				id,
+				metadata: {
+					roles: Object.fromEntries(
+						[...admins].map((entityId) => [entityId, "ADMIN"]),
+					),
+					// Only a "manual" grant is honored as a real role by
+					// resolveEntityRole; a sourceless one folds back to GUEST.
+					roleSources: Object.fromEntries(
+						[...admins].map((entityId) => [entityId, "manual"]),
+					),
+				},
+			};
 		},
 		async getParticipantUserState(): Promise<null> {
 			return null;
 		},
 		// hasRoleAccess reads the canonical-owner config here: when `owner` is set
 		// it is exposed as ELIZA_ADMIN_ENTITY_ID so a message from that entity
-		// resolves to OWNER (>= ADMIN). hasRoleAccess fails CLOSED on an
-		// unresolved role, so this is how these tests grant admin.
+		// resolves to OWNER. `admins` grants ADMIN and nothing more, which is how a
+		// test separates the ADMIN floor from the OWNER floor. hasRoleAccess fails
+		// CLOSED on an unresolved role.
 		getSetting: (key: string) =>
 			key === "ELIZA_ADMIN_ENTITY_ID" && owner ? owner : undefined,
 		_test_owner: owner,

--- a/packages/core/src/features/advanced-capabilities/personality/actions/personality.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/personality.ts
@@ -9,13 +9,20 @@
  * Every trait/gate/directive op requires an explicit scope — "user" (the
  * requesting entity's slot) or "global" (the agent-wide slot) — with no
  * auto-inference: an ambiguous request returns a clarification rather than
- * guessing. Global mutations and profile load/save are admin/owner-gated via
- * hasRoleAccess. The slots written here are injected back into prompts by the
- * user-personality provider and enforced by the reply-gate and verbosity
- * helpers of the same capability.
+ * guessing, because the only default wide enough to satisfy every phrasing is
+ * the agent-wide one and defaulting a blast radius upward is itself a defect.
+ *
+ * Authorization is layered the way CHARACTER's is. The declared `roleGate` is
+ * the coarse USER floor `canActionRun` applies before the handler runs, keeping
+ * an unresolved stranger out while leaving ordinary per-user personalisation
+ * open. PERSONALITY_ACCESS_FLOOR then holds the finer requirement the handler
+ * enforces, derived from what an operation reaches and whether it reconfigures
+ * behaviour rather than from the operation's name. The slots written here are
+ * injected back into prompts by the user-personality provider and enforced by
+ * the reply-gate and verbosity helpers of the same capability.
  */
 import { logger } from "../../../../logger.ts";
-import { hasRoleAccess } from "../../../../roles.ts";
+import { hasRoleAccess, type RoleName } from "../../../../roles.ts";
 import type {
 	Action,
 	ActionExample,
@@ -65,15 +72,68 @@ const PERSONALITY_OPS = [
 ] as const;
 type PersonalityOp = (typeof PERSONALITY_OPS)[number];
 
-const ADMIN_REQUIRED_GLOBAL_OPS = new Set<PersonalityOp>([
-	"set_trait",
-	"clear_trait",
-	"set_reply_gate",
-	"lift_reply_gate",
-	"clear_directives",
-]);
+/** Whose experience an operation governs. */
+type PersonalityReach = "requester" | "agent_wide";
 
-const ADMIN_ONLY_OPS = new Set<PersonalityOp>(["load_profile", "save_profile"]);
+/** Whether an operation changes how the agent behaves or only inspects it. */
+type PersonalityEffect = "inspect" | "reconfigure";
+
+/**
+ * The authorization shape of every operation. `reach: "scoped"` means the reach
+ * is whatever scope the request resolves to; the rest carry no scope parameter
+ * and so have a fixed reach. `load_profile` is the case that shape catches and
+ * an op-name list does not: it takes no scope yet writes the agent-wide slot, so
+ * it is an agent-wide reconfiguration however it is spelled. `save_profile`
+ * files a copy of that slot without changing behaviour, so it sits with the
+ * agent-wide inspections.
+ */
+const PERSONALITY_OP_SHAPE: Record<
+	PersonalityOp,
+	{ effect: PersonalityEffect; reach: PersonalityReach | "scoped" }
+> = {
+	set_trait: { effect: "reconfigure", reach: "scoped" },
+	clear_trait: { effect: "reconfigure", reach: "scoped" },
+	set_reply_gate: { effect: "reconfigure", reach: "scoped" },
+	lift_reply_gate: { effect: "reconfigure", reach: "scoped" },
+	add_directive: { effect: "reconfigure", reach: "scoped" },
+	clear_directives: { effect: "reconfigure", reach: "scoped" },
+	show_state: { effect: "inspect", reach: "scoped" },
+	load_profile: { effect: "reconfigure", reach: "agent_wide" },
+	save_profile: { effect: "inspect", reach: "agent_wide" },
+	list_profiles: { effect: "inspect", reach: "requester" },
+};
+
+/**
+ * Minimum role per (effect, reach) — the authority a personality operation
+ * requires, decided by its blast radius so a new operation inherits a floor
+ * instead of needing another entry in a hand-maintained privileged-op list.
+ *
+ * Reconfiguring the agent-wide slot rewrites the persona every user inherits and
+ * outlives the turn, so it sits at the OWNER floor this codebase already uses
+ * for persistent self-configuration (CHARACTER's `update_identity`, SETTINGS,
+ * MODEL_SWITCH, AGENT_SWITCH, APP). Inspecting agent-wide state also exposes the
+ * cross-user audit tail, so it stays above the ordinary floor. Anything reaching
+ * only the requester's own slot is ordinary personalisation and stays at the
+ * action's declared USER floor.
+ */
+const PERSONALITY_ACCESS_FLOOR: Record<
+	PersonalityEffect,
+	Record<PersonalityReach, RoleName>
+> = {
+	inspect: { requester: "USER", agent_wide: "ADMIN" },
+	reconfigure: { requester: "USER", agent_wide: "OWNER" },
+};
+
+/**
+ * Refusal wording keyed by the same shape as the floor, so an operation cannot
+ * ship with a missing or stale per-op message.
+ */
+const PERSONALITY_DENY_MESSAGE: Record<PersonalityEffect, string> = {
+	inspect:
+		"The personality settings that apply to everyone are admin-only — ask an admin or the owner.",
+	reconfigure:
+		"Changing how I behave for everyone is owner-only. I can change it just for you instead.",
+};
 
 interface PersonalityParameters {
 	op?: string;
@@ -101,6 +161,22 @@ function isPersonalityOp(value: unknown): value is PersonalityOp {
 
 function isPersonalityScope(value: unknown): value is PersonalityScope {
 	return value === "user" || value === "global";
+}
+
+/**
+ * The reach an operation actually has on this turn. Scoped operations take it
+ * from the resolved scope, so the authority required tracks what will really be
+ * written rather than which operation name was chosen.
+ */
+function resolveReach(
+	op: PersonalityOp,
+	scope: PersonalityScope | null,
+): PersonalityReach {
+	const { reach } = PERSONALITY_OP_SHAPE[op];
+	if (reach !== "scoped") {
+		return reach;
+	}
+	return scope === "global" ? "agent_wide" : "requester";
 }
 
 function getStoreOrError(
@@ -163,12 +239,23 @@ async function recordAuditMemory(
 	}
 }
 
-function denyResult(op: PersonalityOp, message: string): ActionResult {
+function denyResult(
+	op: PersonalityOp,
+	message: string,
+	requirement: { reach: PersonalityReach; requiredRole: RoleName },
+): ActionResult {
 	return {
 		text: message,
 		success: false,
 		values: { error: "PERMISSION_DENIED" },
-		data: { action: "PERSONALITY", op },
+		// The refused blast radius and the floor it missed are machine detail for
+		// the planner and the audit reader; the spoken line stays human (#17923).
+		data: {
+			action: "PERSONALITY",
+			op,
+			reach: requirement.reach,
+			requiredRole: requirement.requiredRole,
+		},
 	};
 }
 
@@ -225,6 +312,10 @@ function summarizeSlot(slot: PersonalitySlot): string {
 export const personalityAction: Action = {
 	name: "PERSONALITY",
 	contexts: ["settings", "agent_internal", "media", "admin", "general"],
+	// Coarse floor: personalising the agent for yourself is ordinary user
+	// territory, but an unresolved sender (GUEST) has no personality to set.
+	// The per-reach requirements live in PERSONALITY_ACCESS_FLOOR.
+	roleGate: { minRole: "USER" },
 	similes: [
 		"SET_PERSONALITY",
 		"CHANGE_TONE",
@@ -239,7 +330,7 @@ export const personalityAction: Action = {
 		"BE_COLDER",
 	],
 	description:
-		"Manage personality preferences. Subactions: set_trait | clear_trait | set_reply_gate | lift_reply_gate | add_directive | clear_directives | load_profile | save_profile | list_profiles | show_state. Scope is REQUIRED for trait/gate/directive changes — 'user' affects only the requesting user, 'global' affects all users (admin only).",
+		"Manage personality preferences. Subactions: set_trait | clear_trait | set_reply_gate | lift_reply_gate | add_directive | clear_directives | load_profile | save_profile | list_profiles | show_state. Scope is REQUIRED for trait/gate/directive changes — 'user' affects only the requesting user, 'global' permanently changes the agent for everyone and is owner-only. Never guess 'global': when the request does not say which one, omit scope and the action will ask.",
 	suppressPostActionContinuation: true,
 	parameters: [
 		{
@@ -257,7 +348,7 @@ export const personalityAction: Action = {
 		{
 			name: "scope",
 			description:
-				"Required for set_trait/clear_trait/set_reply_gate/lift_reply_gate/add_directive/clear_directives/show_state. Use 'user' for the requesting user's slot, or 'global' for the agent-wide slot (admin only).",
+				"Required for set_trait/clear_trait/set_reply_gate/lift_reply_gate/add_directive/clear_directives/show_state. Use 'user' for the requesting user's slot. Use 'global' ONLY when the request explicitly says it applies to everyone — it rewrites the agent-wide slot for all users and requires the owner. Omit it when the request is ambiguous.",
 			required: false,
 			schema: { type: "string", enum: [...SCOPE_VALUES] },
 		},
@@ -352,42 +443,31 @@ export const personalityAction: Action = {
 		}
 		const store = storeOrError;
 
-		const isAdmin = await hasRoleAccess(runtime, message, "ADMIN");
-
-		// Admin-only ops gate first
-		if (ADMIN_ONLY_OPS.has(op) && !isAdmin) {
-			return denyResult(
-				op,
-				"Only admins or the owner can manage saved personality profiles.",
-			);
-		}
-
 		const scope: PersonalityScope | null = isPersonalityScope(params.scope)
 			? params.scope
 			: null;
 
-		// Ops that need scope: enforce explicit scope (NO auto-inference) — an
-		// ambiguous request is clarified, never silently resolved to a default.
-		const needsScope: ReadonlySet<PersonalityOp> = new Set<PersonalityOp>([
-			"set_trait",
-			"clear_trait",
-			"set_reply_gate",
-			"lift_reply_gate",
-			"add_directive",
-			"clear_directives",
-			"show_state",
-		]);
-		if (needsScope.has(op) && !scope) {
+		// Scoped ops require an explicit, recognized scope (NO auto-inference) — an
+		// ambiguous or unrecognized scope is clarified, never resolved to a default.
+		if (PERSONALITY_OP_SHAPE[op].reach === "scoped" && !scope) {
 			const result = clarifyScopeResult(op);
 			await callback?.({ text: result.text, thought: "Ambiguous scope" });
 			return result;
 		}
 
-		if (scope === "global" && ADMIN_REQUIRED_GLOBAL_OPS.has(op) && !isAdmin) {
-			return denyResult(
-				op,
-				`Permission denied: only admins or the owner may change the global personality.`,
-			);
+		// One gate for every op, keyed on what this turn actually reaches. The
+		// scope is chosen by the planner from prose, so it may not exceed the
+		// sender's own authority: an under-privileged agent-wide request is
+		// refused here rather than downgraded, so no persistent agent-wide change
+		// is ever acknowledged that did not clear the floor.
+		const effect = PERSONALITY_OP_SHAPE[op].effect;
+		const reach = resolveReach(op, scope);
+		const requiredRole = PERSONALITY_ACCESS_FLOOR[effect][reach];
+		if (!(await hasRoleAccess(runtime, message, requiredRole))) {
+			return denyResult(op, PERSONALITY_DENY_MESSAGE[effect], {
+				reach,
+				requiredRole,
+			});
 		}
 
 		const userId = message.entityId as UUID;


### PR DESCRIPTION
## What

An **agent-wide personality mutation was reachable without any role floor**. The PERSONALITY action declared no `roleGate`, and the global-scope gate was a hand-maintained op-name list — so any resolvable user could permanently reconfigure the persona every other user inherits ("be terse with everyone").

## Root cause

Two op-name allowlists (`ADMIN_REQUIRED_GLOBAL_OPS`, `ADMIN_ONLY_OPS`) stood in for an authorization model. `load_profile` is the shape they miss: it takes no `scope` parameter yet rewrites the agent-wide slot, so it is an agent-wide reconfiguration however it is spelled. Op-name lists also mean every new operation needs another manual entry — the whack-a-mole shape.

## Change

Authorization now derives from the operation's **shape**: what it reaches (`requester` vs `agent_wide`) and whether it **reconfigures** behaviour or only **inspects** it. One gate maps that shape to a floor:

| | requester | agent-wide |
|---|---|---|
| inspect | USER | ADMIN |
| reconfigure | USER | **OWNER** |

- Agent-wide reconfiguration sits at the OWNER floor this codebase already uses for persistent self-configuration (CHARACTER `update_identity`, SETTINGS, MODEL_SWITCH, AGENT_SWITCH, APP).
- An under-privileged agent-wide request is **refused, never downgraded** — no persistent agent-wide change is acknowledged that did not clear the floor.
- The action gains the coarse `roleGate: { minRole: "USER" }` (an unresolved stranger has no personality to set) while the fine floors live in the shape table.
- The refusal carries `reach` + `requiredRole` as machine detail in `data`; the spoken line stays human (#17923).
- Planner-facing descriptions now say `global` is owner-only and must never be guessed from ambiguous phrasing.

## Evidence

<!-- evidence-head:1516d9bcf1c884bb549b1de0c19d9e54aebfedd5 -->

<!-- evidence-row:before-screenshots -->
N/A - no UI surface; chat-action authorization

<!-- evidence-row:after-screenshots -->
N/A - no UI surface; chat-action authorization

<!-- evidence-row:walkthrough-video -->
N/A - no UI surface

<!-- evidence-row:backend-logs -->
N/A - the vulnerable path is silent by design (a successful write logs as an ordinary personality change); the reproducing tests below are the observable form

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface in this change

<!-- evidence-row:llm-trajectory -->
N/A - authorization is enforced in the action handler after planner routing; no model output changes on this path

<!-- evidence-row:domain-artifacts -->
New `authorization floors` suite drives the real handler against a real `PersonalityStore` and the shared role-resolution path (`hasRoleAccess` over world metadata), pinning every cell of the matrix:

- a plain user personalises their own slot but is refused agent-wide reconfiguration (`requiredRole: OWNER`) **and the agent-wide slot is asserted untouched**
- a plain user cannot inspect agent-wide state (`requiredRole: ADMIN`)
- an admin inspects agent-wide state but is refused agent-wide reconfiguration
- `load_profile` is refused as agent-wide reconfiguration despite having no scope parameter — the shape-catch case
- the owner clears the floor and the write lands

<details>
<summary>package suite</summary>
<pre>
 Test Files  9 passed (9)
      Tests  348 passed (348)
</pre>
</details>

`bun run --cwd packages/core typecheck` — clean.

<!-- evidence-row:ocr-review -->
N/A - no rendered text or imagery

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes - agent-authored under human direction
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5, anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored from runtime-code evidence, not the pinned contribute-to-eliza skill
<!-- attribution-row:status -->
- Attribution status: self-reported
